### PR TITLE
AURA offence report system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8827,7 +8827,6 @@ dependencies = [
 name = "pallet-aura"
 version = "4.0.0-dev"
 dependencies = [
- "env_logger 0.10.0",
  "frame-support",
  "frame-system",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8832,6 +8832,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-authorship",
+ "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8827,9 +8827,11 @@ dependencies = [
 name = "pallet-aura"
 version = "4.0.0-dev"
 dependencies = [
+ "env_logger 0.10.0",
  "frame-support",
  "frame-system",
  "log",
+ "pallet-authorship",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -8838,6 +8840,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-session",
+ "sp-staking",
  "sp-std",
 ]
 
@@ -14530,6 +14534,7 @@ dependencies = [
  "sc-network",
  "sc-network-test",
  "sc-telemetry",
+ "sc-transaction-pool-api",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",

--- a/substrate/bin/node-template/node/src/service.rs
+++ b/substrate/bin/node-template/node/src/service.rs
@@ -110,10 +110,11 @@ pub fn new_partial(
 	let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
 
 	let import_queue =
-		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
+		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _, _>(ImportQueueParams {
 			block_import: grandpa_block_import.clone(),
 			justification_import: Some(Box::new(grandpa_block_import.clone())),
 			client: client.clone(),
+			select_chain: select_chain.clone(),
 			create_inherent_data_providers: move |_, ()| async move {
 				let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
@@ -129,6 +130,7 @@ pub fn new_partial(
 			registry: config.prometheus_registry(),
 			check_for_equivocation: Default::default(),
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
+			offchain_tx_pool_factory: OffchainTransactionPoolFactory::new(transaction_pool.clone()),
 			compatibility_mode: Default::default(),
 		})?;
 

--- a/substrate/bin/node-template/runtime/src/lib.rs
+++ b/substrate/bin/node-template/runtime/src/lib.rs
@@ -206,6 +206,7 @@ impl frame_system::Config for Runtime {
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
+	type WeightInfo = pallet_aura::default_weights::SubstrateWeight<0>;
 	type MaxAuthorities = ConstU32<32>;
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 	type KeyOwnerProof = sp_core::Void;

--- a/substrate/client/consensus/aura/Cargo.toml
+++ b/substrate/client/consensus/aura/Cargo.toml
@@ -24,6 +24,7 @@ sc-client-api = { path = "../../api" }
 sc-consensus = { path = "../common" }
 sc-consensus-slots = { path = "../slots" }
 sc-telemetry = { path = "../../telemetry" }
+sc-transaction-pool-api = { path = "../../transaction-pool/api" }
 sp-api = { path = "../../../primitives/api" }
 sp-application-crypto = { path = "../../../primitives/application-crypto" }
 sp-block-builder = { path = "../../../primitives/block-builder" }

--- a/substrate/client/consensus/aura/src/import_queue.rs
+++ b/substrate/client/consensus/aura/src/import_queue.rs
@@ -382,7 +382,7 @@ where
 ///
 /// Implemented as a `bool` newtype (default: true)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CheckForEquivocation(bool);
+pub struct CheckForEquivocation(pub bool);
 
 impl Default for CheckForEquivocation {
 	fn default() -> Self {

--- a/substrate/client/consensus/aura/src/lib.rs
+++ b/substrate/client/consensus/aura/src/lib.rs
@@ -16,9 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Aura (Authority-round) consensus in substrate.
+//! AURA (Authority-round) consensus in Substrate.
 //!
-//! Aura works by having a list of authorities A who are expected to roughly
+//! AURA works by having a list of authorities A who are expected to roughly
 //! agree on the current time. Time is divided up into discrete slots of t
 //! seconds each. For each slot s, the author of that slot is A[s % |A|].
 //!
@@ -28,7 +28,8 @@
 //! Blocks from future steps will be either deferred or rejected depending on how
 //! far in the future they are.
 //!
-//! NOTE: Aura itself is designed to be generic over the crypto used.
+//! NOTE: AURA itself is designed to be generic over the crypto used.
+
 #![forbid(missing_docs, unsafe_code)]
 use std::{fmt::Debug, marker::PhantomData, pin::Pin, sync::Arc};
 
@@ -57,7 +58,8 @@ pub mod standalone;
 
 pub use crate::standalone::{find_pre_digest, slot_duration};
 pub use import_queue::{
-	build_verifier, import_queue, AuraVerifier, BuildVerifierParams, ImportQueueParams,
+	build_verifier, import_queue, AuraVerifier, BuildVerifierParams, CheckForEquivocation,
+	ImportQueueParams,
 };
 pub use sc_consensus_slots::SlotProportion;
 pub use sp_consensus::SyncOracle;
@@ -617,10 +619,8 @@ mod tests {
 		}
 	}
 
-	type TestSelectChain = substrate_test_runtime_client::LongestChain<
-		substrate_test_runtime_client::Backend,
-		TestBlock,
-	>;
+	type TestSelectChain =
+		sc_consensus::LongestChain<substrate_test_runtime_client::Backend, TestBlock>;
 
 	type AuraVerifier = import_queue::AuraVerifier<
 		TestBlock,
@@ -664,7 +664,7 @@ mod tests {
 					);
 					Ok((slot,))
 				}),
-				true,
+				true.into(),
 				None,
 				OffchainTransactionPoolFactory::new(RejectAllTxPool::default()),
 				CompatibilityMode::None,

--- a/substrate/client/consensus/aura/src/standalone.rs
+++ b/substrate/client/consensus/aura/src/standalone.rs
@@ -18,11 +18,9 @@
 
 //! Standalone functions used within the implementation of Aura.
 
-use std::fmt::Debug;
-
-use log::trace;
-
 use codec::Codec;
+use log::trace;
+use std::fmt::Debug;
 
 use sc_client_api::{backend::AuxStore, UsageProvider};
 use sp_api::{Core, ProvideRuntimeApi};

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -1089,13 +1089,13 @@ where
 			},
 		};
 
-		// submit equivocation report at best block.
 		let mut runtime_api = self.client.runtime_api();
 
 		// Register the offchain tx pool to be able to use it from the runtime.
 		runtime_api
 			.register_extension(self.offchain_tx_pool_factory.offchain_transaction_pool(best_hash));
 
+		// Submit equivocation report at best block.
 		runtime_api
 			.submit_report_equivocation_unsigned_extrinsic(
 				best_hash,

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -18,15 +18,19 @@ log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
+pallet-authorship = { path = "../authorship", default-features = false}
 pallet-timestamp = { path = "../timestamp", default-features = false}
 sp-application-crypto = { path = "../../primitives/application-crypto", default-features = false}
 sp-consensus-aura = { path = "../../primitives/consensus/aura", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
+sp-session = { path = "../../primitives/session", default-features = false}
+sp-staking = { path = "../../primitives/staking", default-features = false, features = ["serde"]}
 sp-std = { path = "../../primitives/std", default-features = false}
 
 [dev-dependencies]
 sp-core = { path = "../../primitives/core", default-features = false}
 sp-io = { path = "../../primitives/io" }
+env_logger = "0.10"
 
 [features]
 default = [ "std" ]
@@ -35,6 +39,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"log/std",
+	"pallet-authorship/std",
 	"pallet-timestamp/std",
 	"scale-info/std",
 	"sp-application-crypto/std",
@@ -42,6 +47,8 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-session/std",
+	"sp-staking/std",
 	"sp-std/std",
 ]
 try-runtime = [

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -59,6 +59,7 @@ try-runtime = [
 	"pallet-timestamp/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+# Provide the default equivocation report system.
 default-equivocation-report-system = [
 	"pallet-authorship",
 	"pallet-session",

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -33,7 +33,6 @@ sp-core = { path = "../../primitives/core", default-features = false}
 sp-io = { path = "../../primitives/io" }
 pallet-authorship = { path = "../authorship" }
 pallet-session = { path = "../session" }
-env_logger = "0.10"
 
 [features]
 default = [ "std" ]

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -60,7 +60,7 @@ try-runtime = [
 	"pallet-timestamp/try-runtime",
 	"sp-runtime/try-runtime",
 ]
-equivocation-report = [
+default-equivocation-report-system = [
 	"pallet-authorship",
 	"pallet-session",
 ]

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -18,8 +18,9 @@ log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
-pallet-authorship = { path = "../authorship", default-features = false}
-pallet-timestamp = { path = "../timestamp", default-features = false}
+pallet-authorship = { path = "../authorship", default-features = false, optional = true }
+pallet-session = { path = "../session", default-features = false, optional = true }
+pallet-timestamp = { path = "../timestamp", default-features = false }
 sp-application-crypto = { path = "../../primitives/application-crypto", default-features = false}
 sp-consensus-aura = { path = "../../primitives/consensus/aura", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
@@ -30,6 +31,8 @@ sp-std = { path = "../../primitives/std", default-features = false}
 [dev-dependencies]
 sp-core = { path = "../../primitives/core", default-features = false}
 sp-io = { path = "../../primitives/io" }
+pallet-authorship = { path = "../authorship" }
+pallet-session = { path = "../session" }
 env_logger = "0.10"
 
 [features]
@@ -56,5 +59,9 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"sp-runtime/try-runtime",
+]
+equivocation-report = [
+	"pallet-authorship",
+	"pallet-session",
 ]
 experimental = []

--- a/substrate/frame/aura/src/default_weights.rs
+++ b/substrate/frame/aura/src/default_weights.rs
@@ -23,13 +23,13 @@ use frame_support::weights::{
 	Weight,
 };
 
-/// Default `WeightInfo` generic over the max number of validator's nominators.
+/// Default `WeightInfo` generic over the max number of validator's nominators (`N`).
 pub struct WeightInfo<const N: u32>;
 
 impl<const N: u32> crate::WeightInfo for WeightInfo<N> {
 	fn report_equivocation(validator_count: u32) -> Weight {
 		// We take the validator set count from the membership proof to
-		// calculate the weight but we set a max of 100 validators.
+		// calculate the weight but we set a floor of 100 validators.
 		let validator_count = validator_count.max(100) as u64;
 		let max_nominators_per_validator = N;
 

--- a/substrate/frame/aura/src/default_weights.rs
+++ b/substrate/frame/aura/src/default_weights.rs
@@ -23,10 +23,10 @@ use frame_support::weights::{
 	Weight,
 };
 
-/// Default `WeightInfo` generic over the max number of validator's nominators (`N`).
-pub struct WeightInfo<const N: u32>;
+/// Default `WeightInfo` implementation generic over the max number of validator's nominators (`N`).
+pub struct SubstrateWeight<const N: u32>;
 
-impl<const N: u32> crate::WeightInfo for WeightInfo<N> {
+impl<const N: u32> crate::WeightInfo for SubstrateWeight<N> {
 	fn report_equivocation(validator_count: u32) -> Weight {
 		// We take the validator set count from the membership proof to
 		// calculate the weight but we set a floor of 100 validators.

--- a/substrate/frame/aura/src/default_weights.rs
+++ b/substrate/frame/aura/src/default_weights.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Default weights for the Babe Pallet
+//! Default weights for the AURA Pallet.
 //! This file was not auto-generated.
 
 use frame_support::weights::{
@@ -23,26 +23,26 @@ use frame_support::weights::{
 	Weight,
 };
 
-impl crate::WeightInfo for () {
-	fn plan_config_change() -> Weight {
-		DbWeight::get().writes(1)
-	}
+/// Default `WeightInfo` generic over the max number of validator's nominators.
+pub struct WeightInfo<const N: u32>;
 
-	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight {
-		// we take the validator set count from the membership proof to
+impl<const N: u32> crate::WeightInfo for WeightInfo<N> {
+	fn report_equivocation(validator_count: u32) -> Weight {
+		// We take the validator set count from the membership proof to
 		// calculate the weight but we set a max of 100 validators.
 		let validator_count = validator_count.max(100) as u64;
+		let max_nominators_per_validator = N;
 
-		// checking membership proof
+		// Checking membership proof
 		Weight::from_parts(35u64 * WEIGHT_REF_TIME_PER_MICROS, 0)
 			.saturating_add(
 				Weight::from_parts(175u64 * WEIGHT_REF_TIME_PER_NANOS, 0)
 					.saturating_mul(validator_count),
 			)
 			.saturating_add(DbWeight::get().reads(5))
-			// check equivocation proof
+			// Check equivocation proof
 			.saturating_add(Weight::from_parts(110u64 * WEIGHT_REF_TIME_PER_MICROS, 0))
-			// report offence
+			// Report offence
 			.saturating_add(Weight::from_parts(110u64 * WEIGHT_REF_TIME_PER_MICROS, 0))
 			.saturating_add(Weight::from_parts(
 				25u64 * WEIGHT_REF_TIME_PER_MICROS * max_nominators_per_validator as u64,

--- a/substrate/frame/aura/src/equivocation.rs
+++ b/substrate/frame/aura/src/equivocation.rs
@@ -30,11 +30,14 @@
 //! and report the offences.
 
 use frame_support::traits::{EstimateNextSessionRotation, Get, KeyOwnerProofSystem};
-use frame_system::pallet_prelude::{BlockNumberFor, HeaderFor};
-use log::{error, info};
+use frame_system::{
+	offchain::SubmitTransaction,
+	pallet_prelude::{BlockNumberFor, HeaderFor},
+};
 
 use sp_consensus_aura::{EquivocationProof, Slot, KEY_TYPE};
 use sp_runtime::{
+	traits::{CheckedDiv, Header as _, Zero},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	DispatchError, KeyTypeId, Perbill, RuntimeDebug,
 };
@@ -44,6 +47,8 @@ use sp_staking::{
 	SessionIndex,
 };
 use sp_std::prelude::*;
+
+use log::{error, info};
 
 use crate::{Call, Config, Error, LOG_TARGET};
 
@@ -135,7 +140,6 @@ where
 	fn publish_evidence(
 		evidence: (EquivocationProof<HeaderFor<T>, T::AuthorityId>, T::KeyOwnerProof),
 	) -> Result<(), ()> {
-		use frame_system::offchain::SubmitTransaction;
 		let (equivocation_proof, key_owner_proof) = evidence;
 
 		let call = Call::report_equivocation_unsigned {
@@ -172,7 +176,6 @@ where
 		reporter: Option<T::AccountId>,
 		evidence: (EquivocationProof<HeaderFor<T>, T::AuthorityId>, T::KeyOwnerProof),
 	) -> Result<(), DispatchError> {
-		use sp_runtime::traits::{CheckedDiv, Header as _, Zero};
 		let (equivocation_proof, key_owner_proof) = evidence;
 		let reporter = reporter.or_else(|| <pallet_authorship::Pallet<T>>::author());
 

--- a/substrate/frame/aura/src/equivocation.rs
+++ b/substrate/frame/aura/src/equivocation.rs
@@ -35,10 +35,7 @@ use log::{error, info};
 
 use sp_consensus_aura::{EquivocationProof, Slot, KEY_TYPE};
 use sp_runtime::{
-	transaction_validity::{
-		InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
-		TransactionValidityError, ValidTransaction,
-	},
+	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	DispatchError, KeyTypeId, Perbill, RuntimeDebug,
 };
 use sp_session::{GetSessionNumber, GetValidatorCount};

--- a/substrate/frame/aura/src/equivocation.rs
+++ b/substrate/frame/aura/src/equivocation.rs
@@ -100,6 +100,10 @@ impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 /// - On-chain validity checks and processing are mostly delegated to the user-provided generic
 ///   types implementing `KeyOwnerProofSystem` and `ReportOffence` traits.
 /// - Offence reporter for unsigned transactions is fetched via the the authorship pallet.
+///
+/// Requires the runtime to implement:
+/// - pallet-authorship: to get reporter identity.
+/// - pallet-session: to check the `KeyOwnerProof` validity (map block to session-id).
 pub struct EquivocationReportSystem<T, R, P, L>(sp_std::marker::PhantomData<(T, R, P, L)>);
 
 impl<T, R, P, L>
@@ -108,7 +112,10 @@ impl<T, R, P, L>
 		(EquivocationProof<HeaderFor<T>, T::AuthorityId>, T::KeyOwnerProof),
 	> for EquivocationReportSystem<T, R, P, L>
 where
-	T: Config + pallet_authorship::Config + frame_system::offchain::SendTransactionTypes<Call<T>>,
+	T: Config
+		+ pallet_authorship::Config
+		+ pallet_session::Config
+		+ frame_system::offchain::SendTransactionTypes<Call<T>>,
 	R: ReportOffence<
 		T::AccountId,
 		P::IdentificationTuple,

--- a/substrate/frame/aura/src/lib.rs
+++ b/substrate/frame/aura/src/lib.rs
@@ -55,14 +55,14 @@ use sp_session::{GetSessionNumber, GetValidatorCount};
 use sp_staking::offence::OffenceReportSystem;
 use sp_std::prelude::*;
 
-#[cfg(any(feature = "default-equivocation-report-system", test))]
-mod equivocation;
-
-mod default_weights;
 mod mock;
 mod tests;
 
+pub mod default_weights;
 pub mod migrations;
+
+#[cfg(any(feature = "default-equivocation-report-system", test))]
+pub mod equivocation;
 
 pub use pallet::*;
 

--- a/substrate/frame/aura/src/lib.rs
+++ b/substrate/frame/aura/src/lib.rs
@@ -43,6 +43,7 @@ use frame_support::{
 	traits::{DisabledValidators, FindAuthor, Get, OnTimestampSet, OneSessionHandler},
 	BoundedSlice, BoundedVec, ConsensusEngineId, Parameter,
 };
+use frame_system::pallet_prelude::HeaderFor;
 use sp_consensus_aura::{AuthorityIndex, ConsensusLog, EquivocationProof, Slot, AURA_ENGINE_ID};
 use sp_runtime::{
 	generic::DigestItem,
@@ -445,6 +446,17 @@ impl<T: Config> Pallet<T> {
 		);
 
 		Ok(())
+	}
+
+	/// Submits an extrinsic to report an equivocation.
+	///
+	/// This method will create an unsigned extrinsic with a call to `report_equivocation_unsigned`
+	/// and will push the transaction to the pool. Only useful in an offchain context.
+	pub fn submit_unsigned_equivocation_report(
+		equivocation_proof: EquivocationProof<HeaderFor<T>, T::AuthorityId>,
+		key_owner_proof: T::KeyOwnerProof,
+	) -> Option<()> {
+		T::EquivocationReportSystem::publish_evidence((equivocation_proof, key_owner_proof)).ok()
 	}
 }
 

--- a/substrate/frame/aura/src/lib.rs
+++ b/substrate/frame/aura/src/lib.rs
@@ -468,21 +468,23 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
 		I: Iterator<Item = (&'a T::AccountId, T::AuthorityId)>,
 	{
 		// instant changes
-		if changed {
-			let next_authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
-			let last_authorities = Self::authorities();
-			if last_authorities != next_authorities {
-				if next_authorities.len() as u32 > T::MaxAuthorities::get() {
-					log::warn!(
-						target: LOG_TARGET,
-						"next authorities list larger than {}, truncating",
-						T::MaxAuthorities::get(),
-					);
-				}
-				let bounded = <BoundedVec<_, T::MaxAuthorities>>::truncate_from(next_authorities);
-				Self::change_authorities(bounded);
-			}
+		if !changed {
+			return
 		}
+		let next_authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
+		let last_authorities = Self::authorities();
+		if last_authorities == next_authorities {
+			return
+		}
+		if next_authorities.len() as u32 > T::MaxAuthorities::get() {
+			log::warn!(
+				target: LOG_TARGET,
+				"next authorities list larger than {}, truncating",
+				T::MaxAuthorities::get(),
+			);
+		}
+		let bounded = <BoundedVec<_, T::MaxAuthorities>>::truncate_from(next_authorities);
+		Self::change_authorities(bounded);
 	}
 
 	fn on_disabled(i: u32) {

--- a/substrate/frame/aura/src/lib.rs
+++ b/substrate/frame/aura/src/lib.rs
@@ -40,7 +40,6 @@
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
-	log,
 	traits::{DisabledValidators, FindAuthor, Get, OnTimestampSet, OneSessionHandler},
 	BoundedSlice, BoundedVec, ConsensusEngineId, Parameter,
 };
@@ -54,6 +53,7 @@ use sp_session::{GetSessionNumber, GetValidatorCount};
 use sp_staking::offence::OffenceReportSystem;
 use sp_std::prelude::*;
 
+#[cfg(any(feature = "equivocation-report", test))]
 mod equivocation;
 mod mock;
 mod tests;

--- a/substrate/frame/aura/src/mock.rs
+++ b/substrate/frame/aura/src/mock.rs
@@ -19,14 +19,26 @@
 
 #![cfg(test)]
 
-use crate as pallet_aura;
+use crate::{self as pallet_aura, Config, CurrentSlot};
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, ConstU64, DisabledValidators},
+	traits::{ConstU32, ConstU64, DisabledValidators, KeyOwnerProofSystem},
 };
-use sp_consensus_aura::{ed25519::AuthorityId, AuthorityIndex};
-use sp_core::H256;
-use sp_runtime::{testing::UintAuthorityId, traits::IdentityLookup, BuildStorage};
+use sp_consensus_aura::{
+	digests::CompatibleDigestItem,
+	ed25519::{AuthorityId, AuthorityPair, AuthoritySignature},
+	AuthorityIndex, EquivocationProof, Slot,
+};
+use sp_core::{crypto::Pair, H256, U256};
+use sp_runtime::{
+	testing::{Digest, DigestItem, Header, TestXt},
+	traits::{Header as _, IdentityLookup},
+	BuildStorage,
+};
+use sp_staking::{
+	offence::{OffenceError, ReportOffence},
+	SessionIndex,
+};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -35,11 +47,20 @@ const SLOT_DURATION: u64 = 2;
 frame_support::construct_runtime!(
 	pub enum Test
 	{
-		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Aura: pallet_aura::{Pallet, Storage, Config<T>},
+		System: frame_system,
+		Authorship: pallet_authorship,
+		Timestamp: pallet_timestamp,
+		Aura: pallet_aura,
 	}
 );
+
+impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
+where
+	RuntimeCall: From<C>,
+{
+	type OverarchingCall = RuntimeCall;
+	type Extrinsic = TestXt<RuntimeCall, ()>;
+}
 
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -65,6 +86,11 @@ impl frame_system::Config for Test {
 	type SS58Prefix = ();
 	type OnSetCode = ();
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl pallet_authorship::Config for Test {
+	type FindAuthor = ();
+	type EventHandler = ();
 }
 
 impl pallet_timestamp::Config for Test {
@@ -97,30 +123,188 @@ impl DisabledValidators for MockDisabledValidators {
 	}
 }
 
+/// A mock offence report handler.
+type IdentificationTuple = (sp_core::crypto::KeyTypeId, AuthorityId);
+
+type EquivocationOffence = crate::equivocation::EquivocationOffence<IdentificationTuple>;
+
+pub struct TestOffenceHandler;
+
+// parameter_types! {
+// 	pub static Offences: Vec<(Vec<u64>, EquivocationOffence)> = vec![];
+// }
+
+impl ReportOffence<u64, IdentificationTuple, EquivocationOffence> for TestOffenceHandler {
+	fn report_offence(
+		_reporters: Vec<u64>,
+		_offence: EquivocationOffence,
+	) -> Result<(), OffenceError> {
+		// Offences::mutate(|l| l.push((reporters, offence)));
+		Ok(())
+	}
+
+	fn is_known_offence(_offenders: &[IdentificationTuple], _time_slot: &Slot) -> bool {
+		false
+	}
+}
+
+pub struct TestKeyOwnerProofSystem;
+
+impl KeyOwnerProofSystem<IdentificationTuple> for TestKeyOwnerProofSystem {
+	type Proof = sp_session::MembershipProof;
+	type IdentificationTuple = IdentificationTuple;
+
+	fn prove(_key: IdentificationTuple) -> Option<Self::Proof> {
+		None
+	}
+
+	fn check_proof(
+		key: IdentificationTuple,
+		_proof: Self::Proof,
+	) -> Option<Self::IdentificationTuple> {
+		Some(key)
+	}
+}
+
 impl pallet_aura::Config for Test {
 	type AuthorityId = AuthorityId;
 	type DisabledValidators = MockDisabledValidators;
 	type MaxAuthorities = ConstU32<10>;
 	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
-
+	type KeyOwnerProof = sp_session::MembershipProof;
+	type EquivocationReportSystem = pallet_aura::equivocation::EquivocationReportSystem<
+		Self,
+		TestOffenceHandler,
+		TestKeyOwnerProofSystem,
+		sp_core::ConstU64<{ u64::MAX }>,
+	>;
 	#[cfg(feature = "experimental")]
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
-fn build_ext(authorities: Vec<u64>) -> sp_io::TestExternalities {
+pub fn new_test_ext_and_execute(
+	authorities_len: usize,
+	test: impl FnOnce(Vec<AuthorityPair>) -> (),
+) {
+	let (pairs, mut ext) = new_test_ext_with_pairs(authorities_len);
+	ext.execute_with(|| {
+		test(pairs);
+		Aura::do_try_state().expect("Storage invariants should hold")
+	});
+}
+
+pub fn new_test_ext(authorities_len: usize) -> sp_io::TestExternalities {
+	new_test_ext_with_pairs(authorities_len).1
+}
+
+pub fn new_test_ext_with_pairs(
+	authorities_len: usize,
+) -> (Vec<AuthorityPair>, sp_io::TestExternalities) {
+	let pairs = (0..authorities_len)
+		.map(|i| AuthorityPair::from_seed(&U256::from(i).into()))
+		.collect::<Vec<_>>();
+
+	let public = pairs.iter().map(|p| p.public()).collect();
+
+	(pairs, new_test_ext_raw_authorities(public))
+}
+
+pub fn new_test_ext_raw_authorities(authorities: Vec<AuthorityId>) -> sp_io::TestExternalities {
 	let mut storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	pallet_aura::GenesisConfig::<Test> {
-		authorities: authorities.into_iter().map(|a| UintAuthorityId(a).to_public_key()).collect(),
-	}
-	.assimilate_storage(&mut storage)
-	.unwrap();
+
+	pallet_aura::GenesisConfig::<Test> { authorities }
+		.assimilate_storage(&mut storage)
+		.unwrap();
+
 	storage.into()
 }
 
-pub fn build_ext_and_execute_test(authorities: Vec<u64>, test: impl FnOnce() -> ()) {
-	let mut ext = build_ext(authorities);
-	ext.execute_with(|| {
-		test();
-		Aura::do_try_state().expect("Storage invariants should hold")
-	});
+pub fn go_to_block(n: u64, s: u64) {
+	use frame_support::traits::{OnFinalize, OnInitialize};
+
+	Aura::on_finalize(System::block_number());
+
+	let parent_hash = if System::block_number() > 1 {
+		let hdr = System::finalize();
+		hdr.hash()
+	} else {
+		System::parent_hash()
+	};
+
+	let pre_digest = make_pre_digest(s.into(), None);
+
+	System::reset_events();
+	System::initialize(&n, &parent_hash, &pre_digest);
+
+	Aura::on_initialize(n);
+}
+
+/// Slots will grow accordingly to blocks
+pub fn progress_to_block(n: u64) {
+	let mut slot = u64::from(Aura::current_slot()) + 1;
+	for i in System::block_number() + 1..=n {
+		go_to_block(i, slot);
+		slot += 1;
+	}
+}
+
+fn make_pre_digest(slot: Slot, other: Option<Vec<u8>>) -> Digest {
+	let item = <DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_pre_digest(slot);
+	let mut logs = vec![item];
+	if let Some(other) = other {
+		logs.push(DigestItem::Other(other));
+	}
+	Digest { logs }
+}
+
+/// Creates an equivocation proof at the current block
+pub fn generate_equivocation_proof(
+	offender_authority_pair: &AuthorityPair,
+	slot: Slot,
+) -> EquivocationProof<Header, AuthorityId> {
+	let current_block = System::block_number();
+	let current_slot = CurrentSlot::<Test>::get();
+
+	let make_header = |additional_data| {
+		let parent_hash = System::parent_hash();
+		let pre_digest = make_pre_digest(slot, additional_data);
+		System::reset_events();
+		System::initialize(&current_block, &parent_hash, &pre_digest);
+		System::set_block_number(current_block);
+		Timestamp::set_timestamp(*current_slot * Aura::slot_duration());
+		System::finalize()
+	};
+
+	// Sign the header prehash and sign it, adding it to the block as the seal digest item
+	let seal_header = |header: &mut Header| {
+		let prehash = header.hash();
+		let seal = <DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_seal(
+			offender_authority_pair.sign(prehash.as_ref()),
+		);
+		println!("{:?}", seal);
+		header.digest_mut().push(seal);
+	};
+
+	// Generate two different headers for the current slot.
+	let mut h1 = make_header(None);
+	let mut h2 = make_header(Some(vec![0xFF]));
+	println!("H1: {:?}", h1.hash());
+	println!("H2: {:?}", h2.hash());
+
+	seal_header(&mut h1);
+	seal_header(&mut h2);
+
+	// TODO @davxy remove print
+	println!("H1: {:?}", h1.hash());
+	println!("H2: {:?}", h2.hash());
+
+	// restore previous runtime state
+	// go_to_block(current_block, *current_slot);
+
+	EquivocationProof {
+		slot,
+		offender: offender_authority_pair.public(),
+		first_header: h1,
+		second_header: h2,
+	}
 }

--- a/substrate/frame/aura/src/mock.rs
+++ b/substrate/frame/aura/src/mock.rs
@@ -205,6 +205,7 @@ impl KeyOwnerProofSystem<IdentificationTuple> for TestKeyOwnerProofSystem {
 impl pallet_aura::Config for Test {
 	type AuthorityId = AuthorityId;
 	type DisabledValidators = MockDisabledValidators;
+	type WeightInfo = pallet_aura::default_weights::WeightInfo<0>;
 	type MaxAuthorities = ConstU32<10>;
 	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
 	type KeyOwnerProof = MembershipProof;

--- a/substrate/frame/aura/src/mock.rs
+++ b/substrate/frame/aura/src/mock.rs
@@ -171,6 +171,10 @@ impl ReportOffence<u64, IdentificationTuple, EquivocationOffence> for TestOffenc
 		reporters: Vec<u64>,
 		offence: EquivocationOffence,
 	) -> Result<(), OffenceError> {
+		let offences = Offences::get();
+		if offences.iter().find(|item| item.1 == offence).is_some() {
+			return Err(OffenceError::DuplicateReport)
+		}
 		Offences::mutate(|l| l.push((reporters, offence)));
 		Ok(())
 	}

--- a/substrate/frame/aura/src/mock.rs
+++ b/substrate/frame/aura/src/mock.rs
@@ -43,8 +43,7 @@ type Block = frame_system::mocking::MockBlock<Test>;
 const SLOT_DURATION: u64 = 2;
 
 frame_support::construct_runtime!(
-	pub enum Test
-	{
+	pub enum Test {
 		System: frame_system,
 		Authorship: pallet_authorship,
 		Session: pallet_session,
@@ -162,6 +161,7 @@ type MembershipProof = sp_session::MembershipProof;
 
 pub struct TestOffenceHandler;
 
+// This is used to persist reported offences during tests.
 parameter_types! {
 	pub static Offences: Vec<(Vec<u64>, EquivocationOffence)> = vec![];
 }
@@ -205,7 +205,7 @@ impl KeyOwnerProofSystem<IdentificationTuple> for TestKeyOwnerProofSystem {
 impl pallet_aura::Config for Test {
 	type AuthorityId = AuthorityId;
 	type DisabledValidators = MockDisabledValidators;
-	type WeightInfo = pallet_aura::default_weights::WeightInfo<0>;
+	type WeightInfo = pallet_aura::default_weights::SubstrateWeight<0>;
 	type MaxAuthorities = ConstU32<10>;
 	type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
 	type KeyOwnerProof = MembershipProof;

--- a/substrate/frame/babe/src/default_weights.rs
+++ b/substrate/frame/babe/src/default_weights.rs
@@ -30,7 +30,7 @@ impl crate::WeightInfo for () {
 
 	fn report_equivocation(validator_count: u32, max_nominators_per_validator: u32) -> Weight {
 		// we take the validator set count from the membership proof to
-		// calculate the weight but we set a max of 100 validators.
+		// calculate the weight but we set a floor of 100 validators.
 		let validator_count = validator_count.max(100) as u64;
 
 		// checking membership proof

--- a/substrate/primitives/consensus/aura/src/lib.rs
+++ b/substrate/primitives/consensus/aura/src/lib.rs
@@ -20,11 +20,20 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode};
-use sp_runtime::ConsensusEngineId;
+use scale_info::TypeInfo;
+
+use sp_application_crypto::RuntimeAppPublic;
+use sp_runtime::{generic::DigestItem, traits::Header, ConsensusEngineId};
 use sp_std::vec::Vec;
+
+pub use sp_consensus_slots::{Slot, SlotDuration};
 
 pub mod digests;
 pub mod inherents;
+
+/// Key type for AURA module.
+pub const KEY_TYPE: sp_application_crypto::sp_core::crypto::KeyTypeId =
+	sp_application_crypto::key_types::AURA;
 
 pub mod sr25519 {
 	mod app_sr25519 {
@@ -62,13 +71,39 @@ pub mod ed25519 {
 	pub type AuthorityId = app_ed25519::Public;
 }
 
-pub use sp_consensus_slots::{Slot, SlotDuration};
-
 /// The `ConsensusEngineId` of AuRa.
 pub const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
 
 /// The index of an authority.
 pub type AuthorityIndex = u32;
+
+/// An equivocation proof for multiple block authorships on the same slot.
+pub type EquivocationProof<H, AuthorityId> = sp_consensus_slots::EquivocationProof<H, AuthorityId>;
+
+/// Opaque type representing the key ownership proof at runtime API boundary.
+///
+/// The inner value is an encoded representation of the actual key
+/// ownership proof which will be parameterized when defining the runtime. At
+/// the runtime API boundary this type is unknown and as such we keep this
+/// opaque representation, implementors of the runtime API will have to make
+/// sure that all usages of `OpaqueKeyOwnershipProof` refer to the same type.
+#[derive(Decode, Encode, PartialEq, TypeInfo)]
+pub struct OpaqueKeyOwnershipProof(Vec<u8>);
+
+impl OpaqueKeyOwnershipProof {
+	/// Create a new `OpaqueKeyOwnershipProof` using the given encoded
+	/// representation.
+	pub fn new(inner: Vec<u8>) -> OpaqueKeyOwnershipProof {
+		OpaqueKeyOwnershipProof(inner)
+	}
+
+	// TODO @davxy : Required???? If not remove for BABE as well
+	// /// Try to decode this `OpaqueKeyOwnershipProof` into the given concrete key
+	// /// ownership proof type.
+	// pub fn decode<T: Decode>(self) -> Option<T> {
+	// 	Decode::decode(&mut &self.0[..]).ok()
+	// }
+}
 
 /// An consensus log item for Aura.
 #[derive(Decode, Encode)]
@@ -81,6 +116,56 @@ pub enum ConsensusLog<AuthorityId: Codec> {
 	OnDisabled(AuthorityIndex),
 }
 
+/// Verifies the equivocation proof.
+///
+/// Makes sure that both headers have different hashes, are targetting the same slot,
+/// and have valid signatures by the same authority.
+pub fn check_equivocation_proof<H, AuthorityId: RuntimeAppPublic>(
+	proof: EquivocationProof<H, AuthorityId>,
+) -> bool
+where
+	H: Header,
+{
+	use digests::CompatibleDigestItem;
+
+	let find_pre_digest = |header: &H| {
+		header.digest().logs().iter().find_map(|log| {
+			<DigestItem as CompatibleDigestItem<AuthorityId::Signature>>::as_aura_pre_digest(log)
+		})
+	};
+
+	let verify_signature = |mut header: H, offender: &AuthorityId| {
+		let seal = header.digest_mut().pop()?.as_aura_seal()?;
+		let pre_hash = header.hash();
+		offender.verify(&pre_hash.as_ref(), &seal).then(|| ())
+	};
+
+	let verify_proof = || {
+		// We must have different headers for the equivocation to be valid
+		if proof.first_header.hash() == proof.second_header.hash() {
+			return None
+		}
+
+		let first_slot = find_pre_digest(&proof.first_header)?;
+		let second_slot = find_pre_digest(&proof.second_header)?;
+
+		// Both headers must be targetting the same slot and it must
+		// be the same as the one in the proof.
+		if proof.slot != first_slot || first_slot != second_slot {
+			return None
+		}
+
+		// Finally verify that the expected authority has signed both headers and
+		// that the signature is valid.
+		verify_signature(proof.first_header, &proof.offender)?;
+		verify_signature(proof.second_header, &proof.offender)?;
+
+		Some(())
+	};
+
+	verify_proof().is_some()
+}
+
 sp_api::decl_runtime_apis! {
 	/// API necessary for block authorship with aura.
 	pub trait AuraApi<AuthorityId: Codec> {
@@ -91,5 +176,31 @@ sp_api::decl_runtime_apis! {
 
 		/// Return the current set of authorities.
 		fn authorities() -> Vec<AuthorityId>;
+
+		/// Generates a proof of key ownership for the given authority in the
+		/// current epoch.
+		///
+		/// An example usage of this module is coupled with the session historical
+		/// module to prove that a given authority key is tied to a given staking
+		/// identity during a specific session. Proofs of key ownership are necessary
+		/// for submitting equivocation reports.
+		fn generate_key_ownership_proof(
+			slot: Slot,
+			authority_id: AuthorityId,
+		) -> Option<OpaqueKeyOwnershipProof>;
+
+		/// Submits an unsigned extrinsic to report an equivocation.
+		///
+		/// The caller must provide the equivocation proof and a key ownership
+		/// proof (should be obtained using `generate_key_ownership_proof`).
+		/// The extrinsic will be unsigned and should only be accepted for local
+		/// authorship (not to be broadcast to the network). This method returns
+		/// `None` when creation of the extrinsic fails, e.g. if equivocation
+		/// reporting is disabled for the given runtime (i.e. this method is
+		/// hardcoded to return `None`). Only useful in an offchain context.
+		fn submit_report_equivocation_unsigned_extrinsic(
+			equivocation_proof: EquivocationProof<Block::Header, AuthorityId>,
+			key_owner_proof: OpaqueKeyOwnershipProof,
+		) -> Option<()>;
 	}
 }

--- a/substrate/primitives/consensus/aura/src/lib.rs
+++ b/substrate/primitives/consensus/aura/src/lib.rs
@@ -88,22 +88,7 @@ pub type EquivocationProof<H, AuthorityId> = sp_consensus_slots::EquivocationPro
 /// opaque representation, implementors of the runtime API will have to make
 /// sure that all usages of `OpaqueKeyOwnershipProof` refer to the same type.
 #[derive(Decode, Encode, PartialEq, TypeInfo)]
-pub struct OpaqueKeyOwnershipProof(Vec<u8>);
-
-impl OpaqueKeyOwnershipProof {
-	/// Create a new `OpaqueKeyOwnershipProof` using the given encoded
-	/// representation.
-	pub fn new(inner: Vec<u8>) -> OpaqueKeyOwnershipProof {
-		OpaqueKeyOwnershipProof(inner)
-	}
-
-	// TODO @davxy : Required???? If not remove for BABE as well
-	// /// Try to decode this `OpaqueKeyOwnershipProof` into the given concrete key
-	// /// ownership proof type.
-	// pub fn decode<T: Decode>(self) -> Option<T> {
-	// 	Decode::decode(&mut &self.0[..]).ok()
-	// }
-}
+pub struct OpaqueKeyOwnershipProof(pub Vec<u8>);
 
 /// An consensus log item for Aura.
 #[derive(Decode, Encode)]

--- a/substrate/primitives/consensus/babe/src/lib.rs
+++ b/substrate/primitives/consensus/babe/src/lib.rs
@@ -256,9 +256,10 @@ pub struct BabeEpochConfiguration {
 	pub allowed_slots: AllowedSlots,
 }
 
-/// Verifies the equivocation proof by making sure that: both headers have
-/// different hashes, are targetting the same slot, and have valid signatures by
-/// the same authority.
+/// Verifies the equivocation proof.
+///
+/// Makes sure that both headers have different hashes, are targetting the same slot,
+/// and have valid signatures by the same authority.
 pub fn check_equivocation_proof<H>(proof: EquivocationProof<H>) -> bool
 where
 	H: Header,

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -626,6 +626,23 @@ impl_runtime_apis! {
 		fn authorities() -> Vec<AuraId> {
 			SubstrateTest::authorities().into_iter().map(|auth| AuraId::from(auth)).collect()
 		}
+
+		fn submit_report_equivocation_unsigned_extrinsic(
+			_equivocation_proof: sp_consensus_aura::EquivocationProof<
+				<Block as BlockT>::Header,
+				AuraId,
+			>,
+			_key_owner_proof: sp_consensus_aura::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn generate_key_ownership_proof(
+			_slot: sp_consensus_aura::Slot,
+			_authority_id: AuraId,
+		) -> Option<sp_consensus_aura::OpaqueKeyOwnershipProof> {
+			None
+		}
 	}
 
 	impl sp_consensus_babe::BabeApi<Block> for Runtime {


### PR DESCRIPTION
(Requires tweaks to cumulus, but first I want to be sure that there are not blockers with the implementation) 

Due to some characteristics of current aura-pallet implementation, the report system depends on some other pallets.

In particular it requires that:

- Runtime implements `pallet-authorship` to get reporter identity when not directly passed to the report system function
    - This is a requirement which is set by other consensus protocols offence report systems provided by Substrate (i.e. babe, grandpa, beefy).
    - not a huge requirement as most of the implementations who may need the offence report system already include this pallet

- Runtime implements `session-pallet` to map the block number to session index.
    - not a huge requirement as most of the implementations who may need the offence report system already include this pallet

- `session-pallet` `Config` must use the `PeriodicSessions` type as its `NextSessionRotation` associated type. This is to reliably map the block number to session number. The session index is simply given by the block number divided by session duration (which in this case is constant).

---

The ideas were mostly picked from BABE, BEEFY and GRANDPA.
So there isn't really anything new beside the trick to compute the session index from the block number.

During the implementation I also spotted a couple of possible improvement areas which I'm going to highlight in the code comments.

---

Closes https://github.com/paritytech/polkadot-sdk/issues/70