### PR TITLE
Add bitflags and implement decode state trait

### DIFF
--- a/substrate/frame/executive/src/lib.rs
+++ b/substrate/frame/executive/src/lib.rs
@@ -449,7 +449,7 @@ where
 		let _guard = StorageNoopGuard::default();
 
 		// The state must be decodable:
-		if checks.any() {
+		if checks.should_check_state(UpgradeCheckSelect::All) {
 			let res = AllPalletsWithSystem::try_decode_entire_state();
 			Self::log_decode_result(res)?;
 		}

--- a/substrate/frame/executive/src/lib.rs
+++ b/substrate/frame/executive/src/lib.rs
@@ -449,7 +449,7 @@ where
 		let _guard = StorageNoopGuard::default();
 
 		// The state must be decodable:
-		if checks.should_check_state(UpgradeCheckSelect::All) {
+		if checks.should_decode_state() {
 			let res = AllPalletsWithSystem::try_decode_entire_state();
 			Self::log_decode_result(res)?;
 		}

--- a/substrate/frame/support/src/traits/try_runtime/decode_entire_state.rs
+++ b/substrate/frame/support/src/traits/try_runtime/decode_entire_state.rs
@@ -292,6 +292,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use self::UpgradeCheckSelect;
 	use super::*;
 	use crate::{
 		storage::types::{self, CountedStorageMapInstance, CountedStorageNMapInstance, Key},
@@ -521,6 +522,19 @@ mod tests {
 
 			Map::insert(0, 42);
 			assert_eq!(<(Value, Map) as TryDecodeEntireStorage>::try_decode_entire_state(), Ok(8));
+		});
+	}
+
+	#[test]
+	fn try_decode_entire_state() {
+		sp_io::TestExternalities::new_empty().execute_with(|| {
+			assert_eq!(
+				UpgradeCheckSelect::try_decode_entire_state(),
+				Ok((UpgradeCheckSelect::None
+					&& UpgradeCheckSelect::All
+					&& UpgradeCheckSelect::PreAndPost
+					&& UpgradeCheckSelect::TryState))
+			);
 		});
 	}
 }

--- a/substrate/frame/support/src/traits/try_runtime/decode_entire_state.rs
+++ b/substrate/frame/support/src/traits/try_runtime/decode_entire_state.rs
@@ -524,17 +524,4 @@ mod tests {
 			assert_eq!(<(Value, Map) as TryDecodeEntireStorage>::try_decode_entire_state(), Ok(8));
 		});
 	}
-
-	#[test]
-	fn try_decode_entire_state() {
-		sp_io::TestExternalities::new_empty().execute_with(|| {
-			assert_eq!(
-				UpgradeCheckSelect::try_decode_entire_state(),
-				Ok((UpgradeCheckSelect::None
-					&& UpgradeCheckSelect::All
-					&& UpgradeCheckSelect::PreAndPost
-					&& UpgradeCheckSelect::TryState))
-			);
-		});
-	}
 }

--- a/substrate/frame/support/src/traits/try_runtime/mod.rs
+++ b/substrate/frame/support/src/traits/try_runtime/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod decode_entire_state;
 pub use decode_entire_state::{TryDecodeEntireStorage, TryDecodeEntireStorageError};
+use enumflags2::{bitflags, BitFlags};
 
 use super::StorageInstance;
 
@@ -95,6 +96,8 @@ impl sp_std::str::FromStr for Select {
 }
 
 /// Select which checks should be run when trying a runtime upgrade upgrade.
+#[bitflags]
+#[repr(u64)]
 #[derive(codec::Encode, codec::Decode, Clone, Debug, Copy, scale_info::TypeInfo)]
 pub enum UpgradeCheckSelect {
 	/// Run no checks.
@@ -136,6 +139,13 @@ impl core::str::FromStr for UpgradeCheckSelect {
 			"try-state" => Ok(Self::TryState),
 			_ => Err("Invalid CheckSelector"),
 		}
+	}
+}
+
+impl TryDecodeEntireStorage for UpgradeCheckSelect {
+	fn try_decode_entire_state() -> Result<usize, Vec<TryDecodeEntireStorage<Error>>> {
+		let res = BitFlags::<ExampleEnum>::all();
+		return Ok(res.bits() as usize);
 	}
 }
 

--- a/substrate/frame/support/src/traits/try_runtime/mod.rs
+++ b/substrate/frame/support/src/traits/try_runtime/mod.rs
@@ -125,6 +125,10 @@ impl UpgradeCheckSelect {
 	pub fn any(&self) -> bool {
 		!matches!(self, Self::None)
 	}
+
+	pub fn should_check_state(&self, state: UpgradeCheckSelect) -> bool {
+		self.contains(state)
+	}
 }
 
 #[cfg(feature = "std")]
@@ -139,13 +143,6 @@ impl core::str::FromStr for UpgradeCheckSelect {
 			"try-state" => Ok(Self::TryState),
 			_ => Err("Invalid CheckSelector"),
 		}
-	}
-}
-
-impl TryDecodeEntireStorage for UpgradeCheckSelect {
-	fn try_decode_entire_state() -> Result<usize, Vec<TryDecodeEntireStorage<Error>>> {
-		let res = BitFlags::<ExampleEnum>::all();
-		return Ok(res.bits() as usize);
 	}
 }
 

--- a/substrate/frame/support/src/traits/try_runtime/mod.rs
+++ b/substrate/frame/support/src/traits/try_runtime/mod.rs
@@ -108,6 +108,8 @@ pub enum UpgradeCheckSelect {
 	PreAndPost,
 	/// Run the `try_state` checks.
 	TryState,
+	/// Run if state is decodable
+	DecodeState,
 }
 
 impl UpgradeCheckSelect {
@@ -126,8 +128,8 @@ impl UpgradeCheckSelect {
 		!matches!(self, Self::None)
 	}
 
-	pub fn should_check_state(&self, state: UpgradeCheckSelect) -> bool {
-		self.contains(state)
+	pub fn should_decode_state(&self) -> bool {
+		self.contains(Self::DecodeState)
 	}
 }
 


### PR DESCRIPTION
- [x] Add `#[bitflags]` attribute to the `UpgradeCheckSelect`
- [x] Implement trait `TryDecodeEntireStorage` to decode all possible enum fields of `UpgradableCheckSelect`
- [x] Write a test case in `decode_entire_state` to check a test case for `UpgradableCheckSelect`  
Linked issue: https://github.com/paritytech/polkadot-sdk/issues/2015