### PR TITLE
BEEFY: `expect_validator_set()` fix

### DIFF
--- a/substrate/client/consensus/beefy/src/lib.rs
+++ b/substrate/client/consensus/beefy/src/lib.rs
@@ -543,16 +543,17 @@ where
 	R: ProvideRuntimeApi<B>,
 	R::Api: BeefyApi<B, AuthorityId>,
 {
-	debug!(target: LOG_TARGET, "🥩 Try to find validator set active at header: {:?}", at_header);
-	// walk up the chain looking for the validator set active 'at_header' -  try both state and
-	// header digests
 	let blockchain = backend.blockchain();
+
+	// Walk up the chain looking for the validator set active at 'at_header'. Process both state and
+	// header digests.
+	debug!(target: LOG_TARGET, "🥩 Trying to find validator set active at header: {:?}", at_header);
 	let mut header = at_header.clone();
 	loop {
-		debug!(target: LOG_TARGET, "🥩 look for auth set change in block number: {:?}", *header.number());
-		if let Some(active) = runtime.runtime_api().validator_set(at_header.hash()).ok().flatten() {
+		if let Ok(Some(active)) = runtime.runtime_api().validator_set(at_header.hash()) {
 			return Ok(active)
 		} else {
+			debug!(target: LOG_TARGET, "🥩 Looking for auth set change at block number: {:?}", *header.number());
 			match worker::find_authorities_change::<B>(&header) {
 				Some(active) => return Ok(active),
 				// Move up the chain. Ultimately we'll get it from chain genesis state, or error out


### PR DESCRIPTION
Fixes #https://github.com/paritytech/polkadot-sdk/issues/2699

Modifying `expect_validator_set()` in order to be able to walk back until block 0. The chain state at block 0 is available even if we use `--sync fast` or `--sync warp`. This way we can retrieve the initial authority set even when BEEFY genesis is 1 and there is no authority change entry in the headers log.

Credits to @acatangiu for the solution