### PR TITLE
Stabilize pov-recovery zombienet

### DIFF
--- a/cumulus/zombienet/tests/0002-pov_recovery.zndsl
+++ b/cumulus/zombienet/tests/0002-pov_recovery.zndsl
@@ -13,7 +13,6 @@ alice: reports block height is at least 20 within 600 seconds
 charlie: reports block height is at least 20 within 600 seconds
 one: reports block height is at least 20 within 800 seconds
 two: reports block height is at least 20 within 800 seconds
-three: reports block height is at least 20 within 800 seconds
 eve: reports block height is at least 20 within 800 seconds
 
 one: count of log lines containing "Importing block retrieved using pov_recovery" is greater than 19 within 10 seconds

--- a/cumulus/zombienet/tests/0002-pov_recovery.zndsl
+++ b/cumulus/zombienet/tests/0002-pov_recovery.zndsl
@@ -13,6 +13,8 @@ alice: reports block height is at least 20 within 600 seconds
 charlie: reports block height is at least 20 within 600 seconds
 one: reports block height is at least 20 within 800 seconds
 two: reports block height is at least 20 within 800 seconds
+# Re-enable once we upgraded from smoldot 0.11.0 and https://github.com/paritytech/polkadot-sdk/pull/1631 is merged
+# three: reports block height is at least 20 within 800 seconds
 eve: reports block height is at least 20 within 800 seconds
 
 one: count of log lines containing "Importing block retrieved using pov_recovery" is greater than 19 within 10 seconds


### PR DESCRIPTION
Smoldot sometimes stops reporting finalized blocks to us. Since we are recovering from the relay chain with a huge delay on full nodes, we can not rely on import notifications to set the best block. Because sometimes we also do not receive finality notifications, the height check in zombienet fails.

Proper solution is to update smoldot, there have been some changes since the version we use. But upgrade is blocked by version conflict which will be resolved with https://github.com/paritytech/polkadot-sdk/pull/1631.