### PR TITLE
pallet-xcm: remove extrinsics guessed weight and rely on runtime benchmarks instead

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -882,10 +882,9 @@ pub mod pallet {
 		}
 	}
 
-	#[pallet::call]
+	#[pallet::call(weight(<T as Config>::WeightInfo))]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::send())]
 		pub fn send(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -914,23 +913,6 @@ pub mod pallet {
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
 		#[pallet::call_index(1)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					let count = assets.len() as u32;
-					let mut message = Xcm(vec![
-						WithdrawAsset(assets),
-						SetFeesMode { jit_withdraw: true },
-						InitiateTeleport { assets: Wild(AllCounted(count)), dest, xcm: Xcm(vec![]) },
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::teleport_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
 		pub fn teleport_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -972,23 +954,6 @@ pub mod pallet {
 		/// - `fee_asset_item`: The index into `assets` of the item which should be used to pay
 		///   fees.
 		#[pallet::call_index(2)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					// heaviest version of locally executed XCM program: equivalent in weight to
-					// transfer assets to SA, reanchor them, extend XCM program, and send onward XCM
-					let mut message = Xcm(vec![
-						SetFeesMode { jit_withdraw: true },
-						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::reserve_transfer_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
 		pub fn reserve_transfer_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1041,7 +1006,6 @@ pub mod pallet {
 		/// - `location`: The destination that is being described.
 		/// - `xcm_version`: The latest version of XCM that `location` supports.
 		#[pallet::call_index(4)]
-		#[pallet::weight(T::WeightInfo::force_xcm_version())]
 		pub fn force_xcm_version(
 			origin: OriginFor<T>,
 			location: Box<Location>,
@@ -1060,7 +1024,6 @@ pub mod pallet {
 		/// - `origin`: Must be an origin specified by AdminOrigin.
 		/// - `maybe_xcm_version`: The default XCM encoding version, or `None` to disable.
 		#[pallet::call_index(5)]
-		#[pallet::weight(T::WeightInfo::force_default_xcm_version())]
 		pub fn force_default_xcm_version(
 			origin: OriginFor<T>,
 			maybe_xcm_version: Option<XcmVersion>,
@@ -1075,7 +1038,6 @@ pub mod pallet {
 		/// - `origin`: Must be an origin specified by AdminOrigin.
 		/// - `location`: The location to which we should subscribe for XCM version notifications.
 		#[pallet::call_index(6)]
-		#[pallet::weight(T::WeightInfo::force_subscribe_version_notify())]
 		pub fn force_subscribe_version_notify(
 			origin: OriginFor<T>,
 			location: Box<VersionedLocation>,
@@ -1099,7 +1061,6 @@ pub mod pallet {
 		/// - `location`: The location to which we are currently subscribed for XCM version
 		///   notifications which we no longer desire.
 		#[pallet::call_index(7)]
-		#[pallet::weight(T::WeightInfo::force_unsubscribe_version_notify())]
 		pub fn force_unsubscribe_version_notify(
 			origin: OriginFor<T>,
 			location: Box<VersionedLocation>,
@@ -1147,23 +1108,7 @@ pub mod pallet {
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
 		#[pallet::call_index(8)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					// heaviest version of locally executed XCM program: equivalent in weight to
-					// transfer assets to SA, reanchor them, extend XCM program, and send onward XCM
-					let mut message = Xcm(vec![
-						SetFeesMode { jit_withdraw: true },
-						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::reserve_transfer_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
+		#[pallet::weight(T::WeightInfo::reserve_transfer_assets())]
 		pub fn limited_reserve_transfer_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1201,23 +1146,7 @@ pub mod pallet {
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
 		#[pallet::call_index(9)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					let count = assets.len() as u32;
-					let mut message = Xcm(vec![
-						WithdrawAsset(assets),
-						SetFeesMode { jit_withdraw: true },
-						InitiateTeleport { assets: Wild(AllCounted(count)), dest, xcm: Xcm(vec![]) },
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::teleport_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
+		#[pallet::weight(T::WeightInfo::teleport_assets())]
 		pub fn limited_teleport_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1241,7 +1170,6 @@ pub mod pallet {
 		/// - `origin`: Must be an origin specified by AdminOrigin.
 		/// - `suspended`: `true` to suspend, `false` to resume.
 		#[pallet::call_index(10)]
-		#[pallet::weight(T::WeightInfo::force_suspension())]
 		pub fn force_suspension(origin: OriginFor<T>, suspended: bool) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
 			XcmExecutionSuspended::<T>::set(suspended);
@@ -1282,26 +1210,6 @@ pub mod pallet {
 		///   fees.
 		/// - `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase.
 		#[pallet::call_index(11)]
-		#[pallet::weight({
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_dest: Result<Location, ()> = (*dest.clone()).try_into();
-			match (maybe_assets, maybe_dest) {
-				(Ok(assets), Ok(dest)) => {
-					use sp_std::vec;
-					// heaviest version of locally executed XCM program: equivalent in weight to withdrawing fees,
-					// burning them, transferring rest of assets to SA, reanchoring them, extending XCM program,
-					// and sending onward XCM
-					let mut message = Xcm(vec![
-						SetFeesMode { jit_withdraw: true },
-						WithdrawAsset(assets.clone()),
-						BurnAsset(assets.clone()),
-						TransferReserveAsset { assets, dest, xcm: Xcm(vec![]) }
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::transfer_assets().saturating_add(w))
-				}
-				_ => Weight::MAX,
-			}
-		})]
 		pub fn transfer_assets(
 			origin: OriginFor<T>,
 			dest: Box<VersionedLocation>,
@@ -1391,22 +1299,6 @@ pub mod pallet {
 		/// was the latest when they were trapped.
 		/// - `beneficiary`: The location/account where the claimed assets will be deposited.
 		#[pallet::call_index(12)]
-		#[pallet::weight({
-			let assets_version = assets.identify_version();
-			let maybe_assets: Result<Assets, ()> = (*assets.clone()).try_into();
-			let maybe_beneficiary: Result<Location, ()> = (*beneficiary.clone()).try_into();
-			match (maybe_assets, maybe_beneficiary) {
-				(Ok(assets), Ok(beneficiary)) => {
-					let ticket: Location = GeneralIndex(assets_version as u128).into();
-					let mut message = Xcm(vec![
-						ClaimAsset { assets: assets.clone(), ticket },
-						DepositAsset { assets: AllCounted(assets.len() as u32).into(), beneficiary },
-					]);
-					T::Weigher::weight(&mut message).map_or(Weight::MAX, |w| T::WeightInfo::claim_assets().saturating_add(w))
-				}
-				_ => Weight::MAX
-			}
-		})]
 		pub fn claim_assets(
 			origin: OriginFor<T>,
 			assets: Box<VersionedAssets>,


### PR DESCRIPTION
Relates to: https://github.com/polkadot-fellows/runtimes/issues/231
Fixes: https://github.com/paritytech/parity-bridges-common/issues/2874

Expected patches for (1.7.0):
- pallet-xcm `8.0.3`