### PR TITLE
Tracking allocator: mark `Spinlock::unlock()` as unsafe and provide a safety contract

### DIFF
--- a/polkadot/node/tracking-allocator/src/lib.rs
+++ b/polkadot/node/tracking-allocator/src/lib.rs
@@ -73,7 +73,8 @@ impl<T> Spinlock<T> {
 	}
 
 	// SAFETY: It should be only called from the guard's destructor. Calling it explicitly while
-	// the guard is alive is undefined behavior.
+	// the guard is alive is undefined behavior, as it breaks the security contract of `Deref` and
+	// `DerefMut`, which implies that lock is held at the moment of dereferencing.
 	#[inline]
 	unsafe fn unlock(&self) {
 		self.lock.store(false, Ordering::Release);


### PR DESCRIPTION
As [it was discussed](https://github.com/paritytech/polkadot-sdk/pull/1192#discussion_r1374320227) in #1192, explicitly unlocking the allocator's spinlock is not indeed a safe operation. This PR declares it `unsafe` and provides a safety contract.