### PR TITLE
Increase `cargo-check-each-crate-macos` timeout

### DIFF
--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -270,7 +270,7 @@ cargo-check-benches:
       SKIP_WASM_BUILD=1 time cargo check --locked --benches --all;
       cargo run --locked --release -p node-bench -- ::trie::read::small --json
       | tee ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::trie::read::small.json;
-      echo "___Uploading cache for rusty-cachier___";
+      echo "___Cache could be uploaded___";
       ;;
       2)
       cargo run --locked --release -p node-bench -- ::node::import::sr25519::transfer_keep_alive::paritydb::small --json
@@ -439,7 +439,7 @@ cargo-check-each-crate:
     - .run-immediately
     # - .collect-artifacts
   variables:
-    # $CI_JOB_NAME is set manually so that rusty-cachier can share the cache for all
+    # $CI_JOB_NAME is set manually so that cache could be shared for all jobs
     # "cargo-check-each-crate I/N" jobs
     CI_JOB_NAME: cargo-check-each-crate
   timeout: 2h
@@ -462,10 +462,10 @@ cargo-check-each-crate-macos:
   variables:
     SKIP_WASM_BUILD: 1
   script:
-    # TODO: enable rusty-cachier once it supports Mac
     # TODO: use parallel jobs, as per cargo-check-each-crate, once more Mac runners are available
     # - time ./scripts/ci/gitlab/check-each-crate.py 1 1
     - time cargo check --workspace --locked
+  timeout: 2h
   tags:
     - osx
 
@@ -488,7 +488,7 @@ cargo-hfuzz:
     # use git version of honggfuzz-rs until v0.5.56 is out, we need a few recent changes:
     # https://github.com/rust-fuzz/honggfuzz-rs/pull/75 to avoid breakage on debian
     # https://github.com/rust-fuzz/honggfuzz-rs/pull/81 fix to the above pr
-    # https://github.com/rust-fuzz/honggfuzz-rs/pull/82 fix for handling rusty-cachier's absolute CARGO_TARGET_DIR
+    # https://github.com/rust-fuzz/honggfuzz-rs/pull/82 fix for handling absolute CARGO_TARGET_DIR
     HFUZZ_BUILD_ARGS: >
       --config=patch.crates-io.honggfuzz.git="https://github.com/altaua/honggfuzz-rs"
       --config=patch.crates-io.honggfuzz.rev="205f7c8c059a0d98fe1cb912cdac84f324cb6981"


### PR DESCRIPTION
Sometimes [it's not enough](https://gitlab.parity.io/parity/mirrors/polkadot-sdk/builds/4510257).