### PR TITLE
parachain-system: Do not take `self` for `last_relay_block_number`

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -1630,7 +1630,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Get the relay chain block number which was used as an anchor for the last block in this
 	/// chain.
-	pub fn last_relay_block_number(&self) -> RelayChainBlockNumber {
+	pub fn last_relay_block_number() -> RelayChainBlockNumber {
 		LastRelayChainBlockNumber::<T>::get()
 	}
 }


### PR DESCRIPTION
FRAME DSL is working in a static context.