### PR TITLE
[NTFs] Emit CollectionMaxSupplySet on collection create

### DIFF
--- a/substrate/frame/nfts/src/features/create_delete_collection.rs
+++ b/substrate/frame/nfts/src/features/create_delete_collection.rs
@@ -67,11 +67,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		CollectionConfigOf::<T, I>::insert(&collection, config);
 		CollectionAccount::<T, I>::insert(&owner, &collection, ());
 
+		Self::deposit_event(event);
+
 		if let Some(max_supply) = config.max_supply {
 			Self::deposit_event(Event::CollectionMaxSupplySet { collection, max_supply });
 		}
 
-		Self::deposit_event(event);
 		Ok(())
 	}
 

--- a/substrate/frame/nfts/src/features/create_delete_collection.rs
+++ b/substrate/frame/nfts/src/features/create_delete_collection.rs
@@ -66,6 +66,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		CollectionConfigOf::<T, I>::insert(&collection, config);
 		CollectionAccount::<T, I>::insert(&owner, &collection, ());
+
+		if let Some(max_supply) = config.max_supply {
+			Self::deposit_event(Event::CollectionMaxSupplySet { collection, max_supply });
+		}
+
 		Self::deposit_event(event);
 		Ok(())
 	}

--- a/substrate/frame/nfts/src/tests.rs
+++ b/substrate/frame/nfts/src/tests.rs
@@ -2191,6 +2191,10 @@ fn max_supply_should_work() {
 			default_collection_config()
 		));
 		assert_eq!(CollectionConfigOf::<Test>::get(collection_id).unwrap().max_supply, None);
+		assert!(!events().contains(&Event::<Test>::CollectionMaxSupplySet {
+			collection: collection_id,
+			max_supply,
+		}));
 
 		assert_ok!(Nfts::set_collection_max_supply(
 			RuntimeOrigin::signed(user_id.clone()),
@@ -2242,9 +2246,31 @@ fn max_supply_should_work() {
 			None
 		));
 		assert_noop!(
-			Nfts::mint(RuntimeOrigin::signed(user_id.clone()), collection_id, 2, user_id, None),
+			Nfts::mint(
+				RuntimeOrigin::signed(user_id.clone()),
+				collection_id,
+				2,
+				user_id.clone(),
+				None
+			),
 			Error::<Test>::MaxSupplyReached
 		);
+
+		// validate the event gets emitted when we set the max supply on collection create
+		let collection_id = 1;
+		assert_ok!(Nfts::force_create(
+			RuntimeOrigin::root(),
+			user_id.clone(),
+			CollectionConfig { max_supply: Some(max_supply), ..default_collection_config() }
+		));
+		assert_eq!(
+			CollectionConfigOf::<Test>::get(collection_id).unwrap().max_supply,
+			Some(max_supply)
+		);
+		assert!(events().contains(&Event::<Test>::CollectionMaxSupplySet {
+			collection: collection_id,
+			max_supply,
+		}));
 	});
 }
 


### PR DESCRIPTION
Closes #2293 

if the max_supply is set during the collection creation, we emit the `CollectionMaxSupplySet` event