### PR TITLE
Wasm Builder: Allow explicitly disabling features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
 dependencies = [
  "aead 0.5.2",
  "aes 0.8.3",
@@ -17419,7 +17419,7 @@ dependencies = [
 name = "sp-statement-store"
 version = "4.0.0-dev"
 dependencies = [
- "aes-gcm 0.10.3",
+ "aes-gcm 0.10.2",
  "curve25519-dalek 4.0.0",
  "ed25519-dalek",
  "hkdf",
@@ -19961,7 +19961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a00f4242f2db33307347bd5be53263c52a0331c96c14292118c9a6bb48d267"
 dependencies = [
  "aes 0.6.0",
- "aes-gcm 0.10.3",
+ "aes-gcm 0.10.2",
  "async-trait",
  "bincode",
  "block-modes",

--- a/substrate/utils/wasm-builder/src/builder.rs
+++ b/substrate/utils/wasm-builder/src/builder.rs
@@ -48,6 +48,7 @@ impl WasmBuilderSelectProject {
 			file_name: None,
 			project_cargo_toml: get_manifest_dir().join("Cargo.toml"),
 			features_to_enable: Vec::new(),
+			features_to_disable: Vec::new(),
 			disable_runtime_version_section_check: false,
 		}
 	}
@@ -64,6 +65,7 @@ impl WasmBuilderSelectProject {
 				file_name: None,
 				project_cargo_toml: path,
 				features_to_enable: Vec::new(),
+				features_to_disable: Vec::new(),
 				disable_runtime_version_section_check: false,
 			})
 		} else {
@@ -95,6 +97,8 @@ pub struct WasmBuilder {
 	project_cargo_toml: PathBuf,
 	/// Features that should be enabled when building the wasm binary.
 	features_to_enable: Vec<String>,
+	/// Features that should NOT be enabled when building the wasm binary.
+	features_to_disable: Vec<String>,
 	/// Should the builder not check that the `runtime_version` section exists in the wasm binary?
 	disable_runtime_version_section_check: bool,
 }
@@ -147,6 +151,14 @@ impl WasmBuilder {
 		self
 	}
 
+	/// Disable the given feature when building the wasm binary.
+	///
+	/// `feature` does not need to be a valid feature that is defined in the project `Cargo.toml`.
+	pub fn disable_feature(mut self, feature: impl Into<String>) -> Self {
+		self.features_to_disable.push(feature.into());
+		self
+	}
+
 	/// Disable the check for the `runtime_version` wasm section.
 	///
 	/// By default the `wasm-builder` will ensure that the `runtime_version` section will
@@ -179,6 +191,7 @@ impl WasmBuilder {
 			self.project_cargo_toml,
 			self.rust_flags.into_iter().map(|f| format!("{} ", f)).collect(),
 			self.features_to_enable,
+			self.features_to_disable,
 			self.file_name,
 			!self.disable_runtime_version_section_check,
 		);
@@ -252,6 +265,7 @@ fn build_project(
 	project_cargo_toml: PathBuf,
 	default_rustflags: String,
 	features_to_enable: Vec<String>,
+	features_to_disable: Vec<String>,
 	wasm_binary_name: Option<String>,
 	check_for_runtime_version_section: bool,
 ) {
@@ -268,6 +282,7 @@ fn build_project(
 		&default_rustflags,
 		cargo_cmd,
 		features_to_enable,
+		features_to_disable,
 		wasm_binary_name,
 		check_for_runtime_version_section,
 	);

--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -116,6 +116,7 @@ pub(crate) fn create_and_compile(
 	default_rustflags: &str,
 	cargo_cmd: CargoCommandVersioned,
 	features_to_enable: Vec<String>,
+	features_to_disable: Vec<String>,
 	bloaty_blob_out_name_override: Option<String>,
 	check_for_runtime_version_section: bool,
 ) -> (Option<WasmBinary>, WasmBinaryBloaty) {
@@ -130,6 +131,7 @@ pub(crate) fn create_and_compile(
 		&crate_metadata,
 		crate_metadata.workspace_root.as_ref(),
 		features_to_enable,
+		features_to_disable,
 	);
 
 	let build_config = BuildConfiguration::detect(&project);
@@ -532,6 +534,7 @@ fn create_project(
 	crate_metadata: &Metadata,
 	workspace_root_path: &Path,
 	features_to_enable: Vec<String>,
+	features_to_disable: Vec<String>,
 ) -> PathBuf {
 	let crate_name = get_crate_name(project_cargo_toml);
 	let crate_path = project_cargo_toml.parent().expect("Parent path exists; qed");
@@ -550,6 +553,9 @@ fn create_project(
 
 	let mut enabled_features = enabled_features.into_iter().collect::<HashSet<_>>();
 	enabled_features.extend(features_to_enable.into_iter());
+	for feature_to_disable in &features_to_disable {
+		enabled_features.remove(feature_to_disable);
+	}
 
 	create_project_cargo_toml(
 		&wasm_project_folder,


### PR DESCRIPTION
This PR makes the Substrate Wasm Builder slightly more flexible by allowing users to explicitly disable certain features when building their runtimes' wasm binaries.

Before this PR, the wasm builder already allow _en_abling specific features, but not _dis_abling them. It included good defaults in terms of what features should be disabled (std and any default features) that work for most runtimes.

The usecase that I have in mind is a runtime that can be compiled for a sovereign chain or a parachain. The features will look basically like this.

```toml
[features]
default = [ "std" ]
std = [
	"parity-scale-codec/std",
	"sp-core/std",
	# ...
]
parachain = [
	"cumulus-primitives-core",
	"cumulus-pallet-parachain-system",
	# ...
]
parachain-std = [
	"parachain",
	"std",
	"cumulus-primitives-core/std",
	"cumulus-pallet-parachain-system/std",
	# ...
]
```

The trouble comes when I try to build the parachain node. I need the feature `parachain-std` on the client side, but I only need `parachain` in the wasm. Therefore I need to explicitly disable `parachain-std` when building the wasm.