### PR TITLE
Simplify PayOverXcm

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/treasury.rs
@@ -16,7 +16,6 @@
 use crate::*;
 use frame_support::traits::fungibles::{Create, Inspect, Mutate};
 use integration_tests_common::constants::accounts::{ALICE, BOB};
-use polkadot_runtime_common::impls::VersionedLocatableAsset;
 use xcm_executor::traits::ConvertLocation;
 
 #[test]
@@ -34,12 +33,12 @@ fn create_and_claim_treasury_spend() {
 	let asset_hub_location = MultiLocation::new(0, Parachain(AssetHubWestend::para_id().into()));
 	let root = <Westend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spend from the treasury.
-	let asset_kind = VersionedLocatableAsset::V3 {
-		location: asset_hub_location,
-		asset_id: AssetId::Concrete((PalletInstance(50), GeneralIndex(ASSET_ID.into())).into()),
-	};
+	let asset_kind = AssetId::Concrete((PalletInstance(50), GeneralIndex(ASSET_ID.into())).into());
 	// treasury spend beneficiary.
 	let alice: AccountId = Westend::account_id_of(ALICE);
+	let alice_location_in_asset_hub = asset_hub_location
+		.pushed_with_interior(AccountId32 { id: alice.clone().into(), network: None })
+		.unwrap();
 	let bob: AccountId = Westend::account_id_of(BOB);
 	let bob_signed = <Westend as Chain>::RuntimeOrigin::signed(bob.clone());
 

--- a/polkadot/runtime/common/src/impls.rs
+++ b/polkadot/runtime/common/src/impls.rs
@@ -98,47 +98,6 @@ pub fn era_payout(
 	(staking_payout, rest)
 }
 
-#[cfg(feature = "runtime-benchmarks")]
-pub mod benchmarks {
-	use pallet_asset_rate::AssetKindFactory;
-	use pallet_treasury::ArgumentsFactory as TreasuryArgumentsFactory;
-	use xcm::prelude::*;
-
-	/// Provides a factory method for the [`VersionedLocatableAsset`].
-	/// The location of the asset is determined as a Parachain with an ID equal to the passed seed.
-	pub struct AssetRateArguments;
-	impl AssetKindFactory<VersionedLocatableAsset> for AssetRateArguments {
-		fn create_asset_kind(seed: u32) -> VersionedLocatableAsset {
-			VersionedLocatableAsset::V3 {
-				location: xcm::v3::MultiLocation::new(0, X1(Parachain(seed))),
-				asset_id: xcm::v3::MultiLocation::new(
-					0,
-					X2(PalletInstance(seed.try_into().unwrap()), GeneralIndex(seed.into())),
-				)
-				.into(),
-			}
-		}
-	}
-
-	/// Provide factory methods for the [`VersionedLocatableAsset`] and the `Beneficiary` of the
-	/// [`VersionedMultiLocation`]. The location of the asset is determined as a Parachain with an
-	/// ID equal to the passed seed.
-	pub struct TreasuryArguments;
-	impl TreasuryArgumentsFactory<VersionedLocatableAsset, VersionedMultiLocation>
-		for TreasuryArguments
-	{
-		fn create_asset_kind(seed: u32) -> VersionedLocatableAsset {
-			AssetRateArguments::create_asset_kind(seed)
-		}
-		fn create_beneficiary(seed: [u8; 32]) -> VersionedMultiLocation {
-			VersionedMultiLocation::V3(xcm::v3::MultiLocation::new(
-				0,
-				X1(AccountId32 { network: None, id: seed }),
-			))
-		}
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -31,9 +31,7 @@ use primitives::{
 };
 use runtime_common::{
 	assigned_slots, auctions, claims, crowdloan, impl_runtime_weights,
-	impls::{
-		LocatableAssetConverter, ToAuthor, VersionedLocatableAsset, VersionedMultiLocationConverter,
-	},
+	impls::ToAuthor,
 	paras_registrar, paras_sudo_wrapper, prod_or_fast, slots, BlockHashCount, BlockLength,
 	SlowAdjustingFeeUpdate,
 };
@@ -96,7 +94,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use xcm::{
 	latest::{InteriorMultiLocation, Junction, Junction::PalletInstance},
-	VersionedMultiLocation,
+	VersionedMultiLocation, VersionedAssetId,
 };
 use xcm_builder::PayOverXcm;
 
@@ -428,7 +426,7 @@ impl pallet_treasury::Config for Runtime {
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
 	type SpendFunds = Bounties;
 	type SpendOrigin = TreasurySpender;
-	type AssetKind = VersionedLocatableAsset;
+	type AssetKind = VersionedAssetId;
 	type Beneficiary = VersionedMultiLocation;
 	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
 	type Paymaster = PayOverXcm<
@@ -436,10 +434,6 @@ impl pallet_treasury::Config for Runtime {
 		crate::xcm_config::XcmRouter,
 		crate::XcmPallet,
 		ConstU32<{ 6 * HOURS }>,
-		Self::Beneficiary,
-		Self::AssetKind,
-		LocatableAssetConverter,
-		VersionedMultiLocationConverter,
 	>;
 	type BalanceConverter = AssetRate;
 	type PayoutPeriod = PayoutSpendPeriod;

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -56,9 +56,7 @@ use runtime_common::{
 	assigned_slots, auctions, crowdloan,
 	elections::OnChainAccuracy,
 	impl_runtime_weights,
-	impls::{
-		LocatableAssetConverter, ToAuthor, VersionedLocatableAsset, VersionedMultiLocationConverter,
-	},
+	impls::ToAuthor,
 	paras_registrar, paras_sudo_wrapper, prod_or_fast, slots, BalanceToU256, BlockHashCount,
 	BlockLength, CurrencyToVote, SlowAdjustingFeeUpdate, U256ToBalance,
 };
@@ -96,7 +94,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use xcm::{
 	latest::{InteriorMultiLocation, Junction, Junction::PalletInstance},
-	VersionedMultiLocation,
+	VersionedMultiLocation, VersionedAssetId,
 };
 use xcm_builder::PayOverXcm;
 
@@ -742,7 +740,7 @@ impl pallet_treasury::Config for Runtime {
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
 	type SpendFunds = ();
 	type SpendOrigin = TreasurySpender;
-	type AssetKind = VersionedLocatableAsset;
+	type AssetKind = VersionedAssetId;
 	type Beneficiary = VersionedMultiLocation;
 	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
 	type Paymaster = PayOverXcm<
@@ -750,10 +748,6 @@ impl pallet_treasury::Config for Runtime {
 		crate::xcm_config::XcmRouter,
 		crate::XcmPallet,
 		ConstU32<{ 6 * HOURS }>,
-		Self::Beneficiary,
-		Self::AssetKind,
-		LocatableAssetConverter,
-		VersionedMultiLocationConverter,
 	>;
 	type BalanceConverter = AssetRate;
 	type PayoutPeriod = PayoutSpendPeriod;

--- a/polkadot/xcm/xcm-builder/src/lib.rs
+++ b/polkadot/xcm/xcm-builder/src/lib.rs
@@ -112,4 +112,4 @@ mod origin_aliases;
 pub use origin_aliases::AliasForeignAccountId32;
 
 mod pay;
-pub use pay::{FixedLocation, LocatableAssetId, PayAccountId32OnChainOverXcm, PayOverXcm};
+pub use pay::PayOverXcm;

--- a/polkadot/xcm/xcm-builder/src/location_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/location_conversion.rs
@@ -18,7 +18,7 @@ use crate::universal_exports::ensure_is_remote;
 use frame_support::traits::Get;
 use parity_scale_codec::{Compact, Decode, Encode};
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput, TryConvert};
+use sp_runtime::traits::{AccountIdConversion, TrailingZeroInput, TryConvert, Convert};
 use sp_std::{marker::PhantomData, prelude::*};
 use xcm::latest::prelude::*;
 use xcm_executor::traits::ConvertLocation;
@@ -366,11 +366,18 @@ impl<TreasuryAccount: Get<AccountId>, AccountId: From<[u8; 32]> + Into<[u8; 32]>
 /// `MultiLocation` consisting solely of a `AccountId32` junction with a fixed value for its
 /// network (provided by `Network`) and the `AccountId`'s `[u8; 32]` datum for the `id`.
 pub struct AliasesIntoAccountId32<Network, AccountId>(PhantomData<(Network, AccountId)>);
-impl<'a, Network: Get<Option<NetworkId>>, AccountId: Clone + Into<[u8; 32]> + Clone>
+impl<'a, Network: Get<Option<NetworkId>>, AccountId: Clone + Into<[u8; 32]>>
 	TryConvert<&'a AccountId, MultiLocation> for AliasesIntoAccountId32<Network, AccountId>
 {
 	fn try_convert(who: &AccountId) -> Result<MultiLocation, &AccountId> {
 		Ok(AccountId32 { network: Network::get(), id: who.clone().into() }.into())
+	}
+}
+impl<'a, Network: Get<Option<NetworkId>>, AccountId: Clone + Into<[u8; 32]>>
+	Convert<AccountId, MultiLocation> for AliasesIntoAccountId32<Network, AccountId>
+{
+	fn convert(who: AccountId) -> MultiLocation {
+		AccountId32 { network: Network::get(), id: who.into() }.into()
 	}
 }
 

--- a/polkadot/xcm/xcm-builder/src/pay.rs
+++ b/polkadot/xcm/xcm-builder/src/pay.rs
@@ -26,12 +26,7 @@ use xcm_executor::traits::{QueryHandler, QueryResponseStatus};
 
 /// Implementation of the `frame_support::traits::tokens::Pay` trait, to allow
 /// for XCM-based payments of a given `Balance` of some asset ID existing on some chain under
-/// ownership of some `Interior` location of the local chain to a particular `Beneficiary`. The
-/// `AssetKind` value is not itself bounded (to avoid the issue of needing to wrap some preexisting
-/// datatype), however a converter type `AssetKindToLocatableAsset` must be provided in order to
-/// translate it into a `LocatableAsset`, which comprises both an XCM `MultiLocation` describing
-/// the XCM endpoint on which the asset to be paid resides and an XCM `AssetId` to identify the
-/// specific asset at that endpoint.
+/// ownership of some `Interior` location of the local chain to a particular `Beneficiary`.
 ///
 /// `PayOverXcm::pay` is asynchronous, and returns a `QueryId` which can then be used in
 /// `check_payment` to check the status of the XCM transaction.

--- a/polkadot/xcm/xcm-builder/src/pay.rs
+++ b/polkadot/xcm/xcm-builder/src/pay.rs
@@ -51,8 +51,8 @@ impl<
 	> Pay
 	for PayOverXcm<Interior, Router, Querier, Timeout>
 {
-	type Beneficiary = MultiLocation;
-	type AssetKind = AssetId;
+	type Beneficiary = VersionedMultiLocation;
+	type AssetKind = VersionedAssetId;
 	type Balance = u128;
 	type Id = Querier::QueryId;
 	type Error = xcm::latest::Error;
@@ -62,6 +62,9 @@ impl<
 		asset_kind: Self::AssetKind,
 		amount: Self::Balance,
 	) -> Result<Self::Id, Self::Error> {
+		let who: MultiLocation = who.clone().try_into().map_err(|_| Self::Error::UnhandledXcmVersion)?;
+		let asset_kind: AssetId = asset_kind.try_into().map_err(|_| Self::Error::UnhandledXcmVersion)?;
+
 		let (destination, beneficiary) = who.split_last_interior();
 		let beneficiary: MultiLocation = beneficiary
 			.ok_or(Self::Error::InvalidLocation)?

--- a/polkadot/xcm/xcm-builder/src/tests/pay/mock.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/pay/mock.rs
@@ -64,20 +64,11 @@ parameter_types! {
 	pub const ExistentialDeposit: Balance = 1;
 }
 
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Test {
-	type MaxLocks = ConstU32<0>;
 	type Balance = Balance;
-	type RuntimeEvent = RuntimeEvent;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
-	type WeightInfo = ();
-	type MaxReserves = ();
-	type ReserveIdentifier = [u8; 8];
-	type RuntimeHoldReason = RuntimeHoldReason;
-	type FreezeIdentifier = ();
-	type MaxHolds = ConstU32<0>;
-	type MaxFreezes = ConstU32<0>;
+	type ExistentialDeposit = ExistentialDeposit;
 }
 
 parameter_types! {

--- a/polkadot/xcm/xcm-builder/src/tests/pay/mod.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/pay/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+//! Tests for the `PayOverXcm` struct.
+
 use super::*;
 
 mod mock;

--- a/polkadot/xcm/xcm-simulator/example/src/lib.rs
+++ b/polkadot/xcm/xcm-simulator/example/src/lib.rs
@@ -649,4 +649,17 @@ mod tests {
 			);
 		});
 	}
+
+	#[test]
+	fn testing_location_stuff() {
+		let location: MultiLocation = (Parent, Parachain(1000), AccountId32 {
+			id: [0u8; 32],
+			network: None,
+		}).into();
+		let (prefix, last) = location.split_last_interior();
+		dbg!(&prefix);
+		dbg!(&last);
+		// let junction = location.match_and_split(&(Parent, Parachain(1000)).into());
+		// dbg!(&junction);
+	}
 }

--- a/substrate/frame/salary/src/benchmarking.rs
+++ b/substrate/frame/salary/src/benchmarking.rs
@@ -107,7 +107,7 @@ mod benchmarks {
 		System::<T>::set_block_number(System::<T>::block_number() + T::RegistrationPeriod::get());
 
 		let salary = T::Salary::get_salary(T::Members::rank_of(&caller).unwrap(), &caller);
-		T::Paymaster::ensure_successful(&caller, (), salary);
+		T::Paymaster::ensure_successful(&caller, T::SalaryAsset::get(), salary);
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()));
@@ -134,7 +134,7 @@ mod benchmarks {
 
 		let salary = T::Salary::get_salary(T::Members::rank_of(&caller).unwrap(), &caller);
 		let recipient: T::AccountId = account("recipient", 0, SEED);
-		T::Paymaster::ensure_successful(&recipient, (), salary);
+		T::Paymaster::ensure_successful(&recipient, T::SalaryAsset::get(), salary);
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), recipient.clone());
@@ -161,7 +161,7 @@ mod benchmarks {
 
 		let salary = T::Salary::get_salary(T::Members::rank_of(&caller).unwrap(), &caller);
 		let recipient: T::AccountId = account("recipient", 0, SEED);
-		T::Paymaster::ensure_successful(&recipient, (), salary);
+		T::Paymaster::ensure_successful(&recipient, T::SalaryAsset::get(), salary);
 		Salary::<T, I>::payout(RawOrigin::Signed(caller.clone()).into()).unwrap();
 		let id = match Claimant::<T, I>::get(&caller).unwrap().status {
 			Attempted { id, .. } => id,

--- a/substrate/frame/salary/src/tests.rs
+++ b/substrate/frame/salary/src/tests.rs
@@ -49,6 +49,7 @@ parameter_types! {
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(Weight::from_parts(1_000_000, 0));
 }
+
 impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
@@ -167,11 +168,15 @@ fn set_rank(who: u64, rank: u64) {
 
 parameter_types! {
 	pub static Budget: u64 = 10;
+	pub SalaryAsset: () = ();
 }
 
 impl Config for Test {
 	type WeightInfo = ();
 	type RuntimeEvent = RuntimeEvent;
+	type AssetKind = ();
+	type SalaryAsset = SalaryAsset;
+	type AccountToBeneficiaryConverter = Identity;
 	type Paymaster = TestPay;
 	type Members = TestClub;
 	type Salary = ConvertRank<Identity>;


### PR DESCRIPTION
`PayOverXcm` had quite a lot of hacks that arose from how non-generic the salary pallet was.
This PR aims to simplify it to make things easier to reason about, as well as to allow easier customization.

The location to send the message was being codified into the asset, but the system broke if your beneficiary was not in the given destination, hence it's better to couple it in the `beneficiary` argument itself.
Now the beneficiary is a full fledged location, it is split and the last part is used as the account, while the first part is used as the destination to route the XCM program.

## Open question
The best would be to make pallet salary support `MultiLocation`s as ids for the members of the collective.
Would this break anything with the fellowship?
I think not since their accounts should be in AssetHub for salaries to work anyway.
We should then migrate the collective to using this type.
