### PR TITLE
 Enable asset Owner to mint tokens even if Asset (or account) is frozen

### DIFF
--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -410,19 +410,37 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		amount: T::Balance,
 		maybe_check_issuer: Option<T::AccountId>,
 	) -> DispatchResult {
-		Self::increase_balance(id.clone(), beneficiary, amount, |details| -> DispatchResult {
+
+		// Retrieve asset details to check if the asset is frozen
+		let asset_details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
+
+		// Check if the asset is frozen
+		let is_asset_frozen = asset_details.status == AssetStatus::Frozen;
+	
+		// Check if the beneficiary account is frozen
+		let is_account_frozen = Account::<T, I>::get(&id, beneficiary)
+			.map_or(false, |account| account.status == AccountStatus::Frozen);
+	
+		// If the asset or account is frozen, ensure the caller is the owner
+		if is_asset_frozen || is_account_frozen {
+			ensure!(maybe_check_issuer == Some(asset_details.owner), Error::<T, I>::NoPermission);
+		} else {
+			// Perform the regular issuer check for non-frozen assets/accounts
 			if let Some(check_issuer) = maybe_check_issuer {
-				ensure!(check_issuer == details.issuer, Error::<T, I>::NoPermission);
+				ensure!(check_issuer == asset_details.issuer, Error::<T, I>::NoPermission);
 			}
+		}
+	
+		// Proceed with increasing the balance and updating the supply
+		Self::increase_balance(id.clone(), beneficiary, amount, |details| -> DispatchResult {
 			debug_assert!(details.supply.checked_add(&amount).is_some(), "checked in prep; qed");
-
 			details.supply = details.supply.saturating_add(amount);
-
 			Ok(())
 		})?;
-
+	
+		// Emit the Issued event
 		Self::deposit_event(Event::Issued { asset_id: id, owner: beneficiary.clone(), amount });
-
+	
 		Ok(())
 	}
 

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -559,7 +559,7 @@ pub mod pallet {
 		/// The asset is a live asset and is actively being used. Usually emit for operations such
 		/// as `start_destroy` which require the asset to be in a destroying state.
 		LiveAsset,
-		/// The asset is not live, and likely being destroyed.
+		/// The asset is not live, and has been frozen or likely being destroyed.
 		AssetNotLive,
 		/// The asset status is not the expected status.
 		IncorrectStatus,
@@ -777,7 +777,7 @@ pub mod pallet {
 			let id: T::AssetId = id.into();
 			Self::do_mint(id, &beneficiary, amount, Some(origin))?;
 			Ok(())
-		}
+		} 
 
 		/// Reduce the balance of `who` by as much as possible up to `amount` assets of `id`.
 		///

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -756,6 +756,7 @@ pub mod pallet {
 		/// Mint assets of a particular class.
 		///
 		/// The origin must be Signed and the sender must be the Issuer of the asset `id`.
+		/// If the Asset or account is frozen then only the Owner of the entire asset can still mint. 
 		///
 		/// - `id`: The identifier of the asset to have some amount minted.
 		/// - `beneficiary`: The account to be credited with the minted assets.

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -150,6 +150,63 @@ fn minting_insufficient_assets_with_deposit_without_consumer_should_work() {
 }
 
 #[test]
+fn minting_by_owner_to_entirely_frozen_asset_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
+        assert_ok!(Assets::freeze_asset(RuntimeOrigin::signed(1), 0));
+        assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 2, 100));
+        assert_eq!(Assets::balance(0, 2), 100);
+        System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued {
+            asset_id: 0,
+            owner: 2,
+            amount: 100,
+        }));
+    });
+}
+
+#[test]
+fn minting_by_owner_to_frozen_account_works() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
+        assert_ok!(Assets::freeze(RuntimeOrigin::signed(1), 0, 2));
+        assert_ok!(Assets::mint(RuntimeOrigin::signed(1), 0, 2, 100));
+        assert_eq!(Assets::balance(0, 2), 100);
+        System::assert_last_event(RuntimeEvent::Assets(crate::Event::Issued {
+            asset_id: 0,
+            owner: 2,
+            amount: 100,
+        }));
+    });
+}
+
+#[test]
+fn minting_by_non_owner_to_entirely_frozen_asset_should_fail() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
+        assert_ok!(Assets::freeze_asset(RuntimeOrigin::signed(1), 0));
+        assert_noop!(
+            Assets::mint(RuntimeOrigin::signed(2), 0, 2, 100),
+            Error::<Test>::NoPermission
+        );
+        assert_eq!(Assets::balance(0, 2), 0);
+    });
+}
+
+#[test]
+fn minting_by_non_owner_to_frozen_account_should_fail() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
+        assert_ok!(Assets::freeze(RuntimeOrigin::signed(1), 0, 2));
+        assert_noop!(
+            Assets::mint(RuntimeOrigin::signed(2), 0, 2, 100),
+            Error::<Test>::NoPermission
+        );
+        assert_eq!(Assets::balance(0, 2), 0);
+    });
+}
+
+
+#[test]
 fn refunding_asset_deposit_with_burn_should_work() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));


### PR DESCRIPTION
This PR introduces changes to the `do_mint` function within the Assets pallet. 

The primary objective is to allow the owner of an asset to mint new tokens even when the asset (or specific accounts holding the asset), are frozen. 

Currently, when the **asset** is **frozen**:

- No one with any level of privilege can mint; 
- Or if an account is frozen no one with any level of privilege can mint to the account. 

This PR enables only the Owner of the asset, to be able to mint. A normal account, or issuer, admin or freezer, still would not be able to mint. 


### Why?
This is essential for assets that wish to mint tokens (such as a snapshot distribution) in its entirety, but keep it frozen, so that checks and verifications can be made before any account can move funds. This is also necessary for legal purposes, clearly delineating when an asset is _not live_ and _live_. 

### Real Use Case 
This issue showed up during the DED token distribution. 1.2m DED accounts needed to have asset minted, and had to be frozen. In order to fulfil this requirement, this costed extra fees by having to mint and freeze every account individually, and thereafter having to thaw every account individually, thereafter. 

## Changes Made:
**Modified `do_mint` Function only:** 

Updated the function to include checks that determine if the asset or the account is frozen. If so, the function now verifies whether the caller is the `owner` of the asset. If the caller is the `owner`, minting proceeds even if the asset/account is frozen._("owner of the asset" should not be confused with "owner of the account")._

**Added Tests:** 

Added new tests to ensure:

- Minting a token by the asset owner to a **frozen account**, (using freeze() is successful.
- Making sure that tokens minted by an address that is not the owner of the asset, to a **frozen account**, fails.

- Minting a token by the asset owner to **an entirely frozen asset** (using freeze_asset()), succeeds.
- Making sure that tokens minted to an address when the asset is entirely frozen, fails. 

These changes to `do_mint` should add no extra reads or writes to the pallet call. 