### PR TITLE
pallet-contracts: Fix compilation on latest nightly

### DIFF
--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -1228,6 +1228,9 @@ struct InternalOutput<T: Config, O> {
 	result: Result<O, ExecError>,
 }
 
+// Set up a global reference to the boolean flag used for the re-entrancy guard.
+environmental!(executing_contract: bool);
+
 /// Helper trait to wrap contract execution entry points into a single function
 /// [`Invokable::run_guarded`].
 trait Invokable<T: Config>: Sized {
@@ -1243,9 +1246,6 @@ trait Invokable<T: Config>: Sized {
 	/// We enforce a re-entrancy guard here by initializing and checking a boolean flag through a
 	/// global reference.
 	fn run_guarded(self, common: CommonInput<T>) -> InternalOutput<T, Self::Output> {
-		// Set up a global reference to the boolean flag used for the re-entrancy guard.
-		environmental!(executing_contract: bool);
-
 		let gas_limit = common.gas_limit;
 
 		// Check whether the origin is allowed here. The logic of the access rules


### PR DESCRIPTION
Apparently they changed detection for visibility identifiers on traits, which broke more than it should. There is an issue open: https://github.com/rust-lang/rust/issues/119924 The easy solution for us is to move the declaration of the global variable outside of the trait.

Closes: https://github.com/paritytech/polkadot-sdk/issues/2960