### PR TITLE
Broker pallet: fix interlacing

### DIFF
--- a/prdoc/pr_2811.prdoc
+++ b/prdoc/pr_2811.prdoc
@@ -1,0 +1,13 @@
+title: "Interlacing removes the region on which it is performed."
+
+doc:
+  - audience: Runtime User
+    description: |
+      The current implementation of the broker pallet does not remove
+      the region on which the interlacing is performed. This can create
+      a vulnerability, as the original region owner is still allowed to 
+      assign a task to the region even after transferring an interlaced
+      part of it.
+
+crates:
+  - name: "pallet-broker"

--- a/substrate/frame/broker/src/dispatchable_impls.rs
+++ b/substrate/frame/broker/src/dispatchable_impls.rs
@@ -234,6 +234,9 @@ impl<T: Config> Pallet<T> {
 		ensure!(!pivot.is_void(), Error::<T>::VoidPivot);
 		ensure!(pivot != region_id.mask, Error::<T>::CompletePivot);
 
+		// The old region should be removed.
+		Regions::<T>::remove(&region_id);
+
 		let one = RegionId { mask: pivot, ..region_id };
 		Regions::<T>::insert(&one, &region);
 		let other = RegionId { mask: region_id.mask ^ pivot, ..region_id };


### PR DESCRIPTION
With the current code, when a user interlaces their region, the end result will be three regions in the state:
- the non-interlaced region
- first part of the interlaced region
- second part of the interlaced region

The existing implementation retains the non-interlaced region in the state, leading to a problematic scenario:

1. User 1 acquires a region from the market.
2. User 1 then interlaces this region.
3. Subsequently, User 1 transfers one part of the interlaced regions to User 2.
Despite this transfer, User 1 retains the ability to assign the entire original non-interlaced region, which is inconsistent with the fact that they no longer own one of the interlaced parts.

This PR resolves the issue by removing the original region, ensuring that only the two new interlaced regions remain in the state.