### PR TITLE
Application Crypto and BEEFY Support for paired (ECDSA,BLS) crypto

### DIFF
--- a/substrate/primitives/application-crypto/src/ecdsa_bls377.rs
+++ b/substrate/primitives/application-crypto/src/ecdsa_bls377.rs
@@ -1,0 +1,56 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! BLS12-377 crypto applications.
+use crate::{KeyTypeId, RuntimePublic};
+
+pub use sp_core::paired_crypto::ecdsa_bls377::*;
+
+mod app {
+	crate::app_crypto!(super, sp_core::testing::ECDSA_BLS377);
+}
+
+#[cfg(feature = "full_crypto")]
+pub use app::Pair as AppPair;
+pub use app::{Public as AppPublic, Signature as AppSignature};
+
+impl RuntimePublic for Public {
+	type Signature = Signature;
+
+	/// Dummy implementation. Returns an empty vector.
+	fn all(_key_type: KeyTypeId) -> Vec<Self> {
+		Vec::new()
+	}
+
+	fn generate_pair(key_type: KeyTypeId, seed: Option<Vec<u8>>) -> Self {
+		sp_io::crypto::ecdsa_bls377_generate(key_type, seed)
+	}
+
+	/// Dummy implementation. Returns `None`.
+	fn sign<M: AsRef<[u8]>>(&self, _key_type: KeyTypeId, _msg: &M) -> Option<Self::Signature> {
+		None
+	}
+
+	/// Dummy implementation. Returns `false`.
+	fn verify<M: AsRef<[u8]>>(&self, _msg: &M, _signature: &Self::Signature) -> bool {
+		false
+	}
+
+	fn to_raw_vec(&self) -> Vec<u8> {
+		sp_core::crypto::ByteArray::to_raw_vec(self)
+	}
+}

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -49,9 +49,9 @@ pub mod bandersnatch;
 pub mod bls377;
 #[cfg(feature = "bls-experimental")]
 pub mod bls381;
+pub mod ecdsa;
 #[cfg(feature = "bls-experimental")]
 pub mod ecdsa_bls377;
-pub mod ecdsa;
 pub mod ed25519;
 pub mod sr25519;
 mod traits;

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -49,6 +49,8 @@ pub mod bandersnatch;
 pub mod bls377;
 #[cfg(feature = "bls-experimental")]
 pub mod bls381;
+#[cfg(feature = "bls-experimental")]
+pub mod ecdsa_bls377;
 pub mod ecdsa;
 pub mod ed25519;
 pub mod sr25519;

--- a/substrate/primitives/consensus/beefy/src/lib.rs
+++ b/substrate/primitives/consensus/beefy/src/lib.rs
@@ -155,7 +155,7 @@ pub mod bls_crypto {
 pub mod ecdsa_bls_crypto {
 	use super::{BeefyAuthorityId, Hash, RuntimeAppPublic, KEY_TYPE as BEEFY_KEY_TYPE};
 	use sp_application_crypto::{app_crypto, ecdsa_bls377};
-	use sp_core::{ecdsa_bls377::Pair as EcdsaBlsPair, crypto::Wraps, Pair as _};
+	use sp_core::{crypto::Wraps, ecdsa_bls377::Pair as EcdsaBlsPair, Pair as _};
 	app_crypto!(ecdsa_bls377, BEEFY_KEY_TYPE);
 
 	/// Identity of a BEEFY authority using BLS as its crypto.
@@ -498,7 +498,7 @@ mod tests {
 		assert!(!BeefyAuthorityId::<Keccak256>::verify(&other_pair.public(), &signature, msg,));
 	}
 
-    #[test]
+	#[test]
 	#[cfg(feature = "bls-experimental")]
 	fn ecdsa_bls_beefy_verify_works() {
 		let msg = &b"test-message"[..];
@@ -513,5 +513,4 @@ mod tests {
 		let (other_pair, _) = ecdsa_bls_crypto::Pair::generate();
 		assert!(!BeefyAuthorityId::<Keccak256>::verify(&other_pair.public(), &signature, msg,));
 	}
-
 }

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -89,11 +89,11 @@ const SECRET_KEY_SERIALIZED_SIZE: usize =
 	<SecretKey<TinyBLS381> as SerializableToBytes>::SERIALIZED_BYTES_SIZE;
 
 // Public key serialized size
-const PUBLIC_KEY_SERIALIZED_SIZE: usize =
+pub const PUBLIC_KEY_SERIALIZED_SIZE: usize =
 	<DoublePublicKey<TinyBLS381> as SerializableToBytes>::SERIALIZED_BYTES_SIZE;
 
 // Signature serialized size
-const SIGNATURE_SERIALIZED_SIZE: usize =
+pub const SIGNATURE_SERIALIZED_SIZE: usize =
 	<DoubleSignature<TinyBLS381> as SerializableToBytes>::SERIALIZED_BYTES_SIZE;
 
 /// A secret seed.

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -317,6 +317,10 @@ impl<T> sp_std::hash::Hash for Signature<T> {
 	}
 }
 
+impl<T> ByteArray for Signature<T> {
+	const LEN: usize = SIGNATURE_SERIALIZED_SIZE;
+}
+
 impl<T> TryFrom<&[u8]> for Signature<T> {
 	type Error = ();
 

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -83,16 +83,16 @@ trait BlsBound: EngineBLS + HardJunctionId + Send + Sync + 'static {}
 
 impl<T: EngineBLS + HardJunctionId + Send + Sync + 'static> BlsBound for T {}
 
-// Secret key serialized size
+/// Secret key serialized size
 #[cfg(feature = "full_crypto")]
 const SECRET_KEY_SERIALIZED_SIZE: usize =
 	<SecretKey<TinyBLS381> as SerializableToBytes>::SERIALIZED_BYTES_SIZE;
 
-// Public key serialized size
+/// Public key serialized size
 pub const PUBLIC_KEY_SERIALIZED_SIZE: usize =
 	<DoublePublicKey<TinyBLS381> as SerializableToBytes>::SERIALIZED_BYTES_SIZE;
 
-// Signature serialized size
+/// Signature serialized size
 pub const SIGNATURE_SERIALIZED_SIZE: usize =
 	<DoubleSignature<TinyBLS381> as SerializableToBytes>::SERIALIZED_BYTES_SIZE;
 
@@ -258,7 +258,7 @@ impl<T> sp_std::fmt::Debug for Public<T> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<T: BlsBound> Serialize for Public<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -268,7 +268,7 @@ impl<T: BlsBound> Serialize for Public<T> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<'de, T: BlsBound> Deserialize<'de> for Public<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -330,7 +330,7 @@ impl<T> TryFrom<&[u8]> for Signature<T> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<T> Serialize for Signature<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -340,7 +340,7 @@ impl<T> Serialize for Signature<T> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for Signature<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -529,11 +529,10 @@ mod test {
 		);
 	}
 
-	// Only passes if the seed = (seed mod ScalarField)
 	#[test]
 	fn seed_and_derive_should_work() {
 		let seed = array_bytes::hex2array_unchecked(
-			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f00",
+			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
 		);
 		let pair = Pair::from_seed(&seed);
 		// we are using hash to field so this is not going to work
@@ -543,7 +542,7 @@ mod test {
 		assert_eq!(
 			derived.to_raw_vec(),
 			array_bytes::hex2array_unchecked::<_, 32>(
-				"a4f2269333b3e87c577aa00c4a2cd650b3b30b2e8c286a47c251279ff3a26e0d"
+				"3a0626d095148813cd1642d38254f1cfff7eb8cc1a2fc83b2a135377c3554c12"
 			)
 		);
 	}

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -200,7 +200,7 @@ impl<T> TryFrom<&[u8]> for Public<T> {
 
 	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
 		if data.len() != PUBLIC_KEY_SERIALIZED_SIZE {
-			return Err(())
+			return Err(());
 		}
 		let mut r = [0u8; PUBLIC_KEY_SERIALIZED_SIZE];
 		r.copy_from_slice(data);
@@ -326,7 +326,7 @@ impl<T> TryFrom<&[u8]> for Signature<T> {
 
 	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
 		if data.len() != SIGNATURE_SERIALIZED_SIZE {
-			return Err(())
+			return Err(());
 		}
 		let mut inner = [0u8; SIGNATURE_SERIALIZED_SIZE];
 		inner.copy_from_slice(data);
@@ -436,7 +436,7 @@ impl<T: BlsBound> TraitPair for Pair<T> {
 
 	fn from_seed_slice(seed_slice: &[u8]) -> Result<Self, SecretStringError> {
 		if seed_slice.len() != SECRET_KEY_SERIALIZED_SIZE {
-			return Err(SecretStringError::InvalidSeedLength)
+			return Err(SecretStringError::InvalidSeedLength);
 		}
 		let secret = w3f_bls::SecretKey::from_seed(seed_slice);
 		let public = secret.into_public();

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -1197,7 +1197,7 @@ macro_rules! impl_from_entropy_base {
 			[$type; 17], [$type; 18], [$type; 19], [$type; 20], [$type; 21], [$type; 22], [$type; 23], [$type; 24],
 			[$type; 25], [$type; 26], [$type; 27], [$type; 28], [$type; 29], [$type; 30], [$type; 31], [$type; 32],
 			[$type; 36], [$type; 40], [$type; 44], [$type; 48], [$type; 56], [$type; 64], [$type; 72], [$type; 80],
-			[$type; 96], [$type; 112], [$type; 128], [$type; 160], [$type; 192], [$type; 224], [$type; 256]
+			[$type; 96], [$type; 112], [$type; 128], [$type; 160], [$type; 177], [$type; 192], [$type; 224], [$type; 256]
 		);
 	}
 }

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -51,7 +51,7 @@ use sp_std::vec::Vec;
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecds");
 
 /// The byte length of public key
-pub const PUBLIC_KEY_SERIALIZED_SIZE :usize = 33;
+pub const PUBLIC_KEY_SERIALIZED_SIZE: usize = 33;
 
 /// The byte length of public key
 pub const SIGNATURE_SERIALIZED_SIZE: usize = 65;
@@ -139,7 +139,7 @@ impl TryFrom<&[u8]> for Public {
 
 	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
 		if data.len() != Self::LEN {
-			return Err(())
+			return Err(());
 		}
 		let mut r = [0u8; Self::LEN];
 		r.copy_from_slice(data);
@@ -318,7 +318,7 @@ impl Signature {
 	/// you are certain that the array actually is a signature. GIGO!
 	pub fn from_slice(data: &[u8]) -> Option<Self> {
 		if data.len() != SIGNATURE_SERIALIZED_SIZE {
-			return None
+			return None;
 		}
 		let mut r = [0u8; SIGNATURE_SERIALIZED_SIZE];
 		r.copy_from_slice(data);

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -50,6 +50,12 @@ use sp_std::vec::Vec;
 /// An identifier used to match public keys against ecdsa keys
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecds");
 
+/// The byte length of public key
+pub const PUBLIC_KEY_SERIALIZED_SIZE :usize = 33;
+
+/// The byte length of public key
+pub const SIGNATURE_SERIALIZED_SIZE: usize = 65;
+
 /// A secret seed (which is bytewise essentially equivalent to a SecretKey).
 ///
 /// We need it as a different type because `Seed` is expected to be AsRef<[u8]>.
@@ -71,11 +77,11 @@ type Seed = [u8; 32];
 	PartialOrd,
 	Ord,
 )]
-pub struct Public(pub [u8; 33]);
+pub struct Public(pub [u8; PUBLIC_KEY_SERIALIZED_SIZE]);
 
 impl crate::crypto::FromEntropy for Public {
 	fn from_entropy(input: &mut impl codec::Input) -> Result<Self, codec::Error> {
-		let mut result = Self([0u8; 33]);
+		let mut result = Self([0u8; PUBLIC_KEY_SERIALIZED_SIZE]);
 		input.read(&mut result.0[..])?;
 		Ok(result)
 	}
@@ -86,7 +92,7 @@ impl Public {
 	///
 	/// NOTE: No checking goes on to ensure this is a real public key. Only use it if
 	/// you are certain that the array actually is a pubkey. GIGO!
-	pub fn from_raw(data: [u8; 33]) -> Self {
+	pub fn from_raw(data: [u8; PUBLIC_KEY_SERIALIZED_SIZE]) -> Self {
 		Self(data)
 	}
 
@@ -109,7 +115,7 @@ impl Public {
 }
 
 impl ByteArray for Public {
-	const LEN: usize = 33;
+	const LEN: usize = PUBLIC_KEY_SERIALIZED_SIZE;
 }
 
 impl TraitPublic for Public {}
@@ -148,8 +154,8 @@ impl From<Pair> for Public {
 	}
 }
 
-impl UncheckedFrom<[u8; 33]> for Public {
-	fn unchecked_from(x: [u8; 33]) -> Self {
+impl UncheckedFrom<[u8; PUBLIC_KEY_SERIALIZED_SIZE]> for Public {
+	fn unchecked_from(x: [u8; PUBLIC_KEY_SERIALIZED_SIZE]) -> Self {
 		Public(x)
 	}
 }
@@ -198,14 +204,14 @@ impl<'de> Deserialize<'de> for Public {
 /// A signature (a 512-bit value, plus 8 bits for recovery ID).
 #[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
-pub struct Signature(pub [u8; 65]);
+pub struct Signature(pub [u8; SIGNATURE_SERIALIZED_SIZE]);
 
 impl TryFrom<&[u8]> for Signature {
 	type Error = ();
 
 	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-		if data.len() == 65 {
-			let mut inner = [0u8; 65];
+		if data.len() == SIGNATURE_SERIALIZED_SIZE {
+			let mut inner = [0u8; SIGNATURE_SERIALIZED_SIZE];
 			inner.copy_from_slice(data);
 			Ok(Signature(inner))
 		} else {
@@ -239,7 +245,7 @@ impl<'de> Deserialize<'de> for Signature {
 
 impl Clone for Signature {
 	fn clone(&self) -> Self {
-		let mut r = [0u8; 65];
+		let mut r = [0u8; SIGNATURE_SERIALIZED_SIZE];
 		r.copy_from_slice(&self.0[..]);
 		Signature(r)
 	}
@@ -247,18 +253,18 @@ impl Clone for Signature {
 
 impl Default for Signature {
 	fn default() -> Self {
-		Signature([0u8; 65])
+		Signature([0u8; SIGNATURE_SERIALIZED_SIZE])
 	}
 }
 
-impl From<Signature> for [u8; 65] {
-	fn from(v: Signature) -> [u8; 65] {
+impl From<Signature> for [u8; SIGNATURE_SERIALIZED_SIZE] {
+	fn from(v: Signature) -> [u8; SIGNATURE_SERIALIZED_SIZE] {
 		v.0
 	}
 }
 
-impl AsRef<[u8; 65]> for Signature {
-	fn as_ref(&self) -> &[u8; 65] {
+impl AsRef<[u8; SIGNATURE_SERIALIZED_SIZE]> for Signature {
+	fn as_ref(&self) -> &[u8; SIGNATURE_SERIALIZED_SIZE] {
 		&self.0
 	}
 }
@@ -287,8 +293,8 @@ impl sp_std::fmt::Debug for Signature {
 	}
 }
 
-impl UncheckedFrom<[u8; 65]> for Signature {
-	fn unchecked_from(data: [u8; 65]) -> Signature {
+impl UncheckedFrom<[u8; SIGNATURE_SERIALIZED_SIZE]> for Signature {
+	fn unchecked_from(data: [u8; SIGNATURE_SERIALIZED_SIZE]) -> Signature {
 		Signature(data)
 	}
 }
@@ -298,7 +304,7 @@ impl Signature {
 	///
 	/// NOTE: No checking goes on to ensure this is a real signature. Only use it if
 	/// you are certain that the array actually is a signature. GIGO!
-	pub fn from_raw(data: [u8; 65]) -> Signature {
+	pub fn from_raw(data: [u8; SIGNATURE_SERIALIZED_SIZE]) -> Signature {
 		Signature(data)
 	}
 
@@ -307,10 +313,10 @@ impl Signature {
 	/// NOTE: No checking goes on to ensure this is a real signature. Only use it if
 	/// you are certain that the array actually is a signature. GIGO!
 	pub fn from_slice(data: &[u8]) -> Option<Self> {
-		if data.len() != 65 {
+		if data.len() != SIGNATURE_SERIALIZED_SIZE {
 			return None
 		}
-		let mut r = [0u8; 65];
+		let mut r = [0u8; SIGNATURE_SERIALIZED_SIZE];
 		r.copy_from_slice(data);
 		Some(Signature(r))
 	}
@@ -473,7 +479,7 @@ impl Pair {
 	pub fn verify_deprecated<M: AsRef<[u8]>>(sig: &Signature, message: M, pubkey: &Public) -> bool {
 		let message = libsecp256k1::Message::parse(&blake2_256(message.as_ref()));
 
-		let parse_signature_overflowing = |x: [u8; 65]| {
+		let parse_signature_overflowing = |x: [u8; SIGNATURE_SERIALIZED_SIZE]| {
 			let sig = libsecp256k1::Signature::parse_overflowing_slice(&x[..64]).ok()?;
 			let rid = libsecp256k1::RecoveryId::parse(x[64]).ok()?;
 			Some((sig, rid))
@@ -726,7 +732,7 @@ mod test {
 		let signature = pair.sign(&message[..]);
 		let serialized_signature = serde_json::to_string(&signature).unwrap();
 		// Signature is 65 bytes, so 130 chars + 2 quote chars
-		assert_eq!(serialized_signature.len(), 132);
+		assert_eq!(serialized_signature.len(), SIGNATURE_SERIALIZED_SIZE * 2 + 2);
 		let signature = serde_json::from_str(&serialized_signature).unwrap();
 		assert!(Pair::verify(&signature, &message[..], &pair.public()));
 	}

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -206,6 +206,10 @@ impl<'de> Deserialize<'de> for Public {
 #[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
 pub struct Signature(pub [u8; SIGNATURE_SERIALIZED_SIZE]);
 
+impl ByteArray for Signature {
+	const LEN: usize = SIGNATURE_SERIALIZED_SIZE;
+}
+
 impl TryFrom<&[u8]> for Signature {
 	type Error = ();
 

--- a/substrate/primitives/core/src/hexdisplay.rs
+++ b/substrate/primitives/core/src/hexdisplay.rs
@@ -96,7 +96,7 @@ macro_rules! impl_non_endians {
 impl_non_endians!(
 	[u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7], [u8; 8], [u8; 10], [u8; 12],
 	[u8; 14], [u8; 16], [u8; 20], [u8; 24], [u8; 28], [u8; 32], [u8; 40], [u8; 48], [u8; 56],
-	[u8; 64], [u8; 65], [u8; 80], [u8; 96], [u8; 112], [u8; 128], [u8; 144]
+	[u8; 64], [u8; 65], [u8; 80], [u8; 96], [u8; 112], [u8; 128], [u8; 144], [u8; 177]
 );
 
 /// Format into ASCII + # + hex, suitable for storage key preimages.

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -75,6 +75,8 @@ pub mod uint;
 
 #[cfg(feature = "bls-experimental")]
 pub use bls::{bls377, bls381};
+#[cfg(feature = "bls-experimental")]
+pub use paired_crypto::ecdsa_bls377;
 
 pub use self::{
 	hash::{convert_hash, H160, H256, H512},

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -59,6 +59,7 @@ pub use paste;
 pub mod bandersnatch;
 #[cfg(feature = "bls-experimental")]
 pub mod bls;
+pub mod paired_crypto;
 pub mod defer;
 pub mod ecdsa;
 pub mod ed25519;

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -34,6 +34,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sp_runtime_interface::pass_by::PassByInner;
 use sp_std::{convert::TryFrom, marker::PhantomData, ops::Deref};
 
+
 /// ECDSA and BLS-377 specialized types
 pub mod ecdsa_n_bls377 {
 	use crate::crypto::{CryptoTypeId};
@@ -46,7 +47,7 @@ pub mod ecdsa_n_bls377 {
 	#[cfg(feature = "full_crypto")]
 	//pub type Pair = super::Pair<ecdsa:Pair, bls377:Pair>;
 	/// BLS12-377 public key.
-	pub type Public = super::Public<ecdsa::Public, ed25519::Public>;
+	pub type Public = super::Public<ecdsa::Public, ed25519::Public, 32, 32>;
 	// /// BLS12-377 signature.
 	//pub type Signature = super::Signature<ecdsa:Signature, bls377:Signature>;
 
@@ -63,47 +64,61 @@ pub mod ecdsa_n_bls377 {
 #[cfg(feature = "full_crypto")]
 //type Seed = [u8; SECRET_KEY_SERIALIZED_SIZE];
 
-pub trait PublicKeyBound: TraitPublic + sp_std::hash::Hash + ByteArray {}
+pub trait PublicKeyBound: TraitPublic + sp_std::hash::Hash + ByteArray  {}
 /// A public key.
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, PartialOrd, Ord)]
 #[scale_info(skip_type_params(T))]
-pub struct PublicWithInner<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_SIZE: usize> {
-    inner: [u8; LEFT_PLUS_RIGHT_SIZE],
- 	_phantom: PhantomData<fn() -> (LeftPublic, RightPublic)>,
+pub struct Public<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_LEN: usize, const RIGHT_LEN: usize,> (LeftPublic, RightPublic);
+
+#[cfg(feature = "full_crypto")]
+impl<LeftPublic: PublicKeyBound + UncheckedFrom<[u8; LEFT_LEN]>, RightPublic: PublicKeyBound + UncheckedFrom<[u8; RIGHT_LEN]>, const LEFT_LEN: usize, const RIGHT_LEN: usize> sp_std::hash::Hash for Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN> {
+  	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+ 	    self.0.hash(state);
+	    self.1.hash(state);
+	}
 }
 
-pub struct Public<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound> {
-    left_public : LeftPublic,
-    right_public: RightPublic,
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_LEN: usize, const RIGHT_LEN: usize> ByteArray  for Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN> where for<'a>  Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN>: TryFrom<&'a [u8], Error = ()> + AsRef<[u8]> + AsMut<[u8]>  {
+     const LEN: usize = LeftPublic::LEN + RightPublic::LEN;
 }
 
-// #[cfg(feature = "full_crypto")]
-// impl<T1: PublicKeyBound, T2: PublicKeyBound> sp_std::hash::Hash for Public<T1,T2> {
-//  	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
-//  		self.left_public.hash(state);
-//         self.right_public.hash(state);
-//  	}
-// }
+impl<'a,LeftPublic: PublicKeyBound + UncheckedFrom<[u8; LEFT_LEN]>, RightPublic: PublicKeyBound + UncheckedFrom<[u8; RIGHT_LEN]>, const LEFT_LEN: usize, const RIGHT_LEN: usize>  TryFrom<&'a[u8]> for Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN> {
+    type Error = ();
 
-// impl<T1: TraitPublic, T2: TraitPublic> ByteArray for Public<T1,T2> {
-//  	const LEN: usize = T1::LEN + T2::LEN;
-// }
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+ 		if data.len() != 	LEFT_LEN + RIGHT_LEN {
+			return Err(())
+		}
+	
+ 		let mut r0 = [0u8;  LEFT_LEN];
+ 		let mut r1 = [0u8; RIGHT_LEN];
+		r0.copy_from_slice(&data[0..LEFT_LEN]);  
+ 		r1.copy_from_slice(&data[LEFT_LEN..RIGHT_LEN]);
+		Ok(Self(LeftPublic::unchecked_from(r0),RightPublic::unchecked_from(r1)))
+    }
+}
 
-// impl<T1: PublicKeyBound, T2: PublicKeyBound> TryFrom<&[u8]> for Public<T1,T2> {
-//  	type Error = ();
-
-//  	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-// // 		if data.len() != PUBLIC_KEY_SERIALIZED_SIZE {
-// // 			return Err(())
-// // 		}
-// // 		let mut r = [0u8; PUBLIC_KEY_SERIALIZED_SIZE];
-// // 		r.copy_from_slice(data);
-// // 		Ok(Self::unchecked_from(r))
-//  	}
-// }
-
-// impl<T1,T2> AsMut<[u8]> for Public<T1,T2> {
+// impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_LEN: usize, const RIGHT_LEN: usize> AsMut<[u8]> for Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN> {
 //  	fn as_mut(&mut self) -> &mut [u8] {
-//  		&mut self.inner[..]
+//  	 &mut [self.0.as_mut(), self.1.as_mut()].concat()
 //  	}
+// }
+
+// impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_LEN: usize, const RIGHT_LEN: usize, const RIGHT_PLUS_LEFT_LEN: usize> AsRef<[u8; RIGHT_PLUS_LEFT_LEN]> for Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN> where for<'a>  Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN>: TryFrom<&'a [u8], Error = ()> {
+//     fn as_ref(&self) -> &[u8; RIGHT_PLUS_LEFT_LEN] {
+// 	let mut r = [0u8; RIGHT_PLUS_LEFT_LEN];
+// 	r.copy_from_slice(self.0.as_ref());
+// 	r[LeftPublic::LEN..].copy_from_slice(self.1.as_ref());
+// 	&r
+//     }
+// }
+
+// impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_LEN: usize, const RIGHT_LEN: usize,> AsRef<[u8]> for Public<LeftPublic, RightPublic, LEFT_LEN, RIGHT_LEN> {
+//     fn as_ref(&self) -> &[u8] {
+// 	//let mut r : Vec<u8> = vec![0u8; LEFT_LEN + RIGHT_LEN];
+// 	//r.copy_from_slice(self.0.as_ref(), LeftPublic::LEN);
+// 	//r[LeftPublic::LEN..].copy_from_slice(self.1.as_ref(), RightPublic::LEN);
+// 	let mut r :Vec<u8> = [self.0.as_ref(), self.1.as_ref()].concat();
+// 	&r[..]
+//     }
 // }

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -473,36 +473,17 @@ Seed<LeftPair::Seed, RightPair::Seed, DOUBLE_SEED_LEN>: SeedBound,
 
 	fn sign(&self, message: &[u8]) -> Self::Signature {
 	    let mut mutable_self = self.clone();
-	    let r: [u8; SIGNATURE_LEN] = [0u8; SIGNATURE_LEN];
-	// 		DoublePublicKeyScheme::sign(&mut mutable_self.0, &Message::new(b"", message))
-	// 			.to_bytes()
-	// 			.try_into()
-	// 			.expect("Signature serializer returns vectors of SIGNATURE_SERIALIZED_SIZE size");
+	    let mut r: [u8; SIGNATURE_LEN] = [0u8; SIGNATURE_LEN];
+        r.copy_from_slice(self.left.sign(message).as_ref());
+        r[Self::LEFT_SIGNATURE_LEN..].copy_from_slice(self.right.sign(message).as_ref());
 	    Self::Signature::unchecked_from(r)
 	}
 
-	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
-	// 	let pubkey_array: [u8; PUBLIC_KEY_SERIALIZED_SIZE] =
-	// 		match <[u8; PUBLIC_KEY_SERIALIZED_SIZE]>::try_from(pubkey.as_ref()) {
-	// 			Ok(pk) => pk,
-	// 			Err(_) => return false,
-	// 		};
-	// 	let public_key = match w3f_bls::double::DoublePublicKey::<T>::from_bytes(&pubkey_array) {
-	// 		Ok(pk) => pk,
-	// 		Err(_) => return false,
-	// 	};
+	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool  {
+        let mut vec_message = vec![0u8; message.as_ref().len()];
+        vec_message.clone_from_slice(message.as_ref());
 
-	// 	let sig_array = match sig.inner[..].try_into() {
-	// 		Ok(s) => s,
-	// 		Err(_) => return false,
-	// 	};
-	// 	let sig = match w3f_bls::double::DoubleSignature::from_bytes(sig_array) {
-	// 		Ok(s) => s,
-	// 		Err(_) => return false,
-	// 	};
-
-	    // 	sig.verify(&Message::new(b"", message.as_ref()), &public_key)
-        return false;
+        LeftPair::verify(&sig.left, message, &pubkey.left) && RightPair::verify(&sig.right, vec_message, &pubkey.right)
 	}
 
 	/// Get the seed for this key.
@@ -510,3 +491,4 @@ Seed<LeftPair::Seed, RightPair::Seed, DOUBLE_SEED_LEN>: SeedBound,
 		[self.left.to_raw_vec(), self.left.to_raw_vec()].concat()
 	}
 }
+

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -44,7 +44,7 @@ pub mod ecdsa_n_bls377 {
 
 	/// BLS12-377 key pair.
 	#[cfg(feature = "full_crypto")]
-	pub type Pair = super::Pair<ecdsa::Pair, ed25519::Pair>;
+	pub type Pair = super::Pair<ecdsa::Pair, ed25519::Pair, 64, 64>;
 	/// BLS12-377 public key.
 	pub type Public = super::Public<ecdsa::Public, ed25519::Public, 64>;
 	// /// BLS12-377 signature.
@@ -66,14 +66,26 @@ pub mod ecdsa_n_bls377 {
 
 }
 
+#[cfg(feature = "full_crypto")]
+const SECURE_SEED_LEN: usize = 32;
+
+#[cfg(feature = "full_crypto")]
+const DOUBLE_SEED_LEN: usize = SECURE_SEED_LEN * 2;
+
 /// A secret seed.
 ///
 /// It's not called a "secret key" because ring doesn't expose the secret keys
 /// of the key pair (yeah, dumb); as such we're forced to remember the seed manually if we
 /// will need it later (such as for HDKD).
 #[cfg(feature = "full_crypto")]
-type Seed<const LEFT_PLUS_RIGHT_LEN: usize> = [u8; {LEFT_PLUS_RIGHT_LEN}];
+pub trait SeedBound:  Default + AsRef<[u8]> + AsMut<[u8]> + Clone {}
 
+#[cfg(feature = "full_crypto")]
+pub struct Seed<LeftSeed: SeedBound, RightSeed: SeedBound, const LEFT_PLUS_RIGHT_LEN: usize,> {
+    left: LeftSeed,
+    right: RightSeed,
+    inner: [u8; LEFT_PLUS_RIGHT_LEN],
+}
 //pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {}
 pub trait PublicKeyBound: TraitPublic + Sized + Derive + sp_std::hash::Hash + ByteArray + for<'a> TryFrom<&'a[u8]> + AsMut<[u8]> + CryptoType {}
 
@@ -120,8 +132,8 @@ impl<'a,LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS
   		if data.len() != 	LEFT_PLUS_RIGHT_LEN {
  			return Err(())
  		}
-         	 let mut left : LeftPublic = data[0..LeftPublic::LEN].try_into().unwrap();
-	 let mut right : RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
+         	 let mut left : LeftPublic = data[0..LeftPublic::LEN].try_into()?;
+	 let mut right : RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into()?;
 
 	 let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
 	 Ok(Public { left, right, inner })
@@ -167,9 +179,9 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftPair: TraitPair, RightPair: TraitPair, LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize,> From<Pair<LeftPair, RightPair>> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN> where Pair<LeftPair, RightPair> : TraitPair<Public = Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN>>,
+impl<LeftPair: TraitPair, RightPair: TraitPair, LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize, const SIGNATURE_LEN: usize> From<Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN>> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN> where Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN> : TraitPair<Public = Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN>>,
     {
-	fn from(x: Pair<LeftPair, RightPair>) -> Self {
+	fn from(x: Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN>) -> Self {
 		x.public()
 	}
 }
@@ -179,8 +191,7 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
  	 let mut left : LeftPublic = data[0..LeftPublic::LEN].try_into().unwrap();
 	 let mut right : RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
 
-	 let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
-	 Public { left, right, inner }
+	 Public { left: left, right: right, inner: data }
 	}
 
 }
@@ -248,8 +259,9 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize,> CryptoType for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN> 
 {}
 
+
 //pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {}
-pub trait SignatureBound: sp_std::hash::Hash + for<'a> TryFrom<&'a[u8]> {}
+pub trait SignatureBound: sp_std::hash::Hash + for<'a> TryFrom<&'a[u8]> + AsRef<[u8]> {}
 
 /// A pair of signatures of different types
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
@@ -281,10 +293,13 @@ impl<'a,LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEF
   		if data.len() != 	LEFT_PLUS_RIGHT_LEN {
  			return Err(())
  		}
-         	 let Ok(mut left)  = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
-	 let Ok(mut right) = data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
+         	 let Ok(mut left) : Result<LeftSignature, _> = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
+	 let Ok(mut right) : Result<RightSignature, _>= data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
 
-	 let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
+	     let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
+         inner.copy_from_slice(left.as_ref());
+ 	     inner[Self::LEFT_SIGNATURE_LEN..].copy_from_slice(right.as_ref());
+
 	 Ok(Signature { left, right, inner })
 
      }
@@ -318,15 +333,17 @@ impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_P
 }
 
 #[cfg(feature = "std")]
-impl<'de, LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> Deserialize<'de> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> {
+impl<'de,LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> Deserialize<'de> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> where
+Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: for<'a> TryFrom<&'a[u8]>{
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
 	{
 		let signature_hex = array_bytes::hex2bytes(&String::deserialize(deserializer)?)
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?;
-		Signature::try_from(signature_hex.as_ref())
-			.map_err(|e| de::Error::custom(format!("{:?}", e)))
+        let sighex_ref = signature_hex.as_ref();
+		Signature::try_from(sighex_ref)
+			.map_err(|e| de::Error::custom(format!("Error in converting deserialized data into signature")))
 	}
 }
 
@@ -337,7 +354,7 @@ impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_P
 	}
 }
 
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> sp_std::fmt::Debug for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> {
+impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> sp_std::fmt::Debug for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> where [u8;LEFT_PLUS_RIGHT_LEN]: crate::hexdisplay::AsBytesRef{
 	#[cfg(feature = "std")]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "{}", crate::hexdisplay::HexDisplay::from(&self.inner))
@@ -351,8 +368,8 @@ impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_P
 
 impl<LeftSignature: SignatureBound, RightSignature: SignatureBound,  const LEFT_PLUS_RIGHT_LEN: usize,> UncheckedFrom<[u8; LEFT_PLUS_RIGHT_LEN]> for Signature<LeftSignature, RightSignature,LEFT_PLUS_RIGHT_LEN> where Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: SignaturePair {
 	fn unchecked_from(data: [u8; LEFT_PLUS_RIGHT_LEN]) -> Self {
-        let mut left : LeftSignature = data[0..Self::LEFT_SIGNATURE_LEN].try_into().unwrap();
-	 let mut right : RightSignature = data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
+        let Ok(mut left) = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
+	 let Ok(mut right) = data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
 
 	 let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
 	 Signature { left, right, inner }
@@ -362,7 +379,8 @@ impl<LeftSignature: SignatureBound, RightSignature: SignatureBound,  const LEFT_
 /// A key pair.
 #[cfg(feature = "full_crypto")]
 #[derive(Clone)]
-pub struct Pair<LeftPair: TraitPair, RightPair: TraitPair,> {
+pub struct Pair<LeftPair: TraitPair, RightPair: TraitPair, const PUBLIC_KEY_LEN: usize, const SIGNATURE_LEN: usize>
+{
     left: LeftPair,
     right: RightPair,
     
@@ -383,64 +401,87 @@ trait HardJunctionId {
 }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftPair: TraitPair, RightPair: TraitPair> Pair<LeftPair, RightPair> {
+impl<LeftPair: TraitPair, RightPair: TraitPair, const PUBLIC_KEY_LEN: usize, const SIGNATURE_LEN: usize> Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN> {
 }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftPair: TraitPair, RightPair: TraitPair> TraitPair for Pair<LeftPair, RightPair> where
-    Pair<LeftPair, RightPair>: DoublePair + CryptoType,
+impl<LeftPair: TraitPair, RightPair: TraitPair, const PUBLIC_KEY_LEN: usize, const SIGNATURE_LEN: usize> TraitPair for Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN> where
+    Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: DoublePair + CryptoType,
     LeftPair::Signature: SignatureBound,
     RightPair::Signature: SignatureBound,
+Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>: CryptoType,
+Signature<LeftPair::Signature, RightPair::Signature, SIGNATURE_LEN>: SignaturePair,
+    LeftPair::Seed: SeedBound,
+    RightPair::Seed: SeedBound,
+Seed<LeftPair::Seed, RightPair::Seed, DOUBLE_SEED_LEN>: SeedBound,
 {
-	type Seed = (LeftPair::Seed, RightPair::Seed);
-	type Public = Public<LeftPair::Public, RightPair::Public, {<Self as DoublePair>::PUBLIC_KEY_LEN}>;
-	type Signature = Signature<LeftPair::Signature, RightPair::Signature, { Self::SIGNATURE_LEN }>;
+	type Seed = Seed<LeftPair::Seed, RightPair::Seed, DOUBLE_SEED_LEN>;
+	type Public = Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>;
+	type Signature = Signature<LeftPair::Signature, RightPair::Signature, SIGNATURE_LEN>;
 
 	fn from_seed_slice(seed_slice: &[u8]) -> Result<Self, SecretStringError> {
 		if seed_slice.len() != Self::RIGHT_SEED_LEN + Self::LEFT_SEED_LEN {
 			return Err(SecretStringError::InvalidSeedLength)
 		}
-		let left = LeftPair::from_seed_slice(seed_slice[0..Self::LEFT_SEED_LEN])?;
-        let right =	RightPair::from_seed_slice(seed_slice[Self::LEFT_SEED_LEN..Self::RIGHT_SEED_LEN + Self::LEFT_SEED_LEN])?;
+		let left = LeftPair::from_seed_slice(&seed_slice[0..Self::LEFT_SEED_LEN])?;
+        let right =	RightPair::from_seed_slice(&seed_slice[Self::LEFT_SEED_LEN..Self::RIGHT_SEED_LEN + Self::LEFT_SEED_LEN])?;
 		Ok(Pair { left, right })
 	}
 
-	// fn derive<Iter: Iterator<Item = DeriveJunction>>(
-	// 	&self,
-	// 	path: Iter,
-	// 	_seed: Option<Seed>,
-	// ) -> Result<(Self, Option<Seed>), DeriveError> {
-	// 	let mut acc: [u8; SECRET_KEY_SERIALIZED_SIZE] =
-	// 		self.0.secret.to_bytes().try_into().expect(
-	// 			"Secret key serializer returns a vector of SECRET_KEY_SERIALIZED_SIZE size",
-	// 		);
-	// 	for j in path {
-	// 		match j {
-	// 			DeriveJunction::Soft(_cc) => return Err(DeriveError::SoftKeyInPath),
-	// 			DeriveJunction::Hard(cc) => acc = derive_hard_junction::<T>(&acc, &cc),
-	// 		}
-	// 	}
-	// 	Ok((Self::from_seed(&acc), Some(acc)))
-	// }
+	fn derive<Iter: Iterator<Item = DeriveJunction>>(
+	 	&self,
+	 	path: Iter,
+	 	seed: Option<Self::Seed>,
+	) -> Result<(Self, Option<Self::Seed>), DeriveError> {
 
-	// fn public(&self) -> Self::Public {
-	// 	let mut raw = [0u8; PUBLIC_KEY_SERIALIZED_SIZE];
-	// 	let pk = DoublePublicKeyScheme::into_double_public_key(&self.0).to_bytes();
-	// 	raw.copy_from_slice(pk.as_slice());
-	// 	Self::Public::unchecked_from(raw)
-	// }
+        let seed_left_right = match seed {
+            Some(seed) => (Some(seed.left), Some(seed.right)),
+                //(LeftPair::from_seed_slice(&seed).ok().map(|p|p.to_raw_vec()), RightPair::from_seed_slice(&seed).ok().map(|p| p.to_raw_vec())),
+                None => (None, None),
+        };
 
-	// fn sign(&self, message: &[u8]) -> Self::Signature {
-	// 	let mut mutable_self = self.clone();
-	// 	let r: [u8; SIGNATURE_SERIALIZED_SIZE] =
+        let left_path: Vec<_> = path.map(|p|p.clone()).collect();
+        let right_path = left_path.clone();
+		let derived_left = self.left.derive(left_path.into_iter(), seed_left_right.0)?;
+        let derived_right = self.right.derive(right_path.into_iter(), seed_left_right.1)?;
+
+            let optional_seed = match (derived_left.1, derived_right.1) {
+                (Some(seed_left), Some(seed_right)) => {
+                    let mut inner = [0u8; DOUBLE_SEED_LEN];
+                    inner.copy_from_slice(seed_left.as_ref());
+ 	                inner[SECURE_SEED_LEN..].copy_from_slice(seed_right.as_ref());
+                    Some(Self::Seed{left: seed_left, right: seed_right, inner: inner})},
+                _ => None,
+
+                };
+        //     Some(seed) => (LeftPair::from_seed_slice(&seed).ok().map(|p|p.to_raw_vec()), RightPair::from_seed_slice(&seed).ok().map(|p| p.to_raw_vec())),
+        //     None => (None, None),
+        // };
+
+	 	Ok((Self{left: derived_left.0, right: derived_right.0}, optional_seed))
+	 }
+
+	fn public(&self) -> Self::Public {
+	   let mut raw = [0u8; PUBLIC_KEY_LEN];
+		let left_pub = self.left.public();
+        let right_pub  = self.right.public();	// 	let pk = DoublePublicKeyScheme::into_double_public_key(&self.0).to_bytes();
+        raw.copy_from_slice(left_pub.as_ref());
+ 	    raw[LeftPair::Public::LEN..].copy_from_slice(right_pub.as_ref());
+	    Self::Public::unchecked_from(raw)
+        //Public{left: left_pub, right: right_pub, inner: raw}
+	}
+
+	fn sign(&self, message: &[u8]) -> Self::Signature {
+	    let mut mutable_self = self.clone();
+	    let r: [u8; SIGNATURE_LEN] = [0u8; SIGNATURE_LEN];
 	// 		DoublePublicKeyScheme::sign(&mut mutable_self.0, &Message::new(b"", message))
 	// 			.to_bytes()
 	// 			.try_into()
 	// 			.expect("Signature serializer returns vectors of SIGNATURE_SERIALIZED_SIZE size");
-	// 	Self::Signature::unchecked_from(r)
-	// }
+	    Self::Signature::unchecked_from(r)
+	}
 
-	// fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
+	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
 	// 	let pubkey_array: [u8; PUBLIC_KEY_SERIALIZED_SIZE] =
 	// 		match <[u8; PUBLIC_KEY_SERIALIZED_SIZE]>::try_from(pubkey.as_ref()) {
 	// 			Ok(pk) => pk,
@@ -460,15 +501,12 @@ impl<LeftPair: TraitPair, RightPair: TraitPair> TraitPair for Pair<LeftPair, Rig
 	// 		Err(_) => return false,
 	// 	};
 
-	// 	sig.verify(&Message::new(b"", message.as_ref()), &public_key)
-	// }
+	    // 	sig.verify(&Message::new(b"", message.as_ref()), &public_key)
+        return false;
+	}
 
-	// /// Get the seed for this key.
-	// fn to_raw_vec(&self) -> Vec<u8> {
-	// 	self.0
-	// 		.secret
-	// 		.to_bytes()
-	// 		.try_into()
-	// 		.expect("Secret key serializer returns a vector of SECRET_KEY_SERIALIZED_SIZE size")
-	// }
+	/// Get the seed for this key.
+	fn to_raw_vec(&self) -> Vec<u8> {
+		[self.left.to_raw_vec(), self.left.to_raw_vec()].concat()
+	}
 }

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -63,19 +63,47 @@ pub mod ecdsa_n_bls377 {
 #[cfg(feature = "full_crypto")]
 //type Seed = [u8; SECRET_KEY_SERIALIZED_SIZE];
 
+pub trait PublicKeyBound: TraitPublic + sp_std::hash::Hash + ByteArray {}
 /// A public key.
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, PartialOrd, Ord)]
 #[scale_info(skip_type_params(T))]
-pub struct Public<LeftPublic: TraitPublic, RightPublic: TraitPublic> {
+pub struct PublicWithInner<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_SIZE: usize> {
+    inner: [u8; LEFT_PLUS_RIGHT_SIZE],
+ 	_phantom: PhantomData<fn() -> (LeftPublic, RightPublic)>,
+}
+
+pub struct Public<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound> {
     left_public : LeftPublic,
     right_public: RightPublic,
 }
 
-#[cfg(feature = "full_crypto")]
-impl<T1: TraitPublic, T2: TraitPublicc> sp_std::hash::Hash for Public<T1,T2> {
- 	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
- 		self.left_public.hash(state);
-        self.right_public.hash(state);
- 	}
-}
+// #[cfg(feature = "full_crypto")]
+// impl<T1: PublicKeyBound, T2: PublicKeyBound> sp_std::hash::Hash for Public<T1,T2> {
+//  	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+//  		self.left_public.hash(state);
+//         self.right_public.hash(state);
+//  	}
+// }
 
+// impl<T1: TraitPublic, T2: TraitPublic> ByteArray for Public<T1,T2> {
+//  	const LEN: usize = T1::LEN + T2::LEN;
+// }
+
+// impl<T1: PublicKeyBound, T2: PublicKeyBound> TryFrom<&[u8]> for Public<T1,T2> {
+//  	type Error = ();
+
+//  	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+// // 		if data.len() != PUBLIC_KEY_SERIALIZED_SIZE {
+// // 			return Err(())
+// // 		}
+// // 		let mut r = [0u8; PUBLIC_KEY_SERIALIZED_SIZE];
+// // 		r.copy_from_slice(data);
+// // 		Ok(Self::unchecked_from(r))
+//  	}
+// }
+
+// impl<T1,T2> AsMut<[u8]> for Public<T1,T2> {
+//  	fn as_mut(&mut self) -> &mut [u8] {
+//  		&mut self.inner[..]
+//  	}
+// }

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -1,0 +1,81 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Licenseff is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! API for using a pair of crypto schemes together.
+
+#[cfg(feature = "std")]
+use crate::crypto::Ss58Codec;
+use crate::crypto::{ByteArray, CryptoType, Derive, Public as TraitPublic, UncheckedFrom};
+#[cfg(feature = "full_crypto")]
+use crate::crypto::{DeriveError, DeriveJunction, Pair as TraitPair, SecretStringError};
+
+#[cfg(feature = "full_crypto")]
+use sp_std::vec::Vec;
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+#[cfg(feature = "std")]
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use sp_runtime_interface::pass_by::PassByInner;
+use sp_std::{convert::TryFrom, marker::PhantomData, ops::Deref};
+
+/// ECDSA and BLS-377 specialized types
+pub mod ecdsa_n_bls377 {
+	use crate::crypto::{CryptoTypeId};
+    use crate::{ecdsa, ed25519};
+    
+	/// An identifier used to match public keys against BLS12-377 keys
+	pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecb7");
+
+	/// BLS12-377 key pair.
+	#[cfg(feature = "full_crypto")]
+	//pub type Pair = super::Pair<ecdsa:Pair, bls377:Pair>;
+	/// BLS12-377 public key.
+	pub type Public = super::Public<ecdsa::Public, ed25519::Public>;
+	// /// BLS12-377 signature.
+	//pub type Signature = super::Signature<ecdsa:Signature, bls377:Signature>;
+
+	// impl super::HardJunctionId for TinyBLS377 {
+	// 	const ID: &'static str = "BLS12377HDKD";
+	// }
+}
+
+/// A secret seed.
+///
+/// It's not called a "secret key" because ring doesn't expose the secret keys
+/// of the key pair (yeah, dumb); as such we're forced to remember the seed manually if we
+/// will need it later (such as for HDKD).
+#[cfg(feature = "full_crypto")]
+//type Seed = [u8; SECRET_KEY_SERIALIZED_SIZE];
+
+/// A public key.
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, PartialOrd, Ord)]
+#[scale_info(skip_type_params(T))]
+pub struct Public<LeftPublic: TraitPublic, RightPublic: TraitPublic> {
+    left_public : LeftPublic,
+    right_public: RightPublic,
+}
+
+#[cfg(feature = "full_crypto")]
+impl<T1: TraitPublic, T2: TraitPublicc> sp_std::hash::Hash for Public<T1,T2> {
+ 	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+ 		self.left_public.hash(state);
+        self.right_public.hash(state);
+ 	}
+}
+

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -110,7 +110,7 @@ pub trait PublicKeyBound:
 }
 
 impl<
-		PublicKeyTrait: TraitPublic
+		T: TraitPublic
 			+ Sized
 			+ Derive
 			+ sp_std::hash::Hash
@@ -118,13 +118,13 @@ impl<
 			+ for<'a> TryFrom<&'a [u8]>
 			+ AsMut<[u8]>
 			+ CryptoType,
-	> PublicKeyBound for PublicKeyTrait
+	> PublicKeyBound for T
 {
 }
 
 /// A public key.
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, PartialOrd, Ord)]
-#[scale_info(skip_type_params(T))]
+#[scale_info(skip_type_params(LeftPublic, RightPublic))]
 pub struct Public<
 	LeftPublic: PublicKeyBound,
 	RightPublic: PublicKeyBound,
@@ -152,8 +152,7 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 	sp_std::hash::Hash for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
 {
 	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
-		self.left.hash(state);
-		self.right.hash(state);
+		self.inner.hash(state);
 	}
 }
 
@@ -359,14 +358,11 @@ impl<
 /// trait characterizing a signature which could be used as individual component of an `paired_crypto:Signature` pair.
 pub trait SignatureBound: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> {}
 
-impl<SignatureTrait: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]>> SignatureBound
-	for SignatureTrait
-{
-}
+impl<T: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]>> SignatureBound for T {}
 
 /// A pair of signatures of different types
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
-#[scale_info(skip_type_params(T))]
+#[scale_info(skip_type_params(LeftSignature, RightSignature))]
 pub struct Signature<
 	LeftSignature: SignatureBound,
 	RightSignature: SignatureBound,

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -557,15 +557,6 @@ pub struct Pair<
 }
 
 
-#[cfg(feature = "full_crypto")]
-impl<
-		LeftPair: TraitPair,
-		RightPair: TraitPair,
-		const PUBLIC_KEY_LEN: usize,
-		const SIGNATURE_LEN: usize,
-	> Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>
-{
-}
 
 #[cfg(feature = "full_crypto")]
 impl<

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -556,10 +556,6 @@ pub struct Pair<
 	right: RightPair,
 }
 
-trait DoublePair {
-	const PUBLIC_KEY_LEN: usize;
-	const SIGNATURE_LEN: usize;
-}
 
 #[cfg(feature = "full_crypto")]
 impl<

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -571,8 +571,8 @@ where
 	RightPair::Signature: SignatureBound,
 	Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>: CryptoType,
 	Signature<LeftPair::Signature, RightPair::Signature, SIGNATURE_LEN>: SignaturePair,
-	LeftPair::Seed: From<[u8; SECURE_SEED_LEN]> + Into<[u8; SECURE_SEED_LEN]>,
-	RightPair::Seed: From<[u8; SECURE_SEED_LEN]> + Into<[u8; SECURE_SEED_LEN]>,
+	LeftPair::Seed: From<Seed> + Into<Seed>,
+	RightPair::Seed: From<Seed> + Into<Seed>,
 {
 	type Seed = Seed;
 	type Public = Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>;

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -62,12 +62,6 @@ pub mod ecdsa_n_bls377 {
 		const LEFT_PLUS_RIGHT_LEN: usize = SIGNATURE_LEN;
 	}
 
-	#[cfg(feature = "full_crypto")]
-	impl super::DoublePair for Pair {
-		const PUBLIC_KEY_LEN: usize = PUBLIC_KEY_LEN;
-		const SIGNATURE_LEN: usize = SIGNATURE_LEN;
-	}
-
 	impl super::CryptoType for Public {
 		#[cfg(feature = "full_crypto")]
 		type Pair = Pair;
@@ -566,7 +560,7 @@ impl<
 		const SIGNATURE_LEN: usize,
 	> TraitPair for Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>
 where
-	Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: DoublePair + CryptoType,
+	Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: CryptoType,
 	LeftPair::Signature: SignatureBound,
 	RightPair::Signature: SignatureBound,
 	Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>: CryptoType,

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -10,7 +10,7 @@
 // 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the Licenseff is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -32,91 +32,61 @@ use scale_info::TypeInfo;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use sp_runtime_interface::pass_by::PassByInner;
-use sp_std::{convert::TryFrom, marker::PhantomData, ops::Deref};
+use sp_std::convert::TryFrom;
 
-/// ECDSA and BLS-377 specialized types
+/// ECDSA and BLS-377 paired crypto scheme
 #[cfg(feature = "bls-experimental")]
 pub mod ecdsa_n_bls377 {
-    use crate::crypto::{CryptoTypeId};
-    use crate::{ecdsa, ed25519, bls377};
-    use super::{SECURE_SEED_LEN, DOUBLE_SEED_LEN};
-    
-    /// An identifier used to match public keys against BLS12-377 keys
-    pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecb7");
+	use crate::crypto::CryptoTypeId;
+	use crate::{bls377, ecdsa};
 
-    const PUBLIC_KEY_LEN :usize = 33 + crate::bls::PUBLIC_KEY_SERIALIZED_SIZE;
-    const LEFT_SIGNATURE_LEN :usize = 65;
-    const RIGHT_SIGNATURE_LEN :usize = crate::bls::SIGNATURE_SERIALIZED_SIZE;
-    const SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN + RIGHT_SIGNATURE_LEN;
-    const LEFT_SEED_LEN: usize = SECURE_SEED_LEN;
-    const RIGHT_SEED_LEN: usize = SECURE_SEED_LEN;
-    
-    /// BLS12-377 key pair.
-    #[cfg(feature = "full_crypto")]
-    pub type Pair = super::Pair<ecdsa::Pair, bls377::Pair, PUBLIC_KEY_LEN, SIGNATURE_LEN>;
-	/// BLS12-377 public key.
-    pub type Public = super::Public<ecdsa::Public, bls377::Public, PUBLIC_KEY_LEN>;
-	// /// BLS12-377 signature.
-    pub type Signature = super::Signature<ecdsa::Signature, bls377::Signature,SIGNATURE_LEN>;
+	/// An identifier used to match public keys against BLS12-377 keys
+	pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecb7");
 
-    pub type Seed = super::Seed<[u8; SECURE_SEED_LEN], [u8; SECURE_SEED_LEN], DOUBLE_SEED_LEN,>;
-    
-    impl super::SignaturePair for Signature {
-	const LEFT_SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN;
-	const RIGHT_SIGNATURE_LEN: usize = RIGHT_SIGNATURE_LEN;
-	const LEFT_PLUS_RIGHT_LEN: usize = SIGNATURE_LEN;
-    }
-    
-    #[cfg(feature = "full_crypto")]
-    impl super::DoublePair for Pair{
-	const PUBLIC_KEY_LEN: usize = PUBLIC_KEY_LEN;
-	const LEFT_SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN;
-	const RIGHT_SIGNATURE_LEN:usize = RIGHT_SIGNATURE_LEN;
-	const SIGNATURE_LEN: usize = SIGNATURE_LEN;
-	const LEFT_SEED_LEN: usize = LEFT_SEED_LEN;
-	const RIGHT_SEED_LEN: usize = RIGHT_SEED_LEN;
-    }
+	const PUBLIC_KEY_LEN: usize = 33 + crate::bls::PUBLIC_KEY_SERIALIZED_SIZE;
+	const LEFT_SIGNATURE_LEN: usize = 65;
+	const RIGHT_SIGNATURE_LEN: usize = crate::bls::SIGNATURE_SERIALIZED_SIZE;
+	const SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN + RIGHT_SIGNATURE_LEN;
 
-    impl super::CryptoType for Public
-    {
-     	#[cfg(feature = "full_crypto")]
-     	type Pair = Pair;
-    }	
+	/// (ECDSA, BLS12-377) key-pair pair.
+	#[cfg(feature = "full_crypto")]
+	pub type Pair = super::Pair<ecdsa::Pair, bls377::Pair, PUBLIC_KEY_LEN, SIGNATURE_LEN>;
+	/// (ECDSA, BLS12-377) public key pair.
+	pub type Public = super::Public<ecdsa::Public, bls377::Public, PUBLIC_KEY_LEN>;
+	/// (ECDSA, BLS12-377) signature pair.
+	pub type Signature = super::Signature<ecdsa::Signature, bls377::Signature, SIGNATURE_LEN>;
 
-    impl super::CryptoType for Signature {
- 	#[cfg(feature = "full_crypto")]
- 	type Pair = Pair;
-    }
+	impl super::SignaturePair for Signature {
+		const LEFT_SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN;
+		const RIGHT_SIGNATURE_LEN: usize = RIGHT_SIGNATURE_LEN;
+		const LEFT_PLUS_RIGHT_LEN: usize = SIGNATURE_LEN;
+	}
 
-    #[cfg(feature = "full_crypto")]
-    impl super::CryptoType for Pair{
-	type Pair = Pair;
-    }
+	#[cfg(feature = "full_crypto")]
+	impl super::DoublePair for Pair {
+		const PUBLIC_KEY_LEN: usize = PUBLIC_KEY_LEN;
+		const SIGNATURE_LEN: usize = SIGNATURE_LEN;
+	}
 
-    impl<'a>  TryFrom<&'a[u8]> for Seed {
-     type Error = ();
+	impl super::CryptoType for Public {
+		#[cfg(feature = "full_crypto")]
+		type Pair = Pair;
+	}
 
-     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-  	 if data.len() != DOUBLE_SEED_LEN {
- 	     return Err(())
- 	 }
-         let mut left : [u8; 32] = data[0..SECURE_SEED_LEN].try_into().unwrap();
-	 let mut right : [u8; 32] = data[SECURE_SEED_LEN..DOUBLE_SEED_LEN].try_into().unwrap();
+	impl super::CryptoType for Signature {
+		#[cfg(feature = "full_crypto")]
+		type Pair = Pair;
+	}
 
-	 let mut inner = [0u8; DOUBLE_SEED_LEN];
-	 inner.copy_from_slice(data);
-	 Ok(Seed { left, right, inner })
-
-     }
-    }
-
+	#[cfg(feature = "full_crypto")]
+	impl super::CryptoType for Pair {
+		type Pair = Pair;
+	}
 }
 
+/// currently only supporting sub-schemes whose seed is a 32-bytes array.
 #[cfg(feature = "full_crypto")]
 const SECURE_SEED_LEN: usize = 32;
-
-#[cfg(feature = "full_crypto")]
-const DOUBLE_SEED_LEN: usize = SECURE_SEED_LEN * 2;
 
 /// A secret seed.
 ///
@@ -124,59 +94,48 @@ const DOUBLE_SEED_LEN: usize = SECURE_SEED_LEN * 2;
 /// of the key pair (yeah, dumb); as such we're forced to remember the seed manually if we
 /// will need it later (such as for HDKD).
 #[cfg(feature = "full_crypto")]
-pub trait SeedBound:  Default + AsRef<[u8]> + AsMut<[u8]> + Clone {}
+type Seed = [u8; SECURE_SEED_LEN];
 
-impl<SeedTrait: Default + AsRef<[u8]> + AsMut<[u8]> + Clone> SeedBound for SeedTrait {}
-
-#[cfg(feature = "full_crypto")]
-#[derive(Clone)]
-pub struct Seed<LeftSeed: SeedBound, RightSeed: SeedBound, const LEFT_PLUS_RIGHT_LEN: usize,> {
-    left: LeftSeed,
-    right: RightSeed,
-    inner: [u8; LEFT_PLUS_RIGHT_LEN],
+/// trait characterizing Public key which could be used as individual component of an `paired_crypto:Public` pair.
+pub trait PublicKeyBound:
+	TraitPublic
+	+ Sized
+	+ Derive
+	+ sp_std::hash::Hash
+	+ ByteArray
+	+ for<'a> TryFrom<&'a [u8]>
+	+ AsMut<[u8]>
+	+ CryptoType
+{
 }
 
-#[cfg(feature = "full_crypto")]
-impl<LeftSeed: SeedBound, RightSeed: SeedBound, const LEFT_PLUS_RIGHT_LEN: usize,> Default for Seed<LeftSeed, RightSeed, LEFT_PLUS_RIGHT_LEN>  {
-    fn default() ->  Self{
-	Self {
-	    left: LeftSeed::default(), right: RightSeed::default(), inner: [LeftSeed::default().as_ref(), RightSeed::default().as_ref()].concat().try_into().unwrap()
-	}
-    }
+impl<
+		PublicKeyTrait: TraitPublic
+			+ Sized
+			+ Derive
+			+ sp_std::hash::Hash
+			+ ByteArray
+			+ for<'a> TryFrom<&'a [u8]>
+			+ AsMut<[u8]>
+			+ CryptoType,
+	> PublicKeyBound for PublicKeyTrait
+{
 }
-
-#[cfg(feature = "full_crypto")]
-impl<LeftSeed: SeedBound, RightSeed: SeedBound, const LEFT_PLUS_RIGHT_LEN: usize,> AsRef<[u8]> for Seed<LeftSeed, RightSeed, LEFT_PLUS_RIGHT_LEN>  {
-    fn as_ref(&self) -> &[u8] {
-		&self.inner[..]
-    }
-}
-
-#[cfg(feature = "full_crypto")]
-impl<LeftSeed: SeedBound, RightSeed: SeedBound, const LEFT_PLUS_RIGHT_LEN: usize> AsMut<[u8]> for Seed<LeftSeed, RightSeed, LEFT_PLUS_RIGHT_LEN> {
-    fn as_mut(&mut self) -> &mut [u8] {
-	&mut self.inner[..]
-    }
-}
-
-
-
-
-//pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {}
-pub trait PublicKeyBound: TraitPublic + Sized + Derive + sp_std::hash::Hash + ByteArray + for<'a> TryFrom<&'a[u8]> + AsMut<[u8]> + CryptoType {}
-
-impl<PublicKeyTrait:  TraitPublic + Sized + Derive + sp_std::hash::Hash + ByteArray + for<'a> TryFrom<&'a[u8]> + AsMut<[u8]> + CryptoType> PublicKeyBound for PublicKeyTrait {}
 
 /// A public key.
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, PartialOrd, Ord)]
 #[scale_info(skip_type_params(T))]
-pub struct Public<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> {
-    left: LeftPublic,
-    right: RightPublic,
-    inner: [u8; LEFT_PLUS_RIGHT_LEN],
+pub struct Public<
+	LeftPublic: PublicKeyBound,
+	RightPublic: PublicKeyBound,
+	const LEFT_PLUS_RIGHT_LEN: usize,
+> {
+	left: LeftPublic,
+	right: RightPublic,
+	inner: [u8; LEFT_PLUS_RIGHT_LEN],
 }
 
-// We essentially could implement this instead of storing left and right but we are going to end up copying left and right.
+// We essentially could implement the following instead of storing left and right but we are going to end up copying and deserializing left and right, to perform any operation and that will take a hit on performance.
 // impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>  Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
 //     inline fn left<'a>(&self)-> &'a LeftPublic {
 // 	&LeftPublic::try_from(&self.inner[0..LeftPublic::LEN]).unwrap()
@@ -186,57 +145,69 @@ pub struct Public<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const
 // 	&RightPublic::try_from(&self.inner[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN]).unwrap()
 //     }
 
-    
 // }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize> sp_std::hash::Hash for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
-    fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
- 	    self.left.hash(state);
-	    self.right.hash(state);
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	sp_std::hash::Hash for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+		self.left.hash(state);
+		self.right.hash(state);
 	}
 }
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize> ByteArray  for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>   {
-     const LEN: usize = LEFT_PLUS_RIGHT_LEN;
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	ByteArray for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+	const LEN: usize = LEFT_PLUS_RIGHT_LEN;
 }
 
-impl<'a,LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>  TryFrom<&'a[u8]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
-     type Error = ();
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	TryFrom<&[u8]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+	type Error = ();
 
-     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-  	 if data.len() != 	LEFT_PLUS_RIGHT_LEN {
- 	     return Err(())
- 	 }
-         let mut left : LeftPublic = data[0..LeftPublic::LEN].try_into()?;
-	 let mut right : RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into()?;
+	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+		if data.len() != LEFT_PLUS_RIGHT_LEN {
+			return Err(());
+		}
+		let left: LeftPublic = data[0..LeftPublic::LEN].try_into()?;
+		let right: RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into()?;
 
-	 let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
-	 inner.copy_from_slice(data);
-	 Ok(Public { left, right, inner })
-
-     }
-}
-	
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize> AsMut<[u8]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
-    fn as_mut(&mut self) -> &mut [u8] {
-	&mut self.inner[..]
-    }
+		let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
+		inner.copy_from_slice(data);
+		Ok(Public { left, right, inner })
+	}
 }
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize> AsRef<[u8; LEFT_PLUS_RIGHT_LEN]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>  {
-    fn as_ref(&self) -> &[u8; LEFT_PLUS_RIGHT_LEN] {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	AsMut<[u8]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+	fn as_mut(&mut self) -> &mut [u8] {
+		&mut self.inner[..]
+	}
+}
+
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	AsRef<[u8; LEFT_PLUS_RIGHT_LEN]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+	fn as_ref(&self) -> &[u8; LEFT_PLUS_RIGHT_LEN] {
 		&self.inner
-    }
+	}
 }
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> AsRef<[u8]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
-    fn as_ref(&self) -> &[u8] {
-	&self.inner[..]
-    }
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	AsRef<[u8]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+	fn as_ref(&self) -> &[u8] {
+		&self.inner[..]
+	}
 }
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> PassByInner for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	PassByInner for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
 	type Inner = [u8; LEFT_PLUS_RIGHT_LEN];
 
 	fn into_inner(self) -> Self::Inner {
@@ -248,33 +219,49 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 	}
 
 	fn from_inner(inner: Self::Inner) -> Self {
-            let mut left : LeftPublic = inner[0..LeftPublic::LEN].try_into().unwrap();
-	    let mut right : RightPublic = inner[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
+		let left: LeftPublic = inner[0..LeftPublic::LEN].try_into().unwrap();
+		let right: RightPublic = inner[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
 
 		Self { left, right, inner }
 	}
 }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftPair: TraitPair, RightPair: TraitPair, LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize, const SIGNATURE_LEN: usize> From<Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN>> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN> where Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN> : TraitPair<Public = Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN>>,
-    {
+impl<
+		LeftPair: TraitPair,
+		RightPair: TraitPair,
+		LeftPublic: PublicKeyBound,
+		RightPublic: PublicKeyBound,
+		const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize,
+		const SIGNATURE_LEN: usize,
+	> From<Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN>>
+	for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN>
+where
+	Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN>:
+		TraitPair<Public = Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN>>,
+{
 	fn from(x: Pair<LeftPair, RightPair, LEFT_PLUS_RIGHT_PUBLIC_LEN, SIGNATURE_LEN>) -> Self {
 		x.public()
 	}
 }
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> UncheckedFrom<[u8; LEFT_PLUS_RIGHT_LEN]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	UncheckedFrom<[u8; LEFT_PLUS_RIGHT_LEN]> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
 	fn unchecked_from(data: [u8; LEFT_PLUS_RIGHT_LEN]) -> Self {
- 	 let mut left : LeftPublic = data[0..LeftPublic::LEN].try_into().unwrap();
-	 let mut right : RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
+		let left: LeftPublic = data[0..LeftPublic::LEN].try_into().unwrap();
+		let right: RightPublic = data[LeftPublic::LEN..LEFT_PLUS_RIGHT_LEN].try_into().unwrap();
 
-	 Public { left: left, right: right, inner: data }
+		Public { left, right, inner: data }
 	}
-
 }
 
 #[cfg(feature = "std")]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> std::str::FromStr for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> where Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> : CryptoType {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	std::str::FromStr for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+where
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+{
 	type Err = crate::crypto::PublicError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -283,14 +270,23 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 }
 
 #[cfg(feature = "std")]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> std::fmt::Display for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> where Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> : CryptoType {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	std::fmt::Display for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+where
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+{
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "{}", self.to_ss58check())
 	}
 }
 
 #[cfg(feature = "std")]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> sp_std::fmt::Debug for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> where Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> : CryptoType, [u8;LEFT_PLUS_RIGHT_LEN]: crate::hexdisplay::AsBytesRef {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	sp_std::fmt::Debug for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+where
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+	[u8; LEFT_PLUS_RIGHT_LEN]: crate::hexdisplay::AsBytesRef,
+{
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		let s = self.to_ss58check();
 		write!(f, "{} ({}...)", crate::hexdisplay::HexDisplay::from(&self.inner), &s[0..8])
@@ -298,111 +294,173 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 }
 
 #[cfg(not(feature = "std"))]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> sp_std::fmt::Debug for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>  {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	sp_std::fmt::Debug for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-
-	    Ok(())
+		Ok(())
 	}
 }
 
 #[cfg(feature = "std")]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> Serialize for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> where  Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> : CryptoType {
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	Serialize for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+where
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+{
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
-    {
-	    		serializer.serialize_str(&self.to_ss58check())
-
+	{
+		serializer.serialize_str(&self.to_ss58check())
 	}
 }
 
 #[cfg(feature = "std")]
-impl<'de, LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize> Deserialize<'de> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> where Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> : CryptoType {
+impl<
+		'de,
+		LeftPublic: PublicKeyBound,
+		RightPublic: PublicKeyBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> Deserialize<'de> for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+where
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+{
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
-    {
-	    		Public::from_ss58check(&String::deserialize(deserializer)?)
+	{
+		Public::from_ss58check(&String::deserialize(deserializer)?)
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))
-
 	}
 }
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> TraitPublic for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> where Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> : CryptoType {}
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	TraitPublic for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+where
+	Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>: CryptoType,
+{
+}
 
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize,> Derive for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {}
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	Derive for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+{
+}
 
 #[cfg(not(feature = "full_crypto"))]
-impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize,> CryptoType for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN> 
-{}
+impl<
+		LeftPublic: PublicKeyBound,
+		RightPublic: PublicKeyBound,
+		const LEFT_PLUS_RIGHT_PUBLIC_LEN: usize,
+	> CryptoType for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_PUBLIC_LEN>
+{
+}
 
+/// trait characterizing a signature which could be used as individual component of an `paired_crypto:Signature` pair.
+pub trait SignatureBound: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> {}
 
-//pub trait Public: ByteArray + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync {}
-pub trait SignatureBound: sp_std::hash::Hash + for<'a> TryFrom<&'a[u8]> + AsRef<[u8]> {}
-
-impl<SignatureTrait:  sp_std::hash::Hash + for<'a> TryFrom<&'a[u8]> + AsRef<[u8]>> SignatureBound for SignatureTrait {}
+impl<SignatureTrait: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]>> SignatureBound
+	for SignatureTrait
+{
+}
 
 /// A pair of signatures of different types
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
 #[scale_info(skip_type_params(T))]
-pub struct Signature<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> {
-    left: LeftSignature,
-    right: RightSignature,
-    inner: [u8; LEFT_PLUS_RIGHT_LEN],
+pub struct Signature<
+	LeftSignature: SignatureBound,
+	RightSignature: SignatureBound,
+	const LEFT_PLUS_RIGHT_LEN: usize,
+> {
+	left: LeftSignature,
+	right: RightSignature,
+	inner: [u8; LEFT_PLUS_RIGHT_LEN],
 }
 
 trait SignaturePair {
-    const LEFT_SIGNATURE_LEN: usize;
-    const RIGHT_SIGNATURE_LEN: usize;
-    const LEFT_PLUS_RIGHT_LEN: usize;
+	const LEFT_SIGNATURE_LEN: usize;
+	const RIGHT_SIGNATURE_LEN: usize;
+	const LEFT_PLUS_RIGHT_LEN: usize;
 }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize> sp_std::hash::Hash for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> {
-    fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
- 	    self.left.hash(state);
-	    self.right.hash(state);
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> sp_std::hash::Hash for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+{
+	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+		self.left.hash(state);
+		self.right.hash(state);
 	}
 }
 
-impl<'a,LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize>  TryFrom<&'a[u8]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> where Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: SignaturePair {
-     type Error = ();
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> TryFrom<&[u8]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+where
+	Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: SignaturePair,
+{
+	type Error = ();
 
-     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-  		if data.len() != 	LEFT_PLUS_RIGHT_LEN {
- 			return Err(())
- 		}
-         	 let Ok(mut left) : Result<LeftSignature, _> = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
-	 let Ok(mut right) : Result<RightSignature, _>= data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
+	fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+		if data.len() != LEFT_PLUS_RIGHT_LEN {
+			return Err(());
+		}
+		let Ok(left) : Result<LeftSignature, _> = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
+		let Ok(right) : Result<RightSignature, _>= data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
 
-	     let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
-             inner[..Self::LEFT_SIGNATURE_LEN].copy_from_slice(left.as_ref());
- 	     inner[Self::LEFT_SIGNATURE_LEN..].copy_from_slice(right.as_ref());
+		let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
+		inner[..Self::LEFT_SIGNATURE_LEN].copy_from_slice(left.as_ref());
+		inner[Self::LEFT_SIGNATURE_LEN..].copy_from_slice(right.as_ref());
 
-	 Ok(Signature { left, right, inner })
-
-     }
+		Ok(Signature { left, right, inner })
+	}
 }
-	
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize> AsMut<[u8]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> {
-    fn as_mut(&mut self) -> &mut [u8] {
-	&mut self.inner[..]
-    }
+
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> AsMut<[u8]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+{
+	fn as_mut(&mut self) -> &mut [u8] {
+		&mut self.inner[..]
+	}
 }
 
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize> AsRef<[u8; LEFT_PLUS_RIGHT_LEN]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>  {
-    fn as_ref(&self) -> &[u8; LEFT_PLUS_RIGHT_LEN] {
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> AsRef<[u8; LEFT_PLUS_RIGHT_LEN]>
+	for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+{
+	fn as_ref(&self) -> &[u8; LEFT_PLUS_RIGHT_LEN] {
 		&self.inner
-    }
+	}
 }
 
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> AsRef<[u8]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> {
-    fn as_ref(&self) -> &[u8] {
-	&self.inner[..]
-    }
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> AsRef<[u8]> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+{
+	fn as_ref(&self) -> &[u8] {
+		&self.inner[..]
+	}
 }
 #[cfg(feature = "std")]
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> Serialize for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> {
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> Serialize for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+{
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
@@ -411,29 +469,56 @@ impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_P
 	}
 }
 
-#[cfg(feature = "std")]
-impl<'de,LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> Deserialize<'de> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> where
-Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: for<'a> TryFrom<&'a[u8]>{
+#[cfg(feature = "serde")]
+impl<
+		'de,
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> Deserialize<'de> for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+where
+	Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: SignaturePair,
+{
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
 	{
 		let signature_hex = array_bytes::hex2bytes(&String::deserialize(deserializer)?)
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?;
-        let sighex_ref = signature_hex.as_ref();
-		Signature::try_from(sighex_ref)
-			.map_err(|e| de::Error::custom(format!("Error in converting deserialized data into signature")))
+		Signature::<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>::try_from(
+			signature_hex.as_ref(),
+		)
+		.map_err(|e| {
+			de::Error::custom(format!(
+				"Error in converting deserialized data into signature: {:?}",
+				e
+			))
+		})
 	}
 }
 
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> From<Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>> for [u8; LEFT_PLUS_RIGHT_LEN]
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> From<Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>>
+	for [u8; LEFT_PLUS_RIGHT_LEN]
 {
-	fn from(signature: Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>) -> [u8; LEFT_PLUS_RIGHT_LEN] {
+	fn from(
+		signature: Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>,
+	) -> [u8; LEFT_PLUS_RIGHT_LEN] {
 		signature.inner
 	}
 }
 
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_PLUS_RIGHT_LEN: usize,> sp_std::fmt::Debug for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN> where [u8;LEFT_PLUS_RIGHT_LEN]: crate::hexdisplay::AsBytesRef{
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> sp_std::fmt::Debug for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+where
+	[u8; LEFT_PLUS_RIGHT_LEN]: crate::hexdisplay::AsBytesRef,
+{
 	#[cfg(feature = "std")]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "{}", crate::hexdisplay::HexDisplay::from(&self.inner))
@@ -445,140 +530,149 @@ impl<LeftSignature: SignatureBound, RightSignature: SignatureBound, const LEFT_P
 	}
 }
 
-impl<LeftSignature: SignatureBound, RightSignature: SignatureBound,  const LEFT_PLUS_RIGHT_LEN: usize,> UncheckedFrom<[u8; LEFT_PLUS_RIGHT_LEN]> for Signature<LeftSignature, RightSignature,LEFT_PLUS_RIGHT_LEN> where Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: SignaturePair {
+impl<
+		LeftSignature: SignatureBound,
+		RightSignature: SignatureBound,
+		const LEFT_PLUS_RIGHT_LEN: usize,
+	> UncheckedFrom<[u8; LEFT_PLUS_RIGHT_LEN]>
+	for Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>
+where
+	Signature<LeftSignature, RightSignature, LEFT_PLUS_RIGHT_LEN>: SignaturePair,
+{
 	fn unchecked_from(data: [u8; LEFT_PLUS_RIGHT_LEN]) -> Self {
-        let Ok(mut left) = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
-	 let Ok(mut right) = data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
+		let Ok(left) = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
+		let Ok(right) = data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
 
-	 Signature { left, right, inner: data }
+		Signature { left, right, inner: data }
 	}
 }
 
 /// A key pair.
 #[cfg(feature = "full_crypto")]
 #[derive(Clone)]
-pub struct Pair<LeftPair: TraitPair, RightPair: TraitPair, const PUBLIC_KEY_LEN: usize, const SIGNATURE_LEN: usize>
-{
-    left: LeftPair,
-    right: RightPair,
-    
+pub struct Pair<
+	LeftPair: TraitPair,
+	RightPair: TraitPair,
+	const PUBLIC_KEY_LEN: usize,
+	const SIGNATURE_LEN: usize,
+> {
+	left: LeftPair,
+	right: RightPair,
 }
-
 
 trait DoublePair {
-    const PUBLIC_KEY_LEN: usize;
-    const LEFT_SIGNATURE_LEN: usize;
-    const RIGHT_SIGNATURE_LEN:usize;
-    const SIGNATURE_LEN: usize;
-    const LEFT_SEED_LEN: usize;
-    const RIGHT_SEED_LEN: usize;
-}
-
-trait HardJunctionId {
-	const ID: &'static str;
+	const PUBLIC_KEY_LEN: usize;
+	const SIGNATURE_LEN: usize;
 }
 
 #[cfg(feature = "full_crypto")]
-impl<LeftPair: TraitPair, RightPair: TraitPair, const PUBLIC_KEY_LEN: usize, const SIGNATURE_LEN: usize> Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN> {
-}
-
-#[cfg(feature = "full_crypto")]
-impl<LeftPair: TraitPair, RightPair: TraitPair, const PUBLIC_KEY_LEN: usize, const SIGNATURE_LEN: usize> TraitPair for Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN> where
-    Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: DoublePair + CryptoType,
-    LeftPair::Signature: SignatureBound,
-    RightPair::Signature: SignatureBound,
-Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>: CryptoType,
-Signature<LeftPair::Signature, RightPair::Signature, SIGNATURE_LEN>: SignaturePair,
-    LeftPair::Seed: SeedBound,
-    RightPair::Seed: SeedBound,
-Seed<LeftPair::Seed, RightPair::Seed, DOUBLE_SEED_LEN>: SeedBound,
+impl<
+		LeftPair: TraitPair,
+		RightPair: TraitPair,
+		const PUBLIC_KEY_LEN: usize,
+		const SIGNATURE_LEN: usize,
+	> Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>
 {
-	type Seed = Seed<LeftPair::Seed, RightPair::Seed, DOUBLE_SEED_LEN>;
+}
+
+#[cfg(feature = "full_crypto")]
+impl<
+		LeftPair: TraitPair,
+		RightPair: TraitPair,
+		const PUBLIC_KEY_LEN: usize,
+		const SIGNATURE_LEN: usize,
+	> TraitPair for Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>
+where
+	Pair<LeftPair, RightPair, PUBLIC_KEY_LEN, SIGNATURE_LEN>: DoublePair + CryptoType,
+	LeftPair::Signature: SignatureBound,
+	RightPair::Signature: SignatureBound,
+	Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>: CryptoType,
+	Signature<LeftPair::Signature, RightPair::Signature, SIGNATURE_LEN>: SignaturePair,
+	LeftPair::Seed: From<[u8; SECURE_SEED_LEN]> + Into<[u8; SECURE_SEED_LEN]>,
+	RightPair::Seed: From<[u8; SECURE_SEED_LEN]> + Into<[u8; SECURE_SEED_LEN]>,
+{
+	type Seed = Seed;
 	type Public = Public<LeftPair::Public, RightPair::Public, PUBLIC_KEY_LEN>;
 	type Signature = Signature<LeftPair::Signature, RightPair::Signature, SIGNATURE_LEN>;
 
 	fn from_seed_slice(seed_slice: &[u8]) -> Result<Self, SecretStringError> {
-	    if seed_slice.len() != Self::RIGHT_SEED_LEN + Self::LEFT_SEED_LEN {
-		return Err(SecretStringError::InvalidSeedLength)
-	    }
-	    let left = LeftPair::from_seed_slice(&seed_slice[0..Self::LEFT_SEED_LEN])?;
-            let right =	RightPair::from_seed_slice(&seed_slice[Self::LEFT_SEED_LEN..Self::RIGHT_SEED_LEN + Self::LEFT_SEED_LEN])?;
-	    Ok(Pair { left, right })
+		if seed_slice.len() != SECURE_SEED_LEN {
+			return Err(SecretStringError::InvalidSeedLength);
+		}
+		let left = LeftPair::from_seed_slice(&seed_slice)?;
+		let right = RightPair::from_seed_slice(&seed_slice)?;
+		Ok(Pair { left, right })
 	}
 
 	fn derive<Iter: Iterator<Item = DeriveJunction>>(
-	 	&self,
-	 	path: Iter,
-	 	seed: Option<Self::Seed>,
+		&self,
+		path: Iter,
+		seed: Option<Self::Seed>,
 	) -> Result<(Self, Option<Self::Seed>), DeriveError> {
+		let (left_seed_option, right_seed_option) = match seed {
+			Some(seed) => {
+				let (left_seed, right_seed): (LeftPair::Seed, RightPair::Seed) =
+					(seed.clone().into(), seed.into());
+				(Some(left_seed), Some(right_seed))
+			},
+			None => (None, None),
+		};
 
-        let seed_left_right = match seed {
-            Some(seed) => (Some(seed.left), Some(seed.right)),
-            None => (None, None),
-        };
+		let left_path: Vec<_> = path.map(|p| p.clone()).collect();
+		let right_path = left_path.clone();
+		let derived_left = self.left.derive(left_path.into_iter(), left_seed_option)?;
+		let derived_right = self.right.derive(right_path.into_iter(), right_seed_option)?;
 
-        let left_path: Vec<_> = path.map(|p|p.clone()).collect();
-        let right_path = left_path.clone();
-	let derived_left = self.left.derive(left_path.into_iter(), seed_left_right.0)?;
-        let derived_right = self.right.derive(right_path.into_iter(), seed_left_right.1)?;
-
-            let optional_seed = match (derived_left.1, derived_right.1) {
-                (Some(seed_left), Some(seed_right)) => {
-                    let mut inner = [0u8; DOUBLE_SEED_LEN];
-                    inner[..Self::LEFT_SEED_LEN].copy_from_slice(seed_left.as_ref());
- 	            inner[Self::LEFT_SEED_LEN..Self::LEFT_SEED_LEN + Self::RIGHT_SEED_LEN].copy_from_slice(seed_right.as_ref());
-                    Some(Self::Seed{left: seed_left, right: seed_right, inner: inner})},
-                _ => None,
-
-                };
-        //     Some(seed) => (LeftPair::from_seed_slice(&seed).ok().map(|p|p.to_raw_vec()), RightPair::from_seed_slice(&seed).ok().map(|p| p.to_raw_vec())),
-        //     None => (None, None),
-        // };
-
-	 	Ok((Self{left: derived_left.0, right: derived_right.0}, optional_seed))
-	 }
+		let optional_seed: Option<[u8; SECURE_SEED_LEN]> = match (derived_left.1, derived_right.1) {
+			(Some(seed_left), Some(seed_right)) => {
+				if seed_left.as_ref() == seed_right.as_ref() {
+					Some(seed_left.into())
+				} else {
+					None
+				}
+			},
+			_ => None,
+		};
+		Ok((Self { left: derived_left.0, right: derived_right.0 }, optional_seed))
+	}
 
 	fn public(&self) -> Self::Public {
-	   let mut raw = [0u8; PUBLIC_KEY_LEN];
-	    let left_pub = self.left.public();
-            let right_pub  = self.right.public();	// 	let pk = DoublePublicKeyScheme::into_double_public_key(&self.0).to_bytes();
-            raw[..LeftPair::Public::LEN].copy_from_slice(left_pub.as_ref());
- 	    raw[LeftPair::Public::LEN..].copy_from_slice(right_pub.as_ref());
-	    Self::Public::unchecked_from(raw)
-        //Public{left: left_pub, right: right_pub, inner: raw}
+		let mut raw = [0u8; PUBLIC_KEY_LEN];
+		let left_pub = self.left.public();
+		let right_pub = self.right.public();
+		raw[..LeftPair::Public::LEN].copy_from_slice(left_pub.as_ref());
+		raw[LeftPair::Public::LEN..].copy_from_slice(right_pub.as_ref());
+		Self::Public::unchecked_from(raw)
 	}
 
 	fn sign(&self, message: &[u8]) -> Self::Signature {
-	    let mut mutable_self = self.clone();
-	    let mut r: [u8; SIGNATURE_LEN] = [0u8; SIGNATURE_LEN];
-            r[..Self::LEFT_SIGNATURE_LEN].copy_from_slice(self.left.sign(message).as_ref());
-            r[Self::LEFT_SIGNATURE_LEN..].copy_from_slice(self.right.sign(message).as_ref());
-	    Self::Signature::unchecked_from(r)
+		let mut r: [u8; SIGNATURE_LEN] = [0u8; SIGNATURE_LEN];
+		r[..Self::Signature::LEFT_SIGNATURE_LEN].copy_from_slice(self.left.sign(message).as_ref());
+		r[Self::Signature::LEFT_SIGNATURE_LEN..].copy_from_slice(self.right.sign(message).as_ref());
+		Self::Signature::unchecked_from(r)
 	}
 
-	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool  {
-        let mut vec_message = vec![0u8; message.as_ref().len()];
-        vec_message.clone_from_slice(message.as_ref());
+	fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
+		let mut vec_message = vec![0u8; message.as_ref().len()];
+		vec_message.clone_from_slice(message.as_ref());
 
-        LeftPair::verify(&sig.left, message, &pubkey.left) && RightPair::verify(&sig.right, vec_message, &pubkey.right)
+		LeftPair::verify(&sig.left, message, &pubkey.left)
+			&& RightPair::verify(&sig.right, vec_message, &pubkey.right)
 	}
 
-	/// Get the seed for this key.
+	/// Get the seed/secret key for each key and then concatenate them.
 	fn to_raw_vec(&self) -> Vec<u8> {
 		[self.left.to_raw_vec(), self.right.to_raw_vec()].concat()
 	}
 }
 
-
-
-// Test set exercising the BLS12-377 implementation
+// Test set exercising the (ECDSA, BLS12-377) implementation
 #[cfg(test)]
 mod test {
 	use super::*;
 	use crate::crypto::DEV_PHRASE;
-	use ecdsa_n_bls377::{Pair, Signature, Seed};
+	use ecdsa_n_bls377::{Pair, Signature};
 	use hex_literal::hex;
-
 
 	#[test]
 	fn default_phrase_should_be_used() {
@@ -590,35 +684,38 @@ mod test {
 		);
 	}
 
-    	#[test]
-    fn seed_and_derive_should_work() {
-	let seed_left = hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
-		let seed_right = hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f00");
-		let pair = Pair::from_seed(&([seed_left,seed_right].concat()[..].try_into().unwrap()));
+	#[test]
+	fn seed_and_derive_should_work() {
+		let seed_for_right_and_left =
+			hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+		let pair = Pair::from_seed(&seed_for_right_and_left);
 		// we are using hash to field so this is not going to work
 		// assert_eq!(pair.seed(), seed);
 		let path = vec![DeriveJunction::Hard([0u8; 32])];
 		let derived = pair.derive(path.into_iter(), None).ok().unwrap().0;
 		assert_eq!(
 			derived.to_raw_vec(),
-			[hex!("b8eefc4937200a8382d00050e050ced2d4ab72cc2ef1b061477afb51564fdd61"), hex!("a4f2269333b3e87c577aa00c4a2cd650b3b30b2e8c286a47c251279ff3a26e0d")].concat()
+			[
+				hex!("b8eefc4937200a8382d00050e050ced2d4ab72cc2ef1b061477afb51564fdd61"),
+				hex!("3a0626d095148813cd1642d38254f1cfff7eb8cc1a2fc83b2a135377c3554c12")
+			]
+			.concat()
 		);
 	}
 
-
-    	#[test]
+	#[test]
 	fn test_vector_should_work() {
-	let seed_left = hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
-		let seed_right = hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
-		let pair = Pair::from_seed(&([seed_left,seed_right].concat()[..].try_into().unwrap()));
- 		let public = pair.public();
- 		assert_eq!(
- 			public,
- 			Public::unchecked_from(
- 				hex!("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd917a84ca8ce4c37c93c95ecee6a3c0c9a7b9c225093cf2f12dc4f69cbfb847ef9424a18f5755d5a742247d386ff2aabb806bcf160eff31293ea9616976628f77266c8a8cc1d8753be04197bd6cdd8c5c87a148f782c4c1568d599b48833fd539001e580cff64bbc71850605433fcd051f3afc3b74819786f815ffb5272030a8d03e5df61e6183f8fd8ea85f26defa83400"
+		let seed_left_and_right =
+			hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+		let pair = Pair::from_seed(&([seed_left_and_right].concat()[..].try_into().unwrap()));
+		let public = pair.public();
+		assert_eq!(
+			public,
+			Public::unchecked_from(
+				hex!("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd917a84ca8ce4c37c93c95ecee6a3c0c9a7b9c225093cf2f12dc4f69cbfb847ef9424a18f5755d5a742247d386ff2aabb806bcf160eff31293ea9616976628f77266c8a8cc1d8753be04197bd6cdd8c5c87a148f782c4c1568d599b48833fd539001e580cff64bbc71850605433fcd051f3afc3b74819786f815ffb5272030a8d03e5df61e6183f8fd8ea85f26defa83400"
  ),
-			),
-		);
+    		),
+    	);
 		let message = b"";
 		let signature = hex!("3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b753169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00d1e3013161991e142d8751017d4996209c2ff8a9ee160f373733eda3b4b785ba6edce9f45f87104bbe07aa6aa6eb2780aa705efb2c13d3b317d6409d159d23bdc7cdd5c2a832d1551cf49d811d49c901495e527dbd532e3a462335ce2686009104aba7bc11c5b22be78f3198d2727a0b");
 		let signature = Signature::unchecked_from(signature);
@@ -628,18 +725,19 @@ mod test {
 
 	#[test]
 	fn test_vector_by_string_should_work() {
-	    let pair = Pair::from_string("0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f609d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		let pair = Pair::from_string(
+			"0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
 			None,
 		)
 		.unwrap();
- 		let public = pair.public();
- 		assert_eq!(
- 			public,
- 			Public::unchecked_from(
- 				hex!("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd916dc6be608fab3c6bd894a606be86db346cc170db85c733853a371f3db54ae1b12052c0888d472760c81b537572a26f00db865e5963aef8634f9917571c51b538b564b2a9ceda938c8b930969ee3b832448e08e33a79e9ddd28af419a3ce45300f5dbc768b067781f44f3fe05a19e6b07b1c4196151ec3f8ea37e4f89a8963030d2101e931276bb9ebe1f20102239d780"
+		let public = pair.public();
+		assert_eq!(
+			public,
+			Public::unchecked_from(
+				hex!("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd916dc6be608fab3c6bd894a606be86db346cc170db85c733853a371f3db54ae1b12052c0888d472760c81b537572a26f00db865e5963aef8634f9917571c51b538b564b2a9ceda938c8b930969ee3b832448e08e33a79e9ddd28af419a3ce45300f5dbc768b067781f44f3fe05a19e6b07b1c4196151ec3f8ea37e4f89a8963030d2101e931276bb9ebe1f20102239d780"
  ),
-			),
-		);
+    		),
+    	);
 		let message = b"";
 		let signature = hex!("3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b753169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00bbb395bbdee1a35930912034f5fde3b36df2835a0536c865501b0675776a1d5931a3bea2e66eff73b2546c6af2061a8019223e4ebbbed661b2538e0f5823f2c708eb89c406beca8fcb53a5c13dbc7c0c42e4cf2be2942bba96ea29297915a06bd2b1b979c0e2ac8fd4ec684a6b5d110c");
 		let signature = Signature::unchecked_from(signature);
@@ -647,7 +745,7 @@ mod test {
 		assert!(Pair::verify(&signature, &message[..], &public));
 	}
 
-    	#[test]
+	#[test]
 	fn generated_pair_should_work() {
 		let (pair, _) = Pair::generate();
 		let public = pair.public();
@@ -657,20 +755,20 @@ mod test {
 		assert!(!Pair::verify(&signature, b"Something else", &public));
 	}
 
-
-    	#[test]
+	#[test]
 	fn seeded_pair_should_work() {
-		let pair = Pair::from_seed(&(b"1234567890123456789012345678901212345678901234567890123456789012".as_slice().try_into().unwrap()));
+		let pair =
+			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
 		let public = pair.public();
 		assert_eq!(
-			public,
- 			Public::unchecked_from(
- 				hex!("035676109c54b9a16d271abeb4954316a40a32bcce023ac14c8e26e958aa68fba9754d2f2bbfa67df54d7e0e951979a18a1e0f45948857752cc2bac6bbb0b1d05e8e48bcc453920bf0c4bbd5993212480112a1fb433f04d74af0a8b700d93dc957ab3207f8d071e948f5aca1a7632c00bdf6d06be05b43e2e6216dccc8a5d55a0071cb2313cfd60b7e9114619cd17c06843b352f0b607a99122f6651df8f02e1ad3697bd208e62af047ddd7b942ba80080")
+    		public,
+			Public::unchecked_from(
+				hex!("035676109c54b9a16d271abeb4954316a40a32bcce023ac14c8e26e958aa68fba9754d2f2bbfa67df54d7e0e951979a18a1e0f45948857752cc2bac6bbb0b1d05e8e48bcc453920bf0c4bbd5993212480112a1fb433f04d74af0a8b700d93dc957ab3207f8d071e948f5aca1a7632c00bdf6d06be05b43e2e6216dccc8a5d55a0071cb2313cfd60b7e9114619cd17c06843b352f0b607a99122f6651df8f02e1ad3697bd208e62af047ddd7b942ba80080")
  ),
-		);
+    	);
 		let message =
-		hex!("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000"
-	);
+    	hex!("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000"
+    );
 		let signature = pair.sign(&message[..]);
 		println!("Correct signature: {:?}", signature);
 		assert!(Pair::verify(&signature, &message[..], &public));
@@ -702,8 +800,9 @@ mod test {
 	}
 
 	#[test]
-    fn ss58check_roundtrip_works() {
-	let pair = Pair::from_seed(&(b"1234567890123456789012345678901212345678901234567890123456789012".as_slice().try_into().unwrap()));
+	fn ss58check_roundtrip_works() {
+		let pair =
+			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
 		let public = pair.public();
 		let s = public.to_ss58check();
 		println!("Correct: {}", s);
@@ -713,12 +812,13 @@ mod test {
 
 	#[test]
 	fn signature_serialization_works() {
-	let pair = Pair::from_seed(&(b"1234567890123456789012345678901212345678901234567890123456789012".as_slice().try_into().unwrap()));
+		let pair =
+			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
 		let message = b"Something important";
-	    let signature = pair.sign(&message[..]);
+		let signature = pair.sign(&message[..]);
 
-	    let serialized_signature = serde_json::to_string(&signature).unwrap();
-	    println!("{:?} -- {:}", signature.inner, serialized_signature);
+		let serialized_signature = serde_json::to_string(&signature).unwrap();
+		println!("{:?} -- {:}", signature.inner, serialized_signature);
 		// Signature is 177 bytes, hexify * 2, so 354  chars + 2 quote charsy
 		assert_eq!(serialized_signature.len(), 356);
 		let signature = serde_json::from_str(&serialized_signature).unwrap();

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -31,12 +31,12 @@ use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use sp_runtime_interface::pass_by::PassByInner;
+use sp_runtime_interface::pass_by::{self, PassBy, PassByInner};
 use sp_std::convert::TryFrom;
 
 /// ECDSA and BLS-377 paired crypto scheme
 #[cfg(feature = "bls-experimental")]
-pub mod ecdsa_n_bls377 {
+pub mod ecdsa_bls377 {
 	use crate::crypto::CryptoTypeId;
 	use crate::{bls377, ecdsa};
 
@@ -227,6 +227,11 @@ impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RI
 	}
 }
 
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize> PassBy for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN> {
+	type PassBy = pass_by::Inner<Self, [u8; LEFT_PLUS_RIGHT_LEN]>;
+}
+
+
 #[cfg(feature = "full_crypto")]
 impl<
 		LeftPair: TraitPair,
@@ -369,7 +374,7 @@ impl<T: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> + ByteArray
 }
 
 /// A pair of signatures of different types
-#[derive(Encode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
+#[derive(Clone, Encode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
 #[scale_info(skip_type_params(LeftSignature, RightSignature))]
 pub struct Signature<
 	LeftSignature: SignatureBound,
@@ -666,7 +671,7 @@ where
 mod test {
 	use super::*;
 	use crate::crypto::DEV_PHRASE;
-	use ecdsa_n_bls377::{Pair, Signature};
+	use ecdsa_bls377::{Pair, Signature};
 
 	#[test]
 	fn default_phrase_should_be_used() {

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -823,4 +823,25 @@ mod test {
 		// Poorly-sized
 		assert!(deserialize_signature("\"abc123\"").is_err());
 	}
+
+    #[test]
+    fn encode_and_decode_public_key_works() {
+		let pair =
+			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
+		let public = pair.public();
+        let encoded_public = public.encode();
+        let decoded_public = Public::decode(&mut encoded_public.as_slice()).unwrap();
+        assert_eq!(public, decoded_public)
+    }
+
+    #[test]
+    fn encode_and_decode_signature_works() {
+		let pair =
+			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
+		let message = b"Something important";
+		let signature = pair.sign(&message[..]);
+        let encoded_signature = signature.encode();
+        let decoded_signature = Signature::decode(&mut encoded_signature.as_slice()).unwrap();
+        assert_eq!(signature, decoded_signature)
+    }
 }

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -406,8 +406,8 @@ where
 		if data.len() != LEFT_PLUS_RIGHT_LEN {
 			return Err(());
 		}
-		let Ok(left) : Result<LeftSignature, _> = data[0..Self::LEFT_SIGNATURE_LEN].try_into() else { panic!("invalid signature") };
-		let Ok(right) : Result<RightSignature, _>= data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
+		let left: LeftSignature = data[0..Self::LEFT_SIGNATURE_LEN].try_into().map_err(|_| ())?;
+		let right: RightSignature = data[Self::LEFT_SIGNATURE_LEN..LEFT_PLUS_RIGHT_LEN].try_into().map_err(|_| ())?;
 
 		let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
 		inner[..Self::LEFT_SIGNATURE_LEN].copy_from_slice(left.as_ref());

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -672,7 +672,6 @@ mod test {
 	use super::*;
 	use crate::crypto::DEV_PHRASE;
 	use ecdsa_n_bls377::{Pair, Signature};
-	use hex_literal::hex;
 
 	#[test]
 	fn default_phrase_should_be_used() {
@@ -686,8 +685,8 @@ mod test {
 
 	#[test]
 	fn seed_and_derive_should_work() {
-		let seed_for_right_and_left =
-			hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+		let seed_for_right_and_left: [u8; SECURE_SEED_LEN] =
+			array_bytes::hex2array_unchecked("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
 		let pair = Pair::from_seed(&seed_for_right_and_left);
 		// we are using hash to field so this is not going to work
 		// assert_eq!(pair.seed(), seed);
@@ -696,8 +695,8 @@ mod test {
 		assert_eq!(
 			derived.to_raw_vec(),
 			[
-				hex!("b8eefc4937200a8382d00050e050ced2d4ab72cc2ef1b061477afb51564fdd61"),
-				hex!("3a0626d095148813cd1642d38254f1cfff7eb8cc1a2fc83b2a135377c3554c12")
+				array_bytes::hex2array_unchecked::<&str, SECURE_SEED_LEN>("b8eefc4937200a8382d00050e050ced2d4ab72cc2ef1b061477afb51564fdd61"),
+				array_bytes::hex2array_unchecked::<&str, SECURE_SEED_LEN>("3a0626d095148813cd1642d38254f1cfff7eb8cc1a2fc83b2a135377c3554c12")
 			]
 			.concat()
 		);
@@ -705,19 +704,19 @@ mod test {
 
 	#[test]
 	fn test_vector_should_work() {
-		let seed_left_and_right =
-			hex!("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+		let seed_left_and_right: [u8; SECURE_SEED_LEN] =
+			array_bytes::hex2array_unchecked("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
 		let pair = Pair::from_seed(&([seed_left_and_right].concat()[..].try_into().unwrap()));
 		let public = pair.public();
 		assert_eq!(
 			public,
 			Public::unchecked_from(
-				hex!("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd917a84ca8ce4c37c93c95ecee6a3c0c9a7b9c225093cf2f12dc4f69cbfb847ef9424a18f5755d5a742247d386ff2aabb806bcf160eff31293ea9616976628f77266c8a8cc1d8753be04197bd6cdd8c5c87a148f782c4c1568d599b48833fd539001e580cff64bbc71850605433fcd051f3afc3b74819786f815ffb5272030a8d03e5df61e6183f8fd8ea85f26defa83400"
+				array_bytes::hex2array_unchecked("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd917a84ca8ce4c37c93c95ecee6a3c0c9a7b9c225093cf2f12dc4f69cbfb847ef9424a18f5755d5a742247d386ff2aabb806bcf160eff31293ea9616976628f77266c8a8cc1d8753be04197bd6cdd8c5c87a148f782c4c1568d599b48833fd539001e580cff64bbc71850605433fcd051f3afc3b74819786f815ffb5272030a8d03e5df61e6183f8fd8ea85f26defa83400"
  ),
     		),
     	);
 		let message = b"";
-		let signature = hex!("3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b753169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00d1e3013161991e142d8751017d4996209c2ff8a9ee160f373733eda3b4b785ba6edce9f45f87104bbe07aa6aa6eb2780aa705efb2c13d3b317d6409d159d23bdc7cdd5c2a832d1551cf49d811d49c901495e527dbd532e3a462335ce2686009104aba7bc11c5b22be78f3198d2727a0b");
+		let signature = array_bytes::hex2array_unchecked("3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b753169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00d1e3013161991e142d8751017d4996209c2ff8a9ee160f373733eda3b4b785ba6edce9f45f87104bbe07aa6aa6eb2780aa705efb2c13d3b317d6409d159d23bdc7cdd5c2a832d1551cf49d811d49c901495e527dbd532e3a462335ce2686009104aba7bc11c5b22be78f3198d2727a0b");
 		let signature = Signature::unchecked_from(signature);
 		assert!(pair.sign(&message[..]) == signature);
 		assert!(Pair::verify(&signature, &message[..], &public));
@@ -734,12 +733,12 @@ mod test {
 		assert_eq!(
 			public,
 			Public::unchecked_from(
-				hex!("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd916dc6be608fab3c6bd894a606be86db346cc170db85c733853a371f3db54ae1b12052c0888d472760c81b537572a26f00db865e5963aef8634f9917571c51b538b564b2a9ceda938c8b930969ee3b832448e08e33a79e9ddd28af419a3ce45300f5dbc768b067781f44f3fe05a19e6b07b1c4196151ec3f8ea37e4f89a8963030d2101e931276bb9ebe1f20102239d780"
+				array_bytes::hex2array_unchecked("028db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd916dc6be608fab3c6bd894a606be86db346cc170db85c733853a371f3db54ae1b12052c0888d472760c81b537572a26f00db865e5963aef8634f9917571c51b538b564b2a9ceda938c8b930969ee3b832448e08e33a79e9ddd28af419a3ce45300f5dbc768b067781f44f3fe05a19e6b07b1c4196151ec3f8ea37e4f89a8963030d2101e931276bb9ebe1f20102239d780"
  ),
     		),
     	);
 		let message = b"";
-		let signature = hex!("3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b753169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00bbb395bbdee1a35930912034f5fde3b36df2835a0536c865501b0675776a1d5931a3bea2e66eff73b2546c6af2061a8019223e4ebbbed661b2538e0f5823f2c708eb89c406beca8fcb53a5c13dbc7c0c42e4cf2be2942bba96ea29297915a06bd2b1b979c0e2ac8fd4ec684a6b5d110c");
+		let signature = array_bytes::hex2array_unchecked("3dde91174bd9359027be59a428b8146513df80a2a3c7eda2194f64de04a69ab97b753169e94db6ffd50921a2668a48b94ca11e3d32c1ff19cfe88890aa7e8f3c00bbb395bbdee1a35930912034f5fde3b36df2835a0536c865501b0675776a1d5931a3bea2e66eff73b2546c6af2061a8019223e4ebbbed661b2538e0f5823f2c708eb89c406beca8fcb53a5c13dbc7c0c42e4cf2be2942bba96ea29297915a06bd2b1b979c0e2ac8fd4ec684a6b5d110c");
 		let signature = Signature::unchecked_from(signature);
 		assert!(pair.sign(&message[..]) == signature);
 		assert!(Pair::verify(&signature, &message[..], &public));
@@ -763,11 +762,11 @@ mod test {
 		assert_eq!(
     		public,
 			Public::unchecked_from(
-				hex!("035676109c54b9a16d271abeb4954316a40a32bcce023ac14c8e26e958aa68fba9754d2f2bbfa67df54d7e0e951979a18a1e0f45948857752cc2bac6bbb0b1d05e8e48bcc453920bf0c4bbd5993212480112a1fb433f04d74af0a8b700d93dc957ab3207f8d071e948f5aca1a7632c00bdf6d06be05b43e2e6216dccc8a5d55a0071cb2313cfd60b7e9114619cd17c06843b352f0b607a99122f6651df8f02e1ad3697bd208e62af047ddd7b942ba80080")
+				array_bytes::hex2array_unchecked("035676109c54b9a16d271abeb4954316a40a32bcce023ac14c8e26e958aa68fba9754d2f2bbfa67df54d7e0e951979a18a1e0f45948857752cc2bac6bbb0b1d05e8e48bcc453920bf0c4bbd5993212480112a1fb433f04d74af0a8b700d93dc957ab3207f8d071e948f5aca1a7632c00bdf6d06be05b43e2e6216dccc8a5d55a0071cb2313cfd60b7e9114619cd17c06843b352f0b607a99122f6651df8f02e1ad3697bd208e62af047ddd7b942ba80080")
  ),
     	);
 		let message =
-    	hex!("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000"
+    	array_bytes::hex2bytes_unchecked("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000"
     );
 		let signature = pair.sign(&message[..]);
 		println!("Correct signature: {:?}", signature);

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -43,7 +43,8 @@ pub mod ecdsa_n_bls377 {
 	/// An identifier used to match public keys against BLS12-377 keys
 	pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecb7");
 
-	const PUBLIC_KEY_LEN: usize = crate::ecdsa::PUBLIC_KEY_SERIALIZED_SIZE  + crate::bls::PUBLIC_KEY_SERIALIZED_SIZE;
+	const PUBLIC_KEY_LEN: usize =
+		crate::ecdsa::PUBLIC_KEY_SERIALIZED_SIZE + crate::bls::PUBLIC_KEY_SERIALIZED_SIZE;
 	const LEFT_SIGNATURE_LEN: usize = crate::ecdsa::SIGNATURE_SERIALIZED_SIZE;
 	const RIGHT_SIGNATURE_LEN: usize = crate::bls::SIGNATURE_SERIALIZED_SIZE;
 	const SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN + RIGHT_SIGNATURE_LEN;
@@ -125,9 +126,8 @@ pub struct Public<
 	inner: [u8; LEFT_PLUS_RIGHT_LEN],
 }
 
-impl<
-        LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize
-	> Decode for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
+impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
+	Decode for Public<LeftPublic, RightPublic, LEFT_PLUS_RIGHT_LEN>
 {
 	fn decode<R: codec::Input>(i: &mut R) -> Result<Self, codec::Error> {
 		let buf = <[u8; LEFT_PLUS_RIGHT_LEN]>::decode(i)?;
@@ -148,7 +148,6 @@ impl<
 //     }
 
 // }
-
 
 #[cfg(feature = "full_crypto")]
 impl<LeftPublic: PublicKeyBound, RightPublic: PublicKeyBound, const LEFT_PLUS_RIGHT_LEN: usize>
@@ -359,9 +358,15 @@ impl<
 }
 
 /// trait characterizing a signature which could be used as individual component of an `paired_crypto:Signature` pair.
-pub trait SignatureBound: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> + ByteArray {}
+pub trait SignatureBound:
+	sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> + ByteArray
+{
+}
 
-impl<T: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> + ByteArray> SignatureBound for T {}
+impl<T: sp_std::hash::Hash + for<'a> TryFrom<&'a [u8]> + AsRef<[u8]> + ByteArray> SignatureBound
+	for T
+{
+}
 
 /// A pair of signatures of different types
 #[derive(Encode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
@@ -418,7 +423,8 @@ impl<
 			return Err(());
 		}
 		let left: LeftSignature = data[0..LeftSignature::LEN].try_into().map_err(|_| ())?;
-		let right: RightSignature = data[LeftSignature::LEN..LEFT_PLUS_RIGHT_LEN].try_into().map_err(|_| ())?;
+		let right: RightSignature =
+			data[LeftSignature::LEN..LEFT_PLUS_RIGHT_LEN].try_into().map_err(|_| ())?;
 
 		let mut inner = [0u8; LEFT_PLUS_RIGHT_LEN];
 		inner[..LeftSignature::LEN].copy_from_slice(left.as_ref());
@@ -544,7 +550,9 @@ impl<
 {
 	fn unchecked_from(data: [u8; LEFT_PLUS_RIGHT_LEN]) -> Self {
 		let Ok(left) = data[0..LeftSignature::LEN].try_into() else { panic!("invalid signature") };
-		let Ok(right) = data[LeftSignature::LEN..LEFT_PLUS_RIGHT_LEN].try_into() else { panic!("invalid signature") };
+		let Ok(right) = data[LeftSignature::LEN..LEFT_PLUS_RIGHT_LEN].try_into() else {
+			panic!("invalid signature")
+		};
 
 		Signature { left, right, inner: data }
 	}
@@ -562,8 +570,6 @@ pub struct Pair<
 	left: LeftPair,
 	right: RightPair,
 }
-
-
 
 #[cfg(feature = "full_crypto")]
 impl<
@@ -674,8 +680,9 @@ mod test {
 
 	#[test]
 	fn seed_and_derive_should_work() {
-		let seed_for_right_and_left: [u8; SECURE_SEED_LEN] =
-			array_bytes::hex2array_unchecked("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+		let seed_for_right_and_left: [u8; SECURE_SEED_LEN] = array_bytes::hex2array_unchecked(
+			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		);
 		let pair = Pair::from_seed(&seed_for_right_and_left);
 		// we are using hash to field so this is not going to work
 		// assert_eq!(pair.seed(), seed);
@@ -684,8 +691,12 @@ mod test {
 		assert_eq!(
 			derived.to_raw_vec(),
 			[
-				array_bytes::hex2array_unchecked::<&str, SECURE_SEED_LEN>("b8eefc4937200a8382d00050e050ced2d4ab72cc2ef1b061477afb51564fdd61"),
-				array_bytes::hex2array_unchecked::<&str, SECURE_SEED_LEN>("3a0626d095148813cd1642d38254f1cfff7eb8cc1a2fc83b2a135377c3554c12")
+				array_bytes::hex2array_unchecked::<&str, SECURE_SEED_LEN>(
+					"b8eefc4937200a8382d00050e050ced2d4ab72cc2ef1b061477afb51564fdd61"
+				),
+				array_bytes::hex2array_unchecked::<&str, SECURE_SEED_LEN>(
+					"3a0626d095148813cd1642d38254f1cfff7eb8cc1a2fc83b2a135377c3554c12"
+				)
 			]
 			.concat()
 		);
@@ -693,8 +704,9 @@ mod test {
 
 	#[test]
 	fn test_vector_should_work() {
-		let seed_left_and_right: [u8; SECURE_SEED_LEN] =
-			array_bytes::hex2array_unchecked("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+		let seed_left_and_right: [u8; SECURE_SEED_LEN] = array_bytes::hex2array_unchecked(
+			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		);
 		let pair = Pair::from_seed(&([seed_left_and_right].concat()[..].try_into().unwrap()));
 		let public = pair.public();
 		assert_eq!(
@@ -824,24 +836,24 @@ mod test {
 		assert!(deserialize_signature("\"abc123\"").is_err());
 	}
 
-    #[test]
-    fn encode_and_decode_public_key_works() {
+	#[test]
+	fn encode_and_decode_public_key_works() {
 		let pair =
 			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
 		let public = pair.public();
-        let encoded_public = public.encode();
-        let decoded_public = Public::decode(&mut encoded_public.as_slice()).unwrap();
-        assert_eq!(public, decoded_public)
-    }
+		let encoded_public = public.encode();
+		let decoded_public = Public::decode(&mut encoded_public.as_slice()).unwrap();
+		assert_eq!(public, decoded_public)
+	}
 
-    #[test]
-    fn encode_and_decode_signature_works() {
+	#[test]
+	fn encode_and_decode_signature_works() {
 		let pair =
 			Pair::from_seed(&(b"12345678901234567890123456789012".as_slice().try_into().unwrap()));
 		let message = b"Something important";
 		let signature = pair.sign(&message[..]);
-        let encoded_signature = signature.encode();
-        let decoded_signature = Signature::decode(&mut encoded_signature.as_slice()).unwrap();
-        assert_eq!(signature, decoded_signature)
-    }
+		let encoded_signature = signature.encode();
+		let decoded_signature = Signature::decode(&mut encoded_signature.as_slice()).unwrap();
+		assert_eq!(signature, decoded_signature)
+	}
 }

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -43,8 +43,8 @@ pub mod ecdsa_n_bls377 {
 	/// An identifier used to match public keys against BLS12-377 keys
 	pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecb7");
 
-	const PUBLIC_KEY_LEN: usize = 33 + crate::bls::PUBLIC_KEY_SERIALIZED_SIZE;
-	const LEFT_SIGNATURE_LEN: usize = 65;
+	const PUBLIC_KEY_LEN: usize = crate::ecdsa::PUBLIC_KEY_SERIALIZED_SIZE  + crate::bls::PUBLIC_KEY_SERIALIZED_SIZE;
+	const LEFT_SIGNATURE_LEN: usize = crate::ecdsa::SIGNATURE_SERIALIZED_SIZE;
 	const RIGHT_SIGNATURE_LEN: usize = crate::bls::SIGNATURE_SERIALIZED_SIZE;
 	const SIGNATURE_LEN: usize = LEFT_SIGNATURE_LEN + RIGHT_SIGNATURE_LEN;
 

--- a/substrate/primitives/core/src/testing.rs
+++ b/substrate/primitives/core/src/testing.rs
@@ -31,6 +31,8 @@ pub const BANDERSNATCH: KeyTypeId = KeyTypeId(*b"band");
 pub const BLS377: KeyTypeId = KeyTypeId(*b"bls7");
 /// Key type for generic BLS12-381 key.
 pub const BLS381: KeyTypeId = KeyTypeId(*b"bls8");
+/// Key type for (ECDSA, BLS12-377) key pair
+pub const ECDSA_BLS377: KeyTypeId = KeyTypeId(*b"ecb7");
 
 /// Macro for exporting functions from wasm in with the expected signature for using it with the
 /// wasm executor. This is useful for tests where you need to call a function in wasm.

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -106,7 +106,7 @@ use sp_core::{
 };
 
 #[cfg(feature = "bls-experimental")]
-use sp_core::bls377;
+use sp_core::{bls377, ecdsa_bls377};
 
 #[cfg(feature = "std")]
 use sp_trie::{LayoutV0, LayoutV1, TrieConfiguration};
@@ -1192,7 +1192,8 @@ pub trait Crypto {
 		Ok(pubkey.serialize())
 	}
 
-	/// Generate an `bls12-377` key for the given key type using an optional `seed` and
+
+    	/// Generate an `bls12-377` key for the given key type using an optional `seed` and
 	/// store it in the keystore.
 	///
 	/// The `seed` needs to be a valid utf8.
@@ -1205,6 +1206,21 @@ pub trait Crypto {
 			.expect("No `keystore` associated for the current context!")
 			.bls377_generate_new(id, seed)
 			.expect("`bls377_generate` failed")
+	}
+
+    // Generate an pair of  `(ecdsa,bls12-377)` key for the given key type using an optional `seed` and
+	/// store it in the keystore.
+	///
+	/// The `seed` needs to be a valid utf8.
+	///
+	/// Returns the public key.
+	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_generate(&mut self, id: KeyTypeId, seed: Option<Vec<u8>>) -> ecdsa_bls377::Public {
+		let seed = seed.as_ref().map(|s| std::str::from_utf8(s).expect("Seed is valid utf8!"));
+		self.extension::<KeystoreExt>()
+			.expect("No `keystore` associated for the current context!")
+			.ecdsa_bls377_generate_new(id, seed)
+			.expect("`ecdsa_bls377_generate` failed")
 	}
 
 	/// Generate a `bandersnatch` key pair for the given key type using an optional

--- a/substrate/primitives/keystore/src/lib.rs
+++ b/substrate/primitives/keystore/src/lib.rs
@@ -270,7 +270,7 @@ pub trait Keystore: Send + Sync {
 	#[cfg(feature = "bls-experimental")]
 	fn bls377_public_keys(&self, id: KeyTypeId) -> Vec<bls377::Public>;
 
-    	/// Returns all (ecdsa,bls12-377) paired public keys for the given key type.
+	/// Returns all (ecdsa,bls12-377) paired public keys for the given key type.
 	#[cfg(feature = "bls-experimental")]
 	fn ecdsa_bls377_public_keys(&self, id: KeyTypeId) -> Vec<ecdsa_bls377::Public>;
 
@@ -295,7 +295,6 @@ pub trait Keystore: Send + Sync {
 		key_type: KeyTypeId,
 		seed: Option<&str>,
 	) -> Result<bls377::Public, Error>;
-
 
 	/// Generate a new (ecdsa,bls377) key pair for the given key type and an optional seed.
 	///
@@ -340,7 +339,7 @@ pub trait Keystore: Send + Sync {
 		msg: &[u8],
 	) -> Result<Option<bls377::Signature>, Error>;
 
-  	/// Generate a (ecdsa, bls377) signature pair for a given message.
+	/// Generate a (ecdsa, bls377) signature pair for a given message.
 	///
 	/// Receives [`KeyTypeId`] and a [`ecdsa_bls377::Public`] key to be able to map
 	/// them to a private key that exists in the keystore.
@@ -348,7 +347,7 @@ pub trait Keystore: Send + Sync {
 	/// Returns an [`ecdsa_bls377::Signature`] or `None` in case the given `key_type`
 	/// and `public` combination doesn't exist in the keystore.
 	/// An `Err` will be returned if generating the signature itself failed.
-    #[cfg(feature = "bls-experimental")]
+	#[cfg(feature = "bls-experimental")]
 	fn ecdsa_bls377_sign(
 		&self,
 		key_type: KeyTypeId,
@@ -380,8 +379,8 @@ pub trait Keystore: Send + Sync {
 	/// - ecdsa
 	/// - bandersnatch
 	/// - bls381
-        /// - bls377
-        /// - (ecdsa,bls377) paired keys
+	/// - bls377
+	/// - (ecdsa,bls377) paired keys
 	///
 	/// To support more schemes you can overwrite this method.
 	///
@@ -437,7 +436,7 @@ pub trait Keystore: Send + Sync {
 					.map_err(|_| Error::ValidationError("Invalid public key format".into()))?;
 				self.ecdsa_bls377_sign(id, &public, msg)?.map(|s| s.encode())
 			},
-		    
+
 			_ => return Err(Error::KeyNotSupported(id)),
 		};
 		Ok(signature)
@@ -623,8 +622,7 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 		(**self).bls377_generate_new(key_type, seed)
 	}
 
-
-    	#[cfg(feature = "bls-experimental")]
+	#[cfg(feature = "bls-experimental")]
 	fn ecdsa_bls377_generate_new(
 		&self,
 		key_type: KeyTypeId,
@@ -633,7 +631,7 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 		(**self).ecdsa_bls377_generate_new(key_type, seed)
 	}
 
-    #[cfg(feature = "bls-experimental")]
+	#[cfg(feature = "bls-experimental")]
 	fn bls381_sign(
 		&self,
 		key_type: KeyTypeId,
@@ -653,7 +651,7 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 		(**self).bls377_sign(key_type, public, msg)
 	}
 
-    	#[cfg(feature = "bls-experimental")]
+	#[cfg(feature = "bls-experimental")]
 	fn ecdsa_bls377_sign(
 		&self,
 		key_type: KeyTypeId,
@@ -661,7 +659,7 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 		msg: &[u8],
 	) -> Result<Option<ecdsa_bls377::Signature>, Error> {
 		(**self).ecdsa_bls377_sign(key_type, public, msg)
-    }
+	}
 
 	fn insert(&self, key_type: KeyTypeId, suri: &str, public: &[u8]) -> Result<(), ()> {
 		(**self).insert(key_type, suri, public)

--- a/substrate/primitives/keystore/src/lib.rs
+++ b/substrate/primitives/keystore/src/lib.rs
@@ -23,7 +23,7 @@ pub mod testing;
 #[cfg(feature = "bandersnatch-experimental")]
 use sp_core::bandersnatch;
 #[cfg(feature = "bls-experimental")]
-use sp_core::{bls377, bls381};
+use sp_core::{bls377, bls381, ecdsa_bls377};
 use sp_core::{
 	crypto::{ByteArray, CryptoTypeId, KeyTypeId},
 	ecdsa, ed25519, sr25519,
@@ -270,6 +270,10 @@ pub trait Keystore: Send + Sync {
 	#[cfg(feature = "bls-experimental")]
 	fn bls377_public_keys(&self, id: KeyTypeId) -> Vec<bls377::Public>;
 
+    	/// Returns all (ecdsa,bls12-377) paired public keys for the given key type.
+	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_public_keys(&self, id: KeyTypeId) -> Vec<ecdsa_bls377::Public>;
+
 	/// Generate a new bls381 key pair for the given key type and an optional seed.
 	///
 	/// Returns an `bls381::Public` key of the generated key pair or an `Err` if
@@ -291,6 +295,18 @@ pub trait Keystore: Send + Sync {
 		key_type: KeyTypeId,
 		seed: Option<&str>,
 	) -> Result<bls377::Public, Error>;
+
+
+	/// Generate a new (ecdsa,bls377) key pair for the given key type and an optional seed.
+	///
+	/// Returns an `ecdsa_bls377::Public` key of the generated key pair or an `Err` if
+	/// something failed during key generation.
+	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_generate_new(
+		&self,
+		key_type: KeyTypeId,
+		seed: Option<&str>,
+	) -> Result<ecdsa_bls377::Public, Error>;
 
 	/// Generate a bls381 signature for a given message.
 	///
@@ -324,6 +340,22 @@ pub trait Keystore: Send + Sync {
 		msg: &[u8],
 	) -> Result<Option<bls377::Signature>, Error>;
 
+  	/// Generate a (ecdsa, bls377) signature pair for a given message.
+	///
+	/// Receives [`KeyTypeId`] and a [`ecdsa_bls377::Public`] key to be able to map
+	/// them to a private key that exists in the keystore.
+	///
+	/// Returns an [`ecdsa_bls377::Signature`] or `None` in case the given `key_type`
+	/// and `public` combination doesn't exist in the keystore.
+	/// An `Err` will be returned if generating the signature itself failed.
+    #[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_sign(
+		&self,
+		key_type: KeyTypeId,
+		public: &ecdsa_bls377::Public,
+		msg: &[u8],
+	) -> Result<Option<ecdsa_bls377::Signature>, Error>;
+
 	/// Insert a new secret key.
 	fn insert(&self, key_type: KeyTypeId, suri: &str, public: &[u8]) -> Result<(), ()>;
 
@@ -348,7 +380,8 @@ pub trait Keystore: Send + Sync {
 	/// - ecdsa
 	/// - bandersnatch
 	/// - bls381
-	/// - bls377
+        /// - bls377
+        /// - (ecdsa,bls377) paired keys
 	///
 	/// To support more schemes you can overwrite this method.
 	///
@@ -398,6 +431,13 @@ pub trait Keystore: Send + Sync {
 					.map_err(|_| Error::ValidationError("Invalid public key format".into()))?;
 				self.bls377_sign(id, &public, msg)?.map(|s| s.encode())
 			},
+			#[cfg(feature = "bls-experimental")]
+			ecdsa_bls377::CRYPTO_ID => {
+				let public = ecdsa_bls377::Public::from_slice(public)
+					.map_err(|_| Error::ValidationError("Invalid public key format".into()))?;
+				self.ecdsa_bls377_sign(id, &public, msg)?.map(|s| s.encode())
+			},
+		    
 			_ => return Err(Error::KeyNotSupported(id)),
 		};
 		Ok(signature)
@@ -561,6 +601,11 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 	}
 
 	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_public_keys(&self, id: KeyTypeId) -> Vec<ecdsa_bls377::Public> {
+		(**self).ecdsa_bls377_public_keys(id)
+	}
+
+	#[cfg(feature = "bls-experimental")]
 	fn bls381_generate_new(
 		&self,
 		key_type: KeyTypeId,
@@ -578,7 +623,17 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 		(**self).bls377_generate_new(key_type, seed)
 	}
 
-	#[cfg(feature = "bls-experimental")]
+
+    	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_generate_new(
+		&self,
+		key_type: KeyTypeId,
+		seed: Option<&str>,
+	) -> Result<ecdsa_bls377::Public, Error> {
+		(**self).ecdsa_bls377_generate_new(key_type, seed)
+	}
+
+    #[cfg(feature = "bls-experimental")]
 	fn bls381_sign(
 		&self,
 		key_type: KeyTypeId,
@@ -597,6 +652,16 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 	) -> Result<Option<bls377::Signature>, Error> {
 		(**self).bls377_sign(key_type, public, msg)
 	}
+
+    	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_sign(
+		&self,
+		key_type: KeyTypeId,
+		public: &ecdsa_bls377::Public,
+		msg: &[u8],
+	) -> Result<Option<ecdsa_bls377::Signature>, Error> {
+		(**self).ecdsa_bls377_sign(key_type, public, msg)
+    }
 
 	fn insert(&self, key_type: KeyTypeId, suri: &str, public: &[u8]) -> Result<(), ()> {
 		(**self).insert(key_type, suri, public)

--- a/substrate/primitives/keystore/src/testing.rs
+++ b/substrate/primitives/keystore/src/testing.rs
@@ -22,7 +22,7 @@ use crate::{Error, Keystore, KeystorePtr};
 #[cfg(feature = "bandersnatch-experimental")]
 use sp_core::bandersnatch;
 #[cfg(feature = "bls-experimental")]
-use sp_core::{bls377, bls381};
+use sp_core::{bls377, bls381, ecdsa_bls377};
 use sp_core::{
 	crypto::{ByteArray, KeyTypeId, Pair, VrfSecret},
 	ecdsa, ed25519, sr25519,
@@ -322,6 +322,30 @@ impl Keystore for MemoryKeystore {
 		self.sign::<bls377::Pair>(key_type, public, msg)
 	}
 
+	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_public_keys(&self, key_type: KeyTypeId) -> Vec<ecdsa_bls377::Public> {
+		self.public_keys::<ecdsa_bls377::Pair>(key_type)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_generate_new(
+		&self,
+		key_type: KeyTypeId,
+		seed: Option<&str>,
+	) -> Result<ecdsa_bls377::Public, Error> {
+		self.generate_new::<ecdsa_bls377::Pair>(key_type, seed)
+	}
+
+	#[cfg(feature = "bls-experimental")]
+	fn ecdsa_bls377_sign(
+		&self,
+		key_type: KeyTypeId,
+		public: &ecdsa_bls377::Public,
+		msg: &[u8],
+	) -> Result<Option<ecdsa_bls377::Signature>, Error> {
+		self.sign::<ecdsa_bls377::Pair>(key_type, public, msg)
+	}
+    
 	fn insert(&self, key_type: KeyTypeId, suri: &str, public: &[u8]) -> Result<(), ()> {
 		self.keys
 			.write()

--- a/substrate/primitives/keystore/src/testing.rs
+++ b/substrate/primitives/keystore/src/testing.rs
@@ -345,7 +345,7 @@ impl Keystore for MemoryKeystore {
 	) -> Result<Option<ecdsa_bls377::Signature>, Error> {
 		self.sign::<ecdsa_bls377::Pair>(key_type, public, msg)
 	}
-    
+
 	fn insert(&self, key_type: KeyTypeId, suri: &str, public: &[u8]) -> Result<(), ()> {
 		self.keys
 			.write()


### PR DESCRIPTION
Next step in process of making BEEFY being able to generate both ECDSA and BLS signature after #1705. It allows BEEFY to use a pair of ECDSA and BLS key as a AuthorityId.
