### PR TITLE
Limit max execution time for `test-linux-stable` CI jobs

### DIFF
--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -48,6 +48,7 @@ test-linux-stable:
       - target/nextest/default/junit.xml
     reports:
       junit: target/nextest/default/junit.xml
+  timeout: 90m
 
 test-linux-oldkernel-stable:
   extends: test-linux-stable


### PR DESCRIPTION
Tests that are run as part of the `test-linux-stable` jobs could hang as shown [here](https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/5341393). This PR adds a failsafe for such cases.