### PR TITLE
rpc-v2: Enable the `archive` class of methods

### DIFF
--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -320,6 +320,16 @@ pub enum BlocksPruning {
 	Some(u32),
 }
 
+impl BlocksPruning {
+	/// True if this is an archive pruning mode (either KeepAll or KeepFinalized).
+	pub fn is_archive(&self) -> bool {
+		match *self {
+			BlocksPruning::KeepAll | BlocksPruning::KeepFinalized => true,
+			BlocksPruning::Some(_) => false,
+		}
+	}
+}
+
 /// Where to find the database..
 #[derive(Debug, Clone)]
 pub enum DatabaseSource {

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -66,7 +66,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_finalizedHeight")]
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u64>;
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u128>;
 
 	/// Get the hashes of blocks from the given height.
 	///
@@ -77,7 +77,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_hashByHeight")]
-	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>>;
+	fn archive_unstable_hash_by_height(&self, height: u128) -> RpcResult<Vec<String>>;
 
 	/// Call into the Runtime API at a specified block's state.
 	///

--- a/substrate/client/rpc-spec-v2/src/archive/api.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/api.rs
@@ -66,7 +66,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_finalizedHeight")]
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u128>;
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u64>;
 
 	/// Get the hashes of blocks from the given height.
 	///
@@ -77,7 +77,7 @@ pub trait ArchiveApi<Hash> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[method(name = "archive_unstable_hashByHeight")]
-	fn archive_unstable_hash_by_height(&self, height: u128) -> RpcResult<Vec<String>>;
+	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>>;
 
 	/// Call into the Runtime API at a specified block's state.
 	///

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -104,7 +104,7 @@ impl<BE: Backend<Block>, Block: BlockT, Client> Archive<BE, Block, Client> {
 			backend,
 			genesis_hash,
 			storage_max_descendant_responses: config.max_queried_items,
-			storage_max_queried_items: config.max_reported_items,
+			storage_max_queried_items: config.max_queried_items,
 			_phantom: PhantomData,
 		}
 	}

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -160,11 +160,11 @@ where
 		Ok(Some(hex_string(&header.encode())))
 	}
 
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u64> {
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u128> {
 		Ok(self.client.info().finalized_number.saturated_into())
 	}
 
-	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>> {
+	fn archive_unstable_hash_by_height(&self, height: u128) -> RpcResult<Vec<String>> {
 		let height: NumberFor<Block> = U256::from(height)
 			.try_into()
 			.map_err(|_| ArchiveError::InvalidParam(format!("Invalid block height: {}", height)))?;

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -160,11 +160,11 @@ where
 		Ok(Some(hex_string(&header.encode())))
 	}
 
-	fn archive_unstable_finalized_height(&self) -> RpcResult<u128> {
+	fn archive_unstable_finalized_height(&self) -> RpcResult<u64> {
 		Ok(self.client.info().finalized_number.saturated_into())
 	}
 
-	fn archive_unstable_hash_by_height(&self, height: u128) -> RpcResult<Vec<String>> {
+	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>> {
 		let height: NumberFor<Block> = U256::from(height)
 			.try_into()
 			.map_err(|_| ArchiveError::InvalidParam(format!("Invalid block height: {}", height)))?;

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -103,7 +103,7 @@ impl<BE: Backend<Block>, Block: BlockT, Client> Archive<BE, Block, Client> {
 			client,
 			backend,
 			genesis_hash,
-			storage_max_descendant_responses: config.max_queried_items,
+			storage_max_descendant_responses: config.max_descendant_responses,
 			storage_max_queried_items: config.max_queried_items,
 			_phantom: PhantomData,
 		}

--- a/substrate/client/rpc-spec-v2/src/archive/archive.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive.rs
@@ -34,7 +34,7 @@ use sp_api::{CallApiAt, CallContext};
 use sp_blockchain::{
 	Backend as BlockChainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
-use sp_core::Bytes;
+use sp_core::{Bytes, U256};
 use sp_runtime::{
 	traits::{Block as BlockT, Header as HeaderT, NumberFor},
 	SaturatedConversion,
@@ -127,7 +127,6 @@ impl<BE, Block, Client> ArchiveApiServer<Block::Hash> for Archive<BE, Block, Cli
 where
 	Block: BlockT + 'static,
 	Block::Header: Unpin,
-	<<Block as BlockT>::Header as HeaderT>::Number: From<u64>,
 	BE: Backend<Block> + 'static,
 	Client: BlockBackend<Block>
 		+ ExecutorProvider<Block>
@@ -166,7 +165,10 @@ where
 	}
 
 	fn archive_unstable_hash_by_height(&self, height: u64) -> RpcResult<Vec<String>> {
-		let height: NumberFor<Block> = height.into();
+		let height: NumberFor<Block> = U256::from(height)
+			.try_into()
+			.map_err(|_| ArchiveError::InvalidParam(format!("Invalid block height: {}", height)))?;
+
 		let finalized_num = self.client.info().finalized_number;
 
 		if finalized_num >= height {

--- a/substrate/client/rpc-spec-v2/src/archive/archive_storage.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/archive_storage.rs
@@ -28,12 +28,12 @@ use crate::common::{
 	storage::{IterQueryType, QueryIter, Storage},
 };
 
-/// Generates the events of the `chainHead_storage` method.
+/// Generates the events of the `archive_storage` method.
 pub struct ArchiveStorage<Client, Block, BE> {
 	/// Storage client.
 	client: Storage<Client, Block, BE>,
-	/// The maximum number of reported items by the `archive_storage` at a time.
-	storage_max_reported_items: usize,
+	/// The maximum number of responses the API can return for a descendant query at a time.
+	storage_max_descendant_responses: usize,
 	/// The maximum number of queried items allowed for the `archive_storage` at a time.
 	storage_max_queried_items: usize,
 }
@@ -42,10 +42,14 @@ impl<Client, Block, BE> ArchiveStorage<Client, Block, BE> {
 	/// Constructs a new [`ArchiveStorage`].
 	pub fn new(
 		client: Arc<Client>,
-		storage_max_reported_items: usize,
+		storage_max_descendant_responses: usize,
 		storage_max_queried_items: usize,
 	) -> Self {
-		Self { client: Storage::new(client), storage_max_reported_items, storage_max_queried_items }
+		Self {
+			client: Storage::new(client),
+			storage_max_descendant_responses,
+			storage_max_queried_items,
+		}
 	}
 }
 
@@ -96,7 +100,7 @@ where
 						},
 						hash,
 						child_key.as_ref(),
-						self.storage_max_reported_items,
+						self.storage_max_descendant_responses,
 					) {
 						Ok((results, _)) => storage_results.extend(results),
 						Err(error) => return ArchiveStorageResult::err(error),
@@ -111,7 +115,7 @@ where
 						},
 						hash,
 						child_key.as_ref(),
-						self.storage_max_reported_items,
+						self.storage_max_descendant_responses,
 					) {
 						Ok((results, _)) => storage_results.extend(results),
 						Err(error) => return ArchiveStorageResult::err(error),

--- a/substrate/client/rpc-spec-v2/src/archive/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/mod.rs
@@ -32,3 +32,4 @@ pub mod archive;
 pub mod error;
 
 pub use api::ArchiveApiServer;
+pub use archive::{Archive, ArchiveConfig};

--- a/substrate/client/rpc-spec-v2/src/archive/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/archive/tests.rs
@@ -24,7 +24,10 @@ use crate::{
 	hex_string, MethodResult,
 };
 
-use super::{archive::Archive, *};
+use super::{
+	archive::{Archive, ArchiveConfig},
+	*,
+};
 
 use assert_matches::assert_matches;
 use codec::{Decode, Encode};
@@ -62,7 +65,7 @@ type Header = substrate_test_runtime_client::runtime::Header;
 type Block = substrate_test_runtime_client::runtime::Block;
 
 fn setup_api(
-	max_returned_items: usize,
+	max_descendant_responses: usize,
 	max_queried_items: usize,
 ) -> (Arc<Client<Backend>>, RpcModule<Archive<Backend, Block, Client<Backend>>>) {
 	let child_info = ChildInfo::new_default(CHILD_STORAGE_KEY);
@@ -74,9 +77,13 @@ fn setup_api(
 	let backend = builder.backend();
 	let client = Arc::new(builder.build());
 
-	let api =
-		Archive::new(client.clone(), backend, CHAIN_GENESIS, max_returned_items, max_queried_items)
-			.into_rpc();
+	let api = Archive::new(
+		client.clone(),
+		backend,
+		CHAIN_GENESIS,
+		ArchiveConfig { max_descendant_responses, max_queried_items },
+	)
+	.into_rpc();
 
 	(client, api)
 }

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -670,7 +670,7 @@ where
 	// An archive node that can respond to the `archive` RPC-v2 queries is a node with:
 	// - state pruning in archive mode: The storage of blocks is kept around
 	// - block pruning in archive mode: The block's body is kept around
-	let is_archive_node = config.state_pruning.map(|sp| sp.is_archive()).unwrap_or(false) &&
+	let is_archive_node = config.state_pruning.as_ref().map(|sp| sp.is_archive()).unwrap_or(false) &&
 		config.blocks_pruning.is_archive();
 	let genesis_hash = client.hash(Zero::zero()).ok().flatten().expect("Genesis block exists; qed");
 	let archive_v2 = sc_rpc_spec_v2::archive::Archive::new(

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -63,7 +63,9 @@ use sc_rpc::{
 	system::SystemApiServer,
 	DenyUnsafe, SubscriptionTaskExecutor,
 };
-use sc_rpc_spec_v2::{chain_head::ChainHeadApiServer, transaction::TransactionApiServer};
+use sc_rpc_spec_v2::{
+	archive::ArchiveApiServer, chain_head::ChainHeadApiServer, transaction::TransactionApiServer,
+};
 use sc_telemetry::{telemetry, ConnectionMessage, Telemetry, TelemetryHandle, SUBSTRATE_INFO};
 use sc_transaction_pool_api::{MaintainedTransactionPool, TransactionPool};
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
@@ -663,6 +665,8 @@ where
 		sc_rpc_spec_v2::chain_head::ChainHeadConfig::default(),
 	)
 	.into_rpc();
+
+	let archive_v2 = sc_rpc_spec_v2::archive::Archive::new(client.clone()).into_rpc();
 
 	let author = sc_rpc::author::Author::new(
 		client.clone(),

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -666,7 +666,15 @@ where
 	)
 	.into_rpc();
 
-	let archive_v2 = sc_rpc_spec_v2::archive::Archive::new(client.clone()).into_rpc();
+	let genesis_hash = client.hash(Zero::zero()).ok().flatten().expect("Genesis block exists; qed");
+	let archive_v2 = sc_rpc_spec_v2::archive::Archive::new(
+		client.clone(),
+		backend.clone(),
+		genesis_hash,
+		// Defaults to sensible limits for the `Archive`.
+		sc_rpc_spec_v2::archive::ArchiveConfig::default(),
+	)
+	.into_rpc();
 
 	let author = sc_rpc::author::Author::new(
 		client.clone(),
@@ -688,6 +696,7 @@ where
 	// Part of the RPC v2 spec.
 	rpc_api.merge(transaction_v2).map_err(|e| Error::Application(e.into()))?;
 	rpc_api.merge(chain_head_v2).map_err(|e| Error::Application(e.into()))?;
+	rpc_api.merge(archive_v2).map_err(|e| Error::Application(e.into()))?;
 
 	// Part of the old RPC spec.
 	rpc_api.merge(chain).map_err(|e| Error::Application(e.into()))?;


### PR DESCRIPTION

The [archive](https://github.com/paritytech/json-rpc-interface-spec/blob/main/src/api/archive.md) API is unstable and subject to change.

This PR enables the `archive` class of the RPC-V2 spec to substrate based chains.

The `archive` API is enabled for archive nodes: 
- the state of the blocks is in archive mode
- the block's bodies are in archive mode

While at it, this PR extends the `BlocksPrunning` enum with an `is_archive` helper to check if the pruning mode keeps the block's bodies for long enough.

Defaults used for the `archive` API:
- a maximum of 5 responses are provided for descendants queries (this is similar to chainHead)
- a maximum of 8 item queries are accepted at a time

Before stabilizing the API we should look into these defaults and adjust after collecting some data.