### PR TITLE
Add details in `--dev` cli flag documentation

### DIFF
--- a/substrate/client/cli/src/params/shared_params.rs
+++ b/substrate/client/cli/src/params/shared_params.rs
@@ -35,6 +35,7 @@ pub struct SharedParams {
 	///
 	/// This flag sets `--chain=dev`, `--force-authoring`, `--rpc-cors=all`,
 	/// `--alice`, and `--tmp` flags, unless explicitly overridden.
+	/// It also disables local peer discovery (see --no-mdns and --discover-local)
 	#[arg(long, conflicts_with_all = &["chain"])]
 	pub dev: bool,
 


### PR DESCRIPTION
add details in `--dev` flag to tell that it disables local peer discovery

### Context

When adding automated end-to-end tests, we replaced `--dev` by 

```
`--chain=dev`, `--force-authoring`, `--rpc-cors=all`, `--alice`, and `--tmp` flags
```

as stated in the command line documentation. But the tests started failing due to the nodes connecting to each other.

### Fix

This PR includes additional command line documentation to explain more in detail what `--dev` flag inludes.
