### PR TITLE
sc-informant: Respect `--disable-log-color`

### DIFF
--- a/prdoc/pr_3009.prdoc
+++ b/prdoc/pr_3009.prdoc
@@ -1,0 +1,8 @@
+title: "sc-informant: Respect `--disable-log-color`"
+
+doc:
+  - audience: Node Operator
+    description: |
+      Fixes some places that weren't respecting the `--disable-log-color` CLI flag.
+
+crates: ["sc-informant", "sc-service"]

--- a/prdoc/pr_3009.prdoc
+++ b/prdoc/pr_3009.prdoc
@@ -5,4 +5,6 @@ doc:
     description: |
       Fixes some places that weren't respecting the `--disable-log-color` CLI flag.
 
-crates: ["sc-informant", "sc-service"]
+crates:
+  -name: "sc-informant"
+  -name: "sc-service"

--- a/prdoc/pr_3009.prdoc
+++ b/prdoc/pr_3009.prdoc
@@ -6,5 +6,5 @@ doc:
       Fixes some places that weren't respecting the `--disable-log-color` CLI flag.
 
 crates:
-  -name: "sc-informant"
-  -name: "sc-service"
+  - name: "sc-informant"
+  - name: "sc-service"

--- a/substrate/client/cli/src/config.rs
+++ b/substrate/client/cli/src/config.rs
@@ -27,8 +27,8 @@ use names::{Generator, Name};
 use sc_service::{
 	config::{
 		BasePath, Configuration, DatabaseSource, KeystoreConfig, NetworkConfiguration,
-		NodeKeyConfig, OffchainWorkerConfig, PrometheusConfig, PruningMode, Role, RpcMethods,
-		TelemetryEndpoints, TransactionPoolOptions, WasmExecutionMethod,
+		NodeKeyConfig, OffchainWorkerConfig, OutputFormat, PrometheusConfig, PruningMode, Role,
+		RpcMethods, TelemetryEndpoints, TransactionPoolOptions, WasmExecutionMethod,
 	},
 	BlocksPruning, ChainSpec, TracingReceiver,
 };
@@ -516,7 +516,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			announce_block: self.announce_block()?,
 			role,
 			base_path,
-			informant_output_format: Default::default(),
+			informant_output_format: OutputFormat { enable_color: !self.disable_log_color()? },
 			runtime_cache_size,
 		})
 	}

--- a/substrate/client/informant/src/display.rs
+++ b/substrate/client/informant/src/display.rs
@@ -142,37 +142,20 @@ impl<B: BlockT> InformantDisplay<B> {
 					("⚙️ ", format!("Preparing{}", speed), format!(", target=#{target}")),
 			};
 
-		if self.format.enable_color {
-			info!(
-				target: "substrate",
-				"{} {}{} ({} peers), best: #{} ({}), finalized #{} ({}), {} {}",
-				level,
-				Colour::White.bold().paint(&status),
-				target,
-				Colour::White.bold().paint(format!("{}", num_connected_peers)),
-				Colour::White.bold().paint(format!("{}", best_number)),
-				best_hash,
-				Colour::White.bold().paint(format!("{}", finalized_number)),
-				info.chain.finalized_hash,
-				Colour::Green.paint(format!("⬇ {}", TransferRateFormat(avg_bytes_per_sec_inbound))),
-				Colour::Red.paint(format!("⬆ {}", TransferRateFormat(avg_bytes_per_sec_outbound))),
-			)
-		} else {
-			info!(
-				target: "substrate",
-				"{} {}{} ({} peers), best: #{} ({}), finalized #{} ({}), ⬇ {} ⬆ {}",
-				level,
-				status,
-				target,
-				num_connected_peers,
-				best_number,
-				best_hash,
-				finalized_number,
-				info.chain.finalized_hash,
-				TransferRateFormat(avg_bytes_per_sec_inbound),
-				TransferRateFormat(avg_bytes_per_sec_outbound),
-			)
-		}
+		info!(
+			target: "substrate",
+			"{} {}{} ({} peers), best: #{} ({}), finalized #{} ({}), {} {}",
+			level,
+			self.format.print_with_color(Colour::White.bold(), status),
+			target,
+			self.format.print_with_color(Colour::White.bold(), num_connected_peers),
+			self.format.print_with_color(Colour::White.bold(), best_number),
+			best_hash,
+			self.format.print_with_color(Colour::White.bold(), finalized_number),
+			info.chain.finalized_hash,
+			self.format.print_with_color(Colour::Green, format!("⬇ {}", TransferRateFormat(avg_bytes_per_sec_inbound))),
+			self.format.print_with_color(Colour::Red, format!("⬆ {}", TransferRateFormat(avg_bytes_per_sec_outbound))),
+		)
 	}
 }
 

--- a/substrate/client/informant/src/lib.rs
+++ b/substrate/client/informant/src/lib.rs
@@ -18,7 +18,7 @@
 
 //! Console informant. Prints sync progress and block events. Runs on the calling thread.
 
-use ansi_term::Colour;
+use ansi_term::{Colour, Style};
 use futures::prelude::*;
 use futures_timer::Delay;
 use log::{debug, info, trace};
@@ -39,7 +39,7 @@ fn interval(duration: Duration) -> impl Stream<Item = ()> + Unpin {
 /// The format to print telemetry output in.
 #[derive(Clone, Debug)]
 pub struct OutputFormat {
-	/// Enable color output in logs.
+	/// Enable color output in log s.
 	///
 	/// Is enabled by default.
 	pub enable_color: bool,
@@ -48,6 +48,47 @@ pub struct OutputFormat {
 impl Default for OutputFormat {
 	fn default() -> Self {
 		Self { enable_color: true }
+	}
+}
+
+enum ColorOrStyle {
+	Color(Colour),
+	Style(Style),
+}
+
+impl From<Colour> for ColorOrStyle {
+	fn from(value: Colour) -> Self {
+		Self::Color(value)
+	}
+}
+
+impl From<Style> for ColorOrStyle {
+	fn from(value: Style) -> Self {
+		Self::Style(value)
+	}
+}
+
+impl ColorOrStyle {
+	fn paint(&self, data: String) -> impl Display {
+		match self {
+			Self::Color(c) => c.paint(data),
+			Self::Style(s) => s.paint(data),
+		}
+	}
+}
+
+impl OutputFormat {
+	/// Print with color if `self.enable_color == true`.
+	fn print_with_color(
+		&self,
+		color: impl Into<ColorOrStyle>,
+		data: impl ToString,
+	) -> impl Display {
+		if self.enable_color {
+			color.into().paint(data.to_string()).to_string()
+		} else {
+			data.to_string()
+		}
 	}
 }
 
@@ -89,11 +130,14 @@ where
 
 	futures::select! {
 		() = display_notifications.fuse() => (),
-		() = display_block_import(client).fuse() => (),
+		() = display_block_import(client, format).fuse() => (),
 	};
 }
 
-fn display_block_import<B: BlockT, C>(client: Arc<C>) -> impl Future<Output = ()>
+fn display_block_import<B: BlockT, C>(
+	client: Arc<C>,
+	format: OutputFormat,
+) -> impl Future<Output = ()>
 where
 	C: UsageProvider<B> + HeaderMetadata<B> + BlockchainEvents<B>,
 	<C as HeaderMetadata<B>>::Error: Display,
@@ -117,11 +161,11 @@ where
 				match maybe_ancestor {
 					Ok(ref ancestor) if ancestor.hash != *last_hash => info!(
 						"♻️  Reorg on #{},{} to #{},{}, common ancestor #{},{}",
-						Colour::Red.bold().paint(format!("{}", last_num)),
+						format.print_with_color(Colour::Red.bold(), last_num),
 						last_hash,
-						Colour::Green.bold().paint(format!("{}", n.header.number())),
+						format.print_with_color(Colour::Green.bold(), n.header.number()),
 						n.hash,
-						Colour::White.bold().paint(format!("{}", ancestor.number)),
+						format.print_with_color(Colour::White.bold(), ancestor.number),
 						ancestor.hash,
 					),
 					Ok(_) => {},
@@ -146,7 +190,7 @@ where
 			info!(
 				target: "substrate",
 				"✨ Imported #{} ({})",
-				Colour::White.bold().paint(format!("{}", n.header.number())),
+				format.print_with_color(Colour::White.bold(), n.header.number()),
 				n.hash,
 			);
 		}

--- a/substrate/client/informant/src/lib.rs
+++ b/substrate/client/informant/src/lib.rs
@@ -39,7 +39,7 @@ fn interval(duration: Duration) -> impl Stream<Item = ()> + Unpin {
 /// The format to print telemetry output in.
 #[derive(Clone, Debug)]
 pub struct OutputFormat {
-	/// Enable color output in log s.
+	/// Enable color output in logs.
 	///
 	/// Is enabled by default.
 	pub enable_color: bool,

--- a/substrate/client/service/src/config.rs
+++ b/substrate/client/service/src/config.rs
@@ -18,8 +18,11 @@
 
 //! Service configuration.
 
+use prometheus_endpoint::Registry;
+use sc_chain_spec::ChainSpec;
 pub use sc_client_db::{BlocksPruning, Database, DatabaseSource, PruningMode};
 pub use sc_executor::{WasmExecutionMethod, WasmtimeInstantiationStrategy};
+pub use sc_informant::OutputFormat;
 pub use sc_network::{
 	config::{
 		MultiaddrWithPeerId, NetworkConfiguration, NodeKeyConfig, NonDefaultSetConfig, ProtocolId,
@@ -30,9 +33,6 @@ pub use sc_network::{
 	},
 	Multiaddr,
 };
-
-use prometheus_endpoint::Registry;
-use sc_chain_spec::ChainSpec;
 pub use sc_telemetry::TelemetryEndpoints;
 pub use sc_transaction_pool::Options as TransactionPoolOptions;
 use sp_core::crypto::SecretString;
@@ -134,7 +134,7 @@ pub struct Configuration {
 	/// Base path of the configuration. This is shared between chains.
 	pub base_path: BasePath,
 	/// Configuration of the output format that the informant uses.
-	pub informant_output_format: sc_informant::OutputFormat,
+	pub informant_output_format: OutputFormat,
 	/// Maximum number of different runtime versions that can be cached.
 	pub runtime_cache_size: u8,
 }


### PR DESCRIPTION
Changes `sc-informant` to respect the `--disable-log-color` CLI flag.

Closes: https://github.com/paritytech/polkadot-sdk/issues/2795