### PR TITLE
upgrade to docify v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,18 +4455,18 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff509d6aa8e7ca86b36eb3d593132e64204597de3ccb763ffd8bfd2264d54cf3"
+checksum = "76ee528c501ddd15d5181997e9518e59024844eac44fd1e40cb20ddb2a8562fa"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b135598b950330937f3a0ddfbe908106ee2ecd5fa95d8ae7952a3c3863efe8da"
+checksum = "0ca01728ab2679c464242eca99f94e2ce0514b52ac9ad950e2ed03fca991231c"
 dependencies = [
  "common-path",
  "derive-syn-parse",

--- a/substrate/frame/bags-list/Cargo.toml
+++ b/substrate/frame/bags-list/Cargo.toml
@@ -27,7 +27,7 @@ frame-election-provider-support = { path = "../election-provider-support", defau
 
 # third party
 log = { version = "0.4.17", default-features = false }
-docify = "0.2.3"
+docify = "0.2.4"
 aquamarine = { version = "0.3.2" }
 
 # Optional imports for benchmarking

--- a/substrate/frame/fast-unstake/Cargo.toml
+++ b/substrate/frame/fast-unstake/Cargo.toml
@@ -27,7 +27,7 @@ frame-election-provider-support = { path = "../election-provider-support", defau
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 
-docify = "0.2.3"
+docify = "0.2.4"
 
 [dev-dependencies]
 pallet-staking-reward-curve = { path = "../staking/reward-curve" }

--- a/substrate/frame/paged-list/Cargo.toml
+++ b/substrate/frame/paged-list/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
-docify = "0.2.3"
+docify = "0.2.4"
 scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}

--- a/substrate/frame/scheduler/Cargo.toml
+++ b/substrate/frame/scheduler/Cargo.toml
@@ -20,7 +20,7 @@ sp-io = { path = "../../primitives/io", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-weights = { path = "../../primitives/weights", default-features = false}
-docify = "0.2.3"
+docify = "0.2.4"
 
 [dev-dependencies]
 pallet-preimage = { path = "../preimage" }

--- a/substrate/frame/sudo/Cargo.toml
+++ b/substrate/frame/sudo/Cargo.toml
@@ -22,7 +22,7 @@ sp-io = { path = "../../primitives/io", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 
-docify = "0.2.3"
+docify = "0.2.4"
 
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -43,7 +43,7 @@ k256 = { version = "0.13.1", default-features = false, features = ["ecdsa"] }
 environmental = { version = "1.1.4", default-features = false }
 sp-genesis-builder = { path = "../../primitives/genesis-builder", default-features=false}
 serde_json = { version = "1.0.107", default-features = false, features = ["alloc"] }
-docify = "0.2.3"
+docify = "0.2.4"
 static_assertions = "1.1.0"
 
 aquamarine = { version = "0.3.2" }

--- a/substrate/frame/timestamp/Cargo.toml
+++ b/substrate/frame/timestamp/Cargo.toml
@@ -27,7 +27,7 @@ sp-std = { path = "../../primitives/std", default-features = false}
 sp-storage = { path = "../../primitives/storage", default-features = false}
 sp-timestamp = { path = "../../primitives/timestamp", default-features = false}
 
-docify = "0.2.1"
+docify = "0.2.4"
 
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }


### PR DESCRIPTION
Upgrades to docify v0.2.4 which adds support for exporting trait and impl items in addition to regular items. This fixes @liamaharon's https://github.com/sam0x17/docify/issues/9 issue.

See the release notes for more information:
https://github.com/sam0x17/docify/releases/tag/v0.2.4