### PR TITLE
Reduce Impact on Identity Pallet in Migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12721,6 +12721,7 @@ dependencies = [
  "pallet-balances",
  "pallet-election-provider-multi-phase",
  "pallet-fast-unstake",
+ "pallet-identity",
  "pallet-session",
  "pallet-staking",
  "pallet-staking-reward-fn",

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -30,6 +30,7 @@ sp-npos-elections = { path = "../../../substrate/primitives/npos-elections", def
 pallet-authorship = { path = "../../../substrate/frame/authorship", default-features = false }
 pallet-balances = { path = "../../../substrate/frame/balances", default-features = false }
 pallet-fast-unstake = { path = "../../../substrate/frame/fast-unstake", default-features = false }
+pallet-identity = { path = "../../../substrate/frame/identity", default-features = false }
 pallet-session = { path = "../../../substrate/frame/session", default-features = false }
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 pallet-staking = { path = "../../../substrate/frame/staking", default-features = false }
@@ -85,6 +86,7 @@ std = [
 	"pallet-balances/std",
 	"pallet-election-provider-multi-phase/std",
 	"pallet-fast-unstake/std",
+	"pallet-identity/std",
 	"pallet-session/std",
 	"pallet-staking-reward-fn/std",
 	"pallet-staking/std",
@@ -124,6 +126,7 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"pallet-election-provider-multi-phase/runtime-benchmarks",
 	"pallet-fast-unstake/runtime-benchmarks",
+	"pallet-identity/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
@@ -147,6 +150,7 @@ try-runtime = [
 	"pallet-balances/try-runtime",
 	"pallet-election-provider-multi-phase/try-runtime",
 	"pallet-fast-unstake/try-runtime",
+	"pallet-identity/try-runtime",
 	"pallet-session/try-runtime",
 	"pallet-staking/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/polkadot/runtime/common/src/identity_migrator.rs
+++ b/polkadot/runtime/common/src/identity_migrator.rs
@@ -1,0 +1,79 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This pallet is designed to go into a source chain and destination chain to migrate data. The
+//! design motivations are:
+//!
+//! - Call some function on the source chain that executes some migration (clearing state,
+//!   forwarding an XCM program).
+//! - Call some function (probably from an XCM program) on the destination chain.
+//! - Avoid cluttering the source pallet with new dispatchables that are unrelated to its
+//!   functionality and only used for migration.
+//!
+//! After the migration is complete, the pallet may be removed from both chains' runtimes.
+
+pub use pallet::*;
+use pallet_identity::{self, WeightInfo};
+use sp_core::Get;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::{
+		dispatch::DispatchResultWithPostInfo, pallet_prelude::Pays, traits::EnsureOrigin,
+	};
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_identity::Config {
+		/// The origin that can reap identities. Expected to be `EnsureSigned<AccountId>` on the
+		/// source chain such that anyone can all this function.
+		type Reaper: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// Weight information for the extrinsics in the pallet.
+		type WeightInfo: pallet_identity::WeightInfo;
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Reap the Identity Info of `who` from the Relay Chain, unreserving any deposits held and
+		/// removing storage items associated with `who`.
+		#[pallet::call_index(0)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::reap_identity(
+				T::MaxRegistrars::get(),
+				T::MaxSubAccounts::get()
+		))]
+		pub fn reap_identity(
+			origin: OriginFor<T>,
+			who: T::AccountId,
+		) -> DispatchResultWithPostInfo {
+			T::Reaper::ensure_origin(origin)?;
+			pallet_identity::Pallet::<T>::reap_identity(&who)
+		}
+
+		/// Update the deposit of `who`. Meant to be called by the system with an XCM `Transact`
+		/// Instruction.
+		#[pallet::call_index(1)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::poke_deposit())]
+		pub fn poke_deposit(origin: OriginFor<T>, who: T::AccountId) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			pallet_identity::Pallet::<T>::poke_deposit(&who)?;
+			Ok(Pays::No.into())
+		}
+	}
+}

--- a/polkadot/runtime/common/src/identity_migrator.rs
+++ b/polkadot/runtime/common/src/identity_migrator.rs
@@ -24,15 +24,22 @@
 //!
 //! After the migration is complete, the pallet may be removed from both chains' runtimes.
 
+use frame_support::{dispatch::DispatchResult, traits::Currency};
 pub use pallet::*;
 use pallet_identity::{self, WeightInfo};
 use sp_core::Get;
+
+type BalanceOf<T> = <<T as pallet_identity::Config>::Currency as Currency<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
 
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use frame_support::{
-		dispatch::DispatchResultWithPostInfo, pallet_prelude::Pays, traits::EnsureOrigin,
+		dispatch::{DispatchResultWithPostInfo, PostDispatchInfo},
+		pallet_prelude::*,
+		traits::EnsureOrigin,
 	};
 	use frame_system::pallet_prelude::*;
 
@@ -41,12 +48,28 @@ pub mod pallet {
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + pallet_identity::Config {
+		/// Overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
 		/// The origin that can reap identities. Expected to be `EnsureSigned<AccountId>` on the
 		/// source chain such that anyone can all this function.
 		type Reaper: EnsureOrigin<Self::RuntimeOrigin>;
 
+		/// A handler for what to do when an identity is reaped.
+		type ReapIdentityHandler: OnReapIdentity<Self::AccountId>;
+
 		/// Weight information for the extrinsics in the pallet.
 		type WeightInfo: pallet_identity::WeightInfo;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// The identity and all sub accounts were reaped for `who`.
+		IdentityReaped { who: T::AccountId },
+		/// The deposits held for `who` were updated. `identity` is the new deposit held for
+		/// identity info, and `subs` is the new deposit held for the sub-accounts.
+		DepositUpdated { who: T::AccountId, identity: BalanceOf<T>, subs: BalanceOf<T> },
 	}
 
 	#[pallet::call]
@@ -63,7 +86,16 @@ pub mod pallet {
 			who: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			T::Reaper::ensure_origin(origin)?;
-			pallet_identity::Pallet::<T>::reap_identity(&who)
+			let (registrars, fields, subs) = pallet_identity::Pallet::<T>::reap_identity(&who)?;
+			T::ReapIdentityHandler::on_reap_identity(&who, fields, subs)?;
+			Self::deposit_event(Event::IdentityReaped { who });
+			let post = PostDispatchInfo {
+				actual_weight: Some(<T as pallet::Config>::WeightInfo::reap_identity(
+					registrars, subs,
+				)),
+				pays_fee: Pays::No,
+			};
+			Ok(post)
 		}
 
 		/// Update the deposit of `who`. Meant to be called by the system with an XCM `Transact`
@@ -72,8 +104,34 @@ pub mod pallet {
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::poke_deposit())]
 		pub fn poke_deposit(origin: OriginFor<T>, who: T::AccountId) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			pallet_identity::Pallet::<T>::poke_deposit(&who)?;
+			let (id_deposit, subs_deposit) = pallet_identity::Pallet::<T>::poke_deposit(&who)?;
+			Self::deposit_event(Event::DepositUpdated {
+				who,
+				identity: id_deposit,
+				subs: subs_deposit,
+			});
 			Ok(Pays::No.into())
 		}
+	}
+}
+
+/// Trait to handle reaping identity from state.
+pub trait OnReapIdentity<AccountId> {
+	/// What to do when an identity is reaped. For example, the implementation could send an XCM
+	/// program to another chain. Concretely, a type implementing this trait in the Polkadot
+	/// runtime would teleport enough DOT to the People Chain to cover the Identity deposit there.
+	///
+	/// This could also directly include `Transact { poke_deposit(..), ..}`.
+	///
+	/// Inputs
+	/// - `who`: Whose identity was reaped.
+	/// - `fields`: The number of `additional_fields` they had.
+	/// - `subs`: The number of sub-accounts they had.
+	fn on_reap_identity(who: &AccountId, fields: u32, subs: u32) -> DispatchResult;
+}
+
+impl<AccountId> OnReapIdentity<AccountId> for () {
+	fn on_reap_identity(_who: &AccountId, _fields: u32, _subs: u32) -> DispatchResult {
+		Ok(())
 	}
 }

--- a/polkadot/runtime/common/src/lib.rs
+++ b/polkadot/runtime/common/src/lib.rs
@@ -23,6 +23,7 @@ pub mod auctions;
 pub mod claims;
 pub mod crowdloan;
 pub mod elections;
+pub mod identity_migrator;
 pub mod impls;
 pub mod paras_registrar;
 pub mod paras_sudo_wrapper;

--- a/polkadot/runtime/rococo/src/impls.rs
+++ b/polkadot/runtime/rococo/src/impls.rs
@@ -17,10 +17,10 @@
 use crate::xcm_config;
 use frame_support::pallet_prelude::DispatchResult;
 use frame_system::RawOrigin;
-use pallet_identity::OnReapIdentity;
 use parity_scale_codec::{Decode, Encode};
 use primitives::Balance;
 use rococo_runtime_constants::currency::*;
+use runtime_common::identity_migrator::OnReapIdentity;
 use sp_std::{marker::PhantomData, prelude::*};
 use xcm::{latest::prelude::*, VersionedMultiLocation, VersionedXcm};
 use xcm_executor::traits::TransactAsset;
@@ -29,14 +29,14 @@ use xcm_executor::traits::TransactAsset;
 /// remote calls.
 #[derive(Encode, Decode)]
 enum PeopleRuntimePallets<AccountId: Encode> {
-	#[codec(index = 50)]
-	Identity(IdentityCalls<AccountId>),
+	#[codec(index = 248)]
+	IdentityMigrator(IdentityMigratorCalls<AccountId>),
 }
 
 /// Call encoding for the calls needed from the Identity pallet.
 #[derive(Encode, Decode)]
-enum IdentityCalls<AccountId: Encode> {
-	#[codec(index = 16)]
+enum IdentityMigratorCalls<AccountId: Encode> {
+	#[codec(index = 1)]
 	PokeDeposit(AccountId),
 }
 
@@ -78,7 +78,7 @@ where
 	AccountId: Into<[u8; 32]> + Clone + Encode,
 {
 	fn on_reap_identity(who: &AccountId, fields: u32, subs: u32) -> DispatchResult {
-		use crate::impls::IdentityCalls::PokeDeposit;
+		use crate::impls::IdentityMigratorCalls::PokeDeposit;
 
 		let total_to_send = Self::calculate_remote_deposit(fields, subs);
 
@@ -114,7 +114,7 @@ where
 		}]
 		.into();
 
-		let poke = PeopleRuntimePallets::<AccountId>::Identity(PokeDeposit(who.clone()));
+		let poke = PeopleRuntimePallets::<AccountId>::IdentityMigrator(PokeDeposit(who.clone()));
 
 		// Actual program to execute on People Chain.
 		let program: Xcm<()> = Xcm(vec![

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -620,7 +620,6 @@ impl pallet_identity::Config for Runtime {
 	type Slashed = Treasury;
 	type ForceOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
 	type RegistrarOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
-	type ReapIdentityHandler = ToParachainIdentityReaper<Runtime, Self::AccountId>;
 	type WeightInfo = weights::pallet_identity::WeightInfo<Runtime>;
 }
 
@@ -1078,8 +1077,10 @@ impl auctions::Config for Runtime {
 
 // use frame_system::EnsureSigned;
 impl identity_migrator::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
 	// To be changed to `EnsureSigned` once there is a People Chain to migrate to.
 	type Reaper = EnsureRoot<AccountId>;
+	type ReapIdentityHandler = ToParachainIdentityReaper<Runtime, Self::AccountId>;
 	type WeightInfo = weights::pallet_identity::WeightInfo<Runtime>;
 }
 
@@ -1372,7 +1373,7 @@ construct_runtime! {
 		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config<T>} = 99,
 
 		// Pallet for migrating Identity to a parachain. To be removed post-migration.
-		IdentityMigrator: identity_migrator::{Pallet, Call} = 248,
+		IdentityMigrator: identity_migrator::{Pallet, Call, Event<T>} = 248,
 
 		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call} = 250,
 		AssignedSlots: assigned_slots::{Pallet, Call, Storage, Event<T>, Config<T>} = 251,

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1075,7 +1075,6 @@ impl auctions::Config for Runtime {
 	type WeightInfo = weights::runtime_common_auctions::WeightInfo<Runtime>;
 }
 
-// use frame_system::EnsureSigned;
 impl identity_migrator::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	// To be changed to `EnsureSigned` once there is a People Chain to migrate to.

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -30,7 +30,7 @@ use primitives::{
 	ValidationCode, ValidationCodeHash, ValidatorId, ValidatorIndex, PARACHAIN_KEY_TYPE_ID,
 };
 use runtime_common::{
-	assigned_slots, auctions, claims, crowdloan, impl_runtime_weights,
+	assigned_slots, auctions, claims, crowdloan, identity_migrator, impl_runtime_weights,
 	impls::{
 		LocatableAssetConverter, ToAuthor, VersionedLocatableAsset, VersionedMultiLocationConverter,
 	},
@@ -620,11 +620,7 @@ impl pallet_identity::Config for Runtime {
 	type Slashed = Treasury;
 	type ForceOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
 	type RegistrarOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
-	// Should be `EnsureRoot` until the parachain launches with Identity state. Then, it will be
-	// `EnsureSigned<Self::AccountId>` to allow deposit migration.
-	type ReapOrigin = EnsureRoot<Self::AccountId>;
 	type ReapIdentityHandler = ToParachainIdentityReaper<Runtime, Self::AccountId>;
-	type LockerOrigin = EnsureRoot<Self::AccountId>;
 	type WeightInfo = weights::pallet_identity::WeightInfo<Runtime>;
 }
 
@@ -1080,6 +1076,13 @@ impl auctions::Config for Runtime {
 	type WeightInfo = weights::runtime_common_auctions::WeightInfo<Runtime>;
 }
 
+// use frame_system::EnsureSigned;
+impl identity_migrator::Config for Runtime {
+	// To be changed to `EnsureSigned` once there is a People Chain to migrate to.
+	type Reaper = EnsureRoot<AccountId>;
+	type WeightInfo = weights::pallet_identity::WeightInfo<Runtime>;
+}
+
 type NisCounterpartInstance = pallet_balances::Instance2;
 impl pallet_balances::Config<NisCounterpartInstance> for Runtime {
 	type Balance = Balance;
@@ -1367,6 +1370,9 @@ construct_runtime! {
 
 		// Pallet for sending XCM.
 		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config<T>} = 99,
+
+		// Pallet for migrating Identity to a parachain. To be removed post-migration.
+		IdentityMigrator: identity_migrator::{Pallet, Call} = 248,
 
 		ParasSudoWrapper: paras_sudo_wrapper::{Pallet, Call} = 250,
 		AssignedSlots: assigned_slots::{Pallet, Call, Storage, Event<T>, Config<T>} = 251,

--- a/polkadot/runtime/rococo/src/weights/pallet_identity.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_identity.rs
@@ -402,26 +402,4 @@ impl<T: frame_system::Config> pallet_identity::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn lock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 43_286_000 picoseconds.
-		Weight::from_parts(51_523_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn unlock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 42_243_000 picoseconds.
-		Weight::from_parts(52_907_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
 }

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -881,7 +881,6 @@ impl pallet_identity::Config for Runtime {
 	type MaxRegistrars = MaxRegistrars;
 	type ForceOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
 	type RegistrarOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
-	type ReapIdentityHandler = ();
 	type WeightInfo = weights::pallet_identity::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -881,9 +881,7 @@ impl pallet_identity::Config for Runtime {
 	type MaxRegistrars = MaxRegistrars;
 	type ForceOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
 	type RegistrarOrigin = EitherOf<EnsureRoot<Self::AccountId>, GeneralAdmin>;
-	type ReapOrigin = EnsureRoot<Self::AccountId>;
 	type ReapIdentityHandler = ();
-	type LockerOrigin = EnsureRoot<Self::AccountId>;
 	type WeightInfo = weights::pallet_identity::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/westend/src/weights/pallet_identity.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_identity.rs
@@ -407,26 +407,4 @@ impl<T: frame_system::Config> pallet_identity::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn lock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 43_286_000 picoseconds.
-		Weight::from_parts(51_523_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn unlock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 42_243_000 picoseconds.
-		Weight::from_parts(52_907_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
 }

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1480,7 +1480,6 @@ impl pallet_identity::Config for Runtime {
 	type Slashed = Treasury;
 	type ForceOrigin = EnsureRootOrHalfCouncil;
 	type RegistrarOrigin = EnsureRootOrHalfCouncil;
-	type ReapIdentityHandler = ();
 	type WeightInfo = pallet_identity::weights::SubstrateWeight<Runtime>;
 }
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1480,9 +1480,7 @@ impl pallet_identity::Config for Runtime {
 	type Slashed = Treasury;
 	type ForceOrigin = EnsureRootOrHalfCouncil;
 	type RegistrarOrigin = EnsureRootOrHalfCouncil;
-	type ReapOrigin = EnsureRoot<Self::AccountId>;
 	type ReapIdentityHandler = ();
-	type LockerOrigin = EnsureRoot<Self::AccountId>;
 	type WeightInfo = pallet_identity::weights::SubstrateWeight<Runtime>;
 }
 

--- a/substrate/frame/alliance/src/mock.rs
+++ b/substrate/frame/alliance/src/mock.rs
@@ -125,7 +125,6 @@ impl pallet_identity::Config for Test {
 	type MaxRegistrars = MaxRegistrars;
 	type Slashed = ();
 	type RegistrarOrigin = EnsureOneOrRoot;
-	type ReapIdentityHandler = ();
 	type ForceOrigin = EnsureTwoOrRoot;
 	type WeightInfo = ();
 }

--- a/substrate/frame/alliance/src/mock.rs
+++ b/substrate/frame/alliance/src/mock.rs
@@ -125,10 +125,8 @@ impl pallet_identity::Config for Test {
 	type MaxRegistrars = MaxRegistrars;
 	type Slashed = ();
 	type RegistrarOrigin = EnsureOneOrRoot;
-	type ReapOrigin = EnsureOneOrRoot;
 	type ReapIdentityHandler = ();
 	type ForceOrigin = EnsureTwoOrRoot;
-	type LockerOrigin = EnsureTwoOrRoot;
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/identity/src/benchmarking.rs
+++ b/substrate/frame/identity/src/benchmarking.rs
@@ -587,7 +587,8 @@ mod benchmarks {
 			let _ = Identity::<T>::reap_identity(&target);
 		}
 
-		assert_last_event::<T>(Event::<T>::IdentityReaped { who: target }.into());
+		assert!(IdentityOf::<T>::get(&target).is_none());
+		assert_eq!(SubsOf::<T>::get(&target).0, Zero::zero());
 
 		Ok(())
 	}
@@ -627,14 +628,11 @@ mod benchmarks {
 			let _ = Identity::<T>::poke_deposit(&target);
 		}
 
-		assert_last_event::<T>(
-			Event::<T>::DepositUpdated {
-				who: target,
-				identity: expected_id_deposit,
-				subs: expected_sub_deposit,
-			}
-			.into(),
-		);
+		let info = IdentityOf::<T>::get(&target).unwrap();
+		assert_eq!(info.deposit, expected_id_deposit);
+
+		let subs = SubsOf::<T>::get(&target);
+		assert_eq!(subs.0, expected_sub_deposit);
 
 		Ok(())
 	}

--- a/substrate/frame/identity/src/tests.rs
+++ b/substrate/frame/identity/src/tests.rs
@@ -113,7 +113,6 @@ impl pallet_identity::Config for Test {
 	type IdentityInformation = IdentityInfo<MaxAdditionalFields>;
 	type MaxRegistrars = MaxRegistrars;
 	type RegistrarOrigin = EnsureOneOrRoot;
-	type ReapIdentityHandler = ();
 	type ForceOrigin = EnsureTwoOrRoot;
 	type WeightInfo = ();
 }

--- a/substrate/frame/identity/src/tests.rs
+++ b/substrate/frame/identity/src/tests.rs
@@ -113,10 +113,8 @@ impl pallet_identity::Config for Test {
 	type IdentityInformation = IdentityInfo<MaxAdditionalFields>;
 	type MaxRegistrars = MaxRegistrars;
 	type RegistrarOrigin = EnsureOneOrRoot;
-	type ReapOrigin = EnsureOneOrRoot;
 	type ReapIdentityHandler = ();
 	type ForceOrigin = EnsureTwoOrRoot;
-	type LockerOrigin = EnsureOneOrRoot;
 	type WeightInfo = ();
 }
 
@@ -677,7 +675,7 @@ fn reap_identity_works() {
 		));
 		// 10 for identity, 10 for sub
 		assert_eq!(Balances::free_balance(10), 80);
-		assert_ok!(Identity::reap_identity(RuntimeOrigin::signed(1), 10));
+		assert_ok!(Identity::reap_identity(&10));
 		// no identity or subs
 		assert!(Identity::identity(10).is_none());
 		assert!(Identity::super_of(20).is_none());
@@ -705,7 +703,7 @@ fn poke_deposit_works() {
 		assert_eq!(Balances::free_balance(10), 100);
 
 		// poke
-		assert_ok!(Identity::poke_deposit(RuntimeOrigin::signed(1), 10));
+		assert_ok!(Identity::poke_deposit(&10));
 
 		// free balance reduced by 20
 		assert_eq!(Balances::free_balance(10), 80);
@@ -716,101 +714,5 @@ fn poke_deposit_works() {
 		);
 		// new subs deposit is 10          vv
 		assert_eq!(Identity::subs_of(10), (10, vec![20].try_into().unwrap()));
-	});
-}
-
-#[test]
-fn pallet_locks_and_unlocks() {
-	new_test_ext().execute_with(|| {
-		// Can add registrars and reap
-		let one_as_origin = RuntimeOrigin::signed(1);
-		// Killer
-		let two_as_origin = RuntimeOrigin::signed(2);
-		// Registrar
-		let three_as_origin = RuntimeOrigin::signed(3);
-		// Sets identity
-		let ten_as_origin = RuntimeOrigin::signed(10);
-		// Sets identity
-		let twenty_as_origin = RuntimeOrigin::signed(20);
-		// Sub data to use
-		let data = Data::Raw(vec![40; 1].try_into().unwrap());
-
-		// Set some state before locking so that calls are sensible
-		assert_ok!(Identity::add_registrar(one_as_origin.clone(), 3));
-		assert_ok!(Identity::set_identity(ten_as_origin.clone(), Box::new(ten())));
-		assert_ok!(Identity::request_judgement(ten_as_origin.clone(), 0, 10));
-
-		// Lock
-		assert_ok!(Identity::lock_pallet(one_as_origin.clone()));
-
-		// Almost everything is uncallable
-		assert_noop!(
-			Identity::add_registrar(one_as_origin.clone(), 1),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::set_identity(twenty_as_origin.clone(), Box::new(twenty())),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::set_subs(ten_as_origin.clone(), vec![(20, data.clone())]),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(Identity::clear_identity(ten_as_origin.clone()), Error::<Test>::PalletLocked);
-		assert_noop!(
-			Identity::request_judgement(twenty_as_origin.clone(), 0, 10),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::cancel_request(twenty_as_origin.clone(), 0),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::set_fee(three_as_origin.clone(), 0, 10),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::set_account_id(three_as_origin.clone(), 0, 4),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::set_fields(
-				three_as_origin.clone(),
-				0,
-				IdentityFields(SimpleIdentityField::Display | SimpleIdentityField::Legal)
-			),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::provide_judgement(
-				three_as_origin,
-				0,
-				10,
-				Judgement::Reasonable,
-				BlakeTwo256::hash_of(&ten())
-			),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(Identity::kill_identity(two_as_origin, 10), Error::<Test>::PalletLocked);
-		assert_noop!(
-			Identity::add_sub(ten_as_origin.clone(), 1, data.clone()),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(
-			Identity::rename_sub(ten_as_origin.clone(), 1, data),
-			Error::<Test>::PalletLocked
-		);
-		assert_noop!(Identity::remove_sub(ten_as_origin.clone(), 1), Error::<Test>::PalletLocked);
-		assert_noop!(Identity::quit_sub(one_as_origin.clone()), Error::<Test>::PalletLocked);
-
-		// Reap and Poke are still callable for migration
-		assert_ok!(Identity::poke_deposit(one_as_origin.clone(), 10));
-		assert_ok!(Identity::reap_identity(one_as_origin.clone(), 10));
-
-		// Unlock still needs to be callable, obviously
-		assert_ok!(Identity::unlock_pallet(one_as_origin));
-
-		// And pallet works
-		assert_ok!(Identity::set_identity(twenty_as_origin, Box::new(twenty())));
 	});
 }

--- a/substrate/frame/identity/src/weights.rs
+++ b/substrate/frame/identity/src/weights.rs
@@ -70,8 +70,6 @@ pub trait WeightInfo {
 	fn quit_sub(s: u32, ) -> Weight;
 	fn reap_identity(r: u32, s: u32, ) -> Weight;
 	fn poke_deposit() -> Weight;
-	fn lock_pallet() -> Weight;
-	fn unlock_pallet() -> Weight;
 }
 
 /// Weights for pallet_identity using the Substrate node and recommended hardware.
@@ -418,28 +416,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn lock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 43_286_000 picoseconds.
-		Weight::from_parts(51_523_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn unlock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 42_243_000 picoseconds.
-		Weight::from_parts(52_907_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
 }
 
 // For backwards compatibility and tests
@@ -784,27 +760,5 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(0, 11003))
 			.saturating_add(RocksDbWeight::get().reads(3))
 			.saturating_add(RocksDbWeight::get().writes(3))
-	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn lock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 43_286_000 picoseconds.
-		Weight::from_parts(51_523_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(RocksDbWeight::get().writes(1))
-	}
-	/// Storage: `Identity::Locked` (r:0 w:1)
-	/// Proof: `Identity::Locked` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
-	fn unlock_pallet() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 42_243_000 picoseconds.
-		Weight::from_parts(52_907_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			.saturating_add(RocksDbWeight::get().writes(1))
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/paritytech/polkadot-sdk/pull/1814#pullrequestreview-1701818579

- Removes `lock`/`unlock` extrinsics
- Moves `reap_identity` and `poke_deposit` into special migration pallet to avoid adding new one-time calls to the Identity pallet