### PR TITLE
Always print connectivity report

### DIFF
--- a/polkadot/node/network/gossip-support/src/lib.rs
+++ b/polkadot/node/network/gossip-support/src/lib.rs
@@ -508,7 +508,7 @@ where
 			);
 		}
 		let pretty = PrettyAuthorities(unconnected_authorities);
-		gum::debug!(
+		gum::info!(
 			target: LOG_TARGET,
 			?connected_ratio,
 			?absolute_connected,


### PR DESCRIPTION
This is printed every 10 minutes, I see no reason why it shouldn't be in all the logs, it would give us valuable information about what is going on with node connectivity when validators come-back to us to report issues.