### PR TITLE
Contracts: Stabilize `caller_is_root` API

### DIFF
--- a/prdoc/pr_3154.prdoc
+++ b/prdoc/pr_3154.prdoc
@@ -1,0 +1,8 @@
+title: Contracts: Stabilize caller_is_root API
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Removed the `#[unstable]` attrribute on `caller_is_root` host function.
+
+crates: ["pallet-contracts"]

--- a/prdoc/pr_3154.prdoc
+++ b/prdoc/pr_3154.prdoc
@@ -1,8 +1,9 @@
-title: Contracts: Stabilize caller_is_root API
+title: "Contracts: Stabilize caller_is_root API"
 
 doc:
   - audience: Runtime Dev
     description: |
       Removed the `#[unstable]` attrribute on `caller_is_root` host function.
 
-crates: ["pallet-contracts"]
+crates:
+  - name: pallet-contracts

--- a/substrate/frame/contracts/src/wasm/runtime.rs
+++ b/substrate/frame/contracts/src/wasm/runtime.rs
@@ -1542,7 +1542,6 @@ pub mod env {
 
 	/// Checks whether the caller of the current contract is root.
 	/// See [`pallet_contracts_uapi::HostFn::caller_is_root`].
-	#[unstable]
 	fn caller_is_root(ctx: _, _memory: _) -> Result<u32, TrapReason> {
 		ctx.charge_gas(RuntimeCosts::CallerIsRoot)?;
 		Ok(ctx.ext.caller_is_root() as u32)

--- a/substrate/frame/contracts/uapi/src/host.rs
+++ b/substrate/frame/contracts/uapi/src/host.rs
@@ -277,9 +277,6 @@ pub trait HostFn {
 	///
 	/// A return value of `true` indicates that this contract is being called by a root origin,
 	/// and `false` indicates that the caller is a signed origin.
-	#[deprecated(
-		note = "Unstable function. Behaviour can change without further notice. Use only for testing."
-	)]
 	fn caller_is_root() -> u32;
 
 	/// Clear the value at the given key in the contract storage.


### PR DESCRIPTION
Can this API be marked stable? Implemented in [solang here](https://github.com/hyperledger/solang/pull/1620)