### PR TITLE
pallet-xcm: fix test benchmarks

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/mock.rs
+++ b/polkadot/xcm/pallet-xcm/src/mock.rs
@@ -589,10 +589,23 @@ impl super::benchmarking::Config for Test {
 		let asset_amount = 10u128;
 		let fee_amount = 2u128;
 
+		let existential_deposit = ExistentialDeposit::get();
+		let caller = frame_benchmarking::whitelisted_caller();
+
+		// Give some multiple of the existential deposit
+		let balance = asset_amount + existential_deposit * 1000;
+		let _ = <Balances as frame_support::traits::Currency<_>>::make_free_balance_be(
+			&caller, balance,
+		);
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = fee_amount * 10;
-		let (usdt_chain, _, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+		let (usdt_chain, _, usdt_id_multilocation) = set_up_foreign_asset(
+			USDT_PARA_ID,
+			None,
+			caller.clone(),
+			usdt_initial_local_amount,
+			true,
+		);
 
 		// native assets transfer destination is USDT chain (teleport trust only for USDT)
 		let dest = usdt_chain;
@@ -602,20 +615,13 @@ impl super::benchmarking::Config for Test {
 			// native asset to transfer (not used for fees) - local reserve
 			(MultiLocation::here(), asset_amount).into(),
 		);
-
-		let existential_deposit = ExistentialDeposit::get();
-		let caller = frame_benchmarking::whitelisted_caller();
-		// Give some multiple of the existential deposit
-		let balance = asset_amount + existential_deposit * 1000;
-		let _ = <Balances as frame_support::traits::Currency<_>>::make_free_balance_be(
-			&caller, balance,
-		);
-		// verify initial balance
+		// verify initial balances
 		assert_eq!(Balances::free_balance(&caller), balance);
+		assert_eq!(Assets::balance(usdt_id_multilocation, &caller), usdt_initial_local_amount);
 
 		// verify transferred successfully
 		let verify = Box::new(move || {
-			// verify balance after transfer, decreased by transferred amount
+			// verify balances after transfer, decreased by transferred amounts
 			assert_eq!(Balances::free_balance(&caller), balance - asset_amount);
 			assert_eq!(
 				Assets::balance(usdt_id_multilocation, &caller),

--- a/polkadot/xcm/pallet-xcm/src/tests/assets_transfer.rs
+++ b/polkadot/xcm/pallet-xcm/src/tests/assets_transfer.rs
@@ -244,6 +244,7 @@ fn reserve_transfer_assets_with_paid_router_works() {
 pub(crate) fn set_up_foreign_asset(
 	reserve_para_id: u32,
 	inner_junction: Option<Junction>,
+	benficiary: AccountId,
 	initial_amount: u128,
 	is_sufficient: bool,
 ) -> (MultiLocation, AccountId, MultiLocation) {
@@ -271,7 +272,7 @@ pub(crate) fn set_up_foreign_asset(
 	assert_ok!(Assets::mint(
 		RuntimeOrigin::signed(BOB),
 		foreign_asset_id_multilocation,
-		ALICE,
+		benficiary,
 		initial_amount
 	));
 
@@ -440,6 +441,7 @@ fn destination_asset_reserve_and_local_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				false,
 			);
@@ -595,6 +597,7 @@ fn remote_asset_reserve_and_local_fee_reserve_call_disallowed<Call>(
 		let (_, _, foreign_asset_id_multilocation) = set_up_foreign_asset(
 			FOREIGN_ASSET_RESERVE_PARA_ID,
 			Some(FOREIGN_ASSET_INNER_JUNCTION),
+			ALICE,
 			foreign_initial_amount,
 			false,
 		);
@@ -712,6 +715,7 @@ fn local_asset_reserve_and_destination_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				USDC_RESERVE_PARA_ID,
 				Some(USDC_INNER_JUNCTION),
+				ALICE,
 				usdc_initial_local_amount,
 				true,
 			);
@@ -870,6 +874,7 @@ fn destination_asset_reserve_and_destination_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				true,
 			);
@@ -1013,6 +1018,7 @@ fn remote_asset_reserve_and_destination_fee_reserve_call_disallowed<Call>(
 		let (usdc_chain, _, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -1022,6 +1028,7 @@ fn remote_asset_reserve_and_destination_fee_reserve_call_disallowed<Call>(
 		let (_, _, foreign_asset_id_multilocation) = set_up_foreign_asset(
 			FOREIGN_ASSET_RESERVE_PARA_ID,
 			Some(FOREIGN_ASSET_INNER_JUNCTION),
+			ALICE,
 			foreign_initial_amount,
 			false,
 		);
@@ -1135,6 +1142,7 @@ fn local_asset_reserve_and_remote_fee_reserve_call_disallowed<Call>(
 		let (_, usdc_chain_sovereign_account, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -1244,6 +1252,7 @@ fn destination_asset_reserve_and_remote_fee_reserve_call_disallowed<Call>(
 		let (_, usdc_chain_sovereign_account, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -1254,6 +1263,7 @@ fn destination_asset_reserve_and_remote_fee_reserve_call_disallowed<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				false,
 			);
@@ -1383,6 +1393,7 @@ fn remote_asset_reserve_and_remote_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				USDC_RESERVE_PARA_ID,
 				Some(USDC_INNER_JUNCTION),
+				ALICE,
 				usdc_initial_local_amount,
 				true,
 			);
@@ -1526,7 +1537,7 @@ fn local_asset_reserve_and_teleported_fee_call<Call>(
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// native assets transfer destination is USDT chain (teleport trust only for USDT)
 		let dest = usdt_chain;
@@ -1675,7 +1686,7 @@ fn destination_asset_reserve_and_teleported_fee_call<Call>(
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (_, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// create non-sufficient foreign asset BLA
 		let foreign_initial_amount = 142;
@@ -1683,6 +1694,7 @@ fn destination_asset_reserve_and_teleported_fee_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				false,
 			);
@@ -1845,13 +1857,14 @@ fn remote_asset_reserve_and_teleported_fee_reserve_call_disallowed<Call>(
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// create non-sufficient foreign asset BLA
 		let foreign_initial_amount = 142;
 		let (_, reserve_sovereign_account, foreign_asset_id_multilocation) = set_up_foreign_asset(
 			FOREIGN_ASSET_RESERVE_PARA_ID,
 			Some(FOREIGN_ASSET_INNER_JUNCTION),
+			ALICE,
 			foreign_initial_amount,
 			false,
 		);
@@ -1952,7 +1965,7 @@ fn reserve_transfer_assets_with_teleportable_asset_disallowed() {
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// transfer destination is USDT chain (foreign asset needs to go through its reserve chain)
 		let dest = usdt_chain;
@@ -2037,6 +2050,7 @@ fn intermediary_error_reverts_side_effects() {
 		let (_, usdc_chain_sovereign_account, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -2106,7 +2120,7 @@ fn teleport_asset_using_local_fee_reserve_call<Call>(
 		// create non-sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, false);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, false);
 
 		// transfer destination is reserve location (no teleport trust)
 		let dest = usdt_chain;
@@ -2258,6 +2272,7 @@ fn teleported_asset_using_destination_reserve_fee_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				true,
 			);
@@ -2265,7 +2280,7 @@ fn teleported_asset_using_destination_reserve_fee_call<Call>(
 		// create non-sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (_, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, false);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, false);
 
 		// transfer destination is BLA reserve location
 		let dest = reserve_location;


### PR DESCRIPTION
For some reason original PR passed CI - when it shouldn't have. Fix `pallet-xcm` test benchmarks.