### PR TITLE
no-bound derives: Use absolute path for `core`

### DIFF
--- a/substrate/frame/support/procedural/src/lib.rs
+++ b/substrate/frame/support/procedural/src/lib.rs
@@ -442,8 +442,8 @@ pub fn derive_runtime_debug_no_bound(input: TokenStream) -> TokenStream {
 
 		quote::quote!(
 			const _: () = {
-				impl #impl_generics core::fmt::Debug for #name #ty_generics #where_clause {
-					fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+				impl #impl_generics ::core::fmt::Debug for #name #ty_generics #where_clause {
+					fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> core::fmt::Result {
 						fmt.write_str("<wasm:stripped>")
 					}
 				}
@@ -473,7 +473,7 @@ pub fn derive_eq_no_bound(input: TokenStream) -> TokenStream {
 
 	quote::quote_spanned!(name.span() =>
 		const _: () = {
-			impl #impl_generics core::cmp::Eq for #name #ty_generics #where_clause {}
+			impl #impl_generics ::core::cmp::Eq for #name #ty_generics #where_clause {}
 		};
 	)
 	.into()

--- a/substrate/frame/support/procedural/src/no_bound/clone.rs
+++ b/substrate/frame/support/procedural/src/no_bound/clone.rs
@@ -32,7 +32,7 @@ pub fn derive_clone_no_bound(input: proc_macro::TokenStream) -> proc_macro::Toke
 			syn::Fields::Named(named) => {
 				let fields = named.named.iter().map(|i| &i.ident).map(|i| {
 					quote::quote_spanned!(i.span() =>
-						#i: core::clone::Clone::clone(&self.#i)
+						#i: ::core::clone::Clone::clone(&self.#i)
 					)
 				});
 
@@ -42,7 +42,7 @@ pub fn derive_clone_no_bound(input: proc_macro::TokenStream) -> proc_macro::Toke
 				let fields =
 					unnamed.unnamed.iter().enumerate().map(|(i, _)| syn::Index::from(i)).map(|i| {
 						quote::quote_spanned!(i.span() =>
-							core::clone::Clone::clone(&self.#i)
+							::core::clone::Clone::clone(&self.#i)
 						)
 					});
 
@@ -59,8 +59,8 @@ pub fn derive_clone_no_bound(input: proc_macro::TokenStream) -> proc_macro::Toke
 					syn::Fields::Named(named) => {
 						let captured = named.named.iter().map(|i| &i.ident);
 						let cloned = captured.clone().map(|i| {
-							quote::quote_spanned!(i.span() =>
-								#i: core::clone::Clone::clone(#i)
+							::quote::quote_spanned!(i.span() =>
+								#i: ::core::clone::Clone::clone(#i)
 							)
 						});
 						quote::quote!(
@@ -75,7 +75,7 @@ pub fn derive_clone_no_bound(input: proc_macro::TokenStream) -> proc_macro::Toke
 							.map(|(i, f)| syn::Ident::new(&format!("_{}", i), f.span()));
 						let cloned = captured.clone().map(|i| {
 							quote::quote_spanned!(i.span() =>
-								core::clone::Clone::clone(#i)
+								::core::clone::Clone::clone(#i)
 							)
 						});
 						quote::quote!(
@@ -98,7 +98,7 @@ pub fn derive_clone_no_bound(input: proc_macro::TokenStream) -> proc_macro::Toke
 
 	quote::quote!(
 		const _: () = {
-			impl #impl_generics core::clone::Clone for #name #ty_generics #where_clause {
+			impl #impl_generics ::core::clone::Clone for #name #ty_generics #where_clause {
 				fn clone(&self) -> Self {
 					#impl_
 				}

--- a/substrate/frame/support/procedural/src/no_bound/debug.rs
+++ b/substrate/frame/support/procedural/src/no_bound/debug.rs
@@ -112,8 +112,8 @@ pub fn derive_debug_no_bound(input: proc_macro::TokenStream) -> proc_macro::Toke
 
 	quote::quote!(
 		const _: () = {
-			impl #impl_generics core::fmt::Debug for #input_ident #ty_generics #where_clause {
-				fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+			impl #impl_generics ::core::fmt::Debug for #input_ident #ty_generics #where_clause {
+				fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 					#impl_
 				}
 			}

--- a/substrate/frame/support/procedural/src/no_bound/default.rs
+++ b/substrate/frame/support/procedural/src/no_bound/default.rs
@@ -32,7 +32,7 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 			Fields::Named(named) => {
 				let fields = named.named.iter().map(|field| &field.ident).map(|ident| {
 					quote_spanned! {ident.span() =>
-						#ident: core::default::Default::default()
+						#ident: ::core::default::Default::default()
 					}
 				});
 
@@ -41,7 +41,7 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 			Fields::Unnamed(unnamed) => {
 				let fields = unnamed.unnamed.iter().map(|field| {
 					quote_spanned! {field.span()=>
-						core::default::Default::default()
+						::core::default::Default::default()
 					}
 				});
 
@@ -105,7 +105,7 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 							let fields =
 								named.named.iter().map(|field| &field.ident).map(|ident| {
 									quote_spanned! {ident.span()=>
-										#ident: core::default::Default::default()
+										#ident: ::core::default::Default::default()
 									}
 								});
 
@@ -114,7 +114,7 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 						Fields::Unnamed(unnamed) => {
 							let fields = unnamed.unnamed.iter().map(|field| {
 								quote_spanned! {field.span()=>
-									core::default::Default::default()
+									::core::default::Default::default()
 								}
 							});
 
@@ -149,7 +149,7 @@ pub fn derive_default_no_bound(input: proc_macro::TokenStream) -> proc_macro::To
 
 	quote!(
 		const _: () = {
-			impl #impl_generics core::default::Default for #name #ty_generics #where_clause {
+			impl #impl_generics ::core::default::Default for #name #ty_generics #where_clause {
 				fn default() -> Self {
 					#impl_
 				}

--- a/substrate/frame/support/procedural/src/no_bound/partial_eq.rs
+++ b/substrate/frame/support/procedural/src/no_bound/partial_eq.rs
@@ -128,7 +128,7 @@ pub fn derive_partial_eq_no_bound(input: proc_macro::TokenStream) -> proc_macro:
 
 	quote::quote!(
 		const _: () = {
-			impl #impl_generics core::cmp::PartialEq for #name #ty_generics #where_clause {
+			impl #impl_generics ::core::cmp::PartialEq for #name #ty_generics #where_clause {
 				fn eq(&self, other: &Self) -> bool {
 					#impl_
 				}

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -647,3 +647,17 @@ fn check_storage_parameter_type_works() {
 		assert_eq!(300, StorageParameter::get());
 	})
 }
+
+#[test]
+fn derive_partial_eq_no_bound_core_mod() {
+	mod core {}
+
+	#[derive(
+		crate::PartialEqNoBound,
+		crate::CloneNoBound,
+		crate::DebugNoBound,
+		crate::DefaultNoBound,
+		crate::EqNoBound,
+	)]
+	struct Test;
+}


### PR DESCRIPTION
Closes: https://github.com/paritytech/polkadot-sdk/issues/1718