### PR TITLE
Add matrix public channels for release announcements

### DIFF
--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -32,6 +32,12 @@ jobs:
           - name: '#polkadotvalidatorlounge:web3.foundation'
             room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
             pre-releases: false
+          - name: '#polkadot-announcements:parity.io'
+            room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
+            pre-releases: false
+          - name: '#kusama-announce:parity.io'
+            room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
+            pre-releases: false
 
     steps:
       - name: Matrix notification to ${{ matrix.channel.name }}


### PR DESCRIPTION
This PR adds two more public channels in matrix where should the release announcements go