### PR TITLE
Upgraded review-bot to version 2.0.1

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -10,7 +10,7 @@ rules:
         - ^\.cargo/.*
       exclude: 
         - ^./gitlab/pipeline/zombienet.*
-    min_approvals: 2
+    minApprovals: 2
     type: basic
     teams:
       - ci
@@ -27,7 +27,7 @@ rules:
       exclude: 
         - ^polkadot/runtime\/(kusama|polkadot)\/src\/weights\/.+\.rs$
         - ^substrate\/frame\/.+\.md$
-    min_approvals: 1
+    minApprovals: 1
     allowedToSkipRule:
       teams:
         - core-devs
@@ -54,7 +54,7 @@ rules:
         - ^\.gitlab/.*
         - ^\.config/nextest.toml
         - ^\.cargo/.*
-    min_approvals: 2
+    minApprovals: 2
     type: basic
     teams:
       - core-devs
@@ -70,10 +70,10 @@ rules:
         - ^cumulus/parachains/common/src/[^/]+\.rs$
     type: and-distinct
     reviewers:
-      - min_approvals: 1
+      - minApprovals: 1
         teams:
           - locks-review
-      - min_approvals: 1
+      - minApprovals: 1
         teams:
           - polkadot-review
 
@@ -83,7 +83,7 @@ rules:
     condition: 
       include:
         - ^bridges/.*
-    min_approvals: 1
+    minApprovals: 1
     teams:
       - bridges-core
 
@@ -95,10 +95,10 @@ rules:
         - ^substrate/frame/(?!.*(nfts/.*|uniques/.*|babe/.*|grandpa/.*|beefy|merkle-mountain-range/.*|contracts/.*|election|nomination-pools/.*|staking/.*|aura/.*))
     type: "and"
     reviewers:
-      - min_approvals: 2
+      - minApprovals: 2
         teams:
           - core-devs
-      - min_approvals: 1
+      - minApprovals: 1
         teams:
           - frame-coders
 
@@ -107,15 +107,14 @@ rules:
     condition:
       include: 
         - review-bot\.yml
-    min_approvals: 2
     type: "and"
     reviewers:
-      - min_approvals: 1
+      - minApprovals: 1
         teams:
           - opstooling
-      - min_approvals: 1
+      - minApprovals: 1
         teams:
           - locks-review
-      - min_approvals: 1
+      - minApprovals: 1
         teams:
           - ci

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -24,7 +24,7 @@ jobs:
           app_id: ${{ secrets.REVIEW_APP_ID }}
           private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v1.1.0
+        uses: paritytech/review-bot@v2.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}


### PR DESCRIPTION
## [Updated review bot version](https://github.com/paritytech/polkadot-sdk/commit/677610ba330a8e03f24b46889787e0475f354954) 

updated version to version 2.0.1 which contains https://github.com/paritytech/review-bot/pull/90, a fix for the team members not being fetch in its totality.

## [Updated review-bot.yml minApprovals convention](https://github.com/paritytech/polkadot-sdk/commit/b1446832ddd14f55b2720a65b0ff86b139999419) 

Renamed `min_approvals` to `minApprovals`. A breaking change in https://github.com/paritytech/review-bot/pull/86 which was done to standarize all the cases (so now everything is camelCase)