### PR TITLE
Set parachain-system inherent weights hint to max block weights

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -526,7 +526,7 @@ pub mod pallet {
 		/// As a side effect, this function upgrades the current validation function
 		/// if the appropriate time has come.
 		#[pallet::call_index(0)]
-		#[pallet::weight((0, DispatchClass::Mandatory))]
+		#[pallet::weight((<T as frame_system::Config>::BlockWeights::get().max_block, DispatchClass::Mandatory))]
 		// TODO: This weight should be corrected.
 		pub fn set_validation_data(
 			origin: OriginFor<T>,


### PR DESCRIPTION
The inherent `parachainSystem.setValdiationData` have a zero weights hint, which is problematic because even if the actual consumed weights are correctly returned in the `actual_weight` field, this is not taken into account by `CheckWeight`'s `post_dispatch` logic, so the collator does not consider the blockspace occupied by the parachain-system inherent.

The cleanest solution would be to refactor the substrate weights accounting logic for mandatory inherents, as it makes no sense to have a weight hint for mandatory inherents, because like hooks they must be executed regardless of the weight they consume.

But such refactoring can be complex and add other bugs. A simpler solution is to set the weight hint of mandatory inherents to the maximum weight of the block, so we can be sure that the `actual_weight` value returned will be taken into account when calculating the remaining space for extrinsics.
