### PR TITLE
Backport of fix Pools 6->7 migration (#2942)

### DIFF
--- a/prdoc/pr_2942.prdoc
+++ b/prdoc/pr_2942.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fix pallet-nomination-pools v6 to v7 migration
+
+doc:
+  - audience: Node Dev
+    description: |
+      Restores the behaviour of the nomination pools `V6ToV7` migration so that it still works when
+      the pallet will be upgraded to V8 afterwards.
+
+crates:
+  - name: "pallet-nomination-pools"


### PR DESCRIPTION
This should result as a patched `25.0.1` version for https://crates.io/crates/pallet-nomination-pools/25.0.0.

Relates to: https://github.com/polkadot-fellows/runtimes/pull/159

