### PR TITLE
[testnets][xcm-emulator] add bridge-hub-westend and hook it up to emulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,6 +2299,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bridge-hub-westend-integration-tests"
+version = "1.0.0"
+dependencies = [
+ "asset-test-utils",
+ "bp-messages",
+ "bridge-hub-westend-runtime",
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-xcmp-queue",
+ "frame-support",
+ "frame-system",
+ "integration-tests-common",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-bridge-messages",
+ "pallet-message-queue",
+ "pallet-xcm",
+ "parachains-common",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-parachains",
+ "sp-core",
+ "sp-weights",
+ "staging-xcm",
+ "staging-xcm-executor",
+ "xcm-emulator",
+]
+
+[[package]]
 name = "bridge-hub-westend-runtime"
 version = "0.1.0"
 dependencies = [
@@ -6717,6 +6746,7 @@ dependencies = [
  "bridge-hub-kusama-runtime",
  "bridge-hub-polkadot-runtime",
  "bridge-hub-rococo-runtime",
+ "bridge-hub-westend-runtime",
  "bridge-runtime-common",
  "collectives-polkadot-runtime",
  "cumulus-pallet-parachain-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ members = [
 	"cumulus/parachains/integration-tests/emulated/assets/asset-hub-rococo",
 	"cumulus/parachains/integration-tests/emulated/assets/asset-hub-westend",
 	"cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-rococo",
+	"cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend",
 	"cumulus/parachains/integration-tests/emulated/common",
 	"cumulus/parachains/pallets/collective-content",
 	"cumulus/parachains/pallets/parachain-info",

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "bridge-hub-rococo-integration-tests"
+name = "bridge-hub-westend-integration-tests"
 version = "1.0.0"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
-description = "Bridge Hub Rococo runtime integration tests with xcm-emulator"
+description = "Bridge Hub Westend runtime integration tests with xcm-emulator"
 publish = false
 
 [dependencies]
@@ -34,7 +34,7 @@ cumulus-pallet-xcmp-queue = { path = "../../../../../pallets/xcmp-queue", defaul
 cumulus-pallet-dmp-queue = { path = "../../../../../pallets/dmp-queue", default-features = false}
 pallet-bridge-messages = { path = "../../../../../../bridges/modules/messages", default-features = false}
 bp-messages = { path = "../../../../../../bridges/primitives/messages", default-features = false}
-bridge-hub-rococo-runtime = { path = "../../../../../parachains/runtimes/bridge-hubs/bridge-hub-rococo", default-features = false }
+bridge-hub-westend-runtime = { path = "../../../../../parachains/runtimes/bridge-hubs/bridge-hub-westend", default-features = false }
 
 # Local
 xcm-emulator = { path = "../../../../../xcm/xcm-emulator", default-features = false}

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "bridge-hub-rococo-integration-tests"
+version = "1.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+description = "Bridge Hub Rococo runtime integration tests with xcm-emulator"
+publish = false
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+
+# Substrate
+frame-support = { path = "../../../../../../substrate/frame/support", default-features = false}
+frame-system = { path = "../../../../../../substrate/frame/system", default-features = false}
+sp-core = { path = "../../../../../../substrate/primitives/core", default-features = false}
+sp-weights = { path = "../../../../../../substrate/primitives/weights", default-features = false}
+pallet-balances = { path = "../../../../../../substrate/frame/balances", default-features = false}
+pallet-assets = { path = "../../../../../../substrate/frame/assets", default-features = false}
+pallet-message-queue = { path = "../../../../../../substrate/frame/message-queue", default-features = false }
+
+# Polkadot
+polkadot-core-primitives = { path = "../../../../../../polkadot/core-primitives", default-features = false}
+polkadot-parachain-primitives = { path = "../../../../../../polkadot/parachain", default-features = false}
+polkadot-runtime-parachains = { path = "../../../../../../polkadot/runtime/parachains" }
+xcm = { package = "staging-xcm", path = "../../../../../../polkadot/xcm", default-features = false}
+pallet-xcm = { path = "../../../../../../polkadot/xcm/pallet-xcm", default-features = false}
+xcm-executor = { package = "staging-xcm-executor",  path = "../../../../../../polkadot/xcm/xcm-executor", default-features = false}
+
+# Cumulus
+asset-test-utils = { path = "../../../../../parachains/runtimes/assets/test-utils", default-features = false }
+parachains-common = { path = "../../../../common" }
+cumulus-pallet-xcmp-queue = { path = "../../../../../pallets/xcmp-queue", default-features = false}
+cumulus-pallet-dmp-queue = { path = "../../../../../pallets/dmp-queue", default-features = false}
+pallet-bridge-messages = { path = "../../../../../../bridges/modules/messages", default-features = false}
+bp-messages = { path = "../../../../../../bridges/primitives/messages", default-features = false}
+bridge-hub-rococo-runtime = { path = "../../../../../parachains/runtimes/bridge-hubs/bridge-hub-rococo", default-features = false }
+
+# Local
+xcm-emulator = { path = "../../../../../xcm/xcm-emulator", default-features = false}
+integration-tests-common = { path = "../../common", default-features = false}

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/lib.rs
@@ -1,0 +1,67 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use bp_messages::LaneId;
+pub use frame_support::assert_ok;
+pub use integration_tests_common::{
+	constants::{
+		bridge_hub_rococo::ED as BRIDGE_HUB_ROCOCO_ED, rococo::ED as ROCOCO_ED,
+		PROOF_SIZE_THRESHOLD, REF_TIME_THRESHOLD, XCM_V3,
+	},
+	test_parachain_is_trusted_teleporter,
+	xcm_helpers::{xcm_transact_paid_execution, xcm_transact_unpaid_execution},
+	AssetHubRococo, AssetHubRococoReceiver, AssetHubWococo, BridgeHubRococo, BridgeHubRococoPallet,
+	BridgeHubRococoSender, BridgeHubWococo, PenpalRococoA, Rococo, RococoPallet,
+};
+pub use parachains_common::{AccountId, Balance};
+pub use xcm::{
+	prelude::{AccountId32 as AccountId32Junction, *},
+	v3::{
+		Error,
+		NetworkId::{Rococo as RococoId, Wococo as WococoId},
+	},
+};
+pub use xcm_emulator::{
+	assert_expected_events, bx, helpers::weight_within_threshold, Chain, Parachain as Para,
+	RelayChain as Relay, Test, TestArgs, TestContext, TestExt,
+};
+
+pub const ASSET_ID: u32 = 1;
+pub const ASSET_MIN_BALANCE: u128 = 1000;
+pub const ASSETS_PALLET_ID: u8 = 50;
+
+pub type RelayToSystemParaTest = Test<Rococo, AssetHubRococo>;
+pub type SystemParaToRelayTest = Test<AssetHubRococo, Rococo>;
+pub type SystemParaToParaTest = Test<AssetHubRococo, PenpalRococoA>;
+
+/// Returns a `TestArgs` instance to de used for the Relay Chain accross integraton tests
+pub fn relay_test_args(amount: Balance) -> TestArgs {
+	TestArgs {
+		dest: Rococo::child_location_of(AssetHubRococo::para_id()),
+		beneficiary: AccountId32Junction {
+			network: None,
+			id: AssetHubRococoReceiver::get().into(),
+		}
+		.into(),
+		amount,
+		assets: (Here, amount).into(),
+		asset_id: None,
+		fee_asset_item: 0,
+		weight_limit: WeightLimit::Unlimited,
+	}
+}
+
+#[cfg(test)]
+mod tests;

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/lib.rs
@@ -17,20 +17,20 @@ pub use bp_messages::LaneId;
 pub use frame_support::assert_ok;
 pub use integration_tests_common::{
 	constants::{
-		bridge_hub_rococo::ED as BRIDGE_HUB_ROCOCO_ED, rococo::ED as ROCOCO_ED,
+		bridge_hub_westend::ED as BRIDGE_HUB_WESTEND_ED, westend::ED as WESTEND_ED,
 		PROOF_SIZE_THRESHOLD, REF_TIME_THRESHOLD, XCM_V3,
 	},
 	test_parachain_is_trusted_teleporter,
 	xcm_helpers::{xcm_transact_paid_execution, xcm_transact_unpaid_execution},
-	AssetHubRococo, AssetHubRococoReceiver, AssetHubWococo, BridgeHubRococo, BridgeHubRococoPallet,
-	BridgeHubRococoSender, BridgeHubWococo, PenpalRococoA, Rococo, RococoPallet,
+	AssetHubRococo, AssetHubWestend, AssetHubWestendReceiver, BridgeHubRococo, BridgeHubWestend,
+	BridgeHubWestendPallet, BridgeHubWestendSender, PenpalWestendA, Westend, WestendPallet,
 };
 pub use parachains_common::{AccountId, Balance};
 pub use xcm::{
 	prelude::{AccountId32 as AccountId32Junction, *},
 	v3::{
 		Error,
-		NetworkId::{Rococo as RococoId, Wococo as WococoId},
+		NetworkId::{Rococo as RococoId, Westend as WestendId},
 	},
 };
 pub use xcm_emulator::{
@@ -42,17 +42,17 @@ pub const ASSET_ID: u32 = 1;
 pub const ASSET_MIN_BALANCE: u128 = 1000;
 pub const ASSETS_PALLET_ID: u8 = 50;
 
-pub type RelayToSystemParaTest = Test<Rococo, AssetHubRococo>;
-pub type SystemParaToRelayTest = Test<AssetHubRococo, Rococo>;
-pub type SystemParaToParaTest = Test<AssetHubRococo, PenpalRococoA>;
+pub type RelayToSystemParaTest = Test<Westend, AssetHubWestend>;
+pub type SystemParaToRelayTest = Test<AssetHubWestend, Westend>;
+pub type SystemParaToParaTest = Test<AssetHubWestend, PenpalWestendA>;
 
 /// Returns a `TestArgs` instance to de used for the Relay Chain accross integraton tests
 pub fn relay_test_args(amount: Balance) -> TestArgs {
 	TestArgs {
-		dest: Rococo::child_location_of(AssetHubRococo::para_id()),
+		dest: Westend::child_location_of(AssetHubWestend::para_id()),
 		beneficiary: AccountId32Junction {
 			network: None,
-			id: AssetHubRococoReceiver::get().into(),
+			id: AssetHubWestendReceiver::get().into(),
 		}
 		.into(),
 		amount,

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/example.rs
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/example.rs
@@ -1,0 +1,100 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::*;
+
+#[test]
+fn example() {
+	// Init tests variables
+	// XcmPallet send arguments
+	let sudo_origin = <Rococo as Chain>::RuntimeOrigin::root();
+	let destination = Rococo::child_location_of(BridgeHubRococo::para_id()).into();
+	let weight_limit = WeightLimit::Unlimited;
+	let check_origin = None;
+
+	let remote_xcm = Xcm(vec![ClearOrigin]);
+
+	let xcm = VersionedXcm::from(Xcm(vec![
+		UnpaidExecution { weight_limit, check_origin },
+		ExportMessage {
+			network: WococoId,
+			destination: X1(Parachain(AssetHubWococo::para_id().into())),
+			xcm: remote_xcm,
+		},
+	]));
+
+	//Rococo Global Consensus
+	// Send XCM message from Relay Chain to Bridge Hub source Parachain
+	Rococo::execute_with(|| {
+		assert_ok!(<Rococo as RococoPallet>::XcmPallet::send(
+			sudo_origin,
+			bx!(destination),
+			bx!(xcm),
+		));
+
+		type RuntimeEvent = <Rococo as Chain>::RuntimeEvent;
+
+		assert_expected_events!(
+			Rococo,
+			vec![
+				RuntimeEvent::XcmPallet(pallet_xcm::Event::Sent { .. }) => {},
+			]
+		);
+	});
+	// Receive XCM message in Bridge Hub source Parachain
+	BridgeHubRococo::execute_with(|| {
+		type RuntimeEvent = <BridgeHubRococo as Chain>::RuntimeEvent;
+
+		assert_expected_events!(
+			BridgeHubRococo,
+			vec![
+				RuntimeEvent::MessageQueue(pallet_message_queue::Event::Processed {
+					success: true,
+					..
+				}) => {},
+				RuntimeEvent::BridgeWococoMessages(pallet_bridge_messages::Event::MessageAccepted {
+					lane_id: LaneId([0, 0, 0, 1]),
+					nonce: 1,
+				}) => {},
+			]
+		);
+	});
+
+	// Wococo GLobal Consensus
+	// Receive XCM message in Bridge Hub target Parachain
+	BridgeHubWococo::execute_with(|| {
+		type RuntimeEvent = <BridgeHubWococo as Chain>::RuntimeEvent;
+
+		assert_expected_events!(
+			BridgeHubWococo,
+			vec![
+				RuntimeEvent::XcmpQueue(cumulus_pallet_xcmp_queue::Event::XcmpMessageSent { .. }) => {},
+			]
+		);
+	});
+	// Receive embeded XCM message within `ExportMessage` in Parachain destination
+	AssetHubWococo::execute_with(|| {
+		type RuntimeEvent = <AssetHubWococo as Chain>::RuntimeEvent;
+
+		assert_expected_events!(
+			AssetHubWococo,
+			vec![
+				RuntimeEvent::MessageQueue(pallet_message_queue::Event::ProcessingFailed {
+					..
+				}) => {},
+			]
+		);
+	});
+}

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/mod.rs
@@ -1,0 +1,17 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod example;
+mod teleport;

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/teleport.rs
@@ -1,0 +1,30 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::*;
+use bridge_hub_rococo_runtime::xcm_config::XcmConfig;
+
+#[test]
+fn teleport_to_other_system_parachains_works() {
+	let amount = BRIDGE_HUB_ROCOCO_ED * 100;
+	let native_asset: MultiAssets = (Parent, amount).into();
+
+	test_parachain_is_trusted_teleporter!(
+		BridgeHubRococo,      // Origin
+		XcmConfig,            // XCM configuration
+		vec![AssetHubRococo], // Destinations
+		(native_asset, amount)
+	);
+}

--- a/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/bridges/bridge-hub-westend/src/tests/teleport.rs
@@ -14,17 +14,17 @@
 // limitations under the License.
 
 use crate::*;
-use bridge_hub_rococo_runtime::xcm_config::XcmConfig;
+use bridge_hub_westend_runtime::xcm_config::XcmConfig;
 
 #[test]
 fn teleport_to_other_system_parachains_works() {
-	let amount = BRIDGE_HUB_ROCOCO_ED * 100;
+	let amount = BRIDGE_HUB_WESTEND_ED * 100;
 	let native_asset: MultiAssets = (Parent, amount).into();
 
 	test_parachain_is_trusted_teleporter!(
-		BridgeHubRococo,      // Origin
-		XcmConfig,            // XCM configuration
-		vec![AssetHubRococo], // Destinations
+		BridgeHubWestend,      // Origin
+		XcmConfig,             // XCM configuration
+		vec![AssetHubWestend], // Destinations
 		(native_asset, amount)
 	);
 }

--- a/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
@@ -52,6 +52,7 @@ collectives-polkadot-runtime = { path = "../../../runtimes/collectives/collectiv
 bridge-hub-kusama-runtime = { path = "../../../runtimes/bridge-hubs/bridge-hub-kusama" }
 bridge-hub-polkadot-runtime = { path = "../../../runtimes/bridge-hubs/bridge-hub-polkadot" }
 bridge-hub-rococo-runtime = { path = "../../../runtimes/bridge-hubs/bridge-hub-rococo" }
+bridge-hub-westend-runtime = { path = "../../../runtimes/bridge-hubs/bridge-hub-westend" }
 xcm-emulator = { default-features = false, path = "../../../../xcm/xcm-emulator" }
 cumulus-pallet-xcmp-queue = { default-features = false, path = "../../../../pallets/xcmp-queue" }
 cumulus-pallet-parachain-system = { path = "../../../../pallets/parachain-system" }
@@ -68,6 +69,7 @@ runtime-benchmarks = [
 	"bridge-hub-kusama-runtime/runtime-benchmarks",
 	"bridge-hub-polkadot-runtime/runtime-benchmarks",
 	"bridge-hub-rococo-runtime/runtime-benchmarks",
+	"bridge-hub-westend-runtime/runtime-benchmarks",
 	"bridge-runtime-common/runtime-benchmarks",
 	"collectives-polkadot-runtime/runtime-benchmarks",
 	"cumulus-pallet-parachain-system/runtime-benchmarks",

--- a/cumulus/parachains/integration-tests/emulated/common/src/constants.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/constants.rs
@@ -1160,3 +1160,60 @@ pub mod bridge_hub_rococo {
 		}
 	}
 }
+
+// Bridge Hub Westend
+pub mod bridge_hub_westend {
+	use super::*;
+	pub const PARA_ID: u32 = 1013;
+	pub const ED: Balance = parachains_common::westend::currency::EXISTENTIAL_DEPOSIT;
+
+	pub fn genesis() -> Storage {
+		let genesis_config = serde_json::json!({
+			"balances": {
+				"balances": accounts::init_balances()
+					.iter()
+					.cloned()
+					.map(|k| (k, ED * 4096))
+					.collect::<Vec<_>>(),
+			},
+			"parachainInfo": {
+				"parachainId": cumulus_primitives_core::ParaId::from(PARA_ID),
+			},
+			"collatorSelection": {
+				"invulnerables": collators::invulnerables()
+					.iter()
+					.cloned()
+					.map(|(acc, _)| acc)
+					.collect::<Vec<_>>(),
+				"candidacyBond": ED * 16,
+			},
+			"session": {
+				"keys": collators::invulnerables()
+					.into_iter()
+					.map(|(acc, aura)| {
+						(
+							acc.clone(),                                     // account id
+							acc,                                             // validator id
+							bridge_hub_westend_runtime::SessionKeys { aura }, // session keys
+						)
+					})
+					.collect::<Vec<_>>(),
+			},
+			"polkadotXcm": {
+				"safeXcmVersion": Some(SAFE_XCM_VERSION),
+			},
+			"bridgeRococoGrandpa": {
+				"owner": Some(get_account_id_from_seed::<sr25519::Public>(accounts::BOB)),
+			},
+			"bridgeRococoMessages": {
+				"owner": Some(get_account_id_from_seed::<sr25519::Public>(accounts::BOB)),
+			}
+		});
+
+		build_genesis_storage(
+			genesis_config,
+			bridge_hub_westend_runtime::WASM_BINARY
+				.expect("WASM binary was not built, please build it!"),
+		)
+	}
+}

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -20,8 +20,8 @@ pub mod xcm_helpers;
 
 use constants::{
 	accounts::{ALICE, BOB},
-	asset_hub_rococo, asset_hub_westend, asset_hub_wococo, bridge_hub_rococo, penpal, rococo,
-	westend,
+	asset_hub_rococo, asset_hub_westend, asset_hub_wococo, bridge_hub_rococo, bridge_hub_westend,
+	penpal, rococo, westend,
 };
 use impls::{RococoWococoMessageHandler, WococoRococoMessageHandler};
 pub use paste;
@@ -116,6 +116,23 @@ decl_test_parachains! {
 			ForeignAssets: asset_hub_westend_runtime::ForeignAssets,
 			PoolAssets: asset_hub_westend_runtime::PoolAssets,
 			AssetConversion: asset_hub_westend_runtime::AssetConversion,
+		}
+	},
+	pub struct BridgeHubWestend {
+		genesis = bridge_hub_westend::genesis(),
+		on_init = {
+			bridge_hub_westend_runtime::AuraExt::on_initialize(1);
+		},
+		runtime = bridge_hub_westend_runtime,
+		core = {
+			XcmpMessageHandler: bridge_hub_westend_runtime::XcmpQueue,
+			LocationToAccountId: bridge_hub_westend_runtime::xcm_config::LocationToAccountId,
+			ParachainInfo: bridge_hub_westend_runtime::ParachainInfo,
+			MessageProcessor: DefaultParaMessageProcessor<BridgeHubWestend>,
+		},
+		pallets = {
+			PolkadotXcm: bridge_hub_westend_runtime::PolkadotXcm,
+			Balances: bridge_hub_westend_runtime::Balances,
 		}
 	},
 	pub struct PenpalWestendA {
@@ -257,6 +274,7 @@ decl_test_networks! {
 		relay_chain = Westend,
 		parachains = vec![
 			AssetHubWestend,
+			BridgeHubWestend,
 			PenpalWestendA,
 		],
 		bridge = ()
@@ -323,6 +341,10 @@ impl_assert_events_helpers_for_parachain!(AssetHubRococo);
 // PenpalWestendA implementation
 impl_assert_events_helpers_for_parachain!(PenpalWestendA);
 
+// BridgeHubWestend implementation
+impl_accounts_helpers_for_parachain!(BridgeHubWestend);
+impl_assert_events_helpers_for_parachain!(BridgeHubWestend);
+
 // BridgeHubRococo implementation
 impl_accounts_helpers_for_parachain!(BridgeHubRococo);
 impl_assert_events_helpers_for_parachain!(BridgeHubRococo);
@@ -343,6 +365,7 @@ decl_test_sender_receiver_accounts_parameter_types! {
 	// Bridged Hubs
 	BridgeHubRococo { sender: ALICE, receiver: BOB },
 	BridgeHubWococo { sender: ALICE, receiver: BOB },
+	BridgeHubWestend { sender: ALICE, receiver: BOB },
 	// Penpals
 	PenpalWestendA { sender: ALICE, receiver: BOB },
 	PenpalRococoA { sender: ALICE, receiver: BOB },

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -29,6 +29,7 @@ pallet-aura = { path = "../../../../../substrate/frame/aura", default-features =
 pallet-authorship = { path = "../../../../../substrate/frame/authorship", default-features = false}
 pallet-balances = { path = "../../../../../substrate/frame/balances", default-features = false}
 pallet-session = { path = "../../../../../substrate/frame/session", default-features = false}
+pallet-message-queue = { path = "../../../../../substrate/frame/message-queue", default-features = false }
 pallet-multisig = { path = "../../../../../substrate/frame/multisig", default-features = false}
 pallet-timestamp = { path = "../../../../../substrate/frame/timestamp", default-features = false}
 pallet-transaction-payment = { path = "../../../../../substrate/frame/transaction-payment", default-features = false}
@@ -62,7 +63,6 @@ xcm-executor = { package = "staging-xcm-executor", path = "../../../../../polkad
 
 # Cumulus
 cumulus-pallet-aura-ext = { path = "../../../../pallets/aura-ext", default-features = false }
-pallet-message-queue = { path = "../../../../../substrate/frame/message-queue", default-features = false }
 cumulus-pallet-dmp-queue = { path = "../../../../pallets/dmp-queue", default-features = false }
 cumulus-pallet-parachain-system = { path = "../../../../pallets/parachain-system", default-features = false, features = ["parameterized-consensus-hook",] }
 cumulus-pallet-session-benchmarking = { path = "../../../../pallets/session-benchmarking", default-features = false}


### PR DESCRIPTION
`bridge-hub-westend-runtime` was added to cumulus/parachains, but wasn't hooked up to xcm-emulator to run tests against it.

This PR addresses that ^.