### PR TITLE
[DNM] Decouple `pallet-staking` and `pallet-stake-tracker`

### DIFF
--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -62,6 +62,7 @@ pub(crate) const SPECULATIVE_NUM_SPANS: u32 = 32;
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_election_provider_support::ElectionDataProvider;
+	use sp_staking::StakerStatusProvider;
 
 	use crate::{BenchmarkingConfig, PagedExposureMetadata};
 
@@ -273,7 +274,10 @@ pub mod pallet {
 
 		/// Something that listens to staking updates and performs actions based on the data it
 		/// receives.
-		type EventListeners: OnStakingUpdate<Self::AccountId, BalanceOf<Self>>;
+		type EventListeners: OnStakingUpdate<Self::AccountId, BalanceOf<Self>, VoteWeight>;
+
+		/// TODO: docs
+		type StakerStatus: StakerStatusProvider<Self::AccountId>;
 
 		/// Some parameters of the benchmarking.
 		type BenchmarkingConfig: BenchmarkingConfig;


### PR DESCRIPTION
This PR is a rough estimation of what implementing the changes suggested [here](https://github.com/paritytech/polkadot-sdk/pull/1933#issuecomment-1948221164) would look like.

Key ideas:
- `pallet-staking` is actively driving `pallet-stake-tracker`
- `pallet-stake-tracker` is given the necessary info in the "events" it handles, doesn't query `pallet-staking`
- `pallet-stake-tracker` doesn't question the validity of the ledgers or bonded amounts in `pallet-staking`, assumes the commands are always correct

The next step is to get rid of `pallet_stake_tracker::Pallet::<T>::should_remove_target`. That function is currently guarding the removal from `TargetList` of validators by ensuring their score in the list is `0` and they are not bonded. We can get rid of it by either:
- having a specific event that is emitted from `pallet_staking` when we are sure the conditions are met
- (*preferred*) injecting an `is_bonded: bool` argument into the event which is responsible for this removal (in my POC it seems to be only `on_validator_stake_update`)

I feel the effort is sufficiently fleshed out to get some input and decide whether it's something we want to pursue. The tests aren't fixed yet because I'd like us to settle on what the interfaces look like before fixing them.