### PR TITLE
Remove `#[macro_use]` annotation from `mod service` in all nodes.

### DIFF
--- a/cumulus/parachain-template/node/src/main.rs
+++ b/cumulus/parachain-template/node/src/main.rs
@@ -3,7 +3,6 @@
 #![warn(missing_docs)]
 
 mod chain_spec;
-#[macro_use]
 mod service;
 mod cli;
 mod command;

--- a/cumulus/parachain-template/node/src/main.rs
+++ b/cumulus/parachain-template/node/src/main.rs
@@ -3,10 +3,10 @@
 #![warn(missing_docs)]
 
 mod chain_spec;
-mod service;
 mod cli;
 mod command;
 mod rpc;
+mod service;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/cumulus/polkadot-parachain/src/main.rs
+++ b/cumulus/polkadot-parachain/src/main.rs
@@ -20,10 +20,10 @@
 #![warn(unused_extern_crates)]
 
 mod chain_spec;
-mod service;
 mod cli;
 mod command;
 mod rpc;
+mod service;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/cumulus/polkadot-parachain/src/main.rs
+++ b/cumulus/polkadot-parachain/src/main.rs
@@ -20,7 +20,6 @@
 #![warn(unused_extern_crates)]
 
 mod chain_spec;
-#[macro_use]
 mod service;
 mod cli;
 mod command;

--- a/substrate/bin/minimal/node/src/main.rs
+++ b/substrate/bin/minimal/node/src/main.rs
@@ -19,7 +19,6 @@
 #![warn(missing_docs)]
 
 mod chain_spec;
-#[macro_use]
 mod service;
 mod cli;
 mod command;

--- a/substrate/bin/minimal/node/src/main.rs
+++ b/substrate/bin/minimal/node/src/main.rs
@@ -19,10 +19,10 @@
 #![warn(missing_docs)]
 
 mod chain_spec;
-mod service;
 mod cli;
 mod command;
 mod rpc;
+mod service;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/substrate/bin/node-template/node/src/main.rs
+++ b/substrate/bin/node-template/node/src/main.rs
@@ -2,7 +2,6 @@
 #![warn(missing_docs)]
 
 mod chain_spec;
-#[macro_use]
 mod service;
 mod benchmarking;
 mod cli;

--- a/substrate/bin/node-template/node/src/main.rs
+++ b/substrate/bin/node-template/node/src/main.rs
@@ -1,12 +1,12 @@
 //! Substrate Node Template CLI library.
 #![warn(missing_docs)]
 
-mod chain_spec;
-mod service;
 mod benchmarking;
+mod chain_spec;
 mod cli;
 mod command;
 mod rpc;
+mod service;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/substrate/bin/node/cli/src/lib.rs
+++ b/substrate/bin/node/cli/src/lib.rs
@@ -30,14 +30,14 @@
 
 #![warn(missing_docs)]
 
-pub mod chain_spec;
-pub mod service;
 #[cfg(feature = "cli")]
 mod benchmarking;
+pub mod chain_spec;
 #[cfg(feature = "cli")]
 mod cli;
 #[cfg(feature = "cli")]
 mod command;
+pub mod service;
 
 #[cfg(feature = "cli")]
 pub use cli::*;

--- a/substrate/bin/node/cli/src/lib.rs
+++ b/substrate/bin/node/cli/src/lib.rs
@@ -31,8 +31,6 @@
 #![warn(missing_docs)]
 
 pub mod chain_spec;
-
-#[macro_use]
 pub mod service;
 #[cfg(feature = "cli")]
 mod benchmarking;


### PR DESCRIPTION
This PR removes `#[macro_use]` from the service module in each of the Substrate nodes in the repo.

* Parachain Template
* Polkadot Parachain
* Minimal Node
* Node Template
* Kitchen Sink Node

IDK why this annotation was present, maybe from when we had the `new_partial!` macro?