### PR TITLE
Downgrade logging to `debug`

### DIFF
--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -3343,7 +3343,7 @@ async fn issue_approval<Context>(
 		);
 	}
 
-	gum::info!(
+	gum::debug!(
 		target: LOG_TARGET,
 		?candidate_hash,
 		?block_hash,


### PR DESCRIPTION
There is no need to spawn operators with this debug log.

Closes: https://github.com/paritytech/polkadot-sdk/issues/2974