### PR TITLE
Make penpal-runtime's TrustedReserves more connfigurable (#3564) (patch for 1.8.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,20 +595,6 @@ dependencies = [
 
 [[package]]
 name = "ark-scale"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bd73bb6ddb72630987d37fa963e99196896c0d0ea81b7c894567e74a2f83af"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "ark-scale"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f69c00b3b529be29528a6f2fd5fa7b1790f8bed81b9cdca17e326538545a179"
@@ -619,21 +605,6 @@ dependencies = [
  "ark-std 0.4.0",
  "parity-scale-codec",
  "scale-info",
-]
-
-[[package]]
-name = "ark-secret-scalar"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript",
- "digest 0.10.7",
- "getrandom_or_panic",
- "zeroize",
 ]
 
 [[package]]
@@ -688,19 +659,6 @@ dependencies = [
  "num-traits",
  "rand",
  "rayon",
-]
-
-[[package]]
-name = "ark-transcript"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "rand_core 0.6.4",
- "sha3",
 ]
 
 [[package]]
@@ -804,7 +762,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-hub-rococo-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "asset-hub-rococo-runtime",
  "cumulus-primitives-core",
@@ -818,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "asset-hub-rococo-integration-tests"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "asset-hub-rococo-runtime",
@@ -843,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "asset-hub-rococo-runtime"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -908,8 +866,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "sp-weights",
@@ -923,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "asset-hub-westend-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "asset-hub-westend-runtime",
  "cumulus-primitives-core",
@@ -937,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "asset-hub-westend-integration-tests"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "asset-hub-westend-runtime",
@@ -965,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "asset-hub-westend-runtime"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -1027,8 +985,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -1042,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "asset-test-utils"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -1062,7 +1020,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
@@ -1072,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "assets-common"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1085,7 +1043,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -1308,29 +1266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bandersnatch_vrfs"
-version = "0.0.4"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "dleq_vrf",
- "fflonk",
- "merlin 3.0.0",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "ring 0.1.0",
- "sha2 0.10.7",
- "sp-ark-bls12-381",
- "sp-ark-ed-on-bls12-381-bandersnatch",
- "zeroize",
-]
-
-[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "13.0.0"
+version = "15.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "env_logger 0.9.3",
@@ -1623,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "bp-asset-hub-rococo"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-support",
@@ -1633,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "bp-asset-hub-westend"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-support",
@@ -1643,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "bp-bridge-hub-cumulus"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1652,12 +1587,12 @@ dependencies = [
  "frame-system",
  "polkadot-primitives",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-bridge-hub-kusama"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1665,12 +1600,12 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-bridge-hub-polkadot"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1678,12 +1613,12 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-bridge-hub-rococo"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1691,12 +1626,12 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-bridge-hub-westend"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1704,12 +1639,12 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-header-chain"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-runtime",
  "bp-test-utils",
@@ -1723,24 +1658,24 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-kusama"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-messages"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1751,12 +1686,12 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-parachains"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1767,24 +1702,24 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-polkadot"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-polkadot-bulletin"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1796,12 +1731,12 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-polkadot-core"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1814,12 +1749,12 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-relayers"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1829,24 +1764,24 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-rococo"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-runtime"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1862,14 +1797,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
  "trie-db",
 ]
 
 [[package]]
 name = "bp-test-utils"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1882,32 +1817,32 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "bp-westend"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
 dependencies = [
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1917,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-common"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1927,13 +1862,13 @@ dependencies = [
  "snowbridge-core",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "bridge-hub-rococo-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bridge-hub-common",
  "bridge-hub-rococo-runtime",
@@ -1946,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-rococo-integration-tests"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "asset-hub-rococo-runtime",
  "bp-messages",
@@ -1981,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-rococo-runtime"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "bp-asset-hub-rococo",
  "bp-asset-hub-westend",
@@ -2064,8 +1999,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -2079,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -2109,8 +2044,8 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -2118,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-westend-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bridge-hub-common",
  "bridge-hub-westend-runtime",
@@ -2131,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-westend-integration-tests"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "bp-messages",
  "bridge-hub-westend-runtime",
@@ -2153,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-westend-runtime"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "bp-asset-hub-rococo",
  "bp-asset-hub-westend",
@@ -2222,8 +2157,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -2238,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2266,7 +2201,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2713,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "collectives-westend-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "collectives-westend-runtime",
  "cumulus-primitives-core",
@@ -2726,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "collectives-westend-runtime"
-version = "3.0.0"
+version = "5.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -2785,8 +2720,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -2858,22 +2793,6 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "unicode-width",
-]
-
-[[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "fflonk",
- "getrandom_or_panic",
- "merlin 3.0.0",
- "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -2981,7 +2900,7 @@ checksum = "f272d0c4cf831b4fa80ee529c7707f76585986e910e1fbce1d7921970bc1a241"
 
 [[package]]
 name = "contracts-rococo-runtime"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -3030,8 +2949,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -3075,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "coretime-rococo-runtime"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -3125,8 +3044,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -3139,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "coretime-westend-runtime"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -3187,8 +3106,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -3542,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "clap 4.5.1",
  "parity-scale-codec",
@@ -3558,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3582,13 +3501,13 @@ dependencies = [
  "sp-maybe-compressed-blob",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3629,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3653,7 +3572,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-trie",
  "substrate-prometheus-endpoint",
  "tracing",
@@ -3661,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3675,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3697,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3730,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3745,15 +3664,15 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-trie",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3781,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -3816,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3828,12 +3747,12 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3845,14 +3764,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "assert_matches",
  "bytes",
@@ -3881,14 +3800,14 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-trie",
  "sp-version",
  "staging-xcm",
@@ -3908,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3916,12 +3835,12 @@ dependencies = [
  "pallet-session",
  "parity-scale-codec",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-solo-to-para"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3931,12 +3850,12 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3945,13 +3864,13 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -3970,7 +3889,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3978,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-ping"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3987,13 +3906,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -4001,12 +3920,12 @@ dependencies = [
  "sp-api",
  "sp-consensus-aura",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -4015,14 +3934,14 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
  "staging-xcm",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4032,37 +3951,37 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-io",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "sp-state-machine",
  "sp-trie",
 ]
 
 [[package]]
 name = "cumulus-primitives-timestamp"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "futures",
  "parity-scale-codec",
  "sp-inherents",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -4073,7 +3992,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -4081,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4109,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4126,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-trait",
@@ -4166,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -4193,7 +4112,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 19.0.0",
+ "sp-storage",
  "sp-version",
  "thiserror",
  "tokio",
@@ -4236,14 +4155,14 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
@@ -4274,7 +4193,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -4348,7 +4267,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-test-client",
  "substrate-test-utils",
  "tempfile",
@@ -4683,22 +4602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
 
 [[package]]
-name = "dleq_vrf"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ring-vrf?rev=e9782f9#e9782f938629c90f3adb3fff2358bc8d1386af3e"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-scale 0.0.12",
- "ark-secret-scalar",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript",
- "arrayvec 0.7.4",
- "zeroize",
-]
-
-[[package]]
 name = "dlmalloc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4886,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "3.0.0"
+version = "5.0.0"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -5032,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "erasure_coding_fuzzer"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "honggfuzz",
  "polkadot-erasure-coding",
@@ -5279,19 +5182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fflonk"
-version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#1e854f35e9a65d08b11a86291405cdc95baa0a35"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "merlin 3.0.0",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5426,7 +5316,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame"
-version = "0.0.1-dev"
+version = "0.1.0"
 dependencies = [
  "docify",
  "frame-executive",
@@ -5448,14 +5338,14 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-support",
@@ -5474,15 +5364,15 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "32.0.0"
+version = "34.0.0"
 dependencies = [
  "Inflector",
  "array-bytes 6.1.0",
@@ -5514,22 +5404,22 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 19.0.0",
+ "sp-storage",
  "sp-trie",
- "sp-wasm-interface 20.0.0",
+ "sp-wasm-interface",
  "thiserror",
  "thousands",
 ]
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
-version = "18.0.0"
+version = "20.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5538,7 +5428,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
@@ -5559,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5572,12 +5462,12 @@ dependencies = [
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-election-solution-type-fuzzer"
-version = "2.0.0-alpha.5"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "frame-election-provider-solution-type",
@@ -5594,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-support",
@@ -5609,8 +5499,8 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-version",
 ]
 
@@ -5628,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "frame-remote-externalities"
-version = "0.35.0"
+version = "0.37.0"
 dependencies = [
  "futures",
  "indicatif",
@@ -5641,7 +5531,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "spinners",
  "substrate-rpc-client",
  "tokio",
@@ -5650,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "aquamarine",
  "array-bytes 6.1.0",
@@ -5677,7 +5567,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0",
+ "sp-debug-derive",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -5685,8 +5575,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -5694,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5713,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "10.0.0"
+version = "11.0.0"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.0.0",
@@ -5724,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "11.0.0"
+version = "12.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5733,7 +5623,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-test"
-version = "3.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -5753,7 +5643,7 @@ dependencies = [
  "sp-metadata-ir",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-version",
  "static_assertions",
  "trybuild",
@@ -5761,7 +5651,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-test-compile-pass"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5774,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-test-pallet"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5795,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "cfg-if",
  "criterion 0.4.0",
@@ -5806,10 +5696,10 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-version",
  "sp-weights",
  "substrate-test-runtime-client",
@@ -5817,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5825,16 +5715,16 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-version",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5842,13 +5732,13 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
@@ -6022,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "generate-bags"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "chrono",
  "frame-election-provider-support",
@@ -6144,7 +6034,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "glutton-westend-runtime"
-version = "3.0.0"
+version = "5.0.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -6176,8 +6066,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -7010,7 +6900,7 @@ checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
 
 [[package]]
 name = "kitchensink-runtime"
-version = "3.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-pallet-pov",
@@ -7122,8 +7012,8 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-statement-store",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "static_assertions",
@@ -8105,7 +7995,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minimal-node"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "frame",
@@ -8202,7 +8092,7 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "futures",
  "log",
@@ -8218,14 +8108,14 @@ dependencies = [
  "sp-core",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-test-runtime-client",
  "tokio",
 ]
 
 [[package]]
 name = "mmr-rpc"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8573,7 +8463,7 @@ checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "node-bench"
-version = "0.9.0-dev"
+version = "0.1.0"
 dependencies = [
  "array-bytes 6.1.0",
  "clap 4.5.1",
@@ -8602,7 +8492,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-trie",
  "tempfile",
 ]
@@ -8617,7 +8507,7 @@ dependencies = [
 
 [[package]]
 name = "node-rpc"
-version = "3.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8651,7 +8541,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime-generate-bags"
-version = "3.0.0"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "generate-bags",
@@ -8660,7 +8550,7 @@ dependencies = [
 
 [[package]]
 name = "node-template"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "frame-benchmarking",
@@ -8704,7 +8594,7 @@ dependencies = [
 
 [[package]]
 name = "node-template-release"
-version = "3.0.0"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "flate2",
@@ -8718,7 +8608,7 @@ dependencies = [
 
 [[package]]
 name = "node-template-runtime"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -8748,8 +8638,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -8757,7 +8647,7 @@ dependencies = [
 
 [[package]]
 name = "node-testing"
-version = "3.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "fs_extra",
@@ -9068,7 +8958,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pallet-alliance"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-benchmarking",
@@ -9084,12 +8974,12 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9104,12 +8994,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9122,13 +9012,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "pallet-asset-rate"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9139,12 +9029,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9160,13 +9050,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9178,12 +9068,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-atomic-swap"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9193,12 +9083,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-aura"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9211,12 +9101,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9228,12 +9118,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-authorship"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9243,12 +9133,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-babe"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9271,12 +9161,12 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-bags-list"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9291,13 +9181,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-bags-list-fuzzer"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-election-provider-support",
  "honggfuzz",
@@ -9307,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list-remote-tests"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-election-provider-support",
  "frame-remote-externalities",
@@ -9318,14 +9208,14 @@ dependencies = [
  "pallet-staking",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9339,12 +9229,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -9367,12 +9257,12 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "binary-merkle-tree",
@@ -9392,12 +9282,12 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-bounties"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9410,12 +9300,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge-grandpa"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9431,13 +9321,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -9452,12 +9342,12 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9474,13 +9364,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "bp-messages",
  "bp-relayers",
@@ -9496,12 +9386,12 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9513,12 +9403,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-child-bounties"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9532,12 +9422,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-collator-selection"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9556,13 +9446,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-collective"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9573,12 +9463,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-collective-content"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9588,12 +9478,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
@@ -9627,8 +9517,8 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -9638,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-fixtures"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "frame-system",
@@ -9653,7 +9543,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-mock-network"
-version = "3.0.0"
+version = "5.0.0"
 dependencies = [
  "assert_matches",
  "frame-support",
@@ -9681,8 +9571,8 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9691,7 +9581,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-proc-macro"
-version = "18.0.0"
+version = "20.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9700,7 +9590,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-uapi"
-version = "5.0.0"
+version = "7.0.0"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9711,7 +9601,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9725,12 +9615,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-core-fellowship"
-version = "12.0.0"
+version = "14.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9743,12 +9633,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-default-config-example"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9757,12 +9647,12 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-democracy"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9777,12 +9667,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-dev-mode"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9793,12 +9683,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-election-provider-e2e-test"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -9819,13 +9709,13 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9843,14 +9733,14 @@ dependencies = [
  "sp-io",
  "sp-npos-elections",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9858,12 +9748,12 @@ dependencies = [
  "parity-scale-codec",
  "sp-npos-elections",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9877,14 +9767,14 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "substrate-test-utils",
 ]
 
 [[package]]
 name = "pallet-example-basic"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9896,12 +9786,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-example-frame-crate"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "frame",
  "parity-scale-codec",
@@ -9910,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-example-kitchensink"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9922,12 +9812,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-example-offchain-worker"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9939,12 +9829,12 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-example-split"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9954,12 +9844,12 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-example-tasks"
-version = "1.0.0"
+version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9970,12 +9860,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-examples"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "pallet-default-config-example",
  "pallet-dev-mode",
@@ -9989,7 +9879,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10007,14 +9897,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "substrate-test-utils",
 ]
 
 [[package]]
 name = "pallet-glutton"
-version = "14.0.0"
+version = "16.0.0"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10027,12 +9917,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "finality-grandpa",
  "frame-benchmarking",
@@ -10057,12 +9947,12 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-identity"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10076,12 +9966,12 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-im-online"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10096,12 +9986,12 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-indices"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10113,12 +10003,12 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "16.0.0"
+version = "18.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10128,12 +10018,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-lottery"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10145,12 +10035,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-membership"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10161,12 +10051,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-message-queue"
-version = "31.0.0"
+version = "33.0.0"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10183,14 +10073,14 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-weights",
 ]
 
 [[package]]
 name = "pallet-mixnet"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10204,12 +10094,12 @@ dependencies = [
  "sp-io",
  "sp-mixnet",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "env_logger 0.9.3",
@@ -10224,12 +10114,12 @@ dependencies = [
  "sp-io",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-multisig"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10240,12 +10130,12 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10259,12 +10149,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nfts"
-version = "22.0.0"
+version = "24.0.0"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10278,22 +10168,22 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nfts-runtime-api"
-version = "14.0.0"
+version = "16.0.0"
 dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nis"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10305,12 +10195,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-node-authorization"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10320,12 +10210,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "25.0.0"
+version = "27.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10337,13 +10227,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10360,14 +10250,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-fuzzer"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10377,22 +10267,22 @@ dependencies = [
  "rand",
  "sp-io",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
  "sp-api",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-test-staking"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -10410,13 +10300,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-offences"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10429,12 +10319,12 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10456,12 +10346,12 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-paged-list"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10473,7 +10363,7 @@ dependencies = [
  "sp-io",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
@@ -10489,7 +10379,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parachain-template"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10504,7 +10394,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10519,12 +10409,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-preimage"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10536,12 +10426,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-proxy"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10553,12 +10443,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10571,12 +10461,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-recovery"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10587,12 +10477,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10609,12 +10499,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-remark"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10625,12 +10515,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-offences"
-version = "25.0.0"
+version = "27.0.0"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -10646,12 +10536,12 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "4.0.0"
+version = "6.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10660,12 +10550,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-safe-mode"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10680,12 +10570,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-salary"
-version = "13.0.0"
+version = "15.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10698,31 +10588,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
-]
-
-[[package]]
-name = "pallet-sassafras"
-version = "0.3.5-dev"
-dependencies = [
- "array-bytes 6.1.0",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-consensus-sassafras",
- "sp-core",
- "sp-crypto-hashing",
- "sp-io",
- "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-scheduler"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10735,14 +10606,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-weights",
  "substrate-test-utils",
 ]
 
 [[package]]
 name = "pallet-scored-pool"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10752,12 +10623,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10772,13 +10643,13 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10796,24 +10667,24 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-skip-feeless-payment"
-version = "3.0.0"
+version = "5.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-society"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10829,12 +10700,12 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-staking"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10857,8 +10728,8 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "substrate-test-utils",
 ]
 
@@ -10875,7 +10746,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "19.0.0"
+version = "21.0.0"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10883,7 +10754,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "14.0.0"
+version = "16.0.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10892,7 +10763,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-remote-externalities",
@@ -10907,8 +10778,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "substrate-state-trie-migration-rpc",
  "thousands",
  "tokio",
@@ -10917,7 +10788,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-statement"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10930,12 +10801,12 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-statement-store",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10946,12 +10817,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-template"
-version = "4.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10961,12 +10832,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10979,14 +10850,14 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11000,13 +10871,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11018,12 +10889,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "30.0.0"
+version = "32.0.0"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11038,7 +10909,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11049,7 +10920,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-storage"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-benchmarking",
@@ -11064,13 +10935,13 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-storage-proof",
 ]
 
 [[package]]
 name = "pallet-treasury"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11085,12 +10956,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-tx-pause"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11104,12 +10975,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-uniques"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11121,12 +10992,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-utility"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11140,12 +11011,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-vesting"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11157,12 +11028,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-whitelist"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11175,12 +11046,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-xcm"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11197,7 +11068,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11205,7 +11076,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11221,8 +11092,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11230,7 +11101,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -11247,7 +11118,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -11255,7 +11126,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11267,7 +11138,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -11332,7 +11203,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-template-runtime"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -11377,7 +11248,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -11389,7 +11260,7 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11410,7 +11281,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -11419,7 +11290,7 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -11440,8 +11311,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -11643,7 +11514,7 @@ dependencies = [
 
 [[package]]
 name = "penpal-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
@@ -11657,7 +11528,7 @@ dependencies = [
 
 [[package]]
 name = "penpal-runtime"
-version = "0.14.0"
+version = "0.16.0"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",
@@ -11705,8 +11576,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -11714,7 +11585,6 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "testnet-parachains-constants",
 ]
 
 [[package]]
@@ -11754,7 +11624,7 @@ dependencies = [
 
 [[package]]
 name = "people-rococo-runtime"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -11804,8 +11674,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -11853,7 +11723,7 @@ dependencies = [
 
 [[package]]
 name = "people-westend-runtime"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -11902,8 +11772,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -12065,7 +11935,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot"
-version = "6.0.0"
+version = "8.0.0"
 dependencies = [
  "assert_cmd",
  "color-eyre",
@@ -12086,7 +11956,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -12115,7 +11985,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -12142,7 +12012,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -12164,14 +12034,14 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-keystore",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12202,7 +12072,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "cfg-if",
  "clap 4.5.1",
@@ -12232,7 +12102,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -12262,18 +12132,18 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-channel",
@@ -12299,14 +12169,14 @@ dependencies = [
  "sp-application-crypto",
  "sp-keyring",
  "sp-keystore",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "criterion 0.4.0",
  "parity-scale-codec",
@@ -12320,7 +12190,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12345,13 +12215,13 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-keyring",
  "sp-keystore",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -12380,7 +12250,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "futures",
@@ -12401,7 +12271,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12445,7 +12315,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -12475,7 +12345,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -12496,14 +12366,14 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-keystore",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12519,7 +12389,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -12544,7 +12414,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "futures",
  "maplit",
@@ -12564,7 +12434,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "futures",
@@ -12585,7 +12455,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "fatality",
@@ -12606,14 +12476,14 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-keystore",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -12629,7 +12499,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "6.0.0"
+version = "8.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
@@ -12654,7 +12524,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12674,7 +12544,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "always-assert",
  "array-bytes 6.1.0",
@@ -12707,7 +12577,7 @@ dependencies = [
  "slotmap",
  "sp-core",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0",
+ "sp-wasm-interface",
  "tempfile",
  "test-parachain-adder",
  "test-parachain-halt",
@@ -12718,7 +12588,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12741,7 +12611,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "cfg-if",
@@ -12759,9 +12629,9 @@ dependencies = [
  "seccompiler",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-io",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "tempfile",
  "thiserror",
  "tracing-gum",
@@ -12769,7 +12639,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-execute-worker"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "cfg-if",
  "cpu-time",
@@ -12784,7 +12654,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-prepare-worker"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -12807,7 +12677,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -12828,7 +12698,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "lazy_static",
  "log",
@@ -12845,7 +12715,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_cmd",
  "bs58 0.5.0",
@@ -12871,7 +12741,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -12895,7 +12765,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12918,7 +12788,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -12927,7 +12797,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -12948,7 +12818,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12975,7 +12845,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13018,7 +12888,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13044,7 +12914,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-bin"
-version = "4.0.0"
+version = "6.0.0"
 dependencies = [
  "assert_cmd",
  "asset-hub-rococo-runtime",
@@ -13123,9 +12993,9 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
  "staging-xcm",
@@ -13141,7 +13011,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "6.0.0"
+version = "8.0.0"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -13151,13 +13021,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-weights",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -13178,12 +13048,12 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "polkadot-primitives-test-helpers"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "polkadot-primitives",
  "rand",
@@ -13195,7 +13065,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -13227,7 +13097,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -13274,7 +13144,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -13283,19 +13153,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "bs58 0.5.0",
  "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "bitflags 1.3.2",
@@ -13345,8 +13215,8 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
@@ -13355,7 +13225,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk-docs"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -13395,7 +13265,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13505,7 +13375,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
- "sp-storage 19.0.0",
+ "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
@@ -13520,7 +13390,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "arrayvec 0.7.4",
  "assert_matches",
@@ -13547,14 +13417,14 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-staking",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13564,7 +13434,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-subsystem-bench"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13631,7 +13501,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-client"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "futures",
@@ -13660,7 +13530,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-malus"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -13691,7 +13561,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-runtime"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -13743,7 +13613,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -13757,7 +13627,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-service"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-system",
  "futures",
@@ -13809,7 +13679,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-voter-bags"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "clap 4.5.1",
  "generate-bags",
@@ -14776,14 +14646,14 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "remote-ext-tests-bags-list"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "frame-system",
  "log",
  "pallet-bags-list-remote-tests",
  "sp-core",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "tokio",
  "westend-runtime",
  "westend-runtime-constants",
@@ -14846,22 +14716,6 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle 2.5.0",
-]
-
-[[package]]
-name = "ring"
-version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "blake2 0.10.6",
- "common",
- "fflonk",
- "merlin 3.0.0",
 ]
 
 [[package]]
@@ -14930,7 +14784,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "emulated-integration-tests-common",
  "parachains-common",
@@ -14946,7 +14800,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-parachain-runtime"
-version = "0.6.0"
+version = "0.8.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -14984,7 +14838,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -14997,7 +14851,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -15083,9 +14937,9 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -15100,7 +14954,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15115,7 +14969,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-system-emulated-network"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "asset-hub-rococo-emulated-chain",
  "bridge-hub-rococo-emulated-chain",
@@ -15127,7 +14981,7 @@ dependencies = [
 
 [[package]]
 name = "rococo-westend-system-emulated-network"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "asset-hub-rococo-emulated-chain",
  "asset-hub-westend-emulated-chain",
@@ -15519,17 +15373,17 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 20.0.0",
+ "sp-wasm-interface",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -15552,7 +15406,7 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "thiserror",
@@ -15560,7 +15414,7 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -15585,7 +15439,7 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15601,7 +15455,7 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "docify",
@@ -15640,7 +15494,7 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.36.0"
+version = "0.38.0"
 dependencies = [
  "array-bytes 6.1.0",
  "bip39",
@@ -15674,7 +15528,7 @@ dependencies = [
  "sp-keystore",
  "sp-panic-handler",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-version",
  "tempfile",
  "thiserror",
@@ -15683,7 +15537,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "fnv",
  "futures",
@@ -15698,11 +15552,11 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-database",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-runtime",
  "sp-state-machine",
  "sp-statement-store",
- "sp-storage 19.0.0",
+ "sp-storage",
  "sp-test-primitives",
  "sp-trie",
  "substrate-prometheus-endpoint",
@@ -15712,7 +15566,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.35.0"
+version = "0.37.0"
 dependencies = [
  "array-bytes 6.1.0",
  "criterion 0.4.0",
@@ -15737,7 +15591,7 @@ dependencies = [
  "sp-database",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-trie",
  "substrate-test-runtime-client",
  "tempfile",
@@ -15745,7 +15599,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -15770,7 +15624,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -15798,7 +15652,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
@@ -15808,7 +15662,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15841,7 +15695,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "thiserror",
@@ -15850,7 +15704,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15878,7 +15732,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "13.0.0"
+version = "15.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -15910,7 +15764,7 @@ dependencies = [
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
@@ -15921,7 +15775,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "13.0.0"
+version = "15.0.0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15942,7 +15796,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15954,7 +15808,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.19.0"
+version = "0.21.0"
 dependencies = [
  "ahash 0.8.8",
  "array-bytes 6.1.0",
@@ -15994,7 +15848,7 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "thiserror",
@@ -16003,7 +15857,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.19.0"
+version = "0.21.0"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -16027,7 +15881,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.35.0"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -16065,7 +15919,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-pow"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -16089,7 +15943,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -16112,7 +15966,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.32.0"
+version = "0.34.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
@@ -16131,17 +15985,17 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-io",
  "sp-maybe-compressed-blob",
  "sp-panic-handler",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "sp-state-machine",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 20.0.0",
+ "sp-wasm-interface",
  "substrate-test-runtime",
  "tempfile",
  "tracing",
@@ -16151,18 +16005,18 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.29.0"
+version = "0.31.0"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0",
+ "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.29.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -16177,8 +16031,8 @@ dependencies = [
  "sc-executor-common",
  "sc-runtime-test",
  "sp-io",
- "sp-runtime-interface 24.0.0",
- "sp-wasm-interface 20.0.0",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "tempfile",
  "wasmtime",
  "wat",
@@ -16186,7 +16040,7 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "ansi_term",
  "futures",
@@ -16202,7 +16056,7 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "25.0.0"
+version = "27.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "parking_lot 0.12.1",
@@ -16216,7 +16070,7 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -16244,7 +16098,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
@@ -16280,7 +16134,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-test-primitives",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
@@ -16297,7 +16151,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-bitswap"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "async-channel",
  "cid",
@@ -16323,7 +16177,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -16340,7 +16194,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "ahash 0.8.8",
  "async-trait",
@@ -16363,7 +16217,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -16383,7 +16237,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-statement"
-version = "0.16.0"
+version = "0.18.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -16401,7 +16255,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -16431,7 +16285,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-test-primitives",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "thiserror",
@@ -16441,7 +16295,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-test"
-version = "0.8.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -16463,7 +16317,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
  "tokio",
@@ -16471,7 +16325,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "array-bytes 6.1.0",
  "futures",
@@ -16489,7 +16343,7 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "bytes",
@@ -16517,11 +16371,11 @@ dependencies = [
  "sp-api",
  "sp-consensus",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-keystore",
  "sp-offchain",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-test-runtime-client",
  "threadpool",
  "tokio",
@@ -16538,7 +16392,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "assert_matches",
  "env_logger 0.9.3",
@@ -16580,7 +16434,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16599,7 +16453,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "11.0.0"
+version = "13.0.0"
 dependencies = [
  "futures",
  "governor",
@@ -16617,7 +16471,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
@@ -16644,7 +16498,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-maybe-compressed-blob",
  "sp-rpc",
  "sp-runtime",
@@ -16659,19 +16513,19 @@ dependencies = [
 
 [[package]]
 name = "sc-runtime-test"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
+ "sp-runtime-interface",
+ "sp-std",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "sc-service"
-version = "0.35.0"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "directories",
@@ -16712,12 +16566,12 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-keystore",
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
- "sp-storage 19.0.0",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
@@ -16735,7 +16589,7 @@ dependencies = [
 
 [[package]]
 name = "sc-service-test"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -16760,8 +16614,8 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
+ "sp-storage",
+ "sp-tracing",
  "sp-trie",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
@@ -16771,7 +16625,7 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.30.0"
+version = "0.32.0"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16781,7 +16635,7 @@ dependencies = [
 
 [[package]]
 name = "sc-statement-store"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "env_logger 0.9.3",
  "log",
@@ -16801,7 +16655,7 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.16.0"
+version = "0.18.0"
 dependencies = [
  "clap 4.5.1",
  "fs4",
@@ -16813,7 +16667,7 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16831,7 +16685,7 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -16847,12 +16701,12 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "15.0.0"
+version = "17.0.0"
 dependencies = [
  "chrono",
  "futures",
@@ -16870,7 +16724,7 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -16891,7 +16745,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "thiserror",
  "tracing",
  "tracing-log 0.1.3",
@@ -16910,7 +16764,7 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
@@ -16933,7 +16787,7 @@ dependencies = [
  "sp-core",
  "sp-crypto-hashing",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime",
@@ -16944,7 +16798,7 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -16960,7 +16814,7 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "14.0.0"
+version = "16.0.0"
 dependencies = [
  "async-channel",
  "futures",
@@ -17197,7 +17051,7 @@ dependencies = [
 
 [[package]]
 name = "seedling-runtime"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -17223,7 +17077,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -17507,7 +17361,7 @@ dependencies = [
 
 [[package]]
 name = "shell-runtime"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -17532,7 +17386,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -17619,13 +17473,13 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
@@ -17794,7 +17648,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-beacon-primitives"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -17810,7 +17664,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "ssz_rs",
  "ssz_rs_derive",
  "static_assertions",
@@ -17818,7 +17672,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -17834,14 +17688,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
 ]
 
 [[package]]
 name = "snowbridge-ethereum"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -17859,7 +17713,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "wasm-bindgen-test",
 ]
 
@@ -17880,7 +17734,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-merkle-tree"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "array-bytes 4.2.0",
  "env_logger 0.9.3",
@@ -17895,7 +17749,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17903,13 +17757,13 @@ dependencies = [
  "snowbridge-outbound-queue-merkle-tree",
  "sp-api",
  "sp-core",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "bp-runtime",
  "byte-slice-cast",
@@ -17933,7 +17787,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "ssz_rs",
  "ssz_rs_derive",
  "static_assertions",
@@ -17941,7 +17795,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17950,12 +17804,12 @@ dependencies = [
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17980,7 +17834,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -17988,7 +17842,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -17997,12 +17851,12 @@ dependencies = [
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -18021,13 +17875,13 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
 ]
 
 [[package]]
 name = "snowbridge-pallet-system"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "ethabi-decode",
  "frame-benchmarking",
@@ -18047,7 +17901,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -18055,7 +17909,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-router-primitives"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "ethabi-decode",
  "frame-support",
@@ -18070,7 +17924,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -18078,7 +17932,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-common"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -18086,7 +17940,7 @@ dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
  "sp-arithmetic",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -18094,7 +17948,7 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-test-common"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "assets-common",
  "bridge-hub-test-utils",
@@ -18158,8 +18012,8 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -18171,13 +18025,13 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-system-runtime-api"
-version = "0.0.0"
+version = "0.2.0"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
  "sp-api",
  "sp-core",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
 ]
 
@@ -18220,7 +18074,7 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "hash-db",
  "log",
@@ -18228,12 +18082,12 @@ dependencies = [
  "scale-info",
  "sp-api-proc-macro",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "sp-state-machine",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-test-primitives",
  "sp-trie",
  "sp-version",
@@ -18242,7 +18096,7 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "Inflector",
  "assert_matches",
@@ -18256,7 +18110,7 @@ dependencies = [
 
 [[package]]
 name = "sp-api-test"
-version = "2.0.1"
+version = "0.1.0"
 dependencies = [
  "criterion 0.4.0",
  "futures",
@@ -18270,7 +18124,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-version",
  "static_assertions",
  "substrate-test-runtime-client",
@@ -18279,19 +18133,19 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "30.0.0"
+version = "32.0.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-application-crypto-test"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "sp-api",
  "sp-application-crypto",
@@ -18302,7 +18156,7 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "23.0.0"
+version = "25.0.0"
 dependencies = [
  "criterion 0.4.0",
  "integer-sqrt",
@@ -18313,13 +18167,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing",
- "sp-std 14.0.0",
+ "sp-std",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-arithmetic-fuzzer"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "arbitrary",
  "fraction",
@@ -18329,48 +18183,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-ark-bls12-381"
-version = "0.4.2"
-source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
-dependencies = [
- "ark-bls12-381-ext",
- "sp-crypto-ec-utils 0.4.1",
-]
-
-[[package]]
-name = "sp-ark-ed-on-bls12-381-bandersnatch"
-version = "0.4.2"
-source = "git+https://github.com/paritytech/arkworks-substrate#caa2eed74beb885dd07c7db5f916f2281dad818f"
-dependencies = [
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "sp-crypto-ec-utils 0.4.1",
-]
-
-[[package]]
 name = "sp-authority-discovery"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "futures",
  "log",
@@ -18387,7 +18223,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.32.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -18402,7 +18238,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.32.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18412,13 +18248,13 @@ dependencies = [
  "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.32.0"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18430,13 +18266,13 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "13.0.0"
+version = "15.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "lazy_static",
@@ -18451,14 +18287,14 @@ dependencies = [
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "strum 0.24.1",
  "w3f-bls",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "13.0.0"
+version = "15.0.0"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -18470,52 +18306,36 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-consensus-pow"
-version = "0.32.0"
+version = "0.34.0"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
-]
-
-[[package]]
-name = "sp-consensus-sassafras"
-version = "0.3.4-dev"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-core",
- "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.32.0"
+version = "0.34.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-core"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "array-bytes 6.1.0",
- "bandersnatch_vrfs",
  "bip39",
  "bitflags 1.3.2",
  "blake2 0.10.6",
@@ -18546,11 +18366,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing",
- "sp-debug-derive 14.0.0",
- "sp-externalities 0.25.0",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -18561,7 +18381,7 @@ dependencies = [
 
 [[package]]
 name = "sp-core-fuzz"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "lazy_static",
  "libfuzzer-sys",
@@ -18571,22 +18391,21 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "sp-crypto-hashing",
 ]
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "sp-crypto-hashing-proc-macro",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
-version = "0.4.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
+version = "0.12.0"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -18599,34 +18418,14 @@ dependencies = [
  "ark-ed-on-bls12-377-ext",
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale 0.0.11",
- "sp-runtime-interface 17.0.0",
- "sp-std 8.0.0",
-]
-
-[[package]]
-name = "sp-crypto-ec-utils"
-version = "0.10.0"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-377-ext",
- "ark-bls12-381",
- "ark-bls12-381-ext",
- "ark-bw6-761",
- "ark-bw6-761-ext",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-377-ext",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale 0.0.12",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
+ "ark-scale",
+ "sp-runtime-interface",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-crypto-hashing"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18640,7 +18439,7 @@ dependencies = [
 
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -18657,16 +18456,6 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.50",
-]
-
-[[package]]
-name = "sp-debug-derive"
 version = "14.0.0"
 dependencies = [
  "proc-macro2",
@@ -18676,38 +18465,27 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
+version = "0.27.0"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 8.0.0",
- "sp-storage 13.0.0",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "serde_json",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -18715,13 +18493,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-io"
-version = "30.0.0"
+version = "32.0.0"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -18732,12 +18510,12 @@ dependencies = [
  "secp256k1",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-keystore",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -18745,7 +18523,7 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "31.0.0"
+version = "33.0.0"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -18754,14 +18532,14 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand",
  "rand_chacha 0.2.2",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
 ]
 
 [[package]]
@@ -18779,23 +18557,23 @@ dependencies = [
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-mixnet"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "ckb-merkle-mountain-range",
@@ -18805,15 +18583,15 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-core",
- "sp-debug-derive 14.0.0",
+ "sp-debug-derive",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "parity-scale-codec",
  "rand",
@@ -18822,13 +18600,13 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "substrate-test-utils",
 ]
 
 [[package]]
 name = "sp-npos-elections-fuzzer"
-version = "2.0.0-alpha.5"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "honggfuzz",
@@ -18839,7 +18617,7 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18857,7 +18635,7 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -18867,7 +18645,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "31.0.1"
+version = "33.0.0"
 dependencies = [
  "docify",
  "either",
@@ -18887,8 +18665,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-weights",
  "substrate-test-runtime-client",
  "zstd 0.12.4",
@@ -18896,25 +18674,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.19.0",
- "sp-runtime-interface-proc-macro 11.0.0",
- "sp-std 8.0.0",
- "sp-storage 13.0.0",
- "sp-tracing 10.0.0",
- "sp-wasm-interface 14.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
+version = "26.0.0"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18923,34 +18683,22 @@ dependencies = [
  "primitive-types",
  "rustversion",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-io",
- "sp-runtime-interface-proc-macro 17.0.0",
+ "sp-runtime-interface-proc-macro",
  "sp-runtime-interface-test-wasm",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
  "trybuild",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
-dependencies = [
- "Inflector",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.50",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "Inflector",
  "expander 2.0.0",
@@ -18962,13 +18710,13 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-test"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "sc-executor",
  "sc-executor-common",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "sp-runtime-interface-test-wasm",
  "sp-runtime-interface-test-wasm-deprecated",
  "sp-state-machine",
@@ -18978,29 +18726,29 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-test-wasm"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "sp-core",
  "sp-io",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
+ "sp-runtime-interface",
+ "sp-std",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "sp-runtime-interface-test-wasm-deprecated"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "sp-core",
  "sp-io",
- "sp-runtime-interface 24.0.0",
+ "sp-runtime-interface",
  "substrate-wasm-builder",
 ]
 
 [[package]]
 name = "sp-session"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -19009,12 +18757,12 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-staking"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -19022,12 +18770,12 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.35.0"
+version = "0.37.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
@@ -19039,10 +18787,10 @@ dependencies = [
  "rand",
  "smallvec",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-panic-handler",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
  "thiserror",
  "tracing",
@@ -19051,7 +18799,7 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "curve25519-dalek 4.1.2",
@@ -19065,18 +18813,13 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-runtime",
- "sp-runtime-interface 24.0.0",
- "sp-std 14.0.0",
+ "sp-runtime-interface",
+ "sp-std",
  "thiserror",
  "x25519-dalek 2.0.0",
 ]
-
-[[package]]
-name = "sp-std"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
 
 [[package]]
 name = "sp-std"
@@ -19084,32 +18827,19 @@ version = "14.0.0"
 
 [[package]]
 name = "sp-storage"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
+version = "20.0.0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 8.0.0",
- "sp-std 8.0.0",
-]
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0",
- "sp-std 14.0.0",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-test-primitives"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -19117,31 +18847,19 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-timestamp"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "thiserror",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
-dependencies = [
- "parity-scale-codec",
- "sp-std 8.0.0",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -19149,7 +18867,7 @@ name = "sp-tracing"
 version = "16.0.0"
 dependencies = [
  "parity-scale-codec",
- "sp-std 14.0.0",
+ "sp-std",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.2.25",
@@ -19157,7 +18875,7 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -19165,7 +18883,7 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "26.0.0"
+version = "28.0.0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -19173,13 +18891,13 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "sp-trie"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "ahash 0.8.8",
  "array-bytes 6.1.0",
@@ -19194,9 +18912,9 @@ dependencies = [
  "scale-info",
  "schnellru",
  "sp-core",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "thiserror",
  "tracing",
  "trie-bench",
@@ -19207,7 +18925,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -19216,7 +18934,7 @@ dependencies = [
  "serde",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -19234,32 +18952,19 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "sp-std 8.0.0",
- "wasmtime",
-]
-
-[[package]]
-name = "sp-wasm-interface"
 version = "20.0.0"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std 14.0.0",
+ "sp-std",
  "wasmtime",
 ]
 
 [[package]]
 name = "sp-weights"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -19268,8 +18973,8 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-debug-derive 14.0.0",
- "sp-std 14.0.0",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
@@ -19351,18 +19056,18 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-chain-spec-builder"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "log",
  "sc-chain-spec",
  "serde_json",
- "sp-tracing 16.0.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "staging-node-cli"
-version = "3.0.0-dev"
+version = "0.1.0"
 dependencies = [
  "array-bytes 6.1.0",
  "assert_cmd",
@@ -19445,7 +19150,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-keyring",
@@ -19456,7 +19161,7 @@ dependencies = [
  "sp-state-machine",
  "sp-statement-store",
  "sp-timestamp",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "sp-transaction-storage-proof",
  "sp-trie",
  "staging-node-inspect",
@@ -19474,7 +19179,7 @@ dependencies = [
 
 [[package]]
 name = "staging-node-inspect"
-version = "0.12.0"
+version = "0.14.0"
 dependencies = [
  "clap 4.5.1",
  "parity-scale-codec",
@@ -19491,7 +19196,7 @@ dependencies = [
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -19499,7 +19204,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
 ]
 
 [[package]]
@@ -19508,7 +19213,7 @@ version = "2.0.0"
 
 [[package]]
 name = "staging-xcm"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",
@@ -19529,7 +19234,7 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "assert_matches",
  "frame-support",
@@ -19551,7 +19256,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-executor",
@@ -19559,7 +19264,7 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -19572,7 +19277,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "sp-weights",
  "staging-xcm",
 ]
@@ -19679,7 +19384,7 @@ dependencies = [
 
 [[package]]
 name = "subkey"
-version = "9.0.0"
+version = "11.0.0"
 dependencies = [
  "clap 4.5.1",
  "sc-cli",
@@ -19721,7 +19426,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-cli"
-version = "32.0.0"
+version = "34.0.0"
 dependencies = [
  "clap 4.5.1",
  "frame-support",
@@ -19733,7 +19438,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-support"
-version = "29.0.0"
+version = "31.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -19744,13 +19449,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-storage 19.0.0",
+ "sp-storage",
  "tokio",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "28.0.0"
+version = "30.0.0"
 dependencies = [
  "assert_matches",
  "frame-system-rpc-runtime-api",
@@ -19766,7 +19471,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "substrate-test-runtime-client",
  "tokio",
 ]
@@ -19784,7 +19489,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-rpc-client"
-version = "0.33.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -19798,7 +19503,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "27.0.0"
+version = "29.0.0"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -19815,7 +19520,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-client"
-version = "2.0.1"
+version = "0.1.0"
 dependencies = [
  "array-bytes 6.1.0",
  "async-trait",
@@ -19841,7 +19546,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-runtime"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-executive",
@@ -19871,7 +19576,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-crypto-hashing",
- "sp-externalities 0.25.0",
+ "sp-externalities",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -19880,8 +19585,8 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -19892,7 +19597,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-runtime-client"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -19909,7 +19614,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-runtime-transaction-pool"
-version = "2.0.0"
+version = "0.1.0"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -19924,7 +19629,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-utils"
-version = "4.0.0-dev"
+version = "3.0.0"
 dependencies = [
  "futures",
  "sc-service",
@@ -19934,7 +19639,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "17.0.0"
+version = "19.0.0"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -20189,20 +19894,20 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-parachain-adder"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "dlmalloc",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "sp-io",
- "sp-std 14.0.0",
+ "sp-std",
  "substrate-wasm-builder",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "test-parachain-adder-collator"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "futures",
@@ -20228,7 +19933,7 @@ dependencies = [
 
 [[package]]
 name = "test-parachain-halt"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "rustversion",
  "substrate-wasm-builder",
@@ -20236,21 +19941,21 @@ dependencies = [
 
 [[package]]
 name = "test-parachain-undying"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "dlmalloc",
  "log",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "sp-io",
- "sp-std 14.0.0",
+ "sp-std",
  "substrate-wasm-builder",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "test-parachain-undying-collator"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "clap 4.5.1",
  "futures",
@@ -20276,7 +19981,7 @@ dependencies = [
 
 [[package]]
 name = "test-parachains"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -20287,7 +19992,7 @@ dependencies = [
 
 [[package]]
 name = "test-runtime-constants"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -20300,7 +20005,7 @@ dependencies = [
 
 [[package]]
 name = "testnet-parachains-constants"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -20748,7 +20453,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -20943,7 +20648,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.38.0"
+version = "0.40.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -20963,8 +20668,8 @@ dependencies = [
  "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-core",
- "sp-debug-derive 14.0.0",
- "sp-externalities 0.25.0",
+ "sp-debug-derive",
+ "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-keystore",
@@ -21775,7 +21480,7 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "westend-emulated-chain"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "emulated-integration-tests-common",
  "pallet-staking",
@@ -21793,7 +21498,7 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21888,9 +21593,9 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-storage",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
  "staging-xcm",
@@ -21904,7 +21609,7 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -21919,7 +21624,7 @@ dependencies = [
 
 [[package]]
 name = "westend-system-emulated-network"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "asset-hub-westend-emulated-chain",
  "bridge-hub-westend-emulated-chain",
@@ -22318,7 +22023,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-emulator"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -22343,15 +22048,15 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "xcm-executor-integration-tests"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -22366,14 +22071,14 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 16.0.0",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-executor",
 ]
 
 [[package]]
 name = "xcm-procedural"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -22385,7 +22090,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -22394,7 +22099,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-runtime-parachains",
  "sp-io",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -22402,7 +22107,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator-example"
-version = "7.0.0"
+version = "9.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -22419,8 +22124,8 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
- "sp-tracing 16.0.0",
+ "sp-std",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -22429,7 +22134,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator-fuzzer"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "arbitrary",
  "frame-executive",
@@ -22448,7 +22153,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0",
+ "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -22526,7 +22231,7 @@ dependencies = [
 
 [[package]]
 name = "zombienet-backchannel"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "futures-util",
  "lazy_static",

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -16,7 +16,8 @@
 mod genesis;
 pub use genesis::{genesis, ED, PARA_ID_A, PARA_ID_B};
 pub use penpal_runtime::xcm_config::{
-	LocalTeleportableToAssetHub, LocalTeleportableToAssetHubV3, XcmConfig,
+	CustomizableAssetFromSystemAssetHub, LocalTeleportableToAssetHub,
+	LocalTeleportableToAssetHubV3, XcmConfig,
 };
 
 // Substrate

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -18,6 +18,7 @@ use codec::{Decode, Encode};
 use emulated_integration_tests_common::xcm_emulator::ConvertLocation;
 use frame_support::pallet_prelude::TypeInfo;
 use hex_literal::hex;
+use rococo_system_emulated_network::penpal_emulated_chain::CustomizableAssetFromSystemAssetHub;
 use rococo_westend_system_emulated_network::BridgeHubRococoParaSender as BridgeHubRococoSender;
 use snowbridge_core::outbound::OperatingMode;
 use snowbridge_pallet_inbound_queue_fixtures::{
@@ -252,6 +253,16 @@ fn send_token_from_ethereum_to_penpal() {
 		(PenpalAReceiver::get(), INITIAL_FUND),
 		(PenpalASender::get(), INITIAL_FUND),
 	]);
+
+	PenpalA::execute_with(|| {
+		assert_ok!(<PenpalA as Chain>::System::set_storage(
+			<PenpalA as Chain>::RuntimeOrigin::root(),
+			vec![(
+				CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				Location::new(2, [GlobalConsensus(Ethereum { chain_id: CHAIN_ID })]).encode(),
+			)],
+		));
+	});
 
 	// The Weth asset location, identified by the contract address on Ethereum
 	let weth_asset_location: Location =

--- a/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
@@ -77,7 +77,6 @@ cumulus-primitives-utility = { path = "../../../../primitives/utility", default-
 pallet-collator-selection = { path = "../../../../pallets/collator-selection", default-features = false, version = "11.0.0" }
 parachain-info = { package = "staging-parachain-info", path = "../../../pallets/parachain-info", default-features = false, version = "0.9.0" }
 parachains-common = { path = "../../../common", default-features = false, version = "9.0.0" }
-testnet-parachains-constants = { path = "../../constants", default-features = false, features = ["rococo"], version = "2.0.0" }
 assets-common = { path = "../../assets/common", default-features = false, version = "0.9.0" }
 
 [features]
@@ -133,7 +132,6 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
-	"testnet-parachains-constants/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",

--- a/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
@@ -43,7 +43,6 @@ use pallet_xcm::XcmPassthrough;
 use polkadot_parachain_primitives::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
 use sp_runtime::traits::Zero;
-use testnet_parachains_constants::rococo::snowbridge::EthereumNetwork;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -295,7 +294,13 @@ parameter_types! {
 		0,
 		[xcm::v3::Junction::PalletInstance(50), xcm::v3::Junction::GeneralIndex(TELEPORTABLE_ASSET_ID.into())]
 	);
-	pub EthereumLocation: Location = Location::new(2, [GlobalConsensus(EthereumNetwork::get())]);
+
+	/// The Penpal runtime is utilized for testing with various environment setups.
+	/// This storage item provides the opportunity to customize testing scenarios
+	/// by configuring the trusted asset from the `SystemAssetHub`.
+	///
+	/// By default, it is configured as a `SystemAssetHubLocation` and can be modified using `System::set_storage`.
+	pub storage CustomizableAssetFromSystemAssetHub: Location = SystemAssetHubLocation::get();
 }
 
 /// Accepts asset with ID `AssetLocation` and is coming from `Origin` chain.
@@ -310,11 +315,11 @@ impl<AssetLocation: Get<Location>, Origin: Get<Location>> ContainsPair<Asset, Lo
 	}
 }
 
-pub type Reserves = (
+pub type TrustedReserves = (
 	NativeAsset,
 	AssetsFrom<SystemAssetHubLocation>,
 	NativeAssetFrom<SystemAssetHubLocation>,
-	AssetPrefixFrom<EthereumLocation, SystemAssetHubLocation>,
+	AssetPrefixFrom<CustomizableAssetFromSystemAssetHub, SystemAssetHubLocation>,
 );
 pub type TrustedTeleporters =
 	(AssetFromChain<LocalTeleportableToAssetHub, SystemAssetHubLocation>,);
@@ -326,7 +331,7 @@ impl xcm_executor::Config for XcmConfig {
 	// How to withdraw and deposit an asset.
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = Reserves;
+	type IsReserve = TrustedReserves;
 	// no teleport trust established with other chains
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;


### PR DESCRIPTION
Backport of https://github.com/paritytech/polkadot-sdk/pull/3564

Expected patches for (1.8.0):
- penpal-runtime `0.16.1`