### PR TITLE
Polkadot: add missing `network-protocol-staging` feature

### DIFF
--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -66,6 +66,7 @@ jemalloc-allocator = [
 # Enables timeout-based tests supposed to be run only in CI environment as they may be flaky
 # when run locally depending on system load
 ci-only-tests = [ "polkadot-node-core-pvf/ci-only-tests" ]
+network-protocol-staging = [ "polkadot-cli/network-protocol-staging" ]
 
 # Configuration for building a .deb package - for use with `cargo-deb`
 [package.metadata.deb]


### PR DESCRIPTION
This was somehow dropped during the migration
