### PR TITLE
bump zombienet version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.67"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.68"
   DOCKER_IMAGES_VERSION: "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
 
 default:

--- a/.gitlab/pipeline/zombienet/cumulus.yml
+++ b/.gitlab/pipeline/zombienet/cumulus.yml
@@ -5,7 +5,7 @@
   before_script:
     - echo "Zombie-net Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
-    - echo "${RELAY_IMAGE}"
+    - echo "${POLKADOT_IMAGE}"
     - echo "${COL_IMAGE}"
     - echo "${GH_DIR}"
     - echo "${LOCAL_DIR}"


### PR DESCRIPTION
Includes:
- fix for https://github.com/paritytech/zombienet/issues/1360 (root cause of https://github.com/paritytech/polkadot-sdk/issues/1647)
- Improve default concurrency to spawn nodes.

Also, fix `var` name in CI file.

cc @skunert 
