### PR TITLE
RFC: Reorganise AggregateMessageOrigin to support Snowbridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,6 +1965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bridge-hub-common"
+version = "0.1.0"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "sp-std",
+]
+
+[[package]]
 name = "bridge-hub-kusama-runtime"
 version = "0.1.0"
 dependencies = [
@@ -2137,6 +2146,7 @@ dependencies = [
  "bp-rococo",
  "bp-runtime",
  "bp-wococo",
+ "bridge-hub-common",
  "bridge-hub-test-utils",
  "bridge-runtime-common",
  "cumulus-pallet-aura-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
 	"cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama",
 	"cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot",
 	"cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo",
+	"cumulus/parachains/runtimes/bridge-hubs/common",
 	"cumulus/parachains/runtimes/bridge-hubs/test-utils",
 	"cumulus/parachains/runtimes/collectives/collectives-polkadot",
 	"cumulus/parachains/runtimes/contracts/contracts-rococo",

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -92,6 +92,8 @@ pallet-bridge-messages = { path = "../../../../../bridges/modules/messages", def
 pallet-bridge-parachains = { path = "../../../../../bridges/modules/parachains", default-features = false }
 pallet-bridge-relayers = { path = "../../../../../bridges/modules/relayers", default-features = false }
 bridge-runtime-common = { path = "../../../../../bridges/bin/runtime-common", default-features = false }
+bridge-hub-common = { path = "../common", default-features = false }
+
 
 [dev-dependencies]
 static_assertions = "1.1"
@@ -115,6 +117,7 @@ std = [
 	"bp-runtime/std",
 	"bp-wococo/std",
 	"bridge-runtime-common/std",
+	"bridge-hub-common/std",
 	"codec/std",
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-dmp-queue/std",
@@ -179,6 +182,7 @@ std = [
 
 runtime-benchmarks = [
 	"bridge-runtime-common/runtime-benchmarks",
+	"bridge-hub-common/runtime-benchmarks",
 	"cumulus-pallet-dmp-queue/runtime-benchmarks",
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"cumulus-pallet-session-benchmarking/runtime-benchmarks",

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -372,7 +372,7 @@ impl pallet_message_queue::Config for Runtime {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type MessageProcessor = BridgeHubMessageProcessor<
 		xcm_builder::ProcessXcmMessage<
-			AggregateMessageOrigin,
+			MessageOrigin,
 			xcm_executor::XcmExecutor<xcm_config::XcmConfig>,
 			RuntimeCall,
 		>,

--- a/cumulus/parachains/runtimes/bridge-hubs/common/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/common/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bridge-hub-common"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+description = "Bridge hub common utilities"
+license = "Apache-2.0"
+
+[dependencies]
+sp-std = { path = "../../../../../substrate/primitives/std", default-features = false }
+frame-support = { path = "../../../../../substrate/frame/support", default-features = false }
+cumulus-primitives-core = { path = "../../../../primitives/core", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [
+	"sp-std/std",
+	"frame-support/std",
+	"cumulus-primitives-core/std"
+]
+
+runtime-benchmarks = [
+	"frame-support/runtime-benchmarks",
+	"cumulus-primitives-core/runtime-benchmarks"
+]

--- a/cumulus/parachains/runtimes/bridge-hubs/common/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/common/src/lib.rs
@@ -1,0 +1,36 @@
+use sp_std::marker::PhantomData;
+use frame_support::traits::{ProcessMessage, ProcessMessageError};
+use frame_support::weights::WeightMeter;
+use cumulus_primitives_core::{AggregateMessageOrigin, MessageOrigin};
+
+pub struct BridgeHubMessageProcessor<XcmProcessor, SnowbridgeProcessor>(PhantomData<(XcmProcessor, SnowbridgeProcessor)>)
+where
+	XcmProcessor: ProcessMessage<Origin = MessageOrigin>,
+	SnowbridgeProcessor: ProcessMessage<Origin = MessageOrigin>;
+
+impl<
+	XcmProcessor,
+	SnowbridgeProcessor
+> ProcessMessage for BridgeHubMessageProcessor<
+	XcmProcessor,
+	SnowbridgeProcessor
+>
+where
+	XcmProcessor: ProcessMessage<Origin = MessageOrigin>,
+	SnowbridgeProcessor: ProcessMessage<Origin = MessageOrigin>
+{
+	type Origin = AggregateMessageOrigin;
+
+	fn process_message(
+		message: &[u8],
+		origin: Self::Origin,
+		meter: &mut WeightMeter,
+		id: &mut [u8; 32],
+	) -> Result<bool, ProcessMessageError> {
+		use AggregateMessageOrigin::*;
+		match origin {
+			Xcm(inner) => XcmProcessor::process_message(message, inner, meter, id),
+			Other(inner) => SnowbridgeProcessor::process_message(message, inner, meter, id)
+		}
+	}
+}

--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -120,9 +120,9 @@ impl From<u32> for AggregateMessageOrigin {
 	fn from(x: u32) -> Self {
 		use MessageOrigin::*;
 		match x {
-			0 => Self::Xcmp(Here),
-			1 => Self::Xcmp(Parent),
-			p => Self::Xcmp(Sibling(ParaId::from(p))),
+			0 => Self::Xcm(Here),
+			1 => Self::Xcm(Parent),
+			p => Self::Xcm(Sibling(ParaId::from(p))),
 		}
 	}
 }

--- a/substrate/frame/support/src/traits/messages.rs
+++ b/substrate/frame/support/src/traits/messages.rs
@@ -240,8 +240,14 @@ pub trait QueuePausedQuery<Origin> {
 	fn is_paused(origin: &Origin) -> bool;
 }
 
-impl<Origin> QueuePausedQuery<Origin> for () {
-	fn is_paused(_: &Origin) -> bool {
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl<Origin> QueuePausedQuery<Origin> for Tuple {
+	fn is_paused(origin: &Origin) -> bool {
+		for_tuples!( #(
+			if Tuple::is_paused(origin) {
+				return true;
+			}
+		)* );
 		false
 	}
 }


### PR DESCRIPTION
The `AggregateMessageOrigin` enum now 2 levels of hierarchy, with two top-level variants, `Xcm` and `Other`, to be used by (dmp-queue, hrmp-queue) and snowbridge respectively.

This PR only changes the `bridge-hub-rococo` runtime as a demonstration of the refactor. It also demonstrates how we intend to modify BridgeHub so that our bridge can also use MessageQueue.

```rust
/// The aggregate origin of an inbound message.
#[derive(Encode, Decode, MaxEncodedLen, Clone, Eq, PartialEq, TypeInfo, Debug)]
pub enum AggregateMessageOrigin {
	/// The message came from the DMP or HRMP subsystem
	Xcm(MessageOrigin),
	/// The message came from some other pallet
	Other(MessageOrigin),
}

/// The origin of an inbound message.
#[derive(Encode, Decode, MaxEncodedLen, Clone, Eq, PartialEq, TypeInfo, Debug)]
pub enum MessageOrigin {
	/// The message came from the para-chain itself.
	Here,
	/// The message came from the relay-chain.
	///
	/// This is used by the DMP queue.
	Parent,
	/// The message came from a sibling para-chain.
	///
	/// This is used by the HRMP queue.
	Sibling(ParaId),
}
```

The other change is to register the `MessageQueue` pallet last in the runtime definition for `bridge-hub-rococo`. This is because we need our bridge `on_initialize` handler to run before the MessageQueue `on_initialize` handler. 