### PR TITLE
feat: add futures api to `TransactionPool`

### DIFF
--- a/substrate/bin/node/bench/src/construct.rs
+++ b/substrate/bin/node/bench/src/construct.rs
@@ -282,6 +282,10 @@ impl sc_transaction_pool_api::TransactionPool for Transactions {
 		Default::default()
 	}
 
+	fn futures(&self) -> Vec<Self::InPoolTransaction> {
+		unimplemented!()
+	}
+
 	fn status(&self) -> PoolStatus {
 		unimplemented!()
 	}

--- a/substrate/client/transaction-pool/api/src/lib.rs
+++ b/substrate/client/transaction-pool/api/src/lib.rs
@@ -247,6 +247,9 @@ pub trait TransactionPool: Send + Sync {
 	fn remove_invalid(&self, hashes: &[TxHash<Self>]) -> Vec<Arc<Self::InPoolTransaction>>;
 
 	// *** logging
+	/// Get futures transaction list.
+	fn futures(&self) -> Vec<Self::InPoolTransaction>;
+
 	/// Returns pool status.
 	fn status(&self) -> PoolStatus;
 

--- a/substrate/client/transaction-pool/src/graph/base_pool.rs
+++ b/substrate/client/transaction-pool/src/graph/base_pool.rs
@@ -84,8 +84,7 @@ pub struct PruneStatus<Hash, Ex> {
 }
 
 /// Immutable transaction
-#[cfg_attr(test, derive(Clone))]
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Transaction<Hash, Extrinsic> {
 	/// Raw extrinsic representing that transaction.
 	pub data: Extrinsic,

--- a/substrate/client/transaction-pool/src/graph/validated_pool.rs
+++ b/substrate/client/transaction-pool/src/graph/validated_pool.rs
@@ -106,7 +106,7 @@ pub struct ValidatedPool<B: ChainApi> {
 	is_validator: IsValidator,
 	options: Options,
 	listener: RwLock<Listener<ExtrinsicHash<B>, B>>,
-	pool: RwLock<base::BasePool<ExtrinsicHash<B>, ExtrinsicFor<B>>>,
+	pub(crate) pool: RwLock<base::BasePool<ExtrinsicHash<B>, ExtrinsicFor<B>>>,
 	import_notification_sinks: Mutex<Vec<Sender<ExtrinsicHash<B>>>>,
 	rotator: PoolRotator<ExtrinsicHash<B>>,
 }

--- a/substrate/client/transaction-pool/src/lib.rs
+++ b/substrate/client/transaction-pool/src/lib.rs
@@ -361,9 +361,8 @@ where
 
 	fn futures(&self) -> Vec<Self::InPoolTransaction> {
 		let pool = self.pool.validated_pool().pool.read();
-		let res = pool.futures().cloned().collect::<Vec<_>>();
 
-		res
+		pool.futures().cloned().collect::<Vec<_>>()
 	}
 }
 

--- a/substrate/client/transaction-pool/src/lib.rs
+++ b/substrate/client/transaction-pool/src/lib.rs
@@ -358,6 +358,13 @@ where
 	fn ready(&self) -> ReadyIteratorFor<PoolApi> {
 		Box::new(self.pool.validated_pool().ready())
 	}
+
+	fn futures(&self) -> Vec<Self::InPoolTransaction> {
+		let pool = self.pool.validated_pool().pool.read();
+		let res = pool.futures().cloned().collect::<Vec<_>>();
+
+		res
+	}
 }
 
 impl<Block, Client> FullPool<Block, Client>


### PR DESCRIPTION
Now tx pool have not exported futures related txn.

We want to display more future txns.