### PR TITLE
Update wasm-opt to 0.116

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19522,9 +19522,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.114.1"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d005a95f934878a1fb446a816d51c3601a0120ff929005ba3bab3c749cfd1c7"
+checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
 dependencies = [
  "anyhow",
  "libc",
@@ -19538,9 +19538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.114.1"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d04e240598162810fad3b2e96fa0dec6dba1eb65a03f3bd99a9248ab8b56caa"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
 dependencies = [
  "anyhow",
  "cxx",
@@ -19550,9 +19550,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.114.1"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efd2aaca519d64098c4faefc8b7433a97ed511caf4c9e516384eb6aef1ff4f9"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
 dependencies = [
  "anyhow",
  "cc",

--- a/substrate/utils/wasm-builder/Cargo.toml
+++ b/substrate/utils/wasm-builder/Cargo.toml
@@ -22,5 +22,5 @@ toml = "0.7.3"
 walkdir = "2.3.2"
 sp-maybe-compressed-blob = { path = "../../primitives/maybe-compressed-blob" }
 filetime = "0.2.16"
-wasm-opt = "0.114"
+wasm-opt = "0.116"
 parity-wasm = "0.45"


### PR DESCRIPTION
Just keeping wasm-opt up to date.

I don't see anything in the [binaryen changelog](https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md) that should affect substrate.

This release includes dwarf passes that were accidentally omitted from previous versions of the wasm-opt crate. I suspect this will not affect substrate as their omission hasn't been noticed until recently.