### PR TITLE
Add `recorded_keys` function to get recorded keys from the proof recorder

### DIFF
--- a/substrate/primitives/trie/src/recorder.rs
+++ b/substrate/primitives/trie/src/recorder.rs
@@ -105,6 +105,13 @@ impl<H: Hasher> Clone for Recorder<H> {
 }
 
 impl<H: Hasher> Recorder<H> {
+	/// Keys for which we have recorded the trie nodes till now.
+	/// Note that this does not modify the internals, rather returns snapshot of the recorded keys.
+	/// There can be multiple storage root in case we are tracking more than one tries.
+	pub fn recorded_keys(&self) -> HashMap<<H as Hasher>::Out, HashMap<Arc<[u8]>, RecordedForKey>> {
+		self.inner.lock().recorded_keys.clone()
+	}
+
 	/// Returns the recorder as [`TrieRecorder`](trie_db::TrieRecorder) compatible type.
 	///
 	/// - `storage_root`: The storage root of the trie for which accesses are recorded. This is


### PR DESCRIPTION
# Description

- What does this PR do?
This PR adds function to get recorded keys from proof recorder instance
- Why are these changes needed?
This change is required to get the keys accessed by the trie backend during the runtime execution. The keys are already tracked by proof recorder, just aren't exposed publicly.
- How were these changes implemented and what do they affect?
The changes are implemented by adding a public function in proof recorder that simply clones the `recorded_keys` field. It is pure addition of function and AFAIK does not affect anything.
