### PR TITLE
polkadot: disable block authoring backoff on production networks

### DIFF
--- a/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
@@ -286,6 +286,7 @@ fn build_polkadot_full_node(
 			grandpa_pause: None,
 			// Disable BEEFY. It should not be required by the internal relay chain node.
 			enable_beefy: false,
+			force_authoring_backoff: false,
 			jaeger_agent: None,
 			telemetry_worker_handle,
 

--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -98,6 +98,10 @@ pub struct RunCmd {
 	#[arg(long)]
 	pub no_beefy: bool,
 
+	/// Enable the block authoring backoff that is triggered when finality is lagging.
+	#[arg(long)]
+	pub force_authoring_backoff: bool,
+
 	/// Add the destination address to the 'Jaeger' agent.
 	///
 	/// Must be valid socket address, of format `IP:Port` (commonly `127.0.0.1:6831`).

--- a/polkadot/cli/src/command.rs
+++ b/polkadot/cli/src/command.rs
@@ -259,6 +259,7 @@ where
 				is_parachain_node: service::IsParachainNode::No,
 				grandpa_pause,
 				enable_beefy,
+				force_authoring_backoff: cli.run.force_authoring_backoff,
 				jaeger_agent,
 				telemetry_worker_handle: None,
 				node_version,

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -733,21 +733,22 @@ pub fn new_full<OverseerGenerator: OverseerGen>(
 	let is_offchain_indexing_enabled = config.offchain_worker.indexing_enabled;
 	let role = config.role.clone();
 	let force_authoring = config.force_authoring;
-	let backoff_authoring_blocks = {
-		let mut backoff = sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging::default();
+	let backoff_authoring_blocks =
+		if config.chain_spec.is_polkadot() || config.chain_spec.is_kusama() {
+			// the block authoring backoff is disabled by default on production networks
+			None
+		} else {
+			let mut backoff = sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging::default();
 
-		if config.chain_spec.is_rococo() ||
-			config.chain_spec.is_wococo() ||
-			config.chain_spec.is_versi()
-		{
-			// it's a testnet that's in flux, finality has stalled sometimes due
-			// to operational issues and it's annoying to slow down block
-			// production to 1 block per hour.
-			backoff.max_interval = 10;
-		}
+			if !config.chain_spec.is_westend() {
+				// on testnets that are in flux (like rococo or versi), finality has stalled
+				// sometimes due to operational issues and it's annoying to slow down block
+				// production to 1 block per hour.
+				backoff.max_interval = 10;
+			}
 
-		Some(backoff)
-	};
+			Some(backoff)
+		};
 
 	let disable_grandpa = config.disable_grandpa;
 	let name = config.network.node_name.clone();

--- a/polkadot/node/test/service/src/lib.rs
+++ b/polkadot/node/test/service/src/lib.rs
@@ -82,6 +82,7 @@ pub fn new_full(
 			is_parachain_node,
 			grandpa_pause: None,
 			enable_beefy: true,
+			force_authoring_backoff: false,
 			jaeger_agent: None,
 			telemetry_worker_handle: None,
 			node_version: None,

--- a/polkadot/parachain/test-parachains/adder/collator/src/main.rs
+++ b/polkadot/parachain/test-parachains/adder/collator/src/main.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
 						),
 						grandpa_pause: None,
 						enable_beefy: false,
+						force_authoring_backoff: false,
 						jaeger_agent: None,
 						telemetry_worker_handle: None,
 

--- a/polkadot/parachain/test-parachains/undying/collator/src/main.rs
+++ b/polkadot/parachain/test-parachains/undying/collator/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> Result<()> {
 						),
 						grandpa_pause: None,
 						enable_beefy: false,
+						force_authoring_backoff: false,
 						jaeger_agent: None,
 						telemetry_worker_handle: None,
 


### PR DESCRIPTION
Currently the polkadot node will backoff from block authoring if finality starts lagging. This PR disables this mechanism on production networks (polkadot and kusama) and adds a flags to optionally force enabling it.