### PR TITLE
Fix contracts compilation with `CARGO_TARGET_DIR` set

### DIFF
--- a/substrate/frame/contracts/fixtures/build.rs
+++ b/substrate/frame/contracts/fixtures/build.rs
@@ -203,6 +203,7 @@ fn invoke_wasm_build(current_dir: &Path) -> Result<()> {
 
 	let build_res = Command::new(env::var("CARGO")?)
 		.current_dir(current_dir)
+		.env("CARGO_TARGET_DIR", current_dir.join("target").display().to_string())
 		.env("CARGO_ENCODED_RUSTFLAGS", encoded_rustflags)
 		.args(["build", "--release", "--target=wasm32-unknown-unknown"])
 		.output()


### PR DESCRIPTION
In case `CARGO_TARGET_DIR` is set, build artifacts were in the wrong place and `build.rs` was failing. With `CARGO_TARGET_DIR=/home/nazar-pc/.cache/cargo/target`:
```
error: failed to run custom build command for `pallet-contracts-fixtures v1.0.0 (/web/subspace/polkadot-sdk/substrate/frame/contracts/fixtures)`

Caused by:
  process didn't exit successfully: `/home/nazar-pc/.cache/cargo/target/debug/build/pallet-contracts-fixtures-35d534f7ac3009e0/build-script-build` (exit status: 1)
  --- stderr
  Error: Failed to read "/tmp/.tmpiYwXfv/target/wasm32-unknown-unknown/release/dummy.wasm"

  Caused by:
      Can't read from the file: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

The file was actually in `/home/nazar-pc/.cache/cargo/target/wasm32-unknown-unknown/release/dummy.wasm`.