### PR TITLE
Pin PRDoc image to v0.0.5 until we are ready for v0.0.6

### DIFF
--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize, unlabeled]
 
 env:
-  IMAGE: paritytech/prdoc:latest
+  IMAGE: paritytech/prdoc:v0.0.5
   API_BASE: https://api.github.com/repos
   REPO: ${{ github.repository }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR prevents failures until #1946 is merged.