### PR TITLE
Create `FungibleAdapter`

### DIFF
--- a/substrate/frame/transaction-payment/src/payment.rs
+++ b/substrate/frame/transaction-payment/src/payment.rs
@@ -25,7 +25,11 @@ use sp_runtime::{
 use sp_std::marker::PhantomData;
 
 use frame_support::{
-	traits::{Currency, ExistenceRequirement, Imbalance, OnUnbalanced, WithdrawReasons},
+	traits::{
+		fungible::{Balanced, Credit, Debt, Inspect},
+		tokens::Precision,
+		Currency, ExistenceRequirement, Imbalance, OnUnbalanced, TryDrop, WithdrawReasons,
+	},
 	unsigned::TransactionValidityError,
 };
 
@@ -66,18 +70,89 @@ pub trait OnChargeTransaction<T: Config> {
 	) -> Result<(), TransactionValidityError>;
 }
 
-/// Implements the transaction payment for a pallet implementing the `Currency`
-/// trait (eg. the pallet_balances) using an unbalance handler (implementing
-/// `OnUnbalanced`).
+/// Implements transaction payment for a pallet implementing the [`fungible`]
+/// trait (eg. pallet_balances) using an unbalance handler (implementing
+/// [`OnUnbalanced`]).
 ///
-/// The unbalance handler is given 2 unbalanceds in [`OnUnbalanced::on_unbalanceds`]: fee and
-/// then tip.
+/// The unbalance handler is given 2 unbalanceds in [`OnUnbalanced::on_unbalanceds`]: `fee` and
+/// then `tip`.
+pub struct FungibleAdapter<F, OU>(PhantomData<(F, OU)>);
+
+impl<T, F, OU> OnChargeTransaction<T> for FungibleAdapter<F, OU>
+where
+	T: Config,
+	F: Balanced<T::AccountId>,
+	OU: OnUnbalanced<Credit<T::AccountId, F>>,
+{
+	type LiquidityInfo = Option<Credit<T::AccountId, F>>;
+	type Balance = <F as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
+
+	fn withdraw_fee(
+		who: &<T>::AccountId,
+		_call: &<T>::RuntimeCall,
+		_dispatch_info: &DispatchInfoOf<<T>::RuntimeCall>,
+		fee: Self::Balance,
+		_tip: Self::Balance,
+	) -> Result<Self::LiquidityInfo, TransactionValidityError> {
+		if fee.is_zero() {
+			return Ok(None)
+		}
+
+		match F::withdraw(
+			who,
+			fee,
+			Precision::Exact,
+			frame_support::traits::tokens::Preservation::Preserve,
+			frame_support::traits::tokens::Fortitude::Polite,
+		) {
+			Ok(imbalance) => Ok(Some(imbalance)),
+			Err(_) => Err(InvalidTransaction::Payment.into()),
+		}
+	}
+
+	fn correct_and_deposit_fee(
+		who: &<T>::AccountId,
+		_dispatch_info: &DispatchInfoOf<<T>::RuntimeCall>,
+		_post_info: &PostDispatchInfoOf<<T>::RuntimeCall>,
+		corrected_fee: Self::Balance,
+		tip: Self::Balance,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<(), TransactionValidityError> {
+		if let Some(paid) = already_withdrawn {
+			// Calculate how much refund we should return
+			let refund_amount = paid.peek().saturating_sub(corrected_fee);
+			// refund to the the account that paid the fees. If this fails, the
+			// account might have dropped below the existential balance. In
+			// that case we don't refund anything.
+			let refund_imbalance = F::deposit(who, refund_amount, Precision::BestEffort)
+				.unwrap_or_else(|_| Debt::<T::AccountId, F>::zero());
+			// merge the imbalance caused by paying the fees and refunding parts of it again.
+			let adjusted_paid: Credit<T::AccountId, F> = paid
+				.offset(refund_imbalance)
+				.same()
+				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+			// Call someone else to handle the imbalance (fee and tip separately)
+			let (tip, fee) = adjusted_paid.split(tip);
+			OU::on_unbalanceds(Some(fee).into_iter().chain(Some(tip)));
+		}
+
+		Ok(())
+	}
+}
+
+/// Implements the transaction payment for a pallet implementing the [`Currency`]
+/// trait (eg. the pallet_balances) using an unbalance handler (implementing
+/// [`OnUnbalanced`]).
+///
+/// The unbalance handler is given 2 unbalanceds in [`OnUnbalanced::on_unbalanceds`]: `fee` and
+/// then `tip`.
+#[deprecated(note = "Please use the fungible trait and FungibleAdapter instead where possible.")]
 pub struct CurrencyAdapter<C, OU>(PhantomData<(C, OU)>);
 
 /// Default implementation for a Currency and an OnUnbalanced handler.
 ///
-/// The unbalance handler is given 2 unbalanceds in [`OnUnbalanced::on_unbalanceds`]: fee and
-/// then tip.
+/// The unbalance handler is given 2 unbalanceds in [`OnUnbalanced::on_unbalanceds`]: `fee` and
+/// then `tip`.
 impl<T, C, OU> OnChargeTransaction<T> for CurrencyAdapter<C, OU>
 where
 	T: Config,


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot-sdk/issues/226 
Hopefully resolves https://github.com/paritytech/polkadot-sdk/issues/1833

Creates a `FungibleAdapter` for transaction payment. Mostly mirrors the existing `CurrencyAdapter`. 

---

TODO
- [ ] Add tests