### PR TITLE
wasm-builder: manually set CARGO_TARGET_DIR

### DIFF
--- a/substrate/utils/wasm-builder/src/prerequisites.rs
+++ b/substrate/utils/wasm-builder/src/prerequisites.rs
@@ -143,9 +143,10 @@ fn check_wasm_toolchain_installed(
 	run_cmd.current_dir(&temp);
 	run_cmd.args(&["run", "--manifest-path", &manifest_path]);
 
-	// Unset the `CARGO_TARGET_DIR` to prevent a cargo deadlock
-	build_cmd.env_remove("CARGO_TARGET_DIR");
-	run_cmd.env_remove("CARGO_TARGET_DIR");
+	// manually set the `CARGO_TARGET_DIR` to prevent a cargo deadlock
+	let target_dir = temp.path().join("target").display().to_string();
+	build_cmd.env("CARGO_TARGET_DIR", &target_dir);
+	run_cmd.env("CARGO_TARGET_DIR", &target_dir);
 
 	// Make sure the host's flags aren't used here, e.g. if an alternative linker is specified
 	// in the RUSTFLAGS then the check we do here will break unless we clear these.

--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -670,10 +670,10 @@ fn build_project(
 		.args(&["rustc", "--target=wasm32-unknown-unknown"])
 		.arg(format!("--manifest-path={}", manifest_path.display()))
 		.env("RUSTFLAGS", rustflags)
-		// Unset the `CARGO_TARGET_DIR` to prevent a cargo deadlock (cargo locks a target dir
+		// Manually set the `CARGO_TARGET_DIR` to prevent a cargo deadlock (cargo locks a target dir
 		// exclusive). The runner project is created in `CARGO_TARGET_DIR` and executing it will
 		// create a sub target directory inside of `CARGO_TARGET_DIR`.
-		.env_remove("CARGO_TARGET_DIR")
+		.env("CARGO_TARGET_DIR", &project.join("target").display().to_string())
 		// As we are being called inside a build-script, this env variable is set. However, we set
 		// our own `RUSTFLAGS` and thus, we need to remove this. Otherwise cargo favors this
 		// env variable.


### PR DESCRIPTION

✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏 Please make sure it follows the contribution guidelines outlined in
[this document](https://github.com/paritytech/polkadot-sdk/blob/master/docs/CONTRIBUTING.md) and fill
out the sections below. Once you're ready to submit your PR for review, please
delete this section and leave only the text under the "Description" heading.

# Description

*Please include a summary of the changes and the related issue. Please also include relevant motivation and context,
including:*

- What does this PR do?

make 'substrate-wasm-builder' manually set 'CARGO_TARGET_DIR' to '$project_dir/target' while building instead of unset 'CARGO_TARGET_DIR';

- Why are these changes needed?

If you using this in the `build.rs` with following content in your `~/.cargo/config.toml':

    [build]
    target-dir = "target"

the build process will stuck because of dead lock -- two `cargo build` on same target directory in the same time.
There is already an attempt to avoid such dead lock by unset the `CARGO_TARGET_DIR`, but for users with config above in his build enviroment (like me), this workaround won't work.

- How were these changes implemented and what do they affect?

Instead of unset 'CARGO_TARGET_DIR', we set 'CARGO_TARGET_DIR' to '$project/target/', which is already assumed to be true by rest of the code.

*Use [Github semantic
linking](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
to address any open issues this PR relates to or closes.*

Fixes # (issue number, *if applicable*)

Closes # (issue number, *if applicable*)

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!

✄ -----------------------------------------------------------------------------

I have built my project with this fix, there's still some warnings with `build.target-dir` set but the building process won't hang.
I haven't found related issue in this repo. But I did find one issue [here](https://github.com/substrate-developer-hub/substrate-node-template/issues/116).