### PR TITLE
Backport of fix Pools 6->7 migration (#2942) (#3094)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH
 
 variables:
-  CI_IMAGE: !reference [.ci-unified, variables, CI_IMAGE]
+  CI_IMAGE: "docker.io/paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204"
   # BUILDAH_IMAGE is defined in group variables
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"

--- a/polkadot/node/core/prospective-parachains/src/tests.rs
+++ b/polkadot/node/core/prospective-parachains/src/tests.rs
@@ -101,11 +101,9 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 
 	let mut view = View::new();
 	let subsystem = async move {
-		loop {
-			match run_iteration(&mut context, &mut view, &Metrics(None)).await {
-				Ok(()) => break,
-				Err(e) => panic!("{:?}", e),
-			}
+		match run_iteration(&mut context, &mut view, &Metrics(None)).await {
+			Ok(()) => {},
+			Err(e) => panic!("{:?}", e),
 		}
 
 		view

--- a/polkadot/xcm/pallet-xcm/src/mock.rs
+++ b/polkadot/xcm/pallet-xcm/src/mock.rs
@@ -589,10 +589,23 @@ impl super::benchmarking::Config for Test {
 		let asset_amount = 10u128;
 		let fee_amount = 2u128;
 
+		let existential_deposit = ExistentialDeposit::get();
+		let caller = frame_benchmarking::whitelisted_caller();
+
+		// Give some multiple of the existential deposit
+		let balance = asset_amount + existential_deposit * 1000;
+		let _ = <Balances as frame_support::traits::Currency<_>>::make_free_balance_be(
+			&caller, balance,
+		);
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = fee_amount * 10;
-		let (usdt_chain, _, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+		let (usdt_chain, _, usdt_id_multilocation) = set_up_foreign_asset(
+			USDT_PARA_ID,
+			None,
+			caller.clone(),
+			usdt_initial_local_amount,
+			true,
+		);
 
 		// native assets transfer destination is USDT chain (teleport trust only for USDT)
 		let dest = usdt_chain;
@@ -602,20 +615,13 @@ impl super::benchmarking::Config for Test {
 			// native asset to transfer (not used for fees) - local reserve
 			(MultiLocation::here(), asset_amount).into(),
 		);
-
-		let existential_deposit = ExistentialDeposit::get();
-		let caller = frame_benchmarking::whitelisted_caller();
-		// Give some multiple of the existential deposit
-		let balance = asset_amount + existential_deposit * 1000;
-		let _ = <Balances as frame_support::traits::Currency<_>>::make_free_balance_be(
-			&caller, balance,
-		);
-		// verify initial balance
+		// verify initial balances
 		assert_eq!(Balances::free_balance(&caller), balance);
+		assert_eq!(Assets::balance(usdt_id_multilocation, &caller), usdt_initial_local_amount);
 
 		// verify transferred successfully
 		let verify = Box::new(move || {
-			// verify balance after transfer, decreased by transferred amount
+			// verify balances after transfer, decreased by transferred amounts
 			assert_eq!(Balances::free_balance(&caller), balance - asset_amount);
 			assert_eq!(
 				Assets::balance(usdt_id_multilocation, &caller),

--- a/polkadot/xcm/pallet-xcm/src/tests/assets_transfer.rs
+++ b/polkadot/xcm/pallet-xcm/src/tests/assets_transfer.rs
@@ -244,6 +244,7 @@ fn reserve_transfer_assets_with_paid_router_works() {
 pub(crate) fn set_up_foreign_asset(
 	reserve_para_id: u32,
 	inner_junction: Option<Junction>,
+	benficiary: AccountId,
 	initial_amount: u128,
 	is_sufficient: bool,
 ) -> (MultiLocation, AccountId, MultiLocation) {
@@ -271,7 +272,7 @@ pub(crate) fn set_up_foreign_asset(
 	assert_ok!(Assets::mint(
 		RuntimeOrigin::signed(BOB),
 		foreign_asset_id_multilocation,
-		ALICE,
+		benficiary,
 		initial_amount
 	));
 
@@ -440,6 +441,7 @@ fn destination_asset_reserve_and_local_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				false,
 			);
@@ -595,6 +597,7 @@ fn remote_asset_reserve_and_local_fee_reserve_call_disallowed<Call>(
 		let (_, _, foreign_asset_id_multilocation) = set_up_foreign_asset(
 			FOREIGN_ASSET_RESERVE_PARA_ID,
 			Some(FOREIGN_ASSET_INNER_JUNCTION),
+			ALICE,
 			foreign_initial_amount,
 			false,
 		);
@@ -712,6 +715,7 @@ fn local_asset_reserve_and_destination_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				USDC_RESERVE_PARA_ID,
 				Some(USDC_INNER_JUNCTION),
+				ALICE,
 				usdc_initial_local_amount,
 				true,
 			);
@@ -870,6 +874,7 @@ fn destination_asset_reserve_and_destination_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				true,
 			);
@@ -1013,6 +1018,7 @@ fn remote_asset_reserve_and_destination_fee_reserve_call_disallowed<Call>(
 		let (usdc_chain, _, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -1022,6 +1028,7 @@ fn remote_asset_reserve_and_destination_fee_reserve_call_disallowed<Call>(
 		let (_, _, foreign_asset_id_multilocation) = set_up_foreign_asset(
 			FOREIGN_ASSET_RESERVE_PARA_ID,
 			Some(FOREIGN_ASSET_INNER_JUNCTION),
+			ALICE,
 			foreign_initial_amount,
 			false,
 		);
@@ -1135,6 +1142,7 @@ fn local_asset_reserve_and_remote_fee_reserve_call_disallowed<Call>(
 		let (_, usdc_chain_sovereign_account, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -1244,6 +1252,7 @@ fn destination_asset_reserve_and_remote_fee_reserve_call_disallowed<Call>(
 		let (_, usdc_chain_sovereign_account, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -1254,6 +1263,7 @@ fn destination_asset_reserve_and_remote_fee_reserve_call_disallowed<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				false,
 			);
@@ -1383,6 +1393,7 @@ fn remote_asset_reserve_and_remote_fee_reserve_call<Call>(
 			set_up_foreign_asset(
 				USDC_RESERVE_PARA_ID,
 				Some(USDC_INNER_JUNCTION),
+				ALICE,
 				usdc_initial_local_amount,
 				true,
 			);
@@ -1526,7 +1537,7 @@ fn local_asset_reserve_and_teleported_fee_call<Call>(
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// native assets transfer destination is USDT chain (teleport trust only for USDT)
 		let dest = usdt_chain;
@@ -1675,7 +1686,7 @@ fn destination_asset_reserve_and_teleported_fee_call<Call>(
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (_, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// create non-sufficient foreign asset BLA
 		let foreign_initial_amount = 142;
@@ -1683,6 +1694,7 @@ fn destination_asset_reserve_and_teleported_fee_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				false,
 			);
@@ -1845,13 +1857,14 @@ fn remote_asset_reserve_and_teleported_fee_reserve_call_disallowed<Call>(
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// create non-sufficient foreign asset BLA
 		let foreign_initial_amount = 142;
 		let (_, reserve_sovereign_account, foreign_asset_id_multilocation) = set_up_foreign_asset(
 			FOREIGN_ASSET_RESERVE_PARA_ID,
 			Some(FOREIGN_ASSET_INNER_JUNCTION),
+			ALICE,
 			foreign_initial_amount,
 			false,
 		);
@@ -1952,7 +1965,7 @@ fn reserve_transfer_assets_with_teleportable_asset_disallowed() {
 		// create sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, true);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, true);
 
 		// transfer destination is USDT chain (foreign asset needs to go through its reserve chain)
 		let dest = usdt_chain;
@@ -2037,6 +2050,7 @@ fn intermediary_error_reverts_side_effects() {
 		let (_, usdc_chain_sovereign_account, usdc_id_multilocation) = set_up_foreign_asset(
 			USDC_RESERVE_PARA_ID,
 			Some(USDC_INNER_JUNCTION),
+			ALICE,
 			usdc_initial_local_amount,
 			true,
 		);
@@ -2106,7 +2120,7 @@ fn teleport_asset_using_local_fee_reserve_call<Call>(
 		// create non-sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (usdt_chain, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, false);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, false);
 
 		// transfer destination is reserve location (no teleport trust)
 		let dest = usdt_chain;
@@ -2258,6 +2272,7 @@ fn teleported_asset_using_destination_reserve_fee_call<Call>(
 			set_up_foreign_asset(
 				FOREIGN_ASSET_RESERVE_PARA_ID,
 				Some(FOREIGN_ASSET_INNER_JUNCTION),
+				ALICE,
 				foreign_initial_amount,
 				true,
 			);
@@ -2265,7 +2280,7 @@ fn teleported_asset_using_destination_reserve_fee_call<Call>(
 		// create non-sufficient foreign asset USDT
 		let usdt_initial_local_amount = 42;
 		let (_, usdt_chain_sovereign_account, usdt_id_multilocation) =
-			set_up_foreign_asset(USDT_PARA_ID, None, usdt_initial_local_amount, false);
+			set_up_foreign_asset(USDT_PARA_ID, None, ALICE, usdt_initial_local_amount, false);
 
 		// transfer destination is BLA reserve location
 		let dest = reserve_location;

--- a/prdoc/pr_2942.prdoc
+++ b/prdoc/pr_2942.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fix pallet-nomination-pools v6 to v7 migration
+
+doc:
+  - audience: Node Dev
+    description: |
+      Restores the behaviour of the nomination pools `V6ToV7` migration so that it still works when
+      the pallet will be upgraded to V8 afterwards.
+
+crates:
+  - name: "pallet-nomination-pools"

--- a/substrate/bin/node/cli/tests/websocket_server.rs
+++ b/substrate/bin/node/cli/tests/websocket_server.rs
@@ -205,8 +205,7 @@ impl WsServer {
 								Ok(soketto::Data::Text(len)) => String::from_utf8(buf[..len].to_vec())
 									.map(Message::Text)
 									.map_err(|err| Box::new(err) as Box<_>),
-								Ok(soketto::Data::Binary(len)) => Ok(buf[..len].to_vec())
-									.map(Message::Binary),
+								Ok(soketto::Data::Binary(len)) => Ok(Message::Binary(buf[..len].to_vec())),
 								Err(err) => Err(Box::new(err) as Box<_>),
 							};
 							Some((ret, (receiver, buf)))

--- a/substrate/client/consensus/babe/src/tests.rs
+++ b/substrate/client/consensus/babe/src/tests.rs
@@ -411,7 +411,7 @@ async fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + '
 			let mut net = net.lock();
 			net.poll(cx);
 			for p in net.peers() {
-				for (h, e) in p.failed_verifications() {
+				if let Some((h, e)) = p.failed_verifications().into_iter().next() {
 					panic!("Verification failed for {:?}: {}", h, e);
 				}
 			}

--- a/substrate/frame/sassafras/src/data/tickets-sort.md
+++ b/substrate/frame/sassafras/src/data/tickets-sort.md
@@ -267,7 +267,7 @@ buffer (i.e. how many tickets we retain from the last processed segment)
 | 3 | 14 |
 | 2 | 17 |
 | 1 | 9 |
-| 0 | 13
+| 0 | 13 |
 
 # Graph of the same data
 

--- a/substrate/frame/support/test/tests/construct_runtime_ui/deprecated_where_block.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/deprecated_where_block.stderr
@@ -17,6 +17,7 @@ error: use of deprecated constant `WhereSection::_w`:
    | |_^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
    = note: this error originates in the macro `frame_support::match_and_insert` which comes from the expansion of the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Runtime: Config` is not satisfied

--- a/substrate/frame/support/test/tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.stderr
@@ -31,19 +31,34 @@ error[E0412]: cannot find type `RuntimeOrigin` in this scope
   --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:42:23
    |
 42 |     type RuntimeOrigin = RuntimeOrigin;
-   |                          ^^^^^^^^^^^^^ help: you might have meant to use the associated type: `Self::RuntimeOrigin`
+   |                          ^^^^^^^^^^^^^
+   |
+help: you might have meant to use the associated type
+   |
+42 |     type RuntimeOrigin = Self::RuntimeOrigin;
+   |                          ++++++
 
 error[E0412]: cannot find type `RuntimeCall` in this scope
   --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:44:21
    |
 44 |     type RuntimeCall = RuntimeCall;
-   |                        ^^^^^^^^^^^ help: you might have meant to use the associated type: `Self::RuntimeCall`
+   |                        ^^^^^^^^^^^
+   |
+help: you might have meant to use the associated type
+   |
+44 |     type RuntimeCall = Self::RuntimeCall;
+   |                        ++++++
 
 error[E0412]: cannot find type `RuntimeEvent` in this scope
   --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:50:22
    |
 50 |     type RuntimeEvent = RuntimeEvent;
-   |                         ^^^^^^^^^^^^ help: you might have meant to use the associated type: `Self::RuntimeEvent`
+   |                         ^^^^^^^^^^^^
+   |
+help: you might have meant to use the associated type
+   |
+50 |     type RuntimeEvent = Self::RuntimeEvent;
+   |                         ++++++
 
 error[E0412]: cannot find type `PalletInfo` in this scope
   --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:56:20
@@ -54,7 +69,7 @@ error[E0412]: cannot find type `PalletInfo` in this scope
 help: you might have meant to use the associated type
    |
 56 |     type PalletInfo = Self::PalletInfo;
-   |                       ~~~~~~~~~~~~~~~~
+   |                       ++++++
 help: consider importing one of these items
    |
 18 + use frame_benchmarking::__private::traits::PalletInfo;

--- a/substrate/frame/support/test/tests/derive_impl_ui/inject_runtime_type_fails_when_type_not_in_scope.stderr
+++ b/substrate/frame/support/test/tests/derive_impl_ui/inject_runtime_type_fails_when_type_not_in_scope.stderr
@@ -2,9 +2,13 @@ error[E0412]: cannot find type `RuntimeCall` in this scope
   --> tests/derive_impl_ui/inject_runtime_type_fails_when_type_not_in_scope.rs:30:10
    |
 30 |     type RuntimeCall = ();
-   |          ^^^^^^^^^^^ help: you might have meant to use the associated type: `Self::RuntimeCall`
+   |          ^^^^^^^^^^^
 ...
 35 | #[derive_impl(Pallet)] // Injects type RuntimeCall = RuntimeCall;
    | ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `Pallet` which comes from the expansion of the macro `frame_support::macro_magic::forward_tokens_verbatim` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might have meant to use the associated type
+   |
+30 |     type Self::RuntimeCall = ();
+   |          ++++++

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -10,6 +10,7 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |                          ^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound.rs:38:36

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -10,6 +10,7 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |                          ^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:38:36
@@ -45,9 +46,9 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is
    = note: required for `<T as pallet::Config>::Bar` to implement `Encode`
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is not satisfied
-  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:34:12
+  --> tests/pallet_ui/call_argument_invalid_bound_2.rs:38:42
    |
-34 |     #[pallet::call]
-   |               ^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
+38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
+   |                                                ^^^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
    |
    = note: required for `<T as pallet::Config>::Bar` to implement `Decode`

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -10,6 +10,7 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |                          ^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound_3.rs:40:36

--- a/substrate/frame/support/test/tests/pallet_ui/call_missing_index.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_missing_index.stderr
@@ -11,6 +11,7 @@ error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_0::_w`:
    |                ^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_1::_w`:
                It is deprecated to use implicit call indices.

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_argument_has_suffix.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_argument_has_suffix.stderr
@@ -18,3 +18,4 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |                          ^^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_const_warning.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_const_warning.stderr
@@ -10,3 +10,4 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |                          ^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_const_warning_twice.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_const_warning_twice.stderr
@@ -18,6 +18,7 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |                          ^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error: use of deprecated constant `pallet::warnings::ConstantWeight_1::_w`:
                It is deprecated to use hard-coded constant as call weight.

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_inherited_invalid3.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_inherited_invalid3.stderr
@@ -17,3 +17,4 @@ error: unused import: `frame_system::pallet_prelude::*`
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_unchecked_warning.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_unchecked_warning.stderr
@@ -10,3 +10,4 @@ error: use of deprecated constant `pallet::warnings::UncheckedWeightWitness_0::_
    |                                     ^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`

--- a/substrate/frame/support/test/tests/pallet_ui/deprecated_store_attr.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/deprecated_store_attr.stderr
@@ -7,3 +7,4 @@ error: use of deprecated struct `pallet::_::Store`:
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`

--- a/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_call_index.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_call_index.stderr
@@ -11,6 +11,7 @@ error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_0::_w`:
    |                ^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
                It is deprecated to use hard-coded constant as call weight.

--- a/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
@@ -11,6 +11,7 @@ error: use of deprecated constant `pallet::warnings::ImplicitCallIndex_0::_w`:
    |                ^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
                It is deprecated to use hard-coded constant as call weight.
@@ -26,8 +27,15 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
 error[E0277]: the trait bound `Vec<u8>: MaxEncodedLen` is not satisfied
   --> tests/pallet_ui/dev_mode_without_arg_max_encoded_len.rs:28:12
    |
-28 |     #[pallet::pallet]
-   |               ^^^^^^ the trait `MaxEncodedLen` is not implemented for `Vec<u8>`
+28 |       #[pallet::pallet]
+   |  _______________^
+29 | |     pub struct Pallet<T>(_);
+30 | |
+31 | |     // Your Pallet's configuration trait, representing custom external types and interfaces.
+...  |
+35 | |     #[pallet::storage]
+36 | |     type MyStorage<T: Config> = StorageValue<_, Vec<u8>>;
+   | |__________________^ the trait `MaxEncodedLen` is not implemented for `Vec<u8>`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
              bool

--- a/substrate/frame/support/test/tests/pallet_ui/error_does_not_derive_pallet_error.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/error_does_not_derive_pallet_error.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `MyError: PalletError` is not satisfied
-  --> tests/pallet_ui/error_does_not_derive_pallet_error.rs:18:1
+  --> tests/pallet_ui/error_does_not_derive_pallet_error.rs:28:15
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PalletError` is not implemented for `MyError`
+28 |         CustomError(crate::MyError),
+   |                     ^^^^^^^^^^^^^^ the trait `PalletError` is not implemented for `MyError`
    |
    = help: the following other types implement trait `PalletError`:
              bool
@@ -14,4 +14,3 @@ error[E0277]: the trait bound `MyError: PalletError` is not satisfied
              u8
              u16
            and $N others
-   = note: this error originates in the derive macro `frame_support::PalletError` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -1,8 +1,15 @@
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
    |
-27 |     #[pallet::without_storage_info]
-   |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Box<T>
@@ -16,8 +23,15 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
    |
-27 |     #[pallet::without_storage_info]
-   |               ^^^^^^^^^^^^^^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              <bool as EncodeLike>
@@ -36,8 +50,15 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
    |
-27 |     #[pallet::without_storage_info]
-   |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              Box<T>
@@ -57,8 +78,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `TypeInfo` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `TypeInfo` is not implemented for `Bar`
    |
    = help: the following other types implement trait `TypeInfo`:
              bool
@@ -76,8 +99,10 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Box<T>
@@ -91,8 +116,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              <bool as EncodeLike>
@@ -111,8 +138,10 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              Box<T>
@@ -130,10 +159,12 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:18:1
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Box<T>
@@ -143,13 +174,14 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
    = note: required for `Bar` to implement `Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:18:1
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              <bool as EncodeLike>
@@ -164,13 +196,14 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:18:1
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              Box<T>
@@ -186,4 +219,3 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -1,8 +1,15 @@
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
    |
-27 |     #[pallet::without_storage_info]
-   |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Box<T>
@@ -16,8 +23,15 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
    |
-27 |     #[pallet::without_storage_info]
-   |               ^^^^^^^^^^^^^^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              <bool as EncodeLike>
@@ -36,8 +50,15 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
    |
-27 |     #[pallet::without_storage_info]
-   |               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              Box<T>
@@ -57,8 +78,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `TypeInfo` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `TypeInfo` is not implemented for `Bar`
    |
    = help: the following other types implement trait `TypeInfo`:
              bool
@@ -76,8 +99,10 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Box<T>
@@ -91,8 +116,10 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              <bool as EncodeLike>
@@ -111,8 +138,10 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-38 |     #[pallet::storage]
-   |               ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              Box<T>
@@ -130,10 +159,12 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:18:1
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Box<T>
@@ -143,13 +174,14 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
    = note: required for `Bar` to implement `Decode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:18:1
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `EncodeLike` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              <bool as EncodeLike>
@@ -164,13 +196,14 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:18:1
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
    |
-18 | #[frame_support::pallet]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Bar`
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              Box<T>
@@ -186,4 +219,3 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
@@ -1,8 +1,15 @@
 error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
   --> tests/pallet_ui/storage_info_unsatisfied.rs:26:12
    |
-26 |     #[pallet::pallet]
-   |               ^^^^^^ the trait `MaxEncodedLen` is not implemented for `Bar`
+26 |       #[pallet::pallet]
+   |  _______________^
+27 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+28 | |
+29 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
              bool

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -1,8 +1,15 @@
 error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
   --> tests/pallet_ui/storage_info_unsatisfied_nmap.rs:29:12
    |
-29 |     #[pallet::pallet]
-   |               ^^^^^^ the trait `MaxEncodedLen` is not implemented for `Bar`
+29 |       #[pallet::pallet]
+   |  _______________^
+30 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+31 | |
+32 | |     #[pallet::hooks]
+...  |
+41 | |     #[pallet::storage]
+42 | |     type Foo<T> = StorageNMap<_, Key<Twox64Concat, Bar>, u32>;
+   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
              bool

--- a/substrate/frame/support/test/tests/pallet_ui/store_trait_leak_private.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/store_trait_leak_private.stderr
@@ -7,6 +7,7 @@ error: use of deprecated struct `pallet::_::Store`:
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(deprecated)]`
 
 error[E0446]: private type `_GeneratedPrefixForStorageFoo<T>` in public interface
   --> tests/pallet_ui/store_trait_leak_private.rs:28:37

--- a/substrate/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
+++ b/substrate/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
@@ -1,3 +1,21 @@
+error[E0603]: struct `RuntimeVersion` is private
+  --> tests/ui/impl_incorrect_method_signature.rs:37:27
+   |
+37 |         fn version() -> sp_api::RuntimeVersion {
+   |                                 ^^^^^^^^^^^^^^ private struct
+   |
+note: the struct `RuntimeVersion` is defined here
+  --> $WORKSPACE/substrate/primitives/api/src/lib.rs
+   |
+   | use sp_version::RuntimeVersion;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider importing one of these items instead
+   |
+37 |         fn version() -> sp_api::__private::RuntimeVersion {
+   |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+37 |         fn version() -> sp_version::RuntimeVersion {
+   |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0053]: method `test` has an incompatible type for trait
   --> tests/ui/impl_incorrect_method_signature.rs:33:17
    |

--- a/substrate/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
+++ b/substrate/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
@@ -1,3 +1,21 @@
+error[E0603]: struct `RuntimeVersion` is private
+  --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:39:27
+   |
+39 |         fn version() -> sp_api::RuntimeVersion {
+   |                                 ^^^^^^^^^^^^^^ private struct
+   |
+note: the struct `RuntimeVersion` is defined here
+  --> $WORKSPACE/substrate/primitives/api/src/lib.rs
+   |
+   | use sp_version::RuntimeVersion;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider importing one of these items instead
+   |
+39 |         fn version() -> sp_api::__private::RuntimeVersion {
+   |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+39 |         fn version() -> sp_version::RuntimeVersion {
+   |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0053]: method `test` has an incompatible type for trait
   --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:33:17
    |


### PR DESCRIPTION
This should result as a patched `24.0.1` version for https://crates.io/crates/pallet-nomination-pools/24.0.0.

Relates to: https://github.com/polkadot-fellows/runtimes/pull/137

---------