### PR TITLE
minor: overseer availability-distribution message declaration update

### DIFF
--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -498,7 +498,6 @@ pub struct Overseer<SupportsParachains> {
 
 	#[subsystem(AvailabilityDistributionMessage, sends: [
 		AvailabilityStoreMessage,
-		AvailabilityRecoveryMessage,
 		ChainApiMessage,
 		RuntimeApiMessage,
 		NetworkBridgeTxMessage,


### PR DESCRIPTION
availability-distribution subsystem is not sending availability-recovery messages. Update the overseer declaration to reflect this