### PR TITLE
Add devhub crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4275,6 +4275,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "devhub"
+version = "1.0.0"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
 	"cumulus/test/runtime",
 	"cumulus/test/service",
 	"cumulus/xcm/xcm-emulator",
+	"devhub",
 	"polkadot",
 	"polkadot/cli",
 	"polkadot/core-primitives",

--- a/devhub/Cargo.toml
+++ b/devhub/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "devhub"
+description = "A crate for the Polkadot SDK's reference documentation and tutorials"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://substrate.io"
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+version = "1.0.0"
+
+# The dependencies are only needed for docs.
+[dependencies]

--- a/devhub/src/lib.rs
+++ b/devhub/src/lib.rs
@@ -1,0 +1,6 @@
+//! # Polkadot SDK Developer Hub
+//!
+//! The devhub contains reference documentation and a tutorial for building with the Polkadot SDK.
+
+pub mod reference_docs;
+pub mod tutorial;

--- a/devhub/src/reference_docs/extrinsics.rs
+++ b/devhub/src/reference_docs/extrinsics.rs
@@ -1,0 +1,14 @@
+//! # Extrinsics and Calls
+//!
+//! **This page is currently under construction.**
+//!
+//! Reference documentation for the different types of extrinsics and how to construct them.
+//!
+//! An extrinsic is some data that can be added to a block, and is either signed (a transaction) or
+//! unsigned (an inherent).
+//!
+//! > Note: The term "call", "extrinsic", and "dispatchable" often get mixed together.
+//! > Here is a sentence which should help clarify their relationship, and why they are such similar
+//! > terms:
+//! > **Users submit an **extrinsic** to the blockchain, which is **dispatched** to a Pallet
+//! > **call**.**

--- a/devhub/src/reference_docs/mod.rs
+++ b/devhub/src/reference_docs/mod.rs
@@ -1,0 +1,9 @@
+//! # Reference Documentation
+//!
+//! Reference material for common concepts in Substrate.
+//!
+//! - [Extrinsics](extrinsics)
+//! - [Weights](weights)
+
+pub mod extrinsics;
+pub mod weights;

--- a/devhub/src/reference_docs/weights.rs
+++ b/devhub/src/reference_docs/weights.rs
@@ -1,0 +1,5 @@
+//! # Weights and Benchmarking
+//!
+//! **This page is currently under construction.**
+//!
+//! Reference material for how weights and benchmarking works.

--- a/devhub/src/tutorial/mod.rs
+++ b/devhub/src/tutorial/mod.rs
@@ -1,0 +1,3 @@
+//! The Polkadot SDK Master Tutorial
+
+pub mod step1;

--- a/devhub/src/tutorial/step1.rs
+++ b/devhub/src/tutorial/step1.rs
@@ -1,0 +1,3 @@
+//! # Step 1
+//!
+//! **This module is currently under construction.**


### PR DESCRIPTION
This adds the devhub crate for hosting Polkadot SDK reference docs and tutorials, following the structure proposed [here](https://github.com/paritytech/polkadot-sdk/pull/1477#issuecomment-1731425504).

The reference docs module currently contains `extrinsics.rs` and `weights.rs` with a "**This page is currently under construction.**" message for now. I mostly created this so we can start collaborating with experts to help craft these ref docs in separate PRs. Kian created [this list](https://github.com/paritytech/polkadot-sdk-docs/issues/4) of potential reference material docs that would live here too. The tutorial module would be where I envision the [master tutorial](https://github.com/paritytech/polkadot-sdk-docs/tree/main) will live.
