### PR TITLE
[Example] Pure `md` files with docify for `rustdoc` and `mdbook` compatible format

### DIFF
--- a/docs/sdk/Cargo.toml
+++ b/docs/sdk/Cargo.toml
@@ -64,6 +64,7 @@ sp-runtime = { path = "../../substrate/primitives/runtime", optional = true }
 
 [features]
 default = ["min-docs", "docs-build-deps"]
+gen-docify = []
 min-docs = [
 	"simple-mermaid",
 	"docify",

--- a/docs/sdk/src/lib.rs
+++ b/docs/sdk/src/lib.rs
@@ -23,14 +23,12 @@
 //!
 //! This section paints a picture over the high-level information architecture of this crate.
 #![doc = simple_mermaid::mermaid!("../../mermaid/IA.mmd")]
-
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 // Overide above deny if no deps are being built
 #![cfg(not(feature = "docs-build-deps"))]
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
-
 
 /// Meta information about this crate, how it is built, what principles dictates its evolution and
 /// how one can contribute to it.

--- a/docs/sdk/src/meta_contributing.rs
+++ b/docs/sdk/src/meta_contributing.rs
@@ -134,13 +134,14 @@
 //!
 //! ## How to Develop Locally
 //!
-//! To expedite documentation development and view _only_ the docs specific [`crate`] locally for development, including the correct HTML headers injected, run:
+//! To expedite documentation development and view _only_ the docs specific [`crate`] locally for
+//! development, including the correct HTML headers injected, run:
 //!
 //! ```sh
 //! # (Fastest) HTML ONLY - Only build the documentation crate, with MINIMAL code compilation.
 //! RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --no-default-features -F min-docs --no-deps --open
 //!
-//! # SDK Docs only - Minimal build - Only build the documentation crate, including code compilation for examples. 
+//! # SDK Docs only - Minimal build - Only build the documentation crate, including code compilation for examples.
 //! SKIP_WASM_BUILD=1 RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --no-deps --open
 //!
 //! # All docs, with external deps

--- a/docs/sdk/src/reference_docs/signed_extensions.docify.md
+++ b/docs/sdk/src/reference_docs/signed_extensions.docify.md
@@ -1,0 +1,8 @@
+Signed extensions are, briefly, a means for different chains to extend the "basic" extrinsic
+format with custom data that can be checked by the runtime.
+
+# Example
+
+Defining a couple of very simple signed extensions looks like the following:
+<!-- docify::embed!("./src/reference_docs/signed_extensions.rs", signed_extensions_example) -->
+

--- a/docs/sdk/src/reference_docs/signed_extensions.rs
+++ b/docs/sdk/src/reference_docs/signed_extensions.rs
@@ -1,10 +1,7 @@
-//! Signed extensions are, briefly, a means for different chains to extend the "basic" extrinsic
-//! format with custom data that can be checked by the runtime.
-//!
-//! # Example
-//!
-//! Defining a couple of very simple signed extensions looks like the following:
-#![doc = docify::embed!("./src/reference_docs/signed_extensions.rs", signed_extensions_example)]
+#![doc = include_str!("signed_extensions.md")]
+#[cfg(all(doc, feature = "gen-docify"))]
+docify::compile_markdown!("src/reference_docs/signed_extensions.docify.md", "src/reference_docs/signed_extensions.md");
+
 
 #[cfg(feature = "docs-build-deps")]
 #[docify::export]


### PR DESCRIPTION
## Motivation

Writing great docs in markdown in the context of a rust doc comment is not so great, mostly due to IDEs not having great LSPs, linters, formatters, etc. support for markdown in comments vs. true md files. It's also very cumbersome to use rustdoc to build HTML for docs (see #2937 for some ideas there).

To ease the development of writing great docs, pulling [md files that are included in rustdocs](https://stackoverflow.com/questions/57421461/how-to-include-an-arbitrary-markdown-file-as-a-documentation-attribute) with [md comments for `docify` to include updated and tested rust code](https://github.com/sam0x17/docify/blob/main/examples/markdown_source/index.md#this-is-a-book)

Nice thing with pure md is the protability as well: README that renders github (related to #2930) , includable in `mdbook` or other md tooling, that with docify includes updated, presumably CI tested, rust source code.

## Example

Targets #2937 but the key here is the diff on that to this branch: pure markdown files to write docs that are then `docify`-ed to include rust snippets and then those generated `.md` files can (as proper and full markdown files) be used in rustdocs _and_ pure md formats (like asked for in https://github.com/paritytech/polkadot-sdk-docs/issues/38 )

To see this in action with a hacky method (easy to improve if the general direction of this work is agreed on):

1. `docify` the `docs/sdk/src/reference_docs/signed_extensions.docify.md` file (this **will error out** as we are trying to include a md file about to be generated)
1. rerun the build without docify file generation to yield rustdocs

```sh
# Fails, but generates md files that we latter include:
cargo doc -p polkadot-sdk-docs --no-default-features -F min-docs,gen-docify --no-deps

# Rustdocs yielded, with generated files from above.
clear && RUSTDOCFLAGS="--html-in-header $(pwd)/docs/sdk/headers/toc.html" cargo doc -p polkadot-sdk-docs --no-default-features -F min-docs --no-deps --open
```



## Next steps

If this seems like a desirable direction, happy to work on a better workflow and make a meta_contributing guide with some examples of such. Also could be an interesting thing to introduce as a workflow to PBA in the Book there, as slides are pure md that could be used in the same way with tested code snippets imported from the SDK here.