### PR TITLE
Revive Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Update github actions:
+  - package-ecosystem: github-actions
+    directory: '/'
+    labels: ["A1-insubstantial", "R0-silent"]
+    schedule:
+      interval: daily
+  # Update Rust dependencies:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels: ["A1-insubstantial", "R0-silent"]
+    schedule:
+      interval: "daily"
+    groups:
+      # We assume these crates to be semver abiding and can therefore group them together.
+      known_good_semver:
+        patterns:
+        - "syn"
+        - "quote"
+        - "log"
+        - "paste"
+        - "*serde*"
+        - "clap"
+        update-types:
+        - "minor"
+        - "patch"


### PR DESCRIPTION
Closes #1174 

Configures  Dependabot to run daily but group some dependencies together that I assume to be semver abiding.  

(Maybe still needs to be enabled somewhere in the settings cc @alvicsam)