### PR TITLE
Use `Consideration` ticket for holding Proxy pallet deposits

### DIFF
--- a/substrate/frame/proxy/src/lib.rs
+++ b/substrate/frame/proxy/src/lib.rs
@@ -338,11 +338,6 @@ pub mod pallet {
 
 			let (_, ticket) = Proxies::<T>::take(&who);
 			let _ = ticket.drop(&who);
-			// if let Some(ticket) = ticket {
-			// 	let _ = ticket.drop(&who);
-			// } else {
-			// 	defensive!("`kill_pure` called on an account that has no ticket");
-			// }
 
 			Ok(())
 		}

--- a/substrate/frame/proxy/src/lib.rs
+++ b/substrate/frame/proxy/src/lib.rs
@@ -553,9 +553,6 @@ pub mod pallet {
 		Unannounced,
 		/// Cannot add self as proxy.
 		NoSelfProxy,
-		/// More than [`MAX_HASH_UPGRADE_BULK_COUNT`] hashes were requested to be upgraded at
-		/// once.
-		UpgradeCountExceedsMax,
 	}
 
 	// WIP: Playing with the idea of overriding the default value of the storage item.

--- a/substrate/frame/proxy/src/lib.rs
+++ b/substrate/frame/proxy/src/lib.rs
@@ -133,7 +133,7 @@ pub mod pallet {
 		type AnnoucementConsideration: Consideration<Self::AccountId> + Default;
 
 		/// A means of providing some cost for storing proxy data on-chain.
-		type ProxyConsideration: Consideration<Self::AccountId>;
+		type ProxyConsideration: Consideration<Self::AccountId> + Default;
 
 		/// The maximum amount of proxies allowed for a single account.
 		#[pallet::constant]

--- a/substrate/frame/proxy/src/tests.rs
+++ b/substrate/frame/proxy/src/tests.rs
@@ -25,7 +25,7 @@ use crate as proxy;
 use codec::{Decode, Encode};
 use frame_support::{
 	assert_noop, assert_ok, derive_impl,
-	traits::{ConstU32, ConstU64, Contains},
+	traits::{fungible::HoldConsideration, ConstU32, ConstU64, Contains},
 };
 use sp_core::H256;
 use sp_runtime::{traits::BlakeTwo256, BuildStorage, DispatchError, RuntimeDebug};
@@ -126,6 +126,12 @@ impl Config for Test {
 	type MaxPending = ConstU32<2>;
 	type AnnouncementDepositBase = ConstU64<1>;
 	type AnnouncementDepositFactor = ConstU64<1>;
+	type Consideration = HoldConsideration<
+		AccountId,
+		Balances,
+		PreimageHoldReason,
+		LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
+	>;
 }
 
 use super::{Call as ProxyCall, Event as ProxyEvent};

--- a/substrate/frame/support/src/traits/tokens/fungible/mod.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/mod.rs
@@ -128,6 +128,7 @@ impl<
 	TypeInfo,
 	MaxEncodedLen,
 	RuntimeDebugNoBound,
+	Default,
 )]
 #[scale_info(skip_type_params(A, F, R, D))]
 #[codec(mel_bound())]


### PR DESCRIPTION
Partial https://github.com/paritytech/polkadot-sdk/issues/226

Stores `pallet_proxy` deposits as `Consideration` tickets instead of using `currency` `reserve`/`unreserve` methods.

TODO
- [ ] Multi-block migration (blocked)