### PR TITLE
Added NetworkId::PolkadotBulletin variant

### DIFF
--- a/polkadot/xcm/src/v3/junction.rs
+++ b/polkadot/xcm/src/v3/junction.rs
@@ -75,6 +75,8 @@ pub enum NetworkId {
 	BitcoinCore,
 	/// The Bitcoin network, including hard-forks supported by Bitcoin Cash developers.
 	BitcoinCash,
+	/// The Polkadot Bulletin chain.
+	PolkadotBulletin,
 }
 
 impl From<OldNetworkId> for Option<NetworkId> {


### PR DESCRIPTION
We're going to bridge Polkadot Bridge Hub with [Polkadot Bulletin chain](https://github.com/zdave-parity/polkadot-bulletin-chain) soon (and Rococo Bridge Hub with 1:1 copy of Polkadot Bulletin chain even sooner), so we need a variant for that chain in `NetworkId`. As suggested, I'm adding a new variant for it to the `NetworkId` (we may have used `ByGenesis(_)`, but decision was made to have a dedicated variant for that).