### PR TITLE
Speed up try runtime checks for pallet-bags-list

### DIFF
--- a/substrate/frame/bags-list/src/list/mod.rs
+++ b/substrate/frame/bags-list/src/list/mod.rs
@@ -543,7 +543,7 @@ impl<T: Config<I>, I: 'static> List<T, I> {
 			thresholds.into_iter().filter_map(|t| Bag::<T, I>::get(t))
 		};
 
-		// cached list of nodes in a map of bags to avoid multiple lookups
+		// cached list of node ids mapped to its corresponding bag to avoid multiple lookups
 		let mut cached_node_bags = BTreeMap::<T::Score, Vec<T::AccountId>>::new();
 
 		let _ = active_bags.clone().try_for_each(|b| {
@@ -903,15 +903,15 @@ impl<T: Config<I>, I: 'static> Node<T, I> {
 	#[cfg(any(test, feature = "try-runtime", feature = "fuzz"))]
 	fn do_try_state(
 		&self,
-		cached_node_bags: &BTreeMap<<T as Config<I>>::Score, Vec<T::AccountId>>,
+		cached_bags: &BTreeMap<<T as Config<I>>::Score, Vec<T::AccountId>>,
 	) -> Result<(), TryRuntimeError> {
 		let expected_bag = Bag::<T, I>::get(self.bag_upper).ok_or("bag not found for node")?;
-		let cached_bag_nodes =
-			cached_node_bags.get(&self.bag_upper).ok_or("bag not found in the cache")?;
+		let expected_bag_nodes =
+			cached_bags.get(&self.bag_upper).ok_or("bag not found in the cache")?;
 
 		let id = self.id();
 
-		frame_support::ensure!(cached_bag_nodes.contains(id), "node does not exist in the bag");
+		frame_support::ensure!(expected_bag_nodes.contains(id), "node does not exist in the bag");
 
 		let non_terminal_check = !self.is_terminal() &&
 			expected_bag.head.as_ref() != Some(id) &&

--- a/substrate/frame/bags-list/src/list/mod.rs
+++ b/substrate/frame/bags-list/src/list/mod.rs
@@ -799,12 +799,6 @@ impl<T: Config<I>, I: 'static> Bag<T, I> {
 	pub fn std_iter(&self) -> impl Iterator<Item = Node<T, I>> {
 		sp_std::iter::successors(self.head(), |prev| prev.next())
 	}
-
-	/// Check if the bag contains a node with `id`.
-	#[cfg(any(test, feature = "fuzz"))]
-	fn contains(&self, id: &T::AccountId) -> bool {
-		self.iter().any(|n| n.id() == id)
-	}
 }
 
 /// A Node is the fundamental element comprising the doubly-linked list described by `Bag`.


### PR DESCRIPTION
closes https://github.com/paritytech/polkadot-sdk/issues/2020.

This improves running time for pallet-bags-list try runtime checks on westend from ~90 minutes to 6 seconds on M2 pro.

