### PR TITLE
`GenesisBuilder`: `arbitrary_precision` feature enabled for `serde_json`

### DIFF
--- a/substrate/primitives/genesis-builder/Cargo.toml
+++ b/substrate/primitives/genesis-builder/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 sp-api = { path = "../api", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }
 sp-std = { path = "../std", default-features = false }
-serde_json = { version = "1.0.111", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.111", default-features = false, features = ["alloc", "arbitrary_precision"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
[`arbitrary_precision`](https://github.com/serde-rs/json/blob/6d44b9fac9269b4decf76acac5d68e8ec9d10c58/Cargo.toml#L69-L75) feature allows to (de-)serialize big numbers w/o error. 
For some details refer also to https://github.com/paritytech/polkadot-sdk/pull/1256#discussion_r1455564450

fixes: #2963