### PR TITLE
pallet-vesting: Configurable block number provider

### DIFF
--- a/substrate/frame/vesting/src/mock.rs
+++ b/substrate/frame/vesting/src/mock.rs
@@ -95,6 +95,7 @@ impl Config for Test {
 	type MinVestedTransfer = MinVestedTransfer;
 	type WeightInfo = ();
 	type UnvestedFundsAllowedWithdrawReasons = UnvestedFundsAllowedWithdrawReasons;
+	type BlockNumberProvider = System;
 }
 
 pub struct ExtBuilder {


### PR DESCRIPTION
This PR makes the block number provider configurable through the Config trait in pallet-vesting, this gives parachains the option to use the relay chain block number provider from ParachainSystem.