### PR TITLE
review-bot: prevent request review of core-devs

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -118,3 +118,7 @@ rules:
       - minApprovals: 1
         teams:
           - ci
+
+preventReviewRequests:
+  teams:
+    - core-devs


### PR DESCRIPTION
This will remove `core-devs` from being required reviewers of PRs,