### PR TITLE
Contracts: Add benchmarks to include files

### DIFF
--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://substrate.io"
 repository.workspace = true
 description = "FRAME pallet for WASM contracts"
 readme = "README.md"
-include = ["src/**/*", "build.rs", "README.md", "CHANGELOG.md"]
+include = ["src/**/*", "benchmarks/**", "build.rs", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Project that includes pallet-contracts via crates.io will fail to run 
```bash
cargo check --features=runtime-benchmarks
```

without the currently not included benchmarks files