### PR TITLE
Workspace maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
 	"cumulus/parachains/integration-tests/emulated/assets/asset-hub-westend",
 	"cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-rococo",
 	"cumulus/parachains/integration-tests/emulated/common",
+	"cumulus/parachains/pallets/collective-content",
 	"cumulus/parachains/pallets/parachain-info",
 	"cumulus/parachains/pallets/ping",
 	"cumulus/parachains/runtimes/assets/asset-hub-kusama",

--- a/substrate/bin/node-template/runtime/Cargo.toml
+++ b/substrate/bin/node-template/runtime/Cargo.toml
@@ -39,7 +39,7 @@ sp-std = { path = "../../../primitives/std", default-features = false}
 sp-storage = { path = "../../../primitives/storage", default-features = false}
 sp-transaction-pool = { path = "../../../primitives/transaction-pool", default-features = false}
 sp-version = { path = "../../../primitives/version", default-features = false}
-sp-genesis-builder = { version = "0.1.0-dev", default-features = false, path = "../../../primitives/genesis-builder" }
+sp-genesis-builder = { default-features = false, path = "../../../primitives/genesis-builder" }
 
 # Used for the node template's RPCs
 frame-system-rpc-runtime-api = { path = "../../../frame/system/rpc/runtime-api", default-features = false}

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -32,7 +32,7 @@ sp-authority-discovery = { path = "../../../primitives/authority-discovery", def
 sp-consensus-babe = { path = "../../../primitives/consensus/babe", default-features = false}
 sp-consensus-grandpa = { path = "../../../primitives/consensus/grandpa", default-features = false}
 sp-block-builder = { path = "../../../primitives/block-builder", default-features = false}
-sp-genesis-builder = { version = "0.1.0-dev", default-features = false, path = "../../../primitives/genesis-builder" }
+sp-genesis-builder = { default-features = false, path = "../../../primitives/genesis-builder" }
 sp-inherents = { path = "../../../primitives/inherents", default-features = false}
 node-primitives = { path = "../primitives", default-features = false}
 sp-mixnet = { path = "../../../primitives/mixnet", default-features = false }

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -18,12 +18,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.163", default-features = false, features = ["derive"], optional = true }
-sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
-sp-application-crypto = { version = "23.0.0", default-features = false, path = "../../application-crypto", features = ["bandersnatch-experimental"] }
-sp-consensus-slots = { version = "0.10.0-dev", default-features = false, path = "../slots" }
-sp-core = { version = "21.0.0", default-features = false, path = "../../core", features = ["bandersnatch-experimental"] }
-sp-runtime = { version = "24.0.0", default-features = false, path = "../../runtime" }
-sp-std = { version = "8.0.0", default-features = false, path = "../../std" }
+sp-api = { default-features = false, path = "../../api" }
+sp-application-crypto = { default-features = false, path = "../../application-crypto", features = ["bandersnatch-experimental"] }
+sp-consensus-slots = { default-features = false, path = "../slots" }
+sp-core = { default-features = false, path = "../../core", features = ["bandersnatch-experimental"] }
+sp-runtime = { default-features = false, path = "../../runtime" }
+sp-std = { default-features = false, path = "../../std" }
 
 [features]
 default = [ "std" ]


### PR DESCRIPTION
Changes:
- Add missing crate to the workspace
- Remove versions from local dependency links

Maybe it is finally worth it to add this scrip to the CI to find these things earlier: [check-deps.py](https://github.com/ggwpez/substrate-scripts/blob/master/import-runtime-repos/check-deps.py).  

@paritytech/ci what would be the best location for that check?  
It takes only a second to run, so maybe we can squeeze it into one of the existing checks?  
Otherwise creating a new GH workflow feels a bit wasteful... maybe i can group it with https://github.com/paritytech/polkadot-sdk/pull/1831