### PR TITLE
Update the alerts to use a new metric substrate_unbounded_channel_size

### DIFF
--- a/substrate/scripts/ci/monitoring/alerting-rules/alerting-rules.yaml
+++ b/substrate/scripts/ci/monitoring/alerting-rules/alerting-rules.yaml
@@ -146,11 +146,7 @@ groups:
       hours.'
 
   - alert: UnboundedChannelPersistentlyLarge
-    expr: '(
-        (substrate_unbounded_channel_len{action = "send"} -
-            ignoring(action) substrate_unbounded_channel_len{action = "received"})
-        or on(instance) substrate_unbounded_channel_len{action = "send"}
-    ) >= 200'
+    expr: 'substrate_unbounded_channel_size >= 200'
     for: 5m
     labels:
       severity: warning


### PR DESCRIPTION
# Description

Follow up for https://github.com/paritytech/polkadot-sdk/pull/1489.
Closes #611 

Before we calculated the channel size during alert expression but in #1489 a new metric was introduced that reports channel size.
## Changes:
1. updated alert rule to use new metric. 

