### PR TITLE
fix: export-genesis-state command

### DIFF
--- a/cumulus/polkadot-parachain/src/command.rs
+++ b/cumulus/polkadot-parachain/src/command.rs
@@ -381,7 +381,7 @@ impl SubstrateCli for RelayChainCli {
 }
 
 /// Creates partial components for the runtimes that are supported by the benchmarks.
-macro_rules! construct_benchmark_partials {
+macro_rules! construct_partials {
 	($config:expr, |$partials:ident| $code:expr) => {
 		match $config.chain_spec.runtime() {
 			Runtime::AssetHubKusama => {
@@ -768,7 +768,7 @@ pub fn run() -> Result<()> {
 		Some(Subcommand::ExportGenesisState(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| {
-				construct_benchmark_partials!(config, |partials| cmd.run(&*config.chain_spec, &*partials.client))
+				construct_partials!(config, |partials| cmd.run(&*config.chain_spec, &*partials.client))
 			})
 		},
 		Some(Subcommand::ExportGenesisWasm(cmd)) => {
@@ -792,7 +792,7 @@ pub fn run() -> Result<()> {
 							.into())
 					},
 				BenchmarkCmd::Block(cmd) => runner.sync_run(|config| {
-					construct_benchmark_partials!(config, |partials| cmd.run(partials.client))
+					construct_partials!(config, |partials| cmd.run(partials.client))
 				}),
 				#[cfg(not(feature = "runtime-benchmarks"))]
 				BenchmarkCmd::Storage(_) =>
@@ -804,7 +804,7 @@ pub fn run() -> Result<()> {
 					.into()),
 				#[cfg(feature = "runtime-benchmarks")]
 				BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
-					construct_benchmark_partials!(config, |partials| {
+					construct_partials!(config, |partials| {
 						let db = partials.backend.expose_db();
 						let storage = partials.backend.expose_storage();
 

--- a/cumulus/polkadot-parachain/src/command.rs
+++ b/cumulus/polkadot-parachain/src/command.rs
@@ -477,58 +477,6 @@ macro_rules! construct_partials {
 				)?;
 				$code
 			},
-			Runtime::BridgeHub(bridge_hub_runtime_type) => match bridge_hub_runtime_type {
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::Polkadot |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::PolkadotLocal |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::PolkadotDevelopment => {
-					let $partials = new_partial::<chain_spec::bridge_hubs::polkadot::RuntimeApi, _>(
-						&$config,
-						crate::service::aura_build_import_queue::<_, AuraId>,
-					)?;
-
-					let task_manager = $partials.task_manager;
-					$code
-				},
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::Kusama |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::KusamaLocal |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::KusamaDevelopment => {
-					let $partials = new_partial::<chain_spec::bridge_hubs::kusama::RuntimeApi, _>(
-						&$config,
-						crate::service::aura_build_import_queue::<_, AuraId>,
-					)?;
-
-					$code
-				},
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::Westend => {
-					let $partials = new_partial::<chain_spec::bridge_hubs::westend::RuntimeApi, _>(
-						&$config,
-						crate::service::aura_build_import_queue::<_, AuraId>,
-					)?;
-
-					let task_manager = $partials.task_manager;
-					$code
-				},
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::Rococo |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::RococoLocal |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::RococoDevelopment => {
-					let $partials = new_partial::<chain_spec::bridge_hubs::rococo::RuntimeApi, _>(
-						&$config,
-						crate::service::aura_build_import_queue::<_, AuraId>,
-					)?;
-
-					$code
-				},
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::Wococo |
-				chain_spec::bridge_hubs::BridgeHubRuntimeType::WococoLocal => {
-					let $partials = new_partial::<chain_spec::bridge_hubs::wococo::RuntimeApi, _>(
-						&$config,
-						crate::service::aura_build_import_queue::<_, AuraId>,
-					)?;
-
-					let task_manager = $partials.task_manager;
-					$code
-				},
-			},
 			Runtime::Penpal(_) | Runtime::Default => {
 				let $partials = new_partial::<rococo_parachain_runtime::RuntimeApi, _>(
 					&$config,


### PR DESCRIPTION
# Description

Currently the `ExportGenesisState` command in polkadot parachain uses an asynchronous context to run, which seems to display some warnings. See the screenshot below:

![Screenshot 2023-09-12 at 17 12 15](https://github.com/paritytech/polkadot-sdk/assets/2722756/0140b48a-2edb-41fa-b046-579d526f8305)

After the changes in this PR, which essentially runs the command in a synchronous context, the command works properly without any warning.

![Screenshot 2023-09-12 at 18 23 46](https://github.com/paritytech/polkadot-sdk/assets/2722756/31506917-ece2-4a5f-8909-f215cc1ac0de)

The remaining runtimes were added to `construct_benchmark_partials` macro in order not to fail if the runtime was not included in the non-exhaustive initial list, similarly to the `construct_async_run` one.

For completeness: tests were made following this [tutorial](https://docs.substrate.io/tutorials/build-a-parachain/connect-a-local-parachain/).
