### PR TITLE
Skip awaiting for metric verification when booting up local zombienet networks

### DIFF
--- a/polkadot/zombienet_tests/functional/0001-parachains-pvf.toml
+++ b/polkadot/zombienet_tests/functional/0001-parachains-pvf.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"

--- a/polkadot/zombienet_tests/functional/0002-parachains-disputes.toml
+++ b/polkadot/zombienet_tests/functional/0002-parachains-disputes.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 5

--- a/polkadot/zombienet_tests/functional/0003-beefy-and-mmr.toml
+++ b/polkadot/zombienet_tests/functional/0003-beefy-and-mmr.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"

--- a/polkadot/zombienet_tests/functional/0004-parachains-garbage-candidate.toml
+++ b/polkadot/zombienet_tests/functional/0004-parachains-garbage-candidate.toml
@@ -1,6 +1,8 @@
 [settings]
 timeout = 1000
 bootnode = true
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1

--- a/polkadot/zombienet_tests/functional/0005-parachains-disputes-past-session.toml
+++ b/polkadot/zombienet_tests/functional/0005-parachains-disputes-past-session.toml
@@ -1,6 +1,8 @@
 [settings]
 timeout = 1000
 bootnode = true
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1

--- a/polkadot/zombienet_tests/functional/0006-parachains-max-tranche0.toml
+++ b/polkadot/zombienet_tests/functional/0006-parachains-max-tranche0.toml
@@ -1,6 +1,8 @@
 [settings]
 timeout = 1000
 bootnode = true
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1

--- a/polkadot/zombienet_tests/functional/0007-dispute-freshly-finalized.toml
+++ b/polkadot/zombienet_tests/functional/0007-dispute-freshly-finalized.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1

--- a/polkadot/zombienet_tests/functional/0008-dispute-old-finalized.toml
+++ b/polkadot/zombienet_tests/functional/0008-dispute-old-finalized.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1

--- a/polkadot/zombienet_tests/functional/0009-approval-voting-coalescing.toml
+++ b/polkadot/zombienet_tests/functional/0009-approval-voting-coalescing.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"

--- a/polkadot/zombienet_tests/functional/0010-validator-disabling.toml
+++ b/polkadot/zombienet_tests/functional/0010-validator-disabling.toml
@@ -1,6 +1,8 @@
 [settings]
 timeout = 1000
 bootnode = true
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 1

--- a/polkadot/zombienet_tests/functional/0011-async-backing-6-seconds-rate.toml
+++ b/polkadot/zombienet_tests/functional/0011-async-backing-6-seconds-rate.toml
@@ -1,5 +1,7 @@
 [settings]
 timeout = 1000
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain]
 default_image = "{{ZOMBIENET_INTEGRATION_TEST_IMAGE}}"

--- a/polkadot/zombienet_tests/functional/0012-elastic-scaling-mvp.toml
+++ b/polkadot/zombienet_tests/functional/0012-elastic-scaling-mvp.toml
@@ -1,6 +1,8 @@
 [settings]
 timeout = 1000
 bootnode = true
+# Don't wait for metrics to be available when run locally
+{% if not CI_JOB_ID %} node_verifier = "None" {% endif %}
 
 [relaychain.genesis.runtimeGenesis.patch.configuration.config]
   max_validators_per_core = 2


### PR DESCRIPTION
When spinning larger zombienet networks locally during development awaiting for metrics to boot up and verify that nodes are up can take a lot of time:
```
Error 	 fetching metrics from: http://127.0.0.1:39555/metrics

Error 	 fetching metrics from: http://127.0.0.1:43957/metrics

Error 	 fetching metrics from: http://127.0.0.1:35039/metrics

Error 	 fetching metrics from: http://127.0.0.1:33173/metrics

Error 	 fetching metrics from: http://127.0.0.1:36597/metrics

Error 	 fetching metrics from: http://127.0.0.1:43837/metrics

```
Can take some time when playing with larger networks spinning the above error endlessly. 


PR uses the new setting [`node_verifier`](https://github.com/paritytech/zombienet/pull/1731) to disable the wait for metrics locally but keeps it on in CICD.