### PR TITLE
rpc/client: Propagate `rpc_methods` method to reported methods

### DIFF
--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -145,6 +145,9 @@ fn hosts_filtering(enabled: bool, addrs: &[SocketAddr]) -> AllowHosts {
 
 fn build_rpc_api<M: Send + Sync + 'static>(mut rpc_api: RpcModule<M>) -> RpcModule<M> {
 	let mut available_methods = rpc_api.method_names().collect::<Vec<_>>();
+	// The "rpc_methods" method name is guaranteed to not be registered in the rpc module
+	// by `register_method`.
+	available_methods.push("rpc_methods");
 	available_methods.sort();
 
 	rpc_api

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -145,8 +145,7 @@ fn hosts_filtering(enabled: bool, addrs: &[SocketAddr]) -> AllowHosts {
 
 fn build_rpc_api<M: Send + Sync + 'static>(mut rpc_api: RpcModule<M>) -> RpcModule<M> {
 	let mut available_methods = rpc_api.method_names().collect::<Vec<_>>();
-	// The "rpc_methods" method name is guaranteed to not be registered in the rpc module
-	// by `register_method`.
+	// The "rpc_methods" is defined below and we want it to be part of the reported methods.
 	available_methods.push("rpc_methods");
 	available_methods.sort();
 


### PR DESCRIPTION
The PR exposes the `rpc_methods` name in the `rpc_methods` response.
This feature is useful for servers that only forward requests to methods that are reported by the `rpc_methods`.

Jsonrpsee exposes the available methods registered so far. Registering the `rpc_methods` requires a closure that already stores the result. As such, the `rpc_methods` method name is manually added to the available methods.

Closes: https://github.com/paritytech/polkadot-sdk/issues/1627

### Testing Done

```
$> curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "rpc_methods", "params":[]}' http://localhost:9944

{"jsonrpc":"2.0","result":{"methods":["account_nextIndex",... "rpc_methods",..."unsubscribe_newHead"]},"id":1}⏎
```

@paritytech/subxt-team 