### PR TITLE
Contracts Add new version for marking new stable API

### DIFF
--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/contracts.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/contracts.rs
@@ -72,5 +72,6 @@ impl Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type Debug = ();
 	type Environment = ();
+	type ApiVersion = ();
 	type Xcm = pallet_xcm::Pallet<Self>;
 }

--- a/prdoc/pr_3415.prdoc
+++ b/prdoc/pr_3415.prdoc
@@ -1,0 +1,9 @@
+title: "[pallet-contracts] Add APIVersion to the config."
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Add `APIVersion` to the config to communicate the state of the Host functions exposed by the pallet.
+
+crates:
+  - name: pallet-contracts

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1367,6 +1367,7 @@ impl pallet_contracts::Config for Runtime {
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Debug = ();
 	type Environment = ();
+	type ApiVersion = ();
 	type Xcm = ();
 }
 

--- a/substrate/frame/contracts/mock-network/src/parachain/contracts_config.rs
+++ b/substrate/frame/contracts/mock-network/src/parachain/contracts_config.rs
@@ -94,5 +94,6 @@ impl pallet_contracts::Config for Runtime {
 	type WeightPrice = Self;
 	type Debug = ();
 	type Environment = ();
+	type ApiVersion = ();
 	type Xcm = pallet_xcm::Pallet<Self>;
 }

--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -214,6 +214,19 @@ pub struct Environment<T: Config> {
 	block_number: EnvironmentType<BlockNumberFor<T>>,
 }
 
+/// Defines the current version of the HostFn APIs.
+/// This is used to communicate the available APIs in pallet-contracts.
+///
+/// The version is bumped any time a new HostFn is added or stabilized.
+#[derive(Encode, Decode, TypeInfo)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct ApiVersion(u16);
+impl Default for ApiVersion {
+	fn default() -> Self {
+		Self(1)
+	}
+}
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
@@ -401,6 +414,12 @@ pub mod pallet {
 		/// its type appears in the metadata. Only valid value is `()`.
 		#[pallet::constant]
 		type Environment: Get<Environment<Self>>;
+
+		/// The version of the HostFn APIs that are available in the runtime.
+		///
+		/// Only valid value is `()`.
+		#[pallet::constant]
+		type ApiVersion: Get<ApiVersion>;
 
 		/// A type that exposes XCM APIs, allowing contracts to interact with other parachains, and
 		/// execute XCM programs.

--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -219,7 +219,6 @@ pub struct Environment<T: Config> {
 ///
 /// The version is bumped any time a new HostFn is added or stabilized.
 #[derive(Encode, Decode, TypeInfo)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ApiVersion(u16);
 impl Default for ApiVersion {
 	fn default() -> Self {

--- a/substrate/frame/contracts/src/tests.rs
+++ b/substrate/frame/contracts/src/tests.rs
@@ -465,6 +465,7 @@ impl Config for Test {
 	type MaxDelegateDependencies = MaxDelegateDependencies;
 	type Debug = TestDebug;
 	type Environment = ();
+	type ApiVersion = ();
 	type Xcm = ();
 }
 


### PR DESCRIPTION
Add a `ApiVersion` constant to the pallet-contracts Config to communicate with developers the current state of the host functions exposed by the pallet