### PR TITLE
Fix typos in rust setup doc

### DIFF
--- a/substrate/bin/node-template/docs/rust-setup.md
+++ b/substrate/bin/node-template/docs/rust-setup.md
@@ -2,7 +2,7 @@
 title: Installation
 ---
 
-This guide is for reference only, please check the latest information on getting starting with Substrate 
+This guide is for reference only, please check the latest information on getting started with Substrate 
 [here](https://docs.substrate.io/main-docs/install/).
 
 This page will guide you through the **2 steps** needed to prepare a computer for **Substrate** development.
@@ -74,7 +74,7 @@ brew install openssl
 ### Windows
 
 **_PLEASE NOTE:_** Native Windows development of Substrate is _not_ very well supported! It is _highly_
-recommend to use [Windows Subsystem Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+recommended to use [Windows Subsystem Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 (WSL) and follow the instructions for [Ubuntu/Debian](#ubuntudebian).
 Please refer to the separate
 [guide for native Windows development](https://docs.substrate.io/main-docs/install/windows/).


### PR DESCRIPTION
Typo fixes in rust setup doc, originally caught in https://github.com/substrate-developer-hub/substrate-node-template/pull/488 by @omahs 🙏🏻 