### PR TITLE
Use dedicated GitHub-hosted machines for Lychee checks

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   link-checker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Restore lychee cache
         uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.2 (7. Sep 2023)


### PR DESCRIPTION
It seems that the owners of some of the URLs we access during our Lychee checks don't like HTTP requests originating from GHA's shared subnets. Trying to circumvent this with switching to different "larger runners" managed GHA pool.