### PR TITLE
Backport patch for xcm fungible benchmarks required by new FungibleAdapter for 1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "asset-test-utils"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.7.0"
+version = "0.7.3"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10218,7 +10218,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "25.0.0"
+version = "25.0.3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11056,7 +11056,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "7.0.0"
+version = "7.0.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11277,7 +11277,7 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -11518,7 +11518,7 @@ dependencies = [
 
 [[package]]
 name = "penpal-runtime"
-version = "0.14.0"
+version = "0.14.3"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",
@@ -18963,7 +18963,7 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "7.0.0"
+version = "7.0.3"
 dependencies = [
  "assert_matches",
  "frame-support",
@@ -18993,7 +18993,7 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "7.0.0"
+version = "7.0.3"
 dependencies = [
  "environmental",
  "frame-benchmarking",

--- a/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/benchmarking.rs
@@ -71,6 +71,9 @@ benchmarks_instance_pallet! {
 		let dest_account = T::AccountIdConverter::convert_location(&dest_location).unwrap();
 
 		<AssetTransactorOf<T>>::deposit_asset(&asset, &sender_location, None).unwrap();
+		// We deposit the asset twice so we have enough for ED after transferring
+		<AssetTransactorOf<T>>::deposit_asset(&asset, &sender_location, None).unwrap();
+		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 		assert!(T::TransactAsset::balance(&dest_account).is_zero());
 
 		let mut executor = new_executor::<T>(sender_location);
@@ -79,7 +82,7 @@ benchmarks_instance_pallet! {
 	}: {
 		executor.bench_process(xcm)?;
 	} verify {
-		assert!(T::TransactAsset::balance(&sender_account).is_zero());
+		assert!(T::TransactAsset::balance(&sender_account) < sender_account_balance_before);
 		assert!(!T::TransactAsset::balance(&dest_account).is_zero());
 	}
 
@@ -93,12 +96,13 @@ benchmarks_instance_pallet! {
 			&dest_location,
 			FeeReason::TransferReserveAsset
 		);
-		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
 		let asset = T::get_multi_asset();
 		<AssetTransactorOf<T>>::deposit_asset(&asset, &sender_location, None).unwrap();
-		assert!(T::TransactAsset::balance(&sender_account) > sender_account_balance_before);
-		let assets: MultiAssets = vec![ asset ].into();
+		// We deposit the asset twice so we have enough for ED after transferring
+		<AssetTransactorOf<T>>::deposit_asset(&asset, &sender_location, None).unwrap();
+		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
+		let assets: MultiAssets = vec![asset].into();
 		assert!(T::TransactAsset::balance(&dest_account).is_zero());
 
 		let mut executor = new_executor::<T>(sender_location);

--- a/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/mock.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/fungible/mock.rs
@@ -103,8 +103,7 @@ impl xcm_executor::traits::MatchesFungible<u64> for MatchAnyFungible {
 }
 
 // Use balances as the asset transactor.
-#[allow(deprecated)]
-pub type AssetTransactor = xcm_builder::CurrencyAdapter<
+pub type AssetTransactor = xcm_builder::FungibleAdapter<
 	Balances,
 	MatchAnyFungible,
 	AccountIdConverter,
@@ -193,8 +192,7 @@ impl xcm_balances_benchmark::Config for Test {
 	type TrustedReserve = TrustedReserve;
 
 	fn get_multi_asset() -> MultiAsset {
-		let amount =
-			<Balances as frame_support::traits::fungible::Inspect<u64>>::minimum_balance() as u128;
+		let amount = 1_000_000_000_000;
 		MultiAsset { id: Concrete(Here.into()), fun: Fungible(amount) }
 	}
 }


### PR DESCRIPTION
More info here: https://github.com/paritytech/polkadot-sdk/pull/3417

Expected patch for  `pallet-xcm-benchmarks` as `7.0.4`