### PR TITLE
Make downloads in parallel and give more time to complete

### DIFF
--- a/polkadot/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
+++ b/polkadot/zombienet_tests/misc/0002-download-polkadot-from-pr.sh
@@ -12,8 +12,10 @@ export PATH=$CFG_DIR:$PATH
 
 cd $CFG_DIR
 # see 0002-upgrade-node.zndsl to view the args.
-curl -L -O $1/polkadot
-curl -L -O $1/polkadot-prepare-worker
-curl -L -O $1/polkadot-execute-worker
+curl -L -O $1/polkadot &
+curl -L -O $1/polkadot-prepare-worker &
+curl -L -O $1/polkadot-execute-worker &
+wait
+
 chmod +x $CFG_DIR/polkadot $CFG_DIR/polkadot-prepare-worker $CFG_DIR/polkadot-execute-worker
 echo $(polkadot --version)

--- a/polkadot/zombienet_tests/misc/0002-upgrade-node.zndsl
+++ b/polkadot/zombienet_tests/misc/0002-upgrade-node.zndsl
@@ -11,8 +11,8 @@ dave: parachain 2001 block height is at least 10 within 200 seconds
 # with the version of polkadot you want to download.
 
 # avg 30s in our infra
-alice: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_ARTIFACTS_URL}}" within 40 seconds
-bob: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_ARTIFACTS_URL}}" within 40 seconds
+alice: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_ARTIFACTS_URL}}" within 60 seconds
+bob: run ./0002-download-polkadot-from-pr.sh with "{{POLKADOT_PR_ARTIFACTS_URL}}" within 60 seconds
 alice: restart after 5 seconds
 bob: restart after 5 seconds
 


### PR DESCRIPTION
Fix flaky test (e.g https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/3787906). Sometimes just timeout when trying to download the artifacts from ci. This make the download in parallel and allow for more time to complete.

Thx!

cc: @michalkucharczyk 

