### PR TITLE
feat(pallet-assets): define and implement sufficients traits for `pallet-assets`

### DIFF
--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -998,7 +998,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		})
 	}
 
-	/// Do set sufficiency
+	/// Set the sufficiency of an asset class
+	///
+	/// ### Errors
+	///
+	/// - [`Unknown`][crate::Error::Unknown] when the asset ID is unknown.
 	pub(super) fn do_set_sufficiency(asset_id: T::AssetId, is_sufficient: bool) -> DispatchResult {
 		Asset::<T, I>::try_mutate(asset_id, |maybe_asset| {
 			if let Some(asset) = maybe_asset {

--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -998,6 +998,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		})
 	}
 
+	/// Do set sufficiency
+	pub(super) fn do_set_sufficiency(asset_id: T::AssetId, is_sufficient: bool) -> DispatchResult {
+		Asset::<T, I>::try_mutate(asset_id, |maybe_asset| {
+			if let Some(asset) = maybe_asset {
+				asset.is_sufficient = is_sufficient;
+				Ok(())
+			} else {
+				Err(Error::<T, I>::Unknown)?
+			}
+		})
+	}
+
 	/// Calculate the metadata deposit for the provided data.
 	pub(super) fn calc_metadata_deposit(name: &[u8], symbol: &[u8]) -> DepositBalanceOf<T, I> {
 		T::MetadataDepositPerByte::get()

--- a/substrate/frame/assets/src/impl_sufficiency.rs
+++ b/substrate/frame/assets/src/impl_sufficiency.rs
@@ -1,5 +1,5 @@
 use crate::{
-	traits::sufficients::{Inspect, Mutate},
+	traits::sufficiency::{Inspect, Mutate},
 	Asset, Config, Pallet,
 };
 

--- a/substrate/frame/assets/src/impl_sufficiency.rs
+++ b/substrate/frame/assets/src/impl_sufficiency.rs
@@ -1,15 +1,34 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Assets pallet's `StoredMap` implementation.
+
 use crate::{
-	traits::sufficiency::{Inspect, Mutate},
+	traits::sufficiency::{IsSufficient, SetSufficiency},
 	Asset, Config, Pallet,
 };
 
-impl<T: Config<I>, I: 'static> Inspect<<T as Config<I>>::AssetId> for Pallet<T, I> {
+impl<T: Config<I>, I: 'static> IsSufficient<<T as Config<I>>::AssetId> for Pallet<T, I> {
 	fn is_sufficient(asset_id: <T as Config<I>>::AssetId) -> bool {
 		Asset::<T, I>::get(asset_id).map(|asset| asset.is_sufficient).unwrap_or(false)
 	}
 }
 
-impl<T: Config<I>, I: 'static> Mutate<<T as Config<I>>::AssetId> for Pallet<T, I> {
+impl<T: Config<I>, I: 'static> SetSufficiency<<T as Config<I>>::AssetId> for Pallet<T, I> {
 	fn make_sufficient(asset_id: <T as Config<I>>::AssetId) -> sp_runtime::DispatchResult {
 		Pallet::<T, I>::do_set_sufficiency(asset_id, true)
 	}

--- a/substrate/frame/assets/src/impl_sufficients.rs
+++ b/substrate/frame/assets/src/impl_sufficients.rs
@@ -1,0 +1,26 @@
+use crate::{
+	traits::sufficients::{Inspect, Mutate},
+	Asset, Config, Error, Pallet,
+};
+
+impl<T: Config<I>, I: 'static> Inspect<<T as Config<I>>::AssetId> for Pallet<T, I> {
+	fn is_sufficient(asset_id: <T as Config<I>>::AssetId) -> bool {
+		Asset::<T, I>::get(asset_id).map(|asset| asset.is_sufficient).unwrap_or(false)
+	}
+}
+
+impl<T: Config<I>, I: 'static> Mutate<<T as Config<I>>::AssetId> for Pallet<T, I> {
+	fn set_sufficient(
+		asset_id: <T as Config<I>>::AssetId,
+		is_sufficient: bool,
+	) -> sp_runtime::DispatchResult {
+		Asset::<T, I>::try_mutate(asset_id, |maybe_asset| {
+			if let Some(asset) = maybe_asset {
+				asset.is_sufficient = is_sufficient;
+				Ok(())
+			} else {
+				Err(Error::<T, I>::Unknown)?
+			}
+		})
+	}
+}

--- a/substrate/frame/assets/src/impl_sufficients.rs
+++ b/substrate/frame/assets/src/impl_sufficients.rs
@@ -1,6 +1,6 @@
 use crate::{
 	traits::sufficients::{Inspect, Mutate},
-	Asset, Config, Error, Pallet,
+	Asset, Config, Pallet,
 };
 
 impl<T: Config<I>, I: 'static> Inspect<<T as Config<I>>::AssetId> for Pallet<T, I> {
@@ -10,17 +10,11 @@ impl<T: Config<I>, I: 'static> Inspect<<T as Config<I>>::AssetId> for Pallet<T, 
 }
 
 impl<T: Config<I>, I: 'static> Mutate<<T as Config<I>>::AssetId> for Pallet<T, I> {
-	fn set_sufficient(
-		asset_id: <T as Config<I>>::AssetId,
-		is_sufficient: bool,
-	) -> sp_runtime::DispatchResult {
-		Asset::<T, I>::try_mutate(asset_id, |maybe_asset| {
-			if let Some(asset) = maybe_asset {
-				asset.is_sufficient = is_sufficient;
-				Ok(())
-			} else {
-				Err(Error::<T, I>::Unknown)?
-			}
-		})
+	fn make_sufficient(asset_id: <T as Config<I>>::AssetId) -> sp_runtime::DispatchResult {
+		Pallet::<T, I>::do_set_sufficiency(asset_id, true)
+	}
+
+	fn make_insufficient(asset_id: <T as Config<I>>::AssetId) -> sp_runtime::DispatchResult {
+		Pallet::<T, I>::do_set_sufficiency(asset_id, false)
 	}
 }

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -155,7 +155,7 @@ pub use extra_mutator::*;
 mod functions;
 mod impl_fungibles;
 mod impl_stored_map;
-mod impl_sufficients;
+mod impl_sufficiency;
 
 pub mod traits;
 mod types;

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -151,9 +151,13 @@ pub mod weights;
 
 mod extra_mutator;
 pub use extra_mutator::*;
+
 mod functions;
 mod impl_fungibles;
 mod impl_stored_map;
+mod impl_sufficients;
+
+pub mod traits;
 mod types;
 pub use types::*;
 

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -102,7 +102,7 @@ fn basic_minting_should_work() {
 
 #[test]
 fn insufficient_assets_can_turn_into_sufficient() {
-	use sufficients::{Inspect, Mutate};
+	use sufficiency::{Inspect, Mutate};
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -102,7 +102,7 @@ fn basic_minting_should_work() {
 
 #[test]
 fn insufficient_assets_can_turn_into_sufficient() {
-	use sufficiency::{Inspect, Mutate};
+	use sufficiency::{IsSufficient, SetSufficiency};
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -18,7 +18,7 @@
 //! Tests for Assets pallet.
 
 use super::*;
-use crate::{mock::*, Error};
+use crate::{mock::*, traits::*, Error};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::GetDispatchInfo,
@@ -97,6 +97,18 @@ fn basic_minting_should_work() {
 			amount: 100,
 		}));
 		assert_eq!(Assets::account_balances(1), vec![(0, 100), (999, 100), (1, 100)]);
+	});
+}
+
+#[test]
+fn insufficient_assets_can_turn_into_sufficient() {
+	use sufficients::{Inspect, Mutate};
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));
+		assert_eq!(Assets::is_sufficient(0), false);
+		assert_ok!(Assets::set_sufficient(0, true));
+		assert_eq!(Assets::is_sufficient(0), true);
 	});
 }
 

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -109,6 +109,8 @@ fn insufficient_assets_can_turn_into_sufficient() {
 		assert_eq!(Assets::is_sufficient(0), false);
 		assert_ok!(Assets::make_sufficient(0));
 		assert_eq!(Assets::is_sufficient(0), true);
+		assert_ok!(Assets::make_insufficient(0));
+		assert_eq!(Assets::is_sufficient(0), false);
 	});
 }
 

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -107,7 +107,7 @@ fn insufficient_assets_can_turn_into_sufficient() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));
 		assert_eq!(Assets::is_sufficient(0), false);
-		assert_ok!(Assets::set_sufficient(0, true));
+		assert_ok!(Assets::make_sufficient(0));
 		assert_eq!(Assets::is_sufficient(0), true);
 	});
 }

--- a/substrate/frame/assets/src/traits.rs
+++ b/substrate/frame/assets/src/traits.rs
@@ -1,4 +1,4 @@
-pub mod sufficients {
+pub mod sufficiency {
 	use sp_runtime::DispatchResult;
 
 	/// Trait for providing the sufficient state of an asset.

--- a/substrate/frame/assets/src/traits.rs
+++ b/substrate/frame/assets/src/traits.rs
@@ -3,17 +3,24 @@ pub mod sufficients {
 
 	/// Trait for providing the sufficient state of an asset.
 	pub trait Inspect<AssetId> {
-		/// Returns whether an asset is sufficient or not
+		/// Returns whether an asset is sufficient or not.
 		fn is_sufficient(asset_id: AssetId) -> bool;
 	}
 
 	/// Trait for mutating the sufficient state of an asset
 	pub trait Mutate<AssetId> {
-		/// Sets the `is_sufficient` value of an asset.
+		/// Makes the asset to be sufficient.
 		///
 		/// ### Errors
 		///
 		/// - [`Unknown`][crate::Error::Unknown] when the asset ID is unknown.
-		fn set_sufficient(asset_id: AssetId, is_sufficient: bool) -> DispatchResult;
+		fn make_sufficient(asset_id: AssetId) -> DispatchResult;
+
+		/// Makes the asset to be insufficient.
+		///
+		/// ### Errors
+		///
+		/// - [`Unknown`][crate::Error::Unknown] when the asset ID is unknown.
+		fn make_insufficient(asset_id: AssetId) -> DispatchResult;
 	}
 }

--- a/substrate/frame/assets/src/traits.rs
+++ b/substrate/frame/assets/src/traits.rs
@@ -1,26 +1,18 @@
 pub mod sufficiency {
 	use sp_runtime::DispatchResult;
 
-	/// Trait for providing the sufficient state of an asset.
+	/// Trait for providing the sufficiency of an asset.
 	pub trait Inspect<AssetId> {
 		/// Returns whether an asset is sufficient or not.
 		fn is_sufficient(asset_id: AssetId) -> bool;
 	}
 
-	/// Trait for mutating the sufficient state of an asset
+	/// Trait for mutating the sufficiency of an asset
 	pub trait Mutate<AssetId> {
-		/// Makes the asset to be sufficient.
-		///
-		/// ### Errors
-		///
-		/// - [`Unknown`][crate::Error::Unknown] when the asset ID is unknown.
+		/// Makes the asset sufficient.
 		fn make_sufficient(asset_id: AssetId) -> DispatchResult;
 
-		/// Makes the asset to be insufficient.
-		///
-		/// ### Errors
-		///
-		/// - [`Unknown`][crate::Error::Unknown] when the asset ID is unknown.
+		/// Makes the asset insufficient.
 		fn make_insufficient(asset_id: AssetId) -> DispatchResult;
 	}
 }

--- a/substrate/frame/assets/src/traits.rs
+++ b/substrate/frame/assets/src/traits.rs
@@ -2,13 +2,13 @@ pub mod sufficiency {
 	use sp_runtime::DispatchResult;
 
 	/// Trait for providing the sufficiency of an asset.
-	pub trait Inspect<AssetId> {
+	pub trait IsSufficient<AssetId> {
 		/// Returns whether an asset is sufficient or not.
 		fn is_sufficient(asset_id: AssetId) -> bool;
 	}
 
 	/// Trait for mutating the sufficiency of an asset
-	pub trait Mutate<AssetId> {
+	pub trait SetSufficiency<AssetId> {
 		/// Makes the asset sufficient.
 		fn make_sufficient(asset_id: AssetId) -> DispatchResult;
 

--- a/substrate/frame/assets/src/traits.rs
+++ b/substrate/frame/assets/src/traits.rs
@@ -1,0 +1,19 @@
+pub mod sufficients {
+	use sp_runtime::DispatchResult;
+
+	/// Trait for providing the sufficient state of an asset.
+	pub trait Inspect<AssetId> {
+		/// Returns whether an asset is sufficient or not
+		fn is_sufficient(asset_id: AssetId) -> bool;
+	}
+
+	/// Trait for mutating the sufficient state of an asset
+	pub trait Mutate<AssetId> {
+		/// Sets the `is_sufficient` value of an asset.
+		///
+		/// ### Errors
+		///
+		/// - [`Unknown`][crate::Error::Unknown] when the asset ID is unknown.
+		fn set_sufficient(asset_id: AssetId, is_sufficient: bool) -> DispatchResult;
+	}
+}


### PR DESCRIPTION
This pull request supersedes #1768, and implements methods to access and mutate `is_sufficient` value of an asset.

---

# Description

This Pull Request introduces two traits under `pallet-asset`: a trait called `sufficients::Inspect`, and a trait called `sufficients::Mutate`. These methods are useful since pallet implementors can benefit from having this (so far missing) piece of information, either for testing checks or for handling accounts touching on behalf of others.

## Use Cases

### Use Case: Checking whether an asset was appropriately created as sufficient

A pallet might have a rule that allows creating assets, but only marking one of these (i.e. the first) as sufficient. A typical test for this would resemble something like this

```rs
#[test]
fn it_works() {
    new_test_ext().execute_with(|| {
        setup();

        // Can register a new asset
        assert_ok!(
            Communities::create_asset(RuntimeOrigin::signed(COMMUNITY_ADMIN), COMMUNITY, ASSET_B, 1)
        );

        // Can register additional assets
        assert_ok!(
            Communities::create_asset(RuntimeOrigin::signed(COMMUNITY_ADMIN), COMMUNITY, ASSET_C, 1)
        );

        // First asset owned by the community is sufficient by default
        assert_sufficiency(COMMUNITY, ASSET_B, 1, true);

        // Additional assets owned by the community are not sufficient
        // by default
        assert_sufficiency(COMMUNITY, ASSET_C, 1, false);
    });
}
```

Without this getter, implementing `assert_sufficiency` would require (as shown [here](https://github.com/virto-network/virto-node/blob/d7707099d811d94dbb0a13d2b2098c9659446615/pallets/communities/src/tests/helpers.rs#L16-L50)) the following steps:

1. Forcing access to the storage via `sp_io::storage::get`.
2. Encoding a `AssetDetails` struct that resembles the expected one, since `is_sufficient` is a private field.
3. Asserting equality for both structs.

With the getter, it would be something as simple as this, no further illegal accesses required:

```rs
        // First asset owned by the community is sufficient by default
        assert_eq(Assets::is_sufficient(ASSET_B), true);

        // Additional assets owned by the community are not sufficient
        // by default
        assert_eq(Assets::is_sufficient(ASSET_C), false);
```

### Use Case: Checking sufficiency for an existing asset

Some pallets might see it useful to check whether an asset is sufficient, for some cases where it might be useful (e.g. some restricted versions of DEXes where pool implementors would like to check that those assets are sufficient).

Without the getter, this would require building the pallet as an extension of the Assets pallet. Some tricks like the one explained in the use case above would be impractical.

## Implementation

The implementation is actually really simple.

1. Define the traits under `substrate/frame/pallets/assets/src/traits.rs`: `sufficients::Inspect` and `sufficients::Mutate`. The method signature returns `bool`, defaults to `false` when the asset does not exist.
2. Implement on the `impl_sufficients.rs` file, getting the asset's details, and mapping the response as `asset.is_sufficient`.

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable) 