### PR TITLE
Use simple-mermaid from crates-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5406,7 +5406,6 @@ dependencies = [
  "pallet-examples",
  "parity-scale-codec",
  "scale-info",
- "simple-mermaid",
  "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
@@ -17396,8 +17395,9 @@ dependencies = [
 
 [[package]]
 name = "simple-mermaid"
-version = "0.1.0"
-source = "git+https://github.com/kianenigma/simple-mermaid.git?rev=e48b187bcfd5cc75111acd9d241f1bd36604344b#e48b187bcfd5cc75111acd9d241f1bd36604344b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620a1d43d70e142b1d46a929af51d44f383db9c7a2ec122de2cd992ccfcf3c18"
 
 [[package]]
 name = "siphasher"

--- a/docs/sdk/Cargo.toml
+++ b/docs/sdk/Cargo.toml
@@ -22,7 +22,7 @@ pallet-examples = { path = "../../substrate/frame/examples" }
 pallet-default-config-example = { path = "../../substrate/frame/examples/default-config" }
 
 # How we build docs in rust-docs
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b" }
+simple-mermaid = "0.1.1"
 docify = "0.2.7"
 
 # Polkadot SDK deps, typically all should only be in scope such that we can link to their doc item.

--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -48,7 +48,7 @@ frame-executive = { default-features = false, path = "../frame/executive", optio
 frame-system-rpc-runtime-api = { default-features = false, path = "../frame/system/rpc/runtime-api", optional = true }
 
 docify = "0.2.7"
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b", optional = true }
+simple-mermaid = { version = "0.1.1", optional = true }
 log = { workspace = true }
 
 [dev-dependencies]

--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -48,7 +48,6 @@ frame-executive = { default-features = false, path = "../frame/executive", optio
 frame-system-rpc-runtime-api = { default-features = false, path = "../frame/system/rpc/runtime-api", optional = true }
 
 docify = "0.2.7"
-simple-mermaid = { version = "0.1.1", optional = true }
 log = { workspace = true }
 
 [dev-dependencies]
@@ -78,7 +77,6 @@ std = [
 	"log/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"simple-mermaid",
 	"sp-api?/std",
 	"sp-arithmetic/std",
 	"sp-block-builder?/std",

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -34,7 +34,7 @@ sp-std = { path = "../std", default-features = false }
 sp-weights = { path = "../weights", default-features = false }
 docify = { version = "0.2.7" }
 
-simple-mermaid = { git = "https://github.com/kianenigma/simple-mermaid.git", rev = "e48b187bcfd5cc75111acd9d241f1bd36604344b", optional = true }
+simple-mermaid = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
Re https://github.com/paritytech/polkadot-sdk/issues/2922

Changes:
- Use crates-io version of simple-mermaid as [v0.1.1](https://github.com/glueball/simple-mermaid/releases/tag/v0.1.1) supports no-std.
- Remove from `frame` since i did not see it used.