### PR TITLE
Bump ec-utils version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17256,7 +17256,7 @@ dependencies = [
 
 [[package]]
 name = "sp-crypto-ec-utils"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",

--- a/substrate/primitives/crypto/ec-utils/Cargo.toml
+++ b/substrate/primitives/crypto/ec-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-crypto-ec-utils"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 description = "Host functions for common Arkworks elliptic curve operations"
 edition.workspace = true

--- a/substrate/primitives/crypto/ec-utils/src/lib.rs
+++ b/substrate/primitives/crypto/ec-utils/src/lib.rs
@@ -15,14 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Elliptic curves which are mostly compatible with *Arkworks* library
-//! mostly useful in non-native contexts.
+//! This crate offers elliptic curves types which are compatible with the
+//! [Arkworks](https://github.com/arkworks-rs) library functionalities.
 //!
-//! The definitions make use of host functions to offload the non-native
-//! computational environment from the some of the most computationally
-//! expensive operations by internally leveraging the
+//! The implementation has been primarily designed to be used in slow hosted
+//! targets (e.g. wasm32) and offloads the most computationally expensive
+//! operations to the host by leveraging the
 //! [arkworks-extensions](https://github.com/paritytech/arkworks-extensions)
-//! library.
+//! library and Substrate's host functions.
 //!
 //! The exported types are organized and named in a way that mirrors the structure
 //! of the types in the original Arkworks library. This design choice aims to make


### PR DESCRIPTION
This is required to publish on `crates.io` the new versions of the crates hosted here: https://github.com/paritytech/arkworks-substrate (which are depending on this crate).

I overlooked this thing in https://github.com/paritytech/polkadot-sdk/pull/2068 🤦‍♂️