### PR TITLE
added script to require a review post push

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -21,6 +21,24 @@ jobs:
       - name: Skip merge queue
         if: ${{ contains(github.ref, 'gh-readonly-queue') }}
         run: exit 0
+      - name: Fail when author pushes new code
+        # Require new reviews when the author is pushing and he is not a member
+        if: | 
+          github.event.action == 'synchronize' && 
+          github.event.sender.login == github.event.pull_request.user.login && 
+          github.event.pull_request.author_association != 'MEMBER'
+        run: |
+          echo "::error::Project needs to be reviewed again"
+
+          # We get the list of reviewers who approved the PR
+          REVIEWERS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/reviews \
+          --jq '{reviewers: [.[] | select(.state == "APPROVED") | .user.login]}')
+          
+          # We request them to review again
+          echo $REVIEWERS | gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.number }}/requested_reviewers --input -
+          exit 1
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Get PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -23,7 +23,8 @@ jobs:
         run: exit 0
       - name: Fail when author pushes new code
         # Require new reviews when the author is pushing and he is not a member
-        if: | 
+        if: |
+          github.event_name == 'pull_request_target' &&
           github.event.action == 'synchronize' && 
           github.event.sender.login == github.event.pull_request.user.login && 
           github.event.pull_request.author_association != 'MEMBER'

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -47,7 +47,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Comment requirements
         # If the previous step failed and github-actions hasn't commented yet we comment instructions
-        if: failure() && !contains(fromJson(steps.comments.outputs.bodies), 'Review required!')
+        if: failure() && !contains(fromJson(steps.comments.outputs.bodies), 'Review required! Latest push from author must always be reviewed')
         run: |          
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body "Review required! Latest push from author must always be reviewed"
         env:

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Skip merge queue
         if: ${{ contains(github.ref, 'gh-readonly-queue') }}
         run: exit 0
+      - name: Get comments
+        id: comments
+        run: echo "bodies=$(gh pr view ${{ github.event.number }} --repo ${{ github.repository }} --json comments --jq '[.comments[].body]')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Fail when author pushes new code
         # Require new reviews when the author is pushing and he is not a member
         if: |
@@ -29,17 +34,25 @@ jobs:
           github.event.sender.login == github.event.pull_request.user.login && 
           github.event.pull_request.author_association != 'MEMBER'
         run: |
-          echo "::error::Project needs to be reviewed again"
-
           # We get the list of reviewers who approved the PR
           REVIEWERS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/reviews \
           --jq '{reviewers: [.[] | select(.state == "APPROVED") | .user.login]}')
-          
+
           # We request them to review again
           echo $REVIEWERS | gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.number }}/requested_reviewers --input -
+          
+          echo "::error::Project needs to be reviewed again"
           exit 1
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Comment requirements
+        # If the previous step failed and github-actions hasn't commented yet we comment instructions
+        if: failure() && !contains(fromJson(steps.comments.outputs.bodies), 'Review required!')
+        run: |          
+          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body "Review required! Latest push from author must always be reviewed"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTS: ${{ steps.comments.outputs.users }}
       - name: Get PR number
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Closes https://github.com/paritytech/opstooling/issues/174

Added a new step in the action that triggers review bot to stop approval from new pushes.

This step works in the following way:
- If the **author of the PR**, who **is not** a member of the org, pushed a new commit then:
- Review-Trigger requests new reviews from the reviewers and fails.

It *does not dismiss reviews*. It simply request them again, but they will still be available.

This way, if the author changed something in the code, they will still need to have this latest change approved to stop them from uploading malicious code.

Find the requested issue linked to this PR (it is from a private repo so I can't link it here)