### PR TITLE
upgraded review-bot to 2.2.0

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -6,12 +6,10 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
-
 jobs:
   review-approvals:
     runs-on: ubuntu-latest
+    environment: master
     steps:
       - name: Extract content of artifact
         id: number
@@ -25,9 +23,10 @@ jobs:
           app_id: ${{ secrets.REVIEW_APP_ID }}
           private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v2.1.0
+        uses: paritytech/review-bot@v2.2.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.team_token.outputs.token }}
           team-token: ${{ steps.team_token.outputs.token }}
           checks-token: ${{ steps.team_token.outputs.token }}
           pr-number: ${{ steps.number.outputs.content }}
+          request-reviewers: true

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           artifact-name: pr_number
       - name: Generate token
-        id: team_token
+        id: app_token
         uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.REVIEW_APP_ID }}
@@ -25,8 +25,8 @@ jobs:
       - name: "Evaluates PR reviews and assigns reviewers"
         uses: paritytech/review-bot@v2.2.0
         with:
-          repo-token: ${{ steps.team_token.outputs.token }}
-          team-token: ${{ steps.team_token.outputs.token }}
-          checks-token: ${{ steps.team_token.outputs.token }}
+          repo-token: ${{ steps.app_token.outputs.token }}
+          team-token: ${{ steps.app_token.outputs.token }}
+          checks-token: ${{ steps.app_token.outputs.token }}
           pr-number: ${{ steps.number.outputs.content }}
           request-reviewers: true


### PR DESCRIPTION
This version includes paritytech/review-bot#97 which can assign reviewers.

It will be the final step required to replace PRCR.

It also moves the secrets to the environment master.