### PR TITLE
Add virtualization host functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9000,6 +9000,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro-crate 3.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13945,6 +13966,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkavm"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987d321f69aabd7c397b555cb5f57c860d17357fc370e62b8d78b5a03f326ad6"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler",
+ "polkavm-common 0.9.0",
+ "polkavm-linux-raw",
+]
+
+[[package]]
+name = "polkavm-assembler"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa96d6d868243acc12de813dd48e756cbadcc8e13964c70d272753266deadc1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "polkavm-common"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13952,9 +13995,12 @@ checksum = "88b4e215c80fe876147f3d58158d5dfeae7dabdd6047e175af77095b78d0035c"
 
 [[package]]
 name = "polkavm-common"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c99f7eee94e7be43ba37eef65ad0ee8cbaf89b7c00001c3f6d2be985cb1817"
+checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "polkavm-derive"
@@ -13968,9 +14014,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fa916f7962348bd1bb1a65a83401675e6fc86c51a0fdbcf92a3108e58e6125"
+checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
@@ -13989,11 +14035,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10b2654a8a10a83c260bfb93e97b262cf0017494ab94a65d389e0eda6de6c9c"
+checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
 dependencies = [
- "polkavm-common 0.8.0",
+ "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
  "syn 2.0.50",
@@ -14001,11 +14047,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e85319a0d5129dc9f021c62607e0804f5fb777a05cdda44d750ac0732def66"
+checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
- "polkavm-derive-impl 0.8.0",
+ "polkavm-derive-impl 0.9.0",
  "syn 2.0.50",
 ]
 
@@ -14026,18 +14072,24 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linker"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdec1451cb18261d5d01de82acc15305e417fb59588cdcb3127d3dcc9672b925"
+checksum = "b952ae5085ed6011a989a257a88505301bae0153fc389528134038c2e346b93d"
 dependencies = [
  "gimli 0.28.0",
  "hashbrown 0.14.3",
  "log",
  "object 0.32.2",
- "polkavm-common 0.8.0",
+ "polkavm-common 0.9.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
 
 [[package]]
 name = "polling"
@@ -16268,6 +16320,7 @@ dependencies = [
  "sp-tracing 16.0.0",
  "sp-trie",
  "sp-version",
+ "sp-virtualization-test-fixture",
  "sp-wasm-interface 20.0.0",
  "substrate-test-runtime",
  "tempfile",
@@ -16305,6 +16358,7 @@ dependencies = [
  "sc-runtime-test",
  "sp-io",
  "sp-runtime-interface 24.0.0",
+ "sp-virtualization",
  "sp-wasm-interface 20.0.0",
  "tempfile",
  "wasmtime",
@@ -16793,6 +16847,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface 24.0.0",
  "sp-std 14.0.0",
+ "sp-virtualization",
  "substrate-wasm-builder",
 ]
 
@@ -18855,6 +18910,7 @@ dependencies = [
  "ed25519-dalek",
  "libsecp256k1",
  "log",
+ "num_enum",
  "parity-scale-codec",
  "rustversion",
  "secp256k1",
@@ -19047,7 +19103,7 @@ dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.8.0",
+ "polkavm-derive 0.9.1",
  "primitive-types",
  "rustversion",
  "sp-core",
@@ -19358,6 +19414,26 @@ dependencies = [
  "quote",
  "sp-version",
  "syn 2.0.50",
+]
+
+[[package]]
+name = "sp-virtualization"
+version = "1.0.0"
+dependencies = [
+ "log",
+ "polkavm",
+ "sp-io",
+ "sp-std 14.0.0",
+ "sp-tracing 16.0.0",
+ "sp-virtualization-test-fixture",
+]
+
+[[package]]
+name = "sp-virtualization-test-fixture"
+version = "1.0.0"
+dependencies = [
+ "polkavm-derive 0.9.1",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -20069,7 +20145,7 @@ dependencies = [
  "console",
  "filetime",
  "parity-wasm",
- "polkavm-linker 0.8.2",
+ "polkavm-linker 0.9.0",
  "sp-maybe-compressed-blob",
  "strum 0.24.1",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -438,6 +438,8 @@ members = [
 	"substrate/primitives/consensus/pow",
 	"substrate/primitives/consensus/sassafras",
 	"substrate/primitives/consensus/slots",
+	"substrate/primitives/virtualization",
+	"substrate/primitives/virtualization/test-fixture",
 	"substrate/primitives/core",
 	"substrate/primitives/core/fuzz",
 	"substrate/primitives/crypto/ec-utils",
@@ -537,8 +539,9 @@ extra-unused-type-parameters = { level = "allow", priority = 2 }     # stylistic
 default_constructed_unit_structs = { level = "allow", priority = 2 } # stylistic
 
 [workspace.dependencies]
-polkavm-linker = "0.8.2"
-polkavm-derive = "0.8.0"
+polkavm = "0.9.0"
+polkavm-linker = "0.9.0"
+polkavm-derive = "0.9.1"
 log = { version = "0.4.20", default-features = false }
 quote = { version = "1.0.33" }
 serde = { version = "1.0.197", default-features = false }

--- a/substrate/client/executor/Cargo.toml
+++ b/substrate/client/executor/Cargo.toml
@@ -46,6 +46,7 @@ sp-runtime = { path = "../../primitives/runtime" }
 sp-maybe-compressed-blob = { path = "../../primitives/maybe-compressed-blob" }
 sc-tracing = { path = "../tracing" }
 sp-tracing = { path = "../../primitives/tracing" }
+sp-virtualization-test-fixture = { path = "../../primitives/virtualization/test-fixture" }
 tracing-subscriber = "0.2.19"
 paste = "1.0"
 regex = "1.6.0"

--- a/substrate/client/executor/runtime-test/Cargo.toml
+++ b/substrate/client/executor/runtime-test/Cargo.toml
@@ -21,6 +21,7 @@ sp-io = { path = "../../../primitives/io", default-features = false, features = 
 sp-runtime = { path = "../../../primitives/runtime", default-features = false }
 sp-runtime-interface = { path = "../../../primitives/runtime-interface", default-features = false }
 sp-std = { path = "../../../primitives/std", default-features = false }
+sp-virtualization = { path = "../../../primitives/virtualization", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { path = "../../../utils/wasm-builder", optional = true }
@@ -33,5 +34,6 @@ std = [
 	"sp-runtime-interface/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-virtualization/std",
 	"substrate-wasm-builder",
 ]

--- a/substrate/client/executor/runtime-test/src/lib.rs
+++ b/substrate/client/executor/runtime-test/src/lib.rs
@@ -367,6 +367,10 @@ sp_core::wasm_export_functions! {
 		// Mainly a test that the macro is working when we have a return statement here.
 		return 1234;
 	}
+
+	fn test_virtualization(test_fixture: Vec<u8>) {
+		sp_virtualization::run_tests(test_fixture.as_ref());
+	}
 }
 
 // Tests that check output validity. We explicitly return the ptr and len, so we avoid using the

--- a/substrate/client/executor/src/integration_tests/mod.rs
+++ b/substrate/client/executor/src/integration_tests/mod.rs
@@ -799,3 +799,12 @@ fn return_overflow(wasm_method: WasmExecutionMethod) {
 		error => panic!("unexpected error: {:?}", error),
 	}
 }
+
+test_wasm_execution!(test_virtualization);
+fn test_virtualization(wasm_method: WasmExecutionMethod) {
+	let mut ext = TestExternalities::default();
+	let mut ext = ext.ext();
+	let fixture = sp_virtualization_test_fixture::binary().encode();
+
+	call_in_wasm("test_virtualization", fixture.as_ref(), wasm_method, &mut ext).unwrap();
+}

--- a/substrate/client/executor/wasmtime/Cargo.toml
+++ b/substrate/client/executor/wasmtime/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = "1.0.68"
 sc-allocator = { path = "../../allocator" }
 sc-executor-common = { path = "../common" }
 sp-runtime-interface = { path = "../../../primitives/runtime-interface" }
+sp-virtualization = { path = "../../../primitives/virtualization" }
 sp-wasm-interface = { path = "../../../primitives/wasm-interface", features = ["wasmtime"] }
 
 # Here we include the rustix crate in the exactly same semver-compatible version as used by

--- a/substrate/client/executor/wasmtime/src/host.rs
+++ b/substrate/client/executor/wasmtime/src/host.rs
@@ -19,12 +19,15 @@
 //! This module defines `HostState` and `HostContext` structs which provide logic and state
 //! required for execution of host.
 
-use wasmtime::Caller;
-
-use sc_allocator::{AllocationStats, FreeingBumpHeapAllocator};
-use sp_wasm_interface::{Pointer, WordSize};
-
 use crate::{instance_wrapper::MemoryWrapper, runtime::StoreData, util};
+use sc_allocator::{AllocationStats, FreeingBumpHeapAllocator};
+use sp_virtualization::{
+	DestroyError as VirtDestroyError, ExecError as VirtExecError, Memory as VirtMemory, MemoryT,
+	SharedState as VirtSharedState, Virt, VirtT,
+};
+use sp_wasm_interface::{Pointer, WordSize};
+use std::{collections::HashMap, mem};
+use wasmtime::{AsContext, Caller, TypedFunc};
 
 /// The state required to construct a HostContext context. The context only lasts for one host
 /// call, whereas the state is maintained for the duration of a Wasm runtime call, which may make
@@ -37,12 +40,26 @@ pub struct HostState {
 	/// once.
 	allocator: Option<FreeingBumpHeapAllocator>,
 	panic_message: Option<String>,
+	/// Maps virtualization instances to their ids.
+	///
+	/// Within a runtime call multiple instances can be spawned and in existence at the same time.
+	/// We assign non recycled ids to them so the runtime can reference them. Please note that the
+	/// ids are per runtime call so there is no potential for non determinism as long as we assing
+	/// them deterministically.
+	virt_instances: HashMap<u64, VirtOrMem>,
+	/// A incrementing counter used to generate new ids for [`Self::virt_instances`].
+	virt_counter: u64,
 }
 
 impl HostState {
 	/// Constructs a new `HostState`.
 	pub fn new(allocator: FreeingBumpHeapAllocator) -> Self {
-		HostState { allocator: Some(allocator), panic_message: None }
+		HostState {
+			allocator: Some(allocator),
+			panic_message: None,
+			virt_instances: Default::default(),
+			virt_counter: 0,
+		}
 	}
 
 	/// Takes the error message out of the host state, leaving a `None` in its place.
@@ -124,5 +141,259 @@ impl<'a> sp_wasm_interface::FunctionContext for HostContext<'a> {
 
 	fn register_panic_error_message(&mut self, message: &str) {
 		self.host_state_mut().panic_message = Some(message.to_owned());
+	}
+
+	fn virtualization(&mut self) -> &mut dyn sp_wasm_interface::Virtualization {
+		self
+	}
+}
+
+impl<'a> sp_wasm_interface::Virtualization for HostContext<'a> {
+	fn instantiate(&mut self, program: &[u8]) -> sp_wasm_interface::Result<Result<u64, u8>> {
+		let virt = match Virt::instantiate(program) {
+			Ok(virt) => virt,
+			Err(err) => return Ok(Err(err.into())),
+		};
+
+		let host = self.host_state_mut();
+
+		let instance_id = {
+			let old = host.virt_counter;
+			host.virt_counter = old + 1;
+			old
+		};
+
+		host.virt_instances
+			.insert(instance_id, VirtOrMem::Instance { memory: virt.memory(), virt });
+
+		Ok(Ok(instance_id))
+	}
+
+	fn execute(
+		&mut self,
+		instance_id: u64,
+		function: &str,
+		syscall_handler: u32,
+		state_ptr: u32,
+		destroy: bool,
+	) -> sp_wasm_interface::Result<Result<(), u8>> {
+		let (mut virt, memory) = match self.host_state_mut().virt_instances.remove(&instance_id) {
+			Some(VirtOrMem::Instance { virt, memory }) => (virt, memory),
+			Some(VirtOrMem::Memory(_)) =>
+				Err("it is illegal to call execute the same instance while already executing")?,
+			None => return Ok(Err(VirtExecError::InvalidInstance.into())),
+		};
+
+		// Extract a syscall handler from the instance's table by the specified index.
+		let syscall_handler = {
+			let table = self
+				.caller
+				.data()
+				.table
+				.ok_or("Runtime doesn't have a table; sandbox is unavailable")?;
+			let table_item = table.get(&mut self.caller, syscall_handler);
+
+			table_item
+				.ok_or("dispatch_thunk_id is out of bounds")?
+				.funcref()
+				.ok_or("dispatch_thunk_idx should be a funcref")?
+				.ok_or("dispatch_thunk_idx should point to actual func")?
+				.typed(&mut self.caller)
+				.map_err(|_| "dispatch_thunk_idx has the wrong type")?
+		};
+
+		self.host_state_mut()
+			.virt_instances
+			.insert(instance_id, VirtOrMem::Memory(virt.memory()));
+
+		let mut state = VirtSharedState {
+			gas_left: 0,
+			exit: false,
+			user: VirtContext { host: self, syscall_handler, state_ptr },
+		};
+
+		// read values from runtime memory before execution
+		{
+			// SAFETY: no other reference is created from `state_ptr` while borrowing via
+			// `runtime_state()`.
+			let runtime_state =
+				unsafe { state.user.runtime_state().ok_or("state_ptr is out of bounds")? };
+			state.gas_left = runtime_state.gas_left;
+			state.exit = runtime_state.exit;
+		}
+
+		let outcome = virt.execute(function, virt_syscall_handler, &mut state);
+
+		// exit is never synced back runtime memory as it is an input only field
+		{
+			// SAFETY: no other reference is created from `state_ptr` while borrowing via
+			// `runtime_state()`.
+			let runtime_state =
+				unsafe { state.user.runtime_state().expect("pointer was verified above; qed") };
+			runtime_state.gas_left = state.gas_left;
+		}
+
+		if destroy {
+			self.host_state_mut().virt_instances.remove(&instance_id);
+		} else {
+			self.host_state_mut()
+				.virt_instances
+				.insert(instance_id, VirtOrMem::Instance { virt, memory });
+		}
+
+		Ok(outcome.map_err(Into::into))
+	}
+
+	fn destroy(&mut self, instance_id: u64) -> sp_wasm_interface::Result<Result<(), u8>> {
+		if self.host_state_mut().virt_instances.remove(&instance_id).is_some() {
+			Ok(Ok(()))
+		} else {
+			Ok(Err(VirtDestroyError::InvalidInstance.into()))
+		}
+	}
+
+	fn read_memory(
+		&mut self,
+		instance_id: u64,
+		offset: u32,
+		dest: &mut [u8],
+	) -> sp_wasm_interface::Result<Result<(), u8>> {
+		let Some(memory) = self
+			.host_state_mut()
+			.virt_instances
+			.get(&instance_id)
+			.map(|instance| instance.memory())
+		else {
+			return Ok(Err(VirtDestroyError::InvalidInstance.into()))
+		};
+		if let Err(err) = memory.read(offset, dest) {
+			return Ok(Err(err.into()))
+		}
+		Ok(Ok(()))
+	}
+
+	fn write_memory(
+		&mut self,
+		instance_id: u64,
+		offset: u32,
+		src: &[u8],
+	) -> sp_wasm_interface::Result<Result<(), u8>> {
+		let Some(memory) = self
+			.host_state_mut()
+			.virt_instances
+			.get_mut(&instance_id)
+			.map(|instance| instance.memory_mut())
+		else {
+			return Ok(Err(VirtDestroyError::InvalidInstance.into()))
+		};
+		if let Err(err) = memory.write(offset, src) {
+			return Ok(Err(err.into()))
+		}
+		Ok(Ok(()))
+	}
+}
+
+/// Either contains the instance itself or its associated memory.
+///
+/// While executing we don't need to keep the instance itself in the `HashMap` because no recursive
+/// calls into the same instance are valid. However, we still need to provide access to memory.
+/// This is why we replace the instance itselfwith its memory object while executing.
+enum VirtOrMem {
+	/// The instance itself used for executing code.
+	///
+	/// This variant is used whenever the instance is spawned but not currently executing.
+	Instance { virt: Virt, memory: VirtMemory },
+	/// The instances memory object.
+	///
+	/// This variant is used whenever the instance is executing.
+	Memory(VirtMemory),
+}
+
+impl VirtOrMem {
+	fn memory(&self) -> &VirtMemory {
+		match self {
+			Self::Instance { memory, .. } => memory,
+			Self::Memory(memory) => memory,
+		}
+	}
+
+	fn memory_mut(&mut self) -> &mut VirtMemory {
+		match self {
+			Self::Instance { memory, .. } => memory,
+			Self::Memory(memory) => memory,
+		}
+	}
+}
+
+/// Data structure that is passed into our registered callback.
+struct VirtContext<'a, 'b> {
+	/// Needed to get a handle to the runtime executor so we can call our `syscall_hander`.
+	host: &'a mut HostContext<'b>,
+	/// Runtime function we call to handle our syscall.
+	syscall_handler: TypedFunc<(u32, u32, u32, u32, u32, u32, u32, u32), u64>,
+	/// First argument to the `syscall_handler` used to share state with the runtime.
+	state_ptr: u32,
+}
+
+impl<'a, 'b> VirtContext<'a, 'b> {
+	/// Return a mutable reference to the state shared with the syscall handler.
+	///
+	/// Returns `None` if the `state_ptr` is out of bounds.
+	///
+	/// # SAFETY
+	///
+	/// The caller must make sure that no other reference to [`Self::state_ptr`] exists
+	/// while holding the reference returned from this function.
+	unsafe fn runtime_state(&mut self) -> Option<&mut VirtSharedState<()>> {
+		let offset = self.state_ptr as usize;
+		let buf = self.host.caller.as_context().data().memory().data_mut(&mut self.host.caller);
+		let scoped =
+			buf.get_mut(offset..offset.saturating_add(mem::size_of::<VirtSharedState<()>>()))?;
+		Some(&mut *(scoped.as_mut_ptr() as *mut _))
+	}
+}
+
+extern "C" fn virt_syscall_handler(
+	state: &mut VirtSharedState<VirtContext<'_, '_>>,
+	syscall_no: u32,
+	a0: u32,
+	a1: u32,
+	a2: u32,
+	a3: u32,
+	a4: u32,
+	a5: u32,
+) -> u64 {
+	let syscall_handler = state.user.syscall_handler;
+	let state_ptr = state.user.state_ptr;
+
+	// sync current gas counter to runtime memory. exit is not synced as it is input only.
+	{
+		// SAFETY: no other reference is created from `state_ptr` while borrowing via
+		// `runtime_state()`.
+		let runtime_state = unsafe {
+			state.user.runtime_state().expect("was checked before execution started; qed")
+		};
+		runtime_state.gas_left = state.gas_left;
+	}
+
+	let result = syscall_handler
+		.call(&mut state.user.host.caller, (state_ptr, syscall_no, a0, a1, a2, a3, a4, a5));
+	match result {
+		Ok(outcome) => {
+			// SAFETY: no other reference is created from `state_ptr` while borrowing via
+			// `runtime_state()`.
+			let runtime_state =
+				unsafe { state.user.runtime_state().expect("was checked above; qed") };
+			// those fields could have been changed by handler: copy back from runtime memory.
+			state.gas_left = runtime_state.gas_left;
+			state.exit = runtime_state.exit;
+			outcome
+		},
+		Err(err) => {
+			log::error!("virtualization syscall handler failed: {}", err);
+			// we trap the execution. return value is not used in this case.
+			state.exit = true;
+			u64::MAX
+		},
 	}
 }

--- a/substrate/primitives/io/Cargo.toml
+++ b/substrate/primitives/io/Cargo.toml
@@ -31,6 +31,7 @@ sp-trie = { path = "../trie", default-features = false, optional = true }
 sp-externalities = { path = "../externalities", default-features = false }
 sp-tracing = { path = "../tracing", default-features = false }
 log = { optional = true, workspace = true, default-features = true }
+num_enum = { version = "0.7.1", default-features = false }
 secp256k1 = { version = "0.28.0", features = ["global-context", "recovery"], optional = true }
 tracing = { version = "0.1.29", default-features = false }
 tracing-core = { version = "0.1.32", default-features = false }
@@ -50,6 +51,7 @@ std = [
 	"ed25519-dalek?/std",
 	"libsecp256k1",
 	"log/std",
+	"num_enum/std",
 	"secp256k1",
 	"sp-core/std",
 	"sp-crypto-hashing/std",

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -1737,6 +1737,201 @@ mod tracing_setup {
 
 pub use tracing_setup::init_tracing;
 
+/// Errors that can be emitted when instantiating a new virtualization instance.
+#[derive(
+	Encode, Decode, num_enum::TryFromPrimitive, num_enum::IntoPrimitive, Debug, PartialEq, Eq,
+)]
+#[repr(u8)]
+pub enum VirtInstantiateError {
+	/// The supplied code was invalid.
+	InvalidImage = 1,
+}
+
+/// Errors that can be emitted when executing a new virtualization instance.
+#[derive(
+	Encode, Decode, num_enum::TryFromPrimitive, num_enum::IntoPrimitive, Debug, PartialEq, Eq,
+)]
+#[repr(u8)]
+pub enum VirtExecError {
+	/// The supplied `instance_id` was invalid or the instance was destroyed.
+	///
+	/// This error will also be returned if a recursive call into the same instance
+	/// is attempted.
+	InvalidInstance = 1,
+	/// The supplied code was invalid. Most likely caused by invalid entry points.
+	InvalidImage = 2,
+	/// The execution ran out of gas before it could finish.
+	OutOfGas = 3,
+	/// The gas value was not within the valid range.
+	InvalidGasValue = 4,
+	/// The execution trapped before it could finish.
+	///
+	/// This can either be caused by executing an `unimp` instruction or when a host function
+	/// set [`VirtSharedState::exit`] to true.
+	Trap = 5,
+}
+
+/// Errors that can be emitted when accessing a virtualization instance's memory.
+#[derive(
+	Encode, Decode, num_enum::TryFromPrimitive, num_enum::IntoPrimitive, Debug, PartialEq, Eq,
+)]
+#[repr(u8)]
+pub enum VirtMemoryError {
+	/// The supplied `instance_id` was invalid or the instance was destroyed.
+	InvalidInstance = 1,
+	/// The memory region specified is not accessible.
+	OutOfBounds = 2,
+}
+
+/// Errors that can be emitted when destroying a virtualization instance.
+#[derive(
+	Encode, Decode, num_enum::TryFromPrimitive, num_enum::IntoPrimitive, Debug, PartialEq, Eq,
+)]
+#[repr(u8)]
+pub enum VirtDestroyError {
+	/// The supplied `instance_id` was invalid or the instance was destroyed.
+	InvalidInstance = 1,
+}
+
+/// This is used to hold state between different syscall handler invocations of the same exection.
+///
+/// A reference to it is passed in by the user when executing an virtualization instance.
+/// The same reference is passed as first argument to the [`VirtSyscallHandler`].
+///
+/// In addition to allow the user to pass custom data in using [`Self::user`] it is also used
+/// as a means to share data between the virtualization system and the syscall handler.
+#[repr(C)]
+pub struct VirtSharedState<T> {
+	/// How much gas is remaining for the current execution.
+	///
+	/// Needs to be set by the user before starting the execution. Will be updated by the
+	/// virtualization system before calling the syscall handler. Can be reduced by the syscall
+	/// handler in order to consume additional gas. Increments inside the syscall handler will
+	/// be discarded.
+	pub gas_left: u64,
+	/// Can be used by the syscall handler to signal that the execution should stop.
+	///
+	/// When this is set to true by the syscall handler it will make the execution trap upon
+	/// return from the syscall handler. Used to implement diverging host functions or to
+	/// implement fatal errors.
+	pub exit: bool,
+	/// User defined state for use by the syscall handler.
+	///
+	/// Never touched by the virtualization system.
+	pub user: T,
+}
+
+/// The syscall handler responsible for handling host functions.
+///
+/// This is called by the virtualization system for every host function that is called during
+/// execution.
+///
+/// # Arguments
+///
+/// * `state`: A reference to the state that was passed as an agument to execute.
+/// * `syscall_no`: The 4 byte identifier of the syscall being called.
+/// * `a0-a5`: The values of said registers on entering the syscall.
+///
+/// # Return
+///
+/// The returned u64 will be written into register `a0` and `a1` upon leaving the function. The
+/// least significant bits will be written in `a0` and the most significant bits will be written
+/// into `a1`.
+pub type VirtSyscallHandler<T> = extern "C" fn(
+	state: &mut VirtSharedState<T>,
+	syscall_no: u32,
+	a0: u32,
+	a1: u32,
+	a2: u32,
+	a3: u32,
+	a4: u32,
+	a5: u32,
+) -> u64;
+
+/// Host functions used to spawn and call into PolkaVM instances.
+///
+/// Don't use those host functions directly but use the safe wrappers in `sp-virtualization`. This
+/// will also make sure that everything works when running the code in native (test code) as this is
+/// a `wasm_only` interface.
+///
+/// # Warning
+///
+/// This is an unstable API. Its behaviour is subject to change until there is a spec. Don't use
+/// this API in your runtime except for test purposes.
+#[runtime_interface(wasm_only)]
+pub trait Virtualization {
+	/// See `sp_virtualization::Virt::instantiate`.
+	///
+	/// Returns the `instance_id` which needs to be passed to reference this instance
+	/// when using the other functions of this trait.
+	fn instantiate(&mut self, program: &[u8]) -> Result<u64, VirtInstantiateError> {
+		self.virtualization()
+			.instantiate(program)
+			.expect("instantiation failed")
+			.map_err(|err| TryFrom::try_from(err).expect("Invalid error"))
+	}
+
+	/// See `sp_virtualization::Virt::instantiate`.
+	///
+	/// # Arguments
+	///
+	/// * `instance_id`: The id returned from [`Self::instantiate`].
+	/// * `function`: Same as in `sp_virtualization::Virt::execute`.
+	/// * `syscall_handler`: Pointer to a [`VirtSyscallHandler<T>`].
+	/// * `state_ptr`: Pointer to a [`VirtSharedState<T>`].
+	/// * `destroy`: True if the instance should be destroyed after execution. Useful if no further
+	///   calls or memory reads are necessary.
+	fn execute(
+		&mut self,
+		instance_id: u64,
+		function: &str,
+		syscall_handler: u32,
+		state_ptr: u32,
+		destroy: bool,
+	) -> Result<(), VirtExecError> {
+		self.virtualization()
+			.execute(instance_id, function, syscall_handler, state_ptr, destroy)
+			.expect("execution failed")
+			.map_err(|err| TryFrom::try_from(err).expect("Invalid error"))
+	}
+
+	/// Destroy this instance.
+	///
+	/// Any attempt accessing an instance after destruction will yield the `InvalidInstance` error.
+	fn destroy(&mut self, instance_id: u64) -> Result<(), VirtDestroyError> {
+		self.virtualization()
+			.destroy(instance_id)
+			.expect("memory access error")
+			.map_err(|err| TryFrom::try_from(err).expect("Invalid error"))
+	}
+
+	/// See `sp_virtualization::Memory::read`.
+	fn read_memory(
+		&mut self,
+		instance_id: u64,
+		offset: u32,
+		dest: &mut [u8],
+	) -> Result<(), VirtMemoryError> {
+		self.virtualization()
+			.read_memory(instance_id, offset, dest)
+			.expect("memory access error")
+			.map_err(|err| TryFrom::try_from(err).expect("Invalid error"))
+	}
+
+	/// See `sp_virtualization::Memory::write`.
+	fn write_memory(
+		&mut self,
+		instance_id: u64,
+		offset: u32,
+		src: &[u8],
+	) -> Result<(), VirtMemoryError> {
+		self.virtualization()
+			.write_memory(instance_id, offset, src)
+			.expect("memory access error")
+			.map_err(|err| TryFrom::try_from(err).expect("Invalid error"))
+	}
+}
+
 /// Allocator used by Substrate from within the runtime.
 #[cfg(substrate_runtime)]
 struct RuntimeAllocator;
@@ -1834,6 +2029,7 @@ pub type SubstrateHostFunctions = (
 	crate::trie::HostFunctions,
 	offchain_index::HostFunctions,
 	transaction_index::HostFunctions,
+	virtualization::HostFunctions,
 );
 
 #[cfg(test)]

--- a/substrate/primitives/virtualization/Cargo.toml
+++ b/substrate/primitives/virtualization/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "sp-virtualization"
+version = "1.0.0"
+license = "Apache-2.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+description = "Spawn a new polkavm instance from within the runtime/pvf"
+
+[lints]
+workspace = true
+
+[dependencies]
+log = { workspace = true }
+polkavm = { workspace = true, optional = true }
+sp-io = { path = "../io", default-features =  false }
+sp-std = { path = "../std", default-features = false}
+
+[dev-dependencies]
+sp-tracing = { path = "../tracing" }
+sp-virtualization-test-fixture = { path = "./test-fixture" }
+
+[features]
+default = [ "std" ]
+std = [
+	"log/std",
+	"polkavm",
+	"sp-io/std",
+	"sp-std/std",
+]

--- a/substrate/primitives/virtualization/src/forwarder.rs
+++ b/substrate/primitives/virtualization/src/forwarder.rs
@@ -1,0 +1,98 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+	ExecError, InstantiateError, MemoryError, MemoryT, SharedState, SyscallHandler, VirtT,
+};
+use sp_io::virtualization as host_fn;
+
+/// The forwarder implementation of [`VirtT`].
+pub struct Virt {
+	/// The is passed to the host function to identify the instance to operate on.
+	instance_id: u64,
+	/// Is checked in `Drop` so that we don't destruct twice when using `execute_and_destroy`.
+	destroyed: bool,
+}
+
+/// The forwarder implementation of [`MemoryT`].
+pub struct Memory {
+	instance_id: u64,
+}
+
+impl VirtT for Virt {
+	type Memory = Memory;
+
+	fn instantiate(program: &[u8]) -> Result<Self, InstantiateError> {
+		let instance_id = host_fn::instantiate(program)?;
+		let virt = Self { instance_id, destroyed: false };
+		Ok(virt)
+	}
+
+	fn execute<T>(
+		&mut self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError> {
+		host_fn::execute(
+			self.instance_id,
+			function,
+			syscall_handler as u32,
+			state as *mut _ as usize as u32,
+			false,
+		)
+	}
+
+	fn execute_and_destroy<T>(
+		mut self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError> {
+		let result = host_fn::execute(
+			self.instance_id,
+			function,
+			syscall_handler as u32,
+			state as *mut _ as usize as u32,
+			true,
+		);
+		self.destroyed = true;
+		result
+	}
+
+	fn memory(&self) -> Self::Memory {
+		Memory { instance_id: self.instance_id }
+	}
+}
+
+impl Drop for Virt {
+	fn drop(&mut self) {
+		if !self.destroyed {
+			host_fn::destroy(self.instance_id).ok();
+		}
+	}
+}
+
+impl MemoryT for Memory {
+	fn read(&self, offset: u32, dest: &mut [u8]) -> Result<(), MemoryError> {
+		host_fn::read_memory(self.instance_id, offset, dest)
+	}
+
+	fn write(&mut self, offset: u32, src: &[u8]) -> Result<(), MemoryError> {
+		host_fn::write_memory(self.instance_id, offset, src)
+	}
+}

--- a/substrate/primitives/virtualization/src/lib.rs
+++ b/substrate/primitives/virtualization/src/lib.rs
@@ -1,0 +1,115 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This crate is intended for use by runtime code (e.g pallet-contracts) to spawn PolkaVM instances
+//! and execute calls into them. Its purpose is to add one layer of abtraction to that it works
+//! transparently from the actual runtime but also from tests (which run natively). Additionally,
+//! this crate is also used to implement the host functions that are used by this crate. This allows
+//! us to encapsulate all the logic regarding PolkaVM setup in one place.
+//!
+//! Please keep in mind that the interface is kept simple because it has to match the interface
+//! of the host function so that the abtraction works. It will never expose the whole PolkaVM
+//! interface.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+mod forwarder;
+#[cfg(not(feature = "std"))]
+pub use forwarder::Virt;
+
+#[cfg(feature = "std")]
+mod native;
+#[cfg(feature = "std")]
+pub use native::Virt;
+
+mod tests;
+
+pub use tests::run as run_tests;
+
+pub use sp_io::{
+	VirtDestroyError as DestroyError, VirtExecError as ExecError,
+	VirtInstantiateError as InstantiateError, VirtMemoryError as MemoryError,
+	VirtSharedState as SharedState, VirtSyscallHandler as SyscallHandler,
+};
+
+/// The concrete memory type used to access the memory of [`Virt`].
+pub type Memory = <Virt as VirtT>::Memory;
+
+/// A virtualization instance that can be called into multiple times.
+///
+/// There are only two implementations of this trait. One which is used within runtime builds.
+/// We call this the for `forwarder` since it only forwards the calls to host functions. The other
+/// one is the `native` implementation which is used to implement said host functions and is also
+/// used by the pallet's test code.
+///
+/// A trait is not strictly necessary but makes sure that both implementations do not diverge.
+pub trait VirtT: Sized {
+	/// The memory implementation of this instance.
+	type Memory: MemoryT;
+
+	/// Compile and instantiate the passed `program`.
+	///
+	/// The passed program has to be a valid PolkaVM program.
+	fn instantiate(program: &[u8]) -> Result<Self, InstantiateError>;
+
+	/// Execute the exported `function`.
+	///
+	/// The exported function must not take any arguments nor return any results.
+	///
+	/// * `function`: The identifier of the PolkaVM export.
+	/// * `syscall_handler`: Will be called to handle imported functions.
+	/// * `state`: This reference will passed as first argument to the `syscall_handler`. Use to
+	///   hold state.
+	fn execute<T>(
+		&mut self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError>;
+
+	/// Same as [`Self::execute`] but destroys the instance right away.
+	///
+	/// This is an optimization to allow the `forwarder` implementation to
+	/// execute an destroy in a single host function call. Otherwise it would
+	/// need to issue another host function call on drop.
+	fn execute_and_destroy<T>(
+		self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError>;
+
+	/// Get a reference to the instances memory.
+	///
+	/// You want to make this part of the [`SharedState`] in order to be able to access
+	/// the memory from your syscall handler.
+	///
+	/// Memory access will fail with an error when this instance was destroyed.
+	fn memory(&self) -> Self::Memory;
+}
+
+/// Allows to access the memory of a [`VirtT`].
+pub trait MemoryT {
+	/// Read the instances memory at `offset` into `dest`.
+	fn read(&self, offset: u32, dest: &mut [u8]) -> Result<(), MemoryError>;
+
+	/// Write `src` into the instances memory at `offset`.
+	fn write(&mut self, offset: u32, src: &[u8]) -> Result<(), MemoryError>;
+}

--- a/substrate/primitives/virtualization/src/native.rs
+++ b/substrate/primitives/virtualization/src/native.rs
@@ -1,0 +1,331 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+	ExecError, InstantiateError, MemoryError, MemoryT, SharedState, SyscallHandler, VirtT,
+};
+use polkavm::{
+	Caller, CallerRef, Config, Engine, ExecutionError, GasMeteringKind, Instance, Linker, Module,
+	ModuleConfig, Reg, StateArgs, Trap,
+};
+use std::{
+	cell::RefCell,
+	mem,
+	rc::{Rc, Weak},
+	sync::OnceLock,
+};
+
+/// This is the single PolkaVM engine we use for everything.
+///
+/// By using a common engine we allow PolkaVM to use caching. This caching is important
+/// to reduce startup costs. This is even the case when instances use different code.
+static ENGINE: OnceLock<Engine> = OnceLock::new();
+
+/// Engine wide configuration.
+fn engine() -> &'static Engine {
+	ENGINE.get_or_init(|| {
+		let config = Config::new();
+		Engine::new(&config).expect("Default config is always valid; qed")
+	})
+}
+
+/// Native implementation of [`VirtT`].
+pub struct Virt {
+	/// The PolkaVM instance we are managing.
+	instance: Instance<Self>,
+	/// Reference counted memory so that we can hand out multiple references to it.
+	///
+	/// This is needed because we need to make changes to the type from within `on_ecall`
+	/// while we already handed out references to it.
+	memory: Rc<RefCell<Memory>>,
+	/// The fields which are only set while being within [`Self::execute`].
+	while_exec: Option<WhileExec>,
+}
+
+/// Those are fields which are only set while [`Virt::execute`] is running.
+///
+/// Those types have their type parameter deleted because `on_ecall` can't be generic as a free
+/// standing function without requiring `T` to be `'static`. Since we do not actually need
+/// to access `T` in `on_ecall` we opt for deleting the type parameter instead.
+struct WhileExec {
+	/// The handler function that is called for every host function made by the program.
+	///
+	/// Transmuted from `SyscallHandler<T>` passed to [`Virt::execute`].
+	syscall_handler: ErasedSyscallHandler,
+	/// A pointer to the state that is shared between the syscall handler and us.
+	///
+	/// Represents `&mut SharedState<T>` passed to [`Virt::execute`]. We casted it into
+	/// a raw pointer.
+	state: usize,
+}
+
+/// The native [`MemoryT`] implementation.
+pub enum Memory {
+	/// While not executing we access memory through a [`Instance`].
+	Idle(Instance<Virt>),
+	/// While executing we have to use the [`Caller`] passed to `on_ecall` to access memory.
+	///
+	/// Trying to use an `Instance` while already executing it will lead to a dead lock. `on_ecall`
+	/// will make sure to replace `Idle` with `Executing` before callign the syscall handler.
+	Executing(CallerRef<()>),
+}
+
+impl Memory {
+	fn into_caller(self) -> Option<CallerRef<()>> {
+		match self {
+			Self::Executing(caller) => Some(caller),
+			_ => None,
+		}
+	}
+}
+
+/// This is the none generic version of [`SyscallHandler`].
+///
+/// It is identical to [`SyscallHandler`] with the exception of the first parameter which
+/// is replaced by a pointer. It is safe to transmute between the two because `usize` and
+/// references are ABI compatible.
+type ErasedSyscallHandler = extern "C" fn(
+	// &mut SharedState<T>
+	state: usize,
+	syscall_no: u32,
+	a0: u32,
+	a1: u32,
+	a2: u32,
+	a3: u32,
+	a4: u32,
+	a5: u32,
+) -> u64;
+
+impl VirtT for Virt {
+	// We use a weak reference in order to be compatible to the forwarder implementation
+	// where the memory is no longer accessible once the `Virt` is destroyed.
+	type Memory = Weak<RefCell<Memory>>;
+
+	fn instantiate(program: &[u8]) -> Result<Self, InstantiateError> {
+		let engine = engine();
+
+		let mut module_config = ModuleConfig::new();
+		module_config.set_gas_metering(Some(GasMeteringKind::Async));
+		let module = Module::new(&engine, &module_config, program).map_err(|err| {
+			log::error!("Failed to compile program: {}", err);
+			InstantiateError::InvalidImage
+		})?;
+
+		let mut linker = Linker::new(&engine);
+		linker.func_fallback(on_ecall);
+		let instance = linker.instantiate_pre(&module).map_err(|err| {
+			log::error!("Failed to link program: {err}");
+			InstantiateError::InvalidImage
+		})?;
+
+		let instance = instance.instantiate().map_err(|err| {
+			log::error!("Failed to instantiate program: {err}");
+			InstantiateError::InvalidImage
+		})?;
+		let virt = Self {
+			while_exec: None,
+			memory: Rc::new(RefCell::new(Memory::Idle(instance.clone()))),
+			instance,
+		};
+		Ok(virt)
+	}
+
+	fn execute<T>(
+		&mut self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError> {
+		self.internal_execute(function, syscall_handler, state)
+	}
+
+	fn execute_and_destroy<T>(
+		mut self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError> {
+		self.internal_execute(function, syscall_handler, state)
+	}
+
+	fn memory(&self) -> Self::Memory {
+		Rc::downgrade(&self.memory)
+	}
+}
+
+impl MemoryT for Weak<RefCell<Memory>> {
+	fn read(&self, offset: u32, dest: &mut [u8]) -> Result<(), MemoryError> {
+		let rc = self.upgrade().ok_or(MemoryError::InvalidInstance)?;
+		let result = match &*rc.borrow() {
+			Memory::Idle(instance) => instance.read_memory_into_slice(offset, dest),
+			Memory::Executing(caller) => caller.read_memory_into_slice(offset, dest),
+		};
+		result.map(|_| ()).map_err(|_| MemoryError::OutOfBounds)
+	}
+
+	fn write(&mut self, offset: u32, src: &[u8]) -> Result<(), MemoryError> {
+		let rc = self.upgrade().ok_or(MemoryError::InvalidInstance)?;
+		let result = match &mut *rc.borrow_mut() {
+			Memory::Idle(instance) => instance.write_memory(offset, src),
+			Memory::Executing(caller) => caller.write_memory(offset, src),
+		};
+		result.map_err(|_| MemoryError::OutOfBounds)
+	}
+}
+
+impl Virt {
+	/// Return a mutable reference to the state shared with the syscall handler.
+	///
+	/// # SAFETY
+	///
+	/// The caller must make sure that no other reference to [`Self::state`] exists
+	/// while holding the reference returned from this function.
+	///
+	/// # Traps
+	///
+	/// Traps if being called outside of `on_ecall`.
+	unsafe fn state(&mut self) -> &mut SharedState<()> {
+		// # SAFETY
+		//
+		// ## Life Times
+		//
+		// The reference is created from a raw pointer which was in turn created from a
+		// mutable reference passed into [`Self::`execute`]. This makes sure that no other
+		// reference exists while inside `execute`. The pointer is stored within
+		// [`Self::while_exec`] which is only set while being within `execute`.
+		//
+		// ## Change of generic parameter
+		//
+		// We transmute `&mut SharedState<T>` to `&mut SharedState<()>` here. This is safe because
+		// `SharedState` is using #[repr(C)] alignment where the change of the last field will
+		// not impact the alignment of the rest of the fields. Additionally, by chosing a ZST
+		// for `T` we prevent any code that accesses this data from being generated. Hence
+		// no assumptions over `T` will be made.
+		&mut *(self
+			.while_exec
+			.as_mut()
+			.expect(
+				"Is set while executing. This function is only called from on_ecall;
+				on_ecall is only called while executing; qed",
+			)
+			.state as *mut _)
+	}
+
+	fn internal_execute<T>(
+		&mut self,
+		function: &str,
+		syscall_handler: SyscallHandler<T>,
+		state: &mut SharedState<T>,
+	) -> Result<(), ExecError> {
+		let mut state_args = StateArgs::new();
+		state_args.reset_memory(false).set_gas(state.gas_left.try_into().map_err(|_| {
+			log::error!("{} is not a valid gas value", state.gas_left);
+			ExecError::InvalidGasValue
+		})?);
+		self.instance
+			.update_state(state_args)
+			.expect("We only set valid state above; qed");
+
+		// It does not really make sense to set `exit` to true before calling execute. However,
+		// it seems least surprising to not even start the execution in this case.
+		if state.exit {
+			return Ok(())
+		}
+
+		self.while_exec = Some(WhileExec {
+			// SAFETY: `SyscallHandler` and `ErasedSyscallHandler` are ABI compatible
+			syscall_handler: unsafe { mem::transmute(syscall_handler) },
+			state: state as *mut _ as usize,
+		});
+		let outcome = match self.instance.clone().call_typed(self, function, ()) {
+			Ok(()) => Ok(()),
+			Err(ExecutionError::Trap(_)) => Err(ExecError::Trap),
+			Err(ExecutionError::OutOfGas) => Err(ExecError::OutOfGas),
+			Err(ExecutionError::Error(err)) => {
+				log::error!("polkavm execution error: {}", err);
+				Err(ExecError::InvalidImage)
+			},
+		};
+
+		self.while_exec = None;
+		state.gas_left = self.instance.gas_remaining().expect("metering is enabled; qed").get();
+
+		outcome
+	}
+}
+
+fn on_ecall(caller: Caller<'_, Virt>, syscall_id: &[u8]) -> Result<(), Trap> {
+	let syscall_no = if syscall_id.len() == 4 {
+		u32::from_le_bytes([syscall_id[0], syscall_id[1], syscall_id[2], syscall_id[3]])
+	} else {
+		log::error!(
+			"All syscall identifiers need to be exactly 4 bytes. Supplied id: {:?}",
+			syscall_id
+		);
+		return Err(Trap::default());
+	};
+
+	let (caller, virt) = caller.split();
+
+	// caller is moved later and hence we need to copy the register values
+	let a0 = caller.get_reg(Reg::A0);
+	let a1 = caller.get_reg(Reg::A1);
+	let a2 = caller.get_reg(Reg::A2);
+	let a3 = caller.get_reg(Reg::A3);
+	let a4 = caller.get_reg(Reg::A4);
+	let a5 = caller.get_reg(Reg::A5);
+
+	// make gas_left available to the syscall handler
+	let gas_left_before = caller.gas_remaining().expect("metering is enabled; qed").get();
+	// SAFETY: no other reference is created from `state` while borrowing via
+	// `state()`.
+	unsafe {
+		virt.state().gas_left = gas_left_before;
+	}
+
+	let instance =
+		mem::replace(&mut *virt.memory.borrow_mut(), Memory::Executing(caller.into_ref()));
+
+	let while_exec = virt
+		.while_exec
+		.as_ref()
+		.expect("Is set while executing. `on_ecall` is only called while executing; qed");
+
+	// delegate to our syscall handler
+	let result = (while_exec.syscall_handler)(while_exec.state, syscall_no, a0, a1, a2, a3, a4, a5);
+
+	let mut caller = mem::replace(&mut *virt.memory.borrow_mut(), instance).into_caller().expect(
+		"We just set this to a a caller before calling into the syscaller handler.
+		The syscall handler cannot change this field; qed",
+	);
+
+	// SAFETY: no other reference is created from `state` while borrowing via
+	// `state()`.
+	let state = unsafe { virt.state() };
+
+	// syscall handler might have reduced the gas left value
+	let consumed = gas_left_before.saturating_sub(state.gas_left);
+	caller.consume_gas(consumed);
+
+	if state.exit {
+		Err(Trap::default())
+	} else {
+		caller.set_reg(Reg::A0, result as u32);
+		caller.set_reg(Reg::A1, (result >> 32) as u32);
+		Ok(())
+	}
+}

--- a/substrate/primitives/virtualization/src/tests.rs
+++ b/substrate/primitives/virtualization/src/tests.rs
@@ -1,0 +1,278 @@
+use crate::{ExecError, Memory, MemoryT, SharedState, Virt, VirtT};
+use alloc::vec::Vec;
+
+const GAS_MAX: u64 = i64::MAX as u64;
+
+/// Run all tests.
+///
+/// This is exported even without a test build in order to make it callable from the
+/// `sc-runtime-test`. This is necessary in order to compile these tests into a runtime so that
+/// the forwarder implementation is used. Otherwise only the native implemetation is tested through
+/// cargos test framework.
+///
+/// The `program` needs to be set to `sp_virtualization_test_fixture::binary()`. It can't be
+/// hard coded because when this crate is compiled into a runtime the binary is not available.
+/// Instead, was pass it as an argument to the runtime exported function.
+pub fn run(program: &[u8]) {
+	counter_start_at_0(program);
+	counter_start_at_7(program);
+	counter_multiple_calls(program);
+	panic_works(program);
+	exit_works(program);
+	exit_prevents_program_launch(program);
+	run_out_of_gas_works(program);
+	gas_consumption_works(program);
+	memory_reset_on_instantiate(program);
+	memory_persistent(program);
+	counter_in_subcall(program);
+}
+
+#[derive(Default)]
+struct State {
+	counter: u64,
+	memory: Option<Memory>,
+	program: Vec<u8>,
+}
+
+/// The host function implementation for our test fixture.
+extern "C" fn syscall_handler(
+	state: &mut SharedState<State>,
+	syscall_no: u32,
+	a0: u32,
+	_a1: u32,
+	_a2: u32,
+	_a3: u32,
+	_a4: u32,
+	_a5: u32,
+) -> u64 {
+	match syscall_no {
+		// read_counter
+		// memory is used for passing args in order to test memory access
+		1 => {
+			let buf = state.user.counter.to_le_bytes();
+			state.user.memory.as_mut().unwrap().write(a0, buf.as_ref()).unwrap();
+			syscall_no.into()
+		},
+		// increment counter
+		// memory is used for passing args in order to test memory access
+		2 => {
+			let mut buf = [0u8; 8];
+			state.user.memory.as_ref().unwrap().read(a0, buf.as_mut()).unwrap();
+			state.user.counter += u64::from_le_bytes(buf);
+			u64::from(syscall_no) << 56
+		},
+		// exit
+		3 => {
+			state.exit = true;
+			0
+		},
+		// call counter function in a new instance
+		4 => {
+			let instance = Virt::instantiate(state.user.program.as_ref()).unwrap();
+			let mut sub_state = SharedState {
+				gas_left: GAS_MAX,
+				exit: false,
+				user: State { memory: Some(instance.memory()), ..Default::default() },
+			};
+			let ret = instance.execute_and_destroy("counter", syscall_handler, &mut sub_state);
+			assert_eq!(ret, Ok(()));
+			assert!(!sub_state.exit);
+			assert_eq!(sub_state.user.counter, 8);
+			0
+		},
+		_ => panic!("unknown syscall: {:?}", syscall_no),
+	}
+}
+
+/// Checks memory access and user state functionality.
+fn counter_start_at_0(program: &[u8]) {
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("counter", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert!(!state.exit);
+	assert_eq!(state.user.counter, 8);
+}
+
+/// Checks memory access and user state functionality.
+fn counter_start_at_7(program: &[u8]) {
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 7, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("counter", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert!(!state.exit);
+	assert_eq!(state.user.counter, 15);
+}
+
+/// Makes sure user state is persistent between calls into the same instance.
+fn counter_multiple_calls(program: &[u8]) {
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 7, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("counter", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert!(!state.exit);
+	assert_eq!(state.user.counter, 15);
+
+	let ret = instance.execute("counter", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert!(!state.exit);
+	assert_eq!(state.user.counter, 23);
+}
+
+/// Check the correct status is returned when hitting an `unimp` instruction.
+fn panic_works(program: &[u8]) {
+	let instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute_and_destroy("do_panic", syscall_handler, &mut state);
+	assert_eq!(ret, Err(ExecError::Trap));
+	assert!(!state.exit);
+	assert_eq!(state.user.counter, 0);
+}
+
+/// Check that setting exit in a host function aborts the execution.
+fn exit_works(program: &[u8]) {
+	let instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute_and_destroy("do_exit", syscall_handler, &mut state);
+	assert_eq!(ret, Err(ExecError::Trap));
+	assert!(state.exit);
+	assert_eq!(state.user.counter, 0);
+}
+
+/// Setting exit to true prevents the program from even launching.
+fn exit_prevents_program_launch(program: &[u8]) {
+	let instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: true,
+		user: State { counter: 7, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute_and_destroy("add_99", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert!(state.exit);
+	assert_eq!(state.user.counter, 7);
+	assert_eq!(state.gas_left, GAS_MAX);
+}
+
+/// Increment the counter in an endless loop until we run out of gas.
+fn run_out_of_gas_works(program: &[u8]) {
+	let instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: 100_000,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute_and_destroy("increment_forever", syscall_handler, &mut state);
+	assert_eq!(ret, Err(ExecError::OutOfGas));
+	assert!(!state.exit);
+	assert_eq!(state.user.counter, 6_666);
+	assert_eq!(state.gas_left, 0);
+}
+
+/// Call same function with different gas limits and make sure they consume the same amount of gas.
+fn gas_consumption_works(program: &[u8]) {
+	let gas_limit_0 = GAS_MAX;
+	let gas_limit_1 = gas_limit_0 / 2;
+
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: gas_limit_0,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("counter", syscall_handler, &mut state);
+	let gas_consumed = gas_limit_0 - state.gas_left;
+	assert_eq!(ret, Ok(()));
+
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: gas_limit_1,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("counter", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert_eq!(gas_consumed, gas_limit_1 - state.gas_left);
+}
+
+/// Make sure that globals are reset for a new instance.
+fn memory_reset_on_instantiate(program: &[u8]) {
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("offset", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert_eq!(state.user.counter, 3);
+
+	let mut instance = Virt::instantiate(program).unwrap();
+	let ret = instance.execute("offset", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert_eq!(state.user.counter, 6);
+}
+
+/// Make sure globals are not reset between multiple calls into the same instance.
+fn memory_persistent(program: &[u8]) {
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State { counter: 0, memory: Some(instance.memory()), ..Default::default() },
+	};
+	let ret = instance.execute("offset", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert_eq!(state.user.counter, 3);
+
+	let ret = instance.execute("offset", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert_eq!(state.user.counter, 7);
+}
+
+/// Calls a function that spawns another instance where it calls the `counter` entry point.
+fn counter_in_subcall(program: &[u8]) {
+	let mut instance = Virt::instantiate(program).unwrap();
+	let mut state = SharedState {
+		gas_left: GAS_MAX,
+		exit: false,
+		user: State {
+			counter: 0,
+			memory: Some(instance.memory()),
+			program: program.to_vec(),
+			..Default::default()
+		},
+	};
+	let ret = instance.execute("do_subcall", syscall_handler, &mut state);
+	assert_eq!(ret, Ok(()));
+	assert!(!state.exit);
+	// sub call should not affect parent state
+	assert_eq!(state.user.counter, 0);
+}
+
+#[cfg(test)]
+#[test]
+fn tests() {
+	sp_tracing::try_init_simple();
+	run(sp_virtualization_test_fixture::binary());
+}

--- a/substrate/primitives/virtualization/test-fixture/Cargo.toml
+++ b/substrate/primitives/virtualization/test-fixture/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sp-virtualization-test-fixture"
+version = "1.0.0"
+license = "Apache-2.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+description = "A PolkaVM program that is used by the `sp-virtualization` tests"
+
+[target.'cfg(not(substrate_runtime))'.build-dependencies]
+substrate-wasm-builder = { path = "../../../utils/wasm-builder" }
+
+[target.'cfg(substrate_runtime)'.dependencies]
+polkavm-derive = { workspace = true }

--- a/substrate/primitives/virtualization/test-fixture/build.rs
+++ b/substrate/primitives/virtualization/test-fixture/build.rs
@@ -1,0 +1,8 @@
+#[cfg(not(substrate_runtime))]
+fn main() {
+	std::env::set_var("SUBSTRATE_RUNTIME_TARGET", "riscv");
+	substrate_wasm_builder::WasmBuilder::new().with_current_project().build()
+}
+
+#[cfg(substrate_runtime)]
+fn main() {}

--- a/substrate/primitives/virtualization/test-fixture/src/fixture.rs
+++ b/substrate/primitives/virtualization/test-fixture/src/fixture.rs
@@ -1,0 +1,97 @@
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+	unsafe {
+		core::arch::asm!("unimp", options(noreturn));
+	}
+}
+
+mod sys {
+	#[polkavm_derive::polkavm_import]
+	extern "C" {
+		#[polkavm_import(symbol = 1u32)]
+		pub fn read_counter(buf_ptr: *mut u8) -> u32;
+		#[polkavm_import(symbol = 2u32)]
+		pub fn increment_counter(buf_ptr: *const u8) -> u64;
+		#[polkavm_import(symbol = 3u32)]
+		pub fn exit();
+		#[polkavm_import(symbol = 4u32)]
+		pub fn subcall();
+	}
+}
+
+static mut OFFSET: u64 = 3;
+
+fn read_counter() -> u64 {
+	let mut buffer = [42u8; 8];
+	let ret = unsafe { sys::read_counter(buffer.as_mut_ptr()) };
+	assert_eq!(ret, 1);
+	u64::from_le_bytes(buffer)
+}
+
+fn increment_counter(inc: u64) {
+	let ret = unsafe { sys::increment_counter(inc.to_le_bytes().as_ptr()) };
+	assert_eq!(ret, 2 << 56);
+}
+
+fn exit() {
+	unsafe {
+		sys::exit();
+	}
+	// if exit() isn't working properly we can observe that using the counter
+	increment_counter(1_000);
+	panic!("Exit should not return");
+}
+
+fn subcall() {
+	unsafe {
+		sys::subcall();
+	}
+}
+
+#[polkavm_derive::polkavm_export]
+fn counter() {
+	let initial_counter = read_counter();
+	increment_counter(7);
+	assert_eq!(read_counter(), initial_counter + 7);
+	increment_counter(1);
+	assert_eq!(read_counter(), initial_counter + 8);
+	
+}
+
+#[polkavm_derive::polkavm_export]
+fn add_99() {
+	increment_counter(99);
+}
+
+#[polkavm_derive::polkavm_export]
+extern "C" fn do_panic() {
+	panic!("panic_me was called")
+}
+
+#[polkavm_derive::polkavm_export]
+extern "C" fn do_exit() {
+	exit();
+}
+
+#[polkavm_derive::polkavm_export]
+extern "C" fn increment_forever() {
+	loop {
+		increment_counter(1);
+	}
+}
+
+#[polkavm_derive::polkavm_export]
+extern "C" fn offset() {
+	let offset = unsafe {
+		OFFSET
+	};
+	increment_counter(offset);
+	unsafe {
+		OFFSET += 1;
+	}
+}
+
+#[polkavm_derive::polkavm_export]
+extern "C" fn do_subcall() {
+	subcall();
+}

--- a/substrate/primitives/virtualization/test-fixture/src/lib.rs
+++ b/substrate/primitives/virtualization/test-fixture/src/lib.rs
@@ -1,0 +1,15 @@
+#![cfg_attr(substrate_runtime, no_std, no_main)]
+
+#[cfg(substrate_runtime)]
+mod fixture;
+
+#[cfg(not(substrate_runtime))]
+mod binary {
+	include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
+}
+
+#[cfg(not(substrate_runtime))]
+pub fn binary() -> &'static [u8] {
+	let _ = binary::WASM_BINARY_BLOATY;
+	binary::WASM_BINARY.unwrap()
+}

--- a/substrate/primitives/wasm-interface/src/lib.rs
+++ b/substrate/primitives/wasm-interface/src/lib.rs
@@ -325,6 +325,38 @@ pub trait FunctionContext {
 	/// It should only be called once, however calling it more than once
 	/// is harmless and will overwrite the previously set error message.
 	fn register_panic_error_message(&mut self, message: &str);
+	/// Return a type that allows the caller to spawn and run virtualization instances.
+	fn virtualization(&mut self) -> &mut dyn Virtualization;
+}
+
+/// See `sp_io::Virtualization`.
+pub trait Virtualization {
+	fn instantiate(&mut self, program: &[u8]) -> Result<sp_std::result::Result<u64, u8>>;
+
+	fn execute(
+		&mut self,
+		instance_id: u64,
+		function: &str,
+		syscall_handler: u32,
+		state_ptr: u32,
+		destroy: bool,
+	) -> Result<sp_std::result::Result<(), u8>>;
+
+	fn destroy(&mut self, instance_id: u64) -> Result<sp_std::result::Result<(), u8>>;
+
+	fn read_memory(
+		&mut self,
+		instance_id: u64,
+		offset: u32,
+		dest: &mut [u8],
+	) -> Result<sp_std::result::Result<(), u8>>;
+
+	fn write_memory(
+		&mut self,
+		instance_id: u64,
+		offset: u32,
+		src: &[u8],
+	) -> Result<sp_std::result::Result<(), u8>>;
 }
 
 if_wasmtime_is_enabled! {


### PR DESCRIPTION
This PR adds experimental support for the virtualization host functions. Those allow the runtime to spawn and run PolkaVM instances. It is experimental because the behaviour is subject to change until PolkaVM and the host functions have a spec. However, we need to merge the code to go on with development. Docs and tests are all there and hence I argue it is good enough to be merged. I added a note that users should not use those functions in production.

This PR adds or changes the following components:

* `sp-io`: Definition of the new host functions.
* `sc-executor-wasmtime`: Implementation of the new host functions. Those are executor specific because they need to call back into the runtime to handle the host function calls (syscalls) the PolkaVM program performs. Luckily, wasmtime is our only executor.
* `sp-virtualization`: New crate that abstracts away the host functions. Meaning that a user (like pallet-contracts) will interface only with this crate and not with the host functions directly. This is necessary so that the natively running test code still works. The host functions also depend on this crate. Those also contain all the tests. Everything PolkaVM is neatly organized into one crate.
