### PR TITLE
Remove `DmpQueue` from Rococo Contracts

### DIFF
--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -405,7 +405,6 @@ construct_runtime!(
 		XcmpQueue: cumulus_pallet_xcmp_queue::{Pallet, Call, Storage, Event<T>} = 30,
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config<T>} = 31,
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 32,
-		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 33,
 		MessageQueue: pallet_message_queue::{Pallet, Call, Storage, Event<T>} = 34,
 
 		// Smart Contracts.

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/xcm_config.rs
@@ -304,9 +304,3 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 parameter_types! {
 	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
 }
-
-impl cumulus_pallet_dmp_queue::Config for Runtime {
-	type WeightInfo = cumulus_pallet_dmp_queue::weights::SubstrateWeight<Runtime>;
-	type RuntimeEvent = crate::RuntimeEvent;
-	type DmpSink = frame_support::traits::EnqueueWithOrigin<crate::MessageQueue, RelayOrigin>;
-}


### PR DESCRIPTION
`DmpQueue` has finished its migration and can be safely removed from the runtime.

<img width="1506" alt="Screenshot 2023-11-15 at 12 37 04" src="https://github.com/paritytech/polkadot-sdk/assets/16665596/31c779e8-89e2-4ac0-b990-abf260d28c01">
