### PR TITLE
Update trie-db version to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19024,9 +19024,9 @@ dependencies = [
 
 [[package]]
 name = "trie-bench"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f54b4f9d51d368e62cf7e0730c7c1e18fc658cc84333656bab5b328f44aa964"
+checksum = "a4680cb226e31d2a096592d0edecdda91cc371743002f80c0f8cf80219819b3b"
 dependencies = [
  "criterion 0.4.0",
  "hash-db",
@@ -19040,9 +19040,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
+checksum = "ff28e0f815c2fea41ebddf148e008b077d2faddb026c9555b29696114d602642"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",

--- a/bridges/primitives/runtime/Cargo.toml
+++ b/bridges/primitives/runtime/Cargo.toml
@@ -26,7 +26,7 @@ sp-runtime = { path = "../../../substrate/primitives/runtime", default-features 
 sp-state-machine = { path = "../../../substrate/primitives/state-machine", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }
 sp-trie = { path = "../../../substrate/primitives/trie", default-features = false }
-trie-db = { version = "0.27.1", default-features = false }
+trie-db = { version = "0.28.0", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/cumulus/pallets/parachain-system/Cargo.toml
+++ b/cumulus/pallets/parachain-system/Cargo.toml
@@ -11,7 +11,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 environmental = { version = "1.1.4", default-features = false }
 impl-trait-for-tuples = "0.2.1"
 log = { version = "0.4.20", default-features = false }
-trie-db = { version = "0.27.1", default-features = false }
+trie-db = { version = "0.28.0", default-features = false }
 scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
 
 # Substrate

--- a/substrate/primitives/state-machine/Cargo.toml
+++ b/substrate/primitives/state-machine/Cargo.toml
@@ -27,7 +27,7 @@ sp-externalities = { path = "../externalities", default-features = false}
 sp-panic-handler = { path = "../panic-handler", optional = true}
 sp-std = { path = "../std", default-features = false}
 sp-trie = { path = "../trie", default-features = false}
-trie-db = { version = "0.27.1", default-features = false }
+trie-db = { version = "0.28.0", default-features = false }
 
 [dev-dependencies]
 array-bytes = "6.1"

--- a/substrate/primitives/trie/Cargo.toml
+++ b/substrate/primitives/trie/Cargo.toml
@@ -29,7 +29,7 @@ parking_lot = { version = "0.12.1", optional = true }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.48", optional = true }
 tracing = { version = "0.1.29", optional = true }
-trie-db = { version = "0.27.0", default-features = false }
+trie-db = { version = "0.28.0", default-features = false }
 trie-root = { version = "0.18.0", default-features = false }
 sp-core = { path = "../core", default-features = false}
 sp-std = { path = "../std", default-features = false}
@@ -38,7 +38,7 @@ schnellru = { version = "0.2.1", optional = true }
 [dev-dependencies]
 array-bytes = "6.1"
 criterion = "0.4.0"
-trie-bench = "0.37.0"
+trie-bench = "0.38.0"
 trie-standardmap = "0.16.0"
 sp-runtime = { path = "../runtime" }
 

--- a/substrate/primitives/trie/src/recorder.rs
+++ b/substrate/primitives/trie/src/recorder.rs
@@ -386,7 +386,8 @@ impl<H: Hasher, I: DerefMut<Target = RecorderInner<H::Out>>> trie_db::TrieRecord
 					"Recorded inline value access for key",
 				);
 
-				// A value was accessed that is stored inline a node and we recorded all trie nodes to access this value.
+				// A value was accessed that is stored inline a node and we recorded all trie nodes
+				// to access this value.
 				self.update_recorded_keys(full_key, RecordedForKey::Value);
 			},
 		};

--- a/substrate/primitives/trie/src/recorder.rs
+++ b/substrate/primitives/trie/src/recorder.rs
@@ -386,10 +386,7 @@ impl<H: Hasher, I: DerefMut<Target = RecorderInner<H::Out>>> trie_db::TrieRecord
 					"Recorded inline value access for key",
 				);
 
-				// A value was accessed that is stored inline a node.
-				//
-				// As the value is stored inline there is no need to separately record the value as
-				// it is part of a node.
+				// A value was accessed that is stored inline a node and we recorded all trie nodes to access this value.
 				self.update_recorded_keys(full_key, RecordedForKey::Value);
 			},
 		};

--- a/substrate/primitives/trie/src/recorder.rs
+++ b/substrate/primitives/trie/src/recorder.rs
@@ -379,6 +379,19 @@ impl<H: Hasher, I: DerefMut<Target = RecorderInner<H::Out>>> trie_db::TrieRecord
 				// that the value doesn't exist in the trie.
 				self.update_recorded_keys(full_key, RecordedForKey::Value);
 			},
+			TrieAccess::InlineValue { full_key } => {
+				tracing::trace!(
+					target: LOG_TARGET,
+					key = ?sp_core::hexdisplay::HexDisplay::from(&full_key),
+					"Recorded inline value access for key",
+				);
+
+				// A value was accessed that is stored inline a node.
+				//
+				// As the value is stored inline there is no need to separately record the value as
+				// it is part of a node.
+				self.update_recorded_keys(full_key, RecordedForKey::Value);
+			},
 		};
 
 		self.encoded_size_estimation.fetch_add(encoded_size_update, Ordering::Relaxed);

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -40,7 +40,7 @@ pallet-timestamp = { path = "../../frame/timestamp", default-features = false}
 sp-consensus-grandpa = { path = "../../primitives/consensus/grandpa", default-features = false, features = ["serde"] }
 sp-trie = { path = "../../primitives/trie", default-features = false}
 sp-transaction-pool = { path = "../../primitives/transaction-pool", default-features = false}
-trie-db = { version = "0.27.0", default-features = false }
+trie-db = { version = "0.28.0", default-features = false }
 sc-service = { path = "../../client/service", default-features = false, features = ["test-helpers"], optional = true}
 sp-state-machine = { path = "../../primitives/state-machine", default-features = false}
 sp-externalities = { path = "../../primitives/externalities", default-features = false}

--- a/substrate/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
+++ b/substrate/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 sp-core = { path = "../../../../primitives/core" }
 sp-state-machine = { path = "../../../../primitives/state-machine" }
 sp-trie = { path = "../../../../primitives/trie" }
-trie-db = "0.27.0"
+trie-db = "0.28.0"
 
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 


### PR DESCRIPTION
This PR updates:
- trie-db from 0.27.1 to 0.28.0
- trie-bench from 0.37.0 to 0.38.0 (deb-dependency)


While at it, also adapts the recorder to take into account the newly added `TrieAccess::InlineValue`.

Needed by:
- https://github.com/paritytech/polkadot-sdk/pull/1153

@paritytech/subxt-team 