### PR TITLE
Wake the task up when inserting a new response into `PendingResponses`

### DIFF
--- a/substrate/client/network/sync/src/pending_responses.rs
+++ b/substrate/client/network/sync/src/pending_responses.rs
@@ -30,7 +30,7 @@ use log::error;
 use sc_network::request_responses::RequestFailure;
 use sc_network_common::sync::PeerRequest;
 use sp_runtime::traits::Block as BlockT;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 use tokio_stream::StreamMap;
 
 /// Response result.

--- a/substrate/client/network/sync/src/pending_responses.rs
+++ b/substrate/client/network/sync/src/pending_responses.rs
@@ -55,7 +55,7 @@ pub(crate) struct PendingResponses<B: BlockT> {
 
 impl<B: BlockT> PendingResponses<B> {
 	pub fn new() -> Self {
-		Self { pending_responses: StreamMap::new() }
+		Self { pending_responses: StreamMap::new(), waker: None }
 	}
 
 	pub fn insert(


### PR DESCRIPTION
This is a hot fix for https://github.com/paritytech/polkadot-sdk/pull/1650. Basically, `StreamMap` suffers from the same footgun as `FuturesUnordered`: it must be explicitly polled in order for a newly added stream to be registered in the task. The streams are just pushed into the internal container upon insertion: https://github.com/tokio-rs/tokio/blob/master/tokio-stream/src/stream_map.rs#L445-L453

This PR adds a `Waker` to `PendingResponses` to make sure the task is woken up when a new response is added.