### PR TITLE
Broker pallet: `RegionDropped` event fix & additional tests

### DIFF
--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -171,7 +171,9 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorMulti
 		let xcm = msg.take().ok_or(MissingArgument)?;
 
 		// find exporter
-		let Some((bridge, maybe_payment)) = Bridges::exporter_for(&remote_network, &remote_location, &xcm) else {
+		let Some((bridge, maybe_payment)) =
+			Bridges::exporter_for(&remote_network, &remote_location, &xcm)
+		else {
 			// We need to make sure that msg is not consumed in case of `NotApplicable`.
 			*msg = Some(xcm);
 			return Err(SendError::NotApplicable)
@@ -236,7 +238,9 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorMulti
 		let xcm = msg.take().ok_or(MissingArgument)?;
 
 		// find exporter
-		let Some((bridge, maybe_payment)) = Bridges::exporter_for(&remote_network, &remote_location, &xcm) else {
+		let Some((bridge, maybe_payment)) =
+			Bridges::exporter_for(&remote_network, &remote_location, &xcm)
+		else {
 			// We need to make sure that msg is not consumed in case of `NotApplicable`.
 			*msg = Some(xcm);
 			return Err(SendError::NotApplicable)

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -171,9 +171,7 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorMulti
 		let xcm = msg.take().ok_or(MissingArgument)?;
 
 		// find exporter
-		let Some((bridge, maybe_payment)) =
-			Bridges::exporter_for(&remote_network, &remote_location, &xcm)
-		else {
+		let Some((bridge, maybe_payment)) = Bridges::exporter_for(&remote_network, &remote_location, &xcm) else {
 			// We need to make sure that msg is not consumed in case of `NotApplicable`.
 			*msg = Some(xcm);
 			return Err(SendError::NotApplicable)
@@ -238,9 +236,7 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorMulti
 		let xcm = msg.take().ok_or(MissingArgument)?;
 
 		// find exporter
-		let Some((bridge, maybe_payment)) =
-			Bridges::exporter_for(&remote_network, &remote_location, &xcm)
-		else {
+		let Some((bridge, maybe_payment)) = Bridges::exporter_for(&remote_network, &remote_location, &xcm) else {
 			// We need to make sure that msg is not consumed in case of `NotApplicable`.
 			*msg = Some(xcm);
 			return Err(SendError::NotApplicable)

--- a/substrate/frame/broker/src/dispatchable_impls.rs
+++ b/substrate/frame/broker/src/dispatchable_impls.rs
@@ -76,7 +76,7 @@ impl<T: Config> Pallet<T> {
 			last_timeslice: Self::current_timeslice(),
 		};
 		let now = frame_system::Pallet::<T>::block_number();
-		let dummy_sale = SaleInfoRecord {
+		let new_sale = SaleInfoRecord {
 			sale_start: now,
 			leadin_length: Zero::zero(),
 			price,
@@ -89,7 +89,7 @@ impl<T: Config> Pallet<T> {
 			cores_sold: 0,
 		};
 		Self::deposit_event(Event::<T>::SalesStarted { price, core_count });
-		Self::rotate_sale(dummy_sale, &config, &status);
+		Self::rotate_sale(new_sale, &config, &status);
 		Status::<T>::put(&status);
 		Ok(())
 	}

--- a/substrate/frame/broker/src/utility_impls.rs
+++ b/substrate/frame/broker/src/utility_impls.rs
@@ -101,9 +101,9 @@ impl<T: Config> Pallet<T> {
 
 		let last_committed_timeslice = status.last_committed_timeslice;
 		if region_id.begin <= last_committed_timeslice {
+			let duration = region.end.saturating_sub(region_id.begin);
 			region_id.begin = last_committed_timeslice + 1;
 			if region_id.begin >= region.end {
-				let duration = region.end.saturating_sub(region_id.begin);
 				Self::deposit_event(Event::RegionDropped { region_id, duration });
 				return Ok(None)
 			}


### PR DESCRIPTION
This PR includes the following fix:
- [x] The `duration` is always set to zero in the `RegionDropped` event. This is fixed in this PR.

Also added some additional tests to cover some cases that aren't covered :
- [x] Selling a partitioned region to the instantaneous coretime pool.
- [x] Partitioning a region after assigning it to a particular task.
- [x] Interlacing a region after assigning it to a particular task.