### PR TITLE
With many on-demand cores, performance in order processing is subpar

### DIFF
--- a/polkadot/primitives/src/v6/mod.rs
+++ b/polkadot/primitives/src/v6/mod.rs
@@ -393,7 +393,7 @@ pub const MAX_POV_SIZE: u32 = 5 * 1024 * 1024;
 /// Default queue size we use for the on-demand order book.
 ///
 /// Can be adjusted in configuration.
-pub const ON_DEMAND_DEFAULT_QUEUE_MAX_SIZE: u32 = 10_000;
+pub const ON_DEMAND_DEFAULT_QUEUE_MAX_SIZE: u32 = 500;
 
 /// Backing votes threshold used from the host prior to runtime API version 6 and from the runtime
 /// prior to v9 configuration migration.

--- a/polkadot/runtime/parachains/src/scheduler.rs
+++ b/polkadot/runtime/parachains/src/scheduler.rs
@@ -584,7 +584,8 @@ impl<T: Config> Pallet<T> {
 			return
 		}
 		// If there exists a core, ensure we schedule at least one job onto it.
-		let n_lookahead = Self::claimqueue_lookahead().max(1);
+		// TODO (now): Add a test for this. This wax `max` and nobody noticed.
+		let n_lookahead = Self::claimqueue_lookahead().min(1);
 		let n_session_cores = T::AssignmentProvider::session_core_count();
 		let cq = ClaimQueue::<T>::get();
 		let ttl = <configuration::Pallet<T>>::config().on_demand_ttl;


### PR DESCRIPTION
This is a first rudimentary fix. Actual implementation perf improvements are no their way.

This also includes a fix where we used max instead of min: Will become significant once we have >1 claimqueues.