### PR TITLE
Remove clippy clone-double-ref lint noise

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,7 +15,7 @@ rustflags = [
   "-Aclippy::all",
   "-Dclippy::correctness",
   "-Aclippy::if-same-then-else",
-  "-Aclippy::clone-double-ref",
+  "-Asuspicious_double_ref_op",
   "-Dclippy::complexity",
   "-Aclippy::zero-prefixed-literal",     # 00_1000_000
   "-Aclippy::type_complexity",           # raison d'etre


### PR DESCRIPTION
The lint `clippy::clone_double_ref` was renamed to `suspicious_double_ref_op` in [this commit](https://github.com/rust-lang/rust/commit/5c99175a9efcaa3d65712c119f361add22e3a859) (thanks @liamaharon) and now generates a lot of noise in the terminal when run both in CI and locally with 1.73.

This renames the lint in line with this, but does not change functionality.

May cause issues for people running earlier versions locally - @altaua requesting review to get your opinion on this.