### PR TITLE
Contracts: make benchmark dependencies optional in `std` feature

### DIFF
--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -88,7 +88,7 @@ std = [
 	"pallet-proxy/std",
 	"pallet-timestamp/std",
 	"pallet-utility/std",
-	"rand/std",
+	"rand?/std",
 	"scale-info/std",
 	"serde",
 	"sp-api/std",

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -97,6 +97,7 @@ std = [
 	"sp-keystore/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"wasm-instrument?/std",
 	"wasmi/std",
 	"xcm-builder/std",
 	"xcm/std",

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -97,7 +97,6 @@ std = [
 	"sp-keystore/std",
 	"sp-runtime/std",
 	"sp-std/std",
-	"wasm-instrument/std",
 	"wasmi/std",
 	"xcm-builder/std",
 	"xcm/std",


### PR DESCRIPTION
`wasm-instrument` and `rand` are optional and only used in benchmarking, so should not be pulled in by default as part of the `std` feature.