### PR TITLE
[ci] Fix node-bench-regression-guard job

### DIFF
--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -305,6 +305,7 @@ node-bench-regression-guard:
     CI_IMAGE: "paritytech/node-bench-regression-guard:latest"
     # current git limit is 20, set to 100 to avoid failures (gitlab removes old artifacts)
     GIT_LIMIT: 100
+    GIT_STRATEGY: fetch
   before_script: [""]
   script:
     - if [ $(ls -la artifacts/benches/ | grep master | wc -l) == 0 ]; then

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -303,9 +303,14 @@ node-bench-regression-guard:
       artifacts: true
   variables:
     CI_IMAGE: "paritytech/node-bench-regression-guard:latest"
+    # current git limit is 20, set to 100 to avoid failures (gitlab removes old artifacts)
+    GIT_LIMIT: 100
   before_script: [""]
   script:
-    - ls -la artifacts/benches/
+    - if [ $(ls -la artifacts/benches/ | grep master | wc -l) == 0 ]; then
+      echo "Couldn't find master artifacts, consider increasing GIT_LIMIT variable";
+      exit 1;
+      fi
     - echo "------- IMPORTANT -------"
     - echo "node-bench-regression-guard depends on the results of a cargo-check-benches job"
     - echo "In case of this job failure, check your pipeline's cargo-check-benches"

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -305,6 +305,7 @@ node-bench-regression-guard:
     CI_IMAGE: "paritytech/node-bench-regression-guard:latest"
   before_script: [""]
   script:
+    - ls -la artifacts/benches/
     - echo "------- IMPORTANT -------"
     - echo "node-bench-regression-guard depends on the results of a cargo-check-benches job"
     - echo "In case of this job failure, check your pipeline's cargo-check-benches"
@@ -520,6 +521,6 @@ test-syscalls:
     - ./list-syscalls.rb ../../../target/x86_64-unknown-linux-musl/production/polkadot-prepare-worker --only-used-syscalls | diff -u prepare-worker-syscalls -
   after_script:
     - if [[ "$CI_JOB_STATUS" == "failed" ]]; then
-        printf "The x86_64 syscalls used by the worker binaries have changed. Please review if this is expected and update polkadot/scripts/list-syscalls/*-worker-syscalls as needed.\n";
+      printf "The x86_64 syscalls used by the worker binaries have changed. Please review if this is expected and update polkadot/scripts/list-syscalls/*-worker-syscalls as needed.\n";
       fi
   allow_failure: false # this rarely triggers in practice

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -304,7 +304,7 @@ node-bench-regression-guard:
   variables:
     CI_IMAGE: "paritytech/node-bench-regression-guard:latest"
     # current git limit is 20, set to 100 to avoid failures (gitlab removes old artifacts)
-    GIT_LIMIT: 100
+    GIT_DEPTH: 100
     GIT_STRATEGY: fetch
   before_script: [""]
   script:


### PR DESCRIPTION
After GitLab update it started to remove artifacts from master if PR has more than 20 commits. PR fixes this for `node-bench-regression-guard` job

cc https://github.com/paritytech/ci_cd/issues/915