### PR TITLE
cumulus-test-service: block import fix

### DIFF
--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -211,7 +211,8 @@ pub fn new_partial(
 		sc_service::new_full_parts::<Block, RuntimeApi, _>(config, None, executor)?;
 	let client = Arc::new(client);
 
-	let block_import = ParachainBlockImport::new(client.clone(), backend.clone());
+	let block_import =
+		ParachainBlockImport::new_with_delayed_best_block(client.clone(), backend.clone());
 
 	let registry = config.prometheus_registry();
 


### PR DESCRIPTION
This is follow-up for: https://github.com/paritytech/polkadot-sdk/pull/2001

Block import queue for `test-parachain` (`cumulus-test-service`) shall use delayed best block feature.

This should fixed broken zombienet tests.