### PR TITLE
[ci] fix test-frame-ui job

### DIFF
--- a/substrate/frame/support/test/tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.stderr
@@ -81,6 +81,11 @@ error[E0412]: cannot find type `RuntimeTask` in this scope
   --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:39:1
    |
 39 | #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you might have meant to use the associated type: `Self::RuntimeTask`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `frame_system::config_preludes::TestDefaultConfig` which comes from the expansion of the macro `frame_support::macro_magic::forward_tokens_verbatim` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might have meant to use the associated type
+  --> $WORKSPACE/substrate/frame/system/src/lib.rs
+   |
+   |             type Self::RuntimeTask = ();
+   |                  ++++++

--- a/substrate/frame/support/test/tests/pallet_ui/task_condition_invalid_arg.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/task_condition_invalid_arg.stderr
@@ -5,6 +5,7 @@ error: unused import: `frame_system::pallet_prelude::OriginFor`
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
 
 error[E0308]: mismatched types
   --> tests/pallet_ui/task_condition_invalid_arg.rs:35:10

--- a/substrate/frame/support/test/tests/pallet_ui/task_invalid_condition.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/task_invalid_condition.stderr
@@ -5,6 +5,7 @@ error: unused import: `frame_system::pallet_prelude::OriginFor`
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
 
 error[E0308]: mismatched types
   --> tests/pallet_ui/task_invalid_condition.rs:18:1

--- a/substrate/frame/support/test/tests/pallet_ui/task_invalid_list.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/task_invalid_list.stderr
@@ -5,6 +5,7 @@ error: unused import: `frame_system::pallet_prelude::OriginFor`
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
 
 error[E0689]: can't call method `map` on ambiguous numeric type `{integer}`
   --> tests/pallet_ui/task_invalid_list.rs:18:1

--- a/substrate/frame/support/test/tests/pallet_ui/task_invalid_weight.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/task_invalid_weight.stderr
@@ -5,6 +5,7 @@ error: unused import: `frame_system::pallet_prelude::OriginFor`
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
 
 error[E0308]: mismatched types
   --> tests/pallet_ui/task_invalid_weight.rs:18:1


### PR DESCRIPTION
The test frame ui started failing consistently on latest master [1]. I assume it was because of a race between
https://github.com/paritytech/polkadot-sdk/pull/1343 which introduced this warning and a PR that updated our tooling version, hence the warnings don't match perfectly, so regenerated them with `TRYBUILD=overwrite` as the test suggests.

[1] https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/4666766