### PR TITLE
Handle `CollationSeconded` Logs Conditionally

### DIFF
--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -926,9 +926,41 @@ async fn handle_incoming_peer_message<Context>(
 						target: LOG_TARGET,
 						?statement,
 						?origin,
-						"received a valid `CollationSeconded`",
+						"received a valid `CollationSeconded`, forwarding result to collator",
 					);
 					let _ = sender.send(CollationSecondedSignal { statement, relay_parent });
+				} else {
+					// Checking whether the `CollationSeconded` statement is unexpected
+					let relay_parent = match state.per_relay_parent.get(&relay_parent) {
+						Some(per_relay_parent) => per_relay_parent,
+						None => {
+							gum::debug!(
+								target: LOG_TARGET,
+								candidate_relay_parent = %relay_parent,
+								candidate_hash = ?&statement.payload().candidate_hash(),
+								"Seconded statement relay parent is out of our view",
+							);
+							return Ok(())
+						},
+					};
+					match relay_parent.collations.get(&statement.payload().candidate_hash()) {
+						Some(_) => { // We've seen this collation before, so a seconded statement is expected
+							gum::trace!(
+								target: LOG_TARGET,
+								?statement,
+								?origin,
+								"received a valid `CollationSeconded`",
+							);
+						}, 
+						None => {
+							gum::debug!(
+								target: LOG_TARGET,
+								candidate_hash = ?&statement.payload().candidate_hash(),
+								?origin,
+								"received an unexpected `CollationSeconded`: unknown statement",
+							);
+						}
+					}
 				}
 			}
 		},

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -903,8 +903,7 @@ async fn handle_incoming_peer_message<Context>(
 			ctx.send_message(NetworkBridgeTxMessage::DisconnectPeer(origin, PeerSet::Collation))
 				.await;
 		},
-		Versioned::V1(V1::CollationSeconded(relay_parent, statement)) |
-		Versioned::VStaging(VStaging::CollationSeconded(relay_parent, statement)) => {
+		Versioned::V1(V1::CollationSeconded(relay_parent, statement)) => {
 			if !matches!(statement.unchecked_payload(), Statement::Seconded(_)) {
 				gum::warn!(
 					target: LOG_TARGET,
@@ -936,6 +935,34 @@ async fn handle_incoming_peer_message<Context>(
 						?origin,
 						"received an unexpected `CollationSeconded`: unknown statement",
 					);
+				}
+			}
+		},
+		Versioned::VStaging(VStaging::CollationSeconded(relay_parent, statement)) => {
+			if !matches!(statement.unchecked_payload(), Statement::Seconded(_)) {
+				gum::warn!(
+					target: LOG_TARGET,
+					?statement,
+					?origin,
+					"Collation seconded message received with none-seconded statement.",
+				);
+			} else {
+				let statement = runtime
+					.check_signature(ctx.sender(), relay_parent, statement)
+					.await?
+					.map_err(Error::InvalidStatementSignature)?;
+
+				let removed =
+					state.collation_result_senders.remove(&statement.payload().candidate_hash());
+
+				if let Some(sender) = removed {
+					gum::trace!(
+						target: LOG_TARGET,
+						?statement,
+						?origin,
+						"received a valid `CollationSeconded`",
+					);
+					let _ = sender.send(CollationSecondedSignal { statement, relay_parent });
 				}
 			}
 		},

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -953,7 +953,7 @@ async fn handle_incoming_peer_message<Context>(
 							);
 						}, 
 						None => {
-							gum::warn!(
+							gum::debug!(
 								target: LOG_TARGET,
 								candidate_hash = ?&statement.payload().candidate_hash(),
 								?origin,

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -944,14 +944,15 @@ async fn handle_incoming_peer_message<Context>(
 						},
 					};
 					match relay_parent.collations.get(&statement.payload().candidate_hash()) {
-						Some(_) => { // We've seen this collation before, so a seconded statement is expected
+						Some(_) => {
+							// We've seen this collation before, so a seconded statement is expected
 							gum::trace!(
 								target: LOG_TARGET,
 								?statement,
 								?origin,
 								"received a valid `CollationSeconded`",
 							);
-						}, 
+						},
 						None => {
 							gum::debug!(
 								target: LOG_TARGET,
@@ -959,7 +960,7 @@ async fn handle_incoming_peer_message<Context>(
 								?origin,
 								"received an unexpected `CollationSeconded`: unknown statement",
 							);
-						}
+						},
 					}
 				}
 			}

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -953,7 +953,7 @@ async fn handle_incoming_peer_message<Context>(
 							);
 						}, 
 						None => {
-							gum::debug!(
+							gum::warn!(
 								target: LOG_TARGET,
 								candidate_hash = ?&statement.payload().candidate_hash(),
 								?origin,


### PR DESCRIPTION
Separating the VStaging message handling case from V1 made the most sense to me. Let me know if there was a more concise way!

Closes #1469