### PR TITLE
[ci] Fix gitspiegel trigger

### DIFF
--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -13,14 +13,15 @@ on:
       - unlocked
       - ready_for_review
       - reopened
+  # doesn't work as intended, triggers "workflow_run" webhook in any case
   # the job doesn't check out any code, so it is relatively safe to run it on any event
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - unlocked
-      - ready_for_review
-      - reopened
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - unlocked
+  #     - ready_for_review
+  #     - reopened
   merge_group:
 
 # drop all permissions for GITHUB_TOKEN


### PR DESCRIPTION
PR removes `pull_request_target` from gitspiegel trigger because it breaks the logic. With `pull_request_target` the action runs in any case even for first-time contributors.

cc @mutantcornholio 