### PR TITLE
Make collator RPC mode non-experimental

### DIFF
--- a/cumulus/client/cli/src/lib.rs
+++ b/cumulus/client/cli/src/lib.rs
@@ -296,7 +296,14 @@ pub struct RunCmd {
 	#[arg(long, conflicts_with = "validator")]
 	pub collator: bool,
 
-	/// EXPERIMENTAL: Specify an URL to a relay chain full node to communicate with.
+	/// Creates a node that uses fewer resources by retrieving relay chain data from a remote node.
+	/// The provided URLs should point to RPC endpoints of the relay chain.
+	///
+	/// This node connects to the remote nodes following the order they were specified in. If the
+	/// connection to one fails, it attempts to connect to the next in the list.
+	///
+	/// Note: This option doesn't stop the node from connecting to the relay chain network but
+	/// reduces bandwidth use.
 	#[arg(
 		long,
 		value_parser = validate_relay_chain_url,

--- a/cumulus/client/cli/src/lib.rs
+++ b/cumulus/client/cli/src/lib.rs
@@ -296,11 +296,11 @@ pub struct RunCmd {
 	#[arg(long, conflicts_with = "validator")]
 	pub collator: bool,
 
-	/// Creates a node that uses fewer resources by retrieving relay chain data from a remote node.
-	/// The provided URLs should point to RPC endpoints of the relay chain.
+	/// Creates a less resource-hungry node that retrieves relay chain data from an RPC endpoint.
 	///
+	/// The provided URLs should point to RPC endpoints of the relay chain.
 	/// This node connects to the remote nodes following the order they were specified in. If the
-	/// connection to one fails, it attempts to connect to the next in the list.
+	/// connection fails, it attempts to connect to the next endpoint in the list.
 	///
 	/// Note: This option doesn't stop the node from connecting to the relay chain network but
 	/// reduces bandwidth use.


### PR DESCRIPTION
The `--relay-chain-rpc-urls` CLI flag has been available for a while now. We have collators with this running and parachain teams are also using it. It should be fine now to remove the experimental status.