### PR TITLE
Fix polkadot-node-core-pvf-prepare-worker build with jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11626,7 +11626,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-rpc-client",
  "tempfile",
- "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -18728,6 +18728,16 @@ checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11626,7 +11626,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-rpc-client",
  "tempfile",
- "tikv-jemallocator",
+ "tikv-jemalloc-ctl",
  "tokio",
 ]
 
@@ -12297,7 +12297,6 @@ dependencies = [
  "sp-core",
  "sp-maybe-compressed-blob",
  "sp-tracing",
- "tikv-jemalloc-ctl",
  "tokio",
  "tracing-gum",
 ]
@@ -18729,16 +18728,6 @@ checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -22,7 +22,7 @@ version = "1.0.0"
 
 [dependencies]
 color-eyre = { version = "0.6.1", default-features = false }
-tikv-jemallocator = "0.5.0"
+tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
 
 # Crates in our workspace, defined as dependencies so we can pass them feature flags.
 polkadot-cli = { path = "cli", features = [
@@ -37,6 +37,9 @@ polkadot-overseer = { path = "node/overseer" }
 # Needed for worker binaries.
 polkadot-node-core-pvf-common = { path = "node/core/pvf/common" }
 polkadot-node-core-pvf-execute-worker = { path = "node/core/pvf/execute-worker" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemalloc-ctl = "0.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"
@@ -59,6 +62,7 @@ fast-runtime = [ "polkadot-cli/fast-runtime" ]
 runtime-metrics = [ "polkadot-cli/runtime-metrics" ]
 pyroscope = [ "polkadot-cli/pyroscope" ]
 jemalloc-allocator = [
+	"polkadot-node-core-pvf/jemalloc-allocator",
 	"polkadot-node-core-pvf-prepare-worker/jemalloc-allocator",
 	"polkadot-overseer/jemalloc-allocator",
 ]

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -63,8 +63,8 @@ runtime-metrics = [ "polkadot-cli/runtime-metrics" ]
 pyroscope = [ "polkadot-cli/pyroscope" ]
 jemalloc-allocator = [
 	"dep:tikv-jemallocator",
-	"polkadot-node-core-pvf/jemalloc-allocator",
 	"polkadot-node-core-pvf-prepare-worker/jemalloc-allocator",
+	"polkadot-node-core-pvf/jemalloc-allocator",
 	"polkadot-overseer/jemalloc-allocator",
 ]
 

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -22,7 +22,7 @@ version = "1.0.0"
 
 [dependencies]
 color-eyre = { version = "0.6.1", default-features = false }
-tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
+tikv-jemallocator = { version = "0.5.0", optional = true }
 
 # Crates in our workspace, defined as dependencies so we can pass them feature flags.
 polkadot-cli = { path = "cli", features = [
@@ -39,7 +39,7 @@ polkadot-node-core-pvf-common = { path = "node/core/pvf/common" }
 polkadot-node-core-pvf-execute-worker = { path = "node/core/pvf/execute-worker" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemalloc-ctl = "0.5.0"
+tikv-jemallocator = "0.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"
@@ -62,6 +62,7 @@ fast-runtime = [ "polkadot-cli/fast-runtime" ]
 runtime-metrics = [ "polkadot-cli/runtime-metrics" ]
 pyroscope = [ "polkadot-cli/pyroscope" ]
 jemalloc-allocator = [
+	"dep:tikv-jemallocator",
 	"polkadot-node-core-pvf/jemalloc-allocator",
 	"polkadot-node-core-pvf-prepare-worker/jemalloc-allocator",
 	"polkadot-overseer/jemalloc-allocator",

--- a/polkadot/node/core/pvf/Cargo.toml
+++ b/polkadot/node/core/pvf/Cargo.toml
@@ -54,6 +54,7 @@ halt = { package = "test-parachain-halt", path = "../../../parachain/test-parach
 
 [features]
 ci-only-tests = []
+jemalloc-allocator = [ "polkadot-node-core-pvf-common/jemalloc-allocator" ]
 # This feature is used to export test code to other crates without putting it in the production build.
 # This is also used by the `puppet_worker` binary.
 test-utils = [

--- a/polkadot/node/core/pvf/common/Cargo.toml
+++ b/polkadot/node/core/pvf/common/Cargo.toml
@@ -38,3 +38,4 @@ tempfile = "3.3.0"
 # This feature is used to export test code to other crates without putting it in the production build.
 # Also used for building the puppet worker.
 test-utils = []
+jemalloc-allocator = []

--- a/polkadot/node/core/pvf/execute-worker/Cargo.toml
+++ b/polkadot/node/core/pvf/execute-worker/Cargo.toml
@@ -11,7 +11,6 @@ cpu-time = "1.0.0"
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../../gum" }
 rayon = "1.5.1"
-tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
 tokio = { version = "1.24.2", features = ["fs", "process"] }
 
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
@@ -23,9 +22,6 @@ polkadot-primitives = { path = "../../../../primitives" }
 sp-core = { path = "../../../../../substrate/primitives/core" }
 sp-maybe-compressed-blob = { path = "../../../../../substrate/primitives/maybe-compressed-blob" }
 sp-tracing = { path = "../../../../../substrate/primitives/tracing" }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemalloc-ctl = "0.5.0"
 
 [features]
 builder = []

--- a/polkadot/node/core/pvf/prepare-worker/Cargo.toml
+++ b/polkadot/node/core/pvf/prepare-worker/Cargo.toml
@@ -32,4 +32,4 @@ tikv-jemalloc-ctl = "0.5.0"
 
 [features]
 builder = []
-jemalloc-allocator = [ "dep:tikv-jemalloc-ctl" ]
+jemalloc-allocator = [ "dep:tikv-jemalloc-ctl", "polkadot-node-core-pvf-common/jemalloc-allocator" ]

--- a/polkadot/node/core/pvf/prepare-worker/Cargo.toml
+++ b/polkadot/node/core/pvf/prepare-worker/Cargo.toml
@@ -32,4 +32,7 @@ tikv-jemalloc-ctl = "0.5.0"
 
 [features]
 builder = []
-jemalloc-allocator = [ "dep:tikv-jemalloc-ctl", "polkadot-node-core-pvf-common/jemalloc-allocator" ]
+jemalloc-allocator = [
+	"dep:tikv-jemalloc-ctl",
+	"polkadot-node-core-pvf-common/jemalloc-allocator",
+]


### PR DESCRIPTION
The jemalloc feature on polkadot-node-core-pvf-prepare-worker depended on some feature gated code in polkadot-node-core-pvf-common but there way no way to enable this feature gate.

This commit adds the feature and makes prepare-worker enable it.