### PR TITLE
Review: Remove audit rules

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -20,23 +20,6 @@ rules:
         teams:
           - core-devs
 
-  - name: Audit rules
-    type: basic
-    condition:
-      include:
-        - ^polkadot/runtime/common/.*
-        - ^polkadot/primitives/src\/.+\.rs$
-        - ^substrate/primitives/.*
-        - ^substrate/frame/.*
-      exclude:
-        - ^substrate\/frame\/.+\.md$
-    minApprovals: 1
-    allowedToSkipRule:
-      teams:
-        - core-devs
-    teams:
-      - srlabs
-
   - name: Core developers
     countAuthor: true
     condition:


### PR DESCRIPTION
Srlabs review is most of the times just blocking the merge, especially when the changes do not require any audit. This pr removes the requirement of srlabs to approve these prs.