### PR TITLE
Allow skipping block history download in warp sync

### DIFF
--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -453,16 +453,15 @@ where
 	RCInterface: RelayChainInterface + Clone + 'static,
 	IQ: ImportQueue<Block> + 'static,
 {
-	let warp_sync_params = match parachain_config.network.sync_mode {
-		SyncMode::Warp => {
-			let target_block = warp_sync_get::<Block, RCInterface>(
-				para_id,
-				relay_chain_interface.clone(),
-				spawn_handle.clone(),
-			);
-			Some(WarpSyncParams::WaitForTarget(target_block))
-		},
-		_ => None,
+	let warp_sync_params = if parachain_config.network.sync_mode.is_warp() {
+		let target_block = warp_sync_get::<Block, RCInterface>(
+			para_id,
+			relay_chain_interface.clone(),
+			spawn_handle.clone(),
+		);
+		Some(WarpSyncParams::WaitForTarget(target_block))
+	} else {
+		None
 	};
 
 	let block_announce_validator = match sybil_resistance_level {

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -40,7 +40,7 @@ use sc_consensus::{
 	import_queue::{ImportQueue, ImportQueueService},
 	BlockImport,
 };
-use sc_network::{config::SyncMode, NetworkService};
+use sc_network::NetworkService;
 use sc_network_sync::SyncingService;
 use sc_network_transactions::TransactionsHandlerController;
 use sc_service::{Configuration, NetworkStarter, SpawnTaskHandle, TaskManager, WarpSyncParams};

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -231,8 +231,10 @@ pub enum SyncMode {
 	Fast,
 	/// Download blocks without executing them. Download latest state without proofs.
 	FastUnsafe,
-	/// Prove finality and download the latest state.
+	/// Prove finality and download the latest state. Download block history as well.
 	Warp,
+	/// Prove finality and download the latest state. Does not download block history.
+	WarpNoBlockHistory,
 }
 
 impl Into<sc_network::config::SyncMode> for SyncMode {
@@ -247,7 +249,9 @@ impl Into<sc_network::config::SyncMode> for SyncMode {
 				skip_proofs: true,
 				storage_chain_mode: false,
 			},
-			SyncMode::Warp => sc_network::config::SyncMode::Warp,
+			SyncMode::Warp => sc_network::config::SyncMode::Warp { block_history: true },
+			SyncMode::WarpNoBlockHistory =>
+				sc_network::config::SyncMode::Warp { block_history: false },
 		}
 	}
 }

--- a/substrate/client/network/common/src/sync.rs
+++ b/substrate/client/network/common/src/sync.rs
@@ -33,13 +33,16 @@ pub enum SyncMode {
 		storage_chain_mode: bool,
 	},
 	/// Warp sync - verify authority set transitions and the latest state.
-	Warp,
+	Warp {
+		/// Download block history as well
+		block_history: bool,
+	},
 }
 
 impl SyncMode {
 	/// Returns `true` if `self` is [`Self::Warp`].
 	pub fn is_warp(&self) -> bool {
-		matches!(self, Self::Warp)
+		matches!(self, Self::Warp { .. })
 	}
 
 	/// Returns `true` if `self` is [`Self::LightState`].

--- a/substrate/client/network/test/src/lib.rs
+++ b/substrate/client/network/test/src/lib.rs
@@ -758,7 +758,7 @@ pub trait TestNetFactory: Default + Sized + Send {
 			*genesis_extra_storage = storage;
 		}
 
-		if matches!(config.sync_mode, SyncMode::LightState { .. } | SyncMode::Warp) {
+		if matches!(config.sync_mode, SyncMode::LightState { .. } | SyncMode::Warp { .. }) {
 			test_client_builder = test_client_builder.set_no_genesis();
 		}
 		let backend = test_client_builder.backend();

--- a/substrate/client/network/test/src/sync.rs
+++ b/substrate/client/network/test/src/sync.rs
@@ -1225,7 +1225,7 @@ async fn warp_sync() {
 	net.add_full_peer_with_config(Default::default());
 	net.add_full_peer_with_config(Default::default());
 	net.add_full_peer_with_config(FullPeerConfig {
-		sync_mode: SyncMode::Warp,
+		sync_mode: SyncMode::Warp { block_history: true },
 		..Default::default()
 	});
 	let gap_end = net.peer(0).push_blocks(63, false).pop().unwrap();
@@ -1266,7 +1266,7 @@ async fn warp_sync_to_target_block() {
 	let target_block = net.peer(0).client.header(target).unwrap().unwrap();
 
 	net.add_full_peer_with_config(FullPeerConfig {
-		sync_mode: SyncMode::Warp,
+		sync_mode: SyncMode::Warp { block_history: true },
 		target_block: Some(target_block),
 		..Default::default()
 	});

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -769,7 +769,7 @@ where
 		match config.network.sync_mode {
 			SyncMode::LightState { .. } =>
 				return Err("Fast sync doesn't work for archive nodes".into()),
-			SyncMode::Warp => return Err("Warp sync doesn't work for archive nodes".into()),
+			SyncMode::Warp { .. } => return Err("Warp sync doesn't work for archive nodes".into()),
 			SyncMode::Full => {},
 		}
 	}


### PR DESCRIPTION
Adds a new sync mode `--warp-no-block-history` that is exactly the same as `--warp`, but doesn't download block history.

Close #8