### PR TITLE
Add more debug logs to understand if statement-distribution misbehaving

### DIFF
--- a/polkadot/node/network/statement-distribution/src/lib.rs
+++ b/polkadot/node/network/statement-distribution/src/lib.rs
@@ -211,6 +211,7 @@ impl<R: rand::Rng> StatementDistributionSubsystem<R> {
 			.boxed(),
 		)
 		.map_err(FatalError::SpawnTask)?;
+		let mut request_throttle_freq = gum::Freq::new();
 
 		loop {
 			// Wait for the next message.
@@ -293,7 +294,7 @@ impl<R: rand::Rng> StatementDistributionSubsystem<R> {
 				},
 			};
 
-			v2::dispatch_requests(&mut ctx, &mut state).await;
+			v2::dispatch_requests(&mut ctx, &mut state, &mut request_throttle_freq).await;
 		}
 		Ok(())
 	}

--- a/polkadot/node/network/statement-distribution/src/lib.rs
+++ b/polkadot/node/network/statement-distribution/src/lib.rs
@@ -211,7 +211,6 @@ impl<R: rand::Rng> StatementDistributionSubsystem<R> {
 			.boxed(),
 		)
 		.map_err(FatalError::SpawnTask)?;
-		let mut request_throttle_freq = gum::Freq::new();
 
 		loop {
 			// Wait for the next message.
@@ -294,7 +293,7 @@ impl<R: rand::Rng> StatementDistributionSubsystem<R> {
 				},
 			};
 
-			v2::dispatch_requests(&mut ctx, &mut state, &mut request_throttle_freq).await;
+			v2::dispatch_requests(&mut ctx, &mut state).await;
 		}
 		Ok(())
 	}

--- a/polkadot/node/network/statement-distribution/src/v2/cluster.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/cluster.rs
@@ -428,10 +428,13 @@ impl ClusterTracker {
 
 	/// Dumps pending statement for this cluster.
 	///
-	/// Normally we should not have any pending statements for our cluster,
-	/// but if we do for long periods of time something bad happened which
-	/// needs to be investigated.
-	pub fn dump_pending_statements(&self, parent_hash: Hash) {
+	/// Normally we should not have pending statements to validators in our cluster,
+	/// but if we do for all validators in our cluster, then we don't participate
+	/// in backing. Ocasional pending statements are expected if two authorities
+	/// can't detect each otehr or after restart, where it takes a while to discover
+	/// the whole network.
+
+	pub fn warn_if_too_many_pending_statements(&self, parent_hash: Hash) {
 		if self.pending.iter().filter(|pending| !pending.1.is_empty()).count() >=
 			self.validators.len()
 		{

--- a/polkadot/node/network/statement-distribution/src/v2/cluster.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/cluster.rs
@@ -57,6 +57,7 @@
 
 use polkadot_primitives::{CandidateHash, CompactStatement, ValidatorIndex};
 
+use crate::LOG_TARGET;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Hash, PartialEq, Eq)]
@@ -423,6 +424,23 @@ impl ClusterTracker {
 
 	fn is_in_group(&self, validator: ValidatorIndex) -> bool {
 		self.validators.contains(&validator)
+	}
+
+	/// Dumps pending statement for this cluster.
+	///
+	/// Normally we should not have any pending statements for our cluster,
+	/// but if we do for long periods of time something bad happened which
+	/// needs to be investigated.
+	pub fn dump_pending_statements(&self) {
+		if !self.pending.is_empty() {
+			gum::warn!(
+				target: LOG_TARGET,
+				num_pending = ?self.pending.len(),
+				validators  = ?self.pending.keys().collect::<Vec<_>>(),
+				"Cluster has pending statements, something wrong with our connection to our group peers \n
+				 If error persists accross multiple consecutive sessions, validator might need restart"
+			);
+		}
 	}
 }
 

--- a/polkadot/node/network/statement-distribution/src/v2/cluster.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/cluster.rs
@@ -55,7 +55,7 @@
 //! and to keep track of what we have sent to other validators in the group and what we may
 //! continue to send them.
 
-use polkadot_primitives::{CandidateHash, CompactStatement, ValidatorIndex};
+use polkadot_primitives::{CandidateHash, CompactStatement, Hash, ValidatorIndex};
 
 use crate::LOG_TARGET;
 use std::collections::{HashMap, HashSet};
@@ -431,13 +431,15 @@ impl ClusterTracker {
 	/// Normally we should not have any pending statements for our cluster,
 	/// but if we do for long periods of time something bad happened which
 	/// needs to be investigated.
-	pub fn dump_pending_statements(&self) {
-		if !self.pending.is_empty() {
+	pub fn dump_pending_statements(&self, parent_hash: Hash) {
+		if self.pending.iter().filter(|pending| !pending.1.is_empty()).count() >=
+			self.validators.len()
+		{
 			gum::warn!(
 				target: LOG_TARGET,
-				num_pending = ?self.pending.len(),
-				validators  = ?self.pending.keys().collect::<Vec<_>>(),
-				"Cluster has pending statements, something wrong with our connection to our group peers \n
+				pending_statements  = ?self.pending,
+				?parent_hash,
+				"Cluster has too many pending statements, something wrong with our connection to our group peers \n
 				Restart might be needed if validator gets 0 backing rewards for more than 3-4 consecutive sessions"
 			);
 		}

--- a/polkadot/node/network/statement-distribution/src/v2/cluster.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/cluster.rs
@@ -438,7 +438,7 @@ impl ClusterTracker {
 				num_pending = ?self.pending.len(),
 				validators  = ?self.pending.keys().collect::<Vec<_>>(),
 				"Cluster has pending statements, something wrong with our connection to our group peers \n
-				 If error persists accross multiple consecutive sessions, validator might need restart"
+				Restart might be needed if validator gets 0 backing rewards for more than 3-4 consecutive sessions"
 			);
 		}
 	}

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -256,7 +256,7 @@ impl PerSessionState {
 			target: LOG_TARGET,
 			index_in_gossip_topology = ?local_index,
 			index_in_parachain_authorities = ?self.local_validator,
-			"Node uses the following topology indicies "
+			"Node uses the following topology indices"
 		);
 	}
 

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -781,7 +781,7 @@ pub(crate) fn handle_deactivate_leaves(state: &mut State, leaves: &[Hash]) {
 				.as_ref()
 				.and_then(|pruned| pruned.active_validator_state())
 				.map(|active_state| {
-					active_state.cluster_tracker.dump_pending_statements(pruned_rp)
+					active_state.cluster_tracker.warn_if_too_many_pending_statements(pruned_rp)
 				});
 
 			// clean up requests related to this relay parent.

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -251,6 +251,13 @@ impl PerSessionState {
 		if local_index.is_some() {
 			self.local_validator.get_or_insert(LocalValidatorIndex::Inactive);
 		}
+
+		gum::info!(
+			target: LOG_TARGET,
+			index_in_gossip_topology = ?local_index,
+			index_in_parachain_authorities = ?self.local_validator,
+			"Node uses the following topology indicies "
+		);
 	}
 
 	/// Returns `true` if local is neither active or inactive validator node.

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -780,7 +780,9 @@ pub(crate) fn handle_deactivate_leaves(state: &mut State, leaves: &[Hash]) {
 				.remove(&pruned_rp)
 				.as_ref()
 				.and_then(|pruned| pruned.active_validator_state())
-				.map(|active_state| active_state.cluster_tracker.dump_pending_statements());
+				.map(|active_state| {
+					active_state.cluster_tracker.dump_pending_statements(pruned_rp)
+				});
 
 			// clean up requests related to this relay parent.
 			state.request_manager.remove_by_relay_parent(*leaf);

--- a/polkadot/node/network/statement-distribution/src/v2/requests.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/requests.rs
@@ -1042,12 +1042,7 @@ mod tests {
 				.unwrap();
 			assert_eq!(outgoing.payload.candidate_hash, candidate);
 			let outgoing = request_manager
-				.next_request(
-					&mut response_manager,
-					request_props,
-					peer_advertised,
-					&mut request_throttle_freq,
-				)
+				.next_request(&mut response_manager, request_props, peer_advertised)
 				.unwrap();
 			assert_eq!(outgoing.payload.candidate_hash, candidate);
 		}

--- a/polkadot/node/network/statement-distribution/src/v2/requests.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/requests.rs
@@ -328,7 +328,7 @@ impl RequestManager {
 		if response_manager.len() >= 2 * MAX_PARALLEL_ATTESTED_CANDIDATE_REQUESTS as usize {
 			gum::warn_if_frequent!(
 				freq: request_throttle_freq,
-				max_rate: gum::Times::PerSecond(5),
+				max_rate: gum::Times::PerSecond(20),
 				target: LOG_TARGET,
 				"Too many requests in parallel, statement-distribution might be slow"
 			);
@@ -1043,12 +1043,24 @@ mod tests {
 			let peer_advertised = |_identifier: &CandidateIdentifier, _peer: &_| {
 				Some(StatementFilter::full(group_size))
 			};
+			let mut request_throttle_freq = gum::Freq::new();
+
 			let outgoing = request_manager
-				.next_request(&mut response_manager, request_props, peer_advertised)
+				.next_request(
+					&mut response_manager,
+					request_props,
+					peer_advertised,
+					&mut request_throttle_freq,
+				)
 				.unwrap();
 			assert_eq!(outgoing.payload.candidate_hash, candidate);
 			let outgoing = request_manager
-				.next_request(&mut response_manager, request_props, peer_advertised)
+				.next_request(
+					&mut response_manager,
+					request_props,
+					peer_advertised,
+					&mut request_throttle_freq,
+				)
 				.unwrap();
 			assert_eq!(outgoing.payload.candidate_hash, candidate);
 		}
@@ -1164,8 +1176,15 @@ mod tests {
 		{
 			let request_props =
 				|_identifier: &CandidateIdentifier| Some((&request_properties).clone());
+			let mut request_throttle_freq = gum::Freq::new();
+
 			let outgoing = request_manager
-				.next_request(&mut response_manager, request_props, peer_advertised)
+				.next_request(
+					&mut response_manager,
+					request_props,
+					peer_advertised,
+					&mut request_throttle_freq,
+				)
 				.unwrap();
 			assert_eq!(outgoing.payload.candidate_hash, candidate);
 		}
@@ -1246,8 +1265,15 @@ mod tests {
 		{
 			let request_props =
 				|_identifier: &CandidateIdentifier| Some((&request_properties).clone());
+			let mut request_throttle_freq = gum::Freq::new();
+
 			let outgoing = request_manager
-				.next_request(&mut response_manager, request_props, peer_advertised)
+				.next_request(
+					&mut response_manager,
+					request_props,
+					peer_advertised,
+					&mut request_throttle_freq,
+				)
 				.unwrap();
 			assert_eq!(outgoing.payload.candidate_hash, candidate);
 		}


### PR DESCRIPTION
Add more debug logs to understand if statement-distribution is in a bad state, should be useful for debugging https://github.com/paritytech/polkadot-sdk/issues/3314 on production networks.

Additionally, increase the number of parallel requests should make, since I notice that requests take around 100ms on kusama, and the 5 parallel request was picked mostly random, no reason why we can do more than that.