### PR TITLE
Fix `subkey inspect` output text padding

### DIFF
--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -125,7 +125,7 @@ pub enum CryptoScheme {
 	Ed25519,
 	/// Use sr25519.
 	Sr25519,
-	/// Use
+	/// Use ecdsa.
 	Ecdsa,
 }
 

--- a/substrate/client/cli/src/commands/utils.rs
+++ b/substrate/client/cli/src/commands/utils.rs
@@ -136,7 +136,7 @@ pub fn print_from_uri<Pair>(
 			OutputType::Text => {
 				println!(
 					"Secret Key URI `{}` is account:\n  \
-					Network ID:        {} \n \
+					Network ID:        {}\n  \
 					Secret seed:       {}\n  \
 					Public key (hex):  {}\n  \
 					Account ID:        {}\n  \


### PR DESCRIPTION
This pull request is to fix the output text misalignment of `subkey inspect` command:

(the `Network ID` line has an extra space at the end, and the `Secret seed` line lacks a leading space)

```
[btwiuse@railway ~]$ subkey inspect '' | cat -A
Secret Key URI `` is account:$
  Network ID:        substrate $
 Secret seed:       0xfac7959dbfe72f052e5a0c3c8d6530f202b02fd8f9f5ca3580ec8deb7797479e$
  Public key (hex):  0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a$
  Account ID:        0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a$
  Public key (SS58): 5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV$
  SS58 Address:      5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV$
```

The output should be in the same YAML-like format as `subkey generate`:

```
[btwiuse@railway ~]$ subkey generate  | cat -A
Secret phrase:       awkward eagle survey resemble novel resist modify memory pistol shed flower run$
  Network ID:        substrate$
  Secret seed:       0x20502f79366325b7dc7620664e8844ae69d441baf6e5b571a57d3b3ff28e9586$
  Public key (hex):  0x468874b9e5b6b77333fa702b9201b924d6834bf956e33e2bbe37d131134ca830$
  Account ID:        0x468874b9e5b6b77333fa702b9201b924d6834bf956e33e2bbe37d131134ca830$
  Public key (SS58): 5DfBkAMg5xQmsePFr3BWLZm99smiNyy9axWSgembvFgDKh9v$
  SS58 Address:      5DfBkAMg5xQmsePFr3BWLZm99smiNyy9axWSgembvFgDKh9v$
```

This change will fix `subkey` as well as all binaries that embed it as the `key` subcommand, for example: `substrate key`, `polkadot key`, etc.