### PR TITLE
rust docs: add simple analytics

### DIFF
--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -114,7 +114,7 @@ build-rustdoc:
   script:
     # FIXME: it fails with `RUSTDOCFLAGS="-Dwarnings"` and `--all-features`
     # FIXME: return to stable when https://github.com/rust-lang/rust/issues/96937 gets into stable
-    - time cargo doc --workspace --no-deps
+    - time cargo doc --features try-runtime,experimental --workspace --no-deps
     - rm -f ./target/doc/.lock
     - mv ./target/doc ./crate-docs
     # FIXME: remove me after CI image gets nonroot

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -117,6 +117,8 @@ build-rustdoc:
     - time cargo doc --workspace --no-deps
     - rm -f ./target/doc/.lock
     - mv ./target/doc ./crate-docs
+    # FIXME: remove me after CI image gets nonroot
+    - chown -R nonroot:nonroot ./crate-docs
     # Inject Simple Analytics (https://www.simpleanalytics.com/) privacy preserving tracker into
     # all .html files
     - |
@@ -136,8 +138,6 @@ build-rustdoc:
         find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {}
       }
       inject_simple_analytics "./crate-docs"
-    # FIXME: remove me after CI image gets nonroot
-    - chown -R nonroot:nonroot ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=polkadot_service/index.html>" > ./crate-docs/index.html
 
 build-implementers-guide:

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -134,7 +134,7 @@ build-rustdoc:
         }
         export -f process_file
 
-        # Locate all .html files under the documentation root and use xargs to modify them in parallel.
+        # Modify .html files in parallel using xargs, otherwise it can take a long time.
         find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {}
       }
       inject_simple_analytics "./crate-docs"

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -117,6 +117,25 @@ build-rustdoc:
     - time cargo doc --workspace --no-deps
     - rm -f ./target/doc/.lock
     - mv ./target/doc ./crate-docs
+    # Inject Simple Analytics (https://www.simpleanalytics.com/) privacy preserving tracker into
+    # all .html files
+    - |
+      inject_simple_analytics() {
+        local path="$1"
+        local script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"
+
+        # Define a function that injects our script into the head of an html file.
+        process_file() {
+            local file="$1"
+            echo "Adding Simple Analytics script to $file"
+            sed -i "s|</head>|$script_content</head>|" "$file"
+        }
+        export -f process_file
+
+        # Locate all .html files under the documentation root and use xargs to process in parallel.
+        find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {}
+      }
+      inject_simple_analytics "./crate-docs"
     # FIXME: remove me after CI image gets nonroot
     - chown -R nonroot:nonroot ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=polkadot_service/index.html>" > ./crate-docs/index.html

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -124,7 +124,7 @@ build-rustdoc:
         local path="$1"
         local script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"
 
-        # Define a function that injects our script into the head of an html file.
+        # Function that inject script into the head of an html file using sed.
         process_file() {
             local file="$1"
             echo "Adding Simple Analytics script to $file"
@@ -132,7 +132,7 @@ build-rustdoc:
         }
         export -f process_file
 
-        # Locate all .html files under the documentation root and use xargs to process in parallel.
+        # Locate all .html files under the documentation root and use xargs to modify them in parallel.
         find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {}
       }
       inject_simple_analytics "./crate-docs"

--- a/substrate/.maintain/rustdocs-release.sh
+++ b/substrate/.maintain/rustdocs-release.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # set -x
 
-# This script manages the deployment of Substrate rustdocs to https://paritytech.github.io/substrate/.
+# This script used to manage the deployment of Substrate rustdocs to https://paritytech.github.io/substrate/.
+# It is no longer used anywhere, and only here for historical/demonstration purposes.
 # - With `deploy` sub-command, it will checkout the passed-in branch/tag ref, build the rustdocs
 #   locally (this takes some time), update the `index.html` index page, and push it to remote
 #   `gh-pages` branch. So users running this command need to have write access to the remote


### PR DESCRIPTION
Continuation of https://github.com/paritytech/substrate/pull/14805 

- Adds Simple Analytics script injection to `.gitlab/pipeline/build.yml` rust doc build step
- Fixes `cargo doc` features
- Updates `.maintain/rustdocs-release.sh` to clarify it is no longer used anywhere

## Question

`.maintain/rustdocs-release.sh` is no longer used anywhere. 

I updated the documentation to indicate this to prevent future confusion, but unsure if we should just remove it completely? 