### PR TITLE
runtime-api: cleanup after v7 stabilization

### DIFF
--- a/polkadot/node/core/runtime-api/src/cache.rs
+++ b/polkadot/node/core/runtime-api/src/cache.rs
@@ -96,7 +96,6 @@ impl Default for RequestResultCache {
 			unapplied_slashes: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			key_ownership_proof: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			minimum_backing_votes: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
-
 			para_backing_state: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			async_backing_params: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 		}

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -569,7 +569,7 @@ where
 			query!(
 				ParaBackingState,
 				para_backing_state(para),
-				ver = Request::STAGING_BACKING_STATE,
+				ver = Request::ASYNC_BACKING_STATE_RUNTIME_REQUIREMENT,
 				sender
 			)
 		},
@@ -577,7 +577,7 @@ where
 			query!(
 				AsyncBackingParams,
 				async_backing_params(),
-				ver = Request::STAGING_BACKING_STATE,
+				ver = Request::ASYNC_BACKING_STATE_RUNTIME_REQUIREMENT,
 				sender
 			)
 		},

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -725,7 +725,7 @@ impl RuntimeApiRequest {
 	pub const MINIMUM_BACKING_VOTES_RUNTIME_REQUIREMENT: u32 = 6;
 
 	/// Minimum version to enable asynchronous backing: `AsyncBackingParams` and `ParaBackingState`.
-	pub const STAGING_BACKING_STATE: u32 = 7;
+	pub const ASYNC_BACKING_STATE_RUNTIME_REQUIREMENT: u32 = 7;
 }
 
 /// A message to the Runtime API subsystem.

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -226,7 +226,6 @@ specialize_requests! {
 	fn request_unapplied_slashes() -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>; UnappliedSlashes;
 	fn request_key_ownership_proof(validator_id: ValidatorId) -> Option<slashing::OpaqueKeyOwnershipProof>; KeyOwnershipProof;
 	fn request_submit_report_dispute_lost(dp: slashing::DisputeProof, okop: slashing::OpaqueKeyOwnershipProof) -> Option<()>; SubmitReportDisputeLost;
-
 	fn request_async_backing_params() -> AsyncBackingParams; AsyncBackingParams;
 }
 


### PR DESCRIPTION
Follow-up to #1543.