### PR TITLE
wasm-substitutes: Use unique `hash` per substitute to fix caching issues

### DIFF
--- a/substrate/client/service/src/client/wasm_substitutes.rs
+++ b/substrate/client/service/src/client/wasm_substitutes.rs
@@ -126,7 +126,7 @@ where
 				let runtime_code = RuntimeCode {
 					code_fetcher: &WrappedRuntimeCode((&code).into()),
 					heap_pages: None,
-					hash: Vec::new(),
+					hash: make_hash(&code),
 				};
 				let version = Self::runtime_version(&executor, &runtime_code)?;
 				let spec_version = version.spec_version;


### PR DESCRIPTION
Fix the wasm substitute caching bug.

When there exist multiple code substitutes in the spec, the substrate used to keep only one. The current solution fixes this bug by creating a unique hash for each wasm blob.
