### PR TITLE
frame-support: Improve error reporting when having too many pallets

### DIFF
--- a/substrate/frame/support/test/tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.stderr
@@ -4,88 +4,24 @@ error: The number of pallets exceeds the maximum number of tuple elements. To in
 67 |     pub struct Runtime
    |     ^^^
 
-error[E0412]: cannot find type `RuntimeCall` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:35:64
-   |
-35 | pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
-   |                                                                ^^^^^^^^^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-35 | pub type UncheckedExtrinsic<RuntimeCall> = generic::UncheckedExtrinsic<u32, RuntimeCall, Signature, ()>;
-   |                            +++++++++++++
-
-error[E0412]: cannot find type `Runtime` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:37:25
-   |
-37 | impl pallet::Config for Runtime {}
-   |                         ^^^^^^^ not found in this scope
-
-error[E0412]: cannot find type `Runtime` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:40:31
-   |
-40 | impl frame_system::Config for Runtime {
-   |                               ^^^^^^^ not found in this scope
-
-error[E0412]: cannot find type `RuntimeOrigin` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:42:23
-   |
-42 |     type RuntimeOrigin = RuntimeOrigin;
-   |                          ^^^^^^^^^^^^^
-   |
-help: you might have meant to use the associated type
-   |
-42 |     type RuntimeOrigin = Self::RuntimeOrigin;
-   |                          ++++++
-
-error[E0412]: cannot find type `RuntimeCall` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:44:21
-   |
-44 |     type RuntimeCall = RuntimeCall;
-   |                        ^^^^^^^^^^^
-   |
-help: you might have meant to use the associated type
-   |
-44 |     type RuntimeCall = Self::RuntimeCall;
-   |                        ++++++
-
-error[E0412]: cannot find type `RuntimeEvent` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:50:22
-   |
-50 |     type RuntimeEvent = RuntimeEvent;
-   |                         ^^^^^^^^^^^^
-   |
-help: you might have meant to use the associated type
-   |
-50 |     type RuntimeEvent = Self::RuntimeEvent;
-   |                         ++++++
-
-error[E0412]: cannot find type `PalletInfo` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:56:20
-   |
-56 |     type PalletInfo = PalletInfo;
-   |                       ^^^^^^^^^^
-   |
-help: you might have meant to use the associated type
-   |
-56 |     type PalletInfo = Self::PalletInfo;
-   |                       ++++++
-help: consider importing one of these items
-   |
-18 + use frame_benchmarking::__private::traits::PalletInfo;
-   |
-18 + use frame_support::traits::PalletInfo;
-   |
-
-error[E0412]: cannot find type `RuntimeTask` in this scope
-  --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:39:1
-   |
-39 | #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `frame_system::config_preludes::TestDefaultConfig` which comes from the expansion of the macro `frame_support::macro_magic::forward_tokens_verbatim` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you might have meant to use the associated type
-  --> $WORKSPACE/substrate/frame/system/src/lib.rs
-   |
-   |             type Self::RuntimeTask = ();
-   |                  ++++++
+error: recursion limit reached while expanding `frame_support::__private::tt_return!`
+   --> tests/construct_runtime_ui/number_of_pallets_exceeds_tuple_size.rs:22:1
+    |
+22  | /  #[frame_support::pallet]
+23  | |  mod pallet {
+24  | |      #[pallet::config]
+25  | |      pub trait Config: frame_system::Config {}
+...   |
+66  | |/ construct_runtime! {
+67  | ||     pub struct Runtime
+68  | ||     {
+69  | ||         System: frame_system::{Pallet, Call, Storage, Config<T>, Event<T>},
+...   ||
+180 | ||     }
+181 | || }
+    | ||_^
+    |  |_|
+    |    in this macro invocation
+    |
+    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`$CRATE`)
+    = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Instead of only generating the error, we now generate the actual code and the error. This generates in total less errors and helps the user to identify the actual problem and not being confronted with tons of errors.