### PR TITLE
chore: bump zombienter version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.68"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.69"
   DOCKER_IMAGES_VERSION: "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
 
 default:


### PR DESCRIPTION
Bump zombiente version. This version includes the fixes needed for `mixnet`.
Thx!