### PR TITLE
Fix for `poeple-*` benchmarks command + added them to CI

### DIFF
--- a/.gitlab/pipeline/short-benchmarks.yml
+++ b/.gitlab/pipeline/short-benchmarks.yml
@@ -84,6 +84,16 @@ short-benchmark-coretime-westend:
   variables:
     RUNTIME_CHAIN: coretime-westend-dev
 
+short-benchmark-people-rococo:
+  <<: *short-bench-cumulus
+  variables:
+    RUNTIME_CHAIN: people-rococo-dev
+
+short-benchmark-people-westend:
+  <<: *short-bench-cumulus
+  variables:
+    RUNTIME_CHAIN: people-westend-dev
+
 short-benchmark-glutton-westend:
   <<: *short-bench-cumulus
   variables:

--- a/cumulus/polkadot-parachain/src/chain_spec/people.rs
+++ b/cumulus/polkadot-parachain/src/chain_spec/people.rs
@@ -112,7 +112,7 @@ pub mod rococo {
 
 	pub(crate) const PEOPLE_ROCOCO: &str = "people-rococo";
 	pub(crate) const PEOPLE_ROCOCO_LOCAL: &str = "people-rococo-local";
-	pub(crate) const PEOPLE_ROCOCO_DEVELOPMENT: &str = "people-rococo-development";
+	pub(crate) const PEOPLE_ROCOCO_DEVELOPMENT: &str = "people-rococo-dev";
 	const PEOPLE_ROCOCO_ED: PeopleBalance = people_rococo_runtime::ExistentialDeposit::get();
 
 	pub fn local_config(
@@ -222,7 +222,7 @@ pub mod westend {
 
 	pub(crate) const PEOPLE_WESTEND: &str = "people-westend";
 	pub(crate) const PEOPLE_WESTEND_LOCAL: &str = "people-westend-local";
-	pub(crate) const PEOPLE_WESTEND_DEVELOPMENT: &str = "people-westend-development";
+	pub(crate) const PEOPLE_WESTEND_DEVELOPMENT: &str = "people-westend-dev";
 	const PEOPLE_WESTEND_ED: PeopleBalance = people_westend_runtime::ExistentialDeposit::get();
 
 	pub fn local_config(


### PR DESCRIPTION
Found it when trying to run: 
```
bot bench-all pallet --pallet=pallet_balances
```
https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/5081585

## TODO
- [x] check/fix command bot for `people-westend-dev` / `people-rococo-dev` https://github.com/paritytech/command-bot-scripts/pull/67