### PR TITLE
integrations-test: `build_genesis_storage` name fix

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/genesis.rs
@@ -18,7 +18,7 @@ use sp_core::storage::Storage;
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, collators, SAFE_XCM_VERSION,
+	accounts, build_genesis_storage, collators, SAFE_XCM_VERSION,
 };
 use parachains_common::Balance;
 
@@ -63,7 +63,7 @@ pub fn genesis() -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(
+	build_genesis_storage(
 		&genesis_config,
 		asset_hub_rococo_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
 	)

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/genesis.rs
@@ -18,7 +18,7 @@ use sp_core::storage::Storage;
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, collators, SAFE_XCM_VERSION,
+	accounts, build_genesis_storage, collators, SAFE_XCM_VERSION,
 };
 use parachains_common::Balance;
 
@@ -59,7 +59,7 @@ pub fn genesis() -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(
+	build_genesis_storage(
 		&genesis_config,
 		asset_hub_westend_runtime::WASM_BINARY
 			.expect("WASM binary was not built, please build it!"),

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo/src/genesis.rs
@@ -18,7 +18,7 @@ use sp_core::{sr25519, storage::Storage};
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, collators, get_account_id_from_seed, SAFE_XCM_VERSION,
+	accounts, build_genesis_storage, collators, get_account_id_from_seed, SAFE_XCM_VERSION,
 };
 use parachains_common::Balance;
 
@@ -75,7 +75,7 @@ pub fn genesis() -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(
+	build_genesis_storage(
 		&genesis_config,
 		bridge_hub_rococo_runtime::WASM_BINARY
 			.expect("WASM binary was not built, please build it!"),

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-westend/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-westend/src/genesis.rs
@@ -18,7 +18,7 @@ use sp_core::{sr25519, storage::Storage};
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, collators, get_account_id_from_seed, SAFE_XCM_VERSION,
+	accounts, build_genesis_storage, collators, get_account_id_from_seed, SAFE_XCM_VERSION,
 };
 use parachains_common::Balance;
 
@@ -67,7 +67,7 @@ pub fn genesis() -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(
+	build_genesis_storage(
 		&genesis_config,
 		bridge_hub_westend_runtime::WASM_BINARY
 			.expect("WASM binary was not built, please build it!"),

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/genesis.rs
@@ -18,7 +18,7 @@ use sp_core::{sr25519, storage::Storage};
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, collators, get_account_id_from_seed, SAFE_XCM_VERSION,
+	accounts, build_genesis_storage, collators, get_account_id_from_seed, SAFE_XCM_VERSION,
 };
 use parachains_common::Balance;
 
@@ -64,7 +64,7 @@ pub fn genesis(para_id: u32) -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(
+	build_genesis_storage(
 		&genesis_config,
 		penpal_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
 	)

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/genesis.rs
@@ -26,8 +26,8 @@ use polkadot_primitives::{AssignmentId, ValidatorId};
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, get_account_id_from_seed, get_from_seed,
-	get_host_config, validators,
+	accounts, build_genesis_storage, get_account_id_from_seed, get_from_seed, get_host_config,
+	validators,
 };
 use parachains_common::Balance;
 use rococo_runtime_constants::currency::UNITS as ROC;
@@ -97,5 +97,5 @@ pub fn genesis() -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(&genesis_config, rococo_runtime::WASM_BINARY.unwrap())
+	build_genesis_storage(&genesis_config, rococo_runtime::WASM_BINARY.unwrap())
 }

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/genesis.rs
@@ -27,7 +27,7 @@ use polkadot_primitives::{AssignmentId, ValidatorId};
 
 // Cumulus
 use emulated_integration_tests_common::{
-	accounts, build_genesis_storage_legacy, get_from_seed, get_host_config, validators,
+	accounts, build_genesis_storage, get_from_seed, get_host_config, validators,
 };
 use parachains_common::Balance;
 use westend_runtime_constants::currency::UNITS as WND;
@@ -105,5 +105,5 @@ pub fn genesis() -> Storage {
 		..Default::default()
 	};
 
-	build_genesis_storage_legacy(&genesis_config, westend_runtime::WASM_BINARY.unwrap())
+	build_genesis_storage(&genesis_config, westend_runtime::WASM_BINARY.unwrap())
 }

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -86,7 +86,7 @@ pub fn get_host_config() -> HostConfiguration<BlockNumber> {
 /// Helper function used in tests to build the genesis storage using given RuntimeGenesisConfig and
 /// code Used in `legacy_vs_json_check` submods to verify storage building with JSON patch against
 /// building with RuntimeGenesisConfig struct.
-pub fn build_genesis_storage_legacy(builder: &dyn BuildStorage, code: &[u8]) -> Storage {
+pub fn build_genesis_storage(builder: &dyn BuildStorage, code: &[u8]) -> Storage {
 	let mut storage = builder.build_storage().unwrap();
 	storage
 		.top


### PR DESCRIPTION
Some legacy tests were mistakenly merged in #1256 for `emulated-integration-tests-common` crate.
This PR fixes the function name `build_genesis_storage`  (no need to use `legacy` suffix, even though the genesis is built from `RuntimeGenesisConfig`).