### PR TITLE
`xcm`: Change `TypeInfo::path` to not include `staging`

### DIFF
--- a/polkadot/xcm/src/double_encoded.rs
+++ b/polkadot/xcm/src/double_encoded.rs
@@ -24,6 +24,7 @@ use parity_scale_codec::{Decode, DecodeLimit, Encode};
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(T))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct DoubleEncoded<T> {
 	encoded: Vec<u8>,
 	#[codec(skip)]

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -89,6 +89,7 @@ macro_rules! versioned_type {
 		)]
 		#[codec(encode_bound())]
 		#[codec(decode_bound())]
+		#[scale_info(replace_segment("staging_xcm", "xcm"))]
 		$(#[$attr])*
 		pub enum $n {
 			$(#[$index3])*
@@ -150,6 +151,7 @@ macro_rules! versioned_type {
 		)]
 		#[codec(encode_bound())]
 		#[codec(decode_bound())]
+		#[scale_info(replace_segment("staging_xcm", "xcm"))]
 		$(#[$attr])*
 		pub enum $n {
 			$(#[$index2])*
@@ -310,6 +312,7 @@ versioned_type! {
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(RuntimeCall))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum VersionedXcm<RuntimeCall> {
 	#[codec(index = 2)]
 	V2(v2::Xcm<RuntimeCall>),

--- a/polkadot/xcm/src/tests.rs
+++ b/polkadot/xcm/src/tests.rs
@@ -181,3 +181,12 @@ fn encode_decode_versioned_xcm_v3() {
 	let decoded = VersionedXcm::decode(&mut &encoded[..]).unwrap();
 	assert_eq!(xcm, decoded);
 }
+
+// With the renaming of the crate to `staging-xcm` the naming in the metadata changed aswell and
+// this broke downstream users. This test ensures that the name in the metadata isn't changed.
+#[test]
+fn ensure_type_info_is_correct() {
+	let type_info = VersionedXcm::<()>::type_info();
+
+	assert_eq!(type_info.path.segments, vec!["xcm", "VersionedXcm"]);
+}

--- a/polkadot/xcm/src/v2/junction.rs
+++ b/polkadot/xcm/src/v2/junction.rs
@@ -27,6 +27,7 @@ use scale_info::TypeInfo;
 /// Each item assumes a pre-existing location as its context and is defined in terms of it.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junction {
 	/// An indexed parachain belonging to and operated by the context.
 	///

--- a/polkadot/xcm/src/v2/mod.rs
+++ b/polkadot/xcm/src/v2/mod.rs
@@ -81,6 +81,7 @@ pub use traits::{Error, ExecuteXcm, GetWeight, Outcome, Result, SendError, SendR
 
 /// Basically just the XCM (more general) version of `ParachainDispatchOrigin`.
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum OriginKind {
 	/// Origin should just be the native dispatch origin representation for the sender in the
 	/// local runtime framework. For Cumulus/Frame chains this is the `Parachain` or `Relay` origin
@@ -105,6 +106,7 @@ pub enum OriginKind {
 /// A global identifier of an account-bearing consensus system.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum NetworkId {
 	/// Unidentified/any.
 	Any,
@@ -141,6 +143,7 @@ impl TryFrom<NewNetworkId> for NetworkId {
 /// An identifier of a pluralistic body.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyId {
 	/// The only body in its context.
 	Unit,
@@ -195,6 +198,7 @@ impl From<NewBodyId> for BodyId {
 /// A part of a pluralistic body.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyPart {
 	/// The body's declaration, under whatever means it decides.
 	Voice,
@@ -262,6 +266,7 @@ pub type QueryId = u64;
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(RuntimeCall))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct Xcm<RuntimeCall>(pub Vec<Instruction<RuntimeCall>>);
 
 impl<RuntimeCall> Xcm<RuntimeCall> {
@@ -357,6 +362,7 @@ pub mod prelude {
 
 /// Response data to a query.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Response {
 	/// No response. Serves as a neutral default.
 	Null,
@@ -376,6 +382,7 @@ impl Default for Response {
 
 /// An optional weight limit.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WeightLimit {
 	/// No weight limit imposed.
 	Unlimited,
@@ -428,6 +435,7 @@ pub type Weight = u64;
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(RuntimeCall))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Instruction<RuntimeCall> {
 	/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place them into the Holding
 	/// Register.

--- a/polkadot/xcm/src/v2/multiasset.rs
+++ b/polkadot/xcm/src/v2/multiasset.rs
@@ -41,6 +41,7 @@ use scale_info::TypeInfo;
 /// A general identifier for an instance of a non-fungible asset class.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetInstance {
 	/// Undefined - used if the non-fungible asset class has only one instance.
 	Undefined,
@@ -119,6 +120,7 @@ impl TryFrom<NewAssetInstance> for AssetInstance {
 /// Classification of an asset being concrete or abstract.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetId {
 	Concrete(MultiLocation),
 	Abstract(Vec<u8>),
@@ -185,6 +187,7 @@ impl AssetId {
 /// instance.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Fungibility {
 	Fungible(#[codec(compact)] u128),
 	NonFungible(AssetInstance),
@@ -224,6 +227,7 @@ impl TryFrom<NewFungibility> for Fungibility {
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAsset {
 	pub id: AssetId,
 	pub fun: Fungibility,
@@ -309,6 +313,7 @@ impl TryFrom<NewMultiAsset> for MultiAsset {
 /// they must be sorted.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAssets(Vec<MultiAsset>);
 
 impl Decode for MultiAssets {
@@ -479,6 +484,7 @@ impl MultiAssets {
 /// Classification of whether an asset is fungible or not.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildFungibility {
 	Fungible,
 	NonFungible,
@@ -498,6 +504,7 @@ impl TryFrom<NewWildFungibility> for WildFungibility {
 /// A wildcard representing a set of assets.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildMultiAsset {
 	/// All assets in the holding register, up to `usize` individual assets (different instances of
 	/// non-fungibles could be separate assets).
@@ -543,6 +550,7 @@ impl<A: Into<AssetId>, B: Into<WildFungibility>> From<(A, B)> for WildMultiAsset
 /// in this implementation and will result in a decode error.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum MultiAssetFilter {
 	Definite(MultiAssets),
 	Wild(WildMultiAsset),

--- a/polkadot/xcm/src/v2/multilocation.rs
+++ b/polkadot/xcm/src/v2/multilocation.rs
@@ -50,6 +50,7 @@ use scale_info::TypeInfo;
 /// The `MultiLocation` value of `Null` simply refers to the interpreting consensus system.
 #[derive(Clone, Decode, Encode, Eq, PartialEq, Ord, PartialOrd, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiLocation {
 	/// The number of parent junctions at the beginning of this `MultiLocation`.
 	pub parents: u8,
@@ -465,6 +466,7 @@ const MAX_JUNCTIONS: usize = 8;
 /// instructions on constructing parent junctions.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junctions {
 	/// The interpreting consensus system.
 	Here,

--- a/polkadot/xcm/src/v2/traits.rs
+++ b/polkadot/xcm/src/v2/traits.rs
@@ -29,6 +29,7 @@ pub trait GetWeight<W> {
 }
 
 #[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Error {
 	// Errors that happen due to instructions being executed. These alone are defined in the
 	// XCM specification.
@@ -165,6 +166,7 @@ pub type Result = result::Result<(), Error>;
 
 /// Outcome of an XCM execution.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Outcome {
 	/// Execution completed successfully; given weight was used.
 	Complete(Weight),
@@ -246,6 +248,7 @@ impl<C> ExecuteXcm<C> for () {
 
 /// Error result value when attempting to send an XCM message.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, scale_info::TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum SendError {
 	/// The message and destination combination was not recognized as being reachable.
 	///

--- a/polkadot/xcm/src/v3/junction.rs
+++ b/polkadot/xcm/src/v3/junction.rs
@@ -49,6 +49,7 @@ use serde::{Deserialize, Serialize};
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum NetworkId {
 	/// Network specified by the first 32 bytes of its genesis block.
 	ByGenesis([u8; 32]),
@@ -116,6 +117,7 @@ impl TryFrom<OldNetworkId> for NetworkId {
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyId {
 	/// The only body in its context.
 	Unit,
@@ -186,6 +188,7 @@ impl TryFrom<OldBodyId> for BodyId {
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyPart {
 	/// The body's declaration, under whatever means it decides.
 	Voice,
@@ -261,6 +264,7 @@ impl TryFrom<OldBodyPart> for BodyPart {
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junction {
 	/// An indexed parachain belonging to and operated by the context.
 	///

--- a/polkadot/xcm/src/v3/junctions.rs
+++ b/polkadot/xcm/src/v3/junctions.rs
@@ -44,6 +44,7 @@ pub(crate) const MAX_JUNCTIONS: usize = 8;
 	serde::Serialize,
 	serde::Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junctions {
 	/// The interpreting consensus system.
 	Here,

--- a/polkadot/xcm/src/v3/mod.rs
+++ b/polkadot/xcm/src/v3/mod.rs
@@ -68,6 +68,7 @@ pub type QueryId = u64;
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
 #[codec(encode_bound())]
 #[scale_info(bounds(), skip_type_params(Call))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct Xcm<Call>(pub Vec<Instruction<Call>>);
 
 pub const MAX_INSTRUCTIONS_TO_DECODE: u8 = 100;
@@ -236,6 +237,7 @@ parameter_types! {
 }
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct PalletInfo {
 	#[codec(compact)]
 	index: u32,
@@ -266,6 +268,7 @@ impl PalletInfo {
 }
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum MaybeErrorCode {
 	Success,
 	Error(BoundedVec<u8, MaxDispatchErrorLen>),
@@ -289,6 +292,7 @@ impl Default for MaybeErrorCode {
 
 /// Response data to a query.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Response {
 	/// No response. Serves as a neutral default.
 	Null,
@@ -312,6 +316,7 @@ impl Default for Response {
 
 /// Information regarding the composition of a query response.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct QueryResponseInfo {
 	/// The destination to which the query response message should be send.
 	pub destination: MultiLocation,
@@ -324,6 +329,7 @@ pub struct QueryResponseInfo {
 
 /// An optional weight limit.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WeightLimit {
 	/// No weight limit imposed.
 	Unlimited,
@@ -400,6 +406,7 @@ impl XcmContext {
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(Call))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Instruction<Call> {
 	/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place them into the Holding
 	/// Register.

--- a/polkadot/xcm/src/v3/multiasset.rs
+++ b/polkadot/xcm/src/v3/multiasset.rs
@@ -47,6 +47,7 @@ use scale_info::TypeInfo;
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetInstance {
 	/// Undefined - used if the non-fungible asset class has only one instance.
 	Undefined,
@@ -242,6 +243,7 @@ impl TryFrom<AssetInstance> for u128 {
 /// instance.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Fungibility {
 	/// A fungible asset; we record a number of units, as a `u128` in the inner item.
 	Fungible(#[codec(compact)] u128),
@@ -311,6 +313,7 @@ impl TryFrom<OldFungibility> for Fungibility {
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildFungibility {
 	/// The asset is fungible.
 	Fungible,
@@ -334,6 +337,7 @@ impl TryFrom<OldWildFungibility> for WildFungibility {
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetId {
 	/// A specific location identifying an asset.
 	Concrete(MultiLocation),
@@ -408,6 +412,7 @@ impl AssetId {
 /// Either an amount of a single fungible asset, or a single well-identified non-fungible asset.
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAsset {
 	/// The overall asset identity (aka *class*, in the case of a non-fungible).
 	pub id: AssetId,
@@ -505,6 +510,7 @@ impl TryFrom<OldMultiAsset> for MultiAsset {
 /// - The number of items should grow no larger than `MAX_ITEMS_IN_MULTIASSETS`.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, TypeInfo, Default)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAssets(Vec<MultiAsset>);
 
 /// Maximum number of items in a single `MultiAssets` value that can be decoded.
@@ -700,6 +706,7 @@ impl MultiAssets {
 /// A wildcard representing a set of assets.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildMultiAsset {
 	/// All assets in Holding.
 	All,
@@ -812,6 +819,7 @@ impl<A: Into<AssetId>, B: Into<WildFungibility>> From<(A, B)> for WildMultiAsset
 /// `MultiAsset` collection, defined either by a number of `MultiAssets` or a single wildcard.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum MultiAssetFilter {
 	/// Specify the filter as being everything contained by the given `MultiAssets` inner.
 	Definite(MultiAssets),

--- a/polkadot/xcm/src/v3/traits.rs
+++ b/polkadot/xcm/src/v3/traits.rs
@@ -29,6 +29,7 @@ use super::*;
 /// format. Those trailing are merely part of the XCM implementation; there is no expectation that
 /// they will retain the same index over time.
 #[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Error {
 	// Errors that happen due to instructions being executed. These alone are defined in the
 	// XCM specification.
@@ -262,6 +263,7 @@ impl From<Error> for Outcome {
 
 /// Outcome of an XCM execution.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Outcome {
 	/// Execution completed successfully; given weight was used.
 	Complete(Weight),
@@ -410,6 +412,7 @@ impl<C> ExecuteXcm<C> for () {
 
 /// Error result value when attempting to send an XCM message.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, scale_info::TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum SendError {
 	/// The message and destination combination was not recognized as being reachable.
 	///


### PR DESCRIPTION
The `xcm` crate was renamed to `staging-xcm` to be able to publish it to crates.io as someone as squatted `xcm`. The problem with this rename is that the `TypeInfo` includes the crate name which ultimately lands in the metadata. The metadata is consumed by downstream users like `polkadot-js` or people building on top of `polkadot-js`. These people are using the entire `path` to find the type in the type registry. Thus, their code would break as the type path would now be [`staging_xcm`, `VersionedXcm`] instead of [`xcm`, `VersionedXcm`]. This pull request fixes this by renaming the path segment `staging_xcm` to `xcm`.

This requires: https://github.com/paritytech/scale-info/pull/197


