### PR TITLE
Allow debug_assertions in short-benchmarks CI job

### DIFF
--- a/.gitlab/pipeline/short-benchmarks.yml
+++ b/.gitlab/pipeline/short-benchmarks.yml
@@ -15,6 +15,12 @@ short-benchmark-westend: &short-bench
       artifacts: true
   variables:
     RUNTIME: westend
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: "-C debug-assertions -D warnings"
+    RUST_BACKTRACE: "full"
+    WASM_BUILD_NO_COLOR: 1
+    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
   tags:
     - benchmark
   script:
@@ -32,6 +38,12 @@ short-benchmark-westend: &short-bench
       artifacts: true
   variables:
     RUNTIME_CHAIN: benchmarked-runtime-chain
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: "-C debug-assertions -D warnings"
+    RUST_BACKTRACE: "full"
+    WASM_BUILD_NO_COLOR: 1
+    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
   tags:
     - benchmark
   script:


### PR DESCRIPTION
This PR adds debug_assertions to WASM builds for benchmarks in the short-benchmarks CI job. I've copied over the variables from quick-benchmarks to disallow warnings, show a full backtrace and remove the WASM output colour to improve information from this CI step in the event of a failure.

This is motivated by a [case](https://github.com/paritytech/polkadot-sdk/pull/1676/commits/23d64918be3ca68413050383c5d8a73f63d451dd) where a benchmark was misconfigured in master and failing to send notifications, but passing CI. We don't want this to fail if the problem happens in production, but ideally we'd know from the CI if it was misconfigured and the messages weren't getting sent, as that could (would?) affect the weights that the benchmark generates.

Enabling debug-assertions in WASM builds for the short-benchmarks would catch "soft" failures like this in future.