### PR TITLE
Patch release Polkadot v1.2.1 Rococo & Westend runtimes that include crates name fix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,9 @@
-#
+[build]
+rustdocflags = [
+  "-Dwarnings",
+  "-Arustdoc::redundant_explicit_links", # stylistic
+]
+
 # An auto defined `clippy` feature was introduced,
 # but it was found to clash with user defined features,
 # so was renamed to `cargo-clippy`.
@@ -30,4 +35,5 @@ rustflags = [
   "-Aclippy::derivable_impls",           # false positives
   "-Aclippy::stable_sort_primitive",     # prefer stable sort
   "-Aclippy::extra-unused-type-parameters", # stylistic
+  "-Aclippy::default_constructed_unit_structs", # stylistic
 ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH
 
 variables:
-  CI_IMAGE: !reference [.ci-unified, variables, CI_IMAGE]
+  CI_IMAGE: !reference [.ci-unified-1.73.0, variables, CI_IMAGE]
   # BUILDAH_IMAGE is defined in group variables
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -85,6 +85,7 @@ build-rustdoc:
     - .run-immediately
   variables:
     SKIP_WASM_BUILD: 1
+    RUSTDOCFLAGS: ""
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when: on_success
@@ -93,7 +94,6 @@ build-rustdoc:
       - ./crate-docs/
   script:
     # FIXME: it fails with `RUSTDOCFLAGS="-Dwarnings"` and `--all-features`
-    # FIXME: return to stable when https://github.com/rust-lang/rust/issues/96937 gets into stable
     - time cargo doc --features try-runtime,experimental --workspace --no-deps
     - rm -f ./target/doc/.lock
     - mv ./target/doc ./crate-docs

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -181,7 +181,6 @@ test-rustdoc:
     - .run-immediately
   variables:
     SKIP_WASM_BUILD: 1
-    RUSTDOCFLAGS: "-Dwarnings"
   script:
     - time cargo doc --workspace --all-features --no-deps
   allow_failure: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11438,7 +11438,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_cmd",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15896,9 +15896,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -15910,9 +15910,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 hash-db = { version = "0.16.0", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 static_assertions = { version = "1.1", optional = true }
 
 # Bridge dependencies

--- a/bridges/modules/grandpa/Cargo.toml
+++ b/bridges/modules/grandpa/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/modules/messages/Cargo.toml
+++ b/bridges/modules/messages/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 log = { version = "0.4.20", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge dependencies
 

--- a/bridges/modules/parachains/Cargo.toml
+++ b/bridges/modules/parachains/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/modules/relayers/Cargo.toml
+++ b/bridges/modules/relayers/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge dependencies
 

--- a/bridges/modules/xcm-bridge-hub-router/Cargo.toml
+++ b/bridges/modules/xcm-bridge-hub-router/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.8.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
 
 # Bridge dependencies
 

--- a/bridges/primitives/chain-asset-hub-kusama/Cargo.toml
+++ b/bridges/primitives/chain-asset-hub-kusama/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate Dependencies
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/bridges/primitives/chain-asset-hub-polkadot/Cargo.toml
+++ b/bridges/primitives/chain-asset-hub-polkadot/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate Dependencies
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/bridges/primitives/header-chain/Cargo.toml
+++ b/bridges/primitives/header-chain/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Bridge dependencies

--- a/bridges/primitives/messages/Cargo.toml
+++ b/bridges/primitives/messages/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["bit-vec", "derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Bridge dependencies

--- a/bridges/primitives/parachains/Cargo.toml
+++ b/bridges/primitives/parachains/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2"
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge dependencies
 

--- a/bridges/primitives/polkadot-core/Cargo.toml
+++ b/bridges/primitives/polkadot-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 parity-util-mem = { version = "0.12.0", optional = true }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Bridge Dependencies

--- a/bridges/primitives/relayers/Cargo.toml
+++ b/bridges/primitives/relayers/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["bit-vec", "derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
 
 # Bridge Dependencies
 

--- a/bridges/primitives/runtime/Cargo.toml
+++ b/bridges/primitives/runtime/Cargo.toml
@@ -12,7 +12,7 @@ hash-db = { version = "0.16.0", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.19", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Substrate Dependencies

--- a/bridges/primitives/xcm-bridge-hub-router/Cargo.toml
+++ b/bridges/primitives/xcm-bridge-hub-router/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["bit-vec", "derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
 
 # Substrate Dependencies
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false }

--- a/cumulus/pallets/aura-ext/Cargo.toml
+++ b/cumulus/pallets/aura-ext/Cargo.toml
@@ -7,7 +7,7 @@ description = "AURA consensus extension pallet for parachains"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/collator-selection/Cargo.toml
+++ b/cumulus/pallets/collator-selection/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = { version = "0.4.20", default-features = false }
 codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", version = "3.0.0" }
 rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../substrate/primitives/std", default-features = false}
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false}

--- a/cumulus/pallets/dmp-queue/Cargo.toml
+++ b/cumulus/pallets/dmp-queue/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ], default-features = false }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/parachain-system/Cargo.toml
+++ b/cumulus/pallets/parachain-system/Cargo.toml
@@ -12,7 +12,7 @@ environmental = { version = "1.1.4", default-features = false }
 impl-trait-for-tuples = "0.2.1"
 log = { version = "0.4.20", default-features = false }
 trie-db = { version = "0.28.0", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/solo-to-para/Cargo.toml
+++ b/cumulus/pallets/solo-to-para/Cargo.toml
@@ -7,7 +7,7 @@ description = "Adds functionality to migrate from a Solo to a Parachain"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/pallets/xcm/Cargo.toml
+++ b/cumulus/pallets/xcm/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../substrate/primitives/std", default-features = false}
 sp-io = { path = "../../../substrate/primitives/io", default-features = false}

--- a/cumulus/pallets/xcmp-queue/Cargo.toml
+++ b/cumulus/pallets/xcmp-queue/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ], default-features = false }
 log = { version = "0.4.20", default-features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false}

--- a/cumulus/parachain-template/pallets/template/Cargo.toml
+++ b/cumulus/parachain-template/pallets/template/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../substrate/frame/benchmarking", default-features = false, optional = true}

--- a/cumulus/parachain-template/runtime/Cargo.toml
+++ b/cumulus/parachain-template/runtime/Cargo.toml
@@ -18,7 +18,7 @@ substrate-wasm-builder = { path = "../../../substrate/utils/wasm-builder", optio
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Local

--- a/cumulus/parachains/common/Cargo.toml
+++ b/cumulus/parachains/common/Cargo.toml
@@ -11,7 +11,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 log = { version = "0.4.19", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 num-traits = { version = "0.2", default-features = false}
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/pallets/collective-content/Cargo.toml
+++ b/cumulus/parachains/pallets/collective-content/Cargo.toml
@@ -7,7 +7,7 @@ description = "Managed content"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../../../../substrate/frame/benchmarking", optional = true, default-features = false }
 frame-support = { path = "../../../../substrate/frame/support", default-features = false }

--- a/cumulus/parachains/pallets/parachain-info/Cargo.toml
+++ b/cumulus/parachains/pallets/parachain-info/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../../../substrate/frame/support", default-features = false}
 frame-system = { path = "../../../../substrate/frame/system", default-features = false}

--- a/cumulus/parachains/pallets/ping/Cargo.toml
+++ b/cumulus/parachains/pallets/ping/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../../substrate/primitives/std", default-features = false}
 sp-runtime = { path = "../../../../substrate/primitives/runtime", default-features = false}

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml
@@ -9,7 +9,7 @@ description = "Kusama variant of Asset Hub parachain runtime"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml
@@ -9,7 +9,7 @@ description = "Asset Hub Polkadot parachain runtime"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
@@ -9,7 +9,7 @@ description = "Westend variant of Asset Hub parachain runtime"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/assets/common/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/common/Cargo.toml
@@ -7,7 +7,7 @@ description = "Assets common utilities"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.20", default-features = false }
 impl-trait-for-tuples = "0.2.2"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -12,7 +12,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -12,7 +12,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -12,7 +12,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 smallvec = "1.11.0"
 

--- a/cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml
+++ b/cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml
@@ -9,7 +9,7 @@ description = "Polkadot Collectives Parachain Runtime"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
@@ -14,7 +14,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
+++ b/cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true}

--- a/cumulus/parachains/runtimes/starters/seedling/Cargo.toml
+++ b/cumulus/parachains/runtimes/starters/seedling/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false}

--- a/cumulus/parachains/runtimes/starters/shell/Cargo.toml
+++ b/cumulus/parachains/runtimes/starters/shell/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false}

--- a/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
@@ -19,7 +19,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true}

--- a/cumulus/primitives/core/Cargo.toml
+++ b/cumulus/primitives/core/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 sp-api = { path = "../../../substrate/primitives/api", default-features = false}

--- a/cumulus/primitives/parachain-inherent/Cargo.toml
+++ b/cumulus/primitives/parachain-inherent/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 [dependencies]
 async-trait = { version = "0.1.73", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1.37", optional = true }
 
 # Substrate

--- a/cumulus/test/runtime/Cargo.toml
+++ b/cumulus/test/runtime/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.9.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../substrate/frame/executive", default-features = false}

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.64.0"
 readme = "README.md"
 authors.workspace = true
 edition.workspace = true
-version = "1.2.0"
+version = "1.2.1"
 default-run = "polkadot"
 
 [dependencies]

--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 ///
 /// The worker binaries associated to the node binary should ensure that they are using the same
 /// version as the main node that started them.
-pub const NODE_VERSION: &'static str = "1.2.0";
+pub const NODE_VERSION: &'static str = "1.2.1";
 
 #[allow(missing_docs)]
 #[derive(Debug, Parser)]

--- a/polkadot/core-primitives/Cargo.toml
+++ b/polkadot/core-primitives/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 sp-core = { path = "../../substrate/primitives/core", default-features = false }
 sp-std = { path = "../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = [ "derive" ] }
 
 [features]

--- a/polkadot/node/core/backing/src/tests/mod.rs
+++ b/polkadot/node/core/backing/src/tests/mod.rs
@@ -1595,8 +1595,8 @@ fn retry_works() {
 				},
 				AllMessages::RuntimeApi(RuntimeApiMessage::Request(
 					_,
-					RuntimeApiRequest::SessionExecutorParams(sess_idx, tx),
-				)) if sess_idx == 1 => {
+					RuntimeApiRequest::SessionExecutorParams(1, tx),
+				)) => {
 					tx.send(Ok(Some(ExecutorParams::default()))).unwrap();
 				},
 				msg => {

--- a/polkadot/node/overseer/examples/minimal-example.rs
+++ b/polkadot/node/overseer/examples/minimal-example.rs
@@ -163,7 +163,6 @@ fn main() {
 			.unwrap();
 
 		let overseer_fut = overseer.run().fuse();
-		let timer_stream = timer_stream;
 
 		pin_mut!(timer_stream);
 		pin_mut!(overseer_fut);

--- a/polkadot/parachain/Cargo.toml
+++ b/polkadot/parachain/Cargo.toml
@@ -11,7 +11,7 @@ version = "1.0.0"
 # this crate for WASM. This is critical to avoid forcing all parachain WASM into implementing
 # various unnecessary Substrate-specific endpoints.
 parity-scale-codec = { version = "3.6.1", default-features = false, features = [ "derive" ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 sp-std = { path = "../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false, features = ["serde"] }
 sp-core = { path = "../../substrate/primitives/core", default-features = false, features = ["serde"] }

--- a/polkadot/primitives/Cargo.toml
+++ b/polkadot/primitives/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 hex-literal = "0.4.1"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 
 application-crypto = { package = "sp-application-crypto", path = "../../substrate/primitives/application-crypto", default-features = false, features = ["serde"] }

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -11,7 +11,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1.0.117" }
 static_assertions = "1.1.0"

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -11,7 +11,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 derive_more = "0.99.17"
 bitflags = "1.3.2"

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.188", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1554,16 +1554,7 @@ pub mod migrations {
 	use super::*;
 
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = (
-		pallet_society::migrations::VersionCheckedMigrateToV2<Runtime, (), ()>,
-		pallet_im_online::migration::v1::Migration<Runtime>,
-		parachains_configuration::migration::v7::MigrateToV7<Runtime>,
-		assigned_slots::migration::v1::VersionCheckedMigrateToV1<Runtime>,
-		parachains_scheduler::migration::v1::MigrateToV1<Runtime>,
-		parachains_configuration::migration::v8::MigrateToV8<Runtime>,
-		parachains_configuration::migration::v9::MigrateToV9<Runtime>,
-		paras_registrar::migration::VersionCheckedMigrateToV1<Runtime, ()>,
-	);
+	pub type Unreleased = ();
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("rococo"),
 	impl_name: create_runtime_str!("parity-rococo-v2.0"),
 	authoring_version: 0,
-	spec_version: 102000,
+	spec_version: 102001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 23,

--- a/polkadot/runtime/test-runtime/Cargo.toml
+++ b/polkadot/runtime/test-runtime/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false }
 serde_derive = { version = "1.0.117", optional = true }
 smallvec = "1.8.0"

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { version = "1.0.188", default-features = false }

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -122,7 +122,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westend"),
 	impl_name: create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 102000,
+	spec_version: 102001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 23,

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -12,7 +12,7 @@ derivative = { version = "2.2.0", default-features = false, features = [ "use_co
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = [ "derive", "max-encoded-len" ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 sp-weights = { path = "../../substrate/primitives/weights", default-features = false, features = ["serde"] }
 serde = { version = "1.0.188", default-features = false, features = ["alloc", "derive"] }
 xcm-procedural = { path = "procedural" }

--- a/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../../../substrate/frame/support", default-features = false}
 frame-system = { path = "../../../substrate/frame/system", default-features = false}
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false}

--- a/polkadot/xcm/pallet-xcm/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/Cargo.toml
@@ -9,7 +9,7 @@ version = "1.0.0"
 [dependencies]
 bounded-collections = { version = "0.1.8", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 

--- a/polkadot/xcm/src/double_encoded.rs
+++ b/polkadot/xcm/src/double_encoded.rs
@@ -24,6 +24,7 @@ use parity_scale_codec::{Decode, DecodeLimit, Encode};
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(T))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct DoubleEncoded<T> {
 	encoded: Vec<u8>,
 	#[codec(skip)]

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -89,6 +89,7 @@ macro_rules! versioned_type {
 		)]
 		#[codec(encode_bound())]
 		#[codec(decode_bound())]
+		#[scale_info(replace_segment("staging_xcm", "xcm"))]
 		$(#[$attr])*
 		pub enum $n {
 			$(#[$index3])*
@@ -150,6 +151,7 @@ macro_rules! versioned_type {
 		)]
 		#[codec(encode_bound())]
 		#[codec(decode_bound())]
+		#[scale_info(replace_segment("staging_xcm", "xcm"))]
 		$(#[$attr])*
 		pub enum $n {
 			$(#[$index2])*
@@ -310,6 +312,7 @@ versioned_type! {
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(RuntimeCall))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum VersionedXcm<RuntimeCall> {
 	#[codec(index = 2)]
 	V2(v2::Xcm<RuntimeCall>),

--- a/polkadot/xcm/src/tests.rs
+++ b/polkadot/xcm/src/tests.rs
@@ -181,3 +181,12 @@ fn encode_decode_versioned_xcm_v3() {
 	let decoded = VersionedXcm::decode(&mut &encoded[..]).unwrap();
 	assert_eq!(xcm, decoded);
 }
+
+// With the renaming of the crate to `staging-xcm` the naming in the metadata changed as well and
+// this broke downstream users. This test ensures that the name in the metadata isn't changed.
+#[test]
+fn ensure_type_info_is_correct() {
+	let type_info = VersionedXcm::<()>::type_info();
+
+	assert_eq!(type_info.path.segments, vec!["xcm", "VersionedXcm"]);
+}

--- a/polkadot/xcm/src/v2/junction.rs
+++ b/polkadot/xcm/src/v2/junction.rs
@@ -27,6 +27,7 @@ use scale_info::TypeInfo;
 /// Each item assumes a pre-existing location as its context and is defined in terms of it.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junction {
 	/// An indexed parachain belonging to and operated by the context.
 	///

--- a/polkadot/xcm/src/v2/mod.rs
+++ b/polkadot/xcm/src/v2/mod.rs
@@ -81,6 +81,7 @@ pub use traits::{Error, ExecuteXcm, GetWeight, Outcome, Result, SendError, SendR
 
 /// Basically just the XCM (more general) version of `ParachainDispatchOrigin`.
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum OriginKind {
 	/// Origin should just be the native dispatch origin representation for the sender in the
 	/// local runtime framework. For Cumulus/Frame chains this is the `Parachain` or `Relay` origin
@@ -105,6 +106,7 @@ pub enum OriginKind {
 /// A global identifier of an account-bearing consensus system.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum NetworkId {
 	/// Unidentified/any.
 	Any,
@@ -141,6 +143,7 @@ impl TryFrom<NewNetworkId> for NetworkId {
 /// An identifier of a pluralistic body.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyId {
 	/// The only body in its context.
 	Unit,
@@ -195,6 +198,7 @@ impl From<NewBodyId> for BodyId {
 /// A part of a pluralistic body.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyPart {
 	/// The body's declaration, under whatever means it decides.
 	Voice,
@@ -262,6 +266,7 @@ pub type QueryId = u64;
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(RuntimeCall))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct Xcm<RuntimeCall>(pub Vec<Instruction<RuntimeCall>>);
 
 impl<RuntimeCall> Xcm<RuntimeCall> {
@@ -357,6 +362,7 @@ pub mod prelude {
 
 /// Response data to a query.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Response {
 	/// No response. Serves as a neutral default.
 	Null,
@@ -376,6 +382,7 @@ impl Default for Response {
 
 /// An optional weight limit.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WeightLimit {
 	/// No weight limit imposed.
 	Unlimited,
@@ -428,6 +435,7 @@ pub type Weight = u64;
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(RuntimeCall))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Instruction<RuntimeCall> {
 	/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place them into the Holding
 	/// Register.

--- a/polkadot/xcm/src/v2/multiasset.rs
+++ b/polkadot/xcm/src/v2/multiasset.rs
@@ -41,6 +41,7 @@ use scale_info::TypeInfo;
 /// A general identifier for an instance of a non-fungible asset class.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetInstance {
 	/// Undefined - used if the non-fungible asset class has only one instance.
 	Undefined,
@@ -119,6 +120,7 @@ impl TryFrom<NewAssetInstance> for AssetInstance {
 /// Classification of an asset being concrete or abstract.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetId {
 	Concrete(MultiLocation),
 	Abstract(Vec<u8>),
@@ -185,6 +187,7 @@ impl AssetId {
 /// instance.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Fungibility {
 	Fungible(#[codec(compact)] u128),
 	NonFungible(AssetInstance),
@@ -224,6 +227,7 @@ impl TryFrom<NewFungibility> for Fungibility {
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAsset {
 	pub id: AssetId,
 	pub fun: Fungibility,
@@ -309,6 +313,7 @@ impl TryFrom<NewMultiAsset> for MultiAsset {
 /// they must be sorted.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAssets(Vec<MultiAsset>);
 
 impl Decode for MultiAssets {
@@ -479,6 +484,7 @@ impl MultiAssets {
 /// Classification of whether an asset is fungible or not.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildFungibility {
 	Fungible,
 	NonFungible,
@@ -498,6 +504,7 @@ impl TryFrom<NewWildFungibility> for WildFungibility {
 /// A wildcard representing a set of assets.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildMultiAsset {
 	/// All assets in the holding register, up to `usize` individual assets (different instances of
 	/// non-fungibles could be separate assets).
@@ -543,6 +550,7 @@ impl<A: Into<AssetId>, B: Into<WildFungibility>> From<(A, B)> for WildMultiAsset
 /// in this implementation and will result in a decode error.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum MultiAssetFilter {
 	Definite(MultiAssets),
 	Wild(WildMultiAsset),

--- a/polkadot/xcm/src/v2/multilocation.rs
+++ b/polkadot/xcm/src/v2/multilocation.rs
@@ -50,6 +50,7 @@ use scale_info::TypeInfo;
 /// The `MultiLocation` value of `Null` simply refers to the interpreting consensus system.
 #[derive(Clone, Decode, Encode, Eq, PartialEq, Ord, PartialOrd, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiLocation {
 	/// The number of parent junctions at the beginning of this `MultiLocation`.
 	pub parents: u8,
@@ -465,6 +466,7 @@ const MAX_JUNCTIONS: usize = 8;
 /// instructions on constructing parent junctions.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junctions {
 	/// The interpreting consensus system.
 	Here,

--- a/polkadot/xcm/src/v2/traits.rs
+++ b/polkadot/xcm/src/v2/traits.rs
@@ -29,6 +29,7 @@ pub trait GetWeight<W> {
 }
 
 #[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Error {
 	// Errors that happen due to instructions being executed. These alone are defined in the
 	// XCM specification.
@@ -165,6 +166,7 @@ pub type Result = result::Result<(), Error>;
 
 /// Outcome of an XCM execution.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Outcome {
 	/// Execution completed successfully; given weight was used.
 	Complete(Weight),
@@ -246,6 +248,7 @@ impl<C> ExecuteXcm<C> for () {
 
 /// Error result value when attempting to send an XCM message.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, scale_info::TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum SendError {
 	/// The message and destination combination was not recognized as being reachable.
 	///

--- a/polkadot/xcm/src/v3/junction.rs
+++ b/polkadot/xcm/src/v3/junction.rs
@@ -49,6 +49,7 @@ use serde::{Deserialize, Serialize};
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum NetworkId {
 	/// Network specified by the first 32 bytes of its genesis block.
 	ByGenesis([u8; 32]),
@@ -116,6 +117,7 @@ impl TryFrom<OldNetworkId> for NetworkId {
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyId {
 	/// The only body in its context.
 	Unit,
@@ -186,6 +188,7 @@ impl TryFrom<OldBodyId> for BodyId {
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum BodyPart {
 	/// The body's declaration, under whatever means it decides.
 	Voice,
@@ -261,6 +264,7 @@ impl TryFrom<OldBodyPart> for BodyPart {
 	Serialize,
 	Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junction {
 	/// An indexed parachain belonging to and operated by the context.
 	///

--- a/polkadot/xcm/src/v3/junctions.rs
+++ b/polkadot/xcm/src/v3/junctions.rs
@@ -44,6 +44,7 @@ pub(crate) const MAX_JUNCTIONS: usize = 8;
 	serde::Serialize,
 	serde::Deserialize,
 )]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Junctions {
 	/// The interpreting consensus system.
 	Here,

--- a/polkadot/xcm/src/v3/mod.rs
+++ b/polkadot/xcm/src/v3/mod.rs
@@ -68,6 +68,7 @@ pub type QueryId = u64;
 #[derivative(Clone(bound = ""), Eq(bound = ""), PartialEq(bound = ""), Debug(bound = ""))]
 #[codec(encode_bound())]
 #[scale_info(bounds(), skip_type_params(Call))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct Xcm<Call>(pub Vec<Instruction<Call>>);
 
 const MAX_INSTRUCTIONS_TO_DECODE: u8 = 100;
@@ -236,6 +237,7 @@ parameter_types! {
 }
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct PalletInfo {
 	#[codec(compact)]
 	index: u32,
@@ -266,6 +268,7 @@ impl PalletInfo {
 }
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum MaybeErrorCode {
 	Success,
 	Error(BoundedVec<u8, MaxDispatchErrorLen>),
@@ -289,6 +292,7 @@ impl Default for MaybeErrorCode {
 
 /// Response data to a query.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Response {
 	/// No response. Serves as a neutral default.
 	Null,
@@ -312,6 +316,7 @@ impl Default for Response {
 
 /// Information regarding the composition of a query response.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct QueryResponseInfo {
 	/// The destination to which the query response message should be send.
 	pub destination: MultiLocation,
@@ -324,6 +329,7 @@ pub struct QueryResponseInfo {
 
 /// An optional weight limit.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WeightLimit {
 	/// No weight limit imposed.
 	Unlimited,
@@ -400,6 +406,7 @@ impl XcmContext {
 #[codec(encode_bound())]
 #[codec(decode_bound())]
 #[scale_info(bounds(), skip_type_params(Call))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Instruction<Call> {
 	/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place them into the Holding
 	/// Register.

--- a/polkadot/xcm/src/v3/multiasset.rs
+++ b/polkadot/xcm/src/v3/multiasset.rs
@@ -47,6 +47,7 @@ use scale_info::TypeInfo;
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetInstance {
 	/// Undefined - used if the non-fungible asset class has only one instance.
 	Undefined,
@@ -242,6 +243,7 @@ impl TryFrom<AssetInstance> for u128 {
 /// instance.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Fungibility {
 	/// A fungible asset; we record a number of units, as a `u128` in the inner item.
 	Fungible(#[codec(compact)] u128),
@@ -311,6 +313,7 @@ impl TryFrom<OldFungibility> for Fungibility {
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildFungibility {
 	/// The asset is fungible.
 	Fungible,
@@ -334,6 +337,7 @@ impl TryFrom<OldWildFungibility> for WildFungibility {
 	Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum AssetId {
 	/// A specific location identifying an asset.
 	Concrete(MultiLocation),
@@ -408,6 +412,7 @@ impl AssetId {
 /// Either an amount of a single fungible asset, or a single well-identified non-fungible asset.
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAsset {
 	/// The overall asset identity (aka *class*, in the case of a non-fungible).
 	pub id: AssetId,
@@ -505,6 +510,7 @@ impl TryFrom<OldMultiAsset> for MultiAsset {
 /// - The number of items should grow no larger than `MAX_ITEMS_IN_MULTIASSETS`.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, TypeInfo, Default)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub struct MultiAssets(Vec<MultiAsset>);
 
 /// Maximum number of items in a single `MultiAssets` value that can be decoded.
@@ -700,6 +706,7 @@ impl MultiAssets {
 /// A wildcard representing a set of assets.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum WildMultiAsset {
 	/// All assets in Holding.
 	All,
@@ -812,6 +819,7 @@ impl<A: Into<AssetId>, B: Into<WildFungibility>> From<(A, B)> for WildMultiAsset
 /// `MultiAsset` collection, defined either by a number of `MultiAssets` or a single wildcard.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum MultiAssetFilter {
 	/// Specify the filter as being everything contained by the given `MultiAssets` inner.
 	Definite(MultiAssets),

--- a/polkadot/xcm/src/v3/traits.rs
+++ b/polkadot/xcm/src/v3/traits.rs
@@ -29,6 +29,7 @@ use super::*;
 /// format. Those trailing are merely part of the XCM implementation; there is no expectation that
 /// they will retain the same index over time.
 #[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Error {
 	// Errors that happen due to instructions being executed. These alone are defined in the
 	// XCM specification.
@@ -262,6 +263,7 @@ impl From<Error> for Outcome {
 
 /// Outcome of an XCM execution.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum Outcome {
 	/// Execution completed successfully; given weight was used.
 	Complete(Weight),
@@ -410,6 +412,7 @@ impl<C> ExecuteXcm<C> for () {
 
 /// Error result value when attempting to send an XCM message.
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, scale_info::TypeInfo)]
+#[scale_info(replace_segment("staging_xcm", "xcm"))]
 pub enum SendError {
 	/// The message and destination combination was not recognized as being reachable.
 	///

--- a/polkadot/xcm/xcm-builder/Cargo.toml
+++ b/polkadot/xcm/xcm-builder/Cargo.toml
@@ -9,7 +9,7 @@ version = "1.0.0"
 [dependencies]
 impl-trait-for-tuples = "0.2.1"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 xcm = { package = "staging-xcm", path = "..", default-features = false }
 xcm-executor = { package = "staging-xcm-executor", path = "../xcm-executor", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }

--- a/polkadot/xcm/xcm-simulator/example/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/example/Cargo.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.5.0", features = ["derive"] }
+scale-info = { version = "2.10.0", features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 
 frame-system = { path = "../../../../substrate/frame/system" }

--- a/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 honggfuzz = "0.5.55"
 arbitrary = "1.2.0"
-scale-info = { version = "2.5.0", features = ["derive"] }
+scale-info = { version = "2.10.0", features = ["derive"] }
 
 frame-system = { path = "../../../../substrate/frame/system" }
 frame-support = { path = "../../../../substrate/frame/support" }

--- a/substrate/bin/node-template/pallets/template/Cargo.toml
+++ b/substrate/bin/node-template/pallets/template/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../../../frame/benchmarking", default-features = false, optional = true}
 frame-support = { path = "../../../../frame/support", default-features = false}
 frame-system = { path = "../../../../frame/system", default-features = false}

--- a/substrate/bin/node-template/runtime/Cargo.toml
+++ b/substrate/bin/node-template/runtime/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 pallet-aura = { path = "../../../frame/aura", default-features = false}
 pallet-balances = { path = "../../../frame/balances", default-features = false}

--- a/substrate/bin/node/executor/Cargo.toml
+++ b/substrate/bin/node/executor/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.5.0", features = ["derive"] }
+scale-info = { version = "2.10.0", features = ["derive"] }
 frame-benchmarking = { path = "../../../frame/benchmarking" }
 node-primitives = { path = "../primitives" }
 kitchensink-runtime = { path = "../runtime" }

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 static_assertions = "1.1.0"
 log = { version = "0.4.17", default-features = false }
 

--- a/substrate/client/cli/src/commands/inspect_node_key.rs
+++ b/substrate/client/cli/src/commands/inspect_node_key.rs
@@ -85,7 +85,7 @@ mod tests {
 	fn inspect_node_key() {
 		let path = tempfile::tempdir().unwrap().into_path().join("node-id").into_os_string();
 		let path = path.to_str().unwrap();
-		let cmd = GenerateNodeKeyCmd::parse_from(&["generate-node-key", "--file", path.clone()]);
+		let cmd = GenerateNodeKeyCmd::parse_from(&["generate-node-key", "--file", path]);
 
 		assert!(cmd.run().is_ok());
 

--- a/substrate/client/network/common/src/role.rs
+++ b/substrate/client/network/common/src/role.rs
@@ -16,6 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+// file-level lint whitelist to avoid problem with bitflags macro below
+// TODO: can be dropped after an update to bitflags 2.4
+#![allow(clippy::bad_bit_mask)]
+
 use codec::{self, Encode, EncodeLike, Input, Output};
 
 /// Role that the peer sent to us during the handshake, with the addition of what our local node

--- a/substrate/client/network/src/protocol/notifications/behaviour.rs
+++ b/substrate/client/network/src/protocol/notifications/behaviour.rs
@@ -1423,7 +1423,6 @@ impl NetworkBehaviour for Notifications {
 									let delay_id = self.next_delay_id;
 									self.next_delay_id.0 += 1;
 									let delay = futures_timer::Delay::new(ban_duration);
-									let peer_id = peer_id;
 									self.delays.push(
 										async move {
 											delay.await;

--- a/substrate/client/rpc-api/Cargo.toml
+++ b/substrate/client/rpc-api/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "1.0"

--- a/substrate/frame/alliance/Cargo.toml
+++ b/substrate/frame/alliance/Cargo.toml
@@ -17,7 +17,7 @@ array-bytes = { version = "6.1", optional = true }
 log = { version = "0.4.14", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/asset-conversion/Cargo.toml
+++ b/substrate/frame/asset-conversion/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-api = { path = "../../primitives/api", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/asset-rate/Cargo.toml
+++ b/substrate/frame/asset-rate/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/assets/Cargo.toml
+++ b/substrate/frame/assets/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-std = { path = "../../primitives/std", default-features = false}
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/atomic-swap/Cargo.toml
+++ b/substrate/frame/atomic-swap/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 pallet-timestamp = { path = "../timestamp", default-features = false}

--- a/substrate/frame/authority-discovery/Cargo.toml
+++ b/substrate/frame/authority-discovery/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 pallet-session = { path = "../session", default-features = false, features = [

--- a/substrate/frame/authorship/Cargo.toml
+++ b/substrate/frame/authorship/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 impl-trait-for-tuples = "0.2.2"
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/babe/Cargo.toml
+++ b/substrate/frame/babe/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/bags-list/Cargo.toml
+++ b/substrate/frame/bags-list/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 # parity
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # primitives
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/balances/Cargo.toml
+++ b/substrate/frame/balances/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/beefy-mmr/Cargo.toml
+++ b/substrate/frame/beefy-mmr/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://substrate.io"
 array-bytes = { version = "6.1", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 binary-merkle-tree = { path = "../../utils/binary-merkle-tree", default-features = false}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/beefy/Cargo.toml
+++ b/substrate/frame/beefy/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://substrate.io"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/benchmarking/Cargo.toml
+++ b/substrate/frame/benchmarking/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 linregress = { version = "0.5.1", optional = true }
 log = { version = "0.4.17", default-features = false }
 paste = "1.0"
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-support-procedural = { path = "../support/procedural", default-features = false}

--- a/substrate/frame/benchmarking/pov/Cargo.toml
+++ b/substrate/frame/benchmarking/pov/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "..", default-features = false}
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/bounties/Cargo.toml
+++ b/substrate/frame/bounties/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/broker/Cargo.toml
+++ b/substrate/frame/broker/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 bitvec = { version = "1.0.0", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false}
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}

--- a/substrate/frame/child-bounties/Cargo.toml
+++ b/substrate/frame/child-bounties/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/collective/Cargo.toml
+++ b/substrate/frame/collective/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false, features = [

--- a/substrate/frame/contracts/primitives/Cargo.toml
+++ b/substrate/frame/contracts/primitives/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 bitflags = "1.0"
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 
 # Substrate Dependencies (This crate should not rely on frame)

--- a/substrate/frame/contracts/src/wasm/prepare.rs
+++ b/substrate/frame/contracts/src/wasm/prepare.rs
@@ -79,8 +79,7 @@ impl LoadedModule {
 		}
 
 		let engine = Engine::new(&config);
-		let module =
-			Module::new(&engine, code.clone()).map_err(|_| "Can't load the module into wasmi!")?;
+		let module = Module::new(&engine, code).map_err(|_| "Can't load the module into wasmi!")?;
 
 		// Return a `LoadedModule` instance with
 		// __valid__ module.

--- a/substrate/frame/conviction-voting/Cargo.toml
+++ b/substrate/frame/conviction-voting/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/core-fellowship/Cargo.toml
+++ b/substrate/frame/core-fellowship/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/democracy/Cargo.toml
+++ b/substrate/frame/democracy/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/election-provider-multi-phase/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = [
+scale-info = { version = "2.10.0", default-features = false, features = [
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }

--- a/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 parking_lot = "0.12.1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = { version = "2.0.1", features = ["derive"] }
+scale-info = { version = "2.10.0", features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 
 sp-runtime = { path = "../../../primitives/runtime" }

--- a/substrate/frame/election-provider-support/Cargo.toml
+++ b/substrate/frame/election-provider-support/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-election-provider-solution-type = { path = "solution-type" }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/election-provider-support/solution-type/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro-crate = "1.1.3"
 
 [dev-dependencies]
 parity-scale-codec = "3.6.1"
-scale-info = "2.1.1"
+scale-info = "2.10.0"
 sp-arithmetic = { path = "../../../primitives/arithmetic" }
 # used by generate_solution_type:
 frame-election-provider-support = { path = ".." }

--- a/substrate/frame/election-provider-support/solution-type/fuzzer/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/fuzzer/Cargo.toml
@@ -18,7 +18,7 @@ honggfuzz = "0.5"
 rand = { version = "0.8", features = ["std", "small_rng"] }
 
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-election-provider-solution-type = { path = ".." }
 frame-election-provider-support = { path = "../.." }
 sp-arithmetic = { path = "../../../../primitives/arithmetic" }

--- a/substrate/frame/elections-phragmen/Cargo.toml
+++ b/substrate/frame/elections-phragmen/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/examples/basic/Cargo.toml
+++ b/substrate/frame/examples/basic/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/examples/default-config/Cargo.toml
+++ b/substrate/frame/examples/default-config/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 

--- a/substrate/frame/examples/dev-mode/Cargo.toml
+++ b/substrate/frame/examples/dev-mode/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 pallet-balances = { path = "../../balances", default-features = false}

--- a/substrate/frame/examples/kitchensink/Cargo.toml
+++ b/substrate/frame/examples/kitchensink/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/examples/offchain-worker/Cargo.toml
+++ b/substrate/frame/examples/offchain-worker/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 lite-json = { version = "0.2.0", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}
 sp-core = { path = "../../../primitives/core", default-features = false}

--- a/substrate/frame/examples/split/Cargo.toml
+++ b/substrate/frame/examples/split/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "../../system", default-features = false}

--- a/substrate/frame/executive/Cargo.toml
+++ b/substrate/frame/executive/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 frame-try-runtime = { path = "../try-runtime", default-features = false, optional = true }

--- a/substrate/frame/fast-unstake/Cargo.toml
+++ b/substrate/frame/fast-unstake/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/glutton/Cargo.toml
+++ b/substrate/frame/glutton/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 blake2 = { version = "0.10.4", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/grandpa/Cargo.toml
+++ b/substrate/frame/grandpa/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/identity/Cargo.toml
+++ b/substrate/frame/identity/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 enumflags2 = { version = "0.7.7" }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/im-online/Cargo.toml
+++ b/substrate/frame/im-online/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/indices/Cargo.toml
+++ b/substrate/frame/indices/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/insecure-randomness-collective-flip/Cargo.toml
+++ b/substrate/frame/insecure-randomness-collective-flip/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}

--- a/substrate/frame/lottery/Cargo.toml
+++ b/substrate/frame/lottery/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/membership/Cargo.toml
+++ b/substrate/frame/membership/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/merkle-mountain-range/Cargo.toml
+++ b/substrate/frame/merkle-mountain-range/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/message-queue/Cargo.toml
+++ b/substrate/frame/message-queue/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet to queue and process messages"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 

--- a/substrate/frame/multisig/Cargo.toml
+++ b/substrate/frame/multisig/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/nft-fractionalization/Cargo.toml
+++ b/substrate/frame/nft-fractionalization/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/nfts/Cargo.toml
+++ b/substrate/frame/nfts/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 enumflags2 = { version = "0.7.7" }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/nfts/src/tests.rs
+++ b/substrate/frame/nfts/src/tests.rs
@@ -17,7 +17,7 @@
 
 //! Tests for Nfts pallet.
 
-use crate::{mock::*, Event, *};
+use crate::{mock::*, Event, SystemConfig, *};
 use enumflags2::BitFlags;
 use frame_support::{
 	assert_noop, assert_ok,

--- a/substrate/frame/nicks/Cargo.toml
+++ b/substrate/frame/nicks/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/nis/Cargo.toml
+++ b/substrate/frame/nis/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/node-authorization/Cargo.toml
+++ b/substrate/frame/node-authorization/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/nomination-pools/Cargo.toml
+++ b/substrate/frame/nomination-pools/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 # parity
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # FRAME
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/nomination-pools/benchmarking/Cargo.toml
+++ b/substrate/frame/nomination-pools/benchmarking/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 # parity
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # FRAME
 frame-benchmarking = { path = "../../benchmarking", default-features = false}

--- a/substrate/frame/nomination-pools/test-staking/Cargo.toml
+++ b/substrate/frame/nomination-pools/test-staking/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = { version = "2.0.1", features = ["derive"] }
+scale-info = { version = "2.10.0", features = ["derive"] }
 
 sp-runtime = { path = "../../../primitives/runtime" }
 sp-io = { path = "../../../primitives/io" }

--- a/substrate/frame/offences/Cargo.toml
+++ b/substrate/frame/offences/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/offences/benchmarking/Cargo.toml
+++ b/substrate/frame/offences/benchmarking/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false}
 frame-election-provider-support = { path = "../../election-provider-support", default-features = false}
 frame-support = { path = "../../support", default-features = false}

--- a/substrate/frame/paged-list/Cargo.toml
+++ b/substrate/frame/paged-list/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive"] }
 docify = "0.2.4"
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/preimage/Cargo.toml
+++ b/substrate/frame/preimage/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for storing preimages of hashes"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/preimage/src/migration.rs
+++ b/substrate/frame/preimage/src/migration.rs
@@ -133,7 +133,7 @@ pub mod v1 {
 						None =>
 							OldRequestStatus::Requested { deposit: None, count: 1, len: Some(len) },
 					},
-					v0::OldRequestStatus::Requested(count) if count == 0 => {
+					v0::OldRequestStatus::Requested(0) => {
 						log::error!(target: TARGET, "preimage has counter of zero: {:?}", hash);
 						continue
 					},

--- a/substrate/frame/proxy/Cargo.toml
+++ b/substrate/frame/proxy/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["max-encoded-len"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/ranked-collective/Cargo.toml
+++ b/substrate/frame/ranked-collective/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/recovery/Cargo.toml
+++ b/substrate/frame/recovery/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/referenda/Cargo.toml
+++ b/substrate/frame/referenda/Cargo.toml
@@ -17,7 +17,7 @@ assert_matches = { version = "1.5", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}

--- a/substrate/frame/remark/Cargo.toml
+++ b/substrate/frame/remark/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/root-offences/Cargo.toml
+++ b/substrate/frame/root-offences/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 pallet-session = { path = "../session", default-features = false , features = [ "historical" ]}
 pallet-staking = { path = "../staking", default-features = false}

--- a/substrate/frame/root-testing/Cargo.toml
+++ b/substrate/frame/root-testing/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false}

--- a/substrate/frame/safe-mode/Cargo.toml
+++ b/substrate/frame/safe-mode/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}

--- a/substrate/frame/salary/Cargo.toml
+++ b/substrate/frame/salary/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/scheduler/Cargo.toml
+++ b/substrate/frame/scheduler/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/scored-pool/Cargo.toml
+++ b/substrate/frame/scored-pool/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/session/Cargo.toml
+++ b/substrate/frame/session/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 pallet-timestamp = { path = "../timestamp", default-features = false}

--- a/substrate/frame/session/benchmarking/Cargo.toml
+++ b/substrate/frame/session/benchmarking/Cargo.toml
@@ -26,7 +26,7 @@ sp-std = { path = "../../../primitives/std", default-features = false}
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = "2.1.1"
+scale-info = "2.10.0"
 frame-election-provider-support = { path = "../../election-provider-support" }
 pallet-balances = { path = "../../balances" }
 pallet-staking-reward-curve = { path = "../../staking/reward-curve" }

--- a/substrate/frame/society/Cargo.toml
+++ b/substrate/frame/society/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 log = { version = "0.4.17", default-features = false }
 rand_chacha = { version = "0.2", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../primitives/std", default-features = false}

--- a/substrate/frame/staking/Cargo.toml
+++ b/substrate/frame/staking/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.188", default-features = false, features = ["alloc", "d
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 sp-io = { path = "../../primitives/io", default-features = false}
 sp-runtime = { path = "../../primitives/runtime", default-features = false, features = ["serde"] }
 sp-staking = { path = "../../primitives/staking", default-features = false, features = ["serde"] }

--- a/substrate/frame/state-trie-migration/Cargo.toml
+++ b/substrate/frame/state-trie-migration/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 thousands = { version = "0.2.0", optional = true }
 zstd = { version = "0.12.4", default-features = false, optional = true }

--- a/substrate/frame/statement/Cargo.toml
+++ b/substrate/frame/statement/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"]}
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-statement-store = { path = "../../primitives/statement-store", default-features = false}

--- a/substrate/frame/sudo/Cargo.toml
+++ b/substrate/frame/sudo/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
 sp-io = { path = "../../primitives/io", default-features = false}

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.188", default-features = false, features = ["alloc", "derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
 sp-api = { path = "../../primitives/api", default-features = false, features = [ "frame-metadata" ] }
 sp-std = { path = "../../primitives/std", default-features = false}

--- a/substrate/frame/support/test/Cargo.toml
+++ b/substrate/frame/support/test/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 static_assertions = "1.1.0"
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
 sp-api = { path = "../../../primitives/api", default-features = false}
 sp-arithmetic = { path = "../../../primitives/arithmetic", default-features = false}

--- a/substrate/frame/support/test/compile_pass/Cargo.toml
+++ b/substrate/frame/support/test/compile_pass/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 renamed-frame-support = { package = "frame-support", path = "../..", default-features = false}
 frame-system = { path = "../../../system", default-features = false}
 sp-core = { path = "../../../../primitives/core", default-features = false}

--- a/substrate/frame/support/test/pallet/Cargo.toml
+++ b/substrate/frame/support/test/pallet/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive"] }
 frame-support = { path = "../..", default-features = false}
 frame-system = { path = "../../../system", default-features = false}

--- a/substrate/frame/support/test/tests/construct_runtime_ui/deprecated_where_block.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/deprecated_where_block.stderr
@@ -148,7 +148,11 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied in `frame_syste
    | ||_- in this macro invocation
 ...  |
    |
-   = note: required because it appears within the type `Event<Runtime>`
+note: required because it appears within the type `Event<Runtime>`
+  --> $WORKSPACE/substrate/frame/system/src/lib.rs
+   |
+   |     pub enum Event<T: Config> {
+   |              ^^^^^
 note: required by a bound in `From`
   --> $RUST/core/src/convert/mod.rs
    |
@@ -169,7 +173,11 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied in `frame_syste
    | ||_- in this macro invocation
 ...  |
    |
-   = note: required because it appears within the type `Event<Runtime>`
+note: required because it appears within the type `Event<Runtime>`
+  --> $WORKSPACE/substrate/frame/system/src/lib.rs
+   |
+   |     pub enum Event<T: Config> {
+   |              ^^^^^
 note: required by a bound in `TryInto`
   --> $RUST/core/src/convert/mod.rs
    |

--- a/substrate/frame/support/test/tests/derive_no_bound_ui/debug.stderr
+++ b/substrate/frame/support/test/tests/derive_no_bound_ui/debug.stderr
@@ -5,4 +5,4 @@ error[E0277]: `<T as Config>::C` doesn't implement `std::fmt::Debug`
    |     ^ `<T as Config>::C` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as Config>::C`
-   = note: required for the cast from `<T as Config>::C` to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&<T as Config>::C` to `&dyn std::fmt::Debug`

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -19,7 +19,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
-   = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
   --> tests/pallet_ui/call_argument_invalid_bound.rs:38:36

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -19,7 +19,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
-   = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:38:36

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -20,7 +20,7 @@ error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
    = help: the trait `std::fmt::Debug` is not implemented for `Bar`
    = note: add `#[derive(Debug)]` to `Bar` or manually `impl std::fmt::Debug for Bar`
    = note: required for `&Bar` to implement `std::fmt::Debug`
-   = note: required for the cast from `&Bar` to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&&Bar` to `&dyn std::fmt::Debug`
 help: consider annotating `Bar` with `#[derive(Debug)]`
    |
 34 +     #[derive(Debug)]

--- a/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
@@ -30,13 +30,13 @@ error[E0277]: the trait bound `Vec<u8>: MaxEncodedLen` is not satisfied
    |               ^^^^^^ the trait `MaxEncodedLen` is not implemented for `Vec<u8>`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
-             ()
-             (TupleElement0, TupleElement1)
-             (TupleElement0, TupleElement1, TupleElement2)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
+             bool
+             i8
+             i16
+             i32
+             i64
+             i128
+             u8
+             u16
            and $N others
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageMyStorage<T>, Vec<u8>>` to implement `StorageInfoTrait`

--- a/substrate/frame/support/test/tests/pallet_ui/error_does_not_derive_pallet_error.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/error_does_not_derive_pallet_error.stderr
@@ -5,13 +5,13 @@ error[E0277]: the trait bound `MyError: PalletError` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PalletError` is not implemented for `MyError`
    |
    = help: the following other types implement trait `PalletError`:
-             ()
-             (TupleElement0, TupleElement1)
-             (TupleElement0, TupleElement1, TupleElement2)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
+             bool
+             i8
+             i16
+             i32
+             i64
+             i128
+             u8
+             u16
            and $N others
    = note: this error originates in the derive macro `frame_support::PalletError` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
@@ -18,4 +18,4 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
-   = note: required for the cast from `&<T as pallet::Config>::Bar` to the object type `dyn std::fmt::Debug`
+   = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`

--- a/substrate/frame/support/test/tests/pallet_ui/inherent_check_inner_span.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/inherent_check_inner_span.stderr
@@ -4,8 +4,8 @@ error[E0046]: not all trait items implemented, missing: `Call`, `Error`, `INHERE
 36 |     impl<T: Config> ProvideInherent for Pallet<T> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Call`, `Error`, `INHERENT_IDENTIFIER`, `create_inherent`, `is_inherent` in implementation
    |
-   = help: implement the missing item: `type Call = Type;`
-   = help: implement the missing item: `type Error = Type;`
+   = help: implement the missing item: `type Call = /* Type */;`
+   = help: implement the missing item: `type Error = /* Type */;`
    = help: implement the missing item: `const INHERENT_IDENTIFIER: [u8; 8] = value;`
    = help: implement the missing item: `fn create_inherent(_: &InherentData) -> std::option::Option<<Self as ProvideInherent>::Call> { todo!() }`
    = help: implement the missing item: `fn is_inherent(_: &<Self as ProvideInherent>::Call) -> bool { todo!() }`

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -5,10 +5,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
    |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
-             Arc<T>
              Box<T>
-             Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
    = note: required for `Bar` to implement `Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
@@ -20,14 +20,14 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
    |               ^^^^^^^^^^^^^^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
-             <&&T as EncodeLike<T>>
-             <&T as EncodeLike<T>>
-             <&T as EncodeLike>
-             <&[(K, V)] as EncodeLike<BTreeMap<LikeK, LikeV>>>
-             <&[(T,)] as EncodeLike<BTreeSet<LikeT>>>
-             <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
-             <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
-             <&[T] as EncodeLike<Vec<U>>>
+             <bool as EncodeLike>
+             <i8 as EncodeLike>
+             <i16 as EncodeLike>
+             <i32 as EncodeLike>
+             <i64 as EncodeLike>
+             <i128 as EncodeLike>
+             <u8 as EncodeLike>
+             <u16 as EncodeLike>
            and $N others
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
@@ -40,14 +40,14 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
              Box<T>
-             Cow<'a, T>
-             Rc<T>
-             Vec<T>
              bytes::bytes::Bytes
+             Cow<'a, T>
+             parity_scale_codec::Ref<'a, T, U>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
+             Vec<T>
            and $N others
    = note: required for `Bar` to implement `Encode`
    = note: required for `Bar` to implement `FullEncode`
@@ -61,14 +61,14 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
    |               ^^^^^^^ the trait `TypeInfo` is not implemented for `Bar`
    |
    = help: the following other types implement trait `TypeInfo`:
-             &T
-             &mut T
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
+             bool
+             char
+             i8
+             i16
+             i32
+             i64
+             i128
+             u8
            and $N others
    = note: required for `Bar` to implement `StaticTypeInfo`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
@@ -80,10 +80,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
    |               ^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
-             Arc<T>
              Box<T>
-             Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
    = note: required for `Bar` to implement `Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
@@ -95,14 +95,14 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
    |               ^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
-             <&&T as EncodeLike<T>>
-             <&T as EncodeLike<T>>
-             <&T as EncodeLike>
-             <&[(K, V)] as EncodeLike<BTreeMap<LikeK, LikeV>>>
-             <&[(T,)] as EncodeLike<BTreeSet<LikeT>>>
-             <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
-             <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
-             <&[T] as EncodeLike<Vec<U>>>
+             <bool as EncodeLike>
+             <i8 as EncodeLike>
+             <i16 as EncodeLike>
+             <i32 as EncodeLike>
+             <i64 as EncodeLike>
+             <i128 as EncodeLike>
+             <u8 as EncodeLike>
+             <u16 as EncodeLike>
            and $N others
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
@@ -115,14 +115,14 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    |               ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
              Box<T>
-             Cow<'a, T>
-             Rc<T>
-             Vec<T>
              bytes::bytes::Bytes
+             Cow<'a, T>
+             parity_scale_codec::Ref<'a, T, U>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
+             Vec<T>
            and $N others
    = note: required for `Bar` to implement `Encode`
    = note: required for `Bar` to implement `FullEncode`

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -5,10 +5,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
    |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
-             Arc<T>
              Box<T>
-             Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
    = note: required for `Bar` to implement `Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
@@ -20,14 +20,14 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
    |               ^^^^^^^^^^^^^^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
-             <&&T as EncodeLike<T>>
-             <&T as EncodeLike<T>>
-             <&T as EncodeLike>
-             <&[(K, V)] as EncodeLike<BTreeMap<LikeK, LikeV>>>
-             <&[(T,)] as EncodeLike<BTreeSet<LikeT>>>
-             <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
-             <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
-             <&[T] as EncodeLike<Vec<U>>>
+             <bool as EncodeLike>
+             <i8 as EncodeLike>
+             <i16 as EncodeLike>
+             <i32 as EncodeLike>
+             <i64 as EncodeLike>
+             <i128 as EncodeLike>
+             <u8 as EncodeLike>
+             <u16 as EncodeLike>
            and $N others
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
@@ -40,14 +40,14 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
              Box<T>
-             Cow<'a, T>
-             Rc<T>
-             Vec<T>
              bytes::bytes::Bytes
+             Cow<'a, T>
+             parity_scale_codec::Ref<'a, T, U>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
+             Vec<T>
            and $N others
    = note: required for `Bar` to implement `Encode`
    = note: required for `Bar` to implement `FullEncode`
@@ -61,14 +61,14 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
    |               ^^^^^^^ the trait `TypeInfo` is not implemented for `Bar`
    |
    = help: the following other types implement trait `TypeInfo`:
-             &T
-             &mut T
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
+             bool
+             char
+             i8
+             i16
+             i32
+             i64
+             i128
+             u8
            and $N others
    = note: required for `Bar` to implement `StaticTypeInfo`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
@@ -80,10 +80,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
    |               ^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
-             Arc<T>
              Box<T>
-             Rc<T>
              frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
    = note: required for `Bar` to implement `Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
@@ -95,14 +95,14 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
    |               ^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
-             <&&T as EncodeLike<T>>
-             <&T as EncodeLike<T>>
-             <&T as EncodeLike>
-             <&[(K, V)] as EncodeLike<BTreeMap<LikeK, LikeV>>>
-             <&[(T,)] as EncodeLike<BTreeSet<LikeT>>>
-             <&[(T,)] as EncodeLike<BinaryHeap<LikeT>>>
-             <&[(T,)] as EncodeLike<LinkedList<LikeT>>>
-             <&[T] as EncodeLike<Vec<U>>>
+             <bool as EncodeLike>
+             <i8 as EncodeLike>
+             <i16 as EncodeLike>
+             <i32 as EncodeLike>
+             <i64 as EncodeLike>
+             <i128 as EncodeLike>
+             <u8 as EncodeLike>
+             <u16 as EncodeLike>
            and $N others
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
@@ -115,14 +115,14 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    |               ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
              Box<T>
-             Cow<'a, T>
-             Rc<T>
-             Vec<T>
              bytes::bytes::Bytes
+             Cow<'a, T>
+             parity_scale_codec::Ref<'a, T, U>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+             Rc<T>
+             Arc<T>
+             Vec<T>
            and $N others
    = note: required for `Bar` to implement `Encode`
    = note: required for `Bar` to implement `FullEncode`

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
@@ -5,13 +5,13 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
    |               ^^^^^^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
-             ()
-             (TupleElement0, TupleElement1)
-             (TupleElement0, TupleElement1, TupleElement2)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
+             bool
+             i8
+             i16
+             i32
+             i64
+             i128
+             u8
+             u16
            and $N others
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageInfoTrait`

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
    |               ^^^^^^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
-             ()
-             (TupleElement0, TupleElement1)
-             (TupleElement0, TupleElement1, TupleElement2)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
-             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
+             bool
+             i8
+             i16
+             i32
+             i64
+             i128
+             u8
+             u16
            and $N others
-   = note: required for `Key<frame_support::Twox64Concat, Bar>` to implement `KeyGeneratorMaxEncodedLen`
-   = note: required for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, Key<frame_support::Twox64Concat, Bar>, u32>` to implement `StorageInfoTrait`
+   = note: required for `NMapKey<frame_support::Twox64Concat, Bar>` to implement `KeyGeneratorMaxEncodedLen`
+   = note: required for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, NMapKey<frame_support::Twox64Concat, Bar>, u32>` to implement `StorageInfoTrait`

--- a/substrate/frame/system/Cargo.toml
+++ b/substrate/frame/system/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 cfg-if = "1.0"
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
 frame-support = { path = "../support", default-features = false}
 sp-core = { path = "../../primitives/core", default-features = false, features = ["serde"] }

--- a/substrate/frame/system/benchmarking/Cargo.toml
+++ b/substrate/frame/system/benchmarking/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false}
 frame-support = { path = "../../support", default-features = false}
 frame-system = { path = "..", default-features = false}

--- a/substrate/frame/timestamp/Cargo.toml
+++ b/substrate/frame/timestamp/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/tips/Cargo.toml
+++ b/substrate/frame/tips/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/transaction-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
@@ -21,7 +21,7 @@ frame-system = { path = "../../system", default-features = false}
 pallet-asset-conversion = { path = "../../asset-conversion", default-features = false}
 pallet-transaction-payment = { path = "..", default-features = false}
 codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 sp-core = { path = "../../../primitives/core", default-features = false}

--- a/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -26,7 +26,7 @@ frame-benchmarking = { path = "../../benchmarking", default-features = false, op
 
 # Other dependencies
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 
 [dev-dependencies]

--- a/substrate/frame/transaction-storage/Cargo.toml
+++ b/substrate/frame/transaction-storage/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = { version = "6.1", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/treasury/Cargo.toml
+++ b/substrate/frame/treasury/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"max-encoded-len",
 ] }
 impl-trait-for-tuples = "0.2.2"
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}

--- a/substrate/frame/tx-pause/Cargo.toml
+++ b/substrate/frame/tx-pause/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "3.2.2", default-features = 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 pallet-balances = { path = "../balances", default-features = false, optional = true }

--- a/substrate/frame/uniques/Cargo.toml
+++ b/substrate/frame/uniques/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/utility/Cargo.toml
+++ b/substrate/frame/utility/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/vesting/Cargo.toml
+++ b/substrate/frame/vesting/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/frame/whitelist/Cargo.toml
+++ b/substrate/frame/whitelist/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true}
 frame-support = { path = "../support", default-features = false}
 frame-system = { path = "../system", default-features = false}

--- a/substrate/primitives/api/Cargo.toml
+++ b/substrate/primitives/api/Cargo.toml
@@ -24,7 +24,7 @@ sp-state-machine = { path = "../state-machine", default-features = false, option
 sp-trie = { path = "../trie", default-features = false, optional = true}
 hash-db = { version = "0.16.0", optional = true }
 thiserror = { version = "1.0.48", optional = true }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-metadata-ir = { path = "../metadata-ir", default-features = false, optional = true}
 log = { version = "0.4.17", default-features = false }
 

--- a/substrate/primitives/api/test/Cargo.toml
+++ b/substrate/primitives/api/test/Cargo.toml
@@ -23,7 +23,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1" }
 sp-state-machine = { path = "../../state-machine" }
 trybuild = "1.0.74"
 rustversion = "1.0.6"
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/substrate/primitives/application-crypto/Cargo.toml
+++ b/substrate/primitives/application-crypto/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-core = { path = "../core", default-features = false}
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, optional = true, features = ["derive", "alloc"]  }
 sp-std = { path = "../std", default-features = false}
 sp-io = { path = "../io", default-features = false}

--- a/substrate/primitives/arithmetic/Cargo.toml
+++ b/substrate/primitives/arithmetic/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 ] }
 integer-sqrt = "0.1.2"
 num-traits = { version = "0.2.8", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 static_assertions = "1.1.0"
 sp-std = { path = "../std", default-features = false}

--- a/substrate/primitives/authority-discovery/Cargo.toml
+++ b/substrate/primitives/authority-discovery/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-api = { path = "../api", default-features = false}
 sp-application-crypto = { path = "../application-crypto", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}

--- a/substrate/primitives/consensus/aura/Cargo.toml
+++ b/substrate/primitives/consensus/aura/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}
 sp-consensus-slots = { path = "../slots", default-features = false}

--- a/substrate/primitives/consensus/babe/Cargo.toml
+++ b/substrate/primitives/consensus/babe/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false,  optional = true, features =  ["derive", "alloc"] }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}

--- a/substrate/primitives/consensus/grandpa/Cargo.toml
+++ b/substrate/primitives/consensus/grandpa/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 grandpa = { package = "finality-grandpa", version = "0.16.2", default-features = false, features = ["derive-codec"] }
 log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive", "alloc"], default-features = false, optional = true }
 sp-api = { path = "../../api", default-features = false}
 sp-application-crypto = { path = "../../application-crypto", default-features = false}

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.163", default-features = false, features = ["derive"], optional = true }
 sp-api = { version = "4.0.0-dev", default-features = false, path = "../../api" }
 sp-application-crypto = { version = "23.0.0", default-features = false, path = "../../application-crypto", features = ["bandersnatch-experimental"] }

--- a/substrate/primitives/consensus/slots/Cargo.toml
+++ b/substrate/primitives/consensus/slots/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-std = { path = "../../std", default-features = false}
 sp-timestamp = { path = "../../timestamp", default-features = false}

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive","max-encoded-len"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.188", optional = true,  default-features = false, features = ["derive", "alloc"] }
 bounded-collections = { version = "0.1.8", default-features = false }

--- a/substrate/primitives/inherents/Cargo.toml
+++ b/substrate/primitives/inherents/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 thiserror = { version = "1.0.48", optional = true }
 sp-runtime = { path = "../runtime", default-features = false, optional = true}

--- a/substrate/primitives/merkle-mountain-range/Cargo.toml
+++ b/substrate/primitives/merkle-mountain-range/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.17", default-features = false }
 mmr-lib = { package = "ckb-merkle-mountain-range", version = "0.5.2", default-features = false }
 serde = { version = "1.0.188", features = ["derive", "alloc"], default-features = false, optional = true }

--- a/substrate/primitives/metadata-ir/Cargo.toml
+++ b/substrate/primitives/metadata-ir/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-std = { path = "../std", default-features = false}
 
 [features]

--- a/substrate/primitives/npos-elections/Cargo.toml
+++ b/substrate/primitives/npos-elections/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-arithmetic = { path = "../arithmetic", default-features = false}
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/npos-elections/src/lib.rs
+++ b/substrate/primitives/npos-elections/src/lib.rs
@@ -19,7 +19,7 @@
 //! - [`seq_phragmen`]: Implements the Phragmén Sequential Method. An un-ranked, relatively fast
 //!   election method that ensures PJR, but does not provide a constant factor approximation of the
 //!   maximin problem.
-//! - [`phragmms`](phragmms::phragmms): Implements a hybrid approach inspired by Phragmén which is
+//! - [`ghragmms`](phragmms::phragmms()): Implements a hybrid approach inspired by Phragmén which is
 //!   executed faster but it can achieve a constant factor approximation of the maximin problem,
 //!   similar to that of the MMS algorithm.
 //! - [`balance`](balancing::balance): Implements the star balancing algorithm. This iterative

--- a/substrate/primitives/runtime-interface/tests/ui/no_feature_gated_method.stderr
+++ b/substrate/primitives/runtime-interface/tests/ui/no_feature_gated_method.stderr
@@ -3,3 +3,15 @@ error[E0425]: cannot find function `bar` in module `test`
    |
 33 |     test::bar();
    |           ^^^ not found in `test`
+   |
+note: found an item that was configured out
+  --> tests/ui/no_feature_gated_method.rs:25:5
+   |
+25 |     fn bar() {}
+   |        ^^^
+   = note: the item is gated behind the `bar-feature` feature
+note: found an item that was configured out
+  --> tests/ui/no_feature_gated_method.rs:25:5
+   |
+25 |     fn bar() {}
+   |        ^^^

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -21,7 +21,7 @@ impl-trait-for-tuples = "0.2.2"
 log = { version = "0.4.17", default-features = false }
 paste = "1.0"
 rand = { version = "0.8.5", optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 sp-application-crypto = { path = "../application-crypto", default-features = false}
 sp-arithmetic = { path = "../arithmetic", default-features = false}

--- a/substrate/primitives/session/Cargo.toml
+++ b/substrate/primitives/session/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-api = { path = "../api", default-features = false}
 sp-core = { path = "../core", default-features = false}
 sp-runtime = { path = "../runtime", optional = true}

--- a/substrate/primitives/staking/Cargo.toml
+++ b/substrate/primitives/staking/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/statement-store/Cargo.toml
+++ b/substrate/primitives/statement-store/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-core = { path = "../core", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}
 sp-std = { path = "../std", default-features = false}

--- a/substrate/primitives/test-primitives/Cargo.toml
+++ b/substrate/primitives/test-primitives/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive"], optional = true }
 sp-application-crypto = { path = "../application-crypto", default-features = false}
 sp-core = { path = "../core", default-features = false}

--- a/substrate/primitives/transaction-storage-proof/Cargo.toml
+++ b/substrate/primitives/transaction-storage-proof/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-core = { path = "../core", optional = true}
 sp-inherents = { path = "../inherents", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}

--- a/substrate/primitives/trie/Cargo.toml
+++ b/substrate/primitives/trie/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = { version = "1.4.0", optional = true }
 memory-db = { version = "0.32.0", default-features = false }
 nohash-hasher = { version = "0.2.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.48", optional = true }
 tracing = { version = "0.1.29", optional = true }
 trie-db = { version = "0.28.0", default-features = false }

--- a/substrate/primitives/version/Cargo.toml
+++ b/substrate/primitives/version/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 impl-serde = { version = "0.4.0", default-features = false, optional = true }
 parity-wasm = { version = "0.45", optional = true }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188",  default-features = false, features = ["derive", "alloc"], optional = true }
 thiserror = { version = "1.0.48", optional = true }
 sp-core-hashing-proc-macro = { path = "../core/hashing/proc-macro" }

--- a/substrate/primitives/weights/Cargo.toml
+++ b/substrate/primitives/weights/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, optional = true, features = ["derive", "alloc"] }
 smallvec = "1.11.0"
 sp-arithmetic = { path = "../arithmetic", default-features = false}

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -19,7 +19,7 @@ sp-consensus-babe = { path = "../../primitives/consensus/babe", default-features
 sp-genesis-builder = { path = "../../primitives/genesis-builder", default-features = false}
 sp-block-builder = { path = "../../primitives/block-builder", default-features = false}
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-inherents = { path = "../../primitives/inherents", default-features = false}
 sp-keyring = { path = "../../primitives/keyring", optional = true}
 sp-offchain = { path = "../../primitives/offchain", default-features = false}

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -779,6 +779,7 @@ fn worst_case_pov(
 
 /// A simple match statement which outputs the log 16 of some value.
 fn easy_log_16(i: u32) -> u32 {
+	#[allow(clippy::redundant_guards)]
 	match i {
 		i if i == 0 => 0,
 		i if i <= 16 => 1,

--- a/substrate/utils/frame/rpc/support/Cargo.toml
+++ b/substrate/utils/frame/rpc/support/Cargo.toml
@@ -20,7 +20,7 @@ sc-rpc-api = { path = "../../../../client/rpc-api" }
 sp-storage = { path = "../../../../primitives/storage" }
 
 [dev-dependencies]
-scale-info = "2.1.1"
+scale-info = "2.10.0"
 jsonrpsee = { version = "0.16.2", features = ["ws-client", "jsonrpsee-types"] }
 tokio = "1.22.0"
 sp-core = { path = "../../../../primitives/core" }


### PR DESCRIPTION
This is a backport of https://github.com/paritytech/polkadot-sdk/pull/1948 over [Polkadot v1.2.0 release](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.2.0).

`102000` Rococo & Westend runtimes are breaking ecosystem apps because of inner objects renaming (`staging-*`). This PR applies the fix for that and bumps specs to `102001` to be released in patch release `v1.2.1`.