### PR TITLE
Multisig Stateful Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7011,6 +7011,7 @@ dependencies = [
  "pallet-mixnet",
  "pallet-mmr",
  "pallet-multisig",
+ "pallet-multisig-stateful",
  "pallet-nft-fractionalization",
  "pallet-nfts",
  "pallet-nfts-runtime-api",
@@ -10167,6 +10168,23 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0",
+]
+
+[[package]]
+name = "pallet-multisig-stateful"
+version = "28.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,6 +352,7 @@ members = [
 	"substrate/frame/message-queue",
 	"substrate/frame/mixnet",
 	"substrate/frame/multisig",
+	"substrate/frame/multisig-stateful",
 	"substrate/frame/nft-fractionalization",
 	"substrate/frame/nfts",
 	"substrate/frame/nfts/runtime-api",

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -99,6 +99,7 @@ pallet-message-queue = { path = "../../../frame/message-queue", default-features
 pallet-mixnet = { path = "../../../frame/mixnet", default-features = false }
 pallet-mmr = { path = "../../../frame/merkle-mountain-range", default-features = false }
 pallet-multisig = { path = "../../../frame/multisig", default-features = false }
+pallet-multisig-stateful = { path = "../../../frame/multisig-stateful", default-features = false }
 pallet-nfts = { path = "../../../frame/nfts", default-features = false }
 pallet-nfts-runtime-api = { path = "../../../frame/nfts/runtime-api", default-features = false }
 pallet-nft-fractionalization = { path = "../../../frame/nft-fractionalization", default-features = false }
@@ -201,6 +202,7 @@ std = [
 	"pallet-mixnet/std",
 	"pallet-mmr/std",
 	"pallet-multisig/std",
+	"pallet-multisig-stateful/std",
 	"pallet-nft-fractionalization/std",
 	"pallet-nfts-runtime-api/std",
 	"pallet-nfts/std",
@@ -305,6 +307,7 @@ runtime-benchmarks = [
 	"pallet-mixnet/runtime-benchmarks",
 	"pallet-mmr/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
+	"pallet-multisig-stateful/runtime-benchmarks",
 	"pallet-nft-fractionalization/runtime-benchmarks",
 	"pallet-nfts/runtime-benchmarks",
 	"pallet-nis/runtime-benchmarks",
@@ -384,6 +387,7 @@ try-runtime = [
 	"pallet-mixnet/try-runtime",
 	"pallet-mmr/try-runtime",
 	"pallet-multisig/try-runtime",
+	"pallet-multisig-stateful/try-runtime",
 	"pallet-nft-fractionalization/try-runtime",
 	"pallet-nfts/try-runtime",
 	"pallet-nis/try-runtime",

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -149,8 +149,8 @@ pallet-parameters = { path = "../../../frame/parameters", default-features = fal
 substrate-wasm-builder = { path = "../../../utils/wasm-builder", optional = true }
 
 [features]
-default = ["std"]
-with-tracing = ["frame-executive/with-tracing"]
+default = [ "std" ]
+with-tracing = [ "frame-executive/with-tracing" ]
 std = [
 	"codec/std",
 	"frame-benchmarking-pallet-pov/std",
@@ -201,8 +201,8 @@ std = [
 	"pallet-message-queue/std",
 	"pallet-mixnet/std",
 	"pallet-mmr/std",
-	"pallet-multisig/std",
 	"pallet-multisig-stateful/std",
+	"pallet-multisig/std",
 	"pallet-nft-fractionalization/std",
 	"pallet-nfts-runtime-api/std",
 	"pallet-nfts/std",
@@ -306,8 +306,8 @@ runtime-benchmarks = [
 	"pallet-message-queue/runtime-benchmarks",
 	"pallet-mixnet/runtime-benchmarks",
 	"pallet-mmr/runtime-benchmarks",
-	"pallet-multisig/runtime-benchmarks",
 	"pallet-multisig-stateful/runtime-benchmarks",
+	"pallet-multisig/runtime-benchmarks",
 	"pallet-nft-fractionalization/runtime-benchmarks",
 	"pallet-nfts/runtime-benchmarks",
 	"pallet-nis/runtime-benchmarks",
@@ -386,8 +386,8 @@ try-runtime = [
 	"pallet-message-queue/try-runtime",
 	"pallet-mixnet/try-runtime",
 	"pallet-mmr/try-runtime",
-	"pallet-multisig/try-runtime",
 	"pallet-multisig-stateful/try-runtime",
+	"pallet-multisig/try-runtime",
 	"pallet-nft-fractionalization/try-runtime",
 	"pallet-nfts/try-runtime",
 	"pallet-nis/try-runtime",

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -343,6 +343,13 @@ impl pallet_multisig::Config for Runtime {
 	type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
 }
 
+impl pallet_multisig_stateful::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type NativeBalance = Balances;
+	type RuntimeCall = RuntimeCall;
+	type MaxSignatories = ConstU32<100>;
+}
+
 parameter_types! {
 	// One storage item; key size 32, value size 8; .
 	pub const ProxyDepositBase: Balance = deposit(1, 8);
@@ -2203,6 +2210,7 @@ construct_runtime!(
 		Preimage: pallet_preimage,
 		Proxy: pallet_proxy,
 		Multisig: pallet_multisig,
+		MultisigStateful: pallet_multisig_stateful,
 		Bounties: pallet_bounties,
 		Tips: pallet_tips,
 		Assets: pallet_assets::<Instance1>,

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -343,11 +343,20 @@ impl pallet_multisig::Config for Runtime {
 	type WeightInfo = pallet_multisig::weights::SubstrateWeight<Runtime>;
 }
 
+parameter_types! {
+	pub const BaseCreationDeposit: Balance = 2;
+	pub const ProposalDeposit: Balance = 1;
+	pub const PerOwnerDeposit: Balance = 1;
+}
 impl pallet_multisig_stateful::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type NativeBalance = Balances;
+	type Currency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeCall = RuntimeCall;
 	type MaxSignatories = ConstU32<100>;
+	type BaseCreationDeposit = BaseCreationDeposit;
+	type ProposalDeposit = ProposalDeposit;
+	type PerOwnerDeposit = PerOwnerDeposit;
 }
 
 parameter_types! {

--- a/substrate/frame/multisig-stateful/Cargo.toml
+++ b/substrate/frame/multisig-stateful/Cargo.toml
@@ -36,6 +36,7 @@ pallet-balances = { path = "../balances" }
 default = [ "std" ]
 std = [
 	"codec/std",
+	"sp-core/std",
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/substrate/frame/multisig-stateful/Cargo.toml
+++ b/substrate/frame/multisig-stateful/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "pallet-multisig-stateful"
+version = "28.0.0"
+description = "FRAME multi-signature-stateful pallet"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository.workspace = true
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
+frame-support = { path = "../support", default-features = false }
+frame-system = { path = "../system", default-features = false }
+sp-io = { path = "../../primitives/io", default-features = false }
+sp-runtime = { path = "../../primitives/runtime", default-features = false }
+sp-std = { path = "../../primitives/std", default-features = false }
+sp-core = { path = "../../../substrate/primitives/core", default-features = false }
+
+# third party
+log = { version = "0.4.17", default-features = false }
+
+[dev-dependencies]
+pallet-balances = { path = "../balances" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-benchmarking?/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-balances/std",
+	"scale-info/std",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-balances/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/substrate/frame/multisig-stateful/Cargo.toml
+++ b/substrate/frame/multisig-stateful/Cargo.toml
@@ -33,7 +33,7 @@ log = { version = "0.4.17", default-features = false }
 pallet-balances = { path = "../balances" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
 	"codec/std",
 	"frame-benchmarking?/std",

--- a/substrate/frame/multisig-stateful/README.md
+++ b/substrate/frame/multisig-stateful/README.md
@@ -1,0 +1,137 @@
+# Multisig Stateful Pallet
+
+A module to facilitate **stateful** multisig accounts. The statefulness of this means that we store a multisig account id in the state with  
+related info (owners, threshold,..etc). The module affords enhanced control over administrative operations such as adding/removing owners, changing the threshold, account deletion, canceling an existing proposal. Each owner can approve/revoke a proposal.  
+
+We use `proposal` in this module to refer to an extrinsic that is to be dispatched from a multisig account after getting enough approvals.
+
+## Use Cases
+
+* Corporate Governance:
+In a corporate setting, multisig accounts can be employed for decision-making processes. For example, a company may require the approval of multiple executives to initiate   significant financial transactions.
+
+* Joint Accounts:
+Multisig accounts can be used for joint accounts where multiple individuals need to authorize transactions. This is particularly useful in family finances or shared  
+business accounts.
+
+* Decentralized Autonomous Organizations (DAOs):
+DAOs can utilize multisig accounts to ensure that decisions are made collectively. Multiple key holders can be required to approve changes to the organization's rules or  
+the allocation of funds.
+
+... and much more.
+
+## Stateless Multisig vs Stateful Multisig
+
+### Overview
+
+All of the mentioned use cases -and more- are better served by a stateful multisig account. This is because a stateful multisig account is stored in the state and allows for more control over the account itself. For example, a stateful multisig account can be deleted, owners can be added/removed, threshold can be changed, proposals can be canceled,..etc.  
+
+A stateless multisig account is a multisig account that is not stored in the state. It is a simple call that is dispatched from a single account. This is useful for simple use cases where a multisig account is needed for a single purpose and no further control is needed over the account itself.
+
+### Extrensics (Frame/Multisig vs Stateful Multisig) -- Skip if not familiar with Frame/Multisig
+
+Main distinction in proposal approvals and execution between this implementation and the frame/multisig one is that this module  
+has an extrinsic for each step of the process instead of having one entry point that can accept a `CallOrHash`:  
+
+1. Start Proposal
+2. Approve (called N times based on the threshold needed)
+3. Execute Proposal
+
+This is illustrated in the sequence diagram later in the README.
+
+### Technical Comparison
+
+Although a stateful multisig account might seem more expensive than a stateless one because it is stored in the state while stateless multisig is not, We see (on paper) that the stateless footprint is actually larger than the stateful one on the blockchain as for each extrinsic call in a stateless multisig, the caller needs to send all the owners and other parameters which are all stored on the blockchain itself.
+
+TODO: Add benchmark results for both stateless and stateful multisig. (main thing to measure is the storage of extrinsics cost) over one year with 1K multisig accounts,
+each with 5-100 users and doing 50 proposals per day.
+
+## Sequence Diagrams
+
+This is a sequence diagram for a multisig account with 5 owners and a threshold of 3. The multisig account is created with Alice, Bob, Charlie, Dave and Eve as initial owners. The multisig account is used to dispatch a call, which is approved by Bob and Charlie reaching the threshold of 3 including Alice as she started the proposal. The call is then executed by Dave (any owner of the multisig can execute the call even if they haven't approved once the proposal exceeds the required threshold).
+
+       ┌─┐             ┌─┐              ┌─┐               ┌─┐            ┌─┐                                                    
+       ║"│             ║"│              ║"│               ║"│            ║"│                                                    
+       └┬┘             └┬┘              └┬┘               └┬┘            └┬┘                                                    
+       ┌┼┐             ┌┼┐              ┌┼┐               ┌┼┐            ┌┼┐                                                    
+        │               │                │                 │              │            ┌────────┐                               
+       ┌┴┐             ┌┴┐              ┌┴┐               ┌┴┐            ┌┴┐           │Multisig│                               
+      Alice            Bob            Charlie            Dave            Eve           └───┬────┘                               
+        │               │             Create Multisig Account             │                │  ╔═════════════════════════════╗   
+        │─────────────────────────────────────────────────────────────────────────────────>│  ║Owners: Alice, Bob, Charlie ░║   
+        │               │                │                │               │                │  ║Threshold: 3                 ║   
+        │               │                │                │               │                │  ╚═════════════════════════════╝   
+        │               │                │Start Proposal  │               │                │  ╔════════════════════════════════╗
+        │─────────────────────────────────────────────────────────────────────────────────>│  ║Proposal #1                    ░║
+        │               │                │                │               │                │  ║Status: Pending Approval (1/3)  ║
+        │               │                │                │               │                │  ╚════════════════════════════════╝
+        │               │                │      Approve Proposal #1       │                │  ╔═════════════╗                   
+        │               │─────────────────────────────────────────────────────────────────>│  ║Approval    ░║                   
+        │               │                │                │               │                │  ║Status: 2/3  ║                   
+        │               │                │                │               │                │  ╚═════════════╝                   
+        │               │                │              Approve Proposal #1                │  ╔═════════════╗                   
+        │               │                │────────────────────────────────────────────────>│  ║Approval    ░║                   
+        │               │                │                │               │                │  ║Status: 3/3  ║                   
+        │               │                │                │               │                │  ╚═════════════╝                   
+        │               │                │                │  Execute Approved Proposal #1  │  ╔═══════════════╗                 
+        │               │                │                │ ───────────────────────────────>  ║dispatch call ░║                 
+      Alice            Bob            Charlie            Dave            Eve           ┌───┴──╚═══════════════╝                 
+       ┌─┐             ┌─┐              ┌─┐               ┌─┐            ┌─┐           │Multisig│                               
+       ║"│             ║"│              ║"│               ║"│            ║"│           └────────┘                               
+       └┬┘             └┬┘              └┬┘               └┬┘            └┬┘                                                    
+       ┌┼┐             ┌┼┐              ┌┼┐               ┌┼┐            ┌┼┐                                                    
+        │               │                │                 │              │                                                     
+       ┌┴┐             ┌┴┐              ┌┴┐               ┌┴┐            ┌┴┐                                                    
+
+## Tehcnical Overview
+
+### Storage/State
+
+* We use 2 storage maps to store mutlisig accounts and proposals.
+* The storage have 2 main lists:  
+  * owners related to a a multisig account
+  * approvers in each proposal  
+
+For optimizing we're using BoundedBTreeSet to allow for efficient lookups and removals. Especially in the case of approvers, we need to be able to remove an approver from the list when they revoke their approval. (which we do lazily when `execute_proposal` is called)
+
+### State Transition Functions
+
+All functions have rustdoc in the code. Here is a brief overview of the functions:
+
+* `create_multisig` - Create a multisig account with a given threshold and initial owners.
+* `start_proposal` - Start a multisig proposal.
+* `approve` - Approve a multisig proposal.
+* `revoke` - Revoke a multisig approval from an existing proposal.
+* `execute_proposal` - Execute a multisig proposal.
+
+Note: Next functions need to be called from the multisig account itself.
+
+* `add_owner` - Add a new owner to a multisig account.
+* `remove_owner` - Remove an owner from a multisig account.
+* `set_threshold` - Change the threshold of a multisig account.
+* `cancel_proposal` - Cancel a multisig proposal.
+* `delete_multisig` - Delete a multisig account.
+
+### Considerations
+
+* For cases where a multisig account is deleted, we make sure that all proposals are deleted as well.
+* For cases when a multisig has pending proposals and an owner is removed, we make sure that all pending proposals are canceled (lazily when `execute_proposal` is called).
+* Changing thresholds during a pending proposal is allowed without issues. We make sure that the proposal is executed with the threshold the latest threshold set.
+
+### Development Testing
+
+To test while developing, without a full build (thus reduce time to results):
+
+```sh
+cargo t -p pallet-multisig-stateful
+```
+
+## Future Work
+
+* [ ] Reserve funds for all operations and refund them when it's finished.  
+* [ ] Implement call filters. This will allow multisig accounts to only accept certain calls.
+* [ ] Batch proposals. The ability to batch multiple calls into one proposal.  
+* [ ] Add expiry to proposals. After a certain time, proposals will not accept any more approvals or executions and will be deleted.  
+* [ ] Add extra identifier other than call_hash to proposals. This will allow same call to be proposed multiple times and be in pending state.  
+
+License: Apache-2.0

--- a/substrate/frame/multisig-stateful/src/benchmarking.rs
+++ b/substrate/frame/multisig-stateful/src/benchmarking.rs
@@ -18,7 +18,7 @@ mod benchmarks {
 		owners.try_insert(signatory.clone()).unwrap();
 		// owners.try_insert(1).unwrap();
 
-		let multisig_account =
+		let _multisig_account =
 			Multisig::<T>::get_multisig_account_id(&owners, Multisig::<T>::timepoint());
 
 		#[extrinsic_call]
@@ -26,16 +26,6 @@ mod benchmarks {
 		assert_eq!(true, false);
 		// assert_eq!(MultisigAccount::<Test>::get(multisig_account).unwrap().owners, owners);
 	}
-
-	// #[benchmark]
-	// fn cause_error() {
-	// 	Something::<T>::put(100u32);
-	// 	let caller: T::AccountId = whitelisted_caller();
-	// 	#[extrinsic_call]
-	// 	cause_error(RawOrigin::Signed(caller));
-
-	// 	assert_eq!(MultisigAccount::<T>::get(1), Some());
-	// }
 
 	impl_benchmark_test_suite!(Multisig, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/substrate/frame/multisig-stateful/src/benchmarking.rs
+++ b/substrate/frame/multisig-stateful/src/benchmarking.rs
@@ -1,0 +1,41 @@
+//! Benchmarking setup for pallet-voting
+#![cfg(feature = "runtime-benchmarks")]
+use super::*;
+
+#[allow(unused)]
+use crate::Pallet as Multisig;
+use frame_benchmarking::v2::*;
+use frame_system::RawOrigin;
+
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn create_multisig() {
+		let mut owners: BoundedBTreeSet<T::AccountId, T::MaxSignatories> = BoundedBTreeSet::new();
+		let signatory: T::AccountId = account("signatory", 0, 0);
+		owners.try_insert(signatory.clone()).unwrap();
+		// owners.try_insert(1).unwrap();
+
+		let multisig_account =
+			Multisig::<T>::get_multisig_account_id(&owners, Multisig::<T>::timepoint());
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(signatory), owners, 1);
+		assert_eq!(true, false);
+		// assert_eq!(MultisigAccount::<Test>::get(multisig_account).unwrap().owners, owners);
+	}
+
+	// #[benchmark]
+	// fn cause_error() {
+	// 	Something::<T>::put(100u32);
+	// 	let caller: T::AccountId = whitelisted_caller();
+	// 	#[extrinsic_call]
+	// 	cause_error(RawOrigin::Signed(caller));
+
+	// 	assert_eq!(MultisigAccount::<T>::get(1), Some());
+	// }
+
+	impl_benchmark_test_suite!(Multisig, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/substrate/frame/multisig-stateful/src/lib.rs
+++ b/substrate/frame/multisig-stateful/src/lib.rs
@@ -1,0 +1,976 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//!# Multisig Stateful Pallet
+//!
+//! //! ## WARNING
+//!
+//! NOT YET AUDITED. DO NOT USE IN PRODUCTION.
+//!
+//!A module to facilitate **stateful** multisig accounts. The statefulness of this means that we store a multisig account id in the state with  
+//!related info (owners, threshold,..etc). The module affords enhanced control over administrative operations such as adding/removing owners, changing the threshold, account deletion, canceling an existing proposal. Each owner can approve/revoke a proposal.  
+//!
+//!We use `proposal` in this module to refer to an extrinsic that is to be dispatched from a multisig account after getting enough approvals.
+//!
+//!## Use Cases
+//!
+//!* Corporate Governance:
+//!In a corporate setting, multisig accounts can be employed for decision-making processes. For example, a company may require the approval of multiple executives to initiate   significant financial transactions.
+//!
+//!* Joint Accounts:
+//!Multisig accounts can be used for joint accounts where multiple individuals need to authorize transactions. This is particularly useful in family finances or shared  
+//!business accounts.
+//!
+//!* Decentralized Autonomous Organizations (DAOs):
+//!DAOs can utilize multisig accounts to ensure that decisions are made collectively. Multiple key holders can be required to approve changes to the organization's rules or  
+//!the allocation of funds.
+//!
+//!... and much more.
+//!
+//!## Stateless Multisig vs Stateful Multisig
+//!
+//!### Overview
+//!
+//!All of the mentioned use cases -and more- are better served by a stateful multisig account. This is because a stateful multisig account is stored in the state and allows for more control over the account itself. For example, a stateful multisig account can be deleted, owners can be added/removed, threshold can be changed, proposals can be canceled,..etc.  
+//!
+//!A stateless multisig account is a multisig account that is not stored in the state. It is a simple call that is dispatched from a single account. This is useful for simple use cases where a multisig account is needed for a single purpose and no further control is needed over the account itself.
+//!
+//!### Extrensics (Frame/Multisig vs Stateful Multisig) -- Skip if not familiar with Frame/Multisig
+//!
+//!Main distinction in proposal approvals and execution between this implementation and the frame/multisig one is that this module  
+//!has an extrinsic for each step of the process instead of having one entry point that can accept a `CallOrHash`:  
+//!
+//!1. Start Proposal
+//!2. Approve (called N times based on the threshold needed)
+//!3. Execute Proposal
+//!
+//!This is illustrated in the sequence diagram later in the README.
+//!
+//!### Technical Comparison
+//!
+//!Although a stateful multisig account might seem more expensive than a stateless one because it is stored in the state while stateless multisig is not, We see (on paper) that the stateless footprint is actually larger than the stateful one on the blockchain as for each extrinsic call in a stateless multisig, the caller needs to send all the owners and other parameters which are all stored on the blockchain itself.
+//!
+//!TODO: Add benchmark results for both stateless and stateful multisig. (main thing to measure is the storage of extrinsics cost) over one year with 1K multisig accounts,
+//!each with 5-100 users and doing 50 proposals per day.
+//!
+//! - [`Config`]
+//! - [`Call`]
+//!
+//! ### Dispatchable Functions
+//! * [`create_multisig`](Call::create_multisig`) - Creates a new multisig account and attach owners with a threshold to it.
+//! * [`start_proposal`](`Call::start_proposal`) - Start a multisig proposal.
+//! * [`approve`](`Call::approve`) - Approve a multisig proposal.
+//! * [`revoke`](`Call::revoke`) - Revoke a multisig approval from an existing proposal.
+//! * [`execute_proposal`](`Call::execute_proposal`) - Execute a multisig proposal.
+//!
+//! Note: Next functions need to be called from the multisig account itself.
+//!
+//! * [`add_owner`](`Call::add_owner`) - Add a new owner to a multisig account.
+//! * [`remove_owner`](`Call::remove_owner`) - Remove an owner from a multisig account.
+//! * [`set_threshold`](`Call::set_threshold`) - Change the threshold of a multisig account.
+//! * [`cancel_proposal`](`Call::cancel_proposal`) - Cancel a multisig proposal.
+//! * [`delete_account`](`Call::delete_account`) - Delete a multisig account.
+
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// TODO:
+// Cleanup Proposals
+// Deposits
+// Beanchmarking
+
+use frame_support::traits::fungible::MutateHold;
+use frame_support::{
+	pallet_prelude::*,
+	storage::KeyLenOf,
+	traits::{fungible, tokens::Precision},
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+pub use pallet::*;
+use scale_info::prelude::collections::BTreeSet;
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+pub mod types;
+use crate::types::*;
+
+use sp_io::hashing::blake2_256;
+use sp_runtime::{
+	traits::{Dispatchable, Hash, TrailingZeroInput},
+	BoundedBTreeSet,
+};
+/// The log target of this pallet.
+pub const LOG_TARGET: &'static str = "runtime::multisig_stateful";
+
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			concat!("[{:?}] ✍️ ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+
+	use crate::*;
+	use frame_support::dispatch::{GetDispatchInfo, RawOrigin};
+	use frame_support::traits::fungible::MutateHold;
+	use frame_system::pallet_prelude::*;
+
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	pub struct Pallet<T>(_);
+
+	// #[pallet::config(with_default)]
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Overarching event type.
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type Currency: fungible::Inspect<Self::AccountId>
+			+ fungible::hold::Mutate<Self::AccountId, Reason = Self::RuntimeHoldReason>;
+
+		/// The hold reason when reserving funds.
+		type RuntimeHoldReason: From<HoldReason>;
+
+		/// A dispatchable call.
+		// #[pallet::no_default_bounds]
+		type RuntimeCall: Parameter
+			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+			+ GetDispatchInfo;
+
+		/// The amount held on deposit for a created Multisig account.
+		#[pallet::constant]
+		type CreationDeposit: Get<BalanceOf<Self>>;
+
+		/// The amount held on deposit for a new proposal.
+		#[pallet::constant]
+		type ProposalDeposit: Get<BalanceOf<Self>>;
+
+		/// The maximum amount of signatories/owners allowed in the multisig.
+		#[pallet::constant]
+		type MaxSignatories: Get<u32>;
+
+		/// The maximum amount of proposals to remove in one call when cleaning up the storage.
+		/// Don't change the u8 as we don't want to allow a large number of proposals to be removed in one call
+		/// to eliminate the possibility of a DoS attack.
+		#[pallet::constant]
+		type RemoveProposalsLimit: Get<u8>;
+	}
+
+	/// Each multisig account (key) has a set of current owners with a threshold.
+	#[pallet::storage]
+	pub type MultisigAccount<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, MultisigAccountDetails<T>>;
+
+	/// The set of open multisig proposals. A proposal is uniquely identified by the multisig account and the call hash.
+	/// (maybe a nonce as well in the future)
+	#[pallet::storage]
+	pub type PendingProposals<T: Config> = StorageDoubleMap<
+		_,
+		Twox64Concat,
+		T::AccountId,
+		Blake2_128Concat,
+		T::Hash, // Call Hash
+		MultisigProposal<T>,
+	>;
+
+	/// Clear-cursor for pending proposals, map from MultisigAccountId -> (Maybe) Cursor.
+	#[pallet::storage]
+	pub(super) type ProposalsClearCursor<T: Config> =
+		StorageMap<_, Twox64Concat, T::AccountId, BoundedVec<u8, KeyLenOf<PendingProposals<T>>>>;
+
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason {
+		/// Funds are held for creating a new multisig account.
+		#[codec(index = 0)]
+		MultisigCreation,
+		/// Funds are held for creating a new proposal.
+		#[codec(index = 1)]
+		ProposalCreation,
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// New multisig account created
+		CreatedMultisig {
+			multisig_account: T::AccountId,
+			created_by: T::AccountId,
+		},
+		/// Multisig account deleted
+		DeletedMultisig {
+			multisig_account: T::AccountId,
+		},
+		/// A new owner added to multisig account
+		AddedOwner {
+			multisig_account: T::AccountId,
+			added_owner: T::AccountId,
+			threshold: u32,
+		},
+		/// An owner removed from  multisig account
+		RemovedOwner {
+			multisig_account: T::AccountId,
+			removed_owner: T::AccountId,
+			threshold: u32,
+		},
+		/// A multisig proposal has been approved.
+		ApprovedProposal {
+			approving_account: T::AccountId,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		},
+		/// A multisig approval for a specific proposal has been revoked.
+		RevokedApproval {
+			revoking_account: T::AccountId,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		},
+		/// A multisig proposal has started
+		StartedProposal {
+			proposer: T::AccountId,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		},
+		/// A multisig proposal was completely approved and executed.
+		ExecutedProposal {
+			executor: T::AccountId,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash, // Call Hash
+			result: DispatchResult,
+		},
+		/// A multisig proposal has been cancelled.
+		CanceledProposal {
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		},
+		/// New threshold set for multisig account.
+		ChangedThreshold {
+			multisig_account: T::AccountId,
+			new_threshold: u32,
+		},
+		PendingProposalsCleared {
+			multisig_account: T::AccountId,
+		},
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// User already approved this multisig operation.
+		AlreadyApproved,
+		/// Threshold needs to be more than 0 and less than or equal to the number of owners.
+		InvalidThreshold,
+		/// There are too many signatories in approvers.
+		TooManySignatories,
+		/// Too many owners to create a multisig account or to add a new owner.
+		TooManyOwners,
+		/// Multisig account id not found.
+		MultisigNotFound,
+		/// Multisig account id still exists, can't remove related proposals.
+		MultisigStillExists,
+		/// Proposal not found.
+		ProposalNotFound,
+		/// Only accounts that are owners can do operations on multisig.
+		UnAuthorizedOwner,
+		/// Not enough approvers to execute the multisig operation.
+		NotEnoughApprovers,
+		/// The proposal for the call already exists.
+		ProposalAlreadyExists,
+		/// The owner already exists in the multisig account.
+		OwnerAlreadyExists,
+		/// Trying to do an operation concenring an owner that does not exist. (e.g. `remove_owner`` and `revoke` both needs the owner to exist to remove/revoke it.)
+		OwnerNotFound,
+		/// An error from the underlying `Currency`.
+		CurrencyError,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Creates a new multisig account and attach owners with a threshold to it.
+		///
+		/// The dispatch origin for this call must be _Signed_. It is expected to be a nomral AccountId and not a Multisig AccountId.
+		///
+		/// - `owners`: Initial set of accounts to add to the multisig. These may be updated later via `add_owner` and `remove_owner`.
+		/// - `threshold`: The threshold number of accounts required to approve an action. Must be greater than 0 and less than or equal to the total number of owners.
+		///
+		/// # Errors
+		///
+		/// * `TooManySignatories` - The number of signatories exceeds the maximum allowed.
+		/// * `InvalidThreshold` - The threshold is greater than the total number of owners.
+		#[pallet::call_index(0)]
+		#[pallet::weight(Weight::default())]
+		pub fn create_multisig(
+			origin: OriginFor<T>,
+			owners: BoundedBTreeSet<T::AccountId, T::MaxSignatories>,
+			threshold: u32,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			ensure!(owners.len() <= T::MaxSignatories::get() as usize, Error::<T>::TooManyOwners);
+			// Inital check to make sure that the threshold is correct. We have another check later after making sure that the owners are unique.
+			ensure!(
+				threshold > 0 && threshold <= owners.len() as u32,
+				Error::<T>::InvalidThreshold
+			);
+
+			T::Currency::hold(
+				&HoldReason::MultisigCreation.into(),
+				&who,
+				T::CreationDeposit::get(),
+			)
+			.map_err(|_| Error::<T>::CurrencyError)?;
+
+			let multisig_account = Self::get_multisig_account_id(&owners, Self::timepoint());
+
+			let multisig_details: MultisigAccountDetails<T> = MultisigAccountDetails {
+				owners: owners.clone(),
+				threshold,
+				creator: who.clone(),
+				deposit: T::CreationDeposit::get(),
+			};
+			MultisigAccount::<T>::insert(&multisig_account, multisig_details);
+			Self::deposit_event(Event::CreatedMultisig { multisig_account, created_by: who });
+			Ok(())
+		}
+
+		/// Starts a new proposal for a dispatchable call for a multisig account.
+		/// The caller must be one of the owners of the multisig account.
+		///
+		/// # Arguments
+		///
+		/// * `multisig_account` - The multisig account ID.
+		/// * `call` - The dispatchable call to be executed.
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `UnAuthorizedOwner` - The caller is not an owner of the multisig account.
+		/// * `TooManySignatories` - The number of signatories exceeds the maximum allowed. (shouldn't really happen as it's the first approval)
+		#[pallet::call_index(1)]
+		#[pallet::weight(Weight::default())]
+		pub fn start_proposal(
+			origin: OriginFor<T>,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+			// Check that the caller is an owner of the multisig account.
+			ensure!(multisig_details.has_owner(&who), Error::<T>::UnAuthorizedOwner);
+
+			// Shouldn't start a new proposal if it already exists.
+			ensure!(
+				!PendingProposals::<T>::contains_key(&multisig_account, &call_hash),
+				Error::<T>::ProposalAlreadyExists
+			);
+
+			// Hold the proposal deposit.
+			T::Currency::hold(
+				&HoldReason::ProposalCreation.into(),
+				&who,
+				T::ProposalDeposit::get(),
+			)
+			.map_err(|_| Error::<T>::CurrencyError)?;
+
+			// Add the new approver to the list
+			let mut approvers = BoundedBTreeSet::new();
+			approvers.try_insert(who.clone()).map_err(|_| Error::<T>::TooManySignatories)?;
+
+			// Update the proposal with the new approvers.
+			PendingProposals::<T>::insert(
+				&multisig_account,
+				&call_hash,
+				MultisigProposal {
+					creator: who.clone(),
+					creation_deposit: T::ProposalDeposit::get(),
+					when: Self::timepoint(),
+					approvers,
+					expire_after: None,
+				},
+			);
+
+			Self::deposit_event(Event::StartedProposal {
+				proposer: who,
+				multisig_account,
+				call_hash,
+			});
+			Ok(())
+		}
+
+		/// Approves a proposal for a dispatchable call for a multisig account.
+		/// The caller must be one of the owners of the multisig account.
+		///
+		/// # Arguments
+		///
+		/// * `multisig_account` - The multisig account ID.
+		/// * `call_hash` - The hash of the call to be approved. (This will be the hash of the call that was used in `start_proposal`)
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `UnAuthorizedOwner` - The caller is not an owner of the multisig account.
+		/// * `TooManySignatories` - The number of signatories exceeds the maximum allowed.
+		/// This shouldn't really happen as it's an approval, not an addition of a new owner.
+		#[pallet::call_index(2)]
+		#[pallet::weight(Weight::default())]
+		pub fn approve(
+			origin: OriginFor<T>,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+
+			ensure!(multisig_details.has_owner(&who), Error::<T>::UnAuthorizedOwner);
+
+			let multisig_proposal = PendingProposals::<T>::get(&multisig_account, &call_hash)
+				.ok_or(Error::<T>::ProposalNotFound)?;
+			let mut approvers = multisig_proposal.approvers;
+
+			ensure!(!approvers.contains(&who), Error::<T>::AlreadyApproved);
+
+			approvers.try_insert(who.clone()).map_err(|_| Error::<T>::TooManySignatories)?;
+
+			PendingProposals::<T>::insert(
+				&multisig_account,
+				&call_hash,
+				MultisigProposal { approvers, ..multisig_proposal },
+			);
+
+			Self::deposit_event(Event::ApprovedProposal {
+				approving_account: who,
+				multisig_account,
+				call_hash,
+			});
+			Ok(())
+		}
+
+		/// Revokes an existing approval for a proposal for a multisig account.
+		/// The caller must be one of the owners of the multisig account.
+		///
+		/// # Arguments
+		///
+		/// * `multisig_account` - The multisig account ID.
+		/// * `call_hash` - The hash of the call to be approved. (This will be the hash of the call that was used in `start_proposal`)
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `UnAuthorizedOwner` - The caller is not an owner of the multisig account.
+		/// * `OwnerNotFound` - The caller has not approved the proposal.
+		#[pallet::call_index(3)]
+		#[pallet::weight(Weight::default())]
+		pub fn revoke(
+			origin: OriginFor<T>,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+
+			ensure!(multisig_details.has_owner(&who), Error::<T>::UnAuthorizedOwner);
+
+			let multisig_proposal = PendingProposals::<T>::get(&multisig_account, &call_hash)
+				.ok_or(Error::<T>::ProposalNotFound)?;
+			let mut approvers = multisig_proposal.approvers;
+			ensure!(approvers.contains(&who), Error::<T>::OwnerNotFound);
+
+			approvers.remove(&who);
+
+			PendingProposals::<T>::insert(
+				&multisig_account,
+				&call_hash,
+				MultisigProposal { approvers, ..multisig_proposal },
+			);
+
+			Self::deposit_event(Event::RevokedApproval {
+				revoking_account: who,
+				multisig_account,
+				call_hash,
+			});
+
+			Ok(())
+		}
+
+		/// Executes a proposal for a dispatchable call for a multisig account.
+		/// Poropsal needs to be approved by enough owners (exceeding multisig threshold) before it can be executed.
+		/// The caller must be one of the owners of the multisig account.
+		///
+		/// This function does an extra check to make sure that all approvers still exist in the multisig account.
+		/// That is to make sure that the multisig account is not compromised by removing an owner during an active proposal.
+		///
+		/// # Arguments
+		///
+		/// * `multisig_account` - The multisig account ID.
+		/// * `call` - The call to be executed.
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `UnAuthorizedOwner` - The caller is not an owner of the multisig account.
+		/// * `NotEnoughApprovers` - approvers don't exceed the threshold.
+
+		#[pallet::call_index(4)]
+		#[pallet::weight(call.get_dispatch_info().weight)]
+		pub fn execute_proposal(
+			origin: OriginFor<T>,
+			multisig_account: T::AccountId,
+			call: Box<<T as Config>::RuntimeCall>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+
+			ensure!(multisig_details.has_owner(&who), Error::<T>::UnAuthorizedOwner);
+
+			let call_hash = Self::hash_of(&call);
+			let multisig_proposal = PendingProposals::<T>::get(&multisig_account, &call_hash)
+				.ok_or(Error::<T>::ProposalNotFound)?;
+
+			ensure!(
+				multisig_proposal.approvers.len() as u32 >= multisig_details.threshold,
+				Error::<T>::NotEnoughApprovers
+			);
+
+			Self::check_approvers_still_exist(
+				&multisig_account,
+				&multisig_details,
+				&multisig_proposal,
+				&call_hash,
+			)?;
+
+			// Remove the proposal from the state.
+			PendingProposals::<T>::remove(&multisig_account, &call_hash);
+
+			// Make the call the last thing to prevent any possible re-entrancy attacks
+			let result = call
+				.dispatch(RawOrigin::Signed(multisig_account.clone()).into())
+				.map(|_| ())
+				.map_err(|e| e.error);
+
+			Self::return_proposal_deposit(&multisig_proposal)?;
+
+			Self::deposit_event(Event::ExecutedProposal {
+				executor: who,
+				multisig_account,
+				call_hash,
+				result,
+			});
+
+			result
+		}
+
+		/// Cancels an existing proposal for a multisig account Only if the proposal doesn't have approvers other than
+		/// the proposer.
+		///
+		///	This function needs to be called from a the proposer of the proposal as the origin.
+		///
+		/// # Arguments
+		///
+		/// * `multisig_account` - The multisig account ID.
+		/// * `call_hash` - The hash of the call to be canceled. (This will be the hash of the call that was used in `start_proposal`)
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `ProposalNotFound` - The proposal does not exist.
+		#[pallet::call_index(5)]
+		#[pallet::weight(Weight::default())]
+		pub fn cancel_own_proposal(
+			origin: OriginFor<T>,
+			multisig_account: T::AccountId,
+			call_hash: T::Hash,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			ensure!(
+				MultisigAccount::<T>::contains_key(&multisig_account),
+				Error::<T>::MultisigNotFound
+			);
+			let multisig_proposal = PendingProposals::<T>::get(&multisig_account, &call_hash)
+				.ok_or(Error::<T>::ProposalNotFound)?;
+
+			ensure!(
+				multisig_proposal.approvers.len() == 1
+					&& multisig_proposal.approvers.contains(&who),
+				Error::<T>::UnAuthorizedOwner
+			);
+
+			PendingProposals::<T>::remove(&multisig_account, &call_hash);
+			Self::return_proposal_deposit(&multisig_proposal)?;
+			Self::deposit_event(Event::CanceledProposal { multisig_account, call_hash });
+			Ok(())
+		}
+
+		/// Remove up to `max` stale proposals for a deleted multisig account.
+		///
+		/// May be called by any Signed origin, but only after the multisig account is deleted.
+		#[pallet::call_index(25)]
+		#[pallet::weight(Weight::default())]
+		pub fn cleanup_proposals(
+			origin: OriginFor<T>,
+			multisig_account: T::AccountId,
+		) -> DispatchResultWithPostInfo {
+			ensure_signed(origin)?;
+			ensure!(
+				!MultisigAccount::<T>::contains_key(&multisig_account),
+				Error::<T>::MultisigStillExists
+			);
+			let maybe_cursor = ProposalsClearCursor::<T>::get(&multisig_account);
+			let r = PendingProposals::<T>::clear_prefix(
+				&multisig_account,
+				T::RemoveProposalsLimit::get().into(), // RemoveProposalLimit is u8, no worries from a big loop.
+				maybe_cursor.as_ref().map(|x| &x[..]),
+			);
+			if let Some(cursor) = r.maybe_cursor {
+				ProposalsClearCursor::<T>::insert(
+					&multisig_account,
+					BoundedVec::truncate_from(cursor),
+				);
+			} else {
+				// Clear the cursor if we're done.
+				ProposalsClearCursor::<T>::remove(&multisig_account);
+				Self::deposit_event(Event::PendingProposalsCleared { multisig_account });
+			}
+			Ok(if r.loops == 0 { Pays::Yes } else { Pays::No }.into())
+		}
+
+		//==============================================================================================================
+		// Note: All the functions below needs to be called with a multisig account as the origin.
+		// Starting code index from 20 to make it easier to group them and to add extrinsics before them in the future.
+		//==============================================================================================================
+
+		/// Adds a new owner to the multisig account.
+		/// This function needs to be called from a Multisig account as the origin.
+		/// Otherwise it will fail with MultisigNotFound error.
+		///
+		/// # Arguments
+		///
+		/// * `origin` - The origin multisig account who wants to add a new owner to the multisig account.
+		/// * `new_owner` - The AccountId of the new owner to be added.
+		/// * `new_threshold` - The new threshold for the multisig account after adding the new owner.
+		///
+		/// # Errors
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `InvalidThreshold` - The threshold is greater than the total number of owners or is zero.
+		/// * `TooManySignatories` - The number of signatories exceeds the maximum allowed.
+		#[pallet::weight(Weight::default())]
+		#[pallet::call_index(20)]
+		pub fn add_owner(
+			origin: OriginFor<T>,
+			new_owner: T::AccountId,
+			new_threshold: u32,
+		) -> DispatchResult {
+			let multisig_account = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+			let mut owners = multisig_details.owners;
+			// If owner already exists in error.
+			ensure!(!owners.contains(&new_owner), Error::<T>::OwnerAlreadyExists);
+
+			let owners_len = owners.len() as u32;
+			ensure!(new_threshold > 0, Error::<T>::InvalidThreshold);
+			// Fail early if the threshold is greater than the total number of owners after adding the new owner.
+			let owners_after_addition = owners_len
+				.checked_add(1)
+				.ok_or(DispatchError::Arithmetic(sp_runtime::ArithmeticError::Overflow))?;
+			ensure!(new_threshold <= owners_after_addition, Error::<T>::InvalidThreshold);
+
+			owners.try_insert(new_owner.clone()).map_err(|_| Error::<T>::TooManyOwners)?;
+
+			let multisig_details: MultisigAccountDetails<T> =
+				MultisigAccountDetails { owners, threshold: new_threshold, ..multisig_details };
+
+			MultisigAccount::<T>::insert(&multisig_account, multisig_details);
+
+			Self::deposit_event(Event::AddedOwner {
+				multisig_account,
+				added_owner: new_owner,
+				threshold: new_threshold,
+			});
+			Ok(())
+		}
+
+		/// Removes an  owner from the multisig account.
+		/// This function needs to be called from a Multisig account as the origin.
+		/// Otherwise it will fail with MultisigNotFound error.
+		/// If only one owner exists and is removed, the multisig account and any pending proposals for this account will be deleted from the state.
+		///
+		/// # Arguments
+		///
+		/// * `origin` - The origin multisig account who wants to remove an owner from the multisig account.
+		/// * `owner_to_remove` - The AccountId of the owner to be removed.
+		/// * `new_threshold` - The new threshold for the multisig account after removing the owner. Accepts zero if
+		/// the owner is the only one left.kkk
+		///
+		/// # Errors
+		///
+		/// This function can return the following errors:
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `InvalidThreshold` - The new threshold is greater than the total number of owners or is zero.
+		/// * `UnAuthorizedOwner` - The caller is not an owner of the multisig account.
+		///
+		#[pallet::call_index(21)]
+		#[pallet::weight(Weight::default())]
+		pub fn remove_owner(
+			origin: OriginFor<T>,
+			owner_to_remove: T::AccountId,
+			new_threshold: u32,
+		) -> DispatchResult {
+			let multisig_account = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+			let mut owners = multisig_details.owners;
+			let owners_len = owners.len() as u32;
+
+			// Check Threshold first to fail early without a lookup for the owner
+			// In case it's the only owner left, the threshold should be zero. Otherwise, it should be less than the
+			// number of owners but never zero.
+			if owners_len == 1 {
+				ensure!(new_threshold == 0, Error::<T>::InvalidThreshold);
+			} else {
+				ensure!(new_threshold > 0, Error::<T>::InvalidThreshold);
+			}
+			// less than owners_len and not equal because we're removing one owner.
+			ensure!(new_threshold < owners_len, Error::<T>::InvalidThreshold);
+
+			ensure!(owners.contains(&owner_to_remove), Error::<T>::OwnerNotFound);
+			owners.remove(&owner_to_remove);
+
+			// Last owner was removed, remove the multisig account.
+			if owners.len() == 0 {
+				Self::purge_account(&multisig_account)?;
+			} else {
+				// Can't reach here with a zero threshold.
+				let multisig_details: MultisigAccountDetails<T> =
+					MultisigAccountDetails { owners, threshold: new_threshold, ..multisig_details };
+				MultisigAccount::<T>::insert(&multisig_account, multisig_details);
+			}
+
+			Self::deposit_event(Event::RemovedOwner {
+				multisig_account,
+				removed_owner: owner_to_remove,
+				threshold: new_threshold,
+			});
+
+			Ok(())
+		}
+
+		/// Sets a new threshold for a multisig account.
+		///	This function needs to be called from a Multisig account as the origin.
+		/// Otherwise it will fail with MultisigNotFound error.
+		///
+		/// # Arguments
+		///
+		/// * `origin` - The origin multisig account who wants to set the new threshold.
+		/// * `new_threshold` - The new threshold to be set.
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `InvalidThreshold` - The new threshold is greater than the total number of owners or is zero.
+		#[pallet::call_index(22)]
+		#[pallet::weight(Weight::default())]
+		pub fn set_threshold(origin: OriginFor<T>, new_threshold: u32) -> DispatchResult {
+			let multisig_account = ensure_signed(origin)?;
+			let multisig_details =
+				MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+			let owners_len = multisig_details.owners.len() as u32;
+			ensure!(new_threshold > 0 && new_threshold <= owners_len, Error::<T>::InvalidThreshold);
+
+			MultisigAccount::<T>::insert(
+				&multisig_account,
+				MultisigAccountDetails {
+					owners: multisig_details.owners,
+					threshold: new_threshold,
+					..multisig_details
+				},
+			);
+
+			Self::deposit_event(Event::ChangedThreshold { multisig_account, new_threshold });
+			Ok(())
+		}
+
+		/// Cancels an existing proposal for a multisig account.
+		///
+		///	This function needs to be called from a Multisig account as the origin.
+		/// Otherwise it will fail with MultisigNotFound error.
+		///
+		/// # Arguments
+		///
+		/// * `origin` - The origin multisig account who wants to cancel the proposal.
+		/// * `call_hash` - The hash of the call to be canceled. (This will be the hash of the call that was used in `start_proposal`)
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		/// * `ProposalNotFound` - The proposal does not exist.
+		#[pallet::call_index(23)]
+		#[pallet::weight(Weight::default())]
+		pub fn cancel_proposal(origin: OriginFor<T>, call_hash: T::Hash) -> DispatchResult {
+			let multisig_account = ensure_signed(origin)?;
+			ensure!(
+				MultisigAccount::<T>::contains_key(&multisig_account),
+				Error::<T>::MultisigNotFound
+			);
+
+			let proposal = PendingProposals::<T>::take(&multisig_account, &call_hash)
+				.ok_or(Error::<T>::ProposalNotFound)?;
+
+			Self::return_proposal_deposit(&proposal)?;
+			
+			Self::deposit_event(Event::CanceledProposal { multisig_account, call_hash });
+			Ok(())
+		}
+
+		/// Deletes a multisig account and all related proposals.
+		///
+		///	This function needs to be called from a Multisig account as the origin.
+		/// Otherwise it will fail with MultisigNotFound error.
+		///
+		/// # Arguments
+		///
+		/// * `origin` - The origin multisig account who wants to cancel the proposal.
+		///
+		/// # Errors
+		///
+		/// * `MultisigNotFound` - The multisig account does not exist.
+		#[pallet::call_index(24)]
+		#[pallet::weight(Weight::default())]
+		pub fn delete_account(origin: OriginFor<T>) -> DispatchResult {
+			let multisig_account = ensure_signed(origin)?;
+			Self::purge_account(&multisig_account)?;
+			Ok(())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	/// Derive a unique account id using the original account id and the timepoint.
+	pub fn get_multisig_account_id(
+		owners: &BoundedBTreeSet<T::AccountId, T::MaxSignatories>,
+		timepoint: Timepoint<BlockNumberFor<T>>,
+	) -> T::AccountId {
+		let entropy = (b"pba/multisig_stateful", owners, timepoint).using_encoded(blake2_256);
+		Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
+			.expect("infinite length input; no invalid inputs for type; qed")
+	}
+
+	/// The current `Timepoint`.
+	pub fn timepoint() -> Timepoint<BlockNumberFor<T>> {
+		Timepoint {
+			height: <frame_system::Pallet<T>>::block_number(),
+			index: <frame_system::Pallet<T>>::extrinsic_index().unwrap_or_default(),
+		}
+	}
+
+	pub fn hash_of(call: &<T as Config>::RuntimeCall) -> T::Hash {
+		T::Hashing::hash_of(&call)
+	}
+
+	// Check if any approver has been removed from the multisig account.
+	// We ensure that all approvers are still owners of the multisig account.
+	// This is done by checking the intersection between the proposal approvers and the multisig owners.
+	// If the number of final approvers after removing non-owners is still greater than the threshold, it is valid.
+	// Otherwise, it is considered as an error.
+	fn check_approvers_still_exist(
+		multisig_account: &T::AccountId,
+		multisig_details: &MultisigAccountDetails<T>,
+		multisig_proposal: &MultisigProposal<T>,
+		call_hash: &T::Hash,
+	) -> DispatchResult {
+		let current_approvers: BTreeSet<T::AccountId> = multisig_proposal
+			.approvers
+			.intersection(&multisig_details.owners)
+			.cloned()
+			.collect();
+
+		ensure!(
+			multisig_details.threshold <= current_approvers.len() as u32,
+			Error::<T>::NotEnoughApprovers
+		);
+
+		// If the number of current approvers is equal to the number of approvers, then we don't need to update the
+		// proposal.
+		if current_approvers.len() == multisig_proposal.approvers.len() {
+			return Ok(());
+		}
+
+		let updated_approvers_set: BoundedBTreeSet<T::AccountId, T::MaxSignatories> =
+			current_approvers.try_into().map_err(|_| Error::<T>::TooManySignatories)?;
+
+		let updated_proposal = MultisigProposal {
+			approvers: updated_approvers_set, // Updated approvers
+			// Rest are the same.
+			creator: multisig_proposal.creator.clone(),
+			..*multisig_proposal // when: multisig_proposal.when,
+			                     // expire_after: multisig_proposal.expire_after,
+			                     // creation_deposit: multisig_proposal.creation_deposit,
+		};
+		// Overwrites the proposal with the updated approvers.
+		PendingProposals::<T>::insert(multisig_account, call_hash, updated_proposal);
+		Ok(())
+	}
+
+	/// Deletes a multisig account
+	fn purge_account(multisig_account: &T::AccountId) -> DispatchResult {
+		let multisig_details =
+			MultisigAccount::<T>::get(&multisig_account).ok_or(Error::<T>::MultisigNotFound)?;
+		// Remove the multisig account.
+		MultisigAccount::<T>::remove(&multisig_account);
+
+		Self::return_multisig_creation_deposit(&multisig_details)?;
+
+		Self::deposit_event(Event::DeletedMultisig { multisig_account: multisig_account.clone() });
+		Ok(())
+	}
+
+	fn return_proposal_deposit(proposal: &MultisigProposal<T>) -> DispatchResult {
+		T::Currency::release(
+			&&HoldReason::ProposalCreation.into(),
+			&proposal.creator,
+			proposal.creation_deposit,
+			Precision::BestEffort,
+		)?;
+		Ok(())
+	}
+
+	fn return_multisig_creation_deposit(
+		multisig_details: &MultisigAccountDetails<T>,
+	) -> DispatchResult {
+		T::Currency::release(
+			&&HoldReason::MultisigCreation.into(),
+			&multisig_details.creator,
+			multisig_details.deposit,
+			Precision::BestEffort,
+		)?;
+		Ok(())
+	}
+}

--- a/substrate/frame/multisig-stateful/src/lib.rs
+++ b/substrate/frame/multisig-stateful/src/lib.rs
@@ -70,19 +70,20 @@
 //! - [`Call`]
 //!
 //! ### Dispatchable Functions
-//! * [`create_multisig`](Call::create_multisig`) - Creates a new multisig account and attach owners with a threshold to it.
-//! * [`start_proposal`](`Call::start_proposal`) - Start a multisig proposal.
+//! * [`create_multisig`](Call::create_multisig`) -  Create a multisig account with a given threshold and initial owners. (Needs Deposit).
+//! * [`start_proposal`](`Call::start_proposal`) - Start a multisig proposal. (Needs Deposit)
 //! * [`approve`](`Call::approve`) - Approve a multisig proposal.
 //! * [`revoke`](`Call::revoke`) - Revoke a multisig approval from an existing proposal.
-//! * [`execute_proposal`](`Call::execute_proposal`) - Execute a multisig proposal.
+//! * [`execute_proposal`](`Call::execute_proposal`) - Execute a multisig proposal. (Releases Deposit)
+//! * [`cancel_own_proposal`](`Call::cancel_own_proposal`) - Cancel a multisig proposal started by the caller in case no other owners approved it yet. (Releases Deposit)
 //!
 //! Note: Next functions need to be called from the multisig account itself.
 //!
-//! * [`add_owner`](`Call::add_owner`) - Add a new owner to a multisig account.
-//! * [`remove_owner`](`Call::remove_owner`) - Remove an owner from a multisig account.
+//! * [`add_owner`](`Call::add_owner`) - Add a new owner to a multisig account. (Needs Deposit)
+//! * [`remove_owner`](`Call::remove_owner`) - Remove an owner from a multisig account. (Releases Deposit)
 //! * [`set_threshold`](`Call::set_threshold`) - Change the threshold of a multisig account.
-//! * [`cancel_proposal`](`Call::cancel_proposal`) - Cancel a multisig proposal.
-//! * [`delete_account`](`Call::delete_account`) - Delete a multisig account.
+//! * [`cancel_proposal`](`Call::cancel_proposal`) - Cancel a multisig proposal. (Releases Deposit)
+//! * [`delete_account`](`Call::delete_account`) - Delete a multisig account. (Releases Deposit)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/substrate/frame/multisig-stateful/src/lib.rs
+++ b/substrate/frame/multisig-stateful/src/lib.rs
@@ -114,6 +114,7 @@ use sp_runtime::{
 	traits::{Dispatchable, Hash, TrailingZeroInput},
 	BoundedBTreeSet,
 };
+use sp_std::boxed::Box;
 /// The log target of this pallet.
 pub const LOG_TARGET: &'static str = "runtime::multisig_stateful";
 

--- a/substrate/frame/multisig-stateful/src/mock.rs
+++ b/substrate/frame/multisig-stateful/src/mock.rs
@@ -68,7 +68,6 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub static MaxSignatories: u32 = 4; // Adding static makes it easier to set it to different values in tests. MaxSignatories::set(100);
-	pub static RemoveProposalsLimit: u8 = 1;
 	pub static CreationDeposit: u128 = 2;
 	pub static ProposalDeposit: u128 = 1;
 }
@@ -79,7 +78,6 @@ impl pallet_multisig_stateful::Config for Test {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeCall = RuntimeCall;
 	type MaxSignatories = MaxSignatories;
-	type RemoveProposalsLimit = RemoveProposalsLimit;
 	type CreationDeposit = CreationDeposit;
 	type ProposalDeposit = ProposalDeposit;
 }

--- a/substrate/frame/multisig-stateful/src/mock.rs
+++ b/substrate/frame/multisig-stateful/src/mock.rs
@@ -68,8 +68,9 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub static MaxSignatories: u32 = 4; // Adding static makes it easier to set it to different values in tests. MaxSignatories::set(100);
-	pub static CreationDeposit: u128 = 2;
+	pub static BaseCreationDeposit: u128 = 2;
 	pub static ProposalDeposit: u128 = 1;
+	pub static PerOwnerDeposit: u128 = 1;
 }
 
 impl pallet_multisig_stateful::Config for Test {
@@ -78,8 +79,9 @@ impl pallet_multisig_stateful::Config for Test {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeCall = RuntimeCall;
 	type MaxSignatories = MaxSignatories;
-	type CreationDeposit = CreationDeposit;
+	type BaseCreationDeposit = BaseCreationDeposit;
 	type ProposalDeposit = ProposalDeposit;
+	type PerOwnerDeposit = PerOwnerDeposit;
 }
 
 pub(crate) const ALICE: u64 = 1;
@@ -88,13 +90,17 @@ pub(crate) const CHARLIE: u64 = 3;
 pub(crate) const DAVE: u64 = 4;
 pub(crate) const EVE: u64 = 5;
 
-pub(crate) const INITIAL_BALANCE: u128 = 20; 
+pub(crate) const INITIAL_BALANCE: u128 = 20;
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	// frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_balances::GenesisConfig::<Test> {
-		balances: vec![(ALICE, INITIAL_BALANCE), (BOB, INITIAL_BALANCE), (CHARLIE, INITIAL_BALANCE)],
+		balances: vec![
+			(ALICE, INITIAL_BALANCE),
+			(BOB, INITIAL_BALANCE),
+			(CHARLIE, INITIAL_BALANCE),
+		],
 	}
 	.assimilate_storage(&mut t)
 	.unwrap();

--- a/substrate/frame/multisig-stateful/src/mock.rs
+++ b/substrate/frame/multisig-stateful/src/mock.rs
@@ -1,0 +1,107 @@
+use crate as pallet_multisig_stateful;
+use frame_support::{
+	parameter_types,
+	traits::{ConstU128, ConstU16, ConstU32, ConstU64},
+};
+use sp_core::H256;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+type Balance = u128;
+pub type Hash = H256;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test
+	{
+		System: frame_system,
+		Balances: pallet_balances,
+		Multisig: pallet_multisig_stateful,
+	}
+);
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
+	type Hash = Hash;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeTask = ();
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type DustRemoval = ();
+	type RuntimeEvent = RuntimeEvent;
+	type ExistentialDeposit = ConstU128<1>;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxLocks = ConstU32<10>;
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type FreezeIdentifier = ();
+	type MaxFreezes = ConstU32<10>;
+	type RuntimeFreezeReason = ();
+}
+
+parameter_types! {
+	pub static MaxSignatories: u32 = 4; // Adding static makes it easier to set it to different values in tests. MaxSignatories::set(100);
+	pub static RemoveProposalsLimit: u8 = 1;
+	pub static CreationDeposit: u128 = 2;
+	pub static ProposalDeposit: u128 = 1;
+}
+
+impl pallet_multisig_stateful::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeCall = RuntimeCall;
+	type MaxSignatories = MaxSignatories;
+	type RemoveProposalsLimit = RemoveProposalsLimit;
+	type CreationDeposit = CreationDeposit;
+	type ProposalDeposit = ProposalDeposit;
+}
+
+pub(crate) const ALICE: u64 = 1;
+pub(crate) const BOB: u64 = 2;
+pub(crate) const CHARLIE: u64 = 3;
+pub(crate) const DAVE: u64 = 4;
+pub(crate) const EVE: u64 = 5;
+
+pub(crate) const INITIAL_BALANCE: u128 = 20; 
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	// frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	pallet_balances::GenesisConfig::<Test> {
+		balances: vec![(ALICE, INITIAL_BALANCE), (BOB, INITIAL_BALANCE), (CHARLIE, INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	// I can add more stuff directly here.
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/substrate/frame/multisig-stateful/src/tests.rs
+++ b/substrate/frame/multisig-stateful/src/tests.rs
@@ -1026,7 +1026,6 @@ fn cleanup_proposals_works() {
 
 		// Delete account
 		assert_ok!(Multisig::delete_account(RuntimeOrigin::signed(multisig_account)));
-
 		// Still exists
 		call_hash_vec.iter().for_each(|call_hash| {
 			assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
@@ -1046,9 +1045,6 @@ fn cleanup_proposals_works() {
 			alice_current_balance + CreationDeposit::get()
 		);
 
-		//TODO: This should only clear RemoveProposalLimit proposals at a time, It's clearing all instead.
-		// From documentation it mentions that it clears the overlay completely but can't mock the behvaior to check
-		// the actual implementation.
 		call_hash_vec.iter().for_each(|call_hash| {
 			assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
 		});

--- a/substrate/frame/multisig-stateful/src/tests.rs
+++ b/substrate/frame/multisig-stateful/src/tests.rs
@@ -1,0 +1,1112 @@
+use crate::PendingProposals;
+use crate::{mock::*, Error, MultisigAccount, Timepoint};
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::BoundedBTreeSet;
+
+// Helpers - Only call in a TestExternality
+fn now() -> Timepoint<u64> {
+	Multisig::timepoint()
+}
+
+fn add_alice_bob_charlie_dave_multisig(threshold: u32) -> u64 {
+	let mut owners = BoundedBTreeSet::new();
+	owners.try_insert(ALICE).unwrap();
+	owners.try_insert(BOB).unwrap();
+	owners.try_insert(CHARLIE).unwrap();
+	owners.try_insert(DAVE).unwrap();
+
+	let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+	let alice_current_balance = Balances::free_balance(&ALICE);
+	assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners, threshold));
+	assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+	// 3 owners
+	assert!(MultisigAccount::<Test>::get(&multisig_account).unwrap().owners.len() == 4);
+	// reserved creation deposit
+	assert_eq!(Balances::free_balance(&ALICE), alice_current_balance - CreationDeposit::get());
+
+	multisig_account
+}
+
+fn add_alice_bob_charlie_multisig(threshold: u32) -> u64 {
+	let mut owners = BoundedBTreeSet::new();
+	owners.try_insert(ALICE).unwrap();
+	owners.try_insert(BOB).unwrap();
+	owners.try_insert(CHARLIE).unwrap();
+
+	let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+	let alice_current_balance = Balances::free_balance(&ALICE);
+	assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners, threshold));
+	assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+	// 3 owners
+	assert!(MultisigAccount::<Test>::get(&multisig_account).unwrap().owners.len() == 3);
+	// reserved creation deposit
+	assert_eq!(Balances::free_balance(&ALICE), alice_current_balance - CreationDeposit::get());
+
+	multisig_account
+}
+
+fn add_alice_bob_multisig(threshold: u32) -> u64 {
+	let mut owners = BoundedBTreeSet::new();
+	owners.try_insert(ALICE).unwrap();
+	owners.try_insert(BOB).unwrap();
+
+	let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+	let alice_current_balance = Balances::free_balance(&ALICE);
+	assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners, threshold));
+	assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+	// 2 owners
+	assert!(MultisigAccount::<Test>::get(&multisig_account).unwrap().owners.len() == 2);
+	// reserved creation deposit
+	assert_eq!(Balances::free_balance(&ALICE), alice_current_balance - CreationDeposit::get());
+
+	multisig_account
+}
+
+// Makes a multisig with alice as the only owner and threshold 1
+fn add_alice_multisig() -> u64 {
+	let mut owners = BoundedBTreeSet::new();
+	owners.try_insert(ALICE).unwrap();
+
+	let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+	let alice_current_balance = Balances::free_balance(&ALICE);
+	assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners, 1));
+	assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+	// 1 owner
+	assert!(MultisigAccount::<Test>::get(&multisig_account).unwrap().owners.len() == 1);
+	// reserved creation deposit
+	assert_eq!(Balances::free_balance(&ALICE), alice_current_balance - CreationDeposit::get());
+
+	multisig_account
+}
+
+fn transfer(src: u64, dest: u64, value: u128) {
+	assert_ok!(Balances::transfer_allow_death(RuntimeOrigin::signed(src), dest, value));
+}
+
+fn construc_transfer_call(dest: u64, value: u128) -> Box<RuntimeCall> {
+	Box::new(RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {
+		dest,
+		value: value.into(),
+	}))
+}
+
+fn start_alice_bob_charlie_multisig_proposal(
+	call: Box<RuntimeCall>,
+	threshold: u32,
+	proposer: u64,
+) -> (u64, Hash) {
+	let call_hash = Multisig::hash_of(&call.clone());
+	let multisig_account = add_alice_bob_charlie_multisig(threshold);
+
+	let proposer_current_balance = Balances::free_balance(&proposer);
+	assert_ok!(Multisig::start_proposal(
+		RuntimeOrigin::signed(proposer),
+		multisig_account,
+		call_hash,
+	));
+	assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+	// reserved creation deposit
+	assert_eq!(
+		Balances::free_balance(&proposer),
+		proposer_current_balance - ProposalDeposit::get()
+	);
+	System::assert_has_event(
+		crate::Event::StartedProposal { proposer, multisig_account, call_hash }.into(),
+	);
+	(multisig_account, call_hash)
+}
+
+fn start_alice_bob_charlie_dave_multisig_proposal(
+	call: Box<RuntimeCall>,
+	threshold: u32,
+	proposer: u64,
+) -> (u64, Hash) {
+	let call_hash = Multisig::hash_of(&call.clone());
+	let multisig_account = add_alice_bob_charlie_dave_multisig(threshold);
+
+	let proposer_current_balance = Balances::free_balance(&proposer);
+	assert_ok!(Multisig::start_proposal(
+		RuntimeOrigin::signed(proposer),
+		multisig_account,
+		call_hash,
+	));
+	assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+	// reserved creation deposit
+	assert_eq!(
+		Balances::free_balance(&proposer),
+		proposer_current_balance - ProposalDeposit::get()
+	);
+	System::assert_has_event(
+		crate::Event::StartedProposal { proposer, multisig_account, call_hash }.into(),
+	);
+	(multisig_account, call_hash)
+}
+// End Helpers
+
+#[test]
+fn create_multisig_one_owner() {
+	new_test_ext().execute_with(|| {
+		let mut owners = BoundedBTreeSet::new();
+		owners.try_insert(ALICE).unwrap();
+
+		let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+		// No multisig account should exist before creating it
+		assert!(!MultisigAccount::<Test>::contains_key(&multisig_account));
+		// Create multisig account with ALICE as the first signer
+		assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners.clone(), 1));
+		// Check that the multisig account exists
+		assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		assert_eq!(multisig_details.owners, owners);
+		assert_eq!(multisig_details.threshold, 1);
+
+		System::assert_last_event(
+			crate::Event::CreatedMultisig { multisig_account, created_by: ALICE }.into(),
+		);
+	});
+}
+
+#[test]
+fn create_multisig_multiple_owners() {
+	new_test_ext().execute_with(|| {
+		let mut owners = BoundedBTreeSet::new();
+		owners.try_insert(BOB).unwrap();
+		owners.try_insert(CHARLIE).unwrap();
+
+		let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+		// No multisig account should exist before creating it
+		assert!(!MultisigAccount::<Test>::contains_key(&multisig_account));
+		// Create multisig account, someone other than the owners can send the request without issues
+		assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners.clone(), 2));
+		// Check that the multisig account exists
+		assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		assert_eq!(multisig_details.owners, owners.into_inner());
+		assert_eq!(multisig_details.threshold, 2);
+	});
+}
+
+#[test]
+fn create_multisig_fails_wrong_threshold() {
+	new_test_ext().execute_with(|| {
+		let mut owners = BoundedBTreeSet::new();
+		owners.try_insert(BOB).unwrap();
+		let multisig_account = Multisig::get_multisig_account_id(&owners, now());
+		// No multisig account should exist before creating it
+		assert!(!MultisigAccount::<Test>::contains_key(&multisig_account));
+		// Create multisig account with ALICE as the first signer
+		assert_noop!(
+			Multisig::create_multisig(RuntimeOrigin::signed(ALICE), BoundedBTreeSet::default(), 2),
+			Error::<Test>::InvalidThreshold
+		);
+
+		assert_noop!(
+			Multisig::create_multisig(RuntimeOrigin::signed(ALICE), BoundedBTreeSet::default(), 0),
+			Error::<Test>::InvalidThreshold
+		);
+	});
+}
+
+#[test]
+fn multisig_one_owner_add_owner() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_multisig();
+
+		let add_owner_call: RuntimeCall =
+			crate::Call::add_owner { new_owner: BOB, new_threshold: 2 }.into();
+
+		let alice_current_balance = Balances::free_balance(&ALICE);
+		// After calling as multisig, the multisig account should have BOB as an owner and the threshold should be 2
+		// This is due to the fact that the multisig account is created with only ALICE as an owner and threshold 1
+		// which will pass the threshold check for the call.
+		assert_ok!(Multisig::start_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			Multisig::hash_of(&add_owner_call.clone()),
+		));
+
+		// reserved proposal deposit
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance - ProposalDeposit::get());
+
+		assert_ok!(Multisig::execute_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			Box::new(add_owner_call.clone()),
+		));
+
+		// release deposit
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance);
+
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		assert!(multisig_details.owners.contains(&BOB));
+		assert_eq!(multisig_details.threshold, 2);
+
+		System::assert_last_event(
+			crate::Event::ExecutedProposal {
+				executor: 1,
+				multisig_account,
+				call_hash: Multisig::hash_of(&add_owner_call),
+				result: Ok(()),
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn multisig_2_of_2_add_owner() {
+	new_test_ext().execute_with(|| {
+		let bob_initial_balance = Balances::free_balance(&BOB);
+		let multisig_account = add_alice_bob_multisig(2);
+
+		let add_charlie_call: RuntimeCall =
+			crate::Call::add_owner { new_owner: CHARLIE, new_threshold: 2 }.into();
+
+		let call_hash = Multisig::hash_of(&add_charlie_call.clone());
+
+		let alice_current_balance = Balances::free_balance(&ALICE);
+
+		assert_ok!(Multisig::start_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			Multisig::hash_of(&add_charlie_call.clone()),
+		));
+
+		// reserved proposal deposit
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance - ProposalDeposit::get());
+		// Bob stays the same
+		assert_eq!(Balances::free_balance(&BOB), bob_initial_balance);
+
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		// Shouldn't contain CHARLIE yet
+		assert!(!multisig_details.owners.contains(&CHARLIE));
+
+		let proposal = PendingProposals::<Test>::get(&multisig_account, call_hash).unwrap();
+		// Only ALICE approval should be present
+		assert!(proposal.approvers.len() == 1);
+		assert!(proposal.approvers.contains(&ALICE));
+
+		// Call again with BOB
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash,));
+
+		// Though BOB is the one who's executing, the deposit should be released to ALICE
+		assert_ok!(Multisig::execute_proposal(
+			RuntimeOrigin::signed(BOB),
+			multisig_account,
+			Box::new(add_charlie_call),
+		));
+
+		// release deposit to ALICE
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance);
+		// BOB stays the same
+		assert_eq!(Balances::free_balance(&BOB), bob_initial_balance);
+
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		// Shoul contain CHARLIE
+		assert!(multisig_details.owners.contains(&CHARLIE));
+		// No proposal should exist anymore
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash))
+	});
+}
+
+#[test]
+fn multisig_2_of_3() {
+	new_test_ext().execute_with(|| {
+		// Start by making sure Eve doesn't have any balance
+		assert_eq!(Balances::free_balance(EVE), 0);
+		let call = construc_transfer_call(EVE, 15);
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		transfer(ALICE, multisig_account, 5);
+		transfer(BOB, multisig_account, 5);
+		transfer(CHARLIE, multisig_account, 5);
+
+		assert_eq!(Balances::free_balance(multisig_account), 15);
+		// Starting a proposal is not anough to transfer to Eve as the threshold is 2
+		assert_eq!(Balances::free_balance(EVE), 0);
+
+		// Approve with BOB
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash));
+
+		assert_ok!(Multisig::execute_proposal(
+			RuntimeOrigin::signed(CHARLIE),
+			multisig_account,
+			call.clone(),
+		));
+
+		// Eve has 15 balance now since the call has been approved by 2 members.
+		assert_eq!(Balances::free_balance(EVE), 15);
+		assert_eq!(Balances::free_balance(multisig_account), 0);
+		// No proposal should exist anymore
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash))
+	});
+}
+
+#[test]
+fn multisig_3_of_3() {
+	new_test_ext().execute_with(|| {
+		// Start by making sure Eve doesn't have any balance
+		assert_eq!(Balances::free_balance(EVE), 0);
+		let call = construc_transfer_call(EVE, 15);
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 3, ALICE);
+
+		transfer(ALICE, multisig_account, 5);
+		transfer(BOB, multisig_account, 5);
+		transfer(CHARLIE, multisig_account, 5);
+
+		assert_eq!(Balances::free_balance(multisig_account), 15);
+		// Starting a proposal is not anough to transfer to Eve as the threshold is 2
+		assert_eq!(Balances::free_balance(EVE), 0);
+
+		// Bob approves
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash));
+
+		// Still not enough approvers
+		assert_eq!(Balances::free_balance(multisig_account), 15);
+		assert_eq!(Balances::free_balance(EVE), 0);
+
+		// Charlie approves
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(CHARLIE), multisig_account, call_hash));
+
+		// Now we have enough approvers
+		assert_ok!(Multisig::execute_proposal(
+			RuntimeOrigin::signed(CHARLIE),
+			multisig_account,
+			call.clone(),
+		));
+
+		// Eve has 15 balance now since the call has been approved by 2 members.
+		assert_eq!(Balances::free_balance(EVE), 15);
+		assert_eq!(Balances::free_balance(multisig_account), 0);
+		// No proposal should exist anymore
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash))
+	});
+}
+
+#[test]
+fn starting_same_approval_fails() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+
+		transfer(ALICE, multisig_account, 5);
+		transfer(BOB, multisig_account, 5);
+		transfer(CHARLIE, multisig_account, 5);
+
+		let call: Box<RuntimeCall> = construc_transfer_call(EVE, 15);
+
+		// Eve has no initial balance
+		assert_eq!(Balances::free_balance(EVE), 0);
+
+		let call_hash = Multisig::hash_of(&call.clone());
+
+		// Bob approving
+		assert_ok!(Multisig::start_proposal(
+			RuntimeOrigin::signed(BOB),
+			multisig_account,
+			call_hash,
+		));
+
+		// Eve still has 0 balance since the call hasn't been approved by 2 members yet.
+		assert_eq!(Balances::free_balance(EVE), 0);
+
+		// Bob starts the same proposal again
+		assert_noop!(
+			Multisig::start_proposal(RuntimeOrigin::signed(BOB), multisig_account, call_hash),
+			Error::<Test>::ProposalAlreadyExists
+		);
+
+		// Eve still has only 0 balance
+		assert_eq!(Balances::free_balance(EVE), 0);
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		// Only one approver still
+		assert!(
+			PendingProposals::<Test>::get(&multisig_account, &call_hash)
+				.unwrap()
+				.approvers
+				.len() == 1
+		);
+	});
+}
+
+// NOTE: Next tests assumes that the origin is a multisig account which passed the threshold check in a previous start_proposal call that was tested above with both multisig pallet calls and balances calls.
+
+#[test]
+fn add_owner_works() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_multisig(2);
+		assert_ok!(Multisig::add_owner(RuntimeOrigin::signed(multisig_account), CHARLIE, 3));
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		assert!(multisig_details.owners.contains(&CHARLIE));
+		assert!(multisig_details.owners.len() == 3);
+		assert!(multisig_details.threshold == 3);
+		System::assert_has_event(
+			crate::Event::AddedOwner { multisig_account, added_owner: CHARLIE, threshold: 3 }
+				.into(),
+		);
+	});
+}
+
+#[test]
+fn add_owner_fails_when_wrong_threshold() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_multisig(2);
+		assert_noop!(
+			Multisig::add_owner(RuntimeOrigin::signed(multisig_account), multisig_account, 4),
+			Error::<Test>::InvalidThreshold
+		);
+	});
+}
+
+#[test]
+fn add_owner_fails_when_wrong_multisig_origin() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_multisig(2);
+		assert_noop!(
+			Multisig::add_owner(RuntimeOrigin::signed(ALICE), multisig_account, 4),
+			Error::<Test>::MultisigNotFound
+		);
+	});
+}
+
+#[test]
+fn add_owner_fails_when_existing_owner_added() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_multisig(2);
+		assert_noop!(
+			Multisig::add_owner(RuntimeOrigin::signed(multisig_account), ALICE, 2),
+			Error::<Test>::OwnerAlreadyExists
+		);
+	});
+}
+
+#[test]
+fn add_owner_fails_when_more_owners_than_max() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		assert_ok!(Multisig::add_owner(RuntimeOrigin::signed(multisig_account), DAVE, 2));
+		assert!(MultisigAccount::<Test>::get(&multisig_account).unwrap().owners.len() == 4);
+
+		assert_noop!(
+			Multisig::add_owner(RuntimeOrigin::signed(multisig_account), EVE, 2),
+			Error::<Test>::TooManyOwners
+		);
+	});
+}
+
+#[test]
+fn remove_owner_works() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		assert_ok!(Multisig::remove_owner(RuntimeOrigin::signed(multisig_account), CHARLIE, 1));
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		assert!(multisig_details.owners.len() == 2);
+		// Charlie deleted
+		assert!(!multisig_details.owners.contains(&CHARLIE));
+		assert_eq!(multisig_details.threshold, 1);
+		System::assert_has_event(
+			crate::Event::RemovedOwner { multisig_account, removed_owner: CHARLIE, threshold: 1 }
+				.into(),
+		);
+	});
+}
+
+#[test]
+fn remove_owner_deletes_multisig_when_only_one_owner_left() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_multisig();
+		let alice_current_balance = Balances::free_balance(&ALICE);
+
+		assert_ok!(Multisig::remove_owner(RuntimeOrigin::signed(multisig_account), ALICE, 0));
+
+		assert!(MultisigAccount::<Test>::get(&multisig_account).is_none());
+		// Return deposit after deletion
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance + CreationDeposit::get());
+
+		System::assert_has_event(
+			crate::Event::RemovedOwner { multisig_account, removed_owner: ALICE, threshold: 0 }
+				.into(),
+		);
+		System::assert_has_event(crate::Event::DeletedMultisig { multisig_account }.into());
+	});
+}
+
+#[test]
+fn remove_owner_fails_when_only_one_owner_left_and_threshold_above_zero() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_multisig();
+		assert_noop!(
+			Multisig::remove_owner(RuntimeOrigin::signed(multisig_account), ALICE, 1),
+			Error::<Test>::InvalidThreshold
+		);
+	});
+}
+
+#[test]
+fn remove_owner_fails_for_normal_signed_account() {
+	new_test_ext().execute_with(|| {
+		add_alice_bob_charlie_multisig(2);
+		assert_noop!(
+			Multisig::remove_owner(RuntimeOrigin::signed(ALICE), CHARLIE, 2),
+			Error::<Test>::MultisigNotFound
+		);
+	});
+}
+
+#[test]
+fn remove_owner_fails_if_theshold_is_more() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		assert_noop!(
+			Multisig::remove_owner(RuntimeOrigin::signed(multisig_account), CHARLIE, 3),
+			Error::<Test>::InvalidThreshold
+		);
+	});
+}
+
+#[test]
+fn remove_owner_fails_if_owner_doesnt_exist() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		assert_noop!(
+			Multisig::remove_owner(RuntimeOrigin::signed(multisig_account), EVE, 2),
+			Error::<Test>::OwnerNotFound
+		);
+	});
+}
+
+#[test]
+fn set_threshold_works() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		assert_ok!(Multisig::set_threshold(RuntimeOrigin::signed(multisig_account), 1));
+		let multisig_details = MultisigAccount::<Test>::get(&multisig_account).unwrap();
+		assert_eq!(multisig_details.threshold, 1);
+		System::assert_has_event(
+			crate::Event::ChangedThreshold { multisig_account, new_threshold: 1 }.into(),
+		);
+	});
+}
+
+#[test]
+fn set_threshold_fails_if_invalid() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(3);
+		assert_noop!(
+			Multisig::set_threshold(RuntimeOrigin::signed(multisig_account), 4),
+			Error::<Test>::InvalidThreshold
+		);
+		assert_noop!(
+			Multisig::set_threshold(RuntimeOrigin::signed(multisig_account), 0),
+			Error::<Test>::InvalidThreshold
+		);
+	});
+}
+
+#[test]
+fn set_threshold_fails_if_not_owner() {
+	new_test_ext().execute_with(|| {
+		add_alice_bob_charlie_multisig(3);
+		assert_noop!(
+			Multisig::set_threshold(RuntimeOrigin::signed(ALICE), 2),
+			Error::<Test>::MultisigNotFound
+		);
+	});
+}
+
+#[test]
+fn approve_works() {
+	new_test_ext().execute_with(|| {
+		// The call itself doesn't matter in this test, we're testing only that approvers add an approver to the proposal
+		let call = construc_transfer_call(EVE, 15);
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+		let proposal = PendingProposals::<Test>::get(&multisig_account, call_hash).unwrap();
+
+		// Only ALICE approval should be present
+		assert!(proposal.approvers.len() == 1);
+		assert!(proposal.approvers.contains(&ALICE));
+
+		// Bob approves
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash));
+		let proposal_after_approval =
+			PendingProposals::<Test>::get(&multisig_account, call_hash).unwrap();
+		assert!(proposal_after_approval.approvers.len() == 2);
+		assert!(proposal_after_approval.approvers.contains(&ALICE));
+		assert!(proposal_after_approval.approvers.contains(&BOB));
+		System::assert_has_event(
+			crate::Event::ApprovedProposal {
+				approving_account: BOB, // Bob was the approving account
+				multisig_account,
+				call_hash,
+			}
+			.into(),
+		);
+	});
+}
+
+#[test]
+fn duplicate_approvers_fail() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		// Approving again should fail
+		assert_noop!(
+			Multisig::approve(RuntimeOrigin::signed(ALICE), multisig_account, call_hash),
+			Error::<Test>::AlreadyApproved
+		);
+	});
+}
+
+#[test]
+fn revoke_approval_works() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		let proposal = PendingProposals::<Test>::get(&multisig_account, call_hash).unwrap();
+		// Only ALICE approval should be present
+		assert!(proposal.approvers.len() == 1);
+		assert!(proposal.approvers.contains(&ALICE));
+
+		// Revoke approval with ALICE
+		assert_ok!(Multisig::revoke(RuntimeOrigin::signed(ALICE), multisig_account, call_hash));
+
+		let proposal = PendingProposals::<Test>::get(&multisig_account, call_hash).unwrap();
+		// No approvers should be present
+		// Don't delete the proposal itself if all approvers are revoked.
+		assert!(proposal.approvers.len() == 0);
+
+		System::assert_has_event(
+			crate::Event::RevokedApproval { revoking_account: ALICE, multisig_account, call_hash }
+				.into(),
+		);
+	});
+}
+
+#[test]
+fn revoke_approval_fails_if_owner_not_in_approvers() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		// Can't revoke approval with BOB because he's not in the approvers
+		assert_noop!(
+			Multisig::revoke(RuntimeOrigin::signed(BOB), multisig_account, call_hash),
+			Error::<Test>::OwnerNotFound
+		);
+	});
+}
+
+#[test]
+fn revoke_approval_fails_if_not_owner() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		// Revoke approval with EVE fails because she's not an owner
+		assert_noop!(
+			Multisig::revoke(RuntimeOrigin::signed(EVE), multisig_account, call_hash),
+			Error::<Test>::UnAuthorizedOwner
+		);
+	});
+}
+
+#[test]
+fn cancel_proposal_works() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		let alice_current_balance = Balances::free_balance(&ALICE);
+
+		// Cancel proposal, only multisig accounts can cancel proposals directly. So it passed approvers process by the time it reaches this call.
+		assert_ok!(Multisig::cancel_proposal(RuntimeOrigin::signed(multisig_account), call_hash));
+
+		// Proposal should not exist anymore
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		// Deposit released
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance + ProposalDeposit::get());
+
+		System::assert_has_event(
+			crate::Event::CanceledProposal { multisig_account, call_hash }.into(),
+		);
+	});
+}
+
+#[test]
+fn cancel_proposal_fails_if_multisig_doesnt_exist() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (_, call_hash) = start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+		let non_existent_multisig_account = 2199;
+
+		// Cancel proposal with EVE fails because she's not an owner
+		assert_noop!(
+			Multisig::cancel_proposal(
+				RuntimeOrigin::signed(non_existent_multisig_account),
+				call_hash
+			),
+			Error::<Test>::MultisigNotFound
+		);
+	});
+}
+
+#[test]
+fn cancel_proposal_fails_if_no_proposal() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		let call_hash = Multisig::hash_of(&construc_transfer_call(EVE, 15)); // The call itself doesn't matter in this test
+
+		// Proposal should not exist
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// Cancel proposal
+		assert_noop!(
+			Multisig::cancel_proposal(RuntimeOrigin::signed(multisig_account), call_hash),
+			Error::<Test>::ProposalNotFound
+		);
+	});
+}
+
+#[test]
+fn delete_account_works() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+
+		// Account exists
+		assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+
+		let current_alice_balance = Balances::free_balance(&ALICE);
+		// The deletion happens after getting enough approvers already
+		assert_ok!(Multisig::delete_account(RuntimeOrigin::signed(multisig_account)));
+		// Account deleted
+		assert!(!MultisigAccount::<Test>::contains_key(&multisig_account));
+		// return creation deposit after deletion
+		assert_eq!(Balances::free_balance(&ALICE), current_alice_balance + CreationDeposit::get());
+		System::assert_last_event(crate::Event::DeletedMultisig { multisig_account }.into());
+	});
+}
+
+#[test]
+fn delete_account_fails_if_not_multisig() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_multisig(2);
+		let non_existent_multisig_account = 2199;
+
+		// Account exists
+		assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+
+		// Account doesn't exist
+		assert!(!MultisigAccount::<Test>::contains_key(&non_existent_multisig_account));
+
+		// The deletion happens after getting enough approvers already
+		assert_noop!(
+			Multisig::delete_account(RuntimeOrigin::signed(non_existent_multisig_account)),
+			Error::<Test>::MultisigNotFound
+		);
+
+		// Account still exists
+		assert!(MultisigAccount::<Test>::contains_key(&multisig_account));
+	});
+}
+
+#[test]
+fn cancel_own_proposal_works() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		let alice_current_balance = Balances::free_balance(&ALICE);
+
+		// Alice canceling own proposal
+		assert_ok!(Multisig::cancel_own_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			call_hash
+		));
+
+		// Proposal should not exist anymore
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// Deposit released
+		assert_eq!(Balances::free_balance(&ALICE), alice_current_balance + ProposalDeposit::get());
+
+		System::assert_has_event(
+			crate::Event::CanceledProposal { multisig_account, call_hash }.into(),
+		);
+	});
+}
+
+#[test]
+fn cancel_others_proposal_fails() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_multisig_proposal(call.clone(), 2, ALICE);
+
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// BOB tries to cancel Alice's proposal
+		assert_noop!(
+			Multisig::cancel_own_proposal(RuntimeOrigin::signed(BOB), multisig_account, call_hash),
+			Error::<Test>::UnAuthorizedOwner
+		);
+	});
+}
+//==================================================================================================
+// 									  Edge cases
+//==================================================================================================
+#[test]
+fn remove_owner_same_threshold_during_active_proposal() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15);
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_dave_multisig_proposal(call.clone(), 3, ALICE); // Start with threshold 3
+
+		transfer(ALICE, multisig_account, 5);
+		transfer(BOB, multisig_account, 5);
+		transfer(CHARLIE, multisig_account, 5);
+
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// Bob and Charlie approve, We have in total 3 approvers to execute the proposal.
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash));
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(CHARLIE), multisig_account, call_hash));
+
+		// Now remove Charlie from the multisig account
+		assert_ok!(Multisig::remove_owner(RuntimeOrigin::signed(multisig_account), CHARLIE, 3));
+
+		// Proposal should still exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// Charlie should not be an owner anymore
+		assert!(!MultisigAccount::<Test>::get(&multisig_account)
+			.unwrap()
+			.owners
+			.contains(&CHARLIE));
+
+		// Executing proposal fails because the threshold is 3 and one of the 3 approvers is not an owner anymore.
+		assert_noop!(
+			Multisig::execute_proposal(
+				RuntimeOrigin::signed(ALICE),
+				multisig_account,
+				call.clone()
+			),
+			Error::<Test>::NotEnoughApprovers
+		);
+
+		// Dave approves
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(DAVE), multisig_account, call_hash));
+
+		// Now we can execute the proposal
+		assert_ok!(Multisig::execute_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			call
+		));
+		// Proposal removed after executing
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		assert!(Balances::free_balance(multisig_account) == 0);
+		assert!(Balances::free_balance(EVE) == 15);
+	});
+}
+
+#[test]
+fn change_threshold_down_while_proposal_active_works() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15);
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_dave_multisig_proposal(call.clone(), 3, ALICE); // Start with threshold 3
+
+		transfer(ALICE, multisig_account, 5);
+		transfer(BOB, multisig_account, 5);
+		transfer(CHARLIE, multisig_account, 5);
+
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// Bob approves, We have in total 2 approvers to execute the proposal.
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash));
+
+		// Execute proposal fails because the threshold is 3 and we have only 2 approvers
+		assert_noop!(
+			Multisig::execute_proposal(
+				RuntimeOrigin::signed(ALICE),
+				multisig_account,
+				call.clone()
+			),
+			Error::<Test>::NotEnoughApprovers
+		);
+
+		// Now change the threshold to 2
+		assert_ok!(Multisig::set_threshold(RuntimeOrigin::signed(multisig_account), 2));
+
+		// Now we can execute the proposal
+		assert_ok!(Multisig::execute_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			call
+		));
+		// Proposal removed after executing
+		assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		assert!(Balances::free_balance(multisig_account) == 0);
+		assert!(Balances::free_balance(EVE) == 15);
+	});
+}
+
+#[test]
+fn change_threshold_up_while_proposal_active_works() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let (multisig_account, call_hash) =
+			start_alice_bob_charlie_dave_multisig_proposal(call.clone(), 2, ALICE); // Start with threshold 2
+
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+
+		// Bob approves, We have in total 2 approvers to execute the proposal.
+		assert_ok!(Multisig::approve(RuntimeOrigin::signed(BOB), multisig_account, call_hash));
+
+		// Now change the threshold to 3
+		assert_ok!(Multisig::set_threshold(RuntimeOrigin::signed(multisig_account), 3));
+
+		// Execute proposal fails because the threshold is 3 and we have only 2 approvers
+		assert_noop!(
+			Multisig::execute_proposal(
+				RuntimeOrigin::signed(ALICE),
+				multisig_account,
+				call.clone()
+			),
+			Error::<Test>::NotEnoughApprovers
+		);
+	});
+}
+
+#[test]
+fn cleanup_proposals_works() {
+	new_test_ext().execute_with(|| {
+		let multisig_account = add_alice_bob_charlie_dave_multisig(2);
+		let mut call_hash_vec = vec![];
+
+		let alice_current_balance = Balances::free_balance(&ALICE);
+		let n_proposals: u128 = 10;
+		for i in 0..n_proposals {
+			let call = construc_transfer_call(DAVE, 10 + i);
+			call_hash_vec.push(Multisig::hash_of(&call.clone()));
+		}
+
+		call_hash_vec.iter().for_each(|call_hash| {
+			assert_ok!(Multisig::start_proposal(
+				RuntimeOrigin::signed(ALICE),
+				multisig_account,
+				*call_hash,
+			));
+		});
+
+		call_hash_vec.iter().for_each(|call_hash| {
+			assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		});
+
+		// Delete account
+		assert_ok!(Multisig::delete_account(RuntimeOrigin::signed(multisig_account)));
+
+		// Still exists
+		call_hash_vec.iter().for_each(|call_hash| {
+			assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		});
+
+		assert_eq!(
+			Balances::free_balance(&ALICE),
+			// As the account is deleted, the creation deposit should be returned
+			alice_current_balance - (n_proposals * ProposalDeposit::get()) + CreationDeposit::get()
+		);
+
+		assert_ok!(Multisig::cleanup_proposals(RuntimeOrigin::signed(EVE), multisig_account));
+
+		// After cleanup, all deposits should be returned and all proposals should be removed
+		assert_eq!(
+			Balances::free_balance(&ALICE),
+			alice_current_balance + CreationDeposit::get()
+		);
+
+		//TODO: This should only clear RemoveProposalLimit proposals at a time, It's clearing all instead.
+		// From documentation it mentions that it clears the overlay completely but can't mock the behvaior to check
+		// the actual implementation.
+		call_hash_vec.iter().for_each(|call_hash| {
+			assert!(!PendingProposals::<Test>::contains_key(&multisig_account, call_hash));
+		});
+		// This should only be fired after the last proposal is cleared.
+		System::assert_has_event(crate::Event::PendingProposalsCleared { multisig_account }.into());
+	});
+}
+
+#[test]
+fn cleanup_proposals_for_non_deleted_multisig_fails() {
+	new_test_ext().execute_with(|| {
+		let call = construc_transfer_call(EVE, 15); // The call itself doesn't matter in this test
+		let call2 = construc_transfer_call(DAVE, 15); // The call itself doesn't matter in this test
+
+		let (multisig_account, call_hash_1) =
+			start_alice_bob_charlie_dave_multisig_proposal(call.clone(), 2, ALICE);
+
+		assert_ok!(Multisig::start_proposal(
+			RuntimeOrigin::signed(ALICE),
+			multisig_account,
+			Multisig::hash_of(&call2.clone()),
+		));
+
+		let call_hash_2 = Multisig::hash_of(&call.clone());
+		// Proposal should exist
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash_1));
+		assert!(PendingProposals::<Test>::contains_key(&multisig_account, call_hash_2));
+
+		assert_noop!(
+			Multisig::cleanup_proposals(RuntimeOrigin::signed(EVE), multisig_account),
+			Error::<Test>::MultisigStillExists
+		);
+	});
+}
+
+#[test]
+fn multisig_of_multisig_accounts() {
+	new_test_ext().execute_with(|| {
+		// Create two multisig accounts with threshold as 1 for the sake of simplicity of the test
+		let multisig_account = add_alice_bob_multisig(1);
+		let multisig_account_2 = add_alice_bob_charlie_multisig(1);
+		// Add multisig accounts as owners for the new multisig
+		let mut owners = BoundedBTreeSet::new();
+		owners.try_insert(multisig_account).unwrap();
+		owners.try_insert(multisig_account_2).unwrap();
+
+		let multisig_of_multisig_account = Multisig::get_multisig_account_id(&owners, now());
+		assert_ok!(Multisig::create_multisig(RuntimeOrigin::signed(ALICE), owners, 2));
+		assert!(MultisigAccount::<Test>::contains_key(&multisig_of_multisig_account));
+
+		// This multisig contains 2 multisig accounts
+		assert!(
+			MultisigAccount::<Test>::get(&multisig_of_multisig_account)
+				.unwrap()
+				.owners
+				.len() == 2
+		);
+		// Basically the rest is the same as the other tests but longer because of the heirarchical nature of the multisig accounts here.
+		// 1. Alice starts a proposal (The proposal is a `StartProposal` call with the multisig1) - as threshold is 1 it will be approved
+	});
+}

--- a/substrate/frame/multisig-stateful/src/types.rs
+++ b/substrate/frame/multisig-stateful/src/types.rs
@@ -1,9 +1,8 @@
 use super::*;
 use frame_system::pallet_prelude::BlockNumberFor;
 
-pub type BalanceOf<T> = <<T as Config>::Currency as fungible::Inspect<
-	<T as frame_system::Config>::AccountId,
->>::Balance;
+pub type BalanceOf<T> =
+	<<T as Config>::Currency as fungible::Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 
 /// A global extrinsic index, formed as the extrinsic index within a block, together with that
 /// block's height. This allows a transaction in which a multisig operation of a particular

--- a/substrate/frame/multisig-stateful/src/types.rs
+++ b/substrate/frame/multisig-stateful/src/types.rs
@@ -1,0 +1,58 @@
+use super::*;
+use frame_system::pallet_prelude::BlockNumberFor;
+
+pub type BalanceOf<T> = <<T as Config>::Currency as fungible::Inspect<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
+
+/// A global extrinsic index, formed as the extrinsic index within a block, together with that
+/// block's height. This allows a transaction in which a multisig operation of a particular
+/// composite was created to be uniquely identified.
+#[derive(
+	Copy, Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo, MaxEncodedLen,
+)]
+pub struct Timepoint<BlockNumber> {
+	/// The height of the chain at the point in time.
+	pub height: BlockNumber,
+	/// The index of the extrinsic at the point in time.
+	pub index: u32,
+}
+
+/// An open multisig operation.
+///
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(T))]
+pub struct MultisigProposal<T: Config> {
+	/// Proposal creator.
+	pub creator: T::AccountId,
+	pub creation_deposit: BalanceOf<T>,
+	/// The extrinsic when the multisig operation was opened.
+	pub when: Timepoint<BlockNumberFor<T>>,
+	/// The approvers achieved so far, including the depositor.
+	/// The approvers are stored in a BoundedBTreeSet to ensure faster lookup and operations (approve, revoke).
+	/// It's also bounded to ensure that the size don't go over the required limit by the Runtime.
+	pub approvers: BoundedBTreeSet<T::AccountId, T::MaxSignatories>,
+	/// The block number until which this multisig operation is valid. None means no expiry.
+	pub expire_after: Option<BlockNumberFor<T>>,
+}
+
+#[derive(
+	Clone, PartialEq, Eq, Encode, Decode, Default, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen,
+)]
+#[scale_info(skip_type_params(T))]
+pub struct MultisigAccountDetails<T: Config> {
+	/// The owners of the multisig account. This is a BoundedBTreeSet to ensure faster operations (add, remove).
+	/// As well as lookups and faster set operations to ensure approvers is always a subset from owners. (e.g. in case of removal of an owner during an active proposal)
+	pub owners: BoundedBTreeSet<T::AccountId, T::MaxSignatories>,
+	/// The threshold of approvers required for the multisig account to be able to execute a call.
+	pub threshold: u32,
+	pub creator: T::AccountId,
+	pub deposit: BalanceOf<T>,
+}
+
+impl<T: Config> MultisigAccountDetails<T> {
+	/// Check if the given account is an owner of the multisig account.
+	pub fn has_owner(&self, who: &T::AccountId) -> bool {
+		self.owners.contains(who)
+	}
+}


### PR DESCRIPTION
# Multisig Stateful Pallet


A pallet to facilitate enhanced multisig accounts. The main enhancement is that we store a multisig account in the state with related info (owners, threshold,..etc). The module affords enhanced control over administrative operations such as adding/removing owners, changing the threshold, account deletion, canceling an existing proposal. Each owner can approve/revoke a proposal while still exists. The proposal is **not** intended for migrating or getting rid of existing multisig. It's to allow both options to coexist.

For the rest of the document we use the following terms:

* `proposal` to refer to an extrinsic that is to be dispatched from a multisig account after getting enough approvals.
* `Stateful Multisig` to refer to the proposed pallet.
* `Stateless Multi` to refer to the current multisig pallet in polkadot-sdk.

## Use Cases

* Corporate Governance:
In a corporate setting, multisig accounts can be employed for decision-making processes. For example, a company may require the approval of multiple executives to initiate   significant financial transactions.

* Joint Accounts:
Multisig accounts can be used for joint accounts where multiple individuals need to authorize transactions. This is particularly useful in family finances or shared  
business accounts.

* Decentralized Autonomous Organizations (DAOs):
DAOs can utilize multisig accounts to ensure that decisions are made collectively. Multiple key holders can be required to approve changes to the organization's rules or the allocation of funds.

... and much more.

## Stateless Multisig vs Stateful Multisig

### Overview

All of the mentioned use cases -and more- are better served by a stateful multisig account. This is because a stateful multisig account is stored in the state and allows for more control over the account itself. For example, a stateful multisig account can be deleted, owners can be added/removed, threshold can be changed, proposals can be canceled,..etc.  

A stateless multisig account is a multisig account that is not stored in the state. It is a simple call that is dispatched from a single account. This is useful for simple use cases where a multisig account is needed for a single purpose and no further control is needed over the account itself.

### Extrensics (Frame/Multisig vs Stateful Multisig) -- Skip if not familiar with Frame/Multisig

Main distinction in proposal approvals and execution between this implementation and the frame/multisig one is that this module  has an extrinsic for each step of the process instead of having one entry point that can accept a `CallOrHash`:  

1. Start Proposal
2. Approve (called N times based on the threshold needed)
3. Execute Proposal

This is illustrated in the sequence diagram later in the README.

Later we'll explain performance impact and how the suggested pallet is superior to existing stateless multisig and the effect on the blockchain footprint.

## Sequence Diagrams
                               
![multisig operations](https://github.com/paritytech/polkadot-sdk/assets/2677789/7f16b2ab-50c6-44d1-8cc3-680cd404385b)
Notes on above diagram:

* It's a 3 step process to execute a proposal. (Start Proposal --> Approvals --> Execute Proposal)
* `Execute` is an explicit extrinsic for a simpler API. It can be optimized to be executed automatically after getting enough approvals.
* Any user can create a multisig account and they don't need to be part of it. (Alice in the diagram)
* A proposal is any extrinsic including control extrinsics (e.g. add/remove owner, change threshold,..etc).
* Any multisig account owner can start a proposal on behalf of the multisig account. (Bob in the diagram)
* Any multisig account owener can execute proposal if it's approved by enough owners. (Dave in the diagram)       

## Tehcnical Overview
### State Transition Functions

All functions have detailed rustdoc in [PR#3300](https://github.com/paritytech/polkadot-sdk/pull/3300). Here is a brief overview of the functions:

* `create_multisig` - Create a multisig account with a given threshold and initial owners. (Needs Deposit)
* `start_proposal` - Start a multisig proposal. (Needs Deposit)
* `approve` - Approve a multisig proposal.
* `revoke` - Revoke a multisig approval from an existing proposal.
* `execute_proposal` - Execute a multisig proposal. (Releases Deposit)
* `cancel_own_proposal` - Cancel a multisig proposal started by the caller in case no other owners approved it yet. (Releases Deposit)

Note: Next functions need to be called from the multisig account itself. Deposits are reserved from the multisig account as well.

* `add_owner` - Add a new owner to a multisig account. (Needs Deposit)
* `remove_owner` - Remove an owner from a multisig account. (Releases Deposit)
* `set_threshold` - Change the threshold of a multisig account.
* `cancel_proposal` - Cancel a multisig proposal. (Releases Deposit)
* `delete_multisig` - Delete a multisig account. (Releases Deposit)

### Storage/State

* Use 2 main storage maps to store mutlisig accounts and proposals.

```rust
#[pallet::storage]
  pub type MultisigAccount<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, MultisigAccountDetails<T>>;

/// The set of open multisig proposals. A proposal is uniquely identified by the multisig account and the call hash.
/// (maybe a nonce as well in the future)
#[pallet::storage]
pub type PendingProposals<T: Config> = StorageDoubleMap<
    _,
    Twox64Concat,
    T::AccountId, // Multisig Account
    Blake2_128Concat,
    T::Hash, // Call Hash
    MultisigProposal<T>,
>;
```

As for the values:

```rust
pub struct MultisigAccountDetails<T: Config> {
	/// The owners of the multisig account. This is a BoundedBTreeSet to ensure faster operations (add, remove).
	/// As well as lookups and faster set operations to ensure approvers is always a subset from owners. (e.g. in case of removal of an owner during an active proposal)
	pub owners: BoundedBTreeSet<T::AccountId, T::MaxSignatories>,
	/// The threshold of approvers required for the multisig account to be able to execute a call.
	pub threshold: u32,
	pub creator: T::AccountId,
	pub deposit: BalanceOf<T>,
}
```

```rust
pub struct MultisigProposal<T: Config> {
    /// Proposal creator.
    pub creator: T::AccountId,
    pub creation_deposit: BalanceOf<T>,
    /// The extrinsic when the multisig operation was opened.
    pub when: Timepoint<BlockNumberFor<T>>,
    /// The approvers achieved so far, including the depositor.
    /// The approvers are stored in a BoundedBTreeSet to ensure faster lookup and operations (approve, revoke).
    /// It's also bounded to ensure that the size don't go over the required limit by the Runtime.
    pub approvers: BoundedBTreeSet<T::AccountId, T::MaxSignatories>,
    /// The block number until which this multisig operation is valid. None means no expiry.
    pub expire_after: Option<BlockNumberFor<T>>,
}
```

For optimization we're using BoundedBTreeSet to allow for efficient lookups and removals. Especially in the case of approvers, we need to be able to remove an approver from the list when they revoke their approval. (which we do lazily when `execute_proposal` is called).

There's an extra storage map for the deposits of the multisig accounts per owner added. This is to ensure that we can release the deposits when the multisig removes them even if the constant deposit per owner changed in the runtime later on.

### Considerations & Edge cases

#### Removing an owner from the multisig account during an active proposal

 We need to ensure that the approvers are always a subset from owners. This is also partially why we're using BoundedBTreeSet for owners and approvers. Once execute proposal is called we ensure that the proposal is still valid and the approvers are still a subset from current owners.

#### Multisig account deletion and cleaning up existing proposals

Once the last owner of a multisig account is removed or the multisig approved the account deletion we delete the multisig accound from the state and keep the proposals until someone calls `cleanup_proposals` multiple times which iterates over a max limit per extrinsic. This is to ensure we don't have unbounded iteration over the proposals. Users are already incentivized to call `cleanup_proposals` to get their deposits back.

#### Multisig account deletion and existing deposits

We currently just delete the account without checking for deposits (Would like to hear your thoughts here). We can either

* Don't make deposits to begin with and make it a fee.
* Transfer to treasury.
* Error on deletion. (don't like this)

#### Approving a proposal after the threshold is changed

We always use latest threshold and don't store each proposal with different threshold. This allows the following:

* In case threshold is lower than the number of approvers then the proposal is still valid.  
* In case threshold is higher than the number of approvers then we catch it during execute proposal and error.
### Performance

Doing back of the envelop calculation to proof that the stateful multisig is more efficient than the stateless multisig given it's smaller footprint size on blocks.

Quick review over the extrinsics for both as it affects the block size:

Stateless Multisig:
Both `as_multi` and `approve_as_multi` has a similar parameters:

```rust
origin: OriginFor<T>,
threshold: u16,
other_signatories: Vec<T::AccountId>,
maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>,
call_hash: [u8; 32],
max_weight: Weight,
```

Stateful Multisig:
We have the following extrinsics:

```rust
pub fn start_proposal(
			origin: OriginFor<T>,
			multisig_account: T::AccountId,
			call_hash: T::Hash,
		)
```

```rust
pub fn approve(
			origin: OriginFor<T>,
			multisig_account: T::AccountId,
			call_hash: T::Hash,
		)
```

```rust
pub fn execute_proposal(
			origin: OriginFor<T>,
			multisig_account: T::AccountId,
			call: Box<<T as Config>::RuntimeCall>,
		)
```

The main takeway is that we don't need to pass the threshold and other signatories in the extrinsics. This is because we already have the threshold and signatories in the state (only once).

So now for the caclulations, given the following:

* K is the number of multisig accounts.
* N is number of owners in each multisig account.
* For each proposal we need to have 2N/3 approvals.

The table calculates if each of the K multisig accounts has one proposal and it gets approved by the 2N/3 and then executed. How much did the total Blocks and States sizes increased by the end of the day.

Note: We're not calculating the cost of proposal as both in statefull and stateless multisig they're almost the same and gets cleaned up from the state once the proposal is executed or canceled.

Stateless effect on blocksizes = 2/3*K*N^2 (as each user of the 2/3 users will need to call approve_as_multi with all the other signatories(N) in extrinsic body)

Stateful effect on blocksizes = K * N (as each user will need to call approve with the multisig account only in extrinsic body)

Stateless effect on statesizes = Nil (as the multisig account is not stored in the state)

Stateful effect on statesizes = K*N (as each multisig account (K) will be stored with all the owners (K) in the state)

| Pallet         |  Block Size   | State Size |
|----------------|:-------------:|-----------:|
| Stateless      |     2/3*K*N^2 |        Nil |
| Stateful       |          K*N  |       K*N  |

Simplified table removing K from the equation:
| Pallet         |  Block Size   | State Size |
|----------------|:-------------:|-----------:|
| Stateless      |           N^2 |        Nil |
| Stateful       |           N   |         N  |

So even though the stateful multisig has a larger state size, it's still more efficient in terms of block size and total footprint on the blockchain.

### Development Testing

To test while developing, without a full build (thus reduce time to results):

```sh
cargo t -p pallet-multisig-stateful
```

## Future Work

* [ ] Batch proposals. The ability to batch multiple calls into one proposal.  
* [ ] Batch addition/removal of owners.
* [ ] Add expiry to proposals. After a certain time, proposals will not accept any more approvals or executions and will be deleted.  
* [ ] Add extra identifier other than call_hash to proposals (e.g. nonce). This will allow same call to be proposed multiple times and be in pending state.  
* [ ] Implement call filters. This will allow multisig accounts to only accept certain calls.
