### PR TITLE
approval-voting: Move verbose log from debug to tracing

### DIFF
--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -2583,7 +2583,7 @@ where
 			_ => {},
 		}
 
-		gum::debug!(
+		gum::trace!(
 			target: LOG_TARGET,
 			validator_index = approval.validator.0,
 			candidate_hash = ?approved_candidate_hash,
@@ -2700,7 +2700,7 @@ where
 		let is_approved = check.is_approved(tick_now.saturating_sub(APPROVAL_DELAY));
 		if status.last_no_shows != 0 {
 			metrics.on_observed_no_shows(status.last_no_shows);
-			gum::debug!(
+			gum::trace!(
 				target: LOG_TARGET,
 				?candidate_hash,
 				?block_hash,


### PR DESCRIPTION
... it was like that before it was accidentally changed in https://github.com/paritytech/polkadot-sdk/commit/a84dd0dba58d51503b8942360aa4fb30a5a96af5