### PR TITLE
review-bot: trigger only on review approvals

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   trigger-review-bot:
-    if: github.event.pull_request.draft != true
+    if: github.event.pull_request.draft != true || (github.event.review && github.event.review.state == 'APPROVED')
     runs-on: ubuntu-latest
     name: trigger review bot
     steps:

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -13,7 +13,8 @@ on:
 
 jobs:
   trigger-review-bot:
-    if: github.event.pull_request.draft != true || (github.event.review && github.event.review.state == 'APPROVED')
+    # (It is not a draft) && (it is not a review || it is an approving review)
+    if: ${{ github.event.pull_request.draft != true && (github.event_name != 'pull_request_review' || (github.event.review && github.event.review.state == 'APPROVED')) }}
     runs-on: ubuntu-latest
     name: trigger review bot
     steps:


### PR DESCRIPTION
Moved the review event of review-bot to only be triggered in approvals.

Because we only update the required reviews when someone approves, this will stop the bot from immediately requesting a new review when someone comments or request changes as they should have been already notified in the first batch.
