### PR TITLE
migrate pallet-fast-unstake to `fungible::*` trait family

### DIFF
--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -247,8 +247,7 @@ pub mod pallet {
 		type Randomness: Randomness<Self::Hash, BlockNumberFor<Self>>;
 
 		/// The fungible in which fees are paid and contract balances are held.
-		type Currency: Inspect<Self::AccountId>
-			+ Mutate<Self::AccountId>
+		type Currency: Mutate<Self::AccountId>
 			+ MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>;
 
 		/// The overarching event type.

--- a/substrate/frame/fast-unstake/src/migrations.rs
+++ b/substrate/frame/fast-unstake/src/migrations.rs
@@ -15,20 +15,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod v1 {
-	use crate::{types::BalanceOf, *};
-	use frame_support::{
-		storage::unhashed,
-		traits::{Defensive, Get, GetStorageVersion, OnRuntimeUpgrade},
-		weights::Weight,
-	};
-	use sp_staking::EraIndex;
-	use sp_std::prelude::*;
+use crate::{types::BalanceOf, Config, Pallet, *};
+use frame_support::{
+	storage::unhashed,
+	traits::{Defensive, Get, GetStorageVersion, OnRuntimeUpgrade},
+	weights::Weight,
+	Twox64Concat,
+};
+use sp_staking::EraIndex;
+use sp_std::prelude::*;
 
-	#[cfg(feature = "try-runtime")]
-	use frame_support::ensure;
-	#[cfg(feature = "try-runtime")]
-	use sp_runtime::TryRuntimeError;
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+/// The old queue, removed in <TODO>, used in v1 and v2.
+#[frame_support::storage_alias]
+type Queue<T: Config> = CountedStorageMap<
+	Pallet<T>,
+	Twox64Concat,
+	<T as frame_system::Config>::AccountId,
+	BalanceOf<T>,
+>;
+
+pub mod v1 {
+	use super::*;
 
 	pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
@@ -85,6 +97,156 @@ pub mod v1 {
 				"The onchain version must be updated after the migration."
 			);
 			Ok(())
+		}
+	}
+}
+
+/// Migration that moves this pallet into v2, whereby:
+///
+/// 1. Named holds are used instead of `ReservableCurrency`.
+/// 2. Structure of both storage items [`UnstakeQueue`] and [`Head`] are changed to no longer
+///    contain any deposit amounts.
+pub mod v2 {
+	use frame_support::migrations::VersionedMigration;
+	use sp_runtime::BoundedVec;
+
+	use crate::types::{MaxChecking, UnstakeRequest};
+
+	use super::*;
+
+	/// Unchecked migration type.
+	pub struct MigrateQueue<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateQueue<T> {
+		fn on_runtime_upgrade() -> Weight {
+			// move all items of old queue to the new one.
+			let old_count = Queue::<T>::count();
+			Queue::<T>::iter_keys().drain().for_each(|stash| {
+				UnstakeQueue::<T>::insert(stash, ());
+			});
+			// This will in fact trick the counter to be wiped from storage.
+			Queue::<T>::initialize_counter();
+			T::DbWeight::get().reads_writes(old_count.into(), (2 * old_count).into())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			ensure!(UnstakeQueue::<T>::iter().count() == 0, "The unstake queue must be empty.");
+			Ok(Queue::<T>::count().encode().to_vec())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(data: Vec<u8>) -> Result<(), TryRuntimeError> {
+			let pre_count = <u32 as Decode>::decode(&mut &*data)
+				.map_err(|e| "failed to decode pre_upgrade data".into());
+			ensure!(pre_count == UnstakeQueue::<T>::count(), "wrong number of items migrated");
+			Ok(())
+		}
+	}
+
+	#[derive(codec::Decode, codec::Encode)]
+	struct OldUnstakeRequest<T: Config> {
+		/// This list of stashes are being processed in this request.
+		pub stashes: BoundedVec<(T::AccountId, BalanceOf<T>), T::BatchSize>,
+		/// The list of eras for which they have been checked.
+		pub checked: BoundedVec<EraIndex, MaxChecking<T>>,
+	}
+
+	pub struct MigrateHead<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateHead<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let outcome = Head::<T>::translate::<OldUnstakeRequest<T>, _>(|maybe_previous| {
+				maybe_previous.map(|previous| UnstakeRequest {
+					checked: previous.checked,
+					stashes: previous
+						.stashes
+						.into_iter()
+						.map(|(s, _)| s)
+						.collect::<Vec<_>>()
+						.try_into()
+						// bound has not changed, should not fail.
+						.defensive_unwrap_or_default(),
+				})
+			});
+
+			if outcome.is_err() {
+				log!(error, "Failed to migrate head storage item.");
+			}
+
+			T::DbWeight::get().reads_writes(1, 2)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+			use codec::Encode;
+			Ok(Head::<T>::get().map(|head| head.stashes.len()).encode())
+		}
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: Vec<u8>) -> Result<(), TryRuntimeError> {
+			// should be able to decode the head, if it exists.
+			if let Some(stashes_len) = <Option<usize> as Decode>::decode(&mut &*state)
+				.expect("failed to decode pre_upgrade data")
+			{
+				ensure!(
+					stashes_len == Head::<T>::get().map(|head| head.stashes.len()).unwrap_or(0),
+					"wrong number of items migrated"
+				);
+			}
+
+			Ok(())
+		}
+	}
+
+	/// Checked migration type to be added to a runtime.
+	pub type MigrateToV2<T> = VersionedMigration<
+		1,
+		2,
+		(MigrateQueue<T>, MigrateHead<T>),
+		Pallet<T>,
+		<T as frame_system::Config>::DbWeight,
+	>;
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use crate::{
+			migrations::Queue,
+			mock::{Deposit, Runtime},
+			types::UnstakeRequest,
+			Head,
+		};
+		use codec::Encode;
+		use frame_support::traits::OnRuntimeUpgrade;
+		use sp_core::bounded_vec;
+		use sp_io::TestExternalities;
+
+		#[test]
+		fn it_works() {
+			TestExternalities::new_empty().execute_with(|| {
+				// a couple of people in the queue in the old format.
+				Queue::<Runtime>::insert(1, Deposit::get());
+				Queue::<Runtime>::insert(2, Deposit::get());
+				Queue::<Runtime>::insert(3, Deposit::get());
+
+				// a head being migrated.
+				let old_request = OldUnstakeRequest::<Runtime> {
+					stashes: bounded_vec![(4, Deposit::get())],
+					checked: bounded_vec![42],
+				};
+				sp_io::storage::set(&Head::<Runtime>::hashed_key(), &old_request.encode());
+
+				// we can't run the versioned one as it will not work here.
+				<(MigrateQueue<Runtime>, MigrateHead<Runtime>) as OnRuntimeUpgrade>::on_runtime_upgrade();
+
+				// new state.
+				assert_eq!(
+					UnstakeQueue::<Runtime>::iter().collect::<Vec<_>>(),
+					vec![(1, ()), (3, ()), (2, ())]
+				);
+				assert_eq!(
+					Head::<Runtime>::get().unwrap(),
+					UnstakeRequest { checked: bounded_vec![42], stashes: bounded_vec![(4)] }
+				)
+			});
 		}
 	}
 }

--- a/substrate/frame/fast-unstake/src/migrations.rs
+++ b/substrate/frame/fast-unstake/src/migrations.rs
@@ -30,7 +30,7 @@ use frame_support::ensure;
 #[cfg(feature = "try-runtime")]
 use sp_runtime::TryRuntimeError;
 
-/// The old queue, removed in <TODO>, used in v1 and v2.
+// The old queue, removed in <https://github.com/paritytech/polkadot-sdk/pull/1772>, used in v1 and v2.
 #[frame_support::storage_alias]
 type Queue<T: Config> = CountedStorageMap<
 	Pallet<T>,

--- a/substrate/frame/fast-unstake/src/migrations.rs
+++ b/substrate/frame/fast-unstake/src/migrations.rs
@@ -106,6 +106,9 @@ pub mod v1 {
 /// 1. Named holds are used instead of `ReservableCurrency`.
 /// 2. Structure of both storage items [`UnstakeQueue`] and [`Head`] are changed to no longer
 ///    contain any deposit amounts.
+///
+/// TODO: move this migration to use MBMs when ready. For now it is only here for the sake of
+/// demonstration.
 pub mod v2 {
 	use frame_support::migrations::VersionedMigration;
 	use sp_runtime::BoundedVec;

--- a/substrate/frame/fast-unstake/src/mock.rs
+++ b/substrate/frame/fast-unstake/src/mock.rs
@@ -63,20 +63,14 @@ parameter_types! {
 	pub static ExistentialDeposit: Balance = 1;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type MaxLocks = ConstU32<128>;
-	type MaxReserves = ();
-	type ReserveIdentifier = [u8; 8];
 	type Balance = Balance;
-	type RuntimeEvent = RuntimeEvent;
-	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type WeightInfo = ();
-	type FreezeIdentifier = ();
-	type MaxFreezes = ();
-	type RuntimeHoldReason = ();
-	type MaxHolds = ();
+
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type MaxHolds = ConstU32<128>;
 }
 
 pallet_staking_reward_curve::build! {
@@ -167,6 +161,7 @@ parameter_types! {
 
 impl fast_unstake::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Deposit = Deposit;
 	type Currency = Balances;
 	type Staking = Staking;

--- a/substrate/frame/fast-unstake/src/types.rs
+++ b/substrate/frame/fast-unstake/src/types.rs
@@ -19,9 +19,7 @@
 
 use crate::Config;
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{
-	traits::Currency, BoundedVec, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
-};
+use frame_support::{BoundedVec, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound};
 use scale_info::TypeInfo;
 use sp_staking::{EraIndex, StakingInterface};
 use sp_std::prelude::*;
@@ -40,7 +38,9 @@ impl<T: Config> frame_support::traits::Get<u32> for MaxChecking<T> {
 }
 
 pub(crate) type BalanceOf<T> =
-	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+	<<T as Config>::Currency as frame_support::traits::fungible::Inspect<
+		<T as frame_system::Config>::AccountId,
+	>>::Balance;
 /// An unstake request.
 ///
 /// This is stored in [`crate::Head`] storage item and points to the current unstake request that is
@@ -50,8 +50,8 @@ pub(crate) type BalanceOf<T> =
 )]
 #[scale_info(skip_type_params(T))]
 pub struct UnstakeRequest<T: Config> {
-	/// This list of stashes are being processed in this request, and their corresponding deposit.
-	pub stashes: BoundedVec<(T::AccountId, BalanceOf<T>), T::BatchSize>,
+	/// This list of stashes are being processed in this request.
+	pub stashes: BoundedVec<T::AccountId, T::BatchSize>,
 	/// The list of eras for which they have been checked.
 	pub checked: BoundedVec<EraIndex, MaxChecking<T>>,
 }

--- a/substrate/frame/support/src/lib.rs
+++ b/substrate/frame/support/src/lib.rs
@@ -139,14 +139,14 @@ impl TypeId for PalletId {
 /// # Examples
 ///
 /// There are different ways to declare the `prefix` to use. The `prefix` type can either be
-/// declared explicetly by passing it to the macro as an attribute or by letting the macro
+/// declared explicitly by passing it to the macro as an attribute or by letting the macro
 /// guess on what the `prefix` type is. The `prefix` is always passed as the first generic
 /// argument to the type declaration. When using [`#[pallet::storage]`](pallet_macros::storage)
 /// this first generic argument is always `_`. Besides declaring the `prefix`, the rest of the
 /// type declaration works as with [`#[pallet::storage]`](pallet_macros::storage).
 ///
 /// 1. Use the `verbatim` prefix type. This prefix type uses the given identifier as the
-/// `prefix`:
+///    `prefix`:
 #[doc = docify::embed!("src/tests/storage_alias.rs", verbatim_attribute)]
 ///
 /// 2. Use the `pallet_name` prefix type. This prefix type uses the name of the pallet as

--- a/substrate/frame/support/src/storage/types/counted_map.rs
+++ b/substrate/frame/support/src/storage/types/counted_map.rs
@@ -76,8 +76,7 @@ impl<P: CountedStorageMapInstance, H, K, V, Q, O, M> MapWrapper
 }
 
 /// The counter prefix for any given storage map.
-pub type CounterFor<P> =
-	StorageValue<<P as CountedStorageMapInstance>::CounterPrefix, u32, ValueQuery>;
+type CounterFor<P> = StorageValue<<P as CountedStorageMapInstance>::CounterPrefix, u32, ValueQuery>;
 
 /// On removal logic for updating counter while draining upon some prefix with
 /// [`crate::storage::PrefixIterator`].

--- a/substrate/frame/support/src/storage/types/mod.rs
+++ b/substrate/frame/support/src/storage/types/mod.rs
@@ -30,7 +30,7 @@ mod map;
 mod nmap;
 mod value;
 
-pub use counted_map::{CountedStorageMap, CountedStorageMapInstance};
+pub use counted_map::{CountedStorageMap, CountedStorageMapInstance, CounterFor};
 pub use counted_nmap::{CountedStorageNMap, CountedStorageNMapInstance};
 pub use double_map::StorageDoubleMap;
 pub use key::{

--- a/substrate/frame/support/src/storage/types/mod.rs
+++ b/substrate/frame/support/src/storage/types/mod.rs
@@ -30,7 +30,7 @@ mod map;
 mod nmap;
 mod value;
 
-pub use counted_map::{CountedStorageMap, CountedStorageMapInstance, CounterFor};
+pub use counted_map::{CountedStorageMap, CountedStorageMapInstance};
 pub use counted_nmap::{CountedStorageNMap, CountedStorageNMapInstance};
 pub use double_map::StorageDoubleMap;
 pub use key::{

--- a/substrate/frame/support/src/traits/tokens/fungible/hold.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/hold.rs
@@ -321,8 +321,7 @@ pub trait Mutate<AccountId>:
 		precision: Precision,
 		force: Fortitude,
 	) -> Result<Self::Balance, DispatchError> {
-		let amount = Self::balance_on_hold(reason, who);
-		Self::burn_held(reason, who, amount, precision, force)
+		Self::burn_held(reason, who, Self::balance_on_hold(reason, who), precision, force)
 	}
 
 	/// Transfer held funds into a destination account.


### PR DESCRIPTION
part of #226. 

Note that many other pallets could possibly use the `Consideration` api if they are purely holding deposits. In the case of this pallet, I decided to tap into the `fungible::*` traits directly because the type of deposit held in this pallet is fixed, and very rudimentary. We don't want to care about if `type Deposit` even changes. The pallet should at any point put `Deposit::get()` on hold, and upon successful operation, should release all of it. 

I think for these pallets the `fungible` based approach is better because it gives you the ability to stop tracking the amount of deposit held. Contrary, in the `Consideration` you need to store the `ticket` so that you can update or release the deposit. 

I might nonetheless try this approach as well. 

The PR contains some logical changes to the pallet and a migration, namely because, as noted above, we no longer need to store the deposit amount. 