### PR TITLE
Add block header pruning.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20091,9 +20091,9 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
 dependencies = [
  "thiserror-impl",
 ]
@@ -20120,9 +20120,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -419,20 +419,6 @@ impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
 		Ok(self.storage.read().leaves.hashes())
 	}
 
-	fn displaced_leaves_after_finalizing(
-		&self,
-		block_number: NumberFor<Block>,
-	) -> sp_blockchain::Result<Vec<Block::Hash>> {
-		Ok(self
-			.storage
-			.read()
-			.leaves
-			.displaced_by_finalize_height(block_number)
-			.leaves()
-			.cloned()
-			.collect::<Vec<_>>())
-	}
-
 	fn children(&self, _parent_hash: Block::Hash) -> sp_blockchain::Result<Vec<Block::Hash>> {
 		unimplemented!()
 	}

--- a/substrate/client/cli/src/config.rs
+++ b/substrate/client/cli/src/config.rs
@@ -261,7 +261,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	fn blocks_pruning(&self) -> Result<BlocksPruning> {
 		self.pruning_params()
 			.map(|x| x.blocks_pruning())
-			.unwrap_or_else(|| Ok(BlocksPruning::KeepFinalized))
+			.unwrap_or_else(|| Ok(BlocksPruning::KeepFinalized { prune_headers: false }))
 	}
 
 	/// Get the chain ID (string).

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -465,6 +465,17 @@ pub fn read_header<Block: BlockT>(
 	}
 }
 
+/// Drop a header from the database.
+pub fn remove_header<Block: BlockT>(
+	transaction: &mut Transaction<DbHash>,
+	db: &dyn Database<DbHash>,
+	col_index: u32,
+	col: u32,
+	id: BlockId<Block>,
+) -> sp_blockchain::Result<()> {
+	remove_from_db(transaction, db, col_index, col, id)
+}
+
 /// Read meta from the database.
 pub fn read_meta<Block>(
 	db: &dyn Database<DbHash>,

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -973,8 +973,13 @@ where
 
 			// The stale heads are the leaves that will be displaced after the
 			// block is finalized.
-			let stale_heads =
-				self.backend.blockchain().displaced_leaves_after_finalizing(block_number)?;
+			let stale_heads = self
+				.backend
+				.blockchain()
+				.displaced_leaves_after_finalizing(hash, block_number)?
+				.into_iter()
+				.map(|(h, _)| h)
+				.collect();
 
 			let header = self
 				.backend

--- a/substrate/client/service/test/src/lib.rs
+++ b/substrate/client/service/test/src/lib.rs
@@ -240,7 +240,7 @@ fn node_config<
 		database: DatabaseSource::RocksDb { path: root.join("db"), cache_size: 128 },
 		trie_cache_maximum_size: Some(16 * 1024 * 1024),
 		state_pruning: Default::default(),
-		blocks_pruning: BlocksPruning::KeepFinalized,
+		blocks_pruning: BlocksPruning::KeepFinalized { prune_headers: false },
 		chain_spec: Box::new((*spec).clone()),
 		wasm_method: Default::default(),
 		wasm_runtime_overrides: Default::default(),

--- a/substrate/test-utils/client/src/lib.rs
+++ b/substrate/test-utils/client/src/lib.rs
@@ -100,8 +100,10 @@ impl<Block: BlockT, ExecutorDispatch, G: GenesisInit>
 
 	/// Create new `TestClientBuilder` with default backend and storage chain mode
 	pub fn with_tx_storage(blocks_pruning: u32) -> Self {
-		let backend =
-			Arc::new(Backend::new_test_with_tx_storage(BlocksPruning::Some(blocks_pruning), 0));
+		let backend = Arc::new(Backend::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: blocks_pruning, prune_headers: false },
+			0,
+		));
 		Self::with_backend(backend)
 	}
 }


### PR DESCRIPTION
This PR introduces block header pruning for blockchain-db. Original issue: https://github.com/paritytech/polkadot-sdk/issues/1570
This is a draft PR to show a possible solution while having several open questions.

Pruning block headers include:
- removing data from DB using `columns::KEY_LOOKUP`, `columns::HEADER`, and block hash.
- removing data from block header in-memory cache
- removing data from header metadata in-memory cache (the last two using `remove_header_metadata`)

The PR consists of two parts:
- change stale fork calculation: we needed this change because the previous algorithm relied on the block header persistence
- block header pruning:  we enable it using the new CLI argument `---prune-block-headers` which defaults to false

Open questions:
- What is the correct command to test the whole solution locally?
- Are there other places to clean data from during the block header pruning?
- The test `prune_blocks_on_finalize_and_reorg` marks several blocks in a row as finalized and commits the transaction later in contrast with `prune_blocks_on_finalize` which finalized every block in a separate transaction. If we modify `prune_blocks_on_finalize_and_reorg` test to query a header from the pruned fork we will get one, however, the database won't contain it. It seems that the cache gets polluted by dirty reads originating in meta updates because meta updates are saved separately and after the transaction. Is there a way to prevent it? I appreciate an advice here.

cc @nazar-pc @bkchr 