### PR TITLE
contracts: Update to Polkavm 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
  "gimli 0.27.3",
  "hashbrown 0.13.2",
  "log",
- "regalloc2",
+ "regalloc2 0.6.1",
  "smallvec",
  "target-lexicon",
 ]
@@ -13790,6 +13790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fecd2caacfc4a7ee34243758dd7348859e6dec73f5e5df059890f5742ee46f0e"
 
 [[package]]
+name = "polkavm-common"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b4e215c80fe876147f3d58158d5dfeae7dabdd6047e175af77095b78d0035c"
+
+[[package]]
 name = "polkavm-derive"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13805,7 +13811,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99f4e7a9ff434ef9c885b874c99d824c3a5693bf5e3e8569bb1d2245a8c1b7f"
 dependencies = [
- "polkavm-common",
+ "polkavm-common 0.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -13813,15 +13819,16 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linker"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550738c1b49b9279fa19d8ebed81f551b911b869227a20a190f85f6db45d5d0e"
+checksum = "a5a668bb33c7f0b5f4ca91adb1e1e71cf4930fef5e6909f46c2180d65cce37d0"
 dependencies = [
  "gimli 0.28.0",
  "hashbrown 0.14.3",
  "log",
  "object 0.32.2",
- "polkavm-common",
+ "polkavm-common 0.5.0",
+ "regalloc2 0.9.3",
  "rustc-demangle",
 ]
 
@@ -14589,6 +14596,19 @@ checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
 dependencies = [
  "fxhash",
  "log",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
  "slice-group-by",
  "smallvec",
 ]

--- a/substrate/frame/contracts/fixtures/Cargo.toml
+++ b/substrate/frame/contracts/fixtures/Cargo.toml
@@ -21,7 +21,7 @@ parity-wasm = "0.45.0"
 tempfile = "3.8.1"
 toml = "0.8.2"
 twox-hash = "1.6.3"
-polkavm-linker = { version = "0.4.0", optional = true }
+polkavm-linker = { version = "0.5.0", optional = true }
 anyhow = "1.0.0"
 
 [features]

--- a/substrate/frame/contracts/fixtures/build/Cargo.toml
+++ b/substrate/frame/contracts/fixtures/build/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 uapi = { package = 'pallet-contracts-uapi', path = "", default-features = false }
 common = { package = 'pallet-contracts-fixtures-common', path = "" }
-polkavm-derive = '0.4.0'
+polkavm-derive = '0.5.0'
 
 [profile.release]
 opt-level = 3

--- a/substrate/frame/contracts/fixtures/build/riscv_memory_layout.ld
+++ b/substrate/frame/contracts/fixtures/build/riscv_memory_layout.ld
@@ -1,4 +1,0 @@
-SECTIONS {
-    .text : { KEEP(*(.text.polkavm_export)) }
-}
-


### PR DESCRIPTION
This will allow us to change to the target supporting atomics and makes the linker file no longer necessary.