### PR TITLE
pallet-sudo: Accept `Root` origin as valid sudo

### DIFF
--- a/prdoc/pr_2783.prdoc
+++ b/prdoc/pr_2783.prdoc
@@ -1,0 +1,12 @@
+title: "Accept Root origin as valid sudo"
+
+doc:
+  - audience: Runtime User
+    description: |
+      Dispatchables of `pallet-sudo` will now also accept the `Root` origin
+      as valid `sudo` origin. This enhancement is useful for parachains that
+      allow the relay chain as a superuser. It enables the relay chain to send
+      an XCM message to initialize the sudo key.
+
+crates:
+  - name: "pallet-sudo"

--- a/substrate/frame/sudo/src/lib.rs
+++ b/substrate/frame/sudo/src/lib.rs
@@ -349,12 +349,16 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Ensure that the caller is the sudo key.
 		pub(crate) fn ensure_sudo(origin: OriginFor<T>) -> DispatchResult {
-			let sender = ensure_signed(origin)?;
+			let sender = ensure_signed_or_root(origin)?;
 
-			if Self::key().map_or(false, |k| k == sender) {
-				Ok(())
+			if let Some(sender) = sender {
+				if Self::key().map_or(false, |k| k == sender) {
+					Ok(())
+				} else {
+					Err(Error::<T>::RequireSudo.into())
+				}
 			} else {
-				Err(Error::<T>::RequireSudo.into())
+				Ok(())
 			}
 		}
 	}

--- a/substrate/frame/sudo/src/tests.rs
+++ b/substrate/frame/sudo/src/tests.rs
@@ -170,6 +170,18 @@ fn remove_key_works() {
 }
 
 #[test]
+fn using_root_origin_works() {
+	new_test_ext(1).execute_with(|| {
+		assert_ok!(Sudo::remove_key(RuntimeOrigin::root()));
+		assert!(Sudo::key().is_none());
+		System::assert_has_event(TestEvent::Sudo(Event::KeyRemoved {}));
+
+		assert_ok!(Sudo::set_key(RuntimeOrigin::root(), 1));
+		assert_eq!(Some(1), Sudo::key());
+	});
+}
+
+#[test]
 fn sudo_as_basics() {
 	new_test_ext(1).execute_with(|| {
 		// A privileged function will not work when passed to `sudo_as`.


### PR DESCRIPTION
This changes `pallet-sudo` to also accept `Root` origin for `ensure_sudo`. This can be useful for parachains who allow the relay chain to have superuser rights to setup the sudo pallet for example.