### PR TITLE
rename benchmark

### DIFF
--- a/substrate/frame/alliance/src/benchmarking.rs
+++ b/substrate/frame/alliance/src/benchmarking.rs
@@ -782,7 +782,7 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn add_scrupulous_items(
+	fn add_unscrupulous_items(
 		n: Linear<0, { T::MaxUnscrupulousItems::get() }>,
 		l: Linear<0, { T::MaxWebsiteUrlLength::get() }>,
 	) -> Result<(), BenchmarkError> {


### PR DESCRIPTION
A quick fix where a benchmark test was wrongly renamed in this PR https://github.com/paritytech/polkadot-sdk/pull/1868