### PR TITLE
Revert "pallet-core-fellowship: import an unimported member on approve"

### DIFF
--- a/prdoc/pr_2883.prdoc
+++ b/prdoc/pr_2883.prdoc
@@ -1,9 +1,0 @@
-title: "pallet-core-fellowship: import an unimported on approve"
-
-doc:
-  - audience: Runtime User
-    description: |
-      To align with the documentation of the approve call, we import an untracked member on approval.
-
-crates:
-  - name: "pallet-core-fellowship"

--- a/substrate/frame/core-fellowship/src/lib.rs
+++ b/substrate/frame/core-fellowship/src/lib.rs
@@ -362,8 +362,7 @@ pub mod pallet {
 		///
 		/// This resets `last_proof` to the current block, thereby delaying any automatic demotion.
 		///
-		/// If `who` is not already tracked by this pallet, then it will become tracked.
-		/// `last_promotion` will be set to zero.
+		/// `who` must already be tracked by this pallet for this to have an effect.
 		///
 		/// - `origin`: An origin which satisfies `ApproveOrigin` or root.
 		/// - `who`: A member (i.e. of non-zero rank).

--- a/substrate/frame/core-fellowship/src/lib.rs
+++ b/substrate/frame/core-fellowship/src/lib.rs
@@ -382,11 +382,7 @@ pub mod pallet {
 			ensure!(at_rank > 0, Error::<T, I>::InvalidRank);
 			let rank = T::Members::rank_of(&who).ok_or(Error::<T, I>::Unranked)?;
 			ensure!(rank == at_rank, Error::<T, I>::UnexpectedRank);
-			let mut member = if let Some(m) = Member::<T, I>::get(&who) {
-				m
-			} else {
-				Self::import_member(who.clone(), rank)
-			};
+			let mut member = Member::<T, I>::get(&who).ok_or(Error::<T, I>::NotTracked)?;
 
 			member.last_proof = frame_system::Pallet::<T>::block_number();
 			Member::<T, I>::insert(&who, &member);
@@ -522,7 +518,13 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 			ensure!(!Member::<T, I>::contains_key(&who), Error::<T, I>::AlreadyInducted);
 			let rank = T::Members::rank_of(&who).ok_or(Error::<T, I>::Unranked)?;
-			let _ = Self::import_member(who, rank);
+
+			let now = frame_system::Pallet::<T>::block_number();
+			Member::<T, I>::insert(
+				&who,
+				MemberStatus { is_active: true, last_promotion: 0u32.into(), last_proof: now },
+			);
+			Self::deposit_event(Event::<T, I>::Imported { who, rank });
 
 			Ok(Pays::No.into())
 		}
@@ -545,18 +547,6 @@ pub mod pallet {
 				let e = Event::<T, I>::EvidenceJudged { who, wish, evidence, old_rank, new_rank };
 				Self::deposit_event(e);
 			}
-		}
-
-		fn import_member(who: T::AccountId, rank: RankOf<T, I>) -> MemberStatusOf<T> {
-			let now = frame_system::Pallet::<T>::block_number();
-			let status = MemberStatus {
-				is_active: true,
-				last_promotion: BlockNumberFor::<T>::zero(),
-				last_proof: now,
-			};
-			Member::<T, I>::insert(&who, status.clone());
-			Self::deposit_event(Event::<T, I>::Imported { who, rank });
-			status
 		}
 	}
 

--- a/substrate/frame/core-fellowship/src/tests.rs
+++ b/substrate/frame/core-fellowship/src/tests.rs
@@ -378,11 +378,3 @@ fn active_changing_get_salary_works() {
 		}
 	});
 }
-
-#[test]
-fn approve_imports_not_tracked_member() {
-	new_test_ext().execute_with(|| {
-		set_rank(10, 5);
-		assert_ok!(CoreFellowship::approve(signed(5), 10, 5));
-	});
-}


### PR DESCRIPTION
Reverts paritytech/polkadot-sdk#2883

Code, not docs, was intended.