### PR TITLE
Configure MessageQueue for compatibility with Snowbridge

### DIFF
--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -468,11 +468,13 @@ construct_runtime!(
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin, Config<T>} = 31,
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 32,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 33,
-		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 34,
 
 		// Handy utilities.
 		Utility: pallet_utility::{Pallet, Call, Event} = 40,
 		Multisig: pallet_multisig::{Pallet, Call, Storage, Event<T>} = 41,
+
+		// MessageQueue. Comes last so that its on_initialize handler runs last
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 100,
 	}
 );
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -468,11 +468,13 @@ construct_runtime!(
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin, Config<T>} = 31,
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 32,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 33,
-		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 34,
 
 		// Handy utilities.
 		Utility: pallet_utility::{Pallet, Call, Event} = 40,
 		Multisig: pallet_multisig::{Pallet, Call, Storage, Event<T>} = 41,
+
+		// MessageQueue. Comes last so that its on_initialize handler runs last
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 100,
 	}
 );
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -524,7 +524,6 @@ construct_runtime!(
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin, Config<T>} = 31,
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 32,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 33,
-		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 34,
 
 		// Handy utilities.
 		Utility: pallet_utility::{Pallet, Call, Event} = 40,
@@ -564,6 +563,8 @@ construct_runtime!(
 		BridgeWestendMessages: pallet_bridge_messages::<Instance3>::{Pallet, Call, Storage, Event<T>, Config<T>} = 51,
 
 		BridgeRelayers: pallet_bridge_relayers::{Pallet, Call, Storage, Event<T>} = 47,
+
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 255,
 	}
 );
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -564,7 +564,7 @@ construct_runtime!(
 
 		BridgeRelayers: pallet_bridge_relayers::{Pallet, Call, Storage, Event<T>} = 47,
 
-		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 255,
+		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 100,
 	}
 );
 

--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -102,7 +102,7 @@ pub enum MessageOrigin {
 	/// The message came from the relay-chain.
 	Parent,
 	/// The message came from a sibling para-chain.
-	Sibling(ParaId)
+	Sibling(ParaId),
 }
 
 impl From<AggregateMessageOrigin> for xcm::v3::MultiLocation {
@@ -111,18 +111,10 @@ impl From<AggregateMessageOrigin> for xcm::v3::MultiLocation {
 		match origin {
 			Here => MultiLocation::here(),
 			Parent => MultiLocation::parent(),
-			Sibling(id) => {
-				MultiLocation::new(1, Junction::Parachain(id.into()))
-			},
-			Export(MessageOrigin::Here) => {
-				MultiLocation::here()
-			},
-			Export(MessageOrigin::Parent) => {
-				MultiLocation::parent()
-			},
-			Export(MessageOrigin::Sibling(id)) => {
-				MultiLocation::new(1, Junction::Parachain(id.into()))
-			}
+			Sibling(id) => MultiLocation::new(1, Junction::Parachain(id.into())),
+			Export(MessageOrigin::Here) => MultiLocation::here(),
+			Export(MessageOrigin::Parent) => MultiLocation::parent(),
+			Export(MessageOrigin::Sibling(id)) => MultiLocation::new(1, Junction::Parachain(id.into())),
 		}
 	}
 }

--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -91,15 +91,38 @@ pub enum AggregateMessageOrigin {
 	///
 	/// This is used by the HRMP queue.
 	Sibling(ParaId),
+	/// This is used by the snowbridge-outbound-queue pallet
+	Export(MessageOrigin),
+}
+/// The origin of a message
+#[derive(Encode, Decode, MaxEncodedLen, Clone, Eq, PartialEq, TypeInfo, Debug)]
+pub enum MessageOrigin {
+	/// The message came from the para-chain itself.
+	Here,
+	/// The message came from the relay-chain.
+	Parent,
+	/// The message came from a sibling para-chain.
+	Sibling(ParaId)
 }
 
 impl From<AggregateMessageOrigin> for xcm::v3::MultiLocation {
 	fn from(origin: AggregateMessageOrigin) -> Self {
+		use AggregateMessageOrigin::*;
 		match origin {
-			AggregateMessageOrigin::Here => MultiLocation::here(),
-			AggregateMessageOrigin::Parent => MultiLocation::parent(),
-			AggregateMessageOrigin::Sibling(id) =>
-				MultiLocation::new(1, Junction::Parachain(id.into())),
+			Here => MultiLocation::here(),
+			Parent => MultiLocation::parent(),
+			Sibling(id) => {
+				MultiLocation::new(1, Junction::Parachain(id.into()))
+			},
+			Export(MessageOrigin::Here) => {
+				MultiLocation::here()
+			},
+			Export(MessageOrigin::Parent) => {
+				MultiLocation::parent()
+			},
+			Export(MessageOrigin::Sibling(id)) => {
+				MultiLocation::new(1, Junction::Parachain(id.into()))
+			}
 		}
 	}
 }

--- a/substrate/frame/support/src/traits/messages.rs
+++ b/substrate/frame/support/src/traits/messages.rs
@@ -240,8 +240,14 @@ pub trait QueuePausedQuery<Origin> {
 	fn is_paused(origin: &Origin) -> bool;
 }
 
-impl<Origin> QueuePausedQuery<Origin> for () {
-	fn is_paused(_: &Origin) -> bool {
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl<Origin> QueuePausedQuery<Origin> for Tuple {
+	fn is_paused(origin: &Origin) -> bool {
+		for_tuples!( #(
+			if Tuple::is_paused(origin) {
+				return true;
+			}
+		)* );
 		false
 	}
 }


### PR DESCRIPTION
Changes:
* Add `Export` variant to AggregateMessageOrigin enum, to identify queues owned by the[ snowbridge-outbound-queue](https://github.com/Snowfork/snowbridge/blob/main/parachain/pallets/outbound-queue/src/lib.rs) pallet.
* Change registration of MessageQueue as the last pallet in BridgeHub runtimes, to ensure correct `on_initialize` order. The [on_initialize](https://github.com/Snowfork/snowbridge/blob/ab6d7a00e6888aacba8032cb39c524801f714391/parachain/pallets/outbound-queue/src/lib.rs#L265) handler of `snowbridge-outbound-queue` needs to run first.

Checklist:
- [ ] Ensure tests and linters pass 