### PR TITLE
chainHead: Support multiple hashes for `chainHead_unpin` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15978,6 +15978,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-maybe-compressed-blob",
+ "sp-rpc",
  "sp-runtime",
  "sp-version",
  "substrate-test-runtime",

--- a/substrate/client/rpc-spec-v2/Cargo.toml
+++ b/substrate/client/rpc-spec-v2/Cargo.toml
@@ -21,6 +21,7 @@ sc-transaction-pool-api = { path = "../transaction-pool/api" }
 sp-core = { path = "../../primitives/core" }
 sp-runtime = { path = "../../primitives/runtime" }
 sp-api = { path = "../../primitives/api" }
+sp-rpc = { path = "../../primitives/rpc" }
 sp-blockchain = { path = "../../primitives/blockchain" }
 sp-version = { path = "../../primitives/version" }
 sc-client-api = { path = "../api" }

--- a/substrate/client/rpc-spec-v2/src/chain_head/api.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/api.rs
@@ -21,8 +21,7 @@
 //! API trait of the chain head.
 use crate::chain_head::event::{FollowEvent, MethodResponse, StorageQuery};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-
-use super::HashOrHashes;
+use sp_rpc::list::ListOrValue;
 
 #[rpc(client, server)]
 pub trait ChainHeadApi<Hash> {
@@ -125,7 +124,7 @@ pub trait ChainHeadApi<Hash> {
 	fn chain_head_unstable_unpin(
 		&self,
 		follow_subscription: String,
-		hash: HashOrHashes<Hash>,
+		hash: ListOrValue<Hash>,
 	) -> RpcResult<()>;
 
 	/// Resumes a storage fetch started with `chainHead_storage` after it has generated an

--- a/substrate/client/rpc-spec-v2/src/chain_head/api.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/api.rs
@@ -124,7 +124,7 @@ pub trait ChainHeadApi<Hash> {
 	fn chain_head_unstable_unpin(
 		&self,
 		follow_subscription: String,
-		hash: ListOrValue<Hash>,
+		hash_or_hashes: ListOrValue<Hash>,
 	) -> RpcResult<()>;
 
 	/// Resumes a storage fetch started with `chainHead_storage` after it has generated an

--- a/substrate/client/rpc-spec-v2/src/chain_head/api.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/api.rs
@@ -111,10 +111,12 @@ pub trait ChainHeadApi<Hash> {
 		call_parameters: String,
 	) -> RpcResult<MethodResponse>;
 
-	/// Unpin a block reported by the `follow` method.
+	/// Unpin a block or multiple blocks reported by the `follow` method.
 	///
 	/// Ongoing operations that require the provided block
 	/// will continue normally.
+	///
+	/// When this method returns an error, it is guaranteed that no blocks have been unpinned.
 	///
 	/// # Unstable
 	///

--- a/substrate/client/rpc-spec-v2/src/chain_head/api.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/api.rs
@@ -22,6 +22,8 @@
 use crate::chain_head::event::{FollowEvent, MethodResponse, StorageQuery};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
+use super::HashOrHashes;
+
 #[rpc(client, server)]
 pub trait ChainHeadApi<Hash> {
 	/// Track the state of the head of the chain: the finalized, non-finalized, and best blocks.
@@ -118,7 +120,11 @@ pub trait ChainHeadApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "chainHead_unstable_unpin", blocking)]
-	fn chain_head_unstable_unpin(&self, follow_subscription: String, hash: Hash) -> RpcResult<()>;
+	fn chain_head_unstable_unpin(
+		&self,
+		follow_subscription: String,
+		hash: HashOrHashes<Hash>,
+	) -> RpcResult<()>;
 
 	/// Resumes a storage fetch started with `chainHead_storage` after it has generated an
 	/// `operationWaitingForContinue` event.

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -435,12 +435,14 @@ where
 		follow_subscription: String,
 		hash_or_hashes: ListOrValue<Block::Hash>,
 	) -> RpcResult<()> {
-		let hashes = match hash_or_hashes {
-			ListOrValue::Value(hash) => vec![hash],
-			ListOrValue::List(hashes) => hashes,
+		let result = match hash_or_hashes {
+			ListOrValue::Value(hash) =>
+				self.subscriptions.unpin_blocks(&follow_subscription, [hash]),
+			ListOrValue::List(hashes) =>
+				self.subscriptions.unpin_blocks(&follow_subscription, hashes),
 		};
 
-		match self.subscriptions.unpin_blocks(&follow_subscription, hashes) {
+		match result {
 			Ok(()) => Ok(()),
 			Err(SubscriptionManagementError::SubscriptionAbsent) => {
 				// Invalid invalid subscription ID.

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -21,6 +21,7 @@
 use super::{
 	chain_head_storage::ChainHeadStorage,
 	event::{MethodResponseStarted, OperationBodyDone, OperationCallDone},
+	HashOrHashes,
 };
 use crate::{
 	chain_head::{
@@ -432,7 +433,7 @@ where
 	fn chain_head_unstable_unpin(
 		&self,
 		follow_subscription: String,
-		hash: Block::Hash,
+		hash: HashOrHashes<Block::Hash>,
 	) -> RpcResult<()> {
 		match self.subscriptions.unpin_block(&follow_subscription, hash) {
 			Ok(()) => Ok(()),

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -433,9 +433,9 @@ where
 	fn chain_head_unstable_unpin(
 		&self,
 		follow_subscription: String,
-		hash: ListOrValue<Block::Hash>,
+		hash_or_hashes: ListOrValue<Block::Hash>,
 	) -> RpcResult<()> {
-		let hashes = match hash {
+		let hashes = match hash_or_hashes {
 			ListOrValue::Value(hash) => vec![hash],
 			ListOrValue::List(hashes) => hashes,
 		};

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -21,7 +21,6 @@
 use super::{
 	chain_head_storage::ChainHeadStorage,
 	event::{MethodResponseStarted, OperationBodyDone, OperationCallDone},
-	HashOrHashes,
 };
 use crate::{
 	chain_head::{
@@ -49,6 +48,7 @@ use sc_client_api::{
 use sp_api::CallApiAt;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 use sp_core::{traits::CallContext, Bytes};
+use sp_rpc::list::ListOrValue;
 use sp_runtime::traits::Block as BlockT;
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
@@ -433,11 +433,11 @@ where
 	fn chain_head_unstable_unpin(
 		&self,
 		follow_subscription: String,
-		hash: HashOrHashes<Block::Hash>,
+		hash: ListOrValue<Block::Hash>,
 	) -> RpcResult<()> {
 		let hashes = match hash {
-			HashOrHashes::Hash(hash) => vec![hash],
-			HashOrHashes::List(hashes) => hashes,
+			ListOrValue::Value(hash) => vec![hash],
+			ListOrValue::List(hashes) => hashes,
 		};
 
 		match self.subscriptions.unpin_blocks(&follow_subscription, hashes) {

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -435,7 +435,12 @@ where
 		follow_subscription: String,
 		hash: HashOrHashes<Block::Hash>,
 	) -> RpcResult<()> {
-		match self.subscriptions.unpin_block(&follow_subscription, hash) {
+		let hashes = match hash {
+			HashOrHashes::Hash(hash) => vec![hash],
+			HashOrHashes::List(hashes) => hashes,
+		};
+
+		match self.subscriptions.unpin_blocks(&follow_subscription, hashes) {
 			Ok(()) => Ok(()),
 			Err(SubscriptionManagementError::SubscriptionAbsent) => {
 				// Invalid invalid subscription ID.

--- a/substrate/client/rpc-spec-v2/src/chain_head/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/mod.rs
@@ -43,9 +43,20 @@ pub use event::{
 	RuntimeVersionEvent,
 };
 
+use serde::{Deserialize, Serialize};
 use sp_core::hexdisplay::{AsBytesRef, HexDisplay};
 
 /// Util function to print the results of `chianHead` as hex string
 pub(crate) fn hex_string<Data: AsBytesRef>(data: &Data) -> String {
 	format!("0x{:?}", HexDisplay::from(data))
+}
+
+/// A parameter type that can be either a single hash or a list of hashes.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum HashOrHashes<Hash> {
+	/// Single hash.
+	Hash(Hash),
+	/// List of hashes.
+	List(Vec<Hash>),
 }

--- a/substrate/client/rpc-spec-v2/src/chain_head/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/mod.rs
@@ -43,20 +43,9 @@ pub use event::{
 	RuntimeVersionEvent,
 };
 
-use serde::{Deserialize, Serialize};
 use sp_core::hexdisplay::{AsBytesRef, HexDisplay};
 
 /// Util function to print the results of `chianHead` as hex string
 pub(crate) fn hex_string<Data: AsBytesRef>(data: &Data) -> String {
 	format!("0x{:?}", HexDisplay::from(data))
-}
-
-/// A parameter type that can be either a single hash or a list of hashes.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum HashOrHashes<Hash> {
-	/// Single hash.
-	Hash(Hash),
-	/// List of hashes.
-	List(Vec<Hash>),
 }

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
@@ -767,6 +767,10 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionsInner<Block, BE> {
 			}
 		}
 
+		// Note: this needs to be separate from the global mappings to avoid barrow checker
+		// thinking we borrow `&mut self` twice: once from `self.subs.get_mut` and once from
+		// `self.global_unregister_block`. Although the borrowing is correct, since different
+		// fields of the structure are borrowed, one at a time.
 		for hash in &hashes {
 			sub.unregister_block(*hash);
 		}

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
@@ -1053,11 +1053,11 @@ mod tests {
 		assert_eq!(block.has_runtime(), true);
 
 		let invalid_id = "abc-invalid".to_string();
-		let err = subs.unpin_block(&invalid_id, hash).unwrap_err();
+		let err = subs.unpin_blocks(&invalid_id, vec![hash]).unwrap_err();
 		assert_eq!(err, SubscriptionManagementError::SubscriptionAbsent);
 
 		// Unpin the block.
-		subs.unpin_block(&id, hash).unwrap();
+		subs.unpin_blocks(&id, vec![hash]).unwrap();
 		let err = subs.lock_block(&id, hash, 1).unwrap_err();
 		assert_eq!(err, SubscriptionManagementError::BlockHashAbsent);
 	}
@@ -1101,13 +1101,13 @@ mod tests {
 		// Ensure the block propagated to the subscription.
 		subs.subs.get(&id_second).unwrap().blocks.get(&hash).unwrap();
 
-		subs.unpin_block(&id, hash).unwrap();
+		subs.unpin_blocks(&id, vec![hash]).unwrap();
 		assert_eq!(*subs.global_blocks.get(&hash).unwrap(), 1);
 		// Cannot unpin a block twice for the same subscription.
-		let err = subs.unpin_block(&id, hash).unwrap_err();
+		let err = subs.unpin_blocks(&id, vec![hash]).unwrap_err();
 		assert_eq!(err, SubscriptionManagementError::BlockHashAbsent);
 
-		subs.unpin_block(&id_second, hash).unwrap();
+		subs.unpin_blocks(&id_second, vec![hash]).unwrap();
 		// Block unregistered from the memory.
 		assert!(subs.global_blocks.get(&hash).is_none());
 	}

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
@@ -755,22 +755,20 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionsInner<Block, BE> {
 		sub_id: &str,
 		hashes: Vec<Block::Hash>,
 	) -> Result<(), SubscriptionManagementError> {
-		{
-			let Some(sub) = self.subs.get_mut(sub_id) else {
-				return Err(SubscriptionManagementError::SubscriptionAbsent)
-			};
+		let Some(sub) = self.subs.get_mut(sub_id) else {
+			return Err(SubscriptionManagementError::SubscriptionAbsent)
+		};
 
-			// Ensure that all blocks are part of the subscription before removing individual
-			// blocks.
-			for hash in &hashes {
-				if !sub.contains_block(*hash) {
-					return Err(SubscriptionManagementError::BlockHashAbsent);
-				}
+		// Ensure that all blocks are part of the subscription before removing individual
+		// blocks.
+		for hash in &hashes {
+			if !sub.contains_block(*hash) {
+				return Err(SubscriptionManagementError::BlockHashAbsent);
 			}
+		}
 
-			for hash in &hashes {
-				sub.unregister_block(*hash);
-			}
+		for hash in &hashes {
+			sub.unregister_block(*hash);
 		}
 
 		// Block have been removed from the subscription. Remove them from the global tracking.

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
@@ -753,7 +753,7 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionsInner<Block, BE> {
 	pub fn unpin_blocks(
 		&mut self,
 		sub_id: &str,
-		hashes: Vec<Block::Hash>,
+		hashes: impl IntoIterator<Item = Block::Hash> + Clone,
 	) -> Result<(), SubscriptionManagementError> {
 		let Some(sub) = self.subs.get_mut(sub_id) else {
 			return Err(SubscriptionManagementError::SubscriptionAbsent)
@@ -761,8 +761,8 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionsInner<Block, BE> {
 
 		// Ensure that all blocks are part of the subscription before removing individual
 		// blocks.
-		for hash in &hashes {
-			if !sub.contains_block(*hash) {
+		for hash in hashes.clone() {
+			if !sub.contains_block(hash) {
 				return Err(SubscriptionManagementError::BlockHashAbsent);
 			}
 		}
@@ -771,8 +771,8 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionsInner<Block, BE> {
 		// thinking we borrow `&mut self` twice: once from `self.subs.get_mut` and once from
 		// `self.global_unregister_block`. Although the borrowing is correct, since different
 		// fields of the structure are borrowed, one at a time.
-		for hash in &hashes {
-			sub.unregister_block(*hash);
+		for hash in hashes.clone() {
+			sub.unregister_block(hash);
 		}
 
 		// Block have been removed from the subscription. Remove them from the global tracking.

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/inner.rs
@@ -27,7 +27,7 @@ use std::{
 	time::{Duration, Instant},
 };
 
-use crate::chain_head::{subscription::SubscriptionManagementError, FollowEvent, HashOrHashes};
+use crate::chain_head::{subscription::SubscriptionManagementError, FollowEvent};
 
 /// The queue size after which the `sc_utils::mpsc::tracing_unbounded` would produce warnings.
 const QUEUE_SIZE_WARNING: usize = 512;
@@ -750,19 +750,14 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionsInner<Block, BE> {
 		}
 	}
 
-	pub fn unpin_block(
+	pub fn unpin_blocks(
 		&mut self,
 		sub_id: &str,
-		hash: HashOrHashes<Block::Hash>,
+		hashes: Vec<Block::Hash>,
 	) -> Result<(), SubscriptionManagementError> {
 		// Check if the subscription ID is valid or not.
 		if self.subs.get(sub_id).is_none() {
 			return Err(SubscriptionManagementError::SubscriptionAbsent)
-		};
-
-		let hashes = match hash {
-			HashOrHashes::Hash(hash) => vec![hash],
-			HashOrHashes::List(hashes) => hashes,
 		};
 
 		// Ensure that all blocks are part of the subscription.

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs
@@ -30,8 +30,6 @@ pub use self::inner::OperationState;
 pub use error::SubscriptionManagementError;
 pub use inner::{BlockGuard, InsertedSubscriptionData};
 
-use super::HashOrHashes;
-
 /// Manage block pinning / unpinning for subscription IDs.
 pub struct SubscriptionManagement<Block: BlockT, BE: Backend<Block>> {
 	/// Manage subscription by mapping the subscription ID
@@ -96,22 +94,23 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionManagement<Block, BE> {
 		inner.pin_block(sub_id, hash)
 	}
 
-	/// Unpin the block from the subscription.
+	/// Unpin the blocks from the subscription.
 	///
-	/// The last subscription that unpins the block is also unpinning the block
-	/// from the backend.
+	/// Blocks are reference counted and when the last subscription unpins a given block, the block
+	/// is also unpinned from the backend.
 	///
 	/// This method is called only once per subscription.
 	///
-	/// Returns an error if the block is not pinned for the subscription or
-	/// the subscription ID is invalid.
-	pub fn unpin_block(
+	/// Returns an error if the subscription ID is invalid, or any of the blocks are not pinned
+	/// for the subscriptions. When an error is returned, it is guaranteed that no blocks have
+	/// been unpinned.
+	pub fn unpin_blocks(
 		&self,
 		sub_id: &str,
-		hash: HashOrHashes<Block::Hash>,
+		hashes: Vec<Block::Hash>,
 	) -> Result<(), SubscriptionManagementError> {
 		let mut inner = self.inner.write();
-		inner.unpin_block(sub_id, hash)
+		inner.unpin_blocks(sub_id, hashes)
 	}
 
 	/// Ensure the block remains pinned until the return object is dropped.

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs
@@ -30,6 +30,8 @@ pub use self::inner::OperationState;
 pub use error::SubscriptionManagementError;
 pub use inner::{BlockGuard, InsertedSubscriptionData};
 
+use super::HashOrHashes;
+
 /// Manage block pinning / unpinning for subscription IDs.
 pub struct SubscriptionManagement<Block: BlockT, BE: Backend<Block>> {
 	/// Manage subscription by mapping the subscription ID
@@ -106,7 +108,7 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionManagement<Block, BE> {
 	pub fn unpin_block(
 		&self,
 		sub_id: &str,
-		hash: Block::Hash,
+		hash: HashOrHashes<Block::Hash>,
 	) -> Result<(), SubscriptionManagementError> {
 		let mut inner = self.inner.write();
 		inner.unpin_block(sub_id, hash)

--- a/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/subscription/mod.rs
@@ -107,7 +107,7 @@ impl<Block: BlockT, BE: Backend<Block>> SubscriptionManagement<Block, BE> {
 	pub fn unpin_blocks(
 		&self,
 		sub_id: &str,
-		hashes: Vec<Block::Hash>,
+		hashes: impl IntoIterator<Item = Block::Hash> + Clone,
 	) -> Result<(), SubscriptionManagementError> {
 		let mut inner = self.inner.write();
 		inner.unpin_blocks(sub_id, hashes)


### PR DESCRIPTION
This PR adds support for multiple hashes being passed to the `chainHeda_unpin` parameters.

The `hash` parameter is renamed to `hash_or_hashes` per https://github.com/paritytech/json-rpc-interface-spec/pull/111.

While at it, a new integration test is added to check the unpinning of multiple hashes. The API is checked against a hash or a vector of hashes.

cc @paritytech/subxt-team 

