### PR TITLE
XCM: Deprecate old functions

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/tests.rs
+++ b/polkadot/xcm/pallet-xcm/src/tests.rs
@@ -375,7 +375,7 @@ fn teleport_assets_works() {
 				Xcm(vec![
 					ReceiveTeleportedAsset((Here, SEND_AMOUNT).into()),
 					ClearOrigin,
-					buy_limited_execution((Here, SEND_AMOUNT), Weight::from_parts(4000, 4000)),
+					buy_execution((Here, SEND_AMOUNT)),
 					DepositAsset { assets: AllCounted(1).into(), beneficiary: dest },
 				]),
 			)]
@@ -508,7 +508,7 @@ fn reserve_transfer_assets_works() {
 				Xcm(vec![
 					ReserveAssetDeposited((Parent, SEND_AMOUNT).into()),
 					ClearOrigin,
-					buy_limited_execution((Parent, SEND_AMOUNT), Weight::from_parts(4000, 4000)),
+					buy_execution((Parent, SEND_AMOUNT)),
 					DepositAsset { assets: AllCounted(1).into(), beneficiary: dest },
 				]),
 			)]


### PR DESCRIPTION
Two old functions should be deprecated and have their code altered in line with capabilities of XCMv2 and above.

This means we can use the proper `Unlimited` form of weight limit rather than guessing weight from the local chain.