### PR TITLE
refund non-used weight in xcm with respect to require_weight_at_most

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/reserve_transfer.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/reserve_transfer.rs
@@ -475,7 +475,7 @@ fn reserve_transfer_assets_from_system_para_to_para() {
 		ASSET_MIN_BALANCE,
 		false,
 		AssetHubRococoSender::get(),
-		Some(Weight::from_parts(152053000, 3675)),
+		Some(Weight::from_parts(152_053_000, 3_675)),
 		ASSET_MIN_BALANCE * 1_000_000,
 	);
 	PenpalA::force_create_and_mint_asset(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/reserve_transfer.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/reserve_transfer.rs
@@ -475,7 +475,7 @@ fn reserve_transfer_assets_from_system_para_to_para() {
 		ASSET_MIN_BALANCE,
 		false,
 		AssetHubRococoSender::get(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(152053000, 3675)),
 		ASSET_MIN_BALANCE * 1_000_000,
 	);
 	PenpalA::force_create_and_mint_asset(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/send.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/send.rs
@@ -24,7 +24,7 @@ fn send_transact_as_superuser_from_relay_to_system_para_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubRococoSender::get().into(),
-		Some(Weight::from_parts(152053000, 3675)),
+		Some(Weight::from_parts(152_053_000, 3_675)),
 	)
 }
 
@@ -42,7 +42,7 @@ fn send_xcm_from_para_to_system_para_paying_fee_with_assets_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		para_sovereign_account.clone(),
-		Some(Weight::from_parts(152053000, 3675)),
+		Some(Weight::from_parts(152_053_000, 3_675)),
 		ASSET_MIN_BALANCE * 1000000000,
 	);
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/send.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/send.rs
@@ -24,7 +24,7 @@ fn send_transact_as_superuser_from_relay_to_system_para_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubRococoSender::get().into(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(152053000, 3675)),
 	)
 }
 
@@ -42,7 +42,7 @@ fn send_xcm_from_para_to_system_para_paying_fee_with_assets_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		para_sovereign_account.clone(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(152053000, 3675)),
 		ASSET_MIN_BALANCE * 1000000000,
 	);
 
@@ -83,8 +83,8 @@ fn send_xcm_from_para_to_system_para_paying_fee_with_assets_works() {
 		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
 
 		AssetHubRococo::assert_xcmp_queue_success(Some(Weight::from_parts(
-			15_594_564_000,
-			562_893,
+			14_770_030_000,
+			366_568,
 		)));
 
 		assert_expected_events!(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/set_xcm_versions.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/set_xcm_versions.rs
@@ -67,7 +67,7 @@ fn system_para_sets_relay_xcm_supported_version() {
 	AssetHubRococo::execute_with(|| {
 		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
 
-		AssetHubRococo::assert_dmp_queue_complete(Some(Weight::from_parts(1_019_210_000, 200_000)));
+		AssetHubRococo::assert_dmp_queue_complete(Some(Weight::from_parts(122_414_000, 0)));
 
 		assert_expected_events!(
 			AssetHubRococo,

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/reserve_transfer.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/reserve_transfer.rs
@@ -485,7 +485,7 @@ fn reserve_transfer_assets_from_system_para_to_para() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubWestendSender::get(),
-		Some(Weight::from_parts(152053000, 3675)),
+		Some(Weight::from_parts(152_053_000, 3_675)),
 		ASSET_MIN_BALANCE * 1_000_000,
 	);
 	PenpalB::force_create_and_mint_asset(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/reserve_transfer.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/reserve_transfer.rs
@@ -485,7 +485,7 @@ fn reserve_transfer_assets_from_system_para_to_para() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubWestendSender::get(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(152053000, 3675)),
 		ASSET_MIN_BALANCE * 1_000_000,
 	);
 	PenpalB::force_create_and_mint_asset(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/send.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/send.rs
@@ -24,7 +24,7 @@ fn send_transact_as_superuser_from_relay_to_system_para_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubWestendSender::get().into(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(152053000, 3675)),
 	)
 }
 
@@ -42,7 +42,7 @@ fn send_xcm_from_para_to_system_para_paying_fee_with_assets_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		para_sovereign_account.clone(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(152053000, 3675)),
 		ASSET_MIN_BALANCE * 1000000000,
 	);
 
@@ -83,8 +83,8 @@ fn send_xcm_from_para_to_system_para_paying_fee_with_assets_works() {
 		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
 		AssetHubWestend::assert_xcmp_queue_success(Some(Weight::from_parts(
-			16_290_336_000,
-			562_893,
+			14_770_030_000,
+			366_568,
 		)));
 
 		assert_expected_events!(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/send.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/send.rs
@@ -24,7 +24,7 @@ fn send_transact_as_superuser_from_relay_to_system_para_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubWestendSender::get().into(),
-		Some(Weight::from_parts(152053000, 3675)),
+		Some(Weight::from_parts(152_053_000, 3_675)),
 	)
 }
 
@@ -42,7 +42,7 @@ fn send_xcm_from_para_to_system_para_paying_fee_with_assets_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		para_sovereign_account.clone(),
-		Some(Weight::from_parts(152053000, 3675)),
+		Some(Weight::from_parts(152_053_000, 3_675)),
 		ASSET_MIN_BALANCE * 1000000000,
 	);
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/set_xcm_versions.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/set_xcm_versions.rs
@@ -67,10 +67,7 @@ fn system_para_sets_relay_xcm_supported_version() {
 	AssetHubWestend::execute_with(|| {
 		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
-		AssetHubWestend::assert_dmp_queue_complete(Some(Weight::from_parts(
-			1_019_210_000,
-			200_000,
-		)));
+		AssetHubWestend::assert_dmp_queue_complete(Some(Weight::from_parts(122_414_000, 0)));
 
 		assert_expected_events!(
 			AssetHubWestend,

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -755,7 +755,8 @@ impl<Config: config::Config> XcmExecutor<Config> {
 						},
 					};
 				let actual_weight = maybe_actual_weight.unwrap_or(weight);
-				let surplus = weight.saturating_sub(actual_weight);
+
+				let surplus = require_weight_at_most.saturating_sub(actual_weight);
 				// We assume that the `Config::Weigher` will counts the `require_weight_at_most`
 				// for the estimate of how much weight this instruction will take. Now that we know
 				// that it's less, we credit it.

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -755,7 +755,6 @@ impl<Config: config::Config> XcmExecutor<Config> {
 						},
 					};
 				let actual_weight = maybe_actual_weight.unwrap_or(weight);
-
 				let surplus = require_weight_at_most.saturating_sub(actual_weight);
 				// We assume that the `Config::Weigher` will counts the `require_weight_at_most`
 				// for the estimate of how much weight this instruction will take. Now that we know

--- a/prdoc/pr_3612.prdoc
+++ b/prdoc/pr_3612.prdoc
@@ -7,7 +7,7 @@ doc:
      of the dispatched call minus the actual weight returned by executing it. This means that if the xcm-message contained
      a very large `require_weight_at_most` then this would be non-refunded.
 
-     This PR refunds the differencebetween `require_weight_at_most` and `actual_weight` instead
+     This PR refunds the difference between `require_weight_at_most` and `actual_weight` instead
 
 crates:
   - name: xcm-executor

--- a/prdoc/pr_3612.prdoc
+++ b/prdoc/pr_3612.prdoc
@@ -1,0 +1,13 @@
+title: "[xcm-executor] Refund non-used weight in xcm with respect to require_weight_at_most"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+     The `Transact` instruction in the xcm-executor was only refunding the weight difference between the weight hint
+     of the dispatched call minus the actual weight returned by executing it. This means that if the xcm-message contained
+     a very large `require_weight_at_most` then this would be non-refunded.
+
+     This PR refunds the differencebetween `require_weight_at_most` and `actual_weight` instead
+
+crates:
+  - name: xcm-executor


### PR DESCRIPTION
`Transact` was refunding only the difference between `weight` and `actual_weight` in the xcm-executor, which means it was only refunding if the extrinsic consumed less than the weight-hint. However a more fair approach would be that it  refunds the difference between `require_weight_at_most` and `actual_weight` since this is the difference between what the user provided as `max_weight` to spend in the Transact minus the `actual_weight` finally used