### PR TITLE
Add `ConsiderationFromLegacy` traits

### DIFF
--- a/substrate/frame/support/src/traits/tokens/fungible/mod.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/mod.rs
@@ -84,7 +84,10 @@ where
 {
 	/// Create a ticket for a `new` balance attributable to `who`. This ticket *must* ultimately
 	/// be consumed through `update` or `drop` once a footprint changes or is removed.
-	fn new_from_exact(_who: &A, _new: F::Balance) -> Result<Option<Self>, DispatchError> where Self: Sized {
+	fn new_from_exact(_who: &A, _new: F::Balance) -> Result<Option<Self>, DispatchError>
+	where
+		Self: Sized,
+	{
 		Ok(None)
 	}
 }
@@ -100,7 +103,10 @@ where
 {
 	/// Create a ticket for a `new` balance attributable to `who`. This ticket *must* ultimately
 	/// be consumed through `update` or `drop` once a footprint changes or is removed.
-	fn new_from_exact(_who: &A, _new: F::Balance) -> Result<Option<Self>, DispatchError> where Self: Sized {
+	fn new_from_exact(_who: &A, _new: F::Balance) -> Result<Option<Self>, DispatchError>
+	where
+		Self: Sized,
+	{
 		Ok(None)
 	}
 }


### PR DESCRIPTION
This PR addresses a potential issue that may arise when migrating pallets from using `Currency` to `Consideration`. It specifically addresses scenarios where a pallet's migrations involve a `Deposit` that hasn't been constant over time (e.g. increased by a runtime upgrade).

During the migration, the new `HoldConsideration` results in a fixed `Balance` based on a constant `Footprint` and a `Convert` function. For instance, if the new `HoldConsideration` is expected to have a `Balance` of `10`, what happens when, for a particular account, the stored `Deposit` is `5`? After calling `Currency::unreserve(account, 5)`, attempting to create a new ticket to hold a `Balance` of `10` might fail due to insufficient balance. Currently, `HoldConsideration::new()` returns either `Ok(())` or `Err`. What should be done if it's not possible to hold the balance?

Following a similar approach to https://github.com/paritytech/polkadot-sdk/pull/1813#issuecomment-1791081731, I introduced two new traits:
- `FreezeConsiderationFromLegacy`
- `HoldConsiderationFromLegacy`

These traits extend `Consideration` with a new method `new_from_exact()` which proves useful when a new ticket with a precise balance is needed (as illustrated in the migration example) rather than deriving it from a footprint.
