### PR TITLE
Set storage for EthereumGatewayAddress runtime parameter

### DIFF
--- a/bridges/snowbridge/pallets/inbound-queue/src/benchmarking/mod.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/benchmarking/mod.rs
@@ -5,12 +5,20 @@ use super::*;
 use crate::Pallet as InboundQueue;
 use frame_benchmarking::v2::*;
 use frame_support::assert_ok;
+use frame_support::parameter_types;
+use hex_literal::hex;
 use frame_system::RawOrigin;
 use snowbridge_pallet_inbound_queue_fixtures::register_token::make_register_token_message;
+
+parameter_types! {
+	pub storage EthereumGatewayAddress: H160 = H160::zero();
+}
 
 #[benchmarks]
 mod benchmarks {
 	use super::*;
+
+
 
 	#[benchmark]
 	fn submit() -> Result<(), BenchmarkError> {
@@ -22,6 +30,8 @@ mod benchmarks {
 			create_message.message.proof.block_hash,
 			create_message.execution_header,
 		);
+
+		EthereumGatewayAddress::set(hex!["EDa338E4dC46038493b885327842fD3E301CaB39"].into());
 
 		let sovereign_account = sibling_sovereign_account::<T>(1000u32.into());
 

--- a/bridges/snowbridge/pallets/inbound-queue/src/benchmarking/mod.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/benchmarking/mod.rs
@@ -31,7 +31,7 @@ mod benchmarks {
 			create_message.execution_header,
 		);
 
-		EthereumGatewayAddress::set(hex!["EDa338E4dC46038493b885327842fD3E301CaB39"].into());
+		EthereumGatewayAddress::set(&hex!["EDa338E4dC46038493b885327842fD3E301CaB39"].into());
 
 		let sovereign_account = sibling_sovereign_account::<T>(1000u32.into());
 


### PR DESCRIPTION
To fix benchmarking errors for a snowbridge pallet:

```
2024-03-21 13:50:40 Running  benchmark: snowbridge_pallet_ethereum_client.submit_execution_header(0 args) 1/1 1/1    
Running benchmarks for snowbridge_pallet_inbound_queue to ./bridge-hub-kusama-weights/
2024-03-21 13:50:41 Starting benchmark: snowbridge_pallet_inbound_queue::submit    
2024-03-21 13:50:41 💫 Verifying message with block hash 0x3921…3a3f    
2024-03-21 13:50:41 💫 Receipt verification successful for 0x3921…3a3f    
2024-03-21 13:50:41 panicked at /home/bparity/.cargo/registry/src/index.crates.io-6f17d22bba15001f/snowbridge-pallet-inbound-queue-0.1.0/src/benchmarking/mod.rs:43:13:
Expected Ok(_). Got Err(
    Module(
        ModuleError {
            index: 80,
            error: [
                0,
                0,
                0,
                0,
            ],
            message: Some(
                "InvalidGateway",
            ),
        },
    ),
)    
Error: 
   0: Invalid input: Error executing and verifying runtime benchmark: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed
      WASM backtrace:
      error while executing at wasm backtrace:
          0: 0x436fa6 - <unknown>!rust_begin_unwind
          1: 0x2969 - <unknown>!core::panicking::panic_fmt::hbb0c5dd9c7ebab99
          2: 0x329f54 - <unknown>!core::ops::function::FnOnce::call_once{{vtable.shim}}::h0374b352d74ea114
          3: 0x300e24 - <unknown>!<bridge_hub_kusama_runtime::Runtime as frame_benchmarking::utils::runtime_decl_for_benchmark::BenchmarkV1<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u32,sp_runtime::traits::BlakeTwo256>,sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic<sp_runtime::multiaddress::MultiAddress<<<sp_runtime::MultiSignature as sp_runtime::traits::Verify>::Signer as sp_runtime::traits::IdentifyAccount>::AccountId,()>,bridge_hub_kusama_runtime::RuntimeCall,sp_runtime::MultiSignature,(frame_system::extensions::check_non_zero_sender::CheckNonZeroSender<bridge_hub_kusama_runtime::Runtime>,frame_system::extensions::check_spec_version::CheckSpecVersion<bridge_hub_kusama_runtime::Runtime>,frame_system::extensions::check_tx_version::CheckTxVersion<bridge_hub_kusama_runtime::Runtime>,frame_system::extensions::check_genesis::CheckGenesis<bridge_hub_kusama_runtime::Runtime>,frame_system::extensions::check_mortality::CheckMortality<bridge_hub_kusama_runtime::Runtime>,frame_system::extensions::check_nonce::CheckNonce<bridge_hub_kusama_runtime::Runtime>,frame_system::extensions::check_weight::CheckWeight<bridge_hub_kusama_runtime::Runtime>,pallet_transaction_payment::ChargeTransactionPayment<bridge_hub_kusama_runtime::Runtime>,bridge_hub_kusama_runtime::BridgeRejectObsoleteHeadersAndMessages,bridge_runtime_common::refund_relayer_extension::RefundSignedExtensionAdapter<bridge_runtime_common::refund_relayer_extension::RefundBridgedParachainMessages<bridge_hub_kusama_runtime::Runtime,bridge_runtime_common::refund_relayer_extension::RefundableParachain<frame_support::instances::Instance1,bp_bridge_hub_polkadot::BridgeHubPolkadot>,bridge_runtime_common::refund_relayer_extension::RefundableMessagesLane<frame_support::instances::Instance1,bridge_hub_kusama_runtime::bridge_to_polkadot_config::AssetHubKusamaToAssetHubPolkadotMessagesLane>,bridge_runtime_common::refund_relayer_extension::ActualFeeRefund<bridge_hub_kusama_runtime::Runtime>,bridge_hub_kusama_runtime::bridge_to_polkadot_config::PriorityBoostPerMessage,bridge_hub_kusama_runtime::bridge_to_polkadot_config::StrRefundBridgeHubPolkadotMessages>>)>>>>::dispatch_benchmark::h500c8f48422e47bd
          4: 0x3c0b6a - <unknown>!Benchmark_dispatch_benchmark
```