### PR TITLE
[Backport] Version bumps from release 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12340,7 +12340,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-bin"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "asset-hub-kusama-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11395,7 +11395,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11528,7 +11528,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap 4.4.3",
  "frame-benchmarking-cli",

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-parachain-bin"
-version = "1.0.0"
+version = "1.1.0"
 authors.workspace = true
 build = "build.rs"
 edition.workspace = true

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.64.0"
 readme = "README.md"
 authors.workspace = true
 edition.workspace = true
-version = "1.0.0"
+version = "1.1.0"
 default-run = "polkadot"
 
 [dependencies]

--- a/polkadot/cli/Cargo.toml
+++ b/polkadot/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polkadot-cli"
 description = "Polkadot Relay-chain Client Node"
-version = "1.0.0"
+version = "1.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This PR backports version bumps for `polkadot` and `polkadot-parachain` from the v1.1.0 release branch