### PR TITLE
fix(zombienet): docker `img` version to use in merge queues for bridges

### DIFF
--- a/.gitlab/pipeline/zombienet/bridges.yml
+++ b/.gitlab/pipeline/zombienet/bridges.yml
@@ -7,12 +7,12 @@
     - .kubernetes-env
     - .zombienet-refs
   rules:
-    - !reference [.build-refs, rules]
-    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/
-  before_script:
     # Docker images have different tag in merge queues
-    - if [[ $CI_COMMIT_REF_NAME == *"gh-readonly-queue"* ]]; then export DOCKER_IMAGES_VERSION="${CI_COMMIT_SHORT_SHA}"; fi
-    - export BRIDGES_ZOMBIENET_TESTS_IMAGE_TAG="${DOCKER_IMAGES_VERSION}"
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/
+      variables:
+        DOCKER_IMAGES_VERSION: ${CI_COMMIT_SHORT_SHA}
+    - !reference [.build-refs, rules]
+  before_script:
     - echo "Zombienet Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
     - echo "${GH_DIR}"
@@ -27,6 +27,7 @@
     - job: build-push-image-bridges-zombienet-tests
       artifacts: true
   variables:
+    BRIDGES_ZOMBIENET_TESTS_IMAGE_TAG: ${DOCKER_IMAGES_VERSION}
     BRIDGES_ZOMBIENET_TESTS_IMAGE: "docker.io/paritypr/bridges-zombienet-tests"
     GH_DIR: "https://github.com/paritytech/polkadot-sdk/tree/${CI_COMMIT_SHA}/bridges/zombienet"
     LOCAL_DIR: "/builds/parity/mirrors/polkadot-sdk/bridges/zombienet"

--- a/.gitlab/pipeline/zombienet/bridges.yml
+++ b/.gitlab/pipeline/zombienet/bridges.yml
@@ -9,9 +9,9 @@
   rules:
     - !reference [.build-refs, rules]
     - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue.*$/
-      variables:
-        DOCKER_IMAGES_VERSION: ${CI_COMMIT_SHORT_SHA}
   before_script:
+    # Docker images have different tag in merge queues
+    - if [[ $CI_COMMIT_REF_NAME == *"gh-readonly-queue"* ]]; then export DOCKER_IMAGES_VERSION="${CI_COMMIT_SHORT_SHA}"; fi
     - echo "Zombienet Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
     - echo "${GH_DIR}"

--- a/.gitlab/pipeline/zombienet/bridges.yml
+++ b/.gitlab/pipeline/zombienet/bridges.yml
@@ -12,6 +12,7 @@
   before_script:
     # Docker images have different tag in merge queues
     - if [[ $CI_COMMIT_REF_NAME == *"gh-readonly-queue"* ]]; then export DOCKER_IMAGES_VERSION="${CI_COMMIT_SHORT_SHA}"; fi
+    - export BRIDGES_ZOMBIENET_TESTS_IMAGE_TAG="${DOCKER_IMAGES_VERSION}"
     - echo "Zombienet Tests Config"
     - echo "${ZOMBIENET_IMAGE}"
     - echo "${GH_DIR}"
@@ -26,7 +27,6 @@
     - job: build-push-image-bridges-zombienet-tests
       artifacts: true
   variables:
-    BRIDGES_ZOMBIENET_TESTS_IMAGE_TAG: ${DOCKER_IMAGES_VERSION}
     BRIDGES_ZOMBIENET_TESTS_IMAGE: "docker.io/paritypr/bridges-zombienet-tests"
     GH_DIR: "https://github.com/paritytech/polkadot-sdk/tree/${CI_COMMIT_SHA}/bridges/zombienet"
     LOCAL_DIR: "/builds/parity/mirrors/polkadot-sdk/bridges/zombienet"


### PR DESCRIPTION
Fix image tag to use in merge queues tests, currently is failing because is using the wrong tag (e.g https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/5224342).

Thx!


