### PR TITLE
[pallet_broker] Introduce coretime vouchers

### DIFF
--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_broker.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_broker.rs
@@ -495,6 +495,17 @@ impl<T: frame_system::Config> pallet_broker::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn purchase_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 	/// Storage: `Broker::Status` (r:1 w:1)
 	/// Proof: `Broker::Status` (`max_values`: Some(1), `max_size`: Some(18), added: 513, mode: `MaxEncodedLen`)
 	/// Storage: `Broker::Configuration` (r:1 w:0)

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_broker.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_broker.rs
@@ -506,6 +506,39 @@ impl<T: frame_system::Config> pallet_broker::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn assign_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn exchange_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn drop_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 	/// Storage: `Broker::Status` (r:1 w:1)
 	/// Proof: `Broker::Status` (`max_values`: Some(1), `max_size`: Some(18), added: 513, mode: `MaxEncodedLen`)
 	/// Storage: `Broker::Configuration` (r:1 w:0)

--- a/substrate/frame/broker/src/lib.rs
+++ b/substrate/frame/broker/src/lib.rs
@@ -50,7 +50,7 @@ pub mod pallet {
 	use frame_support::{
 		pallet_prelude::{DispatchResult, DispatchResultWithPostInfo, *},
 		traits::{
-			fungible::{hold, Balanced, Credit, Mutate},
+			fungible::{Balanced, Credit, Mutate},
 			EnsureOrigin, OnUnbalanced,
 		},
 		PalletId,
@@ -70,9 +70,7 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		/// Currency used to pay for Coretime.
-		type Currency: Mutate<Self::AccountId>
-			+ hold::Mutate<Self::AccountId>
-			+ Balanced<Self::AccountId>;
+		type Currency: Mutate<Self::AccountId> + Balanced<Self::AccountId>;
 
 		/// The origin test needed for administrating this pallet.
 		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;

--- a/substrate/frame/broker/src/lib.rs
+++ b/substrate/frame/broker/src/lib.rs
@@ -169,7 +169,7 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type NextVoucherId<T> = StorageValue<_, VoucherId, ValueQuery>;
 
-	/// Coretime Vouchers which can be exchanged for credits.
+	/// Coretime Vouchers which can be exchanged for coretime credits.
 	#[pallet::storage]
 	pub type Vouchers<T> = StorageMap<_, Blake2_128Concat, VoucherId, VoucherOf<T>, OptionQuery>;
 

--- a/substrate/frame/broker/src/tests.rs
+++ b/substrate/frame/broker/src/tests.rs
@@ -1134,6 +1134,7 @@ fn vouchers_work() {
 
 		// Exchange this voucher for credit.
 		assert_eq!(balance(3), 0);
+		assert!(CoretimeCredit::get().get(&3).is_none());
 		assert_ok!(Broker::do_exchange_voucher(2, voucher_id, 3));
 		System::assert_last_event(
 			Event::CreditPurchased { who: 2, beneficiary: 3, amount: 100 }.into(),
@@ -1141,9 +1142,7 @@ fn vouchers_work() {
 
 		assert_eq!(balance(1), 900);
 		assert_eq!(balance(2), 0);
-		// Needs a mock for credit_account
-		// assert_eq!(balance(3), 100);
-		// assert_eq!(balance(broker_account), 0);
+		assert_eq!(CoretimeCredit::get().get(&3).unwrap(), &100);
 	});
 }
 

--- a/substrate/frame/broker/src/tests.rs
+++ b/substrate/frame/broker/src/tests.rs
@@ -1146,6 +1146,52 @@ fn vouchers_work() {
 	});
 }
 
-// TODO: Add a test for pre-assigned vouchers
+#[test]
+fn preassigned_vouchers_work() {
+	TestExt::new().endow(1, 1000).execute_with(|| {
+		assert_ok!(Broker::do_start_sales(100, 1));
+		advance_to(2);
+		let broker_account = Broker::account_id();
+		assert_eq!(balance(broker_account), 0);
+
+		// Generate a voucher with an owner.
+		assert_eq!(NextVoucherId::<Test>::get(), 0);
+		let voucher_id = Broker::do_purchase_voucher(1, 100, 10, Some(2)).unwrap();
+		System::assert_last_event(
+			Event::VoucherPurchased {
+				voucher_id,
+				benefactor: 1,
+				amount: 100,
+				expiry: 10,
+				owner: Some(2),
+			}
+			.into(),
+		);
+		assert!(matches!(
+			Vouchers::<Test>::get(voucher_id).unwrap(),
+			Voucher { benefactor, amount, owner, .. }
+			if benefactor == 1 && amount == 100 && owner.unwrap() == 2
+		));
+		assert_eq!(NextVoucherId::<Test>::get(), 1);
+		assert_eq!(balance(1), 900);
+		assert_eq!(balance(broker_account), 100);
+
+		// Voucher can't be reassigned.
+		assert_noop!(Broker::do_assign_voucher(1, voucher_id, 3), Error::<Test>::AlreadyAssigned);
+
+		// Exchange this voucher for credit.
+		assert_eq!(balance(3), 0);
+		assert!(CoretimeCredit::get().get(&3).is_none());
+		assert_ok!(Broker::do_exchange_voucher(2, voucher_id, 3));
+		System::assert_last_event(
+			Event::CreditPurchased { who: 2, beneficiary: 3, amount: 100 }.into(),
+		);
+
+		assert_eq!(balance(1), 900);
+		assert_eq!(balance(2), 0);
+		assert_eq!(CoretimeCredit::get().get(&3).unwrap(), &100);
+	});
+}
+
 // TODO: Add a test for expiry path of vouchers
 // TODO: Flesh out sad path testing

--- a/substrate/frame/broker/src/types.rs
+++ b/substrate/frame/broker/src/types.rs
@@ -289,3 +289,20 @@ where
 		Ok(())
 	}
 }
+
+/// Unique ID to identify a given voucher.
+pub type VoucherId = u64;
+
+/// A record of a voucher for on-demand coretime.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct Voucher<AccountId, Balance> {
+	/// The account to be billed for this coretime upon exchange.
+	pub benefactor: AccountId,
+	/// The amount of coretime for which this voucher can be exchanged.
+	pub amount: Balance,
+	/// The timeslice at which this voucher expires.
+	pub expiry: Timeslice,
+	/// The owner of the voucher, `None` if the Voucher has not yet been awarded.
+	pub owner: Option<AccountId>,
+}
+pub type VoucherOf<T> = Voucher<<T as SConfig>::AccountId, BalanceOf<T>>;

--- a/substrate/frame/broker/src/weights.rs
+++ b/substrate/frame/broker/src/weights.rs
@@ -75,6 +75,10 @@ pub trait WeightInfo {
 	fn process_core_schedule() -> Weight;
 	fn request_revenue_info_at() -> Weight;
 	fn notify_core_count() -> Weight;
+	fn purchase_voucher() -> Weight;
+	fn assign_voucher() -> Weight;
+	fn exchange_voucher() -> Weight;
+	fn drop_voucher() -> Weight;
 	fn do_tick_base() -> Weight;
 }
 
@@ -450,6 +454,50 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	fn notify_core_count() -> Weight {
 		T::DbWeight::get().reads_writes(1, 1)
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn purchase_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn assign_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn exchange_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn drop_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Broker::Status` (r:1 w:1)
 	/// Proof: `Broker::Status` (`max_values`: Some(1), `max_size`: Some(18), added: 513, mode: `MaxEncodedLen`)
@@ -842,6 +890,50 @@ impl WeightInfo for () {
 	fn notify_core_count() -> Weight {
 		RocksDbWeight::get().reads(1)
 			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn purchase_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn assign_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn exchange_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	fn drop_voucher() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `103`
+		//  Estimated: `3593`
+		// Minimum execution time: 46_383_000 picoseconds.
+		Weight::from_parts(47_405_000, 3593)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Broker::Status` (r:1 w:1)
 	/// Proof: `Broker::Status` (`max_values`: Some(1), `max_size`: Some(18), added: 513, mode: `MaxEncodedLen`)


### PR DESCRIPTION
Coretime vouchers can be purchased, assigned and then eventually exchanged for coretime credits by the assigned owner.

Since they are intentionally non-transferrable after being assigned and have a 1-1 mapping for coretime credits, they are designed like a single-owner NFT.

They can be purchased by any account (benefactor) with sufficient credits for the value of the voucher. They can be assigned at the point of purchase or purchased with no assigned owner, then the benefactor account can assign the voucher to an owner at a later stage right up until the expiry timeslice.

An assigned voucher can be exchanged by the owner (the person who has been assigned the voucher) for the specified number of coretime credits. The voucher cannot be split.

Vouchers can be dropped by anybody, but potentially we could introduce a period after the voucher expires where it could be dropped by the benefactor, refunding all or some portion of the original value of the voucher. If not refunded it should be either burnt, transferred to the treasury or added to the on-demand income for the period in which it expires.

TODO:

- [ ] Benchmarks
- [ ] Decide about refunding expired vouchers to original purchaser


This is currently just a draft for feedback on the approach and decisions made.

Implements https://github.com/paritytech/polkadot-sdk/issues/2998