### PR TITLE
Include `bitvec` in `std` for Broker Pallet

### DIFF
--- a/substrate/frame/broker/Cargo.toml
+++ b/substrate/frame/broker/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
 scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
-bitvec = "1"
+bitvec = { version = "1.0.0", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}
@@ -30,6 +30,7 @@ sp-io = { path = "../../primitives/io" }
 default = [ "std" ]
 
 std = [
+	"bitvec/std",
 	"codec/std",
 	"frame-benchmarking?/std",
 	"frame-support/std",

--- a/substrate/frame/broker/README.md
+++ b/substrate/frame/broker/README.md
@@ -4,7 +4,7 @@ Brokerage tool for managing Polkadot Core scheduling.
 
 Properly described in RFC-0001 Agile Coretime.
 
-## Implemnentation Specifics
+## Implementation Specifics
 
 ### Core Mask Bits
 


### PR DESCRIPTION
When adding this pallet to the [Coretime Chain](https://github.com/paritytech/polkadot-sdk/pull/1479), this dependency results in conflicting implementations (rustc error below). This toml change fixes it.

```
error: failed to run custom build command for `coretime-rococo-runtime v1.0.0 (/home/joe/parity/polkadot-sdk/cumulus/parachains/runtimes/coretime/coretime-rococo)`

Caused by:
  process didn't exit successfully: `/home/joe/parity/polkadot-sdk/target/debug/build/coretime-rococo-runtime-7943703d2770a119/build-script-build` (exit status: 1)
  --- stdout
  Information that should be included in a bug report.
  Executing build command: RUSTFLAGS="-C target-cpu=mvp -C target-feature=-sign-ext -C link-arg=--export-table -Clink-arg=--export=__heap_base -C link-arg=--import-memory  " SKIP_WASM_BUILD="" "/home/joe/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo" "rustc" "--target=wasm32-unknown-unknown" "--manifest-path=/home/joe/parity/polkadot-sdk/target/debug/wbuild/coretime-rococo-runtime/Cargo.toml" "--color=always" "--profile" "release"
  Using rustc version: rustc 1.71.1 (eb26296b5 2023-08-03)


  --- stderr
     Compiling sp-io v23.0.0 (/home/joe/parity/polkadot-sdk/substrate/primitives/io)
     Compiling coretime-rococo-runtime v1.0.0 (/home/joe/parity/polkadot-sdk/cumulus/parachains/runtimes/coretime/coretime-rococo)
  error[E0152]: found duplicate lang item `panic_impl`
      --> /home/joe/parity/polkadot-sdk/substrate/primitives/io/src/lib.rs:1749:1
       |
  1749 | pub fn panic(info: &core::panic::PanicInfo) -> ! {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
       = note: the lang item is first defined in crate `std` (which `bitvec` depends on)
       = note: first definition in `std` loaded from /home/joe/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib/libstd-67dfbacfb4b441ef.rlib
       = note: second definition in the local crate (`sp_io`)

  For more information about this error, try `rustc --explain E0152`.
```