### PR TITLE
Remove unnecessary map_error

### DIFF
--- a/polkadot/xcm/xcm-builder/src/routing.rs
+++ b/polkadot/xcm/xcm-builder/src/routing.rs
@@ -49,8 +49,7 @@ impl<Inner: SendXcm> SendXcm for WithUniqueTopic<Inner> {
 			message.0.push(SetTopic(unique_id));
 			unique_id
 		};
-		let (ticket, assets) = Inner::validate(destination, &mut Some(message))
-			.map_err(|_| SendError::NotApplicable)?;
+		let (ticket, assets) = Inner::validate(destination, &mut Some(message))?;
 		Ok(((ticket, unique_id), assets))
 	}
 


### PR DESCRIPTION
This was discovered during a debugging session, and it only served to mask the underlying error, which was not great.