### PR TITLE
check-each-crate: Do not reference crate to check by name

### DIFF
--- a/.gitlab/check-each-crate.py
+++ b/.gitlab/check-each-crate.py
@@ -19,7 +19,11 @@ output = subprocess.check_output(["cargo", "tree", "--locked", "--workspace", "-
 crates = []
 for line in output.splitlines():
 	if line != b"":
-		crates.append(line.decode('utf8').split(" ")[0])
+		line = line.decode('utf8').split(" ")
+		crate_name = line[0]
+		# The crate path is always the last element in the line.
+		crate_path = line[len(line) - 1].replace("(", "").replace(")", "")
+		crates.append((crate_name, crate_path))
 
 # Make the list unique and sorted
 crates = list(set(crates))
@@ -49,9 +53,9 @@ print(f"Crates per group: {crates_per_group}", file=sys.stderr)
 for i in range(0, crates_per_group + overflow_crates):
 	crate = crates_per_group * target_group + i
 
-	print(f"Checking {crates[crate]}", file=sys.stderr)
+	print(f"Checking {crates[crate][0]}", file=sys.stderr)
 
-	res = subprocess.run(["cargo", "check", "--locked", "-p", crates[crate]])
+	res = subprocess.run(["cargo", "check", "--locked"], cwd = crates[crate][1])
 
 	if res.returncode != 0:
 		sys.exit(1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18466,7 +18466,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.8",
+ "rustix 0.38.21",
  "windows-sys 0.48.0",
 ]
 

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -76,7 +76,7 @@ bench = false
 default = [ "std" ]
 std = [
 	"array-bytes",
-	"bandersnatch_vrfs/getrandom",
+	"bandersnatch_vrfs?/getrandom",
 	"bip39/rand",
 	"bip39/std",
 	"blake2/std",


### PR DESCRIPTION
This pull request changes how `check-each-crate.py` is working. Instead of passing the name of the crate via `-p`, we now jump into the directory of the crate and call there `cargo check`. This should fix issues like https://github.com/paritytech/polkadot-sdk/issues/2013 where a crate is present twice in the `Cargo.lock`.

Besides that it also changes `core/Cargo.toml` to not always pull in bandersnatch.


