### PR TITLE
Use workspace.dependenceis to ensure consistent versions of common crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11265,9 +11265,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -11280,9 +11280,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,6 +460,7 @@ default-members = [ "polkadot", "substrate/bin/node/cli" ]
 
 [workspace.dependencies]
 scale-info = "2.10"
+codec = { package = "parity-scale-codec", version = "3.6.5" }
 parity-scale-codec = "3.6.5"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -458,6 +458,10 @@ members = [
 ]
 default-members = [ "polkadot", "substrate/bin/node/cli" ]
 
+[workspace.dependencies]
+scale-info = "2.10"
+parity-scale-codec = "3.6.5"
+
 [profile.release]
 # Polkadot runtime requires unwinding.
 panic = "unwind"

--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -8,10 +8,10 @@ repository.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hash-db = { version = "0.16.0", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 static_assertions = { version = "1.1", optional = true }
 
 # Bridge dependencies

--- a/bridges/modules/grandpa/Cargo.toml
+++ b/bridges/modules/grandpa/Cargo.toml
@@ -9,10 +9,10 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/modules/messages/Cargo.toml
+++ b/bridges/modules/messages/Cargo.toml
@@ -7,10 +7,10 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.20", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Bridge dependencies
 

--- a/bridges/modules/parachains/Cargo.toml
+++ b/bridges/modules/parachains/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/modules/relayers/Cargo.toml
+++ b/bridges/modules/relayers/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Bridge dependencies
 

--- a/bridges/modules/xcm-bridge-hub-router/Cargo.toml
+++ b/bridges/modules/xcm-bridge-hub-router/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["bit-vec", "derive", "serde"] }
 
 # Bridge dependencies
 

--- a/bridges/primitives/chain-asset-hub-kusama/Cargo.toml
+++ b/bridges/primitives/chain-asset-hub-kusama/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate Dependencies
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/bridges/primitives/chain-asset-hub-polkadot/Cargo.toml
+++ b/bridges/primitives/chain-asset-hub-polkadot/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate Dependencies
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/bridges/primitives/chain-asset-hub-rococo/Cargo.toml
+++ b/bridges/primitives/chain-asset-hub-rococo/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate Dependencies
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/bridges/primitives/chain-asset-hub-wococo/Cargo.toml
+++ b/bridges/primitives/chain-asset-hub-wococo/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate Dependencies
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/bridges/primitives/chain-polkadot-bulletin/Cargo.toml
+++ b/bridges/primitives/chain-polkadot-bulletin/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/primitives/header-chain/Cargo.toml
+++ b/bridges/primitives/header-chain/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Bridge dependencies

--- a/bridges/primitives/messages/Cargo.toml
+++ b/bridges/primitives/messages/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "bit-vec"] }
+scale-info = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Bridge dependencies

--- a/bridges/primitives/parachains/Cargo.toml
+++ b/bridges/primitives/parachains/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Bridge dependencies
 

--- a/bridges/primitives/polkadot-core/Cargo.toml
+++ b/bridges/primitives/polkadot-core/Cargo.toml
@@ -7,9 +7,9 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 parity-util-mem = { version = "0.12.0", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Bridge Dependencies

--- a/bridges/primitives/relayers/Cargo.toml
+++ b/bridges/primitives/relayers/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "bit-vec"] }
+scale-info = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/primitives/runtime/Cargo.toml
+++ b/bridges/primitives/runtime/Cargo.toml
@@ -7,12 +7,12 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 hash-db = { version = "0.16.0", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.19", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Substrate Dependencies

--- a/bridges/primitives/test-utils/Cargo.toml
+++ b/bridges/primitives/test-utils/Cargo.toml
@@ -11,7 +11,7 @@ bp-header-chain = { path = "../header-chain", default-features = false  }
 bp-parachains = { path = "../parachains", default-features = false }
 bp-polkadot-core = { path = "../polkadot-core", default-features = false  }
 bp-runtime = { path = "../runtime", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 ed25519-dalek = { version = "2.0", default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
 sp-application-crypto = { path = "../../../substrate/primitives/application-crypto", default-features = false }

--- a/bridges/primitives/xcm-bridge-hub-router/Cargo.toml
+++ b/bridges/primitives/xcm-bridge-hub-router/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "bit-vec"] }
+scale-info = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
 
 # Substrate Dependencies
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false }

--- a/cumulus/client/cli/Cargo.toml
+++ b/cumulus/client/cli/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0" }
+codec = { package = "parity-scale-codec", workspace = true }
 url = "2.4.0"
 
 # Substrate

--- a/cumulus/client/collator/Cargo.toml
+++ b/cumulus/client/collator/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 parking_lot = "0.12.1"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ] }
 futures = "0.3.21"
 tracing = "0.1.25"
 

--- a/cumulus/client/consensus/aura/Cargo.toml
+++ b/cumulus/client/consensus/aura/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.73"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ] }
 futures = "0.3.28"
 tracing = "0.1.37"
 schnellru = "0.2.1"

--- a/cumulus/client/consensus/common/Cargo.toml
+++ b/cumulus/client/consensus/common/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.73"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ] }
 dyn-clone = "1.0.12"
 futures = "0.3.28"
 log = "0.4.20"

--- a/cumulus/client/network/Cargo.toml
+++ b/cumulus/client/network/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.73"
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ] }
 futures = "0.3.28"
 futures-timer = "3.0.2"
 parking_lot = "0.12.1"

--- a/cumulus/client/pov-recovery/Cargo.toml
+++ b/cumulus/client/pov-recovery/Cargo.toml
@@ -6,7 +6,7 @@ description = "Cumulus-specific networking protocol"
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ] }
 futures = "0.3.28"
 futures-timer = "3.0.2"
 rand = "0.8.5"

--- a/cumulus/client/relay-chain-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-interface/Cargo.toml
@@ -18,4 +18,4 @@ futures = "0.3.28"
 async-trait = "0.1.73"
 thiserror = "1.0.48"
 jsonrpsee-core = "0.16.2"
-parity-scale-codec = "3.6.4"
+parity-scale-codec = { workspace = true }

--- a/cumulus/client/relay-chain-rpc-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-rpc-interface/Cargo.toml
@@ -27,7 +27,7 @@ tokio-util = { version = "0.7.8", features = ["compat"] }
 
 futures = "0.3.28"
 futures-timer = "3.0.2"
-parity-scale-codec = "3.6.4"
+parity-scale-codec = { workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["ws-client"] }
 tracing = "0.1.37"
 async-trait = "0.1.73"

--- a/cumulus/pallets/aura-ext/Cargo.toml
+++ b/cumulus/pallets/aura-ext/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 description = "AURA consensus extension pallet for parachains"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/collator-selection/Cargo.toml
+++ b/cumulus/pallets/collator-selection/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 log = { version = "0.4.20", default-features = false }
-codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", version = "3.0.0" }
+codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", workspace = true }
 rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../substrate/primitives/std", default-features = false}
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false}

--- a/cumulus/pallets/dmp-queue/Cargo.toml
+++ b/cumulus/pallets/dmp-queue/Cargo.toml
@@ -5,9 +5,9 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ], default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ], default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/parachain-system/Cargo.toml
+++ b/cumulus/pallets/parachain-system/Cargo.toml
@@ -7,12 +7,12 @@ description = "Base pallet for cumulus-based parachains"
 
 [dependencies]
 bytes = { version = "1.4.0", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 environmental = { version = "1.1.4", default-features = false }
 impl-trait-for-tuples = "0.2.1"
 log = { version = "0.4.20", default-features = false }
 trie-db = { version = "0.28.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/session-benchmarking/Cargo.toml
+++ b/cumulus/pallets/session-benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-parity-scale-codec = { version = "3.6.4", default-features = false }
+parity-scale-codec = { workspace = true, default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false}
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false}
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/solo-to-para/Cargo.toml
+++ b/cumulus/pallets/solo-to-para/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 description = "Adds functionality to migrate from a Solo to a Parachain"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/xcm/Cargo.toml
+++ b/cumulus/pallets/xcm/Cargo.toml
@@ -5,8 +5,8 @@ name = "cumulus-pallet-xcm"
 version = "0.1.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../substrate/primitives/std", default-features = false}
 sp-io = { path = "../../../substrate/primitives/io", default-features = false}

--- a/cumulus/pallets/xcmp-queue/Cargo.toml
+++ b/cumulus/pallets/xcmp-queue/Cargo.toml
@@ -5,10 +5,10 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ], default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ], default-features = false }
 log = { version = "0.4.20", default-features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/parachain-template/node/Cargo.toml
+++ b/cumulus/parachain-template/node/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 log = "0.4.20"
-codec = { package = "parity-scale-codec", version = "3.0.0" }
+codec = { package = "parity-scale-codec", workspace = true }
 serde = { version = "1.0.188", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 futures = "0.3.28"

--- a/cumulus/parachain-template/pallets/template/Cargo.toml
+++ b/cumulus/parachain-template/pallets/template/Cargo.toml
@@ -12,8 +12,8 @@ edition.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"], default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../substrate/frame/benchmarking", default-features = false, optional = true}

--- a/cumulus/parachain-template/runtime/Cargo.toml
+++ b/cumulus/parachain-template/runtime/Cargo.toml
@@ -15,10 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-wasm-builder = { path = "../../../substrate/utils/wasm-builder", optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Local

--- a/cumulus/parachains/common/Cargo.toml
+++ b/cumulus/parachains/common/Cargo.toml
@@ -9,9 +9,9 @@ description = "Logic which is common to all parachain runtimes"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"], default-features = false }
 log = { version = "0.4.19", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 num-traits = { version = "0.2", default-features = false}
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/integration-tests/emulated/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/assets/asset-hub-rococo/Cargo.toml
@@ -8,7 +8,7 @@ description = "Asset Hub Rococo runtime integration tests with xcm-emulator"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 assert_matches = "1.5.0"
 
 # Substrate

--- a/cumulus/parachains/integration-tests/emulated/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/assets/asset-hub-westend/Cargo.toml
@@ -8,7 +8,7 @@ description = "Asset Hub Westend runtime integration tests with xcm-emulator"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 assert_matches = "1.5.0"
 
 # Substrate

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-rococo/Cargo.toml
@@ -8,7 +8,7 @@ description = "Bridge Hub Rococo runtime integration tests with xcm-emulator"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 
 # Substrate
 frame-support = { path = "../../../../../../substrate/frame/support", default-features = false}

--- a/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
@@ -8,7 +8,7 @@ description = "Common resources for integration testing with xcm-emulator"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 paste = "1.0.14"
 
 # Substrate

--- a/cumulus/parachains/pallets/collective-content/Cargo.toml
+++ b/cumulus/parachains/pallets/collective-content/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 description = "Managed content"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../../../../substrate/frame/benchmarking", optional = true, default-features = false }
 frame-support = { path = "../../../../substrate/frame/support", default-features = false }

--- a/cumulus/parachains/pallets/parachain-info/Cargo.toml
+++ b/cumulus/parachains/pallets/parachain-info/Cargo.toml
@@ -5,8 +5,8 @@ name = "parachain-info"
 version = "0.1.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../../../substrate/frame/support", default-features = false}
 frame-system = { path = "../../../../substrate/frame/system", default-features = false}

--- a/cumulus/parachains/pallets/ping/Cargo.toml
+++ b/cumulus/parachains/pallets/ping/Cargo.toml
@@ -5,8 +5,8 @@ name = "cumulus-ping"
 version = "0.1.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../../substrate/primitives/std", default-features = false}
 sp-runtime = { path = "../../../../substrate/primitives/runtime", default-features = false}

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 description = "Kusama variant of Asset Hub parachain runtime"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 description = "Asset Hub Polkadot parachain runtime"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 description = "Rococo variant of Asset Hub parachain runtime"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 description = "Westend variant of Asset Hub parachain runtime"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/common/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/common/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 description = "Assets common utilities"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.20", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 

--- a/cumulus/parachains/runtimes/assets/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/test-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 description = "Test utils for Asset Hub runtimes."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 
 # Substrate
 frame-support = { path = "../../../../../substrate/frame/support", default-features = false}

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -9,10 +9,10 @@ description = "Kusama's BridgeHub parachain runtime"
 substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder", optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -9,10 +9,10 @@ description = "Polkadot's BridgeHub parachain runtime"
 substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder", optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -9,10 +9,10 @@ description = "Rococo's BridgeHub  parachain runtime"
 substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder", optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 description = "Utils for BridgeHub testing"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.20", default-features = false }
 
 # Substrate

--- a/cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml
+++ b/cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 description = "Polkadot Collectives Parachain Runtime"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
@@ -12,10 +12,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder", optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
@@ -6,8 +6,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true}

--- a/cumulus/parachains/runtimes/starters/seedling/Cargo.toml
+++ b/cumulus/parachains/runtimes/starters/seedling/Cargo.toml
@@ -6,8 +6,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false}

--- a/cumulus/parachains/runtimes/starters/shell/Cargo.toml
+++ b/cumulus/parachains/runtimes/starters/shell/Cargo.toml
@@ -6,8 +6,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false}

--- a/cumulus/parachains/runtimes/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/test-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 description = "Utils for Runtimes testing"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 
 # Substrate
 frame-support = { path = "../../../../substrate/frame/support", default-features = false}

--- a/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
@@ -15,10 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder", optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml
@@ -7,8 +7,8 @@ description = "Simple runtime used by the rococo parachain(s)"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true}

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = "0.1.73"
 clap = { version = "4.4.6", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.28"
 hex-literal = "0.4.1"
 log = "0.4.20"

--- a/cumulus/primitives/aura/Cargo.toml
+++ b/cumulus/primitives/aura/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
 
 # Substrate
 sp-api = { path = "../../../substrate/primitives/api", default-features = false}

--- a/cumulus/primitives/core/Cargo.toml
+++ b/cumulus/primitives/core/Cargo.toml
@@ -5,8 +5,8 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 sp-api = { path = "../../../substrate/primitives/api", default-features = false}

--- a/cumulus/primitives/parachain-inherent/Cargo.toml
+++ b/cumulus/primitives/parachain-inherent/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 
 [dependencies]
 async-trait = { version = "0.1.73", optional = true }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 tracing = { version = "0.1.37", optional = true }
 
 # Substrate

--- a/cumulus/primitives/timestamp/Cargo.toml
+++ b/cumulus/primitives/timestamp/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 description = "Provides timestamp related functionality for parachains."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
 futures = "0.3.28"
 
 # Substrate

--- a/cumulus/primitives/utility/Cargo.toml
+++ b/cumulus/primitives/utility/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
 log = { version = "0.4.20", default-features = false }
 
 # Substrate

--- a/cumulus/test/client/Cargo.toml
+++ b/cumulus/test/client/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
 
 # Substrate
 sc-service = { path = "../../../substrate/client/service" }

--- a/cumulus/test/relay-sproof-builder/Cargo.toml
+++ b/cumulus/test/relay-sproof-builder/Cargo.toml
@@ -5,7 +5,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive" ] }
 
 # Substrate
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false}

--- a/cumulus/test/runtime/Cargo.toml
+++ b/cumulus/test/runtime/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../substrate/frame/executive", default-features = false}

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = "0.1.73"
 clap = { version = "4.4.6", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0" }
+codec = { package = "parity-scale-codec", workspace = true }
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 rand = "0.8.5"

--- a/cumulus/xcm/xcm-emulator/Cargo.toml
+++ b/cumulus/xcm/xcm-emulator/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0" }
+codec = { package = "parity-scale-codec", workspace = true }
 paste = "1.0.14"
 log = { version = "0.4.20", default-features = false }
 lazy_static = "1.4.0"

--- a/polkadot/core-primitives/Cargo.toml
+++ b/polkadot/core-primitives/Cargo.toml
@@ -10,8 +10,8 @@ license.workspace = true
 sp-core = { path = "../../substrate/primitives/core", default-features = false }
 sp-std = { path = "../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = [ "derive" ] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = [ "derive" ] }
 
 [features]
 default = [ "std" ]

--- a/polkadot/erasure-coding/Cargo.toml
+++ b/polkadot/erasure-coding/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 polkadot-primitives = { path = "../primitives" }
 polkadot-node-primitives = { package = "polkadot-node-primitives", path = "../node/primitives" }
 novelpoly = { package = "reed-solomon-novelpoly", version = "1.0.0" }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["std", "derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["std", "derive"] }
 sp-core = { path = "../../substrate/primitives/core" }
 sp-trie = { path = "../../substrate/primitives/trie" }
 thiserror = "1.0.48"

--- a/polkadot/node/collation-generation/Cargo.toml
+++ b/polkadot/node/collation-generation/Cargo.toml
@@ -16,7 +16,7 @@ polkadot-primitives = { path = "../../primitives" }
 sp-core = { path = "../../../substrate/primitives/core" }
 sp-maybe-compressed-blob  = { path = "../../../substrate/primitives/maybe-compressed-blob" }
 thiserror = "1.0.48"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
 
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../subsystem-test-helpers" }

--- a/polkadot/node/core/approval-voting/Cargo.toml
+++ b/polkadot/node/core/approval-voting/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 futures = "0.3.21"
 futures-timer = "3.0.2"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
 gum = { package = "tracing-gum", path = "../../gum" }
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 schnellru = "0.2.1"

--- a/polkadot/node/core/av-store/Cargo.toml
+++ b/polkadot/node/core/av-store/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1.0.48"
 gum = { package = "tracing-gum", path = "../../gum" }
 bitvec = "1.0.0"
 
-parity-scale-codec = { version = "3.6.1", features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
 erasure = { package = "polkadot-erasure-coding", path = "../../../erasure-coding" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }

--- a/polkadot/node/core/candidate-validation/Cargo.toml
+++ b/polkadot/node/core/candidate-validation/Cargo.toml
@@ -13,7 +13,7 @@ futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 
 sp-maybe-compressed-blob = { package = "sp-maybe-compressed-blob", path = "../../../../substrate/primitives/maybe-compressed-blob" }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-parachain-primitives = { path = "../../../parachain" }

--- a/polkadot/node/core/chain-api/Cargo.toml
+++ b/polkadot/node/core/chain-api/Cargo.toml
@@ -18,7 +18,7 @@ sc-consensus-babe = { path = "../../../../substrate/client/consensus/babe" }
 [dev-dependencies]
 futures = { version = "0.3.21", features = ["thread-pool"] }
 maplit = "1.0.2"
-parity-scale-codec = "3.6.1"
+parity-scale-codec = { workspace = true }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 sp-core = { path = "../../../../substrate/primitives/core" }

--- a/polkadot/node/core/chain-selection/Cargo.toml
+++ b/polkadot/node/core/chain-selection/Cargo.toml
@@ -16,7 +16,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 kvdb = "0.13.0"
 thiserror = "1.0.48"
-parity-scale-codec = "3.6.1"
+parity-scale-codec = { workspace = true }
 
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/polkadot/node/core/dispute-coordinator/Cargo.toml
+++ b/polkadot/node/core/dispute-coordinator/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
-parity-scale-codec = "3.6.1"
+parity-scale-codec = { workspace = true }
 kvdb = "0.13.0"
 thiserror = "1.0.48"
 schnellru = "0.2.1"

--- a/polkadot/node/core/prospective-parachains/Cargo.toml
+++ b/polkadot/node/core/prospective-parachains/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 futures = "0.3.19"
 gum = { package = "tracing-gum", path = "../../gum" }
-parity-scale-codec = "3.6.4"
+parity-scale-codec = { workspace = true }
 thiserror = "1.0.48"
 fatality = "0.0.6"
 bitvec = "1"

--- a/polkadot/node/core/pvf/Cargo.toml
+++ b/polkadot/node/core/pvf/Cargo.toml
@@ -20,7 +20,7 @@ slotmap = "1.0"
 tempfile = "3.3.0"
 tokio = { version = "1.24.2", features = ["fs", "process"] }
 
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 
 polkadot-parachain-primitives = { path = "../../../parachain" }
 polkadot-core-primitives = { path = "../../../core-primitives" }

--- a/polkadot/node/core/pvf/common/Cargo.toml
+++ b/polkadot/node/core/pvf/common/Cargo.toml
@@ -14,7 +14,7 @@ gum = { package = "tracing-gum", path = "../../../gum" }
 libc = "0.2.139"
 tokio = { version = "1.24.2", features = ["fs", "process", "io-util"] }
 
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 
 polkadot-parachain-primitives = { path = "../../../../parachain" }
 polkadot-primitives = { path = "../../../../primitives" }

--- a/polkadot/node/core/pvf/execute-worker/Cargo.toml
+++ b/polkadot/node/core/pvf/execute-worker/Cargo.toml
@@ -13,7 +13,7 @@ gum = { package = "tracing-gum", path = "../../../gum" }
 rayon = "1.5.1"
 tokio = { version = "1.24.2", features = ["fs", "process"] }
 
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 
 polkadot-node-core-pvf-common = { path = "../common" }
 polkadot-parachain-primitives = { path = "../../../../parachain" }

--- a/polkadot/node/core/pvf/prepare-worker/Cargo.toml
+++ b/polkadot/node/core/pvf/prepare-worker/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.5.1"
 tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
 tokio = { version = "1.24.2", features = ["fs", "process"] }
 
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 
 polkadot-node-core-pvf-common = { path = "../common" }
 polkadot-parachain-primitives = { path = "../../../../parachain" }

--- a/polkadot/node/jaeger/Cargo.toml
+++ b/polkadot/node/jaeger/Cargo.toml
@@ -17,4 +17,4 @@ sp-core = { path = "../../../substrate/primitives/core" }
 thiserror = "1.0.48"
 tokio = "1.24.2"
 log = "0.4.17"
-parity-scale-codec = { version = "3.6.1", default-features = false }
+parity-scale-codec = { workspace = true, default-features = false }

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -18,7 +18,7 @@ sc-cli = { path = "../../../substrate/client/cli" }
 
 substrate-prometheus-endpoint = { path = "../../../substrate/utils/prometheus" }
 sc-tracing = { path = "../../../substrate/client/tracing" }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 primitives = { package = "polkadot-primitives", path = "../../primitives" }
 bs58 = { version = "0.5.0", features = ["alloc"] }
 log = "0.4.17"

--- a/polkadot/node/network/availability-distribution/Cargo.toml
+++ b/polkadot/node/network/availability-distribution/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
-parity-scale-codec = { version = "3.6.1", features = ["std"] }
+parity-scale-codec = { workspace = true, features = ["std"] }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-erasure-coding = { path = "../../../erasure-coding" }
 polkadot-node-network-protocol = { path = "../protocol" }

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -20,7 +20,7 @@ polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-network-protocol = { path = "../protocol" }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sc-network = { path = "../../../../substrate/client/network" }
 
 [dev-dependencies]

--- a/polkadot/node/network/bridge/Cargo.toml
+++ b/polkadot/node/network/bridge/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.57"
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sc-network = { path = "../../../../substrate/client/network" }
 sp-consensus = { path = "../../../../substrate/primitives/consensus/common" }
 polkadot-node-metrics = { path = "../../metrics" }

--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -33,7 +33,7 @@ sp-core = { path = "../../../../substrate/primitives/core", features = ["std"] }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 sc-keystore = { path = "../../../../substrate/client/keystore" }
 sc-network = { path = "../../../../substrate/client/network" }
-parity-scale-codec = { version = "3.6.1", features = ["std"] }
+parity-scale-codec = { workspace = true, features = ["std"] }
 
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-primitives-test-helpers = { path = "../../../primitives/test-helpers" }

--- a/polkadot/node/network/dispute-distribution/Cargo.toml
+++ b/polkadot/node/network/dispute-distribution/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3.21"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 derive_more = "0.99.17"
-parity-scale-codec = { version = "3.6.1", features = ["std"] }
+parity-scale-codec = { workspace = true, features = ["std"] }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-erasure-coding = { path = "../../../erasure-coding" }
 polkadot-node-subsystem = { path = "../../subsystem" }

--- a/polkadot/node/network/protocol/Cargo.toml
+++ b/polkadot/node/network/protocol/Cargo.toml
@@ -13,7 +13,7 @@ hex = "0.4.3"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-jaeger = { path = "../../jaeger" }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sc-network = { path = "../../../../substrate/client/network" }
 sc-authority-discovery = { path = "../../../../substrate/client/authority-discovery" }
 strum = { version = "0.24", features = ["derive"] }

--- a/polkadot/node/network/statement-distribution/Cargo.toml
+++ b/polkadot/node/network/statement-distribution/Cargo.toml
@@ -20,7 +20,7 @@ polkadot-node-subsystem-types = { path = "../../subsystem-types" }
 polkadot-node-network-protocol = { path = "../protocol" }
 arrayvec = "0.7.4"
 indexmap = "1.9.1"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 thiserror = "1.0.48"
 fatality = "0.0.6"
 bitvec = "1"

--- a/polkadot/node/primitives/Cargo.toml
+++ b/polkadot/node/primitives/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 bounded-vec = "0.7"
 futures = "0.3.21"
 polkadot-primitives = { path = "../../primitives" }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sp-core = { path = "../../../substrate/primitives/core" }
 sp-application-crypto = { path = "../../../substrate/primitives/application-crypto" }
 sp-consensus-babe = { path = "../../../substrate/primitives/consensus/babe" }

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -87,7 +87,7 @@ thiserror = "1.0.48"
 kvdb = "0.13.0"
 kvdb-rocksdb = { version = "0.19.0", optional = true }
 parity-db = { version = "0.4.8", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 
 # Polkadot
 polkadot-core-primitives = { path = "../../core-primitives" }

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.57"
 futures = "0.3.21"
 futures-channel = "0.3.23"
 itertools = "0.10"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 parking_lot = "0.11.2"
 pin-project = "1.0.9"
 rand = "0.8.5"

--- a/polkadot/node/test/client/Cargo.toml
+++ b/polkadot/node/test/client/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 
 # Polkadot dependencies
 polkadot-test-runtime = { path = "../../../runtime/test-runtime" }

--- a/polkadot/node/zombienet-backchannel/Cargo.toml
+++ b/polkadot/node/zombienet-backchannel/Cargo.toml
@@ -14,7 +14,7 @@ url = "2.3.1"
 tokio-tungstenite = "0.17"
 futures-util = "0.3.23"
 lazy_static = "1.4.0"
-parity-scale-codec = { version = "3.6.1", features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
 reqwest = { version = "0.11", features = ["rustls-tls"], default-features = false }
 thiserror = "1.0.48"
 gum = { package = "tracing-gum", path = "../gum" }

--- a/polkadot/parachain/Cargo.toml
+++ b/polkadot/parachain/Cargo.toml
@@ -10,8 +10,8 @@ version = "1.0.0"
 # note: special care is taken to avoid inclusion of `sp-io` externals when compiling
 # this crate for WASM. This is critical to avoid forcing all parachain WASM into implementing
 # various unnecessary Substrate-specific endpoints.
-parity-scale-codec = { version = "3.6.1", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+parity-scale-codec = { workspace = true, default-features = false, features = [ "derive" ] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 sp-std = { path = "../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false, features = ["serde"] }
 sp-core = { path = "../../substrate/primitives/core", default-features = false, features = ["serde"] }

--- a/polkadot/parachain/test-parachains/Cargo.toml
+++ b/polkadot/parachain/test-parachains/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 
 adder = { package = "test-parachain-adder", path = "adder" }
 halt = { package = "test-parachain-halt", path = "halt" }

--- a/polkadot/parachain/test-parachains/adder/Cargo.toml
+++ b/polkadot/parachain/test-parachains/adder/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 parachain = { package = "polkadot-parachain-primitives", path = "../..", default-features = false, features = [ "wasm-api" ] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sp-std = { path = "../../../../substrate/primitives/std", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 dlmalloc = { version = "0.2.4", features = [ "global" ] }

--- a/polkadot/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/polkadot/parachain/test-parachains/adder/collator/Cargo.toml
@@ -12,7 +12,7 @@ name = "adder-collator"
 path = "src/main.rs"
 
 [dependencies]
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 clap = { version = "4.4.6", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/polkadot/parachain/test-parachains/undying/Cargo.toml
+++ b/polkadot/parachain/test-parachains/undying/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 parachain = { package = "polkadot-parachain-primitives", path = "../..", default-features = false, features = [ "wasm-api" ] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sp-std = { path = "../../../../substrate/primitives/std", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 dlmalloc = { version = "0.2.4", features = [ "global" ] }

--- a/polkadot/parachain/test-parachains/undying/collator/Cargo.toml
+++ b/polkadot/parachain/test-parachains/undying/collator/Cargo.toml
@@ -12,7 +12,7 @@ name = "undying-collator"
 path = "src/main.rs"
 
 [dependencies]
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 clap = { version = "4.4.6", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/polkadot/primitives/Cargo.toml
+++ b/polkadot/primitives/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-literal = "0.4.1"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["bit-vec", "derive"] }
+scale-info = { workspace = true, default-features = false, features = ["bit-vec", "derive", "serde"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 
 application-crypto = { package = "sp-application-crypto", path = "../../substrate/primitives/application-crypto", default-features = false, features = ["serde"] }

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 [dependencies]
 impl-trait-for-tuples = "0.2.2"
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1.0.117" }
 static_assertions = "1.1.0"

--- a/polkadot/runtime/common/slot_range_helper/Cargo.toml
+++ b/polkadot/runtime/common/slot_range_helper/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 paste = "1.0"
 enumn = "0.1.12"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sp-std = { package = "sp-std", path = "../../../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../../../substrate/primitives/runtime", default-features = false }
 

--- a/polkadot/runtime/metrics/Cargo.toml
+++ b/polkadot/runtime/metrics/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 [dependencies]
 sp-std = { package = "sp-std", path = "../../../substrate/primitives/std", default-features = false}
 sp-tracing = { path = "../../../substrate/primitives/tracing", default-features = false }
-parity-scale-codec = { version = "3.6.1", default-features = false }
+parity-scale-codec = { workspace = true, default-features = false }
 primitives = { package = "polkadot-primitives", path = "../../primitives", default-features = false }
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }
 

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -8,10 +8,10 @@ license.workspace = true
 [dependencies]
 impl-trait-for-tuples = "0.2.2"
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 derive_more = "0.99.17"
 bitflags = "1.3.2"

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -8,8 +8,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.188", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }

--- a/polkadot/runtime/test-runtime/Cargo.toml
+++ b/polkadot/runtime/test-runtime/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.8.0"

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -9,8 +9,8 @@ license.workspace = true
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.188", default-features = false }

--- a/polkadot/statement-table/Cargo.toml
+++ b/polkadot/statement-table/Cargo.toml
@@ -6,6 +6,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 sp-core = { path = "../../substrate/primitives/core" }
 primitives = { package = "polkadot-primitives", path = "../primitives" }

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -11,8 +11,8 @@ bounded-collections = { version = "0.1.8", default-features = false, features = 
 derivative = { version = "2.2.0", default-features = false, features = [ "use_core" ] }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = [ "derive", "max-encoded-len" ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+parity-scale-codec = { workspace = true, default-features = false, features = [ "derive", "max-encoded-len" ] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 sp-weights = { path = "../../substrate/primitives/weights", default-features = false, features = ["serde"] }
 serde = { version = "1.0.188", default-features = false, features = ["alloc", "derive"] }
 xcm-procedural = { path = "procedural" }

--- a/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
@@ -9,8 +9,8 @@ version = "1.0.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../../../substrate/frame/support", default-features = false}
 frame-system = { path = "../../../substrate/frame/system", default-features = false}
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false}

--- a/polkadot/xcm/pallet-xcm/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 
 [dependencies]
 bounded-collections = { version = "0.1.8", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 

--- a/polkadot/xcm/xcm-builder/Cargo.toml
+++ b/polkadot/xcm/xcm-builder/Cargo.toml
@@ -8,8 +8,8 @@ version = "1.0.0"
 
 [dependencies]
 impl-trait-for-tuples = "0.2.1"
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 xcm = { package = "staging-xcm", path = "..", default-features = false }
 xcm-executor = { package = "staging-xcm-executor", path = "../xcm-executor", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }

--- a/polkadot/xcm/xcm-executor/Cargo.toml
+++ b/polkadot/xcm/xcm-executor/Cargo.toml
@@ -9,7 +9,7 @@ version = "1.0.0"
 [dependencies]
 impl-trait-for-tuples = "0.2.2"
 environmental = { version = "1.1.4", default-features = false }
-parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
 xcm = { package = "staging-xcm", path = "..", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }
 sp-io = { path = "../../../substrate/primitives/io", default-features = false }

--- a/polkadot/xcm/xcm-executor/integration-tests/Cargo.toml
+++ b/polkadot/xcm/xcm-executor/integration-tests/Cargo.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 frame-support = { path = "../../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../../substrate/frame/system" }
 futures = "0.3.21"

--- a/polkadot/xcm/xcm-simulator/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 paste = "1.0.7"
 
 frame-support = { path = "../../../substrate/frame/support" }

--- a/polkadot/xcm/xcm-simulator/example/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/example/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 version = "1.0.0"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.10.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 
 frame-system = { path = "../../../../substrate/frame/system" }

--- a/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
@@ -8,10 +8,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 honggfuzz = "0.5.55"
 arbitrary = "1.2.0"
-scale-info = { version = "2.10.0", features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
 
 frame-system = { path = "../../../../substrate/frame/system" }
 frame-support = { path = "../../../../substrate/frame/support" }

--- a/substrate/bin/minimal/runtime/Cargo.toml
+++ b/substrate/bin/minimal/runtime/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { version = "3.0.0", default-features = false }
-scale-info = { version = "2.6.0", default-features = false }
+parity-scale-codec = { workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false }
 
 # this is a frame-based runtime, thus importing `frame` with runtime feature enabled.
 frame = { path = "../../../frame", default-features = false, features = ["runtime", "experimental"] }

--- a/substrate/bin/node-template/pallets/template/Cargo.toml
+++ b/substrate/bin/node-template/pallets/template/Cargo.toml
@@ -13,10 +13,10 @@ repository = "https://github.com/substrate-developer-hub/substrate-node-template
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../../../frame/benchmarking", default-features = false, optional = true}
 frame-support = { path = "../../../../frame/support", default-features = false}
 frame-system = { path = "../../../../frame/system", default-features = false}

--- a/substrate/bin/node-template/runtime/Cargo.toml
+++ b/substrate/bin/node-template/runtime/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/substrate-developer-hub/substrate-node-template
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 pallet-aura = { path = "../../../frame/aura", default-features = false}
 pallet-balances = { path = "../../../frame/balances", default-features = false}

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -39,7 +39,7 @@ crate-type = ["cdylib", "rlib"]
 # third-party dependencies
 array-bytes = "6.1"
 clap = { version = "4.4.6", features = ["derive"], optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 serde = { version = "1.0.188", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 futures = "0.3.21"

--- a/substrate/bin/node/executor/Cargo.toml
+++ b/substrate/bin/node/executor/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.10.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
 frame-benchmarking = { path = "../../../frame/benchmarking" }
 node-primitives = { path = "../primitives" }
 kitchensink-runtime = { path = "../runtime" }

--- a/substrate/bin/node/inspect/Cargo.toml
+++ b/substrate/bin/node/inspect/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 thiserror = "1.0"
 sc-cli = { path = "../../../client/cli" }
 sc-client-api = { path = "../../../client/api" }

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -16,11 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 
 # third-party dependencies
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 static_assertions = "1.1.0"
 log = { version = "0.4.17", default-features = false }
 

--- a/substrate/bin/node/testing/Cargo.toml
+++ b/substrate/bin/node/testing/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 fs_extra = "1"
 futures = "0.3.21"
 log = "0.4.17"

--- a/substrate/client/api/Cargo.toml
+++ b/substrate/client/api/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 fnv = "1.0.6"

--- a/substrate/client/authority-discovery/Cargo.toml
+++ b/substrate/client/authority-discovery/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 prost-build = "0.11"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 ip_network = "0.4.1"

--- a/substrate/client/basic-authorship/Cargo.toml
+++ b/substrate/client/basic-authorship/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"

--- a/substrate/client/block-builder/Cargo.toml
+++ b/substrate/client/block-builder/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = [
+codec = { package = "parity-scale-codec", workspace = true, features = [
 	"derive",
 ] }
 sc-client-api = { path = "../api" }

--- a/substrate/client/cli/Cargo.toml
+++ b/substrate/client/cli/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3.21"
 libp2p-identity = { version = "0.1.3", features = ["peerid", "ed25519"]}
 log = "0.4.17"
 names = { version = "0.13.0", default-features = false }
-parity-scale-codec = "3.6.1"
+parity-scale-codec = { workspace = true }
 rand = "0.8.5"
 regex = "1.6.0"
 rpassword = "7.0.0"

--- a/substrate/client/consensus/aura/Cargo.toml
+++ b/substrate/client/consensus/aura/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 log = "0.4.17"
 thiserror = "1.0"

--- a/substrate/client/consensus/babe/Cargo.toml
+++ b/substrate/client/consensus/babe/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 futures = "0.3.21"
 log = "0.4.17"
 num-bigint = "0.4.3"

--- a/substrate/client/consensus/beefy/Cargo.toml
+++ b/substrate/client/consensus/beefy/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://substrate.io"
 array-bytes = "6.1"
 async-channel = "1.8.0"
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 fnv = "1.0.6"
 futures = "0.3"
 log = "0.4"

--- a/substrate/client/consensus/beefy/rpc/Cargo.toml
+++ b/substrate/client/consensus/beefy/rpc/Cargo.toml
@@ -9,7 +9,7 @@ description = "RPC for the BEEFY Client gadget for substrate"
 homepage = "https://substrate.io"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 futures = "0.3.21"
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 log = "0.4"

--- a/substrate/client/consensus/epochs/Cargo.toml
+++ b/substrate/client/consensus/epochs/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 fork-tree = { path = "../../../utils/fork-tree" }
 sc-client-api = { path = "../../api" }
 sc-consensus = { path = "../common" }

--- a/substrate/client/consensus/grandpa/Cargo.toml
+++ b/substrate/client/consensus/grandpa/Cargo.toml
@@ -22,7 +22,7 @@ finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"
-parity-scale-codec = { version = "3.6.1", features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
 parking_lot = "0.12.1"
 rand = "0.8.5"
 serde_json = "1.0.107"

--- a/substrate/client/consensus/grandpa/rpc/Cargo.toml
+++ b/substrate/client/consensus/grandpa/rpc/Cargo.toml
@@ -14,7 +14,7 @@ finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
 futures = "0.3.16"
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 log = "0.4.8"
-parity-scale-codec = { version = "3.6.1", features = ["derive"] }
+parity-scale-codec = { workspace = true, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"] }
 thiserror = "1.0"
 sc-client-api = { path = "../../../api" }

--- a/substrate/client/consensus/manual-seal/Cargo.toml
+++ b/substrate/client/consensus/manual-seal/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 assert_matches = "1.3.0"
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"

--- a/substrate/client/consensus/pow/Cargo.toml
+++ b/substrate/client/consensus/pow/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"

--- a/substrate/client/consensus/slots/Cargo.toml
+++ b/substrate/client/consensus/slots/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 futures-timer = "3.0.1"
 log = "0.4.17"

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = [
+codec = { package = "parity-scale-codec", workspace = true, features = [
 	"derive",
 ] }
 hash-db = "0.16.0"

--- a/substrate/client/executor/Cargo.toml
+++ b/substrate/client/executor/Cargo.toml
@@ -18,7 +18,7 @@ parking_lot = "0.12.1"
 schnellru = "0.2.1"
 tracing = "0.1.29"
 
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 sc-executor-common = { path = "common" }
 sc-executor-wasmtime = { path = "wasmtime" }
 sp-api = { path = "../../primitives/api" }

--- a/substrate/client/executor/wasmtime/Cargo.toml
+++ b/substrate/client/executor/wasmtime/Cargo.toml
@@ -47,5 +47,5 @@ sc-runtime-test = { path = "../runtime-test" }
 sp-io = { path = "../../../primitives/io" }
 tempfile = "3.3.0"
 paste = "1.0"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 cargo_metadata = "0.15.4"

--- a/substrate/client/merkle-mountain-range/Cargo.toml
+++ b/substrate/client/merkle-mountain-range/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://substrate.io"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3"
 log = "0.4"
 sp-api = { path = "../../primitives/api" }

--- a/substrate/client/merkle-mountain-range/rpc/Cargo.toml
+++ b/substrate/client/merkle-mountain-range/rpc/Cargo.toml
@@ -12,7 +12,7 @@ description = "Node-specific RPC methods for interaction with Merkle Mountain Ra
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 serde = { version = "1.0.188", features = ["derive"] }
 sp-api = { path = "../../../primitives/api" }

--- a/substrate/client/mixnet/Cargo.toml
+++ b/substrate/client/mixnet/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "4.1"
 arrayvec = "0.7.2"
 blake2 = "0.10.4"
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 futures = "0.3.25"
 futures-timer = "3.0.2"
 libp2p-identity = { version = "0.1.3", features = ["peerid"] }

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "6.1"
 async-channel = "1.8.0"
 async-trait = "0.1"
-asynchronous-codec = { workspace = true }
+asynchronous-codec = "0.6"
 bytes = "1"
 codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 either = "1.5.3"

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -17,9 +17,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "6.1"
 async-channel = "1.8.0"
 async-trait = "0.1"
-asynchronous-codec = "0.6"
+asynchronous-codec = { workspace = true }
 bytes = "1"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 either = "1.5.3"
 fnv = "1.0.6"
 futures = "0.3.21"

--- a/substrate/client/network/common/Cargo.toml
+++ b/substrate/client/network/common/Cargo.toml
@@ -18,7 +18,7 @@ prost-build = "0.11"
 [dependencies]
 async-trait = "0.1.57"
 bitflags = "1.3.2"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = [
+codec = { package = "parity-scale-codec", workspace = true, features = [
 	"derive",
 ] }
 futures = "0.3.21"

--- a/substrate/client/network/light/Cargo.toml
+++ b/substrate/client/network/light/Cargo.toml
@@ -18,7 +18,7 @@ prost-build = "0.11"
 [dependencies]
 async-channel = "1.8.0"
 array-bytes = "6.1"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = [
+codec = { package = "parity-scale-codec", workspace = true, features = [
     "derive",
 ] }
 futures = "0.3.21"

--- a/substrate/client/network/statement/Cargo.toml
+++ b/substrate/client/network/statement/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 futures = "0.3.21"
 libp2p = "0.51.3"
 log = "0.4.17"

--- a/substrate/client/network/sync/Cargo.toml
+++ b/substrate/client/network/sync/Cargo.toml
@@ -19,7 +19,7 @@ prost-build = "0.11"
 array-bytes = "6.1"
 async-channel = "1.8.0"
 async-trait = "0.1.58"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.2"
 libp2p = "0.51.3"

--- a/substrate/client/network/transactions/Cargo.toml
+++ b/substrate/client/network/transactions/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 array-bytes = "6.1"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 futures = "0.3.21"
 libp2p = "0.51.3"
 log = "0.4.17"

--- a/substrate/client/offchain/Cargo.toml
+++ b/substrate/client/offchain/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 bytes = "1.1"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 fnv = "1.0.6"
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/substrate/client/rpc-api/Cargo.toml
+++ b/substrate/client/rpc-api/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "1.0"

--- a/substrate/client/rpc-spec-v2/Cargo.toml
+++ b/substrate/client/rpc-spec-v2/Cargo.toml
@@ -25,7 +25,7 @@ sp-blockchain = { path = "../../primitives/blockchain" }
 sp-version = { path = "../../primitives/version" }
 sc-client-api = { path = "../api" }
 sc-utils = { path = "../utils" }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 thiserror = "1.0"
 serde = "1.0"
 hex = "0.4"

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 log = "0.4.17"

--- a/substrate/client/service/Cargo.toml
+++ b/substrate/client/service/Cargo.toml
@@ -60,7 +60,7 @@ sc-chain-spec = { path = "../chain-spec" }
 sc-client-api = { path = "../api" }
 sp-api = { path = "../../primitives/api" }
 sc-client-db = { path = "../db", default-features = false}
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 sc-executor = { path = "../executor" }
 sc-transaction-pool = { path = "../transaction-pool" }
 sp-transaction-pool = { path = "../../primitives/transaction-pool" }

--- a/substrate/client/service/test/Cargo.toml
+++ b/substrate/client/service/test/Cargo.toml
@@ -17,7 +17,7 @@ array-bytes = "6.1"
 fdlimit = "0.2.1"
 futures = "0.3.21"
 log = "0.4.17"
-parity-scale-codec = "3.6.1"
+parity-scale-codec = { workspace = true }
 parking_lot = "0.12.1"
 tempfile = "3.1.0"
 tokio = { version = "1.22.0", features = ["time"] }

--- a/substrate/client/state-db/Cargo.toml
+++ b/substrate/client/state-db/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 log = "0.4.17"
 parking_lot = "0.12.1"
 sp-core = { path = "../../primitives/core" }

--- a/substrate/client/sync-state-rpc/Cargo.toml
+++ b/substrate/client/sync-state-rpc/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/substrate/client/transaction-pool/Cargo.toml
+++ b/substrate/client/transaction-pool/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 futures-timer = "3.0.2"
 linked-hash-map = "0.5.4"

--- a/substrate/client/transaction-pool/api/Cargo.toml
+++ b/substrate/client/transaction-pool/api/Cargo.toml
@@ -10,7 +10,7 @@ description = "Transaction pool client facing API."
 
 [dependencies]
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 log = "0.4.17"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # external deps
-parity-scale-codec = { version = "3.2.2", default-features = false, features = ["derive"] }
-scale-info = {  version = "2.6.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # primitive deps, used for developing FRAME pallets.
 sp-runtime = { default-features = false, path = "../primitives/runtime" }

--- a/substrate/frame/alliance/Cargo.toml
+++ b/substrate/frame/alliance/Cargo.toml
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = { version = "6.1", optional = true }
 log = { version = "0.4.14", default-features = false }
 
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/asset-conversion/Cargo.toml
+++ b/substrate/frame/asset-conversion/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../../primitives/api", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/asset-rate/Cargo.toml
+++ b/substrate/frame/asset-rate/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/assets/Cargo.toml
+++ b/substrate/frame/assets/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-std = { path = "../../primitives/std", default-features = false}
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/atomic-swap/Cargo.toml
+++ b/substrate/frame/atomic-swap/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 pallet-timestamp = { path = "../timestamp", default-features = false}

--- a/substrate/frame/authority-discovery/Cargo.toml
+++ b/substrate/frame/authority-discovery/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 pallet-session = { path = "../session", default-features = false, features = [

--- a/substrate/frame/authorship/Cargo.toml
+++ b/substrate/frame/authorship/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 impl-trait-for-tuples = "0.2.2"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/babe/Cargo.toml
+++ b/substrate/frame/babe/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/bags-list/Cargo.toml
+++ b/substrate/frame/bags-list/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # parity
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # primitives
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/balances/Cargo.toml
+++ b/substrate/frame/balances/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/beefy-mmr/Cargo.toml
+++ b/substrate/frame/beefy-mmr/Cargo.toml
@@ -10,9 +10,9 @@ homepage = "https://substrate.io"
 
 [dependencies]
 array-bytes = { version = "6.1", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 binary-merkle-tree = { path = "../../utils/binary-merkle-tree", default-features = false}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/beefy/Cargo.toml
+++ b/substrate/frame/beefy/Cargo.toml
@@ -9,9 +9,9 @@ description = "BEEFY FRAME pallet"
 homepage = "https://substrate.io"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/benchmarking/Cargo.toml
+++ b/substrate/frame/benchmarking/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 linregress = { version = "0.5.1", optional = true }
 log = { version = "0.4.17", default-features = false }
 paste = "1.0"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-support-procedural = { path = "../support/procedural", default-features = false}

--- a/substrate/frame/benchmarking/pov/Cargo.toml
+++ b/substrate/frame/benchmarking/pov/Cargo.toml
@@ -12,8 +12,8 @@ description = "Pallet for testing FRAME PoV benchmarking"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "..", default-features = false}
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/bounties/Cargo.toml
+++ b/substrate/frame/bounties/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/broker/Cargo.toml
+++ b/substrate/frame/broker/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 bitvec = { version = "1.0.0", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}

--- a/substrate/frame/child-bounties/Cargo.toml
+++ b/substrate/frame/child-bounties/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/collective/Cargo.toml
+++ b/substrate/frame/collective/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -16,11 +16,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 bitflags = "1.3"
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false, features = [

--- a/substrate/frame/contracts/primitives/Cargo.toml
+++ b/substrate/frame/contracts/primitives/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 bitflags = "1.0"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 
 # Substrate Dependencies (This crate should not rely on frame)
 sp-std = { path = "../../../primitives/std", default-features = false}

--- a/substrate/frame/conviction-voting/Cargo.toml
+++ b/substrate/frame/conviction-voting/Cargo.toml
@@ -14,11 +14,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 assert_matches = "1.3.0"
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/core-fellowship/Cargo.toml
+++ b/substrate/frame/core-fellowship/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/democracy/Cargo.toml
+++ b/substrate/frame/democracy/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/election-provider-multi-phase/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/Cargo.toml
@@ -12,10 +12,10 @@ description = "PALLET two phase election providers"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }

--- a/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 parking_lot = "0.12.1"
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = { version = "2.10.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 
 sp-runtime = { path = "../../../primitives/runtime" }

--- a/substrate/frame/election-provider-support/Cargo.toml
+++ b/substrate/frame/election-provider-support/Cargo.toml
@@ -12,8 +12,8 @@ description = "election provider supporting traits"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-election-provider-solution-type = { path = "solution-type" }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/election-provider-support/benchmarking/Cargo.toml
+++ b/substrate/frame/election-provider-support/benchmarking/Cargo.toml
@@ -12,7 +12,7 @@ description = "Benchmarking for election provider support onchain config trait"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false, optional = true}

--- a/substrate/frame/election-provider-support/solution-type/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/Cargo.toml
@@ -21,8 +21,8 @@ proc-macro2 = "1.0.56"
 proc-macro-crate = "1.1.3"
 
 [dev-dependencies]
-parity-scale-codec = "3.6.1"
-scale-info = "2.10.0"
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 sp-arithmetic = { path = "../../../primitives/arithmetic" }
 # used by generate_solution_type:
 frame-election-provider-support = { path = ".." }

--- a/substrate/frame/election-provider-support/solution-type/fuzzer/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/fuzzer/Cargo.toml
@@ -17,8 +17,8 @@ clap = { version = "4.4.6", features = ["derive"] }
 honggfuzz = "0.5"
 rand = { version = "0.8", features = ["std", "small_rng"] }
 
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-election-provider-solution-type = { path = ".." }
 frame-election-provider-support = { path = "../.." }
 sp-arithmetic = { path = "../../../../primitives/arithmetic" }

--- a/substrate/frame/elections-phragmen/Cargo.toml
+++ b/substrate/frame/elections-phragmen/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/examples/basic/Cargo.toml
+++ b/substrate/frame/examples/basic/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/examples/default-config/Cargo.toml
+++ b/substrate/frame/examples/default-config/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 

--- a/substrate/frame/examples/dev-mode/Cargo.toml
+++ b/substrate/frame/examples/dev-mode/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 pallet-balances = { path = "../../balances", default-features = false}

--- a/substrate/frame/examples/frame-crate/Cargo.toml
+++ b/substrate/frame/examples/frame-crate/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame = { path = "../..", default-features = false, features = ["runtime", "experimental"] }
 

--- a/substrate/frame/examples/kitchensink/Cargo.toml
+++ b/substrate/frame/examples/kitchensink/Cargo.toml
@@ -12,9 +12,9 @@ description = "FRAME example kitchensink pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/examples/offchain-worker/Cargo.toml
+++ b/substrate/frame/examples/offchain-worker/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 lite-json = { version = "0.2.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 sp-core = { path = "../../../primitives/core", default-features = false}

--- a/substrate/frame/examples/split/Cargo.toml
+++ b/substrate/frame/examples/split/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/executive/Cargo.toml
+++ b/substrate/frame/executive/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 frame-try-runtime = { path = "../try-runtime", default-features = false, optional = true }

--- a/substrate/frame/fast-unstake/Cargo.toml
+++ b/substrate/frame/fast-unstake/Cargo.toml
@@ -12,9 +12,9 @@ description = "FRAME fast unstake pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/glutton/Cargo.toml
+++ b/substrate/frame/glutton/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 blake2 = { version = "0.10.4", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/grandpa/Cargo.toml
+++ b/substrate/frame/grandpa/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/identity/Cargo.toml
+++ b/substrate/frame/identity/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 enumflags2 = { version = "0.7.7" }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/im-online/Cargo.toml
+++ b/substrate/frame/im-online/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/indices/Cargo.toml
+++ b/substrate/frame/indices/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/insecure-randomness-collective-flip/Cargo.toml
+++ b/substrate/frame/insecure-randomness-collective-flip/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/lottery/Cargo.toml
+++ b/substrate/frame/lottery/Cargo.toml
@@ -12,10 +12,10 @@ description = "FRAME Participation Lottery Pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/membership/Cargo.toml
+++ b/substrate/frame/membership/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/merkle-mountain-range/Cargo.toml
+++ b/substrate/frame/merkle-mountain-range/Cargo.toml
@@ -12,9 +12,9 @@ description = "FRAME Merkle Mountain Range pallet."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/message-queue/Cargo.toml
+++ b/substrate/frame/message-queue/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 description = "FRAME pallet to queue and process messages"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -13,12 +13,12 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 frame-benchmarking = { default-features = false, optional = true, path = "../benchmarking" }
 frame-support = { default-features = false, path = "../support" }
 frame-system = { default-features = false, path = "../system" }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
 sp-application-crypto = { default-features = false, path = "../../primitives/application-crypto" }
 sp-arithmetic = { default-features = false, path = "../../primitives/arithmetic" }

--- a/substrate/frame/multisig/Cargo.toml
+++ b/substrate/frame/multisig/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/nft-fractionalization/Cargo.toml
+++ b/substrate/frame/nft-fractionalization/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/nfts/Cargo.toml
+++ b/substrate/frame/nfts/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 enumflags2 = { version = "0.7.7" }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/nfts/runtime-api/Cargo.toml
+++ b/substrate/frame/nfts/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 pallet-nfts = { path = "..", default-features = false}
 sp-api = { path = "../../../primitives/api", default-features = false}
 

--- a/substrate/frame/nicks/Cargo.toml
+++ b/substrate/frame/nicks/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/nis/Cargo.toml
+++ b/substrate/frame/nis/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/node-authorization/Cargo.toml
+++ b/substrate/frame/node-authorization/Cargo.toml
@@ -12,9 +12,9 @@ description = "FRAME pallet for node authorization"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/nomination-pools/Cargo.toml
+++ b/substrate/frame/nomination-pools/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # parity
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # FRAME
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/nomination-pools/benchmarking/Cargo.toml
+++ b/substrate/frame/nomination-pools/benchmarking/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 # parity
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 # FRAME
 frame-benchmarking = { path = "../../benchmarking", default-features = false}

--- a/substrate/frame/nomination-pools/runtime-api/Cargo.toml
+++ b/substrate/frame/nomination-pools/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../../../primitives/api", default-features = false}
 sp-std = { path = "../../../primitives/std", default-features = false}
 pallet-nomination-pools = { path = "..", default-features = false}

--- a/substrate/frame/nomination-pools/test-staking/Cargo.toml
+++ b/substrate/frame/nomination-pools/test-staking/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = { version = "2.10.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
+scale-info = { workspace = true, features = ["derive"] }
 
 sp-runtime = { path = "../../../primitives/runtime" }
 sp-io = { path = "../../../primitives/io" }

--- a/substrate/frame/offences/Cargo.toml
+++ b/substrate/frame/offences/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/offences/benchmarking/Cargo.toml
+++ b/substrate/frame/offences/benchmarking/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false}
 frame-election-provider-support = { path = "../../election-provider-support", default-features = false}
 frame-support = { path = "../../support", default-features = false}

--- a/substrate/frame/paged-list/Cargo.toml
+++ b/substrate/frame/paged-list/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [ "derive"] }
 docify = "0.2.5"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/preimage/Cargo.toml
+++ b/substrate/frame/preimage/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 description = "FRAME pallet for storing preimages of hashes"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/proxy/Cargo.toml
+++ b/substrate/frame/proxy/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/ranked-collective/Cargo.toml
+++ b/substrate/frame/ranked-collective/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/recovery/Cargo.toml
+++ b/substrate/frame/recovery/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/referenda/Cargo.toml
+++ b/substrate/frame/referenda/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 assert_matches = { version = "1.5", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}

--- a/substrate/frame/remark/Cargo.toml
+++ b/substrate/frame/remark/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/root-offences/Cargo.toml
+++ b/substrate/frame/root-offences/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 pallet-session = { path = "../session", default-features = false , features = [ "historical" ]}
 pallet-staking = { path = "../staking", default-features = false}

--- a/substrate/frame/root-testing/Cargo.toml
+++ b/substrate/frame/root-testing/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/safe-mode/Cargo.toml
+++ b/substrate/frame/safe-mode/Cargo.toml
@@ -12,11 +12,11 @@ description = "FRAME safe-mode pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}

--- a/substrate/frame/salary/Cargo.toml
+++ b/substrate/frame/salary/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/scheduler/Cargo.toml
+++ b/substrate/frame/scheduler/Cargo.toml
@@ -10,9 +10,9 @@ description = "FRAME Scheduler pallet"
 readme = "README.md"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/scored-pool/Cargo.toml
+++ b/substrate/frame/scored-pool/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/session/Cargo.toml
+++ b/substrate/frame/session/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 pallet-timestamp = { path = "../timestamp", default-features = false}

--- a/substrate/frame/session/benchmarking/Cargo.toml
+++ b/substrate/frame/session/benchmarking/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false}
 frame-support = { path = "../../support", default-features = false}
@@ -25,8 +25,8 @@ sp-session = { path = "../../../primitives/session", default-features = false}
 sp-std = { path = "../../../primitives/std", default-features = false}
 
 [dev-dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = "2.10.0"
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
+scale-info = { workspace = true }
 frame-election-provider-support = { path = "../../election-provider-support" }
 pallet-balances = { path = "../../balances" }
 pallet-staking-reward-curve = { path = "../../staking/reward-curve" }

--- a/substrate/frame/society/Cargo.toml
+++ b/substrate/frame/society/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 log = { version = "0.4.17", default-features = false }
 rand_chacha = { version = "0.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/staking/Cargo.toml
+++ b/substrate/frame/staking/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.188", default-features = false, features = ["alloc", "derive"]}
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 sp-io = { path = "../../primitives/io", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false, features = ["serde"] }
 sp-staking = { path = "../../primitives/staking", default-features = false, features = ["serde"] }

--- a/substrate/frame/staking/runtime-api/Cargo.toml
+++ b/substrate/frame/staking/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../../../primitives/api", default-features = false}
 
 [features]

--- a/substrate/frame/state-trie-migration/Cargo.toml
+++ b/substrate/frame/state-trie-migration/Cargo.toml
@@ -12,9 +12,9 @@ description = "FRAME pallet migration of trie"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 thousands = { version = "0.2.0", optional = true }
 zstd = { version = "0.12.4", default-features = false, optional = true }

--- a/substrate/frame/statement/Cargo.toml
+++ b/substrate/frame/statement/Cargo.toml
@@ -12,8 +12,8 @@ description = "FRAME pallet for statement store"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"]}
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"]}
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-statement-store = { path = "../../primitives/statement-store", default-features = false}

--- a/substrate/frame/sudo/Cargo.toml
+++ b/substrate/frame/sudo/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.188", default-features = false, features = ["alloc", "derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
 sp-api = { path = "../../primitives/api", default-features = false, features = [ "frame-metadata" ] }
 sp-std = { path = "../../primitives/std", default-features = false}

--- a/substrate/frame/support/test/Cargo.toml
+++ b/substrate/frame/support/test/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 static_assertions = "1.1.0"
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
 sp-api = { path = "../../../primitives/api", default-features = false}
 sp-arithmetic = { path = "../../../primitives/arithmetic", default-features = false}

--- a/substrate/frame/support/test/compile_pass/Cargo.toml
+++ b/substrate/frame/support/test/compile_pass/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 renamed-frame-support = { package = "frame-support", path = "../..", default-features = false}
 renamed-frame-system = { package = "frame-system", path = "../../../system", default-features = false}
 sp-core = { path = "../../../../primitives/core", default-features = false}

--- a/substrate/frame/support/test/pallet/Cargo.toml
+++ b/substrate/frame/support/test/pallet/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
 frame-support = { path = "../..", default-features = false}
 frame-system = { path = "../../../system", default-features = false}

--- a/substrate/frame/support/test/stg_frame_crate/Cargo.toml
+++ b/substrate/frame/support/test/stg_frame_crate/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 frame = { path = "../../..", default-features = false, features = ["runtime", "experimental"]}
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 [features]
 default = [ "std" ]

--- a/substrate/frame/system/Cargo.toml
+++ b/substrate/frame/system/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 cfg-if = "1.0"
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { workspace = true, default-features = false, features = ["derive", "serde"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 frame-support = { path = "../support", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false, features = ["serde"] }

--- a/substrate/frame/system/benchmarking/Cargo.toml
+++ b/substrate/frame/system/benchmarking/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false}
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "..", default-features = false}

--- a/substrate/frame/system/rpc/runtime-api/Cargo.toml
+++ b/substrate/frame/system/rpc/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 sp-api = { path = "../../../../primitives/api", default-features = false}
 
 [features]

--- a/substrate/frame/timestamp/Cargo.toml
+++ b/substrate/frame/timestamp/Cargo.toml
@@ -14,9 +14,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/tips/Cargo.toml
+++ b/substrate/frame/tips/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/transaction-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
@@ -20,8 +20,8 @@ frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 pallet-asset-conversion = { path = "../../asset-conversion", default-features = false}
 pallet-transaction-payment = { path = "..", default-features = false}
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 sp-core = { path = "../../../primitives/core", default-features = false}

--- a/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -25,8 +25,8 @@ pallet-transaction-payment = { path = "..", default-features = false}
 frame-benchmarking = { path = "../../benchmarking", default-features = false, optional = true }
 
 # Other dependencies
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 
 [dev-dependencies]

--- a/substrate/frame/transaction-payment/rpc/Cargo.toml
+++ b/substrate/frame/transaction-payment/rpc/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 pallet-transaction-payment-rpc-runtime-api = { path = "runtime-api" }
 sp-api = { path = "../../../primitives/api" }

--- a/substrate/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/substrate/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 pallet-transaction-payment = { path = "../..", default-features = false}
 sp-api = { path = "../../../../primitives/api", default-features = false}
 sp-runtime = { path = "../../../../primitives/runtime", default-features = false}

--- a/substrate/frame/transaction-storage/Cargo.toml
+++ b/substrate/frame/transaction-storage/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 array-bytes = { version = "6.1", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/treasury/Cargo.toml
+++ b/substrate/frame/treasury/Cargo.toml
@@ -13,13 +13,13 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }
 docify = "0.2.0"
 impl-trait-for-tuples = "0.2.2"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/try-runtime/Cargo.toml
+++ b/substrate/frame/try-runtime/Cargo.toml
@@ -12,7 +12,7 @@ description = "FRAME pallet for democracy"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"]}
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"]}
 frame-support = { path = "../support", default-features = false}
 sp-api = { path = "../../primitives/api", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/tx-pause/Cargo.toml
+++ b/substrate/frame/tx-pause/Cargo.toml
@@ -12,11 +12,11 @@ description = "FRAME transaction pause pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 pallet-balances = { path = "../balances", default-features = false, optional = true }

--- a/substrate/frame/uniques/Cargo.toml
+++ b/substrate/frame/uniques/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/utility/Cargo.toml
+++ b/substrate/frame/utility/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/vesting/Cargo.toml
+++ b/substrate/frame/vesting/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/whitelist/Cargo.toml
+++ b/substrate/frame/whitelist/Cargo.toml
@@ -12,8 +12,8 @@ description = "FRAME pallet for whitelisting call, and dispatch from specific or
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/primitives/api/Cargo.toml
+++ b/substrate/primitives/api/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 sp-api-proc-macro = { path = "proc-macro" }
 sp-core = { path = "../core", default-features = false}
 sp-std = { path = "../std", default-features = false}
@@ -24,7 +24,7 @@ sp-state-machine = { path = "../state-machine", default-features = false, option
 sp-trie = { path = "../trie", default-features = false, optional = true}
 hash-db = { version = "0.16.0", optional = true }
 thiserror = { version = "1.0.48", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-metadata-ir = { path = "../metadata-ir", default-features = false, optional = true}
 log = { version = "0.4.17", default-features = false }
 

--- a/substrate/primitives/api/test/Cargo.toml
+++ b/substrate/primitives/api/test/Cargo.toml
@@ -19,11 +19,11 @@ sp-tracing = { path = "../../tracing" }
 sp-runtime = { path = "../../runtime" }
 sp-consensus = { path = "../../consensus/common" }
 sc-block-builder = { path = "../../../client/block-builder" }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 sp-state-machine = { path = "../../state-machine" }
 trybuild = "1.0.74"
 rustversion = "1.0.6"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/substrate/primitives/application-crypto/Cargo.toml
+++ b/substrate/primitives/application-crypto/Cargo.toml
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-core = { path = "../core", default-features = false}
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, optional = true, features = ["derive", "alloc"]  }
 sp-std = { path = "../std", default-features = false}
 sp-io = { path = "../io", default-features = false}

--- a/substrate/primitives/arithmetic/Cargo.toml
+++ b/substrate/primitives/arithmetic/Cargo.toml
@@ -14,13 +14,13 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = [
 	"derive",
 	"max-encoded-len",
 ] }
 integer-sqrt = "0.1.2"
 num-traits = { version = "0.2.8", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 static_assertions = "1.1.0"
 sp-std = { path = "../std", default-features = false}

--- a/substrate/primitives/authority-discovery/Cargo.toml
+++ b/substrate/primitives/authority-discovery/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../api", default-features = false}
 sp-application-crypto = { path = "../application-crypto", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}

--- a/substrate/primitives/blockchain/Cargo.toml
+++ b/substrate/primitives/blockchain/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 futures = "0.3.21"
 log = "0.4.17"
 parking_lot = "0.12.1"

--- a/substrate/primitives/consensus/aura/Cargo.toml
+++ b/substrate/primitives/consensus/aura/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}
 sp-consensus-slots = { path = "../slots", default-features = false}

--- a/substrate/primitives/consensus/babe/Cargo.toml
+++ b/substrate/primitives/consensus/babe/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -12,8 +12,8 @@ description = "Primitives for BEEFY protocol."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false,  optional = true, features =  ["derive", "alloc"] }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}
@@ -27,7 +27,7 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 array-bytes = "6.1"
-w3f-bls = { version = "0.1.3", features = ["std"]} 
+w3f-bls = { version = "0.1.3", features = ["std"]}
 
 [features]
 default = [ "std" ]

--- a/substrate/primitives/consensus/grandpa/Cargo.toml
+++ b/substrate/primitives/consensus/grandpa/Cargo.toml
@@ -14,10 +14,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 grandpa = { package = "finality-grandpa", version = "0.16.2", default-features = false, features = ["derive-codec"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive", "alloc"], default-features = false, optional = true }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}

--- a/substrate/primitives/consensus/pow/Cargo.toml
+++ b/substrate/primitives/consensus/pow/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../../api", default-features = false}
 sp-core = { path = "../../core", default-features = false}
 sp-runtime = { path = "../../runtime", default-features = false}

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -15,8 +15,8 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.163", default-features = false, features = ["derive"], optional = true }
 sp-api = { default-features = false, path = "../../api" }
 sp-application-crypto = { default-features = false, path = "../../application-crypto", features = ["bandersnatch-experimental"] }

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-scale-codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.163", default-features = false, features = ["derive"], optional = true }
 sp-api = { default-features = false, path = "../../api" }
@@ -28,7 +28,7 @@ sp-std = { default-features = false, path = "../../std" }
 [features]
 default = [ "std" ]
 std = [
-	"scale-codec/std",
+	"codec/std",
 	"scale-info/std",
 	"serde/std",
 	"sp-api/std",

--- a/substrate/primitives/consensus/sassafras/src/digests.rs
+++ b/substrate/primitives/consensus/sassafras/src/digests.rs
@@ -22,7 +22,7 @@ use crate::{
 	EpochConfiguration, Randomness, Slot, SASSAFRAS_ENGINE_ID,
 };
 
-use scale_codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 use sp_runtime::{DigestItem, RuntimeDebug};

--- a/substrate/primitives/consensus/sassafras/src/lib.rs
+++ b/substrate/primitives/consensus/sassafras/src/lib.rs
@@ -21,7 +21,7 @@
 #![forbid(unsafe_code, missing_docs, unused_variables, unused_imports)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use scale_codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::crypto::KeyTypeId;
 use sp_runtime::{ConsensusEngineId, RuntimeDebug};

--- a/substrate/primitives/consensus/sassafras/src/ticket.rs
+++ b/substrate/primitives/consensus/sassafras/src/ticket.rs
@@ -18,7 +18,7 @@
 //! Primitives related to tickets.
 
 use crate::vrf::RingVrfSignature;
-use scale_codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 pub use sp_core::ed25519::{Public as EphemeralPublic, Signature as EphemeralSignature};

--- a/substrate/primitives/consensus/sassafras/src/vrf.rs
+++ b/substrate/primitives/consensus/sassafras/src/vrf.rs
@@ -18,7 +18,7 @@
 //! Utilities related to VRF input, output and signatures.
 
 use crate::{Randomness, TicketBody, TicketId};
-use scale_codec::Encode;
+use codec::Encode;
 use sp_consensus_slots::Slot;
 use sp_std::vec::Vec;
 

--- a/substrate/primitives/consensus/slots/Cargo.toml
+++ b/substrate/primitives/consensus/slots/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-std = { path = "../../std", default-features = false}
 sp-timestamp = { path = "../../timestamp", default-features = false}

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/sp-core"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive","max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive","max-encoded-len"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.188", optional = true,  default-features = false, features = ["derive", "alloc"] }
 bounded-collections = { version = "0.1.8", default-features = false }

--- a/substrate/primitives/externalities/Cargo.toml
+++ b/substrate/primitives/externalities/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 environmental = { version = "1.1.3", default-features = false }
 sp-std = { path = "../std", default-features = false}
 sp-storage = { path = "../storage", default-features = false}

--- a/substrate/primitives/inherents/Cargo.toml
+++ b/substrate/primitives/inherents/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 thiserror = { version = "1.0.48", optional = true }
 sp-runtime = { path = "../runtime", default-features = false, optional = true}

--- a/substrate/primitives/io/Cargo.toml
+++ b/substrate/primitives/io/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 bytes = { version = "1.1.0", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["bytes"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["bytes"] }
 sp-core = { path = "../core", default-features = false}
 sp-keystore = { path = "../keystore", default-features = false, optional = true}
 sp-std = { path = "../std", default-features = false}

--- a/substrate/primitives/keystore/Cargo.toml
+++ b/substrate/primitives/keystore/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-core"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 parking_lot = { version = "0.12.1", default-features = false }
 thiserror = "1.0"
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/merkle-mountain-range/Cargo.toml
+++ b/substrate/primitives/merkle-mountain-range/Cargo.toml
@@ -12,8 +12,8 @@ description = "Merkle Mountain Range primitives."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 mmr-lib = { package = "ckb-merkle-mountain-range", version = "0.5.2", default-features = false }
 serde = { version = "1.0.188", features = ["derive", "alloc"], default-features = false, optional = true }

--- a/substrate/primitives/metadata-ir/Cargo.toml
+++ b/substrate/primitives/metadata-ir/Cargo.toml
@@ -13,9 +13,9 @@ documentation = "https://docs.rs/sp-metadata-ir"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-std = { path = "../std", default-features = false}
 
 [features]

--- a/substrate/primitives/mixnet/Cargo.toml
+++ b/substrate/primitives/mixnet/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-api = { default-features = false, path = "../api" }
 sp-application-crypto = { default-features = false, path = "../application-crypto" }
 sp-std = { default-features = false, path = "../std" }

--- a/substrate/primitives/npos-elections/Cargo.toml
+++ b/substrate/primitives/npos-elections/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-arithmetic = { path = "../arithmetic", default-features = false}
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/runtime-interface/Cargo.toml
+++ b/substrate/primitives/runtime-interface/Cargo.toml
@@ -20,7 +20,7 @@ sp-std = { path = "../std", default-features = false}
 sp-tracing = { path = "../tracing", default-features = false}
 sp-runtime-interface-proc-macro = { path = "proc-macro" }
 sp-externalities = { path = "../externalities", default-features = false}
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["bytes"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["bytes"] }
 static_assertions = "1.0.0"
 primitive-types = { version = "0.12.0", default-features = false }
 sp-storage = { path = "../storage", default-features = false}

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -14,14 +14,14 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive", "max-encoded-len"] }
 either = { version = "1.5", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
 paste = "1.0"
 rand = { version = "0.8.5", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-application-crypto = { path = "../application-crypto", default-features = false}
 sp-arithmetic = { path = "../arithmetic", default-features = false}

--- a/substrate/primitives/session/Cargo.toml
+++ b/substrate/primitives/session/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-api = { path = "../api", default-features = false}
 sp-core = { path = "../core", default-features = false}
 sp-runtime = { path = "../runtime", optional = true}

--- a/substrate/primitives/staking/Cargo.toml
+++ b/substrate/primitives/staking/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/state-machine/Cargo.toml
+++ b/substrate/primitives/state-machine/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 hash-db = { version = "0.16.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
 parking_lot = { version = "0.12.1", optional = true }

--- a/substrate/primitives/statement-store/Cargo.toml
+++ b/substrate/primitives/statement-store/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-core = { path = "../core", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}
 sp-std = { path = "../std", default-features = false}

--- a/substrate/primitives/storage/Cargo.toml
+++ b/substrate/primitives/storage/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 impl-serde = { version = "0.4.0", optional = true, default-features = false }
 ref-cast = "1.0.0"
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }

--- a/substrate/primitives/test-primitives/Cargo.toml
+++ b/substrate/primitives/test-primitives/Cargo.toml
@@ -12,8 +12,8 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive"], optional = true }
 sp-application-crypto = { path = "../application-crypto", default-features = false}
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/timestamp/Cargo.toml
+++ b/substrate/primitives/timestamp/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.48", optional = true }
 sp-inherents = { path = "../inherents", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}

--- a/substrate/primitives/tracing/Cargo.toml
+++ b/substrate/primitives/tracing/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
 sp-std = { path = "../std", default-features = false }
-codec = { version = "3.6.1", package = "parity-scale-codec", default-features = false, features = [
+codec = { workspace = true, package = "parity-scale-codec", default-features = false, features = [
 	"derive",
 ] }
 tracing = { version = "0.1.29", default-features = false }

--- a/substrate/primitives/transaction-storage-proof/Cargo.toml
+++ b/substrate/primitives/transaction-storage-proof/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-core = { path = "../core", optional = true}
 sp-inherents = { path = "../inherents", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}

--- a/substrate/primitives/trie/Cargo.toml
+++ b/substrate/primitives/trie/Cargo.toml
@@ -19,7 +19,7 @@ harness = false
 
 [dependencies]
 ahash = { version = "0.8.2", optional = true }
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 hashbrown = { version = "0.13.2", optional = true }
 hash-db = { version = "0.16.0", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
@@ -27,7 +27,7 @@ memory-db = { version = "0.32.0", default-features = false }
 nohash-hasher = { version = "0.2.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 rand = { version = "0.8", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.48", optional = true }
 tracing = { version = "0.1.29", optional = true }
 trie-db = { version = "0.28.0", default-features = false }

--- a/substrate/primitives/version/Cargo.toml
+++ b/substrate/primitives/version/Cargo.toml
@@ -14,10 +14,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 impl-serde = { version = "0.4.0", default-features = false, optional = true }
 parity-wasm = { version = "0.45", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188",  default-features = false, features = ["derive", "alloc"], optional = true }
 thiserror = { version = "1.0.48", optional = true }
 sp-core-hashing-proc-macro = { path = "../core/hashing/proc-macro" }

--- a/substrate/primitives/version/proc-macro/Cargo.toml
+++ b/substrate/primitives/version/proc-macro/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 proc-macro = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", workspace = true, features = [ "derive" ] }
 proc-macro2 = "1.0.56"
 quote = "1.0.28"
 syn = { version = "2.0.38", features = ["full", "fold", "extra-traits", "visit"] }

--- a/substrate/primitives/wasm-interface/Cargo.toml
+++ b/substrate/primitives/wasm-interface/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", optional = true }
 wasmtime = { version = "8.0.1", default-features = false, optional = true }

--- a/substrate/primitives/weights/Cargo.toml
+++ b/substrate/primitives/weights/Cargo.toml
@@ -13,8 +13,8 @@ documentation = "https://docs.rs/sp-wasm-interface"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, optional = true, features = ["derive", "alloc"] }
 smallvec = "1.11.0"
 sp-arithmetic = { path = "../arithmetic", default-features = false}

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 async-trait = "0.1.57"
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 serde = "1.0.188"
 serde_json = "1.0.107"

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -18,8 +18,8 @@ sp-consensus-aura = { path = "../../primitives/consensus/aura", default-features
 sp-consensus-babe = { path = "../../primitives/consensus/babe", default-features = false, features = ["serde"] }
 sp-genesis-builder = { path = "../../primitives/genesis-builder", default-features = false}
 sp-block-builder = { path = "../../primitives/block-builder", default-features = false}
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false, features = ["derive"] }
+scale-info = { workspace = true, default-features = false, features = ["derive"] }
 sp-inherents = { path = "../../primitives/inherents", default-features = false}
 sp-keyring = { path = "../../primitives/keyring", optional = true}
 sp-offchain = { path = "../../primitives/offchain", default-features = false}

--- a/substrate/test-utils/runtime/transaction-pool/Cargo.toml
+++ b/substrate/test-utils/runtime/transaction-pool/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 futures = "0.3.21"
 parking_lot = "0.12.1"
 thiserror = "1.0"

--- a/substrate/utils/fork-tree/Cargo.toml
+++ b/substrate/utils/fork-tree/Cargo.toml
@@ -14,4 +14,4 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }

--- a/substrate/utils/frame/benchmarking-cli/Cargo.toml
+++ b/substrate/utils/frame/benchmarking-cli/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "6.1"
 chrono = "0.4"
 clap = { version = "4.4.6", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 comfy-table = { version = "7.0.1", default-features = false }
 handlebars = "4.2.2"
 Inflector = "0.11.4"

--- a/substrate/utils/frame/remote-externalities/Cargo.toml
+++ b/substrate/utils/frame/remote-externalities/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 jsonrpsee = { version = "0.16.2", features = ["http-client"] }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 log = "0.4.17"
 serde = "1.0.188"
 sp-core = { path = "../../../primitives/core" }

--- a/substrate/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
+++ b/substrate/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 sp-core = { path = "../../../../primitives/core" }

--- a/substrate/utils/frame/rpc/support/Cargo.toml
+++ b/substrate/utils/frame/rpc/support/Cargo.toml
@@ -12,7 +12,7 @@ description = "Substrate RPC for FRAME's support"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["jsonrpsee-types"] }
 serde = "1"
 frame-support = { path = "../../../../frame/support" }
@@ -20,7 +20,7 @@ sc-rpc-api = { path = "../../../../client/rpc-api" }
 sp-storage = { path = "../../../../primitives/storage" }
 
 [dev-dependencies]
-scale-info = "2.10.0"
+scale-info = { workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["ws-client", "jsonrpsee-types"] }
 tokio = "1.22.0"
 sp-core = { path = "../../../../primitives/core" }

--- a/substrate/utils/frame/rpc/system/Cargo.toml
+++ b/substrate/utils/frame/rpc/system/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+codec = { package = "parity-scale-codec", workspace = true }
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 futures = "0.3.21"
 log = "0.4.17"

--- a/substrate/utils/frame/try-runtime/cli/Cargo.toml
+++ b/substrate/utils/frame/try-runtime/cli/Cargo.toml
@@ -38,7 +38,7 @@ async-trait = "0.1.57"
 clap = { version = "4.4.6", features = ["derive"] }
 hex = { version = "0.4.3", default-features = false }
 log = "0.4.17"
-parity-scale-codec = "3.6.1"
+parity-scale-codec = { workspace = true }
 serde = "1.0.188"
 serde_json = "1.0.107"
 zstd = { version = "0.12.4", default-features = false }


### PR DESCRIPTION
# Description

This uses the `[workspace.dependencies]` field to give some consistency over versions of common crates used all over the place and make keeping their versions in sync easier.

For now, I just started with two common crates, `scale-info` and `parity-scale-codec`. If this is something that's wanted, I can add some more common crates to the list, or else others can add to the list.

# Downsides

`parity-scale-codec` is renamed to `codec` in many places. Owing to a quirk of workwspace dependencies, it must be declared in the workspace as:

```toml
codec = { package = "parity-scale-codec", version = "3.6.5" }
```

Owing to how the macro discovers which crate path to use, it currently needs the `package` field to be duplicated as in:

```toml
codec = { package = "parity-scale-codec", workspace = true, ... }
```

This leads to a bunch of warnings. It could be fixed in `parity-scale-codec` with a bit of effort.

The other thing leading to warnings is that eg `default-features = false` should be added to the workspace dependencies, else it is ignored in the use site. Fixing any fallout from that would lead to a little churn perhaps. 

# Unknowns

Does this break the tooling to publish crates automatically, or any other CI workflows?

