### PR TITLE
tweak pallet macro (genesis_config etc) to cater for RA users as well.

### DIFF
--- a/substrate/frame/support/procedural/src/lib.rs
+++ b/substrate/frame/support/procedural/src/lib.rs
@@ -1417,11 +1417,15 @@ pub fn type_value(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()
 }
 
+/// **Rust-Analyzer users**: See the documentation of the Rust item in
+/// `frame_support::pallet_macros::genesis_config`.
 #[proc_macro_attribute]
 pub fn genesis_config(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()
 }
 
+/// **Rust-Analyzer users**: See the documentation of the Rust item in
+/// `frame_support::pallet_macros::genesis_build`.
 #[proc_macro_attribute]
 pub fn genesis_build(_: TokenStream, _: TokenStream) -> TokenStream {
 	pallet_macro_stub()


### PR DESCRIPTION
Small tweak to https://github.com/paritytech/polkadot-sdk/pull/1642 to incorporate the ideas from https://github.com/paritytech/polkadot-sdk/issues/247.

I think this is the good middle ground, where we have good rust-docs, and the RA users will also have some hope. 

cc @wentelteefje @aaronbassett @sam0x17