### PR TITLE
Make `simple-mermaid` optional

### DIFF
--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -48,7 +48,7 @@ frame-executive = { default-features = false, path = "../frame/executive", optio
 frame-system-rpc-runtime-api = { default-features = false, path = "../frame/system/rpc/runtime-api", optional = true }
 
 docify = "0.2.0"
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b" }
+simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b", optional = true }
 log = { version = "0.4.20", default-features = false }
 
 [dev-dependencies]
@@ -78,6 +78,7 @@ std = [
 	"log/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
+	"simple-mermaid",
 	"sp-api?/std",
 	"sp-arithmetic/std",
 	"sp-block-builder?/std",

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -34,7 +34,7 @@ sp-std = { path = "../std", default-features = false }
 sp-weights = { path = "../weights", default-features = false }
 docify = { version = "0.2.6" }
 
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b" }
+simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -57,6 +57,7 @@ std = [
 	"rand",
 	"scale-info/std",
 	"serde/std",
+	"simple-mermaid",
 	"sp-api/std",
 	"sp-application-crypto/std",
 	"sp-arithmetic/std",

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -57,7 +57,7 @@ type UncheckedSignaturePayload<Address, Signature, Extra> = (Address, Signature,
 /// could in principle be any other interaction. Transactions are either signed or unsigned. A
 /// sensible transaction pool should ensure that only transactions that are worthwhile are
 /// considered for block-building.
-#[doc = simple_mermaid::mermaid!("../../../../../docs/mermaid/extrinsics.mmd")]
+#[cfg_attr(feature = "std", doc = simple_mermaid::mermaid!("../../../../../docs/mermaid/extrinsics.mmd"))]
 /// This type is by no means enforced within Substrate, but given its genericness, it is highly
 /// likely that for most use-cases it will suffice. Thus, the encoding of this type will dictate
 /// exactly what bytes should be sent to a runtime to transact with it.


### PR DESCRIPTION
This prevents it leaking `std` into `no_std` builds.

Closes: https://github.com/paritytech/polkadot-sdk/issues/2866