### PR TITLE
Fixes import path in benchmark macro

### DIFF
--- a/substrate/bin/node-template/pallets/template/src/benchmarking.rs
+++ b/substrate/bin/node-template/pallets/template/src/benchmarking.rs
@@ -1,7 +1,6 @@
 //! Benchmarking setup for pallet-template
 #![cfg(feature = "runtime-benchmarks")]
 use super::*;
-use sp_std::vec;
 
 #[allow(unused)]
 use crate::Pallet as Template;

--- a/substrate/frame/asset-rate/src/benchmarking.rs
+++ b/substrate/frame/asset-rate/src/benchmarking.rs
@@ -25,7 +25,6 @@ use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
 use frame_system::RawOrigin;
 use sp_core::crypto::FromEntropy;
-use sp_std::vec;
 
 /// Trait describing the factory function for the `AssetKind` parameter.
 pub trait AssetKindFactory<AssetKind> {

--- a/substrate/frame/support/procedural/src/benchmark.rs
+++ b/substrate/frame/support/procedural/src/benchmark.rs
@@ -517,7 +517,7 @@ pub fn benchmarks(
 							components,
 							// TODO: Not supported by V2 syntax as of yet.
 							// https://github.com/paritytech/substrate/issues/13132
-							pov_modes: vec![],
+							pov_modes: #krate::__private::vec![],
 						}
 					}).collect::<#krate::__private::Vec<_>>()
 				}


### PR DESCRIPTION
Fully-qualified path was not being used in benchmark macro for one of the cases. This PR fixes this and removes the unnecessary import in a couple of files, which I believe was done to fix this issue.