### PR TITLE
ProposerFactory impl Clone

### DIFF
--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -189,11 +189,6 @@ impl<A, C, PR> ProposerFactory<A, C, PR> {
 	pub fn set_soft_deadline(&mut self, percent: Percent) {
 		self.soft_deadline_percent = percent;
 	}
-
-	/// Set metrics.
-	pub fn set_metrics(&mut self, metrics: PrometheusMetrics) {
-		self.metrics = metrics;
-	}
 }
 
 impl<Block, C, A, PR> ProposerFactory<A, C, PR>

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -173,6 +173,11 @@ impl<A, C, PR> ProposerFactory<A, C, PR> {
 	pub fn set_soft_deadline(&mut self, percent: Percent) {
 		self.soft_deadline_percent = percent;
 	}
+
+	/// Set metrics.
+	pub fn set_metrics(&mut self, metrics: PrometheusMetrics) {
+		self.metrics = metrics;
+	}
 }
 
 impl<Block, C, A, PR> ProposerFactory<A, C, PR>

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -94,13 +94,11 @@ impl<A, C, PR> Clone for ProposerFactory<A, C, PR> {
 			client: self.client.clone(),
 			transaction_pool: self.transaction_pool.clone(),
 			metrics: self.metrics.clone(),
-			default_block_size_limit: self.default_block_size_limit.clone(),
-			soft_deadline_percent: self.soft_deadline_percent.clone(),
+			default_block_size_limit: self.default_block_size_limit,
+			soft_deadline_percent: self.soft_deadline_percent,
 			telemetry: self.telemetry.clone(),
-			include_proof_in_block_size_estimation: self
-				.include_proof_in_block_size_estimation
-				.clone(),
-			_phantom: self._phantom.clone(),
+			include_proof_in_block_size_estimation: self.include_proof_in_block_size_estimation,
+			_phantom: self._phantom,
 		}
 	}
 }

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -87,6 +87,24 @@ pub struct ProposerFactory<A, C, PR> {
 	_phantom: PhantomData<PR>,
 }
 
+impl<A, C, PR> Clone for ProposerFactory<A, C, PR> {
+	fn clone(&self) -> Self {
+		Self {
+			spawn_handle: self.spawn_handle.clone(),
+			client: self.client.clone(),
+			transaction_pool: self.transaction_pool.clone(),
+			metrics: self.metrics.clone(),
+			default_block_size_limit: self.default_block_size_limit.clone(),
+			soft_deadline_percent: self.soft_deadline_percent.clone(),
+			telemetry: self.telemetry.clone(),
+			include_proof_in_block_size_estimation: self
+				.include_proof_in_block_size_estimation
+				.clone(),
+			_phantom: self._phantom.clone(),
+		}
+	}
+}
+
 impl<A, C> ProposerFactory<A, C, DisableProofRecording> {
 	/// Create a new proposer factory.
 	///


### PR DESCRIPTION
In Tanssi, we need a way to stop the collator code and then start it again. This is to support rotating the same collator between different runtimes. Currently, this works very well, except for the proposer metrics, because they only get registered the first time they are started. Afterwards, we see this warning log:

> Failed to register proposer prometheus metrics: Duplicate metrics collector registration attempted


~~So this PR adds a method to set metrics, to allow us to register metrics manually before creating the `ProposerFactory`, and then clone the same metrics every time we need to start the collator.~~ Implemented Clone instead