### PR TITLE
PVF: include host architecture in artifact filenames

### DIFF
--- a/polkadot/node/core/pvf/common/src/lib.rs
+++ b/polkadot/node/core/pvf/common/src/lib.rs
@@ -86,3 +86,17 @@ pub fn framed_recv_blocking(r: &mut (impl Read + Unpin)) -> io::Result<Vec<u8>> 
 	r.read_exact(&mut buf)?;
 	Ok(buf)
 }
+
+/// Calls `uname` to get the host architecture. Example output: "Linux-x86_64".
+#[cfg(feature = "test-utils")]
+pub fn test_get_host_architecture() -> String {
+	let uname = std::process::Command::new("uname")
+		.arg("-ms")
+		.output()
+		.expect("uname should not fail in tests")
+		.stdout;
+	std::str::from_utf8(&uname)
+		.expect("uname output is printed as an ASCII string; qed")
+		.trim()
+		.replace(" ", "-")
+}

--- a/polkadot/node/core/pvf/common/src/pvf.rs
+++ b/polkadot/node/core/pvf/common/src/pvf.rs
@@ -42,20 +42,23 @@ pub struct PvfPrepData {
 	prep_timeout: Duration,
 	/// The kind of preparation job.
 	prep_kind: PrepareJobKind,
+	/// The host architecture.
+	architecture: String,
 }
 
 impl PvfPrepData {
 	/// Returns an instance of the PVF out of the given PVF code and executor params.
-	pub fn from_code(
+	pub fn new(
 		code: Vec<u8>,
 		executor_params: ExecutorParams,
 		prep_timeout: Duration,
 		prep_kind: PrepareJobKind,
+		architecture: String,
 	) -> Self {
 		let code = Arc::new(code);
 		let code_hash = blake2_256(&code).into();
 		let executor_params = Arc::new(executor_params);
-		Self { code, code_hash, executor_params, prep_timeout, prep_kind }
+		Self { code, code_hash, executor_params, prep_timeout, prep_kind, architecture }
 	}
 
 	/// Returns validation code hash for the PVF
@@ -83,15 +86,21 @@ impl PvfPrepData {
 		self.prep_kind
 	}
 
+	/// Returns host architecture.
+	pub fn architecture(&self) -> &str {
+		&self.architecture
+	}
+
 	/// Creates a structure for tests.
 	#[cfg(feature = "test-utils")]
 	pub fn from_discriminator_and_timeout(num: u32, timeout: Duration) -> Self {
 		let descriminator_buf = num.to_le_bytes().to_vec();
-		Self::from_code(
+		Self::new(
 			descriminator_buf,
 			ExecutorParams::default(),
 			timeout,
 			PrepareJobKind::Compilation,
+			crate::test_get_host_architecture(),
 		)
 	}
 

--- a/polkadot/node/core/pvf/src/host.rs
+++ b/polkadot/node/core/pvf/src/host.rs
@@ -158,6 +158,8 @@ pub struct Config {
 	pub node_version: Option<String>,
 	/// Whether the node is attempting to run as a secure validator.
 	pub secure_validator_mode: bool,
+	/// The architecture of the current host.
+	pub architecture: String,
 
 	/// The path to the program that can be used to spawn the prepare workers.
 	pub prepare_worker_program_path: PathBuf,
@@ -183,6 +185,7 @@ impl Config {
 		cache_path: PathBuf,
 		node_version: Option<String>,
 		secure_validator_mode: bool,
+		architecture: String,
 		prepare_worker_program_path: PathBuf,
 		execute_worker_program_path: PathBuf,
 	) -> Self {
@@ -190,6 +193,7 @@ impl Config {
 			cache_path,
 			node_version,
 			secure_validator_mode,
+			architecture,
 
 			prepare_worker_program_path,
 			prepare_worker_spawn_timeout: Duration::from_secs(3),
@@ -218,7 +222,7 @@ pub async fn start(
 	gum::debug!(target: LOG_TARGET, ?config, "starting PVF validation host");
 
 	// Make sure the cache is initialized before doing anything else.
-	let artifacts = Artifacts::new_and_prune(&config.cache_path).await;
+	let artifacts = Artifacts::new_and_prune(&config.cache_path, &config.architecture).await;
 
 	// Run checks for supported security features once per host startup. If some checks fail, warn
 	// if Secure Validator Mode is disabled and return an error otherwise.

--- a/substrate/client/telemetry/src/lib.rs
+++ b/substrate/client/telemetry/src/lib.rs
@@ -125,7 +125,7 @@ pub struct ConnectionMessage {
 /// so most of the fields here are optional.
 #[derive(Debug, Serialize)]
 pub struct SysInfo {
-	/// The exact CPU model.
+	/// The exact CPU model. Example: "Intel(R) Xeon(TM) CPU 2.40GHz"
 	pub cpu: Option<String>,
 	/// The total amount of memory, in bytes.
 	pub memory: Option<u64>,
@@ -137,6 +137,10 @@ pub struct SysInfo {
 	pub linux_distro: Option<String>,
 	/// Whether the node's running under a virtual machine.
 	pub is_virtual_machine: Option<bool>,
+	/// The system name. Examples: "Darwin", "Linux"
+	pub sysname: Option<String>,
+	/// The CPU architecture. Examples: "x86_64", "arm64"
+	pub architecture: Option<String>,
 }
 
 /// Telemetry worker.


### PR DESCRIPTION
On node restart, artifacts not matching current host architecture get pruned

## Potential Follow-ups / Open Questions

This PR attempts an immediate fix for #2863. There are some potential follow-ups as well as open questions:

1. Try constructing the runtime for each artifact on node startup, and prune any that fail?
  - This requires the executor parameters to be available. Is it sound to use the default set? We don't currently have any exec params that are applicable to runtime construction, but we might in the future.

2. Abstain from voting on `RuntimeConstruction` errors?
  - This seemed sound because we now do runtime construction in prechecking. However, I realized that the exec params might have changed between prechecking and execution, and if they changed in such a way that the runtime construction now fails, abstaining would stall finality.

I am not sure if these are real concerns. We can either implement these follow-ups and leave a note above the exec params about the concerns, or we just skip doing this. @s0me0ne-unkn0wn 

## Related

Closes https://github.com/paritytech/polkadot-sdk/issues/2863