### PR TITLE
skip trigger for review bot on draft PRs

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   trigger-review-bot:
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     name: trigger review bot
     steps:


### PR DESCRIPTION
Added if condition on review-bot's trigger so it does not trigger in `draft` PRs.