### PR TITLE
Publish `substrate-cli-test-utils` to crates.io

### DIFF
--- a/substrate/test-utils/Cargo.toml
+++ b/substrate/test-utils/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository.workspace = true
 description = "Substrate test utilities"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/substrate/test-utils/Cargo.toml
+++ b/substrate/test-utils/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository.workspace = true
 description = "Substrate test utilities"
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/substrate/test-utils/cli/Cargo.toml
+++ b/substrate/test-utils/cli/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository.workspace = true
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Removes `publish = false` from `substrate-cli-test-utils`.