### PR TITLE
remove deprecated type 'GenesisConfig'

### DIFF
--- a/substrate/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -77,10 +77,6 @@ pub fn expand_outer_config(
 		}
 
 		#[cfg(any(feature = "std", test))]
-		#[deprecated(note = "GenesisConfig is planned to be removed in December 2023. Use `RuntimeGenesisConfig` instead.")]
-		pub type GenesisConfig = RuntimeGenesisConfig;
-
-		#[cfg(any(feature = "std", test))]
 		impl #scrate::sp_runtime::BuildStorage for RuntimeGenesisConfig {
 			fn assimilate_storage(
 				&self,


### PR DESCRIPTION

# Description

Removed deprecated type `GenesisConfig` from the codebase.

Fixes https://github.com/paritytech/polkadot-sdk/issues/175

# Checklist

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [ ] I have made corresponding changes to the documentation (if applicable)