### PR TITLE
Small fixes coretime related fixes

### DIFF
--- a/polkadot/runtime/parachains/src/configuration/migration/v11.rs
+++ b/polkadot/runtime/parachains/src/configuration/migration/v11.rs
@@ -253,7 +253,7 @@ mod tests {
 
 		new_test_ext(Default::default()).execute_with(|| {
 			// Implant the v10 version in the state.
-			v10::ActiveConfig::<Test>::set(Some(v10));
+			v10::ActiveConfig::<Test>::set(Some(v10.clone()));
 			v10::PendingConfigs::<Test>::set(Some(pending_configs));
 
 			migrate_to_v11::<Test>();
@@ -264,7 +264,7 @@ mod tests {
 			let mut configs_to_check = v11::PendingConfigs::<Test>::get().unwrap();
 			configs_to_check.push((0, v11.clone()));
 
-			for (_, v10) in configs_to_check {
+			for (_, v11) in configs_to_check {
 				#[rustfmt::skip]
 				{
 					assert_eq!(v10.max_code_size                            , v11.max_code_size);
@@ -286,7 +286,7 @@ mod tests {
 					assert_eq!(v10.hrmp_max_parachain_inbound_channels      , v11.hrmp_max_parachain_inbound_channels);
 					assert_eq!(v10.hrmp_channel_max_message_size            , v11.hrmp_channel_max_message_size);
 					assert_eq!(v10.code_retention_period                    , v11.code_retention_period);
-					assert_eq!(v10.coretime_cores                           , v11.coretime_cores);
+					assert_eq!(v10.on_demand_cores                          , v11.coretime_cores);
 					assert_eq!(v10.on_demand_retries                        , v11.on_demand_retries);
 					assert_eq!(v10.group_rotation_frequency                 , v11.group_rotation_frequency);
 					assert_eq!(v10.paras_availability_period                , v11.paras_availability_period);
@@ -303,8 +303,8 @@ mod tests {
 					assert_eq!(v10.minimum_validation_upgrade_delay         , v11.minimum_validation_upgrade_delay);
 					assert_eq!(v10.async_backing_params.allowed_ancestry_len, v11.async_backing_params.allowed_ancestry_len);
 					assert_eq!(v10.async_backing_params.max_candidate_depth , v11.async_backing_params.max_candidate_depth);
-					assert_eq!(v10.executor_params						   , v11.executor_params);
-				    assert_eq!(v10.minimum_backing_votes					   , v11.minimum_backing_votes);
+					assert_eq!(v10.executor_params						    , v11.executor_params);
+				    assert_eq!(v10.minimum_backing_votes					, v11.minimum_backing_votes);
 				}; // ; makes this a statement. `rustfmt::skip` cannot be put on an expression.
 			}
 		});

--- a/polkadot/runtime/parachains/src/configuration/tests.rs
+++ b/polkadot/runtime/parachains/src/configuration/tests.rs
@@ -38,7 +38,7 @@ fn default_is_consistent() {
 fn scheduled_session_is_two_sessions_from_now() {
 	new_test_ext(Default::default()).execute_with(|| {
 		// The logic here is really tested only with scheduled_session = 2. It should work
-		// with other values, but that should receive a more rigorious testing.
+		// with other values, but that should receive a more rigorous testing.
 		on_new_session(1);
 		assert_eq!(Configuration::scheduled_session(), 3);
 	});
@@ -136,7 +136,7 @@ fn pending_next_session_but_we_upgrade_once_more() {
 		// update.
 		assert_ok!(Configuration::set_validation_upgrade_cooldown(RuntimeOrigin::root(), 99));
 
-		// This should result in yet another configiguration change scheduled.
+		// This should result in yet another configuration change scheduled.
 		assert_eq!(Configuration::config(), initial_config);
 		assert_eq!(
 			PendingConfigs::<Test>::get(),
@@ -179,7 +179,7 @@ fn scheduled_session_config_update_while_next_session_pending() {
 		assert_ok!(Configuration::set_validation_upgrade_cooldown(RuntimeOrigin::root(), 99));
 		assert_ok!(Configuration::set_code_retention_period(RuntimeOrigin::root(), 98));
 
-		// This should result in yet another configiguration change scheduled.
+		// This should result in yet another configuration change scheduled.
 		assert_eq!(Configuration::config(), initial_config);
 		assert_eq!(
 			PendingConfigs::<Test>::get(),

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -74,7 +74,7 @@ mod v_coretime {
 
 			loop {
 				match sp_io::storage::next_key(&next_key) {
-					// StorageVersion is initialized before, so we need to ingore it.
+					// StorageVersion is initialized before, so we need to ignore it.
 					Some(key) if &key == &storage_version_key => {
 						next_key = key;
 					},

--- a/polkadot/runtime/parachains/src/scheduler.rs
+++ b/polkadot/runtime/parachains/src/scheduler.rs
@@ -114,7 +114,7 @@ pub mod pallet {
 		Paras(ParasEntry<N>),
 	}
 
-	/// Conveninece type alias for `CoreOccupied`.
+	/// Convenience type alias for `CoreOccupied`.
 	pub type CoreOccupiedType<T> = CoreOccupied<BlockNumberFor<T>>;
 
 	impl<N> CoreOccupied<N> {

--- a/polkadot/runtime/parachains/src/scheduler.rs
+++ b/polkadot/runtime/parachains/src/scheduler.rs
@@ -145,9 +145,7 @@ pub mod pallet {
 	pub(crate) type SessionStartBlock<T: Config> = StorageValue<_, BlockNumberFor<T>, ValueQuery>;
 
 	/// One entry for each availability core. The `VecDeque` represents the assignments to be
-	/// scheduled on that core. `None` is used to signal to not schedule the next para of the core
-	/// as there is one currently being scheduled. Not using `None` here would overwrite the
-	/// `CoreState` in the runtime API. The value contained here will not be valid after the end of
+	/// scheduled on that core. The value contained here will not be valid after the end of
 	/// a block. Runtime APIs should be used to determine scheduled cores/ for the upcoming block.
 	#[pallet::storage]
 	#[pallet::getter(fn claimqueue)]


### PR DESCRIPTION
The PR contains small fixes for:
* A test `HostConfig v11` storage migration - v11  was compared with itself instead of with `v10`.
* Outdated comment for `ClaimQueue`
* Typos