### PR TITLE
pallet-core-fellowship: import an unimported member on approve

### DIFF
--- a/prdoc/pr_2883.prdoc
+++ b/prdoc/pr_2883.prdoc
@@ -1,4 +1,4 @@
-title: "pallet-core-fellowship: import not tracked member on approve"
+title: "pallet-core-fellowship: import an unimported on approve"
 
 doc:
   - audience: Runtime User

--- a/prdoc/pr_2883.prdoc
+++ b/prdoc/pr_2883.prdoc
@@ -1,0 +1,9 @@
+title: "pallet-core-fellowship: import not tracked member on approve"
+
+doc:
+  - audience: Runtime User
+    description: |
+      To align with the documentation of the approve call, we import an untracked member on approval.
+
+crates:
+  - name: "pallet-core-fellowship"

--- a/substrate/frame/core-fellowship/src/tests.rs
+++ b/substrate/frame/core-fellowship/src/tests.rs
@@ -378,3 +378,11 @@ fn active_changing_get_salary_works() {
 		}
 	});
 }
+
+#[test]
+fn approve_imports_not_tracked_member() {
+	new_test_ext().execute_with(|| {
+		set_rank(10, 5);
+		assert_ok!(CoreFellowship::approve(signed(5), 10, 5));
+	});
+}


### PR DESCRIPTION
To align with the documentation of the approve call, we import an unimported member on approval.

No changes have been made to the benchmarks as they already cover the worst-case scenario.