### PR TITLE
pallet alliance / update to use fungible

### DIFF
--- a/substrate/frame/alliance/src/mock.rs
+++ b/substrate/frame/alliance/src/mock.rs
@@ -87,8 +87,8 @@ impl pallet_balances::Config for Test {
 	type ReserveIdentifier = [u8; 8];
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
-	type RuntimeHoldReason = ();
-	type MaxHolds = ();
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type MaxHolds = ConstU32<1>;
 }
 
 const MOTION_DURATION_IN_BLOCKS: BlockNumber = 3;
@@ -211,6 +211,7 @@ parameter_types! {
 }
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Proposal = RuntimeCall;
 	type AdminOrigin = EnsureSignedBy<One, AccountId>;
 	type MembershipManager = EnsureSignedBy<Two, AccountId>;


### PR DESCRIPTION
This updates the alliance pallet to use the new fungible traits rather than the now deprecated `Currency` and `ReserveCurrency` traits ( https://github.com/paritytech/substrate/pull/12951 ). Partial fix of https://github.com/paritytech/polkadot-sdk/issues/226.

Todo:

- [ ] Add code (if needed) to handle migrations.
- [ ] Update runtimes
