### PR TITLE
zombienet_tests: Fix genesis error in 0006-parachains-max-tranche0.toml

### DIFF
--- a/polkadot/zombienet_tests/functional/0006-parachains-max-tranche0.toml
+++ b/polkadot/zombienet_tests/functional/0006-parachains-max-tranche0.toml
@@ -2,7 +2,7 @@
 timeout = 1000
 bootnode = true
 
-[relaychain.genesis.runtime.configuration.config]
+[relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1
   needed_approvals = 7
   relay_vrf_modulo_samples = 5


### PR DESCRIPTION
There was a race in merging between https://github.com/paritytech/polkadot-sdk/pull/1256 and https://github.com/paritytech/polkadot-sdk/pull/1178, so this newly added tests wasn't updated with the new path for the configuration, so fix that.

