### PR TITLE
Kitchensink: Fix pallet_mmr config

### DIFF
--- a/substrate/bin/node/cli/tests/basic.rs
+++ b/substrate/bin/node/cli/tests/basic.rs
@@ -154,7 +154,7 @@ fn blocks() -> ((Vec<u8>, Hash), (Vec<u8>, Hash)) {
 
 	// session change => consensus authorities change => authorities change digest item appears
 	let digest = Header::decode(&mut &block2.0[..]).unwrap().digest;
-	assert_eq!(digest.logs().len(), 1 /* Just babe slot */);
+	assert_eq!(digest.logs().len(), 2 /* Just babe and BEEFY slots */);
 
 	(block1, block2)
 }

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -879,7 +879,7 @@ parameter_types! {
 	pub const MaxPointsToBalance: u8 = 10;
 }
 
-use sp_runtime::traits::Convert;
+use sp_runtime::traits::{Convert, Keccak256};
 pub struct BalanceToU256;
 impl Convert<Balance, sp_core::U256> for BalanceToU256 {
 	fn convert(balance: Balance) -> sp_core::U256 {
@@ -1578,9 +1578,9 @@ impl pallet_vesting::Config for Runtime {
 
 impl pallet_mmr::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"mmr";
-	type Hashing = <Runtime as frame_system::Config>::Hashing;
+	type Hashing = Keccak256;
 	type LeafData = pallet_mmr::ParentNumberAndHash<Self>;
-	type OnNewRoot = ();
+	type OnNewRoot = pallet_beefy_mmr::DepositBeefyDigest<Runtime>;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/2787

Fixes `pallet_mmr::Config` for the kitchensink runtime 