### PR TITLE
wasm-builder: Optimize `rerun-if-changed` logic

### DIFF
--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -18,7 +18,7 @@
 use crate::{write_file_if_changed, CargoCommandVersioned, OFFLINE};
 
 use build_helper::rerun_if_changed;
-use cargo_metadata::{CargoOpt, Metadata, MetadataCommand};
+use cargo_metadata::{CargoOpt, DependencyKind, Metadata, MetadataCommand};
 use parity_wasm::elements::{deserialize_buffer, Module};
 use std::{
 	borrow::ToOwned,
@@ -89,8 +89,7 @@ fn crate_metadata(cargo_manifest: &Path) -> Metadata {
 		cargo_manifest.to_path_buf()
 	};
 
-	let mut crate_metadata_command = create_metadata_command(cargo_manifest);
-	crate_metadata_command.features(CargoOpt::AllFeatures);
+	let crate_metadata_command = create_metadata_command(cargo_manifest);
 
 	let crate_metadata = crate_metadata_command
 		.exec()
@@ -915,6 +914,11 @@ fn generate_rerun_if_changed_instructions(
 	packages.insert(DeduplicatePackage::from(package));
 
 	while let Some(dependency) = dependencies.pop() {
+		// Ignore all dev dependencies
+		if dependency.kind == DependencyKind::Development {
+			continue;
+		}
+
 		let path_or_git_dep =
 			dependency.source.as_ref().map(|s| s.starts_with("git+")).unwrap_or(true);
 
@@ -967,9 +971,7 @@ fn package_rerun_if_changed(package: &DeduplicatePackage) {
 			p.path() == manifest_path || !p.path().is_dir() || !p.path().join("Cargo.toml").exists()
 		})
 		.filter_map(|p| p.ok().map(|p| p.into_path()))
-		.filter(|p| {
-			p.is_dir() || p.extension().map(|e| e == "rs" || e == "toml").unwrap_or_default()
-		})
+		.filter(|p| p.extension().map(|e| e == "rs" || e == "toml").unwrap_or_default())
 		.for_each(rerun_if_changed);
 }
 


### PR DESCRIPTION
Optimizes the `rerun-if-changed` logic by ignoring `dev-dependencies` and also not outputting paths. Because outputting paths could lead to include unwanted crates in the rerun checks.

