### PR TITLE
[DRAFT] Crypto Refactory

### DIFF
--- a/cumulus/parachain-template/node/src/chain_spec.rs
+++ b/cumulus/parachain-template/node/src/chain_spec.rs
@@ -4,7 +4,7 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
 use sp_core::{
-	crypto::{CryptoType, Pair, Public},
+	crypto::{Pair, Public},
 	sr25519,
 };
 use sp_runtime::traits::{IdentifyAccount, Verify};
@@ -16,7 +16,7 @@ pub type ChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -51,7 +51,7 @@ pub fn get_collator_keys_from_seed(seed: &str) -> AuraId {
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/parachain-template/node/src/chain_spec.rs
+++ b/cumulus/parachain-template/node/src/chain_spec.rs
@@ -3,7 +3,10 @@ use parachain_template_runtime::{AccountId, AuraId, Signature, EXISTENTIAL_DEPOS
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public},
+	sr25519,
+};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
@@ -13,7 +16,7 @@ pub type ChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -48,7 +51,7 @@ pub fn get_collator_keys_from_seed(seed: &str) -> AuraId {
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -23,7 +23,11 @@ pub use xcm_emulator;
 use grandpa::AuthorityId as GrandpaId;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe::AuthorityId as BabeId;
-use sp_core::{sr25519, storage::Storage, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public},
+	sr25519,
+	storage::Storage,
+};
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	BuildStorage, MultiSignature,
@@ -50,7 +54,7 @@ pub const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 type AccountPublic = <MultiSignature as Verify>::Signer;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -59,7 +63,7 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 /// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -24,7 +24,7 @@ use grandpa::AuthorityId as GrandpaId;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe::AuthorityId as BabeId;
 use sp_core::{
-	crypto::{CryptoType, Pair, Public},
+	crypto::{Pair, Public},
 	sr25519,
 	storage::Storage,
 };
@@ -54,7 +54,7 @@ pub const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 type AccountPublic = <MultiSignature as Verify>::Signer;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -63,7 +63,7 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoTyp
 /// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/polkadot-parachain/src/chain_spec/mod.rs
+++ b/cumulus/polkadot-parachain/src/chain_spec/mod.rs
@@ -17,7 +17,7 @@
 use parachains_common::{AccountId, Signature};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use serde::{Deserialize, Serialize};
-use sp_core::{Pair, Public};
+use sp_core::crypto::{CryptoType, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 pub mod asset_hubs;
@@ -56,7 +56,7 @@ impl Extensions {
 pub type GenericChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -67,7 +67,7 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
@@ -75,6 +75,8 @@ where
 /// Generate collator keys from seed.
 ///
 /// This function's return type must always match the session keys of the chain in tuple format.
-pub fn get_collator_keys_from_seed<AuraId: Public>(seed: &str) -> <AuraId::Pair as Pair>::Public {
+pub fn get_collator_keys_from_seed<AuraId: Public>(
+	seed: &str,
+) -> <AuraId::Pair as CryptoType>::Public {
 	get_from_seed::<AuraId>(seed)
 }

--- a/cumulus/polkadot-parachain/src/service.rs
+++ b/cumulus/polkadot-parachain/src/service.rs
@@ -36,7 +36,7 @@ use cumulus_primitives_core::{
 	ParaId,
 };
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface};
-use sp_core::Pair;
+use sp_core::crypto::CryptoType;
 
 use jsonrpsee::RpcModule;
 
@@ -1245,8 +1245,8 @@ where
 		+ sp_api::ApiExt<Block>
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as CryptoType>::Public>,
+	<<AuraId as AppCrypto>::Pair as CryptoType>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	let client2 = client.clone();
@@ -1309,10 +1309,10 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as CryptoType>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<<AuraId as AppCrypto>::Pair as CryptoType>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1405,11 +1405,11 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as CryptoType>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<<AuraId as AppCrypto>::Pair as CryptoType>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1505,10 +1505,10 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as CryptoType>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<<AuraId as AppCrypto>::Pair as CryptoType>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1653,11 +1653,11 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as CryptoType>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<<AuraId as AppCrypto>::Pair as CryptoType>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_node_impl::<RuntimeApi, _, _, _>(
@@ -1803,10 +1803,10 @@ where
 		+ sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
-		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as Pair>::Public>
+		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppCrypto>::Pair as CryptoType>::Public>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
 		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>,
-	<<AuraId as AppCrypto>::Pair as Pair>::Signature:
+	<<AuraId as AppCrypto>::Pair as CryptoType>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
 	start_basic_lookahead_node_impl::<RuntimeApi, _, _, _>(

--- a/cumulus/test/service/src/chain_spec.rs
+++ b/cumulus/test/service/src/chain_spec.rs
@@ -21,14 +21,17 @@ use cumulus_test_runtime::{AccountId, RuntimeGenesisConfig, Signature};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public},
+	sr25519,
+};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig, Extensions>;
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -54,7 +57,7 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -38,7 +38,11 @@ pub use frame_system::{Config as SystemConfig, Pallet as SystemPallet};
 pub use pallet_balances::AccountData;
 pub use pallet_message_queue;
 pub use sp_arithmetic::traits::Bounded;
-pub use sp_core::{parameter_types, sr25519, storage::Storage, Pair};
+pub use sp_core::{
+	crypto::{CryptoType, Pair},
+	parameter_types, sr25519,
+	storage::Storage,
+};
 pub use sp_crypto_hashing::blake2_256;
 pub use sp_io::TestExternalities;
 pub use sp_runtime::BoundedSlice;
@@ -1588,11 +1592,10 @@ pub mod helpers {
 	/// Helper function to generate an account ID from seed.
 	pub fn get_account_id_from_seed<TPublic: sp_core::Public>(seed: &str) -> AccountId
 	where
-		sp_runtime::MultiSigner:
-			From<<<TPublic as sp_runtime::CryptoType>::Pair as sp_core::Pair>::Public>,
+		sp_runtime::MultiSigner: From<<<TPublic as CryptoType>::Pair as CryptoType>::Public>,
 	{
 		use sp_runtime::traits::IdentifyAccount;
-		let pubkey = TPublic::Pair::from_string(&format!("//{}", seed), None)
+		let pubkey = <TPublic as CryptoType>::Pair::from_string(&format!("//{}", seed), None)
 			.expect("static values are valid; qed")
 			.public();
 		sp_runtime::MultiSigner::from(pubkey).into_account()

--- a/polkadot/node/service/src/chain_spec.rs
+++ b/polkadot/node/service/src/chain_spec.rs
@@ -32,7 +32,10 @@ use sc_chain_spec::ChainSpecExtension;
 #[cfg(any(feature = "westend-native", feature = "rococo-native"))]
 use sc_chain_spec::ChainType;
 use serde::{Deserialize, Serialize};
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public},
+	sr25519,
+};
 use sp_runtime::traits::IdentifyAccount;
 #[cfg(feature = "westend-native")]
 use sp_runtime::Perbill;
@@ -710,7 +713,7 @@ pub fn versi_staging_testnet_config() -> Result<RococoChainSpec, String> {
 }
 
 /// Helper function to generate a crypto pair from seed
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -719,7 +722,7 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/polkadot/runtime/common/src/purchase.rs
+++ b/polkadot/runtime/common/src/purchase.rs
@@ -479,7 +479,10 @@ where
 mod tests {
 	use super::*;
 
-	use sp_core::{crypto::AccountId32, ed25519, Pair, Public, H256};
+	use sp_core::{
+		crypto::{AccountId32, CryptoType, Pair, Public},
+		ed25519, H256,
+	};
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 	use crate::purchase;
@@ -625,7 +628,7 @@ mod tests {
 	type AccountPublic = <MultiSignature as Verify>::Signer;
 
 	/// Helper function to generate a crypto pair from seed
-	fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+	fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 		TPublic::Pair::from_string(&format!("//{}", seed), None)
 			.expect("static values are valid; qed")
 			.public()
@@ -634,7 +637,7 @@ mod tests {
 	/// Helper function to generate an account ID from seed
 	fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 	where
-		AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+		AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 	{
 		AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 	}

--- a/substrate/bin/node-template/node/src/chain_spec.rs
+++ b/substrate/bin/node-template/node/src/chain_spec.rs
@@ -2,7 +2,10 @@ use node_template_runtime::{AccountId, RuntimeGenesisConfig, Signature, WASM_BIN
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public},
+	sr25519,
+};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 // The URL for the telemetry server.
@@ -12,8 +15,8 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
 
 /// Generate a crypto pair from seed.
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-	TPublic::Pair::from_string(&format!("//{}", seed), None)
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> TPublic {
+	<TPublic as CryptoType>::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
 }
@@ -23,7 +26,7 @@ type AccountPublic = <Signature as Verify>::Signer;
 /// Generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<TPublic>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/substrate/bin/node/cli/src/chain_spec.rs
+++ b/substrate/bin/node/cli/src/chain_spec.rs
@@ -30,7 +30,10 @@ use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
 use sp_consensus_babe::AuthorityId as BabeId;
-use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public, UncheckedInto},
+	sr25519,
+};
 use sp_mixnet::types::AuthorityId as MixnetId;
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
@@ -245,7 +248,7 @@ pub fn staging_testnet_config() -> ChainSpec {
 }
 
 /// Helper function to generate a crypto pair from seed.
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -254,7 +257,7 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 /// Helper function to generate an account ID from seed.
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/substrate/bin/node/testing/src/bench.rs
+++ b/substrate/bin/node/testing/src/bench.rs
@@ -47,7 +47,11 @@ use sc_executor::{WasmExecutionMethod, WasmtimeInstantiationStrategy};
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_consensus::BlockOrigin;
-use sp_core::{ed25519, sr25519, traits::SpawnNamed, Pair, Public};
+use sp_core::{
+	crypto::{CryptoType, Pair, Public},
+	ed25519, sr25519,
+	traits::SpawnNamed,
+};
 use sp_crypto_hashing::blake2_256;
 use sp_inherents::InherentData;
 use sp_runtime::{
@@ -628,7 +632,7 @@ pub struct BenchContext {
 
 type AccountPublic = <Signature as Verify>::Signer;
 
-fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as CryptoType>::Public {
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
@@ -636,7 +640,7 @@ fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public
 
 fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
-	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+	AccountPublic: From<<TPublic::Pair as CryptoType>::Public>,
 {
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }

--- a/substrate/client/cli/src/commands/utils.rs
+++ b/substrate/client/cli/src/commands/utils.rs
@@ -24,19 +24,18 @@ use crate::{
 use serde_json::json;
 use sp_core::{
 	crypto::{
-		unwrap_or_default_ss58_version, ExposeSecret, SecretString, Ss58AddressFormat, Ss58Codec,
-		Zeroize,
+		unwrap_or_default_ss58_version, CryptoType, ExposeSecret, Pair, SecretString,
+		Ss58AddressFormat, Ss58Codec, Zeroize,
 	},
 	hexdisplay::HexDisplay,
-	Pair,
 };
 use sp_runtime::{traits::IdentifyAccount, MultiSigner};
 use std::path::PathBuf;
 
 /// Public key type for Runtime
-pub type PublicFor<P> = <P as sp_core::Pair>::Public;
+pub type PublicFor<P> = <P as CryptoType>::Public;
 /// Seed type for Runtime
-pub type SeedFor<P> = <P as sp_core::Pair>::Seed;
+pub type SeedFor<P> = <P as Pair>::Seed;
 
 /// helper method to fetch uri from `Option<String>` either as a file or read from stdin
 pub fn read_uri(uri: Option<&String>) -> error::Result<String> {

--- a/substrate/client/consensus/aura/src/lib.rs
+++ b/substrate/client/consensus/aura/src/lib.rs
@@ -47,7 +47,7 @@ use sp_application_crypto::AppPublic;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};
 use sp_consensus_slots::Slot;
-use sp_core::crypto::Pair;
+use sp_core::crypto::{CryptoType, Pair};
 use sp_inherents::CreateInherentDataProviders;
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header, Member, NumberFor};
@@ -70,7 +70,7 @@ pub use sp_consensus_aura::{
 
 const LOG_TARGET: &str = "aura";
 
-type AuthorityId<P> = <P as Pair>::Public;
+type AuthorityId<P> = <P as CryptoType>::Public;
 
 /// Run `AURA` in a compatibility mode.
 ///

--- a/substrate/primitives/application-crypto/src/bandersnatch.rs
+++ b/substrate/primitives/application-crypto/src/bandersnatch.rs
@@ -17,9 +17,9 @@
 
 //! Bandersnatch VRF application crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
+use crate::{KeyTypeId, RuntimePublic, Vec};
+
 pub use sp_core::bandersnatch::*;
-use sp_std::vec::Vec;
 
 mod app {
 	crate::app_crypto!(super, sp_core::testing::BANDERSNATCH);

--- a/substrate/primitives/application-crypto/src/bls377.rs
+++ b/substrate/primitives/application-crypto/src/bls377.rs
@@ -16,7 +16,8 @@
 // limitations under the License.
 
 //! BLS12-377 crypto applications.
-use crate::{KeyTypeId, RuntimePublic};
+
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::bls::bls377::*;
 

--- a/substrate/primitives/application-crypto/src/ecdsa.rs
+++ b/substrate/primitives/application-crypto/src/ecdsa.rs
@@ -17,9 +17,7 @@
 
 //! Ecdsa crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
-
-use sp_std::vec::Vec;
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::ecdsa::*;
 
@@ -34,7 +32,7 @@ pub use app::{Public as AppPublic, Signature as AppSignature};
 impl RuntimePublic for Public {
 	type Signature = Signature;
 
-	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+	fn all(key_type: KeyTypeId) -> Vec<Self> {
 		sp_io::crypto::ecdsa_public_keys(key_type)
 	}
 

--- a/substrate/primitives/application-crypto/src/ecdsa_bls377.rs
+++ b/substrate/primitives/application-crypto/src/ecdsa_bls377.rs
@@ -17,7 +17,7 @@
 
 //! ECDSA and BLS12-377 paired crypto applications.
 
-use crate::{KeyTypeId, RuntimePublic};
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::paired_crypto::ecdsa_bls377::*;
 

--- a/substrate/primitives/application-crypto/src/ed25519.rs
+++ b/substrate/primitives/application-crypto/src/ed25519.rs
@@ -17,9 +17,7 @@
 
 //! Ed25519 crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
-
-use sp_std::vec::Vec;
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::ed25519::*;
 
@@ -34,7 +32,7 @@ pub use app::{Public as AppPublic, Signature as AppSignature};
 impl RuntimePublic for Public {
 	type Signature = Signature;
 
-	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+	fn all(key_type: KeyTypeId) -> Vec<Self> {
 		sp_io::crypto::ed25519_public_keys(key_type)
 	}
 

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -20,7 +20,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use sp_core::crypto::{key_types, CryptoTypeId, KeyTypeId};
+pub use sp_core::crypto::{key_types, CryptoType, CryptoTypeId, KeyTypeId};
 #[doc(hidden)]
 #[cfg(feature = "full_crypto")]
 pub use sp_core::crypto::{DeriveError, Pair, SecretStringError};
@@ -29,7 +29,7 @@ pub use sp_core::crypto::{DeriveJunction, Ss58Codec};
 #[doc(hidden)]
 pub use sp_core::{
 	self,
-	crypto::{ByteArray, CryptoType, Derive, IsWrappedBy, Public, UncheckedFrom, Wraps},
+	crypto::{ByteArray, Derive, IsWrappedBy, Public, Signature, UncheckedFrom, Wraps},
 	RuntimeDebug,
 };
 
@@ -132,12 +132,12 @@ macro_rules! app_crypto_pair {
 
 		impl $crate::CryptoType for Pair {
 			type Pair = Pair;
+			type Public = Public;
+			type Signature = Signature;
 		}
 
 		impl $crate::Pair for Pair {
-			type Public = Public;
 			type Seed = <$pair as $crate::Pair>::Seed;
-			type Signature = Signature;
 
 			$crate::app_crypto_pair_functions_if_std!($pair);
 
@@ -244,11 +244,13 @@ macro_rules! app_crypto_public_full_crypto {
 
 		impl $crate::CryptoType for Public {
 			type Pair = Pair;
+			type Public = Public;
+			type Signature = Signature;
 		}
 
 		impl $crate::AppCrypto for Public {
-			type Public = Public;
 			type Pair = Pair;
+			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
 			const CRYPTO_ID: $crate::CryptoTypeId = $crypto_type;
@@ -277,7 +279,10 @@ macro_rules! app_crypto_public_not_full_crypto {
 			pub struct Public($public);
 		}
 
-		impl $crate::CryptoType for Public {}
+		impl $crate::CryptoType for Public {
+			type Public = Public;
+			type Signature = Signature;
+		}
 
 		impl $crate::AppCrypto for Public {
 			type Public = Public;
@@ -421,6 +426,8 @@ macro_rules! app_crypto_signature_full_crypto {
 
 		impl $crate::CryptoType for Signature {
 			type Pair = Pair;
+			type Public = Public;
+			type Signature = Signature;
 		}
 
 		impl $crate::AppCrypto for Signature {
@@ -452,7 +459,9 @@ macro_rules! app_crypto_signature_not_full_crypto {
 			pub struct Signature($sig);
 		}
 
-		impl $crate::CryptoType for Signature {}
+		impl $crate::CryptoType for Signature {
+			type Public = Public;
+		}
 
 		impl $crate::AppCrypto for Signature {
 			type Public = Public;
@@ -483,6 +492,8 @@ macro_rules! app_crypto_signature_common {
 				self.0.as_ref()
 			}
 		}
+
+		impl $crate::Signature for Signature {}
 
 		impl $crate::AppSignature for Signature {
 			type Generic = $sig;

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -269,7 +269,7 @@ macro_rules! app_crypto_public_not_full_crypto {
 		$crate::wrap! {
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
 			#[derive(
-				Clone, Eq, PartialEq, Ord, PartialOrd,
+				Clone, Eq, Hash, PartialEq, Ord, PartialOrd,
 				$crate::codec::Encode,
 				$crate::codec::Decode,
 				$crate::RuntimeDebug,
@@ -414,13 +414,12 @@ macro_rules! app_crypto_signature_full_crypto {
 	($sig:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap! {
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
-			#[derive(Clone, Eq, PartialEq,
+			#[derive(Clone, Eq, PartialEq, Hash,
 				$crate::codec::Encode,
 				$crate::codec::Decode,
 				$crate::RuntimeDebug,
 				$crate::scale_info::TypeInfo,
 			)]
-			#[derive(Hash)]
 			pub struct Signature($sig);
 		}
 
@@ -450,7 +449,7 @@ macro_rules! app_crypto_signature_not_full_crypto {
 	($sig:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap! {
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
-			#[derive(Clone, Eq, PartialEq,
+			#[derive(Clone, Eq, PartialEq, Hash,
 				$crate::codec::Encode,
 				$crate::codec::Decode,
 				$crate::RuntimeDebug,
@@ -461,6 +460,7 @@ macro_rules! app_crypto_signature_not_full_crypto {
 
 		impl $crate::CryptoType for Signature {
 			type Public = Public;
+			type Signature = Signature;
 		}
 
 		impl $crate::AppCrypto for Signature {

--- a/substrate/primitives/application-crypto/src/sr25519.rs
+++ b/substrate/primitives/application-crypto/src/sr25519.rs
@@ -17,9 +17,7 @@
 
 //! Sr25519 crypto types.
 
-use crate::{KeyTypeId, RuntimePublic};
-
-use sp_std::vec::Vec;
+use crate::{KeyTypeId, RuntimePublic, Vec};
 
 pub use sp_core::sr25519::*;
 
@@ -34,7 +32,7 @@ pub use app::{Public as AppPublic, Signature as AppSignature};
 impl RuntimePublic for Public {
 	type Signature = Signature;
 
-	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+	fn all(key_type: KeyTypeId) -> Vec<Self> {
 		sp_io::crypto::sr25519_public_keys(key_type)
 	}
 

--- a/substrate/primitives/application-crypto/src/traits.rs
+++ b/substrate/primitives/application-crypto/src/traits.rs
@@ -20,7 +20,7 @@ use scale_info::TypeInfo;
 
 #[cfg(feature = "full_crypto")]
 use sp_core::crypto::Pair;
-use sp_core::crypto::{CryptoType, CryptoTypeId, IsWrappedBy, KeyTypeId, Public};
+use sp_core::crypto::{CryptoType, CryptoTypeId, IsWrappedBy, KeyTypeId, Public, Signature};
 use sp_std::{fmt::Debug, vec::Vec};
 
 /// Application-specific cryptographic object.
@@ -64,22 +64,38 @@ impl<T> MaybeHash for T {}
 /// Application-specific key pair.
 #[cfg(feature = "full_crypto")]
 pub trait AppPair:
-	AppCrypto + Pair<Public = <Self as AppCrypto>::Public, Signature = <Self as AppCrypto>::Signature>
+	AppCrypto<Pair = Self>
+	+ Pair<Public = <Self as AppCrypto>::Public, Signature = <Self as AppCrypto>::Signature>
 {
 	/// The wrapped type which is just a plain instance of `Pair`.
 	type Generic: IsWrappedBy<Self>
-		+ Pair<Public = <<Self as AppCrypto>::Public as AppPublic>::Generic>
-		+ Pair<Signature = <<Self as AppCrypto>::Signature as AppSignature>::Generic>;
+		+ Pair<
+			Public = <<Self as AppCrypto>::Public as AppPublic>::Generic,
+			Signature = <<Self as AppCrypto>::Signature as AppSignature>::Generic,
+		>;
 }
 
 /// Application-specific public key.
-pub trait AppPublic: AppCrypto + Public + Debug + MaybeHash + Codec {
+pub trait AppPublic:
+	AppCrypto
+	+ Public<Pair = <Self as AppCrypto>::Pair, Signature = <Self as AppCrypto>::Signature>
+	+ Debug
+	+ MaybeHash
+	+ Codec
+{
 	/// The wrapped type which is just a plain instance of `Public`.
 	type Generic: IsWrappedBy<Self> + Public + Debug + MaybeHash + Codec;
 }
 
 /// Application-specific signature.
-pub trait AppSignature: AppCrypto + Eq + PartialEq + Debug + Clone {
+pub trait AppSignature:
+	AppCrypto
+	+ Signature<Pair = <Self as AppCrypto>::Pair, Public = <Self as AppCrypto>::Public>
+	+ Eq
+	+ PartialEq
+	+ Debug
+	+ Clone
+{
 	/// The wrapped type which is just a plain instance of `Signature`.
 	type Generic: IsWrappedBy<Self> + Eq + PartialEq + Debug;
 }

--- a/substrate/primitives/core/src/bandersnatch.rs
+++ b/substrate/primitives/core/src/bandersnatch.rs
@@ -37,6 +37,7 @@ use bandersnatch_vrfs::CanonicalSerialize;
 #[cfg(feature = "full_crypto")]
 use bandersnatch_vrfs::SecretKey;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
+use core::hash::Hash;
 use scale_info::TypeInfo;
 
 use sp_runtime_interface::pass_by::PassByInner;
@@ -57,7 +58,6 @@ const SIGNATURE_SERIALIZED_SIZE: usize = 65;
 const PREOUT_SERIALIZED_SIZE: usize = 33;
 
 /// Bandersnatch public key.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(
 	Clone,
 	Copy,
@@ -70,6 +70,7 @@ const PREOUT_SERIALIZED_SIZE: usize = 33;
 	PassByInner,
 	MaxEncodedLen,
 	TypeInfo,
+	Hash,
 )]
 pub struct Public(pub [u8; PUBLIC_SERIALIZED_SIZE]);
 
@@ -150,8 +151,9 @@ impl<'de> Deserialize<'de> for Public {
 ///
 /// The signature is created via the [`VrfSecret::vrf_sign`] using [`SIGNING_CTX`] as transcript
 /// `label`.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Clone, Copy, PartialEq, Eq, Encode, Decode, PassByInner, MaxEncodedLen, TypeInfo)]
+#[derive(
+	Clone, Copy, PartialEq, Eq, Encode, Decode, PassByInner, MaxEncodedLen, TypeInfo, Hash,
+)]
 pub struct Signature([u8; SIGNATURE_SERIALIZED_SIZE]);
 
 impl TraitSignature for Signature {}

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -36,6 +36,7 @@ use crate::crypto::{DeriveError, DeriveJunction, Pair as TraitPair, SecretString
 use sp_std::vec::Vec;
 
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::hash::{Hash, Hasher};
 use scale_info::TypeInfo;
 
 #[cfg(feature = "serde")]
@@ -153,9 +154,8 @@ impl<T> Ord for Public<T> {
 	}
 }
 
-#[cfg(feature = "full_crypto")]
-impl<T> sp_std::hash::Hash for Public<T> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<T> Hash for Public<T> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.inner.hash(state)
 	}
 }
@@ -329,9 +329,8 @@ impl<T> PartialEq for Signature<T> {
 
 impl<T> Eq for Signature<T> {}
 
-#[cfg(feature = "full_crypto")]
-impl<T> sp_std::hash::Hash for Signature<T> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<T> Hash for Signature<T> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.inner.hash(state)
 	}
 }

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -25,7 +25,10 @@
 
 #[cfg(feature = "serde")]
 use crate::crypto::Ss58Codec;
-use crate::crypto::{ByteArray, CryptoType, Derive, Public as TraitPublic, UncheckedFrom};
+use crate::crypto::{
+	ByteArray, CryptoType, Derive, Public as TraitPublic, Signature as TraitSignature,
+	UncheckedFrom,
+};
 #[cfg(feature = "full_crypto")]
 use crate::crypto::{DeriveError, DeriveJunction, Pair as TraitPair, SecretStringError};
 
@@ -298,6 +301,8 @@ impl<T> Derive for Public<T> {}
 impl<T: BlsBound> CryptoType for Public<T> {
 	#[cfg(feature = "full_crypto")]
 	type Pair = Pair<T>;
+	type Public = Public<T>;
+	type Signature = Signature<T>;
 }
 
 /// A generic BLS signature.
@@ -307,6 +312,8 @@ pub struct Signature<T> {
 	inner: [u8; SIGNATURE_SERIALIZED_SIZE],
 	_phantom: PhantomData<fn() -> T>,
 }
+
+impl<T: BlsBound> TraitSignature for Signature<T> {}
 
 impl<T> Clone for Signature<T> {
 	fn clone(&self) -> Self {
@@ -414,6 +421,8 @@ impl<T> UncheckedFrom<[u8; SIGNATURE_SERIALIZED_SIZE]> for Signature<T> {
 impl<T: BlsBound> CryptoType for Signature<T> {
 	#[cfg(feature = "full_crypto")]
 	type Pair = Pair<T>;
+	type Public = Public<T>;
+	type Signature = Signature<T>;
 }
 
 /// A key pair.
@@ -443,8 +452,6 @@ impl<T: EngineBLS> Pair<T> {}
 #[cfg(feature = "full_crypto")]
 impl<T: BlsBound> TraitPair for Pair<T> {
 	type Seed = Seed;
-	type Public = Public<T>;
-	type Signature = Signature<T>;
 
 	fn from_seed_slice(seed_slice: &[u8]) -> Result<Self, SecretStringError> {
 		if seed_slice.len() != SECRET_KEY_SERIALIZED_SIZE {
@@ -526,6 +533,8 @@ impl<T: BlsBound> TraitPair for Pair<T> {
 #[cfg(feature = "full_crypto")]
 impl<T: BlsBound> CryptoType for Pair<T> {
 	type Pair = Pair<T>;
+	type Public = Public<T>;
+	type Signature = Signature<T>;
 }
 
 // Test set exercising the BLS12-377 implementation

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -497,7 +497,7 @@ pub trait ByteArray: AsRef<[u8]> + AsMut<[u8]> + for<'a> TryFrom<&'a [u8], Error
 
 /// Trait for cryptographic public keys.
 pub trait Public:
-	CryptoType<Public = Self> + ByteArray + Derive + PartialEq + Eq + Clone + Send + Sync
+	CryptoType<Public = Self> + ByteArray + Derive + PartialEq + Eq + Clone + Send + Sync + Hash
 {
 }
 
@@ -505,8 +505,7 @@ pub trait Public:
 pub trait Signature: CryptoType<Signature = Self> + AsRef<[u8]> {}
 
 /// An opaque 32-byte cryptographic identifier.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Hash))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo, Hash)]
 pub struct AccountId32([u8; 32]);
 
 impl AccountId32 {
@@ -1055,21 +1054,22 @@ where
 
 /// Type which has a particular kind of crypto associated with it.
 pub trait CryptoType {
-	/// The pair key type of this crypto.
+	/// Secret key.
 	#[cfg(feature = "full_crypto")]
 	type Pair: Pair
 		+ CryptoType<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
-	/// The type which is used to encode a public key.
+	/// Public key.
 	#[cfg(feature = "full_crypto")]
 	type Public: Public
-		+ Hash
 		+ CryptoType<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
+	/// Public key.
 	#[cfg(not(feature = "full_crypto"))]
-	type Public: Public + Hash + CryptoType<Public = Self::Public, Signature = Self::Signature>;
-	/// The type which is used to encode a public key.
+	type Public: Public + CryptoType<Public = Self::Public, Signature = Self::Signature>;
+	/// Signature.
 	#[cfg(feature = "full_crypto")]
 	type Signature: Signature
 		+ CryptoType<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
+	/// Signature.
 	#[cfg(not(feature = "full_crypto"))]
 	type Signature: Signature + CryptoType<Public = Self::Public, Signature = Self::Signature>;
 }

--- a/substrate/primitives/core/src/crypto.rs
+++ b/substrate/primitives/core/src/crypto.rs
@@ -1056,22 +1056,19 @@ where
 pub trait CryptoType {
 	/// Secret key.
 	#[cfg(feature = "full_crypto")]
-	type Pair: Pair
-		+ CryptoType<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
+	type Pair: Pair<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
 	/// Public key.
 	#[cfg(feature = "full_crypto")]
-	type Public: Public
-		+ CryptoType<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
+	type Public: Public<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
 	/// Public key.
 	#[cfg(not(feature = "full_crypto"))]
-	type Public: Public + CryptoType<Public = Self::Public, Signature = Self::Signature>;
+	type Public: Public<Public = Self::Public, Signature = Self::Signature>;
 	/// Signature.
 	#[cfg(feature = "full_crypto")]
-	type Signature: Signature
-		+ CryptoType<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
+	type Signature: Signature<Pair = Self::Pair, Public = Self::Public, Signature = Self::Signature>;
 	/// Signature.
 	#[cfg(not(feature = "full_crypto"))]
-	type Signature: Signature + CryptoType<Public = Self::Public, Signature = Self::Signature>;
+	type Signature: Signature<Public = Self::Public, Signature = Self::Signature>;
 }
 
 /// An identifier for a type of cryptographic key.
@@ -1126,7 +1123,7 @@ impl<'a> TryFrom<&'a str> for KeyTypeId {
 }
 
 /// Trait grouping types shared by a VRF signer and verifiers.
-pub trait VrfCrypto {
+pub trait VrfCrypto: CryptoType {
 	/// VRF input.
 	type VrfInput;
 	/// VRF pre-output.

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -29,6 +29,7 @@ use crate::crypto::{
 };
 #[cfg(feature = "full_crypto")]
 use crate::crypto::{DeriveError, DeriveJunction, Pair as TraitPair, SecretStringError};
+use core::hash::Hash;
 #[cfg(all(feature = "full_crypto", not(feature = "std")))]
 use secp256k1::Secp256k1;
 #[cfg(feature = "std")]
@@ -61,7 +62,6 @@ pub const SIGNATURE_SERIALIZED_SIZE: usize = 65;
 type Seed = [u8; 32];
 
 /// The ECDSA compressed public key.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(
 	Clone,
 	Copy,
@@ -74,6 +74,7 @@ type Seed = [u8; 32];
 	PartialEq,
 	PartialOrd,
 	Ord,
+	Hash,
 )]
 pub struct Public(pub [u8; PUBLIC_KEY_SERIALIZED_SIZE]);
 
@@ -200,8 +201,7 @@ impl<'de> Deserialize<'de> for Public {
 }
 
 /// A signature (a 512-bit value, plus 8 bits for recovery ID).
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
+#[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq, Hash)]
 pub struct Signature(pub [u8; SIGNATURE_SERIALIZED_SIZE]);
 
 impl TraitSignature for Signature {}

--- a/substrate/primitives/core/src/ed25519.rs
+++ b/substrate/primitives/core/src/ed25519.rs
@@ -39,6 +39,7 @@ use crate::crypto::{
 use crate::crypto::{DeriveError, DeriveJunction, Pair as TraitPair, SecretStringError};
 #[cfg(feature = "full_crypto")]
 use core::convert::TryFrom;
+use core::hash::Hash;
 #[cfg(feature = "full_crypto")]
 use ed25519_zebra::{SigningKey, VerificationKey};
 #[cfg(feature = "serde")]
@@ -58,7 +59,6 @@ pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ed25");
 type Seed = [u8; 32];
 
 /// A public key.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(
 	PartialEq,
 	Eq,
@@ -71,6 +71,7 @@ type Seed = [u8; 32];
 	PassByInner,
 	MaxEncodedLen,
 	TypeInfo,
+	Hash,
 )]
 pub struct Public(pub [u8; 32]);
 
@@ -211,8 +212,7 @@ impl<'de> Deserialize<'de> for Public {
 }
 
 /// A signature (a 512-bit value).
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
+#[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq, Hash)]
 pub struct Signature(pub [u8; 64]);
 
 impl TraitSignature for Signature {}

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -57,31 +57,32 @@ pub mod const_hex2array;
 pub mod crypto;
 pub mod hexdisplay;
 pub use paste;
-
-#[cfg(any(feature = "full_crypto", feature = "std"))]
-mod address_uri;
-#[cfg(feature = "bandersnatch-experimental")]
-pub mod bandersnatch;
-#[cfg(feature = "bls-experimental")]
-pub mod bls;
 pub mod defer;
-pub mod ecdsa;
-pub mod ed25519;
 pub mod hash;
-#[cfg(feature = "std")]
-mod hasher;
 pub mod offchain;
-pub mod paired_crypto;
-pub mod sr25519;
 pub mod testing;
 #[cfg(feature = "std")]
 pub mod traits;
 pub mod uint;
 
+#[cfg(feature = "bandersnatch-experimental")]
+pub mod bandersnatch;
+#[cfg(feature = "bls-experimental")]
+pub mod bls;
+pub mod ecdsa;
+pub mod ed25519;
+pub mod paired_crypto;
+pub mod sr25519;
+
 #[cfg(feature = "bls-experimental")]
 pub use bls::{bls377, bls381};
 #[cfg(feature = "bls-experimental")]
 pub use paired_crypto::ecdsa_bls377;
+
+#[cfg(any(feature = "full_crypto", feature = "std"))]
+mod address_uri;
+#[cfg(feature = "std")]
+mod hasher;
 
 pub use self::{
 	hash::{convert_hash, H160, H256, H512},

--- a/substrate/primitives/core/src/paired_crypto.rs
+++ b/substrate/primitives/core/src/paired_crypto.rs
@@ -29,6 +29,7 @@ use crate::crypto::{DeriveError, DeriveJunction, Pair as PairT, SecretStringErro
 use sp_std::vec::Vec;
 
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::hash::{Hash, Hasher};
 use scale_info::TypeInfo;
 #[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -146,9 +147,8 @@ type Seed = [u8; SECURE_SEED_LEN];
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Public<const LEFT_PLUS_RIGHT_LEN: usize>([u8; LEFT_PLUS_RIGHT_LEN]);
 
-#[cfg(feature = "full_crypto")]
-impl<const LEFT_PLUS_RIGHT_LEN: usize> sp_std::hash::Hash for Public<LEFT_PLUS_RIGHT_LEN> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<const LEFT_PLUS_RIGHT_LEN: usize> Hash for Public<LEFT_PLUS_RIGHT_LEN> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.0.hash(state);
 	}
 }
@@ -296,12 +296,6 @@ impl<const LEFT_PLUS_RIGHT_LEN: usize> PublicT for Public<LEFT_PLUS_RIGHT_LEN> w
 
 impl<const LEFT_PLUS_RIGHT_LEN: usize> Derive for Public<LEFT_PLUS_RIGHT_LEN> {}
 
-// /// Trait characterizing a signature which could be used as individual component of an
-// /// `paired_crypto:Signature` pair.
-// pub trait SignatureBound: ByteArray {}
-
-// impl<T: ByteArray> SignatureBound for T {}
-
 /// A pair of signatures of different types
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, PartialEq, Eq)]
 pub struct Signature<const LEFT_PLUS_RIGHT_LEN: usize>([u8; LEFT_PLUS_RIGHT_LEN]);
@@ -311,9 +305,8 @@ impl<const LEFT_PLUS_RIGHT_LEN: usize> SignatureT for Signature<LEFT_PLUS_RIGHT_
 {
 }
 
-#[cfg(feature = "full_crypto")]
-impl<const LEFT_PLUS_RIGHT_LEN: usize> sp_std::hash::Hash for Signature<LEFT_PLUS_RIGHT_LEN> {
-	fn hash<H: sp_std::hash::Hasher>(&self, state: &mut H) {
+impl<const LEFT_PLUS_RIGHT_LEN: usize> Hash for Signature<LEFT_PLUS_RIGHT_LEN> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.0.hash(state);
 	}
 }

--- a/substrate/primitives/core/src/sr25519.rs
+++ b/substrate/primitives/core/src/sr25519.rs
@@ -38,8 +38,8 @@ use sp_std::vec::Vec;
 
 use crate::{
 	crypto::{
-		ByteArray, CryptoType, CryptoTypeId, Derive, FromEntropy, Public as TraitPublic,
-		UncheckedFrom,
+		impl_crypto_type, ByteArray, CryptoTypeId, Derive, FromEntropy, Public as TraitPublic,
+		Signature as TraitSignature, UncheckedFrom,
 	},
 	hash::{H256, H512},
 };
@@ -219,6 +219,8 @@ impl<'de> Deserialize<'de> for Public {
 #[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
 pub struct Signature(pub [u8; 64]);
+
+impl TraitSignature for Signature {}
 
 impl TryFrom<&[u8]> for Signature {
 	type Error = ();
@@ -446,9 +448,7 @@ type Seed = [u8; MINI_SECRET_KEY_LENGTH];
 
 #[cfg(feature = "full_crypto")]
 impl TraitPair for Pair {
-	type Public = Public;
 	type Seed = Seed;
-	type Signature = Signature;
 
 	/// Get the public key.
 	fn public(&self) -> Public {
@@ -532,20 +532,10 @@ impl Pair {
 	}
 }
 
-impl CryptoType for Public {
-	#[cfg(feature = "full_crypto")]
-	type Pair = Pair;
-}
-
-impl CryptoType for Signature {
-	#[cfg(feature = "full_crypto")]
-	type Pair = Pair;
-}
-
 #[cfg(feature = "full_crypto")]
-impl CryptoType for Pair {
-	type Pair = Pair;
-}
+impl_crypto_type!(Pair, Public, Signature);
+#[cfg(not(feature = "full_crypto"))]
+impl_crypto_type!(Public, Signature);
 
 /// Schnorrkel VRF related types and operations.
 pub mod vrf {

--- a/substrate/primitives/core/src/sr25519.rs
+++ b/substrate/primitives/core/src/sr25519.rs
@@ -44,6 +44,7 @@ use crate::{
 	hash::{H256, H512},
 };
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::hash::Hash;
 use scale_info::TypeInfo;
 use sp_std::ops::Deref;
 
@@ -63,7 +64,6 @@ const SIGNING_CTX: &[u8] = b"substrate";
 pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"sr25");
 
 /// An Schnorrkel/Ristretto x25519 ("sr25519") public key.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
 #[derive(
 	PartialEq,
 	Eq,
@@ -76,6 +76,7 @@ pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"sr25");
 	PassByInner,
 	MaxEncodedLen,
 	TypeInfo,
+	Hash,
 )]
 pub struct Public(pub [u8; 32]);
 
@@ -216,8 +217,7 @@ impl<'de> Deserialize<'de> for Public {
 }
 
 /// An Schnorrkel/Ristretto x25519 ("sr25519") signature.
-#[cfg_attr(feature = "full_crypto", derive(Hash))]
-#[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq)]
+#[derive(Encode, Decode, MaxEncodedLen, PassByInner, TypeInfo, PartialEq, Eq, Hash)]
 pub struct Signature(pub [u8; 64]);
 
 impl TraitSignature for Signature {}

--- a/substrate/primitives/runtime/src/testing.rs
+++ b/substrate/primitives/runtime/src/testing.rs
@@ -86,6 +86,8 @@ impl UintAuthorityId {
 
 impl CryptoType for UintAuthorityId {
 	type Pair = Dummy;
+	type Public = Dummy;
+	type Signature = Dummy;
 }
 
 impl AsRef<[u8]> for UintAuthorityId {


### PR DESCRIPTION
- Move `Public` and `Signature` associated types from `Pair` to `Crypto` trait
- More strict type checking for `Crypto` trait associated types 
- `impl_crypto_type` macro to implement `Crypto` for the (`Secret`, `Public`, `Signature`) triple
- Brings some coherence wrt to `AppCrypto` trait definition
- Since (with this PR) `Crypto` and `AppCrypto` have exactly the same (`Secret`, `Public`, `Signature`) associated types **and**  `AppCrypto` extends `Crypto`. IMO we can remove these redundant types from `AppCrypto` (eventually in a follow up PR)

Depends on https://github.com/paritytech/polkadot-sdk/pull/2044