### PR TITLE
[ci] Fix buildah and reorder test-doc dag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ workflow:
 
 variables:
   CI_IMAGE: "paritytech/ci-unified:bullseye-1.70.0-2023-05-23-v20230706"
-  BUILDAH_IMAGE: "quay.io/buildah/stable:v1.29"
+  # BUILDAH_IMAGE is defined in group variables
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"
   RUSTY_CACHIER_SINGLE_BRANCH: master

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -147,7 +147,10 @@ test-doc:
   extends:
     - .docker-env
     - .common-refs
-    - .run-immediately
+  # DAG
+  needs:
+    - job: test-rustdoc
+      artifacts: false
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
@@ -160,10 +163,7 @@ test-rustdoc:
   extends:
     - .docker-env
     - .common-refs
-  # DAG
-  needs:
-    - job: test-doc
-      artifacts: false
+    - .run-immediately
   variables:
     SKIP_WASM_BUILD: 1
     RUSTDOCFLAGS: "-Dwarnings"


### PR DESCRIPTION
PR removes `BUILDAH_IMAGE` variable and reorders `test-doc` and `test-rustdoc` jobs