### PR TITLE
Remove treasury deprecated calls in Westend and Rococo runtime `weight::pallet_treasury`

### DIFF
--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
@@ -294,9 +294,6 @@ impl pallet_treasury::Config<FellowshipTreasuryInstance> for Runtime {
 	// Instead, public or fellowship referenda should be used to propose and command the treasury
 	// spend or spend_local dispatchables. The parameters below have been configured accordingly to
 	// discourage its use.
-	// TODO: replace with `NeverEnsure` once polkadot-sdk 1.5 is released.
-	type ApproveOrigin = NeverEnsureOrigin<()>;
-	type OnSlash = ();
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type ProposalBond = HundredPercent;
 	#[cfg(not(feature = "runtime-benchmarks"))]

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_treasury.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_treasury.rs
@@ -62,43 +62,6 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: `FellowshipTreasury::ProposalCount` (r:1 w:1)
-	/// Proof: `FellowshipTreasury::ProposalCount` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
-	/// Storage: `FellowshipTreasury::Proposals` (r:0 w:1)
-	/// Proof: `FellowshipTreasury::Proposals` (`max_values`: None, `max_size`: Some(108), added: 2583, mode: `MaxEncodedLen`)
-	fn propose_spend() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `143`
-		//  Estimated: `1489`
-		// Minimum execution time: 264_000_000 picoseconds.
-		Weight::from_parts(277_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 1489))
-			.saturating_add(T::DbWeight::get().reads(1))
-			.saturating_add(T::DbWeight::get().writes(2))
-	}
-	/// Storage: `FellowshipTreasury::Proposals` (r:1 w:1)
-	/// Proof: `FellowshipTreasury::Proposals` (`max_values`: None, `max_size`: Some(108), added: 2583, mode: `MaxEncodedLen`)
-	/// Storage: `System::Account` (r:1 w:1)
-	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
-	fn reject_proposal() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `301`
-		//  Estimated: `3593`
-		// Minimum execution time: 289_000_000 picoseconds.
-		Weight::from_parts(312_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 3593))
-			.saturating_add(T::DbWeight::get().reads(2))
-			.saturating_add(T::DbWeight::get().writes(2))
-	}
-	/// The range of component `p` is `[0, 99]`.
-	fn approve_proposal(_p: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 0_000 picoseconds.
-		Weight::from_parts(0, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-	}
 	/// Storage: `FellowshipTreasury::Approvals` (r:1 w:1)
 	/// Proof: `FellowshipTreasury::Approvals` (`max_values`: Some(1), `max_size`: Some(402), added: 897, mode: `MaxEncodedLen`)
 	fn remove_approval() -> Weight {

--- a/polkadot/runtime/rococo/src/weights/pallet_treasury.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_treasury.rs
@@ -63,51 +63,6 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: Treasury ProposalCount (r:1 w:1)
-	/// Proof: Treasury ProposalCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: Treasury Proposals (r:0 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	fn propose_spend() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `143`
-		//  Estimated: `1489`
-		// Minimum execution time: 354_000_000 picoseconds.
-		Weight::from_parts(376_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 1489))
-			.saturating_add(T::DbWeight::get().reads(1))
-			.saturating_add(T::DbWeight::get().writes(2))
-	}
-	/// Storage: Treasury Proposals (r:1 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: System Account (r:1 w:1)
-	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
-	fn reject_proposal() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `301`
-		//  Estimated: `3593`
-		// Minimum execution time: 547_000_000 picoseconds.
-		Weight::from_parts(550_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 3593))
-			.saturating_add(T::DbWeight::get().reads(2))
-			.saturating_add(T::DbWeight::get().writes(2))
-	}
-	/// Storage: Treasury Proposals (r:1 w:0)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: Treasury Approvals (r:1 w:1)
-	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
-	/// The range of component `p` is `[0, 99]`.
-	fn approve_proposal(p: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `470 + p * (8 ±0)`
-		//  Estimated: `3573`
-		// Minimum execution time: 104_000_000 picoseconds.
-		Weight::from_parts(121_184_402, 0)
-			.saturating_add(Weight::from_parts(0, 3573))
-			// Standard Error: 42_854
-			.saturating_add(Weight::from_parts(153_112, 0).saturating_mul(p.into()))
-			.saturating_add(T::DbWeight::get().reads(2))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
 	/// Storage: Treasury Approvals (r:1 w:1)
 	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
 	fn remove_approval() -> Weight {

--- a/polkadot/runtime/westend/src/weights/pallet_treasury.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_treasury.rs
@@ -63,51 +63,6 @@ impl<T: frame_system::Config> pallet_treasury::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: Treasury ProposalCount (r:1 w:1)
-	/// Proof: Treasury ProposalCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: Treasury Proposals (r:0 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	fn propose_spend() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `143`
-		//  Estimated: `1489`
-		// Minimum execution time: 354_000_000 picoseconds.
-		Weight::from_parts(376_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 1489))
-			.saturating_add(T::DbWeight::get().reads(1))
-			.saturating_add(T::DbWeight::get().writes(2))
-	}
-	/// Storage: Treasury Proposals (r:1 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: System Account (r:1 w:1)
-	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
-	fn reject_proposal() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `301`
-		//  Estimated: `3593`
-		// Minimum execution time: 547_000_000 picoseconds.
-		Weight::from_parts(550_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 3593))
-			.saturating_add(T::DbWeight::get().reads(2))
-			.saturating_add(T::DbWeight::get().writes(2))
-	}
-	/// Storage: Treasury Proposals (r:1 w:0)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: Treasury Approvals (r:1 w:1)
-	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
-	/// The range of component `p` is `[0, 99]`.
-	fn approve_proposal(p: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `470 + p * (8 ±0)`
-		//  Estimated: `3573`
-		// Minimum execution time: 104_000_000 picoseconds.
-		Weight::from_parts(121_184_402, 0)
-			.saturating_add(Weight::from_parts(0, 3573))
-			// Standard Error: 42_854
-			.saturating_add(Weight::from_parts(153_112, 0).saturating_mul(p.into()))
-			.saturating_add(T::DbWeight::get().reads(2))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
 	/// Storage: Treasury Approvals (r:1 w:1)
 	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
 	fn remove_approval() -> Weight {

--- a/prdoc/pr_3800.prdoc
+++ b/prdoc/pr_3800.prdoc
@@ -1,0 +1,12 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Remove deprecated calls from treasury pallet
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      This PR remove deprecated calls, relevant tests from `pallet-treasury`
+
+crates:
+  - name: pallet-treasury

--- a/substrate/frame/treasury/README.md
+++ b/substrate/frame/treasury/README.md
@@ -26,6 +26,14 @@ and use the funds to pay developers.
 ### Dispatchable Functions
 
 General spending/proposal protocol:
-- `propose_spend` - Make a spending proposal and stake the required deposit.
-- `reject_proposal` - Reject a proposal, slashing the deposit.
-- `approve_proposal` - Accept the proposal, returning the deposit.
+- `spend_local` - Propose and approve a spend of treasury funds, enables the
+  creation of spends using the native currency of the chain, utilizing the funds
+  stored in the pot
+- `spend` - Propose and approve a spend of treasury funds, allows spending any
+  asset kind managed by the treasury
+- `remove_approval` - Force a previously approved proposal to be removed from
+  the approval queue
+- `payout` - Claim a spend
+- `check_status` - Check the status of the spend and remove it from the storage
+  if processed
+- `void_spend` - Void previously approved spend

--- a/substrate/frame/treasury/src/benchmarking.rs
+++ b/substrate/frame/treasury/src/benchmarking.rs
@@ -73,12 +73,10 @@ fn setup_proposal<T: Config<I>, I: 'static>(
 
 // Create proposals that are approved for use in `on_initialize`.
 fn create_approved_proposals<T: Config<I>, I: 'static>(n: u32) -> Result<(), &'static str> {
+	let origin = T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 	for i in 0..n {
-		let (caller, value, lookup) = setup_proposal::<T, I>(i);
-		#[allow(deprecated)]
-		Treasury::<T, I>::propose_spend(RawOrigin::Signed(caller).into(), value, lookup)?;
-		let proposal_id = <ProposalCount<T, I>>::get() - 1;
-		Approvals::<T, I>::try_append(proposal_id).unwrap();
+		let (_, value, lookup) = setup_proposal::<T, I>(i);
+		Treasury::<T, I>::spend_local(origin.clone(), value, lookup)?;
 	}
 	ensure!(<Approvals<T, I>>::get().len() == n as usize, "Not all approved");
 	Ok(())
@@ -127,70 +125,12 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn propose_spend() -> Result<(), BenchmarkError> {
-		let (caller, value, beneficiary_lookup) = setup_proposal::<T, _>(SEED);
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
-
-		#[extrinsic_call]
-		_(RawOrigin::Signed(caller), value, beneficiary_lookup);
-
-		Ok(())
-	}
-
-	#[benchmark]
-	fn reject_proposal() -> Result<(), BenchmarkError> {
-		let (caller, value, beneficiary_lookup) = setup_proposal::<T, _>(SEED);
-		#[allow(deprecated)]
-		Treasury::<T, _>::propose_spend(
-			RawOrigin::Signed(caller).into(),
-			value,
-			beneficiary_lookup,
-		)?;
-		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
-		let reject_origin =
-			T::RejectOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
-
-		#[extrinsic_call]
-		_(reject_origin as T::RuntimeOrigin, proposal_id);
-
-		Ok(())
-	}
-
-	#[benchmark]
-	fn approve_proposal(
-		p: Linear<0, { T::MaxApprovals::get() - 1 }>,
-	) -> Result<(), BenchmarkError> {
-		let approve_origin =
-			T::ApproveOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
-		create_approved_proposals::<T, _>(p)?;
-		let (caller, value, beneficiary_lookup) = setup_proposal::<T, _>(SEED);
-		#[allow(deprecated)]
-		Treasury::<T, _>::propose_spend(
-			RawOrigin::Signed(caller).into(),
-			value,
-			beneficiary_lookup,
-		)?;
-		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
-
-		#[extrinsic_call]
-		_(approve_origin as T::RuntimeOrigin, proposal_id);
-
-		Ok(())
-	}
-
-	#[benchmark]
 	fn remove_approval() -> Result<(), BenchmarkError> {
-		let (caller, value, beneficiary_lookup) = setup_proposal::<T, _>(SEED);
-		#[allow(deprecated)]
-		Treasury::<T, _>::propose_spend(
-			RawOrigin::Signed(caller).into(),
-			value,
-			beneficiary_lookup,
-		)?;
+		let origin =
+			T::SpendOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
+		let (_, value, beneficiary_lookup) = setup_proposal::<T, _>(SEED);
+		Treasury::<T, _>::spend_local(origin, value, beneficiary_lookup)?;
 		let proposal_id = Treasury::<T, _>::proposal_count() - 1;
-		Approvals::<T, _>::try_append(proposal_id).unwrap();
 		let reject_origin =
 			T::RejectOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 

--- a/substrate/frame/treasury/src/benchmarking.rs
+++ b/substrate/frame/treasury/src/benchmarking.rs
@@ -59,7 +59,7 @@ where
 
 const SEED: u32 = 0;
 
-// Create the pre-requisite information needed to create a treasury `propose_spend`.
+// Create the pre-requisite information needed to create a treasury `spend_local`.
 fn setup_proposal<T: Config<I>, I: 'static>(
 	u: u32,
 ) -> (T::AccountId, BalanceOf<T, I>, AccountIdLookupOf<T>) {

--- a/substrate/frame/treasury/src/benchmarking.rs
+++ b/substrate/frame/treasury/src/benchmarking.rs
@@ -64,7 +64,7 @@ fn setup_proposal<T: Config<I>, I: 'static>(
 	u: u32,
 ) -> (T::AccountId, BalanceOf<T, I>, AccountIdLookupOf<T>) {
 	let caller = account("caller", u, SEED);
-	let value: BalanceOf<T, I> = T::ProposalBondMinimum::get().saturating_mul(100u32.into());
+	let value: BalanceOf<T, I> = 100u32.try_into().ok().unwrap();
 	let _ = T::Currency::make_free_balance_be(&caller, value);
 	let beneficiary = account("beneficiary", u, SEED);
 	let beneficiary_lookup = T::Lookup::unlookup(beneficiary);

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -343,24 +343,32 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// We have ended a spend period and will now allocate funds.
+		#[codec(index = 1)]
 		Spending { budget_remaining: BalanceOf<T, I> },
 		/// Some funds have been allocated.
+		#[codec(index = 2)]
 		Awarded { proposal_index: ProposalIndex, award: BalanceOf<T, I>, account: T::AccountId },
 		/// Some of our funds have been burnt.
+		#[codec(index = 4)]
 		Burnt { burnt_funds: BalanceOf<T, I> },
 		/// Spending has finished; this is the amount that rolls over until next spend.
+		#[codec(index = 5)]
 		Rollover { rollover_balance: BalanceOf<T, I> },
 		/// Some funds have been deposited.
+		#[codec(index = 6)]
 		Deposit { value: BalanceOf<T, I> },
 		/// A new spend proposal has been approved.
+		#[codec(index = 7)]
 		SpendApproved {
 			proposal_index: ProposalIndex,
 			amount: BalanceOf<T, I>,
 			beneficiary: T::AccountId,
 		},
 		/// The inactive funds of the pallet have been updated.
+		#[codec(index = 8)]
 		UpdatedInactive { reactivated: BalanceOf<T, I>, deactivated: BalanceOf<T, I> },
 		/// A new asset spend proposal has been approved.
+		#[codec(index = 9)]
 		AssetSpendApproved {
 			index: SpendIndex,
 			asset_kind: T::AssetKind,
@@ -370,13 +378,17 @@ pub mod pallet {
 			expire_at: BlockNumberFor<T>,
 		},
 		/// An approved spend was voided.
+		#[codec(index = 10)]
 		AssetSpendVoided { index: SpendIndex },
 		/// A payment happened.
+		#[codec(index = 11)]
 		Paid { index: SpendIndex, payment_id: <T::Paymaster as Pay>::Id },
 		/// A payment failed and can be retried.
+		#[codec(index = 12)]
 		PaymentFailed { index: SpendIndex, payment_id: <T::Paymaster as Pay>::Id },
 		/// A spend was processed and removed from the storage. It might have been successfully
 		/// paid or it may have expired.
+		#[codec(index = 13)]
 		SpendProcessed { index: SpendIndex },
 	}
 
@@ -384,27 +396,38 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T, I = ()> {
 		/// No proposal, bounty or spend at that index.
+		#[codec(index = 1)]
 		InvalidIndex,
 		/// Too many approvals in the queue.
+		#[codec(index = 2)]
 		TooManyApprovals,
 		/// The spend origin is valid but the amount it is allowed to spend is lower than the
 		/// amount to be spent.
+		#[codec(index = 3)]
 		InsufficientPermission,
 		/// Proposal has not been approved.
+		#[codec(index = 4)]
 		ProposalNotApproved,
 		/// The balance of the asset kind is not convertible to the balance of the native asset.
+		#[codec(index = 5)]
 		FailedToConvertBalance,
 		/// The spend has expired and cannot be claimed.
+		#[codec(index = 6)]
 		SpendExpired,
 		/// The spend is not yet eligible for payout.
+		#[codec(index = 7)]
 		EarlyPayout,
 		/// The payment has already been attempted.
+		#[codec(index = 8)]
 		AlreadyAttempted,
 		/// There was some issue with the mechanism of payment.
+		#[codec(index = 9)]
 		PayoutError,
 		/// The payout was not yet attempted/claimed.
+		#[codec(index = 10)]
 		NotAttempted,
 		/// The payment has neither failed nor succeeded yet.
+		#[codec(index = 11)]
 		Inconclusive,
 	}
 

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -203,9 +203,6 @@ pub mod pallet {
 		/// The staking balance.
 		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 
-		/// Origin from which approvals must come.
-		type ApproveOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-
 		/// Origin from which rejections must come.
 		type RejectOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
@@ -361,14 +358,10 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
-		/// New proposal.
-		Proposed { proposal_index: ProposalIndex },
 		/// We have ended a spend period and will now allocate funds.
 		Spending { budget_remaining: BalanceOf<T, I> },
 		/// Some funds have been allocated.
 		Awarded { proposal_index: ProposalIndex, award: BalanceOf<T, I>, account: T::AccountId },
-		/// A proposal was rejected; funds were slashed.
-		Rejected { proposal_index: ProposalIndex, slashed: BalanceOf<T, I> },
 		/// Some of our funds have been burnt.
 		Burnt { burnt_funds: BalanceOf<T, I> },
 		/// Spending has finished; this is the amount that rolls over until next spend.
@@ -406,8 +399,6 @@ pub mod pallet {
 	/// Error for the treasury pallet.
 	#[pallet::error]
 	pub enum Error<T, I = ()> {
-		/// Proposer's balance is too low.
-		InsufficientProposersBalance,
 		/// No proposal, bounty or spend at that index.
 		InvalidIndex,
 		/// Too many approvals in the queue.
@@ -474,123 +465,6 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
-		/// Put forward a suggestion for spending.
-		///
-		/// ## Dispatch Origin
-		///
-		/// Must be signed.
-		///
-		/// ## Details
-		/// A deposit proportional to the value is reserved and slashed if the proposal is rejected.
-		/// It is returned once the proposal is awarded.
-		///
-		/// ### Complexity
-		/// - O(1)
-		///
-		/// ## Events
-		///
-		/// Emits [`Event::Proposed`] if successful.
-		#[pallet::call_index(0)]
-		#[pallet::weight(T::WeightInfo::propose_spend())]
-		#[allow(deprecated)]
-		#[deprecated(
-			note = "`propose_spend` will be removed in February 2024. Use `spend` instead."
-		)]
-		pub fn propose_spend(
-			origin: OriginFor<T>,
-			#[pallet::compact] value: BalanceOf<T, I>,
-			beneficiary: AccountIdLookupOf<T>,
-		) -> DispatchResult {
-			let proposer = ensure_signed(origin)?;
-			let beneficiary = T::Lookup::lookup(beneficiary)?;
-
-			let bond = Self::calculate_bond(value);
-			T::Currency::reserve(&proposer, bond)
-				.map_err(|_| Error::<T, I>::InsufficientProposersBalance)?;
-
-			let c = Self::proposal_count();
-			<ProposalCount<T, I>>::put(c + 1);
-			<Proposals<T, I>>::insert(c, Proposal { proposer, value, beneficiary, bond });
-
-			Self::deposit_event(Event::Proposed { proposal_index: c });
-			Ok(())
-		}
-
-		/// Reject a proposed spend.
-		///
-		/// ## Dispatch Origin
-		///
-		/// Must be [`Config::RejectOrigin`].
-		///
-		/// ## Details
-		/// The original deposit will be slashed.
-		///
-		/// ### Complexity
-		/// - O(1)
-		///
-		/// ## Events
-		///
-		/// Emits [`Event::Rejected`] if successful.
-		#[pallet::call_index(1)]
-		#[pallet::weight((T::WeightInfo::reject_proposal(), DispatchClass::Operational))]
-		#[allow(deprecated)]
-		#[deprecated(
-			note = "`reject_proposal` will be removed in February 2024. Use `spend` instead."
-		)]
-		pub fn reject_proposal(
-			origin: OriginFor<T>,
-			#[pallet::compact] proposal_id: ProposalIndex,
-		) -> DispatchResult {
-			T::RejectOrigin::ensure_origin(origin)?;
-
-			let proposal =
-				<Proposals<T, I>>::take(&proposal_id).ok_or(Error::<T, I>::InvalidIndex)?;
-			let value = proposal.bond;
-			let imbalance = T::Currency::slash_reserved(&proposal.proposer, value).0;
-			T::OnSlash::on_unbalanced(imbalance);
-
-			Self::deposit_event(Event::<T, I>::Rejected {
-				proposal_index: proposal_id,
-				slashed: value,
-			});
-			Ok(())
-		}
-
-		/// Approve a proposal.
-		///
-		/// ## Dispatch Origin
-		///
-		/// Must be [`Config::ApproveOrigin`].
-		///
-		/// ## Details
-		///
-		/// At a later time, the proposal will be allocated to the beneficiary and the original
-		/// deposit will be returned.
-		///
-		/// ### Complexity
-		///  - O(1).
-		///
-		/// ## Events
-		///
-		/// No events are emitted from this dispatch.
-		#[pallet::call_index(2)]
-		#[pallet::weight((T::WeightInfo::approve_proposal(T::MaxApprovals::get()), DispatchClass::Operational))]
-		#[allow(deprecated)]
-		#[deprecated(
-			note = "`approve_proposal` will be removed in February 2024. Use `spend` instead."
-		)]
-		pub fn approve_proposal(
-			origin: OriginFor<T>,
-			#[pallet::compact] proposal_id: ProposalIndex,
-		) -> DispatchResult {
-			T::ApproveOrigin::ensure_origin(origin)?;
-
-			ensure!(<Proposals<T, I>>::contains_key(proposal_id), Error::<T, I>::InvalidIndex);
-			Approvals::<T, I>::try_append(proposal_id)
-				.map_err(|_| Error::<T, I>::TooManyApprovals)?;
-			Ok(())
-		}
-
 		/// Propose and approve a spend of treasury funds.
 		///
 		/// ## Dispatch Origin

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -213,19 +213,6 @@ pub mod pallet {
 		/// Handler for the unbalanced decrease when slashing for a rejected proposal or bounty.
 		type OnSlash: OnUnbalanced<NegativeImbalanceOf<Self, I>>;
 
-		/// Fraction of a proposal's value that should be bonded in order to place the proposal.
-		/// An accepted proposal gets these back. A rejected proposal does not.
-		#[pallet::constant]
-		type ProposalBond: Get<Permill>;
-
-		/// Minimum amount of funds that should be placed in a deposit for making a proposal.
-		#[pallet::constant]
-		type ProposalBondMinimum: Get<BalanceOf<Self, I>>;
-
-		/// Maximum amount of funds that should be placed in a deposit for making a proposal.
-		#[pallet::constant]
-		type ProposalBondMaximum: Get<Option<BalanceOf<Self, I>>>;
-
 		/// Period between successive spends.
 		#[pallet::constant]
 		type SpendPeriod: Get<BlockNumberFor<Self>>;
@@ -804,15 +791,6 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// value and only call this once.
 	pub fn account_id() -> T::AccountId {
 		T::PalletId::get().into_account_truncating()
-	}
-
-	/// The needed bond for a proposal whose spend is `value`.
-	fn calculate_bond(value: BalanceOf<T, I>) -> BalanceOf<T, I> {
-		let mut r = T::ProposalBondMinimum::get().max(T::ProposalBond::get() * value);
-		if let Some(m) = T::ProposalBondMaximum::get() {
-			r = r.min(m);
-		}
-		r
 	}
 
 	/// Spend some money! returns number of approvals before spend.

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -210,9 +210,6 @@ pub mod pallet {
 		type RuntimeEvent: From<Event<Self, I>>
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		/// Handler for the unbalanced decrease when slashing for a rejected proposal or bounty.
-		type OnSlash: OnUnbalanced<NegativeImbalanceOf<Self, I>>;
-
 		/// Period between successive spends.
 		#[pallet::constant]
 		type SpendPeriod: Get<BlockNumberFor<Self>>;

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -343,12 +343,10 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// We have ended a spend period and will now allocate funds.
-		#[codec(index = 1)]
 		Spending { budget_remaining: BalanceOf<T, I> },
 		/// Some funds have been allocated.
 		Awarded { proposal_index: ProposalIndex, award: BalanceOf<T, I>, account: T::AccountId },
 		/// Some of our funds have been burnt.
-		#[codec(index = 4)]
 		Burnt { burnt_funds: BalanceOf<T, I> },
 		/// Spending has finished; this is the amount that rolls over until next spend.
 		Rollover { rollover_balance: BalanceOf<T, I> },
@@ -386,7 +384,6 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T, I = ()> {
 		/// No proposal, bounty or spend at that index.
-		#[codec(index = 1)]
 		InvalidIndex,
 		/// Too many approvals in the queue.
 		TooManyApprovals,

--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -346,29 +346,23 @@ pub mod pallet {
 		#[codec(index = 1)]
 		Spending { budget_remaining: BalanceOf<T, I> },
 		/// Some funds have been allocated.
-		#[codec(index = 2)]
 		Awarded { proposal_index: ProposalIndex, award: BalanceOf<T, I>, account: T::AccountId },
 		/// Some of our funds have been burnt.
 		#[codec(index = 4)]
 		Burnt { burnt_funds: BalanceOf<T, I> },
 		/// Spending has finished; this is the amount that rolls over until next spend.
-		#[codec(index = 5)]
 		Rollover { rollover_balance: BalanceOf<T, I> },
 		/// Some funds have been deposited.
-		#[codec(index = 6)]
 		Deposit { value: BalanceOf<T, I> },
 		/// A new spend proposal has been approved.
-		#[codec(index = 7)]
 		SpendApproved {
 			proposal_index: ProposalIndex,
 			amount: BalanceOf<T, I>,
 			beneficiary: T::AccountId,
 		},
 		/// The inactive funds of the pallet have been updated.
-		#[codec(index = 8)]
 		UpdatedInactive { reactivated: BalanceOf<T, I>, deactivated: BalanceOf<T, I> },
 		/// A new asset spend proposal has been approved.
-		#[codec(index = 9)]
 		AssetSpendApproved {
 			index: SpendIndex,
 			asset_kind: T::AssetKind,
@@ -378,17 +372,13 @@ pub mod pallet {
 			expire_at: BlockNumberFor<T>,
 		},
 		/// An approved spend was voided.
-		#[codec(index = 10)]
 		AssetSpendVoided { index: SpendIndex },
 		/// A payment happened.
-		#[codec(index = 11)]
 		Paid { index: SpendIndex, payment_id: <T::Paymaster as Pay>::Id },
 		/// A payment failed and can be retried.
-		#[codec(index = 12)]
 		PaymentFailed { index: SpendIndex, payment_id: <T::Paymaster as Pay>::Id },
 		/// A spend was processed and removed from the storage. It might have been successfully
 		/// paid or it may have expired.
-		#[codec(index = 13)]
 		SpendProcessed { index: SpendIndex },
 	}
 
@@ -399,35 +389,25 @@ pub mod pallet {
 		#[codec(index = 1)]
 		InvalidIndex,
 		/// Too many approvals in the queue.
-		#[codec(index = 2)]
 		TooManyApprovals,
 		/// The spend origin is valid but the amount it is allowed to spend is lower than the
 		/// amount to be spent.
-		#[codec(index = 3)]
 		InsufficientPermission,
 		/// Proposal has not been approved.
-		#[codec(index = 4)]
 		ProposalNotApproved,
 		/// The balance of the asset kind is not convertible to the balance of the native asset.
-		#[codec(index = 5)]
 		FailedToConvertBalance,
 		/// The spend has expired and cannot be claimed.
-		#[codec(index = 6)]
 		SpendExpired,
 		/// The spend is not yet eligible for payout.
-		#[codec(index = 7)]
 		EarlyPayout,
 		/// The payment has already been attempted.
-		#[codec(index = 8)]
 		AlreadyAttempted,
 		/// There was some issue with the mechanism of payment.
-		#[codec(index = 9)]
 		PayoutError,
 		/// The payout was not yet attempted/claimed.
-		#[codec(index = 10)]
 		NotAttempted,
 		/// The payment has neither failed nor succeeded yet.
-		#[codec(index = 11)]
 		Inconclusive,
 	}
 

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -176,7 +176,6 @@ impl Config for Test {
 	type Currency = pallet_balances::Pallet<Test>;
 	type RejectOrigin = frame_system::EnsureRoot<u128>;
 	type RuntimeEvent = RuntimeEvent;
-	type OnSlash = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -136,7 +136,6 @@ impl Pay for TestPay {
 }
 
 parameter_types! {
-	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const Burn: Permill = Permill::from_percent(50);
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub TreasuryAccount: u128 = Treasury::account_id();
@@ -178,9 +177,6 @@ impl Config for Test {
 	type RejectOrigin = frame_system::EnsureRoot<u128>;
 	type RuntimeEvent = RuntimeEvent;
 	type OnSlash = ();
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ConstU64<1>;
-	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -152,6 +152,7 @@ impl frame_support::traits::EnsureOrigin<RuntimeOrigin> for TestSpendOrigin {
 			frame_system::RawOrigin::Signed(11) => Ok(10),
 			frame_system::RawOrigin::Signed(12) => Ok(20),
 			frame_system::RawOrigin::Signed(13) => Ok(50),
+			frame_system::RawOrigin::Signed(14) => Ok(500),
 			r => Err(RuntimeOrigin::from(r)),
 		})
 	}
@@ -174,7 +175,6 @@ impl<N: Get<u64>> ConversionFromAssetBalance<u64, u32, u64> for MulBy<N> {
 impl Config for Test {
 	type PalletId = TreasuryPalletId;
 	type Currency = pallet_balances::Pallet<Test>;
-	type ApproveOrigin = frame_system::EnsureRoot<u128>;
 	type RejectOrigin = frame_system::EnsureRoot<u128>;
 	type RuntimeEvent = RuntimeEvent;
 	type OnSlash = ();
@@ -296,55 +296,11 @@ fn minting_works() {
 }
 
 #[test]
-fn spend_proposal_takes_min_deposit() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
-		});
-		assert_eq!(Balances::free_balance(0), 99);
-		assert_eq!(Balances::reserved_balance(0), 1);
-	});
-}
-
-#[test]
-fn spend_proposal_takes_proportional_deposit() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_eq!(Balances::free_balance(0), 95);
-		assert_eq!(Balances::reserved_balance(0), 5);
-	});
-}
-
-#[test]
-fn spend_proposal_fails_when_proposer_poor() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::propose_spend(RuntimeOrigin::signed(2), 100, 3)
-			},
-			Error::<Test, _>::InsufficientProposersBalance,
-		);
-	});
-}
-
-#[test]
 fn accepted_spend_proposal_ignored_outside_spend_period() {
 	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 100, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(1);
 		assert_eq!(Balances::free_balance(3), 0);
@@ -366,111 +322,12 @@ fn unused_pot_should_diminish() {
 }
 
 #[test]
-fn rejected_spend_proposal_ignored_on_spend_period() {
-	ExtBuilder::default().build().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-		});
-
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
-		assert_eq!(Balances::free_balance(3), 0);
-		assert_eq!(Treasury::pot(), 50);
-	});
-}
-
-#[test]
-fn reject_already_rejected_spend_proposal_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-			},
-			Error::<Test, _>::InvalidIndex
-		);
-	});
-}
-
-#[test]
-fn reject_non_existent_spend_proposal_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-			},
-			Error::<Test, _>::InvalidIndex
-		);
-	});
-}
-
-#[test]
-fn accept_non_existent_spend_proposal_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-			},
-			Error::<Test, _>::InvalidIndex
-		);
-	});
-}
-
-#[test]
-fn accept_already_rejected_spend_proposal_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-			},
-			Error::<Test, _>::InvalidIndex
-		);
-	});
-}
-
-#[test]
 fn accepted_spend_proposal_enacted_on_spend_period() {
 	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 100, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 100);
@@ -484,14 +341,7 @@ fn pot_underflow_should_not_diminish() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 150, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 150, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
@@ -512,26 +362,12 @@ fn treasury_account_doesnt_get_deleted() {
 		assert_eq!(Treasury::pot(), 100);
 		let treasury_balance = Balances::free_balance(&Treasury::account_id());
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), treasury_balance, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), treasury_balance, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), Treasury::pot(), 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 1)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), Treasury::pot(), 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(4);
 		assert_eq!(Treasury::pot(), 0); // Pot is emptied
@@ -554,22 +390,9 @@ fn inexistent_account_works() {
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 0); // Account does not exist
 		assert_eq!(Treasury::pot(), 0); // Pot is empty
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 99, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 1)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 99, 3));
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 1, 3));
+
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 0); // Pot hasn't changed
 		assert_eq!(Balances::free_balance(3), 0); // Balance of `3` hasn't changed
@@ -611,26 +434,12 @@ fn max_approvals_limited() {
 		Balances::make_free_balance_be(&0, u64::MAX);
 
 		for _ in 0..<Test as Config>::MaxApprovals::get() {
-			assert_ok!({
-				#[allow(deprecated)]
-				Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-			});
-			assert_ok!({
-				#[allow(deprecated)]
-				Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-			});
+			assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 100, 3));
 		}
 
 		// One too many will fail
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
 		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-			},
+			Treasury::spend_local(RuntimeOrigin::signed(14), 100, 3),
 			Error::<Test, _>::TooManyApprovals
 		);
 	});
@@ -641,14 +450,8 @@ fn remove_already_removed_approval_fails() {
 	ExtBuilder::default().build().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::signed(14), 100, 3));
+
 		assert_eq!(Treasury::approvals(), vec![0]);
 		assert_ok!(Treasury::remove_approval(RuntimeOrigin::root(), 0));
 		assert_eq!(Treasury::approvals(), vec![]);
@@ -975,91 +778,6 @@ fn check_status_works() {
 		let info = Treasury::check_status(RuntimeOrigin::signed(1), 4).unwrap();
 		assert_eq!(info.pays_fee, Pays::No);
 		System::assert_last_event(Event::<Test, _>::SpendProcessed { index: 4 }.into());
-	});
-}
-
-#[test]
-fn try_state_proposals_invariant_1_works() {
-	ExtBuilder::default().build().execute_with(|| {
-		use frame_support::pallet_prelude::DispatchError::Other;
-		// Add a proposal using `propose_spend`
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
-		});
-		assert_eq!(Proposals::<Test>::iter().count(), 1);
-		assert_eq!(ProposalCount::<Test>::get(), 1);
-		// Check invariant 1 holds
-		assert!(ProposalCount::<Test>::get() as usize >= Proposals::<Test>::iter().count());
-		// Break invariant 1 by decreasing `ProposalCount`
-		ProposalCount::<Test>::put(0);
-		// Invariant 1 should be violated
-		assert_eq!(
-			Treasury::do_try_state(),
-			Err(Other("Actual number of proposals exceeds `ProposalCount`."))
-		);
-	});
-}
-
-#[test]
-fn try_state_proposals_invariant_2_works() {
-	ExtBuilder::default().build().execute_with(|| {
-		use frame_support::pallet_prelude::DispatchError::Other;
-		// Add a proposal using `propose_spend`
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
-		});
-		assert_eq!(Proposals::<Test>::iter().count(), 1);
-		let current_proposal_count = ProposalCount::<Test>::get();
-		assert_eq!(current_proposal_count, 1);
-		// Check invariant 2 holds
-		assert!(
-			Proposals::<Test>::iter_keys()
-			.all(|proposal_index| {
-					proposal_index < current_proposal_count
-			})
-		);
-		// Break invariant 2 by inserting the proposal under key = 1
-		let proposal = Proposals::<Test>::take(0).unwrap();
-		Proposals::<Test>::insert(1, proposal);
-		// Invariant 2 should be violated
-		assert_eq!(
-			Treasury::do_try_state(),
-			Err(Other("`ProposalCount` should by strictly greater than any ProposalIndex used as a key for `Proposals`."))
-		);
-	});
-}
-
-#[test]
-fn try_state_proposals_invariant_3_works() {
-	ExtBuilder::default().build().execute_with(|| {
-		use frame_support::pallet_prelude::DispatchError::Other;
-		// Add a proposal using `propose_spend`
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 10, 3)
-		});
-		assert_eq!(Proposals::<Test>::iter().count(), 1);
-		// Approve the proposal
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_eq!(Approvals::<Test>::get().len(), 1);
-		// Check invariant 3 holds
-		assert!(Approvals::<Test>::get()
-			.iter()
-			.all(|proposal_index| { Proposals::<Test>::contains_key(proposal_index) }));
-		// Break invariant 3 by adding another key to `Approvals`
-		let mut approvals_modified = Approvals::<Test>::get();
-		approvals_modified.try_push(2).unwrap();
-		Approvals::<Test>::put(approvals_modified);
-		// Invariant 3 should be violated
-		assert_eq!(
-			Treasury::do_try_state(),
-			Err(Other("Proposal indices in `Approvals` must also be contained in `Proposals`."))
-		);
 	});
 }
 

--- a/substrate/frame/treasury/src/weights.rs
+++ b/substrate/frame/treasury/src/weights.rs
@@ -48,9 +48,6 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_treasury.
 pub trait WeightInfo {
 	fn spend_local() -> Weight;
-	fn propose_spend() -> Weight;
-	fn reject_proposal() -> Weight;
-	fn approve_proposal(p: u32, ) -> Weight;
 	fn remove_approval() -> Weight;
 	fn on_initialize_proposals(p: u32, ) -> Weight;
 	fn spend() -> Weight;
@@ -76,48 +73,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(190_000_000, 1887)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
-	}
-	/// Storage: Treasury ProposalCount (r:1 w:1)
-	/// Proof: Treasury ProposalCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: Treasury Proposals (r:0 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	fn propose_spend() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `177`
-		//  Estimated: `1489`
-		// Minimum execution time: 349_000_000 picoseconds.
-		Weight::from_parts(398_000_000, 1489)
-			.saturating_add(T::DbWeight::get().reads(1_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
-	}
-	/// Storage: Treasury Proposals (r:1 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: System Account (r:1 w:1)
-	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
-	fn reject_proposal() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `335`
-		//  Estimated: `3593`
-		// Minimum execution time: 367_000_000 picoseconds.
-		Weight::from_parts(388_000_000, 3593)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
-	}
-	/// Storage: Treasury Proposals (r:1 w:0)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: Treasury Approvals (r:1 w:1)
-	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
-	/// The range of component `p` is `[0, 99]`.
-	fn approve_proposal(p: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `483 + p * (9 ±0)`
-		//  Estimated: `3573`
-		// Minimum execution time: 111_000_000 picoseconds.
-		Weight::from_parts(108_813_243, 3573)
-			// Standard Error: 147_887
-			.saturating_add(Weight::from_parts(683_216, 0).saturating_mul(p.into()))
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: Treasury Approvals (r:1 w:1)
 	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
@@ -227,48 +182,6 @@ impl WeightInfo for () {
 		Weight::from_parts(190_000_000, 1887)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
-	}
-	/// Storage: Treasury ProposalCount (r:1 w:1)
-	/// Proof: Treasury ProposalCount (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
-	/// Storage: Treasury Proposals (r:0 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	fn propose_spend() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `177`
-		//  Estimated: `1489`
-		// Minimum execution time: 349_000_000 picoseconds.
-		Weight::from_parts(398_000_000, 1489)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
-	}
-	/// Storage: Treasury Proposals (r:1 w:1)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: System Account (r:1 w:1)
-	/// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
-	fn reject_proposal() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `335`
-		//  Estimated: `3593`
-		// Minimum execution time: 367_000_000 picoseconds.
-		Weight::from_parts(388_000_000, 3593)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
-	}
-	/// Storage: Treasury Proposals (r:1 w:0)
-	/// Proof: Treasury Proposals (max_values: None, max_size: Some(108), added: 2583, mode: MaxEncodedLen)
-	/// Storage: Treasury Approvals (r:1 w:1)
-	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)
-	/// The range of component `p` is `[0, 99]`.
-	fn approve_proposal(p: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `483 + p * (9 ±0)`
-		//  Estimated: `3573`
-		// Minimum execution time: 111_000_000 picoseconds.
-		Weight::from_parts(108_813_243, 3573)
-			// Standard Error: 147_887
-			.saturating_add(Weight::from_parts(683_216, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: Treasury Approvals (r:1 w:1)
 	/// Proof: Treasury Approvals (max_values: Some(1), max_size: Some(402), added: 897, mode: MaxEncodedLen)


### PR DESCRIPTION
Parent issue: https://github.com/paritytech/polkadot-sdk/pull/3820
# Description
Because parameter `ApproveOrigin` and `OnSlash` is removed, deprecated calls `propose_spend`, `approve_proposal`, `reject_proposal` are also removed in the parent issue. Hence, we don't need to declare the weight needed for these dispatchable functions. 