### PR TITLE
Prevent opening another substream right after the connection is closed

### DIFF
--- a/substrate/client/network/src/protocol/notifications/behaviour.rs
+++ b/substrate/client/network/src/protocol/notifications/behaviour.rs
@@ -491,7 +491,13 @@ impl Notifications {
 					.iter()
 					.any(|(_, s)| matches!(s, ConnectionState::Opening)));
 
-				*entry.into_mut() = PeerState::Disabled { connections, backoff_until: None }
+				// Prevent opening another substream on the same set over the same connection right
+				// after it has been closed.
+				let ban_duration = Uniform::new(5, 10).sample(&mut rand::thread_rng());
+				*entry.into_mut() = PeerState::Disabled {
+					connections,
+					backoff_until: Some(Instant::now() + Duration::from_secs(ban_duration)),
+				};
 			},
 
 			// Incoming => Disabled.
@@ -787,7 +793,13 @@ impl Notifications {
 					*connec_state = ConnectionState::Closing;
 				}
 
-				*entry.into_mut() = PeerState::Disabled { connections, backoff_until: None }
+				// Prevent opening another substream on the same set over the same connection right
+				// after it has been closed.
+				let ban_duration = Uniform::new(5, 10).sample(&mut rand::thread_rng());
+				*entry.into_mut() = PeerState::Disabled {
+					connections,
+					backoff_until: Some(Instant::now() + Duration::from_secs(ban_duration)),
+				};
 			},
 
 			// Requested => Ø


### PR DESCRIPTION
Back-off wasn't applied to locally closed or rejected connections which could cause `ProtocolController` to reconnect to the node right after a connection to them had been closed. Remote mightn't have noticed that a connection was closed and the immediate reconnection would cause remote side substream to not work as it was no longer writable.