### PR TITLE
Backport of #3340 - Fix `DepositReserveAsset`

### DIFF
--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -827,8 +827,10 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					let to_weigh = self.holding.saturating_take(assets.clone());
 					self.holding.subsume_assets(to_weigh.clone());
 
+					let to_weigh_reanchored = Self::reanchored(to_weigh, &dest, None);
+
 					let mut message_to_weigh =
-						vec![ReserveAssetDeposited(to_weigh.into()), ClearOrigin];
+						vec![ReserveAssetDeposited(to_weigh_reanchored), ClearOrigin];
 					message_to_weigh.extend(xcm.0.clone().into_iter());
 					let (_, fee) =
 						validate_send::<Config::XcmSender>(dest.clone(), Xcm(message_to_weigh))?;


### PR DESCRIPTION
Backport of https://github.com/paritytech/polkadot-sdk/pull/3340

It was backported to `v1.7.0` but changes didn't make it to `v1.8.0`
