### PR TITLE
Changes to handling partial responses

### DIFF
--- a/substrate/client/network/sync/src/extra_requests.rs
+++ b/substrate/client/network/sync/src/extra_requests.rs
@@ -343,14 +343,11 @@ impl<'a, B: BlockT> Matcher<'a, B> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{PeerDownloadState, PeerSync};
+	use crate::PeerSync;
 	use quickcheck::{Arbitrary, Gen, QuickCheck};
 	use sp_blockchain::Error as ClientError;
 	use sp_test_primitives::{Block, BlockNumber, Hash};
-	use std::{
-		collections::{HashMap, HashSet},
-		ops::Range,
-	};
+	use std::collections::{HashMap, HashSet};
 
 	#[test]
 	fn requests_are_processed_in_order() {
@@ -545,10 +542,7 @@ mod tests {
 			let s = match u8::arbitrary(g) % 4 {
 				0 => PeerSyncState::Available,
 				// TODO: 1 => PeerSyncState::AncestorSearch(g.gen(), AncestorSearchState<B>),
-				1 => PeerSyncState::DownloadingNew(PeerDownloadState::new(
-					BlockNumber::arbitrary(g),
-					Range { start: BlockNumber::arbitrary(g), end: BlockNumber::arbitrary(g) },
-				)),
+				1 => PeerSyncState::DownloadingNew(BlockNumber::arbitrary(g)),
 				2 => PeerSyncState::DownloadingStale(Hash::random()),
 				_ => PeerSyncState::DownloadingJustification(Hash::random()),
 			};

--- a/substrate/client/network/sync/src/extra_requests.rs
+++ b/substrate/client/network/sync/src/extra_requests.rs
@@ -343,11 +343,12 @@ impl<'a, B: BlockT> Matcher<'a, B> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::PeerSync;
+	use crate::{PeerDownloadState, PeerSync};
 	use quickcheck::{Arbitrary, Gen, QuickCheck};
 	use sp_blockchain::Error as ClientError;
 	use sp_test_primitives::{Block, BlockNumber, Hash};
 	use std::collections::{HashMap, HashSet};
+	use std::ops::Range;
 
 	#[test]
 	fn requests_are_processed_in_order() {
@@ -542,7 +543,13 @@ mod tests {
 			let s = match u8::arbitrary(g) % 4 {
 				0 => PeerSyncState::Available,
 				// TODO: 1 => PeerSyncState::AncestorSearch(g.gen(), AncestorSearchState<B>),
-				1 => PeerSyncState::DownloadingNew(BlockNumber::arbitrary(g)),
+				1 => PeerSyncState::DownloadingNew(PeerDownloadState::new(
+					BlockNumber::arbitrary(g),
+					Range {
+						start: BlockNumber::arbitrary(g),
+						end: BlockNumber::arbitrary(g),
+					}
+				)),
 				2 => PeerSyncState::DownloadingStale(Hash::random()),
 				_ => PeerSyncState::DownloadingJustification(Hash::random()),
 			};

--- a/substrate/client/network/sync/src/extra_requests.rs
+++ b/substrate/client/network/sync/src/extra_requests.rs
@@ -347,8 +347,10 @@ mod tests {
 	use quickcheck::{Arbitrary, Gen, QuickCheck};
 	use sp_blockchain::Error as ClientError;
 	use sp_test_primitives::{Block, BlockNumber, Hash};
-	use std::collections::{HashMap, HashSet};
-	use std::ops::Range;
+	use std::{
+		collections::{HashMap, HashSet},
+		ops::Range,
+	};
 
 	#[test]
 	fn requests_are_processed_in_order() {
@@ -545,10 +547,7 @@ mod tests {
 				// TODO: 1 => PeerSyncState::AncestorSearch(g.gen(), AncestorSearchState<B>),
 				1 => PeerSyncState::DownloadingNew(PeerDownloadState::new(
 					BlockNumber::arbitrary(g),
-					Range {
-						start: BlockNumber::arbitrary(g),
-						end: BlockNumber::arbitrary(g),
-					}
+					Range { start: BlockNumber::arbitrary(g), end: BlockNumber::arbitrary(g) },
 				)),
 				2 => PeerSyncState::DownloadingStale(Hash::random()),
 				_ => PeerSyncState::DownloadingJustification(Hash::random()),


### PR DESCRIPTION
Context: https://github.com/paritytech/polkadot-sdk/issues/493#issuecomment-1728917139

Problem: When downloading from a fork, the peer may send a partial response that extends the current chain. Even though the response starts at a block number after the current best number, the parent block from the fork is not yet downloaded/imported. We currently try to import the partial response in this scenario, which causes import to fail as parent is not found in the backend. This causes sync to be aborted/restarted which may not converge.

Fix: when we receive a partial response in this scenario, hold on to the partial blocks and try to download the missing blocks. And import when the full range is downloaded.