### PR TITLE
feat: add ApplyAuthorizedUpgradeOrigin

### DIFF
--- a/bridges/snowbridge/parachain/pallets/ethereum-beacon-client/src/mock.rs
+++ b/bridges/snowbridge/parachain/pallets/ethereum-beacon-client/src/mock.rs
@@ -205,6 +205,7 @@ pub mod mainnet {
 	impl frame_system::Config for Test {
 		type BaseCallFilter = frame_support::traits::Everything;
 		type OnSetCode = ();
+		type ApplyAuthorizedUpgradeOrigin = frame_system::EnsureAlways;
 		type BlockWeights = ();
 		type BlockLength = ();
 		type DbWeight = ();

--- a/bridges/snowbridge/parachain/pallets/inbound-queue/src/mock.rs
+++ b/bridges/snowbridge/parachain/pallets/inbound-queue/src/mock.rs
@@ -68,6 +68,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 	type OnSetCode = ();
+	type ApplyAuthorizedUpgradeOrigin = frame_system::EnsureAlways;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	type Nonce = u64;
 	type Block = Block;

--- a/bridges/snowbridge/parachain/pallets/outbound-queue/src/mock.rs
+++ b/bridges/snowbridge/parachain/pallets/outbound-queue/src/mock.rs
@@ -59,6 +59,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 	type OnSetCode = ();
+	type ApplyAuthorizedUpgradeOrigin = frame_system::EnsureAlways;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	type Nonce = u64;
 	type Block = Block;

--- a/bridges/snowbridge/parachain/pallets/system/src/mock.rs
+++ b/bridges/snowbridge/parachain/pallets/system/src/mock.rs
@@ -117,6 +117,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = ConstU16<42>;
 	type OnSetCode = ();
+	type ApplyAuthorizedUpgradeOrigin = frame_system::EnsureAlways;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	type Nonce = u64;
 	type Block = Block;

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -693,9 +693,10 @@ pub mod pallet {
 			note = "To be removed after June 2024. Migrate to `frame_system::apply_authorized_upgrade`."
 		)]
 		pub fn enact_authorized_upgrade(
-			_: OriginFor<T>,
+			origin: OriginFor<T>,
 			code: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
+			<T as frame_system::Config>::ApplyAuthorizedUpgradeOrigin::ensure_origin(origin)?;
 			let post = frame_system::Pallet::<T>::do_apply_authorize_upgrade(code)?;
 			Ok(post)
 		}


### PR DESCRIPTION
This PR introduces an origin check to `apply_authorized_upgrade` (and to `enact_authorized_upgrade` in the ParachainSystem).
By default, this check is set to `EnsureAlways` to ensure backward compatibility.

The check is helpful for better control over upgrade timings. For instance, the technical committee could initiate the upgrade authorized by the community. The committee could do upgrades in the predetermined timeframe.

Also, some upgrades might require additional maintenance right after their enactment. In this scenario, a "maintenance mode" could be enabled to turn off some chain functionality. To minimize the time of the "maintenance", it should be enabled right before the upgrade's enactment. It is only possible if the time of the enactment is predetermined. 