### PR TITLE
Parametrize SlotDurations for system parachain tests (because of `mock_open_hrmp_channel`)

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
@@ -191,7 +191,7 @@ std = [
 	"cumulus-pallet-session-benchmarking/std",
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
-	"cumulus-primitives-aura/std", # TODO: guide is missing this step
+	"cumulus-primitives-aura/std",                    # TODO: guide is missing this step
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -71,7 +71,6 @@ use frame_system::{
 };
 use pallet_asset_conversion_tx_payment::AssetConversionAdapter;
 use pallet_nfts::PalletFeatures;
-pub use parachains_common as common;
 use parachains_common::{
 	impls::DealWithFees,
 	message_queue::{NarrowOriginToSibling, ParaIdToSibling},
@@ -149,7 +148,7 @@ const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
 /// number of blocks authored per slot.
 const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 /// Relay chain slot duration, in milliseconds.
-const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 
 /// This determines the average expected block time that we are targeting.
 /// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/tests/tests.rs
@@ -31,7 +31,10 @@ pub use asset_hub_rococo_runtime::{
 	RuntimeCall, RuntimeEvent, SessionKeys, System, ToWestendXcmRouterInstance,
 	TrustBackedAssetsInstance, XcmpQueue,
 };
-use asset_test_utils::{test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys, ExtBuilder, SlotDurations};
+use asset_test_utils::{
+	test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys,
+	ExtBuilder, SlotDurations,
+};
 use codec::{Decode, Encode};
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
@@ -69,7 +72,9 @@ fn collator_session_keys() -> CollatorSessionKeys<Runtime> {
 
 fn slot_durations() -> SlotDurations {
 	SlotDurations {
-		relay: SlotDuration::from_millis(asset_hub_rococo_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		relay: SlotDuration::from_millis(
+			asset_hub_rococo_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into(),
+		),
 		para: SlotDuration::from_millis(asset_hub_rococo_runtime::SLOT_DURATION),
 	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/tests/tests.rs
@@ -31,9 +31,7 @@ pub use asset_hub_rococo_runtime::{
 	RuntimeCall, RuntimeEvent, SessionKeys, System, ToWestendXcmRouterInstance,
 	TrustBackedAssetsInstance, XcmpQueue,
 };
-use asset_test_utils::{
-	test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys, ExtBuilder,
-};
+use asset_test_utils::{test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys, ExtBuilder, SlotDurations};
 use codec::{Decode, Encode};
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
@@ -44,6 +42,7 @@ use frame_support::{
 use parachains_common::{
 	rococo::fee::WeightToFee, AccountId, AssetIdForTrustBackedAssets, AuraId, Balance,
 };
+use sp_consensus_aura::SlotDuration;
 use sp_runtime::traits::MaybeEquivalence;
 use xcm::latest::prelude::*;
 use xcm_executor::traits::{Identity, JustTry, WeightTrader};
@@ -66,6 +65,13 @@ fn collator_session_key(account: [u8; 32]) -> CollatorSessionKey<Runtime> {
 
 fn collator_session_keys() -> CollatorSessionKeys<Runtime> {
 	CollatorSessionKeys::default().add(collator_session_key(ALICE))
+}
+
+fn slot_durations() -> SlotDurations {
+	SlotDurations {
+		relay: SlotDuration::from_millis(asset_hub_rococo_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		para: SlotDuration::from_millis(asset_hub_rococo_runtime::SLOT_DURATION),
+	}
 }
 
 #[test]
@@ -522,6 +528,7 @@ asset_test_utils::include_teleports_for_native_asset_works!(
 	WeightToFee,
 	ParachainSystem,
 	collator_session_keys(),
+	slot_durations(),
 	ExistentialDeposit::get(),
 	Box::new(|runtime_event_encoded: Vec<u8>| {
 		match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
@@ -542,6 +549,7 @@ asset_test_utils::include_teleports_for_foreign_assets_works!(
 	ForeignCreatorsSovereignAccountOf,
 	ForeignAssetsInstance,
 	collator_session_keys(),
+	slot_durations(),
 	ExistentialDeposit::get(),
 	Box::new(|runtime_event_encoded: Vec<u8>| {
 		match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
@@ -650,6 +658,7 @@ fn limited_reserve_transfer_assets_for_native_asset_over_bridge_works(
 		LocationToAccountId,
 	>(
 		collator_session_keys(),
+		slot_durations(),
 		ExistentialDeposit::get(),
 		AccountId::from(ALICE),
 		Box::new(|runtime_event_encoded: Vec<u8>| {
@@ -821,6 +830,7 @@ mod asset_hub_rococo_tests {
 			LocationToAccountId,
 		>(
 			collator_session_keys(),
+			slot_durations(),
 			ExistentialDeposit::get(),
 			AccountId::from(ALICE),
 			Box::new(|runtime_event_encoded: Vec<u8>| {

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -55,15 +55,15 @@ use frame_system::{
 use pallet_asset_conversion_tx_payment::AssetConversionAdapter;
 use pallet_nfts::{DestroyWitness, PalletFeatures};
 use pallet_xcm::EnsureXcm;
-pub use parachains_common as common;
 use parachains_common::{
 	impls::DealWithFees,
 	message_queue::*,
 	westend::{consensus::*, currency::*, fee::WeightToFee},
 	AccountId, AssetIdForTrustBackedAssets, AuraId, Balance, BlockNumber, Hash, Header, Nonce,
 	Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT,
-	NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	NORMAL_DISPATCH_RATIO,
 };
+pub use parachains_common::{SLOT_DURATION, westend::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -63,7 +63,7 @@ use parachains_common::{
 	Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT,
 	NORMAL_DISPATCH_RATIO,
 };
-pub use parachains_common::{SLOT_DURATION, westend::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS};
+pub use parachains_common::{westend::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS, SLOT_DURATION};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
@@ -28,7 +28,10 @@ use asset_hub_westend_runtime::{
 	PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, SessionKeys,
 	ToRococoXcmRouterInstance, TrustBackedAssetsInstance, XcmpQueue,
 };
-use asset_test_utils::{test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys, ExtBuilder, SlotDurations};
+use asset_test_utils::{
+	test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys,
+	ExtBuilder, SlotDurations,
+};
 use codec::{Decode, Encode};
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
@@ -39,9 +42,9 @@ use frame_support::{
 use parachains_common::{
 	westend::fee::WeightToFee, AccountId, AssetIdForTrustBackedAssets, AuraId, Balance,
 };
+use sp_consensus_aura::SlotDuration;
 use sp_runtime::traits::MaybeEquivalence;
 use std::convert::Into;
-use sp_consensus_aura::SlotDuration;
 use xcm::latest::prelude::*;
 use xcm_executor::traits::{Identity, JustTry, WeightTrader};
 
@@ -67,7 +70,9 @@ fn collator_session_keys() -> CollatorSessionKeys<Runtime> {
 
 fn slot_durations() -> SlotDurations {
 	SlotDurations {
-		relay: SlotDuration::from_millis(asset_hub_westend_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		relay: SlotDuration::from_millis(
+			asset_hub_westend_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into(),
+		),
 		para: SlotDuration::from_millis(asset_hub_westend_runtime::SLOT_DURATION),
 	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
@@ -28,9 +28,7 @@ use asset_hub_westend_runtime::{
 	PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, SessionKeys,
 	ToRococoXcmRouterInstance, TrustBackedAssetsInstance, XcmpQueue,
 };
-use asset_test_utils::{
-	test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys, ExtBuilder,
-};
+use asset_test_utils::{test_cases_over_bridge::TestBridgingConfig, CollatorSessionKey, CollatorSessionKeys, ExtBuilder, SlotDurations};
 use codec::{Decode, Encode};
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
@@ -43,6 +41,7 @@ use parachains_common::{
 };
 use sp_runtime::traits::MaybeEquivalence;
 use std::convert::Into;
+use sp_consensus_aura::SlotDuration;
 use xcm::latest::prelude::*;
 use xcm_executor::traits::{Identity, JustTry, WeightTrader};
 
@@ -64,6 +63,13 @@ fn collator_session_key(account: [u8; 32]) -> CollatorSessionKey<Runtime> {
 
 fn collator_session_keys() -> CollatorSessionKeys<Runtime> {
 	CollatorSessionKeys::default().add(collator_session_key(ALICE))
+}
+
+fn slot_durations() -> SlotDurations {
+	SlotDurations {
+		relay: SlotDuration::from_millis(asset_hub_westend_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		para: SlotDuration::from_millis(asset_hub_westend_runtime::SLOT_DURATION),
+	}
 }
 
 #[test]
@@ -518,6 +524,7 @@ asset_test_utils::include_teleports_for_native_asset_works!(
 	WeightToFee,
 	ParachainSystem,
 	collator_session_keys(),
+	slot_durations(),
 	ExistentialDeposit::get(),
 	Box::new(|runtime_event_encoded: Vec<u8>| {
 		match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
@@ -538,6 +545,7 @@ asset_test_utils::include_teleports_for_foreign_assets_works!(
 	ForeignCreatorsSovereignAccountOf,
 	ForeignAssetsInstance,
 	collator_session_keys(),
+	slot_durations(),
 	ExistentialDeposit::get(),
 	Box::new(|runtime_event_encoded: Vec<u8>| {
 		match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
@@ -660,6 +668,7 @@ fn limited_reserve_transfer_assets_for_native_asset_to_asset_hub_rococo_works() 
 		LocationToAccountId,
 	>(
 		collator_session_keys(),
+		slot_durations(),
 		ExistentialDeposit::get(),
 		AccountId::from(ALICE),
 		Box::new(|runtime_event_encoded: Vec<u8>| {
@@ -827,6 +836,7 @@ fn reserve_transfer_native_asset_to_non_teleport_para_works() {
 		LocationToAccountId,
 	>(
 		collator_session_keys(),
+		slot_durations(),
 		ExistentialDeposit::get(),
 		AccountId::from(ALICE),
 		Box::new(|runtime_event_encoded: Vec<u8>| {

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
@@ -29,10 +29,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::{AccountId, Balance};
-use parachains_runtimes_test_utils::{
-	assert_metadata, assert_total, mock_open_hrmp_channel, AccountIdOf, BalanceOf,
-	CollatorSessionKeys, ExtBuilder, ValidatorIdOf, XcmReceivedFrom,
-};
+use parachains_runtimes_test_utils::{assert_metadata, assert_total, mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, ValidatorIdOf, XcmReceivedFrom, SlotDurations};
 use sp_runtime::{
 	traits::{MaybeEquivalence, StaticLookup, Zero},
 	DispatchError, Saturating,
@@ -57,6 +54,7 @@ pub fn teleports_for_native_asset_works<
 	HrmpChannelOpener,
 >(
 	collator_session_keys: CollatorSessionKeys<Runtime>,
+	slot_durations: SlotDurations,
 	existential_deposit: BalanceOf<Runtime>,
 	target_account: AccountIdOf<Runtime>,
 	unwrap_pallet_xcm_event: Box<dyn Fn(Vec<u8>) -> Option<pallet_xcm::Event<Runtime>>>,
@@ -203,6 +201,7 @@ pub fn teleports_for_native_asset_works<
 					None,
 					included_head.clone(),
 					&alice,
+					&slot_durations,
 				));
 
 				// check balances
@@ -254,6 +253,7 @@ pub fn teleports_for_native_asset_works<
 						Some((runtime_para_id, other_para_id)),
 						included_head,
 						&alice,
+						&slot_durations,
 					),
 					Err(DispatchError::Module(sp_runtime::ModuleError {
 						index: 31,
@@ -285,6 +285,7 @@ macro_rules! include_teleports_for_native_asset_works(
 		$weight_to_fee:path,
 		$hrmp_channel_opener:path,
 		$collator_session_key:expr,
+		$slot_durations:expr,
 		$existential_deposit:expr,
 		$unwrap_pallet_xcm_event:expr,
 		$runtime_para_id:expr
@@ -303,6 +304,7 @@ macro_rules! include_teleports_for_native_asset_works(
 				$hrmp_channel_opener
 			>(
 				$collator_session_key,
+				$slot_durations,
 				$existential_deposit,
 				target_account,
 				$unwrap_pallet_xcm_event,
@@ -325,6 +327,7 @@ pub fn teleports_for_foreign_assets_works<
 	ForeignAssetsPalletInstance,
 >(
 	collator_session_keys: CollatorSessionKeys<Runtime>,
+	slot_durations: SlotDurations,
 	target_account: AccountIdOf<Runtime>,
 	existential_deposit: BalanceOf<Runtime>,
 	asset_owner: AccountIdOf<Runtime>,
@@ -582,6 +585,7 @@ pub fn teleports_for_foreign_assets_works<
 					Some((runtime_para_id, foreign_para_id)),
 					included_head,
 					&alice,
+					&slot_durations,
 				));
 
 				// check balances
@@ -634,6 +638,7 @@ macro_rules! include_teleports_for_foreign_assets_works(
 		$sovereign_account_of:path,
 		$assets_pallet_instance:path,
 		$collator_session_key:expr,
+		$slot_durations:expr,
 		$existential_deposit:expr,
 		$unwrap_pallet_xcm_event:expr,
 		$unwrap_xcmp_queue_event:expr
@@ -656,6 +661,7 @@ macro_rules! include_teleports_for_foreign_assets_works(
 				$assets_pallet_instance
 			>(
 				$collator_session_key,
+				$slot_durations,
 				target_account,
 				$existential_deposit,
 				asset_owner,
@@ -1388,6 +1394,7 @@ pub fn reserve_transfer_native_asset_to_non_teleport_para_works<
 	LocationToAccountId,
 >(
 	collator_session_keys: CollatorSessionKeys<Runtime>,
+	slot_durations: SlotDurations,
 	existential_deposit: BalanceOf<Runtime>,
 	alice_account: AccountIdOf<Runtime>,
 	unwrap_pallet_xcm_event: Box<dyn Fn(Vec<u8>) -> Option<pallet_xcm::Event<Runtime>>>,
@@ -1461,6 +1468,7 @@ pub fn reserve_transfer_native_asset_to_non_teleport_para_works<
 				other_para_id.into(),
 				included_head,
 				&alice,
+				&slot_durations,
 			);
 
 			// we calculate exact delivery fees _after_ sending the message by weighing the sent

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
@@ -29,7 +29,10 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::{AccountId, Balance};
-use parachains_runtimes_test_utils::{assert_metadata, assert_total, mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, ValidatorIdOf, XcmReceivedFrom, SlotDurations};
+use parachains_runtimes_test_utils::{
+	assert_metadata, assert_total, mock_open_hrmp_channel, AccountIdOf, BalanceOf,
+	CollatorSessionKeys, ExtBuilder, SlotDurations, ValidatorIdOf, XcmReceivedFrom,
+};
 use sp_runtime::{
 	traits::{MaybeEquivalence, StaticLookup, Zero},
 	DispatchError, Saturating,

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases_over_bridge.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases_over_bridge.rs
@@ -25,7 +25,10 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::{AccountId, Balance};
-use parachains_runtimes_test_utils::{mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeHelper, ValidatorIdOf, XcmReceivedFrom, SlotDurations};
+use parachains_runtimes_test_utils::{
+	mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeHelper,
+	SlotDurations, ValidatorIdOf, XcmReceivedFrom,
+};
 use sp_runtime::{traits::StaticLookup, Saturating};
 use xcm::{latest::prelude::*, VersionedMultiAssets};
 use xcm_builder::{CreateMatcher, MatchXcm};

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases_over_bridge.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases_over_bridge.rs
@@ -25,10 +25,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::{AccountId, Balance};
-use parachains_runtimes_test_utils::{
-	mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeHelper,
-	ValidatorIdOf, XcmReceivedFrom,
-};
+use parachains_runtimes_test_utils::{mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeHelper, ValidatorIdOf, XcmReceivedFrom, SlotDurations};
 use sp_runtime::{traits::StaticLookup, Saturating};
 use xcm::{latest::prelude::*, VersionedMultiAssets};
 use xcm_builder::{CreateMatcher, MatchXcm};
@@ -51,6 +48,7 @@ pub fn limited_reserve_transfer_assets_for_native_asset_works<
 	LocationToAccountId,
 >(
 	collator_session_keys: CollatorSessionKeys<Runtime>,
+	slot_durations: SlotDurations,
 	existential_deposit: BalanceOf<Runtime>,
 	alice_account: AccountIdOf<Runtime>,
 	unwrap_pallet_xcm_event: Box<dyn Fn(Vec<u8>) -> Option<pallet_xcm::Event<Runtime>>>,
@@ -124,6 +122,7 @@ pub fn limited_reserve_transfer_assets_for_native_asset_works<
 				local_bridge_hub_para_id.into(),
 				included_head,
 				&alice,
+				&slot_durations,
 			);
 
 			// we calculate exact delivery fees _after_ sending the message by weighing the sent

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -96,8 +96,9 @@ use parachains_common::{
 	impls::DealWithFees,
 	rococo::{consensus::*, currency::*, fee::WeightToFee},
 	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
-	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
 };
+pub use parachains_common::{SLOT_DURATION, rococo::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS};
 
 #[cfg(feature = "runtime-benchmarks")]
 use crate::xcm_config::benchmark_helpers::DoNothingRouter;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -98,7 +98,7 @@ use parachains_common::{
 	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
 	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
 };
-pub use parachains_common::{SLOT_DURATION, rococo::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS};
+pub use parachains_common::{rococo::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS, SLOT_DURATION};
 
 #[cfg(feature = "runtime-benchmarks")]
 use crate::xcm_config::benchmark_helpers::DoNothingRouter;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/tests/tests.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/tests/tests.rs
@@ -25,8 +25,10 @@ use bridge_hub_rococo_runtime::{
 	RuntimeEvent, RuntimeOrigin, SessionKeys, SignedExtra, TransactionPayment, UncheckedExtrinsic,
 };
 use codec::{Decode, Encode};
+use bridge_hub_test_utils::SlotDurations;
 use frame_support::{dispatch::GetDispatchInfo, parameter_types, traits::ConstU8};
 use parachains_common::{rococo::fee::WeightToFee, AccountId, AuraId, Balance};
+use sp_consensus_aura::SlotDuration;
 use sp_core::H160;
 use sp_keyring::AccountKeyring::Alice;
 use sp_runtime::{
@@ -95,6 +97,13 @@ fn collator_session_keys() -> bridge_hub_test_utils::CollatorSessionKeys<Runtime
 	)
 }
 
+fn slot_durations() -> SlotDurations {
+	SlotDurations {
+		relay: SlotDuration::from_millis(bridge_hub_rococo_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		para: SlotDuration::from_millis(bridge_hub_rococo_runtime::SLOT_DURATION),
+	}
+}
+
 bridge_hub_test_utils::test_cases::include_teleports_for_native_asset_works!(
 	Runtime,
 	AllPalletsWithoutSystem,
@@ -103,6 +112,7 @@ bridge_hub_test_utils::test_cases::include_teleports_for_native_asset_works!(
 	WeightToFee,
 	ParachainSystem,
 	collator_session_keys(),
+	slot_durations(),
 	ExistentialDeposit::get(),
 	Box::new(|runtime_event_encoded: Vec<u8>| {
 		match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
@@ -264,6 +274,7 @@ mod bridge_hub_westend_tests {
 			ConstU8<2>,
 		>(
 			collator_session_keys(),
+			slot_durations(),
 			bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 			SIBLING_PARACHAIN_ID,
 			Box::new(|runtime_event_encoded: Vec<u8>| {
@@ -288,6 +299,7 @@ mod bridge_hub_westend_tests {
 		// from Westend
 		from_parachain::relayed_incoming_message_works::<RuntimeTestsAdapter>(
 			collator_session_keys(),
+			slot_durations(),
 			bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 			bp_bridge_hub_westend::BRIDGE_HUB_WESTEND_PARACHAIN_ID,
 			BridgeHubWestendChainId::get(),
@@ -304,6 +316,7 @@ mod bridge_hub_westend_tests {
 		// for Westend
 		from_parachain::complex_relay_extrinsic_works::<RuntimeTestsAdapter>(
 			collator_session_keys(),
+			slot_durations(),
 			bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 			bp_bridge_hub_westend::BRIDGE_HUB_WESTEND_PARACHAIN_ID,
 			SIBLING_PARACHAIN_ID,
@@ -459,6 +472,7 @@ mod bridge_hub_bulletin_tests {
 			ConstU8<2>,
 		>(
 			collator_session_keys(),
+			slot_durations(),
 			bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 			SIBLING_PARACHAIN_ID,
 			Box::new(|runtime_event_encoded: Vec<u8>| {
@@ -483,6 +497,7 @@ mod bridge_hub_bulletin_tests {
 		// from Bulletin
 		from_grandpa_chain::relayed_incoming_message_works::<RuntimeTestsAdapter>(
 			collator_session_keys(),
+			slot_durations(),
 			bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 			RococoBulletinChainId::get(),
 			SIBLING_PARACHAIN_ID,
@@ -498,6 +513,7 @@ mod bridge_hub_bulletin_tests {
 		// for Bulletin
 		from_grandpa_chain::complex_relay_extrinsic_works::<RuntimeTestsAdapter>(
 			collator_session_keys(),
+			slot_durations(),
 			bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 			SIBLING_PARACHAIN_ID,
 			RococoBulletinChainId::get(),

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/tests/tests.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/tests/tests.rs
@@ -24,8 +24,8 @@ use bridge_hub_rococo_runtime::{
 	Executive, ExistentialDeposit, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall,
 	RuntimeEvent, RuntimeOrigin, SessionKeys, SignedExtra, TransactionPayment, UncheckedExtrinsic,
 };
-use codec::{Decode, Encode};
 use bridge_hub_test_utils::SlotDurations;
+use codec::{Decode, Encode};
 use frame_support::{dispatch::GetDispatchInfo, parameter_types, traits::ConstU8};
 use parachains_common::{rococo::fee::WeightToFee, AccountId, AuraId, Balance};
 use sp_consensus_aura::SlotDuration;
@@ -99,7 +99,9 @@ fn collator_session_keys() -> bridge_hub_test_utils::CollatorSessionKeys<Runtime
 
 fn slot_durations() -> SlotDurations {
 	SlotDurations {
-		relay: SlotDuration::from_millis(bridge_hub_rococo_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		relay: SlotDuration::from_millis(
+			bridge_hub_rococo_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into(),
+		),
 		para: SlotDuration::from_millis(bridge_hub_rococo_runtime::SLOT_DURATION),
 	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -83,8 +83,9 @@ use parachains_common::{
 	impls::DealWithFees,
 	westend::{consensus::*, currency::*, fee::WeightToFee},
 	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
-	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
 };
+pub use parachains_common::{SLOT_DURATION, westend::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS};
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -85,7 +85,7 @@ use parachains_common::{
 	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
 	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
 };
-pub use parachains_common::{SLOT_DURATION, westend::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS};
+pub use parachains_common::{westend::consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS, SLOT_DURATION};
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/tests/tests.rs
@@ -18,7 +18,7 @@
 
 use bp_polkadot_core::Signature;
 use bridge_common_config::{DeliveryRewardInBalance, RequiredStakeForStakeAndSlash};
-use bridge_hub_test_utils::test_cases::from_parachain;
+use bridge_hub_test_utils::{test_cases::from_parachain, SlotDurations};
 use bridge_hub_westend_runtime::{
 	bridge_common_config, bridge_to_rococo_config,
 	xcm_config::{RelayNetwork, WestendLocation, XcmConfig},
@@ -32,7 +32,6 @@ use bridge_to_rococo_config::{
 	WithBridgeHubRococoMessagesInstance, XCM_LANE_FOR_ASSET_HUB_WESTEND_TO_ASSET_HUB_ROCOCO,
 };
 use codec::{Decode, Encode};
-use bridge_hub_test_utils::SlotDurations;
 use frame_support::{dispatch::GetDispatchInfo, parameter_types, traits::ConstU8};
 use parachains_common::{westend::fee::WeightToFee, AccountId, AuraId, Balance};
 use sp_consensus_aura::SlotDuration;
@@ -115,7 +114,9 @@ fn collator_session_keys() -> bridge_hub_test_utils::CollatorSessionKeys<Runtime
 
 fn slot_durations() -> SlotDurations {
 	SlotDurations {
-		relay: SlotDuration::from_millis(bridge_hub_westend_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		relay: SlotDuration::from_millis(
+			bridge_hub_westend_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into(),
+		),
 		para: SlotDuration::from_millis(bridge_hub_westend_runtime::SLOT_DURATION),
 	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/tests/tests.rs
@@ -32,8 +32,10 @@ use bridge_to_rococo_config::{
 	WithBridgeHubRococoMessagesInstance, XCM_LANE_FOR_ASSET_HUB_WESTEND_TO_ASSET_HUB_ROCOCO,
 };
 use codec::{Decode, Encode};
+use bridge_hub_test_utils::SlotDurations;
 use frame_support::{dispatch::GetDispatchInfo, parameter_types, traits::ConstU8};
 use parachains_common::{westend::fee::WeightToFee, AccountId, AuraId, Balance};
+use sp_consensus_aura::SlotDuration;
 use sp_keyring::AccountKeyring::Alice;
 use sp_runtime::{
 	generic::{Era, SignedPayload},
@@ -111,6 +113,13 @@ fn collator_session_keys() -> bridge_hub_test_utils::CollatorSessionKeys<Runtime
 	)
 }
 
+fn slot_durations() -> SlotDurations {
+	SlotDurations {
+		relay: SlotDuration::from_millis(bridge_hub_westend_runtime::RELAY_CHAIN_SLOT_DURATION_MILLIS.into()),
+		para: SlotDuration::from_millis(bridge_hub_westend_runtime::SLOT_DURATION),
+	}
+}
+
 bridge_hub_test_utils::test_cases::include_teleports_for_native_asset_works!(
 	Runtime,
 	AllPalletsWithoutSystem,
@@ -119,6 +128,7 @@ bridge_hub_test_utils::test_cases::include_teleports_for_native_asset_works!(
 	WeightToFee,
 	ParachainSystem,
 	collator_session_keys(),
+	slot_durations(),
 	ExistentialDeposit::get(),
 	Box::new(|runtime_event_encoded: Vec<u8>| {
 		match RuntimeEvent::decode(&mut &runtime_event_encoded[..]) {
@@ -229,6 +239,7 @@ fn message_dispatch_routing_works() {
 		ConstU8<2>,
 	>(
 		collator_session_keys(),
+		slot_durations(),
 		bp_bridge_hub_westend::BRIDGE_HUB_WESTEND_PARACHAIN_ID,
 		SIBLING_PARACHAIN_ID,
 		Box::new(|runtime_event_encoded: Vec<u8>| {
@@ -252,6 +263,7 @@ fn message_dispatch_routing_works() {
 fn relayed_incoming_message_works() {
 	from_parachain::relayed_incoming_message_works::<RuntimeTestsAdapter>(
 		collator_session_keys(),
+		slot_durations(),
 		bp_bridge_hub_westend::BRIDGE_HUB_WESTEND_PARACHAIN_ID,
 		bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 		BridgeHubRococoChainId::get(),
@@ -267,6 +279,7 @@ fn relayed_incoming_message_works() {
 pub fn complex_relay_extrinsic_works() {
 	from_parachain::complex_relay_extrinsic_works::<RuntimeTestsAdapter>(
 		collator_session_keys(),
+		slot_durations(),
 		bp_bridge_hub_westend::BRIDGE_HUB_WESTEND_PARACHAIN_ID,
 		bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_PARACHAIN_ID,
 		SIBLING_PARACHAIN_ID,

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_grandpa_chain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_grandpa_chain.rs
@@ -38,9 +38,7 @@ use bridge_runtime_common::{
 };
 use frame_support::traits::{Get, OnFinalize, OnInitialize};
 use frame_system::pallet_prelude::BlockNumberFor;
-use parachains_runtimes_test_utils::{
-	AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf,
-};
+use parachains_runtimes_test_utils::{AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf, SlotDurations};
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::Header as HeaderT, AccountId32};
 use xcm::latest::prelude::*;
@@ -107,6 +105,7 @@ where
 /// Also verifies relayer transaction signed extensions work as intended.
 pub fn relayed_incoming_message_works<RuntimeHelper>(
 	collator_session_key: CollatorSessionKeys<RuntimeHelper::Runtime>,
+	slot_durations: SlotDurations,
 	runtime_para_id: u32,
 	bridged_chain_id: bp_runtime::ChainId,
 	sibling_parachain_id: u32,
@@ -136,6 +135,7 @@ pub fn relayed_incoming_message_works<RuntimeHelper>(
 		RuntimeHelper::MPI,
 	>(
 		collator_session_key,
+		slot_durations,
 		runtime_para_id,
 		sibling_parachain_id,
 		local_relay_chain_id,
@@ -205,6 +205,7 @@ pub fn relayed_incoming_message_works<RuntimeHelper>(
 /// Also verifies relayer transaction signed extensions work as intended.
 pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 	collator_session_key: CollatorSessionKeys<RuntimeHelper::Runtime>,
+	slot_durations: SlotDurations,
 	runtime_para_id: u32,
 	sibling_parachain_id: u32,
 	bridged_chain_id: bp_runtime::ChainId,
@@ -237,6 +238,7 @@ pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 		RuntimeHelper::MPI,
 	>(
 		collator_session_key,
+		slot_durations,
 		runtime_para_id,
 		sibling_parachain_id,
 		local_relay_chain_id,

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_grandpa_chain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_grandpa_chain.rs
@@ -38,7 +38,9 @@ use bridge_runtime_common::{
 };
 use frame_support::traits::{Get, OnFinalize, OnInitialize};
 use frame_system::pallet_prelude::BlockNumberFor;
-use parachains_runtimes_test_utils::{AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf, SlotDurations};
+use parachains_runtimes_test_utils::{
+	AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf, SlotDurations,
+};
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::Header as HeaderT, AccountId32};
 use xcm::latest::prelude::*;

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_parachain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_parachain.rs
@@ -39,7 +39,9 @@ use bridge_runtime_common::{
 };
 use frame_support::traits::{Get, OnFinalize, OnInitialize};
 use frame_system::pallet_prelude::BlockNumberFor;
-use parachains_runtimes_test_utils::{AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf, SlotDurations};
+use parachains_runtimes_test_utils::{
+	AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf, SlotDurations,
+};
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::Header as HeaderT, AccountId32};
 use xcm::latest::prelude::*;

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_parachain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_parachain.rs
@@ -39,9 +39,7 @@ use bridge_runtime_common::{
 };
 use frame_support::traits::{Get, OnFinalize, OnInitialize};
 use frame_system::pallet_prelude::BlockNumberFor;
-use parachains_runtimes_test_utils::{
-	AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf,
-};
+use parachains_runtimes_test_utils::{AccountIdOf, BasicParachainRuntime, CollatorSessionKeys, RuntimeCallOf, SlotDurations};
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::Header as HeaderT, AccountId32};
 use xcm::latest::prelude::*;
@@ -112,6 +110,7 @@ where
 /// Also verifies relayer transaction signed extensions work as intended.
 pub fn relayed_incoming_message_works<RuntimeHelper>(
 	collator_session_key: CollatorSessionKeys<RuntimeHelper::Runtime>,
+	slot_durations: SlotDurations,
 	runtime_para_id: u32,
 	bridged_para_id: u32,
 	bridged_chain_id: bp_runtime::ChainId,
@@ -146,6 +145,7 @@ pub fn relayed_incoming_message_works<RuntimeHelper>(
 		RuntimeHelper::MPI,
 	>(
 		collator_session_key,
+		slot_durations,
 		runtime_para_id,
 		sibling_parachain_id,
 		local_relay_chain_id,
@@ -244,6 +244,7 @@ pub fn relayed_incoming_message_works<RuntimeHelper>(
 /// Also verifies relayer transaction signed extensions work as intended.
 pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 	collator_session_key: CollatorSessionKeys<RuntimeHelper::Runtime>,
+	slot_durations: SlotDurations,
 	runtime_para_id: u32,
 	bridged_para_id: u32,
 	sibling_parachain_id: u32,
@@ -281,6 +282,7 @@ pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 		RuntimeHelper::MPI,
 	>(
 		collator_session_key,
+		slot_durations,
 		runtime_para_id,
 		sibling_parachain_id,
 		local_relay_chain_id,

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/helpers.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/helpers.rs
@@ -30,7 +30,9 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_bridge_grandpa::{BridgedBlockHash, BridgedHeader};
 use parachains_common::AccountId;
-use parachains_runtimes_test_utils::{mock_open_hrmp_channel, AccountIdOf, CollatorSessionKeys, RuntimeCallOf, SlotDurations};
+use parachains_runtimes_test_utils::{
+	mock_open_hrmp_channel, AccountIdOf, CollatorSessionKeys, RuntimeCallOf, SlotDurations,
+};
 use sp_core::Get;
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::TrailingZeroInput, AccountId32};

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/helpers.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/helpers.rs
@@ -30,9 +30,7 @@ use frame_support::{
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_bridge_grandpa::{BridgedBlockHash, BridgedHeader};
 use parachains_common::AccountId;
-use parachains_runtimes_test_utils::{
-	mock_open_hrmp_channel, AccountIdOf, CollatorSessionKeys, RuntimeCallOf,
-};
+use parachains_runtimes_test_utils::{mock_open_hrmp_channel, AccountIdOf, CollatorSessionKeys, RuntimeCallOf, SlotDurations};
 use sp_core::Get;
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::TrailingZeroInput, AccountId32};
@@ -220,6 +218,7 @@ pub fn relayer_id_at_bridged_chain<Runtime: pallet_bridge_messages::Config<MPI>,
 /// with proofs (finality, message) independently submitted.
 pub fn relayed_incoming_message_works<Runtime, AllPalletsWithoutSystem, MPI>(
 	collator_session_key: CollatorSessionKeys<Runtime>,
+	slot_durations: SlotDurations,
 	runtime_para_id: u32,
 	sibling_parachain_id: u32,
 	local_relay_chain_id: NetworkId,
@@ -272,6 +271,7 @@ pub fn relayed_incoming_message_works<Runtime, AllPalletsWithoutSystem, MPI>(
 				sibling_parachain_id.into(),
 				included_head,
 				&alice,
+				&slot_durations,
 			);
 
 			// set up relayer details and proofs

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
@@ -43,10 +43,7 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::AccountId;
-use parachains_runtimes_test_utils::{
-	mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeCallOf,
-	XcmReceivedFrom,
-};
+use parachains_runtimes_test_utils::{mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeCallOf, XcmReceivedFrom, SlotDurations};
 use sp_runtime::{traits::Zero, AccountId32};
 use xcm::{latest::prelude::*, AlwaysLatest};
 use xcm_builder::DispatchBlobError;
@@ -418,6 +415,7 @@ pub fn message_dispatch_routing_works<
 	NetworkDistanceAsParentCount,
 >(
 	collator_session_key: CollatorSessionKeys<Runtime>,
+	slot_durations: SlotDurations,
 	runtime_para_id: u32,
 	sibling_parachain_id: u32,
 	unwrap_cumulus_pallet_parachain_system_event: Box<
@@ -528,6 +526,7 @@ pub fn message_dispatch_routing_works<
 			sibling_parachain_id.into(),
 			included_head,
 			&alice,
+			&slot_durations,
 		);
 		let result =
 			<<Runtime as BridgeMessagesConfig<MessagesPalletInstance>>::MessageDispatch>::dispatch(

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
@@ -43,7 +43,10 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use parachains_common::AccountId;
-use parachains_runtimes_test_utils::{mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeCallOf, XcmReceivedFrom, SlotDurations};
+use parachains_runtimes_test_utils::{
+	mock_open_hrmp_channel, AccountIdOf, BalanceOf, CollatorSessionKeys, ExtBuilder, RuntimeCallOf,
+	SlotDurations, XcmReceivedFrom,
+};
 use sp_runtime::{traits::Zero, AccountId32};
 use xcm::{latest::prelude::*, AlwaysLatest};
 use xcm_builder::DispatchBlobError;

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -29,7 +29,6 @@ use frame_support::{
 	weights::Weight,
 };
 use frame_system::pallet_prelude::{BlockNumberFor, HeaderFor};
-use parachains_common::SLOT_DURATION;
 use polkadot_parachain_primitives::primitives::{
 	HeadData, HrmpChannelId, RelayChainBlockNumber, XcmpMessageFormat,
 };
@@ -113,6 +112,11 @@ impl<Runtime: frame_system::Config + pallet_balances::Config + pallet_session::C
 			.map(|item| (item.collator.clone(), item.validator.clone(), item.key.clone()))
 			.collect::<Vec<_>>()
 	}
+}
+
+pub struct SlotDurations {
+	pub relay: SlotDuration,
+	pub para: SlotDuration
 }
 
 /// A set of traits for a minimal parachain runtime, that may be used in conjunction with the
@@ -335,6 +339,7 @@ impl<
 		open_hrmp_channel: Option<(u32, u32)>,
 		included_head: HeaderFor<Runtime>,
 		slot_digest: &[u8],
+		slot_durations: &SlotDurations,
 	) -> DispatchResult
 	where
 		HrmpChannelOpener: frame_support::inherent::ProvideInherent<
@@ -348,6 +353,7 @@ impl<
 				target_para_id.into(),
 				included_head,
 				slot_digest,
+				slot_durations,
 			);
 		}
 
@@ -492,12 +498,12 @@ pub fn mock_open_hrmp_channel<
 	recipient: ParaId,
 	included_head: HeaderFor<C>,
 	mut slot_digest: &[u8],
+	slot_durations: &SlotDurations,
 ) {
-	const RELAY_CHAIN_SLOT_DURATION: SlotDuration = SlotDuration::from_millis(6000);
 	let slot = Slot::decode(&mut slot_digest).expect("failed to decode digest");
 	// Convert para slot to relay chain.
-	let timestamp = slot.saturating_mul(SLOT_DURATION);
-	let relay_slot = Slot::from_timestamp(timestamp.into(), RELAY_CHAIN_SLOT_DURATION);
+	let timestamp = slot.saturating_mul(slot_durations.para.as_millis());
+	let relay_slot = Slot::from_timestamp(timestamp.into(), slot_durations.relay);
 
 	let n = 1_u32;
 	let mut sproof_builder = RelayStateSproofBuilder {

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -116,7 +116,7 @@ impl<Runtime: frame_system::Config + pallet_balances::Config + pallet_session::C
 
 pub struct SlotDurations {
 	pub relay: SlotDuration,
-	pub para: SlotDuration
+	pub para: SlotDuration,
 }
 
 /// A set of traits for a minimal parachain runtime, that may be used in conjunction with the


### PR DESCRIPTION
Fixes system parachains unit-tests for https://github.com/paritytech/polkadot-sdk/pull/2826.