### PR TITLE
Disable trace-level logging from the `test-linux-stable-int`

### DIFF
--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -395,7 +395,6 @@ test-linux-stable-int:
     RUN_UI_TESTS: 1
   script:
     - WASM_BUILD_NO_COLOR=1
-      RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
       time cargo test -p staging-node-cli --release --locked -- --ignored
 
 # more information about this job can be found here:


### PR DESCRIPTION
Output of the job is currently always truncated and cannot fit the 16MB job log size limit.