### PR TITLE
Backport patch for xcm fungible benchmarks required by new FungibleAdapter

### DIFF
--- a/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/mock.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/mock.rs
@@ -103,8 +103,7 @@ impl xcm_executor::traits::MatchesFungible<u64> for MatchAnyFungible {
 }
 
 // Use balances as the asset transactor.
-#[allow(deprecated)]
-pub type AssetTransactor = xcm_builder::CurrencyAdapter<
+pub type AssetTransactor = xcm_builder::FungibleAdapter<
 	Balances,
 	MatchAnyFungible,
 	AccountIdConverter,
@@ -192,8 +191,7 @@ impl xcm_balances_benchmark::Config for Test {
 	type TrustedReserve = TrustedReserve;
 
 	fn get_asset() -> Asset {
-		let amount =
-			<Balances as frame_support::traits::fungible::Inspect<u64>>::minimum_balance() as u128;
+		let amount = 1_000_000_000_000;
 		Asset { id: AssetId(Here.into()), fun: Fungible(amount) }
 	}
 }


### PR DESCRIPTION
We replaced deprecated `CurrencyAdapter` [here](https://github.com/paritytech/polkadot-sdk/pull/3287) and we also did the same for fellows [here](https://github.com/polkadot-fellows/runtimes/pull/187/commits/2d6d3ac530d00f3d7a2495ad24ec286d06113125), but this change requires this patch for xcm benchmarks.

Expected patch for  `pallet-xcm-benchmarks` as `8.0.1`
