### PR TITLE
Remove async_trait in favor of native support

### DIFF
--- a/cumulus/client/collator/Cargo.toml
+++ b/cumulus/client/collator/Cargo.toml
@@ -29,7 +29,6 @@ cumulus-client-network = { path = "../network" }
 cumulus-primitives-core = { path = "../../primitives/core" }
 
 [dev-dependencies]
-async-trait = "0.1.73"
 
 # Substrate
 sp-maybe-compressed-blob = { path = "../../../substrate/primitives/maybe-compressed-blob" }

--- a/cumulus/client/collator/src/lib.rs
+++ b/cumulus/client/collator/src/lib.rs
@@ -333,7 +333,6 @@ pub fn start_collator_sync<Block, RA, BS, Spawner>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use async_trait::async_trait;
 	use cumulus_client_consensus_common::ParachainCandidate;
 	use cumulus_primitives_core::ParachainBlockData;
 	use cumulus_test_client::{
@@ -355,7 +354,6 @@ mod tests {
 
 	struct AlwaysSupportsParachains;
 
-	#[async_trait]
 	impl HeadSupportsParachains for AlwaysSupportsParachains {
 		async fn head_supports_parachains(&self, _head: &PHash) -> bool {
 			true
@@ -367,7 +365,6 @@ mod tests {
 		client: Arc<Client>,
 	}
 
-	#[async_trait::async_trait]
 	impl ParachainConsensus<Block> for DummyParachainConsensus {
 		async fn produce_candidate(
 			&mut self,

--- a/cumulus/client/consensus/aura/Cargo.toml
+++ b/cumulus/client/consensus/aura/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
 futures = "0.3.28"
 tracing = "0.1.37"

--- a/cumulus/client/consensus/aura/src/equivocation_import_queue.rs
+++ b/cumulus/client/consensus/aura/src/equivocation_import_queue.rs
@@ -76,7 +76,6 @@ struct Verifier<P, Client, Block, CIDP> {
 	_phantom: std::marker::PhantomData<fn() -> (Block, P)>,
 }
 
-#[async_trait::async_trait]
 impl<P, Client, Block, CIDP> VerifierT<Block> for Verifier<P, Client, Block, CIDP>
 where
 	P: Pair,

--- a/cumulus/client/consensus/aura/src/lib.rs
+++ b/cumulus/client/consensus/aura/src/lib.rs
@@ -191,7 +191,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, CIDP, W> ParachainConsensus<B> for AuraConsensus<B, CIDP, W>
 where
 	B: BlockT,

--- a/cumulus/client/consensus/common/Cargo.toml
+++ b/cumulus/client/consensus/common/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
 dyn-clone = "1.0.12"
 futures = "0.3.28"

--- a/cumulus/client/consensus/common/src/import_queue.rs
+++ b/cumulus/client/consensus/common/src/import_queue.rs
@@ -47,7 +47,6 @@ use crate::ParachainBlockImportMarker;
 /// This should only be used when the runtime is responsible for checking block seals and inherents.
 pub struct VerifyNothing;
 
-#[async_trait::async_trait]
 impl<Block: BlockT> Verifier<Block> for VerifyNothing {
 	async fn verify(
 		&mut self,

--- a/cumulus/client/consensus/common/src/lib.rs
+++ b/cumulus/client/consensus/common/src/lib.rs
@@ -77,7 +77,6 @@ pub struct ParachainCandidate<B> {
 /// decide if this specific collator should build a candidate for the given relay chain block. The
 /// consensus implementation could, for example, check whether this specific collator is part of a
 /// staked set.
-#[async_trait::async_trait]
 pub trait ParachainConsensus<B: BlockT>: Send + Sync + dyn_clone::DynClone {
 	/// Produce a new candidate at the given parent block and relay-parent blocks.
 	///
@@ -97,7 +96,6 @@ pub trait ParachainConsensus<B: BlockT>: Send + Sync + dyn_clone::DynClone {
 
 dyn_clone::clone_trait_object!(<B> ParachainConsensus<B> where B: BlockT);
 
-#[async_trait::async_trait]
 impl<B: BlockT> ParachainConsensus<B> for Box<dyn ParachainConsensus<B> + Send + Sync> {
 	async fn produce_candidate(
 		&mut self,
@@ -151,7 +149,6 @@ impl<Block: BlockT, I: Clone, BE> Clone for ParachainBlockImport<Block, I, BE> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<Block, BI, BE> BlockImport<Block> for ParachainBlockImport<Block, BI, BE>
 where
 	Block: BlockT,

--- a/cumulus/client/consensus/common/src/tests.rs
+++ b/cumulus/client/consensus/common/src/tests.rs
@@ -16,7 +16,6 @@
 
 use crate::*;
 
-use async_trait::async_trait;
 use codec::Encode;
 use cumulus_client_pov_recovery::RecoveryKind;
 use cumulus_primitives_core::{
@@ -89,7 +88,6 @@ impl Relaychain {
 	}
 }
 
-#[async_trait]
 impl RelayChainInterface for Relaychain {
 	async fn validators(&self, _: PHash) -> RelayChainResult<Vec<ValidatorId>> {
 		unimplemented!("Not needed for test")

--- a/cumulus/client/consensus/proposer/Cargo.toml
+++ b/cumulus/client/consensus/proposer/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1.73"
 thiserror = "1.0.48"
 
 # Substrate

--- a/cumulus/client/consensus/proposer/src/lib.rs
+++ b/cumulus/client/consensus/proposer/src/lib.rs
@@ -19,8 +19,6 @@
 //!
 //! This utility is designed to be composed within any collator consensus algorithm.
 
-use async_trait::async_trait;
-
 use cumulus_primitives_parachain_inherent::ParachainInherentData;
 use sp_consensus::{EnableProofRecording, Environment, Proposal, Proposer as SubstrateProposer};
 use sp_inherents::InherentData;
@@ -53,7 +51,6 @@ impl Error {
 pub type ProposalOf<B> = Proposal<B, StorageProof>;
 
 /// An interface for proposers.
-#[async_trait]
 pub trait ProposerInterface<Block: BlockT> {
 	/// Propose a collation using the supplied `InherentData` and the provided
 	/// `ParachainInherentData`.
@@ -92,7 +89,6 @@ impl<B, T> Proposer<B, T> {
 	}
 }
 
-#[async_trait]
 impl<B, T> ProposerInterface<B> for Proposer<B, T>
 where
 	B: sp_runtime::traits::Block,

--- a/cumulus/client/consensus/relay-chain/Cargo.toml
+++ b/cumulus/client/consensus/relay-chain/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.73"
 futures = "0.3.28"
 parking_lot = "0.12.1"
 tracing = "0.1.37"

--- a/cumulus/client/consensus/relay-chain/src/import_queue.rs
+++ b/cumulus/client/consensus/relay-chain/src/import_queue.rs
@@ -43,7 +43,6 @@ impl<Client, Block, CIDP> Verifier<Client, Block, CIDP> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<Client, Block, CIDP> VerifierT<Block> for Verifier<Client, Block, CIDP>
 where
 	Block: BlockT,

--- a/cumulus/client/consensus/relay-chain/src/lib.rs
+++ b/cumulus/client/consensus/relay-chain/src/lib.rs
@@ -140,7 +140,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, PF, BI, RCInterface, CIDP> ParachainConsensus<B>
 	for RelayChainConsensus<B, PF, BI, RCInterface, CIDP>
 where

--- a/cumulus/client/network/Cargo.toml
+++ b/cumulus/client/network/Cargo.toml
@@ -6,7 +6,6 @@ description = "Cumulus-specific networking protocol"
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
 futures = "0.3.28"
 futures-timer = "3.0.2"

--- a/cumulus/client/network/src/tests.rs
+++ b/cumulus/client/network/src/tests.rs
@@ -15,7 +15,6 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use async_trait::async_trait;
 use cumulus_primitives_core::relay_chain::BlockId;
 use cumulus_relay_chain_inprocess_interface::{check_block_in_chain, BlockCheckStatus};
 use cumulus_relay_chain_interface::{
@@ -76,7 +75,6 @@ impl DummyRelayChainInterface {
 	}
 }
 
-#[async_trait]
 impl RelayChainInterface for DummyRelayChainInterface {
 	async fn validators(&self, _: PHash) -> RelayChainResult<Vec<ValidatorId>> {
 		Ok(self.data.lock().validators.clone())

--- a/cumulus/client/pov-recovery/Cargo.toml
+++ b/cumulus/client/pov-recovery/Cargo.toml
@@ -28,7 +28,6 @@ polkadot-primitives = { path = "../../../polkadot/primitives" }
 # Cumulus
 cumulus-primitives-core = { path = "../../primitives/core" }
 cumulus-relay-chain-interface = { path = "../relay-chain-interface" }
-async-trait = "0.1.73"
 
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros"] }

--- a/cumulus/client/pov-recovery/src/lib.rs
+++ b/cumulus/client/pov-recovery/src/lib.rs
@@ -82,7 +82,6 @@ const LOG_TARGET: &str = "cumulus-pov-recovery";
 
 /// Test-friendly wrapper trait for the overseer handle.
 /// Can be used to simulate failing recovery requests.
-#[async_trait::async_trait]
 pub trait RecoveryHandle: Send {
 	async fn send_recovery_msg(
 		&mut self,
@@ -91,7 +90,6 @@ pub trait RecoveryHandle: Send {
 	);
 }
 
-#[async_trait::async_trait]
 impl RecoveryHandle for OverseerHandle {
 	async fn send_recovery_msg(
 		&mut self,

--- a/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-async-trait = "0.1.73"
 futures = "0.3.28"
 futures-timer = "3.0.2"
 

--- a/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
@@ -16,7 +16,6 @@
 
 use std::{pin::Pin, sync::Arc, time::Duration};
 
-use async_trait::async_trait;
 use cumulus_primitives_core::{
 	relay_chain::{
 		runtime_api::ParachainHost, Block as PBlock, BlockId, CommittedCandidateReceipt,
@@ -66,7 +65,6 @@ impl RelayChainInProcessInterface {
 	}
 }
 
-#[async_trait]
 impl RelayChainInterface for RelayChainInProcessInterface {
 	async fn retrieve_dmq_contents(
 		&self,

--- a/cumulus/client/relay-chain-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-interface/Cargo.toml
@@ -15,7 +15,6 @@ sp-state-machine = { path = "../../../substrate/primitives/state-machine" }
 sc-client-api = { path = "../../../substrate/client/api" }
 
 futures = "0.3.28"
-async-trait = "0.1.73"
 thiserror = "1.0.48"
 jsonrpsee-core = "0.16.2"
 parity-scale-codec = "3.6.4"

--- a/cumulus/client/relay-chain-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-interface/src/lib.rs
@@ -21,7 +21,6 @@ use sc_client_api::StorageProof;
 
 use futures::Stream;
 
-use async_trait::async_trait;
 use jsonrpsee_core::Error as JsonRpcError;
 use parity_scale_codec::Error as CodecError;
 use sp_api::ApiError;
@@ -96,7 +95,6 @@ impl<T: std::error::Error + Send + Sync + 'static> From<Box<T>> for RelayChainEr
 }
 
 /// Trait that provides all necessary methods for interaction between collator and relay chain.
-#[async_trait]
 pub trait RelayChainInterface: Send + Sync {
 	/// Fetch a storage item by key.
 	async fn get_storage_by_key(
@@ -196,7 +194,6 @@ pub trait RelayChainInterface: Send + Sync {
 	) -> RelayChainResult<StorageProof>;
 }
 
-#[async_trait]
 impl<T> RelayChainInterface for Arc<T>
 where
 	T: RelayChainInterface + ?Sized,

--- a/cumulus/client/relay-chain-minimal-node/Cargo.toml
+++ b/cumulus/client/relay-chain-minimal-node/Cargo.toml
@@ -38,6 +38,5 @@ cumulus-primitives-core = { path = "../../primitives/core" }
 
 array-bytes = "6.1"
 tracing = "0.1.37"
-async-trait = "0.1.73"
 futures = "0.3.28"
 

--- a/cumulus/client/relay-chain-minimal-node/src/blockchain_rpc_client.rs
+++ b/cumulus/client/relay-chain-minimal-node/src/blockchain_rpc_client.rs
@@ -53,7 +53,6 @@ impl BlockChainRpcClient {
 	}
 }
 
-#[async_trait::async_trait]
 impl RuntimeApiSubsystemClient for BlockChainRpcClient {
 	async fn validators(
 		&self,
@@ -366,7 +365,6 @@ impl RuntimeApiSubsystemClient for BlockChainRpcClient {
 	}
 }
 
-#[async_trait::async_trait]
 impl AuthorityDiscovery<Block> for BlockChainRpcClient {
 	async fn authorities(
 		&self,

--- a/cumulus/client/relay-chain-rpc-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-rpc-interface/Cargo.toml
@@ -30,7 +30,6 @@ futures-timer = "3.0.2"
 parity-scale-codec = "3.6.4"
 jsonrpsee = { version = "0.16.2", features = ["ws-client"] }
 tracing = "0.1.37"
-async-trait = "0.1.73"
 url = "2.4.0"
 serde_json = "1.0.107"
 serde = "1.0.188"

--- a/cumulus/client/relay-chain-rpc-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/lib.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-use async_trait::async_trait;
 use core::time::Duration;
 use cumulus_primitives_core::{
 	relay_chain::{
@@ -64,7 +63,6 @@ impl RelayChainRpcInterface {
 	}
 }
 
-#[async_trait]
 impl RelayChainInterface for RelayChainRpcInterface {
 	async fn retrieve_dmq_contents(
 		&self,

--- a/cumulus/client/relay-chain-rpc-interface/src/light_client_worker.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/light_client_worker.rs
@@ -60,7 +60,6 @@ struct SimpleStringSender {
 	chain_id: ChainId,
 }
 
-#[async_trait::async_trait]
 impl TransportSenderT for SimpleStringSender {
 	type Error = LightClientError;
 
@@ -76,7 +75,6 @@ struct SimpleStringReceiver {
 	inner: JsonRpcResponses,
 }
 
-#[async_trait::async_trait]
 impl TransportReceiverT for SimpleStringReceiver {
 	type Error = LightClientError;
 

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -11,7 +11,6 @@ name = "polkadot-parachain"
 path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1.73"
 clap = { version = "4.4.6", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.28"

--- a/cumulus/polkadot-parachain/src/service.rs
+++ b/cumulus/polkadot-parachain/src/service.rs
@@ -1173,7 +1173,6 @@ impl<Client, AuraId> Clone for WaitForAuraConsensus<Client, AuraId> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<Client, AuraId> ParachainConsensus<Block> for WaitForAuraConsensus<Client, AuraId>
 where
 	Client: sp_api::ProvideRuntimeApi<Block> + Send + Sync,
@@ -1215,7 +1214,6 @@ struct Verifier<Client, AuraId> {
 	_phantom: PhantomData<AuraId>,
 }
 
-#[async_trait::async_trait]
 impl<Client, AuraId> VerifierT<Block> for Verifier<Client, AuraId>
 where
 	Client: sp_api::ProvideRuntimeApi<Block> + Send + Sync,

--- a/cumulus/primitives/parachain-inherent/Cargo.toml
+++ b/cumulus/primitives/parachain-inherent/Cargo.toml
@@ -5,7 +5,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-async-trait = { version = "0.1.73", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1.37", optional = true }
@@ -29,7 +28,6 @@ cumulus-test-relay-sproof-builder = { path = "../../test/relay-sproof-builder", 
 [features]
 default = [ "std" ]
 std = [
-	"async-trait",
 	"codec/std",
 	"cumulus-primitives-core/std",
 	"cumulus-relay-chain-interface",

--- a/cumulus/primitives/parachain-inherent/src/client_side.rs
+++ b/cumulus/primitives/parachain-inherent/src/client_side.rs
@@ -179,7 +179,6 @@ impl ParachainInherentData {
 	}
 }
 
-#[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for ParachainInherentData {
 	async fn provide_inherent_data(
 		&self,

--- a/cumulus/primitives/parachain-inherent/src/mock.rs
+++ b/cumulus/primitives/parachain-inherent/src/mock.rs
@@ -148,7 +148,6 @@ impl MockXcmConfig {
 	}
 }
 
-#[async_trait::async_trait]
 impl<R: Send + Sync + GenerateRandomness<u64>> InherentDataProvider
 	for MockValidationDataInherentDataProvider<R>
 {

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -10,7 +10,6 @@ name = "test-parachain"
 path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1.73"
 clap = { version = "4.4.6", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -94,7 +94,6 @@ const LOG_TARGET: &str = "cumulus-test-service";
 #[derive(Clone)]
 struct NullConsensus;
 
-#[async_trait::async_trait]
 impl ParachainConsensus<Block> for NullConsensus {
 	async fn produce_candidate(
 		&mut self,
@@ -153,7 +152,6 @@ impl FailingRecoveryHandle {
 	}
 }
 
-#[async_trait::async_trait]
 impl RecoveryHandle for FailingRecoveryHandle {
 	async fn send_recovery_msg(
 		&mut self,

--- a/polkadot/node/core/approval-voting/Cargo.toml
+++ b/polkadot/node/core/approval-voting/Cargo.toml
@@ -32,7 +32,6 @@ sp-application-crypto = { path = "../../../../substrate/primitives/application-c
 sp-runtime = { path = "../../../../substrate/primitives/runtime", default-features = false }
 
 [dev-dependencies]
-async-trait = "0.1.57"
 parking_lot = "0.12.0"
 rand_core = "0.5.1" #                                                                       should match schnorrkel
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -39,7 +39,6 @@ use polkadot_primitives::{
 use std::time::Duration;
 
 use assert_matches::assert_matches;
-use async_trait::async_trait;
 use parking_lot::Mutex;
 use sp_keyring::sr25519::Keyring as Sr25519Keyring;
 use sp_keystore::Keystore;
@@ -122,7 +121,6 @@ pub mod test_constants {
 
 struct MockSupportsParachains;
 
-#[async_trait]
 impl HeadSupportsParachains for MockSupportsParachains {
 	async fn head_supports_parachains(&self, _head: &Hash) -> bool {
 		true

--- a/polkadot/node/core/candidate-validation/Cargo.toml
+++ b/polkadot/node/core/candidate-validation/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1.57"
 futures = "0.3.21"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }

--- a/polkadot/node/core/candidate-validation/src/lib.rs
+++ b/polkadot/node/core/candidate-validation/src/lib.rs
@@ -63,8 +63,6 @@ use std::{
 	time::{Duration, Instant},
 };
 
-use async_trait::async_trait;
-
 mod metrics;
 use self::metrics::Metrics;
 
@@ -691,7 +689,6 @@ async fn validate_candidate_exhaustive(
 	}
 }
 
-#[async_trait]
 trait ValidationBackend {
 	/// Tries executing a PVF a single time (no retries).
 	async fn validate_candidate(
@@ -788,7 +785,6 @@ trait ValidationBackend {
 	async fn precheck_pvf(&mut self, pvf: PvfPrepData) -> Result<PrepareStats, PrepareError>;
 }
 
-#[async_trait]
 impl ValidationBackend for ValidationHost {
 	/// Tries executing a PVF a single time (no retries).
 	async fn validate_candidate(

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -361,7 +361,6 @@ impl MockValidateCandidateBackend {
 	}
 }
 
-#[async_trait]
 impl ValidationBackend for MockValidateCandidateBackend {
 	async fn validate_candidate(
 		&mut self,
@@ -1021,7 +1020,6 @@ impl MockPreCheckBackend {
 	}
 }
 
-#[async_trait]
 impl ValidationBackend for MockPreCheckBackend {
 	async fn validate_candidate(
 		&mut self,

--- a/polkadot/node/core/parachains-inherent/Cargo.toml
+++ b/polkadot/node/core/parachains-inherent/Cargo.toml
@@ -10,7 +10,6 @@ futures = "0.3.21"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 thiserror = "1.0.48"
-async-trait = "0.1.57"
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/core/parachains-inherent/src/lib.rs
+++ b/polkadot/node/core/parachains-inherent/src/lib.rs
@@ -124,7 +124,6 @@ impl<C: sp_blockchain::HeaderBackend<Block>> ParachainsInherentDataProvider<C> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<C: sp_blockchain::HeaderBackend<Block>> sp_inherents::InherentDataProvider
 	for ParachainsInherentDataProvider<C>
 {

--- a/polkadot/node/core/runtime-api/Cargo.toml
+++ b/polkadot/node/core/runtime-api/Cargo.toml
@@ -21,7 +21,6 @@ polkadot-node-subsystem-types = { path = "../../subsystem-types" }
 sp-api = { path = "../../../../substrate/primitives/api" }
 sp-core = { path = "../../../../substrate/primitives/core" }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
-async-trait = "0.1.57"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-node-primitives = { path = "../../primitives" }

--- a/polkadot/node/core/runtime-api/src/tests.rs
+++ b/polkadot/node/core/runtime-api/src/tests.rs
@@ -58,7 +58,6 @@ struct MockSubsystemClient {
 	candidate_events: Vec<CandidateEvent>,
 }
 
-#[async_trait::async_trait]
 impl RuntimeApiSubsystemClient for MockSubsystemClient {
 	async fn api_version_parachain_host(&self, _: Hash) -> Result<Option<u32>, ApiError> {
 		Ok(Some(5))

--- a/polkadot/node/malus/Cargo.toml
+++ b/polkadot/node/malus/Cargo.toml
@@ -37,7 +37,6 @@ polkadot-node-primitives = { path = "../primitives" }
 polkadot-primitives = { path = "../../primitives" }
 color-eyre = { version = "0.6.1", default-features = false }
 assert_matches = "1.5"
-async-trait = "0.1.57"
 sp-keystore = { path = "../../../substrate/primitives/keystore" }
 sp-core = { path = "../../../substrate/primitives/core" }
 clap = { version = "4.4.6", features = ["derive"] }

--- a/polkadot/node/malus/src/interceptor.rs
+++ b/polkadot/node/malus/src/interceptor.rs
@@ -71,7 +71,6 @@ pub struct InterceptedSender<Sender, Fil> {
 	message_filter: Fil,
 }
 
-#[async_trait::async_trait]
 impl<OutgoingMessage, Sender, Fil> overseer::SubsystemSender<OutgoingMessage> for InterceptedSender<Sender, Fil>
 where
 	OutgoingMessage: overseer::AssociateOutgoing + Send + 'static + TryFrom<overseer::AllMessages>,
@@ -193,7 +192,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<Context, Fil> overseer::SubsystemContext for InterceptedContext<Context, Fil>
 where
 	Context: overseer::SubsystemContext<Error=SubsystemError,Signal=OverseerSignal>,

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -11,7 +11,6 @@ schnellru = "0.2.1"
 rand = "0.8.5"
 fatality = "0.0.6"
 thiserror = "1.0.48"
-async-trait = "0.1.73"
 gum = { package = "tracing-gum", path = "../../gum" }
 
 polkadot-erasure-coding = { path = "../../../erasure-coding" }

--- a/polkadot/node/network/availability-recovery/src/task.rs
+++ b/polkadot/node/network/availability-recovery/src/task.rs
@@ -58,7 +58,6 @@ const TIMEOUT_START_NEW_REQUESTS: Duration = CHUNK_REQUEST_TIMEOUT;
 #[cfg(test)]
 const TIMEOUT_START_NEW_REQUESTS: Duration = Duration::from_millis(100);
 
-#[async_trait::async_trait]
 /// Common trait for runnable recovery strategies.
 pub trait RecoveryStrategy<Sender: overseer::AvailabilityRecoverySenderTrait>: Send {
 	/// Main entry point of the strategy.
@@ -465,7 +464,6 @@ impl FetchFull {
 	}
 }
 
-#[async_trait::async_trait]
 impl<Sender: overseer::AvailabilityRecoverySenderTrait> RecoveryStrategy<Sender> for FetchFull {
 	fn display_name(&self) -> &'static str {
 		"Full recovery from backers"
@@ -699,7 +697,6 @@ impl FetchChunks {
 	}
 }
 
-#[async_trait::async_trait]
 impl<Sender: overseer::AvailabilityRecoverySenderTrait> RecoveryStrategy<Sender> for FetchChunks {
 	fn display_name(&self) -> &'static str {
 		"Fetch chunks"

--- a/polkadot/node/network/bridge/Cargo.toml
+++ b/polkadot/node/network/bridge/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 always-assert = "0.1"
-async-trait = "0.1.57"
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/network/bridge/src/network.rs
+++ b/polkadot/node/network/bridge/src/network.rs
@@ -14,10 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{collections::HashSet, sync::Arc};
-
-use async_trait::async_trait;
 use futures::{prelude::*, stream::BoxStream};
+use std::{collections::HashSet, sync::Arc};
 
 use parity_scale_codec::Encode;
 
@@ -83,7 +81,6 @@ pub(crate) fn send_message<M>(
 }
 
 /// An abstraction over networking for the purposes of this subsystem.
-#[async_trait]
 pub trait Network: Clone + Send + 'static {
 	/// Get a stream of all events occurring on the network. This may include events unrelated
 	/// to the Polkadot protocol - the user of this function should filter only for events related
@@ -126,7 +123,6 @@ pub trait Network: Clone + Send + 'static {
 	fn write_notification(&self, who: PeerId, protocol: ProtocolName, message: Vec<u8>);
 }
 
-#[async_trait]
 impl Network for Arc<NetworkService<Block, Hash>> {
 	fn event_stream(&mut self) -> BoxStream<'static, NetworkEvent> {
 		NetworkService::event_stream(self, "polkadot-network-bridge").boxed()

--- a/polkadot/node/network/bridge/src/rx/tests.rs
+++ b/polkadot/node/network/bridge/src/rx/tests.rs
@@ -21,7 +21,6 @@ use polkadot_node_network_protocol::{self as net_protocol, OurView};
 use polkadot_node_subsystem::messages::NetworkBridgeEvent;
 
 use assert_matches::assert_matches;
-use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::{
 	collections::HashSet,
@@ -100,7 +99,6 @@ fn new_test_network(
 	)
 }
 
-#[async_trait]
 impl Network for TestNetwork {
 	fn event_stream(&mut self) -> BoxStream<'static, NetworkEvent> {
 		self.net_events
@@ -161,7 +159,6 @@ impl Network for TestNetwork {
 	}
 }
 
-#[async_trait]
 impl validator_discovery::AuthorityDiscovery for TestAuthorityDiscovery {
 	async fn get_addresses_by_authority_id(
 		&mut self,

--- a/polkadot/node/network/bridge/src/tx/tests.rs
+++ b/polkadot/node/network/bridge/src/tx/tests.rs
@@ -18,7 +18,6 @@ use super::*;
 use futures::{executor, stream::BoxStream};
 use polkadot_node_subsystem_util::TimeoutExt;
 
-use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::HashSet;
 
@@ -87,7 +86,6 @@ fn new_test_network(
 	)
 }
 
-#[async_trait]
 impl Network for TestNetwork {
 	fn event_stream(&mut self) -> BoxStream<'static, NetworkEvent> {
 		self.net_events
@@ -148,7 +146,6 @@ impl Network for TestNetwork {
 	}
 }
 
-#[async_trait]
 impl validator_discovery::AuthorityDiscovery for TestAuthorityDiscovery {
 	async fn get_addresses_by_authority_id(
 		&mut self,

--- a/polkadot/node/network/bridge/src/validator_discovery.rs
+++ b/polkadot/node/network/bridge/src/validator_discovery.rs
@@ -168,7 +168,6 @@ mod tests {
 	use super::*;
 	use crate::network::Network;
 
-	use async_trait::async_trait;
 	use futures::stream::BoxStream;
 	use polkadot_node_network_protocol::{
 		request_response::{outgoing::Requests, ReqProtocolNames},
@@ -222,7 +221,6 @@ mod tests {
 		}
 	}
 
-	#[async_trait]
 	impl Network for TestNetwork {
 		fn event_stream(&mut self) -> BoxStream<'static, NetworkEvent> {
 			panic!()
@@ -268,7 +266,6 @@ mod tests {
 		}
 	}
 
-	#[async_trait]
 	impl AuthorityDiscovery for TestAuthorityDiscovery {
 		async fn get_addresses_by_authority_id(
 			&mut self,

--- a/polkadot/node/network/dispute-distribution/Cargo.toml
+++ b/polkadot/node/network/dispute-distribution/Cargo.toml
@@ -27,7 +27,6 @@ indexmap = "1.9.1"
 
 [dev-dependencies]
 async-channel = "1.8.0"
-async-trait = "0.1.57"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 sp-tracing = { path = "../../../../substrate/primitives/tracing" }

--- a/polkadot/node/network/dispute-distribution/src/tests/mock.rs
+++ b/polkadot/node/network/dispute-distribution/src/tests/mock.rs
@@ -17,14 +17,12 @@
 
 //! Mock data and utility functions for unit tests in this subsystem.
 
+use lazy_static::lazy_static;
 use std::{
 	collections::{HashMap, HashSet},
 	sync::Arc,
 	time::Instant,
 };
-
-use async_trait::async_trait;
-use lazy_static::lazy_static;
 
 use polkadot_node_network_protocol::{authority_discovery::AuthorityDiscovery, PeerId};
 use sc_keystore::LocalKeystore;
@@ -203,7 +201,6 @@ impl MockAuthorityDiscovery {
 	}
 }
 
-#[async_trait]
 impl AuthorityDiscovery for MockAuthorityDiscovery {
 	async fn get_addresses_by_authority_id(
 		&mut self,

--- a/polkadot/node/network/gossip-support/Cargo.toml
+++ b/polkadot/node/network/gossip-support/Cargo.toml
@@ -32,5 +32,4 @@ sp-authority-discovery = { path = "../../../../substrate/primitives/authority-di
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 
 assert_matches = "1.4.0"
-async-trait = "0.1.57"
 lazy_static = "1.4.0"

--- a/polkadot/node/network/gossip-support/src/tests.rs
+++ b/polkadot/node/network/gossip-support/src/tests.rs
@@ -19,7 +19,6 @@
 use std::{collections::HashSet, time::Duration};
 
 use assert_matches::assert_matches;
-use async_trait::async_trait;
 use futures::{executor, future, Future};
 use lazy_static::lazy_static;
 
@@ -113,7 +112,6 @@ impl MockAuthorityDiscovery {
 	}
 }
 
-#[async_trait]
 impl AuthorityDiscovery for MockAuthorityDiscovery {
 	async fn get_addresses_by_authority_id(
 		&mut self,

--- a/polkadot/node/network/protocol/Cargo.toml
+++ b/polkadot/node/network/protocol/Cargo.toml
@@ -8,7 +8,6 @@ description = "Primitives types for the Node-side"
 
 [dependencies]
 async-channel = "1.8.0"
-async-trait = "0.1.57"
 hex = "0.4.3"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }

--- a/polkadot/node/network/protocol/src/authority_discovery.rs
+++ b/polkadot/node/network/protocol/src/authority_discovery.rs
@@ -18,8 +18,6 @@
 
 use std::{collections::HashSet, fmt::Debug};
 
-use async_trait::async_trait;
-
 use sc_authority_discovery::Service as AuthorityDiscoveryService;
 
 use polkadot_primitives::AuthorityDiscoveryId;
@@ -28,7 +26,6 @@ use sc_network::{Multiaddr, PeerId};
 /// An abstraction over the authority discovery service.
 ///
 /// Needed for mocking in tests mostly.
-#[async_trait]
 pub trait AuthorityDiscovery: Send + Debug + 'static {
 	/// Get the addresses for the given [`AuthorityDiscoveryId`] from the local address cache.
 	async fn get_addresses_by_authority_id(
@@ -42,7 +39,6 @@ pub trait AuthorityDiscovery: Send + Debug + 'static {
 	) -> Option<HashSet<AuthorityDiscoveryId>>;
 }
 
-#[async_trait]
 impl AuthorityDiscovery for AuthorityDiscoveryService {
 	async fn get_addresses_by_authority_id(
 		&mut self,

--- a/polkadot/node/overseer/Cargo.toml
+++ b/polkadot/node/overseer/Cargo.toml
@@ -19,7 +19,6 @@ polkadot-primitives = { path = "../../primitives" }
 orchestra = { version = "0.3.3", default-features = false, features=["futures_channel"] }
 gum = { package = "tracing-gum", path = "../gum" }
 sp-core = { path = "../../../substrate/primitives/core" }
-async-trait = "0.1.57"
 tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
 
 [dev-dependencies]

--- a/polkadot/node/overseer/examples/minimal-example.rs
+++ b/polkadot/node/overseer/examples/minimal-example.rs
@@ -20,7 +20,6 @@
 
 use futures::{channel::oneshot, pending, pin_mut, select, stream, FutureExt, StreamExt};
 use futures_timer::Delay;
-use orchestra::async_trait;
 use std::time::Duration;
 
 use ::test_helpers::{dummy_candidate_descriptor, dummy_hash};
@@ -36,7 +35,6 @@ use polkadot_primitives::{CandidateReceipt, Hash, PvfExecTimeoutKind};
 
 struct AlwaysSupportsParachains;
 
-#[async_trait]
 impl HeadSupportsParachains for AlwaysSupportsParachains {
 	async fn head_supports_parachains(&self, _head: &Hash) -> bool {
 		true

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -153,13 +153,11 @@ impl<S: SpawnNamed + Clone + Send + Sync> crate::gen::Spawner for SpawnGlue<S> {
 }
 
 /// Whether a header supports parachain consensus or not.
-#[async_trait::async_trait]
 pub trait HeadSupportsParachains {
 	/// Return true if the given header supports parachain consensus. Otherwise, false.
 	async fn head_supports_parachains(&self, head: &Hash) -> bool;
 }
 
-#[async_trait::async_trait]
 impl<Client> HeadSupportsParachains for Arc<Client>
 where
 	Client: RuntimeApiSubsystemClient + Sync + Send,
@@ -429,7 +427,6 @@ pub async fn forward_events<P: BlockchainEvents<Block>>(client: Arc<P>, mut hand
 ///
 /// struct AlwaysSupportsParachains;
 ///
-/// #[async_trait::async_trait]
 /// impl HeadSupportsParachains for AlwaysSupportsParachains {
 ///      async fn head_supports_parachains(&self, _head: &Hash) -> bool { true }
 /// }

--- a/polkadot/node/overseer/src/tests.rs
+++ b/polkadot/node/overseer/src/tests.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use async_trait::async_trait;
 use futures::{executor, pending, pin_mut, poll, select, stream, FutureExt};
 use std::{collections::HashMap, sync::atomic, task::Poll};
 
@@ -147,7 +146,6 @@ where
 
 struct MockSupportsParachains;
 
-#[async_trait]
 impl HeadSupportsParachains for MockSupportsParachains {
 	async fn head_supports_parachains(&self, _head: &Hash) -> bool {
 		true

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -74,7 +74,6 @@ frame-benchmarking-cli = { path = "../../../substrate/utils/frame/benchmarking-c
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking" }
 
 # External Crates
-async-trait = "0.1.57"
 futures = "0.3.21"
 hex-literal = "0.4.1"
 is_executable = "1.0.1"

--- a/polkadot/node/service/src/relay_chain_selection.rs
+++ b/polkadot/node/service/src/relay_chain_selection.rs
@@ -189,7 +189,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B> SelectChain<PolkadotBlock> for SelectRelayChain<B>
 where
 	B: sc_client_api::Backend<PolkadotBlock> + 'static,
@@ -309,12 +308,10 @@ enum Error {
 /// Decoupling trait for the overseer handle.
 ///
 /// Required for testing purposes.
-#[async_trait::async_trait]
 pub trait OverseerHandleT: Clone + Send + Sync {
 	async fn send_msg<M: Send + Into<AllMessages>>(&mut self, msg: M, origin: &'static str);
 }
 
-#[async_trait::async_trait]
 impl OverseerHandleT for Handle {
 	async fn send_msg<M: Send + Into<AllMessages>>(&mut self, msg: M, origin: &'static str) {
 		Handle::send_msg(self, msg, origin).await

--- a/polkadot/node/service/src/tests.rs
+++ b/polkadot/node/service/src/tests.rs
@@ -48,7 +48,6 @@ use polkadot_overseer::{SubsystemContext, SubsystemSender};
 
 type VirtualOverseer = test_helpers::TestSubsystemContextHandle<ApprovalVotingMessage>;
 
-#[async_trait::async_trait]
 impl OverseerHandleT for TestSubsystemSender {
 	async fn send_msg<M: Send + Into<AllMessages>>(&mut self, msg: M, _origin: &'static str) {
 		TestSubsystemSender::send_message(self, msg.into()).await;

--- a/polkadot/node/subsystem-test-helpers/Cargo.toml
+++ b/polkadot/node/subsystem-test-helpers/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1.57"
 futures = "0.3.21"
 parking_lot = "0.12.0"
 polkadot-node-subsystem = { path = "../subsystem" }

--- a/polkadot/node/subsystem-test-helpers/src/lib.rs
+++ b/polkadot/node/subsystem-test-helpers/src/lib.rs
@@ -150,7 +150,6 @@ pub fn sender_receiver() -> (TestSubsystemSender, mpsc::UnboundedReceiver<AllMes
 	(TestSubsystemSender { tx }, rx)
 }
 
-#[async_trait::async_trait]
 impl<OutgoingMessage> overseer::SubsystemSender<OutgoingMessage> for TestSubsystemSender
 where
 	AllMessages: From<OutgoingMessage>,
@@ -189,7 +188,6 @@ pub struct TestSubsystemContext<M, S> {
 	spawn: S,
 }
 
-#[async_trait::async_trait]
 impl<M, Spawner> overseer::SubsystemContext for TestSubsystemContext<M, Spawner>
 where
 	M: overseer::AssociateOutgoing + std::fmt::Debug + Send + 'static,

--- a/polkadot/node/subsystem-types/Cargo.toml
+++ b/polkadot/node/subsystem-types/Cargo.toml
@@ -24,4 +24,3 @@ sc-transaction-pool-api = { path = "../../../substrate/client/transaction-pool/a
 smallvec = "1.8.0"
 substrate-prometheus-endpoint = { path = "../../../substrate/utils/prometheus" }
 thiserror = "1.0.48"
-async-trait = "0.1.57"

--- a/polkadot/node/subsystem-types/src/runtime_client.rs
+++ b/polkadot/node/subsystem-types/src/runtime_client.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use async_trait::async_trait;
 use polkadot_primitives::{
 	async_backing, runtime_api::ParachainHost, slashing, Block, BlockNumber, CandidateCommitments,
 	CandidateEvent, CandidateHash, CommittedCandidateReceipt, CoreState, DisputeState,
@@ -30,7 +29,6 @@ use sp_consensus_babe::{BabeApi, Epoch};
 use std::{collections::BTreeMap, sync::Arc};
 
 /// Exposes all runtime calls that are used by the runtime API subsystem.
-#[async_trait]
 pub trait RuntimeApiSubsystemClient {
 	/// Parachain host API version
 	async fn api_version_parachain_host(&self, at: Hash) -> Result<Option<u32>, ApiError>;
@@ -277,7 +275,6 @@ impl<Client> DefaultSubsystemClient<Client> {
 	}
 }
 
-#[async_trait]
 impl<Client> RuntimeApiSubsystemClient for DefaultSubsystemClient<Client>
 where
 	Client: ProvideRuntimeApi<Block> + Send + Sync,

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1.57"
 futures = "0.3.21"
 futures-channel = "0.3.23"
 itertools = "0.10"

--- a/substrate/client/authority-discovery/Cargo.toml
+++ b/substrate/client/authority-discovery/Cargo.toml
@@ -36,7 +36,6 @@ sp-blockchain = { path = "../../primitives/blockchain" }
 sp-core = { path = "../../primitives/core" }
 sp-keystore = { path = "../../primitives/keystore" }
 sp-runtime = { path = "../../primitives/runtime" }
-async-trait = "0.1.56"
 
 [dev-dependencies]
 quickcheck = { version = "1.0.3", default-features = false }

--- a/substrate/client/authority-discovery/src/worker.rs
+++ b/substrate/client/authority-discovery/src/worker.rs
@@ -150,7 +150,6 @@ pub struct Worker<Client, Network, Block, DhtEventStream> {
 
 /// Wrapper for [`AuthorityDiscoveryApi`](sp_authority_discovery::AuthorityDiscoveryApi). Can be
 /// be implemented by any struct without dependency on the runtime.
-#[async_trait::async_trait]
 pub trait AuthorityDiscovery<Block: BlockT> {
 	/// Retrieve authority identifiers of the current and next authority set.
 	async fn authorities(&self, at: Block::Hash)
@@ -160,7 +159,6 @@ pub trait AuthorityDiscovery<Block: BlockT> {
 	async fn best_hash(&self) -> std::result::Result<Block::Hash, Error>;
 }
 
-#[async_trait::async_trait]
 impl<Block, T> AuthorityDiscovery<Block> for T
 where
 	T: ProvideRuntimeApi<Block> + HeaderBackend<Block> + Send + Sync,

--- a/substrate/client/consensus/aura/Cargo.toml
+++ b/substrate/client/consensus/aura/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 log = "0.4.17"

--- a/substrate/client/consensus/aura/src/import_queue.rs
+++ b/substrate/client/consensus/aura/src/import_queue.rs
@@ -162,7 +162,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT, C, P, CIDP> Verifier<B> for AuraVerifier<C, P, CIDP, NumberFor<B>>
 where
 	C: ProvideRuntimeApi<B> + Send + Sync + sc_client_api::backend::AuxStore,

--- a/substrate/client/consensus/aura/src/lib.rs
+++ b/substrate/client/consensus/aura/src/lib.rs
@@ -322,7 +322,6 @@ struct AuraWorker<C, E, I, P, SO, L, BS, N> {
 	_phantom: PhantomData<fn() -> P>,
 }
 
-#[async_trait::async_trait]
 impl<B, C, E, I, P, Error, SO, L, BS> sc_consensus_slots::SimpleSlotWorker<B>
 	for AuraWorker<C, E, I, P, SO, L, BS, NumberFor<B>>
 where

--- a/substrate/client/consensus/babe/Cargo.toml
+++ b/substrate/client/consensus/babe/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 log = "0.4.17"

--- a/substrate/client/consensus/babe/rpc/src/lib.rs
+++ b/substrate/client/consensus/babe/rpc/src/lib.rs
@@ -22,7 +22,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use futures::TryFutureExt;
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 	types::{error::CallError, ErrorObject},
 };
@@ -78,7 +78,6 @@ impl<B: BlockT, C, SC> Babe<B, C, SC> {
 	}
 }
 
-#[async_trait]
 impl<B: BlockT, C, SC> BabeApiServer for Babe<B, C, SC>
 where
 	B: BlockT,

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -713,7 +713,6 @@ struct BabeSlotWorker<B: BlockT, C, E, I, SO, L, BS> {
 	telemetry: Option<TelemetryHandle>,
 }
 
-#[async_trait::async_trait]
 impl<B, C, E, I, Error, SO, L, BS> sc_consensus_slots::SimpleSlotWorker<B>
 	for BabeSlotWorker<B, C, E, I, SO, L, BS>
 where
@@ -1110,7 +1109,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<Block, Client, SelectChain, CIDP> Verifier<Block>
 	for BabeVerifier<Block, Client, SelectChain, CIDP>
 where
@@ -1387,7 +1385,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client, Inner>
 where
 	Block: BlockT,

--- a/substrate/client/consensus/babe/src/tests.rs
+++ b/substrate/client/consensus/babe/src/tests.rs
@@ -137,7 +137,6 @@ thread_local! {
 #[derive(Clone)]
 pub struct PanickingBlockImport<B>(B);
 
-#[async_trait::async_trait]
 impl<B: BlockImport<TestBlock>> BlockImport<TestBlock> for PanickingBlockImport<B>
 where
 	B: Send,
@@ -187,7 +186,6 @@ pub struct TestVerifier {
 	mutator: Mutator,
 }
 
-#[async_trait::async_trait]
 impl Verifier<TestBlock> for TestVerifier {
 	/// Verify the given data and return the BlockImportParams and an optional
 	/// new set of validators to import. If not, err with an Error-Message

--- a/substrate/client/consensus/beefy/Cargo.toml
+++ b/substrate/client/consensus/beefy/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://substrate.io"
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 fnv = "1.0.6"
 futures = "0.3"

--- a/substrate/client/consensus/beefy/rpc/src/lib.rs
+++ b/substrate/client/consensus/beefy/rpc/src/lib.rs
@@ -28,7 +28,7 @@ use sp_runtime::traits::Block as BlockT;
 
 use futures::{task::SpawnError, FutureExt, StreamExt};
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 	types::{error::CallError, ErrorObject, SubscriptionResult},
 	SubscriptionSink,
@@ -132,7 +132,6 @@ where
 	}
 }
 
-#[async_trait]
 impl<Block> BeefyApiServer<notification::EncodedVersionedFinalityProof, Block::Hash>
 	for Beefy<Block>
 where

--- a/substrate/client/consensus/beefy/src/import.rs
+++ b/substrate/client/consensus/beefy/src/import.rs
@@ -113,7 +113,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<Block, BE, Runtime, I> BlockImport<Block> for BeefyBlockImport<Block, BE, Runtime, I>
 where
 	Block: BlockT,

--- a/substrate/client/consensus/common/Cargo.toml
+++ b/substrate/client/consensus/common/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 libp2p-identity = { version = "0.1.3", features = ["peerid", "ed25519"] }

--- a/substrate/client/consensus/common/src/block_import.rs
+++ b/substrate/client/consensus/common/src/block_import.rs
@@ -301,7 +301,6 @@ impl<Block: BlockT> BlockImportParams<Block> {
 }
 
 /// Block import trait.
-#[async_trait::async_trait]
 pub trait BlockImport<B: BlockT> {
 	/// The error type.
 	type Error: std::error::Error + Send + 'static;
@@ -319,7 +318,6 @@ pub trait BlockImport<B: BlockT> {
 	) -> Result<ImportResult, Self::Error>;
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT> BlockImport<B> for crate::import_queue::BoxBlockImport<B> {
 	type Error = sp_consensus::error::Error;
 
@@ -340,7 +338,6 @@ impl<B: BlockT> BlockImport<B> for crate::import_queue::BoxBlockImport<B> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT, T, E: std::error::Error + Send + 'static> BlockImport<B> for Arc<T>
 where
 	for<'r> &'r T: BlockImport<B, Error = E>,
@@ -364,7 +361,6 @@ where
 }
 
 /// Justification import trait
-#[async_trait::async_trait]
 pub trait JustificationImport<B: BlockT> {
 	type Error: std::error::Error + Send + 'static;
 

--- a/substrate/client/consensus/common/src/import_queue.rs
+++ b/substrate/client/consensus/common/src/import_queue.rs
@@ -92,7 +92,6 @@ pub struct IncomingBlock<B: BlockT> {
 }
 
 /// Verify a justification of a block
-#[async_trait::async_trait]
 pub trait Verifier<B: BlockT>: Send {
 	/// Verify the given block data and return the `BlockImportParams` to
 	/// continue the block import process.
@@ -117,7 +116,6 @@ pub trait ImportQueueService<B: BlockT>: Send {
 	);
 }
 
-#[async_trait::async_trait]
 pub trait ImportQueue<B: BlockT>: Send {
 	/// Get a copy of the handle to [`ImportQueueService`].
 	fn service(&self) -> Box<dyn ImportQueueService<B>>;

--- a/substrate/client/consensus/common/src/import_queue/basic_queue.rs
+++ b/substrate/client/consensus/common/src/import_queue/basic_queue.rs
@@ -162,7 +162,6 @@ impl<B: BlockT> ImportQueueService<B> for BasicQueueHandle<B> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT> ImportQueue<B> for BasicQueue<B> {
 	/// Get handle to [`ImportQueueService`].
 	fn service(&self) -> Box<dyn ImportQueueService<B>> {
@@ -507,7 +506,6 @@ mod tests {
 	use futures::{executor::block_on, Future};
 	use sp_test_primitives::{Block, BlockNumber, Hash, Header};
 
-	#[async_trait::async_trait]
 	impl Verifier<Block> for () {
 		async fn verify(
 			&mut self,
@@ -517,7 +515,6 @@ mod tests {
 		}
 	}
 
-	#[async_trait::async_trait]
 	impl BlockImport<Block> for () {
 		type Error = sp_consensus::Error;
 
@@ -536,7 +533,6 @@ mod tests {
 		}
 	}
 
-	#[async_trait::async_trait]
 	impl JustificationImport<Block> for () {
 		type Error = sp_consensus::Error;
 

--- a/substrate/client/consensus/common/src/import_queue/mock.rs
+++ b/substrate/client/consensus/common/src/import_queue/mock.rs
@@ -36,7 +36,6 @@ mockall::mock! {
 mockall::mock! {
 	pub ImportQueue<B: BlockT> {}
 
-	#[async_trait::async_trait]
 	impl<B: BlockT> ImportQueue<B> for ImportQueue<B> {
 		fn service(&self) -> Box<dyn ImportQueueService<B>>;
 		fn service_ref(&mut self) -> &mut dyn ImportQueueService<B>;

--- a/substrate/client/consensus/common/src/longest_chain.rs
+++ b/substrate/client/consensus/common/src/longest_chain.rs
@@ -132,7 +132,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, Block> SelectChain<Block> for LongestChain<B, Block>
 where
 	B: backend::Backend<Block>,

--- a/substrate/client/consensus/grandpa/Cargo.toml
+++ b/substrate/client/consensus/grandpa/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 ahash = "0.8.2"
 array-bytes = "6.1"
-async-trait = "0.1.57"
 dyn-clone = "1.0"
 finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
 futures = "0.3.21"

--- a/substrate/client/consensus/grandpa/rpc/src/lib.rs
+++ b/substrate/client/consensus/grandpa/rpc/src/lib.rs
@@ -23,12 +23,7 @@ use futures::{FutureExt, StreamExt};
 use log::warn;
 use std::sync::Arc;
 
-use jsonrpsee::{
-	core::{async_trait, RpcResult},
-	proc_macros::rpc,
-	types::SubscriptionResult,
-	SubscriptionSink,
-};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc, types::SubscriptionResult, SubscriptionSink};
 
 mod error;
 mod finality;
@@ -89,7 +84,6 @@ impl<AuthoritySet, VoterState, Block: BlockT, ProofProvider>
 	}
 }
 
-#[async_trait]
 impl<AuthoritySet, VoterState, Block, ProofProvider>
 	GrandpaApiServer<JustificationNotification, Block::Hash, NumberFor<Block>>
 	for Grandpa<AuthoritySet, VoterState, Block, ProofProvider>

--- a/substrate/client/consensus/grandpa/src/import.rs
+++ b/substrate/client/consensus/grandpa/src/import.rs
@@ -87,7 +87,6 @@ impl<Backend, Block: BlockT, Client, SC: Clone> Clone
 	}
 }
 
-#[async_trait::async_trait]
 impl<BE, Block: BlockT, Client, SC> JustificationImport<Block>
 	for GrandpaBlockImport<BE, Block, Client, SC>
 where
@@ -507,7 +506,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<BE, Block: BlockT, Client, SC> BlockImport<Block> for GrandpaBlockImport<BE, Block, Client, SC>
 where
 	NumberFor<Block>: finality_grandpa::BlockNumberOps,

--- a/substrate/client/consensus/grandpa/src/tests.rs
+++ b/substrate/client/consensus/grandpa/src/tests.rs
@@ -20,7 +20,6 @@
 
 use super::*;
 use assert_matches::assert_matches;
-use async_trait::async_trait;
 use environment::HasVoted;
 use futures_timer::Delay;
 use parking_lot::{Mutex, RwLock};
@@ -230,7 +229,6 @@ impl MockSelectChain {
 	}
 }
 
-#[async_trait]
 impl SelectChain<Block> for MockSelectChain {
 	async fn leaves(&self) -> Result<Vec<Hash>, ConsensusError> {
 		Ok(self.leaves.lock().take().unwrap())

--- a/substrate/client/consensus/manual-seal/Cargo.toml
+++ b/substrate/client/consensus/manual-seal/Cargo.toml
@@ -15,7 +15,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 jsonrpsee = { version = "0.16.2", features = ["client-core", "server", "macros"] }
 assert_matches = "1.3.0"
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 futures-timer = "3.0.1"

--- a/substrate/client/consensus/manual-seal/src/consensus/babe.rs
+++ b/substrate/client/consensus/manual-seal/src/consensus/babe.rs
@@ -89,7 +89,6 @@ impl<B: BlockT, C> BabeVerifier<B, C> {
 }
 
 /// The verifier for the manual seal engine; instantly finalizes.
-#[async_trait::async_trait]
 impl<B, C> Verifier<B> for BabeVerifier<B, C>
 where
 	B: BlockT,

--- a/substrate/client/consensus/manual-seal/src/consensus/timestamp.rs
+++ b/substrate/client/consensus/manual-seal/src/consensus/timestamp.rs
@@ -136,7 +136,6 @@ impl SlotTimestampProvider {
 	}
 }
 
-#[async_trait::async_trait]
 impl InherentDataProvider for SlotTimestampProvider {
 	async fn provide_inherent_data(
 		&self,

--- a/substrate/client/consensus/manual-seal/src/lib.rs
+++ b/substrate/client/consensus/manual-seal/src/lib.rs
@@ -62,7 +62,6 @@ pub const MANUAL_SEAL_ENGINE_ID: ConsensusEngineId = [b'm', b'a', b'n', b'l'];
 /// The verifier for the manual seal engine; instantly finalizes.
 struct ManualSealVerifier;
 
-#[async_trait::async_trait]
 impl<B: BlockT> Verifier<B> for ManualSealVerifier {
 	async fn verify(
 		&mut self,

--- a/substrate/client/consensus/manual-seal/src/rpc.rs
+++ b/substrate/client/consensus/manual-seal/src/rpc.rs
@@ -24,7 +24,7 @@ use futures::{
 	SinkExt,
 };
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 };
 use sc_consensus::ImportedAux;
@@ -108,7 +108,6 @@ impl<Hash> ManualSeal<Hash> {
 	}
 }
 
-#[async_trait]
 impl<Hash: Send + 'static> ManualSealApiServer<Hash> for ManualSeal<Hash> {
 	async fn create_block(
 		&self,

--- a/substrate/client/consensus/pow/Cargo.toml
+++ b/substrate/client/consensus/pow/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.1"

--- a/substrate/client/consensus/pow/src/lib.rs
+++ b/substrate/client/consensus/pow/src/lib.rs
@@ -297,7 +297,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, I, C, S, Algorithm, CIDP> BlockImport<B> for PowBlockImport<B, I, C, S, Algorithm, CIDP>
 where
 	B: BlockT,
@@ -435,7 +434,6 @@ impl<B: BlockT, Algorithm> PowVerifier<B, Algorithm> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT, Algorithm> Verifier<B> for PowVerifier<B, Algorithm>
 where
 	Algorithm: PowAlgorithm<B> + Send + Sync,

--- a/substrate/client/consensus/slots/Cargo.toml
+++ b/substrate/client/consensus/slots/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 futures-timer = "3.0.1"

--- a/substrate/client/consensus/slots/src/lib.rs
+++ b/substrate/client/consensus/slots/src/lib.rs
@@ -68,7 +68,6 @@ pub struct SlotResult<Block: BlockT, Proof> {
 ///
 /// The implementation should not make any assumptions of the slot being bound to the time or
 /// similar. The only valid assumption is that the slot number is always increasing.
-#[async_trait::async_trait]
 pub trait SlotWorker<B: BlockT, Proof> {
 	/// Called when a new slot is triggered.
 	///
@@ -80,7 +79,6 @@ pub trait SlotWorker<B: BlockT, Proof> {
 /// A skeleton implementation for `SlotWorker` which tries to claim a slot at
 /// its beginning and tries to produce a block if successfully claimed, timing
 /// out if block production takes too long.
-#[async_trait::async_trait]
 pub trait SimpleSlotWorker<B: BlockT> {
 	/// A handle to a `BlockImport`.
 	type BlockImport: BlockImport<B> + Send + 'static;
@@ -455,7 +453,6 @@ pub trait SimpleSlotWorker<B: BlockT> {
 /// that would prevent downstream users to implement [`SlotWorker`] for their own types.
 pub struct SimpleSlotWorkerToSlotWorker<T>(pub T);
 
-#[async_trait::async_trait]
 impl<T: SimpleSlotWorker<B> + Send + Sync, B: BlockT>
 	SlotWorker<B, <T::Proposer as Proposer<B>>::Proof> for SimpleSlotWorkerToSlotWorker<T>
 {

--- a/substrate/client/merkle-mountain-range/rpc/src/lib.rs
+++ b/substrate/client/merkle-mountain-range/rpc/src/lib.rs
@@ -24,7 +24,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use codec::{Codec, Decode, Encode};
 use jsonrpsee::{
-	core::{async_trait, RpcResult},
+	core::RpcResult,
 	proc_macros::rpc,
 	types::error::{CallError, ErrorObject},
 };
@@ -143,7 +143,6 @@ impl<C, B, S> Mmr<C, B, S> {
 	}
 }
 
-#[async_trait]
 impl<Client, Block, MmrHash, S> MmrApiServer<<Block as BlockT>::Hash, NumberFor<Block>, MmrHash>
 	for Mmr<Client, (Block, MmrHash), S>
 where

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-async-trait = "0.1"
 asynchronous-codec = "0.6"
 bytes = "1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }

--- a/substrate/client/network/common/Cargo.toml
+++ b/substrate/client/network/common/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 prost-build = "0.11"
 
 [dependencies]
-async-trait = "0.1.57"
 bitflags = "1.3.2"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 	"derive",

--- a/substrate/client/network/common/src/sync.rs
+++ b/substrate/client/network/common/src/sync.rs
@@ -251,13 +251,11 @@ impl fmt::Debug for OpaqueStateResponse {
 }
 
 /// Provides high-level status of syncing.
-#[async_trait::async_trait]
 pub trait SyncStatusProvider<Block: BlockT>: Send + Sync {
 	/// Get high-level view of the syncing status.
 	async fn status(&self) -> Result<SyncStatus<Block>, ()>;
 }
 
-#[async_trait::async_trait]
 impl<T, Block> SyncStatusProvider<Block> for Arc<T>
 where
 	T: ?Sized,

--- a/substrate/client/network/src/request_responses.rs
+++ b/substrate/client/network/src/request_responses.rs
@@ -855,7 +855,6 @@ pub struct GenericCodec {
 	max_response_size: u64,
 }
 
-#[async_trait::async_trait]
 impl Codec for GenericCodec {
 	type Protocol = Vec<u8>;
 	type Request = Vec<u8>;

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -831,7 +831,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, H> NetworkStatusProvider for NetworkService<B, H>
 where
 	B: BlockT + 'static,
@@ -1075,7 +1074,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, H> NetworkRequest for NetworkService<B, H>
 where
 	B: BlockT + 'static,
@@ -1132,7 +1130,6 @@ pub struct NotificationSender {
 	notification_size_metric: Option<Histogram>,
 }
 
-#[async_trait::async_trait]
 impl NotificationSenderT for NotificationSender {
 	async fn ready(
 		&self,

--- a/substrate/client/network/sync/Cargo.toml
+++ b/substrate/client/network/sync/Cargo.toml
@@ -18,7 +18,6 @@ prost-build = "0.11"
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-async-trait = "0.1.58"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/substrate/client/network/sync/src/block_relay_protocol.rs
+++ b/substrate/client/network/sync/src/block_relay_protocol.rs
@@ -25,7 +25,6 @@ use std::sync::Arc;
 
 /// The serving side of the block relay protocol. It runs a single instance
 /// of the server task that processes the incoming protocol messages.
-#[async_trait::async_trait]
 pub trait BlockServer<Block: BlockT>: Send {
 	/// Starts the protocol processing.
 	async fn run(&mut self);
@@ -33,7 +32,6 @@ pub trait BlockServer<Block: BlockT>: Send {
 
 /// The client side stub to download blocks from peers. This is a handle
 /// that can be used to initiate concurrent downloads.
-#[async_trait::async_trait]
 pub trait BlockDownloader<Block: BlockT>: Send + Sync {
 	/// Performs the protocol specific sequence to fetch the blocks from the peer.
 	/// Output: if the download succeeds, the response is a `Vec<u8>` which is

--- a/substrate/client/network/sync/src/block_request_handler.rs
+++ b/substrate/client/network/sync/src/block_request_handler.rs
@@ -460,7 +460,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, Client> BlockServer<B> for BlockRequestHandler<B, Client>
 where
 	B: BlockT,
@@ -562,7 +561,6 @@ impl FullBlockDownloader {
 	}
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT> BlockDownloader<B> for FullBlockDownloader {
 	async fn download_blocks(
 		&self,

--- a/substrate/client/network/sync/src/mock.rs
+++ b/substrate/client/network/sync/src/mock.rs
@@ -86,7 +86,6 @@ mockall::mock! {
 mockall::mock! {
 	pub BlockDownloader<Block: BlockT> {}
 
-	#[async_trait::async_trait]
 	impl<Block: BlockT> BlockDownloaderT<Block> for BlockDownloader<Block> {
 		async fn download_blocks(
 			&self,

--- a/substrate/client/network/sync/src/service/chain_sync.rs
+++ b/substrate/client/network/sync/src/service/chain_sync.rs
@@ -188,7 +188,6 @@ impl<B: BlockT> JustificationSyncLink<B> for SyncingService<B> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT> SyncStatusProvider<B> for SyncingService<B> {
 	/// Get high-level view of the syncing status.
 	async fn status(&self) -> Result<SyncStatus<B>, ()> {

--- a/substrate/client/network/sync/src/service/mock.rs
+++ b/substrate/client/network/sync/src/service/mock.rs
@@ -107,7 +107,6 @@ mockall::mock! {
 		fn sync_num_connected(&self) -> usize;
 	}
 
-	#[async_trait::async_trait]
 	impl NetworkRequest for Network {
 		async fn request(
 			&self,

--- a/substrate/client/network/test/Cargo.toml
+++ b/substrate/client/network/test/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 tokio = "1.22.0"
-async-trait = "0.1.57"
 futures = "0.3.21"
 futures-timer = "3.0.1"
 libp2p = "0.51.3"

--- a/substrate/client/network/test/src/lib.rs
+++ b/substrate/client/network/test/src/lib.rs
@@ -111,7 +111,6 @@ impl PassThroughVerifier {
 }
 
 /// This `Verifier` accepts all data as valid.
-#[async_trait::async_trait]
 impl<B: BlockT> Verifier<B> for PassThroughVerifier {
 	async fn verify(
 		&mut self,
@@ -205,7 +204,6 @@ impl PeersClient {
 	}
 }
 
-#[async_trait::async_trait]
 impl BlockImport<Block> for PeersClient {
 	type Error = ConsensusError;
 
@@ -578,7 +576,6 @@ impl<I> BlockImportAdapter<I> {
 	}
 }
 
-#[async_trait::async_trait]
 impl<I> BlockImport<Block> for BlockImportAdapter<I>
 where
 	I: BlockImport<Block, Error = ConsensusError> + Send + Sync,
@@ -606,7 +603,6 @@ struct VerifierAdapter<B: BlockT> {
 	failed_verifications: Arc<Mutex<HashMap<B::Hash, String>>>,
 }
 
-#[async_trait::async_trait]
 impl<B: BlockT> Verifier<B> for VerifierAdapter<B> {
 	async fn verify(
 		&mut self,
@@ -693,7 +689,6 @@ pub struct FullPeerConfig {
 	pub target_block: Option<<Block as BlockT>::Header>,
 }
 
-#[async_trait::async_trait]
 pub trait TestNetFactory: Default + Sized + Send {
 	type Verifier: 'static + Verifier<Block>;
 	type BlockImport: BlockImport<Block, Error = ConsensusError> + Clone + Send + Sync + 'static;
@@ -1147,7 +1142,6 @@ impl TestNetFactory for TestNet {
 
 pub struct ForceFinalized(PeersClient);
 
-#[async_trait::async_trait]
 impl JustificationImport<Block> for ForceFinalized {
 	type Error = ConsensusError;
 

--- a/substrate/client/network/test/src/service.rs
+++ b/substrate/client/network/test/src/service.rs
@@ -131,7 +131,6 @@ impl TestNetworkBuilder {
 		#[derive(Clone)]
 		struct PassThroughVerifier(bool);
 
-		#[async_trait::async_trait]
 		impl<B: BlockT> sc_consensus::Verifier<B> for PassThroughVerifier {
 			async fn verify(
 				&mut self,

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 use codec::Encode;
-use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::core::RpcResult;
 use sc_client_api::{
 	Backend, BlockBackend, BlockchainEvents, CallExecutor, ExecutorProvider, StorageProvider,
 };
@@ -76,7 +76,6 @@ fn parse_hex_param(param: String) -> Result<Vec<u8>, ArchiveError> {
 	array_bytes::hex2bytes(&param).map_err(|_| ArchiveError::InvalidParam(param))
 }
 
-#[async_trait]
 impl<BE, Block, Client> ArchiveApiServer<Block::Hash> for Archive<BE, Block, Client>
 where
 	Block: BlockT + 'static,

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -36,7 +36,7 @@ use crate::{
 use codec::Encode;
 use futures::future::FutureExt;
 use jsonrpsee::{
-	core::{async_trait, RpcResult},
+	core::RpcResult,
 	types::{SubscriptionEmptyError, SubscriptionId, SubscriptionResult},
 	SubscriptionSink,
 };
@@ -179,7 +179,6 @@ fn parse_hex_param(param: String) -> Result<Vec<u8>, ChainHeadRpcError> {
 	}
 }
 
-#[async_trait]
 impl<BE, Block, Client> ChainHeadApiServer<Block::Hash> for ChainHead<BE, Block, Client>
 where
 	Block: BlockT + 'static,

--- a/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
@@ -30,7 +30,6 @@ use crate::{
 	SubscriptionTaskExecutor,
 };
 use jsonrpsee::{
-	core::async_trait,
 	types::{
 		error::{CallError, ErrorObject},
 		SubscriptionResult,
@@ -82,7 +81,6 @@ const TX_SOURCE: TransactionSource = TransactionSource::External;
 /// This is similar to the old `author` API error code.
 const BAD_FORMAT: i32 = 1001;
 
-#[async_trait]
 impl<Pool, Client> TransactionApiServer<BlockHash<Pool>> for Transaction<Pool, Client>
 where
 	Pool: TransactionPool + Sync + Send + 'static,

--- a/substrate/client/rpc/src/author/mod.rs
+++ b/substrate/client/rpc/src/author/mod.rs
@@ -28,7 +28,7 @@ use crate::SubscriptionTaskExecutor;
 use codec::{Decode, Encode};
 use futures::{FutureExt, TryFutureExt};
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	types::SubscriptionResult,
 	SubscriptionSink,
 };
@@ -82,7 +82,6 @@ impl<P, Client> Author<P, Client> {
 /// some unique transactions via RPC and have them included in the pool.
 const TX_SOURCE: TransactionSource = TransactionSource::External;
 
-#[async_trait]
 impl<P, Client> AuthorApiServer<TxHash<P>, BlockHash<P>> for Author<P, Client>
 where
 	P: TransactionPool + Sync + Send + 'static,

--- a/substrate/client/rpc/src/mixnet/mod.rs
+++ b/substrate/client/rpc/src/mixnet/mod.rs
@@ -18,7 +18,7 @@
 
 //! Substrate mixnet API.
 
-use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::core::RpcResult;
 use sc_mixnet::Api;
 use sc_rpc_api::mixnet::error::Error;
 pub use sc_rpc_api::mixnet::MixnetApiServer;
@@ -34,7 +34,6 @@ impl Mixnet {
 	}
 }
 
-#[async_trait]
 impl MixnetApiServer for Mixnet {
 	async fn submit_extrinsic(&self, extrinsic: Bytes) -> RpcResult<()> {
 		// We only hold the lock while pushing the request into the requests channel

--- a/substrate/client/rpc/src/offchain/mod.rs
+++ b/substrate/client/rpc/src/offchain/mod.rs
@@ -22,7 +22,7 @@
 mod tests;
 
 use self::error::Error;
-use jsonrpsee::core::{async_trait, Error as JsonRpseeError, RpcResult};
+use jsonrpsee::core::{Error as JsonRpseeError, RpcResult};
 use parking_lot::RwLock;
 /// Re-export the API for backward compatibility.
 pub use sc_rpc_api::offchain::*;
@@ -48,7 +48,6 @@ impl<T: OffchainStorage> Offchain<T> {
 	}
 }
 
-#[async_trait]
 impl<T: OffchainStorage + 'static> OffchainApiServer for Offchain<T> {
 	fn set_local_storage(&self, kind: StorageKind, key: Bytes, value: Bytes) -> RpcResult<()> {
 		self.deny_unsafe.check_if_safe()?;

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use crate::SubscriptionTaskExecutor;
 
 use jsonrpsee::{
-	core::{async_trait, server::rpc_module::SubscriptionSink, Error as JsonRpseeError, RpcResult},
+	core::{server::rpc_module::SubscriptionSink, Error as JsonRpseeError, RpcResult},
 	types::SubscriptionResult,
 };
 
@@ -54,7 +54,6 @@ use sp_blockchain::{HeaderBackend, HeaderMetadata};
 const STORAGE_KEYS_PAGED_MAX_COUNT: u32 = 1000;
 
 /// State backend API.
-#[async_trait]
 pub trait StateBackend<Block: BlockT, Client>: Send + Sync + 'static
 where
 	Block: BlockT + 'static,
@@ -201,7 +200,6 @@ pub struct State<Block, Client> {
 	deny_unsafe: DenyUnsafe,
 }
 
-#[async_trait]
 impl<Block, Client> StateApiServer<Block::Hash> for State<Block, Client>
 where
 	Block: BlockT + 'static,

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -28,10 +28,7 @@ use super::{
 use crate::{DenyUnsafe, SubscriptionTaskExecutor};
 
 use futures::{future, stream, FutureExt, StreamExt};
-use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError},
-	SubscriptionSink,
-};
+use jsonrpsee::{core::Error as JsonRpseeError, SubscriptionSink};
 use sc_client_api::{
 	Backend, BlockBackend, BlockchainEvents, CallExecutor, ExecutorProvider, ProofProvider,
 	StorageProvider,
@@ -168,7 +165,6 @@ where
 	}
 }
 
-#[async_trait]
 impl<BE, Block, Client> StateBackend<Block, Client> for FullState<BE, Block, Client>
 where
 	Block: BlockT + 'static,

--- a/substrate/client/rpc/src/statement/mod.rs
+++ b/substrate/client/rpc/src/statement/mod.rs
@@ -19,7 +19,7 @@
 //! Substrate statement store API.
 
 use codec::{Decode, Encode};
-use jsonrpsee::core::{async_trait, RpcResult};
+use jsonrpsee::core::RpcResult;
 /// Re-export the API for backward compatibility.
 pub use sc_rpc_api::statement::{error::Error, StatementApiServer};
 use sc_rpc_api::DenyUnsafe;
@@ -43,7 +43,6 @@ impl StatementStore {
 	}
 }
 
-#[async_trait]
 impl StatementApiServer for StatementStore {
 	fn dump(&self) -> RpcResult<Vec<Bytes>> {
 		self.deny_unsafe.check_if_safe()?;

--- a/substrate/client/rpc/src/system/mod.rs
+++ b/substrate/client/rpc/src/system/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 
 use futures::channel::oneshot;
 use jsonrpsee::{
-	core::{async_trait, error::Error as JsonRpseeError, JsonValue, RpcResult},
+	core::{error::Error as JsonRpseeError, JsonValue, RpcResult},
 	types::error::{CallError, ErrorCode, ErrorObject},
 };
 use sc_rpc_api::DenyUnsafe;
@@ -82,7 +82,6 @@ impl<B: traits::Block> System<B> {
 	}
 }
 
-#[async_trait]
 impl<B: traits::Block> SystemApiServer<B::Hash, <B::Header as HeaderT>::Number> for System<B> {
 	fn system_name(&self) -> RpcResult<String> {
 		Ok(self.info.impl_name.clone())

--- a/substrate/client/service/Cargo.toml
+++ b/substrate/client/service/Cargo.toml
@@ -77,7 +77,6 @@ sc-tracing = { path = "../tracing" }
 sc-sysinfo = { path = "../sysinfo" }
 tracing = "0.1.29"
 tracing-futures = { version = "0.2.4" }
-async-trait = "0.1.57"
 tokio = { version = "1.22.0", features = ["time", "rt-multi-thread", "parking_lot"] }
 tempfile = "3.1.0"
 directories = "5.0.1"

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -1753,7 +1753,6 @@ where
 /// NOTE: only use this implementation when you are sure there are NO consensus-level BlockImport
 /// objects. Otherwise, importing blocks directly into the client would be bypassing
 /// important verification work.
-#[async_trait::async_trait]
 impl<B, E, Block, RA> sc_consensus::BlockImport<Block> for &Client<B, E, Block, RA>
 where
 	B: backend::Backend<Block>,
@@ -1862,7 +1861,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, E, Block, RA> sc_consensus::BlockImport<Block> for Client<B, E, Block, RA>
 where
 	B: backend::Backend<Block>,

--- a/substrate/client/sync-state-rpc/src/lib.rs
+++ b/substrate/client/sync-state-rpc/src/lib.rs
@@ -44,7 +44,7 @@
 use std::sync::Arc;
 
 use jsonrpsee::{
-	core::{async_trait, Error as JsonRpseeError, RpcResult},
+	core::{Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 	types::{error::CallError, ErrorObject},
 };
@@ -187,7 +187,6 @@ where
 	}
 }
 
-#[async_trait]
 impl<Block, Backend> SyncStateApiServer for SyncState<Block, Backend>
 where
 	Block: BlockT,

--- a/substrate/client/transaction-pool/Cargo.toml
+++ b/substrate/client/transaction-pool/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/substrate/client/transaction-pool/api/Cargo.toml
+++ b/substrate/client/transaction-pool/api/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 description = "Transaction pool client facing API."
 
 [dependencies]
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 log = "0.4.17"

--- a/substrate/client/transaction-pool/api/src/lib.rs
+++ b/substrate/client/transaction-pool/api/src/lib.rs
@@ -21,7 +21,6 @@
 
 pub mod error;
 
-use async_trait::async_trait;
 use codec::Codec;
 use futures::{Future, Stream};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -322,7 +321,6 @@ impl<B: BlockT> ChainEvent<B> {
 }
 
 /// Trait for transaction pool maintenance.
-#[async_trait]
 pub trait MaintainedTransactionPool: TransactionPool {
 	/// Perform maintenance
 	async fn maintain(&self, event: ChainEvent<Self::Block>);

--- a/substrate/client/transaction-pool/src/lib.rs
+++ b/substrate/client/transaction-pool/src/lib.rs
@@ -32,7 +32,6 @@ mod revalidation;
 mod tests;
 
 pub use crate::api::FullChainApi;
-use async_trait::async_trait;
 use enactment_state::{EnactmentAction, EnactmentState};
 use futures::{
 	channel::oneshot,
@@ -720,7 +719,6 @@ where
 	}
 }
 
-#[async_trait]
 impl<PoolApi, Block> MaintainedTransactionPool for BasicPool<PoolApi, Block>
 where
 	Block: BlockT,

--- a/substrate/primitives/consensus/aura/Cargo.toml
+++ b/substrate/primitives/consensus/aura/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-api = { path = "../../api", default-features = false}
@@ -27,7 +26,6 @@ sp-timestamp = { path = "../../timestamp", default-features = false}
 [features]
 default = [ "std" ]
 std = [
-	"async-trait",
 	"codec/std",
 	"scale-info/std",
 	"sp-api/std",

--- a/substrate/primitives/consensus/aura/src/inherents.rs
+++ b/substrate/primitives/consensus/aura/src/inherents.rs
@@ -78,7 +78,6 @@ impl sp_std::ops::Deref for InherentDataProvider {
 }
 
 #[cfg(feature = "std")]
-#[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
 	async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
 		inherent_data.put_data(INHERENT_IDENTIFIER, &self.slot)

--- a/substrate/primitives/consensus/babe/Cargo.toml
+++ b/substrate/primitives/consensus/babe/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"], optional = true }
@@ -29,7 +28,6 @@ sp-timestamp = { path = "../../timestamp", optional = true}
 [features]
 default = [ "std" ]
 std = [
-	"async-trait",
 	"codec/std",
 	"scale-info/std",
 	"serde/std",

--- a/substrate/primitives/consensus/babe/src/inherents.rs
+++ b/substrate/primitives/consensus/babe/src/inherents.rs
@@ -84,7 +84,6 @@ impl sp_std::ops::Deref for InherentDataProvider {
 }
 
 #[cfg(feature = "std")]
-#[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
 	async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
 		inherent_data.put_data(INHERENT_IDENTIFIER, &self.slot)

--- a/substrate/primitives/consensus/common/Cargo.toml
+++ b/substrate/primitives/consensus/common/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.57"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 log = "0.4.17"
 thiserror = "1.0.48"

--- a/substrate/primitives/consensus/common/src/select_chain.rs
+++ b/substrate/primitives/consensus/common/src/select_chain.rs
@@ -32,7 +32,6 @@ use sp_runtime::traits::{Block as BlockT, NumberFor};
 /// some implementations.
 ///
 /// Non-deterministically finalizing chains may only use the `_authoring` functions.
-#[async_trait::async_trait]
 pub trait SelectChain<Block: BlockT>: Sync + Send + Clone {
 	/// Get all leaves of the chain, i.e. block hashes that have no children currently.
 	/// Leaves that can never be finalized will not be returned.

--- a/substrate/primitives/inherents/Cargo.toml
+++ b/substrate/primitives/inherents/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
@@ -28,7 +27,6 @@ futures = "0.3.21"
 [features]
 default = [ "std" ]
 std = [
-	"async-trait",
 	"codec/std",
 	"scale-info/std",
 	"sp-runtime/std",

--- a/substrate/primitives/inherents/src/client_side.rs
+++ b/substrate/primitives/inherents/src/client_side.rs
@@ -26,7 +26,6 @@ use sp_runtime::traits::Block as BlockT;
 /// The crate already provides some convience implementations of this trait for
 /// `Box<dyn CreateInherentDataProviders>` and closures. So, it should not be required to implement
 /// this trait manually.
-#[async_trait::async_trait]
 pub trait CreateInherentDataProviders<Block: BlockT, ExtraArgs>: Send + Sync {
 	/// The inherent data providers that will be created.
 	type InherentDataProviders: InherentDataProvider;
@@ -39,7 +38,6 @@ pub trait CreateInherentDataProviders<Block: BlockT, ExtraArgs>: Send + Sync {
 	) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>>;
 }
 
-#[async_trait::async_trait]
 impl<F, Block, IDP, ExtraArgs, Fut> CreateInherentDataProviders<Block, ExtraArgs> for F
 where
 	Block: BlockT,
@@ -61,7 +59,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<Block: BlockT, ExtraArgs: Send, IDPS: InherentDataProvider>
 	CreateInherentDataProviders<Block, ExtraArgs>
 	for Box<dyn CreateInherentDataProviders<Block, ExtraArgs, InherentDataProviders = IDPS>>
@@ -78,7 +75,6 @@ impl<Block: BlockT, ExtraArgs: Send, IDPS: InherentDataProvider>
 }
 
 /// Something that provides inherent data.
-#[async_trait::async_trait]
 pub trait InherentDataProvider: Send + Sync {
 	/// Convenience function for creating [`InherentData`].
 	///
@@ -105,7 +101,6 @@ pub trait InherentDataProvider: Send + Sync {
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]
-#[async_trait::async_trait]
 impl InherentDataProvider for Tuple {
 	for_tuples!( where #( Tuple: Send + Sync )* );
 	async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {

--- a/substrate/primitives/inherents/src/lib.rs
+++ b/substrate/primitives/inherents/src/lib.rs
@@ -54,7 +54,6 @@
 //! /// Some custom inherent data provider
 //! struct InherentDataProvider;
 //!
-//! #[async_trait::async_trait]
 //! impl sp_inherents::InherentDataProvider for InherentDataProvider {
 //! 	async fn provide_inherent_data(
 //! 		&self,
@@ -104,7 +103,6 @@
 //! # type Block = sp_runtime::testing::Block<ExtrinsicWrapper<()>>;
 //! # const INHERENT_IDENTIFIER: InherentIdentifier = *b"testinh0";
 //! # struct InherentDataProvider;
-//! # #[async_trait::async_trait]
 //! # impl sp_inherents::InherentDataProvider for InherentDataProvider {
 //! # 	async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), sp_inherents::Error> {
 //! # 		inherent_data.put_data(INHERENT_IDENTIFIER, &"hello")
@@ -441,7 +439,6 @@ mod tests {
 
 	const ERROR_TO_STRING: &str = "Found error!";
 
-	#[async_trait::async_trait]
 	impl InherentDataProvider for TestInherentDataProvider {
 		async fn provide_inherent_data(&self, data: &mut InherentData) -> Result<(), Error> {
 			data.put_data(TEST_INHERENT_0, &42)

--- a/substrate/primitives/timestamp/Cargo.toml
+++ b/substrate/primitives/timestamp/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.48", optional = true }
 sp-inherents = { path = "../inherents", default-features = false}
@@ -23,7 +22,6 @@ sp-std = { path = "../std", default-features = false}
 [features]
 default = [ "std" ]
 std = [
-	"async-trait",
 	"codec/std",
 	"sp-inherents/std",
 	"sp-runtime/std",

--- a/substrate/primitives/timestamp/src/lib.rs
+++ b/substrate/primitives/timestamp/src/lib.rs
@@ -228,7 +228,6 @@ impl sp_std::ops::Deref for InherentDataProvider {
 }
 
 #[cfg(feature = "std")]
-#[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
 	async fn provide_inherent_data(
 		&self,

--- a/substrate/primitives/transaction-storage-proof/Cargo.toml
+++ b/substrate/primitives/transaction-storage-proof/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.57", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 sp-core = { path = "../core", optional = true}
@@ -25,7 +24,6 @@ sp-trie = { path = "../trie", optional = true}
 [features]
 default = [ "std" ]
 std = [
-	"async-trait",
 	"codec/std",
 	"scale-info/std",
 	"sp-core/std",

--- a/substrate/primitives/transaction-storage-proof/src/lib.rs
+++ b/substrate/primitives/transaction-storage-proof/src/lib.rs
@@ -85,7 +85,6 @@ impl InherentDataProvider {
 }
 
 #[cfg(feature = "std")]
-#[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
 	async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
 		if let Some(proof) = &self.proof {

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 array-bytes = "6.1"
-async-trait = "0.1.57"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 serde = "1.0.188"

--- a/substrate/test-utils/client/src/client_ext.rs
+++ b/substrate/test-utils/client/src/client_ext.rs
@@ -37,7 +37,6 @@ pub trait ClientExt<Block: BlockT>: Sized {
 }
 
 /// Extension trait for a test client around block importing.
-#[async_trait::async_trait]
 pub trait ClientBlockImportExt<Block: BlockT>: Sized {
 	/// Import block to the chain. No finality.
 	async fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError>;
@@ -86,7 +85,6 @@ where
 }
 
 /// This implementation is required, because of the weird api requirements around `BlockImport`.
-#[async_trait::async_trait]
 impl<Block: BlockT, T> ClientBlockImportExt<Block> for std::sync::Arc<T>
 where
 	for<'r> &'r T: BlockImport<Block, Error = ConsensusError>,
@@ -145,7 +143,6 @@ where
 	}
 }
 
-#[async_trait::async_trait]
 impl<B, E, RA, Block: BlockT> ClientBlockImportExt<Block> for Client<B, E, Block, RA>
 where
 	Self: BlockImport<Block, Error = ConsensusError>,

--- a/substrate/test-utils/client/src/lib.rs
+++ b/substrate/test-utils/client/src/lib.rs
@@ -310,7 +310,6 @@ impl std::fmt::Display for RpcTransactionError {
 }
 
 /// An extension trait for `RpcHandlers`.
-#[async_trait::async_trait]
 pub trait RpcHandlersExt {
 	/// Send a transaction through the RpcHandlers.
 	async fn send_transaction(
@@ -319,7 +318,6 @@ pub trait RpcHandlersExt {
 	) -> Result<RpcTransactionOutput, RpcTransactionError>;
 }
 
-#[async_trait::async_trait]
 impl RpcHandlersExt for RpcHandlers {
 	async fn send_transaction(
 		&self,

--- a/substrate/utils/frame/rpc/client/Cargo.toml
+++ b/substrate/utils/frame/rpc/client/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 jsonrpsee = { version = "0.16.2", features = ["ws-client"] }
 sc-rpc-api = { path = "../../../../client/rpc-api" }
-async-trait = "0.1.57"
 serde = "1"
 sp-runtime = { path = "../../../../primitives/runtime" }
 log = "0.4"

--- a/substrate/utils/frame/rpc/client/src/lib.rs
+++ b/substrate/utils/frame/rpc/client/src/lib.rs
@@ -37,7 +37,6 @@
 //! }
 //! ```
 
-use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use std::collections::VecDeque;
@@ -71,7 +70,6 @@ pub async fn ws_client(uri: impl AsRef<str>) -> Result<WsClient, String> {
 }
 
 /// Abstraction over RPC calling for headers.
-#[async_trait]
 pub trait HeaderProvider<Block: BlockT>
 where
 	Block::Header: HeaderT,
@@ -80,7 +78,6 @@ where
 	async fn get_header(&self, hash: Block::Hash) -> Block::Header;
 }
 
-#[async_trait]
 impl<Block: BlockT> HeaderProvider<Block> for WsClient
 where
 	Block::Header: DeserializeOwned,
@@ -94,7 +91,6 @@ where
 }
 
 /// Abstraction over RPC subscription for finalized headers.
-#[async_trait]
 pub trait HeaderSubscription<Block: BlockT>
 where
 	Block::Header: HeaderT,
@@ -106,7 +102,6 @@ where
 	async fn next_header(&mut self) -> Option<Block::Header>;
 }
 
-#[async_trait]
 impl<Block: BlockT> HeaderSubscription<Block> for Subscription<Block::Header>
 where
 	Block::Header: DeserializeOwned,
@@ -219,7 +214,6 @@ mod tests {
 		headers
 	}
 
-	#[async_trait]
 	impl HeaderProvider<Block> for MockHeaderProvider {
 		async fn get_header(&self, _hash: Hash) -> Header {
 			let height = self.0.lock().await.pop_front().unwrap();
@@ -229,7 +223,6 @@ mod tests {
 
 	struct MockHeaderSubscription(pub VecDeque<BlockNumber>);
 
-	#[async_trait]
 	impl HeaderSubscription<Block> for MockHeaderSubscription {
 		async fn next_header(&mut self) -> Option<Header> {
 			self.0.pop_front().map(|h| headers()[h as usize].clone())

--- a/substrate/utils/frame/rpc/system/src/lib.rs
+++ b/substrate/utils/frame/rpc/system/src/lib.rs
@@ -21,7 +21,7 @@ use std::{fmt::Display, sync::Arc};
 
 use codec::{self, Codec, Decode, Encode};
 use jsonrpsee::{
-	core::{async_trait, RpcResult},
+	core::RpcResult,
 	proc_macros::rpc,
 	types::error::{CallError, ErrorObject},
 };
@@ -84,7 +84,6 @@ impl<P: TransactionPool, C, B> System<P, C, B> {
 	}
 }
 
-#[async_trait]
 impl<P, C, Block, AccountId, Nonce>
 	SystemApiServer<<Block as traits::Block>::Hash, AccountId, Nonce> for System<P, C, Block>
 where

--- a/substrate/utils/frame/try-runtime/cli/Cargo.toml
+++ b/substrate/utils/frame/try-runtime/cli/Cargo.toml
@@ -34,7 +34,6 @@ sp-weights = { path = "../../../../primitives/weights" }
 frame-try-runtime = { path = "../../../../frame/try-runtime", optional = true}
 substrate-rpc-client = { path = "../../rpc/client" }
 
-async-trait = "0.1.57"
 clap = { version = "4.4.6", features = ["derive"] }
 hex = { version = "0.4.3", default-features = false }
 log = "0.4.17"

--- a/substrate/utils/frame/try-runtime/cli/src/block_building_info.rs
+++ b/substrate/utils/frame/try-runtime/cli/src/block_building_info.rs
@@ -34,7 +34,6 @@ use sp_timestamp::TimestampInherentData;
 ///
 /// This module already provides some convenience implementation of this trait for closures. So, it
 /// should not be required to implement it directly.
-#[async_trait::async_trait]
 pub trait BlockBuildingInfoProvider<Block: BlockT, ExtraArgs = ()> {
 	type InherentDataProviders: InherentDataProvider;
 
@@ -45,7 +44,6 @@ pub trait BlockBuildingInfoProvider<Block: BlockT, ExtraArgs = ()> {
 	) -> Result<(Self::InherentDataProviders, Vec<DigestItem>)>;
 }
 
-#[async_trait::async_trait]
 impl<F, Block, IDP, ExtraArgs, Fut> BlockBuildingInfoProvider<Block, ExtraArgs> for F
 where
 	Block: BlockT,


### PR DESCRIPTION
With [`async_fn_in_trait`](https://github.com/rust-lang/rust/pull/115822) stabilized we should move away from using the `async-trait` crate.

**NOTE:** Just a WIP for now that simply removes mentions of `async-trait`, `jsonrpsee` should migrate first https://github.com/paritytech/jsonrpsee/issues/1229