### PR TITLE
upgrade to docify 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,18 +4539,18 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bf86c286159ed2d70e9ff5c4de69b793ab8632c8a1d276d44bbff36f052f64"
+checksum = "4235e9b248e2ba4b92007fe9c646f3adf0ffde16dc74713eacc92b8bc58d8d2f"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5ac3bdcdc56f2317e51884a90bd6f595febd6d029cdb75174162107072a8a3"
+checksum = "47020e12d7c7505670d1363dd53d6c23724f71a90a3ae32ff8eba40de8404626"
 dependencies = [
  "common-path",
  "derive-syn-parse",

--- a/substrate/frame/bags-list/Cargo.toml
+++ b/substrate/frame/bags-list/Cargo.toml
@@ -27,7 +27,7 @@ frame-election-provider-support = { path = "../election-provider-support", defau
 
 # third party
 log = { version = "0.4.17", default-features = false }
-docify = "0.2.5"
+docify = "0.2.6"
 aquamarine = { version = "0.3.2" }
 
 # Optional imports for benchmarking

--- a/substrate/frame/fast-unstake/Cargo.toml
+++ b/substrate/frame/fast-unstake/Cargo.toml
@@ -27,7 +27,7 @@ frame-election-provider-support = { path = "../election-provider-support", defau
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 
-docify = "0.2.5"
+docify = "0.2.6"
 
 [dev-dependencies]
 pallet-staking-reward-curve = { path = "../staking/reward-curve" }

--- a/substrate/frame/paged-list/Cargo.toml
+++ b/substrate/frame/paged-list/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
-docify = "0.2.5"
+docify = "0.2.6"
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}

--- a/substrate/frame/scheduler/Cargo.toml
+++ b/substrate/frame/scheduler/Cargo.toml
@@ -20,7 +20,7 @@ sp-io = { path = "../../primitives/io", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-weights = { path = "../../primitives/weights", default-features = false}
-docify = "0.2.5"
+docify = "0.2.6"
 
 [dev-dependencies]
 pallet-preimage = { path = "../preimage" }

--- a/substrate/frame/sudo/Cargo.toml
+++ b/substrate/frame/sudo/Cargo.toml
@@ -22,7 +22,7 @@ sp-io = { path = "../../primitives/io", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 
-docify = "0.2.5"
+docify = "0.2.6"
 
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -43,7 +43,7 @@ k256 = { version = "0.13.1", default-features = false, features = ["ecdsa"] }
 environmental = { version = "1.1.4", default-features = false }
 sp-genesis-builder = { path = "../../primitives/genesis-builder", default-features=false}
 serde_json = { version = "1.0.107", default-features = false, features = ["alloc"] }
-docify = "0.2.5"
+docify = "0.2.6"
 static_assertions = "1.1.0"
 
 aquamarine = { version = "0.3.2" }

--- a/substrate/frame/timestamp/Cargo.toml
+++ b/substrate/frame/timestamp/Cargo.toml
@@ -27,7 +27,7 @@ sp-std = { path = "../../primitives/std", default-features = false}
 sp-storage = { path = "../../primitives/storage", default-features = false}
 sp-timestamp = { path = "../../primitives/timestamp", default-features = false}
 
-docify = "0.2.5"
+docify = "0.2.6"
 
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }


### PR DESCRIPTION
Updates `docify` to 0.2.6, which fixes a bug that was preventing nesting `#[docify::export]` within sub-items of items that already have `#[docify::export]` attached to them from working properly.

Release notes here: https://github.com/sam0x17/docify/releases/tag/v0.2.6

cc @ggwpez @kianenigma 