### PR TITLE
Fix links in contributing and PR template docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ No PR should be merged until all reviews' comments are addressed.
 
 ### Labels:
 
-The set of labels and their description can be found [here](linktobeinserted)
+The set of labels and their description can be found [here](https://paritytech.github.io/labels).
 
 ### Process:
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 ✄ -----------------------------------------------------------------------------
 
 Thank you for your Pull Request! 🙏 Please make sure it follows the contribution
-guidelines outlined in [this document](CONTRIBUTING.md) and fill out the
+guidelines outlined in [this document](https://github.com/paritytech/polkadot-sdk/blob/master/docs/CONTRIBUTING.md) and fill out the
 sections below. Once you're ready to submit your PR for review, please delete
 this section and leave only the text under the "Description" heading.
 
@@ -29,7 +29,7 @@ Cumulus companion: (*if applicable*)
 # Checklist
 
 - [ ] My PR includes a detailed description as outlined in the "Description" section above
-- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required)
+- [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/CONTRIBUTING.md#process) of this project (at minimum one label for `T` required)
 - [ ] I have made corresponding changes to the documentation (if applicable)
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
 - [ ] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)


### PR DESCRIPTION
The PR template when, if previewed when actually making a PR, does not resolve to the expected doc. This fixes that by adding the absolute URL to that doc. And also updates the `linktobeinserted` in CONTRIBUTING.md with https://paritytech.github.io/labels.