### PR TITLE
`keyring`: remove `lazy_static` public hash maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17696,6 +17696,8 @@ dependencies = [
 name = "sp-keyring"
 version = "24.0.0"
 dependencies = [
+ "array-bytes 6.1.0",
+ "hex-literal",
  "lazy_static",
  "sp-core",
  "sp-runtime",

--- a/substrate/primitives/keyring/Cargo.toml
+++ b/substrate/primitives/keyring/Cargo.toml
@@ -14,10 +14,14 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+hex-literal = "0.4.1"
 lazy_static = "1.4.0"
 strum = { version = "0.24.1", features = ["derive"], default-features = false }
 sp-core = { path = "../core" }
 sp-runtime = { path = "../runtime" }
+
+[dev-dependencies]
+array-bytes = { version = "6.1" }
 
 [features]
 # This feature adds Bandersnatch crypto primitives.

--- a/substrate/primitives/keyring/src/ed25519.rs
+++ b/substrate/primitives/keyring/src/ed25519.rs
@@ -3,28 +3,27 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the => "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an => "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 //! Support code for the runtime. A set of test accounts.
 
-use lazy_static::lazy_static;
 pub use sp_core::ed25519;
 use sp_core::{
 	ed25519::{Pair, Public, Signature},
 	ByteArray, Pair as PairT, H256,
 };
 use sp_runtime::AccountId32;
-use std::{collections::HashMap, ops::Deref};
+use std::ops::Deref;
 
 /// Set of test accounts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::Display, strum::EnumIter)]
@@ -44,6 +43,8 @@ pub enum Keyring {
 	One,
 	Two,
 }
+
+use hex_literal::hex;
 
 impl Keyring {
 	pub fn from_public(who: &Public) -> Option<Keyring> {
@@ -99,6 +100,39 @@ impl Keyring {
 	pub fn to_seed(self) -> String {
 		format!("//{}", self)
 	}
+
+	fn public_bytes(&self) -> &'static [u8; 32] {
+		match *self {
+			Keyring::Alice =>
+				&hex!("88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"),
+			Keyring::Bob =>
+				&hex!("d17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69"),
+			Keyring::Charlie =>
+				&hex!("439660b36c6c03afafca027b910b4fecf99801834c62a5e6006f27d978de234f"),
+			Keyring::Dave =>
+				&hex!("5e639b43e0052c47447dac87d6fd2b6ec50bdd4d0f614e4299c665249bbd09d9"),
+			Keyring::Eve =>
+				&hex!("1dfe3e22cc0d45c70779c1095f7489a8ef3cf52d62fbd8c2fa38c9f1723502b5"),
+			Keyring::Ferdie =>
+				&hex!("568cb4a574c6d178feb39c27dfc8b3f789e5f5423e19c71633c748b9acf086b5"),
+			Keyring::AliceStash =>
+				&hex!("451781cd0c5504504f69ceec484cc66e4c22a2b6a9d20fb1a426d91ad074a2a8"),
+			Keyring::BobStash =>
+				&hex!("292684abbb28def63807c5f6e84e9e8689769eb37b1ab130d79dbfbf1b9a0d44"),
+			Keyring::CharlieStash =>
+				&hex!("dd6a6118b6c11c9c9e5a4f34ed3d545e2c74190f90365c60c230fa82e9423bb9"),
+			Keyring::DaveStash =>
+				&hex!("1d0432d75331ab299065bee79cdb1bdc2497c597a3087b4d955c67e3c000c1e2"),
+			Keyring::EveStash =>
+				&hex!("c833bdd2e1a7a18acc1c11f8596e2e697bb9b42d6b6051e474091a1d43a294d7"),
+			Keyring::FerdieStash =>
+				&hex!("199d749dbf4b8135cb1f3c8fd697a390fc0679881a8a110c1d06375b3b62cd09"),
+			Keyring::One =>
+				&hex!("16f97016bbea8f7b45ae6757b49efc1080accc175d8f018f9ba719b60b0815e4"),
+			Keyring::Two =>
+				&hex!("5079bcd20fd97d7d2f752c4607012600b401950260a91821f73e692071c82bf5"),
+		}
+	}
 }
 
 impl From<Keyring> for &'static str {
@@ -128,16 +162,9 @@ impl From<Keyring> for sp_runtime::MultiSigner {
 	}
 }
 
-lazy_static! {
-	static ref PRIVATE_KEYS: HashMap<Keyring, Pair> =
-		Keyring::iter().map(|i| (i, i.pair())).collect();
-	static ref PUBLIC_KEYS: HashMap<Keyring, Public> =
-		PRIVATE_KEYS.iter().map(|(&name, pair)| (name, pair.public())).collect();
-}
-
 impl From<Keyring> for Public {
 	fn from(k: Keyring) -> Self {
-		*(*PUBLIC_KEYS).get(&k).unwrap()
+		Public::from_raw(*k.public_bytes())
 	}
 }
 
@@ -155,38 +182,32 @@ impl From<Keyring> for Pair {
 
 impl From<Keyring> for [u8; 32] {
 	fn from(k: Keyring) -> Self {
-		*(*PUBLIC_KEYS).get(&k).unwrap().as_array_ref()
+		*k.public_bytes()
 	}
 }
 
 impl From<Keyring> for H256 {
 	fn from(k: Keyring) -> Self {
-		(*PUBLIC_KEYS).get(&k).unwrap().as_array_ref().into()
+		k.public_bytes().into()
 	}
 }
 
 impl From<Keyring> for &'static [u8; 32] {
 	fn from(k: Keyring) -> Self {
-		(*PUBLIC_KEYS).get(&k).unwrap().as_array_ref()
+		k.public_bytes()
 	}
 }
 
 impl AsRef<[u8; 32]> for Keyring {
 	fn as_ref(&self) -> &[u8; 32] {
-		(*PUBLIC_KEYS).get(self).unwrap().as_array_ref()
-	}
-}
-
-impl AsRef<Public> for Keyring {
-	fn as_ref(&self) -> &Public {
-		(*PUBLIC_KEYS).get(self).unwrap()
+		self.public_bytes()
 	}
 }
 
 impl Deref for Keyring {
 	type Target = [u8; 32];
 	fn deref(&self) -> &[u8; 32] {
-		(*PUBLIC_KEYS).get(self).unwrap().as_array_ref()
+		self.public_bytes()
 	}
 }
 
@@ -212,5 +233,17 @@ mod tests {
 			b"I am Alice!",
 			&Keyring::Bob.public(),
 		));
+	}
+
+	#[test]
+	fn verify_static_public_keys() {
+		assert!(Keyring::iter().all(|k| { k.pair().public().as_ref() == *k.public_bytes() }));
+		// little helper to print out public keys hex string
+		// use array_bytes::Hex;
+		// Keyring::iter().map(|i| (i, i.pair())).for_each(|(name, pair)| {
+		// 	let public = pair.public();
+		// 	let bytes: &[u8; 32] = public.as_ref();
+		// 	println!("Keyring::{}: {:?}", name, bytes.hex(""));
+		// });
 	}
 }


### PR DESCRIPTION
The `lazy_static` package does not work well in `no-std`: it requires `spin_no_std` feature, which also will propagate into `std` if enabled. This is not what we want.

This PR provides removes public/private key hashmaps and replaces them with simple static byte arrays.