### PR TITLE
Add simple collator election mechanism

### DIFF
--- a/cumulus/pallets/collator-selection/src/benchmarking.rs
+++ b/cumulus/pallets/collator-selection/src/benchmarking.rs
@@ -25,10 +25,7 @@ use codec::Decode;
 use frame_benchmarking::{
 	account, impl_benchmark_test_suite, v2::*, whitelisted_caller, BenchmarkError,
 };
-use frame_support::{
-	dispatch::DispatchResult,
-	traits::{Currency, EnsureOrigin, Get, ReservableCurrency},
-};
+use frame_support::traits::{Currency, EnsureOrigin, Get, ReservableCurrency};
 use frame_system::{pallet_prelude::BlockNumberFor, EventRecord, RawOrigin};
 use pallet_authorship::EventHandler;
 use pallet_session::{self as session, SessionManager};
@@ -94,7 +91,8 @@ fn register_candidates<T: Config>(count: u32) {
 	assert!(<CandidacyBond<T>>::get() > 0u32.into(), "Bond cannot be zero!");
 
 	for who in candidates {
-		T::Currency::make_free_balance_be(&who, <CandidacyBond<T>>::get() * 2u32.into());
+		// TODO[GMP] revisit this, need it for Currency reserve in increase_bid
+		T::Currency::make_free_balance_be(&who, <CandidacyBond<T>>::get() * 3u32.into());
 		<CollatorSelection<T>>::register_as_candidate(RawOrigin::Signed(who).into()).unwrap();
 	}
 }
@@ -107,8 +105,11 @@ fn min_candidates<T: Config>() -> u32 {
 
 fn min_invulnerables<T: Config>() -> u32 {
 	let min_collators = T::MinEligibleCollators::get();
-	let candidates_length = <Candidates<T>>::get().len();
-	min_collators.saturating_sub(candidates_length.try_into().unwrap())
+	let candidates_length = <CandidateList<T>>::decode_len()
+		.unwrap_or_default()
+		.try_into()
+		.unwrap_or_default();
+	min_collators.saturating_sub(candidates_length)
 }
 
 #[benchmarks(where T: pallet_authorship::Config + session::Config)]
@@ -160,22 +161,19 @@ mod benchmarks {
 				.unwrap();
 		}
 		// ... and register them.
-		for (who, _) in candidates {
+		for (who, _) in candidates.iter() {
 			let deposit = <CandidacyBond<T>>::get();
-			T::Currency::make_free_balance_be(&who, deposit * 1000_u32.into());
-			let incoming = CandidateInfo { who: who.clone(), deposit };
-			<Candidates<T>>::try_mutate(|candidates| -> DispatchResult {
-				if !candidates.iter().any(|candidate| candidate.who == who) {
-					T::Currency::reserve(&who, deposit)?;
-					candidates.try_push(incoming).expect("we've respected the bounded vec limit");
-					<LastAuthoredBlock<T>>::insert(
-						who.clone(),
-						frame_system::Pallet::<T>::block_number() + T::KickThreshold::get(),
-					);
-				}
-				Ok(())
+			T::Currency::make_free_balance_be(who, deposit * 1000_u32.into());
+			<CandidateList<T>>::try_mutate(|list| {
+				list.try_push(CandidateInfo { who: who.clone(), deposit }).unwrap();
+				Ok::<(), BenchmarkError>(())
 			})
-			.expect("only returns ok");
+			.unwrap();
+			T::Currency::reserve(who, deposit)?;
+			<LastAuthoredBlock<T>>::insert(
+				who.clone(),
+				frame_system::Pallet::<T>::block_number() + T::KickThreshold::get(),
+			);
 		}
 
 		// now we need to fill up invulnerables
@@ -238,6 +236,35 @@ mod benchmarks {
 		Ok(())
 	}
 
+	#[benchmark]
+	fn update_bond(
+		c: Linear<{ min_candidates::<T>() + 1 }, { T::MaxCandidates::get() }>,
+	) -> Result<(), BenchmarkError> {
+		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
+		<DesiredCandidates<T>>::put(c);
+
+		register_validators::<T>(c);
+		register_candidates::<T>(c);
+
+		let caller = <CandidateList<T>>::get()[0].who.clone();
+		v2::whitelist!(caller);
+
+		let bond_amount: BalanceOf<T> =
+			T::Currency::minimum_balance() + T::Currency::minimum_balance();
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(caller.clone()), bond_amount);
+
+		assert_last_event::<T>(
+			Event::CandidateBondUpdated { account_id: caller, deposit: bond_amount }.into(),
+		);
+		assert!(
+			<CandidateList<T>>::get().iter().last().unwrap().deposit ==
+				T::Currency::minimum_balance() * 2u32.into()
+		);
+		Ok(())
+	}
+
 	// worse case is when we have all the max-candidate slots filled except one, and we fill that
 	// one.
 	#[benchmark]
@@ -267,6 +294,36 @@ mod benchmarks {
 		);
 	}
 
+	#[benchmark]
+	fn take_candidate_slot(c: Linear<{ min_candidates::<T>() + 1 }, { T::MaxCandidates::get() }>) {
+		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
+		<DesiredCandidates<T>>::put(1);
+
+		register_validators::<T>(c);
+		register_candidates::<T>(c);
+
+		let caller: T::AccountId = whitelisted_caller();
+		let bond: BalanceOf<T> = T::Currency::minimum_balance() * 10u32.into();
+		T::Currency::make_free_balance_be(&caller, bond);
+
+		<session::Pallet<T>>::set_keys(
+			RawOrigin::Signed(caller.clone()).into(),
+			keys::<T>(c + 1),
+			Vec::new(),
+		)
+		.unwrap();
+
+		let target = <CandidateList<T>>::get().iter().last().unwrap().who.clone();
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(caller.clone()), bond / 2u32.into(), target.clone());
+
+		assert_last_event::<T>(
+			Event::CandidateReplaced { old: target, new: caller, deposit: bond / 2u32.into() }
+				.into(),
+		);
+	}
+
 	// worse case is the last candidate leaving.
 	#[benchmark]
 	fn leave_intent(c: Linear<{ min_candidates::<T>() + 1 }, { T::MaxCandidates::get() }>) {
@@ -276,7 +333,7 @@ mod benchmarks {
 		register_validators::<T>(c);
 		register_candidates::<T>(c);
 
-		let leaving = <Candidates<T>>::get().last().unwrap().who.clone();
+		let leaving = <CandidateList<T>>::get().iter().last().unwrap().who.clone();
 		v2::whitelist!(leaving);
 
 		#[extrinsic_call]
@@ -323,31 +380,37 @@ mod benchmarks {
 
 		let new_block: BlockNumberFor<T> = 1800u32.into();
 		let zero_block: BlockNumberFor<T> = 0u32.into();
-		let candidates = <Candidates<T>>::get();
+		let candidates: Vec<T::AccountId> = <CandidateList<T>>::get()
+			.iter()
+			.map(|candidate_info| candidate_info.who.clone())
+			.collect();
 
 		let non_removals = c.saturating_sub(r);
 
 		for i in 0..c {
-			<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), zero_block);
+			<LastAuthoredBlock<T>>::insert(candidates[i as usize].clone(), zero_block);
 		}
 
 		if non_removals > 0 {
 			for i in 0..non_removals {
-				<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
+				<LastAuthoredBlock<T>>::insert(candidates[i as usize].clone(), new_block);
 			}
 		} else {
 			for i in 0..c {
-				<LastAuthoredBlock<T>>::insert(candidates[i as usize].who.clone(), new_block);
+				<LastAuthoredBlock<T>>::insert(candidates[i as usize].clone(), new_block);
 			}
 		}
 
 		let min_candidates = min_candidates::<T>();
-		let pre_length = <Candidates<T>>::get().len();
+		let pre_length = <CandidateList<T>>::decode_len().unwrap_or_default();
 
 		frame_system::Pallet::<T>::set_block_number(new_block);
 
-		assert!(<Candidates<T>>::get().len() == c as usize);
-
+		let current_length: u32 = <CandidateList<T>>::decode_len()
+			.unwrap_or_default()
+			.try_into()
+			.unwrap_or_default();
+		assert!(c == current_length);
 		#[block]
 		{
 			<CollatorSelection<T> as SessionManager<_>>::new_session(0);
@@ -357,16 +420,20 @@ mod benchmarks {
 			// candidates > removals and remaining candidates > min candidates
 			// => remaining candidates should be shorter than before removal, i.e. some were
 			//    actually removed.
-			assert!(<Candidates<T>>::get().len() < pre_length);
+			assert!(<CandidateList<T>>::decode_len().unwrap_or_default() < pre_length);
 		} else if c > r && non_removals < min_candidates {
 			// candidates > removals and remaining candidates would be less than min candidates
 			// => remaining candidates should equal min candidates, i.e. some were removed up to
 			//    the minimum, but then any more were "forced" to stay in candidates.
-			assert!(<Candidates<T>>::get().len() == min_candidates as usize);
+			let current_length: u32 = <CandidateList<T>>::decode_len()
+				.unwrap_or_default()
+				.try_into()
+				.unwrap_or_default();
+			assert!(min_candidates == current_length);
 		} else {
 			// removals >= candidates, non removals must == 0
 			// can't remove more than exist
-			assert!(<Candidates<T>>::get().len() == pre_length);
+			assert!(<CandidateList<T>>::decode_len().unwrap_or_default() == pre_length);
 		}
 	}
 

--- a/cumulus/pallets/collator-selection/src/tests.rs
+++ b/cumulus/pallets/collator-selection/src/tests.rs
@@ -28,7 +28,7 @@ fn basic_setup_works() {
 		assert_eq!(CollatorSelection::desired_candidates(), 2);
 		assert_eq!(CollatorSelection::candidacy_bond(), 10);
 
-		assert!(CollatorSelection::candidates().is_empty());
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 		// genesis should sort input
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 	});
@@ -202,7 +202,8 @@ fn candidate_to_invulnerable_works() {
 		initialize_to_block(1);
 		assert_eq!(CollatorSelection::desired_candidates(), 2);
 		assert_eq!(CollatorSelection::candidacy_bond(), 10);
-		assert_eq!(CollatorSelection::candidates(), Vec::new());
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 
 		assert_eq!(Balances::free_balance(3), 100);
@@ -226,7 +227,7 @@ fn candidate_to_invulnerable_works() {
 		));
 		assert!(CollatorSelection::invulnerables().to_vec().contains(&3));
 		assert_eq!(Balances::free_balance(3), 100);
-		assert_eq!(CollatorSelection::candidates().len(), 1);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 1);
 
 		assert_ok!(CollatorSelection::add_invulnerable(
 			RuntimeOrigin::signed(RootAccount::get()),
@@ -240,7 +241,8 @@ fn candidate_to_invulnerable_works() {
 		));
 		assert!(CollatorSelection::invulnerables().to_vec().contains(&4));
 		assert_eq!(Balances::free_balance(4), 100);
-		assert_eq!(CollatorSelection::candidates().len(), 0);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 	});
 }
 
@@ -286,22 +288,23 @@ fn set_candidacy_bond() {
 #[test]
 fn cannot_register_candidate_if_too_many() {
 	new_test_ext().execute_with(|| {
-		// reset desired candidates:
-		<crate::DesiredCandidates<Test>>::put(0);
-
-		// can't accept anyone anymore.
-		assert_noop!(
-			CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)),
-			Error::<Test>::TooManyCandidates,
-		);
-
-		// reset desired candidates:
 		<crate::DesiredCandidates<Test>>::put(1);
-		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
 
-		// but no more
+		// MaxCandidates: u32 = 20
+		// Aside from 3, 4, and 5, create enough accounts to have 21 potential
+		// candidates.
+		for i in 6..=23 {
+			Balances::make_free_balance_be(&i, 100);
+			let key = MockSessionKeys { aura: UintAuthorityId(i) };
+			Session::set_keys(RuntimeOrigin::signed(i).into(), key, Vec::new()).unwrap();
+		}
+
+		for c in 3..=22 {
+			assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(c)));
+		}
+
 		assert_noop!(
-			CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)),
+			CollatorSelection::register_as_candidate(RuntimeOrigin::signed(23)),
 			Error::<Test>::TooManyCandidates,
 		);
 	})
@@ -310,7 +313,7 @@ fn cannot_register_candidate_if_too_many() {
 #[test]
 fn cannot_unregister_candidate_if_too_few() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(CollatorSelection::candidates(), Vec::new());
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 		assert_ok!(CollatorSelection::remove_invulnerable(
 			RuntimeOrigin::signed(RootAccount::get()),
@@ -368,8 +371,12 @@ fn cannot_register_dupe_candidate() {
 	new_test_ext().execute_with(|| {
 		// can add 3 as candidate
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		// tuple of (id, deposit).
 		let addition = CandidateInfo { who: 3, deposit: 10 };
-		assert_eq!(CollatorSelection::candidates(), vec![addition]);
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![addition]
+		);
 		assert_eq!(CollatorSelection::last_authored_block(3), 10);
 		assert_eq!(Balances::free_balance(3), 90);
 
@@ -404,7 +411,8 @@ fn register_as_candidate_works() {
 		// given
 		assert_eq!(CollatorSelection::desired_candidates(), 2);
 		assert_eq!(CollatorSelection::candidacy_bond(), 10);
-		assert_eq!(CollatorSelection::candidates(), Vec::new());
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 
 		// take two endowed, non-invulnerables accounts.
@@ -417,7 +425,402 @@ fn register_as_candidate_works() {
 		assert_eq!(Balances::free_balance(3), 90);
 		assert_eq!(Balances::free_balance(4), 90);
 
-		assert_eq!(CollatorSelection::candidates().len(), 2);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 2);
+	});
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_invulnerable() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// can't 1 because it is invulnerable.
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(1), 50u64.into(), 2),
+			Error::<Test>::AlreadyInvulnerable,
+		);
+	})
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_keys_not_registered() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(42), 50u64.into(), 3),
+			Error::<Test>::ValidatorNotRegistered
+		);
+	})
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_duplicate() {
+	new_test_ext().execute_with(|| {
+		// can add 3 as candidate
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		// tuple of (id, deposit).
+		let candidate_3 = CandidateInfo { who: 3, deposit: 10 };
+		let candidate_4 = CandidateInfo { who: 4, deposit: 10 };
+		let actual_candidates =
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>();
+		assert_eq!(actual_candidates, vec![candidate_4, candidate_3]);
+		assert_eq!(CollatorSelection::last_authored_block(3), 10);
+		assert_eq!(CollatorSelection::last_authored_block(4), 10);
+		assert_eq!(Balances::free_balance(3), 90);
+
+		// but no more
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(3), 50u64.into(), 4),
+			Error::<Test>::AlreadyCandidate,
+		);
+	})
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_target_invalid() {
+	new_test_ext().execute_with(|| {
+		// can add 3 as candidate
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		// tuple of (id, deposit).
+		let candidate_3 = CandidateInfo { who: 3, deposit: 10 };
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![candidate_3]
+		);
+		assert_eq!(CollatorSelection::last_authored_block(3), 10);
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 100);
+
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(4), 50u64.into(), 5),
+			Error::<Test>::TargetIsNotCandidate,
+		);
+	})
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_poor() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(33), 0);
+
+		// works
+		assert_ok!(CollatorSelection::take_candidate_slot(
+			RuntimeOrigin::signed(3),
+			20u64.into(),
+			4
+		));
+
+		// poor
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(33), 30u64.into(), 3),
+			BalancesError::<Test>::InsufficientBalance,
+		);
+	});
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_insufficient_deposit() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 60u64.into()));
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(4), 5u64.into(), 3),
+			Error::<Test>::InsufficientBond,
+		);
+	});
+}
+
+#[test]
+fn cannot_take_candidate_slot_if_deposit_less_than_target() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 60u64.into()));
+		assert_noop!(
+			CollatorSelection::take_candidate_slot(RuntimeOrigin::signed(4), 20u64.into(), 3),
+			Error::<Test>::InsufficientBond,
+		);
+	});
+}
+
+#[test]
+fn take_candidate_slot_works() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take two endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 90);
+		assert_eq!(Balances::free_balance(5), 90);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+
+		Balances::make_free_balance_be(&6, 100);
+		let key = MockSessionKeys { aura: UintAuthorityId(6) };
+		Session::set_keys(RuntimeOrigin::signed(6).into(), key, Vec::new()).unwrap();
+
+		assert_ok!(CollatorSelection::take_candidate_slot(
+			RuntimeOrigin::signed(6),
+			50u64.into(),
+			4
+		));
+
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 90);
+		assert_eq!(Balances::free_balance(6), 50);
+
+		// tuple of (id, deposit).
+		let candidate_3 = CandidateInfo { who: 3, deposit: 10 };
+		let candidate_6 = CandidateInfo { who: 6, deposit: 50 };
+		let candidate_5 = CandidateInfo { who: 5, deposit: 10 };
+		let mut actual_candidates =
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>();
+		actual_candidates.sort_by(|info_1, info_2| info_1.deposit.cmp(&info_2.deposit));
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![candidate_5, candidate_3, candidate_6]
+		);
+	});
+}
+
+#[test]
+fn increase_candidacy_bond_non_candidate_account() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+
+		assert_noop!(
+			CollatorSelection::update_bond(RuntimeOrigin::signed(5), 20),
+			Error::<Test>::NotCandidate
+		);
+	});
+}
+
+#[test]
+fn increase_candidacy_bond_insufficient_balance() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take two endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 90);
+		assert_eq!(Balances::free_balance(5), 90);
+
+		assert_noop!(
+			CollatorSelection::update_bond(RuntimeOrigin::signed(3), 110),
+			BalancesError::<Test>::InsufficientBalance
+		);
+	});
+}
+
+#[test]
+fn increase_candidacy_bond_works() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take three endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 90);
+		assert_eq!(Balances::free_balance(5), 90);
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 20));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 30));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 40));
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+		assert_eq!(Balances::free_balance(3), 80);
+		assert_eq!(Balances::free_balance(4), 70);
+		assert_eq!(Balances::free_balance(5), 60);
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 40));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 60));
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+		assert_eq!(Balances::free_balance(3), 60);
+		assert_eq!(Balances::free_balance(4), 40);
+		assert_eq!(Balances::free_balance(5), 60);
+	});
+}
+
+#[test]
+fn decrease_candidacy_bond_non_candidate_account() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+
+		assert_noop!(
+			CollatorSelection::update_bond(RuntimeOrigin::signed(5), 10),
+			Error::<Test>::NotCandidate
+		);
+	});
+}
+
+#[test]
+fn decrease_candidacy_bond_insufficient_funds() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take two endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 60));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 60));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 60));
+
+		assert_eq!(Balances::free_balance(3), 40);
+		assert_eq!(Balances::free_balance(4), 40);
+		assert_eq!(Balances::free_balance(5), 40);
+
+		assert_noop!(
+			CollatorSelection::update_bond(RuntimeOrigin::signed(3), 0),
+			Error::<Test>::DepositTooLow
+		);
+
+		assert_noop!(
+			CollatorSelection::update_bond(RuntimeOrigin::signed(4), 5),
+			Error::<Test>::DepositTooLow
+		);
+
+		assert_noop!(
+			CollatorSelection::update_bond(RuntimeOrigin::signed(5), 9),
+			Error::<Test>::DepositTooLow
+		);
+	});
+}
+
+#[test]
+fn decrease_candidacy_bond_works() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take three endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 90);
+		assert_eq!(Balances::free_balance(5), 90);
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 20));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 30));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 40));
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+		assert_eq!(Balances::free_balance(3), 80);
+		assert_eq!(Balances::free_balance(4), 70);
+		assert_eq!(Balances::free_balance(5), 60);
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 10));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 20));
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+		assert_eq!(Balances::free_balance(3), 90);
+		assert_eq!(Balances::free_balance(4), 80);
+		assert_eq!(Balances::free_balance(5), 60);
+	});
+}
+
+#[test]
+fn candidate_list_works() {
+	new_test_ext().execute_with(|| {
+		// given
+		assert_eq!(CollatorSelection::desired_candidates(), 2);
+		assert_eq!(CollatorSelection::candidacy_bond(), 10);
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
+		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
+
+		// take three endowed, non-invulnerables accounts.
+		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(4), 100);
+		assert_eq!(Balances::free_balance(5), 100);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 20));
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 30));
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 10));
 	});
 }
 
@@ -457,9 +860,13 @@ fn authorship_event_handler() {
 		// triggers `note_author`
 		Authorship::on_initialize(1);
 
+		// tuple of (id, deposit).
 		let collator = CandidateInfo { who: 4, deposit: 10 };
 
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![collator]
+		);
 		assert_eq!(CollatorSelection::last_authored_block(4), 0);
 
 		// half of the pot goes to the collator who's the author (4 in tests).
@@ -482,9 +889,13 @@ fn fees_edgecases() {
 		// triggers `note_author`
 		Authorship::on_initialize(1);
 
+		// tuple of (id, deposit).
 		let collator = CandidateInfo { who: 4, deposit: 10 };
 
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![collator]
+		);
 		assert_eq!(CollatorSelection::last_authored_block(4), 0);
 		// Nothing received
 		assert_eq!(Balances::free_balance(4), 90);
@@ -494,7 +905,7 @@ fn fees_edgecases() {
 }
 
 #[test]
-fn session_management_works() {
+fn session_management_single_candidate() {
 	new_test_ext().execute_with(|| {
 		initialize_to_block(1);
 
@@ -512,7 +923,7 @@ fn session_management_works() {
 		// session won't see this.
 		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
 		// but we have a new candidate.
-		assert_eq!(CollatorSelection::candidates().len(), 1);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 1);
 
 		initialize_to_block(10);
 		assert_eq!(SessionChangeBlock::get(), 10);
@@ -531,21 +942,240 @@ fn session_management_works() {
 }
 
 #[test]
+fn session_management_max_candidates() {
+	new_test_ext().execute_with(|| {
+		initialize_to_block(1);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(4);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		// session won't see this.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+		// but we have a new candidate.
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+
+		initialize_to_block(10);
+		assert_eq!(SessionChangeBlock::get(), 10);
+		// pallet-session has 1 session delay; current validators are the same.
+		assert_eq!(Session::validators(), vec![1, 2]);
+		// queued ones are changed, and now we have 4.
+		assert_eq!(Session::queued_keys().len(), 4);
+		// session handlers (aura, et. al.) cannot see this yet.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// changed are now reflected to session handlers.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 4]);
+	});
+}
+
+#[test]
+fn session_management_increase_bid_with_list_update() {
+	new_test_ext().execute_with(|| {
+		initialize_to_block(1);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(4);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 60));
+
+		// session won't see this.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+		// but we have a new candidate.
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+
+		initialize_to_block(10);
+		assert_eq!(SessionChangeBlock::get(), 10);
+		// pallet-session has 1 session delay; current validators are the same.
+		assert_eq!(Session::validators(), vec![1, 2]);
+		// queued ones are changed, and now we have 4.
+		assert_eq!(Session::queued_keys().len(), 4);
+		// session handlers (aura, et. al.) cannot see this yet.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// changed are now reflected to session handlers.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 5, 3]);
+	});
+}
+
+#[test]
+fn session_management_candidate_list_eager_sort() {
+	new_test_ext().execute_with(|| {
+		initialize_to_block(1);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(4);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 60));
+
+		// session won't see this.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+		// but we have a new candidate.
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+
+		initialize_to_block(10);
+		assert_eq!(SessionChangeBlock::get(), 10);
+		// pallet-session has 1 session delay; current validators are the same.
+		assert_eq!(Session::validators(), vec![1, 2]);
+		// queued ones are changed, and now we have 4.
+		assert_eq!(Session::queued_keys().len(), 4);
+		// session handlers (aura, et. al.) cannot see this yet.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// changed are now reflected to session handlers.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 5, 3]);
+	});
+}
+
+#[test]
+fn session_management_reciprocal_outbidding() {
+	new_test_ext().execute_with(|| {
+		initialize_to_block(1);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(4);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 60));
+
+		initialize_to_block(5);
+
+		// candidates 3 and 4 saw they were outbid and preemptively bid more
+		// than 5 in the next block.
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 70));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 70));
+
+		// session won't see this.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+		// but we have a new candidate.
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+
+		initialize_to_block(10);
+		assert_eq!(SessionChangeBlock::get(), 10);
+		// pallet-session has 1 session delay; current validators are the same.
+		assert_eq!(Session::validators(), vec![1, 2]);
+		// queued ones are changed, and now we have 4.
+		assert_eq!(Session::queued_keys().len(), 4);
+		// session handlers (aura, et. al.) cannot see this yet.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// changed are now reflected to session handlers.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 4, 3]);
+	});
+}
+
+#[test]
+fn session_management_decrease_bid_after_auction() {
+	new_test_ext().execute_with(|| {
+		initialize_to_block(1);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(4);
+
+		assert_eq!(SessionChangeBlock::get(), 0);
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 60));
+
+		initialize_to_block(5);
+
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(4), 70));
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(3), 70));
+
+		initialize_to_block(5);
+
+		// candidate 5 saw it was outbid and wants to take back its bid, but
+		// not entirely so they still keep their place in the candidate list
+		// in case there is an opportunity in the future.
+		assert_ok!(CollatorSelection::update_bond(RuntimeOrigin::signed(5), 10));
+
+		// session won't see this.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+		// but we have a new candidate.
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 3);
+
+		initialize_to_block(10);
+		assert_eq!(SessionChangeBlock::get(), 10);
+		// pallet-session has 1 session delay; current validators are the same.
+		assert_eq!(Session::validators(), vec![1, 2]);
+		// queued ones are changed, and now we have 4.
+		assert_eq!(Session::queued_keys().len(), 4);
+		// session handlers (aura, et. al.) cannot see this yet.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
+
+		initialize_to_block(20);
+		assert_eq!(SessionChangeBlock::get(), 20);
+		// changed are now reflected to session handlers.
+		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 4, 3]);
+	});
+}
+
+#[test]
 fn kick_mechanism() {
 	new_test_ext().execute_with(|| {
 		// add a new collator
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
 		initialize_to_block(10);
-		assert_eq!(CollatorSelection::candidates().len(), 2);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 2);
 		initialize_to_block(20);
 		assert_eq!(SessionChangeBlock::get(), 20);
 		// 4 authored this block, gets to stay 3 was kicked
-		assert_eq!(CollatorSelection::candidates().len(), 1);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 1);
 		// 3 will be kicked after 1 session delay
 		assert_eq!(SessionHandlerCollators::get(), vec![1, 2, 3, 4]);
+		// tuple of (id, deposit).
 		let collator = CandidateInfo { who: 4, deposit: 10 };
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![collator]
+		);
 		assert_eq!(CollatorSelection::last_authored_block(4), 20);
 		initialize_to_block(30);
 		// 3 gets kicked after 1 session delay
@@ -559,7 +1189,8 @@ fn kick_mechanism() {
 fn should_not_kick_mechanism_too_few() {
 	new_test_ext().execute_with(|| {
 		// remove the invulnerables and add new collators 3 and 5
-		assert_eq!(CollatorSelection::candidates(), Vec::new());
+
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2]);
 		assert_ok!(CollatorSelection::remove_invulnerable(
 			RuntimeOrigin::signed(RootAccount::get()),
@@ -573,30 +1204,34 @@ fn should_not_kick_mechanism_too_few() {
 		));
 
 		initialize_to_block(10);
-		assert_eq!(CollatorSelection::candidates().len(), 2);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 2);
 
 		initialize_to_block(20);
 		assert_eq!(SessionChangeBlock::get(), 20);
 		// 4 authored this block, 3 is kicked, 5 stays because of too few collators
-		assert_eq!(CollatorSelection::candidates().len(), 1);
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 1);
 		// 3 will be kicked after 1 session delay
 		assert_eq!(SessionHandlerCollators::get(), vec![3, 5]);
-		let collator = CandidateInfo { who: 5, deposit: 10 };
-		assert_eq!(CollatorSelection::candidates(), vec![collator]);
+		// tuple of (id, deposit).
+		let collator = CandidateInfo { who: 3, deposit: 10 };
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![collator]
+		);
 		assert_eq!(CollatorSelection::last_authored_block(4), 20);
 
 		initialize_to_block(30);
 		// 3 gets kicked after 1 session delay
-		assert_eq!(SessionHandlerCollators::get(), vec![5]);
+		assert_eq!(SessionHandlerCollators::get(), vec![3]);
 		// kicked collator gets funds back
-		assert_eq!(Balances::free_balance(3), 100);
+		assert_eq!(Balances::free_balance(5), 100);
 	});
 }
 
 #[test]
 fn should_kick_invulnerables_from_candidates_on_session_change() {
 	new_test_ext().execute_with(|| {
-		assert_eq!(CollatorSelection::candidates(), Vec::new());
+		assert_eq!(<crate::CandidateList<Test>>::get().iter().count(), 0);
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
 		assert_eq!(Balances::free_balance(3), 90);
@@ -606,16 +1241,22 @@ fn should_kick_invulnerables_from_candidates_on_session_change() {
 			vec![1, 2, 3]
 		));
 
+		// tuple of (id, deposit).
 		let collator_3 = CandidateInfo { who: 3, deposit: 10 };
 		let collator_4 = CandidateInfo { who: 4, deposit: 10 };
 
-		assert_eq!(CollatorSelection::candidates(), vec![collator_3, collator_4.clone()]);
+		let actual_candidates =
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>();
+		assert_eq!(actual_candidates, vec![collator_4.clone(), collator_3]);
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2, 3]);
 
 		// session change
 		initialize_to_block(10);
 		// 3 is removed from candidates
-		assert_eq!(CollatorSelection::candidates(), vec![collator_4]);
+		assert_eq!(
+			<crate::CandidateList<Test>>::get().iter().cloned().collect::<Vec<_>>(),
+			vec![collator_4]
+		);
 		// but not from invulnerables
 		assert_eq!(CollatorSelection::invulnerables(), vec![1, 2, 3]);
 		// and it got its deposit back

--- a/cumulus/pallets/collator-selection/src/weights.rs
+++ b/cumulus/pallets/collator-selection/src/weights.rs
@@ -33,6 +33,8 @@ pub trait WeightInfo {
 	fn set_candidacy_bond() -> Weight;
 	fn register_as_candidate(_c: u32) -> Weight;
 	fn leave_intent(_c: u32) -> Weight;
+	fn update_bond(_c: u32) -> Weight;
+	fn take_candidate_slot(_c: u32) -> Weight;
 	fn note_author() -> Weight;
 	fn new_session(_c: u32, _r: u32) -> Weight;
 }
@@ -64,6 +66,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 0
 			.saturating_add(Weight::from_parts(151_000_u64, 0).saturating_mul(c as u64))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	fn update_bond(c: u32) -> Weight {
+		Weight::from_parts(55_336_000_u64, 0)
+			// Standard Error: 0
+			.saturating_add(Weight::from_parts(151_000_u64, 0).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	fn take_candidate_slot(c: u32) -> Weight {
+		Weight::from_parts(71_196_000_u64, 0)
+			// Standard Error: 0
+			.saturating_add(Weight::from_parts(198_000_u64, 0).saturating_mul(c as u64))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	fn note_author() -> Weight {
@@ -155,6 +171,20 @@ impl WeightInfo for () {
 	}
 	fn note_author() -> Weight {
 		Weight::from_parts(71_461_000_u64, 0)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
+	fn update_bond(c: u32) -> Weight {
+		Weight::from_parts(55_336_000_u64, 0)
+			// Standard Error: 0
+			.saturating_add(Weight::from_parts(151_000_u64, 0).saturating_mul(c as u64))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
+	fn take_candidate_slot(c: u32) -> Weight {
+		Weight::from_parts(71_196_000_u64, 0)
+			// Standard Error: 0
+			.saturating_add(Weight::from_parts(198_000_u64, 0).saturating_mul(c as u64))
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(4_u64))
 	}


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/106

Port of cumulus PR https://github.com/paritytech/cumulus/pull/2960

This PR adds the ability to bid for collator slots even after the max number of collators have already registered. This eliminates the first come, first served mechanism that was in place before.

Key changes:
- added `update_bond` extrinsic to allow registered candidates to adjust their bonds in order to dynamically control their bids
- added `take_candidate_slot` extrinsic to try to replace an already existing candidate by bidding more than them
- candidates are now kept in a sorted list in the pallet storage, where the top `DesiredCandidates` out of `MaxCandidates` candidates in the list will be selected by the session pallet as collators


# Checklist

- [ ] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/CONTRIBUTING.md#process) of this project (at minimum one label for `T` required)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well as the corresponding Cumulus PR (optional)
