### PR TITLE
Make `penpal-runtime`'s `TrustedReserves` more connfigurable (#3564) (patch for 1.7.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11483,7 +11483,6 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "testnet-parachains-constants",
 ]
 
 [[package]]
@@ -12240,7 +12239,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -12419,7 +12418,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12922,7 +12921,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -13060,7 +13059,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "assert_matches",
  "bitflags 1.3.2",
@@ -13318,7 +13317,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -18956,7 +18955,7 @@ version = "2.0.0"
 
 [[package]]
 name = "staging-xcm"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -16,7 +16,8 @@
 mod genesis;
 pub use genesis::{genesis, ED, PARA_ID_A, PARA_ID_B};
 pub use penpal_runtime::xcm_config::{
-	LocalTeleportableToAssetHub, LocalTeleportableToAssetHubV3, XcmConfig,
+	CustomizableAssetFromSystemAssetHub, LocalTeleportableToAssetHub,
+	LocalTeleportableToAssetHubV3, XcmConfig,
 };
 
 // Substrate

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -18,6 +18,7 @@ use codec::{Decode, Encode};
 use emulated_integration_tests_common::xcm_emulator::ConvertLocation;
 use frame_support::pallet_prelude::TypeInfo;
 use hex_literal::hex;
+use rococo_system_emulated_network::penpal_emulated_chain::CustomizableAssetFromSystemAssetHub;
 use rococo_westend_system_emulated_network::BridgeHubRococoParaSender as BridgeHubRococoSender;
 use snowbridge_core::outbound::OperatingMode;
 use snowbridge_pallet_inbound_queue_fixtures::{
@@ -252,6 +253,16 @@ fn send_token_from_ethereum_to_penpal() {
 		(PenpalAReceiver::get(), INITIAL_FUND),
 		(PenpalASender::get(), INITIAL_FUND),
 	]);
+
+	PenpalA::execute_with(|| {
+		assert_ok!(<PenpalA as Chain>::System::set_storage(
+			<PenpalA as Chain>::RuntimeOrigin::root(),
+			vec![(
+				CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				Location::new(2, [GlobalConsensus(Ethereum { chain_id: CHAIN_ID })]).encode(),
+			)],
+		));
+	});
 
 	// The Weth asset location, identified by the contract address on Ethereum
 	let weth_asset_location: Location =

--- a/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
@@ -77,7 +77,6 @@ cumulus-primitives-utility = { path = "../../../../primitives/utility", default-
 pallet-collator-selection = { path = "../../../../pallets/collator-selection", default-features = false, version = "10.0.0" }
 parachain-info = { package = "staging-parachain-info", path = "../../../pallets/parachain-info", default-features = false, version = "0.8.0" }
 parachains-common = { path = "../../../common", default-features = false, version = "8.0.0" }
-testnet-parachains-constants = { path = "../../constants", default-features = false, features = ["rococo"], version = "1.0.0" }
 assets-common = { path = "../../assets/common", default-features = false, version = "0.8.0" }
 
 [features]
@@ -133,7 +132,6 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
-	"testnet-parachains-constants/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",

--- a/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
@@ -43,7 +43,6 @@ use pallet_xcm::XcmPassthrough;
 use polkadot_parachain_primitives::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
 use sp_runtime::traits::Zero;
-use testnet_parachains_constants::rococo::snowbridge::EthereumNetwork;
 use xcm::latest::prelude::*;
 #[allow(deprecated)]
 use xcm_builder::{
@@ -297,7 +296,13 @@ parameter_types! {
 		0,
 		[xcm::v3::Junction::PalletInstance(50), xcm::v3::Junction::GeneralIndex(TELEPORTABLE_ASSET_ID.into())]
 	);
-	pub EthereumLocation: Location = Location::new(2, [GlobalConsensus(EthereumNetwork::get())]);
+
+	/// The Penpal runtime is utilized for testing with various environment setups.
+	/// This storage item provides the opportunity to customize testing scenarios
+	/// by configuring the trusted asset from the `SystemAssetHub`.
+	///
+	/// By default, it is configured as a `SystemAssetHubLocation` and can be modified using `System::set_storage`.
+	pub storage CustomizableAssetFromSystemAssetHub: Location = SystemAssetHubLocation::get();
 }
 
 /// Accepts asset with ID `AssetLocation` and is coming from `Origin` chain.
@@ -312,11 +317,11 @@ impl<AssetLocation: Get<Location>, Origin: Get<Location>> ContainsPair<Asset, Lo
 	}
 }
 
-pub type Reserves = (
+pub type TrustedReserves = (
 	NativeAsset,
 	AssetsFrom<SystemAssetHubLocation>,
 	NativeAssetFrom<SystemAssetHubLocation>,
-	AssetPrefixFrom<EthereumLocation, SystemAssetHubLocation>,
+	AssetPrefixFrom<CustomizableAssetFromSystemAssetHub, SystemAssetHubLocation>,
 );
 pub type TrustedTeleporters =
 	(AssetFromChain<LocalTeleportableToAssetHub, SystemAssetHubLocation>,);
@@ -328,7 +333,7 @@ impl xcm_executor::Config for XcmConfig {
 	// How to withdraw and deposit an asset.
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = Reserves;
+	type IsReserve = TrustedReserves;
 	// no teleport trust established with other chains
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;


### PR DESCRIPTION
Backport of https://github.com/paritytech/polkadot-sdk/pull/3564

Expected patches for (1.7.0):
- penpal-runtime `0.15.1`