### PR TITLE
:bug: Depositing PalletAttributeSet on incorrect nft

### DIFF
--- a/substrate/frame/nfts/src/lib.rs
+++ b/substrate/frame/nfts/src/lib.rs
@@ -874,8 +874,8 @@ pub mod pallet {
 								),
 							);
 							Self::deposit_event(Event::PalletAttributeSet {
-								collection,
-								item: Some(item),
+								collection: collection_id,
+								item: Some(owned_item),
 								attribute: pallet_attribute,
 								value: attribute_value,
 							});


### PR DESCRIPTION
## Context

Implementing `HolderOf(collection_id)` we have observed a fancy glitch where pallet deposits event with incorrect values

### Test case 

[Observe following extrinsic](https://assethub-polkadot.subscan.io/extrinsic/0xdc72321b7674aa209c2f194ed49bd6bd12708af103f98b5b9196e0132dcba777)

To mint in collection `51` user needs to be `HolderOf(50)`.
Therefore current user is owner of item `394` `witness_data { owned_item: 394 }`

All checking is done correctly, storage is updated correctly

 
![photo_2023-12-18 16 07 11](https://github.com/paritytech/polkadot-sdk/assets/22471030/ca991272-156d-4db1-97b2-1a2873fc5d3f)

However the event which is emitted does not make semantic sense as we updated storage for `50-394` not for `51-114`

![photo_2023-12-18 16 07 17](https://github.com/paritytech/polkadot-sdk/assets/22471030/c998a92c-e306-4433-aad8-103078140e23)

## The fix 

This PR fixes that depositing `PalletAttributeSet` emits correct values.

