### PR TITLE
Fix 0007-dispute-freshly-finalized.zndsl failing

### DIFF
--- a/polkadot/zombienet_tests/functional/0007-dispute-freshly-finalized.zndsl
+++ b/polkadot/zombienet_tests/functional/0007-dispute-freshly-finalized.zndsl
@@ -21,9 +21,9 @@ honest: reports polkadot_parachain_candidate_dispute_concluded{validity="valid"}
 honest: reports polkadot_parachain_candidate_dispute_concluded{validity="invalid"} is 0 within 100 seconds
 
 # Check lag - approval
-honest: reports polkadot_parachain_approval_checking_finality_lag is 0
+honest: reports polkadot_parachain_approval_checking_finality_lag is lower than 2
 
 # Check lag - dispute conclusion
-honest: reports polkadot_parachain_disputes_finality_lag is 0
+honest: reports polkadot_parachain_disputes_finality_lag is lower than 2
 
 


### PR DESCRIPTION
Test started failing after https://github.com/paritytech/polkadot-sdk/commit/66051adb619d2119771920218e2de75fa037d7e8 which enabled approval coalescing, that was expected to happen because the test required an polkadot_parachain_approval_checking_finality_lag of 0, which can't happen with max_approval_coalesce_count greater than 1 because we always delay the approval for no_show_duration_ticks/2 in case we can coalesce it with other approvals.


So relax a bit the restrictions, since we don't actually care that the lags are 0, but the fact the  finalities are progressing and are not stuck.