### PR TITLE
Fix for failed pipeline `test-doc`

### DIFF
--- a/substrate/frame/support/src/storage/types/map.rs
+++ b/substrate/frame/support/src/storage/types/map.rs
@@ -53,7 +53,7 @@ use sp_std::prelude::*;
 /// 	#[pallet::storage_prefix = "OtherFoo"]
 /// 	#[pallet::unbounded]
 ///     pub type Foo<T> = StorageMap<
-/// 		_
+/// 		_,
 /// 		Blake2_128Concat,
 /// 		u32,
 /// 		u32,


### PR DESCRIPTION
Fix for failed pipeline `test-doc`: https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/4174859
I just wonder how could have other PRs been merged after this was merged: https://github.com/paritytech/polkadot-sdk/pull/1714/files#diff-1bde7bb2be0165cbe6db391e10a4a0b2f333348681373a86a0f8502d14d20d32R56 
because `test-doc` is  `{"build_allow_failure":false} `?