### PR TITLE
chore: bump zombienet version (1.3.95)

### DIFF
--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -1,7 +1,7 @@
 .zombienet-refs:
   extends: .build-refs
   variables:
-    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.91"
+    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.95"
 
 include:
   # substrate tests


### PR DESCRIPTION
Bump zombienet version, this version have the latest version of `@polkadot/api` module and fix the failures in CI (e.g https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/5570106).

Thanks!