### PR TITLE
Speed up nominator state checks in staking pallet

### DIFF
--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -1903,12 +1903,12 @@ impl<T: Config> Pallet<T> {
 					})
 					.collect::<Result<Vec<_>, _>>()?;
 
-				// we take total instead of active as the nominator might have requested to unbond
+				// We take total instead of active as the nominator might have requested to unbond
 				// some of their stake that is still exposed in the current era.
-				ensure!(
-					sum <= Self::ledger(StakingAccount::Stash(nominator.clone()))?.total,
-					"nominator stake exceeds what is bonded."
-				);
+				// This can happen when there is a slash in the current era so we only warn.
+				if sum <= Self::ledger(Stash(nominator.clone()))?.total {
+					log!(warn, "nominator stake exceeds what is bonded.");
+				}
 
 				Ok(())
 			})

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -1905,8 +1905,8 @@ impl<T: Config> Pallet<T> {
 
 				// We take total instead of active as the nominator might have requested to unbond
 				// some of their stake that is still exposed in the current era.
-				// This can happen when there is a slash in the current era so we only warn.
 				if sum <= Self::ledger(Stash(nominator.clone()))?.total {
+					// This can happen when there is a slash in the current era so we only warn.
 					log!(warn, "nominator stake exceeds what is bonded.");
 				}
 

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -1903,8 +1903,8 @@ impl<T: Config> Pallet<T> {
 					})
 					.collect::<Result<Vec<_>, _>>()?;
 
-				// we take total as a nominator might have requested to unbond some of their stake
-				// that is active in current era.
+				// we take total instead of active as the nominator might have requested to unbond
+				// some of their stake that is still exposed in the current era.
 				ensure!(
 					sum <= Self::ledger(StakingAccount::Stash(nominator.clone()))?.total,
 					"nominator stake exceeds what is bonded."


### PR DESCRIPTION
Should help https://github.com/paritytech/polkadot-sdk/issues/234.
Related to https://github.com/paritytech/polkadot-sdk/issues/2020 and https://github.com/paritytech/polkadot-sdk/issues/2108.

Refactors and improves running time for try runtime checks for staking pallet. 

Tested on westend on my M2 pro: running time drops from 90 seconds to 7 seconds.