### PR TITLE
`bench pallet`: only require `Hash` instead of `Block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12130,6 +12130,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-maybe-compressed-blob",
+ "sp-runtime",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",

--- a/cumulus/parachain-template/node/src/command.rs
+++ b/cumulus/parachain-template/node/src/command.rs
@@ -183,7 +183,7 @@ pub fn run() -> Result<()> {
 			match cmd {
 				BenchmarkCmd::Pallet(cmd) =>
 					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<Block, ()>(config))
+						runner.sync_run(|config| cmd.run::<sp_runtime::traits::HashingFor<Block>, ()>(config))
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."

--- a/cumulus/polkadot-parachain/src/command.rs
+++ b/cumulus/polkadot-parachain/src/command.rs
@@ -584,7 +584,7 @@ pub fn run() -> Result<()> {
 			match cmd {
 				BenchmarkCmd::Pallet(cmd) =>
 					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<Block, ()>(config))
+						runner.sync_run(|config| cmd.run::<sp_runtime::traits::HashingFor<Block>, ()>(config))
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 				You can enable it with `--features runtime-benchmarks`."

--- a/polkadot/cli/Cargo.toml
+++ b/polkadot/cli/Cargo.toml
@@ -64,13 +64,13 @@ runtime-benchmarks = [
 	"polkadot-node-metrics/runtime-benchmarks",
 	"sc-service?/runtime-benchmarks",
 	"service/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks"
+	"sp-runtime/runtime-benchmarks",
 ]
 full-node = ["service/full-node"]
 try-runtime = [
 	"service/try-runtime",
+	"sp-runtime/try-runtime",
 	"try-runtime-cli/try-runtime",
-	"sp-runtime/try-runtime"
 ]
 fast-runtime = ["service/fast-runtime"]
 pyroscope = ["pyro", "pyroscope_pprofrs"]

--- a/polkadot/cli/Cargo.toml
+++ b/polkadot/cli/Cargo.toml
@@ -42,6 +42,7 @@ sc-tracing = { path = "../../substrate/client/tracing", optional = true }
 sc-sysinfo = { path = "../../substrate/client/sysinfo" }
 sc-executor = { path = "../../substrate/client/executor" }
 sc-storage-monitor = { path = "../../substrate/client/storage-monitor" }
+sp-runtime = { path = "../../substrate/primitives/runtime" }
 
 [build-dependencies]
 substrate-build-script-utils = { path = "../../substrate/utils/build-script-utils" }
@@ -63,9 +64,14 @@ runtime-benchmarks = [
 	"polkadot-node-metrics/runtime-benchmarks",
 	"sc-service?/runtime-benchmarks",
 	"service/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks"
 ]
 full-node = ["service/full-node"]
-try-runtime = ["service/try-runtime", "try-runtime-cli/try-runtime"]
+try-runtime = [
+	"service/try-runtime",
+	"try-runtime-cli/try-runtime",
+	"sp-runtime/try-runtime"
+]
 fast-runtime = ["service/fast-runtime"]
 pyroscope = ["pyro", "pyroscope_pprofrs"]
 

--- a/polkadot/cli/src/command.rs
+++ b/polkadot/cli/src/command.rs
@@ -451,7 +451,7 @@ pub fn run() -> Result<()> {
 
 					if cfg!(feature = "runtime-benchmarks") {
 						runner.sync_run(|config| {
-							cmd.run_with_hasher::<sp_runtime::traits::HashingFor<service::Block>, ()>(config)
+							cmd.run::<sp_runtime::traits::HashingFor<service::Block>, ()>(config)
 								.map_err(|e| Error::SubstrateCli(e))
 						})
 					} else {

--- a/polkadot/cli/src/command.rs
+++ b/polkadot/cli/src/command.rs
@@ -451,7 +451,7 @@ pub fn run() -> Result<()> {
 
 					if cfg!(feature = "runtime-benchmarks") {
 						runner.sync_run(|config| {
-							cmd.run::<service::Block, ()>(config)
+							cmd.run_with_hasher::<sp_runtime::traits::HashingFor<service::Block>, ()>(config)
 								.map_err(|e| Error::SubstrateCli(e))
 						})
 					} else {

--- a/prdoc/pr_3244.prdoc
+++ b/prdoc/pr_3244.prdoc
@@ -3,7 +3,15 @@ title: "Make the `benchmark pallet`` command only require a Hasher"
 doc:
   - audience: Node Dev
     description: |
-      Currently the `benchmark pallet` command requires a `Block` type, whole only using its hash. Now this is changed to only require the hash. Some refactoring in DB crates was needed to achieve this.
+      Currently the `benchmark pallet` command requires a `Block` type, whole only using its hash.
+      Now this is changed to only require the hash. This means to use `HashingFor<Block>` in the
+      spot where `Block` was required.  
+      Example patch for your node with `cmd` being `BenchmarkCmd::Pallet(cmd)`:
+      ```patch
+      - cmd.run::<Block, ()>(config)
+      + cmd.run::<HashingFor<Block>, ()>(config)
+      ```
+
 
 crates:
   - name: sc-client-db

--- a/prdoc/pr_3244.prdoc
+++ b/prdoc/pr_3244.prdoc
@@ -3,7 +3,7 @@ title: "Make the `benchmark pallet`` command only require a Hasher"
 doc:
   - audience: Node Dev
     description: |
-      Currently the `benchmark pallet` command requires a `Block` type, whole only using its hash.
+      Currently the `benchmark pallet` command requires a `Block` type, whole only using its hasher.
       Now this is changed to only require the hash. This means to use `HashingFor<Block>` in the
       spot where `Block` was required.  
       Example patch for your node with `cmd` being `BenchmarkCmd::Pallet(cmd)`:

--- a/prdoc/pr_3244.prdoc
+++ b/prdoc/pr_3244.prdoc
@@ -1,0 +1,10 @@
+title: "Make the `benchmark pallet`` command only require a Hash"
+
+doc:
+  - audience: Node Dev
+    description: |
+      Currently the `benchmark pallet` command requires a `Block` type, whole only using its hash. Now this is changed to only require the hash. Some refactoring in DB crates was needed to achieve this.
+
+crates:
+  - name: sc-client-db
+  - name: frame-benchmarking-cli

--- a/prdoc/pr_3244.prdoc
+++ b/prdoc/pr_3244.prdoc
@@ -1,17 +1,17 @@
-title: "Make the `benchmark pallet`` command only require a Hasher"
+title: "Make the `benchmark pallet` command only require a Hasher"
 
 doc:
   - audience: Node Dev
     description: |
-      Currently the `benchmark pallet` command requires a `Block` type, whole only using its hasher.
-      Now this is changed to only require the hash. This means to use `HashingFor<Block>` in the
-      spot where `Block` was required.  
+      Currently the `benchmark pallet` command requires a `Block` type, while only using its hasher.
+      Now this is changed to only require the hasher. This means to use `HashingFor<Block>` in the
+      place where `Block` was required.  
       Example patch for your node with `cmd` being `BenchmarkCmd::Pallet(cmd)`:
+
       ```patch
       - cmd.run::<Block, ()>(config)
       + cmd.run::<HashingFor<Block>, ()>(config)
       ```
-
 
 crates:
   - name: sc-client-db

--- a/prdoc/pr_3244.prdoc
+++ b/prdoc/pr_3244.prdoc
@@ -1,4 +1,4 @@
-title: "Make the `benchmark pallet`` command only require a Hash"
+title: "Make the `benchmark pallet`` command only require a Hasher"
 
 doc:
   - audience: Node Dev

--- a/substrate/bin/node-template/node/src/command.rs
+++ b/substrate/bin/node-template/node/src/command.rs
@@ -117,7 +117,7 @@ pub fn run() -> sc_cli::Result<()> {
 							)
 						}
 
-						cmd.run::<Block, ()>(config)
+						cmd.run::<sp_runtime::traits::HashingFor<Block>, ()>(config)
 					},
 					BenchmarkCmd::Block(cmd) => {
 						let PartialComponents { client, .. } = service::new_partial(&config)?;

--- a/substrate/bin/node/cli/src/command.rs
+++ b/substrate/bin/node/cli/src/command.rs
@@ -28,6 +28,7 @@ use node_primitives::Block;
 use sc_cli::{Result, SubstrateCli};
 use sc_service::PartialComponents;
 use sp_keyring::Sr25519Keyring;
+use sp_runtime::traits::HashingFor;
 
 use std::sync::Arc;
 
@@ -106,7 +107,7 @@ pub fn run() -> Result<()> {
 							)
 						}
 
-						cmd.run::<Block, sp_statement_store::runtime_api::HostFunctions>(config)
+						cmd.run_with_hasher::<HashingFor<Block>, sp_statement_store::runtime_api::HostFunctions>(config)
 					},
 					BenchmarkCmd::Block(cmd) => {
 						// ensure that we keep the task manager alive

--- a/substrate/bin/node/cli/src/command.rs
+++ b/substrate/bin/node/cli/src/command.rs
@@ -107,7 +107,7 @@ pub fn run() -> Result<()> {
 							)
 						}
 
-						cmd.run_with_hasher::<HashingFor<Block>, sp_statement_store::runtime_api::HostFunctions>(config)
+						cmd.run::<HashingFor<Block>, sp_statement_store::runtime_api::HostFunctions>(config)
 					},
 					BenchmarkCmd::Block(cmd) => {
 						// ensure that we keep the task manager alive

--- a/substrate/client/db/src/bench.rs
+++ b/substrate/client/db/src/bench.rs
@@ -659,6 +659,7 @@ impl<Hasher: Hash> std::fmt::Debug for BenchmarkingState<Hasher> {
 #[cfg(test)]
 mod test {
 	use crate::bench::BenchmarkingState;
+	use sp_runtime::traits::HashingFor;
 	use sp_state_machine::backend::Backend as _;
 
 	fn hex(hex: &str) -> Vec<u8> {
@@ -677,7 +678,8 @@ mod test {
 			..sp_runtime::Storage::default()
 		};
 		let bench_state =
-			BenchmarkingState::<crate::tests::Block>::new(storage, None, false, true).unwrap();
+			BenchmarkingState::<HashingFor<crate::tests::Block>>::new(storage, None, false, true)
+				.unwrap();
 
 		assert_eq!(bench_state.read_write_count(), (0, 0, 0, 0));
 		assert_eq!(bench_state.keys(Default::default()).unwrap().count(), 1);
@@ -686,9 +688,13 @@ mod test {
 
 	#[test]
 	fn read_to_main_and_child_tries() {
-		let bench_state =
-			BenchmarkingState::<crate::tests::Block>::new(Default::default(), None, false, true)
-				.unwrap();
+		let bench_state = BenchmarkingState::<HashingFor<crate::tests::Block>>::new(
+			Default::default(),
+			None,
+			false,
+			true,
+		)
+		.unwrap();
 
 		for _ in 0..2 {
 			let child1 = sp_core::storage::ChildInfo::new_default(b"child1");

--- a/substrate/client/db/src/bench.rs
+++ b/substrate/client/db/src/bench.rs
@@ -44,7 +44,7 @@ use std::{
 
 type State<H> = DbState<H>;
 
-struct StorageDb<Hasher: Hash> {
+struct StorageDb<Hasher> {
 	db: Arc<dyn KeyValueDB>,
 	_phantom: std::marker::PhantomData<Hasher>,
 }

--- a/substrate/client/db/src/bench.rs
+++ b/substrate/client/db/src/bench.rs
@@ -46,7 +46,7 @@ type State<H> = DbState<H>;
 
 struct StorageDb<Hasher: Hash> {
 	db: Arc<dyn KeyValueDB>,
-	_phantom: std::marker::PhantomData<Hasher::Output>,
+	_phantom: std::marker::PhantomData<Hasher>,
 }
 
 impl<Hasher: Hash> sp_state_machine::Storage<Hasher> for StorageDb<Hasher> {

--- a/substrate/client/db/src/bench.rs
+++ b/substrate/client/db/src/bench.rs
@@ -19,7 +19,7 @@
 //! State backend that's useful for benchmarking
 
 use crate::{DbState, DbStateBuilder};
-use hash_db::{Hasher, Prefix};
+use hash_db::{Hasher as DbHasher, Prefix};
 use kvdb::{DBTransaction, KeyValueDB};
 use linked_hash_map::LinkedHashMap;
 use parking_lot::Mutex;
@@ -27,10 +27,7 @@ use sp_core::{
 	hexdisplay::HexDisplay,
 	storage::{ChildInfo, TrackedStorageKey},
 };
-use sp_runtime::{
-	traits::{Block as BlockT, HashingFor},
-	StateVersion, Storage,
-};
+use sp_runtime::{traits::Hash, StateVersion, Storage};
 use sp_state_machine::{
 	backend::Backend as StateBackend, BackendTransaction, ChildStorageCollection, DBValue,
 	IterArgs, StorageCollection, StorageIterator, StorageKey, StorageValue,
@@ -45,16 +42,16 @@ use std::{
 	sync::Arc,
 };
 
-type State<B> = DbState<B>;
+type State<H> = DbState<H>;
 
-struct StorageDb<Block: BlockT> {
+struct StorageDb<Hasher: Hash> {
 	db: Arc<dyn KeyValueDB>,
-	_block: std::marker::PhantomData<Block>,
+	_phantom: std::marker::PhantomData<Hasher::Output>,
 }
 
-impl<Block: BlockT> sp_state_machine::Storage<HashingFor<Block>> for StorageDb<Block> {
-	fn get(&self, key: &Block::Hash, prefix: Prefix) -> Result<Option<DBValue>, String> {
-		let prefixed_key = prefixed_key::<HashingFor<Block>>(key, prefix);
+impl<Hasher: Hash> sp_state_machine::Storage<Hasher> for StorageDb<Hasher> {
+	fn get(&self, key: &Hasher::Output, prefix: Prefix) -> Result<Option<DBValue>, String> {
+		let prefixed_key = prefixed_key::<Hasher>(key, prefix);
 		self.db
 			.get(0, &prefixed_key)
 			.map_err(|e| format!("Database backend error: {:?}", e))
@@ -75,29 +72,29 @@ struct KeyTracker {
 }
 
 /// State that manages the backend database reference. Allows runtime to control the database.
-pub struct BenchmarkingState<B: BlockT> {
-	root: Cell<B::Hash>,
-	genesis_root: B::Hash,
-	state: RefCell<Option<State<B>>>,
+pub struct BenchmarkingState<Hasher: Hash> {
+	root: Cell<Hasher::Output>,
+	genesis_root: Hasher::Output,
+	state: RefCell<Option<State<Hasher>>>,
 	db: Cell<Option<Arc<dyn KeyValueDB>>>,
 	genesis: HashMap<Vec<u8>, (Vec<u8>, i32)>,
 	record: Cell<Vec<Vec<u8>>>,
 	key_tracker: Arc<Mutex<KeyTracker>>,
 	whitelist: RefCell<Vec<TrackedStorageKey>>,
-	proof_recorder: Option<sp_trie::recorder::Recorder<HashingFor<B>>>,
-	proof_recorder_root: Cell<B::Hash>,
-	shared_trie_cache: SharedTrieCache<HashingFor<B>>,
+	proof_recorder: Option<sp_trie::recorder::Recorder<Hasher>>,
+	proof_recorder_root: Cell<Hasher::Output>,
+	shared_trie_cache: SharedTrieCache<Hasher>,
 }
 
 /// A raw iterator over the `BenchmarkingState`.
-pub struct RawIter<B: BlockT> {
-	inner: <DbState<B> as StateBackend<HashingFor<B>>>::RawIter,
+pub struct RawIter<Hasher: Hash> {
+	inner: <DbState<Hasher> as StateBackend<Hasher>>::RawIter,
 	child_trie: Option<Vec<u8>>,
 	key_tracker: Arc<Mutex<KeyTracker>>,
 }
 
-impl<B: BlockT> StorageIterator<HashingFor<B>> for RawIter<B> {
-	type Backend = BenchmarkingState<B>;
+impl<Hasher: Hash> StorageIterator<Hasher> for RawIter<Hasher> {
+	type Backend = BenchmarkingState<Hasher>;
 	type Error = String;
 
 	fn next_key(&mut self, backend: &Self::Backend) -> Option<Result<StorageKey, Self::Error>> {
@@ -128,7 +125,7 @@ impl<B: BlockT> StorageIterator<HashingFor<B>> for RawIter<B> {
 	}
 }
 
-impl<B: BlockT> BenchmarkingState<B> {
+impl<Hasher: Hash> BenchmarkingState<Hasher> {
 	/// Create a new instance that creates a database in a temporary dir.
 	pub fn new(
 		genesis: Storage,
@@ -137,9 +134,9 @@ impl<B: BlockT> BenchmarkingState<B> {
 		enable_tracking: bool,
 	) -> Result<Self, String> {
 		let state_version = sp_runtime::StateVersion::default();
-		let mut root = B::Hash::default();
-		let mut mdb = MemoryDB::<HashingFor<B>>::default();
-		sp_trie::trie_types::TrieDBMutBuilderV1::<HashingFor<B>>::new(&mut mdb, &mut root).build();
+		let mut root = Default::default();
+		let mut mdb = MemoryDB::<Hasher>::default();
+		sp_trie::trie_types::TrieDBMutBuilderV1::<Hasher>::new(&mut mdb, &mut root).build();
 
 		let mut state = BenchmarkingState {
 			state: RefCell::new(None),
@@ -169,7 +166,7 @@ impl<B: BlockT> BenchmarkingState<B> {
 				child_content.data.iter().map(|(k, v)| (k.as_ref(), Some(v.as_ref()))),
 			)
 		});
-		let (root, transaction): (B::Hash, _) =
+		let (root, transaction): (Hasher::Output, _) =
 			state.state.borrow().as_ref().unwrap().full_storage_root(
 				genesis.top.iter().map(|(k, v)| (k.as_ref(), Some(v.as_ref()))),
 				child_delta,
@@ -193,9 +190,9 @@ impl<B: BlockT> BenchmarkingState<B> {
 			recorder.reset();
 			self.proof_recorder_root.set(self.root.get());
 		}
-		let storage_db = Arc::new(StorageDb::<B> { db, _block: Default::default() });
+		let storage_db = Arc::new(StorageDb::<Hasher> { db, _phantom: Default::default() });
 		*self.state.borrow_mut() = Some(
-			DbStateBuilder::<B>::new(storage_db, self.root.get())
+			DbStateBuilder::<Hasher>::new(storage_db, self.root.get())
 				.with_optional_recorder(self.proof_recorder.clone())
 				.with_cache(self.shared_trie_cache.local_cache())
 				.build(),
@@ -341,17 +338,17 @@ fn state_err() -> String {
 	"State is not open".into()
 }
 
-impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
-	type Error = <DbState<B> as StateBackend<HashingFor<B>>>::Error;
-	type TrieBackendStorage = <DbState<B> as StateBackend<HashingFor<B>>>::TrieBackendStorage;
-	type RawIter = RawIter<B>;
+impl<Hasher: Hash> StateBackend<Hasher> for BenchmarkingState<Hasher> {
+	type Error = <DbState<Hasher> as StateBackend<Hasher>>::Error;
+	type TrieBackendStorage = <DbState<Hasher> as StateBackend<Hasher>>::TrieBackendStorage;
+	type RawIter = RawIter<Hasher>;
 
 	fn storage(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
 		self.add_read_key(None, key);
 		self.state.borrow().as_ref().ok_or_else(state_err)?.storage(key)
 	}
 
-	fn storage_hash(&self, key: &[u8]) -> Result<Option<B::Hash>, Self::Error> {
+	fn storage_hash(&self, key: &[u8]) -> Result<Option<Hasher::Output>, Self::Error> {
 		self.add_read_key(None, key);
 		self.state.borrow().as_ref().ok_or_else(state_err)?.storage_hash(key)
 	}
@@ -373,7 +370,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 		&self,
 		child_info: &ChildInfo,
 		key: &[u8],
-	) -> Result<Option<B::Hash>, Self::Error> {
+	) -> Result<Option<Hasher::Output>, Self::Error> {
 		self.add_read_key(Some(child_info.storage_key()), key);
 		self.state
 			.borrow()
@@ -385,7 +382,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 	fn closest_merkle_value(
 		&self,
 		key: &[u8],
-	) -> Result<Option<MerkleValue<B::Hash>>, Self::Error> {
+	) -> Result<Option<MerkleValue<Hasher::Output>>, Self::Error> {
 		self.add_read_key(None, key);
 		self.state.borrow().as_ref().ok_or_else(state_err)?.closest_merkle_value(key)
 	}
@@ -394,7 +391,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 		&self,
 		child_info: &ChildInfo,
 		key: &[u8],
-	) -> Result<Option<MerkleValue<B::Hash>>, Self::Error> {
+	) -> Result<Option<MerkleValue<Hasher::Output>>, Self::Error> {
 		self.add_read_key(None, key);
 		self.state
 			.borrow()
@@ -443,7 +440,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 		&self,
 		delta: impl Iterator<Item = (&'a [u8], Option<&'a [u8]>)>,
 		state_version: StateVersion,
-	) -> (B::Hash, BackendTransaction<HashingFor<B>>) {
+	) -> (Hasher::Output, BackendTransaction<Hasher>) {
 		self.state
 			.borrow()
 			.as_ref()
@@ -455,7 +452,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 		child_info: &ChildInfo,
 		delta: impl Iterator<Item = (&'a [u8], Option<&'a [u8]>)>,
 		state_version: StateVersion,
-	) -> (B::Hash, bool, BackendTransaction<HashingFor<B>>) {
+	) -> (Hasher::Output, bool, BackendTransaction<Hasher>) {
 		self.state
 			.borrow()
 			.as_ref()
@@ -479,8 +476,8 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 
 	fn commit(
 		&self,
-		storage_root: <HashingFor<B> as Hasher>::Out,
-		mut transaction: BackendTransaction<HashingFor<B>>,
+		storage_root: <Hasher as DbHasher>::Out,
+		mut transaction: BackendTransaction<Hasher>,
 		main_storage_changes: StorageCollection,
 		child_storage_changes: ChildStorageCollection,
 	) -> Result<(), Self::Error> {
@@ -634,8 +631,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 				log::debug!(target: "benchmark", "Some proof size: {}", &proof_size);
 				proof_size
 			} else {
-				if let Some(size) = proof.encoded_compact_size::<HashingFor<B>>(proof_recorder_root)
-				{
+				if let Some(size) = proof.encoded_compact_size::<Hasher>(proof_recorder_root) {
 					size as u32
 				} else if proof_recorder_root == self.root.get() {
 					log::debug!(target: "benchmark", "No changes - no proof");
@@ -654,7 +650,7 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for BenchmarkingState<B> {
 	}
 }
 
-impl<Block: BlockT> std::fmt::Debug for BenchmarkingState<Block> {
+impl<Hasher: Hash> std::fmt::Debug for BenchmarkingState<Hasher> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "Bench DB")
 	}

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -101,14 +101,11 @@ pub use bench::BenchmarkingState;
 const CACHE_HEADERS: usize = 8;
 
 /// DB-backed patricia trie state, transaction type is an overlay of changes to commit.
-pub type DbState<B> =
-	sp_state_machine::TrieBackend<Arc<dyn sp_state_machine::Storage<HashingFor<B>>>, HashingFor<B>>;
+pub type DbState<H> = sp_state_machine::TrieBackend<Arc<dyn sp_state_machine::Storage<H>>, H>;
 
 /// Builder for [`DbState`].
-pub type DbStateBuilder<B> = sp_state_machine::TrieBackendBuilder<
-	Arc<dyn sp_state_machine::Storage<HashingFor<B>>>,
-	HashingFor<B>,
->;
+pub type DbStateBuilder<Hasher> =
+	sp_state_machine::TrieBackendBuilder<Arc<dyn sp_state_machine::Storage<Hasher>>, Hasher>;
 
 /// Length of a [`DbHash`].
 const DB_HASH_LEN: usize = 32;
@@ -135,13 +132,17 @@ enum DbExtrinsic<B: BlockT> {
 /// It makes sure that the hash we are using stays pinned in storage
 /// until this structure is dropped.
 pub struct RefTrackingState<Block: BlockT> {
-	state: DbState<Block>,
+	state: DbState<HashingFor<Block>>,
 	storage: Arc<StorageDb<Block>>,
 	parent_hash: Option<Block::Hash>,
 }
 
 impl<B: BlockT> RefTrackingState<B> {
-	fn new(state: DbState<B>, storage: Arc<StorageDb<B>>, parent_hash: Option<B::Hash>) -> Self {
+	fn new(
+		state: DbState<HashingFor<B>>,
+		storage: Arc<StorageDb<B>>,
+		parent_hash: Option<B::Hash>,
+	) -> Self {
 		RefTrackingState { state, parent_hash, storage }
 	}
 }
@@ -162,12 +163,12 @@ impl<Block: BlockT> std::fmt::Debug for RefTrackingState<Block> {
 
 /// A raw iterator over the `RefTrackingState`.
 pub struct RawIter<B: BlockT> {
-	inner: <DbState<B> as StateBackend<HashingFor<B>>>::RawIter,
+	inner: <DbState<HashingFor<B>> as StateBackend<HashingFor<B>>>::RawIter,
 }
 
 impl<B: BlockT> StorageIterator<HashingFor<B>> for RawIter<B> {
 	type Backend = RefTrackingState<B>;
-	type Error = <DbState<B> as StateBackend<HashingFor<B>>>::Error;
+	type Error = <DbState<HashingFor<B>> as StateBackend<HashingFor<B>>>::Error;
 
 	fn next_key(&mut self, backend: &Self::Backend) -> Option<Result<StorageKey, Self::Error>> {
 		self.inner.next_key(&backend.state)
@@ -186,8 +187,9 @@ impl<B: BlockT> StorageIterator<HashingFor<B>> for RawIter<B> {
 }
 
 impl<B: BlockT> StateBackend<HashingFor<B>> for RefTrackingState<B> {
-	type Error = <DbState<B> as StateBackend<HashingFor<B>>>::Error;
-	type TrieBackendStorage = <DbState<B> as StateBackend<HashingFor<B>>>::TrieBackendStorage;
+	type Error = <DbState<HashingFor<B>> as StateBackend<HashingFor<B>>>::Error;
+	type TrieBackendStorage =
+		<DbState<HashingFor<B>> as StateBackend<HashingFor<B>>>::TrieBackendStorage;
 	type RawIter = RawIter<B>;
 
 	fn storage(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -284,7 +286,8 @@ impl<B: BlockT> StateBackend<HashingFor<B>> for RefTrackingState<B> {
 }
 
 impl<B: BlockT> AsTrieBackend<HashingFor<B>> for RefTrackingState<B> {
-	type TrieBackendStorage = <DbState<B> as StateBackend<HashingFor<B>>>::TrieBackendStorage;
+	type TrieBackendStorage =
+		<DbState<HashingFor<B>> as StateBackend<HashingFor<B>>>::TrieBackendStorage;
 
 	fn as_trie_backend(
 		&self,
@@ -1936,7 +1939,7 @@ impl<Block: BlockT> Backend<Block> {
 
 	fn empty_state(&self) -> RecordStatsState<RefTrackingState<Block>, Block> {
 		let root = EmptyStorage::<Block>::new().0; // Empty trie
-		let db_state = DbStateBuilder::<Block>::new(self.storage.clone(), root)
+		let db_state = DbStateBuilder::<HashingFor<Block>>::new(self.storage.clone(), root)
 			.with_optional_cache(self.shared_trie_cache.as_ref().map(|c| c.local_cache()))
 			.build();
 		let state = RefTrackingState::new(db_state, self.storage.clone(), None);
@@ -2428,9 +2431,12 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 		if hash == self.blockchain.meta.read().genesis_hash {
 			if let Some(genesis_state) = &*self.genesis_state.read() {
 				let root = genesis_state.root;
-				let db_state = DbStateBuilder::<Block>::new(genesis_state.clone(), root)
-					.with_optional_cache(self.shared_trie_cache.as_ref().map(|c| c.local_cache()))
-					.build();
+				let db_state =
+					DbStateBuilder::<HashingFor<Block>>::new(genesis_state.clone(), root)
+						.with_optional_cache(
+							self.shared_trie_cache.as_ref().map(|c| c.local_cache()),
+						)
+						.build();
 
 				let state = RefTrackingState::new(db_state, self.storage.clone(), None);
 				return Ok(RecordStatsState::new(state, None, self.state_usage.clone()))
@@ -2449,11 +2455,12 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 					self.storage.state_db.pin(&hash, hdr.number.saturated_into::<u64>(), hint)
 				{
 					let root = hdr.state_root;
-					let db_state = DbStateBuilder::<Block>::new(self.storage.clone(), root)
-						.with_optional_cache(
-							self.shared_trie_cache.as_ref().map(|c| c.local_cache()),
-						)
-						.build();
+					let db_state =
+						DbStateBuilder::<HashingFor<Block>>::new(self.storage.clone(), root)
+							.with_optional_cache(
+								self.shared_trie_cache.as_ref().map(|c| c.local_cache()),
+							)
+							.build();
 					let state = RefTrackingState::new(db_state, self.storage.clone(), Some(hash));
 					Ok(RecordStatsState::new(state, Some(hash), self.state_usage.clone()))
 				} else {

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -37,7 +37,7 @@ use sp_core::{
 };
 use sp_externalities::Extensions;
 use sp_keystore::{testing::MemoryKeystore, KeystoreExt};
-use sp_runtime::traits::{Block as BlockT, Hash, HashingFor};
+use sp_runtime::traits::Hash;
 use sp_state_machine::StateMachine;
 use std::{collections::HashMap, fmt::Debug, fs, str::FromStr, time};
 
@@ -140,19 +140,8 @@ This could mean that you either did not build the node correctly with the \
 not created by a node that was compiled with the flag";
 
 impl PalletCmd {
-	/// Runs the command and benchmarks the chain.
-	#[deprecated(
-		note = "`run` will have a breaking change after July 2024. Use `run_with_hasher` instead."
-	)]
-	pub fn run<BB, ExtraHostFunctions>(&self, config: Configuration) -> Result<()>
-	where
-		BB: BlockT + Debug,
-		ExtraHostFunctions: sp_wasm_interface::HostFunctions,
-	{
-		self.run_with_hasher::<HashingFor<BB>, ExtraHostFunctions>(config)
-	}
-
-	pub fn run_with_hasher<Hasher, ExtraHostFunctions>(&self, config: Configuration) -> Result<()>
+	/// Runs the command and benchmarks a pallet.
+	pub fn run<Hasher, ExtraHostFunctions>(&self, config: Configuration) -> Result<()>
 	where
 		Hasher: Hash,
 		ExtraHostFunctions: sp_wasm_interface::HostFunctions,

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -37,7 +37,7 @@ use sp_core::{
 };
 use sp_externalities::Extensions;
 use sp_keystore::{testing::MemoryKeystore, KeystoreExt};
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::traits::{Block as BlockT, Hash, HashingFor};
 use sp_state_machine::StateMachine;
 use std::{collections::HashMap, fmt::Debug, fs, str::FromStr, time};
 
@@ -141,10 +141,20 @@ not created by a node that was compiled with the flag";
 
 impl PalletCmd {
 	/// Runs the command and benchmarks the chain.
+	#[deprecated(
+		note = "`run` will have a breaking change after July 2024. Use `run_with_hasher` instead."
+	)]
 	pub fn run<BB, ExtraHostFunctions>(&self, config: Configuration) -> Result<()>
 	where
 		BB: BlockT + Debug,
-		<<<BB as BlockT>::Header as HeaderT>::Number as std::str::FromStr>::Err: std::fmt::Debug,
+		ExtraHostFunctions: sp_wasm_interface::HostFunctions,
+	{
+		self.run_with_hasher::<HashingFor<BB>, ExtraHostFunctions>(config)
+	}
+
+	pub fn run_with_hasher<Hasher, ExtraHostFunctions>(&self, config: Configuration) -> Result<()>
+	where
+		Hasher: Hash,
 		ExtraHostFunctions: sp_wasm_interface::HostFunctions,
 	{
 		let _d = self.execution.as_ref().map(|exec| {
@@ -199,7 +209,7 @@ impl PalletCmd {
 		let genesis_storage = spec.build_storage()?;
 		let mut changes = Default::default();
 		let cache_size = Some(self.database_cache_size as usize);
-		let state_with_tracking = BenchmarkingState::<BB>::new(
+		let state_with_tracking = BenchmarkingState::<Hasher>::new(
 			genesis_storage.clone(),
 			cache_size,
 			// Record proof size
@@ -207,7 +217,7 @@ impl PalletCmd {
 			// Enable storage tracking
 			true,
 		)?;
-		let state_without_tracking = BenchmarkingState::<BB>::new(
+		let state_without_tracking = BenchmarkingState::<Hasher>::new(
 			genesis_storage,
 			cache_size,
 			// Do not record proof size

--- a/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/write.rs
@@ -57,7 +57,7 @@ impl StorageCmd {
 		let best_hash = client.usage_info().chain.best_hash;
 		let header = client.header(best_hash)?.ok_or("Header not found")?;
 		let original_root = *header.state_root();
-		let trie = DbStateBuilder::<Block>::new(storage.clone(), original_root).build();
+		let trie = DbStateBuilder::<HashingFor<Block>>::new(storage.clone(), original_root).build();
 
 		info!("Preparing keys from block {}", best_hash);
 		// Load all KV pairs and randomly shuffle them.
@@ -189,7 +189,7 @@ fn convert_tx<B: BlockT>(
 /// if `child_info` exist then it means this is a child tree key
 fn measure_write<Block: BlockT>(
 	db: Arc<dyn sp_database::Database<DbHash>>,
-	trie: &DbState<Block>,
+	trie: &DbState<HashingFor<Block>>,
 	key: Vec<u8>,
 	new_v: Vec<u8>,
 	version: StateVersion,
@@ -220,7 +220,7 @@ fn measure_write<Block: BlockT>(
 /// if `child_info` exist then it means this is a child tree key
 fn check_new_value<Block: BlockT>(
 	db: Arc<dyn sp_database::Database<DbHash>>,
-	trie: &DbState<Block>,
+	trie: &DbState<HashingFor<Block>>,
 	key: &Vec<u8>,
 	new_v: &Vec<u8>,
 	version: StateVersion,


### PR DESCRIPTION
Preparation for https://github.com/paritytech/polkadot-sdk/issues/2664

Changes:
- Only require `Hash` instead of `Block` for the benchmarking
- Refactor DB types to do the same

## Integration

This breaking change can easily be integrated into your node via:  
```patch
- cmd.run::<Block, ()>(config)
+ cmd.run::<HashingFor<Block>, ()>(config)
```

Status: waiting for CI checks