### PR TITLE
Use external reference for the CI image as before

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH
 
 variables:
-  # CI_IMAGE: !reference [.ci-unified, variables, CI_IMAGE]
-  CI_IMAGE: "docker.io/paritytech/ci-unified:bullseye-1.75.0-2024-01-22-v20240109"
+  CI_IMAGE: !reference [.ci-unified, variables, CI_IMAGE]
   # BUILDAH_IMAGE is defined in group variables
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"


### PR DESCRIPTION
Usual chore after bumping Rust toolchain version.