### PR TITLE
Parachains-Aura: Only produce once per slot

### DIFF
--- a/cumulus/client/consensus/aura/src/collator.rs
+++ b/cumulus/client/consensus/aura/src/collator.rs
@@ -258,6 +258,7 @@ where
 pub struct SlotClaim<Pub> {
 	author_pub: Pub,
 	pre_digest: DigestItem,
+	slot: Slot,
 	timestamp: Timestamp,
 }
 
@@ -272,7 +273,7 @@ impl<Pub> SlotClaim<Pub> {
 		P::Public: Codec,
 		P::Signature: Codec,
 	{
-		SlotClaim { author_pub, timestamp, pre_digest: aura_internal::pre_digest::<P>(slot) }
+		SlotClaim { author_pub, timestamp, pre_digest: aura_internal::pre_digest::<P>(slot), slot }
 	}
 
 	/// Get the author's public key.
@@ -283,6 +284,11 @@ impl<Pub> SlotClaim<Pub> {
 	/// Get the Aura pre-digest for this slot.
 	pub fn pre_digest(&self) -> &DigestItem {
 		&self.pre_digest
+	}
+
+	/// Get the slot assigned to this claim.
+	pub fn slot(&self) -> Slot {
+		self.slot
 	}
 
 	/// Get the timestamp corresponding to the relay-chain slot this claim was

--- a/cumulus/client/consensus/aura/src/collators/basic.rs
+++ b/cumulus/client/consensus/aura/src/collators/basic.rs
@@ -204,8 +204,6 @@ where
 			// obsolete and also the underlying issue will be fixed.
 			if last_processed_slot >= *claim.slot() {
 				continue
-			} else {
-				last_processed_slot = *claim.slot();
 			}
 
 			let (parachain_inherent_data, other_inherent_data) = try_request!(
@@ -244,6 +242,8 @@ where
 				request.complete(None);
 				tracing::debug!(target: crate::LOG_TARGET, "No block proposal");
 			}
+
+			last_processed_slot = *claim.slot();
 		}
 	}
 }

--- a/cumulus/client/consensus/aura/src/collators/basic.rs
+++ b/cumulus/client/consensus/aura/src/collators/basic.rs
@@ -141,6 +141,8 @@ where
 			collator_util::Collator::<Block, P, _, _, _, _, _>::new(params)
 		};
 
+		let mut last_processed_slot = 0;
+
 		while let Some(request) = collation_requests.next().await {
 			macro_rules! reject_with_error {
 				($err:expr) => {{
@@ -191,6 +193,20 @@ where
 				Ok(Some(c)) => c,
 				Err(e) => reject_with_error!(e),
 			};
+
+			// With async backing this function will be called every relay chain block.
+			//
+			// Most parachains currently run with 12 seconds slots and thus, they would try to
+			// produce multiple blocks per slot which very likely would fail on chain. Thus, we have
+			// this "hack" to only produce on block per slot.
+			//
+			// With https://github.com/paritytech/polkadot-sdk/issues/3168 this implementation will be
+			// obsolete and also the underlying issue will be fixed.
+			if last_processed_slot >= *claim.slot() {
+				continue
+			} else {
+				last_processed_slot = *claim.slot();
+			}
 
 			let (parachain_inherent_data, other_inherent_data) = try_request!(
 				collator

--- a/prdoc/pr_3308.prdoc
+++ b/prdoc/pr_3308.prdoc
@@ -1,0 +1,14 @@
+title: Parachains-Aura: Only produce once per slot
+
+doc:
+  - audience: Node Dev
+    description: |
+      With the introduction of asynchronous backing the relay chain allows parachain to include blocks every 6 seconds.
+      The Cumulus Aura implementations, besides the lookahead collator, are building blocks when there is a free slot for
+      the parachain in the relay chain. Most parachains are still running with a 12s slot duration and not allowing
+      to build multiple blocks per slot. But, the block production logic will be triggered every 6s, resulting in error
+      logs like: "no space left for the block in the unincluded segment". This is solved by ensuring that we don't build
+      multiple blocks per slot.
+
+crates:
+  - name: "cumulus-client-consensus-aura"


### PR DESCRIPTION
Given how the block production is driven for Parachains right now, with the enabling of async backing we would produce two blocks per slot. Until we have a proper collator implementation, the "hack" is to prevent the production of multiple blocks per slot.


Closes: https://github.com/paritytech/polkadot-sdk/issues/3282