### PR TITLE
Switch prdoc to the latest image

### DIFF
--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize, unlabeled]
 
 env:
-  IMAGE: paritytech/prdoc:v0.0.5
+  IMAGE: paritytech/prdoc:latest
   API_BASE: https://api.github.com/repos
   REPO: ${{ github.repository }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR switches to using the latest image.
This is important for `prdoc` as the schema is, [at least currently](https://github.com/paritytech/prdoc/issues/3), part of the cli/image.