### PR TITLE
Bulk assigner tests update

### DIFF
--- a/polkadot/runtime/parachains/src/assigner_bulk/mod.rs
+++ b/polkadot/runtime/parachains/src/assigner_bulk/mod.rs
@@ -473,16 +473,14 @@ impl<T: Config> Pallet<T> {
 }
 
 // Tests/Invariant:
-// - After `assign_core`, WorkState is `Some`.
 // - next_schedule always points to next item in CoreSchedules. (handled by
 //   next_schedule_always_points_to_next_work_plan_item)
 // - Test insertion in the middle, beginning and end: Should fail in all cases but the last.
-// - Test insertion on empty queue.
-// - Test overwrite vs insert: Overwrite no longer allowed - should fail with error.
+//   (handled by assign_core_enforces_higher_block_number)
+// - Test insertion on empty queue. (handled by assign_core_works_with_no_prior_schedule)
 // - New: Test that assignments are served correctly. E.g. two equal assignments will be served as
-//   ABABAB ... and more importantly have a test that checks that core is shared fairly, even in
-//   case of `ratio` not being divisible by `step` (over multiple rounds). (handled by
-//   assign_core_enforces_higher_block_number)
-// - Test insertion on empty queue. (Handled by assign_core_works_with_no_prior_schedule)
+//   ABABAB (handled by equal_assignments_served_equally)
+// - Have a test that checks that core is shared fairly, even in case of `ratio` not being divisible
+//   by `step` (over multiple rounds). (handled by assignment_proportions_indivisible_by_step_work)
 // - Test overwrite vs insert: Overwrite no longer allowed - should fail with error. (handled using
 //   Error::DuplicateInsert, though earlier errors should prevent this error from ever triggering)

--- a/polkadot/runtime/parachains/src/assigner_bulk/mod.rs
+++ b/polkadot/runtime/parachains/src/assigner_bulk/mod.rs
@@ -478,8 +478,8 @@ impl<T: Config> Pallet<T> {
 // - Test insertion in the middle, beginning and end: Should fail in all cases but the last.
 //   (handled by assign_core_enforces_higher_block_number)
 // - Test insertion on empty queue. (handled by assign_core_works_with_no_prior_schedule)
-// - New: Test that assignments are served correctly. E.g. two equal assignments will be served as
-//   ABABAB (handled by equal_assignments_served_equally)
+// - Test that assignments are served correctly. E.g. two equal assignments will be served as ABABAB
+//   (handled by equal_assignments_served_equally)
 // - Have a test that checks that core is shared fairly, even in case of `ratio` not being divisible
 //   by `step` (over multiple rounds). (handled by assignment_proportions_indivisible_by_step_work)
 // - Test overwrite vs insert: Overwrite no longer allowed - should fail with error. (handled using

--- a/polkadot/runtime/parachains/src/mock.rs
+++ b/polkadot/runtime/parachains/src/mock.rs
@@ -24,7 +24,8 @@ use crate::{
 	paras::ParaKind,
 	paras_inherent, scheduler,
 	scheduler::common::{
-		AssignmentProvider, AssignmentProviderConfig, AssignmentVersion, V0Assignment,
+		AssignmentProvider, AssignmentProviderConfig, AssignmentVersion, FixedAssignmentProvider,
+		V0Assignment,
 	},
 	session_info, shared, ParaId,
 };
@@ -464,15 +465,6 @@ pub mod mock_assigner {
 			old
 		}
 
-		// Provides a core count for scheduler tests defaulting to the most common number,
-		// 5, if no explicit count was set.
-		fn session_core_count() -> u32 {
-			match MockCoreCount::<T>::get() {
-				Some(count) => count,
-				None => 5,
-			}
-		}
-
 		// With regards to popping_assignments, the scheduler just needs to be tested under
 		// the following two conditions:
 		// 1. An assignment is provided
@@ -502,6 +494,17 @@ pub mod mock_assigner {
 					max_availability_timeouts: 1,
 					ttl: BlockNumber::from(5u32),
 				},
+			}
+		}
+	}
+
+	// Provides a core count for scheduler tests defaulting to the most common number,
+	// 5, if no explicit count was set.
+	impl<T: Config> FixedAssignmentProvider<BlockNumber> for Pallet<T> {
+		fn session_core_count() -> u32 {
+			match MockCoreCount::<T>::get() {
+				Some(count) => count,
+				None => 5,
 			}
 		}
 	}


### PR DESCRIPTION
Addressed comments from https://github.com/paritytech/polkadot-sdk/pull/2262

Also added tests to cover the new cases:
- Test that assignments are served correctly. E.g. two equal assignments will be served as ABABAB
- Have a test that checks that core is shared fairly, even in case of `ratio` not being divisible by `step`