### PR TITLE
Fix links to implementers' guide

### DIFF
--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -193,7 +193,7 @@ async fn handle_new_activations<Context>(
 	metrics: Metrics,
 ) -> crate::error::Result<()> {
 	// follow the procedure from the guide:
-	// https://paritytech.github.io/polkadot/book/node/collators/collation-generation.html
+	// https://paritytech.github.io/polkadot-sdk/book/node/collators/collation-generation.html
 
 	if config.collator.is_none() {
 		return Ok(())

--- a/polkadot/node/core/pvf/src/lib.rs
+++ b/polkadot/node/core/pvf/src/lib.rs
@@ -19,8 +19,8 @@
 //! The PVF validation host. Responsible for coordinating preparation and execution of PVFs.
 //!
 //! For more background, refer to the Implementer's Guide: [PVF
-//! Pre-checking](https://paritytech.github.io/polkadot/book/pvf-prechecking.html) and [Candidate
-//! Validation](https://paritytech.github.io/polkadot/book/node/utility/candidate-validation.html#pvf-host).
+//! Pre-checking](https://paritytech.github.io/polkadot-sdk/book/pvf-prechecking.html) and [Candidate
+//! Validation](https://paritytech.github.io/polkadot-sdk/book/node/utility/candidate-validation.html#pvf-host).
 //!
 //! # Entrypoint
 //!

--- a/polkadot/node/core/pvf/src/lib.rs
+++ b/polkadot/node/core/pvf/src/lib.rs
@@ -19,8 +19,10 @@
 //! The PVF validation host. Responsible for coordinating preparation and execution of PVFs.
 //!
 //! For more background, refer to the Implementer's Guide: [PVF
-//! Pre-checking](https://paritytech.github.io/polkadot-sdk/book/pvf-prechecking.html) and [Candidate
-//! Validation](https://paritytech.github.io/polkadot-sdk/book/node/utility/candidate-validation.html#pvf-host).
+//! Pre-checking](https://paritytech.github.io/polkadot-sdk/book/pvf-prechecking.html), [Candidate
+//! Validation](https://paritytech.github.io/polkadot-sdk/book/node/utility/candidate-validation.html)
+//! and [PVF Host and Workers](https://paritytech.github.io/polkadot-sdk/book/node/utility/pvf-host-and-workers.html).
+//!
 //!
 //! # Entrypoint
 //!

--- a/polkadot/node/network/approval-distribution/src/lib.rs
+++ b/polkadot/node/network/approval-distribution/src/lib.rs
@@ -16,7 +16,10 @@
 
 //! [`ApprovalDistribution`] implementation.
 //!
-//! <https://w3f.github.io/parachain-implementers-guide/node/approval/approval-distribution.html>
+//! See the documentation on [approval distribution][approval-distribution-page] in the
+//! implementers' guide.
+//!
+//! [approval-distribution-page]: https://paritytech.github.io/polkadot-sdk/book/node/approval/approval-distribution.html
 
 #![warn(missing_docs)]
 

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -17,7 +17,7 @@
 //! # Overseer
 //!
 //! `overseer` implements the Overseer architecture described in the
-//! [implementers-guide](https://w3f.github.io/parachain-implementers-guide/node/index.html).
+//! [implementers' guide][implementers-guide-page].
 //! For the motivations behind implementing the overseer itself you should
 //! check out that guide, documentation in this crate will be mostly discussing
 //! technical stuff.
@@ -53,6 +53,8 @@
 //!             .  +--------------------+               +---------------------+  .
 //!             ..................................................................
 //! ```
+//!
+//! [implementers-guide-page]: https://paritytech.github.io/polkadot-sdk/book/node/overseer.html
 
 // #![deny(unused_results)]
 // unused dependencies can not work for test and examples at the same time

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -17,7 +17,7 @@
 //! # Overseer
 //!
 //! `overseer` implements the Overseer architecture described in the
-//! [implementers' guide][implementers-guide-page].
+//! [implementers' guide][overseer-page].
 //! For the motivations behind implementing the overseer itself you should
 //! check out that guide, documentation in this crate will be mostly discussing
 //! technical stuff.
@@ -54,7 +54,7 @@
 //!             ..................................................................
 //! ```
 //!
-//! [implementers-guide-page]: https://paritytech.github.io/polkadot-sdk/book/node/overseer.html
+//! [overseer-page]: https://paritytech.github.io/polkadot-sdk/book/node/overseer.html
 
 // #![deny(unused_results)]
 // unused dependencies can not work for test and examples at the same time

--- a/polkadot/node/service/src/relay_chain_selection.rs
+++ b/polkadot/node/service/src/relay_chain_selection.rs
@@ -31,7 +31,7 @@
 //! leaf returned from the chain selection subsystem by calling into other
 //! subsystems which yield information about approvals and disputes.
 //!
-//! [chain-selection-guide]: https://w3f.github.io/parachain-implementers-guide/protocol-chain-selection.html
+//! [chain-selection-guide]: https://paritytech.github.io/polkadot-sdk/book/protocol-chain-selection.html
 
 #![cfg(feature = "full-node")]
 

--- a/polkadot/roadmap/implementers-guide/README.md
+++ b/polkadot/roadmap/implementers-guide/README.md
@@ -4,7 +4,7 @@ The implementers' guide is compiled from several source files with [`mdBook`](ht
 
 ## Hosted build
 
-This is available [here](https://paritytech.github.io/polkadot/book/).
+This is available [here](https://paritytech.github.io/polkadot-sdk/book/).
 
 ## Local build
 

--- a/polkadot/runtime/parachains/src/session_info.rs
+++ b/polkadot/runtime/parachains/src/session_info.rs
@@ -19,7 +19,7 @@
 //!
 //! See the documentation on [session info][session-info-page] in the implementers' guide.
 //!
-//! [session-info-page]: https://paritytech.github.io/polkadot-sdk/master/polkadot_runtime_parachains/session_info/index.html
+//! [session-info-page]: https://paritytech.github.io/polkadot-sdk/book/runtime/session_info.html
 use crate::{
 	configuration, paras, scheduler, shared,
 	util::{take_active_subset, take_active_subset_and_inactive},

--- a/polkadot/runtime/parachains/src/session_info.rs
+++ b/polkadot/runtime/parachains/src/session_info.rs
@@ -17,8 +17,9 @@
 //! The session info pallet provides information about validator sets
 //! from prior sessions needed for approvals and disputes.
 //!
-//! See <https://w3f.github.io/parachain-implementers-guide/runtime/session_info.html>.
-
+//! See the documentation on [session info][session-info-page] in the implementers' guide.
+//!
+//! [session-info-page]: https://paritytech.github.io/polkadot-sdk/master/polkadot_runtime_parachains/session_info/index.html
 use crate::{
 	configuration, paras, scheduler, shared,
 	util::{take_active_subset, take_active_subset_and_inactive},


### PR DESCRIPTION
# Description

In a couple of cases, there were links pointing to the w3f github pages domain. In other instances, there were links pointing to the old polkadot repo's github pages. Both of these are now pointing to the relevant links in https://paritytech.github.io/polkadot-sdk/book/index.html.

These changes were made specifically because the w3f github pages returns a 404, and while fixing the links, the old polkadot repo links were touched up as well even if they do redirect properly.

This shouldn't affect anything as these are documentation link changes only.
