### PR TITLE
Zombienet: add polkadot-debug image publish as needs for cumulus tests

### DIFF
--- a/.gitlab/pipeline/zombienet/cumulus.yml
+++ b/.gitlab/pipeline/zombienet/cumulus.yml
@@ -27,6 +27,8 @@
   needs:
     - job: build-push-image-test-parachain
       artifacts: true
+    - job: build-push-image-polkadot-debug
+      artifacts: true
   variables:
     POLKADOT_IMAGE: "docker.io/paritypr/polkadot-debug:${DOCKER_IMAGES_VERSION}"
     GH_DIR: "https://github.com/paritytech/cumulus/tree/${CI_COMMIT_SHORT_SHA}/zombienet/tests"


### PR DESCRIPTION
Add `build-push-image-polkadot-debug` job to needs since we changed to use the polkadot-debug image from the current branch for cumulus test and we need to be sure that the image is ready. Fix issues like https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/4481059

cc: @bkchr 