### PR TITLE
Removed instruction to call init.sh when buidling from source

### DIFF
--- a/polkadot/README.md
+++ b/polkadot/README.md
@@ -63,7 +63,6 @@ directory of the repo:
 
 ```bash
 git checkout <latest tagged release>
-./scripts/init.sh
 cargo build --release
 ```
 


### PR DESCRIPTION
# Description

Removed instruction to call init.sh when buidling from source from the polkadot readme.