### PR TITLE
Change utility::as_derivative index to u32

### DIFF
--- a/substrate/frame/utility/src/lib.rs
+++ b/substrate/frame/utility/src/lib.rs
@@ -266,7 +266,7 @@ pub mod pallet {
 		})]
 		pub fn as_derivative(
 			origin: OriginFor<T>,
-			index: u16,
+			index: u32,
 			call: Box<<T as Config>::RuntimeCall>,
 		) -> DispatchResultWithPostInfo {
 			let mut origin = origin;
@@ -504,8 +504,13 @@ impl TypeId for IndexedUtilityPalletId {
 
 impl<T: Config> Pallet<T> {
 	/// Derive a derivative account ID from the owner account and the sub-account index.
-	pub fn derivative_account_id(who: T::AccountId, index: u16) -> T::AccountId {
-		let entropy = (b"modlpy/utilisuba", who, index).using_encoded(blake2_256);
+	pub fn derivative_account_id(who: T::AccountId, index: u32) -> T::AccountId {
+		// Derive the same addresses as when index was u16
+		let entropy = if index <= u16::MAX as u32 {
+			(b"modlpy/utilisuba", who, index as u16).using_encoded(blake2_256)
+		} else {
+			(b"modlpy/utilisuba", who, index).using_encoded(blake2_256)
+		};
 		Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
 			.expect("infinite length input; no invalid inputs for type; qed")
 	}

--- a/substrate/frame/utility/src/tests.rs
+++ b/substrate/frame/utility/src/tests.rs
@@ -399,6 +399,15 @@ fn as_derivative_filters() {
 }
 
 #[test]
+fn as_derivative_u32_compat_with_old_u16() {
+	new_test_ext().execute_with(|| {
+		let sub_1_0 = Utility::derivative_account_id(1, 0);
+		const SAME_DERIVATIVE_AS_WITH_OLD_U16_INDEX: u64 = 13950085325555297514;
+		assert_eq!(sub_1_0, SAME_DERIVATIVE_AS_WITH_OLD_U16_INDEX);
+	})
+}
+
+#[test]
 fn batch_with_root_works() {
 	new_test_ext().execute_with(|| {
 		let k = b"a".to_vec();


### PR DESCRIPTION
This PR proposes to change the index in `utility::as_derivative` to be a `u32` instead of `u16`. More than being able to derive  `u16::MAX`+ accounts, `u32` can map better to existing values that need the extra bits. Personally I would use it to derive accounts for [indexed pluralities](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/src/v3/junction.rs#L129) from a parachain that are represented with a `u32`.