### PR TITLE
remove unnecessary hash string

### DIFF
--- a/substrate/frame/support/procedural/src/no_bound/default.rs
+++ b/substrate/frame/support/procedural/src/no_bound/default.rs
@@ -66,14 +66,12 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 				.collect::<Vec<_>>();
 
 			match &*default_variants {
-				[] => {
-					return syn::Error::new(
-						name.clone().span(),
-						"no default declared, make a variant default by placing `#[default]` above it",
-					)
-					.into_compile_error()
-					.into()
-				},
+				[] => return syn::Error::new(
+					name.clone().span(),
+					"no default declared, make a variant default by placing `#[default]` above it",
+				)
+				.into_compile_error()
+				.into(),
 				// only one variant with the #[default] attribute set
 				[default_variant] => {
 					let variant_attrs = default_variant

--- a/substrate/frame/support/procedural/src/no_bound/default.rs
+++ b/substrate/frame/support/procedural/src/no_bound/default.rs
@@ -69,8 +69,7 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 				[] => {
 					return syn::Error::new(
 						name.clone().span(),
-						// writing this as a regular string breaks rustfmt for some reason
-						r#"no default declared, make a variant default by placing `#[default]` above it"#,
+						"no default declared, make a variant default by placing `#[default]` above it",
 					)
 					.into_compile_error()
 					.into()


### PR DESCRIPTION
This PR removes some unnecessary `r#`...`#` around a string and the corresponding comment that it was done because rustfmt wasn't working for "some reason". It seems to work fine now and clippy prefers it this way.
