### PR TITLE
sp-api: Move macro related re-exports to `__private`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,8 +1493,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -4233,6 +4233,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-storage 13.0.0",
+ "sp-version",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -10419,6 +10420,7 @@ dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
  "sp-api",
+ "sp-std 8.0.0",
 ]
 
 [[package]]
@@ -16116,6 +16118,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-externalities 0.19.0",
  "sp-maybe-compressed-blob",
  "sp-rpc",
  "sp-runtime",
@@ -16349,6 +16352,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "parity-scale-codec",
  "parking_lot 0.12.1",
  "regex",
  "rustc-hash",
@@ -20003,7 +20007,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/cumulus/client/relay-chain-rpc-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-rpc-interface/Cargo.toml
@@ -20,6 +20,7 @@ sp-authority-discovery = { path = "../../../substrate/primitives/authority-disco
 sp-state-machine = { path = "../../../substrate/primitives/state-machine" }
 sp-storage = { path = "../../../substrate/primitives/storage" }
 sp-runtime = { path = "../../../substrate/primitives/runtime" }
+sp-version = { path = "../../../substrate/primitives/version" }
 sc-client-api = { path = "../../../substrate/client/api" }
 sc-rpc-api = { path = "../../../substrate/client/rpc-api" }
 sc-service = { path = "../../../substrate/client/service" }

--- a/cumulus/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -46,10 +46,10 @@ use cumulus_relay_chain_interface::{RelayChainError, RelayChainResult};
 use sc_client_api::StorageData;
 use sc_rpc_api::{state::ReadProof, system::Health};
 use sc_service::TaskManager;
-use sp_api::RuntimeVersion;
 use sp_consensus_babe::Epoch;
 use sp_core::sp_std::collections::btree_map::BTreeMap;
 use sp_storage::StorageKey;
+use sp_version::RuntimeVersion;
 
 use crate::{
 	light_client_worker::{build_smoldot_client, LightClientRpcWorker},

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -155,7 +155,7 @@ fn xcm_enqueueing_broken_xcm_works() {
 				.take(20)
 				.collect::<Vec<_>>(),
 		);
-		EnqueuedMessages::set(&vec![]);
+		EnqueuedMessages::take();
 
 		// But if we do it all in one page, then it only uses the first 10:
 		XcmpQueue::handle_xcmp_messages(

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -98,7 +98,7 @@ pub use service::{
 	ChainSpec, Configuration, Error as SubstrateServiceError, PruningMode, Role, RuntimeGenesis,
 	TFullBackend, TFullCallExecutor, TFullClient, TaskManager, TransactionPoolOptions,
 };
-pub use sp_api::{ApiRef, ConstructRuntimeApi, Core as CoreApi, ProvideRuntimeApi, StateBackend};
+pub use sp_api::{ApiRef, ConstructRuntimeApi, Core as CoreApi, ProvideRuntimeApi};
 pub use sp_runtime::{
 	generic,
 	traits::{self as runtime_traits, BlakeTwo256, Block as BlockT, Header as HeaderT, NumberFor},

--- a/substrate/client/api/src/call_executor.rs
+++ b/substrate/client/api/src/call_executor.rs
@@ -21,12 +21,12 @@
 use sc_executor::{RuntimeVersion, RuntimeVersionOf};
 use sp_core::traits::CallContext;
 use sp_externalities::Extensions;
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, HashingFor};
 use sp_state_machine::{OverlayedChanges, StorageProof};
 use std::cell::RefCell;
 
 use crate::execution_extensions::ExecutionExtensions;
-use sp_api::{HashingFor, ProofRecorder};
+use sp_api::ProofRecorder;
 
 /// Executor Provider
 pub trait ExecutorProvider<Block: BlockT> {

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -812,9 +812,8 @@ pub fn check_genesis_storage(storage: &Storage) -> sp_blockchain::Result<()> {
 #[cfg(test)]
 mod tests {
 	use crate::{in_mem::Blockchain, NewBlockState};
-	use sp_api::HeaderT;
 	use sp_blockchain::Backend;
-	use sp_runtime::{ConsensusEngineId, Justifications};
+	use sp_runtime::{traits::Header as HeaderT, ConsensusEngineId, Justifications};
 	use substrate_test_runtime::{Block, Header, H256};
 
 	pub const ID1: ConsensusEngineId = *b"TST1";

--- a/substrate/client/consensus/beefy/src/lib.rs
+++ b/substrate/client/consensus/beefy/src/lib.rs
@@ -40,7 +40,7 @@ use sc_client_api::{Backend, BlockBackend, BlockchainEvents, FinalityNotificatio
 use sc_consensus::BlockImport;
 use sc_network::{NetworkRequest, ProtocolName};
 use sc_network_gossip::{GossipEngine, Network as GossipNetwork, Syncing as GossipSyncing};
-use sp_api::{HeaderT, NumberFor, ProvideRuntimeApi};
+use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{
 	Backend as BlockchainBackend, Error as ClientError, HeaderBackend, Result as ClientResult,
 };
@@ -51,7 +51,7 @@ use sp_consensus_beefy::{
 };
 use sp_keystore::KeystorePtr;
 use sp_mmr_primitives::MmrApi;
-use sp_runtime::traits::{Block, Zero};
+use sp_runtime::traits::{Block, Header as HeaderT, NumberFor, Zero};
 use std::{
 	collections::{BTreeMap, VecDeque},
 	marker::PhantomData,

--- a/substrate/client/consensus/beefy/src/worker.rs
+++ b/substrate/client/consensus/beefy/src/worker.rs
@@ -36,7 +36,7 @@ use log::{debug, error, info, log_enabled, trace, warn};
 use sc_client_api::{Backend, FinalityNotification, FinalityNotifications, HeaderBackend};
 use sc_network_gossip::GossipEngine;
 use sc_utils::{mpsc::TracingUnboundedReceiver, notification::NotificationReceiver};
-use sp_api::{BlockId, ProvideRuntimeApi};
+use sp_api::ProvideRuntimeApi;
 use sp_arithmetic::traits::{AtLeast32Bit, Saturating};
 use sp_consensus::SyncOracle;
 use sp_consensus_beefy::{
@@ -46,7 +46,7 @@ use sp_consensus_beefy::{
 	VersionedFinalityProof, VoteMessage, BEEFY_ENGINE_ID,
 };
 use sp_runtime::{
-	generic::OpaqueDigestItemId,
+	generic::{BlockId, OpaqueDigestItemId},
 	traits::{Block, Header, NumberFor, Zero},
 	SaturatedConversion,
 };
@@ -1074,13 +1074,12 @@ pub(crate) mod tests {
 	use sc_client_api::{Backend as BackendT, HeaderBackend};
 	use sc_network_sync::SyncingService;
 	use sc_network_test::TestNetFactory;
-	use sp_api::HeaderT;
 	use sp_blockchain::Backend as BlockchainBackendT;
 	use sp_consensus_beefy::{
 		generate_equivocation_proof, known_payloads, known_payloads::MMR_ROOT_ID,
 		mmr::MmrRootProvider, Keyring, Payload, SignedCommitment,
 	};
-	use sp_runtime::traits::One;
+	use sp_runtime::traits::{Header as HeaderT, One};
 	use substrate_test_runtime_client::{
 		runtime::{Block, Digest, DigestItem, Header},
 		Backend,

--- a/substrate/client/executor/src/wasm_runtime.rs
+++ b/substrate/client/executor/src/wasm_runtime.rs
@@ -441,6 +441,7 @@ mod tests {
 	use codec::Encode;
 	use sp_api::{Core, RuntimeApiInfo};
 	use sp_runtime::RuntimeString;
+	use sp_version::{create_apis_vec, RuntimeVersion};
 	use sp_wasm_interface::HostFunctions;
 	use substrate_test_runtime::Block;
 
@@ -470,7 +471,7 @@ mod tests {
 			authoring_version: 1,
 			spec_version: 1,
 			impl_version: 1,
-			apis: sp_api::create_apis_vec!([(<dyn Core::<Block>>::ID, 1)]),
+			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 1)]),
 		};
 
 		let version = decode_version(&old_runtime_version.encode()).unwrap();
@@ -486,7 +487,7 @@ mod tests {
 			authoring_version: 1,
 			spec_version: 1,
 			impl_version: 1,
-			apis: sp_api::create_apis_vec!([(<dyn Core::<Block>>::ID, 3)]),
+			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 3)]),
 		};
 
 		decode_version(&old_runtime_version.encode()).unwrap_err();
@@ -494,13 +495,13 @@ mod tests {
 
 	#[test]
 	fn new_runtime_version_decodes() {
-		let old_runtime_version = sp_api::RuntimeVersion {
+		let old_runtime_version = RuntimeVersion {
 			spec_name: "test".into(),
 			impl_name: "test".into(),
 			authoring_version: 1,
 			spec_version: 1,
 			impl_version: 1,
-			apis: sp_api::create_apis_vec!([(<dyn Core::<Block>>::ID, 3)]),
+			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 3)]),
 			transaction_version: 3,
 			state_version: 4,
 		};
@@ -509,13 +510,13 @@ mod tests {
 		assert_eq!(3, version.transaction_version);
 		assert_eq!(0, version.state_version);
 
-		let old_runtime_version = sp_api::RuntimeVersion {
+		let old_runtime_version = RuntimeVersion {
 			spec_name: "test".into(),
 			impl_name: "test".into(),
 			authoring_version: 1,
 			spec_version: 1,
 			impl_version: 1,
-			apis: sp_api::create_apis_vec!([(<dyn Core::<Block>>::ID, 4)]),
+			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 4)]),
 			transaction_version: 3,
 			state_version: 4,
 		};
@@ -538,7 +539,7 @@ mod tests {
 			authoring_version: 100,
 			spec_version: 100,
 			impl_version: 100,
-			apis: sp_api::create_apis_vec!([(<dyn Core::<Block>>::ID, 4)]),
+			apis: create_apis_vec!([(<dyn Core::<Block>>::ID, 4)]),
 			transaction_version: 100,
 			state_version: 1,
 		};

--- a/substrate/client/merkle-mountain-range/rpc/src/lib.rs
+++ b/substrate/client/merkle-mountain-range/rpc/src/lib.rs
@@ -30,14 +30,14 @@ use jsonrpsee::{
 };
 use serde::{Deserialize, Serialize};
 
-use sp_api::{ApiExt, NumberFor, ProvideRuntimeApi};
+use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_core::{
 	offchain::{storage::OffchainDb, OffchainDbExt, OffchainStorage},
 	Bytes,
 };
 use sp_mmr_primitives::{Error as MmrError, Proof};
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
 
 pub use sp_mmr_primitives::MmrApi as MmrRuntimeApi;
 

--- a/substrate/client/rpc-spec-v2/Cargo.toml
+++ b/substrate/client/rpc-spec-v2/Cargo.toml
@@ -37,12 +37,14 @@ tokio = { version = "1.22.0", features = ["sync"] }
 array-bytes = "6.1"
 log = "0.4.17"
 futures-util = { version = "0.3.19", default-features = false }
+
 [dev-dependencies]
 serde_json = "1.0.108"
 tokio = { version = "1.22.0", features = ["macros"] }
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
 substrate-test-runtime = { path = "../../test-utils/runtime" }
 sp-consensus = { path = "../../primitives/consensus/common" }
+sp-externalities = { path = "../../primitives/externalities" }
 sp-maybe-compressed-blob = { path = "../../primitives/maybe-compressed-blob" }
 sc-block-builder = { path = "../block-builder" }
 sc-service = { path = "../service", features = ["test-helpers"]}

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -29,13 +29,13 @@ use jsonrpsee::core::{async_trait, RpcResult};
 use sc_client_api::{
 	Backend, BlockBackend, BlockchainEvents, CallExecutor, ExecutorProvider, StorageProvider,
 };
-use sp_api::{CallApiAt, CallContext, NumberFor};
+use sp_api::{CallApiAt, CallContext};
 use sp_blockchain::{
 	Backend as BlockChainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
 use sp_core::Bytes;
 use sp_runtime::{
-	traits::{Block as BlockT, Header as HeaderT},
+	traits::{Block as BlockT, Header as HeaderT, NumberFor},
 	SaturatedConversion,
 };
 use std::{collections::HashSet, marker::PhantomData, sync::Arc};

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head_storage.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head_storage.rs
@@ -22,8 +22,8 @@ use std::{collections::VecDeque, marker::PhantomData, sync::Arc};
 
 use sc_client_api::{Backend, ChildInfo, StorageKey, StorageProvider};
 use sc_utils::mpsc::TracingUnboundedSender;
-use sp_api::BlockT;
 use sp_core::storage::well_known_keys;
+use sp_runtime::traits::Block as BlockT;
 
 use crate::chain_head::event::OperationStorageItems;
 

--- a/substrate/client/rpc-spec-v2/src/chain_head/test_utils.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/test_utils.rs
@@ -24,14 +24,15 @@ use sc_client_api::{
 	StorageData, StorageEventStream, StorageKey, StorageProvider,
 };
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
-use sp_api::{CallApiAt, CallApiAtParams, NumberFor, RuntimeVersion};
+use sp_api::{CallApiAt, CallApiAtParams};
 use sp_blockchain::{BlockStatus, CachedHeaderMetadata, HeaderBackend, HeaderMetadata, Info};
 use sp_consensus::BlockOrigin;
 use sp_runtime::{
 	generic::SignedBlock,
-	traits::{Block as BlockT, Header as HeaderT},
+	traits::{Block as BlockT, Header as HeaderT, NumberFor},
 	Justifications,
 };
+use sp_version::RuntimeVersion;
 use std::sync::Arc;
 use substrate_test_runtime::{Block, Hash, Header};
 
@@ -235,7 +236,7 @@ impl<Block: BlockT, Client: CallApiAt<Block>> CallApiAt<Block> for ChainHeadMock
 	fn initialize_extensions(
 		&self,
 		at: <Block as BlockT>::Hash,
-		extensions: &mut sp_api::Extensions,
+		extensions: &mut sp_externalities::Extensions,
 	) -> Result<(), sp_api::ApiError> {
 		self.client.initialize_extensions(at, extensions)
 	}

--- a/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
@@ -34,7 +34,6 @@ use jsonrpsee::{
 use sc_block_builder::BlockBuilderBuilder;
 use sc_client_api::ChildInfo;
 use sc_service::client::new_in_mem;
-use sp_api::BlockT;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockOrigin;
 use sp_core::{
@@ -42,6 +41,7 @@ use sp_core::{
 	testing::TaskExecutor,
 	Blake2Hasher, Hasher,
 };
+use sp_runtime::traits::Block as BlockT;
 use sp_version::RuntimeVersion;
 use std::{
 	collections::{HashMap, HashSet},

--- a/substrate/client/tracing/Cargo.toml
+++ b/substrate/client/tracing/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 ansi_term = "0.12.1"
 atty = "0.2.13"
 chrono = "0.4.27"
+codec = { package = "parity-scale-codec", version = "3.6.1" }
 lazy_static = "1.4.0"
 libc = "0.2.121"
 log = { version = "0.4.17" }

--- a/substrate/client/tracing/src/block/mod.rs
+++ b/substrate/client/tracing/src/block/mod.rs
@@ -25,6 +25,7 @@ use std::{
 	time::Instant,
 };
 
+use codec::Encode;
 use parking_lot::Mutex;
 use tracing::{
 	dispatcher,
@@ -34,7 +35,7 @@ use tracing::{
 
 use crate::{SpanDatum, TraceEvent, Values};
 use sc_client_api::BlockBackend;
-use sp_api::{Core, Encode, Metadata, ProvideRuntimeApi};
+use sp_api::{Core, Metadata, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_core::hexdisplay::HexDisplay;
 use sp_rpc::tracing::{BlockTrace, Span, TraceBlockResponse};

--- a/substrate/frame/beefy-mmr/src/lib.rs
+++ b/substrate/frame/beefy-mmr/src/lib.rs
@@ -36,6 +36,7 @@
 use sp_runtime::traits::{Convert, Member};
 use sp_std::prelude::*;
 
+use codec::Decode;
 use pallet_mmr::{LeafDataProvider, ParentNumberAndHash};
 use sp_consensus_beefy::{
 	mmr::{BeefyAuthoritySet, BeefyDataProvider, BeefyNextAuthoritySet, MmrLeaf, MmrLeafVersion},
@@ -226,7 +227,7 @@ sp_api::decl_runtime_apis! {
 	/// API useful for BEEFY light clients.
 	pub trait BeefyMmrApi<H>
 	where
-		BeefyAuthoritySet<H>: sp_api::Decode,
+		BeefyAuthoritySet<H>: Decode,
 	{
 		/// Return the currently active BEEFY authority set proof.
 		fn authority_set_proof() -> BeefyAuthoritySet<H>;

--- a/substrate/frame/contracts/src/storage/meter.rs
+++ b/substrate/frame/contracts/src/storage/meter.rs
@@ -34,7 +34,7 @@ use frame_support::{
 	DefaultNoBound, RuntimeDebugNoBound,
 };
 use sp_runtime::{
-	traits::{Saturating, Zero, Hash as HashT},
+	traits::{Hash as HashT, Saturating, Zero},
 	DispatchError, FixedPointNumber, FixedU128,
 };
 use sp_std::{fmt::Debug, marker::PhantomData, vec, vec::Vec};

--- a/substrate/frame/contracts/src/storage/meter.rs
+++ b/substrate/frame/contracts/src/storage/meter.rs
@@ -33,9 +33,8 @@ use frame_support::{
 	},
 	DefaultNoBound, RuntimeDebugNoBound,
 };
-use sp_api::HashT;
 use sp_runtime::{
-	traits::{Saturating, Zero},
+	traits::{Saturating, Zero, Hash as HashT},
 	DispatchError, FixedPointNumber, FixedU128,
 };
 use sp_std::{fmt::Debug, marker::PhantomData, vec, vec::Vec};

--- a/substrate/frame/nfts/runtime-api/Cargo.toml
+++ b/substrate/frame/nfts/runtime-api/Cargo.toml
@@ -14,9 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-pallet-nfts = { path = "..", default-features = false}
-sp-api = { path = "../../../primitives/api", default-features = false}
+pallet-nfts = { path = "..", default-features = false }
+sp-api = { path = "../../../primitives/api", default-features = false }
+sp-std = { path = "../../../primitives/std", default-features = false }
 
 [features]
 default = [ "std" ]
-std = [ "codec/std", "pallet-nfts/std", "sp-api/std" ]
+std = [ "codec/std", "pallet-nfts/std", "sp-api/std", "sp-std/std" ]

--- a/substrate/frame/nfts/runtime-api/src/lib.rs
+++ b/substrate/frame/nfts/runtime-api/src/lib.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
-use sp_api::vec::Vec;
+use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
 	pub trait NftsApi<AccountId, CollectionId, ItemId>

--- a/substrate/frame/support/test/tests/construct_runtime.rs
+++ b/substrate/frame/support/test/tests/construct_runtime.rs
@@ -27,13 +27,13 @@ use frame_support::{
 };
 use frame_system::limits::{BlockLength, BlockWeights};
 use scale_info::TypeInfo;
-use sp_api::RuntimeVersion;
 use sp_core::{sr25519, ConstU64};
 use sp_runtime::{
 	generic,
 	traits::{BlakeTwo256, Verify},
 	DispatchError, ModuleError,
 };
+use sp_version::RuntimeVersion;
 
 parameter_types! {
 	pub static IntegrityTestExec: u32 = 0;

--- a/substrate/primitives/api/Cargo.toml
+++ b/substrate/primitives/api/Cargo.toml
@@ -15,17 +15,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 sp-api-proc-macro = { path = "proc-macro" }
-sp-core = { path = "../core", default-features = false}
-sp-std = { path = "../std", default-features = false}
-sp-runtime = { path = "../runtime", default-features = false}
-sp-externalities = { path = "../externalities", default-features = false, optional = true}
-sp-version = { path = "../version", default-features = false}
-sp-state-machine = { path = "../state-machine", default-features = false, optional = true}
-sp-trie = { path = "../trie", default-features = false, optional = true}
+sp-core = { path = "../core", default-features = false }
+sp-std = { path = "../std", default-features = false }
+sp-runtime = { path = "../runtime", default-features = false }
+sp-externalities = { path = "../externalities", default-features = false, optional = true }
+sp-version = { path = "../version", default-features = false }
+sp-state-machine = { path = "../state-machine", default-features = false, optional = true }
+sp-trie = { path = "../trie", default-features = false, optional = true }
 hash-db = { version = "0.16.0", optional = true }
 thiserror = { version = "1.0.48", optional = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-sp-metadata-ir = { path = "../metadata-ir", default-features = false, optional = true}
+sp-metadata-ir = { path = "../metadata-ir", default-features = false, optional = true }
 log = { version = "0.4.17", default-features = false }
 
 [dev-dependencies]

--- a/substrate/primitives/api/proc-macro/src/utils.rs
+++ b/substrate/primitives/api/proc-macro/src/utils.rs
@@ -28,14 +28,14 @@ use syn::{
 /// Generates the access to the `sc_client` crate.
 pub fn generate_crate_access() -> TokenStream {
 	match crate_name("sp-api") {
-		Ok(FoundCrate::Itself) => quote!(sp_api),
+		Ok(FoundCrate::Itself) => quote!(sp_api::__private),
 		Ok(FoundCrate::Name(renamed_name)) => {
 			let renamed_name = Ident::new(&renamed_name, Span::call_site());
-			quote!(#renamed_name)
+			quote!(#renamed_name::__private)
 		},
 		Err(e) =>
 			if let Ok(FoundCrate::Name(name)) = crate_name(&"frame") {
-				let path = format!("{}::deps::{}", name, "sp_api");
+				let path = format!("{}::deps::sp_api::__private", name);
 				let path = syn::parse_str::<syn::Path>(&path).expect("is a valid path; qed");
 				quote!( #path )
 			} else {

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -70,48 +70,58 @@
 // Make doc tests happy
 extern crate self as sp_api;
 
+/// Private exports used by the macros.
+///
+/// This is seen as internal API and can change at any point.
 #[doc(hidden)]
-pub use codec::{self, Decode, DecodeLimit, Encode};
-#[doc(hidden)]
-#[cfg(feature = "std")]
-pub use hash_db::Hasher;
-#[doc(hidden)]
-pub use scale_info;
-#[doc(hidden)]
-pub use sp_core::offchain;
-#[doc(hidden)]
-#[cfg(not(feature = "std"))]
-pub use sp_core::to_substrate_wasm_fn_return_value;
-#[doc(hidden)]
+pub mod __private {
+	#[cfg(feature = "std")]
+	mod std_imports {
+		pub use hash_db::Hasher;
+		pub use sp_core::traits::CallContext;
+		pub use sp_externalities::{Extension, Extensions};
+		pub use sp_runtime::StateVersion;
+		pub use sp_state_machine::{
+			Backend as StateBackend, InMemoryBackend, OverlayedChanges, StorageProof, TrieBackend,
+			TrieBackendBuilder,
+		};
+	}
+	#[cfg(feature = "std")]
+	pub use std_imports::*;
+
+	pub use crate::*;
+	pub use codec::{self, Decode, DecodeLimit, Encode};
+	pub use scale_info;
+	pub use sp_core::offchain;
+	#[cfg(not(feature = "std"))]
+	pub use sp_core::to_substrate_wasm_fn_return_value;
+	#[cfg(feature = "frame-metadata")]
+	pub use sp_metadata_ir::{self as metadata_ir, frame_metadata as metadata};
+	pub use sp_runtime::{
+		generic::BlockId,
+		traits::{Block as BlockT, Hash as HashT, HashingFor, Header as HeaderT, NumberFor},
+		transaction_validity::TransactionValidity,
+		RuntimeString, TransactionOutcome,
+	};
+	pub use sp_std::{mem, slice, vec};
+	pub use sp_version::{create_apis_vec, ApiId, ApisVec, RuntimeVersion};
+}
+
 #[cfg(feature = "std")]
 pub use sp_core::traits::CallContext;
 use sp_core::OpaqueMetadata;
-#[doc(hidden)]
 #[cfg(feature = "std")]
-pub use sp_externalities::{Extension, Extensions};
-#[doc(hidden)]
-#[cfg(feature = "frame-metadata")]
-pub use sp_metadata_ir::{self as metadata_ir, frame_metadata as metadata};
-#[doc(hidden)]
+use sp_externalities::{Extension, Extensions};
+use sp_runtime::traits::Block as BlockT;
 #[cfg(feature = "std")]
-pub use sp_runtime::StateVersion;
-#[doc(hidden)]
-pub use sp_runtime::{
-	generic::BlockId,
-	traits::{Block as BlockT, Hash as HashT, HashingFor, Header as HeaderT, NumberFor},
-	transaction_validity::TransactionValidity,
-	RuntimeString, TransactionOutcome,
-};
-#[doc(hidden)]
+use sp_runtime::traits::HashingFor;
 #[cfg(feature = "std")]
-pub use sp_state_machine::{
-	backend::AsTrieBackend, Backend as StateBackend, InMemoryBackend, OverlayedChanges,
-	StorageProof, TrieBackend, TrieBackendBuilder,
-};
-#[doc(hidden)]
-pub use sp_std::{mem, slice, vec};
-#[doc(hidden)]
-pub use sp_version::{create_apis_vec, ApiId, ApisVec, RuntimeVersion};
+pub use sp_runtime::TransactionOutcome;
+#[cfg(feature = "std")]
+pub use sp_state_machine::StorageProof;
+#[cfg(feature = "std")]
+use sp_state_machine::{backend::AsTrieBackend, Backend as StateBackend, OverlayedChanges};
+use sp_version::RuntimeVersion;
 #[cfg(feature = "std")]
 use std::cell::RefCell;
 

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -15,19 +15,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.188", default-features = false,  optional = true, features =  ["derive", "alloc"] }
-sp-api = { path = "../../api", default-features = false}
-sp-application-crypto = { path = "../../application-crypto", default-features = false}
-sp-core = { path = "../../core", default-features = false}
-sp-io = { path = "../../io", default-features = false}
-sp-mmr-primitives = { path = "../../merkle-mountain-range", default-features = false}
-sp-runtime = { path = "../../runtime", default-features = false}
-sp-std = { path = "../../std", default-features = false}
+sp-api = { path = "../../api", default-features = false }
+sp-application-crypto = { path = "../../application-crypto", default-features = false }
+sp-core = { path = "../../core", default-features = false }
+sp-io = { path = "../../io", default-features = false }
+sp-mmr-primitives = { path = "../../merkle-mountain-range", default-features = false }
+sp-runtime = { path = "../../runtime", default-features = false }
+sp-std = { path = "../../std", default-features = false }
 strum = { version = "0.24.1", features = ["derive"], default-features = false }
 lazy_static = "1.4.0"
 
 [dev-dependencies]
 array-bytes = "6.1"
-w3f-bls = { version = "0.1.3", features = ["std"]} 
+w3f-bls = { version = "0.1.3", features = ["std"] }
 
 [features]
 default = [ "std" ]

--- a/substrate/primitives/consensus/beefy/src/mmr.rs
+++ b/substrate/primitives/consensus/beefy/src/mmr.rs
@@ -150,8 +150,9 @@ pub use mmr_root_provider::MmrRootProvider;
 mod mmr_root_provider {
 	use super::*;
 	use crate::{known_payloads, payload::PayloadProvider, Payload};
-	use sp_api::{NumberFor, ProvideRuntimeApi};
+	use sp_api::ProvideRuntimeApi;
 	use sp_mmr_primitives::MmrApi;
+	use sp_runtime::traits::NumberFor;
 	use sp_std::{marker::PhantomData, sync::Arc};
 
 	/// A [`crate::Payload`] provider where payload is Merkle Mountain Range root hash.

--- a/substrate/utils/frame/benchmarking-cli/src/block/bench.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/block/bench.rs
@@ -25,9 +25,13 @@ use sc_cli::{Error, Result};
 use sc_client_api::{
 	Backend as ClientBackend, BlockBackend, HeaderBackend, StorageProvider, UsageProvider,
 };
-use sp_api::{ApiExt, Core, HeaderT, ProvideRuntimeApi};
+use sp_api::{ApiExt, Core, ProvideRuntimeApi};
 use sp_blockchain::Error::RuntimeApiError;
-use sp_runtime::{generic::BlockId, traits::Block as BlockT, DigestItem, OpaqueExtrinsic};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, Header as HeaderT},
+	DigestItem, OpaqueExtrinsic,
+};
 use sp_storage::StorageKey;
 
 use clap::Args;

--- a/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -18,10 +18,10 @@
 use sc_cli::Result;
 use sc_client_api::{Backend as ClientBackend, StorageProvider, UsageProvider};
 use sc_client_db::{DbHash, DbState, DbStateBuilder};
-use sp_api::StateBackend;
 use sp_blockchain::HeaderBackend;
 use sp_database::{ColumnId, Transaction};
 use sp_runtime::traits::{Block as BlockT, HashingFor, Header as HeaderT};
+use sp_state_machine::Backend as StateBackend;
 use sp_trie::PrefixedMemoryDB;
 
 use log::{info, trace};


### PR DESCRIPTION
This moves the macro related re-exports to `__private` to make it more obvious for downstream users that they are using an internal api.

