### PR TITLE
Publicly expose inaccessible `pallet_uniques` state

### DIFF
--- a/substrate/frame/uniques/src/lib.rs
+++ b/substrate/frame/uniques/src/lib.rs
@@ -165,7 +165,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::storage_prefix = "Class"]
 	/// Details of a collection.
-	pub(super) type Collection<T: Config<I>, I: 'static = ()> = StorageMap<
+	pub type Collection<T: Config<I>, I: 'static = ()> = StorageMap<
 		_,
 		Blake2_128Concat,
 		T::CollectionId,
@@ -174,7 +174,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	/// The collection, if any, of which an account is willing to take ownership.
-	pub(super) type OwnershipAcceptance<T: Config<I>, I: 'static = ()> =
+	pub type OwnershipAcceptance<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, T::CollectionId>;
 
 	#[pallet::storage]
@@ -208,7 +208,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::storage_prefix = "Asset"]
 	/// The items in existence and their ownership details.
-	pub(super) type Item<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
+	pub type Item<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		T::CollectionId,
@@ -257,7 +257,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	/// Price of an asset instance.
-	pub(super) type ItemPriceOf<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
+	pub type ItemPriceOf<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
 		_,
 		Blake2_128Concat,
 		T::CollectionId,


### PR DESCRIPTION
A small PR to publicly expose the `pallet_uniques` state that is not accessible through the nonfungibles implementation.

Currently, this state is unreachable from chain extensions.