### PR TITLE
Forgotten `polkadot-core-primitives/std`

### DIFF
--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -84,6 +84,7 @@ std = [
 	"pallet-timestamp/std",
 	"pallet-vesting/std",
 	"parity-scale-codec/std",
+	"polkadot-core-primitives/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-runtime-metrics/std",
 	"primitives/std",
@@ -101,7 +102,6 @@ std = [
 	"sp-std/std",
 	"xcm-executor/std",
 	"xcm/std",
-	"polkadot-core-primitives/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -101,6 +101,7 @@ std = [
 	"sp-std/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"polkadot-core-primitives/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",


### PR DESCRIPTION
Other PRs fail like this: https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/3597850