### PR TITLE
statement-distribution: Ensure we deactivate leaves before activating

### DIFF
--- a/polkadot/node/network/statement-distribution/src/lib.rs
+++ b/polkadot/node/network/statement-distribution/src/lib.rs
@@ -319,8 +319,10 @@ impl<R: rand::Rng> StatementDistributionSubsystem<R> {
 				if let Some(ref activated) = activated {
 					let mode = prospective_parachains_mode(ctx.sender(), activated.hash).await?;
 					if let ProspectiveParachainsMode::Enabled { .. } = mode {
-						v2::handle_active_leaves_update(ctx, state, activated, mode).await?;
+						// Ensure we deactivate first, before we activate the new block.
+						// Activation can fail and then we would skip the deactivation.
 						v2::handle_deactivate_leaves(state, &deactivated);
+						v2::handle_active_leaves_update(ctx, state, activated, mode).await?;
 					} else if let ProspectiveParachainsMode::Disabled = mode {
 						for deactivated in &deactivated {
 							crate::legacy_v1::handle_deactivate_leaf(legacy_v1_state, *deactivated);


### PR DESCRIPTION
As activation can fail, we ensure that we don't miss deactivation of leaves.