### PR TITLE
Bump coretime-rococo to get leases fix

### DIFF
--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("coretime-rococo"),
 	impl_name: create_runtime_str!("coretime-rococo"),
 	authoring_version: 1,
-	spec_version: 1_007_000,
+	spec_version: 1_007_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,


### PR DESCRIPTION
Leases can be force set, but since Leases is a StorageValue, if a lease misses its sale rotation in which it should expire, it can never be cleared.

This can happen if a lease is added with an until timeslice that lies in a region whose sale has already started or has passed, even if the timeslice itself hasn't passed.

Trappist is currently trapped in a lease that will never end, so this will remove it at the next sale rotation.

A fix was introduced in https://github.com/paritytech/polkadot-sdk/pull/3213 but this missed the 1.7 release. This PR bumps the `coretime-rococo` version to get these changes on Rococo.