### PR TITLE
Publish `penpal-runtime` crate

### DIFF
--- a/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
@@ -7,7 +7,6 @@ license = "Unlicense"
 homepage = "https://substrate.io"
 repository.workspace = true
 edition.workspace = true
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Remove `publish = false` to publish the crate