### PR TITLE
Give up liveness slashing

### DIFF
--- a/substrate/frame/im-online/src/lib.rs
+++ b/substrate/frame/im-online/src/lib.rs
@@ -855,15 +855,8 @@ impl<Offender: Clone> Offence<Offender> for UnresponsivenessOffence<Offender> {
 		DisableStrategy::Never
 	}
 
-	fn slash_fraction(&self, offenders: u32) -> Perbill {
-		// the formula is min((3 * (k - (n / 10 + 1))) / n, 1) * 0.07
-		// basically, 10% can be offline with no slash, but after that, it linearly climbs up to 7%
-		// when 13/30 are offline (around 5% when 1/3 are offline).
-		if let Some(threshold) = offenders.checked_sub(self.validator_set_count / 10 + 1) {
-			let x = Perbill::from_rational(3 * threshold, self.validator_set_count);
-			x.saturating_mul(Perbill::from_percent(7))
-		} else {
-			Perbill::default()
-		}
+	fn slash_fraction(&self, _offenders: u32) -> Perbill {
+		// We're not slashing for being offline anymore (see #1964)
+		Perbill::zero()
 	}
 }

--- a/substrate/frame/im-online/src/tests.rs
+++ b/substrate/frame/im-online/src/tests.rs
@@ -32,33 +32,6 @@ use sp_runtime::{
 };
 
 #[test]
-fn test_unresponsiveness_slash_fraction() {
-	let dummy_offence =
-		UnresponsivenessOffence { session_index: 0, validator_set_count: 50, offenders: vec![()] };
-	// A single case of unresponsiveness is not slashed.
-	assert_eq!(dummy_offence.slash_fraction(1), Perbill::zero());
-
-	assert_eq!(
-		dummy_offence.slash_fraction(5),
-		Perbill::zero(), // 0%
-	);
-
-	assert_eq!(
-		dummy_offence.slash_fraction(7),
-		Perbill::from_parts(4200000), // 0.42%
-	);
-
-	// One third offline should be punished around 5%.
-	assert_eq!(
-		dummy_offence.slash_fraction(17),
-		Perbill::from_parts(46200000), // 4.62%
-	);
-
-	// Offline offences should never lead to being disabled.
-	assert_eq!(dummy_offence.disable_strategy(), DisableStrategy::Never);
-}
-
-#[test]
 fn should_report_offline_validators() {
 	new_test_ext().execute_with(|| {
 		// given


### PR DESCRIPTION
In accordance with #1964, we give up liveness slashing. The first step is to always return zero offense threshold. This will be followed up by removing the `im-online` pallet entirely.