### PR TITLE
Fix(zombienet): allow finality_lag be to be 1 or less and increase timeout

### DIFF
--- a/polkadot/zombienet_tests/misc/0001-paritydb.zndsl
+++ b/polkadot/zombienet_tests/misc/0001-paritydb.zndsl
@@ -31,28 +31,28 @@ validator-0: parachain 2008 is registered
 validator-0: parachain 2009 is registered
 
 # Ensure parachains made some progress.
-validator-0: parachain 2000 block height is at least 3 within 30 seconds
-validator-0: parachain 2001 block height is at least 3 within 30 seconds
-validator-0: parachain 2002 block height is at least 3 within 30 seconds
-validator-0: parachain 2003 block height is at least 3 within 30 seconds
-validator-0: parachain 2004 block height is at least 3 within 30 seconds
-validator-0: parachain 2005 block height is at least 3 within 30 seconds
-validator-0: parachain 2006 block height is at least 3 within 30 seconds
-validator-0: parachain 2007 block height is at least 3 within 30 seconds
-validator-0: parachain 2008 block height is at least 3 within 30 seconds
-validator-0: parachain 2009 block height is at least 3 within 30 seconds
+validator-0: parachain 2000 block height is at least 3 within 60 seconds
+validator-0: parachain 2001 block height is at least 3 within 60 seconds
+validator-0: parachain 2002 block height is at least 3 within 60 seconds
+validator-0: parachain 2003 block height is at least 3 within 60 seconds
+validator-0: parachain 2004 block height is at least 3 within 60 seconds
+validator-0: parachain 2005 block height is at least 3 within 60 seconds
+validator-0: parachain 2006 block height is at least 3 within 60 seconds
+validator-0: parachain 2007 block height is at least 3 within 60 seconds
+validator-0: parachain 2008 block height is at least 3 within 60 seconds
+validator-0: parachain 2009 block height is at least 3 within 60 seconds
 
 # Check lag - approval
-validator-0: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-1: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-2: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-3: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-4: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-5: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-6: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-7: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-8: reports polkadot_parachain_approval_checking_finality_lag is 0
-validator-9: reports polkadot_parachain_approval_checking_finality_lag is 0
+validator-0: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-1: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-2: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-3: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-4: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-5: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-6: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-7: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-8: reports polkadot_parachain_approval_checking_finality_lag <= 1
+validator-9: reports polkadot_parachain_approval_checking_finality_lag <= 1
 
 # Check lag - dispute conclusion
 validator-0: reports polkadot_parachain_candidate_disputes_total is 0


### PR DESCRIPTION
Change `parityDb` test assertions after a quick check with @alexggh in order to resolve failures in `zombienet-polkadot-misc-0001-parachains-paritydb`(e.g https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/5186277).
Thx!