### PR TITLE
Fix `runtime-benchmarks` feature propagation for cumulus test utils  (backport for 1.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11279,7 +11279,6 @@ dependencies = [
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
 dependencies = [
- "assets-common",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",

--- a/cumulus/parachains/runtimes/assets/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/test-utils/Cargo.toml
@@ -83,3 +83,7 @@ std = [
 	"xcm-executor/std",
 	"xcm/std",
 ]
+
+runtime-benchmarks = [
+	"assets-common/runtime-benchmarks",
+]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -219,6 +219,7 @@ std = [
 
 runtime-benchmarks = [
 	"bridge-hub-common/runtime-benchmarks",
+	"bridge-hub-test-utils/runtime-benchmarks",
 	"bridge-runtime-common/runtime-benchmarks",
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"cumulus-pallet-session-benchmarking/runtime-benchmarks",

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
@@ -185,6 +185,7 @@ std = [
 
 runtime-benchmarks = [
 	"bridge-hub-common/runtime-benchmarks",
+	"bridge-hub-test-utils/runtime-benchmarks",
 	"bridge-runtime-common/runtime-benchmarks",
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"cumulus-pallet-session-benchmarking/runtime-benchmarks",

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml
@@ -98,3 +98,7 @@ std = [
 	"xcm-executor/std",
 	"xcm/std",
 ]
+
+runtime-benchmarks = [
+	"asset-test-utils/runtime-benchmarks",
+]

--- a/cumulus/parachains/runtimes/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/test-utils/Cargo.toml
@@ -31,7 +31,6 @@ cumulus-pallet-xcmp-queue = { path = "../../../pallets/xcmp-queue", default-feat
 pallet-collator-selection = { path = "../../../pallets/collator-selection", default-features = false, version = "9.0.0" }
 parachains-common = { path = "../../common", default-features = false, version = "7.0.0" }
 parachain-info = { package = "staging-parachain-info", path = "../../pallets/parachain-info", default-features = false, version = "0.7.0" }
-assets-common = { path = "../assets/common", default-features = false, version = "0.7.0" }
 cumulus-primitives-core = { path = "../../../primitives/core", default-features = false, version = "0.7.0" }
 cumulus-primitives-parachain-inherent = { path = "../../../primitives/parachain-inherent", default-features = false, version = "0.7.0" }
 cumulus-test-relay-sproof-builder = { path = "../../../test/relay-sproof-builder", default-features = false, version = "0.7.0" }
@@ -51,7 +50,6 @@ substrate-wasm-builder = { version = "17.0.0", path = "../../../../substrate/uti
 [features]
 default = ["std"]
 std = [
-	"assets-common/std",
 	"codec/std",
 	"cumulus-pallet-parachain-system/std",
 	"cumulus-pallet-xcmp-queue/std",


### PR DESCRIPTION
This PR should fix compilation for BridgeHub runtimes with `runtime-benchmarks`. This problem occurs only if we try to build exact package:
```
cargo test -p bridge-hub-rococo-runtime --release --features=runtime-benchmarks,try-runtime
cargo test -p bridge-hub-westend-runtime --release --features=runtime-benchmarks,try-runtime
```
This problem was discovered in the `fellows` repo when trying to split test pipelines per runtime: https://github.com/polkadot-fellows/runtimes/pull/189. E.g. https://github.com/polkadot-fellows/runtimes/actions/runs/7918178465/job/21616001877?pr=189

Relevant patched crates:
- asset-test-utils
- bridge-hub-test-utils
- parachains-runtimes-test-utils