### PR TITLE
pallet-xcm: add extrinsic to allow withdrawal of reserve-based assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "staging-xcm",
+ "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
 ]

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/weights/pallet_xcm.rs
@@ -93,7 +93,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	fn reserve_withdraw_assets() -> Weight {
-		Weight::from_parts(20_000_000, 0)
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/weights/pallet_xcm.rs
@@ -92,6 +92,9 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(0, 1489))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(20_000_000, 0)
+	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn execute() -> Weight {

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/tests/tests.rs
@@ -18,13 +18,14 @@
 //! Tests for the Statemine (Kusama Assets Hub) chain.
 
 use asset_hub_kusama_runtime::xcm_config::{
-	AssetFeeAsExistentialDepositMultiplierFeeCharger, KsmLocation, TrustBackedAssetsPalletLocation,
+	AssetFeeAsExistentialDepositMultiplierFeeCharger, KsmLocation, LocationToAccountId,
+	TrustBackedAssetsPalletLocation,
 };
 pub use asset_hub_kusama_runtime::{
 	xcm_config::{CheckingAccount, ForeignCreatorsSovereignAccountOf, XcmConfig},
 	AllPalletsWithoutSystem, AssetDeposit, Assets, Balances, ExistentialDeposit, ForeignAssets,
 	ForeignAssetsInstance, MetadataDepositBase, MetadataDepositPerByte, ParachainSystem, Runtime,
-	RuntimeCall, RuntimeEvent, SessionKeys, System, TrustBackedAssetsInstance,
+	RuntimeCall, RuntimeEvent, SessionKeys, System, TrustBackedAssetsInstance, XcmpQueue,
 };
 use asset_test_utils::{CollatorSessionKeys, ExtBuilder};
 use codec::{Decode, Encode};
@@ -632,3 +633,32 @@ asset_test_utils::include_create_and_manage_foreign_assets_for_local_consensus_p
 		assert_eq!(ForeignAssets::asset_ids().collect::<Vec<_>>().len(), 1);
 	})
 );
+
+#[test]
+fn reserve_transfer_native_asset_works() {
+	asset_test_utils::test_cases::reserve_transfer_native_asset_works::<
+		Runtime,
+		AllPalletsWithoutSystem,
+		XcmConfig,
+		ParachainSystem,
+		XcmpQueue,
+		LocationToAccountId,
+	>(
+		collator_session_keys(),
+		ExistentialDeposit::get(),
+		AccountId::from(ALICE),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::PolkadotXcm(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::XcmpQueue(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		WeightLimit::Unlimited,
+	);
+}

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/tests/tests.rs
@@ -662,3 +662,33 @@ fn reserve_transfer_native_asset_works() {
 		WeightLimit::Unlimited,
 	);
 }
+
+#[test]
+fn reserve_withdraw_foreign_asset_works() {
+	asset_test_utils::test_cases::reserve_withdraw_foreign_asset_works::<
+		Runtime,
+		AllPalletsWithoutSystem,
+		XcmConfig,
+		ForeignAssetsInstance,
+		ParachainSystem,
+		XcmpQueue,
+		LocationToAccountId,
+	>(
+		collator_session_keys(),
+		ExistentialDeposit::get(),
+		AccountId::from(ALICE),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::PolkadotXcm(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::XcmpQueue(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		WeightLimit::Unlimited,
+	);
+}

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/weights/pallet_xcm.rs
@@ -93,7 +93,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	fn reserve_withdraw_assets() -> Weight {
-		Weight::from_parts(20_000_000, 0)
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/weights/pallet_xcm.rs
@@ -92,6 +92,9 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(0, 1489))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(20_000_000, 0)
+	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn execute() -> Weight {

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/tests/tests.rs
@@ -19,12 +19,13 @@
 
 use asset_hub_polkadot_runtime::xcm_config::{
 	AssetFeeAsExistentialDepositMultiplierFeeCharger, CheckingAccount, DotLocation,
-	ForeignCreatorsSovereignAccountOf, TrustBackedAssetsPalletLocation, XcmConfig,
+	ForeignCreatorsSovereignAccountOf, LocationToAccountId, TrustBackedAssetsPalletLocation,
+	XcmConfig,
 };
 pub use asset_hub_polkadot_runtime::{
 	AllPalletsWithoutSystem, AssetDeposit, Assets, Balances, ExistentialDeposit, ForeignAssets,
 	ForeignAssetsInstance, MetadataDepositBase, MetadataDepositPerByte, ParachainSystem, Runtime,
-	RuntimeCall, RuntimeEvent, SessionKeys, System, TrustBackedAssetsInstance,
+	RuntimeCall, RuntimeEvent, SessionKeys, System, TrustBackedAssetsInstance, XcmpQueue,
 };
 use asset_test_utils::{CollatorSessionKeys, ExtBuilder};
 use codec::{Decode, Encode};
@@ -657,3 +658,32 @@ asset_test_utils::include_create_and_manage_foreign_assets_for_local_consensus_p
 		assert_eq!(ForeignAssets::asset_ids().collect::<Vec<_>>().len(), 1);
 	})
 );
+
+#[test]
+fn reserve_transfer_native_asset_works() {
+	asset_test_utils::test_cases::reserve_transfer_native_asset_works::<
+		Runtime,
+		AllPalletsWithoutSystem,
+		XcmConfig,
+		ParachainSystem,
+		XcmpQueue,
+		LocationToAccountId,
+	>(
+		collator_session_keys(),
+		ExistentialDeposit::get(),
+		AccountId::from(ALICE),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::PolkadotXcm(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::XcmpQueue(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		WeightLimit::Unlimited,
+	);
+}

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/tests/tests.rs
@@ -687,3 +687,33 @@ fn reserve_transfer_native_asset_works() {
 		WeightLimit::Unlimited,
 	);
 }
+
+#[test]
+fn reserve_withdraw_foreign_asset_works() {
+	asset_test_utils::test_cases::reserve_withdraw_foreign_asset_works::<
+		Runtime,
+		AllPalletsWithoutSystem,
+		XcmConfig,
+		ForeignAssetsInstance,
+		ParachainSystem,
+		XcmpQueue,
+		LocationToAccountId,
+	>(
+		collator_session_keys(),
+		ExistentialDeposit::get(),
+		AccountId::from(ALICE),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::PolkadotXcm(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::XcmpQueue(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		WeightLimit::Unlimited,
+	);
+}

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_xcm.rs
@@ -93,7 +93,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	fn reserve_withdraw_assets() -> Weight {
-		Weight::from_parts(20_000_000, 0)
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	fn execute() -> Weight {
 		// Proof Size summary in bytes:

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_xcm.rs
@@ -92,6 +92,9 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(0, 1489))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(20_000_000, 0)
+	}
 	fn execute() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
@@ -695,3 +695,33 @@ fn reserve_transfer_native_asset_works() {
 		WeightLimit::Unlimited,
 	);
 }
+
+#[test]
+fn reserve_withdraw_foreign_asset_works() {
+	asset_test_utils::test_cases::reserve_withdraw_foreign_asset_works::<
+		Runtime,
+		AllPalletsWithoutSystem,
+		XcmConfig,
+		ForeignAssetsInstance,
+		ParachainSystem,
+		XcmpQueue,
+		LocationToAccountId,
+	>(
+		collator_session_keys(),
+		ExistentialDeposit::get(),
+		AccountId::from(ALICE),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::PolkadotXcm(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		Box::new(|runtime_event_encoded: Vec<u8>| {
+			match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
+				Ok(RuntimeEvent::XcmpQueue(event)) => Some(event),
+				_ => None,
+			}
+		}),
+		WeightLimit::Unlimited,
+	);
+}

--- a/cumulus/parachains/runtimes/assets/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/test-utils/Cargo.toml
@@ -36,6 +36,7 @@ parachains-runtimes-test-utils = { path = "../../test-utils", default-features =
 
 # Polkadot
 xcm = { package = "staging-xcm", path = "../../../../../polkadot/xcm", default-features = false}
+xcm-builder = { package = "staging-xcm-builder", path = "../../../../../polkadot/xcm/xcm-builder", default-features = false}
 xcm-executor = { package = "staging-xcm-executor", path = "../../../../../polkadot/xcm/xcm-executor", default-features = false}
 pallet-xcm = { path = "../../../../../polkadot/xcm/pallet-xcm", default-features = false}
 polkadot-parachain-primitives = { path = "../../../../../polkadot/parachain", default-features = false}
@@ -72,6 +73,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
 ]

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
@@ -15,23 +15,25 @@
 
 //! Module contains predefined test-case scenarios for `Runtime` with various assets.
 
+use crate::assert_matches_reserve_asset_deposited_instructions;
 use codec::Encode;
+use cumulus_primitives_core::XcmpMessageSource;
 use frame_support::{
 	assert_noop, assert_ok,
-	traits::{fungibles::InspectEnumerable, Get, OnFinalize, OnInitialize, OriginTrait},
+	traits::{fungibles::InspectEnumerable, Currency, Get, OnFinalize, OnInitialize, OriginTrait},
 	weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::{AccountId, Balance};
 use parachains_runtimes_test_utils::{
-	assert_metadata, assert_total, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder,
-	ValidatorIdOf, XcmReceivedFrom,
+	assert_metadata, assert_total, mock_open_hrmp_channel, AccountIdOf, BalanceOf,
+	CollatorSessionKeys, ExtBuilder, ValidatorIdOf, XcmReceivedFrom,
 };
 use sp_runtime::{
 	traits::{MaybeEquivalence, StaticLookup, Zero},
 	DispatchError, Saturating,
 };
-use xcm::latest::prelude::*;
+use xcm::{latest::prelude::*, VersionedMultiAssets};
 use xcm_executor::{traits::ConvertLocation, XcmExecutor};
 
 type RuntimeHelper<Runtime, AllPalletsWithoutSystem = ()> =
@@ -1339,3 +1341,188 @@ macro_rules! include_create_and_manage_foreign_assets_for_local_consensus_parach
 		}
 	}
 );
+
+/// Test-case makes sure that `Runtime` can reserve-transfer asset to other parachains
+pub fn reserve_transfer_native_asset_works<
+	Runtime,
+	AllPalletsWithoutSystem,
+	XcmConfig,
+	HrmpChannelOpener,
+	HrmpChannelSource,
+	LocationToAccountId,
+>(
+	collator_session_keys: CollatorSessionKeys<Runtime>,
+	existential_deposit: BalanceOf<Runtime>,
+	alice_account: AccountIdOf<Runtime>,
+	unwrap_pallet_xcm_event: Box<dyn Fn(Vec<u8>) -> Option<pallet_xcm::Event<Runtime>>>,
+	unwrap_xcmp_queue_event: Box<
+		dyn Fn(Vec<u8>) -> Option<cumulus_pallet_xcmp_queue::Event<Runtime>>,
+	>,
+	weight_limit: WeightLimit,
+) where
+	Runtime: frame_system::Config
+		+ pallet_balances::Config
+		+ pallet_session::Config
+		+ pallet_xcm::Config
+		+ parachain_info::Config
+		+ pallet_collator_selection::Config
+		+ cumulus_pallet_parachain_system::Config
+		+ cumulus_pallet_xcmp_queue::Config,
+	AllPalletsWithoutSystem:
+		OnInitialize<BlockNumberFor<Runtime>> + OnFinalize<BlockNumberFor<Runtime>>,
+	AccountIdOf<Runtime>: Into<[u8; 32]>,
+	ValidatorIdOf<Runtime>: From<AccountIdOf<Runtime>>,
+	BalanceOf<Runtime>: From<Balance>,
+	<Runtime as pallet_balances::Config>::Balance: From<Balance> + Into<u128>,
+	XcmConfig: xcm_executor::Config,
+	LocationToAccountId: ConvertLocation<AccountIdOf<Runtime>>,
+	<Runtime as frame_system::Config>::AccountId:
+		Into<<<Runtime as frame_system::Config>::RuntimeOrigin as OriginTrait>::AccountId>,
+	<<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source:
+		From<<Runtime as frame_system::Config>::AccountId>,
+	<Runtime as frame_system::Config>::AccountId: From<AccountId>,
+	HrmpChannelOpener: frame_support::inherent::ProvideInherent<
+		Call = cumulus_pallet_parachain_system::Call<Runtime>,
+	>,
+	HrmpChannelSource: XcmpMessageSource,
+{
+	let runtime_para_id = 1000;
+	ExtBuilder::<Runtime>::default()
+		.with_collators(collator_session_keys.collators())
+		.with_session_keys(collator_session_keys.session_keys())
+		.with_tracing()
+		.with_safe_xcm_version(3)
+		.with_para_id(runtime_para_id.into())
+		.build()
+		.execute_with(|| {
+			let mut alice = [0u8; 32];
+			alice[0] = 1;
+			let included_head = RuntimeHelper::<Runtime, AllPalletsWithoutSystem>::run_to_block(
+				2,
+				AccountId::from(alice).into(),
+			);
+
+			// reserve-transfer native asset with local reserve to remote parachain (1234)
+
+			let other_para_id = 1234;
+			let native_asset = MultiLocation::parent();
+			let dest = MultiLocation::new(1, X1(Parachain(other_para_id)));
+			let dest_beneficiary = MultiLocation::new(1, X1(Parachain(other_para_id)))
+				.appended_with(AccountId32 {
+					network: None,
+					id: sp_runtime::AccountId32::new([3; 32]).into(),
+				})
+				.unwrap();
+
+			let reserve_account = LocationToAccountId::convert_location(&dest)
+				.expect("Sovereign account for reserves");
+			let balance_to_transfer = 1_000_000_000_000_u128;
+
+			// open HRMP to other parachain
+			mock_open_hrmp_channel::<Runtime, HrmpChannelOpener>(
+				runtime_para_id.into(),
+				other_para_id.into(),
+				included_head,
+				&alice,
+			);
+
+			// drip ED to account
+			let alice_account_init_balance = existential_deposit + balance_to_transfer.into();
+			let _ = <pallet_balances::Pallet<Runtime>>::deposit_creating(
+				&alice_account,
+				alice_account_init_balance,
+			);
+			// SA of target location needs to have at least ED, otherwise making reserve fails
+			let _ = <pallet_balances::Pallet<Runtime>>::deposit_creating(
+				&reserve_account,
+				existential_deposit,
+			);
+
+			// we just check here, that user retains enough balance after withdrawal
+			// and also we check if `balance_to_transfer` is more than `existential_deposit`,
+			assert!(
+				(<pallet_balances::Pallet<Runtime>>::free_balance(&alice_account) -
+					balance_to_transfer.into()) >=
+					existential_deposit
+			);
+			// SA has just ED
+			assert_eq!(
+				<pallet_balances::Pallet<Runtime>>::free_balance(&reserve_account),
+				existential_deposit
+			);
+
+			// local native asset (pallet_balances)
+			let asset_to_transfer = MultiAsset {
+				fun: Fungible(balance_to_transfer.into()),
+				id: Concrete(native_asset),
+			};
+
+			// pallet_xcm call reserve transfer
+			assert_ok!(<pallet_xcm::Pallet<Runtime>>::limited_reserve_transfer_assets(
+				RuntimeHelper::<Runtime, AllPalletsWithoutSystem>::origin_of(alice_account.clone()),
+				Box::new(dest.into_versioned()),
+				Box::new(dest_beneficiary.into_versioned()),
+				Box::new(VersionedMultiAssets::from(MultiAssets::from(asset_to_transfer))),
+				0,
+				weight_limit,
+			));
+
+			// check alice account decreased by balance_to_transfer
+			// TODO:check-parameter: change and assert in tests when (https://github.com/paritytech/polkadot/pull/7005) merged
+			assert_eq!(
+				<pallet_balances::Pallet<Runtime>>::free_balance(&alice_account),
+				alice_account_init_balance - balance_to_transfer.into()
+			);
+
+			// check reserve account
+			// check reserve account increased by balance_to_transfer
+			assert_eq!(
+				<pallet_balances::Pallet<Runtime>>::free_balance(&reserve_account),
+				existential_deposit + balance_to_transfer.into()
+			);
+
+			// check events
+			// check pallet_xcm attempted
+			RuntimeHelper::<Runtime, AllPalletsWithoutSystem>::assert_pallet_xcm_event_outcome(
+				&unwrap_pallet_xcm_event,
+				|outcome| {
+					assert_ok!(outcome.ensure_complete());
+				},
+			);
+
+			// check that xcm was sent
+			let xcm_sent_message_hash = <frame_system::Pallet<Runtime>>::events()
+				.into_iter()
+				.filter_map(|e| unwrap_xcmp_queue_event(e.event.encode()))
+				.find_map(|e| match e {
+					cumulus_pallet_xcmp_queue::Event::XcmpMessageSent { message_hash } =>
+						Some(message_hash),
+					_ => None,
+				});
+
+			// read xcm
+			let xcm_sent = RuntimeHelper::<HrmpChannelSource, AllPalletsWithoutSystem>::take_xcm(
+				other_para_id.into(),
+			)
+			.unwrap();
+
+			assert_eq!(
+				xcm_sent_message_hash,
+				Some(xcm_sent.using_encoded(sp_io::hashing::blake2_256))
+			);
+			let mut xcm_sent: Xcm<()> = xcm_sent.try_into().expect("versioned xcm");
+
+			// check sent XCM Program to other parachain
+			println!("reserve_transfer_native_asset_works sent xcm: {:?}", xcm_sent);
+			let reserve_assets_deposited = MultiAssets::from(vec![MultiAsset {
+				id: Concrete(MultiLocation { parents: 1, interior: Here }),
+				fun: Fungible(1000000000000),
+			}]);
+
+			assert_matches_reserve_asset_deposited_instructions(
+				&mut xcm_sent,
+				&reserve_assets_deposited,
+				&dest_beneficiary,
+			);
+		})
+}

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
@@ -91,6 +91,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(18_446_744_073_709_551_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn execute() -> Weight {

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
@@ -91,6 +91,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(18_446_744_073_709_551_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn execute() -> Weight {

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_xcm.rs
@@ -91,6 +91,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(18_446_744_073_709_551_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn execute() -> Weight {

--- a/cumulus/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
@@ -91,6 +91,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(18_446_744_073_709_551_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	/// Storage: `Benchmark::Override` (r:0 w:0)
 	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn execute() -> Weight {

--- a/polkadot/runtime/kusama/src/weights/pallet_xcm.rs
+++ b/polkadot/runtime/kusama/src/weights/pallet_xcm.rs
@@ -89,6 +89,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(22_407_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	fn execute() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`

--- a/polkadot/runtime/polkadot/src/weights/pallet_xcm.rs
+++ b/polkadot/runtime/polkadot/src/weights/pallet_xcm.rs
@@ -89,6 +89,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(23_138_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	/// Storage: Benchmark Override (r:0 w:0)
 	/// Proof Skipped: Benchmark Override (max_values: None, max_size: None, mode: Measured)
 	fn execute() -> Weight {

--- a/polkadot/runtime/rococo/src/weights/pallet_xcm.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_xcm.rs
@@ -85,6 +85,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(21_768_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	fn execute() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`

--- a/polkadot/runtime/westend/src/weights/pallet_xcm.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_xcm.rs
@@ -89,6 +89,10 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(21_942_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn reserve_withdraw_assets() -> Weight {
+		Weight::from_parts(23_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 	/// Storage: Benchmark Override (r:0 w:0)
 	/// Proof Skipped: Benchmark Override (max_values: None, max_size: None, mode: Measured)
 	fn execute() -> Weight {

--- a/polkadot/xcm/pallet-xcm/src/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm/src/benchmarking.rs
@@ -79,6 +79,24 @@ benchmarks! {
 		let versioned_assets: VersionedMultiAssets = asset.into();
 	}: _<RuntimeOrigin<T>>(send_origin, Box::new(versioned_dest), Box::new(versioned_beneficiary), Box::new(versioned_assets), 0)
 
+	reserve_withdraw_assets {
+		let send_origin =
+			T::ExecuteXcmOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
+		let origin_location = T::ExecuteXcmOrigin::try_origin(send_origin.clone())
+			.map_err(|_| BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)))?;
+
+		let recipient = [0u8; 32];
+		let dest = T::ReachableDest::get().ok_or(
+			BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)),
+		)?;
+		// use native asset of destination
+		let asset: MultiAsset = (dest.clone(), 10).into();
+		let versioned_dest: VersionedMultiLocation = dest.into();
+		let versioned_beneficiary: VersionedMultiLocation =
+			AccountId32 { network: None, id: recipient.into() }.into();
+		let versioned_assets: VersionedMultiAssets = asset.into();
+	}: _<RuntimeOrigin<T>>(send_origin, Box::new(versioned_dest), Box::new(versioned_beneficiary), Box::new(versioned_assets), 0)
+
 	execute {
 		let execute_origin =
 			T::ExecuteXcmOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;

--- a/polkadot/xcm/pallet-xcm/src/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm/src/benchmarking.rs
@@ -82,15 +82,13 @@ benchmarks! {
 	reserve_withdraw_assets {
 		let send_origin =
 			T::ExecuteXcmOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
-		let origin_location = T::ExecuteXcmOrigin::try_origin(send_origin.clone())
-			.map_err(|_| BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)))?;
-
 		let recipient = [0u8; 32];
 		let dest = T::ReachableDest::get().ok_or(
 			BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)),
 		)?;
-		// use native asset of destination
-		let asset: MultiAsset = (dest.clone(), 10).into();
+		// For reserve_withdraw_assets we'd use destination native asset `(dest.clone(), 10).into()`,
+		// but for weighing it doesn't matter, and it's easier to use Balances asset here.
+		let asset: MultiAsset = (Here, 10).into();
 		let versioned_dest: VersionedMultiLocation = dest.into();
 		let versioned_beneficiary: VersionedMultiLocation =
 			AccountId32 { network: None, id: recipient.into() }.into();


### PR DESCRIPTION
# Description

## Motivation

`pallet-xcm` is the main user-facing interface for XCM functionality, including assets manipulation functions like `teleportAssets()` and `reserve_transfer_assets()` calls.

While `teleportAsset()` works both ways, `reserve_transfer_assets()` works only for sending reserve-based assets to a remote destination and beneficiary, but there is no user-facing extrinsic for burning reserved-based assets and getting back the original reserved assets.

## Solution

This PR adds `(limited_)reserve_withdraw_assets()` extrinsics that builds and locally executes XCM program containing `InitiateReserveWithdraw` XCVM instruction to burn synthetic asset on (local) chain and send notification to destination (reserve chain) for releasing locked asset.

## Testing

Added synthetic `pallet-xcm` unit-test for testing extrinsic when used with native asset, and `AssetHub`s runtime unit-tests that test extrinsic when used with foreign asset.

Partially fixes https://github.com/paritytech/parity-bridges-common/issues/2405

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [x] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] ~If this PR alters any external APIs or interfaces used by Polkadot, the corresponding Polkadot PR is ready as well
  as the corresponding Cumulus PR (optional)~
