### PR TITLE
Allow Locks/Holds/Reserves/Freezes by default when using `pallet_balances` `TestDefaultConfig`

### DIFF
--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -238,10 +238,10 @@ pub mod pallet {
 
 			type DustRemoval = ();
 
-			type MaxLocks = ();
-			type MaxReserves = ();
-			type MaxFreezes = ();
-			type MaxHolds = ();
+			type MaxLocks = ConstU32<100>;
+			type MaxReserves = ConstU32<100>;
+			type MaxFreezes = ConstU32<100>;
+			type MaxHolds = ConstU32<100>;
 
 			type WeightInfo = ();
 		}


### PR DESCRIPTION
Allow Locks/Holds/Reserves/Freezes by default when using `pallet_balances` `TestDefaultConfig`.