### PR TITLE
Ensure force_set_metadata controls if asset is live + code reformat to avoid code duplications

### DIFF
--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -86,7 +86,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			// allow accidental usage of all consumer references which could cause grief.
 			if !frame_system::Pallet::<T>::can_inc_consumer(who) {
 				frame_system::Pallet::<T>::dec_consumers(who);
-				return Err(Error::<T, I>::UnavailableConsumer.into())
+				return Err(Error::<T, I>::UnavailableConsumer.into());
 			}
 			ExistenceReason::Consumer
 		};
@@ -133,24 +133,24 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			None => return DepositConsequence::UnknownAsset,
 		};
 		if increase_supply && details.supply.checked_add(&amount).is_none() {
-			return DepositConsequence::Overflow
+			return DepositConsequence::Overflow;
 		}
 		if let Some(account) = Account::<T, I>::get(id, who) {
 			if account.status.is_blocked() {
-				return DepositConsequence::Blocked
+				return DepositConsequence::Blocked;
 			}
 			if account.balance.checked_add(&amount).is_none() {
-				return DepositConsequence::Overflow
+				return DepositConsequence::Overflow;
 			}
 		} else {
 			if amount < details.min_balance {
-				return DepositConsequence::BelowMinimum
+				return DepositConsequence::BelowMinimum;
 			}
 			if !details.is_sufficient && !frame_system::Pallet::<T>::can_accrue_consumers(who, 2) {
-				return DepositConsequence::CannotCreate
+				return DepositConsequence::CannotCreate;
 			}
 			if details.is_sufficient && details.sufficients.checked_add(1).is_none() {
-				return DepositConsequence::Overflow
+				return DepositConsequence::Overflow;
 			}
 		}
 
@@ -170,20 +170,20 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			None => return UnknownAsset,
 		};
 		if details.supply.checked_sub(&amount).is_none() {
-			return Underflow
+			return Underflow;
 		}
 		if details.status == AssetStatus::Frozen {
-			return Frozen
+			return Frozen;
 		}
 		if amount.is_zero() {
-			return Success
+			return Success;
 		}
 		let account = match Account::<T, I>::get(&id, who) {
 			Some(a) => a,
 			None => return BalanceLow,
 		};
 		if account.status.is_frozen() {
-			return Frozen
+			return Frozen;
 		}
 		if let Some(rest) = account.balance.checked_sub(&amount) {
 			if let Some(frozen) = T::Freezer::frozen_balance(id.clone(), who) {
@@ -267,7 +267,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			Ok(dust) => actual.saturating_add(dust), //< guaranteed by reducible_balance
 			Err(e) => {
 				debug_assert!(false, "passed from reducible_balance; qed");
-				return Err(e)
+				return Err(e);
 			},
 		};
 
@@ -360,7 +360,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			debug_assert!(false, "refund did not result in dead account?!");
 			// deposit may have been refunded, need to update `Account`
 			Account::<T, I>::insert(id, &who, account);
-			return Ok(())
+			return Ok(());
 		}
 		Asset::<T, I>::insert(&id, details);
 		// Executing a hook here is safe, since it is not in a `mutate`.
@@ -391,12 +391,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			debug_assert!(false, "refund did not result in dead account?!");
 			// deposit may have been refunded, need to update `Account`
 			Account::<T, I>::insert(&id, &who, account);
-			return Ok(())
+			return Ok(());
 		}
 		Asset::<T, I>::insert(&id, details);
 		// Executing a hook here is safe, since it is not in a `mutate`.
 		T::Freezer::died(id, &who);
-		return Ok(())
+		return Ok(());
 	}
 
 	/// Increases the asset `id` balance of `beneficiary` by `amount`.
@@ -441,7 +441,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		) -> DispatchResult,
 	) -> DispatchResult {
 		if amount.is_zero() {
-			return Ok(())
+			return Ok(());
 		}
 
 		Self::can_increase(id.clone(), beneficiary, amount, true).into_result()?;
@@ -528,7 +528,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		) -> DispatchResult,
 	) -> Result<T::Balance, DispatchError> {
 		if amount.is_zero() {
-			return Ok(amount)
+			return Ok(amount);
 		}
 
 		let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
@@ -551,7 +551,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					debug_assert!(account.balance.is_zero(), "checked in prep; qed");
 					target_died = Some(Self::dead_account(target, details, &account.reason, false));
 					if let Some(Remove) = target_died {
-						return Ok(())
+						return Ok(());
 					}
 				};
 				*maybe_account = Some(account);
@@ -604,7 +604,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> Result<(T::Balance, Option<DeadConsequence>), DispatchError> {
 		// Early exit if no-op.
 		if amount.is_zero() {
-			return Ok((amount, None))
+			return Ok((amount, None));
 		}
 		let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
@@ -627,7 +627,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 			// Skip if source == dest
 			if source == dest {
-				return Ok(())
+				return Ok(());
 			}
 
 			// Burn any dust if needed.
@@ -672,7 +672,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					Some(Self::dead_account(source, details, &source_account.reason, false));
 				if let Some(Remove) = source_died {
 					Account::<T, I>::remove(&id, &source);
-					return Ok(())
+					return Ok(());
 				}
 			}
 			Account::<T, I>::insert(&id, &source, &source_account);
@@ -776,7 +776,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						defensive!("destroy did not result in dead account?!");
 					}
 					if i + 1 >= (max_items as usize) {
-						break
+						break;
 					}
 				}
 				remaining_accounts = details.accounts;
@@ -817,7 +817,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					removed_approvals = removed_approvals.saturating_add(1);
 					details.approvals = details.approvals.saturating_sub(1);
 					if removed_approvals >= max_items {
-						break
+						break;
 					}
 				}
 				Self::deposit_event(Event::ApprovalsDestroyed {
@@ -953,38 +953,51 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Do set metadata
 	pub(super) fn do_set_metadata(
 		id: T::AssetId,
-		from: &T::AccountId,
 		name: Vec<u8>,
 		symbol: Vec<u8>,
 		decimals: u8,
+		request: MetadataRequestOf<T::AccountId>,
 	) -> DispatchResult {
 		let bounded_name: BoundedVec<u8, T::StringLimit> =
 			name.clone().try_into().map_err(|_| Error::<T, I>::BadMetadata)?;
 		let bounded_symbol: BoundedVec<u8, T::StringLimit> =
 			symbol.clone().try_into().map_err(|_| Error::<T, I>::BadMetadata)?;
 
+		let (is_frozen, is_force_origin) = request.origin();
 		let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(d.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
-		ensure!(from == &d.owner, Error::<T, I>::NoPermission);
+		if !is_force_origin {
+			ensure!(request.account::<T, I>()? == &d.owner, Error::<T, I>::NoPermission);
+		}
 
 		Metadata::<T, I>::try_mutate_exists(id.clone(), |metadata| {
-			ensure!(metadata.as_ref().map_or(true, |m| !m.is_frozen), Error::<T, I>::NoPermission);
+			ensure!(
+				is_force_origin || metadata.as_ref().map_or(true, |m| !m.is_frozen),
+				Error::<T, I>::NoPermission
+			);
 
 			let old_deposit = metadata.take().map_or(Zero::zero(), |m| m.deposit);
-			let new_deposit = Self::calc_metadata_deposit(&name, &symbol);
 
-			if new_deposit > old_deposit {
-				T::Currency::reserve(from, new_deposit - old_deposit)?;
+			let deposit = if is_force_origin {
+				old_deposit
 			} else {
-				T::Currency::unreserve(from, old_deposit - new_deposit);
-			}
+				let new_deposit = Self::calc_metadata_deposit(&name, &symbol);
+
+				let from = request.account::<T, I>()?;
+				if new_deposit > old_deposit {
+					T::Currency::reserve(from, new_deposit - old_deposit)?;
+				} else {
+					T::Currency::unreserve(from, old_deposit - new_deposit);
+				}
+				new_deposit
+			};
 
 			*metadata = Some(AssetMetadata {
-				deposit: new_deposit,
+				deposit,
 				name: bounded_name,
 				symbol: bounded_symbol,
 				decimals,
-				is_frozen: false,
+				is_frozen,
 			});
 
 			Self::deposit_event(Event::MetadataSet {
@@ -992,7 +1005,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				name,
 				symbol,
 				decimals,
-				is_frozen: false,
+				is_frozen,
 			});
 			Ok(())
 		})

--- a/substrate/frame/assets/src/impl_fungibles.rs
+++ b/substrate/frame/assets/src/impl_fungibles.rs
@@ -222,7 +222,13 @@ impl<T: Config<I>, I: 'static> fungibles::metadata::Mutate<<T as SystemConfig>::
 		symbol: Vec<u8>,
 		decimals: u8,
 	) -> DispatchResult {
-		Self::do_set_metadata(asset, from, name, symbol, decimals)
+		Self::do_set_metadata(
+			asset,
+			name,
+			symbol,
+			decimals,
+			MetadataRequestOf::Origin(from.to_owned()),
+		)
 	}
 }
 


### PR DESCRIPTION
- The force_set_metadata function does not control whether the asset is live. 
- To avoid code duplication I reused the do_set_metadata function for both force_set_metadata and set_metadata, differentiating between origins.