### PR TITLE
Backport of fix Pools 6->7 migration (#2942) (#3093)

### DIFF
--- a/prdoc/pr_2942.prdoc
+++ b/prdoc/pr_2942.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fix pallet-nomination-pools v6 to v7 migration
+
+doc:
+  - audience: Node Dev
+    description: |
+      Restores the behaviour of the nomination pools `V6ToV7` migration so that it still works when
+      the pallet will be upgraded to V8 afterwards.
+
+crates:
+  - name: "pallet-nomination-pools"

--- a/substrate/frame/sassafras/src/data/tickets-sort.md
+++ b/substrate/frame/sassafras/src/data/tickets-sort.md
@@ -267,7 +267,7 @@ buffer (i.e. how many tickets we retain from the last processed segment)
 | 3 | 14 |
 | 2 | 17 |
 | 1 | 9 |
-| 0 | 13
+| 0 | 13 |
 
 # Graph of the same data
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/paritytech/polkadot-sdk/pull/3093 (patch to `release-polkadot-v1.6.0`).

This should result as a patched `25.0.1` version for https://crates.io/crates/pallet-nomination-pools/25.0.0.

Relates to: https://github.com/polkadot-fellows/runtimes/pull/159