### PR TITLE
chainHead: Remove `chainHead_genesis` method

### DIFF
--- a/substrate/client/rpc-spec-v2/src/chain_head/api.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/api.rs
@@ -73,14 +73,6 @@ pub trait ChainHeadApi<Hash> {
 		hash: Hash,
 	) -> RpcResult<Option<String>>;
 
-	/// Get the chain's genesis hash.
-	///
-	/// # Unstable
-	///
-	/// This method is unstable and subject to change in the future.
-	#[method(name = "chainHead_unstable_genesisHash", blocking)]
-	fn chain_head_unstable_genesis_hash(&self) -> RpcResult<String>;
-
 	/// Returns storage entries at a specific block's state.
 	///
 	/// # Unstable

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -106,8 +106,6 @@ pub struct ChainHead<BE: Backend<Block>, Block: BlockT, Client> {
 	executor: SubscriptionTaskExecutor,
 	/// Keep track of the pinned blocks for each subscription.
 	subscriptions: Arc<SubscriptionManagement<Block, BE>>,
-	/// The hexadecimal encoded hash of the genesis block.
-	genesis_hash: String,
 	/// The maximum number of items reported by the `chainHead_storage` before
 	/// pagination is required.
 	operation_max_storage_items: usize,
@@ -121,10 +119,8 @@ impl<BE: Backend<Block>, Block: BlockT, Client> ChainHead<BE, Block, Client> {
 		client: Arc<Client>,
 		backend: Arc<BE>,
 		executor: SubscriptionTaskExecutor,
-		genesis_hash: GenesisHash,
 		config: ChainHeadConfig,
 	) -> Self {
-		let genesis_hash = hex_string(&genesis_hash.as_ref());
 		Self {
 			client,
 			backend: backend.clone(),
@@ -136,7 +132,6 @@ impl<BE: Backend<Block>, Block: BlockT, Client> ChainHead<BE, Block, Client> {
 				backend,
 			)),
 			operation_max_storage_items: config.operation_max_storage_items,
-			genesis_hash,
 			_phantom: PhantomData,
 		}
 	}
@@ -312,10 +307,6 @@ where
 			.map(|opt_header| opt_header.map(|h| hex_string(&h.encode())))
 			.map_err(ChainHeadRpcError::FetchBlockHeader)
 			.map_err(Into::into)
-	}
-
-	fn chain_head_unstable_genesis_hash(&self) -> RpcResult<String> {
-		Ok(self.genesis_hash.clone())
 	}
 
 	fn chain_head_unstable_storage(

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -115,7 +115,7 @@ pub struct ChainHead<BE: Backend<Block>, Block: BlockT, Client> {
 
 impl<BE: Backend<Block>, Block: BlockT, Client> ChainHead<BE, Block, Client> {
 	/// Create a new [`ChainHead`].
-	pub fn new<GenesisHash: AsRef<[u8]>>(
+	pub fn new(
 		client: Arc<Client>,
 		backend: Arc<BE>,
 		executor: SubscriptionTaskExecutor,

--- a/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
@@ -61,7 +61,6 @@ const MAX_PINNED_BLOCKS: usize = 32;
 const MAX_PINNED_SECS: u64 = 60;
 const MAX_OPERATIONS: usize = 16;
 const MAX_PAGINATION_LIMIT: usize = 5;
-const CHAIN_GENESIS: [u8; 32] = [0; 32];
 const INVALID_HASH: [u8; 32] = [1; 32];
 const KEY: &[u8] = b":mock";
 const VALUE: &[u8] = b"hello world";
@@ -111,7 +110,6 @@ async fn setup_api() -> (
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -162,7 +160,6 @@ async fn follow_subscription_produces_blocks() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -231,7 +228,6 @@ async fn follow_with_runtime() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -355,7 +351,6 @@ async fn get_genesis() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -569,7 +564,6 @@ async fn call_runtime_without_flag() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1228,7 +1222,6 @@ async fn separate_operation_ids_for_subscriptions() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1316,7 +1309,6 @@ async fn follow_generates_initial_blocks() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1472,7 +1464,6 @@ async fn follow_exceeding_pinned_blocks() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: 2,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1549,7 +1540,6 @@ async fn follow_with_unpin() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: 2,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1655,7 +1645,6 @@ async fn follow_prune_best_block() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1841,7 +1830,6 @@ async fn follow_forks_pruned_block() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -1993,7 +1981,6 @@ async fn follow_report_multiple_pruned_block() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -2239,7 +2226,6 @@ async fn pin_block_references() {
 		client.clone(),
 		backend.clone(),
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: 3,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -2374,7 +2360,6 @@ async fn follow_finalized_before_new_block() {
 		client_mock.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -2489,7 +2474,6 @@ async fn ensure_operation_limits_works() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -2594,7 +2578,6 @@ async fn check_continue_operation() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
@@ -2777,7 +2760,6 @@ async fn stop_storage_operation() {
 		client.clone(),
 		backend,
 		Arc::new(TaskExecutor::default()),
-		CHAIN_GENESIS,
 		ChainHeadConfig {
 			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
 			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),

--- a/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
@@ -28,7 +28,7 @@ use futures::Future;
 use jsonrpsee::{
 	core::{error::Error, server::rpc_module::Subscription as RpcSubscription},
 	rpc_params,
-	types::{error::CallError, EmptyServerParams as EmptyParams},
+	types::error::CallError,
 	RpcModule,
 };
 use sc_block_builder::BlockBuilderBuilder;
@@ -339,30 +339,6 @@ async fn follow_with_runtime() {
 		with_runtime: false,
 	});
 	assert_eq!(event, expected);
-}
-
-#[tokio::test]
-async fn get_genesis() {
-	let builder = TestClientBuilder::new();
-	let backend = builder.backend();
-	let client = Arc::new(builder.build());
-
-	let api = ChainHead::new(
-		client.clone(),
-		backend,
-		Arc::new(TaskExecutor::default()),
-		ChainHeadConfig {
-			global_max_pinned_blocks: MAX_PINNED_BLOCKS,
-			subscription_max_pinned_duration: Duration::from_secs(MAX_PINNED_SECS),
-			subscription_max_ongoing_operations: MAX_OPERATIONS,
-			operation_max_storage_items: MAX_PAGINATION_LIMIT,
-		},
-	)
-	.into_rpc();
-
-	let genesis: String =
-		api.call("chainHead_unstable_genesisHash", EmptyParams::new()).await.unwrap();
-	assert_eq!(genesis, hex_string(&CHAIN_GENESIS));
 }
 
 #[tokio::test]

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -637,7 +637,6 @@ where
 		client.clone(),
 		backend.clone(),
 		task_executor.clone(),
-		client.info().genesis_hash,
 		// Defaults to sensible limits for the `ChainHead`.
 		sc_rpc_spec_v2::chain_head::ChainHeadConfig::default(),
 	)


### PR DESCRIPTION
The method has been removed from the spec (https://github.com/paritytech/json-rpc-interface-spec/tree/main/src), this PR keeps the `chainHead` in sync with that change.

@paritytech/subxt-team 