### PR TITLE
chainSpec: Add `Checkpoint` extension to the chainSpec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16602,7 +16602,9 @@ dependencies = [
  "sc-consensus-grandpa",
  "serde",
  "serde_json",
+ "sp-api",
  "sp-blockchain",
+ "sp-core",
  "sp-runtime",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16595,6 +16595,7 @@ version = "0.34.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
+ "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -16604,9 +16605,12 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
+ "sp-consensus",
  "sp-core",
  "sp-runtime",
+ "substrate-test-runtime-client",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/polkadot/node/service/src/chain_spec.rs
+++ b/polkadot/node/service/src/chain_spec.rs
@@ -67,6 +67,10 @@ pub struct Extensions {
 	///
 	/// This value will be set by the `sync-state rpc` implementation.
 	pub light_sync_state: sc_sync_state_rpc::LightSyncStateExtension,
+	/// The checkpoint extension.
+	///
+	/// This value will be set by the `sync-state rpc` implementation.
+	pub light_sync_state: sc_sync_state_rpc::CheckpointExtension<Block>,
 }
 
 // Generic chain spec, in case when we don't have the native runtime.

--- a/polkadot/node/service/src/chain_spec.rs
+++ b/polkadot/node/service/src/chain_spec.rs
@@ -70,7 +70,7 @@ pub struct Extensions {
 	/// The checkpoint extension.
 	///
 	/// This value will be set by the `sync-state rpc` implementation.
-	pub light_sync_state: sc_sync_state_rpc::CheckpointExtension<Block>,
+	pub checkpoint: sc_sync_state_rpc::CheckpointExtension,
 }
 
 // Generic chain spec, in case when we don't have the native runtime.

--- a/polkadot/rpc/src/lib.rs
+++ b/polkadot/rpc/src/lib.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use jsonrpsee::RpcModule;
 use polkadot_primitives::{AccountId, Balance, Block, BlockNumber, Hash, Nonce};
-use sc_client_api::AuxStore;
+use sc_client_api::{AuxStore, ProofProvider};
 use sc_consensus_beefy::communication::notification::{
 	BeefyBestBlockStream, BeefyVersionedFinalityProofStream,
 };
@@ -102,6 +102,7 @@ where
 		+ HeaderBackend<Block>
 		+ AuxStore
 		+ HeaderMetadata<Block, Error = BlockChainError>
+		+ ProofProvider<Block>
 		+ Send
 		+ Sync
 		+ 'static,

--- a/substrate/bin/node/cli/src/chain_spec.rs
+++ b/substrate/bin/node/cli/src/chain_spec.rs
@@ -60,7 +60,7 @@ pub struct Extensions {
 	/// The light sync state extension used by the sync-state rpc.
 	pub light_sync_state: sc_sync_state_rpc::LightSyncStateExtension,
 	/// The checkpoint extension used by the sync-state rpc.
-	pub light_sync_state: sc_sync_state_rpc::CheckpointExtension<Block>,
+	pub checkpoint: sc_sync_state_rpc::CheckpointExtension,
 }
 
 /// Specialized `ChainSpec`.

--- a/substrate/bin/node/cli/src/chain_spec.rs
+++ b/substrate/bin/node/cli/src/chain_spec.rs
@@ -59,6 +59,8 @@ pub struct Extensions {
 	pub bad_blocks: sc_client_api::BadBlocks<Block>,
 	/// The light sync state extension used by the sync-state rpc.
 	pub light_sync_state: sc_sync_state_rpc::LightSyncStateExtension,
+	/// The checkpoint extension used by the sync-state rpc.
+	pub light_sync_state: sc_sync_state_rpc::CheckpointExtension<Block>,
 }
 
 /// Specialized `ChainSpec`.

--- a/substrate/bin/node/rpc/src/lib.rs
+++ b/substrate/bin/node/rpc/src/lib.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 
 use jsonrpsee::RpcModule;
 use node_primitives::{AccountId, Balance, Block, BlockNumber, Hash, Nonce};
-use sc_client_api::AuxStore;
+use sc_client_api::{AuxStore, ProofProvider};
 use sc_consensus_babe::BabeWorkerHandle;
 use sc_consensus_beefy::communication::notification::{
 	BeefyBestBlockStream, BeefyVersionedFinalityProofStream,
@@ -133,6 +133,7 @@ where
 		+ HeaderBackend<Block>
 		+ AuxStore
 		+ HeaderMetadata<Block, Error = BlockChainError>
+		+ ProofProvider<Block>
 		+ Sync
 		+ Send
 		+ 'static,

--- a/substrate/client/chain-spec/src/chain_spec.rs
+++ b/substrate/client/chain-spec/src/chain_spec.rs
@@ -648,6 +648,7 @@ where
 				storage.top.insert(sp_core::storage::well_known_keys::CODE.to_vec(), code);
 				RawGenesis::from(storage)
 			},
+
 			(
 				true,
 				Genesis::RuntimeGenesis(RuntimeGenesisInner {

--- a/substrate/client/sync-state-rpc/Cargo.toml
+++ b/substrate/client/sync-state-rpc/Cargo.toml
@@ -29,3 +29,9 @@ sc-consensus-epochs = { path = "../consensus/epochs" }
 sc-consensus-grandpa = { path = "../consensus/grandpa" }
 sp-blockchain = { path = "../../primitives/blockchain" }
 sp-runtime = { path = "../../primitives/runtime" }
+
+[dev-dependencies]
+tokio = { version = "1.22.0", features = ["macros"] }
+substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
+sp-consensus = { path = "../../primitives/consensus/common" }
+sc-block-builder = { path = "../block-builder" }

--- a/substrate/client/sync-state-rpc/Cargo.toml
+++ b/substrate/client/sync-state-rpc/Cargo.toml
@@ -22,6 +22,8 @@ serde_json = "1.0.111"
 thiserror = "1.0.48"
 sc-chain-spec = { path = "../chain-spec" }
 sc-client-api = { path = "../api" }
+sp-api = { path = "../../primitives/api" }
+sp-core = { path = "../../primitives/core" }
 sc-consensus-babe = { path = "../consensus/babe" }
 sc-consensus-epochs = { path = "../consensus/epochs" }
 sc-consensus-grandpa = { path = "../consensus/grandpa" }

--- a/substrate/client/sync-state-rpc/src/lib.rs
+++ b/substrate/client/sync-state-rpc/src/lib.rs
@@ -243,6 +243,7 @@ where
 {
 	async fn system_gen_sync_spec(&self, raw: bool) -> Result<serde_json::Value, Error<Block>> {
 		// Build data to pass to the chainSpec as extensions.
+		// TODO: Both these states could be cached to avoid recomputation.
 		let current_sync_state = self.build_sync_state().await?;
 		let checkpoint_state = self.build_checkpoint()?;
 


### PR DESCRIPTION
The `Checkpoint` extension is needed for the lightclient to synchronize faster to the head of the chain.

This is a replacement for the current `lightSyncState`, which doesn't expose directly any particular data about the grandpa or babe; and therefore doesn't cause a breaking change when switching consensus mechanisms (sassafras).

Instead, the finalized block's `:code` section is exposed indirectly in a storage proof. Then, the user of the checkpoint will regenerate the state of the consensus using the runtime APIs.

The `checkpoint` is a Merkle proof that consists of:
- `:code` and `:heappages` storage proofs
- `BabeApi_current_epoch`, `BabeApi_next_epoch`, `BabeApi_configuration`, `GrandpaApi_grandpa_authorities`, and `GrandpaApi_current_set_id` call proofs

```json
"checkpoint": {
    "header": "...",
    "callProof": "..."
}
```

For now, the `checkpoint` extension is added next to the `lightSyncState`. A future PR will deprecate and remove the `lightSyncState`.

This PR validates the proposal from: https://github.com/paritytech/polkadot-sdk/issues/60; as well as unblocks the `chainSpec` V2 method which awaits a consensus on the `checkpoint` format: https://github.com/paritytech/json-rpc-interface-spec/pull/124.


### Testing Done
- Checked that the storage proof contains the `:code` section needed for users to regenerate the consensus state.
