### PR TITLE
chore(zombienet): bump version

### DIFF
--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -1,7 +1,7 @@
 .zombienet-refs:
   extends: .build-refs
   variables:
-    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.98"
+    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.99"
 
 include:
   # substrate tests

--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -2,6 +2,7 @@
   extends: .build-refs
   variables:
     ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.99"
+    PUSHGATEWAY_URL: "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics"
 
 include:
   # substrate tests


### PR DESCRIPTION
This version includes:

- Internal metrics of zombienet (used to benchmark with v2).