### PR TITLE
 Add environment to claim workflow

### DIFF
--- a/.github/workflows/claim-crates.yml
+++ b/.github/workflows/claim-crates.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   claim-crates:
     runs-on: ubuntu-latest
+    environment: master
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 


### PR DESCRIPTION
Turns out to access environment secrets the workflow must explicitly opt in to the environment.
