### PR TITLE
Add telemetry reports for backed and included candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11806,6 +11806,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
+ "sc-telemetry",
  "sp-consensus",
  "sp-core",
  "sp-keyring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11830,6 +11830,7 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "polkadot-statement-table",
  "sc-keystore",
+ "sc-telemetry",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",

--- a/polkadot/node/core/av-store/Cargo.toml
+++ b/polkadot/node/core/av-store/Cargo.toml
@@ -21,6 +21,7 @@ polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 sp-consensus = { path = "../../../../substrate/primitives/consensus/common", default-features = false }
+sc-telemetry = { path = "../../../../substrate/client/telemetry" }
 polkadot-node-jaeger = { path = "../../jaeger" }
 
 [dev-dependencies]

--- a/polkadot/node/core/av-store/src/tests.rs
+++ b/polkadot/node/core/av-store/src/tests.rs
@@ -136,9 +136,10 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		Box::new(state.clock),
 		Box::new(NoSyncOracle),
 		Metrics::default(),
+		None,
 	);
 
-	let subsystem = run(subsystem, context);
+	let subsystem = run(subsystem, context, None);
 
 	let test_fut = test(virtual_overseer);
 

--- a/polkadot/node/core/backing/Cargo.toml
+++ b/polkadot/node/core/backing/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 futures = "0.3.21"
 sp-keystore = { path = "../../../../substrate/primitives/keystore" }
+sc-telemetry = { path = "../../../../substrate/client/telemetry" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }

--- a/polkadot/node/core/backing/src/tests/mod.rs
+++ b/polkadot/node/core/backing/src/tests/mod.rs
@@ -163,7 +163,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 	let (context, virtual_overseer) = test_helpers::make_subsystem_context(pool.clone());
 
 	let subsystem = async move {
-		if let Err(e) = super::run(context, keystore, Metrics(None)).await {
+		if let Err(e) = super::run(context, keystore, Metrics(None), None).await {
 			panic!("{:?}", e);
 		}
 	};

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -1071,6 +1071,7 @@ pub fn new_full<OverseerGenerator: OverseerGen>(
 					offchain_transaction_pool_factory: OffchainTransactionPoolFactory::new(
 						transaction_pool.clone(),
 					),
+					telemetry: telemetry.as_ref().map(|x| x.handle()),
 				},
 			)
 			.map_err(|e| {

--- a/polkadot/node/service/src/overseer.rs
+++ b/polkadot/node/service/src/overseer.rs
@@ -51,6 +51,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_consensus_babe::BabeApi;
 use std::sync::Arc;
+use telemetry::TelemetryHandle;
 
 pub use polkadot_approval_distribution::ApprovalDistribution as ApprovalDistributionSubsystem;
 pub use polkadot_availability_bitfield_distribution::BitfieldDistribution as BitfieldDistributionSubsystem;
@@ -143,6 +144,7 @@ where
 	pub peerset_protocol_names: PeerSetProtocolNames,
 	/// The offchain transaction pool factory.
 	pub offchain_transaction_pool_factory: OffchainTransactionPoolFactory<Block>,
+	pub telemetry: Option<TelemetryHandle>,
 }
 
 /// Obtain a prepared `OverseerBuilder`, that is initialized
@@ -176,6 +178,7 @@ pub fn prepared_overseer_builder<Spawner, RuntimeClient>(
 		req_protocol_names,
 		peerset_protocol_names,
 		offchain_transaction_pool_factory,
+		telemetry,
 	}: OverseerGenArgs<Spawner, RuntimeClient>,
 ) -> Result<
 	InitializedOverseerBuilder<
@@ -269,6 +272,7 @@ where
 		.candidate_backing(CandidateBackingSubsystem::new(
 			keystore.clone(),
 			Metrics::register(registry)?,
+			telemetry,
 		))
 		.candidate_validation(CandidateValidationSubsystem::with_config(
 			candidate_validation_config,

--- a/polkadot/node/service/src/overseer.rs
+++ b/polkadot/node/service/src/overseer.rs
@@ -263,6 +263,7 @@ where
 			availability_config,
 			Box::new(sync_service.clone()),
 			Metrics::register(registry)?,
+			telemetry.clone(),
 		))
 		.bitfield_distribution(BitfieldDistributionSubsystem::new(Metrics::register(registry)?))
 		.bitfield_signing(BitfieldSigningSubsystem::new(
@@ -272,7 +273,7 @@ where
 		.candidate_backing(CandidateBackingSubsystem::new(
 			keystore.clone(),
 			Metrics::register(registry)?,
-			telemetry,
+			telemetry.clone(),
 		))
 		.candidate_validation(CandidateValidationSubsystem::with_config(
 			candidate_validation_config,


### PR DESCRIPTION
# Description

To improve the observability of validators nodes as a part of parachains consensus added telemetry reports for backed and included candidates:
`parachains.candidate_backed`
`parachains.candidate_included`
