### PR TITLE
Contract fixtures tests: fixe nightly version

### DIFF
--- a/substrate/frame/contracts/fixtures/build.rs
+++ b/substrate/frame/contracts/fixtures/build.rs
@@ -159,7 +159,7 @@ fn invoke_cargo_fmt<'a>(
 ) -> Result<()> {
 	// If rustfmt is not installed, skip the check.
 	if !Command::new("rustup")
-		.args(["run", "nightly", "rustfmt", "--version"])
+		.args(["nightly-2023-11-01", "run", "rustfmt", "--version"])
 		.output()
 		.map_or(false, |o| o.status.success())
 	{
@@ -167,7 +167,7 @@ fn invoke_cargo_fmt<'a>(
 	}
 
 	let fmt_res = Command::new("rustup")
-		.args(["run", "nightly", "rustfmt", "--check", "--config-path"])
+		.args(["nightly-2023-11-01", "run", "rustfmt", "--check", "--config-path"])
 		.arg(config_path)
 		.args(files)
 		.output()
@@ -182,7 +182,7 @@ fn invoke_cargo_fmt<'a>(
 	eprintln!("{}\n{}", stdout, stderr);
 	eprintln!(
 		"Fixtures files are not formatted.\n
-		Please run `rustup run nightly rustfmt --config-path {} {}/*.rs`",
+		Please run `rustup nightly-2023-11-01 run rustfmt --config-path {} {}/*.rs`",
 		config_path.display(),
 		contract_dir.display()
 	);


### PR DESCRIPTION
Using just `nightly` is too generic and can fail on different systems.  
Now its fixed to the nightly version of the CI.

Another way would be to use a toolchain file, since this already assumes `rustup`.
