### PR TITLE
pallet-xcm: fix transport fees for remote reserve transfers

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -1875,6 +1875,7 @@ impl<T: Config> Pallet<T> {
 		]);
 		Ok(Xcm(vec![
 			WithdrawAsset(assets.into()),
+			SetFeesMode { jit_withdraw: true },
 			InitiateReserveWithdraw {
 				assets: Wild(AllCounted(max_assets)),
 				reserve,


### PR DESCRIPTION
Add `SetFeesMode { jit_withdraw: true }` before `InitiateReserveWithdraw` instruction to allow paying JIT fees in the executor.

This is backport of https://github.com/paritytech/polkadot-sdk/pull/3792