### PR TITLE
`BlockId` removal: `tx-pool` refactor

### DIFF
--- a/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
@@ -46,7 +46,7 @@ use std::sync::Arc;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::Bytes;
-use sp_runtime::{generic, traits::Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 
 use codec::Decode;
 use futures::{FutureExt, StreamExt, TryFutureExt};
@@ -110,11 +110,7 @@ where
 
 		let submit = self
 			.pool
-			.submit_and_watch(
-				&generic::BlockId::hash(best_block_hash),
-				TX_SOURCE,
-				decoded_extrinsic,
-			)
+			.submit_and_watch(best_block_hash, TX_SOURCE, decoded_extrinsic)
 			.map_err(|e| {
 				e.into_pool_error()
 					.map(Error::from)

--- a/substrate/client/service/src/lib.rs
+++ b/substrate/client/service/src/lib.rs
@@ -48,10 +48,7 @@ use sc_network_sync::SyncingService;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_blockchain::HeaderMetadata;
 use sp_consensus::SyncOracle;
-use sp_runtime::{
-	generic::BlockId,
-	traits::{Block as BlockT, Header as HeaderT},
-};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 pub use self::{
 	builder::{
@@ -481,10 +478,8 @@ where
 			},
 		};
 
-		let best_block_id = BlockId::hash(self.client.info().best_hash);
-
 		let import_future = self.pool.submit_one(
-			&best_block_id,
+			self.client.info().best_hash,
 			sc_transaction_pool_api::TransactionSource::External,
 			uxt,
 		);

--- a/substrate/client/transaction-pool/api/src/lib.rs
+++ b/substrate/client/transaction-pool/api/src/lib.rs
@@ -27,7 +27,6 @@ use futures::{Future, Stream};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sp_core::offchain::TransactionPoolExt;
 use sp_runtime::{
-	generic::BlockId,
 	traits::{Block as BlockT, Member, NumberFor},
 };
 use std::{collections::HashMap, hash::Hash, marker::PhantomData, pin::Pin, sync::Arc};
@@ -202,7 +201,7 @@ pub trait TransactionPool: Send + Sync {
 	/// Returns a future that imports a bunch of unverified transactions to the pool.
 	fn submit_at(
 		&self,
-		at: &BlockId<Self::Block>,
+		at: <Self::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xts: Vec<TransactionFor<Self>>,
 	) -> PoolFuture<Vec<Result<TxHash<Self>, Self::Error>>, Self::Error>;
@@ -210,7 +209,7 @@ pub trait TransactionPool: Send + Sync {
 	/// Returns a future that imports one unverified transaction to the pool.
 	fn submit_one(
 		&self,
-		at: &BlockId<Self::Block>,
+		at: <Self::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xt: TransactionFor<Self>,
 	) -> PoolFuture<TxHash<Self>, Self::Error>;
@@ -219,7 +218,7 @@ pub trait TransactionPool: Send + Sync {
 	/// pool.
 	fn submit_and_watch(
 		&self,
-		at: &BlockId<Self::Block>,
+		at: <Self::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xt: TransactionFor<Self>,
 	) -> PoolFuture<Pin<Box<TransactionStatusStreamFor<Self>>>, Self::Error>;

--- a/substrate/client/transaction-pool/src/graph/pool.rs
+++ b/substrate/client/transaction-pool/src/graph/pool.rs
@@ -71,7 +71,7 @@ pub trait ChainApi: Send + Sync {
 	/// Verify extrinsic at given block.
 	fn validate_transaction(
 		&self,
-		at: &BlockId<Self::Block>,
+		at: <Self::Block as BlockT>::Hash,
 		source: TransactionSource,
 		uxt: ExtrinsicFor<Self>,
 	) -> Self::ValidationFuture;
@@ -154,7 +154,7 @@ impl<B: ChainApi> Pool<B> {
 	/// Imports a bunch of unverified extrinsics to the pool
 	pub async fn submit_at(
 		&self,
-		at: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xts: impl IntoIterator<Item = ExtrinsicFor<B>>,
 	) -> Result<Vec<Result<ExtrinsicHash<B>, B::Error>>, B::Error> {
@@ -168,7 +168,7 @@ impl<B: ChainApi> Pool<B> {
 	/// This does not check if a transaction is banned, before we verify it again.
 	pub async fn resubmit_at(
 		&self,
-		at: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xts: impl IntoIterator<Item = ExtrinsicFor<B>>,
 	) -> Result<Vec<Result<ExtrinsicHash<B>, B::Error>>, B::Error> {
@@ -180,7 +180,7 @@ impl<B: ChainApi> Pool<B> {
 	/// Imports one unverified extrinsic to the pool
 	pub async fn submit_one(
 		&self,
-		at: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xt: ExtrinsicFor<B>,
 	) -> Result<ExtrinsicHash<B>, B::Error> {
@@ -191,11 +191,11 @@ impl<B: ChainApi> Pool<B> {
 	/// Import a single extrinsic and starts to watch its progress in the pool.
 	pub async fn submit_and_watch(
 		&self,
-		at: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
 		source: TransactionSource,
 		xt: ExtrinsicFor<B>,
 	) -> Result<Watcher<ExtrinsicHash<B>, ExtrinsicHash<B>>, B::Error> {
-		let block_number = self.resolve_block_number(at)?;
+		let block_number = self.resolve_block_number(&BlockId::Hash(at))?;
 		let (_, tx) = self
 			.verify_one(at, block_number, source, xt, CheckBannedBeforeVerify::Yes)
 			.await;
@@ -246,8 +246,8 @@ impl<B: ChainApi> Pool<B> {
 	/// their provided tags from there. Otherwise we query the runtime at the `parent` block.
 	pub async fn prune(
 		&self,
-		at: &BlockId<B::Block>,
-		parent: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
+		parent: <B::Block as BlockT>::Hash,
 		extrinsics: &[ExtrinsicFor<B>],
 	) -> Result<(), B::Error> {
 		log::debug!(
@@ -324,7 +324,7 @@ impl<B: ChainApi> Pool<B> {
 	/// prevent importing them in the (near) future.
 	pub async fn prune_tags(
 		&self,
-		at: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
 		tags: impl IntoIterator<Item = Tag>,
 		known_imported_hashes: impl IntoIterator<Item = ExtrinsicHash<B>> + Clone,
 	) -> Result<(), B::Error> {
@@ -351,7 +351,7 @@ impl<B: ChainApi> Pool<B> {
 		// And finally - submit reverified transactions back to the pool
 
 		self.validated_pool.resubmit_pruned(
-			at,
+			&BlockId::Hash(at),
 			known_imported_hashes,
 			pruned_hashes,
 			reverified_transactions.into_values().collect(),
@@ -373,12 +373,12 @@ impl<B: ChainApi> Pool<B> {
 	/// Returns future that validates a bunch of transactions at given block.
 	async fn verify(
 		&self,
-		at: &BlockId<B::Block>,
+		at: <B::Block as BlockT>::Hash,
 		xts: impl IntoIterator<Item = (TransactionSource, ExtrinsicFor<B>)>,
 		check: CheckBannedBeforeVerify,
 	) -> Result<HashMap<ExtrinsicHash<B>, ValidatedTransactionFor<B>>, B::Error> {
 		// we need a block number to compute tx validity
-		let block_number = self.resolve_block_number(at)?;
+		let block_number = self.resolve_block_number(&BlockId::Hash(at))?;
 
 		let res = futures::future::join_all(
 			xts.into_iter()
@@ -394,7 +394,7 @@ impl<B: ChainApi> Pool<B> {
 	/// Returns future that validates single transaction at given block.
 	async fn verify_one(
 		&self,
-		block_id: &BlockId<B::Block>,
+		block_hash: <B::Block as BlockT>::Hash,
 		block_number: NumberFor<B>,
 		source: TransactionSource,
 		xt: ExtrinsicFor<B>,
@@ -410,7 +410,7 @@ impl<B: ChainApi> Pool<B> {
 		let validation_result = self
 			.validated_pool
 			.api()
-			.validate_transaction(block_id, source, xt.clone())
+			.validate_transaction(block_hash, source, xt.clone())
 			.await;
 
 		let status = match validation_result {
@@ -458,6 +458,7 @@ mod tests {
 	use super::{super::base_pool::Limit, *};
 	use crate::tests::{pool, uxt, TestApi, INVALID_NONCE};
 	use assert_matches::assert_matches;
+	use codec::Encode;
 	use futures::executor::block_on;
 	use parking_lot::Mutex;
 	use sc_transaction_pool_api::TransactionStatus;
@@ -471,11 +472,11 @@ mod tests {
 	#[test]
 	fn should_validate_and_import_transaction() {
 		// given
-		let pool = pool();
+		let (pool, api) = pool();
 
 		// when
 		let hash = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			api.expect_hash_from_number(0),
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -493,7 +494,7 @@ mod tests {
 	#[test]
 	fn should_reject_if_temporarily_banned() {
 		// given
-		let pool = pool();
+		let (pool, api) = pool();
 		let uxt = uxt(Transfer {
 			from: Alice.into(),
 			to: AccountId::from_h256(H256::from_low_u64_be(2)),
@@ -503,7 +504,7 @@ mod tests {
 
 		// when
 		pool.validated_pool.ban(&Instant::now(), vec![pool.hash_of(&uxt)]);
-		let res = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, uxt));
+		let res = block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt));
 		assert_eq!(pool.validated_pool().status().ready, 0);
 		assert_eq!(pool.validated_pool().status().future, 0);
 
@@ -514,18 +515,19 @@ mod tests {
 	#[test]
 	fn should_reject_unactionable_transactions() {
 		// given
+		let api = Arc::new(TestApi::default());
 		let pool = Pool::new(
 			Default::default(),
 			// the node does not author blocks
 			false.into(),
-			TestApi::default().into(),
+			api.clone(),
 		);
 
 		// after validation `IncludeData` will be set to non-propagable (validate_transaction mock)
 		let uxt = ExtrinsicBuilder::new_include_data(vec![42]).build();
 
 		// when
-		let res = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, uxt));
+		let res = block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt));
 
 		// then
 		assert_matches!(res.unwrap_err(), error::Error::Unactionable);
@@ -535,12 +537,13 @@ mod tests {
 	fn should_notify_about_pool_events() {
 		let (stream, hash0, hash1) = {
 			// given
-			let pool = pool();
+			let (pool, api) = pool();
+			let hash_of_block0 = api.expect_hash_from_number(0);
 			let stream = pool.validated_pool().import_notification_stream();
 
 			// when
 			let hash0 = block_on(pool.submit_one(
-				&BlockId::Number(0),
+				hash_of_block0,
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -551,7 +554,7 @@ mod tests {
 			))
 			.unwrap();
 			let hash1 = block_on(pool.submit_one(
-				&BlockId::Number(0),
+				hash_of_block0,
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -563,7 +566,7 @@ mod tests {
 			.unwrap();
 			// future doesn't count
 			let _hash = block_on(pool.submit_one(
-				&BlockId::Number(0),
+				hash_of_block0,
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -590,9 +593,10 @@ mod tests {
 	#[test]
 	fn should_clear_stale_transactions() {
 		// given
-		let pool = pool();
+		let (pool, api) = pool();
+		let hash_of_block0 = api.expect_hash_from_number(0);
 		let hash1 = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			hash_of_block0,
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -603,7 +607,7 @@ mod tests {
 		))
 		.unwrap();
 		let hash2 = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			hash_of_block0,
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -614,7 +618,7 @@ mod tests {
 		))
 		.unwrap();
 		let hash3 = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			hash_of_block0,
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -641,9 +645,9 @@ mod tests {
 	#[test]
 	fn should_ban_mined_transactions() {
 		// given
-		let pool = pool();
+		let (pool, api) = pool();
 		let hash1 = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			api.expect_hash_from_number(0),
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -655,12 +659,12 @@ mod tests {
 		.unwrap();
 
 		// when
-		block_on(pool.prune_tags(&BlockId::Number(1), vec![vec![0]], vec![hash1])).unwrap();
+		block_on(pool.prune_tags(api.expect_hash_from_number(1), vec![vec![0]], vec![hash1]))
+			.unwrap();
 
 		// then
 		assert!(pool.validated_pool.is_banned(&hash1));
 	}
-	use codec::Encode;
 
 	#[test]
 	fn should_limit_futures() {
@@ -678,14 +682,15 @@ mod tests {
 
 		let options = Options { ready: limit.clone(), future: limit.clone(), ..Default::default() };
 
-		let pool = Pool::new(options, true.into(), TestApi::default().into());
+		let api = Arc::new(TestApi::default());
+		let pool = Pool::new(options, true.into(), api.clone());
 
-		let hash1 = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, xt)).unwrap();
+		let hash1 = block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt)).unwrap();
 		assert_eq!(pool.validated_pool().status().future, 1);
 
 		// when
 		let hash2 = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			api.expect_hash_from_number(0),
 			SOURCE,
 			uxt(Transfer {
 				from: Bob.into(),
@@ -709,11 +714,12 @@ mod tests {
 
 		let options = Options { ready: limit.clone(), future: limit.clone(), ..Default::default() };
 
-		let pool = Pool::new(options, true.into(), TestApi::default().into());
+		let api = Arc::new(TestApi::default());
+		let pool = Pool::new(options, true.into(), api.clone());
 
 		// when
 		block_on(pool.submit_one(
-			&BlockId::Number(0),
+			api.expect_hash_from_number(0),
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -732,11 +738,11 @@ mod tests {
 	#[test]
 	fn should_reject_transactions_with_no_provides() {
 		// given
-		let pool = pool();
+		let (pool, api) = pool();
 
 		// when
 		let err = block_on(pool.submit_one(
-			&BlockId::Number(0),
+			api.expect_hash_from_number(0),
 			SOURCE,
 			uxt(Transfer {
 				from: Alice.into(),
@@ -759,9 +765,9 @@ mod tests {
 		#[test]
 		fn should_trigger_ready_and_finalized() {
 			// given
-			let pool = pool();
+			let (pool, api) = pool();
 			let watcher = block_on(pool.submit_and_watch(
-				&BlockId::Number(0),
+				api.expect_hash_from_number(0),
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -774,26 +780,25 @@ mod tests {
 			assert_eq!(pool.validated_pool().status().ready, 1);
 			assert_eq!(pool.validated_pool().status().future, 0);
 
+			let hash_of_block2 = api.expect_hash_from_number(2);
+
 			// when
-			block_on(pool.prune_tags(&BlockId::Number(2), vec![vec![0u8]], vec![])).unwrap();
+			block_on(pool.prune_tags(hash_of_block2, vec![vec![0u8]], vec![])).unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 0);
 			assert_eq!(pool.validated_pool().status().future, 0);
 
 			// then
 			let mut stream = futures::executor::block_on_stream(watcher.into_stream());
 			assert_eq!(stream.next(), Some(TransactionStatus::Ready));
-			assert_eq!(
-				stream.next(),
-				Some(TransactionStatus::InBlock((H256::from_low_u64_be(2).into(), 0))),
-			);
+			assert_eq!(stream.next(), Some(TransactionStatus::InBlock((hash_of_block2.into(), 0))),);
 		}
 
 		#[test]
 		fn should_trigger_ready_and_finalized_when_pruning_via_hash() {
 			// given
-			let pool = pool();
+			let (pool, api) = pool();
 			let watcher = block_on(pool.submit_and_watch(
-				&BlockId::Number(0),
+				api.expect_hash_from_number(0),
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -806,8 +811,10 @@ mod tests {
 			assert_eq!(pool.validated_pool().status().ready, 1);
 			assert_eq!(pool.validated_pool().status().future, 0);
 
+			let hash_of_block2 = api.expect_hash_from_number(2);
+
 			// when
-			block_on(pool.prune_tags(&BlockId::Number(2), vec![vec![0u8]], vec![*watcher.hash()]))
+			block_on(pool.prune_tags(hash_of_block2, vec![vec![0u8]], vec![*watcher.hash()]))
 				.unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 0);
 			assert_eq!(pool.validated_pool().status().future, 0);
@@ -815,18 +822,17 @@ mod tests {
 			// then
 			let mut stream = futures::executor::block_on_stream(watcher.into_stream());
 			assert_eq!(stream.next(), Some(TransactionStatus::Ready));
-			assert_eq!(
-				stream.next(),
-				Some(TransactionStatus::InBlock((H256::from_low_u64_be(2).into(), 0))),
-			);
+			assert_eq!(stream.next(), Some(TransactionStatus::InBlock((hash_of_block2.into(), 0))),);
 		}
 
 		#[test]
 		fn should_trigger_future_and_ready_after_promoted() {
 			// given
-			let pool = pool();
+			let (pool, api) = pool();
+			let hash_of_block0 = api.expect_hash_from_number(0);
+
 			let watcher = block_on(pool.submit_and_watch(
-				&BlockId::Number(0),
+				hash_of_block0,
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -841,7 +847,7 @@ mod tests {
 
 			// when
 			block_on(pool.submit_one(
-				&BlockId::Number(0),
+				hash_of_block0,
 				SOURCE,
 				uxt(Transfer {
 					from: Alice.into(),
@@ -862,7 +868,7 @@ mod tests {
 		#[test]
 		fn should_trigger_invalid_and_ban() {
 			// given
-			let pool = pool();
+			let (pool, api) = pool();
 			let uxt = uxt(Transfer {
 				from: Alice.into(),
 				to: AccountId::from_h256(H256::from_low_u64_be(2)),
@@ -870,7 +876,8 @@ mod tests {
 				nonce: 0,
 			});
 			let watcher =
-				block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, uxt)).unwrap();
+				block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, uxt))
+					.unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 1);
 
 			// when
@@ -886,7 +893,7 @@ mod tests {
 		#[test]
 		fn should_trigger_broadcasted() {
 			// given
-			let pool = pool();
+			let (pool, api) = pool();
 			let uxt = uxt(Transfer {
 				from: Alice.into(),
 				to: AccountId::from_h256(H256::from_low_u64_be(2)),
@@ -894,7 +901,8 @@ mod tests {
 				nonce: 0,
 			});
 			let watcher =
-				block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, uxt)).unwrap();
+				block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, uxt))
+					.unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 1);
 
 			// when
@@ -916,7 +924,8 @@ mod tests {
 			let options =
 				Options { ready: limit.clone(), future: limit.clone(), ..Default::default() };
 
-			let pool = Pool::new(options, true.into(), TestApi::default().into());
+			let api = Arc::new(TestApi::default());
+			let pool = Pool::new(options, true.into(), api.clone());
 
 			let xt = uxt(Transfer {
 				from: Alice.into(),
@@ -924,7 +933,9 @@ mod tests {
 				amount: 5,
 				nonce: 0,
 			});
-			let watcher = block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, xt)).unwrap();
+			let watcher =
+				block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, xt))
+					.unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 1);
 
 			// when
@@ -934,7 +945,7 @@ mod tests {
 				amount: 4,
 				nonce: 1,
 			});
-			block_on(pool.submit_one(&BlockId::Number(1), SOURCE, xt)).unwrap();
+			block_on(pool.submit_one(api.expect_hash_from_number(1), SOURCE, xt)).unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 1);
 
 			// then
@@ -951,12 +962,13 @@ mod tests {
 				let options =
 					Options { ready: limit.clone(), future: limit.clone(), ..Default::default() };
 
-				let pool = Pool::new(options, true.into(), TestApi::default().into());
+				let api = Arc::new(TestApi::default());
+				let pool = Pool::new(options, true.into(), api.clone());
 
 				// after validation `IncludeData` will have priority set to 9001
 				// (validate_transaction mock)
 				let xt = ExtrinsicBuilder::new_include_data(Vec::new()).build();
-				block_on(pool.submit_one(&BlockId::Number(0), SOURCE, xt)).unwrap();
+				block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt)).unwrap();
 				assert_eq!(pool.validated_pool().status().ready, 1);
 
 				// then
@@ -968,7 +980,7 @@ mod tests {
 					amount: 4,
 					nonce: 1,
 				});
-				let result = block_on(pool.submit_one(&BlockId::Number(1), SOURCE, xt));
+				let result = block_on(pool.submit_one(api.expect_hash_from_number(1), SOURCE, xt));
 				assert!(matches!(
 					result,
 					Err(sc_transaction_pool_api::error::Error::ImmediatelyDropped)
@@ -980,12 +992,15 @@ mod tests {
 				let options =
 					Options { ready: limit.clone(), future: limit.clone(), ..Default::default() };
 
-				let pool = Pool::new(options, true.into(), TestApi::default().into());
+				let api = Arc::new(TestApi::default());
+				let pool = Pool::new(options, true.into(), api.clone());
+
+				let hash_of_block0 = api.expect_hash_from_number(0);
 
 				// after validation `IncludeData` will have priority set to 9001
 				// (validate_transaction mock)
 				let xt = ExtrinsicBuilder::new_include_data(Vec::new()).build();
-				block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, xt)).unwrap();
+				block_on(pool.submit_and_watch(hash_of_block0, SOURCE, xt)).unwrap();
 				assert_eq!(pool.validated_pool().status().ready, 1);
 
 				// after validation `Transfer` will have priority set to 4 (validate_transaction
@@ -996,15 +1011,14 @@ mod tests {
 					amount: 5,
 					nonce: 0,
 				});
-				let watcher =
-					block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, xt)).unwrap();
+				let watcher = block_on(pool.submit_and_watch(hash_of_block0, SOURCE, xt)).unwrap();
 				assert_eq!(pool.validated_pool().status().ready, 2);
 
 				// when
 				// after validation `Store` will have priority set to 9001 (validate_transaction
 				// mock)
 				let xt = ExtrinsicBuilder::new_indexed_call(Vec::new()).build();
-				block_on(pool.submit_one(&BlockId::Number(1), SOURCE, xt)).unwrap();
+				block_on(pool.submit_one(api.expect_hash_from_number(1), SOURCE, xt)).unwrap();
 				assert_eq!(pool.validated_pool().status().ready, 2);
 
 				// then
@@ -1021,7 +1035,10 @@ mod tests {
 			let (tx, rx) = std::sync::mpsc::sync_channel(1);
 			let mut api = TestApi::default();
 			api.delay = Arc::new(Mutex::new(rx.into()));
-			let pool = Arc::new(Pool::new(Default::default(), true.into(), api.into()));
+			let api = Arc::new(api);
+			let pool = Arc::new(Pool::new(Default::default(), true.into(), api.clone()));
+
+			let hash_of_block0 = api.expect_hash_from_number(0);
 
 			// when
 			let xt = uxt(Transfer {
@@ -1034,7 +1051,7 @@ mod tests {
 			// This transaction should go to future, since we use `nonce: 1`
 			let pool2 = pool.clone();
 			std::thread::spawn(move || {
-				block_on(pool2.submit_one(&BlockId::Number(0), SOURCE, xt)).unwrap();
+				block_on(pool2.submit_one(hash_of_block0, SOURCE, xt)).unwrap();
 				ready.send(()).unwrap();
 			});
 
@@ -1048,12 +1065,13 @@ mod tests {
 			});
 			// The tag the above transaction provides (TestApi is using just nonce as u8)
 			let provides = vec![0_u8];
-			block_on(pool.submit_one(&BlockId::Number(0), SOURCE, xt)).unwrap();
+			block_on(pool.submit_one(hash_of_block0, SOURCE, xt)).unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 1);
 
 			// Now block import happens before the second transaction is able to finish
 			// verification.
-			block_on(pool.prune_tags(&BlockId::Number(1), vec![provides], vec![])).unwrap();
+			block_on(pool.prune_tags(api.expect_hash_from_number(1), vec![provides], vec![]))
+				.unwrap();
 			assert_eq!(pool.validated_pool().status().ready, 0);
 
 			// so when we release the verification of the previous one it will have

--- a/substrate/client/transaction-pool/tests/pool.rs
+++ b/substrate/client/transaction-pool/tests/pool.rs
@@ -47,8 +47,9 @@ use substrate_test_runtime_transaction_pool::{uxt, TestApi};
 
 const LOG_TARGET: &str = "txpool";
 
-fn pool() -> Pool<TestApi> {
-	Pool::new(Default::default(), true.into(), TestApi::with_alice_nonce(209).into())
+fn pool() -> (Pool<TestApi>, Arc<TestApi>) {
+	let api = Arc::new(TestApi::with_alice_nonce(209));
+	(Pool::new(Default::default(), true.into(), api.clone()), api)
 }
 
 fn maintained_pool() -> (BasicPool<TestApi, Block>, Arc<TestApi>, futures::executor::ThreadPool) {
@@ -83,8 +84,8 @@ const SOURCE: TransactionSource = TransactionSource::External;
 
 #[test]
 fn submission_should_work() {
-	let pool = pool();
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 209))).unwrap();
+	let (pool, api) = pool();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 209))).unwrap();
 
 	let pending: Vec<_> = pool
 		.validated_pool()
@@ -96,9 +97,9 @@ fn submission_should_work() {
 
 #[test]
 fn multiple_submission_should_work() {
-	let pool = pool();
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 209))).unwrap();
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 210))).unwrap();
+	let (pool, api) = pool();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 209))).unwrap();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 210))).unwrap();
 
 	let pending: Vec<_> = pool
 		.validated_pool()
@@ -111,8 +112,8 @@ fn multiple_submission_should_work() {
 #[test]
 fn early_nonce_should_be_culled() {
 	sp_tracing::try_init_simple();
-	let pool = pool();
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 208))).unwrap();
+	let (pool, api) = pool();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 208))).unwrap();
 
 	let pending: Vec<_> = pool
 		.validated_pool()
@@ -124,9 +125,9 @@ fn early_nonce_should_be_culled() {
 
 #[test]
 fn late_nonce_should_be_queued() {
-	let pool = pool();
+	let (pool, api) = pool();
 
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 210))).unwrap();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 210))).unwrap();
 	let pending: Vec<_> = pool
 		.validated_pool()
 		.ready()
@@ -134,7 +135,7 @@ fn late_nonce_should_be_queued() {
 		.collect();
 	assert_eq!(pending, Vec::<Nonce>::new());
 
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 209))).unwrap();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 209))).unwrap();
 	let pending: Vec<_> = pool
 		.validated_pool()
 		.ready()
@@ -145,9 +146,10 @@ fn late_nonce_should_be_queued() {
 
 #[test]
 fn prune_tags_should_work() {
-	let pool = pool();
-	let hash209 = block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 209))).unwrap();
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt(Alice, 210))).unwrap();
+	let (pool, api) = pool();
+	let hash209 =
+		block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 209))).unwrap();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt(Alice, 210))).unwrap();
 
 	let pending: Vec<_> = pool
 		.validated_pool()
@@ -157,7 +159,7 @@ fn prune_tags_should_work() {
 	assert_eq!(pending, vec![209, 210]);
 
 	pool.validated_pool().api().push_block(1, Vec::new(), true);
-	block_on(pool.prune_tags(&BlockId::number(1), vec![vec![209]], vec![hash209]))
+	block_on(pool.prune_tags(api.expect_hash_from_number(1), vec![vec![209]], vec![hash209]))
 		.expect("Prune tags");
 
 	let pending: Vec<_> = pool
@@ -170,11 +172,12 @@ fn prune_tags_should_work() {
 
 #[test]
 fn should_ban_invalid_transactions() {
-	let pool = pool();
+	let (pool, api) = pool();
 	let uxt = uxt(Alice, 209);
-	let hash = block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt.clone())).unwrap();
+	let hash =
+		block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt.clone())).unwrap();
 	pool.validated_pool().remove_invalid(&[hash]);
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt.clone())).unwrap_err();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt.clone())).unwrap_err();
 
 	// when
 	let pending: Vec<_> = pool
@@ -185,7 +188,7 @@ fn should_ban_invalid_transactions() {
 	assert_eq!(pending, Vec::<Nonce>::new());
 
 	// then
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, uxt.clone())).unwrap_err();
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, uxt.clone())).unwrap_err();
 }
 
 #[test]
@@ -193,9 +196,9 @@ fn only_prune_on_new_best() {
 	let (pool, api, _) = maintained_pool();
 	let uxt = uxt(Alice, 209);
 
-	let _ = block_on(pool.submit_and_watch(&BlockId::number(0), SOURCE, uxt.clone()))
+	let _ = block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, uxt.clone()))
 		.expect("1. Imported");
-	pool.api().push_block(1, vec![uxt.clone()], true);
+	api.push_block(1, vec![uxt.clone()], true);
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(2, vec![uxt], true);
@@ -212,13 +215,15 @@ fn should_correctly_prune_transactions_providing_more_than_one_tag() {
 	}));
 	let pool = Pool::new(Default::default(), true.into(), api.clone());
 	let xt = uxt(Alice, 209);
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+		.expect("1. Imported");
 	assert_eq!(pool.validated_pool().status().ready, 1);
 
 	// remove the transaction that just got imported.
 	api.increment_nonce(Alice.into());
 	api.push_block(1, Vec::new(), true);
-	block_on(pool.prune_tags(&BlockId::number(1), vec![vec![209]], vec![])).expect("1. Pruned");
+	block_on(pool.prune_tags(api.expect_hash_from_number(1), vec![vec![209]], vec![]))
+		.expect("1. Pruned");
 	assert_eq!(pool.validated_pool().status().ready, 0);
 	// it's re-imported to future
 	assert_eq!(pool.validated_pool().status().future, 1);
@@ -227,7 +232,8 @@ fn should_correctly_prune_transactions_providing_more_than_one_tag() {
 	api.increment_nonce(Alice.into());
 	api.push_block(2, Vec::new(), true);
 	let xt = uxt(Alice, 211);
-	block_on(pool.submit_one(&BlockId::number(2), SOURCE, xt.clone())).expect("2. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(2), SOURCE, xt.clone()))
+		.expect("2. Imported");
 	assert_eq!(pool.validated_pool().status().ready, 1);
 	assert_eq!(pool.validated_pool().status().future, 1);
 	let pending: Vec<_> = pool
@@ -240,7 +246,8 @@ fn should_correctly_prune_transactions_providing_more_than_one_tag() {
 	// prune it and make sure the pool is empty
 	api.increment_nonce(Alice.into());
 	api.push_block(3, Vec::new(), true);
-	block_on(pool.prune_tags(&BlockId::number(3), vec![vec![155]], vec![])).expect("2. Pruned");
+	block_on(pool.prune_tags(api.expect_hash_from_number(3), vec![vec![155]], vec![]))
+		.expect("2. Pruned");
 	assert_eq!(pool.validated_pool().status().ready, 0);
 	assert_eq!(pool.validated_pool().status().future, 2);
 }
@@ -270,7 +277,8 @@ fn should_prune_old_during_maintenance() {
 
 	let (pool, api, _guard) = maintained_pool();
 
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+		.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(1, vec![xt.clone()], true);
@@ -285,9 +293,11 @@ fn should_revalidate_during_maintenance() {
 	let xt2 = uxt(Alice, 210);
 
 	let (pool, api, _guard) = maintained_pool();
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt1.clone())).expect("1. Imported");
-	let watcher = block_on(pool.submit_and_watch(&BlockId::number(0), SOURCE, xt2.clone()))
-		.expect("2. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt1.clone()))
+		.expect("1. Imported");
+	let watcher =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, xt2.clone()))
+			.expect("2. Imported");
 	assert_eq!(pool.status().ready, 2);
 	assert_eq!(api.validation_requests().len(), 2);
 
@@ -311,7 +321,8 @@ fn should_resubmit_from_retracted_during_maintenance() {
 
 	let (pool, api, _guard) = maintained_pool();
 
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+		.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(1, vec![], true);
@@ -329,7 +340,8 @@ fn should_not_resubmit_from_retracted_during_maintenance_if_tx_is_also_in_enacte
 
 	let (pool, api, _guard) = maintained_pool();
 
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+		.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(1, vec![xt.clone()], true);
@@ -347,8 +359,9 @@ fn should_not_retain_invalid_hashes_from_retracted() {
 
 	let (pool, api, _guard) = maintained_pool();
 
-	let watcher = block_on(pool.submit_and_watch(&BlockId::number(0), SOURCE, xt.clone()))
-		.expect("1. Imported");
+	let watcher =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+			.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(1, vec![], true);
@@ -374,15 +387,18 @@ fn should_revalidate_across_many_blocks() {
 
 	let (pool, api, _guard) = maintained_pool();
 
-	let watcher1 = block_on(pool.submit_and_watch(&BlockId::number(0), SOURCE, xt1.clone()))
+	let watcher1 =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, xt1.clone()))
+			.expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt2.clone()))
 		.expect("1. Imported");
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt2.clone())).expect("1. Imported");
 	assert_eq!(pool.status().ready, 2);
 
 	let header = api.push_block(1, vec![], true);
 	block_on(pool.maintain(block_event(header)));
 
-	block_on(pool.submit_one(&BlockId::number(1), SOURCE, xt3.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(1), SOURCE, xt3.clone()))
+		.expect("1. Imported");
 	assert_eq!(pool.status().ready, 3);
 
 	let header = api.push_block(2, vec![xt1.clone()], true);
@@ -409,19 +425,24 @@ fn should_push_watchers_during_maintenance() {
 
 	let tx0 = alice_uxt(0);
 	let watcher0 =
-		block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, tx0.clone())).unwrap();
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, tx0.clone()))
+			.unwrap();
 	let tx1 = alice_uxt(1);
 	let watcher1 =
-		block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, tx1.clone())).unwrap();
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, tx1.clone()))
+			.unwrap();
 	let tx2 = alice_uxt(2);
 	let watcher2 =
-		block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, tx2.clone())).unwrap();
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, tx2.clone()))
+			.unwrap();
 	let tx3 = alice_uxt(3);
 	let watcher3 =
-		block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, tx3.clone())).unwrap();
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, tx3.clone()))
+			.unwrap();
 	let tx4 = alice_uxt(4);
 	let watcher4 =
-		block_on(pool.submit_and_watch(&BlockId::Number(0), SOURCE, tx4.clone())).unwrap();
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, tx4.clone()))
+			.unwrap();
 	assert_eq!(pool.status().ready, 5);
 
 	// when
@@ -489,11 +510,13 @@ fn finalization() {
 	let api = TestApi::with_alice_nonce(209);
 	api.push_block(1, vec![], true);
 	let pool = create_basic_pool(api);
-	let watcher = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, xt.clone()))
-		.expect("1. Imported");
-	pool.api().push_block(2, vec![xt.clone()], true);
+	let api = pool.api();
+	let watcher =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, xt.clone()))
+			.expect("1. Imported");
+	api.push_block(2, vec![xt.clone()], true);
 
-	let header = pool.api().chain().read().block_by_number.get(&2).unwrap()[0].0.header().clone();
+	let header = api.chain().read().block_by_number.get(&2).unwrap()[0].0.header().clone();
 	let event = ChainEvent::NewBestBlock { hash: header.hash(), tree_route: None };
 	block_on(pool.maintain(event));
 
@@ -515,16 +538,17 @@ fn fork_aware_finalization() {
 	let a_header = api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 	let mut canon_watchers = vec![];
 
 	let from_alice = uxt(Alice, 1);
 	let from_dave = uxt(Dave, 2);
 	let from_bob = uxt(Bob, 1);
 	let from_charlie = uxt(Charlie, 1);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Dave.into());
-	pool.api().increment_nonce(Charlie.into());
-	pool.api().increment_nonce(Bob.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Dave.into());
+	api.increment_nonce(Charlie.into());
+	api.increment_nonce(Bob.into());
 
 	let from_dave_watcher;
 	let from_bob_watcher;
@@ -538,10 +562,13 @@ fn fork_aware_finalization() {
 
 	// block B1
 	{
-		let watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-				.expect("1. Imported");
-		let header = pool.api().push_block(2, vec![from_alice.clone()], true);
+		let watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_alice.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block(2, vec![from_alice.clone()], true);
 		canon_watchers.push((watcher, header.hash()));
 		assert_eq!(pool.status().ready, 1);
 
@@ -556,10 +583,13 @@ fn fork_aware_finalization() {
 
 	// block C2
 	{
-		let header = pool.api().push_block_with_parent(b1, vec![from_dave.clone()], true);
-		from_dave_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_dave.clone()))
-				.expect("1. Imported");
+		let header = api.push_block_with_parent(b1, vec![from_dave.clone()], true);
+		from_dave_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_dave.clone(),
+		))
+		.expect("1. Imported");
 		assert_eq!(pool.status().ready, 1);
 		log::trace!(target: LOG_TARGET, ">> C2: {:?} {:?}", header.hash(), header);
 		let event = ChainEvent::NewBestBlock { hash: header.hash(), tree_route: None };
@@ -570,11 +600,14 @@ fn fork_aware_finalization() {
 
 	// block D2
 	{
-		from_bob_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_bob.clone()))
-				.expect("1. Imported");
+		from_bob_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_bob.clone(),
+		))
+		.expect("1. Imported");
 		assert_eq!(pool.status().ready, 1);
-		let header = pool.api().push_block_with_parent(c2, vec![from_bob.clone()], true);
+		let header = api.push_block_with_parent(c2, vec![from_bob.clone()], true);
 
 		log::trace!(target: LOG_TARGET, ">> D2: {:?} {:?}", header.hash(), header);
 		let event = ChainEvent::NewBestBlock { hash: header.hash(), tree_route: None };
@@ -585,15 +618,18 @@ fn fork_aware_finalization() {
 
 	// block C1
 	{
-		let watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_charlie.clone()))
-				.expect("1.Imported");
+		let watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_charlie.clone(),
+		))
+		.expect("1.Imported");
 		assert_eq!(pool.status().ready, 1);
-		let header = pool.api().push_block_with_parent(b1, vec![from_charlie.clone()], true);
+		let header = api.push_block_with_parent(b1, vec![from_charlie.clone()], true);
 		log::trace!(target: LOG_TARGET, ">> C1: {:?} {:?}", header.hash(), header);
 		c1 = header.hash();
 		canon_watchers.push((watcher, header.hash()));
-		let event = block_event_with_retracted(header.clone(), d2, pool.api());
+		let event = block_event_with_retracted(header.clone(), d2, api);
 		block_on(pool.maintain(event));
 		assert_eq!(pool.status().ready, 2);
 
@@ -604,10 +640,10 @@ fn fork_aware_finalization() {
 	// block D1
 	{
 		let xt = uxt(Eve, 0);
-		let w = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, xt.clone()))
+		let w = block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, xt.clone()))
 			.expect("1. Imported");
 		assert_eq!(pool.status().ready, 3);
-		let header = pool.api().push_block_with_parent(c1, vec![xt.clone()], true);
+		let header = api.push_block_with_parent(c1, vec![xt.clone()], true);
 		log::trace!(target: LOG_TARGET, ">> D1: {:?} {:?}", header.hash(), header);
 		d1 = header.hash();
 		canon_watchers.push((w, header.hash()));
@@ -623,7 +659,7 @@ fn fork_aware_finalization() {
 
 	// block E1
 	{
-		let header = pool.api().push_block_with_parent(d1, vec![from_dave, from_bob], true);
+		let header = api.push_block_with_parent(d1, vec![from_dave, from_bob], true);
 		log::trace!(target: LOG_TARGET, ">> E1: {:?} {:?}", header.hash(), header);
 		e1 = header.hash();
 		let event = ChainEvent::NewBestBlock { hash: header.hash(), tree_route: None };
@@ -673,16 +709,18 @@ fn prune_and_retract_tx_at_same_time() {
 	api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let from_alice = uxt(Alice, 1);
-	pool.api().increment_nonce(Alice.into());
+	api.increment_nonce(Alice.into());
 
-	let watcher = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-		.expect("1. Imported");
+	let watcher =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, from_alice.clone()))
+			.expect("1. Imported");
 
 	// Block B1
 	let b1 = {
-		let header = pool.api().push_block(2, vec![from_alice.clone()], true);
+		let header = api.push_block(2, vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 
 		let event = ChainEvent::NewBestBlock { hash: header.hash(), tree_route: None };
@@ -693,10 +731,10 @@ fn prune_and_retract_tx_at_same_time() {
 
 	// Block B2
 	let b2 = {
-		let header = pool.api().push_block(2, vec![from_alice.clone()], true);
+		let header = api.push_block(2, vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 0);
 
-		let event = block_event_with_retracted(header.clone(), b1, pool.api());
+		let event = block_event_with_retracted(header.clone(), b1, api);
 		block_on(pool.maintain(event));
 		assert_eq!(pool.status().ready, 0);
 
@@ -739,19 +777,21 @@ fn resubmit_tx_of_fork_that_is_not_part_of_retracted() {
 	api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let tx0 = uxt(Alice, 1);
 	let tx1 = uxt(Dave, 2);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Dave.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Dave.into());
 
 	let d0;
 
 	// Block D0
 	{
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx0.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block(2, vec![tx0.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx0.clone()))
+				.expect("1. Imported");
+		let header = api.push_block(2, vec![tx0.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 
 		let event = ChainEvent::NewBestBlock { hash: header.hash(), tree_route: None };
@@ -762,17 +802,18 @@ fn resubmit_tx_of_fork_that_is_not_part_of_retracted() {
 
 	// Block D1
 	{
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx1.clone()))
-			.expect("1. Imported");
-		pool.api().push_block(2, vec![tx1.clone()], false);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx1.clone()))
+				.expect("1. Imported");
+		api.push_block(2, vec![tx1.clone()], false);
 		assert_eq!(pool.status().ready, 1);
 	}
 
 	// Block D2
 	{
 		//push new best block
-		let header = pool.api().push_block(2, vec![], true);
-		let event = block_event_with_retracted(header, d0, pool.api());
+		let header = api.push_block(2, vec![], true);
+		let event = block_event_with_retracted(header, d0, api);
 		block_on(pool.maintain(event));
 		assert_eq!(pool.status().ready, 2);
 	}
@@ -786,6 +827,8 @@ fn resubmit_from_retracted_fork() {
 
 	let pool = create_basic_pool(api);
 
+	let api = pool.api();
+
 	let tx0 = uxt(Alice, 1);
 	let tx1 = uxt(Dave, 2);
 	let tx2 = uxt(Bob, 3);
@@ -795,18 +838,19 @@ fn resubmit_from_retracted_fork() {
 	let tx4 = uxt(Ferdie, 2);
 	let tx5 = uxt(One, 3);
 
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Dave.into());
-	pool.api().increment_nonce(Bob.into());
-	pool.api().increment_nonce(Eve.into());
-	pool.api().increment_nonce(Ferdie.into());
-	pool.api().increment_nonce(One.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Dave.into());
+	api.increment_nonce(Bob.into());
+	api.increment_nonce(Eve.into());
+	api.increment_nonce(Ferdie.into());
+	api.increment_nonce(One.into());
 
 	// Block D0
 	{
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx0.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block(2, vec![tx0.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx0.clone()))
+				.expect("1. Imported");
+		let header = api.push_block(2, vec![tx0.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 
 		block_on(pool.maintain(block_event(header)));
@@ -815,18 +859,20 @@ fn resubmit_from_retracted_fork() {
 
 	// Block E0
 	{
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx1.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block(3, vec![tx1.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx1.clone()))
+				.expect("1. Imported");
+		let header = api.push_block(3, vec![tx1.clone()], true);
 		block_on(pool.maintain(block_event(header)));
 		assert_eq!(pool.status().ready, 0);
 	}
 
 	// Block F0
 	let f0 = {
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx2.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block(4, vec![tx2.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx2.clone()))
+				.expect("1. Imported");
+		let header = api.push_block(4, vec![tx2.clone()], true);
 		block_on(pool.maintain(block_event(header.clone())));
 		assert_eq!(pool.status().ready, 0);
 		header.hash()
@@ -834,27 +880,30 @@ fn resubmit_from_retracted_fork() {
 
 	// Block D1
 	let d1 = {
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx3.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block(2, vec![tx3.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx3.clone()))
+				.expect("1. Imported");
+		let header = api.push_block(2, vec![tx3.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 		header.hash()
 	};
 
 	// Block E1
 	let e1 = {
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx4.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block_with_parent(d1, vec![tx4.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx4.clone()))
+				.expect("1. Imported");
+		let header = api.push_block_with_parent(d1, vec![tx4.clone()], true);
 		assert_eq!(pool.status().ready, 2);
 		header.hash()
 	};
 
 	// Block F1
 	let f1_header = {
-		let _ = block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, tx5.clone()))
-			.expect("1. Imported");
-		let header = pool.api().push_block_with_parent(e1, vec![tx5.clone()], true);
+		let _ =
+			block_on(pool.submit_and_watch(api.expect_hash_from_number(1), SOURCE, tx5.clone()))
+				.expect("1. Imported");
+		let header = api.push_block_with_parent(e1, vec![tx5.clone()], true);
 		// Don't announce the block event to the pool directly, because we will
 		// re-org to this block.
 		assert_eq!(pool.status().ready, 3);
@@ -865,7 +914,7 @@ fn resubmit_from_retracted_fork() {
 	let expected_ready = vec![tx3, tx4, tx5].iter().map(Encode::encode).collect::<BTreeSet<_>>();
 	assert_eq!(expected_ready, ready);
 
-	let event = block_event_with_retracted(f1_header, f0, pool.api());
+	let event = block_event_with_retracted(f1_header, f0, api);
 	block_on(pool.maintain(event));
 
 	assert_eq!(pool.status().ready, 3);
@@ -876,9 +925,10 @@ fn resubmit_from_retracted_fork() {
 
 #[test]
 fn ready_set_should_not_resolve_before_block_update() {
-	let (pool, _api, _guard) = maintained_pool();
+	let (pool, api, _guard) = maintained_pool();
 	let xt1 = uxt(Alice, 209);
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt1.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt1.clone()))
+		.expect("1. Imported");
 
 	assert!(pool.ready_at(1).now_or_never().is_none());
 }
@@ -890,7 +940,8 @@ fn ready_set_should_resolve_after_block_update() {
 
 	let xt1 = uxt(Alice, 209);
 
-	block_on(pool.submit_one(&BlockId::number(1), SOURCE, xt1.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(1), SOURCE, xt1.clone()))
+		.expect("1. Imported");
 	block_on(pool.maintain(block_event(header)));
 
 	assert!(pool.ready_at(1).now_or_never().is_some());
@@ -903,7 +954,8 @@ fn ready_set_should_eventually_resolve_when_block_update_arrives() {
 
 	let xt1 = uxt(Alice, 209);
 
-	block_on(pool.submit_one(&BlockId::number(1), SOURCE, xt1.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(1), SOURCE, xt1.clone()))
+		.expect("1. Imported");
 
 	let noop_waker = futures::task::noop_waker();
 	let mut context = futures::task::Context::from_waker(&noop_waker);
@@ -948,7 +1000,12 @@ fn import_notification_to_pool_maintain_works() {
 
 	// Prepare the extrisic, push it to the pool and check that it was added.
 	let xt = uxt(Alice, 0);
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt.clone())).expect("1. Imported");
+	block_on(pool.submit_one(
+		pool.api().block_id_to_hash(&BlockId::Number(0)).unwrap().unwrap(),
+		SOURCE,
+		xt.clone(),
+	))
+	.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let mut import_stream = block_on_stream(client.import_notification_stream());
@@ -973,7 +1030,8 @@ fn pruning_a_transaction_should_remove_it_from_best_transaction() {
 
 	let xt1 = ExtrinsicBuilder::new_include_data(Vec::new()).build();
 
-	block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt1.clone())).expect("1. Imported");
+	block_on(pool.submit_one(api.expect_hash_from_number(0), SOURCE, xt1.clone()))
+		.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 	let header = api.push_block(1, vec![xt1.clone()], true);
 
@@ -997,8 +1055,12 @@ fn stale_transactions_are_pruned() {
 	let (pool, api, _guard) = maintained_pool();
 
 	xts.into_iter().for_each(|xt| {
-		block_on(pool.submit_one(&BlockId::number(0), SOURCE, xt.into_unchecked_extrinsic()))
-			.expect("1. Imported");
+		block_on(pool.submit_one(
+			api.expect_hash_from_number(0),
+			SOURCE,
+			xt.into_unchecked_extrinsic(),
+		))
+		.expect("1. Imported");
 	});
 	assert_eq!(pool.status().ready, 0);
 	assert_eq!(pool.status().future, 3);
@@ -1038,8 +1100,9 @@ fn finalized_only_handled_correctly() {
 
 	let (pool, api, _guard) = maintained_pool();
 
-	let watcher = block_on(pool.submit_and_watch(&BlockId::number(0), SOURCE, xt.clone()))
-		.expect("1. Imported");
+	let watcher =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+			.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(1, vec![xt], true);
@@ -1066,8 +1129,9 @@ fn best_block_after_finalized_handled_correctly() {
 
 	let (pool, api, _guard) = maintained_pool();
 
-	let watcher = block_on(pool.submit_and_watch(&BlockId::number(0), SOURCE, xt.clone()))
-		.expect("1. Imported");
+	let watcher =
+		block_on(pool.submit_and_watch(api.expect_hash_from_number(0), SOURCE, xt.clone()))
+			.expect("1. Imported");
 	assert_eq!(pool.status().ready, 1);
 
 	let header = api.push_block(1, vec![xt], true);
@@ -1096,11 +1160,12 @@ fn switching_fork_with_finalized_works() {
 	let a_header = api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let from_alice = uxt(Alice, 1);
 	let from_bob = uxt(Bob, 2);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Bob.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Bob.into());
 
 	let from_alice_watcher;
 	let from_bob_watcher;
@@ -1109,12 +1174,13 @@ fn switching_fork_with_finalized_works() {
 
 	// block B1
 	{
-		from_alice_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
+		from_alice_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_alice.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 		log::trace!(target: LOG_TARGET, ">> B1: {:?} {:?}", header.hash(), header);
 		b1_header = header;
@@ -1122,10 +1188,13 @@ fn switching_fork_with_finalized_works() {
 
 	// block B2
 	{
-		from_bob_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_bob.clone()))
-				.expect("1. Imported");
-		let header = pool.api().push_block_with_parent(
+		from_bob_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_bob.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(
 			a_header.hash(),
 			vec![from_alice.clone(), from_bob.clone()],
 			true,
@@ -1174,11 +1243,12 @@ fn switching_fork_multiple_times_works() {
 	let a_header = api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let from_alice = uxt(Alice, 1);
 	let from_bob = uxt(Bob, 2);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Bob.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Bob.into());
 
 	let from_alice_watcher;
 	let from_bob_watcher;
@@ -1187,12 +1257,13 @@ fn switching_fork_multiple_times_works() {
 
 	// block B1
 	{
-		from_alice_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
+		from_alice_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_alice.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 		log::trace!(target: LOG_TARGET, ">> B1: {:?} {:?}", header.hash(), header);
 		b1_header = header;
@@ -1200,10 +1271,13 @@ fn switching_fork_multiple_times_works() {
 
 	// block B2
 	{
-		from_bob_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_bob.clone()))
-				.expect("1. Imported");
-		let header = pool.api().push_block_with_parent(
+		from_bob_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_bob.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(
 			a_header.hash(),
 			vec![from_alice.clone(), from_bob.clone()],
 			true,
@@ -1223,14 +1297,14 @@ fn switching_fork_multiple_times_works() {
 
 	{
 		// phase-1
-		let event = block_event_with_retracted(b2_header.clone(), b1_header.hash(), pool.api());
+		let event = block_event_with_retracted(b2_header.clone(), b1_header.hash(), api);
 		block_on(pool.maintain(event));
 		assert_eq!(pool.status().ready, 0);
 	}
 
 	{
 		// phase-2
-		let event = block_event_with_retracted(b1_header.clone(), b2_header.hash(), pool.api());
+		let event = block_event_with_retracted(b1_header.clone(), b2_header.hash(), api);
 		block_on(pool.maintain(event));
 		assert_eq!(pool.status().ready, 1);
 	}
@@ -1282,13 +1356,14 @@ fn two_blocks_delayed_finalization_works() {
 	let a_header = api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let from_alice = uxt(Alice, 1);
 	let from_bob = uxt(Bob, 2);
 	let from_charlie = uxt(Charlie, 3);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Bob.into());
-	pool.api().increment_nonce(Charlie.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Bob.into());
+	api.increment_nonce(Charlie.into());
 
 	let from_alice_watcher;
 	let from_bob_watcher;
@@ -1299,12 +1374,13 @@ fn two_blocks_delayed_finalization_works() {
 
 	// block B1
 	{
-		from_alice_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
+		from_alice_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_alice.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 
 		log::trace!(target: LOG_TARGET, ">> B1: {:?} {:?}", header.hash(), header);
@@ -1313,12 +1389,13 @@ fn two_blocks_delayed_finalization_works() {
 
 	// block C1
 	{
-		from_bob_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_bob.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(b1_header.hash(), vec![from_bob.clone()], true);
+		from_bob_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_bob.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(b1_header.hash(), vec![from_bob.clone()], true);
 		assert_eq!(pool.status().ready, 2);
 
 		log::trace!(target: LOG_TARGET, ">> C1: {:?} {:?}", header.hash(), header);
@@ -1327,12 +1404,13 @@ fn two_blocks_delayed_finalization_works() {
 
 	// block D1
 	{
-		from_charlie_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_charlie.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(c1_header.hash(), vec![from_charlie.clone()], true);
+		from_charlie_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_charlie.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(c1_header.hash(), vec![from_charlie.clone()], true);
 		assert_eq!(pool.status().ready, 3);
 
 		log::trace!(target: LOG_TARGET, ">> D1: {:?} {:?}", header.hash(), header);
@@ -1398,11 +1476,12 @@ fn delayed_finalization_does_not_retract() {
 	let a_header = api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let from_alice = uxt(Alice, 1);
 	let from_bob = uxt(Bob, 2);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Bob.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Bob.into());
 
 	let from_alice_watcher;
 	let from_bob_watcher;
@@ -1411,12 +1490,13 @@ fn delayed_finalization_does_not_retract() {
 
 	// block B1
 	{
-		from_alice_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
+		from_alice_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_alice.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 
 		log::trace!(target: LOG_TARGET, ">> B1: {:?} {:?}", header.hash(), header);
@@ -1425,12 +1505,13 @@ fn delayed_finalization_does_not_retract() {
 
 	// block C1
 	{
-		from_bob_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_bob.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(b1_header.hash(), vec![from_bob.clone()], true);
+		from_bob_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_bob.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(b1_header.hash(), vec![from_bob.clone()], true);
 		assert_eq!(pool.status().ready, 2);
 
 		log::trace!(target: LOG_TARGET, ">> C1: {:?} {:?}", header.hash(), header);
@@ -1493,11 +1574,12 @@ fn best_block_after_finalization_does_not_retract() {
 	let a_header = api.push_block(1, vec![], true);
 
 	let pool = create_basic_pool(api);
+	let api = pool.api();
 
 	let from_alice = uxt(Alice, 1);
 	let from_bob = uxt(Bob, 2);
-	pool.api().increment_nonce(Alice.into());
-	pool.api().increment_nonce(Bob.into());
+	api.increment_nonce(Alice.into());
+	api.increment_nonce(Bob.into());
 
 	let from_alice_watcher;
 	let from_bob_watcher;
@@ -1506,12 +1588,13 @@ fn best_block_after_finalization_does_not_retract() {
 
 	// block B1
 	{
-		from_alice_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_alice.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
+		from_alice_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_alice.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(a_header.hash(), vec![from_alice.clone()], true);
 		assert_eq!(pool.status().ready, 1);
 
 		log::trace!(target: LOG_TARGET, ">> B1: {:?} {:?}", header.hash(), header);
@@ -1520,12 +1603,13 @@ fn best_block_after_finalization_does_not_retract() {
 
 	// block C1
 	{
-		from_bob_watcher =
-			block_on(pool.submit_and_watch(&BlockId::number(1), SOURCE, from_bob.clone()))
-				.expect("1. Imported");
-		let header =
-			pool.api()
-				.push_block_with_parent(b1_header.hash(), vec![from_bob.clone()], true);
+		from_bob_watcher = block_on(pool.submit_and_watch(
+			api.expect_hash_from_number(1),
+			SOURCE,
+			from_bob.clone(),
+		))
+		.expect("1. Imported");
+		let header = api.push_block_with_parent(b1_header.hash(), vec![from_bob.clone()], true);
 		assert_eq!(pool.status().ready, 2);
 
 		log::trace!(target: LOG_TARGET, ">> C1: {:?} {:?}", header.hash(), header);


### PR DESCRIPTION
It changes following APIs:
- trait ChainApi 
-- `validate_transaction`

- trait `TransactionPool` --`submit_at`
--`submit_one`
--`submit_and_watch`

and some implementation details, in particular:
- impl `Pool` --`submit_at`
--`resubmit_at`
--`submit_one`
--`submit_and_watch`
--`prune_known`
--`prune`
--`prune_tags`
--`resolve_block_number`
--`verify`
--`verify_one`A

- revalidation queue

All tests are also adjusted.

This PR is part of BlockId::Number refactoring analysis (https://github.com/paritytech/polkadot-sdk/issues/53)
Some ground work towards: (https://github.com/paritytech/polkadot-sdk/issues/1202)
