### PR TITLE
Build more runtimes targeting PolkaVM

### DIFF
--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -329,13 +329,16 @@ build-linux-substrate:
     # - printf '\n# building node-template\n\n'
     # - ./scripts/ci/node-template-release.sh ./artifacts/substrate/substrate-node-template.tar.gz
 
-build-minimal-runtime-polkavm:
+build-runtimes-polkavm:
   stage: build
   extends:
     - .docker-env
     - .common-refs
   script:
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p minimal-runtime
+    - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p westend-runtime
+    - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p rococo-runtime
+    - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p polkadot-test-runtime
 
 .build-subkey:
   stage: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13798,9 +13798,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linker"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc03593918a5890f96c276fb1e34ab77002bea1f9136cdcb55107c241011ab7"
+checksum = "fdec1451cb18261d5d01de82acc15305e417fb59588cdcb3127d3dcc9672b925"
 dependencies = [
  "gimli 0.28.0",
  "hashbrown 0.14.3",
@@ -19712,7 +19712,7 @@ dependencies = [
  "console",
  "filetime",
  "parity-wasm",
- "polkavm-linker 0.8.1",
+ "polkavm-linker 0.8.2",
  "sp-maybe-compressed-blob",
  "strum 0.24.1",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -533,7 +533,7 @@ extra-unused-type-parameters = { level = "allow", priority = 2 }     # stylistic
 default_constructed_unit_structs = { level = "allow", priority = 2 } # stylistic
 
 [workspace.dependencies]
-polkavm-linker = "0.8.1"
+polkavm-linker = "0.8.2"
 polkavm-derive = "0.8.0"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -595,6 +595,7 @@ num-bigint = { opt-level = 3 }
 parking_lot = { opt-level = 3 }
 parking_lot_core = { opt-level = 3 }
 percent-encoding = { opt-level = 3 }
+polkavm-linker = { opt-level = 3 }
 primitive-types = { opt-level = 3 }
 reed-solomon-novelpoly = { opt-level = 3 }
 ring = { opt-level = 3 }

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -37,6 +37,7 @@ w3f-bls = { version = "0.1.3", features = ["std"] }
 default = ["std"]
 std = [
 	"codec/std",
+	"dep:lazy_static",
 	"scale-info/std",
 	"serde/std",
 	"sp-api/std",
@@ -48,7 +49,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"strum/std",
-	"dep:lazy_static",
 ]
 
 # Serde support without relying on std features.

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -27,7 +27,7 @@ sp-mmr-primitives = { path = "../../merkle-mountain-range", default-features = f
 sp-runtime = { path = "../../runtime", default-features = false }
 sp-std = { path = "../../std", default-features = false }
 strum = { version = "0.24.1", features = ["derive"], default-features = false }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 array-bytes = "6.1"
@@ -48,6 +48,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"strum/std",
+	"dep:lazy_static",
 ]
 
 # Serde support without relying on std features.

--- a/substrate/primitives/merkle-mountain-range/Cargo.toml
+++ b/substrate/primitives/merkle-mountain-range/Cargo.toml
@@ -25,7 +25,7 @@ sp-core = { path = "../core", default-features = false }
 sp-debug-derive = { path = "../debug-derive", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }
 sp-std = { path = "../std", default-features = false }
-thiserror = "1.0"
+thiserror = { version = "1.0", optional = true }
 
 [dev-dependencies]
 array-bytes = "6.1"
@@ -43,6 +43,7 @@ std = [
 	"sp-debug-derive/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"dep:thiserror",
 ]
 
 # Serde support without relying on std features.

--- a/substrate/primitives/merkle-mountain-range/Cargo.toml
+++ b/substrate/primitives/merkle-mountain-range/Cargo.toml
@@ -34,6 +34,7 @@ array-bytes = "6.1"
 default = ["std"]
 std = [
 	"codec/std",
+	"dep:thiserror",
 	"log/std",
 	"mmr-lib/std",
 	"scale-info/std",
@@ -43,7 +44,6 @@ std = [
 	"sp-debug-derive/std",
 	"sp-runtime/std",
 	"sp-std/std",
-	"dep:thiserror",
 ]
 
 # Serde support without relying on std features.

--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -462,6 +462,18 @@ fn create_project_cargo_toml(
 
 	wasm_workspace_toml.insert("workspace".into(), Table::new().into());
 
+	if target == RuntimeTarget::Riscv {
+		// This dependency currently doesn't compile under RISC-V, so patch it with our own fork.
+		//
+		// TODO: Remove this once a new version of `bitvec` (which uses a new version of `radium`
+		//       which doesn't have this problem) is released on crates.io.
+		let patch = toml::toml! {
+			[crates-io]
+			radium = { git = "https://github.com/paritytech/radium-0.7-fork.git", rev = "a5da15a15c90fd169d661d206cf0db592487f52b" }
+		};
+		wasm_workspace_toml.insert("patch".into(), patch.into());
+	}
+
 	write_file_if_changed(
 		wasm_workspace.join("Cargo.toml"),
 		toml::to_string_pretty(&wasm_workspace_toml).expect("Wasm workspace toml is valid; qed"),


### PR DESCRIPTION
This PR improves compatibility with RISC-V and PolkaVM, allowing more runtimes to successfully compile.

In particular, it makes the following changes:

- The `sp-mmr-primitives` and `sp-consensus-beefy` crates unconditionally required an `std`-only dependency; now they only require those dependencies when the `std` feature is actually enabled. (Our RISC-V target is, unlike WASM, a true `no_std` target where you can't accidentally use stuff from `std` anymore.)
- One of our dependencies (the `bitvec` trace) uses a crate called `radium` which doesn't compile under RISC-V due to incomplete autodetection logic in their `build.rs` file. The good news is that this is already fixed in the newest upstream version of `radium`, and the newest version of `bitvec` uses it. The bad news is that the newest version of `bitvec` is not currently released on crates.io, so we can't use it. I've [created an issue](https://github.com/ferrilab/ferrilab/issues/5) asking for a new release, but in the meantime I forked the currently used `radium` 0.7, [fixed the faulty logic](https://github.com/paritytech/radium-0.7-fork/commit/ed66c8a294b138c67f93499644051d97d4c7fbda) and used cargo's patching capabilities to use it for the RISC-V runtime builds. This might be a little hacky, but it is the least intrusive way to fix the problem, doesn't affect WASM builds at all, and we can trivially remove it once a new `bitvec` is released.
- The new runtimes are added to the CI to make sure their compilation doesn't break.