### PR TITLE
pallet-contracts: Do not return an error on already applied upgrades

### DIFF
--- a/substrate/frame/contracts/src/migration.rs
+++ b/substrate/frame/contracts/src/migration.rs
@@ -311,11 +311,6 @@ impl<T: Config, const TEST_ALL_STEPS: bool> OnRuntimeUpgrade for Migration<T, TE
 		let storage_version = <Pallet<T>>::on_chain_storage_version();
 		let target_version = <Pallet<T>>::current_storage_version();
 
-		ensure!(
-			storage_version != target_version,
-			"No upgrade: Please remove this migration from your runtime upgrade configuration."
-		);
-
 		log::debug!(
 			target: LOG_TARGET,
 			"Requested migration of {} from {:?}(on-chain storage version) to {:?}(current storage version)",

--- a/substrate/frame/contracts/src/migration.rs
+++ b/substrate/frame/contracts/src/migration.rs
@@ -312,11 +312,6 @@ impl<T: Config, const TEST_ALL_STEPS: bool> OnRuntimeUpgrade for Migration<T, TE
 		let target_version = <Pallet<T>>::current_storage_version();
 
 		if storage_version == target_version {
-			log::info!(
-				target: LOG_TARGET,
-				"Pallet is already at the latest version {storage_version:?}",
-			);
-
 			return Ok(Default::default())
 		}
 

--- a/substrate/frame/contracts/src/migration.rs
+++ b/substrate/frame/contracts/src/migration.rs
@@ -311,6 +311,15 @@ impl<T: Config, const TEST_ALL_STEPS: bool> OnRuntimeUpgrade for Migration<T, TE
 		let storage_version = <Pallet<T>>::on_chain_storage_version();
 		let target_version = <Pallet<T>>::current_storage_version();
 
+		if storage_version == target_version {
+			log::info!(
+				target: LOG_TARGET,
+				"Pallet is already at the latest version {storage_version:?}",
+			);
+
+			return Ok(Default::default())
+		}
+
 		log::debug!(
 			target: LOG_TARGET,
 			"Requested migration of {} from {:?}(on-chain storage version) to {:?}(current storage version)",


### PR DESCRIPTION
Migrations in general should just skip the operation, if they were already applied. This is especially useful for CI checks that run in each pr to check that the current set of migrations are valid.

