### PR TITLE
[DO NOT MERGE] Test `Notifications` protocol fast reconnect

### DIFF
--- a/substrate/client/network/src/protocol.rs
+++ b/substrate/client/network/src/protocol.rs
@@ -95,9 +95,11 @@ pub struct Protocol<B: BlockT> {
 	sync_substream_validations: FuturesUnordered<PendingSyncSubstreamValidation>,
 	tx: TracingUnboundedSender<crate::event::SyncEvent<B>>,
 	_marker: std::marker::PhantomData<B>,
+	// TESTING ONLY
 	dummy_protocol_set_id: SetId,
 	dummy_connection_counter: usize,
 	server: Option<bool>,
+	// END OF TESTING ONLY
 }
 
 impl<B: BlockT> Protocol<B> {

--- a/substrate/client/network/src/protocol.rs
+++ b/substrate/client/network/src/protocol.rs
@@ -93,6 +93,7 @@ pub struct Protocol<B: BlockT> {
 	sync_substream_validations: FuturesUnordered<PendingSyncSubstreamValidation>,
 	tx: TracingUnboundedSender<crate::event::SyncEvent<B>>,
 	_marker: std::marker::PhantomData<B>,
+	dummy_protocol_set_id: SetId,
 }
 
 impl<B: BlockT> Protocol<B> {
@@ -128,6 +129,8 @@ impl<B: BlockT> Protocol<B> {
 			)
 		};
 
+		let dummy_protocol_set_id = notification_protocols.len().into();
+
 		let protocol = Self {
 			peer_store_handle,
 			behaviour,
@@ -140,6 +143,7 @@ impl<B: BlockT> Protocol<B> {
 			tx,
 			// TODO: remove when `BlockAnnouncesHandshake` is moved away from `Protocol`
 			_marker: Default::default(),
+			dummy_protocol_set_id,
 		};
 
 		Ok(protocol)

--- a/substrate/client/network/src/protocol/notifications/behaviour.rs
+++ b/substrate/client/network/src/protocol/notifications/behaviour.rs
@@ -378,6 +378,15 @@ impl Notifications {
 			})
 			.collect::<Vec<_>>();
 
+		for (set_id, protocol) in notif_protocols.iter().enumerate() {
+			trace!(
+				target: "sub-libp2p",
+				"Notifications protocol set id: {}, name: {}",
+				set_id,
+				protocol.name,
+			);
+		}
+
 		assert!(!notif_protocols.is_empty());
 
 		Self {

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -276,7 +276,7 @@ where
 
 		// TESTING ONLY
 		notification_protocols.push(NonDefaultSetConfig {
-			notifications_protocol: "dummy_protocol".into(),
+			notifications_protocol: "/dummy_protocol/1.0".into(),
 			fallback_names: Default::default(),
 			handshake: None,
 			max_notification_size: 100_000,


### PR DESCRIPTION
This is a test code for https://github.com/paritytech/polkadot-sdk/issues/1499 debugging.

The nodes are expected to be run as following:
Server:
```
./substrate-node -d=./server --chain local --port=12345 -lsub-libp2p=trace
```
Client:
```
./substrate-node -d=./client --chain local --bootnodes '/ip4/127.0.0.1/tcp/12345/ws/p2p/<peer_id>' -lsub-libp2p=trace,peerset=trace
```

Here are the relevant findings: https://github.com/paritytech/polkadot-sdk/issues/1499#issuecomment-1717779093