### PR TITLE
Send xcm to coretime chain on migration

### DIFF
--- a/polkadot/runtime/parachains/src/assigner_coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/assigner_coretime/mod.rs
@@ -449,9 +449,6 @@ impl<T: Config> Pallet<T> {
 		assignments: Vec<(CoreAssignment, PartsOf57600)>,
 		end_hint: Option<BlockNumberFor<T>>,
 	) -> Result<(), DispatchError> {
-		// TODO: Add this assert once the calls `request_core_count` and `notify_core_count`
-		// have been established. assert!(core < core_count);
-
 		// There should be at least one assignment.
 		ensure!(!assignments.is_empty(), Error::<T>::AssignmentsEmpty);
 

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -145,7 +145,8 @@ pub fn migrate_to_coretime<T: Config>() -> Weight {
 	let single_weight = <T as Config>::WeightInfo::assign_core(1);
 	single_weight
 		.saturating_mul(u64::from(legacy_count.saturating_add(config.coretime_cores)))
-		.saturating_add(T::DbWeight::get().reads_writes(1, 1))
+		// Second read from sending assignments to the coretime chain.
+		.saturating_add(T::DbWeight::get().reads_writes(2, 1))
 }
 
 fn migrate_send_assignments_to_coretime_chain<T: Config>() -> result::Result<(), SendError> {

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -14,66 +14,100 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Migration of legacy parachains to Coretime.
+//! Migrations for the Coretime pallet.
 
-use sp_runtime::BoundedVec;
-use sp_std::{iter, prelude::*, result};
+pub use v_coretime::{GetLegacyLease, MigrateToCoretime};
 
-use parity_scale_codec::Encode;
-
-use sp_core::Get;
-
-use frame_support::weights::Weight;
-use pallet_broker::{CoreAssignment, CoreMask, ScheduleItem};
-use xcm::v3::{
-	send_xcm, Instruction, Junction, Junctions, MultiLocation, OriginKind, SendError, WeightLimit,
-	Xcm,
-};
-
-use crate::{configuration, paras};
-use polkadot_parachain_primitives::primitives::IsSystem;
-use primitives::CoreIndex;
-
-use super::{BrokerRuntimePallets, Config, GetLegacyLease, Pallet, PartsOf57600, WeightInfo};
-use crate::assigner_coretime;
-
-pub mod v_coretime {
-
+mod v_coretime {
 	#[cfg(feature = "try-runtime")]
-	use sp_std::vec::Vec;
-
+	use crate::scheduler::common::FixedAssignmentProvider;
+	use crate::{
+		assigner_coretime, configuration,
+		coretime::{BrokerRuntimePallets, Config, PartsOf57600, WeightInfo},
+		paras,
+	};
 	#[cfg(feature = "try-runtime")]
 	use frame_support::ensure;
 	use frame_support::{
-		migrations::VersionedMigration, traits::OnRuntimeUpgrade, weights::Weight,
+		traits::{OnRuntimeUpgrade, PalletInfoAccess, StorageVersion},
+		weights::Weight,
 	};
-
+	use frame_system::pallet_prelude::BlockNumberFor;
+	use pallet_broker::{CoreAssignment, CoreMask, ScheduleItem};
+	use parity_scale_codec::Encode;
+	use polkadot_parachain_primitives::primitives::IsSystem;
+	use primitives::{CoreIndex, Id as ParaId};
+	use sp_core::Get;
+	use sp_runtime::BoundedVec;
 	#[cfg(feature = "try-runtime")]
-	use crate::{
-		assigner_coretime, configuration, paras, scheduler::common::FixedAssignmentProvider,
+	use sp_std::vec::Vec;
+	use sp_std::{iter, prelude::*, result};
+	use xcm::v3::{
+		send_xcm, Instruction, Junction, Junctions, MultiLocation, OriginKind, SendError,
+		WeightLimit, Xcm,
 	};
 
-	use super::{Config, Pallet};
+	/// Return information about a legacy lease of a parachain.
+	pub trait GetLegacyLease<N> {
+		/// If parachain is a lease holding parachain, return the block at which the lease expires.
+		fn get_parachain_lease_in_blocks(para: ParaId) -> Option<N>;
+	}
 
-	#[allow(deprecated)]
-	pub type MigrateToCoretime<T> = VersionedMigration<
-		0,
-		1,
-		UncheckedMigrateToCoretime<T>,
-		Pallet<T>,
-		<T as frame_system::Config>::DbWeight,
-	>;
+	/// Migrate a chain to use coretime.
+	///
+	/// This assumes that the `Coretime` and the `AssignerCoretime` pallets are added at the same
+	/// time to a runtime.
+	pub struct MigrateToCoretime<T, SendXcm, LegacyLease>(
+		sp_std::marker::PhantomData<(T, SendXcm, LegacyLease)>,
+	);
 
-	pub struct UncheckedMigrateToCoretime<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config, SendXcm: xcm::v3::SendXcm, LegacyLease: GetLegacyLease<BlockNumberFor<T>>>
+		MigrateToCoretime<T, SendXcm, LegacyLease>
+	{
+		fn already_migrated() -> bool {
+			// We are using the assigner coretime because the coretime pallet doesn't has any
+			// storage data. But both pallets are introduced at the same time, so this is fine.
+			let name_hash = assigner_coretime::Pallet::<T>::name_hash();
+			let mut next_key = name_hash.to_vec();
+			let storage_version_key = StorageVersion::storage_key::<assigner_coretime::Pallet<T>>();
 
-	impl<T: Config> OnRuntimeUpgrade for UncheckedMigrateToCoretime<T> {
+			loop {
+				match sp_io::storage::next_key(&next_key) {
+					// StorageVersion is initialized before, so we need to ingore it.
+					Some(key) if &key == &storage_version_key => {
+						next_key = key;
+					},
+					// If there is any other key with the prefix of the pallet,
+					// we already have executed the migration.
+					Some(key) if key.starts_with(&name_hash) => {
+						log::info!("`MigrateToCoretime` already executed!");
+						return true
+					},
+					// Any other key/no key means that we did not yet have migrated.
+					None | Some(_) => return false,
+				}
+			}
+		}
+	}
+
+	impl<T: Config, SendXcm: xcm::v3::SendXcm, LegacyLease: GetLegacyLease<BlockNumberFor<T>>>
+		OnRuntimeUpgrade for MigrateToCoretime<T, SendXcm, LegacyLease>
+	{
 		fn on_runtime_upgrade() -> Weight {
+			if Self::already_migrated() {
+				return Weight::zero()
+			}
+
 			log::info!("Migrating existing parachains to coretime.");
-			super::migrate_to_coretime::<T>()
+			migrate_to_coretime::<T, SendXcm, LegacyLease>()
 		}
 
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+			if Self::already_migrated() {
+				return Ok(Vec::new())
+			}
+
 			let legacy_paras = paras::Parachains::<T>::get();
 			let config = <configuration::Pallet<T>>::config();
 			let total_core_count = config.coretime_cores + legacy_paras.len() as u32;
@@ -85,6 +119,10 @@ pub mod v_coretime {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+			if state.is_empty() {
+				return Ok(())
+			}
+
 			log::trace!("Running post_upgrade()");
 
 			let prev_core_count = u32::from_be_bytes(state.try_into().unwrap());
@@ -94,116 +132,124 @@ pub mod v_coretime {
 			Ok(())
 		}
 	}
-}
 
-// Migrate to Coretime.
-//
-// NOTE: Also migrates coretime_cores config value in configuration::ActiveConfig.
-pub fn migrate_to_coretime<T: Config>() -> Weight {
-	let legacy_paras = paras::Pallet::<T>::parachains();
-	let legacy_count = legacy_paras.len() as u32;
-	let now = <frame_system::Pallet<T>>::block_number();
-	for (core, para_id) in legacy_paras.into_iter().enumerate() {
-		let r = assigner_coretime::Pallet::<T>::assign_core(
-			CoreIndex(core as u32),
-			now,
-			vec![(CoreAssignment::Task(para_id.into()), PartsOf57600::FULL)],
-			None,
-		);
-		if let Err(err) = r {
-			log::error!(
-				"Creating assignment for existing para failed: {:?}, error: {:?}",
-				para_id,
-				err
+	// Migrate to Coretime.
+	//
+	// NOTE: Also migrates coretime_cores config value in configuration::ActiveConfig.
+	fn migrate_to_coretime<
+		T: Config,
+		SendXcm: xcm::v3::SendXcm,
+		LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
+	>() -> Weight {
+		let legacy_paras = paras::Pallet::<T>::parachains();
+		let legacy_count = legacy_paras.len() as u32;
+		let now = <frame_system::Pallet<T>>::block_number();
+		for (core, para_id) in legacy_paras.into_iter().enumerate() {
+			let r = assigner_coretime::Pallet::<T>::assign_core(
+				CoreIndex(core as u32),
+				now,
+				vec![(CoreAssignment::Task(para_id.into()), PartsOf57600::FULL)],
+				None,
 			);
+			if let Err(err) = r {
+				log::error!(
+					"Creating assignment for existing para failed: {:?}, error: {:?}",
+					para_id,
+					err
+				);
+			}
 		}
-	}
 
-	let config = <configuration::Pallet<T>>::config();
-	// coretime_cores was on_demand_cores until now:
-	for on_demand in 0..config.coretime_cores {
-		let core = CoreIndex(legacy_count.saturating_add(on_demand as _));
-		let r = assigner_coretime::Pallet::<T>::assign_core(
-			core,
-			now,
-			vec![(CoreAssignment::Pool, PartsOf57600::FULL)],
-			None,
-		);
-		if let Err(err) = r {
-			log::error!("Creating assignment for existing on-demand core, failed: {:?}", err);
+		let config = <configuration::Pallet<T>>::config();
+		// coretime_cores was on_demand_cores until now:
+		for on_demand in 0..config.coretime_cores {
+			let core = CoreIndex(legacy_count.saturating_add(on_demand as _));
+			let r = assigner_coretime::Pallet::<T>::assign_core(
+				core,
+				now,
+				vec![(CoreAssignment::Pool, PartsOf57600::FULL)],
+				None,
+			);
+			if let Err(err) = r {
+				log::error!("Creating assignment for existing on-demand core, failed: {:?}", err);
+			}
 		}
+		let total_cores = config.coretime_cores + legacy_count;
+		configuration::ActiveConfig::<T>::mutate(|c| {
+			c.coretime_cores = total_cores;
+		});
+
+		if let Err(err) = migrate_send_assignments_to_coretime_chain::<T, SendXcm, LegacyLease>() {
+			log::error!("Sending legacy chain data to coretime chain failed: {:?}", err);
+		}
+
+		let single_weight = <T as Config>::WeightInfo::assign_core(1);
+		single_weight
+			.saturating_mul(u64::from(legacy_count.saturating_add(config.coretime_cores)))
+			// Second read from sending assignments to the coretime chain.
+			.saturating_add(T::DbWeight::get().reads_writes(2, 1))
 	}
-	let total_cores = config.coretime_cores + legacy_count;
-	configuration::ActiveConfig::<T>::mutate(|c| {
-		c.coretime_cores = total_cores;
-	});
 
-	if let Err(err) = migrate_send_assignments_to_coretime_chain::<T>() {
-		log::error!("Sending legacy chain data to coretime chain failed: {:?}", err);
-	}
+	fn migrate_send_assignments_to_coretime_chain<
+		T: Config,
+		SendXcm: xcm::v3::SendXcm,
+		LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
+	>() -> result::Result<(), SendError> {
+		let legacy_paras = paras::Pallet::<T>::parachains();
+		let (system_chains, lease_holding): (Vec<_>, Vec<_>) =
+			legacy_paras.into_iter().partition(IsSystem::is_system);
 
-	let single_weight = <T as Config>::WeightInfo::assign_core(1);
-	single_weight
-		.saturating_mul(u64::from(legacy_count.saturating_add(config.coretime_cores)))
-		// Second read from sending assignments to the coretime chain.
-		.saturating_add(T::DbWeight::get().reads_writes(2, 1))
-}
+		let reservations = system_chains.into_iter().map(|p| {
+			let schedule = BoundedVec::truncate_from(vec![ScheduleItem {
+				mask: CoreMask::complete(),
+				assignment: CoreAssignment::Task(p.into()),
+			}]);
+			mk_coretime_call(crate::coretime::CoretimeCalls::Reserve(schedule))
+		});
 
-fn migrate_send_assignments_to_coretime_chain<T: Config>() -> result::Result<(), SendError> {
-	let legacy_paras = paras::Pallet::<T>::parachains();
-	let (system_chains, lease_holding): (Vec<_>, Vec<_>) =
-		legacy_paras.into_iter().partition(IsSystem::is_system);
-
-	let reservations = system_chains.into_iter().map(|p| {
-		let schedule = BoundedVec::truncate_from(vec![ScheduleItem {
-			mask: CoreMask::complete(),
-			assignment: CoreAssignment::Task(p.into()),
-		}]);
-		mk_coretime_call(super::CoretimeCalls::Reserve(schedule))
-	});
-
-	let leases = lease_holding.into_iter().filter_map(|p| {
-		let Some(valid_until) = T::GetLegacyLease::get_parachain_lease_in_blocks(p) else {
-			log::error!("Lease holding chain with no lease information?!");
-			return None
-		};
-		let valid_until: u32 = match valid_until.try_into() {
-			Ok(val) => val,
-			Err(_) => {
-				log::error!("Converting block number to u32 failed!");
+		let leases = lease_holding.into_iter().filter_map(|p| {
+			let Some(valid_until) = LegacyLease::get_parachain_lease_in_blocks(p) else {
+				log::error!("Lease holding chain with no lease information?!");
 				return None
+			};
+			let valid_until: u32 = match valid_until.try_into() {
+				Ok(val) => val,
+				Err(_) => {
+					log::error!("Converting block number to u32 failed!");
+					return None
+				},
+			};
+			// We assume the coretime chain set this parameter to the recommened value in RFC-1:
+			const TIME_SLICE_PERIOD: u32 = 80;
+			let round_up = if valid_until % TIME_SLICE_PERIOD > 0 { 1 } else { 0 };
+			let time_slice = valid_until / TIME_SLICE_PERIOD + TIME_SLICE_PERIOD * round_up;
+			Some(mk_coretime_call(crate::coretime::CoretimeCalls::SetLease(p.into(), time_slice)))
+		});
+
+		let message_content = iter::once(Instruction::UnpaidExecution {
+			weight_limit: WeightLimit::Unlimited,
+			check_origin: None,
+		})
+		.chain(reservations)
+		.chain(leases)
+		.collect();
+
+		let message = Xcm(message_content);
+		send_xcm::<SendXcm>(
+			MultiLocation {
+				parents: 0,
+				interior: Junctions::X1(Junction::Parachain(T::BrokerId::get())),
 			},
-		};
-		// We assume the coretime chain set this parameter to the recommened value in RFC-1:
-		const TIME_SLICE_PERIOD: u32 = 80;
-		let round_up = if valid_until % TIME_SLICE_PERIOD > 0 { 1 } else { 0 };
-		let time_slice = valid_until / TIME_SLICE_PERIOD + TIME_SLICE_PERIOD * round_up;
-		Some(mk_coretime_call(super::CoretimeCalls::SetLease(p.into(), time_slice)))
-	});
+			message,
+		)?;
+		Ok(())
+	}
 
-	let message_content = iter::once(Instruction::UnpaidExecution {
-		weight_limit: WeightLimit::Unlimited,
-		check_origin: None,
-	})
-	.chain(reservations)
-	.chain(leases)
-	.collect();
-
-	let message = Xcm(message_content);
-	send_xcm::<T::SendXcm>(
-		MultiLocation {
-			parents: 0,
-			interior: Junctions::X1(Junction::Parachain(T::BrokerId::get())),
-		},
-		message,
-	)?;
-	Ok(())
-}
-
-fn mk_coretime_call(call: super::CoretimeCalls) -> Instruction<()> {
-	Instruction::Transact {
-		origin_kind: OriginKind::Native,
-		require_weight_at_most: Weight::from_parts(1000000000, 200000),
-		call: BrokerRuntimePallets::Broker(call).encode().into(),
+	fn mk_coretime_call(call: crate::coretime::CoretimeCalls) -> Instruction<()> {
+		Instruction::Transact {
+			origin_kind: OriginKind::Native,
+			require_weight_at_most: Weight::from_parts(1000000000, 200000),
+			call: BrokerRuntimePallets::Broker(call).encode().into(),
+		}
 	}
 }

--- a/polkadot/runtime/parachains/src/coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/coretime/mod.rs
@@ -90,24 +90,13 @@ enum CoretimeCalls {
 
 #[frame_support::pallet]
 pub mod pallet {
-
-	use xcm::v3::SendXcm;
-
 	use crate::configuration;
 
 	use super::*;
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
-
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
-	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
-
-	pub trait GetLegacyLease<N> {
-		/// If parachain is a lease holding parachain, return the block at which the lease expires.
-		fn get_parachain_lease_in_blocks(para: ParaId) -> Option<N>;
-	}
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config + assigner_coretime::Config {
@@ -121,10 +110,6 @@ pub mod pallet {
 		type BrokerId: Get<u32>;
 		/// Something that provides the weight of this pallet.
 		type WeightInfo: WeightInfo;
-		/// XCM message sender for talking to the coretime chain.
-		type SendXcm: SendXcm;
-		/// For migration of legacy parachains.
-		type GetLegacyLease: GetLegacyLease<BlockNumberFor<Self>>;
 	}
 
 	#[pallet::event]

--- a/polkadot/runtime/parachains/src/coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/coretime/mod.rs
@@ -24,7 +24,7 @@ mod benchmarking;
 
 use crate::{
 	assigner_coretime::{self, PartsOf57600},
-	initializer::SessionChangeNotification,
+	initializer::{OnNewSession, SessionChangeNotification},
 	origin::{ensure_parachain, Origin},
 };
 use frame_support::{pallet_prelude::*, traits::Currency};
@@ -221,5 +221,11 @@ impl<T: Config> Pallet<T> {
 		if new_core_count != old_core_count {
 			// TODO: call notify_core_count
 		}
+	}
+}
+
+impl<T: Config> OnNewSession<BlockNumberFor<T>> for Pallet<T> {
+	fn on_new_session(notification: &SessionChangeNotification<BlockNumberFor<T>>) {
+		Self::initializer_on_new_session(notification);
 	}
 }

--- a/polkadot/runtime/parachains/src/mock.rs
+++ b/polkadot/runtime/parachains/src/mock.rs
@@ -186,6 +186,7 @@ impl crate::initializer::Config for Test {
 	type Randomness = TestRandomness<Self>;
 	type ForceOrigin = frame_system::EnsureRoot<u64>;
 	type WeightInfo = ();
+	type CoretimeOnNewSession = Coretime;
 }
 
 impl crate::configuration::Config for Test {

--- a/polkadot/runtime/parachains/src/mock.rs
+++ b/polkadot/runtime/parachains/src/mock.rs
@@ -51,7 +51,6 @@ use sp_runtime::{
 	BuildStorage, FixedU128, Perbill, Permill,
 };
 use sp_std::collections::vec_deque::VecDeque;
-use xcm::v3::{SendXcm, MultiAssets, SendError, MultiLocation, XcmHash, SendResult, Xcm};
 use std::{cell::RefCell, collections::HashMap};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -83,17 +82,6 @@ frame_support::construct_runtime!(
 		Babe: pallet_babe,
 	}
 );
-
-pub struct XcmDevNull;
-impl SendXcm for XcmDevNull {
-	type Ticket = ();
-	fn validate(_: &mut Option<MultiLocation>, _: &mut Option<Xcm<()>>) -> SendResult<()> {
-		Ok(((), MultiAssets::new()))
-	}
-	fn deliver(_: ()) -> Result<XcmHash, SendError> {
-		Ok([0; 32])
-	}
-}
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
@@ -387,15 +375,6 @@ impl coretime::Config for Test {
 	type Currency = pallet_balances::Pallet<Test>;
 	type BrokerId = BrokerId;
 	type WeightInfo = crate::coretime::TestWeightInfo;
-	type SendXcm = XcmDevNull;
-	type GetLegacyLease = DummyLegacyLease;
-}
-
-pub struct DummyLegacyLease;
-impl coretime::GetLegacyLease<BlockNumber> for DummyLegacyLease {
-	fn get_parachain_lease_in_blocks(_: ParaId) -> Option<BlockNumber> {
-		None
-	}
 }
 
 impl crate::inclusion::Config for Test {

--- a/polkadot/runtime/parachains/src/scheduler/migration.rs
+++ b/polkadot/runtime/parachains/src/scheduler/migration.rs
@@ -27,7 +27,7 @@ use frame_support::{
 /// `Assignment` used to be a concrete type with the same layout V0Assignment, idential on all
 /// assignment providers. This can be removed once storage has been migrated.
 #[derive(Encode, Decode, RuntimeDebug, TypeInfo, PartialEq, Clone)]
-struct V0Assignment {
+pub struct V0Assignment {
 	pub para_id: ParaId,
 }
 

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1039,6 +1039,7 @@ impl parachains_initializer::Config for Runtime {
 	type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
 	type ForceOrigin = EnsureRoot<AccountId>;
 	type WeightInfo = weights::runtime_parachains_initializer::WeightInfo<Runtime>;
+	type CoretimeOnNewSession = Coretime;
 }
 
 impl parachains_disputes::Config for Runtime {

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -38,7 +38,6 @@ use runtime_common::{
 		LocatableAssetConverter, ToAuthor, VersionedLocatableAsset, VersionedMultiLocationConverter,
 	},
 	paras_registrar, paras_sudo_wrapper, prod_or_fast, slots,
-	traits::Leaser,
 	BlockHashCount, BlockLength, SlowAdjustingFeeUpdate,
 };
 use scale_info::TypeInfo;

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1637,7 +1637,6 @@ pub mod migrations {
 		parachains_configuration::migration::v7::MigrateToV7<Runtime>,
 		assigned_slots::migration::v1::MigrateToV1<Runtime>,
 		parachains_scheduler::migration::MigrateV1ToV2<Runtime>,
-		coretime::migration::MigrateToCoretime<Runtime, crate::xcm_config::XcmRouter, GetLegacyLeaseImpl>,
 		parachains_configuration::migration::v8::MigrateToV8<Runtime>,
 		parachains_configuration::migration::v9::MigrateToV9<Runtime>,
 		paras_registrar::migration::MigrateToV1<Runtime, ()>,
@@ -1668,6 +1667,8 @@ pub mod migrations {
 		// Remove `im-online` pallet on-chain storage
 		frame_support::migrations::RemovePallet<ImOnlinePalletName, <Runtime as frame_system::Config>::DbWeight>,
 		parachains_configuration::migration::v11::MigrateToV11<Runtime>,
+		// This needs to come after the `parachains_configuration` above as we are reading the configuration.
+		coretime::migration::MigrateToCoretime<Runtime, crate::xcm_config::XcmRouter, GetLegacyLeaseImpl>,
 	);
 }
 

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -25,8 +25,8 @@ use parity_scale_codec::Encode;
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use polkadot_runtime_parachains::{
-	assigner_coretime, assigner_on_demand, assigner_parachains as parachains_assigner_parachains,
-	configuration as parachains_configuration, coretime, disputes as parachains_disputes,
+	assigner_parachains as parachains_assigner_parachains,
+	configuration as parachains_configuration, disputes as parachains_disputes,
 	disputes::slashing as parachains_slashing, dmp as parachains_dmp, hrmp as parachains_hrmp,
 	inclusion as parachains_inclusion, initializer as parachains_initializer,
 	origin as parachains_origin, paras as parachains_paras,
@@ -520,6 +520,7 @@ impl parachains_initializer::Config for Runtime {
 	type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type WeightInfo = ();
+	type CoretimeOnNewSession = ();
 }
 
 impl parachains_session_info::Config for Runtime {
@@ -543,26 +544,9 @@ parameter_types! {
 	pub const BrokerId: u32 = 10u32;
 }
 
-impl coretime::Config for Runtime {
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = pallet_balances::Pallet<Runtime>;
-	type BrokerId = BrokerId;
-	type WeightInfo = coretime::TestWeightInfo;
-}
-
 parameter_types! {
 	pub const OnDemandTrafficDefaultValue: FixedU128 = FixedU128::from_u32(1);
 }
-
-impl assigner_on_demand::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type TrafficDefaultValue = OnDemandTrafficDefaultValue;
-	type WeightInfo = assigner_on_demand::TestWeightInfo;
-}
-
-impl assigner_coretime::Config for Runtime {}
 
 impl parachains_dmp::Config for Runtime {}
 
@@ -729,9 +713,6 @@ construct_runtime! {
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>},
 
 		TestNotifier: pallet_test_notifier::{Pallet, Call, Event<T>},
-		Coretime: coretime,
-		AssignerCoretime: assigner_coretime,
-		AssignerOnDemand: assigner_on_demand,
 	}
 }
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1638,26 +1638,6 @@ pub mod migrations {
 		}
 	}
 
-	pub struct GetLegacyLeaseImpl;
-	impl coretime::migration::GetLegacyLease<BlockNumber> for GetLegacyLeaseImpl {
-		fn get_parachain_lease_in_blocks(para: ParaId) -> Option<BlockNumber> {
-			let now = frame_system::Pallet::<Runtime>::block_number();
-			let mut leases = slots::Pallet::<Runtime>::lease(para).into_iter();
-			let Some(Some(_)) = leases.next() else { return None };
-
-			let (_, progress) = slots::Pallet::<Runtime>::lease_period_index_plus_progress(now)?;
-			let initial_sum =
-				<Runtime as slots::Config>::LeasePeriod::get().saturating_sub(progress);
-
-			leases.into_iter().fold(Some(initial_sum), |sum, lease| {
-				if lease.is_none() {
-					return None
-				};
-				Some(sum? + <Runtime as slots::Config>::LeasePeriod::get())
-			})
-		}
-	}
-
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = (
 		parachains_configuration::migration::v7::MigrateToV7<Runtime>,

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -66,7 +66,7 @@ use runtime_common::{
 };
 use runtime_parachains::{
 	assigner_parachains as parachains_assigner_parachains,
-	configuration as parachains_configuration, coretime, disputes as parachains_disputes,
+	configuration as parachains_configuration, disputes as parachains_disputes,
 	disputes::slashing as parachains_slashing,
 	dmp as parachains_dmp, hrmp as parachains_hrmp, inclusion as parachains_inclusion,
 	inclusion::{AggregateMessageOrigin, UmpQueueId},


### PR DESCRIPTION
For bringing it to the same state with regards to system- and lease-holding paras.