### PR TITLE
Move `AllPalletsWithSystem::decode_entire_state` to own runtime API

### DIFF
--- a/cumulus/parachain-template/runtime/src/lib.rs
+++ b/cumulus/parachain-template/runtime/src/lib.rs
@@ -722,6 +722,13 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
+
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-kusama/src/lib.rs
@@ -1188,6 +1188,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-polkadot/src/lib.rs
@@ -1070,6 +1070,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1303,6 +1303,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1285,6 +1285,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -658,6 +658,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -659,6 +659,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -921,6 +921,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -760,6 +760,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
@@ -927,6 +927,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -666,6 +666,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -801,6 +801,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2048,6 +2048,12 @@ sp_api::impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2130,6 +2130,12 @@ sp_api::impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/substrate/bin/node-template/runtime/src/lib.rs
+++ b/substrate/bin/node-template/runtime/src/lib.rs
@@ -579,6 +579,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).expect("execute-block failed")
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	impl sp_genesis_builder::GenesisBuilder<Block> for Runtime {

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2747,6 +2747,12 @@ impl_runtime_apis! {
 			// have a backtrace here.
 			Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()
 		}
+
+		fn decode_entire_state() {
+			// NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
+			// have a backtrace here.
+			Executive::try_decode_entire_state().unwrap()
+		}
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/substrate/frame/executive/src/lib.rs
+++ b/substrate/frame/executive/src/lib.rs
@@ -322,10 +322,6 @@ where
 			log::error!(target: LOG_TARGET, "failure: {:?}", e);
 			e
 		})?;
-		if select.any() {
-			let res = AllPalletsWithSystem::try_decode_entire_state();
-			Self::log_decode_result(res)?;
-		}
 		drop(_guard);
 
 		// do some of the checks that would normally happen in `final_checks`, but perhaps skip
@@ -362,6 +358,12 @@ where
 		Ok(frame_system::Pallet::<System>::block_weight().total())
 	}
 
+	pub fn try_decode_entire_state() -> Result<(), TryRuntimeError> {
+		let _ = frame_support::StorageNoopGuard::default();
+		let res = AllPalletsWithSystem::try_decode_entire_state();
+		Self::log_decode_result(res)
+	}
+
 	/// Execute all `OnRuntimeUpgrade` of this runtime.
 	///
 	/// The `checks` param determines whether to execute `pre/post_upgrade` and `try_state` hooks.
@@ -374,12 +376,6 @@ where
 			)?;
 		// Nothing should modify the state after the migrations ran:
 		let _guard = StorageNoopGuard::default();
-
-		// The state must be decodable:
-		if checks.any() {
-			let res = AllPalletsWithSystem::try_decode_entire_state();
-			Self::log_decode_result(res)?;
-		}
 
 		// Check all storage invariants:
 		if checks.try_state() {

--- a/substrate/frame/try-runtime/src/lib.rs
+++ b/substrate/frame/try-runtime/src/lib.rs
@@ -49,5 +49,10 @@ sp_api::decl_runtime_apis! {
 			signature_check: bool,
 			try_state: TryStateSelect,
 		) -> Weight;
+
+		/// Decode the state of all pallets in the runtime.
+		///
+		/// Panics and logs info to assist with debugging if any pallets are not decodable.
+		fn decode_entire_state();
 	}
 }


### PR DESCRIPTION
`AllPalletsWithSystem::decode_entire_state` is currently called in `Executive::try_runtime_upgrade` and `Executive::try_execute_block` if any checks are selected.

This is very inflexible and cripples the usefulness of existing runtime APIs if there are any issues with decoding the entire state, as we are currently seeing with Asset Hub Westend CI.

We need to make running these checks optional. 

Rather than add complexity to the existing runtime APIs to make the checks optional, in the spirit of @xlc's suggestions here https://github.com/paritytech/polkadot-sdk/issues/2108#issuecomment-1788277595, I've opted to create a new runtime api for these checks. This pushes the complexity of deciding whether and when to run the checks out of the runtime and into the caller (such as `try-runtime-cli`).

This approach seems cleaner to me. If in agreement, in the future we may wish to deprecate the existing `try-runtime` runtime APIs and replace them with simpler, minimal configuration runtime APIs that perform atomic pieces of work.