### PR TITLE
Removed `pallet::getter` usage from Beefy and MMR pallets

### DIFF
--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2029,11 +2029,11 @@ sp_api::impl_runtime_apis! {
 	#[api_version(2)]
 	impl mmr::MmrApi<Block, mmr::Hash, BlockNumber> for Runtime {
 		fn mmr_root() -> Result<mmr::Hash, mmr::Error> {
-			Ok(Mmr::mmr_root())
+			Ok(pallet_mmr::RootHash::<Runtime>::get())
 		}
 
 		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
-			Ok(Mmr::mmr_leaves())
+			Ok(pallet_mmr::NumberOfLeaves::<Runtime>::get())
 		}
 
 		fn generate_proof(

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1991,7 +1991,7 @@ sp_api::impl_runtime_apis! {
 	#[api_version(3)]
 	impl beefy_primitives::BeefyApi<Block, BeefyId> for Runtime {
 		fn beefy_genesis() -> Option<BlockNumber> {
-			Beefy::genesis_block()
+			pallet_beefy::GenesisBlock::<Runtime>::get()
 		}
 
 		fn validator_set() -> Option<beefy_primitives::ValidatorSet<BeefyId>> {

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2052,11 +2052,11 @@ sp_api::impl_runtime_apis! {
 
 	impl mmr::MmrApi<Block, Hash, BlockNumber> for Runtime {
 		fn mmr_root() -> Result<mmr::Hash, mmr::Error> {
-			Ok(Mmr::mmr_root())
+			Ok(pallet_mmr::RootHash::<Runtime>::get())
 		}
 
 		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
-			Ok(Mmr::mmr_leaves())
+			Ok(pallet_mmr::NumberOfLeaves::<Runtime>::get())
 		}
 
 		fn generate_proof(

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2015,7 +2015,7 @@ sp_api::impl_runtime_apis! {
 
 	impl beefy_primitives::BeefyApi<Block, BeefyId> for Runtime {
 		fn beefy_genesis() -> Option<BlockNumber> {
-			Beefy::genesis_block()
+			pallet_beefy::GenesisBlock::<Runtime>::get()
 		}
 
 		fn validator_set() -> Option<beefy_primitives::ValidatorSet<BeefyId>> {

--- a/prdoc/pr_3740.prdoc
+++ b/prdoc/pr_3740.prdoc
@@ -1,0 +1,18 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Removed `pallet::getter` usage from Beefy and MMR pallets
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      This PR removes `pallet::getter` usage from `pallet-beefy`, `pallet-beefy-mmr` and `pallet-mmr`, and updates dependant code and runtimes accordingly.
+      The syntax `StorageItem::<T, I>::get()` should be used instead.
+
+crates: 
+  - name: pallet-beefy
+  - name: pallet-beefy-mmr
+  - name: pallet-mmr
+  - name: kitchensink-runtime
+  - name: rococo-runtime
+  - name: westend-runtime

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2979,7 +2979,7 @@ impl_runtime_apis! {
 	#[api_version(3)]
 	impl sp_consensus_beefy::BeefyApi<Block, BeefyId> for Runtime {
 		fn beefy_genesis() -> Option<BlockNumber> {
-			Beefy::genesis_block()
+			pallet_beefy::GenesisBlock::<Runtime>::get()
 		}
 
 		fn validator_set() -> Option<sp_consensus_beefy::ValidatorSet<BeefyId>> {

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3018,11 +3018,11 @@ impl_runtime_apis! {
 		BlockNumber,
 	> for Runtime {
 		fn mmr_root() -> Result<mmr::Hash, mmr::Error> {
-			Ok(Mmr::mmr_root())
+			Ok(pallet_mmr::RootHash::<Runtime>::get())
 		}
 
 		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
-			Ok(Mmr::mmr_leaves())
+			Ok(pallet_mmr::NumberOfLeaves::<Runtime>::get())
 		}
 
 		fn generate_proof(

--- a/substrate/frame/beefy-mmr/src/lib.rs
+++ b/substrate/frame/beefy-mmr/src/lib.rs
@@ -68,7 +68,7 @@ where
 				<T as pallet_beefy::Config>::BeefyId,
 			>::MmrRoot(*root)),
 		);
-		<frame_system::Pallet<T>>::deposit_log(digest);
+		frame_system::Pallet::<T>::deposit_log(digest);
 	}
 }
 
@@ -126,7 +126,6 @@ pub mod pallet {
 
 	/// Details of current BEEFY authority set.
 	#[pallet::storage]
-	#[pallet::getter(fn beefy_authorities)]
 	pub type BeefyAuthorities<T: Config> =
 		StorageValue<_, BeefyAuthoritySet<MerkleRootOf<T>>, ValueQuery>;
 
@@ -134,7 +133,6 @@ pub mod pallet {
 	///
 	/// This storage entry is used as cache for calls to `update_beefy_next_authority_set`.
 	#[pallet::storage]
-	#[pallet::getter(fn beefy_next_authorities)]
 	pub type BeefyNextAuthorities<T: Config> =
 		StorageValue<_, BeefyNextAuthoritySet<MerkleRootOf<T>>, ValueQuery>;
 }
@@ -152,7 +150,7 @@ impl<T: Config> LeafDataProvider for Pallet<T> {
 			version: T::LeafVersion::get(),
 			parent_number_and_hash: ParentNumberAndHash::<T>::leaf_data(),
 			leaf_extra: T::BeefyDataProvider::extra_data(),
-			beefy_next_authority_set: Pallet::<T>::beefy_next_authorities(),
+			beefy_next_authority_set: BeefyNextAuthorities::<T>::get(),
 		}
 	}
 }
@@ -177,12 +175,12 @@ where
 impl<T: Config> Pallet<T> {
 	/// Return the currently active BEEFY authority set proof.
 	pub fn authority_set_proof() -> BeefyAuthoritySet<MerkleRootOf<T>> {
-		Pallet::<T>::beefy_authorities()
+		BeefyAuthorities::<T>::get()
 	}
 
 	/// Return the next/queued BEEFY authority set proof.
 	pub fn next_authority_set_proof() -> BeefyNextAuthoritySet<MerkleRootOf<T>> {
-		Pallet::<T>::beefy_next_authorities()
+		BeefyNextAuthorities::<T>::get()
 	}
 
 	/// Returns details of a BEEFY authority set.

--- a/substrate/frame/beefy-mmr/src/tests.rs
+++ b/substrate/frame/beefy-mmr/src/tests.rs
@@ -107,7 +107,7 @@ fn should_contain_valid_leaf_data() {
 	let mut ext = new_test_ext(vec![1, 2, 3, 4]);
 	let parent_hash = ext.execute_with(|| {
 		init_block(1);
-		<frame_system::Pallet<Test>>::parent_hash()
+		frame_system::Pallet::<Test>::parent_hash()
 	});
 
 	let mmr_leaf = read_mmr_leaf(&mut ext, node_offchain_key(0, parent_hash));
@@ -132,7 +132,7 @@ fn should_contain_valid_leaf_data() {
 	// build second block on top
 	let parent_hash = ext.execute_with(|| {
 		init_block(2);
-		<frame_system::Pallet<Test>>::parent_hash()
+		frame_system::Pallet::<Test>::parent_hash()
 	});
 
 	let mmr_leaf = read_mmr_leaf(&mut ext, node_offchain_key(1, parent_hash));

--- a/substrate/frame/beefy/src/equivocation.rs
+++ b/substrate/frame/beefy/src/equivocation.rs
@@ -190,7 +190,7 @@ where
 		evidence: EquivocationEvidenceFor<T>,
 	) -> Result<(), DispatchError> {
 		let (equivocation_proof, key_owner_proof) = evidence;
-		let reporter = reporter.or_else(|| <pallet_authorship::Pallet<T>>::author());
+		let reporter = reporter.or_else(|| pallet_authorship::Pallet::<T>::author());
 		let offender = equivocation_proof.offender_id().clone();
 
 		// We check the equivocation within the context of its set id (and

--- a/substrate/frame/beefy/src/lib.rs
+++ b/substrate/frame/beefy/src/lib.rs
@@ -180,7 +180,7 @@ pub mod pallet {
 				// we panic here as runtime maintainers can simply reconfigure genesis and restart
 				// the chain easily
 				.expect("Authorities vec too big");
-			<GenesisBlock<T>>::put(&self.genesis_block);
+			GenesisBlock::<T>::put(&self.genesis_block);
 		}
 	}
 
@@ -320,19 +320,19 @@ impl<T: Config> Pallet<T> {
 		new: BoundedVec<T::BeefyId, T::MaxAuthorities>,
 		queued: BoundedVec<T::BeefyId, T::MaxAuthorities>,
 	) {
-		<Authorities<T>>::put(&new);
+		Authorities::<T>::put(&new);
 
 		let new_id = ValidatorSetId::<T>::get() + 1u64;
-		<ValidatorSetId<T>>::put(new_id);
+		ValidatorSetId::<T>::put(new_id);
 
-		<NextAuthorities<T>>::put(&queued);
+		NextAuthorities::<T>::put(&queued);
 
 		if let Some(validator_set) = ValidatorSet::<T::BeefyId>::new(new, new_id) {
 			let log = DigestItem::Consensus(
 				BEEFY_ENGINE_ID,
 				ConsensusLog::AuthoritiesChange(validator_set.clone()).encode(),
 			);
-			<frame_system::Pallet<T>>::deposit_log(log);
+			frame_system::Pallet::<T>::deposit_log(log);
 
 			let next_id = new_id + 1;
 			if let Some(next_validator_set) = ValidatorSet::<T::BeefyId>::new(queued, next_id) {
@@ -349,7 +349,7 @@ impl<T: Config> Pallet<T> {
 			return Ok(())
 		}
 
-		if !<Authorities<T>>::get().is_empty() {
+		if !Authorities::<T>::get().is_empty() {
 			return Err(())
 		}
 
@@ -358,10 +358,10 @@ impl<T: Config> Pallet<T> {
 				.map_err(|_| ())?;
 
 		let id = GENESIS_AUTHORITY_SET_ID;
-		<Authorities<T>>::put(bounded_authorities);
-		<ValidatorSetId<T>>::put(id);
+		Authorities::<T>::put(bounded_authorities);
+		ValidatorSetId::<T>::put(id);
 		// Like `pallet_session`, initialize the next validator set as well.
-		<NextAuthorities<T>>::put(bounded_authorities);
+		NextAuthorities::<T>::put(bounded_authorities);
 
 		if let Some(validator_set) = ValidatorSet::<T::BeefyId>::new(authorities.clone(), id) {
 			let next_id = id + 1;
@@ -438,7 +438,7 @@ where
 
 		let validator_set_id = ValidatorSetId::<T>::get();
 		// Update the mapping for the new set id that corresponds to the latest session (i.e. now).
-		let session_index = <pallet_session::Pallet<T>>::current_index();
+		let session_index = pallet_session::Pallet::<T>::current_index();
 		SetIdSession::<T>::insert(validator_set_id, &session_index);
 		// Prune old entry if limit reached.
 		let max_set_id_session_entries = T::MaxSetIdSessionEntries::get().max(1);
@@ -453,7 +453,7 @@ where
 			ConsensusLog::<T::BeefyId>::OnDisabled(i as AuthorityIndex).encode(),
 		);
 
-		<frame_system::Pallet<T>>::deposit_log(log);
+		frame_system::Pallet::<T>::deposit_log(log);
 	}
 }
 

--- a/substrate/frame/merkle-mountain-range/src/lib.rs
+++ b/substrate/frame/merkle-mountain-range/src/lib.rs
@@ -183,7 +183,6 @@ pub mod pallet {
 
 	/// Latest MMR Root hash.
 	#[pallet::storage]
-	#[pallet::getter(fn mmr_root_hash)]
 	pub type RootHash<T: Config<I>, I: 'static = ()> = StorageValue<_, HashOf<T, I>, ValueQuery>;
 
 	/// Current size of the MMR (number of leaves).
@@ -204,7 +203,7 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
 		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
 			use primitives::LeafDataProvider;
-			let leaves = Self::mmr_leaves();
+			let leaves = NumberOfLeaves::<T, I>::get();
 			let peaks_before = sp_mmr_primitives::utils::NodesUtils::new(leaves).number_of_peaks();
 			let data = T::LeafData::leaf_data();
 
@@ -301,7 +300,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	{
 		let first_mmr_block = utils::first_mmr_block_num::<HeaderFor<T>>(
 			<frame_system::Pallet<T>>::block_number(),
-			Self::mmr_leaves(),
+			NumberOfLeaves::<T, I>::get(),
 		)?;
 
 		utils::block_num_to_leaf_index::<HeaderFor<T>>(block_num, first_mmr_block)
@@ -341,7 +340,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 	/// Return the on-chain MMR root hash.
 	pub fn mmr_root() -> HashOf<T, I> {
-		Self::mmr_root_hash()
+		RootHash::<T, I>::get()
 	}
 
 	/// Verify MMR proof for given `leaves`.
@@ -354,7 +353,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		leaves: Vec<LeafOf<T, I>>,
 		proof: primitives::Proof<HashOf<T, I>>,
 	) -> Result<(), primitives::Error> {
-		if proof.leaf_count > Self::mmr_leaves() ||
+		if proof.leaf_count > NumberOfLeaves::<T, I>::get() ||
 			proof.leaf_count == 0 ||
 			(proof.items.len().saturating_add(leaves.len())) as u64 > proof.leaf_count
 		{

--- a/substrate/frame/merkle-mountain-range/src/lib.rs
+++ b/substrate/frame/merkle-mountain-range/src/lib.rs
@@ -224,8 +224,8 @@ pub mod pallet {
 			};
 			<T::OnNewRoot as primitives::OnNewRoot<_>>::on_new_root(&root);
 
-			<NumberOfLeaves<T, I>>::put(leaves);
-			<RootHash<T, I>>::put(root);
+			NumberOfLeaves::<T, I>::put(leaves);
+			RootHash::<T, I>::put(root);
 
 			let peaks_after = sp_mmr_primitives::utils::NodesUtils::new(leaves).number_of_peaks();
 

--- a/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -111,7 +111,7 @@ where
 	L: primitives::FullLeaf,
 {
 	fn get_elem(&self, pos: NodeIndex) -> mmr_lib::Result<Option<NodeOf<T, I, L>>> {
-		Ok(<Nodes<T, I>>::get(pos).map(Node::Hash))
+		Ok(Nodes::<T, I>::get(pos).map(Node::Hash))
 	}
 
 	fn append(&mut self, pos: NodeIndex, elems: Vec<NodeOf<T, I, L>>) -> mmr_lib::Result<()> {
@@ -147,7 +147,7 @@ where
 		for elem in elems {
 			// On-chain we are going to only store new peaks.
 			if peaks_to_store.next_if_eq(&node_index).is_some() {
-				<Nodes<T, I>>::insert(node_index, elem.hash());
+				Nodes::<T, I>::insert(node_index, elem.hash());
 			}
 			// We are storing full node off-chain (using indexing API).
 			Self::store_to_offchain(node_index, parent_hash, &elem);
@@ -164,7 +164,7 @@ where
 
 		// And remove all remaining items from `peaks_before` collection.
 		for pos in peaks_to_prune {
-			<Nodes<T, I>>::remove(pos);
+			Nodes::<T, I>::remove(pos);
 		}
 
 		Ok(())

--- a/substrate/frame/merkle-mountain-range/src/tests.rs
+++ b/substrate/frame/merkle-mountain-range/src/tests.rs
@@ -608,9 +608,9 @@ fn verification_should_be_stateless() {
 	let mut ext = new_test_ext();
 	let (root_6, root_7) = ext.execute_with(|| {
 		add_blocks(6);
-		let root_6 = crate::Pallet::<Test>::mmr_root_hash();
+		let root_6 = crate::Pallet::<Test>::mmr_root();
 		add_blocks(1);
-		let root_7 = crate::Pallet::<Test>::mmr_root_hash();
+		let root_7 = crate::Pallet::<Test>::mmr_root();
 		(root_6, root_7)
 	});
 	ext.persist_offchain_overlay();
@@ -656,9 +656,9 @@ fn should_verify_batch_proof_statelessly() {
 	let mut ext = new_test_ext();
 	let (root_6, root_7) = ext.execute_with(|| {
 		add_blocks(6);
-		let root_6 = crate::Pallet::<Test>::mmr_root_hash();
+		let root_6 = crate::Pallet::<Test>::mmr_root();
 		add_blocks(1);
-		let root_7 = crate::Pallet::<Test>::mmr_root_hash();
+		let root_7 = crate::Pallet::<Test>::mmr_root();
 		(root_6, root_7)
 	});
 	ext.persist_offchain_overlay();


### PR DESCRIPTION
Part of #3326 

cc @kianenigma @ggwpez @liamaharon 

polkadot address: 12poSUQPtcF1HUPQGY3zZu2P8emuW9YnsPduA4XG3oCEfJVp