### PR TITLE
sc-tracing: swap atty with is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16330,9 +16330,9 @@ name = "sc-tracing"
 version = "4.0.0-dev"
 dependencies = [
  "ansi_term",
- "atty",
  "chrono",
  "criterion 0.4.0",
+ "is-terminal",
  "lazy_static",
  "libc",
  "log",

--- a/substrate/client/tracing/Cargo.toml
+++ b/substrate/client/tracing/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ansi_term = "0.12.1"
-atty = "0.2.13"
+is-terminal = "0.4.9"
 chrono = "0.4.27"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 lazy_static = "1.4.0"

--- a/substrate/client/tracing/src/logging/mod.rs
+++ b/substrate/client/tracing/src/logging/mod.rs
@@ -33,6 +33,7 @@ pub(crate) type DefaultLogger = stderr_writer::MakeStderrWriter;
 pub use directives::*;
 pub use sc_tracing_proc_macro::*;
 
+use is_terminal::IsTerminal;
 use std::io;
 use tracing::Subscriber;
 use tracing_subscriber::{
@@ -170,7 +171,7 @@ where
 		_ => true,
 	} || detailed_output;
 
-	let enable_color = force_colors.unwrap_or_else(|| atty::is(atty::Stream::Stderr));
+	let enable_color = force_colors.unwrap_or_else(|| io::stderr().is_terminal());
 	let timer = fast_local_time::FastLocalTime { with_fractional: detailed_output };
 
 	let event_format = EventFormat {
@@ -179,7 +180,7 @@ where
 		display_level: detailed_output,
 		display_thread_name: detailed_output,
 		enable_color,
-		dup_to_stdout: !atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdout),
+		dup_to_stdout: !io::stderr().is_terminal() && io::stdout().is_terminal(),
 	};
 	let builder = FmtSubscriber::builder().with_env_filter(env_filter);
 


### PR DESCRIPTION
`atty` is unmaintaned. See the advisory https://github.com/advisories/GHSA-g98v-hv3f-hcfr

I picked is-terminal because rustix is already in-tree, so doesn't increase the dependency footprint, and I am not sure if we can rely on `IsTerminal` from the std because I am not sure what our MSRV.

