### PR TITLE
pallet-broker: Small improvements to the origin checks

### DIFF
--- a/substrate/frame/broker/src/lib.rs
+++ b/substrate/frame/broker/src/lib.rs
@@ -716,55 +716,51 @@ pub mod pallet {
 
 		/// Drop an expired Region from the chain.
 		///
-		/// - `origin`: Must be a Signed origin.
+		/// - `origin`: Can be any kind of origin.
 		/// - `region_id`: The Region which has expired.
 		#[pallet::call_index(14)]
 		pub fn drop_region(
-			origin: OriginFor<T>,
+			_origin: OriginFor<T>,
 			region_id: RegionId,
 		) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin)?;
 			Self::do_drop_region(region_id)?;
 			Ok(Pays::No.into())
 		}
 
 		/// Drop an expired Instantaneous Pool Contribution record from the chain.
 		///
-		/// - `origin`: Must be a Signed origin.
+		/// - `origin`: Can be any kind of origin.
 		/// - `region_id`: The Region identifying the Pool Contribution which has expired.
 		#[pallet::call_index(15)]
 		pub fn drop_contribution(
-			origin: OriginFor<T>,
+			_origin: OriginFor<T>,
 			region_id: RegionId,
 		) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin)?;
 			Self::do_drop_contribution(region_id)?;
 			Ok(Pays::No.into())
 		}
 
 		/// Drop an expired Instantaneous Pool History record from the chain.
 		///
-		/// - `origin`: Must be a Signed origin.
+		/// - `origin`: Can be any kind of origin.
 		/// - `region_id`: The time of the Pool History record which has expired.
 		#[pallet::call_index(16)]
-		pub fn drop_history(origin: OriginFor<T>, when: Timeslice) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin)?;
+		pub fn drop_history(_origin: OriginFor<T>, when: Timeslice) -> DispatchResultWithPostInfo {
 			Self::do_drop_history(when)?;
 			Ok(Pays::No.into())
 		}
 
 		/// Drop an expired Allowed Renewal record from the chain.
 		///
-		/// - `origin`: Must be a Signed origin of the account which owns the Region `region_id`.
+		/// - `origin`: Can be any kind of origin.
 		/// - `core`: The core to which the expired renewal refers.
 		/// - `when`: The timeslice to which the expired renewal refers. This must have passed.
 		#[pallet::call_index(17)]
 		pub fn drop_renewal(
-			origin: OriginFor<T>,
+			_origin: OriginFor<T>,
 			core: CoreIndex,
 			when: Timeslice,
 		) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin)?;
 			Self::do_drop_renewal(core, when)?;
 			Ok(Pays::No.into())
 		}

--- a/substrate/frame/broker/src/mock.rs
+++ b/substrate/frame/broker/src/mock.rs
@@ -29,11 +29,8 @@ use frame_support::{
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
 use sp_arithmetic::Perbill;
-use sp_core::{ConstU16, ConstU32, ConstU64, H256};
-use sp_runtime::{
-	traits::{BlakeTwo256, Identity, IdentityLookup},
-	BuildStorage, Saturating,
-};
+use sp_core::{ConstU32, ConstU64};
+use sp_runtime::{traits::Identity, BuildStorage, Saturating};
 use sp_std::collections::btree_map::BTreeMap;
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -49,29 +46,7 @@ frame_support::construct_runtime!(
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
-	type BlockWeights = ();
-	type BlockLength = ();
-	type DbWeight = ();
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type Nonce = u64;
-	type Hash = H256;
-	type Hashing = BlakeTwo256;
-	type AccountId = u64;
-	type Lookup = IdentityLookup<Self::AccountId>;
 	type Block = Block;
-	type RuntimeEvent = RuntimeEvent;
-	type BlockHashCount = ConstU64<250>;
-	type Version = ();
-	type PalletInfo = PalletInfo;
-	type AccountData = ();
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
-	type SystemWeightInfo = ();
-	type SS58Prefix = ConstU16<42>;
-	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
The permissionless calls do not need to ensure that the `origin` is signed. Anyone can execute these calls.