### PR TITLE
Ensure `cumulus/bridges` is ignored by formatter and run it

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -19,7 +19,7 @@ trailing_comma = "Vertical"
 trailing_semicolon = false
 use_field_init_shorthand = true
 ignore = [
-    "bridges",
+    "cumulus/bridges",
 ]
 edition = "2021"
 # Format comments

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -943,9 +943,10 @@ where
 		peers: HashSet<Multiaddr>,
 	) -> Result<(), String> {
 		let Some(set_id) = self.notification_protocol_ids.get(&protocol) else {
-			return Err(
-				format!("Cannot add peers to reserved set of unknown protocol: {}", protocol)
-			)
+			return Err(format!(
+				"Cannot add peers to reserved set of unknown protocol: {}",
+				protocol
+			))
 		};
 
 		let peers = self.split_multiaddr_and_peer_id(peers)?;
@@ -974,9 +975,10 @@ where
 		peers: Vec<PeerId>,
 	) -> Result<(), String> {
 		let Some(set_id) = self.notification_protocol_ids.get(&protocol) else {
-			return Err(
-				format!("Cannot remove peers from reserved set of unknown protocol: {}", protocol)
-			)
+			return Err(format!(
+				"Cannot remove peers from reserved set of unknown protocol: {}",
+				protocol
+			))
 		};
 
 		for peer_id in peers.into_iter() {

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -462,7 +462,8 @@ where
 		follow_subscription: String,
 		operation_id: String,
 	) -> RpcResult<()> {
-		let Some(operation) = self.subscriptions.get_operation(&follow_subscription, &operation_id) else {
+		let Some(operation) = self.subscriptions.get_operation(&follow_subscription, &operation_id)
+		else {
 			return Ok(())
 		};
 
@@ -479,7 +480,8 @@ where
 		follow_subscription: String,
 		operation_id: String,
 	) -> RpcResult<()> {
-		let Some(operation) = self.subscriptions.get_operation(&follow_subscription, &operation_id) else {
+		let Some(operation) = self.subscriptions.get_operation(&follow_subscription, &operation_id)
+		else {
 			return Ok(())
 		};
 

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head_storage.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head_storage.rs
@@ -166,9 +166,7 @@ where
 
 		let mut ret = Vec::with_capacity(self.operation_max_storage_items);
 		for _ in 0..self.operation_max_storage_items {
-			let Some(key) = keys_iter.next() else {
-				break
-			};
+			let Some(key) = keys_iter.next() else { break };
 
 			let result = match ty {
 				IterQueryType::Value => self.query_storage_value(hash, &key, child_key),

--- a/substrate/frame/broker/src/dispatchable_impls.rs
+++ b/substrate/frame/broker/src/dispatchable_impls.rs
@@ -334,10 +334,10 @@ impl<T: Config> Pallet<T> {
 			contribution.length.saturating_dec();
 
 			let Some(mut pool_record) = InstaPoolHistory::<T>::get(r) else {
-				continue;
+				continue
 			};
 			let Some(total_payout) = pool_record.maybe_payout else {
-				break;
+				break
 			};
 			let p = total_payout
 				.saturating_mul(contributed_parts.into())

--- a/substrate/frame/broker/src/tick_impls.rs
+++ b/substrate/frame/broker/src/tick_impls.rs
@@ -96,7 +96,7 @@ impl<T: Config> Pallet<T> {
 
 	pub(crate) fn process_revenue() -> bool {
 		let Some((until, amount)) = T::Coretime::check_notify_revenue_info() else {
-			return false;
+			return false
 		};
 		let when: Timeslice =
 			(until / T::TimeslicePeriod::get()).saturating_sub(One::one()).saturated_into();
@@ -290,7 +290,7 @@ impl<T: Config> Pallet<T> {
 		core: CoreIndex,
 	) {
 		let Some(workplan) = Workplan::<T>::take((timeslice, core)) else {
-			return;
+			return
 		};
 		let workload = Workload::<T>::get(core);
 		let parts_used = workplan.iter().map(|i| i.mask).fold(CoreMask::void(), |a, i| a | i);

--- a/substrate/frame/safe-mode/src/lib.rs
+++ b/substrate/frame/safe-mode/src/lib.rs
@@ -398,7 +398,7 @@ pub mod pallet {
 		/// [`EnteredUntil`].
 		fn on_initialize(current: BlockNumberFor<T>) -> Weight {
 			let Some(limit) = EnteredUntil::<T>::get() else {
-				return T::WeightInfo::on_initialize_noop();
+				return T::WeightInfo::on_initialize_noop()
 			};
 
 			if current > limit {


### PR DESCRIPTION
Just a minor fix to `.rustfmt.toml` which had the incorrect path for bridges together with the few changes resulting from running it.