### PR TITLE
rpc-v2: Change method name for provided events

### DIFF
--- a/substrate/client/rpc-spec-v2/src/chain_head/api.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/api.rs
@@ -30,7 +30,7 @@ pub trait ChainHeadApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[subscription(
-		name = "chainHead_unstable_follow",
+		name = "chainHead_unstable_follow" => "chainHead_unstable_followEvent",
 		unsubscribe = "chainHead_unstable_unfollow",
 		item = FollowEvent<Hash>,
 	)]

--- a/substrate/client/rpc-spec-v2/src/transaction/api.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/api.rs
@@ -29,7 +29,7 @@ pub trait TransactionApi<Hash: Clone> {
 	/// See [`TransactionEvent`](crate::transaction::event::TransactionEvent) for details on
 	/// transaction life cycle.
 	#[subscription(
-		name = "transaction_unstable_submitAndWatch" => "transaction_unstable_submitExtrinsic",
+		name = "transaction_unstable_submitAndWatch" => "transaction_unstable_watchEvent",
 		unsubscribe = "transaction_unstable_unwatch",
 		item = TransactionEvent<Hash>,
 	)]


### PR DESCRIPTION
This PR changes the method name of the subscription that provides JSON-RPC notifications (ie subscription events).
This brings the raw JSON response in sync with the rpc-spec-v2 format.

Changes:
- `chainHead_unstable_follow` to `chainHead_unstable_followEvent` [spec/chainHead](https://github.com/paritytech/json-rpc-interface-spec/blob/main/src/api/chainHead_unstable_follow.md#notifications-format)
- `transaction_unstable_submitAndWatch` to `transaction_unstable_watchEvent` [spec/tx](https://github.com/paritytech/json-rpc-interface-spec/blob/main/src/api/transaction_unstable_submitAndWatch.md#notifications-format)

@paritytech/subxt-team 