### PR TITLE
archive: Fetch body, genesisHash and header

### DIFF
--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -42,4 +42,15 @@ pub trait ArchiveApi<Hash> {
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_genesisHash")]
 	fn archive_unstable_genesis_hash(&self) -> RpcResult<String>;
+
+	/// Get the block's header.
+	///
+	/// Returns a string containing the hexadecimal-encoded SCALE-codec encoding header of the
+	/// block.
+	///
+	/// # Unstable
+	///
+	/// This method is unstable and subject to change in the future.
+	#[method(name = "archive_unstable_header")]
+	fn archive_unstable_header(&self, hash: Hash) -> RpcResult<Option<String>>;
 }

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -31,7 +31,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_body")]
-	fn archive_unstable_body(&self, hash: Hash) -> RpcResult<Option<String>>;
+	fn archive_unstable_body(&self, hash: Hash) -> RpcResult<Option<Vec<String>>>;
 
 	/// Get the chain's genesis hash.
 	///

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! API trait of the archive methods.
+
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+#[rpc(client, server)]
+pub trait ArchiveApi<Hash> {
+	/// Retrieves the body (list of transactions) of a given block hash.
+	///
+	/// Returns an array of strings containing the hexadecimal-encoded SCALE-codec-encoded
+	/// transactions in that block. If no block with that hash is found, null.
+	///
+	/// # Unstable
+	///
+	/// This method is unstable and subject to change in the future.
+	#[method(name = "archive_unstable_body")]
+	fn archive_unstable_body(&self, hash: Hash) -> RpcResult<Option<String>>;
+
+	/// Get the chain's genesis hash.
+	///
+	/// Returns a string containing the hexadecimal-encoded hash of the genesis block of the chain.
+	///
+	/// # Unstable
+	///
+	/// This method is unstable and subject to change in the future.
+	#[method(name = "archive_unstable_genesisHash")]
+	fn archive_unstable_genesis_hash(&self) -> RpcResult<String>;
+}

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -92,4 +92,10 @@ where
 	fn archive_unstable_genesis_hash(&self) -> RpcResult<String> {
 		Ok(self.genesis_hash.clone())
 	}
+
+	fn archive_unstable_header(&self, hash: Block::Hash) -> RpcResult<Option<String>> {
+		let Ok(Some(header)) = self.client.header(hash) else { return Ok(None) };
+
+		Ok(Some(hex_string(&header.encode())))
+	}
 }

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -1,0 +1,51 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! API implementation for `archive`.
+
+use crate::{chain_head::hex_string, SubscriptionTaskExecutor};
+use sc_client_api::Backend;
+use sp_runtime::traits::Block as BlockT;
+use std::{marker::PhantomData, sync::Arc};
+
+/// An API for archive RPC calls.
+pub struct Archive<BE: Backend<Block>, Block: BlockT, Client> {
+	/// Substrate client.
+	client: Arc<Client>,
+	/// Backend of the chain.
+	backend: Arc<BE>,
+	/// Executor to spawn subscriptions.
+	executor: SubscriptionTaskExecutor,
+	/// The hexadecimal encoded hash of the genesis block.
+	genesis_hash: String,
+	/// Phantom member to pin the block type.
+	_phantom: PhantomData<Block>,
+}
+
+impl<BE: Backend<Block>, Block: BlockT, Client> Archive<BE, Block, Client> {
+	/// Create a new [`Archive`].
+	pub fn new<GenesisHash: AsRef<[u8]>>(
+		client: Arc<Client>,
+		backend: Arc<BE>,
+		executor: SubscriptionTaskExecutor,
+		genesis_hash: GenesisHash,
+	) -> Self {
+		let genesis_hash = hex_string(&genesis_hash.as_ref());
+		Self { client, backend: backend.clone(), executor, genesis_hash, _phantom: PhantomData }
+	}
+}

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -19,7 +19,7 @@
 //! API implementation for `archive`.
 
 use super::ArchiveApiServer;
-use crate::{chain_head::hex_string, SubscriptionTaskExecutor};
+use crate::chain_head::hex_string;
 use codec::Encode;
 use jsonrpsee::core::{async_trait, RpcResult};
 use sc_client_api::{Backend, BlockBackend, BlockchainEvents, ExecutorProvider, StorageProvider};
@@ -32,32 +32,17 @@ use std::{marker::PhantomData, sync::Arc};
 pub struct Archive<BE: Backend<Block>, Block: BlockT, Client> {
 	/// Substrate client.
 	client: Arc<Client>,
-	/// Backend of the chain.
-	_backend: Arc<BE>,
-	/// Executor to spawn subscriptions.
-	_executor: SubscriptionTaskExecutor,
 	/// The hexadecimal encoded hash of the genesis block.
 	genesis_hash: String,
 	/// Phantom member to pin the block type.
-	_phantom: PhantomData<Block>,
+	_phantom: PhantomData<(Block, BE)>,
 }
 
 impl<BE: Backend<Block>, Block: BlockT, Client> Archive<BE, Block, Client> {
 	/// Create a new [`Archive`].
-	pub fn new<GenesisHash: AsRef<[u8]>>(
-		client: Arc<Client>,
-		backend: Arc<BE>,
-		executor: SubscriptionTaskExecutor,
-		genesis_hash: GenesisHash,
-	) -> Self {
+	pub fn new<GenesisHash: AsRef<[u8]>>(client: Arc<Client>, genesis_hash: GenesisHash) -> Self {
 		let genesis_hash = hex_string(&genesis_hash.as_ref());
-		Self {
-			client,
-			_backend: backend.clone(),
-			_executor: executor,
-			genesis_hash,
-			_phantom: PhantomData,
-		}
+		Self { client, genesis_hash, _phantom: PhantomData }
 	}
 }
 

--- a/substrate/client/rpc-spec-v2/src/archive/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/mod.rs
@@ -16,17 +16,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Substrate JSON-RPC interface v2.
+//! Substrate archive API.
 //!
-//! Specification [document](https://paritytech.github.io/json-rpc-interface-spec/).
+//! # Note
+//!
+//! Methods are prefixed by `archive`.
 
-#![warn(missing_docs)]
-#![deny(unused_crate_dependencies)]
+pub mod api;
 
-pub mod archive;
-pub mod chain_head;
-pub mod chain_spec;
-pub mod transaction;
-
-/// Task executor that is being used by RPC subscriptions.
-pub type SubscriptionTaskExecutor = std::sync::Arc<dyn sp_core::traits::SpawnNamed>;
+pub use api::ArchiveApiServer;

--- a/substrate/client/rpc-spec-v2/src/archive/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/mod.rs
@@ -23,5 +23,6 @@
 //! Methods are prefixed by `archive`.
 
 pub mod api;
+pub mod archive;
 
 pub use api::ArchiveApiServer;

--- a/substrate/client/rpc-spec-v2/src/archive/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/mod.rs
@@ -22,6 +22,9 @@
 //!
 //! Methods are prefixed by `archive`.
 
+#[cfg(test)]
+mod tests;
+
 pub mod api;
 pub mod archive;
 

--- a/substrate/client/rpc-spec-v2/src/archive/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/tests.rs
@@ -25,7 +25,6 @@ use jsonrpsee::{types::EmptyServerParams as EmptyParams, RpcModule};
 use sc_block_builder::BlockBuilderProvider;
 
 use sp_consensus::BlockOrigin;
-use sp_core::testing::TaskExecutor;
 use std::sync::Arc;
 use substrate_test_runtime_client::{
 	prelude::*, runtime, Backend, BlockBuilderExt, Client, ClientBlockImportExt,
@@ -39,12 +38,9 @@ type Block = substrate_test_runtime_client::runtime::Block;
 
 fn setup_api() -> (Arc<Client<Backend>>, RpcModule<Archive<Backend, Block, Client<Backend>>>) {
 	let builder = TestClientBuilder::new();
-	let backend = builder.backend();
 	let client = Arc::new(builder.build());
 
-	let api =
-		Archive::new(client.clone(), backend, Arc::new(TaskExecutor::default()), CHAIN_GENESIS)
-			.into_rpc();
+	let api = Archive::new(client.clone(), CHAIN_GENESIS).into_rpc();
 
 	(client, api)
 }

--- a/substrate/client/rpc-spec-v2/src/archive/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/tests.rs
@@ -1,0 +1,81 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::chain_head::hex_string;
+
+use super::{archive::Archive, *};
+
+use codec::Encode;
+use jsonrpsee::{types::EmptyServerParams as EmptyParams, RpcModule};
+use sc_block_builder::BlockBuilderProvider;
+
+use sp_consensus::BlockOrigin;
+use sp_core::testing::TaskExecutor;
+use std::sync::Arc;
+use substrate_test_runtime_client::{
+	prelude::*, runtime, Backend, BlockBuilderExt, Client, ClientBlockImportExt,
+};
+
+const CHAIN_GENESIS: [u8; 32] = [0; 32];
+
+type Block = substrate_test_runtime_client::runtime::Block;
+
+fn setup_api() -> (Arc<Client<Backend>>, RpcModule<Archive<Backend, Block, Client<Backend>>>) {
+	let builder = TestClientBuilder::new();
+	let backend = builder.backend();
+	let client = Arc::new(builder.build());
+
+	let api =
+		Archive::new(client.clone(), backend, Arc::new(TaskExecutor::default()), CHAIN_GENESIS)
+			.into_rpc();
+
+	(client, api)
+}
+
+#[tokio::test]
+async fn archive_genesis() {
+	let (_client, api) = setup_api();
+
+	let genesis: String =
+		api.call("archive_unstable_genesisHash", EmptyParams::new()).await.unwrap();
+	assert_eq!(genesis, hex_string(&CHAIN_GENESIS));
+}
+
+#[tokio::test]
+async fn archive_body() {
+	let (mut client, api) = setup_api();
+
+	// Import a new block with an extrinsic.
+	let mut builder = client.new_block(Default::default()).unwrap();
+	builder
+		.push_transfer(runtime::Transfer {
+			from: AccountKeyring::Alice.into(),
+			to: AccountKeyring::Ferdie.into(),
+			amount: 42,
+			nonce: 0,
+		})
+		.unwrap();
+	let block = builder.build().unwrap().block;
+	let block_hash = format!("{:?}", block.header.hash());
+	client.import(BlockOrigin::Own, block.clone()).await.unwrap();
+
+	let expected_tx = hex_string(&block.extrinsics[0].encode());
+
+	let body: Vec<String> = api.call("archive_unstable_body", [block_hash]).await.unwrap();
+	assert_eq!(vec![expected_tx], body);
+}


### PR DESCRIPTION
This PR lays the foundation for implementing the archive RPC methods.

The methods implemented by this PR:
- archive_unstable_body: Fetch the block's body (a vector of hex-encoded scale-encoded extrinsics) from a given block hash
- archive_unstable_genesisHash: Fetch the genesis hash
- archive_unstable_header: Fetch the header from a given block hash

Added unit tests for the methods.

This PR is implementing the methods without exposing them to the RPC layer; which are to be exposed by a follow-up PR.

Closes: https://github.com/paritytech/polkadot-sdk/issues/1509 
Closes: https://github.com/paritytech/polkadot-sdk/issues/1514

@paritytech/subxt-team 