### PR TITLE
sc-client: expose pinning API

### DIFF
--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -306,6 +306,20 @@ pub trait AuxStore {
 	fn get_aux(&self, key: &[u8]) -> sp_blockchain::Result<Option<Vec<u8>>>;
 }
 
+/// Client API for pinning and unpinning blocks.
+pub trait BlockPinning<Block: BlockT> {
+	/// Pin the block to keep state available in-memory after pruning.
+	///
+	/// Note: number of pinned blocks is limited by `PINNING_CACHE_SIZE` constant.
+	///
+	/// Note: pins are reference counted. Users need to make sure to perform
+	/// one call to [`Self::unpin_block`] per call to [`Self::pin_block`].
+	fn pin_block(&self, hash: <Block as BlockT>::Hash) -> sp_blockchain::Result<()>;
+
+	/// Unpin the block to allow pruning.
+	fn unpin_block(&self, hash: <Block as BlockT>::Hash);
+}
+
 /// An `Iterator` that iterates keys in a given block under a prefix.
 pub struct KeysIter<State, Block>
 where

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -28,8 +28,9 @@ use sc_block_builder::{BlockBuilderApi, BlockBuilderProvider, RecordProof};
 use sc_chain_spec::{resolve_state_version_from_wasm, BuildGenesisBlock};
 use sc_client_api::{
 	backend::{
-		self, apply_aux, BlockImportOperation, ClientImportOperation, FinalizeSummary, Finalizer,
-		ImportNotificationAction, ImportSummary, LockImportRun, NewBlockState, StorageProvider,
+		self, apply_aux, BlockImportOperation, BlockPinning, ClientImportOperation,
+		FinalizeSummary, Finalizer, ImportNotificationAction, ImportSummary, LockImportRun,
+		NewBlockState, StorageProvider,
 	},
 	client::{
 		BadBlocks, BlockBackend, BlockImportNotification, BlockOf, BlockchainEvents, ClientInfo,
@@ -1619,6 +1620,20 @@ where
 
 	fn hash(&self, number: NumberFor<Block>) -> sp_blockchain::Result<Option<Block::Hash>> {
 		self.backend.blockchain().hash(number)
+	}
+}
+
+impl<B, E, Block, RA> BlockPinning<Block> for Client<B, E, Block, RA>
+where
+	B: backend::Backend<Block>,
+	Block: BlockT,
+{
+	fn pin_block(&self, hash: Block::Hash) -> sp_blockchain::Result<()> {
+		self.backend.pin_block(hash)
+	}
+
+	fn unpin_block(&self, hash: Block::Hash) {
+		self.backend.unpin_block(hash)
 	}
 }
 


### PR DESCRIPTION
Required for #623.

I've considered another design with RAAI similar to [`lock_block`](https://github.com/paritytech/polkadot-sdk/blob/4252e488a06d2c5ec4531697ea699b78c56d316b/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs#L115C1-L122C1), but opted for a lower-level albeit less safe API. The reason is that the caller can provide a safer abstraction on top (see the follow-up PR).