### PR TITLE
XCM remove extra QueryId types from traits

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -374,7 +374,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			timeout: BlockNumberFor<T>,
 			match_querier: VersionedLocation,
-		) -> Result<Self::QueryId, DispatchError> {
+		) -> Result<QueryId, DispatchError> {
 			let responder = <T as Config>::ExecuteXcmOrigin::ensure_origin(origin)?;
 			let query_id = <Self as QueryHandler>::new_query(
 				responder,
@@ -1478,7 +1478,6 @@ impl<T: Config> sp_std::fmt::Debug for FeesHandling<T> {
 }
 
 impl<T: Config> QueryHandler for Pallet<T> {
-	type QueryId = u64;
 	type BlockNumber = BlockNumberFor<T>;
 	type Error = XcmError;
 	type UniversalLocation = T::UniversalLocation;
@@ -1488,7 +1487,7 @@ impl<T: Config> QueryHandler for Pallet<T> {
 		responder: impl Into<Location>,
 		timeout: BlockNumberFor<T>,
 		match_querier: impl Into<Location>,
-	) -> Self::QueryId {
+	) -> QueryId {
 		Self::do_new_query(responder, None, timeout, match_querier)
 	}
 
@@ -1498,7 +1497,7 @@ impl<T: Config> QueryHandler for Pallet<T> {
 		message: &mut Xcm<()>,
 		responder: impl Into<Location>,
 		timeout: Self::BlockNumber,
-	) -> Result<Self::QueryId, Self::Error> {
+	) -> Result<QueryId, Self::Error> {
 		let responder = responder.into();
 		let destination = Self::UniversalLocation::get()
 			.invert_target(&responder)
@@ -1511,7 +1510,7 @@ impl<T: Config> QueryHandler for Pallet<T> {
 	}
 
 	/// Removes response when ready and emits [Event::ResponseTaken] event.
-	fn take_response(query_id: Self::QueryId) -> QueryResponseStatus<Self::BlockNumber> {
+	fn take_response(query_id: QueryId) -> QueryResponseStatus<Self::BlockNumber> {
 		match Queries::<T>::get(query_id) {
 			Some(QueryStatus::Ready { response, at }) => match response.try_into() {
 				Ok(response) => {
@@ -1528,7 +1527,7 @@ impl<T: Config> QueryHandler for Pallet<T> {
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn expect_response(id: Self::QueryId, response: Response) {
+	fn expect_response(id: QueryId, response: Response) {
 		let response = response.into();
 		Queries::<T>::insert(
 			id,

--- a/polkadot/xcm/xcm-builder/src/controller.rs
+++ b/polkadot/xcm/xcm-builder/src/controller.rs
@@ -132,7 +132,7 @@ pub trait QueryController<Origin, Timeout>: QueryHandler {
 		origin: Origin,
 		timeout: Timeout,
 		match_querier: VersionedLocation,
-	) -> Result<Self::QueryId, DispatchError>;
+	) -> Result<QueryId, DispatchError>;
 }
 
 impl<Origin, RuntimeCall> ExecuteController<Origin, RuntimeCall> for () {
@@ -186,7 +186,7 @@ impl<Origin, Timeout> QueryController<Origin, Timeout> for () {
 		_origin: Origin,
 		_timeout: Timeout,
 		_match_querier: VersionedLocation,
-	) -> Result<Self::QueryId, DispatchError> {
+	) -> Result<QueryId, DispatchError> {
 		Ok(Default::default())
 	}
 }

--- a/polkadot/xcm/xcm-builder/src/pay.rs
+++ b/polkadot/xcm/xcm-builder/src/pay.rs
@@ -88,7 +88,7 @@ impl<
 	type Beneficiary = Beneficiary;
 	type AssetKind = AssetKind;
 	type Balance = u128;
-	type Id = Querier::QueryId;
+	type Id = QueryId;
 	type Error = xcm::latest::Error;
 
 	fn pay(

--- a/polkadot/xcm/xcm-builder/src/tests/mock.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/mock.rs
@@ -38,7 +38,7 @@ pub use sp_std::{
 	collections::{btree_map::BTreeMap, btree_set::BTreeSet},
 	fmt::Debug,
 };
-pub use xcm::latest::{prelude::*, Weight};
+pub use xcm::latest::{prelude::*, QueryId, Weight};
 use xcm_executor::traits::{Properties, QueryHandler, QueryResponseStatus};
 pub use xcm_executor::{
 	traits::{
@@ -414,7 +414,6 @@ pub struct TestQueryHandler<T, BlockNumber>(core::marker::PhantomData<(T, BlockN
 impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 	for TestQueryHandler<T, BlockNumber>
 {
-	type QueryId = u64;
 	type BlockNumber = BlockNumber;
 	type Error = XcmError;
 	type UniversalLocation = T::UniversalLocation;
@@ -423,7 +422,7 @@ impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 		responder: impl Into<Location>,
 		_timeout: Self::BlockNumber,
 		_match_querier: impl Into<Location>,
-	) -> Self::QueryId {
+	) -> QueryId {
 		let query_id = 1;
 		expect_response(query_id, responder.into());
 		query_id
@@ -433,7 +432,7 @@ impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 		message: &mut Xcm<()>,
 		responder: impl Into<Location>,
 		timeout: Self::BlockNumber,
-	) -> Result<Self::QueryId, Self::Error> {
+	) -> Result<QueryId, Self::Error> {
 		let responder = responder.into();
 		let destination = Self::UniversalLocation::get()
 			.invert_target(&responder)
@@ -445,7 +444,7 @@ impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 		Ok(query_id)
 	}
 
-	fn take_response(query_id: Self::QueryId) -> QueryResponseStatus<Self::BlockNumber> {
+	fn take_response(query_id: QueryId) -> QueryResponseStatus<Self::BlockNumber> {
 		QUERIES
 			.with(|q| {
 				q.borrow().get(&query_id).and_then(|v| match v {
@@ -460,7 +459,7 @@ impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn expect_response(_id: Self::QueryId, _response: xcm::latest::Response) {
+	fn expect_response(_id: QueryId, _response: xcm::latest::Response) {
 		// Unnecessary since it's only a test implementation
 	}
 }

--- a/polkadot/xcm/xcm-executor/src/traits/on_response.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/on_response.rs
@@ -16,11 +16,8 @@
 
 use crate::{Junctions::Here, Xcm};
 use core::result;
-use frame_support::{
-	pallet_prelude::{Get, TypeInfo},
-	parameter_types,
-};
-use parity_scale_codec::{Decode, Encode, FullCodec, MaxEncodedLen};
+use frame_support::{pallet_prelude::Get, parameter_types};
+use parity_scale_codec::{Decode, Encode};
 use sp_arithmetic::traits::Zero;
 use sp_std::fmt::Debug;
 use xcm::latest::{
@@ -115,15 +112,6 @@ pub enum QueryResponseStatus<BlockNumber> {
 
 /// Provides methods to expect responses from XCMs and query their status.
 pub trait QueryHandler {
-	type QueryId: From<u64>
-		+ FullCodec
-		+ MaxEncodedLen
-		+ TypeInfo
-		+ Clone
-		+ Eq
-		+ PartialEq
-		+ Debug
-		+ Copy;
 	type BlockNumber: Zero + Encode;
 	type Error;
 	type UniversalLocation: Get<InteriorLocation>;
@@ -151,14 +139,14 @@ pub trait QueryHandler {
 		message: &mut Xcm<()>,
 		responder: impl Into<Location>,
 		timeout: Self::BlockNumber,
-	) -> result::Result<Self::QueryId, Self::Error>;
+	) -> result::Result<QueryId, Self::Error>;
 
 	/// Attempt to remove and return the response of query with ID `query_id`.
-	fn take_response(id: Self::QueryId) -> QueryResponseStatus<Self::BlockNumber>;
+	fn take_response(id: QueryId) -> QueryResponseStatus<Self::BlockNumber>;
 
 	/// Makes sure to expect a response with the given id.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn expect_response(id: Self::QueryId, response: Response);
+	fn expect_response(id: QueryId, response: Response);
 }
 
 parameter_types! {
@@ -168,17 +156,16 @@ parameter_types! {
 impl QueryHandler for () {
 	type BlockNumber = u64;
 	type Error = ();
-	type QueryId = u64;
 	type UniversalLocation = UniversalLocation;
 
-	fn take_response(_query_id: Self::QueryId) -> QueryResponseStatus<Self::BlockNumber> {
+	fn take_response(_query_id: QueryId) -> QueryResponseStatus<Self::BlockNumber> {
 		QueryResponseStatus::NotFound
 	}
 	fn new_query(
 		_responder: impl Into<Location>,
 		_timeout: Self::BlockNumber,
 		_match_querier: impl Into<Location>,
-	) -> Self::QueryId {
+	) -> QueryId {
 		0u64
 	}
 
@@ -186,10 +173,10 @@ impl QueryHandler for () {
 		_message: &mut Xcm<()>,
 		_responder: impl Into<Location>,
 		_timeout: Self::BlockNumber,
-	) -> Result<Self::QueryId, Self::Error> {
+	) -> Result<QueryId, Self::Error> {
 		Err(())
 	}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	fn expect_response(_id: Self::QueryId, _response: crate::Response) {}
+	fn expect_response(_id: QueryId, _response: crate::Response) {}
 }


### PR DESCRIPTION
We do not need to make these traits generic over QueryId type, we can
just use the QueryId alias everywhere
