### PR TITLE
xcm-builder: PayOverXcm supports fallible convertors for asset kind and beneficiary conversion 

### DIFF
--- a/polkadot/xcm/xcm-builder/src/location_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/location_conversion.rs
@@ -18,7 +18,7 @@ use crate::universal_exports::ensure_is_remote;
 use frame_support::traits::Get;
 use parity_scale_codec::{Compact, Decode, Encode};
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{AccountIdConversion, Convert, TrailingZeroInput};
+use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput, TryConvert};
 use sp_std::{marker::PhantomData, prelude::*};
 use xcm::latest::prelude::*;
 use xcm_executor::traits::ConvertLocation;
@@ -322,10 +322,10 @@ impl<Network: Get<Option<NetworkId>>, AccountId: From<[u8; 32]> + Into<[u8; 32]>
 /// network (provided by `Network`) and the `AccountId`'s `[u8; 32]` datum for the `id`.
 pub struct AliasesIntoAccountId32<Network, AccountId>(PhantomData<(Network, AccountId)>);
 impl<'a, Network: Get<Option<NetworkId>>, AccountId: Clone + Into<[u8; 32]> + Clone>
-	Convert<&'a AccountId, MultiLocation> for AliasesIntoAccountId32<Network, AccountId>
+	TryConvert<&'a AccountId, MultiLocation> for AliasesIntoAccountId32<Network, AccountId>
 {
-	fn convert(who: &AccountId) -> MultiLocation {
-		AccountId32 { network: Network::get(), id: who.clone().into() }.into()
+	fn try_convert(who: &AccountId) -> Result<MultiLocation, &AccountId> {
+		Ok(AccountId32 { network: Network::get(), id: who.clone().into() }.into())
 	}
 }
 

--- a/polkadot/xcm/xcm-builder/src/tests/pay/pay.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/pay/pay.rs
@@ -29,9 +29,9 @@ pub struct AssetKind {
 }
 
 pub struct LocatableAssetKindConverter;
-impl sp_runtime::traits::Convert<AssetKind, LocatableAssetId> for LocatableAssetKindConverter {
-	fn convert(value: AssetKind) -> LocatableAssetId {
-		LocatableAssetId { asset_id: value.asset_id, location: value.destination }
+impl sp_runtime::traits::TryConvert<AssetKind, LocatableAssetId> for LocatableAssetKindConverter {
+	fn try_convert(value: AssetKind) -> Result<LocatableAssetId, AssetKind> {
+		Ok(LocatableAssetId { asset_id: value.asset_id, location: value.destination })
 	}
 }
 


### PR DESCRIPTION
`PayOverXcm` type accepts two converters to transform the `AssetKind` and `Beneficiary` parameter types into recognized `xcm` types. In this PR, we've modified the bounds for these converters, transitioning from `Convert` to `TryConvert`.

One such use case for this adjustment is when dealing with versioned xcm types for `AssetKind` and `Beneficiary`. These types might be not convertible to the latest xcm version, hence the need for fallible conversion.

This changes required for https://github.com/paritytech/polkadot-sdk/pull/1333