### PR TITLE
CI: Fix `build-and-attach-release-runtimes.yml`

### DIFF
--- a/.github/workflows/build-and-attach-release-runtimes.yml
+++ b/.github/workflows/build-and-attach-release-runtimes.yml
@@ -3,7 +3,7 @@ name: Build and Attach Runtimes to Releases/RC
 on:
   release:
     types:
-      - created
+      - published
 
 env:
   PROFILE: production
@@ -43,12 +43,6 @@ jobs:
         package: ${{ matrix.runtime.package }}
         runtime_dir: ${{ matrix.runtime.path }}
         profile: ${{ env.PROFILE }}
-
-    - name: Build Summary
-      run: |
-        echo "${{ steps.srtool_build.outputs.json }}" | jq . > ${{ matrix.runtime.name }}-srtool-digest.json
-        cat ${{ matrix.runtime.name }}-srtool-digest.json
-        echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
 
     - name: Set up paths and runtime names
       id: setup


### PR DESCRIPTION
Incorporate suggestion from release team to get this workflow working.

edit: worked on this test GH release: https://github.com/paritytech/polkadot-sdk/releases/tag/liam-debug-ghw. let's try it.