### PR TITLE
Automatically build and attach production and dev runtimes to GH releases

### DIFF
--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -13,10 +13,11 @@ jobs:
           # TODO: Add parachain runtimes
           - { name: westend, package: westend-runtime, path: polkadot/runtime/westend }
           - { name: rococo, package: rococo-runtime, path: polkadot/runtime/rococo }
-        build_type:
-          # No prefix indicates a release build
-          - { prefix: "", build_opts: "--features on-chain-release-build" } 
-          - { prefix: DEBUG_BUILD__, build_opts: "--features try-runtime" }
+        build_config:
+          # Release build has disabled logging and no dev features
+          - { type: on-chain-release, opts: --features on-chain-release-build } 
+          # Debug build has logging and the try-runtime feature
+          - { type: debug-build, opts: --features try-runtime }
 
     runs-on: ubuntu-22.04
 
@@ -28,21 +29,28 @@ jobs:
       id: srtool_build
       uses: chevdor/srtool-actions@v0.8.0
       env:
-        BUILD_OPTS: ${{ matrix.build_type.build_opts }}
+        BUILD_OPTS: ${{ matrix.build_config.opts }}
       with:
         chain: ${{ matrix.runtime.name }}
         package: ${{ matrix.runtime.package }}
         runtime_dir: ${{ matrix.runtime.path }}
         profile: "production"
 
+    - name: Build Summary
+      run: |
+        echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.runtime.name }}-srtool-digest.json
+        cat ${{ matrix.runtime.name }}-srtool-digest.json
+        echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+
     - name: Upload Runtime to Release
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ./${{ matrix.runtime.path }}/target/srtool/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
-        asset_name: ${{ matrix.build_type.prefix }}$RUNTIME_BLOB_NAME
+        asset_name: $PREFIX$RUNTIME_BLOB_NAME
         asset_content_type: application/octet-stream
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PACKAGE_NAME: ${{ matrix.runtime.package }}
         RUNTIME_BLOB_NAME: $(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+        PREFIX: ${{ matrix.build_config.type == 'debug-build' && 'DEBUG_BUILD__' || '' }}

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -1,0 +1,48 @@
+name: Build and Attach Runtimes to Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build_and_upload:
+    strategy:
+      matrix:
+        runtime:
+          # TODO: Add parachain runtimes
+          - { name: westend, package: westend-runtime, path: relay/westend }
+          - { name: rococo, package: rococo-runtime, path: relay/rococo }
+        build_type:
+          # No prefix indicates a release build
+          - { prefix: "", build_opts: "--features on-chain-release-build" } 
+          - { prefix: DEBUG_BUILD__, build_opts: "--features try-runtime" }
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Build ${{ matrix.runtime.name }}
+      id: srtool_build
+      uses: chevdor/srtool-actions@v0.8.0
+      env:
+        BUILD_OPTS: ${{ matrix.build_type.build_opts }}
+      with:
+        chain: ${{ matrix.runtime.name }}
+        package: ${{ matrix.runtime.package }}
+        runtime_dir: ${{ matrix.runtime.path }}
+        profile: "production"
+
+    - name: Upload Runtime to Release
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ matrix.runtime.path }}/target/srtool/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
+        asset_name: ${{ matrix.build_type.prefix }}$RUNTIME_BLOB_NAME
+        asset_content_type: application/octet-stream
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PACKAGE_NAME: ${{ matrix.runtime.package }}
+        RUNTIME_BLOB_NAME: $(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+env:
+  PROFILE: production
+
 jobs:
   build_and_upload:
     strategy:
@@ -37,7 +40,7 @@ jobs:
         chain: ${{ matrix.runtime.name }}
         package: ${{ matrix.runtime.package }}
         runtime_dir: ${{ matrix.runtime.path }}
-        profile: "production"
+        profile: ${{ env.PROFILE }}
 
     - name: Build Summary
       run: |
@@ -52,7 +55,7 @@ jobs:
         PREFIX=${{ matrix.build_config.type == 'dev-debug-build' && 'DEV_DEBUG_BUILD__' || '' }}
 
         echo "RUNTIME_BLOB_NAME=$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
-        echo "ASSET_PATH=./${{ matrix.runtime.path }}/target/srtool/production/wbuild/${{ matrix.runtime.package }}/$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+        echo "ASSET_PATH=./${{ matrix.runtime.path }}/target/srtool/${{ env.PROFILE }}/wbuild/${{ matrix.runtime.package }}/$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
         echo "ASSET_NAME=$PREFIX$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
 
     - name: Upload Runtime to Release

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -14,7 +14,7 @@ jobs:
           - { name: rococo, package: rococo-runtime, path: polkadot/runtime/rococo }
           - { name: asset-hub-rococo, package: asset-hub-rococo-runtime, path: cumulus/parachains/runtimes/assets/asset-hub-rococo }
           - { name: asset-hub-westend, package: asset-hub-westend-runtime, path: cumulus/parachains/runtimes/assets/asset-hub-westend }
-          - { name: bridge-hub-rococo, package: bridge-hub-rococo-runtime, path: cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend }
+          - { name: bridge-hub-rococo, package: bridge-hub-rococo-runtime, path: cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo }
           - { name: contracts-rococo, package: contracts-rococo-runtime, path: cumulus/parachains/runtimes/contracts/contracts-rococo }
         build_config:
           # Release build has logging disabled and no dev features

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Build ${{ matrix.runtime.name }}
+    - name: Build ${{ matrix.runtime.name }} ${{ matrix.build_config.type }}
       id: srtool_build
       uses: chevdor/srtool-actions@v0.8.0
       env:
@@ -42,15 +42,23 @@ jobs:
         cat ${{ matrix.runtime.name }}-srtool-digest.json
         echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
+    - name: Set up paths and names
+      id: setup
+      run: |
+        echo "PACKAGE_NAME=${{ matrix.runtime.package }}" >> $GITHUB_ENV
+        RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+        echo "RUNTIME_BLOB_NAME=$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+        PREFIX=${{ matrix.build_config.type == 'debug-build' && 'DEBUG_BUILD__' || '' }}
+        echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+        echo "ASSET_PATH=./${{ matrix.runtime.path }}/target/srtool/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+        echo "ASSET_NAME=$PREFIX$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+
     - name: Upload Runtime to Release
       uses: actions/upload-release-asset@v1
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./${{ matrix.runtime.path }}/target/srtool/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
-        asset_name: $PREFIX$RUNTIME_BLOB_NAME
+        asset_path: ${{ env.ASSET_PATH }}
+        asset_name: ${{ env.ASSET_NAME }}
         asset_content_type: application/octet-stream
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PACKAGE_NAME: ${{ matrix.runtime.package }}
-        RUNTIME_BLOB_NAME: $(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
-        PREFIX: ${{ matrix.build_config.type == 'debug-build' && 'DEBUG_BUILD__' || '' }}

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -25,32 +25,31 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Build ${{ matrix.runtime.name }} ${{ matrix.build_config.type }}
-      id: srtool_build
-      uses: chevdor/srtool-actions@v0.8.0
-      env:
-        BUILD_OPTS: ${{ matrix.build_config.opts }}
-      with:
-        chain: ${{ matrix.runtime.name }}
-        package: ${{ matrix.runtime.package }}
-        runtime_dir: ${{ matrix.runtime.path }}
-        profile: "production"
+    # - name: Build ${{ matrix.runtime.name }} ${{ matrix.build_config.type }}
+    #   id: srtool_build
+    #   uses: chevdor/srtool-actions@v0.8.0
+    #   env:
+    #     BUILD_OPTS: ${{ matrix.build_config.opts }}
+    #   with:
+    #     chain: ${{ matrix.runtime.name }}
+    #     package: ${{ matrix.runtime.package }}
+    #     runtime_dir: ${{ matrix.runtime.path }}
+    #     profile: "production"
 
-    - name: Build Summary
-      run: |
-        echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.runtime.name }}-srtool-digest.json
-        cat ${{ matrix.runtime.name }}-srtool-digest.json
-        echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+    # - name: Build Summary
+    #   run: |
+    #     echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.runtime.name }}-srtool-digest.json
+    #     cat ${{ matrix.runtime.name }}-srtool-digest.json
+    #     echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
-    - name: Set up paths and names
+    - name: Set up paths and runtime names
       id: setup
       run: |
-        echo "PACKAGE_NAME=${{ matrix.runtime.package }}" >> $GITHUB_ENV
-        RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
-        echo "RUNTIME_BLOB_NAME=$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+        RUNTIME_BLOB_NAME=$(echo ${{ matrix.runtime.package }} | sed 's/-/_/g').compact.compressed.wasm
         PREFIX=${{ matrix.build_config.type == 'debug-build' && 'DEBUG_BUILD__' || '' }}
-        echo "PREFIX=$PREFIX" >> $GITHUB_ENV
-        echo "ASSET_PATH=./${{ matrix.runtime.path }}/target/srtool/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+
+        echo "RUNTIME_BLOB_NAME=$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
+        echo "ASSET_PATH=./${{ matrix.runtime.path }}/target/srtool/production/wbuild/${{ matrix.runtime.package }}/$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
         echo "ASSET_NAME=$PREFIX$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
 
     - name: Upload Runtime to Release

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build ${{ matrix.runtime.name }} ${{ matrix.build_config.type }}
       id: srtool_build

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -10,14 +10,17 @@ jobs:
     strategy:
       matrix:
         runtime:
-          # TODO: Add parachain runtimes
           - { name: westend, package: westend-runtime, path: polkadot/runtime/westend }
           - { name: rococo, package: rococo-runtime, path: polkadot/runtime/rococo }
+          - { name: asset-hub-rococo, package: asset-hub-rococo-runtime, path: cumulus/parachains/runtimes/assets/asset-hub-rococo }
+          - { name: asset-hub-westend, package: asset-hub-westend-runtime, path: cumulus/parachains/runtimes/assets/asset-hub-westend }
+          - { name: bridge-hub-rococo, package: bridge-hub-rococo-runtime, path: cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend }
+          - { name: contracts-rococo, package: contracts-rococo-runtime, path: cumulus/parachains/runtimes/contracts/contracts-rococo }
         build_config:
-          # Release build has disabled logging and no dev features
+          # Release build has logging disabled and no dev features
           - { type: on-chain-release, opts: --features on-chain-release-build } 
-          # Debug build has logging and the try-runtime feature
-          - { type: debug-build, opts: --features try-runtime }
+          # Debug build has logging enabled and developer features
+          - { type: dev-debug-build, opts: --features try-runtime --features experimental }
 
     runs-on: ubuntu-22.04
 
@@ -46,7 +49,7 @@ jobs:
       id: setup
       run: |
         RUNTIME_BLOB_NAME=$(echo ${{ matrix.runtime.package }} | sed 's/-/_/g').compact.compressed.wasm
-        PREFIX=${{ matrix.build_config.type == 'debug-build' && 'DEBUG_BUILD__' || '' }}
+        PREFIX=${{ matrix.build_config.type == 'dev-debug-build' && 'DEV_DEBUG_BUILD__' || '' }}
 
         echo "RUNTIME_BLOB_NAME=$RUNTIME_BLOB_NAME" >> $GITHUB_ENV
         echo "ASSET_PATH=./${{ matrix.runtime.path }}/target/srtool/production/wbuild/${{ matrix.runtime.package }}/$RUNTIME_BLOB_NAME" >> $GITHUB_ENV

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -25,22 +25,22 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    # - name: Build ${{ matrix.runtime.name }} ${{ matrix.build_config.type }}
-    #   id: srtool_build
-    #   uses: chevdor/srtool-actions@v0.8.0
-    #   env:
-    #     BUILD_OPTS: ${{ matrix.build_config.opts }}
-    #   with:
-    #     chain: ${{ matrix.runtime.name }}
-    #     package: ${{ matrix.runtime.package }}
-    #     runtime_dir: ${{ matrix.runtime.path }}
-    #     profile: "production"
+    - name: Build ${{ matrix.runtime.name }} ${{ matrix.build_config.type }}
+      id: srtool_build
+      uses: chevdor/srtool-actions@v0.8.0
+      env:
+        BUILD_OPTS: ${{ matrix.build_config.opts }}
+      with:
+        chain: ${{ matrix.runtime.name }}
+        package: ${{ matrix.runtime.package }}
+        runtime_dir: ${{ matrix.runtime.path }}
+        profile: "production"
 
-    # - name: Build Summary
-    #   run: |
-    #     echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.runtime.name }}-srtool-digest.json
-    #     cat ${{ matrix.runtime.name }}-srtool-digest.json
-    #     echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+    - name: Build Summary
+      run: |
+        echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.runtime.name }}-srtool-digest.json
+        cat ${{ matrix.runtime.name }}-srtool-digest.json
+        echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
     - name: Set up paths and runtime names
       id: setup

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         runtime:
           # TODO: Add parachain runtimes
-          - { name: westend, package: westend-runtime, path: relay/westend }
-          - { name: rococo, package: rococo-runtime, path: relay/rococo }
+          - { name: westend, package: westend-runtime, path: polkadot/runtime/westend }
+          - { name: rococo, package: rococo-runtime, path: polkadot/runtime/rococo }
         build_type:
           # No prefix indicates a release build
           - { prefix: "", build_opts: "--features on-chain-release-build" } 

--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -20,7 +20,7 @@ jobs:
           # Release build has logging disabled and no dev features
           - { type: on-chain-release, opts: --features on-chain-release-build } 
           # Debug build has logging enabled and developer features
-          - { type: dev-debug-build, opts: --features try-runtime --features experimental }
+          - { type: dev-debug-build, opts: --features try-runtime }
 
     runs-on: ubuntu-22.04
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
@@ -241,7 +241,7 @@ std = [
 
 experimental = [ "pallet-aura/experimental" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
@@ -240,3 +240,8 @@ std = [
 ]
 
 experimental = [ "pallet-aura/experimental" ]
+
+# A feature that should be enabled when the runtime should be build for on-chain
+# deployment. This will disable stuff that shouldn't be part of the on-chain wasm
+# to make it smaller like logging for example.
+on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
@@ -218,7 +218,7 @@ std = [
 
 experimental = [ "pallet-aura/experimental" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
@@ -217,3 +217,8 @@ std = [
 ]
 
 experimental = [ "pallet-aura/experimental" ]
+
+# A feature that should be enabled when the runtime should be build for on-chain
+# deployment. This will disable stuff that shouldn't be part of the on-chain wasm
+# to make it smaller like logging for example.
+on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -234,7 +234,7 @@ try-runtime = [
 
 experimental = [ "pallet-aura/experimental" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -233,3 +233,8 @@ try-runtime = [
 ]
 
 experimental = [ "pallet-aura/experimental" ]
+
+# A feature that should be enabled when the runtime should be build for on-chain
+# deployment. This will disable stuff that shouldn't be part of the on-chain wasm
+# to make it smaller like logging for example.
+on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
@@ -193,7 +193,7 @@ try-runtime = [
 
 experimental = [ "pallet-aura/experimental" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
@@ -192,3 +192,8 @@ try-runtime = [
 ]
 
 experimental = [ "pallet-aura/experimental" ]
+
+# A feature that should be enabled when the runtime should be build for on-chain
+# deployment. This will disable stuff that shouldn't be part of the on-chain wasm
+# to make it smaller like logging for example.
+on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
@@ -125,3 +125,8 @@ try-runtime = [
 ]
 
 experimental = [ "pallet-aura/experimental" ]
+
+# A feature that should be enabled when the runtime should be build for on-chain
+# deployment. This will disable stuff that shouldn't be part of the on-chain wasm
+# to make it smaller like logging for example.
+on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
@@ -126,7 +126,7 @@ try-runtime = [
 
 experimental = [ "pallet-aura/experimental" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -314,7 +314,7 @@ fast-runtime = []
 
 runtime-metrics = [ "runtime-parachains/runtime-metrics", "sp-io/with-tracing" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -338,7 +338,7 @@ fast-runtime = []
 
 runtime-metrics = [ "runtime-parachains/runtime-metrics", "sp-io/with-tracing" ]
 
-# A feature that should be enabled when the runtime should be build for on-chain
+# A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]


### PR DESCRIPTION
Closes https://github.com/paritytech/release-engineering/issues/6

Adds a new Github Workflow which on a new release being created, builds and attaches all runtimes managed in this repository in two flavours:
- `dev-debug-build`: Built with the `try-runtime` feature and has logging enabled
- `on-chain-release`: Built with the regular old `on-chain-release` feature

The new Github Workflow could be extended in the future by the @paritytech/release-engineering team to fully automate the release process if they choose to, similar to how it is fully automated in the Fellowship repo (https://github.com/polkadot-fellows/runtimes/blob/main/.github/workflows/release.yml). 

The `on-chain-release` did not exist for parachains, so I added it. 

---

Tested on my fork: 
- https://github.com/liamaharon/polkadot-sdk/actions/runs/6663773523
- https://github.com/liamaharon/polkadot-sdk/releases/tag/test-6
