### PR TITLE
pallet-xcm: fix transport fees for remote reserve transfers (#3798) - backport for 1.9

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -1883,6 +1883,7 @@ impl<T: Config> Pallet<T> {
 		]);
 		Ok(Xcm(vec![
 			WithdrawAsset(assets.into()),
+			SetFeesMode { jit_withdraw: true },
 			InitiateReserveWithdraw {
 				assets: Wild(AllCounted(max_assets)),
 				reserve,


### PR DESCRIPTION
This is backport of https://github.com/paritytech/polkadot-sdk/pull/3792

Expected patches for:
- pallet-xcm