### PR TITLE
ci: remove obsolete `allow_failure` annotations

### DIFF
--- a/.gitlab/pipeline/check.yml
+++ b/.gitlab/pipeline/check.yml
@@ -30,7 +30,6 @@ cargo-fmt-manifest:
     - cargo install zepter --locked --version 0.11.0 -q -f --no-default-features && zepter --version
     - echo "👉 Hello developer! If you see this CI check failing then it means that one of the your changes in a Cargo.toml file introduced ill-formatted or unsorted features. Please take a look at 'docs/STYLE_GUIDE.md#manifest-formatting' to find out more."
     - zepter format features --check
-  allow_failure: true # Experimental
 
 # FIXME
 .cargo-deny-licenses:

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -183,7 +183,6 @@ test-rustdoc:
     SKIP_WASM_BUILD: 1
   script:
     - time cargo doc --workspace --all-features --no-deps
-  allow_failure: true
 
 cargo-check-all-benches:
   stage: test


### PR DESCRIPTION
These two jobs are now required by github branch protection settings.