### PR TITLE
Fix `polkadot-node-subsystem-types` build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,8 +1493,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -12860,6 +12860,7 @@ dependencies = [
  "sp-authority-discovery",
  "sp-blockchain",
  "sp-consensus-babe",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -20015,7 +20016,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/polkadot/node/subsystem-types/Cargo.toml
+++ b/polkadot/node/subsystem-types/Cargo.toml
@@ -14,10 +14,13 @@ polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-network-protocol = { path = "../network/protocol" }
 polkadot-statement-table = { path = "../../statement-table" }
 polkadot-node-jaeger = { path = "../jaeger" }
-orchestra = { version = "0.3.3", default-features = false, features=["futures_channel"] }
+orchestra = { version = "0.3.3", default-features = false, features = [
+  "futures_channel",
+] }
 sc-network = { path = "../../../substrate/client/network" }
 sp-api = { path = "../../../substrate/primitives/api" }
 sp-blockchain = { path = "../../../substrate/primitives/blockchain" }
+sp-runtime = { path = "../../../substrate/primitives/runtime" }
 sp-consensus-babe = { path = "../../../substrate/primitives/consensus/babe" }
 sp-authority-discovery = { path = "../../../substrate/primitives/authority-discovery" }
 sc-client-api = { path = "../../../substrate/client/api" }

--- a/polkadot/node/subsystem-types/src/runtime_client.rs
+++ b/polkadot/node/subsystem-types/src/runtime_client.rs
@@ -25,10 +25,11 @@ use polkadot_primitives::{
 };
 use sc_client_api::HeaderBackend;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
-use sp_api::{ApiError, ApiExt, HeaderT, NumberFor, ProvideRuntimeApi};
+use sp_api::{ApiError, ApiExt, ProvideRuntimeApi};
 use sp_authority_discovery::AuthorityDiscoveryApi;
 use sp_blockchain::Info;
 use sp_consensus_babe::{BabeApi, Epoch};
+use sp_runtime::traits::{Header as HeaderT, NumberFor};
 use std::{collections::BTreeMap, sync::Arc};
 
 /// Offers header utilities.


### PR DESCRIPTION
`polkadot-node-subsystem-types` compilation broke in https://github.com/paritytech/polkadot-sdk/pull/2446

Not sure how it got past CI 🤔