### PR TITLE
fix: 🔥 feat(logs): Commented Substrate logs to allow Madara logs locally

### DIFF
--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -189,7 +189,7 @@ where
 	) -> Proposer<Block, C, A, PR> {
 		let parent_hash = parent_header.hash();
 
-		info!("🙌 Starting consensus session on top of parent {:?}", parent_hash);
+		// info!("🙌 Starting consensus session on top of parent {:?}", parent_hash);
 
 		let proposer = Proposer::<_, _, _, PR> {
 			spawn_handle: self.spawn_handle.clone(),
@@ -556,13 +556,13 @@ where
 			)
 		};
 
-		info!(
-			"🎁 Prepared block for proposing at {} ({} ms) [hash: {:?}; parent_hash: {}; {extrinsics_summary}",
-			block.header().number(),
-			block_took.as_millis(),
-			<Block as BlockT>::Hash::from(block.header().hash()),
-			block.header().parent_hash(),
-		);
+		// info!(
+		// 	"🎁 Prepared block for proposing at {} ({} ms) [hash: {:?}; parent_hash: {}; {extrinsics_summary}",
+		// 	block.header().number(),
+		// 	block_took.as_millis(),
+		// 	<Block as BlockT>::Hash::from(block.header().hash()),
+		// 	block.header().parent_hash(),
+		// );
 		telemetry!(
 			self.telemetry;
 			CONSENSUS_INFO;

--- a/substrate/client/informant/src/lib.rs
+++ b/substrate/client/informant/src/lib.rs
@@ -187,12 +187,12 @@ where
 				last_blocks.pop_front();
 			}
 
-			info!(
-				target: "substrate",
-				"✨ Imported #{} ({})",
-				format.print_with_color(Colour::White.bold(), n.header.number()),
-				n.hash,
-			);
+			// info!(
+			// 	target: "substrate",
+			// 	"✨ Imported #{} ({})",
+			// 	format.print_with_color(Colour::White.bold(), n.header.number()),
+			// 	n.hash,
+			// );
 		}
 
 		future::ready(())


### PR DESCRIPTION
## fix: 🔥 feat(logs): Commented Substrate logs to allow Madara logs locally

Currently Madara and any other product inherithing from the Starknet pallet display logs from Substrate showing data related to the Substrate block wrapping the app chain block:

![image](https://github.com/paritytech/polkadot-sdk/assets/74653697/7eeafe98-e930-4749-bdf1-49923491def9)

The goal of this issue is to solve https://github.com/keep-starknet-strange/madara/issues/1484 in the most optimal way by commenting the block related logs allowing anyone to chose what to display locally with their relevant data.