### PR TITLE
[Cumulus] Add `GeneralKey` variant to `AggregateMessageOrigin`

### DIFF
--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -115,10 +115,8 @@ impl From<AggregateMessageOrigin> for xcm::v3::MultiLocation {
 		match origin {
 			Here => MultiLocation::here(),
 			Parent => MultiLocation::parent(),
-			Sibling(id) =>
-				MultiLocation::new(1, Junction::Parachain(id.into())),
-			GeneralKey(id) =>
-				MultiLocation::new(0, Junction::GeneralKey { length: 32, data: id }),
+			Sibling(id) => MultiLocation::new(1, Junction::Parachain(id.into())),
+			GeneralKey(id) => MultiLocation::new(0, Junction::GeneralKey { length: 32, data: id }),
 		}
 	}
 }


### PR DESCRIPTION
Adds `GeneralKey` variant to `AggregateMessageOrigin`.

This change is needed for the system BridgeHub runtimes, so that Snowbridge can also make use of the `MessageQueue` pallet. See previous discussion at https://github.com/paritytech/polkadot-sdk/pull/2146#discussion_r1382568956.

We have reworked Snowbridge to utilize the more generic approach introduced by this PR.
This avoids the need for BridgeHub runtimes to define their own `AggregateMessageOrigin` and associated helper types.

 Other parachain teams may also benefit from this.