### PR TITLE
Fix failing rc-automation GHA

### DIFF
--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -17,6 +17,7 @@ jobs:
         channel:
           - name: "RelEng: Polkadot Release Coordination"
             room: '!cqAmzdIcbOFwrdrubV:parity.io'
+    environment: release
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
This PR adds missing `environment: release` parameter to the `rc-automation ` GHA