### PR TITLE
Make `sp-keystore` `no_std`-compatible and fix the `build-runtimes-polkavm` CI job

### DIFF
--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -341,7 +341,6 @@ build-runtimes-polkavm:
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p westend-runtime
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p rococo-runtime
     - SUBSTRATE_RUNTIME_TARGET=riscv cargo check -p polkadot-test-runtime
-  allow_failure: true
 
 .build-subkey:
   stage: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18655,7 +18655,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "sp-core",
  "sp-externalities 0.25.0",
- "thiserror",
 ]
 
 [[package]]

--- a/substrate/primitives/externalities/src/extensions.rs
+++ b/substrate/primitives/externalities/src/extensions.rs
@@ -78,16 +78,16 @@ macro_rules! decl_extension {
 		$vis struct $ext_name (pub $inner);
 
 		impl $crate::Extension for $ext_name {
-			fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+			fn as_mut_any(&mut self) -> &mut dyn core::any::Any {
 				self
 			}
 
-			fn type_id(&self) -> std::any::TypeId {
-				std::any::Any::type_id(self)
+			fn type_id(&self) -> core::any::TypeId {
+				core::any::Any::type_id(self)
 			}
 		}
 
-		impl std::ops::Deref for $ext_name {
+		impl core::ops::Deref for $ext_name {
 			type Target = $inner;
 
 			fn deref(&self) -> &Self::Target {
@@ -95,7 +95,7 @@ macro_rules! decl_extension {
 			}
 		}
 
-		impl std::ops::DerefMut for $ext_name {
+		impl core::ops::DerefMut for $ext_name {
 			fn deref_mut(&mut self) -> &mut Self::Target {
 				&mut self.0
 			}
@@ -115,12 +115,12 @@ macro_rules! decl_extension {
 		$vis struct $ext_name;
 
 		impl $crate::Extension for $ext_name {
-			fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+			fn as_mut_any(&mut self) -> &mut dyn core::any::Any {
 				self
 			}
 
-			fn type_id(&self) -> std::any::TypeId {
-				std::any::Any::type_id(self)
+			fn type_id(&self) -> core::any::TypeId {
+				core::any::Any::type_id(self)
 			}
 		}
 	}

--- a/substrate/primitives/keystore/Cargo.toml
+++ b/substrate/primitives/keystore/Cargo.toml
@@ -17,8 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-parking_lot = { version = "0.12.1", default-features = false }
-thiserror = "1.0"
+parking_lot = { version = "0.12.1", default-features = false, optional = true }
 sp-core = { path = "../core", default-features = false }
 sp-externalities = { path = "../externalities", default-features = false }
 
@@ -28,7 +27,7 @@ rand_chacha = "0.2.2"
 
 [features]
 default = ["std"]
-std = ["codec/std", "sp-core/std", "sp-externalities/std"]
+std = ["codec/std", "dep:parking_lot", "sp-core/std", "sp-externalities/std"]
 
 # This feature adds BLS crypto primitives.
 # It should not be used in production since the implementation and interface may still

--- a/substrate/primitives/keystore/src/lib.rs
+++ b/substrate/primitives/keystore/src/lib.rs
@@ -17,6 +17,10 @@
 
 //! Keystore traits
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 #[cfg(feature = "std")]
 pub mod testing;
 
@@ -29,24 +33,34 @@ use sp_core::{
 	ecdsa, ed25519, sr25519,
 };
 
-use std::sync::Arc;
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 /// Keystore error
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
 	/// Public key type is not supported
-	#[error("Key not supported: {0:?}")]
 	KeyNotSupported(KeyTypeId),
 	/// Validation error
-	#[error("Validation error: {0}")]
 	ValidationError(String),
 	/// Keystore unavailable
-	#[error("Keystore unavailable")]
 	Unavailable,
 	/// Programming errors
-	#[error("An unknown keystore error occurred: {0}")]
 	Other(String),
 }
+
+impl core::fmt::Display for Error {
+	fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+		match self {
+			Error::KeyNotSupported(key_type) => write!(fmt, "Key not supported: {key_type:?}"),
+			Error::ValidationError(error) => write!(fmt, "Validation error: {error}"),
+			Error::Unavailable => fmt.write_str("Keystore unavailable"),
+			Error::Other(error) => write!(fmt, "An unknown keystore error occurred: {error}"),
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 /// Something that generates, stores and provides access to secret keys.
 pub trait Keystore: Send + Sync {


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/3352