### PR TITLE
Add broker system parachain config to rococo

### DIFF
--- a/polkadot/runtime/parachains/src/assigner_bulk/mod.rs
+++ b/polkadot/runtime/parachains/src/assigner_bulk/mod.rs
@@ -180,6 +180,10 @@ pub mod pallet {
 	{
 		/// Something that provides the weight of this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Origin from which coretime extrinsics may be called. This is generally the Broker
+		/// system parachain.
+		type ExternalBrokerOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 	}
 
 	/// Scheduled assignment sets.
@@ -217,8 +221,32 @@ pub mod pallet {
 		}
 	}
 
+	/// Receive instructions from the `ExternalBrokerOrigin`, detailing how a specific core is to be
+	/// used.
+	///
+	/// Parameters:
+	/// -`origin`: The `ExternalBrokerOrigin`, assumed to be the Broker system parachain.
+	/// -`core`: The core that should be scheduled.
+	/// -`begin`: The starting blockheight of the instruction.
+	/// -`assignment`: How the blockspace should be utilised.
+	/// -`end_hint`: An optional hint as to when this particular set of instructions will end.
 	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
+	impl<T: Config> Pallet<T> {
+		//TODO: Weights
+		#[pallet::call_index(0)]
+		pub fn assign_core(
+			origin: OriginFor<T>,
+			core: CoreIndex,
+			begin: BlockNumberFor<T>,
+			assignment: Vec<(CoreAssignment, PartsOf57600)>,
+			end_hint: Option<BlockNumberFor<T>>,
+		) -> DispatchResult {
+			// Ignore requests not coming from the External Broker parachain.
+			let _multi_location = <T as Config>::ExternalBrokerOrigin::ensure_origin(origin)?;
+
+			Pallet::<T>::do_assign_core(core, begin, assignment, end_hint)
+		}
+	}
 
 	#[pallet::error]
 	pub enum Error<T> {
@@ -412,7 +440,7 @@ impl<T: Config> Pallet<T> {
 	/// The problem is that insertion complexity then depends on the size of the existing queue,
 	/// which makes determining weights hard and could lead to issues like overweight blocks (at
 	/// least in theory).
-	pub fn assign_core(
+	pub fn do_assign_core(
 		core_idx: CoreIndex,
 		begin: BlockNumberFor<T>,
 		assignments: Vec<(CoreAssignment, PartsOf57600)>,

--- a/polkadot/runtime/rococo/constants/src/lib.rs
+++ b/polkadot/runtime/rococo/constants/src/lib.rs
@@ -113,10 +113,12 @@ pub mod system_parachain {
 	pub const ENCOINTER_ID: u32 = 1003;
 	/// BridgeHub parachain ID.
 	pub const BRIDGE_HUB_ID: u32 = 1013;
+	/// Brokerage parachain ID.
+	pub const BROKER_ID: u32 = 1004;
 
 	frame_support::match_types! {
 		pub type SystemParachains: impl Contains<MultiLocation> = {
-			MultiLocation { parents: 0, interior: X1(Parachain(ASSET_HUB_ID | CONTRACTS_ID | ENCOINTER_ID | BRIDGE_HUB_ID)) }
+			MultiLocation { parents: 0, interior: X1(Parachain(ASSET_HUB_ID | CONTRACTS_ID | ENCOINTER_ID | BRIDGE_HUB_ID | BROKER_ID)) }
 		};
 	}
 }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -21,6 +21,7 @@
 #![recursion_limit = "512"]
 
 use pallet_nis::WithMaximumOf;
+use pallet_xcm::EnsureXcm;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use primitives::{
 	slashing, AccountId, AccountIndex, Balance, BlockNumber, CandidateEvent, CandidateHash,
@@ -120,6 +121,7 @@ use governance::{
 	pallet_custom_origins, AuctionAdmin, Fellows, GeneralAdmin, LeaseAdmin, Treasurer,
 	TreasurySpender,
 };
+use xcm_config::Broker;
 
 #[cfg(test)]
 mod tests;
@@ -979,6 +981,7 @@ impl parachains_assigner_bulk::Config for Runtime {
 	// FIXME: Proper weights:
 	type WeightInfo = ();
 	// type WeightInfo = weights::runtime_parachains_assigner_bulk::WeightInfo<Runtime>;
+	type ExternalBrokerOrigin = EnsureXcm<Broker>;
 }
 
 impl parachains_assigner_parachains::Config for Runtime {}

--- a/polkadot/runtime/rococo/src/xcm_config.rs
+++ b/polkadot/runtime/rococo/src/xcm_config.rs
@@ -25,7 +25,7 @@ use crate::governance::StakingAdmin;
 
 use frame_support::{
 	match_types, parameter_types,
-	traits::{Everything, Nothing},
+	traits::{Contains, Everything, Nothing},
 	weights::Weight,
 };
 use frame_system::EnsureRoot;
@@ -118,6 +118,7 @@ parameter_types! {
 	pub const Contracts: MultiLocation = Parachain(CONTRACTS_ID).into_location();
 	pub const Encointer: MultiLocation = Parachain(ENCOINTER_ID).into_location();
 	pub const BridgeHub: MultiLocation = Parachain(BRIDGE_HUB_ID).into_location();
+	pub const Broker: MultiLocation = Parachain(BROKER_ID).into_location();
 	pub const Tick: MultiLocation = Parachain(100).into_location();
 	pub const Trick: MultiLocation = Parachain(110).into_location();
 	pub const Track: MultiLocation = Parachain(120).into_location();
@@ -128,6 +129,7 @@ parameter_types! {
 	pub const RocForContracts: (MultiAssetFilter, MultiLocation) = (Roc::get(), Contracts::get());
 	pub const RocForEncointer: (MultiAssetFilter, MultiLocation) = (Roc::get(), Encointer::get());
 	pub const RocForBridgeHub: (MultiAssetFilter, MultiLocation) = (Roc::get(), BridgeHub::get());
+	pub const RocForBroker: (MultiAssetFilter, MultiLocation) = (Roc::get(), Broker::get());
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
 }
@@ -139,6 +141,7 @@ pub type TrustedTeleporters = (
 	xcm_builder::Case<RocForContracts>,
 	xcm_builder::Case<RocForEncointer>,
 	xcm_builder::Case<RocForBridgeHub>,
+	xcm_builder::Case<RocForBroker>,
 );
 
 match_types! {


### PR DESCRIPTION
Adds system parachain configuration and gates the `assign_core` call to only the Broker system parachain.
