### PR TITLE
Remove `forklift clean` call from CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,6 @@ default:
       fi
     - ls -al
     - rm -f forklift.sock
-    - forklift clean
     #
     - echo "FL_FORKLIFT_VERSION ${FL_FORKLIFT_VERSION}"
     - echo "FORKLIFT_PACKAGE_SUFFIX $FORKLIFT_PACKAGE_SUFFIX"


### PR DESCRIPTION
In CI jobs I see calls to `forklift clean`, which apparently does not exist. 
From CI logs:
```
1m$ forklift clean[0;m
Cargo cache management utility

Usage:
  forklift [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  serve       Run forklift coordinator server for current location
  start       Start detached forklift coordinator server for current location
  stop        Stop forklift coordinator server for current location

Flags:
  -c, --compression string     Compression algorithm to use
                               Available: none, xz (default "zstd")
  -h, --help                   help for forklift
  -p, --param stringToString   map of additional parameters
                                ex: -p S3_BUCKET_NAME=my_bucket (default [])
  -s, --storage string         Storage driver
                               Available: s3, fs (default "s3")
  -v, --verbose string         Available: panic, fatal, error, warn, warning, info, debug, trace (default "info")
      --version                version for forklift

Use "forklift [command] --help" for more information about a command.
```