### PR TITLE
archive: Implement height, hashByHeight and call

### DIFF
--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -62,5 +62,16 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_finalizedHeight")]
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u64>;
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u32>;
+
+	/// Get the hashes of blocks from the given height.
+	///
+	/// Returns an array (possibly empty) of strings containing an hexadecimal-encoded hash of a
+	/// block header.
+	///
+	/// # Unstable
+	///
+	/// This method is unstable and subject to change in the future.
+	#[method(name = "archive_unstable_hashByHeight")]
+	fn archive_unstable_hash_by_height(&self, height: u32) -> RpcResult<Vec<String>>;
 }

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -18,6 +18,7 @@
 
 //! API trait of the archive methods.
 
+use crate::MethodResult;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 #[rpc(client, server)]
@@ -86,5 +87,5 @@ pub trait ArchiveApi<Hash> {
 		hash: Hash,
 		function: String,
 		call_parameters: String,
-	) -> RpcResult<String>;
+	) -> RpcResult<MethodResult>;
 }

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -19,7 +19,6 @@
 //! API trait of the archive methods.
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use serde::{Deserialize, Serialize};
 
 #[rpc(client, server)]
 pub trait ArchiveApi<Hash> {
@@ -87,35 +86,5 @@ pub trait ArchiveApi<Hash> {
 		hash: Hash,
 		function: String,
 		call_parameters: String,
-	) -> RpcResult<ArchiveCallResult>;
-}
-
-/// The successful result of `archive_unstable_call`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ArchiveCallOk {
-	/// True if the call was successful.
-	pub success: bool,
-	/// The result of the call.
-	pub value: String,
-}
-
-/// The error result of `archive_unstable_call`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ArchiveCallError {
-	/// True if the call was successful.
-	pub success: bool,
-	/// The error reason.
-	pub error: String,
-}
-
-/// The result of `archive_unstable_call`.
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-#[serde(untagged)]
-pub enum ArchiveCallResult {
-	/// The call was successful.
-	Ok(ArchiveCallOk),
-	/// The call produced an error.
-	Err(ArchiveCallError),
+	) -> RpcResult<String>;
 }

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -53,4 +53,14 @@ pub trait ArchiveApi<Hash> {
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_header")]
 	fn archive_unstable_header(&self, hash: Hash) -> RpcResult<Option<String>>;
+
+	/// Get the height of the current finalized block.
+	///
+	/// Returns an integer height of the current finalized block of the chain.
+	///
+	/// # Unstable
+	///
+	/// This method is unstable and subject to change in the future.
+	#[method(name = "archive_unstable_finalizedHeight")]
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u64>;
 }

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -19,6 +19,7 @@
 //! API trait of the archive methods.
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use serde::{Deserialize, Serialize};
 
 #[rpc(client, server)]
 pub trait ArchiveApi<Hash> {
@@ -74,4 +75,47 @@ pub trait ArchiveApi<Hash> {
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_hashByHeight")]
 	fn archive_unstable_hash_by_height(&self, height: u32) -> RpcResult<Vec<String>>;
+
+	/// Call into the Runtime API at a specified block's state.
+	///
+	/// # Unstable
+	///
+	/// This method is unstable and subject to change in the future.
+	#[method(name = "archive_unstable_call")]
+	fn archive_unstable_call(
+		&self,
+		hash: Hash,
+		function: String,
+		call_parameters: String,
+	) -> RpcResult<ArchiveCallResult>;
+}
+
+/// The successful result of `archive_unstable_call`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveCallOk {
+	/// True if the call was successful.
+	pub success: bool,
+	/// The result of the call.
+	pub value: String,
+}
+
+/// The error result of `archive_unstable_call`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveCallError {
+	/// True if the call was successful.
+	pub success: bool,
+	/// The error reason.
+	pub error: String,
+}
+
+/// The result of `archive_unstable_call`.
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum ArchiveCallResult {
+	/// The call was successful.
+	Ok(ArchiveCallOk),
+	/// The call produced an error.
+	Err(ArchiveCallError),
 }

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -62,7 +62,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_finalizedHeight")]
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u32>;
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u64>;
 
 	/// Get the hashes of blocks from the given height.
 	///
@@ -73,7 +73,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_hashByHeight")]
-	fn archive_unstable_hash_by_height(&self, height: u32) -> RpcResult<Vec<String>>;
+	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>>;
 
 	/// Call into the Runtime API at a specified block's state.
 	///

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -117,7 +117,7 @@ where
 
 		while let Some(parent) = next_hash.pop() {
 			if parent.number == height {
-				result.push(parent.hash);
+				result.push(hex_string(&parent.hash.as_ref()));
 				continue
 			}
 
@@ -129,6 +129,6 @@ where
 			}
 		}
 
-		Ok(vec![])
+		Ok(result)
 	}
 }

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -85,6 +85,6 @@ where
 	}
 
 	fn archive_unstable_finalized_height(&self) -> RpcResult<u64> {
-		Ok(self.client.info().best_number.saturated_into())
+		Ok(self.client.info().finalized_number.saturated_into())
 	}
 }

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -25,7 +25,7 @@ use jsonrpsee::core::{async_trait, RpcResult};
 use sc_client_api::{Backend, BlockBackend, BlockchainEvents, ExecutorProvider, StorageProvider};
 use sp_api::CallApiAt;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::{traits::Block as BlockT, SaturatedConversion};
 use std::{marker::PhantomData, sync::Arc};
 
 /// An API for archive RPC calls.
@@ -82,5 +82,9 @@ where
 		let Ok(Some(header)) = self.client.header(hash) else { return Ok(None) };
 
 		Ok(Some(hex_string(&header.encode())))
+	}
+
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u64> {
+		Ok(self.client.info().best_number.saturated_into())
 	}
 }

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -72,10 +72,7 @@ fn parse_hex_param(param: String) -> Result<Vec<u8>, ArchiveError> {
 		return Ok(Default::default())
 	}
 
-	match array_bytes::hex2bytes(&param) {
-		Ok(bytes) => Ok(bytes),
-		Err(_) => Err(ArchiveError::InvalidParam(param)),
-	}
+	array_bytes::hex2bytes(&param).map_err(|_| ArchiveError::InvalidParam(param))
 }
 
 #[async_trait]

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -153,11 +153,11 @@ where
 			}
 
 			let parent_hash = *header.parent_hash();
-			let Ok(Some(next_header)) = self.client.header(parent_hash) else { continue };
 
 			// Continue the iteration for unique hashes.
 			// Forks might intersect on a common chain that is not yet finalized.
 			if visited.insert(parent_hash) {
+				let Ok(Some(next_header)) = self.client.header(parent_hash) else { continue };
 				headers.push(next_header);
 			}
 		}

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -34,7 +34,7 @@ use sp_blockchain::{
 };
 use sp_core::Bytes;
 use sp_runtime::{
-	traits::{Block as BlockT, Header},
+	traits::{Block as BlockT, Header as HeaderT},
 	SaturatedConversion,
 };
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};
@@ -80,6 +80,7 @@ impl<BE, Block, Client> ArchiveApiServer<Block::Hash> for Archive<BE, Block, Cli
 where
 	Block: BlockT + 'static,
 	Block::Header: Unpin,
+	<<Block as BlockT>::Header as HeaderT>::Number: From<u64>,
 	BE: Backend<Block> + 'static,
 	Client: BlockBackend<Block>
 		+ ExecutorProvider<Block>
@@ -113,11 +114,11 @@ where
 		Ok(Some(hex_string(&header.encode())))
 	}
 
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u32> {
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u64> {
 		Ok(self.client.info().finalized_number.saturated_into())
 	}
 
-	fn archive_unstable_hash_by_height(&self, height: u32) -> RpcResult<Vec<String>> {
+	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>> {
 		let height: NumberFor<Block> = height.into();
 		let finalized_num = self.client.info().finalized_number;
 

--- a/substrate/client/rpc-spec-v2/src/archive/error.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/error.rs
@@ -32,6 +32,9 @@ pub enum Error {
 	/// Runtime call failed.
 	#[error("Runtime call: {0}")]
 	RuntimeCall(String),
+	/// Failed to fetch leaves.
+	#[error("Failed to fetch leaves of the chain: {0}")]
+	FetchLeaves(String),
 }
 
 // Base code for all `archive` errors.
@@ -40,6 +43,8 @@ const BASE_ERROR: i32 = 3000;
 const INVALID_PARAM_ERROR: i32 = BASE_ERROR + 1;
 /// Runtime call error.
 const RUNTIME_CALL_ERROR: i32 = BASE_ERROR + 2;
+/// Failed to fetch leaves.
+const FETCH_LEAVES_ERROR: i32 = BASE_ERROR + 3;
 
 impl From<Error> for ErrorObject<'static> {
 	fn from(e: Error) -> Self {
@@ -48,6 +53,7 @@ impl From<Error> for ErrorObject<'static> {
 		match e {
 			Error::InvalidParam(_) => ErrorObject::owned(INVALID_PARAM_ERROR, msg, None::<()>),
 			Error::RuntimeCall(_) => ErrorObject::owned(RUNTIME_CALL_ERROR, msg, None::<()>),
+			Error::FetchLeaves(_) => ErrorObject::owned(FETCH_LEAVES_ERROR, msg, None::<()>),
 		}
 		.into()
 	}

--- a/substrate/client/rpc-spec-v2/src/archive/error.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/error.rs
@@ -29,12 +29,17 @@ pub enum Error {
 	/// Invalid parameter provided to the RPC method.
 	#[error("Invalid parameter: {0}")]
 	InvalidParam(String),
+	/// Runtime call failed.
+	#[error("Runtime call: {0}")]
+	RuntimeCall(String),
 }
 
 // Base code for all `archive` errors.
 const BASE_ERROR: i32 = 3000;
 /// Invalid parameter error.
 const INVALID_PARAM_ERROR: i32 = BASE_ERROR + 1;
+/// Runtime call error.
+const RUNTIME_CALL_ERROR: i32 = BASE_ERROR + 2;
 
 impl From<Error> for ErrorObject<'static> {
 	fn from(e: Error) -> Self {
@@ -42,6 +47,7 @@ impl From<Error> for ErrorObject<'static> {
 
 		match e {
 			Error::InvalidParam(_) => ErrorObject::owned(INVALID_PARAM_ERROR, msg, None::<()>),
+			Error::RuntimeCall(_) => ErrorObject::owned(RUNTIME_CALL_ERROR, msg, None::<()>),
 		}
 		.into()
 	}

--- a/substrate/client/rpc-spec-v2/src/archive/error.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/error.rs
@@ -16,17 +16,39 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Substrate archive API.
-//!
-//! # Note
-//!
-//! Methods are prefixed by `archive`.
+//! Error helpers for `archive` RPC module.
 
-#[cfg(test)]
-mod tests;
+use jsonrpsee::{
+	core::Error as RpcError,
+	types::error::{CallError, ErrorObject},
+};
 
-pub mod api;
-pub mod archive;
-pub mod error;
+/// ChainHead RPC errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	/// Invalid parameter provided to the RPC method.
+	#[error("Invalid parameter: {0}")]
+	InvalidParam(String),
+}
 
-pub use api::ArchiveApiServer;
+// Base code for all `archive` errors.
+const BASE_ERROR: i32 = 3000;
+/// Invalid parameter error.
+const INVALID_PARAM_ERROR: i32 = BASE_ERROR + 1;
+
+impl From<Error> for ErrorObject<'static> {
+	fn from(e: Error) -> Self {
+		let msg = e.to_string();
+
+		match e {
+			Error::InvalidParam(_) => ErrorObject::owned(INVALID_PARAM_ERROR, msg, None::<()>),
+		}
+		.into()
+	}
+}
+
+impl From<Error> for RpcError {
+	fn from(e: Error) -> Self {
+		CallError::Custom(e.into()).into()
+	}
+}

--- a/substrate/client/rpc-spec-v2/src/archive/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/tests.rs
@@ -23,8 +23,10 @@ use super::{archive::Archive, *};
 use codec::{Decode, Encode};
 use jsonrpsee::{types::EmptyServerParams as EmptyParams, RpcModule};
 use sc_block_builder::BlockBuilderProvider;
-
+use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockOrigin;
+use sp_core::testing::TaskExecutor;
+use sp_runtime::SaturatedConversion;
 use std::sync::Arc;
 use substrate_test_runtime_client::{
 	prelude::*, runtime, Backend, BlockBuilderExt, Client, ClientBlockImportExt,
@@ -110,4 +112,16 @@ async fn archive_header() {
 	let bytes = array_bytes::hex2bytes(&header).unwrap();
 	let header: Header = Decode::decode(&mut &bytes[..]).unwrap();
 	assert_eq!(header, block.header);
+}
+
+#[tokio::test]
+async fn archive_finalized_height() {
+	let (client, api) = setup_api();
+
+	let client_height: u64 = client.info().finalized_number.saturated_into();
+
+	let height: u64 =
+		api.call("archive_unstable_finalizedHeight", EmptyParams::new()).await.unwrap();
+
+	assert_eq!(client_height, height);
 }

--- a/substrate/client/rpc-spec-v2/src/archive/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/tests.rs
@@ -186,7 +186,6 @@ async fn archive_hash_by_height() {
 	// Test nonfinalized heights.
 	// Height N must include block 1.
 	let mut height = block_1.header.number;
-	println!("Heigh {:?}", height);
 	let hashes: Vec<String> = api.call("archive_unstable_hashByHeight", [height]).await.unwrap();
 	assert_eq!(hashes, vec![format!("{:?}", block_1_hash)]);
 

--- a/substrate/client/rpc-spec-v2/src/archive/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/tests.rs
@@ -118,9 +118,9 @@ async fn archive_header() {
 async fn archive_finalized_height() {
 	let (client, api) = setup_api();
 
-	let client_height: u64 = client.info().finalized_number.saturated_into();
+	let client_height: u32 = client.info().finalized_number.saturated_into();
 
-	let height: u64 =
+	let height: u32 =
 		api.call("archive_unstable_finalizedHeight", EmptyParams::new()).await.unwrap();
 
 	assert_eq!(client_height, height);

--- a/substrate/client/rpc-spec-v2/src/lib.rs
+++ b/substrate/client/rpc-spec-v2/src/lib.rs
@@ -23,6 +23,8 @@
 #![warn(missing_docs)]
 #![deny(unused_crate_dependencies)]
 
+use serde::{Deserialize, Serialize};
+
 pub mod archive;
 pub mod chain_head;
 pub mod chain_spec;
@@ -30,3 +32,74 @@ pub mod transaction;
 
 /// Task executor that is being used by RPC subscriptions.
 pub type SubscriptionTaskExecutor = std::sync::Arc<dyn sp_core::traits::SpawnNamed>;
+
+/// The result of an RPC method.
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum MethodResult {
+	/// Method generated a result.
+	Ok(MethodResultOk),
+	/// Method ecountered an error.
+	Err(MethodResultErr),
+}
+
+impl MethodResult {
+	/// Constructs a successful result.
+	pub fn ok(result: impl Into<String>) -> MethodResult {
+		MethodResult::Ok(MethodResultOk { success: true, result: result.into() })
+	}
+
+	/// Constructs an error result.
+	pub fn err(error: impl Into<String>) -> MethodResult {
+		MethodResult::Err(MethodResultErr { success: false, error: error.into() })
+	}
+}
+
+/// The successful result of an RPC method.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MethodResultOk {
+	/// Method was successful.
+	success: bool,
+	/// The result of the method.
+	pub result: String,
+}
+
+/// The error result of an RPC method.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MethodResultErr {
+	/// Method encountered an error.
+	success: bool,
+	/// The error of the method.
+	pub error: String,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn method_result_ok() {
+		let ok = MethodResult::ok("hello");
+
+		let ser = serde_json::to_string(&ok).unwrap();
+		let exp = r#"{"success":true,"result":"hello"}"#;
+		assert_eq!(ser, exp);
+
+		let ok_dec: MethodResult = serde_json::from_str(exp).unwrap();
+		assert_eq!(ok_dec, ok);
+	}
+
+	#[test]
+	fn method_result_error() {
+		let ok = MethodResult::err("hello");
+
+		let ser = serde_json::to_string(&ok).unwrap();
+		let exp = r#"{"success":false,"error":"hello"}"#;
+		assert_eq!(ser, exp);
+
+		let ok_dec: MethodResult = serde_json::from_str(exp).unwrap();
+		assert_eq!(ok_dec, ok);
+	}
+}


### PR DESCRIPTION
This PR implements:
- `archive_unstable_finalized_height`: Get the height of the most recent finalized block
- `archive_unstable_hash_by_height`: Get the hashes (possible empty) of blocks from the given height
- `archive_unstable_call`: Call into the runtime of a block

Builds on top of: https://github.com/paritytech/polkadot-sdk/pull/1560

### Testing Done
- unit tests for the methods with custom block tree for different heights / forks

Closes: https://github.com/paritytech/polkadot-sdk/issues/1510
Closes: https://github.com/paritytech/polkadot-sdk/issues/1513
Closes: https://github.com/paritytech/polkadot-sdk/issues/1511

@paritytech/subxt-team 