### PR TITLE
fix(frame-benchmarking-cli): Pass heap_pages param to WasmExecutor

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -25,9 +25,7 @@ use frame_support::traits::StorageInfo;
 use linked_hash_map::LinkedHashMap;
 use sc_cli::{execution_method_from_cli, CliConfiguration, Result, SharedParams};
 use sc_client_db::BenchmarkingState;
-use sc_executor::{
-	HeapAllocStrategy, NativeElseWasmExecutor, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY,
-};
+use sc_executor::{HeapAllocStrategy, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY};
 use sc_service::Configuration;
 use serde::Serialize;
 use sp_core::{
@@ -227,15 +225,17 @@ impl PalletCmd {
 					extra_pages: p as _,
 				});
 
-		let executor = NativeElseWasmExecutor::<ExecDispatch>::new_with_wasm_executor(
-			WasmExecutor::builder()
-				.with_execution_method(method)
-				.with_onchain_heap_alloc_strategy(heap_pages)
-				.with_offchain_heap_alloc_strategy(heap_pages)
-				.with_max_runtime_instances(2)
-				.with_runtime_cache_size(2)
-				.build(),
-		);
+		let executor = WasmExecutor::<(
+			sp_io::SubstrateHostFunctions,
+			frame_benchmarking::benchmarking::HostFunctions,
+			ExtraHostFunctions,
+		)>::builder()
+		.with_execution_method(method)
+		.with_onchain_heap_alloc_strategy(heap_pages)
+		.with_offchain_heap_alloc_strategy(heap_pages)
+		.with_max_runtime_instances(2)
+		.with_runtime_cache_size(2)
+		.build();
 
 		let extensions = || -> Extensions {
 			let mut extensions = Extensions::default();


### PR DESCRIPTION
In https://github.com/paritytech/substrate/pull/13740 the use of the `heap-pages` param inside the `frame-benchmarking-cli` has been removed.
This results in running out of memory and this PR fixes the heap allocation strategy for benchmarks wasm executor.