### PR TITLE
Fix code duplication in tests

### DIFF
--- a/polkadot/node/core/backing/src/tests/mod.rs
+++ b/polkadot/node/core/backing/src/tests/mod.rs
@@ -18,7 +18,7 @@ use self::test_helpers::mock::new_leaf;
 use super::*;
 use ::test_helpers::{
 	dummy_candidate_receipt_bad_sig, dummy_collator, dummy_collator_signature,
-	dummy_committed_candidate_receipt, dummy_hash,
+	dummy_committed_candidate_receipt, dummy_hash, validator_pubkeys
 };
 use assert_matches::assert_matches;
 use futures::{future, Future};
@@ -47,10 +47,6 @@ mod prospective_parachains;
 
 const ASYNC_BACKING_DISABLED_ERROR: RuntimeApiError =
 	RuntimeApiError::NotSupported { runtime_api_name: "test-runtime" };
-
-fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
-	val_ids.iter().map(|v| v.public().into()).collect()
-}
 
 fn table_statement_to_primitive(statement: TableStatement) -> Statement {
 	match statement {

--- a/polkadot/node/core/backing/src/tests/mod.rs
+++ b/polkadot/node/core/backing/src/tests/mod.rs
@@ -295,7 +295,7 @@ async fn test_startup(virtual_overseer: &mut VirtualOverseer, test_state: &TestS
 	);
 }
 
-async fn handle_validation_requests(virtual_overseer: &mut VirtualOverseer, validation_code: ValidationCode) {
+async fn test_validation_requests(virtual_overseer: &mut VirtualOverseer, validation_code: ValidationCode) {
 	assert_matches!(
 			virtual_overseer.recv().await,
 			AllMessages::RuntimeApi(
@@ -324,7 +324,7 @@ async fn handle_validation_requests(virtual_overseer: &mut VirtualOverseer, vali
 		);
 }
 
-async fn handle_validate_from_exhaustive(virtual_overseer: &mut VirtualOverseer, pvd: &PersistedValidationData, pov: &PoV, validation_code: &ValidationCode, candidate: &CommittedCandidateReceipt, expected_head_data: &HeadData, result_validation_data: PersistedValidationData) {
+async fn test_validate_from_exhaustive(virtual_overseer: &mut VirtualOverseer, pvd: &PersistedValidationData, pov: &PoV, validation_code: &ValidationCode, candidate: &CommittedCandidateReceipt, expected_head_data: &HeadData, result_validation_data: PersistedValidationData) {
 	assert_matches!(
 			virtual_overseer.recv().await,
 			AllMessages::CandidateValidation(
@@ -394,9 +394,9 @@ fn backing_second_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
-		handle_validate_from_exhaustive(&mut virtual_overseer, &pvd, &pov, &validation_code, &candidate, expected_head_data, test_state.validation_data.clone()).await;
+		test_validate_from_exhaustive(&mut virtual_overseer, &pvd, &pov, &validation_code, &candidate, expected_head_data, test_state.validation_data.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -503,7 +503,7 @@ fn backing_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Sending a `Statement::Seconded` for our assignment will start
 		// validation process. The first thing requested is the PoV.
@@ -681,7 +681,7 @@ fn backing_works_while_validation_ongoing() {
 			CandidateBackingMessage::Statement(test_state.relay_parent, signed_a.clone());
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Sending a `Statement::Seconded` for our assignment will start
 		// validation process. The first thing requested is PoV from the
@@ -847,7 +847,7 @@ fn backing_misbehavior_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1027,7 +1027,7 @@ fn backing_dont_second_invalid() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code_a.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code_a.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1067,7 +1067,7 @@ fn backing_dont_second_invalid() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code_b.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code_b.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1179,7 +1179,7 @@ fn backing_second_after_first_fails_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Subsystem requests PoV and requests validation.
 		assert_matches!(
@@ -1262,7 +1262,7 @@ fn backing_second_after_first_fails_works() {
 		// triggered on the prev step.
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code_to_second.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code_to_second.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1323,7 +1323,7 @@ fn backing_works_after_failed_validation() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Subsystem requests PoV and requests validation.
 		assert_matches!(
@@ -1526,7 +1526,7 @@ fn retry_works() {
 			CandidateBackingMessage::Statement(test_state.relay_parent, signed_a.clone());
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Subsystem requests PoV and requests validation.
 		// We cancel - should mean retry on next backing statement.
@@ -1589,7 +1589,7 @@ fn retry_works() {
 			CandidateBackingMessage::Statement(test_state.relay_parent, signed_c.clone());
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1780,9 +1780,9 @@ fn cannot_second_multiple_candidates_per_parent() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
-		handle_validate_from_exhaustive(&mut virtual_overseer, &pvd, &pov, &validation_code, &candidate, expected_head_data, test_state.validation_data.clone()).await;
+		test_validate_from_exhaustive(&mut virtual_overseer, &pvd, &pov, &validation_code, &candidate, expected_head_data, test_state.validation_data.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1829,7 +1829,7 @@ fn cannot_second_multiple_candidates_per_parent() {
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
 		// The validation is still requested.
-		handle_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,

--- a/polkadot/node/core/backing/src/tests/mod.rs
+++ b/polkadot/node/core/backing/src/tests/mod.rs
@@ -295,7 +295,7 @@ async fn test_startup(virtual_overseer: &mut VirtualOverseer, test_state: &TestS
 	);
 }
 
-async fn test_validation_requests(
+async fn assert_validation_requests(
 	virtual_overseer: &mut VirtualOverseer,
 	validation_code: ValidationCode,
 ) {
@@ -327,7 +327,7 @@ async fn test_validation_requests(
 	);
 }
 
-async fn test_validate_from_exhaustive(
+async fn assert_validate_from_exhaustive(
 	virtual_overseer: &mut VirtualOverseer,
 	pvd: &PersistedValidationData,
 	pov: &PoV,
@@ -405,9 +405,9 @@ fn backing_second_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
-		test_validate_from_exhaustive(
+		assert_validate_from_exhaustive(
 			&mut virtual_overseer,
 			&pvd,
 			&pov,
@@ -523,7 +523,7 @@ fn backing_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Sending a `Statement::Seconded` for our assignment will start
 		// validation process. The first thing requested is the PoV.
@@ -701,7 +701,7 @@ fn backing_works_while_validation_ongoing() {
 			CandidateBackingMessage::Statement(test_state.relay_parent, signed_a.clone());
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Sending a `Statement::Seconded` for our assignment will start
 		// validation process. The first thing requested is PoV from the
@@ -867,7 +867,7 @@ fn backing_misbehavior_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1047,7 +1047,7 @@ fn backing_dont_second_invalid() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code_a.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code_a.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1087,7 +1087,7 @@ fn backing_dont_second_invalid() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code_b.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code_b.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1199,7 +1199,7 @@ fn backing_second_after_first_fails_works() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Subsystem requests PoV and requests validation.
 		assert_matches!(
@@ -1282,7 +1282,7 @@ fn backing_second_after_first_fails_works() {
 		// triggered on the prev step.
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code_to_second.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code_to_second.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1343,7 +1343,7 @@ fn backing_works_after_failed_validation() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Subsystem requests PoV and requests validation.
 		assert_matches!(
@@ -1546,7 +1546,7 @@ fn retry_works() {
 			CandidateBackingMessage::Statement(test_state.relay_parent, signed_a.clone());
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		// Subsystem requests PoV and requests validation.
 		// We cancel - should mean retry on next backing statement.
@@ -1609,7 +1609,7 @@ fn retry_works() {
 			CandidateBackingMessage::Statement(test_state.relay_parent, signed_c.clone());
 		virtual_overseer.send(FromOrchestra::Communication { msg: statement }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,
@@ -1800,9 +1800,9 @@ fn cannot_second_multiple_candidates_per_parent() {
 
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
-		test_validate_from_exhaustive(
+		assert_validate_from_exhaustive(
 			&mut virtual_overseer,
 			&pvd,
 			&pov,
@@ -1858,7 +1858,7 @@ fn cannot_second_multiple_candidates_per_parent() {
 		virtual_overseer.send(FromOrchestra::Communication { msg: second }).await;
 
 		// The validation is still requested.
-		test_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
+		assert_validation_requests(&mut virtual_overseer, validation_code.clone()).await;
 
 		assert_matches!(
 			virtual_overseer.recv().await,

--- a/polkadot/node/core/backing/src/tests/prospective_parachains.rs
+++ b/polkadot/node/core/backing/src/tests/prospective_parachains.rs
@@ -208,7 +208,7 @@ async fn assert_validate_seconded_candidate(
 	expected_head_data: &HeadData,
 	fetch_pov: bool,
 ) {
-	handle_validation_requests(virtual_overseer, validation_code.clone()).await;
+	test_validation_requests(virtual_overseer, validation_code.clone()).await;
 
 	if fetch_pov {
 		assert_matches!(

--- a/polkadot/node/core/backing/src/tests/prospective_parachains.rs
+++ b/polkadot/node/core/backing/src/tests/prospective_parachains.rs
@@ -208,32 +208,7 @@ async fn assert_validate_seconded_candidate(
 	expected_head_data: &HeadData,
 	fetch_pov: bool,
 ) {
-	assert_matches!(
-		virtual_overseer.recv().await,
-		AllMessages::RuntimeApi(
-			RuntimeApiMessage::Request(parent, RuntimeApiRequest::ValidationCodeByHash(hash, tx))
-		) if parent == relay_parent && hash == validation_code.hash() => {
-			tx.send(Ok(Some(validation_code.clone()))).unwrap();
-		}
-	);
-
-	assert_matches!(
-		virtual_overseer.recv().await,
-		AllMessages::RuntimeApi(
-			RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))
-		) => {
-			tx.send(Ok(1u32.into())).unwrap();
-		}
-	);
-
-	assert_matches!(
-		virtual_overseer.recv().await,
-		AllMessages::RuntimeApi(
-			RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(sess_idx, tx))
-		) if sess_idx == 1 => {
-			tx.send(Ok(Some(ExecutorParams::default()))).unwrap();
-		}
-	);
+	handle_validation_requests(virtual_overseer, validation_code.clone()).await;
 
 	if fetch_pov {
 		assert_matches!(

--- a/polkadot/node/core/backing/src/tests/prospective_parachains.rs
+++ b/polkadot/node/core/backing/src/tests/prospective_parachains.rs
@@ -208,7 +208,7 @@ async fn assert_validate_seconded_candidate(
 	expected_head_data: &HeadData,
 	fetch_pov: bool,
 ) {
-	test_validation_requests(virtual_overseer, validation_code.clone()).await;
+	assert_validation_requests(virtual_overseer, validation_code.clone()).await;
 
 	if fetch_pov {
 		assert_matches!(

--- a/polkadot/node/core/pvf-checker/src/tests.rs
+++ b/polkadot/node/core/pvf-checker/src/tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use ::test_helpers::{dummy_digest, dummy_hash};
+use ::test_helpers::{dummy_digest, dummy_hash, validator_pubkeys};
 use futures::{channel::oneshot, future::BoxFuture, prelude::*};
 use polkadot_node_subsystem::{
 	messages::{
@@ -93,10 +93,6 @@ struct TestState {
 }
 
 const OUR_VALIDATOR: Sr25519Keyring = Sr25519Keyring::Alice;
-
-fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
-	val_ids.iter().map(|v| v.public().into()).collect()
-}
 
 impl TestState {
 	fn new() -> Self {

--- a/polkadot/primitives/test-helpers/src/lib.rs
+++ b/polkadot/primitives/test-helpers/src/lib.rs
@@ -308,5 +308,3 @@ impl rand::RngCore for AlwaysZeroRng {
 		Ok(())
 	}
 }
-
-

--- a/polkadot/primitives/test-helpers/src/lib.rs
+++ b/polkadot/primitives/test-helpers/src/lib.rs
@@ -159,6 +159,11 @@ pub fn dummy_pvd(parent_head: HeadData, relay_parent_number: u32) -> PersistedVa
 	}
 }
 
+/// Creates a meaningless signature
+pub fn dummy_signature() -> polkadot_primitives::ValidatorSignature {
+	sp_core::crypto::UncheckedFrom::unchecked_from([1u8; 64])
+}
+
 /// Create a meaningless candidate, returning its receipt and PVD.
 pub fn make_candidate(
 	relay_parent_hash: Hash,
@@ -244,6 +249,11 @@ pub fn resign_candidate_descriptor_with_collator<H: AsRef<[u8]>>(
 	descriptor.signature = signature;
 }
 
+/// Extracts validators's public keus (`ValidatorId`) from `Sr25519Keyring`
+pub fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
+	val_ids.iter().map(|v| v.public().into()).collect()
+}
+
 /// Builder for `CandidateReceipt`.
 pub struct TestCandidateBuilder {
 	pub para_id: ParaId,
@@ -299,6 +309,4 @@ impl rand::RngCore for AlwaysZeroRng {
 	}
 }
 
-pub fn dummy_signature() -> polkadot_primitives::ValidatorSignature {
-	sp_core::crypto::UncheckedFrom::unchecked_from([1u8; 64])
-}
+

--- a/polkadot/runtime/parachains/src/paras/tests.rs
+++ b/polkadot/runtime/parachains/src/paras/tests.rs
@@ -21,7 +21,7 @@ use primitives::{BlockNumber, ValidatorId, PARACHAIN_KEY_TYPE_ID};
 use sc_keystore::LocalKeystore;
 use sp_keystore::{Keystore, KeystorePtr};
 use std::sync::Arc;
-use test_helpers::{dummy_head_data, dummy_validation_code};
+use test_helpers::{dummy_head_data, dummy_validation_code, validator_pubkeys};
 
 use crate::{
 	configuration::HostConfiguration,
@@ -38,10 +38,6 @@ static VALIDATORS: &[Sr25519Keyring] = &[
 	Sr25519Keyring::Dave,
 	Sr25519Keyring::Ferdie,
 ];
-
-fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
-	val_ids.iter().map(|v| v.public().into()).collect()
-}
 
 fn sign_and_include_pvf_check_statement(stmt: PvfCheckStatement) {
 	let validators = &[

--- a/polkadot/runtime/parachains/src/paras/tests.rs
+++ b/polkadot/runtime/parachains/src/paras/tests.rs
@@ -17,7 +17,7 @@
 use super::*;
 use frame_support::{assert_err, assert_ok, assert_storage_noop};
 use keyring::Sr25519Keyring;
-use primitives::{BlockNumber, ValidatorId, PARACHAIN_KEY_TYPE_ID};
+use primitives::{BlockNumber, PARACHAIN_KEY_TYPE_ID};
 use sc_keystore::LocalKeystore;
 use sp_keystore::{Keystore, KeystorePtr};
 use std::sync::Arc;

--- a/polkadot/runtime/parachains/src/shared/tests.rs
+++ b/polkadot/runtime/parachains/src/shared/tests.rs
@@ -22,10 +22,7 @@ use crate::{
 use assert_matches::assert_matches;
 use keyring::Sr25519Keyring;
 use primitives::Hash;
-
-fn validator_pubkeys(val_ids: &[Sr25519Keyring]) -> Vec<ValidatorId> {
-	val_ids.iter().map(|v| v.public().into()).collect()
-}
+use test_helpers::validator_pubkeys;
 
 #[test]
 fn tracker_earliest_block_number() {


### PR DESCRIPTION
The PR contains two changes:
* Extract some duplicated code from backing tests as functions.
* Move `validator_pubkeys` to test helpers