### PR TITLE
Fix `new_session` benchmark in `pallet_collator_selection`

### DIFF
--- a/cumulus/pallets/collator-selection/src/benchmarking.rs
+++ b/cumulus/pallets/collator-selection/src/benchmarking.rs
@@ -394,7 +394,7 @@ mod benchmarks {
 		register_validators::<T>(c);
 		register_candidates::<T>(c);
 
-		let new_block: BlockNumberFor<T> = 3600u32.into();
+		let new_block: BlockNumberFor<T> = T::KickThreshold::get();
 		let zero_block: BlockNumberFor<T> = 0u32.into();
 		let candidates: Vec<T::AccountId> = <CandidateList<T>>::get()
 			.iter()


### PR DESCRIPTION
Issue was discovered by enabling async backing on all parachains in [this PR](https://github.com/paritytech/polkadot-sdk/pull/2949).

The reason it happened is because with the move to async backing, the `DAYS` and `HOURS` constants doubled compared to the [previously imported values from parachain_common](https://github.com/paritytech/polkadot-sdk/blob/5ba8921787609dddbabb8be3443186b65fdde190/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs#L78), which led to the [`Period`](https://github.com/paritytech/polkadot-sdk/blob/5db7a7e1438f518714a7b41793ed6eb01f5668f7/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs#L703) doubling. This matters because in `pallet_collator_selection::Config`, the [allowed period of inactivity for collators is a `Period`](https://github.com/paritytech/polkadot-sdk/blob/5db7a7e1438f518714a7b41793ed6eb01f5668f7/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs#L752). When a new session is initialized, candidates which don't meet the criteria [here](https://github.com/paritytech/polkadot-sdk/blob/5db7a7e1438f518714a7b41793ed6eb01f5668f7/cumulus/pallets/collator-selection/src/lib.rs#L868) are removed.

The benchmark code [hardcoded](https://github.com/paritytech/polkadot-sdk/blob/5ba8921787609dddbabb8be3443186b65fdde190/cumulus/pallets/collator-selection/src/benchmarking.rs#L397) the last active block value which is safe from kick to the pervious value of a period, `1800`, with the chain starting at `0`. When running the check, `KickThreshold` was `1800`, so it would pass, but it obviously doesn't work if the `Period` isn't `1800`.

This PR fixes the benchmark by setting the `new_block` value to `T::KickThreshold::get()`, which will work for any chosen `Period`.

Opening this PR against the original branch to expedite the merge.