### PR TITLE
test-runtime: json_patch dep removed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6831,17 +6831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
-name = "json-patch"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "jsonrpsee"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19593,13 +19582,13 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
- "json-patch",
  "log",
  "pallet-babe",
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "sc-block-builder",
+ "sc-chain-spec",
  "sc-executor",
  "sc-executor-common",
  "sc-service",

--- a/substrate/client/chain-spec/src/lib.rs
+++ b/substrate/client/chain-spec/src/lib.rs
@@ -338,6 +338,7 @@ pub use self::{
 		GenesisBlockBuilder,
 	},
 	genesis_config_builder::GenesisConfigBuilderRuntimeCaller,
+	json_patch::merge as json_merge,
 };
 pub use sc_chain_spec_derive::{ChainSpecExtension, ChainSpecGroup};
 

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -55,12 +55,12 @@ log = { version = "0.4.17", default-features = false }
 [dev-dependencies]
 futures = "0.3.21"
 sc-block-builder = { path = "../../client/block-builder" }
+sc-chain-spec = { path = "../../client/chain-spec" }
 sc-executor = { path = "../../client/executor" }
 sc-executor-common = { path = "../../client/executor/common" }
 sp-consensus = { path = "../../primitives/consensus/common" }
 substrate-test-runtime-client = { path = "client" }
 sp-tracing = { path = "../../primitives/tracing" }
-json-patch = { version = "1.0.0", default-features = false }
 serde = { version = "1.0.195", features = ["alloc", "derive"], default-features = false }
 serde_json = { version = "1.0.111", default-features = false, features = ["alloc"] }
 

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -1410,7 +1410,7 @@ mod tests {
 				}
 			});
 
-			json_patch::merge(&mut default_config, &patch);
+			sc_chain_spec::json_merge(&mut default_config, patch);
 
 			// Build genesis config using custom json:
 			let mut t = BasicExternalities::new_empty();


### PR DESCRIPTION
We don't need dependency on `json_patch` there is implementation of needed function in `sc_chain_spec` crate.
This PR makes this function publicly available and removes the dep.