### PR TITLE
fungible/s decrease balance preserves account

### DIFF
--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -184,6 +184,7 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 		if let BestEffort = precision {
 			amount = amount.min(free);
 		}
+		ensure!(free >= amount, TokenError::FundsUnavailable);
 		let new_balance = old_balance.checked_sub(&amount).ok_or(TokenError::FundsUnavailable)?;
 		if let Some(dust) = Self::write_balance(who, new_balance)? {
 			Self::handle_dust(Dust(dust));

--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -181,10 +181,10 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 	) -> Result<Self::Balance, DispatchError> {
 		let old_balance = Self::balance(who);
 		let free = Self::reducible_balance(who, preservation, force);
-		if let BestEffort = precision {
-			amount = amount.min(free);
+		match precision {
+			BestEffort => amount = amount.min(free),
+			Exact => ensure!(free >= amount, TokenError::FundsUnavailable),
 		}
-		ensure!(free >= amount, TokenError::FundsUnavailable);
 		let new_balance = old_balance.checked_sub(&amount).ok_or(TokenError::FundsUnavailable)?;
 		if let Some(dust) = Self::write_balance(who, new_balance)? {
 			Self::handle_dust(Dust(dust));

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -198,6 +198,7 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 		if let BestEffort = precision {
 			amount = amount.min(free);
 		}
+		ensure!(free >= amount, TokenError::FundsUnavailable);
 		let new_balance = old_balance.checked_sub(&amount).ok_or(TokenError::FundsUnavailable)?;
 		if let Some(dust) = Self::write_balance(asset.clone(), who, new_balance)? {
 			Self::handle_dust(Dust(asset, dust));

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -195,10 +195,10 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 	) -> Result<Self::Balance, DispatchError> {
 		let old_balance = Self::balance(asset.clone(), who);
 		let free = Self::reducible_balance(asset.clone(), who, preservation, force);
-		if let BestEffort = precision {
-			amount = amount.min(free);
+		match precision {
+			BestEffort => amount = amount.min(free),
+			Exact => ensure!(free >= amount, TokenError::FundsUnavailable),
 		}
-		ensure!(free >= amount, TokenError::FundsUnavailable);
 		let new_balance = old_balance.checked_sub(&amount).ok_or(TokenError::FundsUnavailable)?;
 		if let Some(dust) = Self::write_balance(asset.clone(), who, new_balance)? {
 			Self::handle_dust(Dust(asset, dust));


### PR DESCRIPTION
Ensure `preservation` is respected when decreasing balance through `fangible/s::Unbalanced::decrease_balance`.

At present, an account might be removed even if `preservation` is set to `Preserve` or `Protect`. Given the default implementation of `decrease_balance`, we can't pinpoint the exact constraint that wasn't satisfied (frozen or ED). As a result, we return the `FundsUnavailable` error.

There's a more extensive PR that aims to address the same problem: https://github.com/paritytech/polkadot-sdk/pull/1296. Due to its broader scope, I'm maintaining this one separately, in the event it can be merged sooner. The new tests introduced here will eventually be superseded by the conformance tests from the referenced PR.

Closes: https://github.com/paritytech/polkadot-sdk/issues/1698