### PR TITLE
bridges: add missing crate descriptions

### DIFF
--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bridge-runtime-common"
 version = "0.1.0"
+description = "Common types and functions that may be used by substrate-based runtimes of all bridged chains"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/bridges/modules/grandpa/Cargo.toml
+++ b/bridges/modules/grandpa/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
+description = "Module implementing GRANDPA on-chain light client used for bridging consensus of substrate-based chains."
 authors.workspace = true
 edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/bridges/modules/parachains/Cargo.toml
+++ b/bridges/modules/parachains/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pallet-bridge-parachains"
 version = "0.1.0"
+description = "Module that allows bridged relay chains to exchange information on their parachains' heads."
 authors.workspace = true
 edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/bridges/primitives/test-utils/Cargo.toml
+++ b/bridges/primitives/test-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bp-test-utils"
 version = "0.1.0"
+description = "Utilities for testing substrate-based runtime bridge code"
 authors.workspace = true
 edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
Adds descriptions needed for publishing bridges crates to crates.io.

see https://forum.parity.io/t/crates-need-descriptions/2115
