### PR TITLE
Migrate lease deposits from reserves to named holds

### DIFF
--- a/polkadot/runtime/common/src/assigned_slots/mod.rs
+++ b/polkadot/runtime/common/src/assigned_slots/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 	slots::{self, Pallet as Slots, WeightInfo as SlotsWeightInfo},
 	traits::{LeaseError, Leaser, Registrar},
 };
-use frame_support::{pallet_prelude::*, traits::Currency};
+use frame_support::{pallet_prelude::*, traits::{Currency, fungible::Inspect as FunInspect}};
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -98,9 +98,10 @@ impl WeightInfo for TestWeightInfo {
 	}
 }
 
-type BalanceOf<T> = <<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as Currency<
+type BalanceOf<T> = <<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as FunInspect<
 	<T as frame_system::Config>::AccountId,
 >>::Balance;
+
 type LeasePeriodOf<T> = <<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::LeasePeriod;
 
 #[frame_support::pallet]

--- a/polkadot/runtime/common/src/assigned_slots/mod.rs
+++ b/polkadot/runtime/common/src/assigned_slots/mod.rs
@@ -664,7 +664,7 @@ mod tests {
 			Configuration: parachains_configuration::{Pallet, Call, Storage, Config<T>},
 			ParasShared: parachains_shared::{Pallet, Call, Storage},
 			Parachains: parachains_paras::{Pallet, Call, Storage, Config<T>, Event},
-			Slots: slots::{Pallet, Call, Storage, Event<T>},
+			Slots: slots::{Pallet, Call, Storage, Event<T>, HoldReason},
 			AssignedSlots: assigned_slots::{Pallet, Call, Storage, Event<T>},
 		}
 	);
@@ -754,6 +754,7 @@ mod tests {
 	impl slots::Config for Test {
 		type RuntimeEvent = RuntimeEvent;
 		type Currency = Balances;
+		type RuntimeHoldReason = RuntimeHoldReason;
 		type Registrar = TestRegistrar<Test>;
 		type LeasePeriod = LeasePeriod;
 		type LeaseOffset = LeaseOffset;

--- a/polkadot/runtime/common/src/assigned_slots/mod.rs
+++ b/polkadot/runtime/common/src/assigned_slots/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 	slots::{self, Pallet as Slots, WeightInfo as SlotsWeightInfo},
 	traits::{LeaseError, Leaser, Registrar},
 };
-use frame_support::{pallet_prelude::*, traits::{Currency, fungible::Inspect as FunInspect}};
+use frame_support::{pallet_prelude::*, traits::fungible::Inspect as FunInspect};
 use frame_system::pallet_prelude::*;
 pub use pallet::*;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -98,9 +98,10 @@ impl WeightInfo for TestWeightInfo {
 	}
 }
 
-type BalanceOf<T> = <<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as FunInspect<
-	<T as frame_system::Config>::AccountId,
->>::Balance;
+type BalanceOf<T> =
+	<<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as FunInspect<
+		<T as frame_system::Config>::AccountId,
+	>>::Balance;
 
 type LeasePeriodOf<T> = <<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::LeasePeriod;
 
@@ -783,7 +784,7 @@ mod tests {
 	pub fn new_test_ext() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 		pallet_balances::GenesisConfig::<Test> {
-			balances: vec![(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)],
+			balances: vec![(0, 5), (1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)],
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/polkadot/runtime/common/src/auctions.rs
+++ b/polkadot/runtime/common/src/auctions.rs
@@ -686,7 +686,7 @@ mod tests {
 	use ::test_helpers::{dummy_hash, dummy_head_data, dummy_validation_code};
 	use frame_support::{
 		assert_noop, assert_ok, assert_storage_noop, ord_parameter_types, parameter_types,
-		traits::{ConstU32, EitherOfDiverse, OnFinalize, OnInitialize},
+		traits::{ConstU32, EitherOfDiverse, OnFinalize, OnInitialize, Currency},
 	};
 	use frame_system::{EnsureRoot, EnsureSignedBy};
 	use pallet_balances;

--- a/polkadot/runtime/common/src/auctions.rs
+++ b/polkadot/runtime/common/src/auctions.rs
@@ -25,7 +25,7 @@ use crate::{
 use frame_support::{
 	dispatch::DispatchResult,
 	ensure,
-	traits::{{Currency, Get, Randomness, ReservableCurrency}, fungible::Inspect as FunInspect},
+	traits::{fungible::Inspect as FunInspect, Get, Randomness, ReservableCurrency},
 	weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -36,9 +36,10 @@ use sp_runtime::traits::{CheckedSub, One, Saturating, Zero};
 use sp_std::{mem::swap, prelude::*};
 
 type CurrencyOf<T> = <T as Config>::Currency;
-type BalanceOf<T> = <<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as FunInspect<
-	<T as frame_system::Config>::AccountId,
->>::Balance;
+type BalanceOf<T> =
+	<<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as FunInspect<
+		<T as frame_system::Config>::AccountId,
+	>>::Balance;
 
 pub trait WeightInfo {
 	fn new_auction() -> Weight;
@@ -98,7 +99,12 @@ pub mod pallet {
 			LeasePeriod = BlockNumberFor<Self>,
 		>;
 
-		type Currency: ReservableCurrency<Self::AccountId, Balance = <<Self::Leaser as Leaser<BlockNumberFor<Self>>>::Currency as FunInspect<Self::AccountId>>::Balance>;
+		type Currency: ReservableCurrency<
+			Self::AccountId,
+			Balance = <<Self::Leaser as Leaser<BlockNumberFor<Self>>>::Currency as FunInspect<
+				Self::AccountId,
+			>>::Balance,
+		>;
 
 		/// The parachain registrar type.
 		type Registrar: Registrar<AccountId = Self::AccountId>;

--- a/polkadot/runtime/common/src/auctions.rs
+++ b/polkadot/runtime/common/src/auctions.rs
@@ -875,6 +875,7 @@ mod tests {
 	impl Config for Test {
 		type RuntimeEvent = RuntimeEvent;
 		type Leaser = TestLeaser;
+		type Currency = Balances;
 		type Registrar = TestRegistrar<Self>;
 		type EndingPeriod = EndingPeriod;
 		type SampleLength = SampleLength;

--- a/polkadot/runtime/common/src/auctions.rs
+++ b/polkadot/runtime/common/src/auctions.rs
@@ -25,7 +25,7 @@ use crate::{
 use frame_support::{
 	dispatch::DispatchResult,
 	ensure,
-	traits::{Currency, Get, Randomness, ReservableCurrency},
+	traits::{{Currency, Get, Randomness, ReservableCurrency}, fungible::Inspect as FunInspect},
 	weights::Weight,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -35,8 +35,8 @@ use primitives::Id as ParaId;
 use sp_runtime::traits::{CheckedSub, One, Saturating, Zero};
 use sp_std::{mem::swap, prelude::*};
 
-type CurrencyOf<T> = <<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency;
-type BalanceOf<T> = <<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as Currency<
+type CurrencyOf<T> = <T as Config>::Currency;
+type BalanceOf<T> = <<<T as Config>::Leaser as Leaser<BlockNumberFor<T>>>::Currency as FunInspect<
 	<T as frame_system::Config>::AccountId,
 >>::Balance;
 
@@ -97,6 +97,8 @@ pub mod pallet {
 			AccountId = Self::AccountId,
 			LeasePeriod = BlockNumberFor<Self>,
 		>;
+
+		type Currency: ReservableCurrency<Self::AccountId, Balance = <<Self::Leaser as Leaser<BlockNumberFor<Self>>>::Currency as FunInspect<Self::AccountId>>::Balance>;
 
 		/// The parachain registrar type.
 		type Registrar: Registrar<AccountId = Self::AccountId>;

--- a/polkadot/runtime/common/src/integration_tests.rs
+++ b/polkadot/runtime/common/src/integration_tests.rs
@@ -182,7 +182,7 @@ impl pallet_balances::Config for Test {
 	type ReserveIdentifier = [u8; 8];
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type FreezeIdentifier = ();
-	type MaxHolds = ConstU32<0>;
+	type MaxHolds = ConstU32<1>;
 	type MaxFreezes = ConstU32<0>;
 }
 

--- a/polkadot/runtime/common/src/integration_tests.rs
+++ b/polkadot/runtime/common/src/integration_tests.rs
@@ -87,7 +87,7 @@ frame_support::construct_runtime!(
 		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>},
 		Auctions: auctions::{Pallet, Call, Storage, Event<T>},
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>},
-		Slots: slots::{Pallet, Call, Storage, Event<T>},
+		Slots: slots::{Pallet, Call, Storage, Event<T>, HoldReason},
 	}
 );
 
@@ -230,6 +230,7 @@ parameter_types! {
 impl auctions::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Leaser = Slots;
+	type Currency = Balances;
 	type Registrar = Registrar;
 	type EndingPeriod = EndingPeriod;
 	type SampleLength = SampleLength;
@@ -246,6 +247,7 @@ parameter_types! {
 impl slots::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Registrar = Registrar;
 	type LeasePeriod = LeasePeriod;
 	type LeaseOffset = LeaseOffset;

--- a/polkadot/runtime/common/src/slots/migration.rs
+++ b/polkadot/runtime/common/src/slots/migration.rs
@@ -41,10 +41,12 @@ mod v1 {
 	use super::*;
 	use frame_support::traits::ReservableCurrency;
 
+	/// Balance type of OldCurrency.
 	pub type OldBalanceOf<T, OldCurrency> = <OldCurrency as frame_support::traits::Currency<
 		<T as frame_system::Config>::AccountId,
 	>>::Balance;
 
+	/// Alias to leases storage map with old currency.
 	#[frame_support::storage_alias]
 	pub type Leases<T: Config, OldCurrency> =
 	StorageMap<Pallet<T>, Twox64Concat, ParaId, Vec<Option<(<T as frame_system::Config>::AccountId, OldBalanceOf<T, OldCurrency>)>>, ValueQuery>;

--- a/polkadot/runtime/common/src/slots/mod.rs
+++ b/polkadot/runtime/common/src/slots/mod.rs
@@ -28,10 +28,7 @@ use crate::traits::{LeaseError, Leaser, Registrar};
 use frame_support::{
 	defensive_assert,
 	pallet_prelude::*,
-	traits::fungible::{
-		hold::{Inspect as FunHoldInspect, Mutate as FunHoldMutate},
-		Inspect as FunInspect, Mutate as FunMutate,
-	},
+	traits::fungible::{hold::Mutate as FunHoldMutate, Inspect as FunInspect},
 	weights::Weight,
 };
 use frame_system::pallet_prelude::*;

--- a/polkadot/runtime/common/src/slots/mod.rs
+++ b/polkadot/runtime/common/src/slots/mod.rs
@@ -70,6 +70,7 @@ pub mod pallet {
 	use super::*;
 
 	#[pallet::pallet]
+	#[pallet::storage_version(migration::STORAGE_VERSION)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 

--- a/polkadot/runtime/common/src/slots/mod.rs
+++ b/polkadot/runtime/common/src/slots/mod.rs
@@ -347,14 +347,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn release(leaser: &T::AccountId, amount: BalanceOf<T>) {
-		let amount = T::Currency::release(
+		let released_amount = T::Currency::release(
 			&HoldReason::LeaseDeposit.into(),
 			&leaser,
 			amount,
 			frame_support::traits::tokens::Precision::BestEffort,
 		);
 
-		defensive_assert!(amount.is_ok() && amount.unwrap() == amount);
+		defensive_assert!(released_amount.is_ok() && released_amount.unwrap() == amount);
 	}
 }
 
@@ -548,7 +548,7 @@ mod tests {
 		{
 			System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-			Slots: slots::{Pallet, Call, Storage, Event<T>},
+			Slots: slots::{Pallet, Call, Storage, Event<T>, HoldReason},
 		}
 	);
 

--- a/polkadot/runtime/common/src/traits.rs
+++ b/polkadot/runtime/common/src/traits.rs
@@ -18,7 +18,13 @@
 
 use frame_support::{
 	dispatch::DispatchResult,
-	traits::{Currency, ReservableCurrency},
+	traits::{
+		fungible::{
+			hold::{Inspect as FunHoldInspect, Mutate as FunHoldMutate},
+			Inspect as FunInspect, Mutate as FunMutate,
+		},
+		Currency, ReservableCurrency,
+	},
 };
 use primitives::{HeadData, Id as ParaId, ValidationCode};
 use sp_std::vec::*;
@@ -109,7 +115,7 @@ pub trait Leaser<BlockNumber> {
 	type LeasePeriod;
 
 	/// The currency type in which the lease is taken.
-	type Currency: ReservableCurrency<Self::AccountId>;
+	type Currency: FunHoldMutate<Self::AccountId>;
 
 	/// Lease a new parachain slot for `para`.
 	///
@@ -126,7 +132,7 @@ pub trait Leaser<BlockNumber> {
 	fn lease_out(
 		para: ParaId,
 		leaser: &Self::AccountId,
-		amount: <Self::Currency as Currency<Self::AccountId>>::Balance,
+		amount: <Self::Currency as FunInspect<Self::AccountId>>::Balance,
 		period_begin: Self::LeasePeriod,
 		period_count: Self::LeasePeriod,
 	) -> Result<(), LeaseError>;
@@ -136,7 +142,7 @@ pub trait Leaser<BlockNumber> {
 	fn deposit_held(
 		para: ParaId,
 		leaser: &Self::AccountId,
-	) -> <Self::Currency as Currency<Self::AccountId>>::Balance;
+	) -> <Self::Currency as FunInspect<Self::AccountId>>::Balance;
 
 	/// The length of a lease period, and any offset which may be introduced.
 	/// This is only used in benchmarking to automate certain calls.

--- a/polkadot/runtime/common/src/traits.rs
+++ b/polkadot/runtime/common/src/traits.rs
@@ -19,10 +19,7 @@
 use frame_support::{
 	dispatch::DispatchResult,
 	traits::{
-		fungible::{
-			hold::{Inspect as FunHoldInspect, Mutate as FunHoldMutate},
-			Inspect as FunInspect, Mutate as FunMutate,
-		},
+		fungible::{hold::Mutate as FunHoldMutate, Inspect as FunInspect},
 		Currency, ReservableCurrency,
 	},
 };

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1255,6 +1255,7 @@ parameter_types! {
 impl slots::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Registrar = Registrar;
 	type LeasePeriod = LeasePeriod;
 	type LeaseOffset = ();
@@ -1294,6 +1295,7 @@ parameter_types! {
 impl auctions::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Leaser = Slots;
+	type Currency = Balances;
 	type Registrar = Registrar;
 	type EndingPeriod = EndingPeriod;
 	type SampleLength = SampleLength;
@@ -1432,7 +1434,7 @@ construct_runtime! {
 
 		// Parachain Onboarding Pallets. Start indices at 60 to leave room.
 		Registrar: paras_registrar::{Pallet, Call, Storage, Event<T>, Config<T>} = 60,
-		Slots: slots::{Pallet, Call, Storage, Event<T>} = 61,
+		Slots: slots::{Pallet, Call, Storage, Event<T>, HoldReason} = 61,
 		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call} = 62,
 		Auctions: auctions::{Pallet, Call, Storage, Event<T>} = 63,
 		Crowdloan: crowdloan::{Pallet, Call, Storage, Event<T>} = 64,
@@ -1509,6 +1511,7 @@ pub mod migrations {
 		pallet_nomination_pools::migration::versioned_migrations::V5toV6<Runtime>,
 		pallet_referenda::migration::v1::MigrateV0ToV1<Runtime, ()>,
 		pallet_nomination_pools::migration::versioned_migrations::V6ToV7<Runtime>,
+		slots::migration::versioned::ToV1<Runtime, Balances>,
 	);
 }
 


### PR DESCRIPTION
Partially addresses https://github.com/paritytech/polkadot-sdk/issues/226.

Useful for redoing this [PR](https://github.com/paritytech/polkadot-sdk/pull/1749) without needing to have an extra storage for keeping track of reserved amounts.

This PR will be followed by another PR that adds the new extrinsic `early_lease_refund` functionally same as [these changes](https://github.com/paritytech/polkadot-sdk/pull/1749/files#diff-698c14f82108db1ab5cb7f00799188057e3350e4aec3e688bbaa69b7e2adfcddR256).

### Migration note
`Leases` storage is unbounded but leases can only be assigned via auction and new auctions can only be created by root origin. The number of leases currently on Kusama and Polkadot is `45` and `53` respectively and hence safe to migrate all of them in one block (instead of a lazy migrate approach). 

You can use the following query to check the count of keys that we are iterating over in the migration:

`console.log((await api.query.slots.leases.entries()).length);`

