### PR TITLE
Remove bounds from `PrevalidateAttests` struct definition

### DIFF
--- a/polkadot/runtime/common/src/claims.rs
+++ b/polkadot/runtime/common/src/claims.rs
@@ -1467,12 +1467,6 @@ mod tests {
 			);
 		});
 	}
-
-	#[test]
-	fn prevalidate_assets_is_send_and_sync() {
-		fn is_send_and_sync<T: Send + Sync>() {}
-		is_send_and_sync::<PrevalidateAttests<Test>>();
-	}
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/polkadot/runtime/common/src/claims.rs
+++ b/polkadot/runtime/common/src/claims.rs
@@ -591,11 +591,9 @@ impl<T: Config> Pallet<T> {
 /// otherwise free to place on chain.
 #[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
-pub struct PrevalidateAttests<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>)
-where
-	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>;
+pub struct PrevalidateAttests<T>(core::marker::PhantomData<fn(T)>);
 
-impl<T: Config + Send + Sync> Debug for PrevalidateAttests<T>
+impl<T: Config> Debug for PrevalidateAttests<T>
 where
 	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>,
 {
@@ -610,7 +608,7 @@ where
 	}
 }
 
-impl<T: Config + Send + Sync> PrevalidateAttests<T>
+impl<T: Config> PrevalidateAttests<T>
 where
 	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>,
 {
@@ -620,7 +618,7 @@ where
 	}
 }
 
-impl<T: Config + Send + Sync> SignedExtension for PrevalidateAttests<T>
+impl<T: Config> SignedExtension for PrevalidateAttests<T>
 where
 	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>,
 {
@@ -1468,6 +1466,12 @@ mod tests {
 				InvalidTransaction::Custom(ValidityError::InvalidStatement.into()).into(),
 			);
 		});
+	}
+
+	#[test]
+	fn prevalidate_assets_is_send_and_sync() {
+		fn is_send_and_sync<T: Send + Sync>() {}
+		is_send_and_sync::<PrevalidateAttests<Test>>();
 	}
 }
 

--- a/prdoc/pr_2886.prdoc
+++ b/prdoc/pr_2886.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Remove bounds from `PrevalidateAttests` struct definition
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Minimal change to `PrevalidateAssets` to remove some trait bounds on the struct itself while
+      keeping all its capabilities.
+
+crates:
+  - name: polkadot-runtime-common


### PR DESCRIPTION
Removing some bounds as it came up in https://github.com/paritytech/polkadot-sdk/pull/2726 while still keeping `Send + Sync` capabilities.