### PR TITLE
staking: Moves all `StakingLedger` logic to `staking/src/ledger.rs`

### DIFF
--- a/substrate/frame/staking/src/ledger.rs
+++ b/substrate/frame/staking/src/ledger.rs
@@ -31,30 +31,82 @@
 //! performed through the methods exposed by the [`StakingLedger`] implementation in order to ensure
 //! state consistency.
 
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	defensive,
-	traits::{LockableCurrency, WithdrawReasons},
+	traits::{Defensive, DefensiveSaturating, Get, LockableCurrency, WithdrawReasons},
+	BoundedVec, CloneNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
-use sp_staking::StakingAccount;
-use sp_std::prelude::*;
+use scale_info::TypeInfo;
+use sp_runtime::{traits::Zero, Perquintill, Rounding, Saturating};
+use sp_staking::{OnStakingUpdate, StakingAccount};
+use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use crate::{
-	BalanceOf, Bonded, Config, Error, Ledger, Payee, RewardDestination, StakingLedger, STAKING_ID,
+	log, BalanceOf, Bonded, Config, EraIndex, Error, Ledger, Payee, RewardDestination, UnlockChunk,
+	STAKING_ID,
 };
 
-#[cfg(any(feature = "runtime-benchmarks", test))]
-use sp_runtime::traits::Zero;
+/// The ledger of a (bonded) stash.
+///
+/// Note: All the reads and mutations to the [`Ledger`], [`Bonded`] and [`Payee`] storage items
+/// *MUST* be performed through the methods exposed by this struct, to ensure the consistency of
+/// ledger's data and corresponding staking lock
+#[derive(
+	PartialEqNoBound,
+	EqNoBound,
+	CloneNoBound,
+	Encode,
+	Decode,
+	RuntimeDebugNoBound,
+	TypeInfo,
+	MaxEncodedLen,
+)]
+#[scale_info(skip_type_params(T))]
+pub struct StakingLedger<T: Config> {
+	/// The stash account whose balance is actually locked and at stake.
+	pub stash: T::AccountId,
+
+	/// The total amount of the stash's balance that we are currently accounting for.
+	/// It's just `active` plus all the `unlocking` balances.
+	#[codec(compact)]
+	pub total: BalanceOf<T>,
+
+	/// The total amount of the stash's balance that will be at stake in any forthcoming
+	/// rounds.
+	#[codec(compact)]
+	pub active: BalanceOf<T>,
+
+	/// Any balance that is becoming free, which may eventually be transferred out of the stash
+	/// (assuming it doesn't get slashed first). It is assumed that this will be treated as a first
+	/// in, first out queue where the new (higher value) eras get pushed on the back.
+	pub unlocking: BoundedVec<UnlockChunk<BalanceOf<T>>, T::MaxUnlockingChunks>,
+
+	/// List of eras for which the stakers behind a validator have claimed rewards. Only updated
+	/// for validators.
+	///
+	/// This is deprecated as of V14 in favor of `T::ClaimedRewards` and will be removed in future.
+	/// Refer to issue <https://github.com/paritytech/polkadot-sdk/issues/433>
+	pub legacy_claimed_rewards: BoundedVec<EraIndex, T::HistoryDepth>,
+
+	/// The controller associated with this ledger's stash.
+	///
+	/// This is not stored on-chain, and is only bundled when the ledger is read from storage.
+	/// Use [`controller`] function to get the controller associated with the ledger.
+	#[codec(skip)]
+	controller: Option<T::AccountId>,
+}
 
 impl<T: Config> StakingLedger<T> {
 	#[cfg(any(feature = "runtime-benchmarks", test))]
-	pub fn default_from(stash: T::AccountId) -> Self {
+	pub fn default_from(stash: T::AccountId, ctrl: Option<T::AccountId>) -> Self {
 		Self {
 			stash: stash.clone(),
 			total: Zero::zero(),
 			active: Zero::zero(),
 			unlocking: Default::default(),
 			legacy_claimed_rewards: Default::default(),
-			controller: Some(stash),
+			controller: ctrl,
 		}
 	}
 
@@ -216,14 +268,213 @@ impl<T: Config> StakingLedger<T> {
 			Ok(())
 		})?
 	}
-}
 
-#[cfg(test)]
-use {
-	crate::UnlockChunk,
-	codec::{Decode, Encode, MaxEncodedLen},
-	scale_info::TypeInfo,
-};
+	/// Remove entries from `unlocking` that are sufficiently old and reduce the
+	/// total by the sum of their balances.
+	pub(crate) fn consolidate_unlocked(self, current_era: EraIndex) -> Self {
+		let mut total = self.total;
+		let unlocking: BoundedVec<_, _> = self
+			.unlocking
+			.into_iter()
+			.filter(|chunk| {
+				if chunk.era > current_era {
+					true
+				} else {
+					total = total.saturating_sub(chunk.value);
+					false
+				}
+			})
+			.collect::<Vec<_>>()
+			.try_into()
+			.expect(
+				"filtering items from a bounded vec always leaves length less than bounds. qed",
+			);
+
+		Self {
+			stash: self.stash,
+			total,
+			active: self.active,
+			unlocking,
+			legacy_claimed_rewards: self.legacy_claimed_rewards,
+			controller: self.controller,
+		}
+	}
+
+	/// Re-bond funds that were scheduled for unlocking.
+	///
+	/// Returns the updated ledger, and the amount actually rebonded.
+	pub(crate) fn rebond(mut self, value: BalanceOf<T>) -> (Self, BalanceOf<T>) {
+		let mut unlocking_balance = BalanceOf::<T>::zero();
+
+		while let Some(last) = self.unlocking.last_mut() {
+			if unlocking_balance.defensive_saturating_add(last.value) <= value {
+				unlocking_balance += last.value;
+				self.active += last.value;
+				self.unlocking.pop();
+			} else {
+				let diff = value.defensive_saturating_sub(unlocking_balance);
+
+				unlocking_balance += diff;
+				self.active += diff;
+				last.value -= diff;
+			}
+
+			if unlocking_balance >= value {
+				break
+			}
+		}
+
+		(self, unlocking_balance)
+	}
+
+	/// Slash the staker for a given amount of balance.
+	///
+	/// This implements a proportional slashing system, whereby we set our preference to slash as
+	/// such:
+	///
+	/// - If any unlocking chunks exist that are scheduled to be unlocked at `slash_era +
+	///   bonding_duration` and onwards, the slash is divided equally between the active ledger and
+	///   the unlocking chunks.
+	/// - If no such chunks exist, then only the active balance is slashed.
+	///
+	/// Note that the above is only a *preference*. If for any reason the active ledger, with or
+	/// without some portion of the unlocking chunks that are more justified to be slashed are not
+	/// enough, then the slashing will continue and will consume as much of the active and unlocking
+	/// chunks as needed.
+	///
+	/// This will never slash more than the given amount. If any of the chunks become dusted, the
+	/// last chunk is slashed slightly less to compensate. Returns the amount of funds actually
+	/// slashed.
+	///
+	/// `slash_era` is the era in which the slash (which is being enacted now) actually happened.
+	///
+	/// This calls `Config::OnStakingUpdate::on_slash` with information as to how the slash was
+	/// applied.
+	pub(crate) fn slash(
+		&mut self,
+		slash_amount: BalanceOf<T>,
+		minimum_balance: BalanceOf<T>,
+		slash_era: EraIndex,
+	) -> BalanceOf<T> {
+		if slash_amount.is_zero() {
+			return Zero::zero()
+		}
+
+		use sp_runtime::PerThing as _;
+		let mut remaining_slash = slash_amount;
+		let pre_slash_total = self.total;
+
+		// for a `slash_era = x`, any chunk that is scheduled to be unlocked at era `x + 28`
+		// (assuming 28 is the bonding duration) onwards should be slashed.
+		let slashable_chunks_start = slash_era.saturating_add(T::BondingDuration::get());
+
+		// `Some(ratio)` if this is proportional, with `ratio`, `None` otherwise. In both cases, we
+		// slash first the active chunk, and then `slash_chunks_priority`.
+		let (maybe_proportional, slash_chunks_priority) = {
+			if let Some(first_slashable_index) =
+				self.unlocking.iter().position(|c| c.era >= slashable_chunks_start)
+			{
+				// If there exists a chunk who's after the first_slashable_start, then this is a
+				// proportional slash, because we want to slash active and these chunks
+				// proportionally.
+
+				// The indices of the first chunk after the slash up through the most recent chunk.
+				// (The most recent chunk is at greatest from this era)
+				let affected_indices = first_slashable_index..self.unlocking.len();
+				let unbonding_affected_balance =
+					affected_indices.clone().fold(BalanceOf::<T>::zero(), |sum, i| {
+						if let Some(chunk) = self.unlocking.get(i).defensive() {
+							sum.saturating_add(chunk.value)
+						} else {
+							sum
+						}
+					});
+				let affected_balance = self.active.saturating_add(unbonding_affected_balance);
+				let ratio = Perquintill::from_rational_with_rounding(
+					slash_amount,
+					affected_balance,
+					Rounding::Up,
+				)
+				.unwrap_or_else(|_| Perquintill::one());
+				(
+					Some(ratio),
+					affected_indices.chain((0..first_slashable_index).rev()).collect::<Vec<_>>(),
+				)
+			} else {
+				// We just slash from the last chunk to the most recent one, if need be.
+				(None, (0..self.unlocking.len()).rev().collect::<Vec<_>>())
+			}
+		};
+
+		// Helper to update `target` and the ledgers total after accounting for slashing `target`.
+		log!(
+			debug,
+			"slashing {:?} for era {:?} out of {:?}, priority: {:?}, proportional = {:?}",
+			slash_amount,
+			slash_era,
+			self,
+			slash_chunks_priority,
+			maybe_proportional,
+		);
+
+		let mut slash_out_of = |target: &mut BalanceOf<T>, slash_remaining: &mut BalanceOf<T>| {
+			let mut slash_from_target = if let Some(ratio) = maybe_proportional {
+				ratio.mul_ceil(*target)
+			} else {
+				*slash_remaining
+			}
+			// this is the total that that the slash target has. We can't slash more than
+			// this anyhow!
+			.min(*target)
+			// this is the total amount that we would have wanted to slash
+			// non-proportionally, a proportional slash should never exceed this either!
+			.min(*slash_remaining);
+
+			// slash out from *target exactly `slash_from_target`.
+			*target = *target - slash_from_target;
+			if *target < minimum_balance {
+				// Slash the rest of the target if it's dust. This might cause the last chunk to be
+				// slightly under-slashed, by at most `MaxUnlockingChunks * ED`, which is not a big
+				// deal.
+				slash_from_target =
+					sp_std::mem::replace(target, Zero::zero()).saturating_add(slash_from_target)
+			}
+
+			self.total = self.total.saturating_sub(slash_from_target);
+			*slash_remaining = slash_remaining.saturating_sub(slash_from_target);
+		};
+
+		// If this is *not* a proportional slash, the active will always wiped to 0.
+		slash_out_of(&mut self.active, &mut remaining_slash);
+
+		let mut slashed_unlocking = BTreeMap::<_, _>::new();
+		for i in slash_chunks_priority {
+			if remaining_slash.is_zero() {
+				break
+			}
+
+			if let Some(chunk) = self.unlocking.get_mut(i).defensive() {
+				slash_out_of(&mut chunk.value, &mut remaining_slash);
+				// write the new slashed value of this chunk to the map.
+				slashed_unlocking.insert(chunk.era, chunk.value);
+			} else {
+				break
+			}
+		}
+
+		// clean unlocking chunks that are set to zero.
+		self.unlocking.retain(|c| !c.value.is_zero());
+
+		let final_slashed_amount = pre_slash_total.saturating_sub(self.total);
+		T::EventListeners::on_slash(
+			&self.stash,
+			self.active,
+			&slashed_unlocking,
+			final_slashed_amount,
+		);
+		final_slashed_amount
+	}
+}
 
 // This structs makes it easy to write tests to compare staking ledgers fetched from storage. This
 // is required because the controller field is not stored in storage and it is private.

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -305,23 +305,23 @@ use frame_support::{
 		ConstU32, Currency, Defensive, DefensiveMax, DefensiveSaturating, Get, LockIdentifier,
 	},
 	weights::Weight,
-	BoundedVec, CloneNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
+	BoundedVec, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
 use scale_info::TypeInfo;
 use sp_runtime::{
 	curve::PiecewiseLinear,
 	traits::{AtLeast32BitUnsigned, Convert, StaticLookup, Zero},
-	Perbill, Perquintill, Rounding, RuntimeDebug, Saturating,
+	Perbill, RuntimeDebug,
 };
 use sp_staking::{
 	offence::{Offence, OffenceError, ReportOffence},
-	EraIndex, ExposurePage, OnStakingUpdate, Page, PagedExposureMetadata, SessionIndex,
-	StakingAccount,
+	EraIndex, ExposurePage, Page, PagedExposureMetadata, SessionIndex, StakingAccount,
 };
 pub use sp_staking::{Exposure, IndividualExposure, StakerStatus};
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 pub use weights::WeightInfo;
 
+pub(crate) use crate::ledger::StakingLedger;
 pub use pallet::{pallet::*, UseNominatorsAndValidatorsMap, UseValidatorsMap};
 
 pub(crate) const STAKING_ID: LockIdentifier = *b"staking ";
@@ -429,268 +429,6 @@ pub struct UnlockChunk<Balance: HasCompact + MaxEncodedLen> {
 	/// Era number at which point it'll be unlocked.
 	#[codec(compact)]
 	era: EraIndex,
-}
-
-/// The ledger of a (bonded) stash.
-///
-/// Note: All the reads and mutations to the [`Ledger`], [`Bonded`] and [`Payee`] storage items
-/// *MUST* be performed through the methods exposed by this struct, to ensure the consistency of
-/// ledger's data and corresponding staking lock
-///
-/// TODO: move struct definition and full implementation into `/src/ledger.rs`. Currently
-/// leaving here to enforce a clean PR diff, given how critical this logic is. Tracking issue
-/// <https://github.com/paritytech/substrate/issues/14749>.
-#[derive(
-	PartialEqNoBound,
-	EqNoBound,
-	CloneNoBound,
-	Encode,
-	Decode,
-	RuntimeDebugNoBound,
-	TypeInfo,
-	MaxEncodedLen,
-)]
-#[scale_info(skip_type_params(T))]
-pub struct StakingLedger<T: Config> {
-	/// The stash account whose balance is actually locked and at stake.
-	pub stash: T::AccountId,
-
-	/// The total amount of the stash's balance that we are currently accounting for.
-	/// It's just `active` plus all the `unlocking` balances.
-	#[codec(compact)]
-	pub total: BalanceOf<T>,
-
-	/// The total amount of the stash's balance that will be at stake in any forthcoming
-	/// rounds.
-	#[codec(compact)]
-	pub active: BalanceOf<T>,
-
-	/// Any balance that is becoming free, which may eventually be transferred out of the stash
-	/// (assuming it doesn't get slashed first). It is assumed that this will be treated as a first
-	/// in, first out queue where the new (higher value) eras get pushed on the back.
-	pub unlocking: BoundedVec<UnlockChunk<BalanceOf<T>>, T::MaxUnlockingChunks>,
-
-	/// List of eras for which the stakers behind a validator have claimed rewards. Only updated
-	/// for validators.
-	///
-	/// This is deprecated as of V14 in favor of `T::ClaimedRewards` and will be removed in future.
-	/// Refer to issue <https://github.com/paritytech/polkadot-sdk/issues/433>
-	pub legacy_claimed_rewards: BoundedVec<EraIndex, T::HistoryDepth>,
-
-	/// The controller associated with this ledger's stash.
-	///
-	/// This is not stored on-chain, and is only bundled when the ledger is read from storage.
-	/// Use [`controller`] function to get the controller associated with the ledger.
-	#[codec(skip)]
-	controller: Option<T::AccountId>,
-}
-
-impl<T: Config> StakingLedger<T> {
-	/// Remove entries from `unlocking` that are sufficiently old and reduce the
-	/// total by the sum of their balances.
-	fn consolidate_unlocked(self, current_era: EraIndex) -> Self {
-		let mut total = self.total;
-		let unlocking: BoundedVec<_, _> = self
-			.unlocking
-			.into_iter()
-			.filter(|chunk| {
-				if chunk.era > current_era {
-					true
-				} else {
-					total = total.saturating_sub(chunk.value);
-					false
-				}
-			})
-			.collect::<Vec<_>>()
-			.try_into()
-			.expect(
-				"filtering items from a bounded vec always leaves length less than bounds. qed",
-			);
-
-		Self {
-			stash: self.stash,
-			total,
-			active: self.active,
-			unlocking,
-			legacy_claimed_rewards: self.legacy_claimed_rewards,
-			controller: self.controller,
-		}
-	}
-
-	/// Re-bond funds that were scheduled for unlocking.
-	///
-	/// Returns the updated ledger, and the amount actually rebonded.
-	fn rebond(mut self, value: BalanceOf<T>) -> (Self, BalanceOf<T>) {
-		let mut unlocking_balance = BalanceOf::<T>::zero();
-
-		while let Some(last) = self.unlocking.last_mut() {
-			if unlocking_balance.defensive_saturating_add(last.value) <= value {
-				unlocking_balance += last.value;
-				self.active += last.value;
-				self.unlocking.pop();
-			} else {
-				let diff = value.defensive_saturating_sub(unlocking_balance);
-
-				unlocking_balance += diff;
-				self.active += diff;
-				last.value -= diff;
-			}
-
-			if unlocking_balance >= value {
-				break
-			}
-		}
-
-		(self, unlocking_balance)
-	}
-
-	/// Slash the staker for a given amount of balance.
-	///
-	/// This implements a proportional slashing system, whereby we set our preference to slash as
-	/// such:
-	///
-	/// - If any unlocking chunks exist that are scheduled to be unlocked at `slash_era +
-	///   bonding_duration` and onwards, the slash is divided equally between the active ledger and
-	///   the unlocking chunks.
-	/// - If no such chunks exist, then only the active balance is slashed.
-	///
-	/// Note that the above is only a *preference*. If for any reason the active ledger, with or
-	/// without some portion of the unlocking chunks that are more justified to be slashed are not
-	/// enough, then the slashing will continue and will consume as much of the active and unlocking
-	/// chunks as needed.
-	///
-	/// This will never slash more than the given amount. If any of the chunks become dusted, the
-	/// last chunk is slashed slightly less to compensate. Returns the amount of funds actually
-	/// slashed.
-	///
-	/// `slash_era` is the era in which the slash (which is being enacted now) actually happened.
-	///
-	/// This calls `Config::OnStakingUpdate::on_slash` with information as to how the slash was
-	/// applied.
-	pub fn slash(
-		&mut self,
-		slash_amount: BalanceOf<T>,
-		minimum_balance: BalanceOf<T>,
-		slash_era: EraIndex,
-	) -> BalanceOf<T> {
-		if slash_amount.is_zero() {
-			return Zero::zero()
-		}
-
-		use sp_runtime::PerThing as _;
-		let mut remaining_slash = slash_amount;
-		let pre_slash_total = self.total;
-
-		// for a `slash_era = x`, any chunk that is scheduled to be unlocked at era `x + 28`
-		// (assuming 28 is the bonding duration) onwards should be slashed.
-		let slashable_chunks_start = slash_era.saturating_add(T::BondingDuration::get());
-
-		// `Some(ratio)` if this is proportional, with `ratio`, `None` otherwise. In both cases, we
-		// slash first the active chunk, and then `slash_chunks_priority`.
-		let (maybe_proportional, slash_chunks_priority) = {
-			if let Some(first_slashable_index) =
-				self.unlocking.iter().position(|c| c.era >= slashable_chunks_start)
-			{
-				// If there exists a chunk who's after the first_slashable_start, then this is a
-				// proportional slash, because we want to slash active and these chunks
-				// proportionally.
-
-				// The indices of the first chunk after the slash up through the most recent chunk.
-				// (The most recent chunk is at greatest from this era)
-				let affected_indices = first_slashable_index..self.unlocking.len();
-				let unbonding_affected_balance =
-					affected_indices.clone().fold(BalanceOf::<T>::zero(), |sum, i| {
-						if let Some(chunk) = self.unlocking.get(i).defensive() {
-							sum.saturating_add(chunk.value)
-						} else {
-							sum
-						}
-					});
-				let affected_balance = self.active.saturating_add(unbonding_affected_balance);
-				let ratio = Perquintill::from_rational_with_rounding(
-					slash_amount,
-					affected_balance,
-					Rounding::Up,
-				)
-				.unwrap_or_else(|_| Perquintill::one());
-				(
-					Some(ratio),
-					affected_indices.chain((0..first_slashable_index).rev()).collect::<Vec<_>>(),
-				)
-			} else {
-				// We just slash from the last chunk to the most recent one, if need be.
-				(None, (0..self.unlocking.len()).rev().collect::<Vec<_>>())
-			}
-		};
-
-		// Helper to update `target` and the ledgers total after accounting for slashing `target`.
-		log!(
-			debug,
-			"slashing {:?} for era {:?} out of {:?}, priority: {:?}, proportional = {:?}",
-			slash_amount,
-			slash_era,
-			self,
-			slash_chunks_priority,
-			maybe_proportional,
-		);
-
-		let mut slash_out_of = |target: &mut BalanceOf<T>, slash_remaining: &mut BalanceOf<T>| {
-			let mut slash_from_target = if let Some(ratio) = maybe_proportional {
-				ratio.mul_ceil(*target)
-			} else {
-				*slash_remaining
-			}
-			// this is the total that that the slash target has. We can't slash more than
-			// this anyhow!
-			.min(*target)
-			// this is the total amount that we would have wanted to slash
-			// non-proportionally, a proportional slash should never exceed this either!
-			.min(*slash_remaining);
-
-			// slash out from *target exactly `slash_from_target`.
-			*target = *target - slash_from_target;
-			if *target < minimum_balance {
-				// Slash the rest of the target if it's dust. This might cause the last chunk to be
-				// slightly under-slashed, by at most `MaxUnlockingChunks * ED`, which is not a big
-				// deal.
-				slash_from_target =
-					sp_std::mem::replace(target, Zero::zero()).saturating_add(slash_from_target)
-			}
-
-			self.total = self.total.saturating_sub(slash_from_target);
-			*slash_remaining = slash_remaining.saturating_sub(slash_from_target);
-		};
-
-		// If this is *not* a proportional slash, the active will always wiped to 0.
-		slash_out_of(&mut self.active, &mut remaining_slash);
-
-		let mut slashed_unlocking = BTreeMap::<_, _>::new();
-		for i in slash_chunks_priority {
-			if remaining_slash.is_zero() {
-				break
-			}
-
-			if let Some(chunk) = self.unlocking.get_mut(i).defensive() {
-				slash_out_of(&mut chunk.value, &mut remaining_slash);
-				// write the new slashed value of this chunk to the map.
-				slashed_unlocking.insert(chunk.era, chunk.value);
-			} else {
-				break
-			}
-		}
-
-		// clean unlocking chunks that are set to zero.
-		self.unlocking.retain(|c| !c.value.is_zero());
-
-		let final_slashed_amount = pre_slash_total.saturating_sub(self.total);
-		T::EventListeners::on_slash(
-			&self.stash,
-			self.active,
-			&slashed_unlocking,
-			final_slashed_amount,
-		);
-		final_slashed_amount
-	}
 }
 
 /// A record of the nominations made by a specific account.

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -809,7 +809,7 @@ pub(crate) fn bond_controller_stash(controller: AccountId, stash: AccountId) -> 
 	<Ledger<Test>>::get(&controller).map_or(Ok(()), |_| Err("controller already bonded"))?;
 
 	<Bonded<Test>>::insert(stash, controller);
-	<Ledger<Test>>::insert(controller, StakingLedger::<Test>::default_from(stash));
+	<Ledger<Test>>::insert(controller, StakingLedger::<Test>::default_from(stash, Some(stash)));
 
 	Ok(())
 }

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -1875,7 +1875,7 @@ impl<T: Config> Pallet<T> {
 					Ledger::<T>::get(ctrl.clone())
 						.expect("try_check: bonded stash/ctrl does not have an associated ledger")
 				});
-				ensure!(raw.controller.is_none(), "raw storage controller should be None");
+				ensure!(raw.controller().is_none(), "raw storage controller should be None");
 
 				// ensure ledger consistency.
 				Self::ensure_ledger_consistent(ctrl)


### PR DESCRIPTION
Moves all the `StakingLedger` struct definition and impl logic into `staking/src/ledger.rs`.

Closes https://github.com/paritytech/polkadot-sdk/issues/402