### PR TITLE
[ci] allow fail build-runtimes-polkavm job

### DIFF
--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -335,11 +335,13 @@ build-runtimes-polkavm:
   extends:
     - .docker-env
     - .common-refs
+    - .run-immediately
   script:
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p minimal-runtime
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p westend-runtime
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p rococo-runtime
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p polkadot-test-runtime
+  allow_failure: true
 
 .build-subkey:
   stage: build


### PR DESCRIPTION
PR allows `build-runtimes-polkavm` to fail. Also added DAG to run the job immediately.

cc https://github.com/paritytech/ci_cd/issues/945
cc https://github.com/paritytech/polkadot-sdk/issues/3352