### PR TITLE
[ci] Don't run prdoc and lables GHA on master

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,6 +3,7 @@ name: Check labels
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
+  push:
     branches-ignore:
       - master
   merge_group:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,9 +3,6 @@ name: Check labels
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
-  push:
-    branches-ignore:
-      - master
   merge_group:
 
 jobs:
@@ -14,6 +11,9 @@ jobs:
     steps:
       - name: Skip merge queue
         if: ${{ contains(github.ref, 'gh-readonly-queue') }}
+        run: exit 0
+      - name: Skip master
+        if: ${{ contains(github.ref, 'master') }}
         run: exit 0
       - name: Pull image
         env:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,17 +9,6 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip merge queue
-        if: ${{ contains(github.ref, 'gh-readonly-queue') }}
-        run: exit 0
-      - name: Skip master
-        if: ${{ contains(github.ref, 'master') }}
-        run: exit 0
-      - name: Pull image
-        env:
-          IMAGE: paritytech/ruled_labels:0.4.0
-        run: docker pull $IMAGE
-
       - name: Check labels
         env:
           IMAGE: paritytech/ruled_labels:0.4.0
@@ -31,6 +20,16 @@ jobs:
           RULES_PATH: labels/ruled_labels
           CHECK_SPECS: "specs_polkadot-sdk.yaml"
         run: |
+          if [ ${{ github.ref }} == "refs/heads/master" ]; then
+            echo "Skipping master"
+            exit 0
+          fi
+          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
+            echo "Skipping merge queue"
+            exit 0
+          fi
+
+          docker pull $IMAGE
           echo "REPO: ${REPO}"
           echo "GITHUB_PR: ${GITHUB_PR}"
 

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,6 +3,8 @@ name: Check labels
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
+    branches-ignore:
+      - master
   merge_group:
 
 jobs:

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -41,7 +41,7 @@ jobs:
           echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest
-    if: ${{ needs.check-prdoc-mq-and-master.outputs.status }} == 'true'
+    if: needs.check-prdoc-mq-and-master.outputs.status == 'true'
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -31,10 +31,6 @@ jobs:
             echo "skip=true"  >> "$GITHUB_OUTPUT"
             echo "Skipping merge queue"
           fi
-          if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
-            echo "skip=true"  >> "$GITHUB_OUTPUT"
-            echo "Check that skip works"
-          fi
   check-prdoc:
     runs-on: ubuntu-latest
     if: ${{ needs.check-prdoc-mq-and-master.outputs.status == 'true' }}

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -33,6 +33,11 @@ jobs:
             echo "Skipping merge queue"
             exit 0
           fi
+          if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
+            echo "skip=true"  >> "$GITHUB_OUTPUT"
+            echo "Check that skip works"
+            exit 0
+          fi
           echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -33,10 +33,15 @@ jobs:
             echo "Skipping merge queue"
             exit 0
           fi
+          if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
+            echo "skip=true"  >> "$GITHUB_OUTPUT"
+            echo "Check that skip works"
+            exit 0
+          fi
           echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest
-    if: ${{ needs.check-prdoc-mq-and-master.outputs.status == 'true' }}
+    if: ${{ needs.check-prdoc-mq-and-master.outputs.status }} == 'true'
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -15,8 +15,23 @@ env:
   PRDOC_DOC: https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/prdoc.md
 
 jobs:
+  check-prdoc-mq-and-master:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.prdoc-check.outputs.skip }}
+    steps:
+      - name: Test if PRdoc runs on master or merge queue
+        id: prdoc-check
+        run: |
+          if [ ${{ github.ref }} == "refs/heads/master" ]; then
+            echo "skip=true"  >> "$GITHUB_OUTPUT"
+          fi
+          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
+            echo "skip=true"  >> "$GITHUB_OUTPUT"
+          fi
   check-prdoc:
     runs-on: ubuntu-latest
+    if: ${{ needs.check-prdoc-mq-and-master.outputs.status != 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
@@ -25,15 +40,6 @@ jobs:
       - name: Check if PRdoc is required
         id: get-labels
         run: |
-          if [ ${{ github.ref }} == "refs/heads/master" ]; then
-            echo "Skipping master"
-            exit 0
-          fi
-          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
-            echo "Skipping merge queue"
-            exit 0
-          fi
-
           echo "Pulling $IMAGE"
           $ENGINE pull $IMAGE
 
@@ -49,15 +55,6 @@ jobs:
       - name: Early exit if PR is silent
         if: ${{ contains(steps.get-labels.outputs.labels, 'R0') }}
         run: |
-          if [ ${{ github.ref }} == "refs/heads/master" ]; then
-            echo "Skipping master"
-            exit 0
-          fi
-          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
-            echo "Skipping merge queue"
-            exit 0
-          fi
-
           hits=$(find prdoc -name "pr_$GITHUB_PR*.prdoc" | wc -l)
           if (( hits > 0 )); then
             echo "PR detected as silent, but a PRDoc was found, checking it as information"
@@ -71,15 +68,6 @@ jobs:
       - name: PRdoc check for PR#${{ github.event.pull_request.number }}
         if: ${{ !contains(steps.get-labels.outputs.labels, 'R0') }}
         run: |
-          if [ ${{ github.ref }} == "refs/heads/master" ]; then
-            echo "Skipping master"
-            exit 0
-          fi
-          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
-            echo "Skipping merge queue"
-            exit 0
-          fi
-
           echo "Checking for PR#${GITHUB_PR}"
           echo "You can find more information about PRDoc at $PRDOC_DOC"
           $ENGINE run --rm -v $PWD:/repo $IMAGE check -n ${GITHUB_PR}

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -36,7 +36,7 @@ jobs:
           echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest
-    if: needs.check-prdoc-mq-and-master.outputs.status == 'true'
+    if: needs.check-prdoc-mq-and-master.outputs.status != 'false'
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -37,7 +37,7 @@ jobs:
           fi
   check-prdoc:
     runs-on: ubuntu-latest
-    if: ${{ needs.check-prdoc-mq-and-master.outputs.status != 'true' }}
+    if: ${{ needs.check-prdoc-mq-and-master.outputs.status == 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -15,33 +15,33 @@ env:
   PRDOC_DOC: https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/prdoc.md
 
 jobs:
-  check-prdoc-mq-and-master:
-    runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.prdoc-check.outputs.skip }}
-    steps:
-      - name: Test if PRdoc runs on master or merge queue
-        id: prdoc-check
-        run: |
-          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-            echo "skip=true"  >> "$GITHUB_OUTPUT"
-            echo "Skipping master"
-            exit 0
-          fi
-          if [ $(echo "${{ github.ref }}" | grep -c "gh-readonly-queue") -eq 1 ]; then
-            echo "skip=true"  >> "$GITHUB_OUTPUT"
-            echo "Skipping merge queue"
-            exit 0
-          fi
-          if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
-            echo "skip=true"  >> "$GITHUB_OUTPUT"
-            echo "Check that skip works"
-            exit 0
-          fi
-          echo "skip=false"  >> "$GITHUB_OUTPUT"
+  # check-prdoc-mq-and-master:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     status: ${{ steps.prdoc-check.outputs.skip }}
+  #   steps:
+  #     - name: Test if PRdoc runs on master or merge queue
+  #       id: prdoc-check
+  #       run: |
+  #         if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+  #           echo "skip=true"  >> "$GITHUB_OUTPUT"
+  #           echo "Skipping master"
+  #           exit 0
+  #         fi
+  #         if [ $(echo "${{ github.ref }}" | grep -c "gh-readonly-queue") -eq 1 ]; then
+  #           echo "skip=true"  >> "$GITHUB_OUTPUT"
+  #           echo "Skipping merge queue"
+  #           exit 0
+  #         fi
+  #         if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
+  #           echo "skip=true"  >> "$GITHUB_OUTPUT"
+  #           echo "Check that skip works"
+  #           exit 0
+  #         fi
+  #         echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest
-    if: needs.check-prdoc-mq-and-master.outputs.status != 'false'
+    if: ${{ !github.ref == 'refs/heads/master' && !contains(github.ref, 'gh-readonly-queue') && !github.ref == 'refs/pull/3257/merge' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -26,11 +26,14 @@ jobs:
           if [ "${{ github.ref }}" == "refs/heads/master" ]; then
             echo "skip=true"  >> "$GITHUB_OUTPUT"
             echo "Skipping master"
+            exit 0
           fi
           if [ $(echo "${{ github.ref }}" | grep -c "gh-readonly-queue") -eq 1 ]; then
             echo "skip=true"  >> "$GITHUB_OUTPUT"
             echo "Skipping merge queue"
+            exit 0
           fi
+          echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest
     if: ${{ needs.check-prdoc-mq-and-master.outputs.status == 'true' }}

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -3,9 +3,6 @@ name: Check PRdoc
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
-  push:
-    branches-ignore:
-      - master
   merge_group:
 
 env:
@@ -25,6 +22,9 @@ jobs:
       # due to https://github.com/paritytech/prdoc/issues/15
       - name: Skip merge queue
         if: ${{ contains(github.ref, 'gh-readonly-queue') }}
+        run: exit 0
+      - name: Skip master
+        if: ${{ contains(github.ref, 'master') }}
         run: exit 0
       - name: Pull image
         run: |

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -3,6 +3,7 @@ name: Check PRdoc
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
+  push:
     branches-ignore:
       - master
   merge_group:

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -33,11 +33,6 @@ jobs:
             echo "Skipping merge queue"
             exit 0
           fi
-          if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
-            echo "skip=true"  >> "$GITHUB_OUTPUT"
-            echo "Check that skip works"
-            exit 0
-          fi
           echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -15,33 +15,9 @@ env:
   PRDOC_DOC: https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/prdoc.md
 
 jobs:
-  # check-prdoc-mq-and-master:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     status: ${{ steps.prdoc-check.outputs.skip }}
-  #   steps:
-  #     - name: Test if PRdoc runs on master or merge queue
-  #       id: prdoc-check
-  #       run: |
-  #         if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-  #           echo "skip=true"  >> "$GITHUB_OUTPUT"
-  #           echo "Skipping master"
-  #           exit 0
-  #         fi
-  #         if [ $(echo "${{ github.ref }}" | grep -c "gh-readonly-queue") -eq 1 ]; then
-  #           echo "skip=true"  >> "$GITHUB_OUTPUT"
-  #           echo "Skipping merge queue"
-  #           exit 0
-  #         fi
-  #         if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
-  #           echo "skip=true"  >> "$GITHUB_OUTPUT"
-  #           echo "Check that skip works"
-  #           exit 0
-  #         fi
-  #         echo "skip=false"  >> "$GITHUB_OUTPUT"
   check-prdoc:
     runs-on: ubuntu-latest
-    if: ${{ !github.ref == 'refs/heads/master' && !contains(github.ref, 'gh-readonly-queue') && !github.ref == 'refs/pull/3257/merge' }}
+    if: ${{ !github.ref == 'refs/heads/master' && !contains(github.ref, 'gh-readonly-queue') }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -3,6 +3,8 @@ name: Check PRdoc
 on:
   pull_request:
     types: [labeled, opened, synchronize, unlabeled]
+    branches-ignore:
+      - master
   merge_group:
 
 env:

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -18,6 +18,8 @@ jobs:
   check-prdoc:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       # we cannot show the version in this step (ie before checking out the repo)
       # due to https://github.com/paritytech/prdoc/issues/15
       - name: Check if PRdoc is required
@@ -43,9 +45,6 @@ jobs:
 
           echo "Checking PRdoc version"
           $ENGINE run --rm -v $PWD:/repo $IMAGE --version
-
-      - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Early exit if PR is silent
         if: ${{ contains(steps.get-labels.outputs.labels, 'R0') }}

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -20,36 +20,45 @@ jobs:
     steps:
       # we cannot show the version in this step (ie before checking out the repo)
       # due to https://github.com/paritytech/prdoc/issues/15
-      - name: Skip merge queue
-        if: ${{ contains(github.ref, 'gh-readonly-queue') }}
-        run: exit 0
-      - name: Skip master
-        if: ${{ contains(github.ref, 'master') }}
-        run: exit 0
-      - name: Pull image
-        run: |
-          echo "Pulling $IMAGE"
-          $ENGINE pull $IMAGE
-
       - name: Check if PRdoc is required
         id: get-labels
         run: |
+          if [ ${{ github.ref }} == "refs/heads/master" ]; then
+            echo "Skipping master"
+            exit 0
+          fi
+          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
+            echo "Skipping merge queue"
+            exit 0
+          fi
+
+          echo "Pulling $IMAGE"
+          $ENGINE pull $IMAGE
+
           # Fetch the labels for the PR under test
           echo "Fetch the labels for $API_BASE/${REPO}/pulls/${GITHUB_PR}"
           labels=$( curl -H "Authorization: token ${GITHUB_TOKEN}" -s "$API_BASE/${REPO}/pulls/${GITHUB_PR}" | jq '.labels | .[] | .name' | tr "\n" ",")
           echo "Labels: ${labels}"
           echo "labels=${labels}" >> "$GITHUB_OUTPUT"
 
+          echo "Checking PRdoc version"
+          $ENGINE run --rm -v $PWD:/repo $IMAGE --version
+
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
-
-      - name: Check PRDoc version
-        run: |
-          $ENGINE run --rm -v $PWD:/repo $IMAGE --version
 
       - name: Early exit if PR is silent
         if: ${{ contains(steps.get-labels.outputs.labels, 'R0') }}
         run: |
+          if [ ${{ github.ref }} == "refs/heads/master" ]; then
+            echo "Skipping master"
+            exit 0
+          fi
+          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
+            echo "Skipping merge queue"
+            exit 0
+          fi
+
           hits=$(find prdoc -name "pr_$GITHUB_PR*.prdoc" | wc -l)
           if (( hits > 0 )); then
             echo "PR detected as silent, but a PRDoc was found, checking it as information"
@@ -63,6 +72,15 @@ jobs:
       - name: PRdoc check for PR#${{ github.event.pull_request.number }}
         if: ${{ !contains(steps.get-labels.outputs.labels, 'R0') }}
         run: |
+          if [ ${{ github.ref }} == "refs/heads/master" ]; then
+            echo "Skipping master"
+            exit 0
+          fi
+          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
+            echo "Skipping merge queue"
+            exit 0
+          fi
+
           echo "Checking for PR#${GITHUB_PR}"
           echo "You can find more information about PRDoc at $PRDOC_DOC"
           $ENGINE run --rm -v $PWD:/repo $IMAGE check -n ${GITHUB_PR}

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -23,11 +23,17 @@ jobs:
       - name: Test if PRdoc runs on master or merge queue
         id: prdoc-check
         run: |
-          if [ ${{ github.ref }} == "refs/heads/master" ]; then
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
             echo "skip=true"  >> "$GITHUB_OUTPUT"
+            echo "Skipping master"
           fi
-          if [ $(echo ${{ github.ref }} | grep -c "gh-readonly-queue") -eq 1 ]; then
+          if [ $(echo "${{ github.ref }}" | grep -c "gh-readonly-queue") -eq 1 ]; then
             echo "skip=true"  >> "$GITHUB_OUTPUT"
+            echo "Skipping merge queue"
+          fi
+          if [ "${{ github.ref }}" == "refs/pull/3257/merge" ]; then
+            echo "skip=true"  >> "$GITHUB_OUTPUT"
+            echo "Check that skip works"
           fi
   check-prdoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-prdoc.yml
+++ b/.github/workflows/check-prdoc.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   check-prdoc:
     runs-on: ubuntu-latest
-    if: ${{ !github.ref == 'refs/heads/master' && !contains(github.ref, 'gh-readonly-queue') }}
+    if: github.event.pull_request.number != ''
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1


### PR DESCRIPTION
PR adds condition to ignore master branch for prdoc and labels GHA.

This option doesn't work because all PRs are for master thus the actions won't start:
```yml
on:
  pull_request:
    branches-ignore:
      - master
```

This option doesn't work because actions don't see the PR number and [break](https://github.com/paritytech/polkadot-sdk/actions/runs/7827272667/job/21354764953):
```yml
on:
  push:
    branches-ignore:
      - master
```

cc https://github.com/paritytech/ci_cd/issues/940
cc https://github.com/paritytech/polkadot-sdk/issues/3240