### PR TITLE
frame/beefy: add privileged call to reset BEEFY consensus

### DIFF
--- a/substrate/frame/beefy/src/default_weights.rs
+++ b/substrate/frame/beefy/src/default_weights.rs
@@ -49,4 +49,8 @@ impl crate::WeightInfo for () {
 			// fetching set id -> session index mappings
 			.saturating_add(DbWeight::get().reads(2))
 	}
+
+	fn set_new_genesis() -> Weight {
+		DbWeight::get().writes(1)
+	}
 }

--- a/substrate/frame/beefy/src/tests.rs
+++ b/substrate/frame/beefy/src/tests.rs
@@ -791,3 +791,25 @@ fn valid_equivocation_reports_dont_pay_fees() {
 		assert_eq!(post_info.pays_fee, Pays::Yes);
 	})
 }
+
+#[test]
+fn set_new_genesis_works() {
+	let authorities = test_authorities();
+
+	new_test_ext_raw_authorities(authorities).execute_with(|| {
+		start_era(1);
+
+		let new_genesis_delay = 10u64;
+		// the call for setting new genesis should work
+		assert_ok!(Beefy::set_new_genesis(RuntimeOrigin::root(), new_genesis_delay,));
+		let expected = System::block_number() + new_genesis_delay;
+		// verify new genesis was set
+		assert_eq!(Beefy::genesis_block(), Some(expected));
+
+		// setting delay < 1 should fail
+		assert_err!(
+			Beefy::set_new_genesis(RuntimeOrigin::root(), 0u64,),
+			Error::<Test>::InvalidConfiguration,
+		);
+	});
+}


### PR DESCRIPTION
# Description

We want to be able to (re)set BEEFY genesis in order to (re)start BEEFY consensus on chains which didn't run it since genesis.

This commit adds privileged helper call to (re)set BEEFY genesis to some block in the future.

