### PR TITLE
Rococo: Build two versions of the wasm binary

### DIFF
--- a/polkadot/node/service/src/chain_spec.rs
+++ b/polkadot/node/service/src/chain_spec.rs
@@ -1068,7 +1068,7 @@ fn rococo_local_testnet_genesis() -> serde_json::Value {
 #[cfg(feature = "rococo-native")]
 pub fn rococo_local_testnet_config() -> Result<RococoChainSpec, String> {
 	Ok(RococoChainSpec::builder(
-		rococo::WASM_BINARY.ok_or("Rococo development wasm not available")?,
+		rococo::fast_runtime_binary::WASM_BINARY.ok_or("Rococo development wasm not available")?,
 		Default::default(),
 	)
 	.with_name("Rococo Local Testnet")

--- a/polkadot/runtime/rococo/build.rs
+++ b/polkadot/runtime/rococo/build.rs
@@ -16,16 +16,19 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	// note: needs to be synced with rococo-runtime-constants::time hard-coded string literal
-	const ROCOCO_EPOCH_DURATION_ENV: &str = "ROCOCO_EPOCH_DURATION";
-
 	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.import_memory()
 		.export_heap_base()
 		.build();
 
-	println!("cargo:rerun-if-env-changed={}", ROCOCO_EPOCH_DURATION_ENV);
+	substrate_wasm_builder::WasmBuilder::new()
+		.with_current_project()
+		.set_file_name("fast_runtime_binary.rs")
+		.enable_feature("fast-runtime")
+		.import_memory()
+		.export_heap_base()
+		.build();
 }
 
 #[cfg(not(feature = "std"))]

--- a/polkadot/runtime/rococo/constants/src/lib.rs
+++ b/polkadot/runtime/rococo/constants/src/lib.rs
@@ -37,14 +37,15 @@ pub mod currency {
 
 /// Time and blocks.
 pub mod time {
+	use runtime_common::prod_or_fast;
+
 	use primitives::{BlockNumber, Moment};
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
 
 	frame_support::parameter_types! {
-		pub storage EpochDurationInBlocks: BlockNumber = option_env!("ROCOCO_EPOCH_DURATION")
-			.map(|s| s.parse().expect("`ROCOCO_EPOCH_DURATION` is not a valid `BlockNumber`"))
-			.unwrap_or(1 * MINUTES);
+		pub EpochDurationInBlocks: BlockNumber =
+			prod_or_fast!(1 * HOURS, 1 * MINUTES, "ROCOCO_EPOCH_DURATION");
 	}
 
 	// These time units are defined in number of blocks.

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -131,6 +131,14 @@ impl_runtime_weights!(rococo_runtime_constants);
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+/// Provides the `WASM_BINARY` build with `fast-runtime` feature enabled.
+///
+/// This is for example useful for local test chains.
+#[cfg(feature = "std")]
+pub mod fast_runtime_binary {
+	include!(concat!(env!("OUT_DIR"), "/fast_runtime_binary.rs"));
+}
+
 /// Runtime version (Rococo).
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {


### PR DESCRIPTION
One for local networks with `fast-runtime` feature activated (1 minute sessions) and one without the feature activated that will be the default that runs with 1 hour long sessions.

