### PR TITLE
Use generic hash for runtime wasm in resolve_state_version_from_wasm

### DIFF
--- a/prdoc/pr_3447.prdoc
+++ b/prdoc/pr_3447.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Use generic hash for runtime wasm in resolve_state_version_from_wasm
+
+doc:
+  - audience: Node Dev
+    description: |
+      Changes the runtime hash algorithm used in resolve_state_version_from_wasm from DefaultHasher to a caller-provided
+      one (usually HashingFor<Block>). Fixes a bug where the runtime wasm was being compiled again when it was not
+      needed, because the hash did not match
+crates:
+  - name: sc-chain-spec

--- a/substrate/client/chain-spec/src/genesis_block.rs
+++ b/substrate/client/chain-spec/src/genesis_block.rs
@@ -20,6 +20,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
+use codec::Encode;
 use sc_client_api::{backend::Backend, BlockImportOperation};
 use sc_executor::RuntimeVersionOf;
 use sp_core::storage::{well_known_keys, StateVersion, Storage};
@@ -44,7 +45,7 @@ where
 		let runtime_code = sp_core::traits::RuntimeCode {
 			code_fetcher: &code_fetcher,
 			heap_pages: None,
-			hash: <H as HashT>::hash(wasm).as_ref().to_vec(),
+			hash: <H as HashT>::hash(wasm).encode(),
 		};
 		let runtime_version = RuntimeVersionOf::runtime_version(executor, &mut ext, &runtime_code)
 			.map_err(|e| sp_blockchain::Error::VersionInvalid(e.to_string()))?;

--- a/substrate/client/chain-spec/src/genesis_block.rs
+++ b/substrate/client/chain-spec/src/genesis_block.rs
@@ -18,7 +18,7 @@
 
 //! Tool for creating the genesis block.
 
-use std::{collections::hash_map::DefaultHasher, marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc};
 
 use sc_client_api::{backend::Backend, BlockImportOperation};
 use sc_executor::RuntimeVersionOf;
@@ -43,12 +43,7 @@ where
 		let runtime_code = sp_core::traits::RuntimeCode {
 			code_fetcher: &code_fetcher,
 			heap_pages: None,
-			hash: {
-				use std::hash::{Hash, Hasher};
-				let mut state = DefaultHasher::new();
-				wasm.hash(&mut state);
-				state.finish().to_le_bytes().to_vec()
-			},
+			hash: sp_core::blake2_256(wasm).to_vec(),
 		};
 		let runtime_version = RuntimeVersionOf::runtime_version(executor, &mut ext, &runtime_code)
 			.map_err(|e| sp_blockchain::Error::VersionInvalid(e.to_string()))?;

--- a/substrate/client/chain-spec/src/genesis_block.rs
+++ b/substrate/client/chain-spec/src/genesis_block.rs
@@ -24,17 +24,18 @@ use sc_client_api::{backend::Backend, BlockImportOperation};
 use sc_executor::RuntimeVersionOf;
 use sp_core::storage::{well_known_keys, StateVersion, Storage};
 use sp_runtime::{
-	traits::{Block as BlockT, Hash as HashT, Header as HeaderT, Zero},
+	traits::{Block as BlockT, Hash as HashT, HashingFor, Header as HeaderT, Zero},
 	BuildStorage,
 };
 
 /// Return the state version given the genesis storage and executor.
-pub fn resolve_state_version_from_wasm<E>(
+pub fn resolve_state_version_from_wasm<E, H>(
 	storage: &Storage,
 	executor: &E,
 ) -> sp_blockchain::Result<StateVersion>
 where
 	E: RuntimeVersionOf,
+	H: HashT,
 {
 	if let Some(wasm) = storage.top.get(well_known_keys::CODE) {
 		let mut ext = sp_state_machine::BasicExternalities::new_empty(); // just to read runtime version.
@@ -43,7 +44,7 @@ where
 		let runtime_code = sp_core::traits::RuntimeCode {
 			code_fetcher: &code_fetcher,
 			heap_pages: None,
-			hash: sp_core::blake2_256(wasm).to_vec(),
+			hash: <H as HashT>::hash(wasm).as_ref().to_vec(),
 		};
 		let runtime_version = RuntimeVersionOf::runtime_version(executor, &mut ext, &runtime_code)
 			.map_err(|e| sp_blockchain::Error::VersionInvalid(e.to_string()))?;
@@ -124,7 +125,8 @@ impl<Block: BlockT, B: Backend<Block>, E: RuntimeVersionOf> BuildGenesisBlock<Bl
 	fn build_genesis_block(self) -> sp_blockchain::Result<(Block, Self::BlockImportOperation)> {
 		let Self { genesis_storage, commit_genesis_state, backend, executor, _phantom } = self;
 
-		let genesis_state_version = resolve_state_version_from_wasm(&genesis_storage, &executor)?;
+		let genesis_state_version =
+			resolve_state_version_from_wasm::<_, HashingFor<Block>>(&genesis_storage, &executor)?;
 		let mut op = backend.begin_operation()?;
 		let state_root =
 			op.set_genesis_state(genesis_storage, commit_genesis_state, genesis_state_version)?;

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -675,8 +675,10 @@ where
 
 						// This is use by fast sync for runtime version to be resolvable from
 						// changes.
-						let state_version =
-							resolve_state_version_from_wasm(&storage, &self.executor)?;
+						let state_version = resolve_state_version_from_wasm::<_, HashingFor<Block>>(
+							&storage,
+							&self.executor,
+						)?;
 						let state_root = operation.op.reset_storage(storage, state_version)?;
 						if state_root != *import_headers.post().state_root() {
 							// State root mismatch when importing state. This should not happen in


### PR DESCRIPTION
Changes the runtime hash algorithm used in `resolve_state_version_from_wasm` from `DefaultHasher` to a caller-provided one (usually `HashingFor<Block>`), to match the one used elsewhere.

This fixes an issue where the runtime wasm is compiled 3 times when starting the `tanssi-node` with `--dev`. With this fix, the runtime wasm is only compiled 2 times. The other redundant compilation is caused by the `GenesisConfigBuilderRuntimeCaller` struct, which ignores the runtime cache.