### PR TITLE
[FRAME] Short-circuit fungible self transfer

### DIFF
--- a/bridges/modules/relayers/src/stake_adapter.rs
+++ b/bridges/modules/relayers/src/stake_adapter.rs
@@ -36,7 +36,7 @@ impl<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>
 	StakeAndSlash<AccountId, BlockNumber, Currency::Balance>
 	for StakeAndSlashNamed<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>
 where
-	AccountId: Codec + Debug + PartialEq,
+	AccountId: Codec + Debug,
 	Currency: NamedReservableCurrency<AccountId>,
 	ReserveId: Get<Currency::ReserveIdentifier>,
 	Stake: Get<Currency::Balance>,

--- a/bridges/modules/relayers/src/stake_adapter.rs
+++ b/bridges/modules/relayers/src/stake_adapter.rs
@@ -36,7 +36,7 @@ impl<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>
 	StakeAndSlash<AccountId, BlockNumber, Currency::Balance>
 	for StakeAndSlashNamed<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>
 where
-	AccountId: Codec + Debug,
+	AccountId: Codec + Debug + PartialEq,
 	Currency: NamedReservableCurrency<AccountId>,
 	ReserveId: Get<Currency::ReserveIdentifier>,
 	Stake: Get<Currency::Balance>,

--- a/bridges/primitives/relayers/src/lib.rs
+++ b/bridges/primitives/relayers/src/lib.rs
@@ -115,7 +115,7 @@ where
 impl<T, Relayer> PaymentProcedure<Relayer, T::Balance> for PayRewardFromAccount<T, Relayer>
 where
 	T: frame_support::traits::fungible::Mutate<Relayer>,
-	Relayer: Decode + Encode + PartialEq,
+	Relayer: Decode + Encode + Eq,
 {
 	type Error = sp_runtime::DispatchError;
 

--- a/bridges/primitives/relayers/src/lib.rs
+++ b/bridges/primitives/relayers/src/lib.rs
@@ -104,7 +104,7 @@ pub struct PayRewardFromAccount<T, Relayer>(PhantomData<(T, Relayer)>);
 
 impl<T, Relayer> PayRewardFromAccount<T, Relayer>
 where
-	Relayer: Decode + Encode + PartialEq,
+	Relayer: Decode + Encode,
 {
 	/// Return account that pays rewards based on the provided parameters.
 	pub fn rewards_account(params: RewardsAccountParams) -> Relayer {

--- a/bridges/primitives/relayers/src/lib.rs
+++ b/bridges/primitives/relayers/src/lib.rs
@@ -104,7 +104,7 @@ pub struct PayRewardFromAccount<T, Relayer>(PhantomData<(T, Relayer)>);
 
 impl<T, Relayer> PayRewardFromAccount<T, Relayer>
 where
-	Relayer: Decode + Encode,
+	Relayer: Decode + Encode + PartialEq,
 {
 	/// Return account that pays rewards based on the provided parameters.
 	pub fn rewards_account(params: RewardsAccountParams) -> Relayer {
@@ -115,7 +115,7 @@ where
 impl<T, Relayer> PaymentProcedure<Relayer, T::Balance> for PayRewardFromAccount<T, Relayer>
 where
 	T: frame_support::traits::fungible::Mutate<Relayer>,
-	Relayer: Decode + Encode,
+	Relayer: Decode + Encode + PartialEq,
 {
 	type Error = sp_runtime::DispatchError;
 

--- a/cumulus/primitives/utility/src/lib.rs
+++ b/cumulus/primitives/utility/src/lib.rs
@@ -102,7 +102,7 @@ struct AssetTraderRefunder {
 /// Important: Errors if the Trader is being called twice by 2 BuyExecution instructions
 /// Alternatively we could just return payment in the aforementioned case
 pub struct TakeFirstAssetTrader<
-	AccountId: PartialEq,
+	AccountId: Eq,
 	FeeCharger: ChargeWeightInFungibles<AccountId, ConcreteAssets>,
 	Matcher: MatchesFungibles<ConcreteAssets::AssetId, ConcreteAssets::Balance>,
 	ConcreteAssets: fungibles::Mutate<AccountId> + fungibles::Balanced<AccountId>,
@@ -112,7 +112,7 @@ pub struct TakeFirstAssetTrader<
 	PhantomData<(AccountId, FeeCharger, Matcher, ConcreteAssets, HandleRefund)>,
 );
 impl<
-		AccountId: PartialEq,
+		AccountId: Eq,
 		FeeCharger: ChargeWeightInFungibles<AccountId, ConcreteAssets>,
 		Matcher: MatchesFungibles<ConcreteAssets::AssetId, ConcreteAssets::Balance>,
 		ConcreteAssets: fungibles::Mutate<AccountId> + fungibles::Balanced<AccountId>,
@@ -241,7 +241,7 @@ impl<
 }
 
 impl<
-		AccountId: PartialEq,
+		AccountId: Eq,
 		FeeCharger: ChargeWeightInFungibles<AccountId, ConcreteAssets>,
 		Matcher: MatchesFungibles<ConcreteAssets::AssetId, ConcreteAssets::Balance>,
 		ConcreteAssets: fungibles::Mutate<AccountId> + fungibles::Balanced<AccountId>,

--- a/cumulus/primitives/utility/src/lib.rs
+++ b/cumulus/primitives/utility/src/lib.rs
@@ -102,7 +102,7 @@ struct AssetTraderRefunder {
 /// Important: Errors if the Trader is being called twice by 2 BuyExecution instructions
 /// Alternatively we could just return payment in the aforementioned case
 pub struct TakeFirstAssetTrader<
-	AccountId,
+	AccountId: PartialEq,
 	FeeCharger: ChargeWeightInFungibles<AccountId, ConcreteAssets>,
 	Matcher: MatchesFungibles<ConcreteAssets::AssetId, ConcreteAssets::Balance>,
 	ConcreteAssets: fungibles::Mutate<AccountId> + fungibles::Balanced<AccountId>,
@@ -112,7 +112,7 @@ pub struct TakeFirstAssetTrader<
 	PhantomData<(AccountId, FeeCharger, Matcher, ConcreteAssets, HandleRefund)>,
 );
 impl<
-		AccountId,
+		AccountId: PartialEq,
 		FeeCharger: ChargeWeightInFungibles<AccountId, ConcreteAssets>,
 		Matcher: MatchesFungibles<ConcreteAssets::AssetId, ConcreteAssets::Balance>,
 		ConcreteAssets: fungibles::Mutate<AccountId> + fungibles::Balanced<AccountId>,
@@ -241,7 +241,7 @@ impl<
 }
 
 impl<
-		AccountId,
+		AccountId: PartialEq,
 		FeeCharger: ChargeWeightInFungibles<AccountId, ConcreteAssets>,
 		Matcher: MatchesFungibles<ConcreteAssets::AssetId, ConcreteAssets::Balance>,
 		ConcreteAssets: fungibles::Mutate<AccountId> + fungibles::Balanced<AccountId>,

--- a/polkadot/xcm/xcm-builder/src/fungibles_adapter.rs
+++ b/polkadot/xcm/xcm-builder/src/fungibles_adapter.rs
@@ -34,8 +34,7 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
-		                               * over it. */
+		AccountId: Eq + Clone, /* can't get away without it since Currency is generic over it. */
 	> TransactAsset for FungiblesTransferAdapter<Assets, Matcher, AccountIdConverter, AccountId>
 {
 	fn internal_transfer_asset(
@@ -151,8 +150,7 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
-		                               * over it. */
+		AccountId: Eq + Clone, /* can't get away without it since Currency is generic over it. */
 		CheckAsset: AssetChecking<Assets::AssetId>,
 		CheckingAccount: Get<AccountId>,
 	>
@@ -187,8 +185,7 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
-		                               * over it. */
+		AccountId: Eq + Clone, /* can't get away without it since Currency is generic over it. */
 		CheckAsset: AssetChecking<Assets::AssetId>,
 		CheckingAccount: Get<AccountId>,
 	> TransactAsset
@@ -328,8 +325,7 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
-		                               * over it. */
+		AccountId: Eq + Clone, /* can't get away without it since Currency is generic over it. */
 		CheckAsset: AssetChecking<Assets::AssetId>,
 		CheckingAccount: Get<AccountId>,
 	> TransactAsset

--- a/polkadot/xcm/xcm-builder/src/fungibles_adapter.rs
+++ b/polkadot/xcm/xcm-builder/src/fungibles_adapter.rs
@@ -34,7 +34,8 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: Clone, // can't get away without it since Currency is generic over it.
+		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
+		                               * over it. */
 	> TransactAsset for FungiblesTransferAdapter<Assets, Matcher, AccountIdConverter, AccountId>
 {
 	fn internal_transfer_asset(
@@ -150,7 +151,8 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: Clone, // can't get away without it since Currency is generic over it.
+		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
+		                               * over it. */
 		CheckAsset: AssetChecking<Assets::AssetId>,
 		CheckingAccount: Get<AccountId>,
 	>
@@ -185,7 +187,8 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: Clone, // can't get away without it since Currency is generic over it.
+		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
+		                               * over it. */
 		CheckAsset: AssetChecking<Assets::AssetId>,
 		CheckingAccount: Get<AccountId>,
 	> TransactAsset
@@ -325,7 +328,8 @@ impl<
 		Assets: fungibles::Mutate<AccountId>,
 		Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
 		AccountIdConverter: ConvertLocation<AccountId>,
-		AccountId: Clone, // can't get away without it since Currency is generic over it.
+		AccountId: PartialEq + Clone, /* can't get away without it since Currency is generic
+		                               * over it. */
 		CheckAsset: AssetChecking<Assets::AssetId>,
 		CheckingAccount: Get<AccountId>,
 	> TransactAsset

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -1369,9 +1369,8 @@ fn freezing_and_locking_should_work() {
 }
 
 #[test]
-fn account_removal_and_total_issuance_does_update_properly() {
+fn self_transfer_noop() {
 	ExtBuilder::default().existential_deposit(100).build_and_execute_with(|| {
-		ExistentialDeposit::set(100);
 		assert_eq!(Balances::total_issuance(), 0);
 		let _ = Balances::deposit_creating(&1, 100);
 

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -18,14 +18,18 @@
 //! Tests regarding the functionality of the `Currency` trait set implementations.
 
 use super::*;
-use crate::NegativeImbalance;
-use frame_support::traits::{
-	BalanceStatus::{Free, Reserved},
-	Currency,
-	ExistenceRequirement::{self, AllowDeath, KeepAlive},
-	Hooks, LockIdentifier, LockableCurrency, NamedReservableCurrency, ReservableCurrency,
-	WithdrawReasons,
+use crate::{Event, NegativeImbalance};
+use frame_support::{
+	traits::{
+		BalanceStatus::{Free, Reserved},
+		Currency,
+		ExistenceRequirement::{self, AllowDeath, KeepAlive},
+		Hooks, LockIdentifier, LockableCurrency, NamedReservableCurrency, ReservableCurrency,
+		WithdrawReasons,
+	},
+	StorageNoopGuard,
 };
+use frame_system::Event as SysEvent;
 
 const ID_1: LockIdentifier = *b"1       ";
 const ID_2: LockIdentifier = *b"2       ";
@@ -1362,4 +1366,41 @@ fn freezing_and_locking_should_work() {
 			assert_eq!(Balances::account(&1).frozen, 0);
 			assert_eq!(System::consumers(&1), 0);
 		});
+}
+
+#[test]
+fn account_removal_and_total_issuance_does_update_properly() {
+	ExtBuilder::default().existential_deposit(100).build_and_execute_with(|| {
+		ExistentialDeposit::set(100);
+		assert_eq!(Balances::total_issuance(), 0);
+		let _ = Balances::deposit_creating(&1, 100);
+
+		// The account is set up properly:
+		assert_eq!(
+			events(),
+			[
+				Event::Deposit { who: 1, amount: 100 }.into(),
+				SysEvent::NewAccount { account: 1 }.into(),
+				Event::Endowed { account: 1, free_balance: 100 }.into(),
+			]
+		);
+		assert_eq!(Balances::free_balance(1), 100);
+		assert_eq!(Balances::total_issuance(), 100);
+
+		// Transfers to self are No-OPs:
+		let _g = StorageNoopGuard::new();
+		for i in 0..200 {
+			let r = Balances::transfer_allow_death(Some(1).into(), 1, i);
+
+			if i <= 100 {
+				assert_ok!(r);
+			} else {
+				assert!(r.is_err());
+			}
+
+			assert!(events().is_empty());
+			assert_eq!(Balances::free_balance(1), 100, "Balance unchanged by self transfer");
+			assert_eq!(Balances::total_issuance(), 100, "TI unchanged by self transfers");
+		}
+	});
 }

--- a/substrate/frame/broker/src/test_fungibles.rs
+++ b/substrate/frame/broker/src/test_fungibles.rs
@@ -168,7 +168,7 @@ where
 
 impl<
 		Instance: Get<u32>,
-		AccountId: Encode,
+		AccountId: Encode + PartialEq,
 		AssetId: tokens::AssetId + Copy,
 		MinimumBalance: TypedGet,
 		HoldReason,

--- a/substrate/frame/broker/src/test_fungibles.rs
+++ b/substrate/frame/broker/src/test_fungibles.rs
@@ -168,7 +168,7 @@ where
 
 impl<
 		Instance: Get<u32>,
-		AccountId: Encode + PartialEq,
+		AccountId: Encode + Eq,
 		AssetId: tokens::AssetId + Copy,
 		MinimumBalance: TypedGet,
 		HoldReason,

--- a/substrate/frame/nis/src/lib.rs
+++ b/substrate/frame/nis/src/lib.rs
@@ -148,7 +148,7 @@ impl<T> fungible::Unbalanced<T> for NoCounterpart<T> {
 	}
 	fn set_total_issuance(_: Self::Balance) {}
 }
-impl<T> FunMutate<T> for NoCounterpart<T> {}
+impl<T: PartialEq> FunMutate<T> for NoCounterpart<T> {}
 impl<T> Convert<Perquintill, u32> for NoCounterpart<T> {
 	fn convert(_: Perquintill) -> u32 {
 		0

--- a/substrate/frame/nis/src/lib.rs
+++ b/substrate/frame/nis/src/lib.rs
@@ -148,7 +148,7 @@ impl<T> fungible::Unbalanced<T> for NoCounterpart<T> {
 	}
 	fn set_total_issuance(_: Self::Balance) {}
 }
-impl<T: PartialEq> FunMutate<T> for NoCounterpart<T> {}
+impl<T: Eq> FunMutate<T> for NoCounterpart<T> {}
 impl<T> Convert<Perquintill, u32> for NoCounterpart<T> {
 	fn convert(_: Perquintill) -> u32 {
 		0

--- a/substrate/frame/support/src/traits/tokens/fungible/item_of.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/item_of.rs
@@ -256,7 +256,7 @@ impl<
 impl<
 		F: fungibles::MutateHold<AccountId>,
 		A: Get<<F as fungibles::Inspect<AccountId>>::AssetId>,
-		AccountId: PartialEq,
+		AccountId,
 	> MutateHold<AccountId> for ItemOf<F, A, AccountId>
 {
 	fn hold(reason: &Self::Reason, who: &AccountId, amount: Self::Balance) -> DispatchResult {

--- a/substrate/frame/support/src/traits/tokens/fungible/item_of.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/item_of.rs
@@ -219,7 +219,7 @@ impl<
 impl<
 		F: fungibles::Mutate<AccountId>,
 		A: Get<<F as fungibles::Inspect<AccountId>>::AssetId>,
-		AccountId: PartialEq,
+		AccountId: Eq,
 	> Mutate<AccountId> for ItemOf<F, A, AccountId>
 {
 	fn mint_into(who: &AccountId, amount: Self::Balance) -> Result<Self::Balance, DispatchError> {

--- a/substrate/frame/support/src/traits/tokens/fungible/item_of.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/item_of.rs
@@ -219,7 +219,7 @@ impl<
 impl<
 		F: fungibles::Mutate<AccountId>,
 		A: Get<<F as fungibles::Inspect<AccountId>>::AssetId>,
-		AccountId,
+		AccountId: PartialEq,
 	> Mutate<AccountId> for ItemOf<F, A, AccountId>
 {
 	fn mint_into(who: &AccountId, amount: Self::Balance) -> Result<Self::Balance, DispatchError> {
@@ -256,7 +256,7 @@ impl<
 impl<
 		F: fungibles::MutateHold<AccountId>,
 		A: Get<<F as fungibles::Inspect<AccountId>>::AssetId>,
-		AccountId,
+		AccountId: PartialEq,
 	> MutateHold<AccountId> for ItemOf<F, A, AccountId>
 {
 	fn hold(reason: &Self::Reason, who: &AccountId, amount: Self::Balance) -> DispatchResult {

--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -237,7 +237,7 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 /// Trait for providing a basic fungible asset.
 pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId>
 where
-	AccountId: PartialEq,
+	AccountId: Eq,
 {
 	/// Increase the balance of `who` by exactly `amount`, minting new tokens. If that isn't
 	/// possible then an `Err` is returned and nothing is changed.

--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -306,6 +306,9 @@ where
 	}
 
 	/// Transfer funds from one account into another.
+	///
+	/// A transfer where the source and destination account are identical is treated as No-OP after
+	/// checking the preconditions.
 	fn transfer(
 		source: &AccountId,
 		dest: &AccountId,

--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -311,6 +311,10 @@ pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 	) -> Result<Self::Balance, DispatchError> {
 		let _extra = Self::can_withdraw(source, amount).into_result(preservation != Expendable)?;
 		Self::can_deposit(dest, amount, Extant).into_result()?;
+		if source == dest {
+			return Ok(amount)
+		}
+
 		Self::decrease_balance(source, amount, BestEffort, preservation, Polite)?;
 		// This should never fail as we checked `can_deposit` earlier. But we do a best-effort
 		// anyway.

--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -235,7 +235,10 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 }
 
 /// Trait for providing a basic fungible asset.
-pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
+pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId>
+where
+	AccountId: PartialEq,
+{
 	/// Increase the balance of `who` by exactly `amount`, minting new tokens. If that isn't
 	/// possible then an `Err` is returned and nothing is changed.
 	fn mint_into(who: &AccountId, amount: Self::Balance) -> Result<Self::Balance, DispatchError> {

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -363,6 +363,10 @@ pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
 		let _extra = Self::can_withdraw(asset.clone(), source, amount)
 			.into_result(preservation != Expendable)?;
 		Self::can_deposit(asset.clone(), dest, amount, Extant).into_result()?;
+		if source == dest {
+			return Ok(amount)
+		}
+
 		Self::decrease_balance(asset.clone(), source, amount, BestEffort, preservation, Polite)?;
 		// This should never fail as we checked `can_deposit` earlier. But we do a best-effort
 		// anyway.

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -250,7 +250,10 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 }
 
 /// Trait for providing a basic fungible asset.
-pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId> {
+pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId>
+where
+	AccountId: PartialEq,
+{
 	/// Increase the balance of `who` by exactly `amount`, minting new tokens. If that isn't
 	/// possible then an `Err` is returned and nothing is changed.
 	fn mint_into(

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -252,7 +252,7 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 /// Trait for providing a basic fungible asset.
 pub trait Mutate<AccountId>: Inspect<AccountId> + Unbalanced<AccountId>
 where
-	AccountId: PartialEq,
+	AccountId: Eq,
 {
 	/// Increase the balance of `who` by exactly `amount`, minting new tokens. If that isn't
 	/// possible then an `Err` is returned and nothing is changed.

--- a/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/regular.rs
@@ -356,6 +356,9 @@ where
 	}
 
 	/// Transfer funds from one account into another.
+	///
+	/// A transfer where the source and destination account are identical is treated as No-OP after
+	/// checking the preconditions.
 	fn transfer(
 		asset: Self::AssetId,
 		source: &AccountId,

--- a/substrate/frame/support/src/traits/tokens/pay.rs
+++ b/substrate/frame/support/src/traits/tokens/pay.rs
@@ -87,7 +87,7 @@ impl<A, F> Pay for PayFromAccount<F, A>
 where
 	A: TypedGet,
 	F: fungible::Mutate<A::Type>,
-	A::Type: PartialEq,
+	A::Type: Eq,
 {
 	type Balance = F::Balance;
 	type Beneficiary = A::Type;
@@ -120,7 +120,7 @@ impl<A, F> frame_support::traits::tokens::Pay for PayAssetFromAccount<F, A>
 where
 	A: TypedGet,
 	F: fungibles::Mutate<A::Type> + fungibles::Create<A::Type>,
-	A::Type: PartialEq,
+	A::Type: Eq,
 {
 	type Balance = F::Balance;
 	type Beneficiary = A::Type;

--- a/substrate/frame/support/src/traits/tokens/pay.rs
+++ b/substrate/frame/support/src/traits/tokens/pay.rs
@@ -82,8 +82,13 @@ pub enum PaymentStatus {
 }
 
 /// Simple implementation of `Pay` which makes a payment from a "pot" - i.e. a single account.
-pub struct PayFromAccount<F, A>(sp_std::marker::PhantomData<(F, A)>);
-impl<A: TypedGet, F: fungible::Mutate<A::Type>> Pay for PayFromAccount<F, A> {
+pub struct PayFromAccount<F, A>(core::marker::PhantomData<(F, A)>);
+impl<A, F> Pay for PayFromAccount<F, A>
+where
+	A: TypedGet,
+	F: fungible::Mutate<A::Type>,
+	A::Type: PartialEq,
+{
 	type Balance = F::Balance;
 	type Beneficiary = A::Type;
 	type AssetKind = ();
@@ -110,11 +115,12 @@ impl<A: TypedGet, F: fungible::Mutate<A::Type>> Pay for PayFromAccount<F, A> {
 
 /// Simple implementation of `Pay` for assets which makes a payment from a "pot" - i.e. a single
 /// account.
-pub struct PayAssetFromAccount<F, A>(sp_std::marker::PhantomData<(F, A)>);
+pub struct PayAssetFromAccount<F, A>(core::marker::PhantomData<(F, A)>);
 impl<A, F> frame_support::traits::tokens::Pay for PayAssetFromAccount<F, A>
 where
 	A: TypedGet,
 	F: fungibles::Mutate<A::Type> + fungibles::Create<A::Type>,
+	A::Type: PartialEq,
 {
 	type Balance = F::Balance;
 	type Beneficiary = A::Type;


### PR DESCRIPTION
Changes:
- Change the fungible(s) logic to treat a self-transfer as No-OP (as long as all pre-checks pass).

Note that the self-transfer case will not emit an event since no state was changed.