### PR TITLE
Return latest known relay chain block number in `on_initialize` etc

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -1709,7 +1709,7 @@ impl<T: Config> BlockNumberProvider for RelaychainDataProvider<T> {
 	fn current_block_number() -> relay_chain::BlockNumber {
 		Pallet::<T>::validation_data()
 			.map(|d| d.relay_parent_number)
-			.unwrap_or_default()
+			.unwrap_or_else(|| Pallet::<T>::last_relay_block_number())
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -1683,14 +1683,27 @@ pub trait RelaychainStateProvider {
 }
 
 /// Implements [`BlockNumberProvider`] that returns relay chain block number fetched from validation
-/// data. When validation data is not available (e.g. within on_initialize), 0 will be returned.
+/// data.
+///
+/// When validation data is not available (e.g. within `on_initialize`), it will fallback to use
+/// [`Pallet::last_relay_block_number()`].
 ///
 /// **NOTE**: This has been deprecated, please use [`RelaychainDataProvider`]
 #[deprecated = "Use `RelaychainDataProvider` instead"]
-pub struct RelaychainBlockNumberProvider<T>(sp_std::marker::PhantomData<T>);
+pub type RelaychainBlockNumberProvider<T> = RelaychainDataProvider<T>;
 
-#[allow(deprecated)]
-impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
+/// Implements [`BlockNumberProvider`] and [`RelaychainStateProvider`] that returns relevant relay
+/// data fetched from validation data.
+///
+/// NOTE: When validation data is not available (e.g. within `on_initialize`):
+///
+/// - [`current_relay_chain_state`](Self::current_relay_chain_state): Will return the default value
+///   of [`RelayChainState`].
+/// - [`current_block_number`](Self::current_block_number): Will return
+///   [`Pallet::last_relay_block_number()`].
+pub struct RelaychainDataProvider<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: Config> BlockNumberProvider for RelaychainDataProvider<T> {
 	type BlockNumber = relay_chain::BlockNumber;
 
 	fn current_block_number() -> relay_chain::BlockNumber {
@@ -1736,36 +1749,6 @@ impl<T: Config> RelaychainStateProvider for RelaychainDataProvider<T> {
 			});
 		validation_data.relay_parent_number = state.number;
 		validation_data.relay_parent_storage_root = state.state_root;
-		ValidationData::<T>::put(validation_data)
-	}
-}
-
-/// Implements [`BlockNumberProvider`] and [`RelaychainStateProvider`] that returns relevant relay
-/// data fetched from validation data.
-/// NOTE: When validation data is not available (e.g. within on_initialize), default values will be
-/// returned.
-pub struct RelaychainDataProvider<T>(sp_std::marker::PhantomData<T>);
-
-impl<T: Config> BlockNumberProvider for RelaychainDataProvider<T> {
-	type BlockNumber = relay_chain::BlockNumber;
-
-	fn current_block_number() -> relay_chain::BlockNumber {
-		Pallet::<T>::validation_data()
-			.map(|d| d.relay_parent_number)
-			.unwrap_or_default()
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn set_block_number(block: Self::BlockNumber) {
-		let mut validation_data = Pallet::<T>::validation_data().unwrap_or_else(||
-			// PersistedValidationData does not impl default in non-std
-			PersistedValidationData {
-				parent_head: vec![].into(),
-				relay_parent_number: Default::default(),
-				max_pov_size: Default::default(),
-				relay_parent_storage_root: Default::default(),
-			});
-		validation_data.relay_parent_number = block;
 		ValidationData::<T>::put(validation_data)
 	}
 }

--- a/prdoc/pr_2862.prdoc
+++ b/prdoc/pr_2862.prdoc
@@ -1,0 +1,11 @@
+title: Return latest known relay chain block number in on_initialize et all
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      `RelaychainDataProvider` and `RelaychainBlockNumberProvider` will now return the latest known
+      relay chain block number in `on_initialize`, aka when `validation_data` wasn't yet set by
+      the inherent.
+
+crates:
+  - name: "cumulus-pallet-parachain-system"

--- a/prdoc/pr_2862.prdoc
+++ b/prdoc/pr_2862.prdoc
@@ -1,4 +1,4 @@
-title: Return latest known relay chain block number in on_initialize et all
+title: Return latest known relay chain block number in `on_initialize` etc.
 
 doc:
   - audience: Runtime Dev


### PR DESCRIPTION
This changes `RelaychainDataProvider` to return the latest known relay chain block number in `on_initialize` et all, aka when the `validation_data` wasn't yet set by the inherent.