### PR TITLE
Upgrade aquamarine to v0.5.0, v0.4.0 has yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074b80d14d0240b6ce94d68f059a2d26a5d77280ae142662365a21ef6e2594ef"
+checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
 dependencies = [
  "include_dir",
  "itertools 0.10.5",

--- a/substrate/frame/bags-list/Cargo.toml
+++ b/substrate/frame/bags-list/Cargo.toml
@@ -35,7 +35,7 @@ frame-election-provider-support = { path = "../election-provider-support", defau
 # third party
 log = { version = "0.4.17", default-features = false }
 docify = "0.2.6"
-aquamarine = { version = "0.4.0" }
+aquamarine = { version = "0.5.0" }
 
 # Optional imports for benchmarking
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = { version = "1.0.111", default-features = false, features = ["alloc
 docify = "0.2.6"
 static_assertions = "1.1.0"
 
-aquamarine = { version = "0.4.0" }
+aquamarine = { version = "0.5.0" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"


### PR DESCRIPTION
aquamarine v0.4.0 has yanked, see https://crates.io/crates/aquamarine/0.4.0