### PR TITLE
Remove `dotgraph` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7166,15 +7166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "layout-rs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1164ef87cb9607c2d887216eca79f0fc92895affe1789bba805dd38d829584e0"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8983,12 +8974,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d035b1f968d91a826f2e34a9d6d02cb2af5aa7ca39ebd27922d850ab4b2dd2c6"
 dependencies = [
- "anyhow",
  "expander 2.0.0",
- "fs-err",
  "indexmap 2.0.0",
  "itertools 0.11.0",
- "layout-rs",
  "petgraph",
  "proc-macro-crate 1.3.1",
  "proc-macro2",

--- a/polkadot/node/overseer/Cargo.toml
+++ b/polkadot/node/overseer/Cargo.toml
@@ -40,7 +40,6 @@ tikv-jemalloc-ctl = "0.5.0"
 
 [features]
 default = ["futures_channel"]
-dotgraph = ["orchestra/dotgraph"]
 expand = ["orchestra/expand"]
 futures_channel = ["metered/futures_channel", "orchestra/futures_channel"]
 jemalloc-allocator = ["dep:tikv-jemalloc-ctl"]


### PR DESCRIPTION
Apparently the implementation is broken and is generating warnings in the build. Not sure this was used any way by anyone.

Closes: https://github.com/paritytech/polkadot-sdk/issues/2836