### PR TITLE
Try to fix bridges+zombienet tests when running in a merge queue

### DIFF
--- a/.gitlab/pipeline/zombienet/bridges.yml
+++ b/.gitlab/pipeline/zombienet/bridges.yml
@@ -6,6 +6,10 @@
   before_script:
     # Exit if the job is not merge queue
     # - if [[ $CI_COMMIT_REF_NAME != *"gh-readonly-queue"* ]]; then echo "I will run only in a merge queue"; exit 0; fi
+    # Docker images have different tag in merge queues
+    - if [[ $CI_COMMIT_REF_NAME == *"gh-readonly-queue"* ]]; then export DOCKER_IMAGES_VERSION="${CI_COMMIT_SHORT_SHA}"; fi
+    - export BRIDGES_ZOMBIENET_TESTS_IMAGE_TAG=${DOCKER_IMAGES_VERSION}
+    - export BRIDGES_ZOMBIENET_TESTS_IMAGE="docker.io/paritypr/bridges-zombienet-tests"
     - echo "Zombienet Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
     - echo "${GH_DIR}"
@@ -29,6 +33,11 @@
     LOCAL_DIR: "/builds/parity/mirrors/polkadot-sdk/bridges/zombienet"
     FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: 1
     RUN_IN_CONTAINER: "1"
+  rules:
+    - !reference [.build-refs, rules]
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/ # merge queues
+      variables:
+        BRIDGES_ZOMBIENET_TESTS_IMAGE_TAG: ${CI_COMMIT_SHORT_SHA}
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}_zombienet_bridge_tests"
     when: always


### PR DESCRIPTION
Looks like some collision has happened here recently - while we've been adding new zombienet tests in [this PR](https://github.com/paritytech/polkadot-sdk/pull/2439) and some changes were introduced for the merge queues [here](https://github.com/paritytech/polkadot-sdk/pull/2502). I've missed the latter PR and now our new tests are failing when started in a merge queue. Example: https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/pipelines/434816 (job: https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/4925064).

We can't use the fix from #2502 directly, because we use `DOCKER_IMAGES_VERSION` (aka `CI_COMMIT_SHORT_SHA` for merge queue case) in `image` name and (IIUC) it can't used shell variables from `.before_script`. So we need to use gitlab variables. I haven't found an easy way to change variable value, based on some conditions. The "hard" option is to use [`rules::variables`](https://docs.gitlab.com/ee/ci/yaml/#rulesvariables), which I've tried to use here.

Don't know if there's a way to tests those changes, especially given that the problem appears only in a merge queue, so I'm kindly asking for @paritytech/ci help here - am I doing this right? Thank you!