### PR TITLE
bump `zombienet` to latest version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.59"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.65"
   DOCKER_IMAGES_VERSION: "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
 
 default:

--- a/.gitlab/pipeline/zombienet/cumulus.yml
+++ b/.gitlab/pipeline/zombienet/cumulus.yml
@@ -31,6 +31,7 @@
     LOCAL_DIR: "/builds/parity/mirrors/polkadot-sdk/cumulus/zombienet/tests"
     COL_IMAGE: "docker.io/paritypr/test-parachain:${DOCKER_IMAGES_VERSION}"
     FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: 1
+    RUN_IN_CONTAINER: "1"
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when: always

--- a/.gitlab/pipeline/zombienet/polkadot.yml
+++ b/.gitlab/pipeline/zombienet/polkadot.yml
@@ -147,7 +147,7 @@ zombienet-polkadot-misc-0002-upgrade-node:
     - echo "Overrided poladot image ${ZOMBIENET_INTEGRATION_TEST_IMAGE}"
     - export COL_IMAGE="${COLANDER_IMAGE}":${PIPELINE_IMAGE_TAG}
     - BUILD_LINUX_JOB_ID="$(cat ./artifacts/BUILD_LINUX_JOB_ID)"
-    - export POLKADOT_PR_BIN_URL="https://gitlab-stg.parity.io/parity/mirrors/polkadot-sdk/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/raw/artifacts/polkadot"
+    - export POLKADOT_PR_ARTIFACTS_URL="https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/raw/artifacts"
     - echo "Zombienet Tests Config"
     - echo "gh-dir ${GH_DIR}"
     - echo "local-dir ${LOCAL_DIR}"

--- a/.gitlab/pipeline/zombienet/polkadot.yml
+++ b/.gitlab/pipeline/zombienet/polkadot.yml
@@ -34,6 +34,7 @@
     GH_DIR: "https://github.com/paritytech/substrate/tree/${CI_COMMIT_SHA}/zombienet"
     LOCAL_DIR: "/builds/parity/mirrors/polkadot-sdk/polkadot/zombienet_tests"
     FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: 1
+    RUN_IN_CONTAINER: "1"
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when: always

--- a/.gitlab/pipeline/zombienet/substrate.yml
+++ b/.gitlab/pipeline/zombienet/substrate.yml
@@ -24,6 +24,7 @@
     GH_DIR: "https://github.com/paritytech/substrate/tree/${CI_COMMIT_SHA}/zombienet"
     LOCAL_DIR: "/builds/parity/mirrors/polkadot-sdk/substrate/zombienet"
     FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: 1
+    RUN_IN_CONTAINER: "1"
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when: always


### PR DESCRIPTION
Includes fixes from `v1.3.59` (e.g chain-spec generation / cmd generation for collators).
Thx!