### PR TITLE
Add `asset_sufficient` getter for fungibles

### DIFF
--- a/cumulus/parachains/runtimes/assets/common/src/local_and_foreign_assets.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/local_and_foreign_assets.rs
@@ -247,6 +247,15 @@ where
 			ForeignAssets::asset_exists(asset)
 		}
 	}
+
+	/// Returns `Some(true)` if an `asset` exists and is sufficient.
+	fn asset_sufficient(asset: Self::AssetId) -> Option<bool> {
+		if let Some(asset) = LocalAssetIdConverter::convert(&asset) {
+			Assets::asset_sufficient(asset)
+		} else {
+			ForeignAssets::asset_sufficient(asset)
+		}
+	}
 }
 
 impl<Assets, LocalAssetIdConverter, ForeignAssets> Mutate<AccountId>

--- a/substrate/frame/assets/src/impl_fungibles.rs
+++ b/substrate/frame/assets/src/impl_fungibles.rs
@@ -79,6 +79,10 @@ impl<T: Config<I>, I: 'static> fungibles::Inspect<<T as SystemConfig>::AccountId
 	fn asset_exists(asset: Self::AssetId) -> bool {
 		Asset::<T, I>::contains_key(asset)
 	}
+
+	fn asset_sufficient(asset: Self::AssetId) -> Option<bool> {
+		Asset::<T, I>::get(asset).map(|d| d.is_sufficient)
+	}
 }
 
 impl<T: Config<I>, I: 'static> fungibles::Mutate<<T as SystemConfig>::AccountId> for Pallet<T, I> {

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -117,6 +117,9 @@ pub trait Inspect<AccountId>: Sized {
 
 	/// Returns `true` if an `asset` exists.
 	fn asset_exists(asset: Self::AssetId) -> bool;
+
+	/// Returns `Some(true)` if an `asset` exists and is sufficient.
+	fn asset_sufficient(asset: Self::AssetId) -> Option<bool>;
 }
 
 /// Special dust type which can be type-safely converted into a `Credit`.


### PR DESCRIPTION
# Description

This Pull Request introduces a method inside the `fungibles::Inspect` trait called `asset_sufficient`. This method is useful since pallet implementors can benefit from having this (so far missing) piece of information, either for testing checks or for handling accounts touching on behalf of others.

## Use Cases

### Use Case: Checking whether an asset was appropriately created as sufficient

A pallet might have a rule that allows creating assets, but only marking one of these (i.e. the first) as sufficient. A typical test for this would resemble something like this

```rs
#[test]
fn it_works() {
    new_test_ext().execute_with(|| {
        setup();

        // Can register a new asset
        assert_ok!(
            Communities::create_asset(RuntimeOrigin::signed(COMMUNITY_ADMIN), COMMUNITY, ASSET_B, 1)
        );

        // Can register additional assets
        assert_ok!(
            Communities::create_asset(RuntimeOrigin::signed(COMMUNITY_ADMIN), COMMUNITY, ASSET_C, 1)
        );

        // First asset owned by the community is sufficient by default
        assert_sufficiency(COMMUNITY, ASSET_B, 1, true);

        // Additional assets owned by the community are not sufficient
        // by default
        assert_sufficiency(COMMUNITY, ASSET_C, 1, false);
    });
}
```

Without this getter, implementing `assert_sufficiency` would require (as shown [here](https://github.com/virto-network/virto-node/blob/d7707099d811d94dbb0a13d2b2098c9659446615/pallets/communities/src/tests/helpers.rs#L16-L50)) the following steps:

1. Forcing access to the storage via `sp_io::storage::get`.
2. Encoding a `AssetDetails` struct that resembles the expected one, since `is_sufficient` is a private field.
3. Asserting equality for both structs.

With the getter, it would be something as simple as this, no further illegal accesses required:

```rs
        // First asset owned by the community is sufficient by default
        assert_eq(Assets::asset_sufficient(ASSET_B), Some(true));

        // Additional assets owned by the community are not sufficient
        // by default
        assert_eq(Assets::asset_sufficient(ASSET_C), Some(false));
```

## Implementation

The implementation is actually really simple.

1. Define the method under the `fungibles::Inspect` trait. The method signature conveniently returns `Option<bool>`: to be `None` implies that the asset does not exist, so it's also a shortcut for `asset_exists(asset) && asset_sufficient(asset)`, reducing code.
2. Implement on the `impl_fungibles.rs` file, getting the asset's details, and mapping the response whenever `Some(d)` to `d.is_sufficient`.
3. It was also necessary to implement the call for `LocalAndForeignAssets`.

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable) 
  - _Note:_ Since I've checked similar getter methods are not included in tests, I left the tests intact (but I still modified them locally to ensure the implementation works).
  
### Optional Test Case

```patch
diff --git a/substrate/frame/assets/src/tests.rs b/substrate/frame/assets/src/tests.rs
index 06d4ec1211..d9c1e5b71a 100644
--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -22,7 +22,11 @@ use crate::{mock::*, Error};
 use frame_support::{
        assert_noop, assert_ok,
        dispatch::GetDispatchInfo,
-       traits::{fungibles::InspectEnumerable, tokens::Preservation::Protect, Currency},
+       traits::{
+               fungibles::{Inspect, InspectEnumerable},
+               tokens::Preservation::Protect,
+               Currency,
+       },
 };
 use pallet_balances::Error as BalancesError;
 use sp_io::storage;
@@ -44,6 +48,8 @@ fn asset_account_counts(asset_id: u32) -> (u32, u32) {
 fn transfer_should_never_burn() {
        new_test_ext().execute_with(|| {
                assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));
+               assert_eq!(Assets::asset_sufficient(0), Some(false));
+
                Balances::make_free_balance_be(&1, 100);
                Balances::make_free_balance_be(&2, 100);
```
