### PR TITLE
Fix compilation: allow unused imports

### DIFF
--- a/substrate/primitives/consensus/babe/src/lib.rs
+++ b/substrate/primitives/consensus/babe/src/lib.rs
@@ -16,8 +16,7 @@
 // limitations under the License.
 
 //! Primitives for BABE.
-#![deny(warnings)]
-#![forbid(unsafe_code, missing_docs, unused_variables, unused_imports)]
+#![forbid(unsafe_code, missing_docs, unused_variables)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod digests;


### PR DESCRIPTION
With the newest nightly compiler, there are lots of unused import warnings. Forbidding unused imports (and also denying warnings) breaks compilation. Other than the sassafras crate, no other crate forbids unused imports or denies warnings.