### PR TITLE
Adding `try_state` hook for `Treasury` pallet

### DIFF
--- a/substrate/frame/treasury/src/benchmarking.rs
+++ b/substrate/frame/treasury/src/benchmarking.rs
@@ -336,5 +336,9 @@ mod benchmarks {
 		Ok(())
 	}
 
-	impl_benchmark_test_suite!(Treasury, crate::tests::ExtBuilder::default().build(), crate::tests::Test);
+	impl_benchmark_test_suite!(
+		Treasury,
+		crate::tests::ExtBuilder::default().build(),
+		crate::tests::Test
+	);
 }

--- a/substrate/frame/treasury/src/benchmarking.rs
+++ b/substrate/frame/treasury/src/benchmarking.rs
@@ -336,5 +336,5 @@ mod benchmarks {
 		Ok(())
 	}
 
-	impl_benchmark_test_suite!(Treasury, crate::tests::new_test_ext(), crate::tests::Test);
+	impl_benchmark_test_suite!(Treasury, crate::tests::ExtBuilder::default().build(), crate::tests::Test);
 }

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -82,9 +82,6 @@ pub use benchmarking::ArgumentsFactory;
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
-#[cfg(any(feature = "try-runtime", test))]
-use sp_runtime::traits::SaturatedConversion;
-
 use sp_runtime::{
 	traits::{AccountIdConversion, CheckedAdd, Saturating, StaticLookup, Zero},
 	Permill, RuntimeDebug,
@@ -1055,6 +1052,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Note, that this automatically implies Approvals.count() <= Proposals.count().
 	#[cfg(any(feature = "try-runtime", test))]
 	fn try_state_proposals() -> Result<(), sp_runtime::TryRuntimeError> {
+		use sp_runtime::traits::SaturatedConversion;
+		
 		let current_proposal_count = ProposalCount::<T, I>::get();
 		ensure!(
 			current_proposal_count as usize >= Proposals::<T, I>::iter().count(),

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -462,7 +462,7 @@ pub mod pallet {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn try_state(_: T::BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+		fn try_state(_: frame_system::pallet_prelude::BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
 			Self::do_try_state()?;
 			Ok(())
 		}

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -864,7 +864,7 @@ pub mod pallet {
 				// spend has expired and no further status update is expected.
 				Spends::<T, I>::remove(index);
 				Self::deposit_event(Event::<T, I>::SpendProcessed { index });
-				return Ok(Pays::No.into());
+				return Ok(Pays::No.into())
 			}
 
 			let payment_id = match spend.status {
@@ -881,11 +881,11 @@ pub mod pallet {
 				Status::Success | Status::Unknown => {
 					Spends::<T, I>::remove(index);
 					Self::deposit_event(Event::<T, I>::SpendProcessed { index });
-					return Ok(Pays::No.into());
+					return Ok(Pays::No.into())
 				},
 				Status::InProgress => return Err(Error::<T, I>::Inconclusive.into()),
 			}
-			return Ok(Pays::Yes.into());
+			return Ok(Pays::Yes.into())
 		}
 
 		/// Void previously approved spend.

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -462,7 +462,9 @@ pub mod pallet {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn try_state(_: frame_system::pallet_prelude::BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+		fn try_state(
+			_: frame_system::pallet_prelude::BlockNumberFor<T>,
+		) -> Result<(), sp_runtime::TryRuntimeError> {
 			Self::do_try_state()?;
 			Ok(())
 		}
@@ -1043,11 +1045,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// ### Invariants of proposal storage items
 	///
 	/// 1. `ProposalCount` >= Number of elements in `Proposals`.
-	/// 2. Each entry in `Proposals` should be saved under a key stricly less than current `ProposalCount`.
-	/// 3. `T::ProposalBondMinimum` * Number of proposals with non-zero bond <= sum_{p in Proposals} p.bond.
-	/// 4. (Optional) `T::ProposalBondMaximum` * Number of proposals with non-zero bond >= sum_{p in Proposals} p.bond.
-	/// 5. Each `ProposalIndex` contained in `Approvals` should exist in `Proposals`. Note, that this
-	///    automatically implies Approvals.count() <= Proposals.count().
+	/// 2. Each entry in `Proposals` should be saved under a key stricly less than current
+	/// `ProposalCount`. 3. `T::ProposalBondMinimum` * Number of proposals with non-zero bond <=
+	/// sum_{p in Proposals} p.bond. 4. (Optional) `T::ProposalBondMaximum` * Number of proposals
+	/// with non-zero bond >= sum_{p in Proposals} p.bond. 5. Each `ProposalIndex` contained in
+	/// `Approvals` should exist in `Proposals`. Note, that this    automatically implies
+	/// Approvals.count() <= Proposals.count().
 	#[cfg(any(feature = "try-runtime", test))]
 	fn try_state_proposals() -> Result<(), sp_runtime::TryRuntimeError> {
 		let current_proposal_count = ProposalCount::<T, I>::get();
@@ -1101,8 +1104,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// ## Invariants of spend storage items
 	///
 	/// 1. `SpendCount` >= Number of elements in `Spends`.
-	/// 2. Each entry in `Spends` should be saved under a key stricly less than current `SpendCount`.
-	/// 3. For each spend entry contained in `Spends` we should have spend.expire_at > spend.valid_from.
+	/// 2. Each entry in `Spends` should be saved under a key stricly less than current
+	/// `SpendCount`. 3. For each spend entry contained in `Spends` we should have spend.expire_at >
+	/// spend.valid_from.
 	#[cfg(any(feature = "try-runtime", test))]
 	fn try_state_spends() -> Result<(), sp_runtime::TryRuntimeError> {
 		let current_spend_count = SpendCount::<T, I>::get();

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -1046,11 +1046,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// 1. `ProposalCount` >= Number of elements in `Proposals`.
 	/// 2. Each entry in `Proposals` should be saved under a key stricly less than current
-	/// `ProposalCount`. 3. `T::ProposalBondMinimum` * Number of proposals with non-zero bond <=
-	/// sum_{p in Proposals} p.bond. 4. (Optional) `T::ProposalBondMaximum` * Number of proposals
-	/// with non-zero bond >= sum_{p in Proposals} p.bond. 5. Each `ProposalIndex` contained in
-	/// `Approvals` should exist in `Proposals`. Note, that this    automatically implies
-	/// Approvals.count() <= Proposals.count().
+	/// `ProposalCount`.
+	/// 3. `T::ProposalBondMinimum` * Number of proposals with
+	/// non-zero bond <= sum_{p in Proposals} p.bond.
+	/// 4. (Optional) `T::ProposalBondMaximum` * Number of proposals with
+	/// non-zero bond >= sum_{p in Proposals} p.bond.
+	/// 5. Each `ProposalIndex` contained in `Approvals` should exist in `Proposals`.
+	/// Note, that this automatically implies Approvals.count() <= Proposals.count().
 	#[cfg(any(feature = "try-runtime", test))]
 	fn try_state_proposals() -> Result<(), sp_runtime::TryRuntimeError> {
 		let current_proposal_count = ProposalCount::<T, I>::get();
@@ -1105,8 +1107,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// 1. `SpendCount` >= Number of elements in `Spends`.
 	/// 2. Each entry in `Spends` should be saved under a key stricly less than current
-	/// `SpendCount`. 3. For each spend entry contained in `Spends` we should have spend.expire_at >
-	/// spend.valid_from.
+	/// `SpendCount`.
+	/// 3. For each spend entry contained in `Spends` we should have spend.expire_at
+	/// > spend.valid_from.
 	#[cfg(any(feature = "try-runtime", test))]
 	fn try_state_spends() -> Result<(), sp_runtime::TryRuntimeError> {
 		let current_spend_count = SpendCount::<T, I>::get();

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -462,7 +462,7 @@ pub mod pallet {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn try_state(_: T::BlockNumber) -> Result<(), sp_runtime::TryRuntimeError> {
+		fn try_state(_: T::BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
 			Self::do_try_state()?;
 			Ok(())
 		}

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -456,6 +456,12 @@ pub mod pallet {
 				Weight::zero()
 			}
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_: T::BlockNumber) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()?;
+			Ok(())
+		
 	}
 
 	#[derive(Default)]

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -1052,7 +1052,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let (total_amount_bonded, non_zero_count) = Proposals::<T, I>::iter().fold(
 			(BalanceOf::<T, I>::zero(), 0usize),
 			|(sum, count), (_index, proposal)| {
-				if proposal.bond != BalanceOf::<T, I>::zero() {
+				if !proposal.bond.is_zero() {
 					(sum + proposal.bond, count + 1)
 				} else {
 					(sum, count)

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -239,13 +239,6 @@ impl ExtBuilder {
 		ext.execute_with(|| System::set_block_number(1));
 		ext
 	}
-
-	pub fn build_ext_and_execute(self, test: impl FnOnce() -> ()) {
-		self.build().execute_with(|| {
-			test();
-			Treasury::do_try_state().expect("Storage invariants should hold.")
-		});
-	}
 }
 
 fn get_payment_id(i: SpendIndex) -> Option<u64> {
@@ -258,7 +251,7 @@ fn get_payment_id(i: SpendIndex) -> Option<u64> {
 
 #[test]
 fn genesis_config_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Treasury::pot(), 0);
 		assert_eq!(Treasury::proposal_count(), 0);
 	});
@@ -266,7 +259,7 @@ fn genesis_config_works() {
 
 #[test]
 fn spend_local_origin_permissioning_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(Treasury::spend_local(RuntimeOrigin::signed(1), 1, 1), BadOrigin);
 		assert_noop!(
 			Treasury::spend_local(RuntimeOrigin::signed(10), 6, 1),
@@ -290,7 +283,7 @@ fn spend_local_origin_permissioning_works() {
 #[docify::export]
 #[test]
 fn spend_local_origin_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Check that accumulate works when we have Some value in Dummy already.
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		// approve spend of some amount to beneficiary `6`.
@@ -314,7 +307,7 @@ fn spend_local_origin_works() {
 
 #[test]
 fn minting_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Check that accumulate works when we have Some value in Dummy already.
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
@@ -323,7 +316,7 @@ fn minting_works() {
 
 #[test]
 fn spend_proposal_takes_min_deposit() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!({
 			#[allow(deprecated)]
 			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
@@ -335,7 +328,7 @@ fn spend_proposal_takes_min_deposit() {
 
 #[test]
 fn spend_proposal_takes_proportional_deposit() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!({
 			#[allow(deprecated)]
 			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
@@ -347,7 +340,7 @@ fn spend_proposal_takes_proportional_deposit() {
 
 #[test]
 fn spend_proposal_fails_when_proposer_poor() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
 			{
 				#[allow(deprecated)]
@@ -360,7 +353,7 @@ fn spend_proposal_fails_when_proposer_poor() {
 
 #[test]
 fn accepted_spend_proposal_ignored_outside_spend_period() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!({
@@ -380,7 +373,7 @@ fn accepted_spend_proposal_ignored_outside_spend_period() {
 
 #[test]
 fn unused_pot_should_diminish() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		let init_total_issuance = Balances::total_issuance();
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
@@ -393,7 +386,7 @@ fn unused_pot_should_diminish() {
 
 #[test]
 fn rejected_spend_proposal_ignored_on_spend_period() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!({
@@ -413,7 +406,7 @@ fn rejected_spend_proposal_ignored_on_spend_period() {
 
 #[test]
 fn reject_already_rejected_spend_proposal_fails() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!({
@@ -436,7 +429,7 @@ fn reject_already_rejected_spend_proposal_fails() {
 
 #[test]
 fn reject_non_existent_spend_proposal_fails() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
 			{
 				#[allow(deprecated)]
@@ -449,7 +442,7 @@ fn reject_non_existent_spend_proposal_fails() {
 
 #[test]
 fn accept_non_existent_spend_proposal_fails() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_noop!(
 			{
 				#[allow(deprecated)]
@@ -462,7 +455,7 @@ fn accept_non_existent_spend_proposal_fails() {
 
 #[test]
 fn accept_already_rejected_spend_proposal_fails() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!({
@@ -485,7 +478,7 @@ fn accept_already_rejected_spend_proposal_fails() {
 
 #[test]
 fn accepted_spend_proposal_enacted_on_spend_period() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 
@@ -506,7 +499,7 @@ fn accepted_spend_proposal_enacted_on_spend_period() {
 
 #[test]
 fn pot_underflow_should_not_diminish() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 
@@ -533,7 +526,7 @@ fn pot_underflow_should_not_diminish() {
 // i.e. pot should not include existential deposit needed for account survival.
 #[test]
 fn treasury_account_doesnt_get_deleted() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 		let treasury_balance = Balances::free_balance(&Treasury::account_id());
@@ -632,7 +625,7 @@ fn genesis_funding_works() {
 
 #[test]
 fn max_approvals_limited() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), u64::MAX);
 		Balances::make_free_balance_be(&0, u64::MAX);
 
@@ -664,7 +657,7 @@ fn max_approvals_limited() {
 
 #[test]
 fn remove_already_removed_approval_fails() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!({
@@ -688,7 +681,7 @@ fn remove_already_removed_approval_fails() {
 
 #[test]
 fn spending_local_in_batch_respects_max_total() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Respect the `max_total` for the given origin.
 		assert_ok!(RuntimeCall::from(UtilityCall::batch_all {
 			calls: vec![
@@ -713,7 +706,7 @@ fn spending_local_in_batch_respects_max_total() {
 
 #[test]
 fn spending_in_batch_respects_max_total() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Respect the `max_total` for the given origin.
 		assert_ok!(RuntimeCall::from(UtilityCall::batch_all {
 			calls: vec![
@@ -758,7 +751,7 @@ fn spending_in_batch_respects_max_total() {
 
 #[test]
 fn spend_origin_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 1, Box::new(6), None));
 		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(6), None));
 		assert_noop!(
@@ -783,7 +776,7 @@ fn spend_origin_works() {
 
 #[test]
 fn spend_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(6), None));
 
@@ -815,7 +808,7 @@ fn spend_works() {
 
 #[test]
 fn spend_expires() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(<Test as Config>::PayoutPeriod::get(), 5);
 
 		// spend `0` expires in 5 blocks after the creating.
@@ -835,7 +828,7 @@ fn spend_expires() {
 #[docify::export]
 #[test]
 fn spend_payout_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		// approve a `2` coins spend of asset `1` to beneficiary `6`, the spend valid from now.
 		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(6), None));
@@ -857,7 +850,7 @@ fn spend_payout_works() {
 
 #[test]
 fn payout_retry_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(6), None));
 		assert_ok!(Treasury::payout(RuntimeOrigin::signed(1), 0));
@@ -882,7 +875,7 @@ fn payout_retry_works() {
 
 #[test]
 fn spend_valid_from_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(<Test as Config>::PayoutPeriod::get(), 5);
 		System::set_block_number(1);
 
@@ -914,7 +907,7 @@ fn spend_valid_from_works() {
 
 #[test]
 fn void_spend_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		// spend cannot be voided if already attempted.
 		assert_ok!(Treasury::spend(
@@ -945,7 +938,7 @@ fn void_spend_works() {
 
 #[test]
 fn check_status_works() {
-	ExtBuilder::default().build_ext_and_execute(|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(<Test as Config>::PayoutPeriod::get(), 5);
 		System::set_block_number(1);
 
@@ -1001,5 +994,174 @@ fn check_status_works() {
 		let info = Treasury::check_status(RuntimeOrigin::signed(1), 4).unwrap();
 		assert_eq!(info.pays_fee, Pays::No);
 		System::assert_last_event(Event::<Test, _>::SpendProcessed { index: 4 }.into());
+	});
+}
+
+#[test]
+fn try_state_proposals_invariant_1_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		use frame_support::pallet_prelude::DispatchError::Other;
+		// Add a proposal using `propose_spend`
+		assert_ok!({
+			#[allow(deprecated)]
+			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
+		});
+		assert_eq!(Proposals::<Test>::iter().count(), 1);
+		assert_eq!(ProposalCount::<Test>::get(), 1);
+		// Check invariant 1 holds
+		assert!(ProposalCount::<Test>::get() as usize >= Proposals::<Test>::iter().count());
+		// Break invariant 1 by decreasing `ProposalCount`
+		ProposalCount::<Test>::put(0);
+		// Invariant 1 should be violated
+		assert_eq!(
+			Treasury::do_try_state(),
+			Err(Other("Actual number of proposals exceeds `ProposalCount`."))
+		);
+	});
+}
+
+#[test]
+fn try_state_proposals_invariant_2_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		use frame_support::pallet_prelude::DispatchError::Other;
+		// Add a proposal using `propose_spend`
+		assert_ok!({
+			#[allow(deprecated)]
+			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
+		});
+		assert_eq!(Proposals::<Test>::iter().count(), 1);
+		let current_proposal_count = ProposalCount::<Test>::get();
+		assert_eq!(current_proposal_count, 1);
+		// Check invariant 2 holds
+		assert!(
+			Proposals::<Test>::iter_keys()
+			.all(|proposal_index| {
+					proposal_index < current_proposal_count
+			})
+		);
+		// Break invariant 2 by inserting the proposal under key = 1
+		let proposal = Proposals::<Test>::take(0).unwrap();
+		Proposals::<Test>::insert(1, proposal);
+		// Invariant 2 should be violated
+		assert_eq!(
+			Treasury::do_try_state(),
+			Err(Other("`ProposalCount` should by strictly greater than any ProposalIndex used as a key for `Proposals`."))
+		);
+	});
+}
+
+#[test]
+fn try_state_proposals_invariant_3_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		use frame_support::pallet_prelude::DispatchError::Other;
+		// Add a proposal using `propose_spend`
+		assert_ok!({
+			#[allow(deprecated)]
+			Treasury::propose_spend(RuntimeOrigin::signed(0), 10, 3)
+		});
+		assert_eq!(Proposals::<Test>::iter().count(), 1);
+		// Approve the proposal
+		assert_ok!({
+			#[allow(deprecated)]
+			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
+		});
+		assert_eq!(Approvals::<Test>::get().len(), 1);
+		// Check invariant 3 holds
+		assert!(
+			Approvals::<Test>::get()
+			.iter()
+			.all(|proposal_index| {
+					Proposals::<Test>::contains_key(proposal_index)
+			})
+		);
+		// Break invariant 3 by adding another key to `Approvals`
+		let mut approvals_modified = Approvals::<Test>::get();
+		approvals_modified.try_push(2).unwrap();
+		Approvals::<Test>::put(approvals_modified);
+		// Invariant 3 should be violated
+		assert_eq!(
+			Treasury::do_try_state(),
+			Err(Other("Proposal indices in `Approvals` must also be contained in `Proposals`."))
+		);
+	});
+}
+
+#[test]
+fn try_state_spends_invariant_1_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		use frame_support::pallet_prelude::DispatchError::Other;
+		// Propose and approve a spend
+		assert_ok!({
+			Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 1, Box::new(6), None)
+		});
+		assert_eq!(Spends::<Test>::iter().count(), 1);
+		assert_eq!(SpendCount::<Test>::get(), 1);
+		// Check invariant 1 holds
+		assert!(SpendCount::<Test>::get() as usize >= Spends::<Test>::iter().count());
+		// Break invariant 1 by decreasing `SpendCount`
+		SpendCount::<Test>::put(0);
+		// Invariant 1 should be violated
+		assert_eq!(
+			Treasury::do_try_state(),
+			Err(Other("Actual number of spends exceeds `SpendCount`."))
+		);
+	});
+}
+
+#[test]
+fn try_state_spends_invariant_2_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		use frame_support::pallet_prelude::DispatchError::Other;
+		// Propose and approve a spend
+		assert_ok!({
+			Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 1, Box::new(6), None)
+		});
+		assert_eq!(Spends::<Test>::iter().count(), 1);
+		let current_spend_count = SpendCount::<Test>::get();
+		assert_eq!(current_spend_count, 1);
+		// Check invariant 2 holds
+		assert!(
+			Spends::<Test>::iter_keys()
+			.all(|spend_index| {
+					spend_index < current_spend_count
+			})
+		);
+		// Break invariant 2 by inserting the spend under key = 1
+		let spend = Spends::<Test>::take(0).unwrap();
+		Spends::<Test>::insert(1, spend);
+		// Invariant 2 should be violated
+		assert_eq!(
+			Treasury::do_try_state(),
+			Err(Other("`SpendCount` should by strictly greater than any SpendIndex used as a key for `Spends`."))
+		);
+	});
+}
+
+#[test]
+fn try_state_spends_invariant_3_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		use frame_support::pallet_prelude::DispatchError::Other;
+		// Propose and approve a spend
+		assert_ok!({
+			Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 1, Box::new(6), None)
+		});
+		assert_eq!(Spends::<Test>::iter().count(), 1);
+		let current_spend_count = SpendCount::<Test>::get();
+		assert_eq!(current_spend_count, 1);
+		// Check invariant 3 holds
+		assert!(
+			Spends::<Test>::iter_values()
+			.all(|SpendStatus {valid_from, expire_at, ..}| {
+					valid_from < expire_at
+			})
+		);
+		// Break invariant 3 by reversing spend.expire_at and spend.valid_from
+		let spend = Spends::<Test>::take(0).unwrap();
+		Spends::<Test>::insert(0, SpendStatus {valid_from: spend.expire_at, expire_at: spend.valid_from, ..spend});
+		// Invariant 3 should be violated
+		assert_eq!(
+			Treasury::do_try_state(),
+			Err(Other("Spend cannot expire before it becomes valid."))
+		);
 	});
 }

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -1067,13 +1067,9 @@ fn try_state_proposals_invariant_3_works() {
 		});
 		assert_eq!(Approvals::<Test>::get().len(), 1);
 		// Check invariant 3 holds
-		assert!(
-			Approvals::<Test>::get()
+		assert!(Approvals::<Test>::get()
 			.iter()
-			.all(|proposal_index| {
-					Proposals::<Test>::contains_key(proposal_index)
-			})
-		);
+			.all(|proposal_index| { Proposals::<Test>::contains_key(proposal_index) }));
 		// Break invariant 3 by adding another key to `Approvals`
 		let mut approvals_modified = Approvals::<Test>::get();
 		approvals_modified.try_push(2).unwrap();
@@ -1149,15 +1145,14 @@ fn try_state_spends_invariant_3_works() {
 		let current_spend_count = SpendCount::<Test>::get();
 		assert_eq!(current_spend_count, 1);
 		// Check invariant 3 holds
-		assert!(
-			Spends::<Test>::iter_values()
-			.all(|SpendStatus {valid_from, expire_at, ..}| {
-					valid_from < expire_at
-			})
-		);
+		assert!(Spends::<Test>::iter_values()
+			.all(|SpendStatus { valid_from, expire_at, .. }| { valid_from < expire_at }));
 		// Break invariant 3 by reversing spend.expire_at and spend.valid_from
 		let spend = Spends::<Test>::take(0).unwrap();
-		Spends::<Test>::insert(0, SpendStatus {valid_from: spend.expire_at, expire_at: spend.valid_from, ..spend});
+		Spends::<Test>::insert(
+			0,
+			SpendStatus { valid_from: spend.expire_at, expire_at: spend.valid_from, ..spend },
+		);
 		// Invariant 3 should be violated
 		assert_eq!(
 			Treasury::do_try_state(),

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -184,7 +184,7 @@ pub struct MulBy<N>(PhantomData<N>);
 impl<N: Get<u64>> ConversionFromAssetBalance<u64, u32, u64> for MulBy<N> {
 	type Error = ();
 	fn from_asset_balance(balance: u64, _asset_id: u32) -> Result<u64, Self::Error> {
-		return balance.checked_mul(N::get()).ok_or(());
+		return balance.checked_mul(N::get()).ok_or(())
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn ensure_successful(_: u32) {}


### PR DESCRIPTION
This PR adds a `try_state` hook for the `Treasury` pallet.
Part of #239.
The invariants checked are:

1. `ProposalCount` must be $\geq$ number of elements in `Proposals`. The `ProposalCount` storage value is only increased, but never decreased, whereas individual proposals can be removed from the `Proposals` storage map.
2. `T::ProposalBondMinimum` * Number of proposals with non-zero bond $\leq \sum_{p \in \textrm{Proposals}} \textrm{p.bond}$.

Since the introduction of the dispatchable `spend`, a bond is no longer required (bond is set to zero in these cases). However, the old way of proposing using a bond is still available and we can filter for these by looking at proposals with $\textrm{p.bond} \neq 0 $.

3. (Optional) `T::ProposalBondMaximum` * Number of proposals with non-zero bond $\geq \sum_{p \in \textrm{Proposals}} \textrm{p.bond}$.

Analogous to 2., but only relevant when `T::ProposalBondMaximum` is not `None`.

4. Each `ProposalIndex` contained in `Approvals` should exist in `Proposals`. Note, that this
   automatically implies `Approvals.count() <= Proposals.count()`.
5. `SpendCount` must be $\geq$ number of elements in `Spends`. Follows the same reasoning as invariant 1.
6. For each spend entry contained in `Spends` we should have `spend.expire_at > spend.valid_from`.

