### PR TITLE
rpc-v2/tx: Rename `transaction` to `transactionWatch`

### DIFF
--- a/substrate/client/rpc-spec-v2/src/transaction/api.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/api.rs
@@ -29,8 +29,8 @@ pub trait TransactionApi<Hash: Clone> {
 	/// See [`TransactionEvent`](crate::transaction::event::TransactionEvent) for details on
 	/// transaction life cycle.
 	#[subscription(
-		name = "transaction_unstable_submitAndWatch" => "transaction_unstable_watchEvent",
-		unsubscribe = "transaction_unstable_unwatch",
+		name = "transactionWatch_unstable_submitAndWatch" => "transactionWatch_unstable_watchEvent",
+		unsubscribe = "transactionWatch_unstable_unwatch",
 		item = TransactionEvent<Hash>,
 	)]
 	fn submit_and_watch(&self, bytes: Bytes);


### PR DESCRIPTION
This PR backports the changes from https://github.com/paritytech/json-rpc-interface-spec/pull/107.

The `transaction` class becomes `transactionWatch`, and the other functionality remains the same.