### PR TITLE
PRCR - Reduced required reviews for srlabs

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -26,7 +26,7 @@ rules:
       - min_approvals: 1
         teams:
           - polkadot-review
-      - min_approvals: 2
+      - min_approvals: 1
         teams:
           - srlabs
 


### PR DESCRIPTION
As requested by @the-right-joyce and @louismerlin, the amount of required reviews from the `srlabs` team has been reduced to 1.

See related discussion: https://github.com/paritytech/pr-custom-review/issues/136#issuecomment-1695262664