### PR TITLE
pallet-uniques/nfts: Small optimizations

### DIFF
--- a/substrate/frame/nfts/src/features/transfer.rs
+++ b/substrate/frame/nfts/src/features/transfer.rs
@@ -172,8 +172,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		who: T::AccountId,
 		maybe_collection: Option<T::CollectionId>,
 	) -> DispatchResult {
-		let old = OwnershipAcceptance::<T, I>::get(&who);
-		match (old.is_some(), maybe_collection.is_some()) {
+		let exists = OwnershipAcceptance::<T, I>::contains_key(&who);
+		match (exists, maybe_collection.is_some()) {
 			(false, true) => {
 				frame_system::Pallet::<T>::inc_consumers(&who)?;
 			},

--- a/substrate/frame/uniques/src/lib.rs
+++ b/substrate/frame/uniques/src/lib.rs
@@ -1430,8 +1430,8 @@ pub mod pallet {
 			maybe_collection: Option<T::CollectionId>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			let old = OwnershipAcceptance::<T, I>::get(&who);
-			match (old.is_some(), maybe_collection.is_some()) {
+			let exists = OwnershipAcceptance::<T, I>::contains_key(&who);
+			match (exists, maybe_collection.is_some()) {
 				(false, true) => {
 					frame_system::Pallet::<T>::inc_consumers(&who)?;
 				},


### PR DESCRIPTION
Use `contains_key` to not require decoding the actual value.