### PR TITLE
polkadot: enable tikv-jemallocator/unprefixed_malloc_on_supported_platforms

### DIFF
--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -23,7 +23,7 @@ default-run = "polkadot"
 
 [dependencies]
 color-eyre = { version = "0.6.1", default-features = false }
-tikv-jemallocator = { version = "0.5.0", optional = true }
+tikv-jemallocator = { version = "0.5.0", optional = true, features = [ "unprefixed_malloc_on_supported_platforms" ] }
 
 # Crates in our workspace, defined as dependencies so we can pass them feature flags.
 polkadot-cli = { path = "cli", features = [ "westend-native", "rococo-native" ]  }
@@ -36,7 +36,7 @@ polkadot-node-core-pvf-common = { path = "node/core/pvf/common" }
 polkadot-node-core-pvf-execute-worker = { path = "node/core/pvf/execute-worker" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemallocator = "0.5.0"
+tikv-jemallocator = { version = "0.5.0", features = [ "unprefixed_malloc_on_supported_platforms" ] }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"


### PR DESCRIPTION
This is indirectly enabled by rocksdb crate, better to make it explicit (https://github.com/tikv/rust-rocksdb/blob/2096b9a161f93e437f7adee49e68cd1570aea42f/librocksdb_sys/Cargo.toml#L35-L38).