### PR TITLE
Fix failing release notifications GHA

### DIFF
--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   ping_matrix:
     runs-on: ubuntu-latest
+    environment: release
     strategy:
       matrix:
         channel:
@@ -37,8 +38,8 @@ jobs:
           # - name: '#kusama-announcements:matrix.parity.io'
           #   room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
           #   pre-release: false
-          # - name: '#polkadotvalidatorlounge:web3.foundation'
-          #   room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
+          - name: '#polkadotvalidatorlounge:web3.foundation'
+            room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
           #   pre-release: false
           # - name: '#polkadot-announcements:matrix.parity.io'
           #   room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -31,6 +31,7 @@ jobs:
           # Public
           - name: '#polkadotvalidatorlounge:web3.foundation'
             room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
+            pre-releases: false
 
     steps:
       - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -13,9 +13,6 @@ jobs:
       matrix:
         channel:
           # Internal
-          - name: 'RelEng: Cumulus Release Coordination'
-            room: '!NAEMyPAHWOiOQHsvus:parity.io'
-            pre-releases: true
           - name: "RelEng: Polkadot Release Coordination"
             room: '!cqAmzdIcbOFwrdrubV:parity.io'
             pre-release: true
@@ -32,18 +29,8 @@ jobs:
             pre-release: true
 
           # Public
-          # - name: '#KusamaValidatorLounge:polkadot.builders'
-          #   room: '!LhjZccBOqFNYKLdmbb:polkadot.builders'
-          #   pre-releases: false
-          # - name: '#kusama-announcements:matrix.parity.io'
-          #   room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
-          #   pre-release: false
           - name: '#polkadotvalidatorlounge:web3.foundation'
             room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
-          #   pre-release: false
-          # - name: '#polkadot-announcements:matrix.parity.io'
-          #   room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
-          #   pre-release: false
 
     steps:
       - name: Matrix notification to ${{ matrix.channel.name }}


### PR DESCRIPTION
This PR should fix the issue with the failing GHA which sends notifications to the different matrix channels, when the new release is published