### PR TITLE
Add `s` utility function to frame support

### DIFF
--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -954,6 +954,23 @@ pub fn print(print: impl traits::Printable) {
 	print.print();
 }
 
+/// Utility function to declare string literals backed by an array of length N.
+/// The input can be shorter than N, in that case the end of the array is padded with zeros.
+///
+/// [`str_array`] is useful when converting strings that end up in the storage as fixed size arrays
+/// or in const contexts where static data types have strings that could also end up in the storage.
+pub const fn str_array<const N: usize>(s: &str) -> [u8; N] {
+	debug_assert!(s.len() <= N, "String literal doesn't fit in array");
+	let mut i = 0;
+	let mut arr = [0; N];
+	let s = s.as_bytes();
+	while i < s.len() {
+		arr[i] = s[i];
+		i += 1;
+	}
+	arr
+}
+
 /// Describes on what should happen with a storage transaction.
 pub enum TransactionOutcome<R> {
 	/// Commit the transaction.

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -955,6 +955,7 @@ pub fn print(print: impl traits::Printable) {
 }
 
 /// Utility function to declare string literals backed by an array of length N.
+///
 /// The input can be shorter than N, in that case the end of the array is padded with zeros.
 ///
 /// [`str_array`] is useful when converting strings that end up in the storage as fixed size arrays

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -960,6 +960,14 @@ pub fn print(print: impl traits::Printable) {
 ///
 /// [`str_array`] is useful when converting strings that end up in the storage as fixed size arrays
 /// or in const contexts where static data types have strings that could also end up in the storage.
+///
+/// # Example
+///
+/// ```rust
+/// # use sp_runtime::str_array;
+/// const MY_STR: [u8; 6] = str_array("data");
+/// assert_eq!(MY_STR, *b"data\0\0");
+/// ```
 pub const fn str_array<const N: usize>(s: &str) -> [u8; N] {
 	debug_assert!(s.len() <= N, "String literal doesn't fit in array");
 	let mut i = 0;


### PR DESCRIPTION
A utility function I consider quite useful to declare string literals that are backed by an array.