### PR TITLE
[CI] Prepare CI for Merge Queues

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,6 +3,7 @@ name: Check labels
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
+  merge_group:
 
 jobs:
   check-labels:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,6 +9,9 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip merge queue
+        if: ${{ contains(github.ref, 'gh-readonly-queue') }}
+        run: exit 0
       - name: Pull image
         env:
           IMAGE: paritytech/ruled_labels:0.4.0

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -2,6 +2,7 @@ name: Check licenses
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   packages: read

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/check-links.yml"
       - ".config/lychee.toml"
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
 
 permissions:
   packages: read

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -3,6 +3,7 @@ name: Check Markdown
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
 
 permissions:
   packages: read
@@ -23,8 +24,8 @@ jobs:
 
       - name: Install tooling
         run: |
-            npm install -g markdownlint-cli
-            markdownlint --version
+          npm install -g markdownlint-cli
+          markdownlint --version
 
       - name: Check Markdown
         env:

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -3,6 +3,7 @@ name: Check PRdoc
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
+  merge_group:
 
 env:
   IMAGE: paritytech/prdoc:v0.0.5
@@ -17,6 +18,9 @@ jobs:
   check-prdoc:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip merge queue
+        if: ${{ contains(github.ref, 'gh-readonly-queue') }}
+        run: exit 0
       - name: Pull image
         run: |
           echo "Pulling $IMAGE"

--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
 
 jobs:
   check-publish:

--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
 
 jobs:
   quick_check:

--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -13,6 +13,7 @@ on:
       - unlocked
       - ready_for_review
       - reopened
+  merge_group:
 
 jobs:
   sync:

--- a/.github/workflows/pr-custom-review.yml
+++ b/.github/workflows/pr-custom-review.yml
@@ -14,11 +14,15 @@ on:
       - ready_for_review
       - converted_to_draft
   pull_request_review:
+  merge_group:
 
 jobs:
   pr-custom-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Skip merge queue
+        if: ${{ contains(github.ref, 'gh-readonly-queue') }}
+        run: exit 0
       - name: Skip if pull request is in Draft
         # `if: github.event.pull_request.draft == true` should be kept here, at
         # the step level, rather than at the job level. The latter is not

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,6 +1,6 @@
 name: Review-Trigger
 
-on: 
+on:
   pull_request_target:
     types:
       - opened
@@ -10,6 +10,7 @@ on:
       - review_request_removed
       - ready_for_review
   pull_request_review:
+  merge_group:
 
 jobs:
   trigger-review-bot:
@@ -18,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     name: trigger review bot
     steps:
+      - name: Skip merge queue
+        if: ${{ contains(github.ref, 'gh-readonly-queue') }}
+        run: exit 0
       - name: Get PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ variables:
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
   ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.79"
-  DOCKER_IMAGES_VERSION: "${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
+  DOCKER_IMAGES_VERSION: "${CI_COMMIT_SHA}"
 
 default:
   retry:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,6 +136,7 @@ default:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/ # i.e. v1.0, v2.1rc1
 
 .test-pr-refs:
@@ -152,6 +153,7 @@ default:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/ # i.e. v1.0, v2.1rc1
 
 .test-refs-no-trigger:
@@ -162,6 +164,7 @@ default:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/ # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
 
@@ -172,6 +175,7 @@ default:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
 
 .publish-refs:
   rules:
@@ -192,6 +196,7 @@ default:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/ # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
 
 .zombienet-refs:
   extends: .build-refs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,6 +142,7 @@ default:
 .test-pr-refs:
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
 
 # handle the specific case where benches could store incorrect bench data because of the downstream staging runs
 # exclude cargo-check-benches from such runs

--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -71,8 +71,8 @@ publish-rustdoc:
     DOCKERFILE: "" # docker/path-to.Dockerfile
     IMAGE_NAME: "" # docker.io/paritypr/image_name
   script:
-    # - test "$PARITYPR_USER" -a "$PARITYPR_PASS" ||
-    #   ( echo "no docker credentials provided"; exit 1 )
+    # Exit if the job is not running in a merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - $BUILDAH_COMMAND build
       --format=docker
       --build-arg VCS_REF="${CI_COMMIT_SHA}"

--- a/.gitlab/pipeline/zombienet/cumulus.yml
+++ b/.gitlab/pipeline/zombienet/cumulus.yml
@@ -3,6 +3,8 @@
 
 .zombienet-before-script:
   before_script:
+    # Exit if the job is not merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - echo "Zombie-net Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
     - echo "${POLKADOT_IMAGE}"

--- a/.gitlab/pipeline/zombienet/polkadot.yml
+++ b/.gitlab/pipeline/zombienet/polkadot.yml
@@ -4,6 +4,8 @@
 # common settings for all zombienet jobs
 .zombienet-polkadot-common:
   before_script:
+    # Exit if the job is not merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - export BUILD_RELEASE_VERSION="$(cat ./artifacts/BUILD_RELEASE_VERSION)" # from build-linux-stable job
     - export DEBUG=zombie,zombie::network-node
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="${POLKADOT_IMAGE}":${PIPELINE_IMAGE_TAG}
@@ -12,12 +14,12 @@
     - export MALUS_IMAGE="${MALUS_IMAGE}":${PIPELINE_IMAGE_TAG}
     - IMAGE_AVAILABLE=$(curl -o /dev/null -w "%{http_code}" -I -L -s https://registry.hub.docker.com/v2/repositories/parity/polkadot/tags/${BUILD_RELEASE_VERSION})
     - if [ $IMAGE_AVAILABLE -eq 200 ]; then
-        export ZOMBIENET_INTEGRATION_TEST_SECONDARY_IMAGE="docker.io/parity/polkadot:${BUILD_RELEASE_VERSION}";
+      export ZOMBIENET_INTEGRATION_TEST_SECONDARY_IMAGE="docker.io/parity/polkadot:${BUILD_RELEASE_VERSION}";
       else
-        echo "Getting the image to use as SECONDARY, using ${BUILD_RELEASE_VERSION} as base";
-        VERSIONS=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/parity/polkadot/tags/' | jq -r '.results[].name'| grep -E "v[0-9]" |grep -vE "[0-9]-");
-        VERSION_TO_USE=$(echo "${BUILD_RELEASE_VERSION}\n$VERSIONS"|sort -r|grep -A1 "${BUILD_RELEASE_VERSION}"|tail -1);
-        export ZOMBIENET_INTEGRATION_TEST_SECONDARY_IMAGE="docker.io/parity/polkadot:${VERSION_TO_USE}";
+      echo "Getting the image to use as SECONDARY, using ${BUILD_RELEASE_VERSION} as base";
+      VERSIONS=$(curl -L -s 'https://registry.hub.docker.com/v2/repositories/parity/polkadot/tags/' | jq -r '.results[].name'| grep -E "v[0-9]" |grep -vE "[0-9]-");
+      VERSION_TO_USE=$(echo "${BUILD_RELEASE_VERSION}\n$VERSIONS"|sort -r|grep -A1 "${BUILD_RELEASE_VERSION}"|tail -1);
+      export ZOMBIENET_INTEGRATION_TEST_SECONDARY_IMAGE="docker.io/parity/polkadot:${VERSION_TO_USE}";
       fi
     - echo "Zombienet Tests Config"
     - echo "gh-dir ${GH_DIR}"
@@ -117,6 +119,8 @@ zombienet-polkadot-smoke-0001-parachains-smoke-test:
   extends:
     - .zombienet-polkadot-common
   before_script:
+    # Exit if the job is not merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="${POLKADOT_IMAGE}":${PIPELINE_IMAGE_TAG}
     - export COL_IMAGE="${COLANDER_IMAGE}":${PIPELINE_IMAGE_TAG}
     - echo "Zombienet Tests Config"
@@ -134,6 +138,8 @@ zombienet-polkadot-smoke-0002-parachains-parachains-upgrade-smoke:
   extends:
     - .zombienet-polkadot-common
   before_script:
+    # Exit if the job is not merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="${POLKADOT_IMAGE}":${PIPELINE_IMAGE_TAG}
     - export CUMULUS_IMAGE="docker.io/paritypr/polkadot-parachain-debug:${DOCKER_IMAGES_VERSION}"
     - echo "Zombienet Tests Config"
@@ -176,6 +182,8 @@ zombienet-polkadot-misc-0002-upgrade-node:
     - job: build-linux-stable
       artifacts: true
   before_script:
+    # Exit if the job is not merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:latest"
     - echo "Overrided poladot image ${ZOMBIENET_INTEGRATION_TEST_IMAGE}"
     - export COL_IMAGE="${COLANDER_IMAGE}":${PIPELINE_IMAGE_TAG}

--- a/.gitlab/pipeline/zombienet/substrate.yml
+++ b/.gitlab/pipeline/zombienet/substrate.yml
@@ -4,6 +4,8 @@
 # common settings for all zombienet jobs
 .zombienet-substrate-common:
   before_script:
+    # Exit if the job is not merge queue
+    - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - echo "Zombienet Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
     - echo "${GH_DIR}"


### PR DESCRIPTION
PR prepares CI to the GitHub Merge Queues. All github actions that were running in PR adjusted so they can run in the merge queues. Zombienet jobs will do nothing during PRs but they will run during merge queues. 

Jobs that will be skipped during PR:
 - all zombienet jobs
 - all publish docker jobs

Jobs that will be skipped during merge queue:
 - check-labels
 - check-prdoc
 - pr-custom-review
 - review trigger

cc https://github.com/paritytech/ci_cd/issues/862