### PR TITLE
Updates the ideal staking calculation in Polkadot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12573,6 +12573,7 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-reward-curve",
+ "pallet-staking-reward-fn",
  "pallet-staking-runtime-api",
  "pallet-timestamp",
  "pallet-tips",

--- a/polkadot/runtime/polkadot/Cargo.toml
+++ b/polkadot/runtime/polkadot/Cargo.toml
@@ -71,6 +71,7 @@ pallet-session = { path = "../../../substrate/frame/session", default-features =
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 pallet-staking = { path = "../../../substrate/frame/staking", default-features = false }
 pallet-staking-reward-curve = { path = "../../../substrate/frame/staking/reward-curve" }
+pallet-staking-reward-fn = { path = "../../../substrate/frame/staking/reward-fn", default-features = false }
 pallet-staking-runtime-api = { path = "../../../substrate/frame/staking/runtime-api", default-features = false }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }
 frame-system-rpc-runtime-api = { path = "../../../substrate/frame/system/rpc/runtime-api", default-features = false }

--- a/polkadot/runtime/polkadot/src/lib.rs
+++ b/polkadot/runtime/polkadot/src/lib.rs
@@ -545,6 +545,54 @@ parameter_types! {
 	pub const MaxNominations: u32 = <NposCompactSolution16 as frame_election_provider_support::NposSolution>::LIMIT as u32;
 }
 
+/// Custom version of `runtime_commong::era_payout` somewhat tailored for Polkadot's crowdloan
+/// unlock history. The only tweak should be
+///
+/// ```diff
+/// - let auction_proportion = Perquintill::from_rational(auctioned_slots.min(60), 200u64);
+/// + let auction_proportion = Perquintill::from_rational(auctioned_slots.min(60), 300u64);
+/// ```
+///
+/// See https://forum.polkadot.network/t/adjusting-polkadots-ideal-staking-rate-calculation/3897/2
+fn polkadot_era_payout(
+	total_staked: Balance,
+	total_stakable: Balance,
+	max_annual_inflation: Perquintill,
+	period_fraction: Perquintill,
+	auctioned_slots: u64,
+) -> (Balance, Balance) {
+	use pallet_staking_reward_fn::compute_inflation;
+	use sp_runtime::traits::Saturating;
+
+	let min_annual_inflation = Perquintill::from_rational(25u64, 1000u64);
+	let delta_annual_inflation = max_annual_inflation.saturating_sub(min_annual_inflation);
+
+	// 20% reserved for up to 60 slots.
+	let auction_proportion = Perquintill::from_rational(auctioned_slots.min(60), 300u64);
+
+	// Therefore the ideal amount at stake (as a percentage of total issuance) is 75% less the
+	// amount that we expect to be taken up with auctions.
+	let ideal_stake = Perquintill::from_percent(75).saturating_sub(auction_proportion);
+
+	let stake = Perquintill::from_rational(total_staked, total_stakable);
+	let falloff = Perquintill::from_percent(5);
+	let adjustment = compute_inflation(stake, ideal_stake, falloff);
+	let staking_inflation =
+		min_annual_inflation.saturating_add(delta_annual_inflation * adjustment);
+
+	let max_payout = period_fraction * max_annual_inflation * total_stakable;
+	let staking_payout = (period_fraction * staking_inflation) * total_stakable;
+	let rest = max_payout.saturating_sub(staking_payout);
+
+	let other_issuance = total_stakable.saturating_sub(total_staked);
+	if total_staked > other_issuance {
+		let _cap_rest = Perquintill::from_rational(other_issuance, total_staked) * staking_payout;
+		// We don't do anything with this, but if we wanted to, we could introduce a cap on the
+		// treasury amount with: `rest = rest.min(cap_rest);`
+	}
+	(staking_payout, rest)
+}
+
 pub struct EraPayout;
 impl pallet_staking::EraPayout<Balance> for EraPayout {
 	fn era_payout(
@@ -563,7 +611,7 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 		const MAX_ANNUAL_INFLATION: Perquintill = Perquintill::from_percent(10);
 		const MILLISECONDS_PER_YEAR: u64 = 1000 * 3600 * 24 * 36525 / 100;
 
-		runtime_common::impls::era_payout(
+		polkadot_era_payout(
 			total_staked,
 			total_issuance,
 			MAX_ANNUAL_INFLATION,


### PR DESCRIPTION
As per https://forum.polkadot.network/t/adjusting-polkadots-ideal-staking-rate-calculation, this PR updates the ideal staking calculation so that the system can handle the crouwdloan fund unlocking happening around 23rd of October.

Note: this PR is similar to https://github.com/polkadot-fellows/runtimes/pull/26. Since the change needs to be released asap due to the time constraints, I'm opening this PR here as it is unclear when the `runtime-common` is moved to the fellowship repo.

Closes https://github.com/paritytech/polkadot-sdk/issues/1611