### PR TITLE
[DNM] Refactoring delegated staking interfaces

### DIFF
--- a/substrate/frame/delegated-staking/src/lib.rs
+++ b/substrate/frame/delegated-staking/src/lib.rs
@@ -215,7 +215,7 @@ pub mod pallet {
 		type RuntimeHoldReason: From<HoldReason>;
 
 		/// Core staking implementation.
-		type CoreStaking: StakingInterface<Balance = BalanceOf<Self>, AccountId = Self::AccountId>;
+		type CoreStaking: DelegateeSupport<Balance = BalanceOf<Self>, AccountId = Self::AccountId>;
 	}
 
 	#[pallet::error]
@@ -542,7 +542,7 @@ impl<T: Config> Pallet<T> {
 		if delegatee.is_bonded() {
 			T::CoreStaking::bond_extra(&delegatee.key, amount)
 		} else {
-			T::CoreStaking::bond(&delegatee.key, amount, &delegatee.reward_account())
+			T::CoreStaking::delegated_bond(&delegatee.key, amount, &delegatee.reward_account())
 		}
 	}
 

--- a/substrate/frame/nomination-pools/test-staking/src/mock.rs
+++ b/substrate/frame/nomination-pools/test-staking/src/mock.rs
@@ -111,7 +111,6 @@ parameter_types! {
 impl pallet_staking::Config for Runtime {
 	type Currency = Balances;
 	type CurrencyBalance = Balance;
-	type DelegateeSupport = pallet_staking::NoDelegation<Self>;
 	type UnixTime = pallet_timestamp::Pallet<Self>;
 	type CurrencyToVote = ();
 	type RewardRemainder = ();

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -328,7 +328,7 @@ pub use sp_staking::{Exposure, IndividualExposure, StakerStatus};
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 pub use weights::WeightInfo;
 
-pub use pallet::{pallet::*, NoDelegation, UseNominatorsAndValidatorsMap, UseValidatorsMap};
+pub use pallet::{pallet::*, UseNominatorsAndValidatorsMap, UseValidatorsMap};
 
 pub(crate) const STAKING_ID: LockIdentifier = *b"staking ";
 pub(crate) const LOG_TARGET: &str = "runtime::staking";
@@ -413,21 +413,6 @@ pub enum RewardDestination<AccountId> {
 	None,
 }
 
-impl<AccountId: Clone> RewardDestination<AccountId> {
-	fn from(self, stash: &AccountId) -> Option<AccountId> {
-		match self {
-			// FIXME(ank4n): Figure out later how to handle Controller
-			RewardDestination::Staked | RewardDestination::Stash => Some(stash.clone()),
-			RewardDestination::Account(a) => Some(a),
-			#[allow(deprecated)]
-			_ => {
-				defensive!("reward destination not set or set as deprecated controller");
-				None
-			},
-		}
-	}
-}
-
 /// Preference of what happens regarding validation.
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, Default, MaxEncodedLen)]
 pub struct ValidatorPrefs {
@@ -498,6 +483,9 @@ pub struct StakingLedger<T: Config> {
 	/// Refer to issue <https://github.com/paritytech/polkadot-sdk/issues/433>
 	pub legacy_claimed_rewards: BoundedVec<EraIndex, T::HistoryDepth>,
 
+	/// TODO: docs
+	pub locked_locally: bool,
+
 	/// The controller associated with this ledger's stash.
 	///
 	/// This is not stored on-chain, and is only bundled when the ledger is read from storage.
@@ -560,6 +548,7 @@ impl<T: Config> StakingLedger<T> {
 			active: self.active,
 			unlocking,
 			legacy_claimed_rewards: self.legacy_claimed_rewards,
+			locked_locally: self.locked_locally,
 			controller: self.controller,
 		}
 	}

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -483,9 +483,6 @@ pub struct StakingLedger<T: Config> {
 	/// Refer to issue <https://github.com/paritytech/polkadot-sdk/issues/433>
 	pub legacy_claimed_rewards: BoundedVec<EraIndex, T::HistoryDepth>,
 
-	/// TODO: docs
-	pub locked_locally: bool,
-
 	/// The controller associated with this ledger's stash.
 	///
 	/// This is not stored on-chain, and is only bundled when the ledger is read from storage.
@@ -548,7 +545,6 @@ impl<T: Config> StakingLedger<T> {
 			active: self.active,
 			unlocking,
 			legacy_claimed_rewards: self.legacy_claimed_rewards,
-			locked_locally: self.locked_locally,
 			controller: self.controller,
 		}
 	}

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -290,6 +290,9 @@ impl crate::pallet::pallet::Config for Test {
 	type MaxUnlockingChunks = MaxUnlockingChunks;
 	type HistoryDepth = HistoryDepth;
 	type MaxControllersInDeprecationBatch = MaxControllersInDeprecationBatch;
+	// In a production environment, it would be something like
+	// EnsureXcm<Equals<xcm_config::some_delegated_staking_location::Location>>
+	type DelegateOrigin = EnsureRoot<AccountId>;
 	type EventListeners = EventListenerMock;
 	type BenchmarkingConfig = TestBenchmarkingConfig;
 	type WeightInfo = ();

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -266,7 +266,6 @@ impl OnStakingUpdate<AccountId, Balance> for EventListenerMock {
 impl crate::pallet::pallet::Config for Test {
 	type Currency = Balances;
 	type CurrencyBalance = <Self as pallet_balances::Config>::Balance;
-	type DelegateeSupport = pallet_staking::NoDelegation<Self>;
 	type UnixTime = Timestamp;
 	type CurrencyToVote = ();
 	type RewardRemainder = RewardRemainderMock;

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -1102,8 +1102,6 @@ impl<T: Config> Pallet<T> {
 		}
 
 		frame_system::Pallet::<T>::inc_consumers(&stash).map_err(|_| Error::<T>::BadState)?;
-		let stash_balance = T::Currency::free_balance(&stash);
-		let value = value.min(stash_balance);
 		Self::deposit_event(Event::<T>::Bonded { stash: stash.clone(), amount: value });
 		Delegatees::<T>::insert(stash.clone(), ());
 		let ledger = StakingLedger::<T>::new(stash.clone(), value);

--- a/substrate/frame/staking/src/slashing.rs
+++ b/substrate/frame/staking/src/slashing.rs
@@ -50,7 +50,7 @@
 //! Based on research at <https://research.web3.foundation/en/latest/polkadot/slashing/npos.html>
 
 use crate::{
-	BalanceOf, Config, Error, Exposure, NegativeImbalanceOf, NominatorSlashInEra,
+	BalanceOf, Config, Delegatees, Error, Exposure, NegativeImbalanceOf, NominatorSlashInEra,
 	OffendingValidators, Pallet, Perbill, SessionInterface, SpanSlash, UnappliedSlash,
 	ValidatorSlashInEra,
 };
@@ -608,7 +608,7 @@ pub fn do_slash<T: Config>(
 			Err(_) => return, // nothing to do.
 		};
 
-	let lazy_slash = !ledger.locked_locally;
+	let lazy_slash = Delegatees::<T>::contains_key(stash);
 	let value = ledger.slash(value, T::Currency::minimum_balance(), slash_era);
 
 	if value.is_zero() {


### PR DESCRIPTION
Built on top of #2680 , but with #1933 in mind.

This PR roughly implements decoupling changes in `pallet-delegated-staking` and `pallet-staking`. The changes are most notably reflected in `trait StakingInterface`, `trait DelegateeSupport` and `trait DelegatedStakingInterface`.

The main difference from the original approach is:
- `trait DelegateeSupport` becomes an interface which extends a `trait StakingInterface` to allow registering bonds without locking the funds
- `trait DelegatedStakingInterface` no longer provides the full staking functionality, but instead it's meant to be a buffer which abstracts away any `StakingInterface` and lets users just delegate

NOTE: the traits might need renaming given the shift in functionality

Consequently, `pallet-staking` implements `DelegateeSupport` and `pallet-delegated-staking` implements `DelegatedStakingInterface`. Entities which use `DelegateeSupport` are inherently privileged because they are allowed to stake without being checked by the staking interface. This will need some origin validation in the near future.

What this means is that all of the responsibility for validating the state of delegators/delegatees falls on the callers of `DelegateeSupport`, which would be `DelegatedStakingInterface` implementors in our case. Most of the core staking logic remains unchanged.

Next step here would be to refactor the interface usage of  `pallet-nomination-pools`, but until then, feedback is welcome on the direction of the interfaces.