### PR TITLE
Publish `xcm-emulator` crate

### DIFF
--- a/cumulus/xcm/xcm-emulator/Cargo.toml
+++ b/cumulus/xcm/xcm-emulator/Cargo.toml
@@ -4,7 +4,6 @@ description = "Test kit to emulate XCM program execution."
 version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
-publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0" }


### PR DESCRIPTION
Remove `publish = false` to publish the crate
