### PR TITLE
wasm-builder: Disable building when running on docs.rs

### DIFF
--- a/substrate/utils/wasm-builder/src/builder.rs
+++ b/substrate/utils/wasm-builder/src/builder.rs
@@ -203,7 +203,10 @@ fn generate_crate_skip_build_env_name() -> String {
 /// Checks if the build of the WASM binary should be skipped.
 fn check_skip_build() -> bool {
 	env::var(crate::SKIP_BUILD_ENV).is_ok() ||
-		env::var(generate_crate_skip_build_env_name()).is_ok()
+		env::var(generate_crate_skip_build_env_name()).is_ok() ||
+		// If we are running in docs.rs, let's skip building.
+		// https://docs.rs/about/builds#detecting-docsrs
+		env::var("DOCS_RS").is_ok()
 }
 
 /// Provide a dummy WASM binary if there doesn't exist one.


### PR DESCRIPTION
This pull request changes the `wasm-builder` to skip building the wasm files when the build process is running on docs.rs.

