### PR TITLE
Fix "slashaed" typo

### DIFF
--- a/substrate/frame/referenda/src/lib.rs
+++ b/substrate/frame/referenda/src/lib.rs
@@ -305,7 +305,7 @@ pub mod pallet {
 			/// The amount placed by the account.
 			amount: BalanceOf<T, I>,
 		},
-		/// A deposit has been slashaed.
+		/// A deposit has been slashed.
 		DepositSlashed {
 			/// The account who placed the deposit.
 			who: T::AccountId,


### PR DESCRIPTION

# Description

This merely fixes a typo in the documentation, replacing the typo "slashaed" with "slashed". Since external entities use the comments for explanations of events, this will then be shown externally. I noticed this when reviewing [this event](https://polkadot.subscan.io/extrinsic/0xb6bc1e3abde0c2ed9c500c74cfc64cdb8179e5d9af97f4bf53242ce4cdd15a1d?event=18064194-6) on Subscan.

This is not related to any other issues or PRs.