### PR TITLE
ci: fix worker binaries could not be found

### DIFF
--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -66,7 +66,7 @@ build-malus:
     - .run-immediately
     - .collect-artifacts
   script:
-    - time cargo build --locked --profile testnet --verbose -p polkadot-test-malus --bin polkadot-prepare-worker --bin polkadot-execute-worker
+    - time cargo build --locked --profile testnet --verbose -p polkadot-test-malus --bin malus --bin polkadot-prepare-worker --bin polkadot-execute-worker
     # pack artifacts
     - mkdir -p ./artifacts
     - mv ./target/testnet/malus ./artifacts/.

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -23,6 +23,8 @@ build-linux-stable:
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
     - mv ./target/testnet/polkadot ./artifacts/.
+    - mv ./target/testnet/polkadot-prepare-worker ./artifacts/.
+    - mv ./target/testnet/polkadot-execute-worker ./artifacts/.
     - pushd artifacts
     - sha256sum polkadot | tee polkadot.sha256
     - shasum -c polkadot.sha256
@@ -68,6 +70,8 @@ build-malus:
     # pack artifacts
     - mkdir -p ./artifacts
     - mv ./target/testnet/malus ./artifacts/.
+    - mv ./target/testnet/polkadot-execute-worker ./artifacts/.
+    - mv ./target/testnet/polkadot-prepare-worker ./artifacts/.
     - echo -n "${CI_COMMIT_REF_NAME}" > ./artifacts/VERSION
     - echo -n "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}" > ./artifacts/EXTRATAG
     - echo "polkadot-test-malus = $(cat ./artifacts/VERSION) (EXTRATAG = $(cat ./artifacts/EXTRATAG))"

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -18,7 +18,7 @@ build-linux-stable:
     # Ensure we run the UI tests.
     RUN_UI_TESTS: 1
   script:
-    - time cargo build --locked --profile testnet --features pyroscope,fast-runtime --bin polkadot
+    - time cargo build --locked --profile testnet --features pyroscope,fast-runtime --bin polkadot --bin polkadot-prepare-worker --bin polkadot-execute-worker
     # pack artifacts
     - mkdir -p ./artifacts
     - VERSION="${CI_COMMIT_REF_NAME}" # will be tag or branch name
@@ -66,7 +66,7 @@ build-malus:
     - .run-immediately
     - .collect-artifacts
   script:
-    - time cargo build --locked --profile testnet --verbose -p polkadot-test-malus
+    - time cargo build --locked --profile testnet --verbose -p polkadot-test-malus --bin polkadot-prepare-worker --bin polkadot-execute-worker
     # pack artifacts
     - mkdir -p ./artifacts
     - mv ./target/testnet/malus ./artifacts/.

--- a/docker/malus_injected.Dockerfile
+++ b/docker/malus_injected.Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
 
 
 # add adder-collator binary to docker image
-COPY ./artifacts/malus /usr/local/bin
+COPY ./artifacts/malus ./artifacts/polkadot-execute-worker ./artifacts/polkadot-prepare-worker /usr/local/bin
 
 USER nonroot
 

--- a/docker/polkadot_injected_debug.Dockerfile
+++ b/docker/polkadot_injected_debug.Dockerfile
@@ -32,13 +32,15 @@ RUN apt-get update && \
 	chown -R polkadot:polkadot /data && \
 	ln -s /data /polkadot/.local/share/polkadot
 
-# add polkadot binary to docker image
-COPY ./artifacts/polkadot /usr/local/bin
+# add polkadot binaries to docker image
+COPY ./artifacts/polkadot ./artifacts/polkadot-execute-worker ./artifacts/polkadot-prepare-worker /usr/local/bin
 
 USER polkadot
 
 # check if executable works in this container
 RUN /usr/local/bin/polkadot --version
+RUN /usr/local/bin/polkadot-execute-worker --version
+RUN /usr/local/bin/polkadot-prepare-worker --version
 
 EXPOSE 30333 9933 9944
 VOLUME ["/polkadot"]

--- a/docker/polkadot_injected_release.Dockerfile
+++ b/docker/polkadot_injected_release.Dockerfile
@@ -44,6 +44,8 @@ USER polkadot
 
 # check if executable works in this container
 RUN /usr/bin/polkadot --version
+RUN /usr/local/bin/polkadot-execute-worker --version
+RUN /usr/local/bin/polkadot-prepare-worker --version
 
 EXPOSE 30333 9933 9944
 VOLUME ["/polkadot"]

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -160,6 +160,16 @@ assets = [
 		"755",
 	],
 	[
+		"target/release/polkadot-prepare-worker",
+		"/usr/lib/polkadot/",
+		"755"
+	],
+	[
+		"target/release/polkadot-execute-worker",
+		"/usr/lib/polkadot/",
+		"755"
+	],
+	[
 		"scripts/packaging/polkadot.service",
 		"/lib/systemd/system/",
 		"644",


### PR DESCRIPTION
It seems that some of the changes in polkadot have not been migrated to polkadot-sdk, so the generated docker images fail to start, fix this by porting the changes in `scripts`  directory that were present in: https://github.com/paritytech/polkadot/pull/7337

Fixes: https://github.com/paritytech/polkadot-sdk/issues/1197

## TODO
- [x] Test in Versi the image starts