### PR TITLE
pallet-xcm: add new extrinsic for asset transfers using explicit reserve

### DIFF
--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -942,7 +942,10 @@ impl<T: Config> SendXcm for Pallet<T> {
 				Self::deposit_event(Event::XcmpMessageSent { message_hash: hash });
 				Ok(hash)
 			},
-			Err(e) => Err(SendError::Transport(e.into())),
+			Err(e) => {
+				log::error!(target: "xcm::XcmpQueue::deliver", "error: {:?}", e);
+				Err(SendError::Transport(e.into()))
+			},
 		}
 	}
 }

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -25,7 +25,8 @@ use frame_support::traits::OnInitialize;
 // Cumulus
 use emulated_integration_tests_common::{
 	impl_accounts_helpers_for_parachain, impl_assert_events_helpers_for_parachain,
-	impl_assets_helpers_for_parachain, impls::Parachain, xcm_emulator::decl_test_parachains,
+	impl_assets_helpers_for_parachain, impl_xcm_helpers_for_parachain, impls::Parachain,
+	xcm_emulator::decl_test_parachains,
 };
 
 // Penpal Parachain declaration
@@ -77,3 +78,5 @@ impl_assert_events_helpers_for_parachain!(PenpalA);
 impl_assert_events_helpers_for_parachain!(PenpalB);
 impl_assets_helpers_for_parachain!(PenpalA);
 impl_assets_helpers_for_parachain!(PenpalB);
+impl_xcm_helpers_for_parachain!(PenpalA);
+impl_xcm_helpers_for_parachain!(PenpalB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/teleport.rs
@@ -245,16 +245,6 @@ fn relay_limited_teleport_assets(t: RelayToSystemParaTest) -> DispatchResult {
 	)
 }
 
-fn relay_teleport_assets(t: RelayToSystemParaTest) -> DispatchResult {
-	<Rococo as RococoPallet>::XcmPallet::teleport_assets(
-		t.signed_origin,
-		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
-		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
-	)
-}
-
 fn system_para_limited_teleport_assets(t: SystemParaToRelayTest) -> DispatchResult {
 	<AssetHubRococo as AssetHubRococoPallet>::PolkadotXcm::limited_teleport_assets(
 		t.signed_origin,
@@ -263,16 +253,6 @@ fn system_para_limited_teleport_assets(t: SystemParaToRelayTest) -> DispatchResu
 		bx!(t.args.assets.into()),
 		t.args.fee_asset_item,
 		t.args.weight_limit,
-	)
-}
-
-fn system_para_teleport_assets(t: SystemParaToRelayTest) -> DispatchResult {
-	<AssetHubRococo as AssetHubRococoPallet>::PolkadotXcm::teleport_assets(
-		t.signed_origin,
-		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
-		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
 	)
 }
 
@@ -414,129 +394,6 @@ fn limited_teleport_native_assets_from_system_para_to_relay_fails() {
 			<AssetHubRococoXcmConfig as xcm_executor::Config>::XcmSender,
 		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
-
-	// Sender's balance is reduced
-	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);
-	// Receiver's balance does not change
-	assert_eq!(receiver_balance_after, receiver_balance_before);
-}
-
-/// Teleport of native asset from Relay Chain to the System Parachain should work
-#[test]
-fn teleport_native_assets_from_relay_to_system_para_works() {
-	// Init values for Relay Chain
-	let amount_to_send: Balance = ROCOCO_ED * 1000;
-	let dest = Rococo::child_location_of(AssetHubRococo::para_id());
-	let beneficiary_id = AssetHubRococoReceiver::get();
-	let test_args = TestContext {
-		sender: RococoSender::get(),
-		receiver: AssetHubRococoReceiver::get(),
-		args: TestArgs::new_relay(dest, beneficiary_id, amount_to_send),
-	};
-
-	let mut test = RelayToSystemParaTest::new(test_args);
-
-	let sender_balance_before = test.sender.balance;
-	let receiver_balance_before = test.receiver.balance;
-
-	test.set_assertion::<Rococo>(relay_origin_assertions);
-	test.set_assertion::<AssetHubRococo>(para_dest_assertions);
-	test.set_dispatchable::<Rococo>(relay_teleport_assets);
-	test.assert();
-
-	let delivery_fees = Rococo::execute_with(|| {
-		xcm_helpers::transfer_assets_delivery_fees::<
-			<RococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
-	});
-
-	let sender_balance_after = test.sender.balance;
-	let receiver_balance_after = test.receiver.balance;
-
-	// Sender's balance is reduced
-	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);
-	// Receiver's balance is increased
-	assert!(receiver_balance_after > receiver_balance_before);
-}
-
-/// Teleport of native asset from System Parachains to the Relay Chain
-/// should work when there is enough balance in Relay Chain's `CheckAccount`
-#[test]
-fn teleport_native_assets_back_from_system_para_to_relay_works() {
-	// Dependency - Relay Chain's `CheckAccount` should have enough balance
-	teleport_native_assets_from_relay_to_system_para_works();
-
-	// Init values for Relay Chain
-	let amount_to_send: Balance = ASSET_HUB_ROCOCO_ED * 1000;
-	let destination = AssetHubRococo::parent_location();
-	let beneficiary_id = RococoReceiver::get();
-	let assets = (Parent, amount_to_send).into();
-
-	let test_args = TestContext {
-		sender: AssetHubRococoSender::get(),
-		receiver: RococoReceiver::get(),
-		args: TestArgs::new_para(destination, beneficiary_id, amount_to_send, assets, None, 0),
-	};
-
-	let mut test = SystemParaToRelayTest::new(test_args);
-
-	let sender_balance_before = test.sender.balance;
-	let receiver_balance_before = test.receiver.balance;
-
-	test.set_assertion::<AssetHubRococo>(para_origin_assertions);
-	test.set_assertion::<Rococo>(relay_dest_assertions);
-	test.set_dispatchable::<AssetHubRococo>(system_para_teleport_assets);
-	test.assert();
-
-	let sender_balance_after = test.sender.balance;
-	let receiver_balance_after = test.receiver.balance;
-
-	let delivery_fees = AssetHubRococo::execute_with(|| {
-		xcm_helpers::transfer_assets_delivery_fees::<
-			<AssetHubRococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
-	});
-
-	// Sender's balance is reduced
-	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);
-	// Receiver's balance is increased
-	assert!(receiver_balance_after > receiver_balance_before);
-}
-
-/// Teleport of native asset from System Parachain to Relay Chain
-/// shouldn't work when there is not enough balance in Relay Chain's `CheckAccount`
-#[test]
-fn teleport_native_assets_from_system_para_to_relay_fails() {
-	// Init values for Relay Chain
-	let amount_to_send: Balance = ASSET_HUB_ROCOCO_ED * 1000;
-	let destination = AssetHubRococo::parent_location();
-	let beneficiary_id = RococoReceiver::get();
-	let assets = (Parent, amount_to_send).into();
-
-	let test_args = TestContext {
-		sender: AssetHubRococoSender::get(),
-		receiver: RococoReceiver::get(),
-		args: TestArgs::new_para(destination, beneficiary_id, amount_to_send, assets, None, 0),
-	};
-
-	let mut test = SystemParaToRelayTest::new(test_args);
-
-	let sender_balance_before = test.sender.balance;
-	let receiver_balance_before = test.receiver.balance;
-
-	test.set_assertion::<AssetHubRococo>(para_origin_assertions);
-	test.set_assertion::<Rococo>(relay_dest_assertions_fail);
-	test.set_dispatchable::<AssetHubRococo>(system_para_teleport_assets);
-	test.assert();
-
-	let delivery_fees = AssetHubRococo::execute_with(|| {
-		xcm_helpers::transfer_assets_delivery_fees::<
-			<AssetHubRococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
-	});
-
-	let sender_balance_after = test.sender.balance;
-	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced
 	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/teleport.rs
@@ -245,16 +245,6 @@ fn relay_limited_teleport_assets(t: RelayToSystemParaTest) -> DispatchResult {
 	)
 }
 
-fn relay_teleport_assets(t: RelayToSystemParaTest) -> DispatchResult {
-	<Westend as WestendPallet>::XcmPallet::teleport_assets(
-		t.signed_origin,
-		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
-		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
-	)
-}
-
 fn system_para_limited_teleport_assets(t: SystemParaToRelayTest) -> DispatchResult {
 	<AssetHubWestend as AssetHubWestendPallet>::PolkadotXcm::limited_teleport_assets(
 		t.signed_origin,
@@ -263,16 +253,6 @@ fn system_para_limited_teleport_assets(t: SystemParaToRelayTest) -> DispatchResu
 		bx!(t.args.assets.into()),
 		t.args.fee_asset_item,
 		t.args.weight_limit,
-	)
-}
-
-fn system_para_teleport_assets(t: SystemParaToRelayTest) -> DispatchResult {
-	<AssetHubWestend as AssetHubWestendPallet>::PolkadotXcm::teleport_assets(
-		t.signed_origin,
-		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
-		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
 	)
 }
 
@@ -414,129 +394,6 @@ fn limited_teleport_native_assets_from_system_para_to_relay_fails() {
 			<AssetHubWestendXcmConfig as xcm_executor::Config>::XcmSender,
 		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
-
-	// Sender's balance is reduced
-	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);
-	// Receiver's balance does not change
-	assert_eq!(receiver_balance_after, receiver_balance_before);
-}
-
-/// Teleport of native asset from Relay Chain to the System Parachain should work
-#[test]
-fn teleport_native_assets_from_relay_to_system_para_works() {
-	// Init values for Relay Chain
-	let amount_to_send: Balance = WESTEND_ED * 1000;
-	let dest = Westend::child_location_of(AssetHubWestend::para_id());
-	let beneficiary_id = AssetHubWestendReceiver::get();
-	let test_args = TestContext {
-		sender: WestendSender::get(),
-		receiver: AssetHubWestendReceiver::get(),
-		args: TestArgs::new_relay(dest, beneficiary_id, amount_to_send),
-	};
-
-	let mut test = RelayToSystemParaTest::new(test_args);
-
-	let sender_balance_before = test.sender.balance;
-	let receiver_balance_before = test.receiver.balance;
-
-	test.set_assertion::<Westend>(relay_origin_assertions);
-	test.set_assertion::<AssetHubWestend>(para_dest_assertions);
-	test.set_dispatchable::<Westend>(relay_teleport_assets);
-	test.assert();
-
-	let delivery_fees = Westend::execute_with(|| {
-		xcm_helpers::transfer_assets_delivery_fees::<
-			<WestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
-	});
-
-	let sender_balance_after = test.sender.balance;
-	let receiver_balance_after = test.receiver.balance;
-
-	// Sender's balance is reduced
-	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);
-	// Receiver's balance is increased
-	assert!(receiver_balance_after > receiver_balance_before);
-}
-
-/// Teleport of native asset from System Parachains to the Relay Chain
-/// should work when there is enough balance in Relay Chain's `CheckAccount`
-#[test]
-fn teleport_native_assets_back_from_system_para_to_relay_works() {
-	// Dependency - Relay Chain's `CheckAccount` should have enough balance
-	teleport_native_assets_from_relay_to_system_para_works();
-
-	// Init values for Relay Chain
-	let amount_to_send: Balance = ASSET_HUB_WESTEND_ED * 1000;
-	let destination = AssetHubWestend::parent_location();
-	let beneficiary_id = WestendReceiver::get();
-	let assets = (Parent, amount_to_send).into();
-
-	let test_args = TestContext {
-		sender: AssetHubWestendSender::get(),
-		receiver: WestendReceiver::get(),
-		args: TestArgs::new_para(destination, beneficiary_id, amount_to_send, assets, None, 0),
-	};
-
-	let mut test = SystemParaToRelayTest::new(test_args);
-
-	let sender_balance_before = test.sender.balance;
-	let receiver_balance_before = test.receiver.balance;
-
-	test.set_assertion::<AssetHubWestend>(para_origin_assertions);
-	test.set_assertion::<Westend>(relay_dest_assertions);
-	test.set_dispatchable::<AssetHubWestend>(system_para_teleport_assets);
-	test.assert();
-
-	let sender_balance_after = test.sender.balance;
-	let receiver_balance_after = test.receiver.balance;
-
-	let delivery_fees = AssetHubWestend::execute_with(|| {
-		xcm_helpers::transfer_assets_delivery_fees::<
-			<AssetHubWestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
-	});
-
-	// Sender's balance is reduced
-	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);
-	// Receiver's balance is increased
-	assert!(receiver_balance_after > receiver_balance_before);
-}
-
-/// Teleport of native asset from System Parachain to Relay Chain
-/// shouldn't work when there is not enough balance in Relay Chain's `CheckAccount`
-#[test]
-fn teleport_native_assets_from_system_para_to_relay_fails() {
-	// Init values for Relay Chain
-	let amount_to_send: Balance = ASSET_HUB_WESTEND_ED * 1000;
-	let destination = AssetHubWestend::parent_location();
-	let beneficiary_id = WestendReceiver::get();
-	let assets = (Parent, amount_to_send).into();
-
-	let test_args = TestContext {
-		sender: AssetHubWestendSender::get(),
-		receiver: WestendReceiver::get(),
-		args: TestArgs::new_para(destination, beneficiary_id, amount_to_send, assets, None, 0),
-	};
-
-	let mut test = SystemParaToRelayTest::new(test_args);
-
-	let sender_balance_before = test.sender.balance;
-	let receiver_balance_before = test.receiver.balance;
-
-	test.set_assertion::<AssetHubWestend>(para_origin_assertions);
-	test.set_assertion::<Westend>(relay_dest_assertions_fail);
-	test.set_dispatchable::<AssetHubWestend>(system_para_teleport_assets);
-	test.assert();
-
-	let delivery_fees = AssetHubWestend::execute_with(|| {
-		xcm_helpers::transfer_assets_delivery_fees::<
-			<AssetHubWestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
-	});
-
-	let sender_balance_after = test.sender.balance;
-	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced
 	assert_eq!(sender_balance_before - amount_to_send - delivery_fees, sender_balance_after);

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
@@ -46,7 +46,7 @@ mod imports {
 		bridge_hub_rococo_emulated_chain::{
 			genesis::ED as BRIDGE_HUB_ROCOCO_ED, BridgeHubRococoParaPallet as BridgeHubRococoPallet,
 		},
-		penpal_emulated_chain::PenpalAParaPallet as PenpalAPallet,
+		penpal_emulated_chain::{PenpalAParaPallet as PenpalAPallet, PenpalAssetOwner},
 		rococo_emulated_chain::{genesis::ED as ROCOCO_ED, RococoRelayPallet as RococoPallet},
 		AssetHubRococoPara as AssetHubRococo, AssetHubRococoParaReceiver as AssetHubRococoReceiver,
 		AssetHubRococoParaSender as AssetHubRococoSender, AssetHubWestendPara as AssetHubWestend,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
@@ -31,6 +31,72 @@ fn send_asset_from_asset_hub_rococo_to_asset_hub_westend(id: Location, amount: u
 	assert_bridge_hub_westend_message_received();
 }
 
+fn send_asset_from_penpal_rococo_through_local_asset_hub_to_westend_asset_hub(
+	id: Location,
+	transfer_amount: u128,
+) {
+	let destination = asset_hub_westend_location();
+	let local_asset_hub: Location = PenpalA::sibling_location_of(AssetHubRococo::para_id());
+	let sov_penpal_on_ahr = AssetHubRococo::sovereign_account_id_of(
+		AssetHubRococo::sibling_location_of(PenpalA::para_id()),
+	);
+	let sov_ahw_on_ahr = AssetHubRococo::sovereign_account_of_parachain_on_other_global_consensus(
+		Westend,
+		AssetHubWestend::para_id(),
+	);
+
+	// fund the AHR's SA on BHR for paying bridge transport fees
+	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id(), 10_000_000_000_000u128);
+
+	// set XCM versions
+	PenpalA::force_xcm_version(local_asset_hub.clone(), XCM_VERSION);
+	AssetHubRococo::force_xcm_version(destination.clone(), XCM_VERSION);
+	BridgeHubRococo::force_xcm_version(bridge_hub_westend_location(), XCM_VERSION);
+
+	// send message over bridge
+	assert_ok!(PenpalA::execute_with(|| {
+		let signed_origin = <PenpalA as Chain>::RuntimeOrigin::signed(PenpalASender::get());
+		let beneficiary: Location =
+			AccountId32Junction { network: None, id: AssetHubWestendReceiver::get().into() }.into();
+		let fees: Asset = (id, transfer_amount).into();
+		let assets: Assets = fees.clone().into();
+
+		<PenpalA as PenpalAPallet>::PolkadotXcm::transfer_assets_using_reserve(
+			signed_origin,
+			bx!(destination.into()),
+			bx!(beneficiary.into()),
+			bx!(assets.into()),
+			bx!(fees.into()),
+			bx!(local_asset_hub.into()),
+			WeightLimit::Unlimited,
+		)
+	}));
+	AssetHubRococo::execute_with(|| {
+		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
+		assert_expected_events!(
+			AssetHubRococo,
+			vec![
+				// Amount to reserve transfer is withdrawn from Penpal's sovereign account
+				RuntimeEvent::Balances(
+					pallet_balances::Event::Burned { who, amount }
+				) => {
+					who: *who == sov_penpal_on_ahr.clone().into(),
+					amount: *amount == transfer_amount,
+				},
+				// Amount deposited in AHW's sovereign account
+				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, .. }) => {
+					who: *who == sov_ahw_on_ahr.clone().into(),
+				},
+				RuntimeEvent::XcmpQueue(
+					cumulus_pallet_xcmp_queue::Event::XcmpMessageSent { .. }
+				) => {},
+			]
+		);
+	});
+	assert_bridge_hub_rococo_message_accepted(true);
+	assert_bridge_hub_westend_message_received();
+}
+
 #[test]
 fn send_rocs_from_asset_hub_rococo_to_asset_hub_westend() {
 	let roc_at_asset_hub_rococo: v3::Location = v3::Parent.into();
@@ -135,7 +201,7 @@ fn send_rocs_from_asset_hub_rococo_to_asset_hub_westend() {
 	assert!(sender_rocs_before > sender_rocs_after);
 	// Receiver's balance is increased
 	assert!(receiver_rocs_after > receiver_rocs_before);
-	// Reserve balance is reduced by sent amount
+	// Reserve balance is increased by sent amount
 	assert_eq!(rocs_in_reserve_on_ahr_after, rocs_in_reserve_on_ahr_before + amount);
 }
 
@@ -216,4 +282,141 @@ fn send_wnds_from_asset_hub_rococo_to_asset_hub_westend() {
 	assert!(receiver_wnds_after > receiver_wnds_before);
 	// Reserve balance is reduced by sent amount
 	assert_eq!(wnds_in_reserve_on_ahw_after, wnds_in_reserve_on_ahw_before - amount_to_send);
+}
+
+#[test]
+fn send_rocs_from_penpal_rococo_through_asset_hub_rococo_to_asset_hub_westend() {
+	let roc_at_rococo_parachains: v3::Location = v3::Parent.into();
+	let roc_at_asset_hub_westend =
+		v3::Location::new(2, [v3::Junction::GlobalConsensus(v3::NetworkId::Rococo)]);
+	let roc_at_rococo_parachains_latest: Location = roc_at_rococo_parachains.try_into().unwrap();
+	let owner: AccountId = AssetHubWestend::account_id_of(ALICE);
+	AssetHubWestend::force_create_foreign_asset(
+		roc_at_asset_hub_westend,
+		owner,
+		true,
+		ASSET_MIN_BALANCE,
+		vec![],
+	);
+	let sov_ahw_on_ahr = AssetHubRococo::sovereign_account_of_parachain_on_other_global_consensus(
+		NetworkId::Westend,
+		AssetHubWestend::para_id(),
+	);
+
+	AssetHubWestend::execute_with(|| {
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
+
+		// setup a pool to pay xcm fees with `roc_at_asset_hub_westend` tokens
+		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::ForeignAssets::mint(
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			roc_at_asset_hub_westend.into(),
+			AssetHubWestendSender::get().into(),
+			3_000_000_000_000,
+		));
+
+		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::create_pool(
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			Box::new(xcm::v3::Parent.into()),
+			Box::new(roc_at_asset_hub_westend),
+		));
+
+		assert_expected_events!(
+			AssetHubWestend,
+			vec![
+				RuntimeEvent::AssetConversion(pallet_asset_conversion::Event::PoolCreated { .. }) => {},
+			]
+		);
+
+		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::add_liquidity(
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			Box::new(xcm::v3::Parent.into()),
+			Box::new(roc_at_asset_hub_westend),
+			1_000_000_000_000,
+			2_000_000_000_000,
+			1,
+			1,
+			AssetHubWestendSender::get().into()
+		));
+
+		assert_expected_events!(
+			AssetHubWestend,
+			vec![
+				RuntimeEvent::AssetConversion(pallet_asset_conversion::Event::LiquidityAdded {..}) => {},
+			]
+		);
+	});
+
+	let penpal_location = AssetHubRococo::sibling_location_of(PenpalA::para_id());
+	let sov_penpal_on_ahr = AssetHubRococo::sovereign_account_id_of(penpal_location);
+	// fund Penpal's sovereign account on AssetHub
+	AssetHubRococo::fund_accounts(vec![(
+		sov_penpal_on_ahr.into(),
+		ASSET_HUB_ROCOCO_ED * 10_000_001,
+	)]);
+	// fund Penpal's sender account
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		roc_at_rococo_parachains,
+		PenpalASender::get(),
+		ASSET_HUB_ROCOCO_ED * 10_000_001,
+	);
+
+	let rocs_in_reserve_on_ahr_before =
+		<AssetHubRococo as Chain>::account_data_of(sov_ahw_on_ahr.clone()).free;
+	let sender_rocs_before = PenpalA::execute_with(|| {
+		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		<ForeignAssets as Inspect<_>>::balance(
+			roc_at_rococo_parachains.into(),
+			&PenpalASender::get(),
+		)
+	});
+	let receiver_rocs_before = AssetHubWestend::execute_with(|| {
+		type Assets = <AssetHubWestend as AssetHubWestendPallet>::ForeignAssets;
+		<Assets as Inspect<_>>::balance(roc_at_asset_hub_westend, &AssetHubWestendReceiver::get())
+	});
+	let amount = ASSET_HUB_ROCOCO_ED * 10_000_000;
+	send_asset_from_penpal_rococo_through_local_asset_hub_to_westend_asset_hub(
+		roc_at_rococo_parachains_latest,
+		amount,
+	);
+
+	AssetHubWestend::execute_with(|| {
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
+		assert_expected_events!(
+			AssetHubWestend,
+			vec![
+				// issue ROCs on AHW
+				RuntimeEvent::ForeignAssets(pallet_assets::Event::Issued { asset_id, owner, .. }) => {
+					asset_id: *asset_id == roc_at_rococo_parachains,
+					owner: *owner == AssetHubWestendReceiver::get(),
+				},
+				// message processed successfully
+				RuntimeEvent::MessageQueue(
+					pallet_message_queue::Event::Processed { success: true, .. }
+				) => {},
+			]
+		);
+	});
+
+	let sender_rocs_after = PenpalA::execute_with(|| {
+		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		<ForeignAssets as Inspect<_>>::balance(
+			roc_at_rococo_parachains.into(),
+			&PenpalASender::get(),
+		)
+	});
+	let receiver_rocs_after = AssetHubWestend::execute_with(|| {
+		type Assets = <AssetHubWestend as AssetHubWestendPallet>::ForeignAssets;
+		<Assets as Inspect<_>>::balance(roc_at_asset_hub_westend, &AssetHubWestendReceiver::get())
+	});
+	let rocs_in_reserve_on_ahr_after =
+		<AssetHubRococo as Chain>::account_data_of(sov_ahw_on_ahr.clone()).free;
+
+	// Sender's balance is reduced
+	assert!(sender_rocs_after < sender_rocs_before);
+	// Receiver's balance is increased
+	assert!(receiver_rocs_after > receiver_rocs_before);
+	// Reserve balance is increased by sent amount (less fess)
+	assert!(rocs_in_reserve_on_ahr_after > rocs_in_reserve_on_ahr_before);
+	assert!(rocs_in_reserve_on_ahr_after <= rocs_in_reserve_on_ahr_before + amount);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -458,12 +458,13 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 			AssetHubRococoReceiver::get(),
 		);
 		// Send the Weth back to Ethereum
-		<AssetHubRococo as AssetHubRococoPallet>::PolkadotXcm::reserve_transfer_assets(
+		<AssetHubRococo as AssetHubRococoPallet>::PolkadotXcm::limited_reserve_transfer_assets(
 			RuntimeOrigin::signed(AssetHubRococoReceiver::get()),
 			Box::new(destination),
 			Box::new(beneficiary),
 			Box::new(multi_assets),
 			0,
+			Unlimited,
 		)
 		.unwrap();
 		let free_balance_after = <AssetHubRococo as AssetHubRococoPallet>::Balances::free_balance(

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/cumulus/parachains/runtimes/assets/common/src/matching.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/matching.rs
@@ -113,17 +113,14 @@ impl<UniversalLocation: Get<InteriorLocation>, Reserves: ContainsPair<Asset, Loc
 		);
 
 		// check remote origin
-		let _ = match ensure_is_remote(universal_source.clone(), origin.clone()) {
-			Ok(devolved) => devolved,
-			Err(_) => {
-				log::trace!(
-					target: "xcm::contains",
-					"IsTrustedBridgedReserveLocationForConcreteAsset origin: {:?} is not remote to the universal_source: {:?}",
-					origin, universal_source
-				);
-				return false
-			},
-		};
+		if ensure_is_remote(universal_source.clone(), origin.clone()).is_err() {
+			log::trace!(
+				target: "xcm::contains",
+				"IsTrustedBridgedReserveLocationForConcreteAsset origin: {:?} is not remote to the universal_source: {:?}",
+				origin, universal_source
+			);
+			return false
+		}
 
 		// check asset according to the configured reserve locations
 		Reserves::contains(asset, origin)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)
 	/// Proof: `PolkadotXcm::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::VersionDiscoveryQueue` (r:1 w:1)

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)
 	/// Proof: `PolkadotXcm::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::VersionDiscoveryQueue` (r:1 w:1)

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)
 	/// Proof: `PolkadotXcm::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::VersionDiscoveryQueue` (r:1 w:1)

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/pallet_xcm.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)
 	/// Proof: `PolkadotXcm::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::VersionDiscoveryQueue` (r:1 w:1)

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -425,12 +425,13 @@ impl<
 		}
 
 		// do teleport
-		<pallet_xcm::Pallet<Runtime>>::teleport_assets(
+		<pallet_xcm::Pallet<Runtime>>::limited_teleport_assets(
 			origin,
 			Box::new(dest.into()),
 			Box::new(beneficiary.into()),
 			Box::new((AssetId(asset), amount).into()),
 			0,
+			Unlimited,
 		)
 	}
 }

--- a/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
@@ -56,10 +56,16 @@ parameter_types! {
 	pub const RelayLocation: Location = Location::parent();
 	// Local native currency which is stored in `pallet_balances``
 	pub const PenpalNativeCurrency: Location = Location::here();
-	pub const RelayNetwork: Option<NetworkId> = None;
+	// The Penpal runtime is utilized for testing with various environment setups.
+	// This storage item allows us to customize the `NetworkId` where Penpal is deployed.
+	// By default, it is set to `NetworkId::Rococo` and can be changed using `System::set_storage`.
+	pub storage RelayNetworkId: NetworkId = NetworkId::Rococo;
+	pub RelayNetwork: Option<NetworkId> = Some(RelayNetworkId::get());
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
-	// FIXME: should also work for Westend
-	pub UniversalLocation: InteriorLocation = [GlobalConsensus(NetworkId::Rococo), Parachain(ParachainInfo::parachain_id().into())].into();
+	pub UniversalLocation: InteriorLocation = [
+		GlobalConsensus(RelayNetworkId::get()),
+		Parachain(ParachainInfo::parachain_id().into())
+	].into();
 }
 
 /// Type for specifying how a `Location` can be converted into an `AccountId`. This is used

--- a/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
@@ -58,7 +58,8 @@ parameter_types! {
 	pub const PenpalNativeCurrency: Location = Location::here();
 	pub const RelayNetwork: Option<NetworkId> = None;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
-	pub UniversalLocation: InteriorLocation = [Parachain(ParachainInfo::parachain_id().into())].into();
+	// FIXME: should also work for Westend
+	pub UniversalLocation: InteriorLocation = [GlobalConsensus(NetworkId::Rococo), Parachain(ParachainInfo::parachain_id().into())].into();
 }
 
 /// Type for specifying how a `Location` can be converted into an `AccountId`. This is used

--- a/polkadot/runtime/rococo/src/weights/pallet_xcm.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_xcm.rs
@@ -346,4 +346,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 }

--- a/polkadot/runtime/westend/src/tests.rs
+++ b/polkadot/runtime/westend/src/tests.rs
@@ -55,11 +55,12 @@ fn sanity_check_teleport_assets_weight() {
 	// Usually when XCM runs into an issue, it will return a weight of `Weight::MAX`,
 	// so this test will certainly ensure that this problem does not occur.
 	use frame_support::dispatch::GetDispatchInfo;
-	let weight = pallet_xcm::Call::<Runtime>::teleport_assets {
+	let weight = pallet_xcm::Call::<Runtime>::limited_teleport_assets {
 		dest: Box::new(Here.into()),
 		beneficiary: Box::new(Here.into()),
 		assets: Box::new((Here, 200_000).into()),
 		fee_asset_item: 0,
+		weight_limit: Unlimited,
 	}
 	.get_dispatch_info()
 	.weight;

--- a/polkadot/runtime/westend/src/weights/pallet_xcm.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_xcm.rs
@@ -48,6 +48,10 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn transfer_assets_using_reserve() -> Weight {
+		// TODO: benchmark
+		Weight::from_parts(0, 0)
+	}
 	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `XcmPallet::SupportedVersion` (r:1 w:0)

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -898,10 +898,9 @@ pub mod pallet {
 		}
 	}
 
-	#[pallet::call]
+	#[pallet::call(weight(<T as Config>::WeightInfo))]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::send())]
 		pub fn send(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -930,23 +929,6 @@ pub mod pallet {
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
 		#[pallet::call_index(1)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					let count = assets.len() as u32;
-					let mut message = Xcm(vec![
-						WithdrawAsset(assets),
-						SetFeesMode { jit_withdraw: true },
-						InitiateTeleport { assets: Wild(AllCounted(count)), dest, xcm: Xcm(vec![]) },
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::teleport_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
 		#[allow(deprecated)]
 		#[deprecated(
 			note = "This extrinsic uses `WeightLimit::Unlimited`, please migrate to `limited_teleport_assets` or `transfer_assets`"
@@ -992,23 +974,6 @@ pub mod pallet {
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
 		#[pallet::call_index(2)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					// heaviest version of locally executed XCM program: equivalent in weight to
-					// transfer assets to SA, reanchor them, extend XCM program, and send onward XCM
-					let mut message = Xcm(vec![
-						SetFeesMode { jit_withdraw: true },
-						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::reserve_transfer_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
 		#[allow(deprecated)]
 		#[deprecated(
 			note = "This extrinsic uses `WeightLimit::Unlimited`, please migrate to `limited_reserve_transfer_assets` or `transfer_assets`"
@@ -1057,7 +1022,6 @@ pub mod pallet {
 		/// - `location`: The destination that is being described.
 		/// - `xcm_version`: The latest version of XCM that `location` supports.
 		#[pallet::call_index(4)]
-		#[pallet::weight(T::WeightInfo::force_xcm_version())]
 		pub fn force_xcm_version(
 			origin: OriginFor<T>,
 			location: Box<Location>,
@@ -1076,7 +1040,6 @@ pub mod pallet {
 		/// - `origin`: Must be an origin specified by AdminOrigin.
 		/// - `maybe_xcm_version`: The default XCM encoding version, or `None` to disable.
 		#[pallet::call_index(5)]
-		#[pallet::weight(T::WeightInfo::force_default_xcm_version())]
 		pub fn force_default_xcm_version(
 			origin: OriginFor<T>,
 			maybe_xcm_version: Option<XcmVersion>,
@@ -1091,7 +1054,6 @@ pub mod pallet {
 		/// - `origin`: Must be an origin specified by AdminOrigin.
 		/// - `location`: The location to which we should subscribe for XCM version notifications.
 		#[pallet::call_index(6)]
-		#[pallet::weight(T::WeightInfo::force_subscribe_version_notify())]
 		pub fn force_subscribe_version_notify(
 			origin: OriginFor<T>,
 			location: Box<VersionedLocation>,
@@ -1115,7 +1077,6 @@ pub mod pallet {
 		/// - `location`: The location to which we are currently subscribed for XCM version
 		///   notifications which we no longer desire.
 		#[pallet::call_index(7)]
-		#[pallet::weight(T::WeightInfo::force_unsubscribe_version_notify())]
 		pub fn force_unsubscribe_version_notify(
 			origin: OriginFor<T>,
 			location: Box<VersionedLocation>,
@@ -1163,23 +1124,7 @@ pub mod pallet {
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
 		#[pallet::call_index(8)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					// heaviest version of locally executed XCM program: equivalent in weight to
-					// transfer assets to SA, reanchor them, extend XCM program, and send onward XCM
-					let mut message = Xcm(vec![
-						SetFeesMode { jit_withdraw: true },
-						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::reserve_transfer_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
+		#[pallet::weight(T::WeightInfo::reserve_transfer_assets())]
 		pub fn limited_reserve_transfer_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1217,23 +1162,7 @@ pub mod pallet {
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
 		#[pallet::call_index(9)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					let count = assets.len() as u32;
-					let mut message = Xcm(vec![
-						WithdrawAsset(assets),
-						SetFeesMode { jit_withdraw: true },
-						InitiateTeleport { assets: Wild(AllCounted(count)), dest, xcm: Xcm(vec![]) },
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::teleport_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
+		#[pallet::weight(T::WeightInfo::teleport_assets())]
 		pub fn limited_teleport_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1257,7 +1186,6 @@ pub mod pallet {
 		/// - `origin`: Must be an origin specified by AdminOrigin.
 		/// - `suspended`: `true` to suspend, `false` to resume.
 		#[pallet::call_index(10)]
-		#[pallet::weight(T::WeightInfo::force_suspension())]
 		pub fn force_suspension(origin: OriginFor<T>, suspended: bool) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 			XcmExecutionSuspended::<T>::set(suspended);
@@ -1298,26 +1226,6 @@ pub mod pallet {
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
 		#[pallet::call_index(11)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					// heaviest version of locally executed XCM program: equivalent in weight to withdrawing fees,
-					// burning them, transferring rest of assets to SA, reanchoring them, extending XCM program,
-					// and sending onward XCM
-					let mut message = Xcm(vec![
-						SetFeesMode { jit_withdraw: true },
-						WithdrawAsset(assets.clone()),
-						BurnAsset(assets.clone()),
-						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::transfer_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
 		pub fn transfer_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1407,22 +1315,6 @@ pub mod pallet {
 		/// was the latest when they were trapped.
 		/// - `beneficiary`: The location/account where the claimed assets will be deposited.
 		#[pallet::call_index(12)]
-		#[pallet::weight({
-			let assets_version = assets.identify_version();
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_beneficiary: Result<Location, ()> = (*beneficiary.clone()).try_into();
-			match (maybe_assets, maybe_beneficiary) {
-				(Ok(assets), Ok(beneficiary)) => {
-					let ticket: Location = GeneralIndex(assets_version as u128).into();
-					let mut message = Xcm(vec![
-						ClaimAsset { assets: assets.clone(), ticket },
-						DepositAsset { assets: AllCounted(assets.len() as u32).into(), beneficiary },
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::claim_assets().saturating_add(w))
-				}
-				_ => Weight::MAX
-			}
-		})]
 		pub fn claim_assets(
 			origin: OriginFor<T>,
 			assets: Box<VersionedAssets>,

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -947,6 +947,10 @@ pub mod pallet {
 				_ => Weight::MAX,
 			}
 		})]
+		#[allow(deprecated)]
+		#[deprecated(
+			note = "This extrinsic uses `WeightLimit::Unlimited`, please migrate to `limited_teleport_assets` or `transfer_assets`"
+		)]
 		pub fn teleport_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1005,6 +1009,10 @@ pub mod pallet {
 				_ => Weight::MAX,
 			}
 		})]
+		#[allow(deprecated)]
+		#[deprecated(
+			note = "This extrinsic uses `WeightLimit::Unlimited`, please migrate to `limited_reserve_transfer_assets` or `transfer_assets`"
+		)]
 		pub fn reserve_transfer_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1140,7 +1148,7 @@ pub mod pallet {
 		///
 		/// Fee payment on the destination side is made from the asset in the `assets` vector of
 		/// index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight
-		/// is needed than `weight_limit`, then the operation will fail and the assets send may be
+		/// is needed than `weight_limit`, then the operation will fail and the sent assets may be
 		/// at risk.
 		///
 		/// - `origin`: Must be capable of withdrawing the `assets` and executing XCM.
@@ -1194,7 +1202,7 @@ pub mod pallet {
 		///
 		/// Fee payment on the destination side is made from the asset in the `assets` vector of
 		/// index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight
-		/// is needed than `weight_limit`, then the operation will fail and the assets send may be
+		/// is needed than `weight_limit`, then the operation will fail and the sent assets may be
 		/// at risk.
 		///
 		/// - `origin`: Must be capable of withdrawing the `assets` and executing XCM.
@@ -1262,7 +1270,7 @@ pub mod pallet {
 		/// Fee payment on the destination side is made from the asset in the `assets` vector of
 		/// index `fee_asset_item` (hence referred to as `fees`), up to enough to pay for
 		/// `weight_limit` of weight. If more weight is needed than `weight_limit`, then the
-		/// operation will fail and the assets sent may be at risk.
+		/// operation will fail and the sent assets may be at risk.
 		///
 		/// `assets` (excluding `fees`) must have same reserve location or otherwise be teleportable
 		/// to `dest`, no limitations imposed on `fees`.

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -346,6 +346,10 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		msg: Xcm<()>,
 		reason: FeeReason,
 	) -> Result<XcmHash, XcmError> {
+		log::trace!(
+			target: "xcm::send", "Sending msg: {:?}, to destination: {:?}, (reason: {:?})",
+			msg, dest, reason,
+		);
 		let (ticket, fee) = validate_send::<Config::XcmSender>(dest, msg)?;
 		self.take_fee(fee, reason)?;
 		Config::XcmSender::deliver(ticket).map_err(Into::into)

--- a/polkadot/xcm/xcm-simulator/example/src/lib.rs
+++ b/polkadot/xcm/xcm-simulator/example/src/lib.rs
@@ -250,12 +250,13 @@ mod tests {
 		let withdraw_amount = 123;
 
 		Relay::execute_with(|| {
-			assert_ok!(RelayChainPalletXcm::reserve_transfer_assets(
+			assert_ok!(RelayChainPalletXcm::limited_reserve_transfer_assets(
 				relay_chain::RuntimeOrigin::signed(ALICE),
 				Box::new(Parachain(1).into()),
 				Box::new(AccountId32 { network: None, id: ALICE.into() }.into()),
 				Box::new((Here, withdraw_amount).into()),
 				0,
+				Unlimited,
 			));
 			assert_eq!(
 				relay_chain::Balances::free_balance(&child_account_id(1)),


### PR DESCRIPTION
## Description

Add `transfer_assets_using_reserve()` for transferring assets from local chain to destination chain using an explicit reserve location (typically local Asset Hub).

By default, an asset's reserve is its origin chain. But sometimes we may want to explicitly use another chain as reserve (as long as allowed by runtime `IsReserve` filter).

This is very helpful for transferring assets with multiple configured reserves (such as Asset Hub ForeignAssets), when the transfer strictly depends on the used reserve.

E.g. For transferring Foreign Assets over a bridge, Asset Hub must be used as the reserve location.

## Tests

Added integration tests for showcasing transferring assets from parachain over bridge using local Asset Hub reserve.

## TODOs

- [ ] benchmarks for new extrinsic
- [ ] add same tests on Westend side
- [ ] optional: deduplicate test code