### PR TITLE
[DNM] bump zombienet version 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.73"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.75"
   DOCKER_IMAGES_VERSION: "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
 
 default:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.71"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.73"
   DOCKER_IMAGES_VERSION: "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
 
 default:

--- a/polkadot/zombienet_tests/functional/0001-parachains-pvf.toml
+++ b/polkadot/zombienet_tests/functional/0001-parachains-pvf.toml
@@ -4,7 +4,6 @@ timeout = 1000
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 chain = "rococo-local"
-chain_spec_command = "polkadot build-spec --chain rococo-local --disable-default-bootnode"
 
 [relaychain.default_resources]
 limits = { memory = "4G", cpu = "2" }

--- a/polkadot/zombienet_tests/functional/0002-parachains-disputes.toml
+++ b/polkadot/zombienet_tests/functional/0002-parachains-disputes.toml
@@ -8,7 +8,6 @@ timeout = 1000
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 chain = "rococo-local"
-chain_spec_command = "polkadot build-spec --chain rococo-local --disable-default-bootnode"
 default_command = "polkadot"
 
 [relaychain.default_resources]

--- a/polkadot/zombienet_tests/functional/0004-parachains-garbage-candidate.toml
+++ b/polkadot/zombienet_tests/functional/0004-parachains-garbage-candidate.toml
@@ -9,7 +9,6 @@ bootnode = true
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 chain = "rococo-local"
-chain_spec_command = "polkadot build-spec --chain rococo-local --disable-default-bootnode"
 default_command = "polkadot"
 
 [relaychain.default_resources]

--- a/polkadot/zombienet_tests/misc/0001-paritydb.toml
+++ b/polkadot/zombienet_tests/misc/0001-paritydb.toml
@@ -9,7 +9,6 @@ bootnode = true
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"
 chain = "rococo-local"
-chain_spec_command = "polkadot build-spec --chain rococo-local"
 default_command = "polkadot"
 
 [relaychain.default_resources]


### PR DESCRIPTION
This version includes:
- Move `spot` usage in CI to 50%
- Fix `PodMonitor`, metrics will be relayed to grafana