### PR TITLE
Add forklift to remaining jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,7 @@ default:
     - 'curl --header "PRIVATE-TOKEN: $FL_CI_GROUP_TOKEN" -o forklift  -L "${CI_API_V4_URL}/projects/676/packages/generic/forklift/${FL_FORKLIFT_VERSION}/forklift_${FL_FORKLIFT_VERSION}_linux_amd64"'
     - chmod +x forklift
     - mkdir ~/.forklift
-    - cp $FL_FORKLIFT_CONFIG_ALT ~/.forklift/config.toml
+    - cp $FL_FORKLIFT_CONFIG ~/.forklift/config.toml
     - shopt -s expand_aliases
     - export PATH=$PATH:$(pwd)
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,9 +121,8 @@ default:
   before_script:
     - 'curl --header "PRIVATE-TOKEN: $FL_CI_GROUP_TOKEN" -o forklift  -L "${CI_API_V4_URL}/projects/676/packages/generic/forklift/${FL_FORKLIFT_VERSION}/forklift_${FL_FORKLIFT_VERSION}_linux_amd64"'
     - chmod +x forklift
-    - mkdir .forklift
-    - cp $FL_FORKLIFT_CONFIG .forklift/config.toml
-    - export FORKLIFT_PACKAGE_SUFFIX=${CI_JOB_NAME/ [0-9 \/]*}
+    - mkdir ~/.forklift
+    - cp $FL_FORKLIFT_CONFIG_ALT ~/.forklift/config.toml
     - shopt -s expand_aliases
     - export PATH=$PATH:$(pwd)
     - |
@@ -131,11 +130,8 @@ default:
       echo "FORKLIFT_BYPASS not set, creating alias cargo='forklift cargo'"
       alias cargo="forklift cargo"
       fi
-    - ls -al
-    - rm -f forklift.sock
     #
     - echo "FL_FORKLIFT_VERSION ${FL_FORKLIFT_VERSION}"
-    - echo "FORKLIFT_PACKAGE_SUFFIX $FORKLIFT_PACKAGE_SUFFIX"
 
 .common-refs:
   rules:

--- a/.gitlab/check-each-crate.py
+++ b/.gitlab/check-each-crate.py
@@ -55,7 +55,7 @@ for i in range(0, crates_per_group + overflow_crates):
 
 	print(f"Checking {crates[crate][0]}", file=sys.stderr)
 
-	res = subprocess.run(["cargo", "check", "--locked"], cwd = crates[crate][1])
+	res = subprocess.run(["forklift", "cargo", "check", "--locked"], cwd = crates[crate][1])
 
 	if res.returncode != 0:
 		sys.exit(1)

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -316,7 +316,7 @@ build-linux-substrate:
     - git checkout -B "$CI_COMMIT_REF_NAME" "$CI_COMMIT_SHA"
     - !reference [.forklift-cache, before_script]
   script:
-    - WASM_BUILD_NO_COLOR=1 time cargo build --locked --release -p staging-node-cli
+    - time WASM_BUILD_NO_COLOR=1 cargo build --locked --release -p staging-node-cli
     - mv $CARGO_TARGET_DIR/release/substrate-node ./artifacts/substrate/substrate
     - echo -n "Substrate version = "
     - if [ "${CI_COMMIT_TAG}" ]; then
@@ -356,7 +356,7 @@ build-runtimes-polkavm:
     - !reference [.forklift-cache, before_script]
   script:
     - cd ./substrate/bin/utils/subkey
-    - SKIP_WASM_BUILD=1 time cargo build --locked --release
+    - time SKIP_WASM_BUILD=1 cargo build --locked --release
     # - cd -
     # - mv $CARGO_TARGET_DIR/release/subkey ./artifacts/subkey/.
     # - echo -n "Subkey version = "

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -314,6 +314,7 @@ build-linux-substrate:
     # tldr: we need to checkout the branch HEAD explicitly because of our dynamic versioning approach while building the substrate binary
     # see https://github.com/paritytech/ci_cd/issues/682#issuecomment-1340953589
     - git checkout -B "$CI_COMMIT_REF_NAME" "$CI_COMMIT_SHA"
+    - !reference [.forklift-cache, before_script]
   script:
     - WASM_BUILD_NO_COLOR=1 time cargo build --locked --release -p staging-node-cli
     - mv $CARGO_TARGET_DIR/release/substrate-node ./artifacts/substrate/substrate
@@ -352,6 +353,7 @@ build-runtimes-polkavm:
     CARGO_TARGET_DIR: "$CI_PROJECT_DIR/target"
   before_script:
     - mkdir -p ./artifacts/subkey
+    - !reference [.forklift-cache, before_script]
   script:
     - cd ./substrate/bin/utils/subkey
     - SKIP_WASM_BUILD=1 time cargo build --locked --release

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -224,6 +224,7 @@ cargo-check-benches:
       git merge --verbose --no-edit FETCH_HEAD;
       fi
       fi'
+      - !reference [.forklift-cache, before_script]
   parallel: 2
   script:
     - mkdir -p ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -224,7 +224,7 @@ cargo-check-benches:
       git merge --verbose --no-edit FETCH_HEAD;
       fi
       fi'
-      - !reference [.forklift-cache, before_script]
+    - !reference [.forklift-cache, before_script]
   parallel: 2
   script:
     - mkdir -p ./artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA

--- a/polkadot/scripts/build-only-wasm.sh
+++ b/polkadot/scripts/build-only-wasm.sh
@@ -13,6 +13,14 @@ fi
 
 WASM_BUILDER_RUNNER="$PROJECT_ROOT/target/release/wbuild-runner/$1"
 
+fl_cargo () {
+    if command -v forklift >/dev/null 2>&1; then
+        forklift cargo "$@";
+    else
+        cargo "$@";
+    fi
+}
+
 if [ -z "$2" ]; then
   export WASM_TARGET_DIRECTORY=$(pwd)
 else
@@ -22,8 +30,8 @@ fi
 if [ -d $WASM_BUILDER_RUNNER ]; then
   export DEBUG=false
   export OUT_DIR="$PROJECT_ROOT/target/release/build"
-  forklift cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
+  fl_cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
     | grep -vE "cargo:rerun-if-|Executing build command"
 else
-  forklift cargo build --release -p $1
+  fl_cargo cargo build --release -p $1
 fi

--- a/polkadot/scripts/build-only-wasm.sh
+++ b/polkadot/scripts/build-only-wasm.sh
@@ -33,5 +33,5 @@ if [ -d $WASM_BUILDER_RUNNER ]; then
   fl_cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
     | grep -vE "cargo:rerun-if-|Executing build command"
 else
-  fl_cargo cargo build --release -p $1
+  fl_cargo build --release -p $1
 fi

--- a/polkadot/scripts/build-only-wasm.sh
+++ b/polkadot/scripts/build-only-wasm.sh
@@ -22,8 +22,8 @@ fi
 if [ -d $WASM_BUILDER_RUNNER ]; then
   export DEBUG=false
   export OUT_DIR="$PROJECT_ROOT/target/release/build"
-  cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
+  forklift cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
     | grep -vE "cargo:rerun-if-|Executing build command"
 else
-  cargo build --release -p $1
+  forklift cargo build --release -p $1
 fi


### PR DESCRIPTION
Add [forklift caching](https://gitlab.parity.io/parity/infrastructure/ci_cd/forklift/forklift) to remainig jobs

by .sh and .py scripts:
- cargo-check-each-crate x6 (`.gitlab/check-each-crate.py`)
- build-linux-stable (`polkadot/scripts/build-only-wasm.sh`)

by before_script:
- build-linux-substrate
- build-subkey-linux (with `.build-subkey` job)
- cargo-check-benches x2

**To disable feature set FORKLIFT_BYPASS variable to true in [project settings in gitlab](https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/settings/ci_cd)**
(forklift now handles FORKLIFT_BYPASS by itself)