### PR TITLE
add `extrinsic_state_version` to RuntimeVersion and bump CoreApi version to 5

### DIFF
--- a/cumulus/pallets/parachain-system/src/mock.rs
+++ b/cumulus/pallets/parachain-system/src/mock.rs
@@ -65,6 +65,7 @@ parameter_types! {
 		apis: sp_version::create_apis_vec!([]),
 		transaction_version: 1,
 		state_version: 1,
+		extrinsic_state_version: 0,
 	};
 	pub const ParachainId: ParaId = ParaId::new(200);
 	pub const ReservedXcmpWeight: Weight = Weight::zero();

--- a/cumulus/parachain-template/runtime/src/lib.rs
+++ b/cumulus/parachain-template/runtime/src/lib.rs
@@ -187,6 +187,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// This determines the average expected block time that we are targeting.

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -116,6 +116,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 #[cfg(not(feature = "state-trie-version-1"))]
@@ -129,6 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -114,6 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 14,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -206,6 +206,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -180,6 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -121,6 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -138,6 +138,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -134,6 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -125,6 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -104,6 +104,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -129,6 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -129,6 +129,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/cumulus/parachains/runtimes/starters/seedling/src/lib.rs
@@ -80,6 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/starters/shell/src/lib.rs
+++ b/cumulus/parachains/runtimes/starters/shell/src/lib.rs
@@ -88,6 +88,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -236,6 +236,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// This determines the average expected block time that we are targeting.

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -113,6 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 6000;

--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -103,6 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 #[cfg(feature = "increment-spec-version")]
@@ -117,6 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 12000;

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -158,6 +158,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 24,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The BABE epoch configuration at genesis.

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -112,6 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The BABE epoch configuration at genesis.

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -152,6 +152,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 24,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The BABE epoch configuration at genesis.

--- a/substrate/bin/minimal/runtime/src/lib.rs
+++ b/substrate/bin/minimal/runtime/src/lib.rs
@@ -43,6 +43,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/substrate/bin/node-template/runtime/src/lib.rs
+++ b/substrate/bin/node-template/runtime/src/lib.rs
@@ -108,6 +108,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// This determines the average expected block time that we are targeting.

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -162,6 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 /// The BABE epoch configuration at genesis.

--- a/substrate/client/executor/src/wasm_runtime.rs
+++ b/substrate/client/executor/src/wasm_runtime.rs
@@ -504,6 +504,7 @@ mod tests {
 			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 3)]),
 			transaction_version: 3,
 			state_version: 4,
+			extrinsic_state_version: 0,
 		};
 
 		let version = decode_version(&old_runtime_version.encode()).unwrap();
@@ -516,14 +517,16 @@ mod tests {
 			authoring_version: 1,
 			spec_version: 1,
 			impl_version: 1,
-			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 4)]),
+			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 5)]),
 			transaction_version: 3,
 			state_version: 4,
+			extrinsic_state_version: 1,
 		};
 
 		let version = decode_version(&old_runtime_version.encode()).unwrap();
 		assert_eq!(3, version.transaction_version);
 		assert_eq!(4, version.state_version);
+		assert_eq!(1, version.extrinsic_state_version);
 	}
 
 	#[test]
@@ -542,6 +545,7 @@ mod tests {
 			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 4)]),
 			transaction_version: 100,
 			state_version: 1,
+			extrinsic_state_version: 0,
 		};
 
 		let embedded = sp_version::embed::embed_runtime_version(&wasm, runtime_version.clone())

--- a/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
@@ -245,11 +245,12 @@ async fn follow_with_runtime() {
 
 	// it is basically json-encoded substrate_test_runtime_client::runtime::VERSION
 	let runtime_str = "{\"specName\":\"test\",\"implName\":\"parity-test\",\"authoringVersion\":0,\
-		\"specVersion\":2,\"implVersion\":2,\"apis\":[[\"0xdf6acb689907609b\",4],\
+		\"specVersion\":2,\"implVersion\":2,\"apis\":[[\"0xdf6acb689907609b\",5],\
 		[\"0x37e397fc7c91f5e4\",2],[\"0xd2bc9897eed08f15\",3],[\"0x40fe3ad401f8959a\",6],\
 		[\"0xbc9d89904f5b923f\",1],[\"0xc6e9a76309f39b09\",2],[\"0xdd718d5cc53262d4\",1],\
 		[\"0xcbca25e39f142387\",2],[\"0xf78b278be53f454c\",2],[\"0xab3c0572291feb8b\",1],\
-		[\"0xed99c5acb25eedf5\",3],[\"0xfbc577b9d747efd6\",1]],\"transactionVersion\":1,\"stateVersion\":0}";
+		[\"0xed99c5acb25eedf5\",3],[\"0xfbc577b9d747efd6\",1]],\"transactionVersion\":1,\"stateVersion\":0,\
+		\"extrinsicStateVersion\":0}";
 
 	let runtime: RuntimeVersion = serde_json::from_str(runtime_str).unwrap();
 

--- a/substrate/client/rpc/src/state/tests.rs
+++ b/substrate/client/rpc/src/state/tests.rs
@@ -526,11 +526,12 @@ async fn should_return_runtime_version() {
 
 	// it is basically json-encoded substrate_test_runtime_client::runtime::VERSION
 	let result = "{\"specName\":\"test\",\"implName\":\"parity-test\",\"authoringVersion\":1,\
-		\"specVersion\":2,\"implVersion\":2,\"apis\":[[\"0xdf6acb689907609b\",4],\
+		\"specVersion\":2,\"implVersion\":2,\"apis\":[[\"0xdf6acb689907609b\",5],\
 		[\"0x37e397fc7c91f5e4\",2],[\"0xd2bc9897eed08f15\",3],[\"0x40fe3ad401f8959a\",6],\
 		[\"0xbc9d89904f5b923f\",1],[\"0xc6e9a76309f39b09\",2],[\"0xdd718d5cc53262d4\",1],\
 		[\"0xcbca25e39f142387\",2],[\"0xf78b278be53f454c\",2],[\"0xab3c0572291feb8b\",1],\
-		[\"0xed99c5acb25eedf5\",3],[\"0xfbc577b9d747efd6\",1]],\"transactionVersion\":1,\"stateVersion\":1}";
+		[\"0xed99c5acb25eedf5\",3],[\"0xfbc577b9d747efd6\",1]],\"transactionVersion\":1,\"stateVersion\":1,\
+		\"extrinsicStateVersion\":0}";
 
 	let runtime_version = api.runtime_version(None.into()).unwrap();
 	let serialized = serde_json::to_string(&runtime_version).unwrap();

--- a/substrate/frame/support/test/compile_pass/src/lib.rs
+++ b/substrate/frame/support/test/compile_pass/src/lib.rs
@@ -41,6 +41,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: sp_version::create_apis_vec!([]),
 	transaction_version: 0,
 	state_version: 0,
+	extrinsic_state_version: 0,
 };
 
 pub type Signature = sr25519::Signature;

--- a/substrate/frame/system/src/mock.rs
+++ b/substrate/frame/system/src/mock.rs
@@ -48,6 +48,7 @@ parameter_types! {
 		apis: sp_version::create_apis_vec!([]),
 		transaction_version: 1,
 		state_version: 1,
+		extrinsic_state_version: 0,
 	};
 	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
 		read: 10,

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -21,14 +21,13 @@ use frame_support::{
 	dispatch::{Pays, PostDispatchInfo, WithPostDispatchInfo},
 	traits::{OnRuntimeUpgrade, WhitelistedStorageKeys},
 };
-use std::collections::BTreeSet;
-
 use mock::{RuntimeOrigin, *};
-use sp_core::{hexdisplay::HexDisplay, H256};
+use sp_core::{hexdisplay::HexDisplay, storage::StateVersion, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, Header},
 	DispatchError, DispatchErrorWithPostInfo,
 };
+use std::collections::BTreeSet;
 
 #[test]
 fn check_whitelist() {
@@ -761,7 +760,8 @@ fn extrinsics_root_is_calculated_correctly() {
 		System::note_finished_extrinsics();
 		let header = System::finalize();
 
-		let ext_root = extrinsics_data_root::<BlakeTwo256>(vec![vec![1], vec![2]]);
+		let ext_root =
+			extrinsics_data_root::<BlakeTwo256>(vec![vec![1], vec![2]], StateVersion::V0);
 		assert_eq!(ext_root, *header.extrinsics_root());
 	});
 }

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -334,6 +334,7 @@ pub use sp_api_proc_macro::decl_runtime_apis;
 ///     apis: RUNTIME_API_VERSIONS,
 ///     transaction_version: 1,
 ///     state_version: 1,
+///     extrinsic_state_version: 0,
 /// };
 ///
 /// # fn main() {}
@@ -797,7 +798,7 @@ pub fn deserialize_runtime_api_info(bytes: [u8; RUNTIME_API_INFO_SIZE]) -> ([u8;
 decl_runtime_apis! {
 	/// The `Core` runtime api that every Substrate runtime needs to implement.
 	#[core_trait]
-	#[api_version(4)]
+	#[api_version(5)]
 	pub trait Core {
 		/// Returns the version of the runtime.
 		fn version() -> RuntimeVersion;

--- a/substrate/primitives/version/proc-macro/src/decl_runtime_version.rs
+++ b/substrate/primitives/version/proc-macro/src/decl_runtime_version.rs
@@ -64,6 +64,7 @@ struct RuntimeVersion {
 	apis: u8,
 	transaction_version: u32,
 	state_version: u8,
+	extrinsic_state_version: u8,
 }
 
 #[derive(Default, Debug)]
@@ -75,6 +76,7 @@ struct ParseRuntimeVersion {
 	impl_version: Option<u32>,
 	transaction_version: Option<u32>,
 	state_version: Option<u8>,
+	extrinsic_state_version: Option<u8>,
 }
 
 impl ParseRuntimeVersion {
@@ -126,6 +128,8 @@ impl ParseRuntimeVersion {
 			parse_once(&mut self.transaction_version, field_value, Self::parse_num_literal)?;
 		} else if field_name == "state_version" {
 			parse_once(&mut self.state_version, field_value, Self::parse_num_literal_u8)?;
+		} else if field_name == "extrinsic_state_version" {
+			parse_once(&mut self.extrinsic_state_version, field_value, Self::parse_num_literal_u8)?;
 		} else if field_name == "apis" {
 			// Intentionally ignored
 			//
@@ -199,6 +203,7 @@ impl ParseRuntimeVersion {
 			impl_version,
 			transaction_version,
 			state_version,
+			extrinsic_state_version,
 		} = self;
 
 		Ok(RuntimeVersion {
@@ -210,6 +215,7 @@ impl ParseRuntimeVersion {
 			transaction_version: required!(transaction_version),
 			state_version: required!(state_version),
 			apis: 0,
+			extrinsic_state_version: extrinsic_state_version.unwrap_or(0),
 		})
 	}
 }
@@ -241,6 +247,7 @@ mod tests {
 			apis: 0,
 			transaction_version: 2,
 			state_version: 1,
+			extrinsic_state_version: 0,
 		}
 		.encode();
 
@@ -256,6 +263,7 @@ mod tests {
 				apis: Cow::Owned(vec![]),
 				transaction_version: 2,
 				state_version: 1,
+				extrinsic_state_version: 0
 			},
 		);
 	}

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -115,6 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 1,
+	extrinsic_state_version: 0,
 };
 
 fn version() -> RuntimeVersion {


### PR DESCRIPTION
# Description

- What does this PR do?
Adds `extrinsic_state_version` field to RuntimeVersion so that projects can pick V0/V1 depending on the use case.
- Why are these changes needed?
Currently extrinsic root is derived using StateVersion::V0. In order to generate the extrinsic root, we would need to have access to full extrinsic data. We have a use case where, domains extrinsic root need to be derived on consensus runtime and passing all the extrinsic data through Fraud proof will exceed block limit. We are planning to use StateVersion::V1 so that we can just use extrinsic hashes if the extrinsic data is more than 32 bytes.
- How were these changes implemented and what do they affect?
Field `extrinsic_state_version` is added to RuntimeVersion struct and `CoreApi` version is bumped to 5. `CoreApi version < 5` always leads to `StateVersion::V0` while `CoreApi verision >= 5` can let projects to pick ether V0 or V1

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

