### PR TITLE
use a single source for simple-mermaid dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5423,7 +5423,7 @@ dependencies = [
  "pallet-examples",
  "parity-scale-codec",
  "scale-info",
- "simple-mermaid 0.1.0 (git+https://github.com/kianenigma/simple-mermaid.git?rev=e48b187bcfd5cc75111acd9d241f1bd36604344b)",
+ "simple-mermaid",
  "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
@@ -13239,7 +13239,7 @@ dependencies = [
  "sc-rpc",
  "sc-rpc-api",
  "scale-info",
- "simple-mermaid 0.1.0 (git+https://github.com/kianenigma/simple-mermaid.git?branch=main)",
+ "simple-mermaid",
  "sp-api",
  "sp-core",
  "sp-io",
@@ -17167,11 +17167,6 @@ dependencies = [
 [[package]]
 name = "simple-mermaid"
 version = "0.1.0"
-source = "git+https://github.com/kianenigma/simple-mermaid.git?branch=main#e48b187bcfd5cc75111acd9d241f1bd36604344b"
-
-[[package]]
-name = "simple-mermaid"
-version = "0.1.0"
 source = "git+https://github.com/kianenigma/simple-mermaid.git?rev=e48b187bcfd5cc75111acd9d241f1bd36604344b#e48b187bcfd5cc75111acd9d241f1bd36604344b"
 
 [[package]]
@@ -18032,7 +18027,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "simple-mermaid 0.1.0 (git+https://github.com/kianenigma/simple-mermaid.git?branch=main)",
+ "simple-mermaid",
  "sp-api",
  "sp-application-crypto",
  "sp-arithmetic",

--- a/docs/sdk/Cargo.toml
+++ b/docs/sdk/Cargo.toml
@@ -22,7 +22,7 @@ pallet-examples = { path = "../../substrate/frame/examples" }
 pallet-default-config-example = { path = "../../substrate/frame/examples/default-config" }
 
 # How we build docs in rust-docs
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", branch = "main" }
+simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b" }
 docify = "0.2.6"
 
 # Polkadot SDK deps, typically all should only be in scope such that we can link to their doc item.

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -34,7 +34,7 @@ sp-std = { path = "../std", default-features = false }
 sp-weights = { path = "../weights", default-features = false }
 docify = { version = "0.2.6" }
 
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", branch = "main" }
+simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b" }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
this breaks cargo vendor which is necessary for building polkadot with nix