### PR TITLE
Beefy: small fixes

### DIFF
--- a/substrate/client/consensus/beefy/src/worker.rs
+++ b/substrate/client/consensus/beefy/src/worker.rs
@@ -478,6 +478,9 @@ where
 				}
 			}
 
+			crate::aux_schema::write_voter_state(&*self.backend, &self.persisted_state)
+				.map_err(|e| Error::Backend(e.to_string()))?;
+
 			// Update gossip validator votes filter.
 			if let Err(e) = self
 				.persisted_state


### PR DESCRIPTION
Related to #2285

- save the state of the BEEFY gadget after processing a finality proof. We need this in order to avoid skipping blocks.
- avoid reprocessing the old state when not necessary