### PR TITLE
Introduce `BlockWeightsForAsyncBacking` and `MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING` to bridges primitives

### DIFF
--- a/bridges/primitives/chain-bridge-hub-cumulus/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-cumulus/src/lib.rs
@@ -54,6 +54,14 @@ const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(constants::WEIGHT_REF_TI
 	.saturating_div(2)
 	.set_proof_size(polkadot_primitives::MAX_POV_SIZE as u64);
 
+/// We allow for 2 seconds of compute with a 6 second average block.
+///
+/// This is a copy-paste from the `polkadot-sdk` repo where all system parachains are switched to async backing (https://github.com/paritytech/polkadot-sdk/pull/2949).
+const MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING: Weight = Weight::from_parts(
+	constants::WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
+	polkadot_primitives::MAX_POV_SIZE as u64,
+);
+
 /// All cumulus bridge hubs assume that about 5 percent of the block weight is consumed by
 /// `on_initialize` handlers. This is used to limit the maximal weight of a single extrinsic.
 ///
@@ -87,6 +95,25 @@ parameter_types! {
 			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT`.
 			weights.reserved = Some(
 				MAXIMUM_BLOCK_WEIGHT - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT,
+			);
+		})
+		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
+		.build_or_panic();
+
+	pub BlockWeightsForAsyncBacking: limits::BlockWeights = limits::BlockWeights::builder()
+		.base_block(BlockExecutionWeight::get())
+		.for_class(DispatchClass::all(), |weights| {
+			weights.base_extrinsic = ExtrinsicBaseWeight::get();
+		})
+		.for_class(DispatchClass::Normal, |weights| {
+			weights.max_total = Some(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING);
+		})
+		.for_class(DispatchClass::Operational, |weights| {
+			weights.max_total = Some(MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING);
+			// Operational transactions have an extra reserved space, so that they
+			// are included even if block reached `MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING`.
+			weights.reserved = Some(
+				MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING - NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING,
 			);
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)

--- a/bridges/primitives/chain-bridge-hub-cumulus/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-cumulus/src/lib.rs
@@ -55,8 +55,7 @@ const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(constants::WEIGHT_REF_TI
 	.set_proof_size(polkadot_primitives::MAX_POV_SIZE as u64);
 
 /// We allow for 2 seconds of compute with a 6 second average block.
-///
-/// This is a copy-paste from the `polkadot-sdk` repo where all system parachains are switched to async backing (https://github.com/paritytech/polkadot-sdk/pull/2949).
+/// This is a copy-paste of system parachain runtimes switched to async backing (https://github.com/paritytech/polkadot-sdk/pull/2949).
 const MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING: Weight = Weight::from_parts(
 	constants::WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
 	polkadot_primitives::MAX_POV_SIZE as u64,

--- a/bridges/primitives/chain-bridge-hub-cumulus/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-cumulus/src/lib.rs
@@ -55,6 +55,7 @@ const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(constants::WEIGHT_REF_TI
 	.set_proof_size(polkadot_primitives::MAX_POV_SIZE as u64);
 
 /// We allow for 2 seconds of compute with a 6 second average block.
+///
 /// This is a copy-paste of system parachain runtimes switched to async backing (https://github.com/paritytech/polkadot-sdk/pull/2949).
 const MAXIMUM_BLOCK_WEIGHT_FOR_ASYNC_BACKING: Weight = Weight::from_parts(
 	constants::WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),

--- a/bridges/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -47,7 +47,7 @@ impl Chain for BridgeHubRococo {
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		BlockWeights::get()
+		BlockWeightsForAsyncBacking::get()
 			.get(DispatchClass::Normal)
 			.max_extrinsic
 			.unwrap_or(Weight::MAX)

--- a/bridges/primitives/chain-bridge-hub-westend/src/lib.rs
+++ b/bridges/primitives/chain-bridge-hub-westend/src/lib.rs
@@ -47,7 +47,7 @@ impl Chain for BridgeHubWestend {
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		BlockWeights::get()
+		BlockWeightsForAsyncBacking::get()
 			.get(DispatchClass::Normal)
 			.max_extrinsic
 			.unwrap_or(Weight::MAX)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
@@ -302,7 +302,7 @@ mod tests {
 		>(AssertCompleteBridgeConstants {
 			this_chain_constants: AssertChainConstants {
 				block_length: bp_bridge_hub_rococo::BlockLength::get(),
-				block_weights: bp_bridge_hub_rococo::BlockWeights::get(),
+				block_weights: bp_bridge_hub_rococo::BlockWeightsForAsyncBacking::get(),
 			},
 			messages_pallet_constants: AssertBridgeMessagesPalletConstants {
 				max_unrewarded_relayers_in_bridged_confirmation_tx:

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
@@ -337,7 +337,7 @@ mod tests {
 		>(AssertCompleteBridgeConstants {
 			this_chain_constants: AssertChainConstants {
 				block_length: bp_bridge_hub_westend::BlockLength::get(),
-				block_weights: bp_bridge_hub_westend::BlockWeights::get(),
+				block_weights: bp_bridge_hub_westend::BlockWeightsForAsyncBacking::get(),
 			},
 			messages_pallet_constants: AssertBridgeMessagesPalletConstants {
 				max_unrewarded_relayers_in_bridged_confirmation_tx:


### PR DESCRIPTION
Fixes: https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/4943591