### PR TITLE
fix zombienet test

### DIFF
--- a/.gitlab/pipeline/zombienet/polkadot.yml
+++ b/.gitlab/pipeline/zombienet/polkadot.yml
@@ -209,7 +209,7 @@ zombienet-polkadot-misc-0002-upgrade-node:
     # Exit if the job is not merge queue
     # - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/parity/polkadot:latest"
-    - echo "Overrided poladot image ${ZOMBIENET_INTEGRATION_TEST_IMAGE}"
+    - echo "Overrided polkadot image ${ZOMBIENET_INTEGRATION_TEST_IMAGE}"
     - export COL_IMAGE="${COLANDER_IMAGE}":${PIPELINE_IMAGE_TAG}
     - BUILD_LINUX_JOB_ID="$(cat ./artifacts/BUILD_LINUX_JOB_ID)"
     - export POLKADOT_PR_ARTIFACTS_URL="https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/${BUILD_LINUX_JOB_ID}/artifacts/raw/artifacts"

--- a/polkadot/zombienet_tests/misc/0002-upgrade-node.toml
+++ b/polkadot/zombienet_tests/misc/0002-upgrade-node.toml
@@ -9,12 +9,10 @@ chain = "rococo-local"
   [[relaychain.nodes]]
   name = "alice"
   args = [ "-lparachain=debug,runtime=debug", "--db paritydb" ]
-  substrate_cli_args_version = 1
 
   [[relaychain.nodes]]
   name = "bob"
   args = [ "-lparachain=debug,runtime=debug", "--db rocksdb" ]
-  substrate_cli_args_version = 1
 
   [[relaychain.nodes]]
   name = "charlie"


### PR DESCRIPTION
Remove old version for `cli_args`, since this was fixed in the latest version of zombienet and the `latest` version of polkadot introduce the new flag `--insecure-validator-i-know-what-i-do`.

Fix jobs like https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/4726174
Thx!