### PR TITLE
Changed LPFee to Percent type in Asset Conversion Pallet

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/lib.rs
@@ -41,7 +41,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, Permill,
+	ApplyExtrinsicResult, PerThing, Percent, Permill, Rounding,
 };
 
 use sp_std::prelude::*;
@@ -291,6 +291,7 @@ parameter_types! {
 	pub const AllowMultiAssetPools: bool = false;
 	// should be non-zero if AllowMultiAssetPools is true, otherwise can be zero
 	pub const LiquidityWithdrawalFee: Permill = Permill::from_percent(0);
+	pub LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
 }
 
 ord_parameter_types! {
@@ -342,7 +343,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	// should be non-zero if `AllowMultiAssetPools` is true, otherwise can be zero.
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;
-	type LPFee = ConstU32<3>;
+	type LPFee = LiquidityPoolFee;
 	type PalletId = AssetConversionPalletId;
 	type AllowMultiAssetPools = AllowMultiAssetPools;
 	type MaxSwapPathLength = ConstU32<4>;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -67,7 +67,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, Permill, RuntimeDebug,
+	ApplyExtrinsicResult, PerThing, Percent, Permill, Rounding, RuntimeDebug,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -269,6 +269,7 @@ parameter_types! {
 	pub const AllowMultiAssetPools: bool = false;
 	// should be non-zero if AllowMultiAssetPools is true, otherwise can be zero
 	pub const LiquidityWithdrawalFee: Permill = Permill::from_percent(0);
+	pub LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
 }
 
 ord_parameter_types! {
@@ -318,7 +319,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type PoolSetupFee = ConstU128<0>; // Asset class deposit fees are sufficient to prevent spam
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee; // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero.
-	type LPFee = ConstU32<3>;
+	type LPFee = LiquidityPoolFee;
 	type PalletId = AssetConversionPalletId;
 	type AllowMultiAssetPools = AllowMultiAssetPools;
 	type MaxSwapPathLength = ConstU32<4>;

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ use sp_runtime::{
 	},
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, FixedPointNumber, FixedU128, Perbill, Percent, Permill, Perquintill,
-	RuntimeDebug,
+	Rounding, RuntimeDebug,
 };
 use sp_std::prelude::*;
 #[cfg(any(feature = "std", test))]
@@ -1617,6 +1617,7 @@ parameter_types! {
 	pub const PoolSetupFee: Balance = 1 * DOLLARS; // should be more or equal to the existential deposit
 	pub const MintMinLiquidity: Balance = 100;  // 100 is good enough when the main currency has 10-12 decimals.
 	pub const LiquidityWithdrawalFee: Permill = Permill::from_percent(0);  // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero.
+	pub const LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
 }
 
 impl pallet_asset_conversion::Config for Runtime {
@@ -1631,7 +1632,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type MultiAssetId = NativeOrAssetId<u32>;
 	type PoolAssetId = <Self as pallet_assets::Config<Instance2>>::AssetId;
 	type PalletId = AssetConversionPalletId;
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = LiquidityPoolFee;
 	type PoolSetupFee = PoolSetupFee;
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -79,8 +79,8 @@ use sp_runtime::{
 		OpaqueKeys, SaturatedConversion, StaticLookup,
 	},
 	transaction_validity::{TransactionPriority, TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, FixedPointNumber, FixedU128, Perbill, Percent, Permill, Perquintill,
-	Rounding, RuntimeDebug,
+	ApplyExtrinsicResult, FixedPointNumber, FixedU128, PerThing, Perbill, Percent, Permill,
+	Perquintill, Rounding, RuntimeDebug,
 };
 use sp_std::prelude::*;
 #[cfg(any(feature = "std", test))]
@@ -1617,7 +1617,7 @@ parameter_types! {
 	pub const PoolSetupFee: Balance = 1 * DOLLARS; // should be more or equal to the existential deposit
 	pub const MintMinLiquidity: Balance = 100;  // 100 is good enough when the main currency has 10-12 decimals.
 	pub const LiquidityWithdrawalFee: Permill = Permill::from_percent(0);  // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero.
-	pub const LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
+	pub LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
 }
 
 impl pallet_asset_conversion::Config for Runtime {

--- a/substrate/frame/asset-conversion/src/mock.rs
+++ b/substrate/frame/asset-conversion/src/mock.rs
@@ -28,7 +28,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureSigned, EnsureSignedBy};
-use sp_arithmetic::Permill;
+use sp_arithmetic::{PerThing, Percent, Permill, Rounding};
 use sp_core::H256;
 use sp_runtime::{
 	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup},
@@ -143,6 +143,7 @@ parameter_types! {
 	pub const AssetConversionPalletId: PalletId = PalletId(*b"py/ascon");
 	pub storage AllowMultiAssetPools: bool = true;
 	pub storage LiquidityWithdrawalFee: Permill = Permill::from_percent(0); // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero
+	pub LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
 }
 
 ord_parameter_types! {
@@ -159,7 +160,7 @@ impl Config for Test {
 	type PoolAssets = PoolAssets;
 	type PalletId = AssetConversionPalletId;
 	type WeightInfo = ();
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = LiquidityPoolFee;
 	type PoolSetupFee = ConstU128<100>; // should be more or equal to the existential deposit
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
@@ -34,7 +34,7 @@ use pallet_transaction_payment::CurrencyAdapter;
 use sp_core::H256;
 use sp_runtime::{
 	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup, SaturatedConversion},
-	Permill,
+	PerThing, Percent, Permill, Rounding,
 };
 
 type Block = frame_system::mocking::MockBlock<Runtime>;
@@ -225,6 +225,7 @@ parameter_types! {
 	pub storage AllowMultiAssetPools: bool = false;
 	// should be non-zero if AllowMultiAssetPools is true, otherwise can be zero
 	pub storage LiquidityWithdrawalFee: Permill = Permill::from_percent(0);
+	pub LiquidityPoolFee: Percent = Percent::from_rational_with_rounding(997u32, 1000u32, Rounding::NearestPrefDown).unwrap(); // 0.3%
 	pub const MaxSwapPathLength: u32 = 4;
 }
 
@@ -242,7 +243,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type PoolAssets = PoolAssets;
 	type PalletId = AssetConversionPalletId;
 	type WeightInfo = ();
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = LiquidityPoolFee;
 	type PoolSetupFee = ConstU64<100>; // should be more or equal to the existential deposit
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/88

Changed Liquidity Pool fee in Asset Conversion pallet from a u32 to a Percent type.

TODO: Fix fee multipliers