### PR TITLE
PVF: fix detection of unshare-and-change-root security capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12462,6 +12462,7 @@ dependencies = [
  "polkadot-node-core-pvf-prepare-worker",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
+ "polkadot-node-subsystem",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "procfs",

--- a/polkadot/node/core/candidate-validation/src/lib.rs
+++ b/polkadot/node/core/candidate-validation/src/lib.rs
@@ -150,7 +150,7 @@ async fn run<Context>(
 		),
 		pvf_metrics,
 	)
-	.await;
+	.await?;
 	ctx.spawn_blocking("pvf-validation-host", task.boxed())?;
 
 	loop {

--- a/polkadot/node/core/pvf/Cargo.toml
+++ b/polkadot/node/core/pvf/Cargo.toml
@@ -27,6 +27,7 @@ polkadot-core-primitives = { path = "../../../core-primitives" }
 polkadot-node-core-pvf-common = { path = "common" }
 polkadot-node-metrics = { path = "../../metrics" }
 polkadot-node-primitives = { path = "../../primitives" }
+polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-primitives = { path = "../../../primitives" }
 
 sp-core = { path = "../../../../substrate/primitives/core" }

--- a/polkadot/node/core/pvf/benches/host_prepare_rococo_runtime.rs
+++ b/polkadot/node/core/pvf/benches/host_prepare_rococo_runtime.rs
@@ -47,7 +47,7 @@ impl TestHost {
 			execute_worker_path,
 		);
 		f(&mut config);
-		let (host, task) = start(config, Metrics::default()).await;
+		let (host, task) = start(config, Metrics::default()).await.unwrap();
 		let _ = handle.spawn(task);
 		Self { host: Mutex::new(host) }
 	}

--- a/polkadot/node/core/pvf/common/src/worker/mod.rs
+++ b/polkadot/node/core/pvf/common/src/worker/mod.rs
@@ -93,12 +93,12 @@ macro_rules! decl_worker_main {
 				},
 				"--check-can-unshare-user-namespace-and-change-root" => {
 					#[cfg(target_os = "linux")]
+					let cache_path_tempdir = std::path::Path::new(&args[2]);
+					#[cfg(target_os = "linux")]
 					let status = if let Err(err) = security::unshare_user_namespace_and_change_root(
 						$crate::worker::WorkerKind::CheckPivotRoot,
 						worker_pid,
-						// We're not accessing any files, so we can try to pivot_root in the temp
-						// dir without conflicts with other processes.
-						&std::env::temp_dir(),
+						&cache_path_tempdir,
 					) {
 						// Write the error to stderr, log it on the host-side.
 						eprintln!("{}", err);

--- a/polkadot/node/core/pvf/src/host.rs
+++ b/polkadot/node/core/pvf/src/host.rs
@@ -35,6 +35,7 @@ use polkadot_node_core_pvf_common::{
 	error::{PrepareError, PrepareResult},
 	pvf::PvfPrepData,
 };
+use polkadot_node_subsystem::SubsystemResult;
 use polkadot_parachain_primitives::primitives::ValidationResult;
 use std::{
 	collections::HashMap,
@@ -203,11 +204,14 @@ impl Config {
 /// The future should not return normally but if it does then that indicates an unrecoverable error.
 /// In that case all pending requests will be canceled, dropping the result senders and new ones
 /// will be rejected.
-pub async fn start(config: Config, metrics: Metrics) -> (ValidationHost, impl Future<Output = ()>) {
+pub async fn start(
+	config: Config,
+	metrics: Metrics,
+) -> SubsystemResult<(ValidationHost, impl Future<Output = ()>)> {
 	gum::debug!(target: LOG_TARGET, ?config, "starting PVF validation host");
 
 	// Run checks for supported security features once per host startup. Warn here if not enabled.
-	let security_status = security::check_security_status(&config).await;
+	let security_status = security::check_security_status(&config).await?;
 
 	let (to_host_tx, to_host_rx) = mpsc::channel(10);
 
@@ -273,7 +277,7 @@ pub async fn start(config: Config, metrics: Metrics) -> (ValidationHost, impl Fu
 		};
 	};
 
-	(validation_host, task)
+	Ok((validation_host, task))
 }
 
 /// A mapping from an artifact ID which is in preparation state to the list of pending execution

--- a/polkadot/node/core/pvf/src/host.rs
+++ b/polkadot/node/core/pvf/src/host.rs
@@ -211,7 +211,7 @@ pub async fn start(
 	gum::debug!(target: LOG_TARGET, ?config, "starting PVF validation host");
 
 	// Run checks for supported security features once per host startup. Warn here if not enabled.
-	let security_status = security::check_security_status(&config).await?;
+	let security_status = security::check_security_status(&config).await;
 
 	let (to_host_tx, to_host_rx) = mpsc::channel(10);
 

--- a/polkadot/node/core/pvf/tests/it/main.rs
+++ b/polkadot/node/core/pvf/tests/it/main.rs
@@ -61,7 +61,7 @@ impl TestHost {
 			execute_worker_path,
 		);
 		f(&mut config);
-		let (host, task) = start(config, Metrics::default()).await;
+		let (host, task) = start(config, Metrics::default()).await.unwrap();
 		let _ = tokio::task::spawn(task);
 		Self { cache_dir, host: Mutex::new(host) }
 	}


### PR DESCRIPTION
## Overview 

One of our security features isn't working on a user's machine. Right now this feature should be optional, but the bug is that the node detects that the feature works, so the worker tries to apply it.

The problem is that the detection and application are happening in different directories. Detection tries `/tmp` whereas application tries the database path.

User reported back:

> there are different permissions for the /tmp/ folder (root ownership) vs the
.local folder (my user account)

## Error

For discoverability:

```
ERROR parachain::pvf-common: Could not change root to be the worker cache path: mount MS_BIND: Permission denied (os error 13) worker_kind=prepare
```