### PR TITLE
Adds `stake-tracker` pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10373,6 +10373,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-stake-tracker"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "pallet-bags-list",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "sp-tracing",
+]
+
+[[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,6 +335,7 @@ members = [
 	"substrate/frame/session",
 	"substrate/frame/session/benchmarking",
 	"substrate/frame/society",
+	"substrate/frame/stake-tracker",
 	"substrate/frame/staking",
 	"substrate/frame/staking/reward-curve",
 	"substrate/frame/staking/reward-fn",

--- a/substrate/frame/stake-tracker/Cargo.toml
+++ b/substrate/frame/stake-tracker/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "pallet-stake-tracker"
+version = "0.1.0"
+description = "FRAME stake tracker pallet"
+authors = ["Parity Technologies <admin@parity.io>"]
+homepage = "https://substrate.io"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/paritytech/substrate"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
+scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+
+sp-runtime = { version = "24.0.0", default-features = false, path = "../../primitives/runtime", features = ["serde"] }
+sp-staking = { version = "4.0.0-dev", default-features = false, path = "../../primitives/staking", features = ["serde"] }
+sp-std = { version = "8.0.0", default-features = false, path = "../../primitives/std" }
+
+sp-npos-elections = { version = "4.0.0-dev", path = "../../primitives/npos-elections" }
+frame-election-provider-support = { version = "4.0.0-dev", default-features = false, path = "../election-provider-support" }
+frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true, path = "../benchmarking" }
+frame-support = { version = "4.0.0-dev", default-features = false, path = "../support"}
+frame-system = { version = "4.0.0-dev", default-features = false, path = "../system" }
+
+[dev-dependencies]
+sp-std = { version = "8.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "21.0.0", path = "../../primitives/core" }
+sp-io = { version = "23.0.0", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "24.0.0", default-features = false, path = "../../primitives/runtime", features = ["serde"] }
+sp-tracing = { version = "10.0.0", path = "../../primitives/tracing" }
+pallet-bags-list = { version = "4.0.0-dev", path = "../bags-list" }
+pallet-balances = { version = "4.0.0-dev", path = "../balances" }
+
+[features]
+default = ["std"]
+
+std = [
+	"codec/std",
+	"frame-benchmarking?/std",
+	"frame-support/std",
+	"frame-system/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
+
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/substrate/frame/stake-tracker/README.md
+++ b/substrate/frame/stake-tracker/README.md
@@ -1,0 +1,9 @@
+# Pallet `stake-tracker`
+
+The stake-tracker pallet is listens to staking events through implemeting the
+[`OnStakingUpdate`] trait and forwards those events to one or multiple types (e.g. pallets) that
+must be kept up to date with certain updates in staking. The pallet does not expose any
+callables and acts as a multiplexer of staking events.
+
+ Currently, the stake tracker pallet is used to update the semi-sorted target and voter lists
+ implemented through bags lists.

--- a/substrate/frame/stake-tracker/src/lib.rs
+++ b/substrate/frame/stake-tracker/src/lib.rs
@@ -1,0 +1,325 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # StakeTracker
+//!
+//! FRAME stake tracker pallet
+//!
+//! ## Overview
+//!
+//! The stake-tracker pallet listens to staking events through implementing the
+//! [`OnStakingUpdate`] trait and forwards those events to one or multiple types (e.g. pallets) that
+//! must be kept up to date with certain updates in staking. The pallet does not expose any
+//! callables and acts as a multiplexer of staking events.
+//!
+//! Currently, the stake tracker pallet is used to update the semi-sorted target and voter lists
+//! implemented through the bags lists pallet.
+//!
+//! ## Goals
+//!
+//! The [`OnStakingUpdate`] implementation aims at achieving the following goals:
+//!
+//! * The [`Config::TargetList`] keeps a semi-sorted list of validators, sorted by approvals
+//! (including self-vote and nominations).
+//! * The [`Config::VoterList`] keeps a semi-sorted list of voters, sorted by bonded stake.
+//! * The [`Config::TargetList`] sorting must be *always* kept up to date, even in the event of new
+//! nomination updates, nominator/validator slashes and rewards.
+//! * The [`Config::VoterList`] does not need to necessarily be kept up to date at all times (e.g.
+//! slashes). Those updates may be done externally if possible (e.g. if the voter sorted list
+//! provider is implemented using a bags-list pallet, the updates can be accomplished through
+//! callables).
+//!
+//! ## Event emitter ordering and staking ledger state updates
+//!
+//! It is important to ensure that the events are emitted from staking (i.e. the calls into
+//! [`OnStakingUpdate`]) *after* the caller ensures that the state of the staking ledger is up to
+//! date, since the new state will be fetched and used to update the sorted lists accordingly.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+use frame_election_provider_support::SortedListProvider;
+use frame_support::traits::{Currency, Defensive};
+use sp_staking::{
+	currency_to_vote::CurrencyToVote, OnStakingUpdate, StakerStatus, StakingInterface,
+};
+use sp_std::collections::btree_map::BTreeMap;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+/// The balance type of this pallet.
+pub type BalanceOf<T> = <<T as Config>::Staking as StakingInterface>::Balance;
+/// The account ID of this pallet.
+pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+
+/// Represents a stake imbalance to be applied to a staker's score.
+#[derive(Copy, Clone, Debug)]
+pub enum StakeImbalance<Balance> {
+	// Represents the reduction of stake by `Balance`.
+	Negative(Balance),
+	// Represents the increase of stake by `Balance`.
+	Positive(Balance),
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use crate::*;
+	use frame_election_provider_support::VoteWeight;
+	use frame_support::pallet_prelude::*;
+
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Currency: Currency<Self::AccountId, Balance = BalanceOf<Self>>;
+
+		/// The staking interface.
+		type Staking: StakingInterface<AccountId = Self::AccountId>;
+
+		/// Something that provides a best-effort sorted list of voters.
+		///
+		/// To keep the load off the chain as much as possible, changes made to the staked amount
+		/// via rewards and slashes are dropped and thus need to be manually updated through
+		/// extrinsics. In case of `bags-list`, this always means using `rebag` and `putInFrontOf`.
+		type VoterList: SortedListProvider<Self::AccountId, Score = VoteWeight>;
+
+		/// Something that provides a best-effort sorted list of targets.
+		///
+		/// Unlike `VoterList`, the values in this list are always kept up to date with rewards and
+		/// slashes, and thus represent the accurate approval stake of all validator accounts being
+		/// nominated by nominators.
+		///
+		/// Note that while at the time of nomination all targets are checked to be real
+		/// validators, they can chill at any point, and their approval stakes will still be
+		/// recorded. This implies that what comes out of iterating this list MIGHT NOT BE AN ACTIVE
+		/// VALIDATOR.
+		type TargetList: SortedListProvider<Self::AccountId, Score = VoteWeight>;
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Returns the vote weight of a staker based on its current stake.
+		pub(crate) fn active_vote_of(who: &T::AccountId) -> VoteWeight {
+			T::Staking::stake(who)
+				.map(|s| Self::to_vote(s.active))
+				.defensive_unwrap_or_default()
+		}
+
+		/// Converts a staker's balance to its vote weight.
+		pub(crate) fn to_vote(balance: BalanceOf<T>) -> VoteWeight {
+			<T::Staking as StakingInterface>::CurrencyToVote::to_vote(
+				balance,
+				T::Currency::total_issuance(),
+			)
+		}
+
+		/// Updates a staker's score by increasing/decreasing an imbalance of the current score in
+		/// the list.
+		pub(crate) fn update_score<L>(who: &T::AccountId, imbalance: StakeImbalance<VoteWeight>)
+		where
+			L: SortedListProvider<AccountIdOf<T>, Score = VoteWeight>,
+		{
+			match imbalance {
+				StakeImbalance::Positive(imbalance) => {
+					let _ = L::on_increase(who, imbalance).defensive_proof(
+						"the staker exists in the list as per the contract with staking; qed.",
+					);
+				},
+				StakeImbalance::Negative(imbalance) => {
+					let _ = L::on_decrease(who, imbalance).defensive_proof(
+						"the staker exists in the list as per the contract with staking; qed.",
+					);
+				},
+			}
+		}
+	}
+}
+
+impl<T: Config> OnStakingUpdate<T::AccountId, BalanceOf<T>> for Pallet<T> {
+	// Fired when the stake amount of someone updates.
+	//
+	// When a nominator's stake is updated, all the nominated targets must be updated accordingly.
+	//
+	// Note: it is assumed that who's staking state is updated *before* the caller calling into
+	// this method.
+	fn on_stake_update(who: &T::AccountId, prev_stake: Option<sp_staking::Stake<BalanceOf<T>>>) {
+		if let Ok(stake) = T::Staking::stake(who) {
+			let voter_weight = Self::to_vote(stake.active);
+
+			match T::Staking::status(who).defensive_unwrap_or(StakerStatus::Idle) {
+				StakerStatus::Nominator(_) => {
+					let _ = T::VoterList::on_update(who, voter_weight)
+						.defensive_proof("Nominator's position in voter list updated; qed."); // TODO(gpestana): check this defensive out
+
+					// calculate imbalace to update the score of nominated targets.
+					let stake_imbalance = if let Some(prev_stake) = prev_stake {
+						let prev_voter_weight = Self::to_vote(prev_stake.active);
+						if prev_voter_weight > voter_weight {
+							StakeImbalance::Negative(prev_voter_weight - voter_weight)
+						} else {
+							StakeImbalance::Positive(voter_weight - prev_voter_weight)
+						}
+					} else {
+						// if nominator had no stake before update, then add all the voter weight
+						// to the target's score.
+						StakeImbalance::Positive(voter_weight)
+					};
+
+					// updates vote weight of nominated targets accordingly.
+					for target in <T::Staking as StakingInterface>::nominations(who)
+						.unwrap_or_default()
+						.into_iter()
+					{
+						// target may be chilling due to a recent slash, verify if it is active
+						// before updating the score.
+						if <T::Staking as StakingInterface>::is_validator(&target) {
+							Self::update_score::<T::TargetList>(&target, stake_imbalance);
+						}
+					}
+				},
+				StakerStatus::Validator => {
+					let _ = T::TargetList::on_update(who, voter_weight)
+						.defensive_proof("Validator's position in voter list updated; qed.");
+				},
+				StakerStatus::Idle => (), // nothing to see here.
+			}
+		}
+	}
+
+	// Fired when someone sets their intention to nominate.
+	//
+	// Note: it is assumed that who's staking state is updated *before* the caller calling into
+	// this method.
+	fn on_nominator_add(who: &T::AccountId) {
+		let nominator_vote = Self::active_vote_of(who);
+
+		let _ = T::VoterList::on_insert(who.clone(), nominator_vote).defensive_proof(
+			"the nominator is not part of the VoterList, as per the contract with \
+                staking; qed.",
+		);
+
+		// on_nominator_add could be called on a validator. If who is a nominator, update the vote
+		// weight of the nominations if they exist.
+		match T::Staking::status(who) {
+			Ok(StakerStatus::Nominator(nominations)) =>
+				for t in nominations {
+					Self::update_score::<T::TargetList>(
+						&t,
+						StakeImbalance::Positive(nominator_vote),
+					)
+				},
+			Ok(StakerStatus::Idle) | Ok(StakerStatus::Validator) | Err(_) => (), // nada.
+		};
+	}
+
+	// Fired when someone sets their intention to validate.
+	//
+	// A validator is also considered a voter with self-vote and should be added to
+	// [`Config::VoterList`].
+	//
+	// Note: it is assumed that who's staking state is updated *before* the caller calling into
+	// this method.
+	fn on_validator_add(who: &T::AccountId) {
+		let _ = T::TargetList::on_insert(who.clone(), Self::active_vote_of(who)).defensive_proof(
+			"the validator is not part of the TargetList, as per the contract \
+                with staking; qed.",
+		);
+
+		// a validator is also a nominator.
+		Self::on_nominator_add(who)
+	}
+
+	// Fired when someone removes their intention to nominate, either due to chill or validating.
+	//
+	// Note: it is assumed that who's staking state is updated *before* the caller calling into
+	// this method. Thus, the nominations before the nominator has been removed from staking are
+	// passed in, so that the target list can be updated accordingly.
+	fn on_nominator_remove(who: &T::AccountId, nominations: Vec<T::AccountId>) {
+		let nominator_vote = Self::active_vote_of(who);
+
+		// updates the nominated target's score.
+		for t in nominations.iter() {
+			Self::update_score::<T::TargetList>(&t, StakeImbalance::Negative(nominator_vote))
+		}
+
+		let _ = T::VoterList::on_remove(&who).defensive_proof(
+			"the nominator exists in the list as per the contract with staking; qed.",
+		);
+	}
+
+	// Fired when someone removes their intention to validate, either due to chill or nominating.
+	fn on_validator_remove(who: &T::AccountId) {
+		let _ = T::TargetList::on_remove(&who).defensive_proof(
+			"the validator exists in the list as per the contract with staking; qed.",
+		);
+
+		// validator is also a nominator.
+		Self::on_nominator_remove(who, vec![]);
+	}
+
+	// Fired when an existing nominator updates their nominations.
+	//
+	// This is called when a nominator updates their nominations. The nominator's stake remains the
+	// same (updates to the nominator's stake should emit [`Self::on_stake_update`] instead).
+	// However, the score of the nominated targets must be updated accordingly.
+	//
+	// Note: it is assumed that who's staking state is updated *before* the caller calling into
+	// this method.
+	fn on_nominator_update(who: &T::AccountId, prev_nominations: Vec<T::AccountId>) {
+		let nominator_vote = Self::active_vote_of(who);
+		let curr_nominations =
+			<T::Staking as StakingInterface>::nominations(&who).unwrap_or_default();
+
+		// new nominations
+		for target in curr_nominations.iter() {
+			if !prev_nominations.contains(target) {
+				Self::update_score::<T::TargetList>(
+					&target,
+					StakeImbalance::Positive(nominator_vote),
+				);
+			}
+		}
+		// removed nominations
+		for target in prev_nominations.iter() {
+			if !curr_nominations.contains(target) {
+				Self::update_score::<T::TargetList>(
+					&target,
+					StakeImbalance::Negative(nominator_vote),
+				);
+			}
+		}
+	}
+
+	// noop: the updates to target and voter lists when applying a slash are performed
+	// through [`Self::on_nominator_remove`] and [`Self::on_validator_remove`] when the stakers are
+	// chilled.
+	fn on_slash(
+		_stash: &T::AccountId,
+		_slashed_active: BalanceOf<T>,
+		_slashed_unlocking: &BTreeMap<sp_staking::EraIndex, BalanceOf<T>>,
+	) {
+		frame_support::defensive!("unexpected call to OnStakingUpdate::on_slash");
+	}
+}

--- a/substrate/frame/stake-tracker/src/mock.rs
+++ b/substrate/frame/stake-tracker/src/mock.rs
@@ -1,0 +1,385 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(test)]
+
+use crate::{self as pallet_stake_tracker, *};
+
+use frame_election_provider_support::{ScoreProvider, VoteWeight};
+use frame_support::{derive_impl, parameter_types, traits::ConstU32};
+use sp_runtime::BuildStorage;
+use sp_staking::{Stake, StakingInterface};
+
+pub(crate) type AccountId = u64;
+pub(crate) type Balance = u64;
+
+type Block = frame_system::mocking::MockBlockU32<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test
+	{
+		System: frame_system,
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		VoterBagsList: pallet_bags_list::<Instance1>::{Pallet, Call, Storage, Event<T>},
+		TargetBagsList: pallet_bags_list::<Instance2>::{Pallet, Call, Storage, Event<T>},
+		StakeTracker: crate,
+	}
+);
+
+parameter_types! {
+	pub static ExistentialDeposit: Balance = 1;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockHashCount = ConstU32<10>;
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type PalletInfo = PalletInfo;
+	type OnSetCode = ();
+
+	type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type DustRemoval = ();
+	type RuntimeEvent = RuntimeEvent;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxLocks = frame_support::traits::ConstU32<1024>;
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type RuntimeHoldReason = ();
+	type MaxFreezes = ();
+}
+
+const THRESHOLDS: [sp_npos_elections::VoteWeight; 9] =
+	[10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000];
+
+parameter_types! {
+	pub static BagThresholds: &'static [VoteWeight] = &THRESHOLDS;
+}
+
+type VoterBagsListInstance = pallet_bags_list::Instance1;
+impl pallet_bags_list::Config<VoterBagsListInstance> for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type ScoreProvider = StakingMock;
+	type BagThresholds = BagThresholds;
+	type Score = VoteWeight;
+}
+
+type TargetBagsListInstance = pallet_bags_list::Instance2;
+impl pallet_bags_list::Config<TargetBagsListInstance> for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type ScoreProvider = StakingMock;
+	type BagThresholds = BagThresholds;
+	type Score = VoteWeight;
+}
+
+impl pallet_stake_tracker::Config for Test {
+	type Currency = Balances;
+
+	type Staking = StakingMock;
+	type VoterList = VoterBagsList;
+	type TargetList = TargetBagsList;
+}
+
+pub struct StakingMock {}
+
+impl ScoreProvider<AccountId> for StakingMock {
+	type Score = VoteWeight;
+
+	fn score(_id: &AccountId) -> Self::Score {
+		todo!();
+	}
+
+	fn set_score_of(_: &AccountId, _: Self::Score) {
+		unreachable!();
+	}
+}
+
+impl StakingInterface for StakingMock {
+	type Balance = Balance;
+	type AccountId = AccountId;
+	type CurrencyToVote = ();
+
+	fn stake(who: &Self::AccountId) -> Result<Stake<Self::Balance>, sp_runtime::DispatchError> {
+		let n = TestNominators::get();
+		match n.get(who) {
+			Some(nominator) => Some(nominator.0),
+			None => {
+				let v = TestValidators::get();
+				v.get(who).copied()
+			},
+		}
+		.ok_or("not a staker".into())
+	}
+
+	fn status(
+		who: &Self::AccountId,
+	) -> Result<sp_staking::StakerStatus<Self::AccountId>, sp_runtime::DispatchError> {
+		let n = TestNominators::get();
+
+		if n.contains_key(who) {
+			Ok(StakerStatus::Nominator(n.get(&who).expect("exists").1.clone()))
+		} else if TestValidators::get().contains_key(who) {
+			Ok(StakerStatus::Validator)
+		} else {
+			Err("not a staker".into())
+		}
+	}
+
+	fn nominations(who: &Self::AccountId) -> Option<Vec<Self::AccountId>> {
+		let n = TestNominators::get();
+		if let Some(nominator) = n.get(&who) {
+			Some(nominator.1.clone())
+		} else {
+			None
+		}
+	}
+
+	fn minimum_nominator_bond() -> Self::Balance {
+		unreachable!();
+	}
+
+	fn minimum_validator_bond() -> Self::Balance {
+		unreachable!();
+	}
+
+	fn stash_by_ctrl(
+		_controller: &Self::AccountId,
+	) -> Result<Self::AccountId, sp_runtime::DispatchError> {
+		unreachable!();
+	}
+
+	fn bonding_duration() -> sp_staking::EraIndex {
+		unreachable!();
+	}
+
+	fn current_era() -> sp_staking::EraIndex {
+		unreachable!();
+	}
+
+	fn bond(
+		_who: &Self::AccountId,
+		_value: Self::Balance,
+		_payee: &Self::AccountId,
+	) -> sp_runtime::DispatchResult {
+		unreachable!();
+	}
+
+	fn nominate(
+		_who: &Self::AccountId,
+		_validators: Vec<Self::AccountId>,
+	) -> sp_runtime::DispatchResult {
+		unreachable!();
+	}
+
+	fn chill(_who: &Self::AccountId) -> sp_runtime::DispatchResult {
+		unreachable!();
+	}
+
+	fn bond_extra(_who: &Self::AccountId, _extra: Self::Balance) -> sp_runtime::DispatchResult {
+		unreachable!();
+	}
+
+	fn withdraw_unbonded(
+		_stash: Self::AccountId,
+		_num_slashing_spans: u32,
+	) -> Result<bool, sp_runtime::DispatchError> {
+		unreachable!();
+	}
+
+	fn desired_validator_count() -> u32 {
+		unreachable!();
+	}
+
+	fn election_ongoing() -> bool {
+		unreachable!();
+	}
+
+	fn force_unstake(_who: Self::AccountId) -> sp_runtime::DispatchResult {
+		unreachable!();
+	}
+
+	fn is_exposed_in_era(_who: &Self::AccountId, _era: &sp_staking::EraIndex) -> bool {
+		unreachable!();
+	}
+
+	fn unbond(_stash: &Self::AccountId, _value: Self::Balance) -> sp_runtime::DispatchResult {
+		unreachable!();
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn add_era_stakers(
+		current_era: &sp_staking::EraIndex,
+		stash: &Self::AccountId,
+		exposures: Vec<(Self::AccountId, Self::Balance)>,
+	) {
+		unreachable!();
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn set_current_era(era: sp_staking::EraIndex) {
+		unreachable!();
+	}
+}
+
+type Nominations = Vec<AccountId>;
+
+parameter_types! {
+	pub static TestNominators: BTreeMap<AccountId, (Stake<Balance>, Nominations)> = Default::default();
+	pub static TestValidators: BTreeMap<AccountId, Stake<Balance>> = Default::default();
+}
+
+pub(crate) fn get_scores<L: SortedListProvider<AccountId, Score = VoteWeight>>(
+) -> Vec<(AccountId, Balance)> {
+	let scores: Vec<_> = L::iter().map(|e| (e, L::get_score(&e).unwrap())).collect();
+	scores
+}
+
+pub(crate) fn populate_lists() {
+	add_validator(10, 100);
+	add_validator(11, 100);
+
+	add_nominator_with_nominations(1, 100, vec![10]);
+	add_nominator_with_nominations(2, 100, vec![10, 11]);
+}
+
+pub(crate) fn add_nominator(who: AccountId, stake: Balance) {
+	TestNominators::mutate(|n| {
+		n.insert(who, (Stake::<Balance> { active: stake, total: stake }, vec![]));
+	});
+
+	// add new nominator (called at `fn bond` in staking)
+	<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_nominator_add(&who);
+}
+
+pub(crate) fn add_nominator_with_nominations(
+	who: AccountId,
+	stake: Balance,
+	nominations: Nominations,
+) {
+	// add new nominator (called at `fn bond` in staking)
+	add_nominator(who, stake);
+
+	// add nominations (called at `fn nominate` in staking)
+	TestNominators::mutate(|n| {
+		n.insert(who, (Stake::<Balance> { active: stake, total: stake }, nominations));
+	});
+
+	<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_nominator_update(&who, vec![]);
+}
+
+pub(crate) fn update_nominations_of(who: AccountId, new_nominations: Nominations) {
+	// add nominations (called at `fn nominate` in staking)
+	let current_nom = TestNominators::get();
+	let (current_stake, prev_nominations) = current_nom.get(&who).unwrap();
+
+	TestNominators::mutate(|n| {
+		n.insert(who, (current_stake.clone(), new_nominations));
+	});
+
+	<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_nominator_update(
+		&who,
+		prev_nominations.clone(),
+	);
+}
+
+pub(crate) fn add_validator(who: AccountId, stake: Balance) {
+	TestValidators::mutate(|v| {
+		v.insert(who, Stake::<Balance> { active: stake, total: stake });
+	});
+
+	<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_validator_add(&who);
+}
+
+pub(crate) fn update_stake(who: AccountId, new: Balance) {
+	match StakingMock::status(&who) {
+		Ok(StakerStatus::Nominator(nominations)) => {
+			TestNominators::mutate(|n| {
+				n.insert(who, (Stake { active: new, total: new }, nominations));
+			});
+		},
+		Ok(StakerStatus::Validator) => {
+			TestValidators::mutate(|n| {
+				n.insert(who, Stake { active: new, total: new });
+			});
+		},
+		Ok(StakerStatus::Idle) | Err(_) => panic!("not a staker"),
+	}
+
+	<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_stake_update(&who, None);
+}
+
+pub(crate) fn remove_staker(who: AccountId) {
+	if TestNominators::get().contains_key(&who) {
+		let nominations = <StakingMock as StakingInterface>::nominations(&who).unwrap();
+
+		<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_nominator_remove(
+			&who,
+			nominations,
+		);
+		TestNominators::mutate(|n| {
+			n.remove(&who);
+		});
+	} else if TestValidators::get().contains_key(&who) {
+		<StakeTracker as OnStakingUpdate<AccountId, Balance>>::on_validator_remove(&who);
+		TestValidators::mutate(|v| v.remove(&who));
+	};
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct ExtBuilder {
+	populate_lists: bool,
+}
+
+impl ExtBuilder {
+	pub fn populate_lists(mut self) -> Self {
+		self.populate_lists = true;
+		self
+	}
+
+	pub fn build(self) -> sp_io::TestExternalities {
+		sp_tracing::try_init_simple();
+		let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+
+		sp_io::TestExternalities::from(storage)
+	}
+
+	pub fn build_and_execute(self, test: impl FnOnce() -> ()) {
+		sp_tracing::try_init_simple();
+
+		let mut ext = self.build();
+		ext.execute_with(|| {
+			if self.populate_lists {
+				populate_lists();
+			}
+			test()
+		});
+	}
+}

--- a/substrate/frame/stake-tracker/src/tests.rs
+++ b/substrate/frame/stake-tracker/src/tests.rs
@@ -1,0 +1,142 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(test)]
+
+use crate::mock::*;
+
+use frame_election_provider_support::SortedListProvider;
+use sp_staking::Stake;
+
+#[test]
+fn setup_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		assert!(TestNominators::get().is_empty());
+		assert_eq!(VoterBagsList::count(), 0);
+
+		assert!(TestValidators::get().is_empty());
+		assert_eq!(TargetBagsList::count(), 0);
+	});
+
+	ExtBuilder::default().populate_lists().build_and_execute(|| {
+		assert!(!TestNominators::get().is_empty());
+		assert_eq!(VoterBagsList::count(), 4); // voter list has 2x nominatiors + 2x validators
+
+		assert!(!TestValidators::get().is_empty());
+		assert_eq!(TargetBagsList::count(), 2);
+	});
+}
+
+#[test]
+fn staking_interface_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		add_nominator(1, 100);
+		let n = TestNominators::get();
+		assert_eq!(n.get(&1).unwrap().0, Stake { active: 100u64, total: 100u64 });
+
+		add_validator(2, 200);
+		let v = TestValidators::get();
+		assert_eq!(v.get(&2).copied().unwrap(), Stake { active: 200u64, total: 200u64 });
+	})
+}
+
+#[test]
+fn on_add_stakers_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		add_nominator(1, 100);
+
+		assert_eq!(TargetBagsList::count(), 0);
+		assert_eq!(VoterBagsList::count(), 1);
+		assert_eq!(VoterBagsList::get_score(&1).unwrap(), 100);
+
+		add_validator(10, 200);
+		assert_eq!(VoterBagsList::count(), 2); // 1x nominator + 1x validator
+		assert_eq!(TargetBagsList::count(), 1);
+		assert_eq!(TargetBagsList::get_score(&10).unwrap(), 200);
+	})
+}
+
+#[test]
+fn on_update_stake_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		add_nominator(1, 100);
+		assert_eq!(VoterBagsList::get_score(&1).unwrap(), 100);
+		update_stake(1, 200);
+		assert_eq!(VoterBagsList::get_score(&1).unwrap(), 200);
+
+		add_validator(10, 100);
+		assert_eq!(TargetBagsList::get_score(&10).unwrap(), 100);
+		update_stake(10, 200);
+		assert_eq!(TargetBagsList::get_score(&10).unwrap(), 200);
+	})
+}
+
+#[test]
+fn on_remove_stakers_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		add_nominator(1, 100);
+		assert!(VoterBagsList::contains(&1));
+		remove_staker(1);
+		assert!(!VoterBagsList::contains(&1));
+
+		add_validator(10, 100);
+		assert!(TargetBagsList::contains(&10));
+		remove_staker(10);
+		assert!(!TargetBagsList::contains(&10));
+	})
+}
+
+#[test]
+fn on_remove_stakers_with_nominations_works() {
+	ExtBuilder::default().populate_lists().build_and_execute(|| {
+		assert_eq!(get_scores::<TargetBagsList>(), vec![(10, 300), (11, 200)]);
+
+		assert!(VoterBagsList::contains(&1));
+		assert_eq!(VoterBagsList::get_score(&1), Ok(100));
+		assert_eq!(TargetBagsList::get_score(&10), Ok(300));
+
+		// remove nominator deletes node from voter list and updates the stake of its nominations.
+		remove_staker(1);
+		assert!(!VoterBagsList::contains(&1));
+		assert_eq!(TargetBagsList::get_score(&10), Ok(200));
+	})
+}
+
+#[test]
+fn on_nominator_update_works() {
+	ExtBuilder::default().populate_lists().build_and_execute(|| {
+		assert_eq!(get_scores::<VoterBagsList>(), vec![(10, 100), (11, 100), (1, 100), (2, 100)]);
+		assert_eq!(get_scores::<TargetBagsList>(), vec![(10, 300), (11, 200)]);
+
+		add_validator(20, 50);
+		// removes nomination from 10 and adds nomination to new validator, 20.
+		update_nominations_of(2, vec![11, 20]);
+
+		// new voter (validator) 2 with 100 stake. note that the voter score is not updated
+		// automatically.
+		assert_eq!(
+			get_scores::<VoterBagsList>(),
+			vec![(10, 100), (11, 100), (1, 100), (2, 100), (20, 50)]
+		);
+
+		// target list has been updated:
+		// -100 score for 10
+		// +100 score for 11
+		// +100 score for 20
+		assert_eq!(get_scores::<TargetBagsList>(), vec![(10, 200), (11, 200), (20, 150)]);
+	})
+}


### PR DESCRIPTION
This PR adds the `stake-tracker` pallet without integrating it with the staking and bags lists pallets.

The stake-tracker pallet implements the `OnStakingUpdate` trait to listen to staking events and multiplexes those events to one or multiple types (e.g. pallets). Initially, the stake tracker pallet is used as a degree of indirection to maintain the target and voter semi-sorted lists up to date.

The final goal is to achieve a design where the targets and voters lists are updated at each relevant staking event through the stake-tracker pallet. The list reads in staking are performed directly through the `SortedListProvider`.

![stake-tracker](https://github.com/paritytech/polkadot-sdk/assets/1398860/88dc1aa6-d3f0-4359-af0e-5133fc658553)

**To finalize**
- [ ] Consider a multi-block event processing to handle updates on slashes and rewards for both targets and voters (unconfirmed, perhaps on a follow-up PR).

Related and step towards https://github.com/paritytech/polkadot-sdk/issues/443