### PR TITLE
subsystem-bench: adjust test config to Kusama

### DIFF
--- a/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
@@ -39,14 +39,14 @@ fn main() -> Result<(), String> {
 	// TODO: Adjust the test configurations to Kusama values
 	let mut config = TestConfiguration::default();
 	config.latency = Some(PeerLatency { mean_latency_ms: 30, std_dev: 2.0 });
-	config.n_validators = 1000;
-	config.n_cores = 200;
-	config.max_validators_per_core = 5;
-	config.min_pov_size = 5120;
-	config.max_pov_size = 5120;
-	config.peer_bandwidth = 52428800;
-	config.bandwidth = 52428800;
-	config.connectivity = 75;
+	config.n_validators = 300; // max number of validators
+	config.n_cores = 50; // 42 paras producing blocks
+	config.max_validators_per_core = 3; // from config
+	config.min_pov_size = 5120; // https://grafana.teleport.parity.io/goto/Kr34vOASR?orgId=1
+	config.max_pov_size = 5120; // https://grafana.teleport.parity.io/goto/Kr34vOASR?orgId=1
+	config.peer_bandwidth = 52428800; // need to find out
+	config.bandwidth = 52428800; // need to find out
+	config.connectivity = 75; // we need to be connected to 90-95% of peers
 	config.num_blocks = 3;
 	config.generate_pov_sizes();
 

--- a/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
@@ -16,7 +16,7 @@
 
 //! availability-read regression tests
 //!
-//! Simulated process of availability reading on Kusama
+//! Availability read benchmark based on Kusama parameters and scale.
 //!
 //! Subsystems involved:
 //! - availability-distribution

--- a/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
@@ -30,12 +30,14 @@ use polkadot_subsystem_bench::{
 };
 
 const BENCH_COUNT: usize = 3;
-const WARM_UP_COUNT: usize = 20;
+const WARM_UP_COUNT: usize = 30;
 const WARM_UP_PRECISION: f64 = 0.01;
 
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
 	let mut config = TestConfiguration::default();
+	// A single node effort roughly n_cores * needed_approvals / n_validators = 60 * 30 / 300
+	config.n_cores = 6;
 	config.num_blocks = 3;
 	config.generate_pov_sizes();
 

--- a/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
@@ -25,7 +25,7 @@
 
 use polkadot_subsystem_bench::{
 	availability::{benchmark_availability_write, prepare_test, TestDataAvailability, TestState},
-	configuration::{PeerLatency, TestConfiguration},
+	configuration::TestConfiguration,
 	usage::BenchmarkUsage,
 };
 

--- a/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/tests/availability-distribution-regression-bench.rs
@@ -16,7 +16,7 @@
 
 //! availability-read regression tests
 //!
-//! TODO: Explain the test case after configuration adjusted to Kusama
+//! Simulated process of availability reading on Kusama
 //!
 //! Subsystems involved:
 //! - availability-distribution
@@ -35,18 +35,7 @@ const WARM_UP_PRECISION: f64 = 0.01;
 
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
-
-	// TODO: Adjust the test configurations to Kusama values
 	let mut config = TestConfiguration::default();
-	config.latency = Some(PeerLatency { mean_latency_ms: 30, std_dev: 2.0 });
-	config.n_validators = 300; // max number of validators
-	config.n_cores = 50; // 42 paras producing blocks
-	config.max_validators_per_core = 3; // from config
-	config.min_pov_size = 5120; // https://grafana.teleport.parity.io/goto/Kr34vOASR?orgId=1
-	config.max_pov_size = 5120; // https://grafana.teleport.parity.io/goto/Kr34vOASR?orgId=1
-	config.peer_bandwidth = 52428800; // need to find out
-	config.bandwidth = 52428800; // need to find out
-	config.connectivity = 75; // we need to be connected to 90-95% of peers
 	config.num_blocks = 3;
 	config.generate_pov_sizes();
 

--- a/polkadot/node/network/availability-recovery/tests/availability-recovery-regression-bench.rs
+++ b/polkadot/node/network/availability-recovery/tests/availability-recovery-regression-bench.rs
@@ -16,7 +16,7 @@
 
 //! availability-write regression tests
 //!
-//! TODO: Explain the test case after configuration adjusted to Kusama
+//! Simulated process of availability writing on Kusama
 //!
 //! Subsystems involved:
 //! - availability-recovery
@@ -26,7 +26,7 @@ use polkadot_subsystem_bench::{
 		benchmark_availability_read, prepare_test, DataAvailabilityReadOptions,
 		TestDataAvailability, TestState,
 	},
-	configuration::{PeerLatency, TestConfiguration},
+	configuration::TestConfiguration,
 	usage::BenchmarkUsage,
 };
 
@@ -37,18 +37,9 @@ const WARM_UP_PRECISION: f64 = 0.01;
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
 
-	// TODO: Adjust the test configurations to Kusama values
 	let options = DataAvailabilityReadOptions { fetch_from_backers: true };
 	let mut config = TestConfiguration::default();
-	config.latency = Some(PeerLatency { mean_latency_ms: 100, std_dev: 1.0 });
-	config.n_validators = 300;
-	config.n_cores = 20;
-	config.min_pov_size = 5120;
-	config.max_pov_size = 5120;
-	config.peer_bandwidth = 52428800;
-	config.bandwidth = 52428800;
 	config.num_blocks = 3;
-	config.connectivity = 90;
 	config.generate_pov_sizes();
 
 	warm_up(config.clone(), options.clone())?;

--- a/polkadot/node/network/availability-recovery/tests/availability-recovery-regression-bench.rs
+++ b/polkadot/node/network/availability-recovery/tests/availability-recovery-regression-bench.rs
@@ -16,7 +16,7 @@
 
 //! availability-write regression tests
 //!
-//! Simulated process of availability writing on Kusama
+//! Availability write benchmark based on Kusama parameters and scale.
 //!
 //! Subsystems involved:
 //! - availability-recovery

--- a/polkadot/node/subsystem-bench/src/lib/configuration.rs
+++ b/polkadot/node/subsystem-bench/src/lib/configuration.rs
@@ -35,24 +35,39 @@ pub struct PeerLatency {
 	pub std_dev: f64,
 }
 
-// Default PoV size in KiB.
-fn default_pov_size() -> usize {
-	5120
+// Based on Kusama `max_validators`
+fn default_n_validators() -> usize {
+	300
 }
 
-// Default bandwidth in bytes
+// Based on number of kusama validators producing blocks
+fn default_n_cores() -> usize {
+	50
+}
+
+// PoV size, KiB. Based on empirical data from Kusama
+fn default_pov_size() -> usize {
+	2 * 1024
+}
+
+// Default bandwidth in bytes, based stats from Kusama validators
 fn default_bandwidth() -> usize {
-	52428800
+	42 * 1024 * 1024
+}
+
+// Default peer latency
+fn default_peer_latency() -> Option<PeerLatency> {
+	Some(PeerLatency { mean_latency_ms: 30, std_dev: 2.0 })
 }
 
 // Default connectivity percentage
 fn default_connectivity() -> usize {
-	100
+	90
 }
 
-// Default backing group size
+// Based on Kusama `max_validators_per_core`
 fn default_backing_group_size() -> usize {
-	5
+	3
 }
 
 // Default needed approvals
@@ -63,6 +78,7 @@ fn default_needed_approvals() -> usize {
 fn default_zeroth_delay_tranche_width() -> usize {
 	0
 }
+
 fn default_relay_vrf_modulo_samples() -> usize {
 	6
 }
@@ -78,8 +94,10 @@ fn default_no_show_slots() -> usize {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TestConfiguration {
 	/// Number of validators
+	#[serde(default = "default_n_validators")]
 	pub n_validators: usize,
 	/// Number of cores
+	#[serde(default = "default_n_cores")]
 	pub n_cores: usize,
 	/// The number of needed votes to approve a candidate.
 	#[serde(default = "default_needed_approvals")]
@@ -111,7 +129,7 @@ pub struct TestConfiguration {
 	#[serde(default = "default_bandwidth")]
 	pub bandwidth: usize,
 	/// Optional peer emulation latency (round trip time) wrt node under test
-	#[serde(default)]
+	#[serde(default = "default_peer_latency")]
 	pub latency: Option<PeerLatency>,
 	/// Connectivity ratio, the percentage of peers we are connected to, but as part of the
 	/// topology.
@@ -124,8 +142,8 @@ pub struct TestConfiguration {
 impl Default for TestConfiguration {
 	fn default() -> Self {
 		Self {
-			n_validators: Default::default(),
-			n_cores: Default::default(),
+			n_validators: default_n_validators(),
+			n_cores: default_n_cores(),
 			needed_approvals: default_needed_approvals(),
 			zeroth_delay_tranche_width: default_zeroth_delay_tranche_width(),
 			relay_vrf_modulo_samples: default_relay_vrf_modulo_samples(),
@@ -137,7 +155,7 @@ impl Default for TestConfiguration {
 			pov_sizes: Default::default(),
 			peer_bandwidth: default_bandwidth(),
 			bandwidth: default_bandwidth(),
-			latency: Default::default(),
+			latency: default_peer_latency(),
 			connectivity: default_connectivity(),
 			num_blocks: Default::default(),
 		}

--- a/polkadot/node/subsystem-bench/src/lib/configuration.rs
+++ b/polkadot/node/subsystem-bench/src/lib/configuration.rs
@@ -113,8 +113,8 @@ pub struct TestConfiguration {
 	/// Optional peer emulation latency (round trip time) wrt node under test
 	#[serde(default)]
 	pub latency: Option<PeerLatency>,
-	/// Connectivity ratio, the percentage of peers we are not connected to, but ar part of
-	/// the topology.
+	/// Connectivity ratio, the percentage of peers we are connected to, but as part of the
+	/// topology.
 	#[serde(default = "default_connectivity")]
 	pub connectivity: usize,
 	/// Number of blocks to run the test for

--- a/polkadot/node/subsystem-bench/src/lib/configuration.rs
+++ b/polkadot/node/subsystem-bench/src/lib/configuration.rs
@@ -42,7 +42,7 @@ fn default_n_validators() -> usize {
 
 // Based on number of kusama validators producing blocks
 fn default_n_cores() -> usize {
-	50
+	60
 }
 
 // Default PoV size in KiB.

--- a/polkadot/node/subsystem-bench/src/lib/configuration.rs
+++ b/polkadot/node/subsystem-bench/src/lib/configuration.rs
@@ -45,9 +45,9 @@ fn default_n_cores() -> usize {
 	50
 }
 
-// PoV size, KiB. Based on empirical data from Kusama
+// Default PoV size in KiB.
 fn default_pov_size() -> usize {
-	2 * 1024
+	5 * 1024
 }
 
 // Default bandwidth in bytes, based stats from Kusama validators
@@ -65,9 +65,9 @@ fn default_connectivity() -> usize {
 	90
 }
 
-// Based on Kusama `max_validators_per_core`
+// Default backing group size
 fn default_backing_group_size() -> usize {
-	3
+	5
 }
 
 // Default needed approvals

--- a/polkadot/node/subsystem-bench/src/lib/configuration.rs
+++ b/polkadot/node/subsystem-bench/src/lib/configuration.rs
@@ -40,7 +40,7 @@ fn default_n_validators() -> usize {
 	300
 }
 
-// Based on number of kusama validators producing blocks
+// Based on Kusama cores
 fn default_n_cores() -> usize {
 	60
 }


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/3528

```rust
latency:
    mean_latency_ms = 30 // common sense
    std_dev = 2.0 // common sense
n_validators = 300 // max number of validators, from chain config
n_cores = 60 // 300/5
max_validators_per_core = 5 // default
min_pov_size = 5120 // max
max_pov_size = 5120 // max
peer_bandwidth = 44040192 // from the Parity's kusama validators
bandwidth = 44040192 // from the Parity's kusama validators
connectivity = 90 // we need to be connected to 90-95% of peers
```
