### PR TITLE
add NotBefore variant for DispatchTime

### DIFF
--- a/substrate/frame/scheduler/src/lib.rs
+++ b/substrate/frame/scheduler/src/lib.rs
@@ -735,6 +735,8 @@ impl<T: Config> Pallet<T> {
 			// The current block has already completed it's scheduled tasks, so
 			// Schedule the task at lest one block after this current block.
 			DispatchTime::After(x) => now.saturating_add(x).saturating_add(One::one()),
+			// If x is future, schedule it at x, otherwise schedule it at the next block.
+			DispatchTime::NotBefore(x) => x.max(now.saturating_add(One::one())),
 		};
 
 		if when <= now {

--- a/substrate/frame/support/src/traits/schedule.rs
+++ b/substrate/frame/support/src/traits/schedule.rs
@@ -40,13 +40,16 @@ pub enum DispatchTime<BlockNumber> {
 	At(BlockNumber),
 	/// After specified number of blocks.
 	After(BlockNumber),
+	/// At or after specified block.
+	NotBefore(BlockNumber),
 }
 
-impl<BlockNumber: Saturating + Copy> DispatchTime<BlockNumber> {
+impl<BlockNumber: Saturating + Copy + Ord> DispatchTime<BlockNumber> {
 	pub fn evaluate(&self, since: BlockNumber) -> BlockNumber {
 		match &self {
 			Self::At(m) => *m,
 			Self::After(m) => m.saturating_add(since),
+			Self::NotBefore(m) => *m.max(&since),
 		}
 	}
 }


### PR DESCRIPTION
Useful for many cases.
For example, we cannot use `DispatchTime::At` for a proposal in OpenGov with block before the end of max voting time, otherwise there is a risk that the proposal will be executed after the `At` block and therefore cannot be dispatched at all.
`After` is not a good thing is some cases before it could be dispatched at any time (e.g. holiday).
`NotBefore` allow us to specify a date and if for some reason the voting takes the full duration, the proposal can still be enacted.

Let me know what do you think and then I will finish this.

TODO: 
- [ ] some tests
- [ ] PRdoc?