### PR TITLE
[nomination-pools] Backwards fix for `post_upgrade` migration V6ToV7

### DIFF
--- a/substrate/frame/nomination-pools/src/migration.rs
+++ b/substrate/frame/nomination-pools/src/migration.rs
@@ -150,6 +150,7 @@ pub(crate) mod v7 {
 			Pallet::<T>::create_bonded_account(self.id)
 		}
 
+		#[allow(dead_code)]
 		fn points_to_balance(&self, points: BalanceOf<T>) -> BalanceOf<T> {
 			let bonded_balance =
 				T::Staking::active_stake(&self.bonded_account()).unwrap_or(Zero::zero());
@@ -243,6 +244,7 @@ pub(crate) mod v7 {
 	}
 
 	impl<T: Config> UnbondPool<T> {
+		#[allow(dead_code)]
 		fn point_to_balance(&self, points: BalanceOf<T>) -> BalanceOf<T> {
 			point_to_balance::<T>(self.balance, self.points, points)
 		}
@@ -265,6 +267,7 @@ pub(crate) mod v7 {
 	pub type SubPoolsStorage<T: Config> =
 		CountedStorageMap<Pallet<T>, Twox64Concat, PoolId, SubPools<T>>;
 
+	#[allow(dead_code)]
 	fn total_balance<T: Config>(self_as_member: &PoolMember<T>) -> BalanceOf<T> {
 		// let pool = V7BondedPool::<T>::get(self_as_member.pool_id).unwrap();
 		let id = self_as_member.pool_id;
@@ -292,6 +295,7 @@ pub(crate) mod v7 {
 		active_balance + unbonding_balance
 	}
 
+	#[allow(dead_code)]
 	fn point_to_balance<T: Config>(
 		current_balance: BalanceOf<T>,
 		current_points: BalanceOf<T>,


### PR DESCRIPTION
Continuation of: https://github.com/paritytech/polkadot-sdk/pull/2942, which was tested directly in fellows repo with [commit](https://github.com/polkadot-fellows/runtimes/pull/137/commits/3e55fe6d9f124794d192b5b414acc41107d4320b) but this `post_upgrade` check was part of the original fix.

This PR/patch unblocks `Polkadot` check-migrations for [`polkadot-sdk@1.5.0` bump](https://github.com/polkadot-fellows/runtimes/pull/137)  [`polkadot-sdk@1.6.0` bump](https://github.com/polkadot-fellows/runtimes/pull/159) or we just wait for `polkadot@1.1.2`  is enacted on Feb 19 here: https://polkadot.polkassembly.io/referenda/458
