### PR TITLE
Inclusions struct unit tests

### DIFF
--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -419,8 +419,8 @@ fn scraper_requests_candidates_of_non_finalized_ancestors() {
 			&mut virtual_overseer,
 			&chain,
 			finalized_block_number,
-			BLOCKS_TO_SKIP
-				- (finalized_block_number - DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION) as usize, /* Expect the provider not to go past finalized block. */
+			BLOCKS_TO_SKIP -
+				(finalized_block_number - DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION) as usize, /* Expect the provider not to go past finalized block. */
 			get_backed_and_included_candidate_events,
 		);
 		join(process_active_leaves_update(ctx.sender(), &mut ordering, next_update), overseer_fut)
@@ -524,8 +524,8 @@ fn scraper_handles_backed_but_not_included_candidate() {
 		// Bump the finalized block outside `BACKED_CANDIDATE_LIFETIME_AFTER_FINALIZATION`.
 		// The candidate should be removed.
 		assert!(
-			finalized_block_number
-				< TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION
+			finalized_block_number <
+				TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION
 		);
 		finalized_block_number +=
 			TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
@@ -575,8 +575,8 @@ fn scraper_handles_the_same_candidate_incuded_in_two_different_block_heights() {
 		// Finalize blocks to enforce pruning of scraped events.
 		// The magic candidate was added twice, so it shouldn't be removed if we finalize two more
 		// blocks.
-		finalized_block_number = test_targets.first().expect("there are two block nums")
-			+ DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+		finalized_block_number = test_targets.first().expect("there are two block nums") +
+			DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		let magic_candidate = make_candidate_receipt(get_magic_candidate_hash());
@@ -731,7 +731,8 @@ fn inclusions_get() {
 	// Call the get method for that candidate
 	let result = inclusions.get(&candidate_hash);
 
-	// Verify that the method returns the correct list of block numbers and hashes associated with that candidate
+	// Verify that the method returns the correct list of block numbers and hashes associated with
+	// that candidate
 	assert_eq!(
 		result.len(),
 		block_numbers.len(),

--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -776,8 +776,7 @@ fn inclusions_iterative_removal() {
 	// C2		x
 	// C3	x		x
 	// C4			x
-	// C5				x	
-
+	// C5				x
 	inclusions.insert(candidate1, 0, get_block_number_hash(0));
 	inclusions.insert(candidate2, 1, get_block_number_hash(1));
 	inclusions.insert(candidate3, 0, get_block_number_hash(0));
@@ -811,8 +810,7 @@ fn inclusions_iterative_removal() {
 	assert!(!inclusions.contains(&candidate2), "Expected candidate2 to be removed");
 	assert!(!inclusions.contains(&candidate3), "Expected candidate3 to be removed");
 	assert!(!inclusions.contains(&candidate4), "Expected candidate4 to be removed");
-	assert!(!inclusions.contains(&candidate5), "Expected candidate4 to be removed");
-
+	assert!(!inclusions.contains(&candidate5), "Expected candidate5 to be removed");
 }
 
 #[test]

--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -686,16 +686,19 @@ fn inclusions_insertion() {
 	inclusions.insert(candidate_hash, block_number, block_hash);
 
 	// Check inclusions_inner
+	assert!(inclusions.inclusions_inner.len() == 1, "Expected inclusions_inner to have length 1");
 	assert!(
 		inclusions.inclusions_inner.contains_key(&candidate_hash),
 		"Expected candidate_hash to be present in inclusions_inner"
 	);
 	let inner_map = inclusions.inclusions_inner.get(&candidate_hash).unwrap();
+	assert!(inner_map.len() == 1, "Expected inner_map to have length 1");
 	assert!(
 		inner_map.contains_key(&block_number),
 		"Expected block_number to be present for the candidate_hash in inclusions_inner"
 	);
 	let hash_set = inner_map.get(&block_number).unwrap();
+	assert!(hash_set.len() == 1, "Expected hash_map to have length 1");
 	assert!(
 		hash_set.contains(&block_hash),
 		"Expected block_hash to be present for the block_number in inclusions_inner"
@@ -703,10 +706,18 @@ fn inclusions_insertion() {
 
 	// Check candidates_by_block_number
 	assert!(
+		inclusions.candidates_by_block_number.len() == 1,
+		"Expected candidates_by_block_number to have length 1"
+	);
+	assert!(
 		inclusions.candidates_by_block_number.contains_key(&block_number),
 		"Expected block_number to be present in candidates_by_block_number"
 	);
 	let candidate_set = inclusions.candidates_by_block_number.get(&block_number).unwrap();
+	assert!(
+		candidate_set.len() == 1,
+		"Expected candidate_set to have length 1 for the block_number in candidates_by_block_number"
+	);
 	assert!(
 		candidate_set.contains(&candidate_hash),
 		"Expected candidate_hash to be present for the block_number in candidates_by_block_number"

--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -683,7 +683,7 @@ fn inclusions_insertion() {
 	let block_number = 0;
 	let block_hash = get_block_number_hash(block_number);
 
-	inclusions.insert(candidate_hash.clone(), block_number.clone(), block_hash.clone());
+	inclusions.insert(candidate_hash, block_number, block_hash);
 
 	// Check inclusions_inner
 	assert!(
@@ -725,7 +725,7 @@ fn inclusions_get() {
 		block_numbers.iter().map(|&num| get_block_number_hash(num)).collect();
 
 	for (&block_number, &block_hash) in block_numbers.iter().zip(&block_hashes) {
-		inclusions.insert(candidate_hash.clone(), block_number, block_hash);
+		inclusions.insert(candidate_hash, block_number, block_hash);
 	}
 
 	// Call the get method for that candidate
@@ -758,10 +758,10 @@ fn inclusions_iterative_removal() {
 	let candidate2 = make_candidate_receipt(BlakeTwo256::hash(&"c2".encode())).hash();
 	let candidate3 = make_candidate_receipt(BlakeTwo256::hash(&"c3".encode())).hash();
 
-	inclusions.insert(candidate1.clone(), 0, get_block_number_hash(0));
-	inclusions.insert(candidate2.clone(), 1, get_block_number_hash(1));
-	inclusions.insert(candidate3.clone(), 0, get_block_number_hash(0));
-	inclusions.insert(candidate3.clone(), 2, get_block_number_hash(2));
+	inclusions.insert(candidate1, 0, get_block_number_hash(0));
+	inclusions.insert(candidate2, 1, get_block_number_hash(1));
+	inclusions.insert(candidate3, 0, get_block_number_hash(0));
+	inclusions.insert(candidate3, 2, get_block_number_hash(2));
 
 	// Remove a height that has no blocks and observe no changes
 	inclusions.remove_up_to_height(&0);
@@ -798,10 +798,10 @@ fn inclusions_duplicate_insertion_same_height_and_block() {
 	let block_hash = get_block_number_hash(block_number);
 
 	// Insert the candidate once
-	inclusions.insert(candidate1.clone(), block_number, block_hash.clone());
+	inclusions.insert(candidate1, block_number, block_hash);
 
 	// Insert the same candidate again at the same height and block
-	inclusions.insert(candidate1.clone(), block_number, block_hash.clone());
+	inclusions.insert(candidate1, block_number, block_hash);
 
 	// Check inclusions_inner
 	assert!(
@@ -850,8 +850,8 @@ fn test_duplicate_insertion_same_height_different_blocks() {
 	let block_number = 0;
 	let block_hash1 = BlakeTwo256::hash(&"b1".encode());
 	let block_hash2 = BlakeTwo256::hash(&"b2".encode()); // Different block hash for the same height
-	inclusions.insert(candidate1.clone(), block_number, block_hash1.clone());
-	inclusions.insert(candidate1.clone(), block_number, block_hash2.clone());
+	inclusions.insert(candidate1, block_number, block_hash1);
+	inclusions.insert(candidate1, block_number, block_hash2);
 
 	// Check inclusions_inner
 	assert!(

--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -768,35 +768,51 @@ fn inclusions_iterative_removal() {
 	let candidate1 = make_candidate_receipt(BlakeTwo256::hash(&"c1".encode())).hash();
 	let candidate2 = make_candidate_receipt(BlakeTwo256::hash(&"c2".encode())).hash();
 	let candidate3 = make_candidate_receipt(BlakeTwo256::hash(&"c3".encode())).hash();
+	let candidate4 = make_candidate_receipt(BlakeTwo256::hash(&"c4".encode())).hash();
+	let candidate5 = make_candidate_receipt(BlakeTwo256::hash(&"c5".encode())).hash();
+
+	//	B	0	1	2	3
+	// C1	x
+	// C2		x
+	// C3	x		x
+	// C4			x
+	// C5				x	
 
 	inclusions.insert(candidate1, 0, get_block_number_hash(0));
 	inclusions.insert(candidate2, 1, get_block_number_hash(1));
 	inclusions.insert(candidate3, 0, get_block_number_hash(0));
 	inclusions.insert(candidate3, 2, get_block_number_hash(2));
+	inclusions.insert(candidate4, 2, get_block_number_hash(2));
+	inclusions.insert(candidate5, 3, get_block_number_hash(3));
 
-	// Remove a height that has no blocks and observe no changes
 	inclusions.remove_up_to_height(&0);
 	assert!(inclusions.contains(&candidate1), "Expected candidate1 to remain");
 	assert!(inclusions.contains(&candidate2), "Expected candidate2 to remain");
 	assert!(inclusions.contains(&candidate3), "Expected candidate3 to remain");
+	assert!(inclusions.contains(&candidate4), "Expected candidate4 to remain");
+	assert!(inclusions.contains(&candidate5), "Expected candidate5 to remain");
 
-	// Remove block 0 and check
 	inclusions.remove_up_to_height(&1);
 	assert!(!inclusions.contains(&candidate1), "Expected candidate1 to be removed");
 	assert!(inclusions.contains(&candidate2), "Expected candidate2 to remain");
 	assert!(inclusions.contains(&candidate3), "Expected candidate3 to remain");
+	assert!(inclusions.contains(&candidate4), "Expected candidate4 to remain");
+	assert!(inclusions.contains(&candidate5), "Expected candidate5 to remain");
 
-	// Remove block 1 and check
 	inclusions.remove_up_to_height(&2);
 	assert!(!inclusions.contains(&candidate1), "Expected candidate1 to be removed");
 	assert!(!inclusions.contains(&candidate2), "Expected candidate2 to be removed");
 	assert!(inclusions.contains(&candidate3), "Expected candidate3 to remain");
+	assert!(inclusions.contains(&candidate4), "Expected candidate4 to remain");
+	assert!(inclusions.contains(&candidate5), "Expected candidate5 to remain");
 
-	// Remove block 2 and check
-	inclusions.remove_up_to_height(&3);
+	inclusions.remove_up_to_height(&10);
 	assert!(!inclusions.contains(&candidate1), "Expected candidate1 to be removed");
 	assert!(!inclusions.contains(&candidate2), "Expected candidate2 to be removed");
 	assert!(!inclusions.contains(&candidate3), "Expected candidate3 to be removed");
+	assert!(!inclusions.contains(&candidate4), "Expected candidate4 to be removed");
+	assert!(!inclusions.contains(&candidate5), "Expected candidate4 to be removed");
+
 }
 
 #[test]


### PR DESCRIPTION
In follow-up to https://github.com/paritytech/polkadot-sdk/pull/1432

Some additional unit tests for the inclusion struct used in the scraper.