### PR TITLE
fix simple analytics injection script

### DIFF
--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -111,6 +111,8 @@ build-rustdoc:
             sed -i "s|</head>|$script_content</head>|" "$file"
         }
         export -f process_file
+        # xargs runs process_file in seperate shells without access to outer variables.
+        # to make script_content available inside process_file, export it as an env var here.
         export script_content
 
         # Modify .html files in parallel using xargs, otherwise it can take a long time.

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -111,6 +111,7 @@ build-rustdoc:
             sed -i "s|</head>|$script_content</head>|" "$file"
         }
         export -f process_file
+        export script_content
 
         # Modify .html files in parallel using xargs, otherwise it can take a long time.
         find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {}


### PR DESCRIPTION
When `process_file` is run by `xargs`, it is executed inside a new shell without access to variables defined outside of its scope. 

This resulted in `script_content` being an empty string.

By exporting `script_content` prior to running `xargs` it is available inside the new shells.