### PR TITLE
Fix deps for local docs build for Rust `1.75.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17418,9 +17418,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smol"

--- a/docs/mermaid/polkadot_sdk_parachain.mmd
+++ b/docs/mermaid/polkadot_sdk_parachain.mmd
@@ -5,7 +5,7 @@ flowchart LR
 	end
 
     FRAME -.-> ParachainRuntime
-    Substrate[Substrate Node Libraries] -.-> ParachainNoe
+    Substrate[Substrate Node Libraries] -.-> ParachainNode
 
     CumulusC[Cumulus Node Libraries] -.-> ParachainNode
     CumulusR[Cumulus Runtime Libraries] -.-> ParachainRuntime

--- a/docs/sdk/src/guides/your_first_pallet/mod.rs
+++ b/docs/sdk/src/guides/your_first_pallet/mod.rs
@@ -365,7 +365,7 @@ pub mod pallet {
 			// ensure sender has enough balance, and if so, calculate what is left after `amount`.
 			let sender_balance = Balances::<T>::get(&sender).ok_or("NonExistentAccount")?;
 			if sender_balance < amount {
-				return Err("InsufficientBalance".into())
+				return Err("InsufficientBalance".into());
 			}
 			let reminder = sender_balance - amount;
 

--- a/docs/sdk/src/meta_contributing.rs
+++ b/docs/sdk/src/meta_contributing.rs
@@ -132,14 +132,16 @@
 //! compromise, but in the long term, we should work towards finding a way to maintain different
 //! revisions of this crate.
 //!
-//! ## How to Build
+//! ## How to Develop Locally
 //!
-//! To build and view this crate locally, with with right HTML headers injected, run:
+//! To view the docs specific [`crate`] locally for development, including the correct HTML headers
+//! injected, run:
 //!
 //! ```sh
-//! RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --open
+//! SKIP_WASM_BUILD=1 RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --no-deps --open
 //! ```
 //!
-//! Adding `--no-deps` would speed up the process while development. If even faster build time for
-//! docs is needed, you can temporarily remove most of the substrate/cumulus dependencies that are
-//! only used for linking purposes.
+//! If even faster build time for docs is needed, you can temporarily remove most of the
+//! substrate/cumulus dependencies that are only used for linking purposes.
+//!
+//! For more on local development, see [`crate::reference_docs::development_environment_advice`].

--- a/docs/sdk/src/meta_contributing.rs
+++ b/docs/sdk/src/meta_contributing.rs
@@ -69,8 +69,7 @@
 //! > what topics are already covered in this crate, and how you can build on top of the information
 //! > that they already pose, rather than repeating yourself**.
 //!
-//! For more details about documenting guidelines, see:
-//! <https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/DOCUMENTATION_GUIDELINES.md#L23>
+//! For more details see the [latest documenting guidelines](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/DOCUMENTATION_GUIDELINES.md).
 //!
 //! #### Example: Explaining `#[pallet::call]`
 //!
@@ -135,12 +134,12 @@
 //!
 //! ## How to Build
 //!
-//! To build this crate properly, with with right HTML headers injected, run:
+//! To build and view this crate locally, with with right HTML headers injected, run:
 //!
 //! ```no_compile
-//! RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs
+//! RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --open
 //! ```
 //!
-//! adding `--no-deps` would speed up the process while development. If even faster build time for
+//! Adding `--no-deps` would speed up the process while development. If even faster build time for
 //! docs is needed, you can temporarily remove most of the substrate/cumulus dependencies that are
 //! only used for linking purposes.

--- a/docs/sdk/src/meta_contributing.rs
+++ b/docs/sdk/src/meta_contributing.rs
@@ -54,8 +54,8 @@
 //! > high level tutorial. They should be explained in the rust-doc of the corresponding type or
 //! > macro.
 //!
-//! 2. 🧘 Less is More: For reasons mentioned [above](#crate::why-rust-docs), the more concise this
-//!    crate is, the better.
+//! 2. 🧘 Less is More: For reasons mentioned [above](#why-rust-docs), the more concise this crate
+//!    is, the better.
 //! 3. √ Don’t Repeat Yourself – DRY: A summary of the above two points. Authors should always
 //!    strive to avoid any duplicate information. Every concept should ideally be documented in
 //!    *ONE* place and one place only. This makes the task of maintaining topics significantly

--- a/docs/sdk/src/meta_contributing.rs
+++ b/docs/sdk/src/meta_contributing.rs
@@ -136,7 +136,7 @@
 //!
 //! To build and view this crate locally, with with right HTML headers injected, run:
 //!
-//! ```no_compile
+//! ```sh
 //! RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --open
 //! ```
 //!


### PR DESCRIPTION
- Fix docs deps build issue (https://github.com/servo/rust-smallvec/issues/327) (Please forgive me and LMK if there are processes I need to follow for the bump a dep here I am not aware of).
- Fix links for `meta_contributing` docs, internal and external.
- `cargo +nightly fmt` for `/docs/...` files