### PR TITLE
fix chain-spec path for substrate tests

### DIFF
--- a/cumulus/zombienet/tests/0007-full_node_warp_sync.toml
+++ b/cumulus/zombienet/tests/0007-full_node_warp_sync.toml
@@ -3,7 +3,7 @@ default_image = "{{RELAY_IMAGE}}"
 default_command = "polkadot"
 default_args = [ "-lparachain=debug" ]
 chain = "rococo-local"
-chain_spec_path = "zombienet/tests/0007-warp-sync-relaychain-spec.json"
+chain_spec_path = "cumulus/zombienet/tests/0007-warp-sync-relaychain-spec.json"
 
   [[relaychain.nodes]]
   name = "alice"
@@ -28,7 +28,7 @@ chain_spec_path = "zombienet/tests/0007-warp-sync-relaychain-spec.json"
 [[parachains]]
 id = 2000
 cumulus_based = true
-chain_spec_path = "zombienet/tests/0007-warp-sync-parachain-spec.json"
+chain_spec_path = "cumulus/zombienet/tests/0007-warp-sync-parachain-spec.json"
 add_to_genesis = false
 
   # Run 'dave' as parachain collator.

--- a/substrate/zombienet/0001-basic-warp-sync/test-warp-sync.toml
+++ b/substrate/zombienet/0001-basic-warp-sync/test-warp-sync.toml
@@ -6,7 +6,7 @@ default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 default_command = "substrate"
 
 chain = "gen-db"
-chain_spec_path = "zombienet/0001-basic-warp-sync/chain-spec.json"
+chain_spec_path = "substrate/zombienet/0001-basic-warp-sync/chain-spec.json"
 
   [[relaychain.nodes]]
   name = "alice"

--- a/substrate/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
+++ b/substrate/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
@@ -6,7 +6,7 @@ default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 default_command = "substrate"
 
 chain = "gen-db"
-chain_spec_path = "zombienet/0002-validators-warp-sync/chain-spec.json"
+chain_spec_path = "substrate/zombienet/0002-validators-warp-sync/chain-spec.json"
 
   [[relaychain.nodes]]
   name = "alice"

--- a/substrate/zombienet/0003-block-building-warp-sync/test-block-building-warp-sync.toml
+++ b/substrate/zombienet/0003-block-building-warp-sync/test-block-building-warp-sync.toml
@@ -6,7 +6,7 @@ default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 default_command = "substrate"
 
 chain = "gen-db"
-chain_spec_path = "zombienet/0003-block-building-warp-sync/chain-spec.json"
+chain_spec_path = "substrate/zombienet/0003-block-building-warp-sync/chain-spec.json"
 
   #we need at least 3 nodes for warp sync
   [[relaychain.nodes]]


### PR DESCRIPTION
Update chain-spec path in network definition.
These tests are affected by this [bug](https://github.com/paritytech/zombienet/issues/1291) and reported as success when are not.

Thx!