### PR TITLE
FIX: Make types public

### DIFF
--- a/substrate/client/network/sync/src/lib.rs
+++ b/substrate/client/network/sync/src/lib.rs
@@ -28,7 +28,7 @@ mod futures_stream;
 mod pending_responses;
 mod request_metrics;
 mod schema;
-mod types;
+pub mod types;
 
 pub mod block_relay_protocol;
 pub mod block_request_handler;


### PR DESCRIPTION
This PR makes `sc-network-sync` types public following [this](https://github.com/paritytech/polkadot-sdk/issues/3556) issue.

Fixes #3556 