### PR TITLE
[pallet-message-queue] Implement impl_trait_for_tuples for QueuePausedQuery

### DIFF
--- a/substrate/frame/support/src/traits/messages.rs
+++ b/substrate/frame/support/src/traits/messages.rs
@@ -240,8 +240,14 @@ pub trait QueuePausedQuery<Origin> {
 	fn is_paused(origin: &Origin) -> bool;
 }
 
-impl<Origin> QueuePausedQuery<Origin> for () {
-	fn is_paused(_: &Origin) -> bool {
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl<Origin> QueuePausedQuery<Origin> for Tuple {
+	fn is_paused(origin: &Origin) -> bool {
+		for_tuples!( #(
+			if Tuple::is_paused(origin) {
+				return true;
+			}
+		)* );
 		false
 	}
 }

--- a/substrate/frame/support/src/traits/messages.rs
+++ b/substrate/frame/support/src/traits/messages.rs
@@ -240,7 +240,7 @@ pub trait QueuePausedQuery<Origin> {
 	fn is_paused(origin: &Origin) -> bool;
 }
 
-#[impl_trait_for_tuples::impl_for_tuples(30)]
+#[impl_trait_for_tuples::impl_for_tuples(8)]
 impl<Origin> QueuePausedQuery<Origin> for Tuple {
 	fn is_paused(origin: &Origin) -> bool {
 		for_tuples!( #(


### PR DESCRIPTION
These changes are required so that the bridgehub system runtimes can more easily be configured with multiple message processors

Example usage:

```rust
use frame_support::traits::QueuePausedQuery;

impl pallet_message_queue::Config for Runtime {
    type QueuePausedQuery = (A, B, C)
}