### PR TITLE
Fix `wasm-builder` not exiting if compilation fails

### DIFF
--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -877,7 +877,7 @@ fn build_bloaty_blob(
 			if polkavm_path
 				.metadata()
 				.map(|polkavm_metadata| {
-					polkavm_metadata.modified().unwrap() >= elf_metadata.modified().unwrap()
+					polkavm_metadata.modified().unwrap() < elf_metadata.modified().unwrap()
 				})
 				.unwrap_or(true)
 			{

--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -855,7 +855,7 @@ fn build_bloaty_blob(
 	println!("{} {}", colorize_info_message("Using rustc version:"), cargo_cmd.rustc_version());
 
 	// Use `process::exit(1)` to have a clean error output.
-	if build_cmd.status().map(|s| s.success()).is_err() {
+	if !matches!(build_cmd.status().map(|s| s.success()), Ok(true)) {
 		process::exit(1);
 	}
 


### PR DESCRIPTION
This PR fixes a subtle bug in `wasm-builder` first introduced in https://github.com/paritytech/polkadot-sdk/pull/1851 (sorry, my bad! I should have caught this during review) where the status code of the `cargo` subprocess is not properly checked, which results in builds silently succeeding when they shouldn't (that is: if we successfully build a runtime blob, and then modify the code so that it won't compile, and recompile it again, then the build will succeed and silently use the *old* blob).

cc @athei This is the bug you were seeing.

[edit]Also fixes a similar PolkaVM-specific bug where I accidentally used the wrong comparison operator.[/edit]