### PR TITLE
Increase MaxExecutionHeadersToKeep

### DIFF
--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -98,8 +98,6 @@ use parachains_common::{
 	AVERAGE_ON_INITIALIZE_RATIO, NORMAL_DISPATCH_RATIO,
 };
 
-use polkadot_runtime_common::prod_or_fast;
-
 #[cfg(feature = "runtime-benchmarks")]
 use benchmark_helpers::DoNothingRouter;
 
@@ -647,7 +645,7 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const MaxExecutionHeadersToKeep: u32 = prod_or_fast!(8192 * 2, 1000);
+	pub const MaxExecutionHeadersToKeep: u32 = 8192 * 20;
 }
 
 impl snowbridge_pallet_ethereum_client::Config for Runtime {


### PR DESCRIPTION
### Motivations

The `MaxExecutionHeadersToKeep` here is the limit size to store execution headers which will be used to verify messages from Ethereum through Snowbridge, we prefer to increase it so that there will be enough time to respond for any potential fix/upgrade.

The change is already included in https://github.com/polkadot-fellows/runtimes/pull/130 and under review, so this is the companion one only for Rococo. 