### PR TITLE
Make RocksDb optional throughout Polkadot and Cumulus

### DIFF
--- a/cumulus/client/cli/Cargo.toml
+++ b/cumulus/client/cli/Cargo.toml
@@ -12,9 +12,9 @@ codec = { package = "parity-scale-codec", version = "3.0.0" }
 url = "2.4.0"
 
 # Substrate
-sc-cli = { path = "../../../substrate/client/cli" }
+sc-cli = { default-features = false, path = "../../../substrate/client/cli" }
 sc-client-api = { path = "../../../substrate/client/api" }
 sc-chain-spec = { path = "../../../substrate/client/chain-spec" }
-sc-service = { path = "../../../substrate/client/service" }
+sc-service = { default-features = false, path = "../../../substrate/client/service" }
 sp-core = { path = "../../../substrate/primitives/core" }
 sp-runtime = { path = "../../../substrate/primitives/runtime" }

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -13,8 +13,9 @@ gum = { package = "tracing-gum", path = "../gum" }
 
 metered = { package = "prioritized-metered-channel", version = "0.5.1", default-features = false, features=["futures_channel"] }
 # Both `sc-service` and `sc-cli` are required by runtime metrics `logger_hook()`.
-sc-service = { path = "../../../substrate/client/service" }
-sc-cli = { path = "../../../substrate/client/cli" }
+# Regarding the above comment, should they be optional dependencies then?
+sc-service = { path = "../../../substrate/client/service", default-features = false }
+sc-cli = { path = "../../../substrate/client/cli", default-features = false }
 
 substrate-prometheus-endpoint = { path = "../../../substrate/utils/prometheus" }
 sc-tracing = { path = "../../../substrate/client/tracing" }
@@ -28,9 +29,8 @@ assert_cmd = "2.0.4"
 tempfile = "3.2.0"
 hyper = { version = "0.14.20", default-features = false, features = ["http1", "tcp"] }
 tokio = "1.24.2"
-polkadot-test-service = { path = "../test/service", features=["runtime-metrics"]}
+polkadot-test-service = { path = "../test/service", features=["runtime-metrics"], default-features = false}
 substrate-test-utils = { path = "../../../substrate/test-utils" }
-sc-service = { path = "../../../substrate/client/service" }
 sp-keyring = { path = "../../../substrate/primitives/keyring" }
 prometheus-parse = {version = "0.2.2"}
 

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -150,7 +150,6 @@ tempfile = "3.2"
 [features]
 default = [ "db", "full-node" ]
 
-# TODO revisit the frame benchmarking features. It only has an std feature as default. And disabling it somehow disables rocksdb.
 db = [ "service/rocksdb", "sc-client-db/rocksdb", "frame-benchmarking-cli/rocksdb", "kvdb-rocksdb" ]
 
 full-node = [

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -18,7 +18,7 @@ sp-mmr-primitives = { path = "../../../substrate/primitives/merkle-mountain-rang
 sc-block-builder = { path = "../../../substrate/client/block-builder" }
 sc-chain-spec = { path = "../../../substrate/client/chain-spec" }
 sc-client-api = { path = "../../../substrate/client/api" }
-sc-client-db = { path = "../../../substrate/client/db" }
+sc-client-db = { default-features = false, path = "../../../substrate/client/db" }
 sc-consensus = { path = "../../../substrate/client/consensus/common" }
 sc-consensus-slots = { path = "../../../substrate/client/consensus/slots" }
 sc-executor = { path = "../../../substrate/client/executor" }
@@ -71,8 +71,8 @@ frame-system = { path = "../../../substrate/frame/system" }
 frame-system-rpc-runtime-api = { path = "../../../substrate/frame/system/rpc/runtime-api" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../../substrate/utils/prometheus" }
 frame-support = { path = "../../../substrate/frame/support" }
-frame-benchmarking-cli = { path = "../../../substrate/utils/frame/benchmarking-cli" }
-frame-benchmarking = { path = "../../../substrate/frame/benchmarking" }
+frame-benchmarking-cli = { path = "../../../substrate/utils/frame/benchmarking-cli", default-features = false }
+frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false }
 
 # External Crates
 async-trait = "0.1.57"
@@ -150,10 +150,10 @@ tempfile = "3.2"
 [features]
 default = [ "db", "full-node" ]
 
-db = [ "service/rocksdb" ]
+# TODO revisit the frame benchmarking features. It only has an std feature as default. And disabling it somehow disables rocksdb.
+db = [ "service/rocksdb", "sc-client-db/rocksdb", "frame-benchmarking-cli/rocksdb", "kvdb-rocksdb" ]
 
 full-node = [
-	"kvdb-rocksdb",
 	"parity-db",
 	"polkadot-approval-distribution",
 	"polkadot-availability-bitfield-distribution",

--- a/polkadot/node/service/src/parachains_db/mod.rs
+++ b/polkadot/node/service/src/parachains_db/mod.rs
@@ -26,6 +26,10 @@ const LOG_TARGET: &str = "parachain::db";
 /// Column configuration per version.
 #[cfg(any(test, feature = "full-node"))]
 pub(crate) mod columns {
+	// This v0 module is only used in tests for parity_db; not in main code. But it is
+	// used in both tests and main code for rocks db. This feature gating makes sure there
+	// is never a warning, but perhaps there is a better way?
+	#[cfg(any(test, feature = "db"))]
 	pub mod v0 {
 		pub const NUM_COLUMNS: u32 = 3;
 	}
@@ -91,6 +95,7 @@ pub const REAL_COLUMNS: ColumnsConfig = ColumnsConfig {
 #[derive(PartialEq, Copy, Clone)]
 pub(crate) enum DatabaseKind {
 	ParityDB,
+	#[cfg(feature = "db")]
 	RocksDB,
 }
 
@@ -125,6 +130,7 @@ pub(crate) fn other_io_error(err: String) -> io::Error {
 
 /// Open the database on disk, creating it if it doesn't exist.
 #[cfg(feature = "full-node")]
+#[cfg(feature = "db")]
 pub fn open_creating_rocksdb(
 	root: PathBuf,
 	cache_sizes: CacheSizes,

--- a/polkadot/node/service/src/parachains_db/upgrade.rs
+++ b/polkadot/node/service/src/parachains_db/upgrade.rs
@@ -107,6 +107,7 @@ pub(crate) fn try_upgrade_db_to_next_version(
 			// This is an arbitrary future version, we don't handle it.
 			Some(v) => return Err(Error::FutureVersion { current: CURRENT_VERSION, got: v }),
 			// No version file. For `RocksDB` we dont need to do anything.
+			#[cfg(feature = "db")]
 			None if db_kind == DatabaseKind::RocksDB => CURRENT_VERSION,
 			// No version file. `ParityDB` did not previously have a version defined.
 			// We handle this as a `0 -> 1` migration.
@@ -153,6 +154,7 @@ fn migrate_from_version_0_to_1(path: &Path, db_kind: DatabaseKind) -> Result<Ver
 
 	match db_kind {
 		DatabaseKind::ParityDB => paritydb_migrate_from_version_0_to_1(path),
+		#[cfg(feature = "db")]
 		DatabaseKind::RocksDB => rocksdb_migrate_from_version_0_to_1(path),
 	}
 	.and_then(|result| {
@@ -166,6 +168,7 @@ fn migrate_from_version_1_to_2(path: &Path, db_kind: DatabaseKind) -> Result<Ver
 
 	match db_kind {
 		DatabaseKind::ParityDB => paritydb_migrate_from_version_1_to_2(path),
+		#[cfg(feature = "db")]
 		DatabaseKind::RocksDB => rocksdb_migrate_from_version_1_to_2(path),
 	}
 	.and_then(|result| {
@@ -178,9 +181,9 @@ fn migrate_from_version_1_to_2(path: &Path, db_kind: DatabaseKind) -> Result<Ver
 // As these are backwards compatible, we'll convert the old entries in the new format.
 fn migrate_from_version_3_to_4(path: &Path, db_kind: DatabaseKind) -> Result<Version, Error> {
 	gum::info!(target: LOG_TARGET, "Migrating parachains db from version 3 to version 4 ...");
-	use polkadot_node_subsystem_util::database::{
-		kvdb_impl::DbAdapter as RocksDbAdapter, paritydb_impl::DbAdapter as ParityDbAdapter,
-	};
+	use polkadot_node_subsystem_util::database::paritydb_impl::DbAdapter as ParityDbAdapter;
+	#[cfg(feature = "db")]
+	use polkadot_node_subsystem_util::database::kvdb_impl::DbAdapter as RocksDbAdapter;
 	use std::sync::Arc;
 
 	let approval_db_config =
@@ -196,6 +199,7 @@ fn migrate_from_version_3_to_4(path: &Path, db_kind: DatabaseKind) -> Result<Ver
 
 			v1_to_v2(Arc::new(db), approval_db_config).map_err(|_| Error::MigrationFailed)?;
 		},
+		#[cfg(feature = "db")]
 		DatabaseKind::RocksDB => {
 			let db_path = path
 				.to_str()
@@ -219,6 +223,7 @@ fn migrate_from_version_2_to_3(path: &Path, db_kind: DatabaseKind) -> Result<Ver
 	gum::info!(target: LOG_TARGET, "Migrating parachains db from version 2 to version 3 ...");
 	match db_kind {
 		DatabaseKind::ParityDB => paritydb_migrate_from_version_2_to_3(path),
+		#[cfg(feature = "db")]
 		DatabaseKind::RocksDB => rocksdb_migrate_from_version_2_to_3(path),
 	}
 	.and_then(|result| {
@@ -229,6 +234,7 @@ fn migrate_from_version_2_to_3(path: &Path, db_kind: DatabaseKind) -> Result<Ver
 
 /// Migration from version 0 to version 1:
 /// * the number of columns has changed from 3 to 5;
+#[cfg(feature = "db")]
 fn rocksdb_migrate_from_version_0_to_1(path: &Path) -> Result<Version, Error> {
 	use kvdb_rocksdb::{Database, DatabaseConfig};
 
@@ -246,6 +252,7 @@ fn rocksdb_migrate_from_version_0_to_1(path: &Path) -> Result<Version, Error> {
 
 /// Migration from version 1 to version 2:
 /// * the number of columns has changed from 5 to 6;
+#[cfg(feature = "db")]
 fn rocksdb_migrate_from_version_1_to_2(path: &Path) -> Result<Version, Error> {
 	use kvdb_rocksdb::{Database, DatabaseConfig};
 
@@ -260,6 +267,7 @@ fn rocksdb_migrate_from_version_1_to_2(path: &Path) -> Result<Version, Error> {
 	Ok(2)
 }
 
+#[cfg(feature = "db")]
 fn rocksdb_migrate_from_version_2_to_3(path: &Path) -> Result<Version, Error> {
 	use kvdb_rocksdb::{Database, DatabaseConfig};
 
@@ -520,6 +528,7 @@ mod tests {
 		);
 	}
 
+	#[cfg(feature = "db")]
 	#[test]
 	fn test_rocksdb_migrate_1_to_2() {
 		use kvdb::{DBKey, DBOp};
@@ -579,8 +588,9 @@ mod tests {
 		);
 	}
 
+	#[cfg(feature = "db")]
 	#[test]
-	fn test_migrate_3_to_4() {
+	fn test_rocksdb_migrate_3_to_4() {
 		use kvdb_rocksdb::{Database, DatabaseConfig};
 		use polkadot_node_core_approval_voting::approval_db::v2::migration_helpers::v1_to_v2_sanity_check;
 		use polkadot_node_subsystem_util::database::kvdb_impl::DbAdapter;
@@ -613,6 +623,7 @@ mod tests {
 		v1_to_v2_sanity_check(std::sync::Arc::new(db), approval_cfg, expected_candidates).unwrap();
 	}
 
+	#[cfg(feature = "db")]
 	#[test]
 	fn test_rocksdb_migrate_0_to_4() {
 		use kvdb_rocksdb::{Database, DatabaseConfig};
@@ -682,6 +693,7 @@ mod tests {
 		assert_eq!(db.num_columns(), columns::v3::NUM_COLUMNS as u8);
 	}
 
+	#[cfg(feature = "db")]
 	#[test]
 	fn test_rocksdb_migrate_2_to_3() {
 		use kvdb_rocksdb::{Database, DatabaseConfig};

--- a/polkadot/node/test/client/Cargo.toml
+++ b/polkadot/node/test/client/Cargo.toml
@@ -17,7 +17,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 
 # Substrate dependencies
 substrate-test-client = { path = "../../../../substrate/test-utils/client" }
-sc-service = { path = "../../../../substrate/client/service" }
+sc-service = { path = "../../../../substrate/client/service", default-features = false }
 sc-block-builder = { path = "../../../../substrate/client/block-builder" }
 sc-consensus = { path = "../../../../substrate/client/consensus/common" }
 sc-offchain = { path = "../../../../substrate/client/offchain" }

--- a/polkadot/node/test/service/Cargo.toml
+++ b/polkadot/node/test/service/Cargo.toml
@@ -21,7 +21,8 @@ polkadot-primitives = { path = "../../../primitives" }
 polkadot-parachain-primitives = { path = "../../../parachain" }
 polkadot-rpc = { path = "../../../rpc" }
 polkadot-runtime-common = { path = "../../../runtime/common" }
-polkadot-service = { path = "../../service" }
+# polkadot-service = { path = "../../service" }
+polkadot-service = { default-features = false, features = ["full-node"], path = "../../service" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-test-runtime = { path = "../../../runtime/test-runtime" }
@@ -42,7 +43,7 @@ pallet-staking = { path = "../../../../substrate/frame/staking" }
 pallet-balances = { path = "../../../../substrate/frame/balances" }
 pallet-transaction-payment = { path = "../../../../substrate/frame/transaction-payment" }
 sc-chain-spec = { path = "../../../../substrate/client/chain-spec" }
-sc-cli = { path = "../../../../substrate/client/cli" }
+sc-cli = { path = "../../../../substrate/client/cli", default-features = false }
 sc-client-api = { path = "../../../../substrate/client/api" }
 sc-consensus = { path = "../../../../substrate/client/consensus/common" }
 sc-network = { path = "../../../../substrate/client/network" }

--- a/polkadot/node/test/service/src/lib.rs
+++ b/polkadot/node/test/service/src/lib.rs
@@ -163,7 +163,10 @@ pub fn node_config(
 		transaction_pool: Default::default(),
 		network: network_config,
 		keystore: KeystoreConfig::InMemory,
+		#[cfg(feature = "db")]
 		database: DatabaseSource::RocksDb { path: root.join("db"), cache_size: 128 },
+		#[cfg(not(feature = "db"))]
+		database: DatabaseSource::ParityDb { path: root.join("db")},
 		trie_cache_maximum_size: Some(64 * 1024 * 1024),
 		state_pruning: Default::default(),
 		blocks_pruning: BlocksPruning::KeepFinalized,

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -37,7 +37,9 @@ sp-trie = { path = "../../primitives/trie" }
 
 [dev-dependencies]
 criterion = "0.4.0"
-kvdb-rocksdb = "0.19.0"
+# TODO Remove this comment
+# For now it serves as a reminder that I completely removed a dev dependency on kvdb-rocksdb
+# I guess that should be okay following the logic of the first comment in https://stackoverflow.com/questions/62989096
 rand = "0.8.5"
 tempfile = "3.1.0"
 quickcheck = { version = "1.0.3", default-features = false }

--- a/substrate/test-utils/Cargo.toml
+++ b/substrate/test-utils/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1.22.0", features = ["macros", "time"] }
 
 [dev-dependencies]
 trybuild = { version = "1.0.74", features = [ "diff" ] }
-sc-service = { path = "../client/service" }
+sc-service = { path = "../client/service", default-features = false }


### PR DESCRIPTION
Many Substrate crates have a `rocksdb` feature that allows faster builds by removing rocks db from the dependency graph. This practice was not extended throughout parts of Cumulus and Polkadot.

This meant that parachain projects always had to build RockDb, which consumes time and energy, and now, even makes my github actions runners run out of disk space :laughing: 

This PR, extends the practice of making rocksdb optional throughout Polkadot and cumulus.

Note, that I also discovered a compile problem along the way and reported it in #2551. I need guess I will need a little guidance on that before tidying this one up.