### PR TITLE
`serde_json`: bumped to 1.0.108

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,8 +1470,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -16459,9 +16459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",

--- a/cumulus/client/relay-chain-rpc-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-rpc-interface/Cargo.toml
@@ -33,7 +33,7 @@ jsonrpsee = { version = "0.16.2", features = ["ws-client"] }
 tracing = "0.1.37"
 async-trait = "0.1.73"
 url = "2.4.0"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 serde = "1.0.188"
 schnellru = "0.2.1"
 smoldot = { version = "0.11.0",  default_features = false, features = ["std"]}

--- a/cumulus/parachain-template/node/Cargo.toml
+++ b/cumulus/parachain-template/node/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 serde = { version = "1.0.188", features = ["derive"] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 futures = "0.3.28"
-serde_json = "1.0.104"
+serde_json = "1.0.108"
 
 # Local
 parachain-template-runtime = { path = "../runtime" }

--- a/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
 paste = "1.0.14"
-serde_json = "1.0.104"
+serde_json = "1.0.108"
 
 # Substrate
 grandpa = { package = "sc-consensus-grandpa", path = "../../../../../substrate/client/consensus/grandpa" }

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.28"
 hex-literal = "0.4.1"
 log = "0.4.20"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 # Local
 rococo-parachain-runtime = { path = "../parachains/runtimes/testing/rococo-parachain" }

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -17,7 +17,7 @@ criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 tokio = { version = "1.32.0", features = ["macros"] }
 tracing = "0.1.37"
 url = "2.4.0"

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -82,7 +82,7 @@ gum = { package = "tracing-gum", path = "../gum" }
 log = "0.4.17"
 schnellru = "0.2.1"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0.48"
 kvdb = "0.13.0"
 kvdb-rocksdb = { version = "0.19.0", optional = true }

--- a/polkadot/node/test/service/Cargo.toml
+++ b/polkadot/node/test/service/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 gum = { package = "tracing-gum", path = "../../gum" }
 rand = "0.8.5"
-serde_json = "1.0.106"
+serde_json = "1.0.108"
 tempfile = "3.2.0"
 tokio = "1.24.2"
 

--- a/polkadot/node/zombienet-backchannel/Cargo.toml
+++ b/polkadot/node/zombienet-backchannel/Cargo.toml
@@ -19,4 +19,4 @@ reqwest = { version = "0.11", features = ["rustls-tls"], default-features = fals
 thiserror = "1.0.48"
 gum = { package = "tracing-gum", path = "../gum" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+serde_json = "1.0.108"

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -64,7 +64,7 @@ pallet-babe = { path = "../../../substrate/frame/babe" }
 pallet-treasury = { path = "../../../substrate/frame/treasury" }
 sp-keystore = { path = "../../../substrate/primitives/keystore" }
 sp-keyring = { path = "../../../substrate/primitives/keyring" }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 libsecp256k1 = "0.7.0"
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../primitives/test-helpers" }
 

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -62,7 +62,7 @@ test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../pri
 sp-tracing = { path = "../../../substrate/primitives/tracing" }
 thousands = "0.2.0"
 assert_matches = "1"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 [features]
 default = [ "std" ]

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -108,7 +108,7 @@ keyring = { package = "sp-keyring", path = "../../../substrate/primitives/keyrin
 remote-externalities = { package = "frame-remote-externalities" , path = "../../../substrate/utils/frame/remote-externalities" }
 sp-trie = { path = "../../../substrate/primitives/trie" }
 separator = "0.4.1"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sp-tracing = { path = "../../../substrate/primitives/tracing", default-features = false }
 tokio = { version = "1.24.2", features = ["macros"] }
 

--- a/polkadot/runtime/test-runtime/Cargo.toml
+++ b/polkadot/runtime/test-runtime/Cargo.toml
@@ -71,7 +71,7 @@ hex-literal = "0.4.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 keyring = { package = "sp-keyring", path = "../../../substrate/primitives/keyring" }
 sp-trie = { path = "../../../substrate/primitives/trie" }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 [build-dependencies]
 substrate-wasm-builder = { path = "../../../substrate/utils/wasm-builder" }

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -116,7 +116,7 @@ xcm-builder = { package = "staging-xcm-builder", path = "../../xcm/xcm-builder",
 hex-literal = "0.4.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 keyring = { package = "sp-keyring", path = "../../../substrate/primitives/keyring" }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 remote-externalities = { package = "frame-remote-externalities" , path = "../../../substrate/utils/frame/remote-externalities" }
 tokio = { version = "1.24.2", features = ["macros"] }
 sp-tracing = { path = "../../../substrate/primitives/tracing", default-features = false }

--- a/substrate/bin/minimal/node/Cargo.toml
+++ b/substrate/bin/minimal/node/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.0.9", features = ["derive"] }
 futures = { version = "0.3.21", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 sc-cli = { path = "../../../client/cli" }
 sc-executor = {  path = "../../../client/executor" }

--- a/substrate/bin/node-template/node/Cargo.toml
+++ b/substrate/bin/node-template/node/Cargo.toml
@@ -19,7 +19,7 @@ name = "node-template"
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 futures = { version = "0.3.21", features = ["thread-pool"]}
-serde_json = "1.0.85"
+serde_json = "1.0.108"
 
 sc-cli = { path = "../../../client/cli" }
 sp-core = { path = "../../../primitives/core" }

--- a/substrate/bin/node-template/runtime/Cargo.toml
+++ b/substrate/bin/node-template/runtime/Cargo.toml
@@ -39,7 +39,7 @@ sp-std = { path = "../../../primitives/std", default-features = false}
 sp-storage = { path = "../../../primitives/storage", default-features = false}
 sp-transaction-pool = { path = "../../../primitives/transaction-pool", default-features = false}
 sp-version = { path = "../../../primitives/version", default-features = false, features = ["serde"] }
-serde_json = { version = "1.0.85", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.108", default-features = false, features = ["alloc"] }
 sp-genesis-builder = { default-features = false, path = "../../../primitives/genesis-builder" }
 
 # Used for the node template's RPCs

--- a/substrate/bin/node/bench/Cargo.toml
+++ b/substrate/bin/node/bench/Cargo.toml
@@ -22,7 +22,7 @@ sc-client-api = { path = "../../../client/api" }
 sp-runtime = { path = "../../../primitives/runtime" }
 sp-state-machine = { path = "../../../primitives/state-machine" }
 serde = "1.0.188"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 derive_more = { version = "0.99.17", default-features = false, features = ["display"] }
 kvdb = "0.13.0"
 kvdb-rocksdb = "0.19.0"

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -108,7 +108,7 @@ sc-cli = { path = "../../../client/cli", optional = true}
 frame-benchmarking-cli = { path = "../../../utils/frame/benchmarking-cli", optional = true}
 node-inspect = { package = "staging-node-inspect", path = "../inspect", optional = true}
 try-runtime-cli = { path = "../../../utils/frame/try-runtime/cli", optional = true}
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 [dev-dependencies]
 sc-keystore = { path = "../../../client/keystore" }

--- a/substrate/bin/node/executor/Cargo.toml
+++ b/substrate/bin/node/executor/Cargo.toml
@@ -47,7 +47,7 @@ sp-consensus-babe = { path = "../../../primitives/consensus/babe" }
 sp-externalities = { path = "../../../primitives/externalities" }
 sp-keyring = { path = "../../../primitives/keyring" }
 sp-runtime = { path = "../../../primitives/runtime" }
-serde_json = "1.0.85"
+serde_json = "1.0.108"
 
 [features]
 stress-test = []

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -23,7 +23,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
 static_assertions = "1.1.0"
 log = { version = "0.4.17", default-features = false }
-serde_json = { version = "1.0.85", default-features = false, features = ["alloc", "arbitrary_precision"] }
+serde_json = { version = "1.0.108", default-features = false, features = ["alloc", "arbitrary_precision"] }
 
 # pallet-asset-conversion: turn on "num-traits" feature
 primitive-types = { version = "0.12.0", default-features = false, features = ["codec", "scale-info", "num-traits"] }

--- a/substrate/bin/utils/chain-spec-builder/Cargo.toml
+++ b/substrate/bin/utils/chain-spec-builder/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.17"
 node-cli = { package = "staging-node-cli", path = "../../node/cli" }
 sc-chain-spec = { path = "../../../client/chain-spec" }
 sc-keystore = { path = "../../../client/keystore" }
-serde_json = "1.0.100"
+serde_json = "1.0.108"
 sp-core = { path = "../../../primitives/core" }
 sp-keystore = { path = "../../../primitives/keystore" }
 sp-tracing = { version = "10.0.0", path = "../../../primitives/tracing" }

--- a/substrate/client/chain-spec/Cargo.toml
+++ b/substrate/client/chain-spec/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 memmap2 = "0.5.0"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sc-client-api = { path = "../api" }
 sc-chain-spec-derive = { path = "derive" }
 sc-executor = { path = "../executor" }

--- a/substrate/client/cli/Cargo.toml
+++ b/substrate/client/cli/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.5"
 regex = "1.6.0"
 rpassword = "7.0.0"
 serde = "1.0.188"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0.48"
 bip39 = "2.0.0"
 tokio = { version = "1.22.0", features = ["signal", "rt-multi-thread", "parking_lot"] }

--- a/substrate/client/consensus/babe/rpc/Cargo.toml
+++ b/substrate/client/consensus/babe/rpc/Cargo.toml
@@ -30,7 +30,7 @@ sp-keystore = { path = "../../../../primitives/keystore" }
 sp-runtime = { path = "../../../../primitives/runtime" }
 
 [dev-dependencies]
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 tokio = "1.22.0"
 sc-consensus = { path = "../../common" }
 sc-keystore = { path = "../../../keystore" }

--- a/substrate/client/consensus/beefy/rpc/Cargo.toml
+++ b/substrate/client/consensus/beefy/rpc/Cargo.toml
@@ -23,7 +23,7 @@ sp-core = { path = "../../../../primitives/core" }
 sp-runtime = { path = "../../../../primitives/runtime" }
 
 [dev-dependencies]
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sc-rpc = { path = "../../../rpc", features = ["test-helpers"]}
 substrate-test-runtime-client = { path = "../../../../test-utils/runtime/client" }
 tokio = { version = "1.22.0", features = ["macros"] }

--- a/substrate/client/consensus/grandpa/Cargo.toml
+++ b/substrate/client/consensus/grandpa/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.17"
 parity-scale-codec = { version = "3.6.1", features = ["derive"] }
 parking_lot = "0.12.1"
 rand = "0.8.5"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0"
 fork-tree = { path = "../../../utils/fork-tree" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../../utils/prometheus" }

--- a/substrate/client/keystore/Cargo.toml
+++ b/substrate/client/keystore/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 parking_lot = "0.12.1"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0"
 sp-application-crypto = { path = "../../primitives/application-crypto" }
 sp-core = { path = "../../primitives/core" }

--- a/substrate/client/merkle-mountain-range/rpc/Cargo.toml
+++ b/substrate/client/merkle-mountain-range/rpc/Cargo.toml
@@ -23,4 +23,4 @@ sp-runtime = { path = "../../../primitives/runtime" }
 anyhow = "1"
 
 [dev-dependencies]
-serde_json = "1.0.107"
+serde_json = "1.0.108"

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -34,7 +34,7 @@ partial_sort = "0.2.0"
 pin-project = "1.0.12"
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 smallvec = "1.11.0"
 thiserror = "1.0"
 unsigned-varint = { version = "0.7.1", features = ["futures", "asynchronous_codec"] }

--- a/substrate/client/rpc-api/Cargo.toml
+++ b/substrate/client/rpc-api/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0"
 sc-chain-spec = { path = "../chain-spec" }
 sc-mixnet = { path = "../mixnet" }

--- a/substrate/client/rpc-servers/Cargo.toml
+++ b/substrate/client/rpc-servers/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 log = "0.4.17"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 tokio = { version = "1.22.0", features = ["parking_lot"] }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" }
 tower-http = { version = "0.4.0", features = ["cors"] }

--- a/substrate/client/rpc-spec-v2/Cargo.toml
+++ b/substrate/client/rpc-spec-v2/Cargo.toml
@@ -37,7 +37,7 @@ array-bytes = "6.1"
 log = "0.4.17"
 futures-util = { version = "0.3.19", default-features = false }
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.108"
 tokio = { version = "1.22.0", features = ["macros"] }
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
 substrate-test-runtime = { path = "../../test-utils/runtime" }

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.21"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 log = "0.4.17"
 parking_lot = "0.12.1"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sc-block-builder = { path = "../block-builder" }
 sc-chain-spec = { path = "../chain-spec" }
 sc-client-api = { path = "../api" }

--- a/substrate/client/service/Cargo.toml
+++ b/substrate/client/service/Cargo.toml
@@ -35,7 +35,7 @@ futures-timer = "3.0.1"
 exit-future = "0.2.0"
 pin-project = "1.0.12"
 serde = "1.0.188"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sc-keystore = { path = "../keystore" }
 sp-runtime = { path = "../../primitives/runtime" }
 sp-trie = { path = "../../primitives/trie" }

--- a/substrate/client/sync-state-rpc/Cargo.toml
+++ b/substrate/client/sync-state-rpc/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0.48"
 sc-chain-spec = { path = "../chain-spec" }
 sc-client-api = { path = "../api" }

--- a/substrate/client/sysinfo/Cargo.toml
+++ b/substrate/client/sysinfo/Cargo.toml
@@ -22,7 +22,7 @@ rand_pcg = "0.3.1"
 derive_more = "0.99"
 regex = "1"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sc-telemetry = { path = "../telemetry" }
 sp-core = { path = "../../primitives/core" }
 sp-io = { path = "../../primitives/io" }

--- a/substrate/client/telemetry/Cargo.toml
+++ b/substrate/client/telemetry/Cargo.toml
@@ -23,6 +23,6 @@ pin-project = "1.0.12"
 sc-utils = { path = "../utils" }
 rand = "0.8.5"
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0.48"
 wasm-timer = "0.2.5"

--- a/substrate/client/transaction-pool/api/Cargo.toml
+++ b/substrate/client/transaction-pool/api/Cargo.toml
@@ -20,4 +20,4 @@ sp-core = { path = "../../../primitives/core", default-features = false}
 sp-runtime = { path = "../../../primitives/runtime", default-features = false}
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.108"

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -42,7 +42,7 @@ sp-core-hashing-proc-macro = { path = "../../primitives/core/hashing/proc-macro"
 k256 = { version = "0.13.1", default-features = false, features = ["ecdsa"] }
 environmental = { version = "1.1.4", default-features = false }
 sp-genesis-builder = { path = "../../primitives/genesis-builder", default-features=false}
-serde_json = { version = "1.0.107", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.108", default-features = false, features = ["alloc"] }
 docify = "0.2.6"
 static_assertions = "1.1.0"
 

--- a/substrate/frame/transaction-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/Cargo.toml
@@ -26,7 +26,7 @@ sp-runtime = { path = "../../primitives/runtime", default-features = false}
 sp-std = { path = "../../primitives/std", default-features = false}
 
 [dev-dependencies]
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 pallet-balances = { path = "../balances" }
 
 [features]

--- a/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -30,7 +30,7 @@ scale-info = { version = "2.10.0", default-features = false, features = ["derive
 serde = { version = "1.0.188", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 sp-storage = { path = "../../../primitives/storage", default-features = false}
 

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.163", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0.188", default-features = false, features = ["derive"], optional = true }
 sp-api = { default-features = false, path = "../../api" }
 sp-application-crypto = { default-features = false, path = "../../application-crypto", features = ["bandersnatch-experimental"] }
 sp-consensus-slots = { default-features = false, path = "../slots" }

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -62,7 +62,7 @@ bandersnatch_vrfs = { git = "https://github.com/w3f/ring-vrf", rev = "cbc342e", 
 
 [dev-dependencies]
 criterion = "0.4.0"
-serde_json = "1.0"
+serde_json = "1.0.108"
 sp-core-hashing-proc-macro = { path = "hashing/proc-macro" }
 
 [[bench]]

--- a/substrate/primitives/genesis-builder/Cargo.toml
+++ b/substrate/primitives/genesis-builder/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-api = { path = "../api", default-features = false}
 sp-runtime = { path = "../runtime", default-features = false}
 sp-std = { path = "../std", default-features = false}
-serde_json = { version = "1.0.107", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.108", default-features = false, features = ["alloc"] }
 
 [features]
 default = [ "std" ]

--- a/substrate/primitives/rpc/Cargo.toml
+++ b/substrate/primitives/rpc/Cargo.toml
@@ -18,4 +18,4 @@ serde = { version = "1.0.188", features = ["derive"] }
 sp-core = { path = "../core" }
 
 [dev-dependencies]
-serde_json = "1.0.107"
+serde_json = "1.0.108"

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -32,7 +32,7 @@ sp-weights = { path = "../weights", default-features = false}
 
 [dev-dependencies]
 rand = "0.8.5"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 zstd = { version = "0.12.4", default-features = false }
 sp-api = { path = "../api" }
 sp-state-machine = { path = "../state-machine" }

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 serde = "1.0.188"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 sc-client-api = { path = "../../client/api" }
 sc-client-db = { path = "../../client/db", default-features = false, features = [
 	"test-helpers",

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -59,7 +59,7 @@ substrate-test-runtime-client = { path = "client" }
 sp-tracing = { path = "../../primitives/tracing" }
 json-patch = { version = "1.0.0", default-features = false }
 serde = { version = "1.0.188", features = ["alloc", "derive"], default-features = false }
-serde_json = { version = "1.0.107", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.108", default-features = false, features = ["alloc"] }
 
 [build-dependencies]
 substrate-wasm-builder = { path = "../../utils/wasm-builder", optional = true }

--- a/substrate/utils/frame/benchmarking-cli/Cargo.toml
+++ b/substrate/utils/frame/benchmarking-cli/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.17"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rand_pcg = "0.3.1"
 serde = "1.0.188"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 thiserror = "1.0.48"
 thousands = "0.2.0"
 frame-benchmarking = { path = "../../../frame/benchmarking" }

--- a/substrate/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
+++ b/substrate/utils/frame/rpc/state-trie-migration-rpc/Cargo.toml
@@ -29,4 +29,4 @@ sc-rpc-api = { path = "../../../../client/rpc-api" }
 sp-runtime = { path = "../../../../primitives/runtime" }
 
 [dev-dependencies]
-serde_json = "1"
+serde_json = "1.0.108"

--- a/substrate/utils/frame/try-runtime/cli/Cargo.toml
+++ b/substrate/utils/frame/try-runtime/cli/Cargo.toml
@@ -40,7 +40,7 @@ hex = { version = "0.4.3", default-features = false }
 log = "0.4.17"
 parity-scale-codec = "3.6.1"
 serde = "1.0.188"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 zstd = { version = "0.12.4", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates the version of `serde_json` to `1.0.108` throughout the codebase.