### PR TITLE
bump zombienet version `v1.3.80`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   RUSTY_CACHIER_COMPRESSION_METHOD: zstd
   NEXTEST_FAILURE_OUTPUT: immediate-final
   NEXTEST_SUCCESS_OUTPUT: final
-  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.79"
+  ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.80"
   DOCKER_IMAGES_VERSION: "${CI_COMMIT_SHA}"
 
 default:


### PR DESCRIPTION
New release includes logic to move all jobs to `spot instances`.
Thx!