### PR TITLE
Girazoki modify native asset to consider chain location

### DIFF
--- a/polkadot/xcm/xcm-builder/src/filter_asset_location.rs
+++ b/polkadot/xcm/xcm-builder/src/filter_asset_location.rs
@@ -26,7 +26,7 @@ pub struct NativeAsset;
 impl ContainsPair<Asset, Location> for NativeAsset {
 	fn contains(asset: &Asset, origin: &Location) -> bool {
 		log::trace!(target: "xcm::contains", "NativeAsset asset: {:?}, origin: {:?}", asset, origin);
-		matches!(asset.id, AssetId(ref id) if id == origin)
+		matches!(asset.id, AssetId(ref id) if id.chain_location() == *origin)
 	}
 }
 

--- a/polkadot/xcm/xcm-builder/src/filter_asset_location.rs
+++ b/polkadot/xcm/xcm-builder/src/filter_asset_location.rs
@@ -206,4 +206,32 @@ mod tests {
 			)
 		}
 	}
+	#[test]
+	fn native_asset_filter_works() {
+		frame_support::parameter_types! {
+			pub ParaA: Location = Location::new(1, [Parachain(1001)]);
+			pub ParaB: Location = Location::new(1, [Parachain(1002)]);
+
+			pub AssetXLocation: Location = Location::new(1, [Parachain(1001), GeneralIndex(1111)]);
+			pub AssetYLocation: Location = Location::new(1, [Parachain(1001)]);
+			pub AssetZLocation: Location = Location::new(1, [Parachain(1002)]);
+		}
+
+		let test_data: Vec<(Location, Asset, bool)> = vec![
+			(ParaA::get(), (AssetXLocation::get(), 1).into(), true),
+			(ParaA::get(), (AssetYLocation::get(), 1).into(), true),
+			(ParaA::get(), (AssetZLocation::get(), 1).into(), false),
+			(ParaB::get(), (AssetXLocation::get(), 1).into(), false),
+			(ParaB::get(), (AssetYLocation::get(), 1).into(), false),
+			(ParaB::get(), (AssetZLocation::get(), 1).into(), true),
+		];
+
+		for (location, asset, expected_result) in test_data {
+			assert_eq!(
+				NativeAsset::contains(&asset.clone(), &location.clone()),
+				expected_result,
+				"expected_result: {expected_result} not matched for (location, asset): ({:?}, {:?})!", location, asset,
+			)
+		}
+	}
 }


### PR DESCRIPTION
Modifies the behavior of the `NativeAsset` xcm filter to allow any asset that comes from the same origin. The motivation for this change is to be able to accept assets whose reserve chain is the one sending the message (origin):

Before this change:
```
- origin: (1, Parachain(100))
- asset: (1, Parachain(100))
- result: accepted
```

```
- origin: (1, Parachain(100))
- asset: (1, Parachain(100), GeneralIndex(1))
- result: **not accepted**
```

After this change:

```
- origin: (1, Parachain(100))
- asset: (1, Parachain(100))
- result: accepted
```

```
- origin: (1, Parachain(100))
- asset: (1, Parachain(100), GeneralIndex(1))
- result: **accepted**
```

I can this as a separate struct though if we feel like `NativeAsset` should just accept the asset if `origin === location`
