### PR TITLE
Align dependencies with `parity-bridges-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9767,7 +9767,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 14.0.0",
  "sp-tracing 16.0.0",
- "strum 0.24.1",
+ "strum 0.26.2",
 ]
 
 [[package]]
@@ -12884,7 +12884,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "sc-authority-discovery",
  "sc-network",
- "strum 0.24.1",
+ "strum 0.26.2",
  "thiserror",
  "tracing-gum",
 ]
@@ -18537,7 +18537,7 @@ dependencies = [
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
- "strum 0.24.1",
+ "strum 0.26.2",
  "w3f-bls",
 ]
 
@@ -18828,7 +18828,7 @@ version = "31.0.0"
 dependencies = [
  "sp-core",
  "sp-runtime",
- "strum 0.24.1",
+ "strum 0.26.2",
 ]
 
 [[package]]
@@ -19715,6 +19715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19732,6 +19741,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -20005,7 +20027,7 @@ dependencies = [
  "parity-wasm",
  "polkavm-linker",
  "sp-maybe-compressed-blob",
- "strum 0.24.1",
+ "strum 0.26.2",
  "tempfile",
  "toml 0.8.8",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17000,9 +17000,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef2175c2907e7c8bc0a9c3f86aeb5ec1f3b275300ad58a44d0c3ae379a5e52e"
+checksum = "788745a868b0e751750388f4e6546eb921ef714a4317fa6954f7cde114eb2eb7"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -17014,9 +17014,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b8eb8fd61c5cdd3390d9b2132300a7e7618955b98b8416f118c1b4e144f"
+checksum = "7dc2f4e8bc344b9fc3d5f74f72c2e55bfc38d28dc2ebc69c194a3df424e4d9ac"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -1393,7 +1393,7 @@ name = "binary-merkle-tree"
 version = "13.0.0"
 dependencies = [
  "array-bytes 6.1.0",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "hash-db",
  "log",
  "sp-core",
@@ -4991,10 +4991,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
+name = "env_filter"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
  "regex",
@@ -5002,15 +5002,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -5024,6 +5021,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -9520,7 +9530,7 @@ dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
  "bitflags 1.3.2",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "environmental",
  "frame-benchmarking",
  "frame-support",
@@ -10188,7 +10198,7 @@ name = "pallet-mmr"
 version = "27.0.0"
 dependencies = [
  "array-bytes 6.1.0",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -12080,7 +12090,7 @@ version = "7.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "futures",
  "futures-timer",
  "itertools 0.10.5",
@@ -12110,7 +12120,7 @@ dependencies = [
  "always-assert",
  "assert_matches",
  "bitvec",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "futures",
  "futures-timer",
  "log",
@@ -12166,7 +12176,7 @@ version = "7.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "fatality",
  "futures",
  "futures-timer",
@@ -12228,7 +12238,7 @@ version = "7.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "fatality",
  "futures",
  "futures-timer",
@@ -12400,7 +12410,7 @@ dependencies = [
  "async-trait",
  "bitvec",
  "derive_more",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "futures",
  "futures-timer",
  "itertools 0.10.5",
@@ -12442,7 +12452,7 @@ version = "7.0.0"
 dependencies = [
  "assert_matches",
  "bitvec",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "futures",
  "futures-timer",
  "kvdb",
@@ -12976,7 +12986,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "derive_more",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "fatality",
  "futures",
  "futures-channel",
@@ -13420,7 +13430,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "bitvec",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-support",
@@ -13596,7 +13606,7 @@ dependencies = [
  "clap-num",
  "color-eyre",
  "colored",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "futures",
  "futures-timer",
  "hex",
@@ -16130,7 +16140,7 @@ dependencies = [
  "array-bytes 6.1.0",
  "assert_matches",
  "criterion 0.4.0",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "num_cpus",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -16566,7 +16576,7 @@ name = "sc-rpc"
 version = "29.0.0"
 dependencies = [
  "assert_matches",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "futures",
  "jsonrpsee",
  "log",
@@ -16808,7 +16818,7 @@ dependencies = [
 name = "sc-statement-store"
 version = "10.0.0"
 dependencies = [
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "log",
  "parity-db",
  "parking_lot 0.12.1",
@@ -17891,7 +17901,7 @@ name = "snowbridge-outbound-queue-merkle-tree"
 version = "0.3.0"
 dependencies = [
  "array-bytes 4.2.0",
- "env_logger 0.9.3",
+ "env_logger 0.11.3",
  "hex",
  "hex-literal",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6758,7 +6758,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.3",
+ "socket2 0.5.6",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -18201,12 +18201,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -20553,9 +20553,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -20565,16 +20565,16 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite 0.2.12",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bridges/snowbridge/pallets/outbound-queue/merkle-tree/Cargo.toml
+++ b/bridges/snowbridge/pallets/outbound-queue/merkle-tree/Cargo.toml
@@ -23,7 +23,7 @@ sp-runtime = { path = "../../../../../substrate/primitives/runtime", default-fea
 
 [dev-dependencies]
 hex-literal = { version = "0.4.1" }
-env_logger = "0.9"
+env_logger = "0.11"
 hex = "0.4"
 array-bytes = "4.1"
 sp-crypto-hashing = { path = "../../../../../substrate/primitives/crypto/hashing" }

--- a/bridges/snowbridge/runtime/test-common/Cargo.toml
+++ b/bridges/snowbridge/runtime/test-common/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
 smallvec = "1.11.0"
 

--- a/cumulus/client/collator/Cargo.toml
+++ b/cumulus/client/collator/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 parking_lot = "0.12.1"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 tracing = "0.1.25"
 
 # Substrate

--- a/cumulus/client/collator/Cargo.toml
+++ b/cumulus/client/collator/Cargo.toml
@@ -34,7 +34,7 @@ cumulus-client-network = { path = "../network" }
 cumulus-primitives-core = { path = "../../primitives/core" }
 
 [dev-dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 
 # Substrate
 sp-maybe-compressed-blob = { path = "../../../substrate/primitives/maybe-compressed-blob" }

--- a/cumulus/client/consensus/aura/Cargo.toml
+++ b/cumulus/client/consensus/aura/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 futures = "0.3.28"
 tracing = "0.1.37"

--- a/cumulus/client/consensus/common/Cargo.toml
+++ b/cumulus/client/consensus/common/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 dyn-clone = "1.0.16"
 futures = "0.3.28"

--- a/cumulus/client/consensus/proposer/Cargo.toml
+++ b/cumulus/client/consensus/proposer/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 thiserror = { workspace = true }
 
 # Substrate

--- a/cumulus/client/consensus/relay-chain/Cargo.toml
+++ b/cumulus/client/consensus/relay-chain/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.28"
 parking_lot = "0.12.1"
 tracing = "0.1.37"

--- a/cumulus/client/network/Cargo.toml
+++ b/cumulus/client/network/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 futures = "0.3.28"
 futures-timer = "3.0.2"

--- a/cumulus/client/parachain-inherent/Cargo.toml
+++ b/cumulus/client/parachain-inherent/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 async-trait = "0.1.73"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
-scale-info = { version = "2.10.0", features = ["derive"] }
+scale-info = { version = "2.11.1", features = ["derive"] }
 tracing = { version = "0.1.37" }
 
 # Substrate

--- a/cumulus/client/parachain-inherent/Cargo.toml
+++ b/cumulus/client/parachain-inherent/Cargo.toml
@@ -7,7 +7,7 @@ description = "Inherent that needs to be present in every parachain block. Conta
 license = "Apache-2.0"
 
 [dependencies]
-async-trait = "0.1.73"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 scale-info = { version = "2.11.1", features = ["derive"] }
 tracing = { version = "0.1.37" }

--- a/cumulus/client/pov-recovery/Cargo.toml
+++ b/cumulus/client/pov-recovery/Cargo.toml
@@ -32,7 +32,7 @@ polkadot-primitives = { path = "../../../polkadot/primitives" }
 # Cumulus
 cumulus-primitives-core = { path = "../../primitives/core" }
 cumulus-relay-chain-interface = { path = "../relay-chain-interface" }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros"] }

--- a/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.28"
 futures-timer = "3.0.2"
 

--- a/cumulus/client/relay-chain-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-interface/Cargo.toml
@@ -20,7 +20,7 @@ sp-state-machine = { path = "../../../substrate/primitives/state-machine" }
 sc-client-api = { path = "../../../substrate/client/api" }
 
 futures = "0.3.28"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 thiserror = { workspace = true }
 jsonrpsee-core = "0.22"
 parity-scale-codec = "3.6.4"

--- a/cumulus/client/relay-chain-minimal-node/Cargo.toml
+++ b/cumulus/client/relay-chain-minimal-node/Cargo.toml
@@ -49,6 +49,6 @@ cumulus-primitives-core = { path = "../../primitives/core" }
 
 array-bytes = "6.1"
 tracing = "0.1.37"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.28"
 parking_lot = "0.12.1"

--- a/cumulus/client/relay-chain-rpc-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-rpc-interface/Cargo.toml
@@ -35,7 +35,7 @@ futures-timer = "3.0.2"
 parity-scale-codec = "3.6.4"
 jsonrpsee = { version = "0.22", features = ["ws-client"] }
 tracing = "0.1.37"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 url = "2.4.0"
 serde_json = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }

--- a/cumulus/pallets/aura-ext/Cargo.toml
+++ b/cumulus/pallets/aura-ext/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/cumulus/pallets/collator-selection/Cargo.toml
+++ b/cumulus/pallets/collator-selection/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = { workspace = true }
 codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", version = "3.0.0" }
 rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false }

--- a/cumulus/pallets/dmp-queue/Cargo.toml
+++ b/cumulus/pallets/dmp-queue/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/cumulus/pallets/parachain-system/Cargo.toml
+++ b/cumulus/pallets/parachain-system/Cargo.toml
@@ -16,7 +16,7 @@ environmental = { version = "1.1.4", default-features = false }
 impl-trait-for-tuples = "0.2.1"
 log = { workspace = true }
 trie-db = { version = "0.28.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }

--- a/cumulus/pallets/solo-to-para/Cargo.toml
+++ b/cumulus/pallets/solo-to-para/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/cumulus/pallets/xcm/Cargo.toml
+++ b/cumulus/pallets/xcm/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }
 sp-io = { path = "../../../substrate/primitives/io", default-features = false }

--- a/cumulus/pallets/xcmp-queue/Cargo.toml
+++ b/cumulus/pallets/xcmp-queue/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/cumulus/parachains/common/Cargo.toml
+++ b/cumulus/parachains/common/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-support = { path = "../../../substrate/frame/support", default-features = false }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 hex-literal = "0.4.1"
 
 # Substrate

--- a/cumulus/parachains/pallets/collective-content/Cargo.toml
+++ b/cumulus/parachains/pallets/collective-content/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../../../../substrate/frame/benchmarking", default-features = false, optional = true }
 frame-support = { path = "../../../../substrate/frame/support", default-features = false }

--- a/cumulus/parachains/pallets/parachain-info/Cargo.toml
+++ b/cumulus/parachains/pallets/parachain-info/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../../substrate/frame/system", default-features = false }

--- a/cumulus/parachains/pallets/ping/Cargo.toml
+++ b/cumulus/parachains/pallets/ping/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../../../substrate/primitives/runtime", default-features = false }

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }

--- a/cumulus/parachains/runtimes/assets/common/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/common/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 impl-trait-for-tuples = "0.2.2"
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 hex-literal = { version = "0.4.1" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
@@ -16,7 +16,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
 
 # Substrate

--- a/cumulus/parachains/runtimes/bridge-hubs/common/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/common/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../../../../../substrate/frame/support", default-features = false }
 sp-std = { path = "../../../../../substrate/primitives/std", default-features = false }
 sp-core = { path = "../../../../../substrate/primitives/core", default-features = false }

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 hex-literal = { version = "0.4.1" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
@@ -19,7 +19,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 sp-api = { path = "../../../../../substrate/primitives/api", default-features = false }

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }

--- a/cumulus/parachains/runtimes/starters/seedling/Cargo.toml
+++ b/cumulus/parachains/runtimes/starters/seedling/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false }

--- a/cumulus/parachains/runtimes/starters/shell/Cargo.toml
+++ b/cumulus/parachains/runtimes/starters/shell/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false }

--- a/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/penpal/Cargo.toml
@@ -21,7 +21,7 @@ substrate-wasm-builder = { path = "../../../../../substrate/utils/wasm-builder",
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 smallvec = "1.11.0"
 
 # Substrate

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -15,7 +15,7 @@ name = "polkadot-parachain"
 path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 clap = { version = "4.5.3", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 futures = "0.3.28"

--- a/cumulus/primitives/core/Cargo.toml
+++ b/cumulus/primitives/core/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 sp-api = { path = "../../../substrate/primitives/api", default-features = false }

--- a/cumulus/primitives/parachain-inherent/Cargo.toml
+++ b/cumulus/primitives/parachain-inherent/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 workspace = true
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.79", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 

--- a/cumulus/primitives/parachain-inherent/Cargo.toml
+++ b/cumulus/primitives/parachain-inherent/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 async-trait = { version = "0.1.74", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 sp-core = { path = "../../../substrate/primitives/core", default-features = false }

--- a/cumulus/primitives/storage-weight-reclaim/Cargo.toml
+++ b/cumulus/primitives/storage-weight-reclaim/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }

--- a/cumulus/test/runtime/Cargo.toml
+++ b/cumulus/test/runtime/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # Substrate
 frame-executive = { path = "../../../substrate/frame/executive", default-features = false }

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -13,7 +13,7 @@ name = "test-parachain"
 path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 clap = { version = "4.5.3", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -45,7 +45,7 @@ tikv-jemallocator = { version = "0.5.0", features = ["unprefixed_malloc_on_suppo
 assert_cmd = "2.0.4"
 nix = { version = "0.26.1", features = ["signal"] }
 tempfile = "3.2.0"
-tokio = "1.24.2"
+tokio = "1.37"
 substrate-rpc-client = { path = "../substrate/utils/frame/rpc/client" }
 polkadot-core-primitives = { path = "core-primitives" }
 

--- a/polkadot/cli/Cargo.toml
+++ b/polkadot/cli/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 clap = { version = "4.5.3", features = ["derive"], optional = true }
 log = { workspace = true, default-features = true }
 thiserror = { workspace = true }
-futures = "0.3.21"
+futures = "0.3.30"
 pyro = { package = "pyroscope", version = "0.5.3", optional = true }
 pyroscope_pprofrs = { version = "0.2", optional = true }
 

--- a/polkadot/core-primitives/Cargo.toml
+++ b/polkadot/core-primitives/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 sp-core = { path = "../../substrate/primitives/core", default-features = false }
 sp-std = { path = "../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 
 [features]

--- a/polkadot/node/collation-generation/Cargo.toml
+++ b/polkadot/node/collation-generation/Cargo.toml
@@ -10,7 +10,7 @@ description = "Collator-side subsystem that handles incoming candidate submissio
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../gum" }
 polkadot-erasure-coding = { path = "../../erasure-coding" }
 polkadot-node-primitives = { path = "../primitives" }

--- a/polkadot/node/core/approval-voting/Cargo.toml
+++ b/polkadot/node/core/approval-voting/Cargo.toml
@@ -10,7 +10,7 @@ description = "Approval Voting Subsystem of the Polkadot node"
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
 gum = { package = "tracing-gum", path = "../../gum" }

--- a/polkadot/node/core/approval-voting/Cargo.toml
+++ b/polkadot/node/core/approval-voting/Cargo.toml
@@ -52,4 +52,4 @@ assert_matches = "1.4.0"
 kvdb-memorydb = "0.13.0"
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../../primitives/test-helpers" }
 log = { workspace = true, default-features = true }
-env_logger = "0.9.0"
+env_logger = "0.11"

--- a/polkadot/node/core/approval-voting/Cargo.toml
+++ b/polkadot/node/core/approval-voting/Cargo.toml
@@ -41,7 +41,7 @@ rand_chacha = { version = "0.3.1" }
 rand = "0.8.5"
 
 [dev-dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 parking_lot = "0.12.1"
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 sp-keystore = { path = "../../../../substrate/primitives/keystore" }

--- a/polkadot/node/core/av-store/Cargo.toml
+++ b/polkadot/node/core/av-store/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 kvdb = "0.13.0"
 thiserror = { workspace = true }

--- a/polkadot/node/core/av-store/Cargo.toml
+++ b/polkadot/node/core/av-store/Cargo.toml
@@ -29,7 +29,7 @@ polkadot-node-jaeger = { path = "../../jaeger" }
 
 [dev-dependencies]
 log = { workspace = true, default-features = true }
-env_logger = "0.9.0"
+env_logger = "0.11"
 assert_matches = "1.4.0"
 kvdb-memorydb = "0.13.0"
 

--- a/polkadot/node/core/backing/Cargo.toml
+++ b/polkadot/node/core/backing/Cargo.toml
@@ -10,7 +10,7 @@ description = "The Candidate Backing Subsystem. Tracks parachain candidates that
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 sp-keystore = { path = "../../../../substrate/primitives/keystore" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }
@@ -30,7 +30,7 @@ sp-application-crypto = { path = "../../../../substrate/primitives/application-c
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 sc-keystore = { path = "../../../../substrate/client/keystore" }
 sp-tracing = { path = "../../../../substrate/primitives/tracing" }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 assert_matches = "1.4.0"
 rstest = "0.18.2"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/polkadot/node/core/bitfield-signing/Cargo.toml
+++ b/polkadot/node/core/bitfield-signing/Cargo.toml
@@ -10,7 +10,7 @@ description = "Bitfield signing subsystem for the Polkadot node"
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }

--- a/polkadot/node/core/candidate-validation/Cargo.toml
+++ b/polkadot/node/core/candidate-validation/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1.79"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 
@@ -31,7 +31,7 @@ polkadot-node-core-pvf = { path = "../pvf" }
 
 [dev-dependencies]
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 assert_matches = "1.4.0"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 sp-core = { path = "../../../../substrate/primitives/core" }

--- a/polkadot/node/core/candidate-validation/Cargo.toml
+++ b/polkadot/node/core/candidate-validation/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.21"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }

--- a/polkadot/node/core/chain-api/Cargo.toml
+++ b/polkadot/node/core/chain-api/Cargo.toml
@@ -10,7 +10,7 @@ description = "The Chain API subsystem provides access to chain related utility 
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-node-metrics = { path = "../../metrics" }
 polkadot-node-subsystem = { path = "../../subsystem" }
@@ -19,7 +19,7 @@ sc-client-api = { path = "../../../../substrate/client/api" }
 sc-consensus-babe = { path = "../../../../substrate/client/consensus/babe" }
 
 [dev-dependencies]
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 maplit = "1.0.2"
 parity-scale-codec = "3.6.1"
 polkadot-node-primitives = { path = "../../primitives" }

--- a/polkadot/node/core/chain-selection/Cargo.toml
+++ b/polkadot/node/core/chain-selection/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/core/dispute-coordinator/Cargo.toml
+++ b/polkadot/node/core/dispute-coordinator/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 parity-scale-codec = "3.6.1"
 kvdb = "0.13.0"

--- a/polkadot/node/core/parachains-inherent/Cargo.toml
+++ b/polkadot/node/core/parachains-inherent/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.21"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 thiserror = { workspace = true }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-overseer = { path = "../../overseer" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/core/parachains-inherent/Cargo.toml
+++ b/polkadot/node/core/parachains-inherent/Cargo.toml
@@ -10,7 +10,7 @@ description = "Parachains inherent data provider for Polkadot node"
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 thiserror = { workspace = true }

--- a/polkadot/node/core/prospective-parachains/Cargo.toml
+++ b/polkadot/node/core/prospective-parachains/Cargo.toml
@@ -10,7 +10,7 @@ description = "The Prospective Parachains subsystem. Tracks and handles prospect
 workspace = true
 
 [dependencies]
-futures = "0.3.19"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 parity-scale-codec = "3.6.4"
 thiserror = { workspace = true }

--- a/polkadot/node/core/provisioner/Cargo.toml
+++ b/polkadot/node/core/provisioner/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 thiserror = { workspace = true }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/core/pvf-checker/Cargo.toml
+++ b/polkadot/node/core/pvf-checker/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 thiserror = { workspace = true }
 gum = { package = "tracing-gum", path = "../../gum" }
 

--- a/polkadot/node/core/pvf/Cargo.toml
+++ b/polkadot/node/core/pvf/Cargo.toml
@@ -14,7 +14,7 @@ always-assert = "0.1"
 array-bytes = "6.1"
 blake3 = "1.5"
 cfg-if = "1.0"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 is_executable = "1.0.1"

--- a/polkadot/node/core/pvf/common/Cargo.toml
+++ b/polkadot/node/core/pvf/common/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 cfg-if = "1.0"
 cpu-time = "1.0.0"
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../../gum" }
 libc = "0.2.152"
 thiserror = { workspace = true }

--- a/polkadot/node/core/runtime-api/Cargo.toml
+++ b/polkadot/node/core/runtime-api/Cargo.toml
@@ -25,7 +25,7 @@ polkadot-node-subsystem-types = { path = "../../subsystem-types" }
 sp-api = { path = "../../../../substrate/primitives/api" }
 sp-core = { path = "../../../../substrate/primitives/core" }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-node-primitives = { path = "../../primitives" }

--- a/polkadot/node/core/runtime-api/Cargo.toml
+++ b/polkadot/node/core/runtime-api/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 schnellru = "0.2.1"
 
@@ -26,7 +26,7 @@ sp-api = { path = "../../../../substrate/primitives/api" }
 sp-core = { path = "../../../../substrate/primitives/core" }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 async-trait = "0.1.79"
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 polkadot-node-primitives = { path = "../../primitives" }
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../../primitives/test-helpers" }

--- a/polkadot/node/jaeger/Cargo.toml
+++ b/polkadot/node/jaeger/Cargo.toml
@@ -18,6 +18,6 @@ polkadot-node-primitives = { path = "../primitives" }
 sc-network = { path = "../../../substrate/client/network" }
 sp-core = { path = "../../../substrate/primitives/core" }
 thiserror = { workspace = true }
-tokio = "1.24.2"
+tokio = "1.37"
 log = { workspace = true, default-features = true }
 parity-scale-codec = { version = "3.6.1", default-features = false }

--- a/polkadot/node/malus/Cargo.toml
+++ b/polkadot/node/malus/Cargo.toml
@@ -44,7 +44,7 @@ async-trait = "0.1.79"
 sp-keystore = { path = "../../../substrate/primitives/keystore" }
 sp-core = { path = "../../../substrate/primitives/core" }
 clap = { version = "4.5.3", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../gum" }
 erasure = { package = "polkadot-erasure-coding", path = "../../erasure-coding" }
@@ -58,7 +58,7 @@ polkadot-node-core-pvf-prepare-worker = { path = "../core/pvf/prepare-worker" }
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../subsystem-test-helpers" }
 sp-core = { path = "../../../substrate/primitives/core" }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 
 [build-dependencies]
 substrate-build-script-utils = { path = "../../../substrate/utils/build-script-utils" }

--- a/polkadot/node/malus/Cargo.toml
+++ b/polkadot/node/malus/Cargo.toml
@@ -40,7 +40,7 @@ polkadot-node-primitives = { path = "../primitives" }
 polkadot-primitives = { path = "../../primitives" }
 color-eyre = { version = "0.6.1", default-features = false }
 assert_matches = "1.5"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 sp-keystore = { path = "../../../substrate/primitives/keystore" }
 sp-core = { path = "../../../substrate/primitives/core" }
 clap = { version = "4.5.3", features = ["derive"] }

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../gum" }
 

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -30,7 +30,7 @@ log = { workspace = true, default-features = true }
 assert_cmd = "2.0.4"
 tempfile = "3.2.0"
 hyper = { version = "0.14.20", default-features = false, features = ["http1", "tcp"] }
-tokio = "1.24.2"
+tokio = "1.37"
 polkadot-test-service = { path = "../test/service", features = ["runtime-metrics"] }
 substrate-test-utils = { path = "../../../substrate/test-utils" }
 sc-service = { path = "../../../substrate/client/service" }

--- a/polkadot/node/network/approval-distribution/Cargo.toml
+++ b/polkadot/node/network/approval-distribution/Cargo.toml
@@ -37,5 +37,5 @@ schnorrkel = { version = "0.11.4", default-features = false }
 # rand_core should match schnorrkel
 rand_core = "0.6.2"
 rand_chacha = "0.3.1"
-env_logger = "0.9.0"
+env_logger = "0.11"
 log = { workspace = true, default-features = true }

--- a/polkadot/node/network/approval-distribution/Cargo.toml
+++ b/polkadot/node/network/approval-distribution/Cargo.toml
@@ -20,7 +20,7 @@ polkadot-node-jaeger = { path = "../../jaeger" }
 rand = "0.8"
 itertools = "0.10.5"
 
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/polkadot/node/network/availability-distribution/Cargo.toml
+++ b/polkadot/node/network/availability-distribution/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 parity-scale-codec = { version = "3.6.1", features = ["std"] }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -30,7 +30,7 @@ sc-network = { path = "../../../../substrate/client/network" }
 
 [dev-dependencies]
 assert_matches = "1.4.0"
-env_logger = "0.9.0"
+env_logger = "0.11"
 futures-timer = "3.0.2"
 log = { workspace = true, default-features = true }
 

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -16,7 +16,7 @@ schnellru = "0.2.1"
 rand = "0.8.5"
 fatality = "0.0.6"
 thiserror = { workspace = true }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 gum = { package = "tracing-gum", path = "../../gum" }
 
 polkadot-erasure-coding = { path = "../../../erasure-coding" }

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 tokio = "1.24.2"
 schnellru = "0.2.1"
 rand = "0.8.5"

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 futures = "0.3.30"
-tokio = "1.24.2"
+tokio = "1.37"
 schnellru = "0.2.1"
 rand = "0.8.5"
 fatality = "0.0.6"

--- a/polkadot/node/network/bitfield-distribution/Cargo.toml
+++ b/polkadot/node/network/bitfield-distribution/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 always-assert = "0.1"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/network/bitfield-distribution/Cargo.toml
+++ b/polkadot/node/network/bitfield-distribution/Cargo.toml
@@ -30,6 +30,6 @@ sp-keystore = { path = "../../../../substrate/primitives/keystore" }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 maplit = "1.0.2"
 log = { workspace = true, default-features = true }
-env_logger = "0.9.0"
+env_logger = "0.11"
 assert_matches = "1.4.0"
 rand_chacha = "0.3.1"

--- a/polkadot/node/network/bridge/Cargo.toml
+++ b/polkadot/node/network/bridge/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 always-assert = "0.1"
 async-trait = "0.1.79"
-futures = "0.3.21"
+futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }

--- a/polkadot/node/network/bridge/Cargo.toml
+++ b/polkadot/node/network/bridge/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 always-assert = "0.1"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.21"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 bitvec = { version = "1.0.1", default-features = false, features = ["alloc"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3"
 gum = { package = "tracing-gum", path = "../../gum" }
 

--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -30,7 +30,7 @@ tokio-util = "0.7.1"
 
 [dev-dependencies]
 log = { workspace = true, default-features = true }
-env_logger = "0.9.0"
+env_logger = "0.11"
 assert_matches = "1.4.0"
 
 sp-core = { path = "../../../../substrate/primitives/core", features = ["std"] }

--- a/polkadot/node/network/dispute-distribution/Cargo.toml
+++ b/polkadot/node/network/dispute-distribution/Cargo.toml
@@ -31,7 +31,7 @@ indexmap = "2.0.0"
 
 [dev-dependencies]
 async-channel = "1.8.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
 sp-tracing = { path = "../../../../substrate/primitives/tracing" }

--- a/polkadot/node/network/dispute-distribution/Cargo.toml
+++ b/polkadot/node/network/dispute-distribution/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 derive_more = "0.99.17"

--- a/polkadot/node/network/gossip-support/Cargo.toml
+++ b/polkadot/node/network/gossip-support/Cargo.toml
@@ -22,7 +22,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-primitives = { path = "../../../primitives" }
 
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }

--- a/polkadot/node/network/gossip-support/Cargo.toml
+++ b/polkadot/node/network/gossip-support/Cargo.toml
@@ -37,7 +37,7 @@ sp-authority-discovery = { path = "../../../../substrate/primitives/authority-di
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }
 
 assert_matches = "1.4.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 parking_lot = "0.12.1"
 lazy_static = "1.4.0"
 quickcheck = "1.0.3"

--- a/polkadot/node/network/protocol/Cargo.toml
+++ b/polkadot/node/network/protocol/Cargo.toml
@@ -19,7 +19,7 @@ polkadot-node-jaeger = { path = "../../jaeger" }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 sc-network = { path = "../../../../substrate/client/network" }
 sc-authority-discovery = { path = "../../../../substrate/client/authority-discovery" }
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.26.2", features = ["derive"] }
 futures = "0.3.30"
 thiserror = { workspace = true }
 fatality = "0.0.6"

--- a/polkadot/node/network/protocol/Cargo.toml
+++ b/polkadot/node/network/protocol/Cargo.toml
@@ -20,7 +20,7 @@ parity-scale-codec = { version = "3.6.1", default-features = false, features = [
 sc-network = { path = "../../../../substrate/client/network" }
 sc-authority-discovery = { path = "../../../../substrate/client/authority-discovery" }
 strum = { version = "0.24", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 thiserror = { workspace = true }
 fatality = "0.0.6"
 rand = "0.8"

--- a/polkadot/node/network/protocol/Cargo.toml
+++ b/polkadot/node/network/protocol/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 async-channel = "1.8.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 hex = "0.4.3"
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }

--- a/polkadot/node/network/statement-distribution/Cargo.toml
+++ b/polkadot/node/network/statement-distribution/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 gum = { package = "tracing-gum", path = "../../gum" }
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/overseer/Cargo.toml
+++ b/polkadot/node/overseer/Cargo.toml
@@ -23,7 +23,7 @@ polkadot-primitives = { path = "../../primitives" }
 orchestra = { version = "0.3.5", default-features = false, features = ["futures_channel"] }
 gum = { package = "tracing-gum", path = "../gum" }
 sp-core = { path = "../../../substrate/primitives/core" }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
 
 [dev-dependencies]

--- a/polkadot/node/overseer/Cargo.toml
+++ b/polkadot/node/overseer/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 client = { package = "sc-client-api", path = "../../../substrate/client/api" }
 sp-api = { path = "../../../substrate/primitives/api" }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 parking_lot = "0.12.1"
 polkadot-node-network-protocol = { path = "../network/protocol" }
@@ -29,7 +29,7 @@ tikv-jemalloc-ctl = { version = "0.5.0", optional = true }
 [dev-dependencies]
 metered = { package = "prioritized-metered-channel", version = "0.6.1", default-features = false, features = ["futures_channel"] }
 sp-core = { path = "../../../substrate/primitives/core" }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 femme = "2.2.1"
 assert_matches = "1.4.0"
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../primitives/test-helpers" }

--- a/polkadot/node/primitives/Cargo.toml
+++ b/polkadot/node/primitives/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 bounded-vec = "0.7"
-futures = "0.3.21"
+futures = "0.3.30"
 polkadot-primitives = { path = "../../primitives" }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 sp-core = { path = "../../../substrate/primitives/core" }

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -77,7 +77,7 @@ frame-benchmarking-cli = { path = "../../../substrate/utils/frame/benchmarking-c
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking" }
 
 # External Crates
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.21"
 hex-literal = "0.4.1"
 is_executable = "1.0.1"

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -148,7 +148,7 @@ xcm-fee-payment-runtime-api = { path = "../../xcm/xcm-fee-payment-runtime-api" }
 polkadot-test-client = { path = "../test/client" }
 polkadot-node-subsystem-test-helpers = { path = "../subsystem-test-helpers" }
 test-helpers = { package = "polkadot-primitives-test-helpers", path = "../../primitives/test-helpers" }
-env_logger = "0.9.0"
+env_logger = "0.11"
 assert_matches = "1.5.0"
 serial_test = "2.0.0"
 tempfile = "3.2"

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -78,7 +78,7 @@ frame-benchmarking = { path = "../../../substrate/frame/benchmarking" }
 
 # External Crates
 async-trait = "0.1.79"
-futures = "0.3.21"
+futures = "0.3.30"
 hex-literal = "0.4.1"
 is_executable = "1.0.1"
 gum = { package = "tracing-gum", path = "../gum" }

--- a/polkadot/node/subsystem-bench/Cargo.toml
+++ b/polkadot/node/subsystem-bench/Cargo.toml
@@ -48,7 +48,7 @@ hex = "0.4.3"
 gum = { package = "tracing-gum", path = "../gum" }
 polkadot-erasure-coding = { package = "polkadot-erasure-coding", path = "../../erasure-coding" }
 log = { workspace = true, default-features = true }
-env_logger = "0.9.0"
+env_logger = "0.11"
 rand = "0.8.5"
 # `rand` only supports uniform distribution, we need normal distribution for latency.
 rand_distr = "0.4.3"

--- a/polkadot/node/subsystem-bench/Cargo.toml
+++ b/polkadot/node/subsystem-bench/Cargo.toml
@@ -40,7 +40,7 @@ sp-keystore = { path = "../../../substrate/primitives/keystore" }
 sc-keystore = { path = "../../../substrate/client/keystore" }
 sp-core = { path = "../../../substrate/primitives/core" }
 clap = { version = "4.5.3", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 bincode = "1.3.3"
 sha1 = "0.10.6"

--- a/polkadot/node/subsystem-bench/Cargo.toml
+++ b/polkadot/node/subsystem-bench/Cargo.toml
@@ -35,7 +35,7 @@ color-eyre = { version = "0.6.1", default-features = false }
 polkadot-overseer = { path = "../overseer" }
 colored = "2.0.4"
 assert_matches = "1.5"
-async-trait = "0.1.57"
+async-trait = "0.1.79"
 sp-keystore = { path = "../../../substrate/primitives/keystore" }
 sc-keystore = { path = "../../../substrate/client/keystore" }
 sp-core = { path = "../../../substrate/primitives/core" }

--- a/polkadot/node/subsystem-test-helpers/Cargo.toml
+++ b/polkadot/node/subsystem-test-helpers/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.21"
 parking_lot = "0.12.1"
 polkadot-node-subsystem = { path = "../subsystem" }

--- a/polkadot/node/subsystem-test-helpers/Cargo.toml
+++ b/polkadot/node/subsystem-test-helpers/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1.79"
-futures = "0.3.21"
+futures = "0.3.30"
 parking_lot = "0.12.1"
 polkadot-node-subsystem = { path = "../subsystem" }
 polkadot-erasure-coding = { path = "../../erasure-coding" }

--- a/polkadot/node/subsystem-types/Cargo.toml
+++ b/polkadot/node/subsystem-types/Cargo.toml
@@ -29,5 +29,5 @@ sc-transaction-pool-api = { path = "../../../substrate/client/transaction-pool/a
 smallvec = "1.8.0"
 substrate-prometheus-endpoint = { path = "../../../substrate/utils/prometheus" }
 thiserror = { workspace = true }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }

--- a/polkadot/node/subsystem-types/Cargo.toml
+++ b/polkadot/node/subsystem-types/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 derive_more = "0.99.17"
-futures = "0.3.21"
+futures = "0.3.30"
 polkadot-primitives = { path = "../../primitives" }
 polkadot-node-primitives = { path = "../primitives" }
 polkadot-node-network-protocol = { path = "../network/protocol" }

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.21"
 futures-channel = "0.3.23"
 itertools = "0.10"

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 async-trait = "0.1.79"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-channel = "0.3.23"
 itertools = "0.10"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
@@ -45,7 +45,7 @@ parity-db = { version = "0.4.12" }
 [dev-dependencies]
 assert_matches = "1.4.0"
 env_logger = "0.9.0"
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 log = { workspace = true, default-features = true }
 polkadot-node-subsystem-test-helpers = { path = "../subsystem-test-helpers" }
 lazy_static = "1.4.0"

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -44,7 +44,7 @@ parity-db = { version = "0.4.12" }
 
 [dev-dependencies]
 assert_matches = "1.4.0"
-env_logger = "0.9.0"
+env_logger = "0.11"
 futures = { version = "0.3.30", features = ["thread-pool"] }
 log = { workspace = true, default-features = true }
 polkadot-node-subsystem-test-helpers = { path = "../subsystem-test-helpers" }

--- a/polkadot/node/test/client/Cargo.toml
+++ b/polkadot/node/test/client/Cargo.toml
@@ -38,7 +38,7 @@ frame-benchmarking = { path = "../../../../substrate/frame/benchmarking" }
 
 [dev-dependencies]
 sp-keyring = { path = "../../../../substrate/primitives/keyring" }
-futures = "0.3.21"
+futures = "0.3.30"
 
 [features]
 runtime-benchmarks = [

--- a/polkadot/node/test/service/Cargo.toml
+++ b/polkadot/node/test/service/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 hex = "0.4.3"
 gum = { package = "tracing-gum", path = "../../gum" }
 rand = "0.8.5"

--- a/polkadot/node/test/service/Cargo.toml
+++ b/polkadot/node/test/service/Cargo.toml
@@ -16,7 +16,7 @@ gum = { package = "tracing-gum", path = "../../gum" }
 rand = "0.8.5"
 serde_json = { workspace = true, default-features = true }
 tempfile = "3.2.0"
-tokio = "1.24.2"
+tokio = "1.37"
 
 # Polkadot dependencies
 polkadot-overseer = { path = "../../overseer" }
@@ -63,7 +63,7 @@ substrate-test-client = { path = "../../../../substrate/test-utils/client" }
 [dev-dependencies]
 pallet-balances = { path = "../../../../substrate/frame/balances", default-features = false }
 substrate-test-utils = { path = "../../../../substrate/test-utils" }
-tokio = { version = "1.24.2", features = ["macros"] }
+tokio = { version = "1.37", features = ["macros"] }
 
 [features]
 runtime-metrics = ["polkadot-test-runtime/runtime-metrics"]

--- a/polkadot/parachain/Cargo.toml
+++ b/polkadot/parachain/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 # this crate for WASM. This is critical to avoid forcing all parachain WASM into implementing
 # various unnecessary Substrate-specific endpoints.
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 sp-std = { path = "../../substrate/primitives/std", default-features = false }
 sp-runtime = { path = "../../substrate/primitives/runtime", default-features = false, features = ["serde"] }
 sp-core = { path = "../../substrate/primitives/core", default-features = false, features = ["serde"] }

--- a/polkadot/parachain/test-parachains/adder/collator/Cargo.toml
+++ b/polkadot/parachain/test-parachains/adder/collator/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 clap = { version = "4.5.3", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 log = { workspace = true, default-features = true }
 

--- a/polkadot/parachain/test-parachains/undying/collator/Cargo.toml
+++ b/polkadot/parachain/test-parachains/undying/collator/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 clap = { version = "4.5.3", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 log = { workspace = true, default-features = true }
 

--- a/polkadot/primitives/Cargo.toml
+++ b/polkadot/primitives/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc", "serde"] }
 hex-literal = "0.4.1"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["bit-vec", "derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["bit-vec", "derive", "serde"] }
 log = { workspace = true, default-features = false }
 serde = { features = ["alloc", "derive"], workspace = true }
 

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -15,7 +15,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc"], workspace = true }
 serde_derive = { workspace = true }
 static_assertions = "1.1.0"

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -59,7 +59,7 @@ polkadot-runtime-metrics = { path = "../metrics", default-features = false }
 polkadot-core-primitives = { path = "../../core-primitives", default-features = false }
 
 [dev-dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 hex-literal = "0.4.1"
 keyring = { package = "sp-keyring", path = "../../../substrate/primitives/keyring" }
 frame-support-test = { path = "../../../substrate/frame/support/test" }

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -15,7 +15,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { workspace = true }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.11.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], workspace = true }
 derive_more = "0.99.17"
 bitflags = "1.3.2"

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 serde = { workspace = true }
 serde_derive = { optional = true, workspace = true }

--- a/polkadot/runtime/test-runtime/Cargo.toml
+++ b/polkadot/runtime/test-runtime/Cargo.toml
@@ -15,7 +15,7 @@ bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 rustc-hex = { version = "2.1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { workspace = true }
 serde_derive = { optional = true, workspace = true }
 smallvec = "1.8.0"

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 rustc-hex = { version = "2.1.0", default-features = false }
 serde = { workspace = true }

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -16,7 +16,7 @@ derivative = { version = "2.2.0", default-features = false, features = ["use_cor
 impl-trait-for-tuples = "0.2.2"
 log = { workspace = true }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 sp-weights = { path = "../../substrate/primitives/weights", default-features = false, features = ["serde"] }
 serde = { features = ["alloc", "derive", "rc"], workspace = true }
 schemars = { version = "0.8.13", default-features = true, optional = true }

--- a/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false }

--- a/polkadot/xcm/pallet-xcm/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 bounded-collections = { version = "0.2.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
 log = { workspace = true }
 

--- a/polkadot/xcm/xcm-builder/Cargo.toml
+++ b/polkadot/xcm/xcm-builder/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 impl-trait-for-tuples = "0.2.1"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 xcm = { package = "staging-xcm", path = "..", default-features = false }
 xcm-executor = { package = "staging-xcm-executor", path = "../xcm-executor", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }

--- a/polkadot/xcm/xcm-executor/Cargo.toml
+++ b/polkadot/xcm/xcm-executor/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 impl-trait-for-tuples = "0.2.2"
 environmental = { version = "1.1.4", default-features = false }
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 xcm = { package = "staging-xcm", path = "..", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }
 sp-io = { path = "../../../substrate/primitives/io", default-features = false }

--- a/polkadot/xcm/xcm-executor/integration-tests/Cargo.toml
+++ b/polkadot/xcm/xcm-executor/integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 frame-support = { path = "../../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../../substrate/frame/system" }
-futures = "0.3.21"
+futures = "0.3.30"
 pallet-transaction-payment = { path = "../../../../substrate/frame/transaction-payment" }
 pallet-xcm = { path = "../../pallet-xcm" }
 polkadot-test-client = { path = "../../../node/test/client" }

--- a/polkadot/xcm/xcm-fee-payment-runtime-api/Cargo.toml
+++ b/polkadot/xcm/xcm-fee-payment-runtime-api/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 ] }
 
 sp-api = { path = "../../../substrate/primitives/api", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 	"serde",
 ] }

--- a/polkadot/xcm/xcm-simulator/example/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/example/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.10.0", features = ["derive"] }
+scale-info = { version = "2.11.1", features = ["derive"] }
 log = { workspace = true }
 
 frame-system = { path = "../../../../substrate/frame/system" }

--- a/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 honggfuzz = "0.5.55"
 arbitrary = "1.3.2"
-scale-info = { version = "2.10.0", features = ["derive"] }
+scale-info = { version = "2.11.1", features = ["derive"] }
 
 frame-system = { path = "../../../../substrate/frame/system" }
 frame-support = { path = "../../../../substrate/frame/support" }

--- a/substrate/bin/node/bench/Cargo.toml
+++ b/substrate/bin/node/bench/Cargo.toml
@@ -44,4 +44,4 @@ lazy_static = "1.4.0"
 parity-db = "0.4.12"
 sc-transaction-pool = { path = "../../../client/transaction-pool" }
 sc-transaction-pool-api = { path = "../../../client/transaction-pool/api" }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -160,7 +160,7 @@ sp-externalities = { path = "../../../primitives/externalities" }
 sp-keyring = { path = "../../../primitives/keyring" }
 sp-runtime = { path = "../../../primitives/runtime" }
 serde_json = { workspace = true, default-features = true }
-scale-info = { version = "2.10.0", features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", features = ["derive", "serde"] }
 sp-trie = { path = "../../../primitives/trie" }
 sp-state-machine = { path = "../../../primitives/state-machine" }
 

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -45,7 +45,7 @@ clap = { version = "4.5.3", features = ["derive"], optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 serde = { features = ["derive"], workspace = true, default-features = true }
 jsonrpsee = { version = "0.22", features = ["server"] }
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 rand = "0.8"
 
@@ -129,7 +129,7 @@ sc-block-builder = { path = "../../../client/block-builder" }
 sp-tracing = { path = "../../../primitives/tracing" }
 sp-blockchain = { path = "../../../primitives/blockchain" }
 sp-crypto-hashing = { path = "../../../primitives/crypto/hashing" }
-futures = "0.3.21"
+futures = "0.3.30"
 tempfile = "3.1.0"
 assert_cmd = "2.0.2"
 nix = { version = "0.26.1", features = ["signal"] }

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -23,7 +23,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 static_assertions = "1.1.0"
 log = { workspace = true }
 serde_json = { features = ["alloc", "arbitrary_precision"], workspace = true }

--- a/substrate/bin/node/testing/Cargo.toml
+++ b/substrate/bin/node/testing/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 fs_extra = "1"
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 tempfile = "3.1.0"
 frame-system = { path = "../../../frame/system" }

--- a/substrate/client/api/Cargo.toml
+++ b/substrate/client/api/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 fnv = "1.0.6"
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" }

--- a/substrate/client/authority-discovery/Cargo.toml
+++ b/substrate/client/authority-discovery/Cargo.toml
@@ -21,7 +21,7 @@ prost-build = "0.11"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 ip_network = "0.4.1"
 libp2p = { version = "0.51.4", features = ["ed25519", "kad"] }

--- a/substrate/client/authority-discovery/Cargo.toml
+++ b/substrate/client/authority-discovery/Cargo.toml
@@ -43,7 +43,7 @@ sp-blockchain = { path = "../../primitives/blockchain" }
 sp-core = { path = "../../primitives/core" }
 sp-keystore = { path = "../../primitives/keystore" }
 sp-runtime = { path = "../../primitives/runtime" }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 multihash-codetable = { version = "0.1.1", features = [
 	"digest",
 	"serde",

--- a/substrate/client/basic-authorship/Cargo.toml
+++ b/substrate/client/basic-authorship/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 log = { workspace = true, default-features = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" }

--- a/substrate/client/cli/Cargo.toml
+++ b/substrate/client/cli/Cargo.toml
@@ -20,7 +20,7 @@ array-bytes = "6.1"
 chrono = "0.4.31"
 clap = { version = "4.5.3", features = ["derive", "string", "wrap_help"] }
 fdlimit = "0.3.0"
-futures = "0.3.21"
+futures = "0.3.30"
 itertools = "0.10.3"
 libp2p-identity = { version = "0.1.3", features = ["ed25519", "peerid"] }
 log = { workspace = true, default-features = true }

--- a/substrate/client/consensus/aura/Cargo.toml
+++ b/substrate/client/consensus/aura/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 log = { workspace = true, default-features = true }

--- a/substrate/client/consensus/aura/Cargo.toml
+++ b/substrate/client/consensus/aura/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../../utils/prometheus" }

--- a/substrate/client/consensus/babe/Cargo.toml
+++ b/substrate/client/consensus/babe/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 num-bigint = "0.4.3"
 num-rational = "0.4.1"

--- a/substrate/client/consensus/babe/Cargo.toml
+++ b/substrate/client/consensus/babe/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 log = { workspace = true, default-features = true }

--- a/substrate/client/consensus/babe/Cargo.toml
+++ b/substrate/client/consensus/babe/Cargo.toml
@@ -54,4 +54,4 @@ sc-network-test = { path = "../../network/test" }
 sp-timestamp = { path = "../../../primitives/timestamp" }
 sp-tracing = { path = "../../../primitives/tracing" }
 substrate-test-runtime-client = { path = "../../../test-utils/runtime/client" }
-tokio = "1.22.0"
+tokio = "1.37"

--- a/substrate/client/consensus/babe/rpc/Cargo.toml
+++ b/substrate/client/consensus/babe/rpc/Cargo.toml
@@ -34,7 +34,7 @@ sp-runtime = { path = "../../../../primitives/runtime" }
 
 [dev-dependencies]
 serde_json = { workspace = true, default-features = true }
-tokio = "1.22.0"
+tokio = "1.37"
 sc-consensus = { path = "../../common" }
 sc-keystore = { path = "../../../keystore" }
 sc-transaction-pool-api = { path = "../../../transaction-pool/api" }

--- a/substrate/client/consensus/babe/rpc/Cargo.toml
+++ b/substrate/client/consensus/babe/rpc/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 jsonrpsee = { version = "0.22", features = ["client-core", "macros", "server"] }
-futures = "0.3.21"
+futures = "0.3.30"
 serde = { features = ["derive"], workspace = true, default-features = true }
 thiserror = { workspace = true }
 sc-consensus-babe = { path = ".." }

--- a/substrate/client/consensus/beefy/Cargo.toml
+++ b/substrate/client/consensus/beefy/Cargo.toml
@@ -17,7 +17,7 @@ async-channel = "1.8.0"
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 fnv = "1.0.6"
-futures = "0.3"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"
 thiserror = { workspace = true }

--- a/substrate/client/consensus/beefy/Cargo.toml
+++ b/substrate/client/consensus/beefy/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 fnv = "1.0.6"
 futures = "0.3"

--- a/substrate/client/consensus/beefy/Cargo.toml
+++ b/substrate/client/consensus/beefy/Cargo.toml
@@ -40,7 +40,7 @@ sp-crypto-hashing = { path = "../../../primitives/crypto/hashing" }
 sp-keystore = { path = "../../../primitives/keystore" }
 sp-mmr-primitives = { path = "../../../primitives/merkle-mountain-range" }
 sp-runtime = { path = "../../../primitives/runtime" }
-tokio = "1.22.0"
+tokio = "1.37"
 
 
 [dev-dependencies]

--- a/substrate/client/consensus/beefy/rpc/Cargo.toml
+++ b/substrate/client/consensus/beefy/rpc/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 jsonrpsee = { version = "0.22", features = ["client-core", "macros", "server"] }
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"

--- a/substrate/client/consensus/common/Cargo.toml
+++ b/substrate/client/consensus/common/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 libp2p-identity = { version = "0.1.3", features = ["ed25519", "peerid"] }

--- a/substrate/client/consensus/common/Cargo.toml
+++ b/substrate/client/consensus/common/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.79"
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 libp2p-identity = { version = "0.1.3", features = ["ed25519", "peerid"] }
 log = { workspace = true, default-features = true }

--- a/substrate/client/consensus/grandpa/Cargo.toml
+++ b/substrate/client/consensus/grandpa/Cargo.toml
@@ -22,7 +22,7 @@ array-bytes = "6.1"
 async-trait = "0.1.79"
 dyn-clone = "1.0"
 finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 log = { workspace = true, default-features = true }
 parity-scale-codec = { version = "3.6.1", features = ["derive"] }

--- a/substrate/client/consensus/grandpa/Cargo.toml
+++ b/substrate/client/consensus/grandpa/Cargo.toml
@@ -58,7 +58,7 @@ sp-runtime = { path = "../../../primitives/runtime" }
 assert_matches = "1.3.0"
 finality-grandpa = { version = "0.16.2", features = ["derive-codec", "test-helpers"] }
 serde = { workspace = true, default-features = true }
-tokio = "1.22.0"
+tokio = "1.37"
 sc-network = { path = "../../network" }
 sc-network-test = { path = "../../network/test" }
 sp-keyring = { path = "../../../primitives/keyring" }

--- a/substrate/client/consensus/grandpa/Cargo.toml
+++ b/substrate/client/consensus/grandpa/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 ahash = "0.8.2"
 array-bytes = "6.1"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 dyn-clone = "1.0"
 finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
 futures = "0.3.21"

--- a/substrate/client/consensus/grandpa/rpc/Cargo.toml
+++ b/substrate/client/consensus/grandpa/rpc/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 finality-grandpa = { version = "0.16.2", features = ["derive-codec"] }
-futures = "0.3.16"
+futures = "0.3.30"
 jsonrpsee = { version = "0.22", features = ["client-core", "macros", "server"] }
 log = { workspace = true, default-features = true }
 parity-scale-codec = { version = "3.6.1", features = ["derive"] }

--- a/substrate/client/consensus/manual-seal/Cargo.toml
+++ b/substrate/client/consensus/manual-seal/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 jsonrpsee = { version = "0.22", features = ["client-core", "macros", "server"] }
 assert_matches = "1.3.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 futures-timer = "3.0.1"

--- a/substrate/client/consensus/manual-seal/Cargo.toml
+++ b/substrate/client/consensus/manual-seal/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpsee = { version = "0.22", features = ["client-core", "macros", "server"] }
 assert_matches = "1.3.0"
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 log = { workspace = true, default-features = true }
 serde = { features = ["derive"], workspace = true, default-features = true }

--- a/substrate/client/consensus/pow/Cargo.toml
+++ b/substrate/client/consensus/pow/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"

--- a/substrate/client/consensus/pow/Cargo.toml
+++ b/substrate/client/consensus/pow/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.1"

--- a/substrate/client/consensus/slots/Cargo.toml
+++ b/substrate/client/consensus/slots/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 log = { workspace = true, default-features = true }
 sc-client-api = { path = "../../api" }

--- a/substrate/client/consensus/slots/Cargo.toml
+++ b/substrate/client/consensus/slots/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 futures-timer = "3.0.1"

--- a/substrate/client/executor/Cargo.toml
+++ b/substrate/client/executor/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber = "0.2.19"
 paste = "1.0"
 regex = "1.6.0"
 criterion = "0.4.0"
-env_logger = "0.9"
+env_logger = "0.11"
 num_cpus = "1.13.1"
 tempfile = "3.3.0"
 

--- a/substrate/client/informant/Cargo.toml
+++ b/substrate/client/informant/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ansi_term = "0.12.1"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 log = { workspace = true, default-features = true }
 sc-client-api = { path = "../api" }

--- a/substrate/client/merkle-mountain-range/Cargo.toml
+++ b/substrate/client/merkle-mountain-range/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 sp-api = { path = "../../primitives/api" }
 sp-blockchain = { path = "../../primitives/blockchain" }

--- a/substrate/client/merkle-mountain-range/Cargo.toml
+++ b/substrate/client/merkle-mountain-range/Cargo.toml
@@ -32,4 +32,4 @@ parking_lot = "0.12.1"
 sc-block-builder = { path = "../block-builder" }
 sp-tracing = { path = "../../primitives/tracing" }
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
-tokio = "1.17.0"
+tokio = "1.37"

--- a/substrate/client/mixnet/Cargo.toml
+++ b/substrate/client/mixnet/Cargo.toml
@@ -21,7 +21,7 @@ arrayvec = "0.7.2"
 blake2 = "0.10.4"
 bytes = "1"
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-futures = "0.3.25"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 libp2p-identity = { version = "0.1.3", features = ["peerid"] }
 log = { workspace = true, default-features = true }

--- a/substrate/client/network-gossip/Cargo.toml
+++ b/substrate/client/network-gossip/Cargo.toml
@@ -31,7 +31,7 @@ sc-network-sync = { path = "../network/sync" }
 sp-runtime = { path = "../../primitives/runtime" }
 
 [dev-dependencies]
-tokio = "1.22.0"
+tokio = "1.37"
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 quickcheck = { version = "1.0.3", default-features = false }

--- a/substrate/client/network-gossip/Cargo.toml
+++ b/substrate/client/network-gossip/Cargo.toml
@@ -32,7 +32,7 @@ sp-runtime = { path = "../../primitives/runtime" }
 
 [dev-dependencies]
 tokio = "1.22.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 quickcheck = { version = "1.0.3", default-features = false }
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }

--- a/substrate/client/network-gossip/Cargo.toml
+++ b/substrate/client/network-gossip/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ahash = "0.8.2"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 libp2p = "0.51.4"
 log = { workspace = true, default-features = true }

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-async-trait = "0.1"
+async-trait = "0.1.79"
 asynchronous-codec = "0.6"
 bytes = "1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 either = "1.5.3"
 fnv = "1.0.6"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 ip_network = "0.4.1"
 libp2p = { version = "0.51.4", features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "request-response", "tcp", "tokio", "websocket", "yamux"] }

--- a/substrate/client/network/bitswap/Cargo.toml
+++ b/substrate/client/network/bitswap/Cargo.toml
@@ -21,7 +21,7 @@ prost-build = "0.11"
 [dependencies]
 async-channel = "1.8.0"
 cid = "0.9.0"
-futures = "0.3.21"
+futures = "0.3.30"
 libp2p-identity = { version = "0.1.3", features = ["peerid"] }
 log = { workspace = true, default-features = true }
 prost = "0.12"

--- a/substrate/client/network/common/Cargo.toml
+++ b/substrate/client/network/common/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 prost-build = "0.11"
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 bitflags = "1.3.2"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 	"derive",

--- a/substrate/client/network/common/Cargo.toml
+++ b/substrate/client/network/common/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = "1.3.2"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 	"derive",
 ] }
-futures = "0.3.21"
+futures = "0.3.30"
 libp2p-identity = { version = "0.1.3", features = ["peerid"] }
 sc-consensus = { path = "../../consensus/common" }
 sp-consensus = { path = "../../../primitives/consensus/common" }

--- a/substrate/client/network/light/Cargo.toml
+++ b/substrate/client/network/light/Cargo.toml
@@ -24,7 +24,7 @@ array-bytes = "6.1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 	"derive",
 ] }
-futures = "0.3.21"
+futures = "0.3.30"
 libp2p-identity = { version = "0.1.3", features = ["peerid"] }
 log = { workspace = true, default-features = true }
 prost = "0.12"

--- a/substrate/client/network/statement/Cargo.toml
+++ b/substrate/client/network/statement/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "6.1"
 async-channel = "1.8.0"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 libp2p = "0.51.4"
 log = { workspace = true, default-features = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../../utils/prometheus" }

--- a/substrate/client/network/sync/Cargo.toml
+++ b/substrate/client/network/sync/Cargo.toml
@@ -23,7 +23,7 @@ array-bytes = "6.1"
 async-channel = "1.8.0"
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 libp2p = "0.51.4"
 log = { workspace = true, default-features = true }

--- a/substrate/client/network/sync/Cargo.toml
+++ b/substrate/client/network/sync/Cargo.toml
@@ -21,7 +21,7 @@ prost-build = "0.11"
 [dependencies]
 array-bytes = "6.1"
 async-channel = "1.8.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/substrate/client/network/test/Cargo.toml
+++ b/substrate/client/network/test/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 tokio = "1.22.0"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = "0.3.21"
 futures-timer = "3.0.1"
 libp2p = "0.51.4"

--- a/substrate/client/network/test/Cargo.toml
+++ b/substrate/client/network/test/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-tokio = "1.22.0"
+tokio = "1.37"
 async-trait = "0.1.79"
 futures = "0.3.30"
 futures-timer = "3.0.1"

--- a/substrate/client/network/test/Cargo.toml
+++ b/substrate/client/network/test/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 tokio = "1.22.0"
 async-trait = "0.1.79"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.1"
 libp2p = "0.51.4"
 log = { workspace = true, default-features = true }

--- a/substrate/client/network/transactions/Cargo.toml
+++ b/substrate/client/network/transactions/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = "6.1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 libp2p = "0.51.4"
 log = { workspace = true, default-features = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../../utils/prometheus" }

--- a/substrate/client/offchain/Cargo.toml
+++ b/substrate/client/offchain/Cargo.toml
@@ -20,7 +20,7 @@ array-bytes = "6.1"
 bytes = "1.1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
 fnv = "1.0.6"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 hyper = { version = "0.14.16", features = ["http2", "stream"] }
 hyper-rustls = { version = "0.24.0", features = ["http2"] }

--- a/substrate/client/offchain/Cargo.toml
+++ b/substrate/client/offchain/Cargo.toml
@@ -46,7 +46,7 @@ log = { workspace = true, default-features = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tokio = "1.22.0"
+tokio = "1.37"
 sc-block-builder = { path = "../block-builder" }
 sc-client-db = { path = "../db", default-features = true }
 sc-transaction-pool = { path = "../transaction-pool" }

--- a/substrate/client/rpc-api/Cargo.toml
+++ b/substrate/client/rpc-api/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 thiserror = { workspace = true }

--- a/substrate/client/rpc-servers/Cargo.toml
+++ b/substrate/client/rpc-servers/Cargo.toml
@@ -25,5 +25,5 @@ tower-http = { version = "0.4.0", features = ["cors"] }
 tower = { version = "0.4.13", features = ["util"] }
 http = "0.2.8"
 hyper = "0.14.27"
-futures = "0.3.29"
+futures = "0.3.30"
 governor = "0.6.0"

--- a/substrate/client/rpc-spec-v2/Cargo.toml
+++ b/substrate/client/rpc-spec-v2/Cargo.toml
@@ -34,7 +34,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1" }
 thiserror = { workspace = true }
 serde = { workspace = true, default-features = true }
 hex = "0.4"
-futures = "0.3.21"
+futures = "0.3.30"
 parking_lot = "0.12.1"
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tokio = { version = "1.22.0", features = ["sync"] }

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -40,7 +40,7 @@ sp-runtime = { path = "../../primitives/runtime" }
 sp-session = { path = "../../primitives/session" }
 sp-version = { path = "../../primitives/version" }
 sp-statement-store = { path = "../../primitives/statement-store" }
-tokio = "1.22.0"
+tokio = "1.37"
 
 [dev-dependencies]
 env_logger = "0.9"
@@ -51,7 +51,7 @@ sc-network-common = { path = "../network/common" }
 sc-transaction-pool = { path = "../transaction-pool" }
 sp-consensus = { path = "../../primitives/consensus/common" }
 sp-crypto-hashing = { path = "../../primitives/crypto/hashing" }
-tokio = "1.22.0"
+tokio = "1.37"
 sp-io = { path = "../../primitives/io" }
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
 pretty_assertions = "1.2.1"

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -43,7 +43,7 @@ sp-statement-store = { path = "../../primitives/statement-store" }
 tokio = "1.37"
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.11"
 assert_matches = "1.3.0"
 sc-block-builder = { path = "../block-builder" }
 sc-network = { path = "../network" }

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 jsonrpsee = { version = "0.22", features = ["server"] }
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"

--- a/substrate/client/service/Cargo.toml
+++ b/substrate/client/service/Cargo.toml
@@ -30,7 +30,7 @@ runtime-benchmarks = [
 [dependencies]
 jsonrpsee = { version = "0.22", features = ["server"] }
 thiserror = { workspace = true }
-futures = "0.3.21"
+futures = "0.3.30"
 rand = "0.8.5"
 parking_lot = "0.12.1"
 log = { workspace = true, default-features = true }

--- a/substrate/client/service/Cargo.toml
+++ b/substrate/client/service/Cargo.toml
@@ -79,7 +79,7 @@ sc-tracing = { path = "../tracing" }
 sc-sysinfo = { path = "../sysinfo" }
 tracing = "0.1.29"
 tracing-futures = { version = "0.2.4" }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 tokio = { version = "1.22.0", features = ["parking_lot", "rt-multi-thread", "time"] }
 tempfile = "3.1.0"
 directories = "5.0.1"

--- a/substrate/client/service/test/Cargo.toml
+++ b/substrate/client/service/test/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 async-channel = "1.8.0"
 array-bytes = "6.1"
 fdlimit = "0.3.0"
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 parity-scale-codec = "3.6.1"
 parking_lot = "0.12.1"

--- a/substrate/client/statement-store/Cargo.toml
+++ b/substrate/client/statement-store/Cargo.toml
@@ -31,4 +31,4 @@ sc-keystore = { path = "../keystore" }
 
 [dev-dependencies]
 tempfile = "3.1.0"
-env_logger = "0.9"
+env_logger = "0.11"

--- a/substrate/client/sysinfo/Cargo.toml
+++ b/substrate/client/sysinfo/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-futures = "0.3.19"
+futures = "0.3.30"
 libc = "0.2"
 log = { workspace = true, default-features = true }
 rand = "0.8.5"

--- a/substrate/client/telemetry/Cargo.toml
+++ b/substrate/client/telemetry/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 chrono = "0.4.31"
-futures = "0.3.21"
+futures = "0.3.30"
 libp2p = { version = "0.51.4", features = ["dns", "tcp", "tokio", "wasm-ext", "websocket"] }
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"

--- a/substrate/client/transaction-pool/Cargo.toml
+++ b/substrate/client/transaction-pool/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/substrate/client/transaction-pool/Cargo.toml
+++ b/substrate/client/transaction-pool/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 linked-hash-map = "0.5.4"
 log = { workspace = true, default-features = true }

--- a/substrate/client/transaction-pool/api/Cargo.toml
+++ b/substrate/client/transaction-pool/api/Cargo.toml
@@ -12,7 +12,7 @@ description = "Transaction pool client facing API."
 workspace = true
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 log = { workspace = true, default-features = true }

--- a/substrate/client/transaction-pool/api/Cargo.toml
+++ b/substrate/client/transaction-pool/api/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 serde = { features = ["derive"], workspace = true, default-features = true }
 thiserror = { workspace = true }

--- a/substrate/client/utils/Cargo.toml
+++ b/substrate/client/utils/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 async-channel = "1.8.0"
-futures = "0.3.21"
+futures = "0.3.30"
 futures-timer = "3.0.2"
 lazy_static = "1.4.0"
 log = { workspace = true, default-features = true }

--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -22,7 +22,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parity-scale-codec = { version = "3.2.2", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.6.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 

--- a/substrate/frame/alliance/Cargo.toml
+++ b/substrate/frame/alliance/Cargo.toml
@@ -20,7 +20,7 @@ array-bytes = { version = "6.1", optional = true }
 log = { workspace = true }
 
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../primitives/std", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }

--- a/substrate/frame/asset-conversion/Cargo.toml
+++ b/substrate/frame/asset-conversion/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { path = "../../primitives/api", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }
 sp-io = { path = "../../primitives/io", default-features = false }

--- a/substrate/frame/asset-rate/Cargo.toml
+++ b/substrate/frame/asset-rate/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/assets/Cargo.toml
+++ b/substrate/frame/assets/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-std = { path = "../../primitives/std", default-features = false }
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { path = "../../primitives/runtime", default-features = false }

--- a/substrate/frame/atomic-swap/Cargo.toml
+++ b/substrate/frame/atomic-swap/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 pallet-timestamp = { path = "../timestamp", default-features = false }

--- a/substrate/frame/authority-discovery/Cargo.toml
+++ b/substrate/frame/authority-discovery/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 pallet-session = { path = "../session", default-features = false, features = [

--- a/substrate/frame/authorship/Cargo.toml
+++ b/substrate/frame/authorship/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 impl-trait-for-tuples = "0.2.2"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }

--- a/substrate/frame/babe/Cargo.toml
+++ b/substrate/frame/babe/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/bags-list/Cargo.toml
+++ b/substrate/frame/bags-list/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 

--- a/substrate/frame/balances/Cargo.toml
+++ b/substrate/frame/balances/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/beefy-mmr/Cargo.toml
+++ b/substrate/frame/beefy-mmr/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 array-bytes = { version = "6.1", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 binary-merkle-tree = { path = "../../utils/binary-merkle-tree", default-features = false }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/beefy/Cargo.toml
+++ b/substrate/frame/beefy/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 serde = { optional = true, workspace = true, default-features = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/benchmarking/Cargo.toml
+++ b/substrate/frame/benchmarking/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 linregress = { version = "0.5.1", optional = true }
 log = { workspace = true }
 paste = "1.0"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 frame-support = { path = "../support", default-features = false }
 frame-support-procedural = { path = "../support/procedural", default-features = false }

--- a/substrate/frame/benchmarking/pov/Cargo.toml
+++ b/substrate/frame/benchmarking/pov/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "..", default-features = false }
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }

--- a/substrate/frame/bounties/Cargo.toml
+++ b/substrate/frame/bounties/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/broker/Cargo.toml
+++ b/substrate/frame/broker/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 bitvec = { version = "1.0.0", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false }

--- a/substrate/frame/child-bounties/Cargo.toml
+++ b/substrate/frame/child-bounties/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/collective/Cargo.toml
+++ b/substrate/frame/collective/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -58,7 +58,7 @@ xcm-builder = { package = "staging-xcm-builder", path = "../../../polkadot/xcm/x
 [dev-dependencies]
 array-bytes = "6.1"
 assert_matches = "1"
-env_logger = "0.9"
+env_logger = "0.11"
 pretty_assertions = "1"
 wat = "1"
 pallet-contracts-fixtures = { path = "./fixtures" }

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -24,7 +24,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
 smallvec = { version = "1", default-features = false, features = [

--- a/substrate/frame/contracts/mock-network/Cargo.toml
+++ b/substrate/frame/contracts/mock-network/Cargo.toml
@@ -30,7 +30,7 @@ pallet-xcm = { path = "../../../../polkadot/xcm/pallet-xcm", default-features = 
 polkadot-parachain-primitives = { path = "../../../../polkadot/parachain" }
 polkadot-primitives = { path = "../../../../polkadot/primitives" }
 polkadot-runtime-parachains = { path = "../../../../polkadot/runtime/parachains" }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { path = "../../../primitives/api", default-features = false }
 sp-core = { path = "../../../primitives/core", default-features = false }
 sp-io = { path = "../../../primitives/io", default-features = false }

--- a/substrate/frame/contracts/uapi/Cargo.toml
+++ b/substrate/frame/contracts/uapi/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 paste = { version = "1.0", default-features = false }
 bitflags = "1.0"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"], optional = true }
 scale = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 	"max-encoded-len",

--- a/substrate/frame/conviction-voting/Cargo.toml
+++ b/substrate/frame/conviction-voting/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/core-fellowship/Cargo.toml
+++ b/substrate/frame/core-fellowship/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/democracy/Cargo.toml
+++ b/substrate/frame/democracy/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/election-provider-multi-phase/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/Cargo.toml
@@ -38,7 +38,7 @@ frame-election-provider-support = { path = "../election-provider-support", defau
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 pallet-election-provider-support-benchmarking = { path = "../election-provider-support/benchmarking", default-features = false, optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["alloc", "small_rng"], optional = true }
-strum = { version = "0.24.1", default-features = false, features = ["derive"], optional = true }
+strum = { version = "0.26.2", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 parking_lot = "0.12.1"

--- a/substrate/frame/election-provider-multi-phase/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 log = { workspace = true }

--- a/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 parking_lot = "0.12.1"
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = { version = "2.10.0", features = ["derive"] }
+scale-info = { version = "2.11.1", features = ["derive"] }
 log = { workspace = true }
 
 sp-runtime = { path = "../../../primitives/runtime" }

--- a/substrate/frame/election-provider-support/Cargo.toml
+++ b/substrate/frame/election-provider-support/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-election-provider-solution-type = { path = "solution-type" }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/election-provider-support/solution-type/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro-crate = "3.0.0"
 
 [dev-dependencies]
 parity-scale-codec = "3.6.1"
-scale-info = "2.10.0"
+scale-info = "2.11.1"
 sp-arithmetic = { path = "../../../primitives/arithmetic" }
 # used by generate_solution_type:
 frame-election-provider-support = { path = ".." }

--- a/substrate/frame/election-provider-support/solution-type/fuzzer/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/fuzzer/Cargo.toml
@@ -21,7 +21,7 @@ honggfuzz = "0.5"
 rand = { version = "0.8", features = ["small_rng", "std"] }
 
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-election-provider-solution-type = { path = ".." }
 frame-election-provider-support = { path = "../.." }
 sp-arithmetic = { path = "../../../../primitives/arithmetic" }

--- a/substrate/frame/elections-phragmen/Cargo.toml
+++ b/substrate/frame/elections-phragmen/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/examples/basic/Cargo.toml
+++ b/substrate/frame/examples/basic/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }

--- a/substrate/frame/examples/default-config/Cargo.toml
+++ b/substrate/frame/examples/default-config/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }
 

--- a/substrate/frame/examples/dev-mode/Cargo.toml
+++ b/substrate/frame/examples/dev-mode/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }
 pallet-balances = { path = "../../balances", default-features = false }

--- a/substrate/frame/examples/frame-crate/Cargo.toml
+++ b/substrate/frame/examples/frame-crate/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame = { path = "../..", default-features = false, features = ["experimental", "runtime"] }
 

--- a/substrate/frame/examples/kitchensink/Cargo.toml
+++ b/substrate/frame/examples/kitchensink/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false, features = ["experimental"] }
 frame-system = { path = "../../system", default-features = false }

--- a/substrate/frame/examples/offchain-worker/Cargo.toml
+++ b/substrate/frame/examples/offchain-worker/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 lite-json = { version = "0.2.0", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }
 sp-core = { path = "../../../primitives/core", default-features = false }

--- a/substrate/frame/examples/single-block-migrations/Cargo.toml
+++ b/substrate/frame/examples/single-block-migrations/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 docify = "0.2.8"
 log = { version = "0.4.21", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../../support", default-features = false }
 frame-executive = { path = "../../executive", default-features = false }
 frame-system = { path = "../../system", default-features = false }

--- a/substrate/frame/examples/split/Cargo.toml
+++ b/substrate/frame/examples/split/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }

--- a/substrate/frame/examples/tasks/Cargo.toml
+++ b/substrate/frame/examples/tasks/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "../../system", default-features = false }

--- a/substrate/frame/executive/Cargo.toml
+++ b/substrate/frame/executive/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 frame-try-runtime = { path = "../try-runtime", default-features = false, optional = true }

--- a/substrate/frame/fast-unstake/Cargo.toml
+++ b/substrate/frame/fast-unstake/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/glutton/Cargo.toml
+++ b/substrate/frame/glutton/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 blake2 = { version = "0.10.4", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/grandpa/Cargo.toml
+++ b/substrate/frame/grandpa/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/identity/Cargo.toml
+++ b/substrate/frame/identity/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 enumflags2 = { version = "0.7.7" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/im-online/Cargo.toml
+++ b/substrate/frame/im-online/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/indices/Cargo.toml
+++ b/substrate/frame/indices/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/insecure-randomness-collective-flip/Cargo.toml
+++ b/substrate/frame/insecure-randomness-collective-flip/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }

--- a/substrate/frame/lottery/Cargo.toml
+++ b/substrate/frame/lottery/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/membership/Cargo.toml
+++ b/substrate/frame/membership/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/merkle-mountain-range/Cargo.toml
+++ b/substrate/frame/merkle-mountain-range/Cargo.toml
@@ -29,7 +29,7 @@ sp-std = { path = "../../primitives/std", default-features = false }
 
 [dev-dependencies]
 array-bytes = "6.1"
-env_logger = "0.9"
+env_logger = "0.11"
 itertools = "0.10.3"
 
 [features]

--- a/substrate/frame/merkle-mountain-range/Cargo.toml
+++ b/substrate/frame/merkle-mountain-range/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/message-queue/Cargo.toml
+++ b/substrate/frame/message-queue/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
 log = { workspace = true }
 environmental = { version = "1.1.4", default-features = false }

--- a/substrate/frame/migrations/Cargo.toml
+++ b/substrate/frame/migrations/Cargo.toml
@@ -15,7 +15,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 docify = "0.2.8"
 impl-trait-for-tuples = "0.2.2"
 log = "0.4.21"
-scale-info = { version = "2.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { default-features = false, optional = true, path = "../benchmarking" }
 frame-support = { default-features = false, path = "../support" }

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -21,7 +21,7 @@ frame-benchmarking = { default-features = false, optional = true, path = "../ben
 frame-support = { default-features = false, path = "../support" }
 frame-system = { default-features = false, path = "../system" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], workspace = true }
 sp-application-crypto = { default-features = false, path = "../../primitives/application-crypto" }
 sp-arithmetic = { default-features = false, path = "../../primitives/arithmetic" }

--- a/substrate/frame/multisig/Cargo.toml
+++ b/substrate/frame/multisig/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/nft-fractionalization/Cargo.toml
+++ b/substrate/frame/nft-fractionalization/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/nfts/Cargo.toml
+++ b/substrate/frame/nfts/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 enumflags2 = { version = "0.7.7" }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/nis/Cargo.toml
+++ b/substrate/frame/nis/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/node-authorization/Cargo.toml
+++ b/substrate/frame/node-authorization/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }

--- a/substrate/frame/nomination-pools/Cargo.toml
+++ b/substrate/frame/nomination-pools/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 

--- a/substrate/frame/nomination-pools/benchmarking/Cargo.toml
+++ b/substrate/frame/nomination-pools/benchmarking/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 # parity
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 # FRAME
 frame-benchmarking = { path = "../../benchmarking", default-features = false }

--- a/substrate/frame/nomination-pools/test-staking/Cargo.toml
+++ b/substrate/frame/nomination-pools/test-staking/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = { version = "2.10.0", features = ["derive"] }
+scale-info = { version = "2.11.1", features = ["derive"] }
 
 sp-runtime = { path = "../../../primitives/runtime" }
 sp-io = { path = "../../../primitives/io" }

--- a/substrate/frame/offences/Cargo.toml
+++ b/substrate/frame/offences/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/offences/benchmarking/Cargo.toml
+++ b/substrate/frame/offences/benchmarking/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false }
 frame-election-provider-support = { path = "../../election-provider-support", default-features = false }
 frame-support = { path = "../../support", default-features = false }

--- a/substrate/frame/paged-list/Cargo.toml
+++ b/substrate/frame/paged-list/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 docify = "0.2.8"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/parameters/Cargo.toml
+++ b/substrate/frame/parameters/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 paste = { version = "1.0.14", default-features = false }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 docify = "0.2.8"

--- a/substrate/frame/preimage/Cargo.toml
+++ b/substrate/frame/preimage/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/proxy/Cargo.toml
+++ b/substrate/frame/proxy/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/ranked-collective/Cargo.toml
+++ b/substrate/frame/ranked-collective/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/recovery/Cargo.toml
+++ b/substrate/frame/recovery/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/referenda/Cargo.toml
+++ b/substrate/frame/referenda/Cargo.toml
@@ -20,7 +20,7 @@ assert_matches = { version = "1.5", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }

--- a/substrate/frame/remark/Cargo.toml
+++ b/substrate/frame/remark/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/root-offences/Cargo.toml
+++ b/substrate/frame/root-offences/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 pallet-session = { path = "../session", default-features = false, features = ["historical"] }
 pallet-staking = { path = "../staking", default-features = false }

--- a/substrate/frame/root-testing/Cargo.toml
+++ b/substrate/frame/root-testing/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }

--- a/substrate/frame/safe-mode/Cargo.toml
+++ b/substrate/frame/safe-mode/Cargo.toml
@@ -20,7 +20,7 @@ docify = "0.2.8"
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-arithmetic = { path = "../../primitives/arithmetic", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false }

--- a/substrate/frame/salary/Cargo.toml
+++ b/substrate/frame/salary/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/sassafras/Cargo.toml
+++ b/substrate/frame/sassafras/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 scale-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/scheduler/Cargo.toml
+++ b/substrate/frame/scheduler/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/scored-pool/Cargo.toml
+++ b/substrate/frame/scored-pool/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-io = { path = "../../primitives/io", default-features = false }

--- a/substrate/frame/session/Cargo.toml
+++ b/substrate/frame/session/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 pallet-timestamp = { path = "../timestamp", default-features = false }

--- a/substrate/frame/session/benchmarking/Cargo.toml
+++ b/substrate/frame/session/benchmarking/Cargo.toml
@@ -29,7 +29,7 @@ sp-std = { path = "../../../primitives/std", default-features = false }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"] }
-scale-info = "2.10.0"
+scale-info = "2.11.1"
 frame-election-provider-support = { path = "../../election-provider-support" }
 pallet-balances = { path = "../../balances" }
 pallet-staking-reward-curve = { path = "../../staking/reward-curve" }

--- a/substrate/frame/society/Cargo.toml
+++ b/substrate/frame/society/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 log = { workspace = true }
 rand_chacha = { version = "0.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 
 sp-std = { path = "../../primitives/std", default-features = false }

--- a/substrate/frame/staking/Cargo.toml
+++ b/substrate/frame/staking/Cargo.toml
@@ -20,7 +20,7 @@ serde = { features = ["alloc", "derive"], workspace = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 sp-io = { path = "../../primitives/io", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false, features = ["serde"] }
 sp-staking = { path = "../../primitives/staking", default-features = false, features = ["serde"] }

--- a/substrate/frame/state-trie-migration/Cargo.toml
+++ b/substrate/frame/state-trie-migration/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 thousands = { version = "0.2.0", optional = true }
 zstd = { version = "0.12.4", default-features = false, optional = true }

--- a/substrate/frame/statement/Cargo.toml
+++ b/substrate/frame/statement/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-statement-store = { path = "../../primitives/statement-store", default-features = false }

--- a/substrate/frame/sudo/Cargo.toml
+++ b/substrate/frame/sudo/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
 sp-io = { path = "../../primitives/io", default-features = false }

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -22,7 +22,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 	"max-encoded-len",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 frame-metadata = { version = "16.0.0", default-features = false, features = [

--- a/substrate/frame/support/test/Cargo.toml
+++ b/substrate/frame/support/test/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 static_assertions = "1.1.0"
 serde = { features = ["derive"], workspace = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
 sp-api = { path = "../../../primitives/api", default-features = false }
 sp-arithmetic = { path = "../../../primitives/arithmetic", default-features = false }

--- a/substrate/frame/support/test/compile_pass/Cargo.toml
+++ b/substrate/frame/support/test/compile_pass/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 renamed-frame-support = { package = "frame-support", path = "../..", default-features = false }
 renamed-frame-system = { package = "frame-system", path = "../../../system", default-features = false }
 sp-core = { path = "../../../../primitives/core", default-features = false }

--- a/substrate/frame/support/test/pallet/Cargo.toml
+++ b/substrate/frame/support/test/pallet/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], workspace = true }
 frame-support = { path = "../..", default-features = false }
 frame-system = { path = "../../../system", default-features = false }

--- a/substrate/frame/support/test/stg_frame_crate/Cargo.toml
+++ b/substrate/frame/support/test/stg_frame_crate/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 frame = { path = "../../..", default-features = false, features = ["experimental", "runtime"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/substrate/frame/system/Cargo.toml
+++ b/substrate/frame/system/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 cfg-if = "1.0"
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
 serde = { features = ["alloc", "derive"], workspace = true }
 frame-support = { path = "../support", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false, features = ["serde"] }

--- a/substrate/frame/system/benchmarking/Cargo.toml
+++ b/substrate/frame/system/benchmarking/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../../benchmarking", default-features = false }
 frame-support = { path = "../../support", default-features = false }
 frame-system = { path = "..", default-features = false }

--- a/substrate/frame/timestamp/Cargo.toml
+++ b/substrate/frame/timestamp/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/tips/Cargo.toml
+++ b/substrate/frame/tips/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/transaction-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
@@ -24,7 +24,7 @@ frame-system = { path = "../../system", default-features = false }
 pallet-asset-conversion = { path = "../../asset-conversion", default-features = false }
 pallet-transaction-payment = { path = "..", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 sp-core = { path = "../../../primitives/core", default-features = false }

--- a/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -29,7 +29,7 @@ frame-benchmarking = { path = "../../benchmarking", default-features = false, op
 
 # Other dependencies
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/substrate/frame/transaction-storage/Cargo.toml
+++ b/substrate/frame/transaction-storage/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 array-bytes = { version = "6.1", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, workspace = true, default-features = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/treasury/Cargo.toml
+++ b/substrate/frame/treasury/Cargo.toml
@@ -22,7 +22,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 ] }
 docify = "0.2.8"
 impl-trait-for-tuples = "0.2.2"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }

--- a/substrate/frame/tx-pause/Cargo.toml
+++ b/substrate/frame/tx-pause/Cargo.toml
@@ -20,7 +20,7 @@ docify = "0.2.8"
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false }
 pallet-balances = { path = "../balances", default-features = false, optional = true }

--- a/substrate/frame/uniques/Cargo.toml
+++ b/substrate/frame/uniques/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/utility/Cargo.toml
+++ b/substrate/frame/utility/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/vesting/Cargo.toml
+++ b/substrate/frame/vesting/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 	"derive",
 ] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/frame/whitelist/Cargo.toml
+++ b/substrate/frame/whitelist/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }

--- a/substrate/primitives/api/Cargo.toml
+++ b/substrate/primitives/api/Cargo.toml
@@ -28,7 +28,7 @@ sp-state-machine = { path = "../state-machine", default-features = false, option
 sp-trie = { path = "../trie", default-features = false, optional = true }
 hash-db = { version = "0.16.0", optional = true }
 thiserror = { optional = true, workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 sp-metadata-ir = { path = "../metadata-ir", default-features = false, optional = true }

--- a/substrate/primitives/api/test/Cargo.toml
+++ b/substrate/primitives/api/test/Cargo.toml
@@ -26,7 +26,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1" }
 sp-state-machine = { path = "../../state-machine" }
 trybuild = "1.0.88"
 rustversion = "1.0.6"
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/substrate/primitives/api/test/Cargo.toml
+++ b/substrate/primitives/api/test/Cargo.toml
@@ -30,7 +30,7 @@ scale-info = { version = "2.11.1", default-features = false, features = ["derive
 
 [dev-dependencies]
 criterion = "0.4.0"
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 sp-core = { path = "../../core" }
 static_assertions = "1.1.0"

--- a/substrate/primitives/application-crypto/Cargo.toml
+++ b/substrate/primitives/application-crypto/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-core = { path = "../core", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }
 sp-std = { path = "../std", default-features = false }
 sp-io = { path = "../io", default-features = false }

--- a/substrate/primitives/arithmetic/Cargo.toml
+++ b/substrate/primitives/arithmetic/Cargo.toml
@@ -23,7 +23,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 ] }
 integer-sqrt = "0.1.2"
 num-traits = { version = "0.2.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 static_assertions = "1.1.0"
 sp-std = { path = "../std", default-features = false }

--- a/substrate/primitives/authority-discovery/Cargo.toml
+++ b/substrate/primitives/authority-discovery/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { path = "../api", default-features = false }
 sp-application-crypto = { path = "../application-crypto", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }

--- a/substrate/primitives/blockchain/Cargo.toml
+++ b/substrate/primitives/blockchain/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 parking_lot = "0.12.1"
 schnellru = "0.2.1"

--- a/substrate/primitives/consensus/aura/Cargo.toml
+++ b/substrate/primitives/consensus/aura/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.74", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { path = "../../api", default-features = false }
 sp-application-crypto = { path = "../../application-crypto", default-features = false }
 sp-consensus-slots = { path = "../slots", default-features = false }

--- a/substrate/primitives/consensus/aura/Cargo.toml
+++ b/substrate/primitives/consensus/aura/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.79", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { path = "../../api", default-features = false }

--- a/substrate/primitives/consensus/babe/Cargo.toml
+++ b/substrate/primitives/consensus/babe/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.79", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }

--- a/substrate/primitives/consensus/babe/Cargo.toml
+++ b/substrate/primitives/consensus/babe/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.74", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 sp-api = { path = "../../api", default-features = false }
 sp-application-crypto = { path = "../../application-crypto", default-features = false }

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { path = "../../io", default-features = false }
 sp-mmr-primitives = { path = "../../merkle-mountain-range", default-features = false }
 sp-runtime = { path = "../../runtime", default-features = false }
 sp-keystore = { path = "../../keystore", default-features = false }
-strum = { version = "0.24.1", features = ["derive"], default-features = false }
+strum = { version = "0.26.2", features = ["derive"], default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]

--- a/substrate/primitives/consensus/beefy/Cargo.toml
+++ b/substrate/primitives/consensus/beefy/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }
 sp-api = { path = "../../api", default-features = false }
 sp-application-crypto = { path = "../../application-crypto", default-features = false }

--- a/substrate/primitives/consensus/common/Cargo.toml
+++ b/substrate/primitives/consensus/common/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 log = { workspace = true, default-features = true }
 thiserror = { workspace = true }

--- a/substrate/primitives/consensus/common/Cargo.toml
+++ b/substrate/primitives/consensus/common/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = "0.1.79"
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 log = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 sp-core = { path = "../../core" }
@@ -27,7 +27,7 @@ sp-runtime = { path = "../../runtime" }
 sp-state-machine = { path = "../../state-machine" }
 
 [dev-dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 sp-test-primitives = { path = "../../test-primitives" }
 
 [features]

--- a/substrate/primitives/consensus/grandpa/Cargo.toml
+++ b/substrate/primitives/consensus/grandpa/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 grandpa = { package = "finality-grandpa", version = "0.16.2", default-features = false, features = ["derive-codec"] }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 sp-api = { path = "../../api", default-features = false }
 sp-application-crypto = { path = "../../application-crypto", default-features = false }

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true }
 sp-api = { path = "../../api", default-features = false }
 sp-application-crypto = { path = "../../application-crypto", default-features = false, features = ["bandersnatch-experimental"] }

--- a/substrate/primitives/consensus/slots/Cargo.toml
+++ b/substrate/primitives/consensus/slots/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 sp-timestamp = { path = "../../timestamp", default-features = false }
 

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -38,7 +38,7 @@ sp-std = { path = "../std", default-features = false }
 sp-debug-derive = { path = "../debug-derive", default-features = false }
 sp-storage = { path = "../storage", default-features = false }
 sp-externalities = { path = "../externalities", optional = true }
-futures = { version = "0.3.21", optional = true }
+futures = { version = "0.3.30", optional = true }
 dyn-clonable = { version = "0.9.0", optional = true }
 thiserror = { optional = true, workspace = true }
 tracing = { version = "0.1.29", optional = true }

--- a/substrate/primitives/inherents/Cargo.toml
+++ b/substrate/primitives/inherents/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { optional = true, workspace = true }
 sp-runtime = { path = "../runtime", default-features = false, optional = true }
 
 [dev-dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 
 [features]
 default = ["std"]

--- a/substrate/primitives/inherents/Cargo.toml
+++ b/substrate/primitives/inherents/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.74", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 thiserror = { optional = true, workspace = true }
 sp-runtime = { path = "../runtime", default-features = false, optional = true }

--- a/substrate/primitives/inherents/Cargo.toml
+++ b/substrate/primitives/inherents/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.79", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"

--- a/substrate/primitives/keyring/Cargo.toml
+++ b/substrate/primitives/keyring/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-strum = { version = "0.24.1", features = ["derive"], default-features = false }
+strum = { version = "0.26.2", features = ["derive"], default-features = false }
 sp-core = { path = "../core", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }
 

--- a/substrate/primitives/merkle-mountain-range/Cargo.toml
+++ b/substrate/primitives/merkle-mountain-range/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 log = { workspace = true }
 mmr-lib = { package = "ckb-merkle-mountain-range", version = "0.5.2", default-features = false }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }

--- a/substrate/primitives/metadata-ir/Cargo.toml
+++ b/substrate/primitives/metadata-ir/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false }
 frame-metadata = { version = "16.0.0", default-features = false, features = ["current"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/substrate/primitives/mixnet/Cargo.toml
+++ b/substrate/primitives/mixnet/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { default-features = false, path = "../api" }
 sp-application-crypto = { default-features = false, path = "../application-crypto" }
 

--- a/substrate/primitives/npos-elections/Cargo.toml
+++ b/substrate/primitives/npos-elections/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 sp-arithmetic = { path = "../arithmetic", default-features = false }
 sp-core = { path = "../core", default-features = false }

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -24,7 +24,7 @@ impl-trait-for-tuples = "0.2.2"
 log = { workspace = true }
 paste = "1.0"
 rand = { version = "0.8.5", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 sp-application-crypto = { path = "../application-crypto", default-features = false }
 sp-arithmetic = { path = "../arithmetic", default-features = false }

--- a/substrate/primitives/session/Cargo.toml
+++ b/substrate/primitives/session/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-api = { path = "../api", default-features = false }
 sp-core = { path = "../core", default-features = false }
 sp-runtime = { path = "../runtime", optional = true }

--- a/substrate/primitives/staking/Cargo.toml
+++ b/substrate/primitives/staking/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 impl-trait-for-tuples = "0.2.2"
 
 sp-core = { path = "../core", default-features = false }

--- a/substrate/primitives/statement-store/Cargo.toml
+++ b/substrate/primitives/statement-store/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-core = { path = "../core", default-features = false }
 sp-crypto-hashing = { path = "../crypto/hashing", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }

--- a/substrate/primitives/test-primitives/Cargo.toml
+++ b/substrate/primitives/test-primitives/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true }
 sp-application-crypto = { path = "../application-crypto", default-features = false }
 sp-core = { path = "../core", default-features = false }

--- a/substrate/primitives/timestamp/Cargo.toml
+++ b/substrate/primitives/timestamp/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.79", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 thiserror = { optional = true, workspace = true }
 sp-inherents = { path = "../inherents", default-features = false }

--- a/substrate/primitives/transaction-storage-proof/Cargo.toml
+++ b/substrate/primitives/transaction-storage-proof/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-trait = { version = "0.1.74", optional = true }
+async-trait = { version = "0.1.79", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-core = { path = "../core", optional = true }

--- a/substrate/primitives/transaction-storage-proof/Cargo.toml
+++ b/substrate/primitives/transaction-storage-proof/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-trait = { version = "0.1.74", optional = true }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-core = { path = "../core", optional = true }
 sp-inherents = { path = "../inherents", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }

--- a/substrate/primitives/trie/Cargo.toml
+++ b/substrate/primitives/trie/Cargo.toml
@@ -29,7 +29,7 @@ memory-db = { version = "0.32.0", default-features = false }
 nohash-hasher = { version = "0.2.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 rand = { version = "0.8", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 thiserror = { optional = true, workspace = true }
 tracing = { version = "0.1.29", optional = true }
 trie-db = { version = "0.28.0", default-features = false }

--- a/substrate/primitives/version/Cargo.toml
+++ b/substrate/primitives/version/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 impl-serde = { version = "0.4.0", default-features = false, optional = true }
 parity-wasm = { version = "0.45", optional = true }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { features = ["alloc", "derive"], optional = true, workspace = true }
 thiserror = { optional = true, workspace = true }
 sp-crypto-hashing-proc-macro = { path = "../crypto/hashing/proc-macro" }

--- a/substrate/primitives/weights/Cargo.toml
+++ b/substrate/primitives/weights/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 bounded-collections = { version = "0.2.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }
 smallvec = "1.11.0"
 sp-arithmetic = { path = "../arithmetic", default-features = false }

--- a/substrate/test-utils/Cargo.toml
+++ b/substrate/test-utils/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-futures = "0.3.16"
+futures = "0.3.30"
 tokio = { version = "1.22.0", features = ["macros", "time"] }
 
 [dev-dependencies]

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 array-bytes = "6.1"
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 serde = { workspace = true, default-features = true }

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 array-bytes = "6.1"
 async-trait = "0.1.79"
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 sc-client-api = { path = "../../client/api" }

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -53,7 +53,7 @@ array-bytes = { version = "6.1", optional = true }
 log = { workspace = true }
 
 [dev-dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 sc-block-builder = { path = "../../client/block-builder" }
 sc-chain-spec = { path = "../../client/chain-spec" }
 sc-executor = { path = "../../client/executor" }

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -22,7 +22,7 @@ sp-consensus-babe = { path = "../../primitives/consensus/babe", default-features
 sp-genesis-builder = { path = "../../primitives/genesis-builder", default-features = false }
 sp-block-builder = { path = "../../primitives/block-builder", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 sp-inherents = { path = "../../primitives/inherents", default-features = false }
 sp-keyring = { path = "../../primitives/keyring", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false }

--- a/substrate/test-utils/runtime/client/Cargo.toml
+++ b/substrate/test-utils/runtime/client/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-futures = "0.3.21"
+futures = "0.3.30"
 sc-block-builder = { path = "../../../client/block-builder" }
 sc-client-api = { path = "../../../client/api" }
 sc-consensus = { path = "../../../client/consensus/common" }

--- a/substrate/test-utils/runtime/transaction-pool/Cargo.toml
+++ b/substrate/test-utils/runtime/transaction-pool/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.21"
+futures = "0.3.30"
 parking_lot = "0.12.1"
 thiserror = { workspace = true }
 sc-transaction-pool = { path = "../../../client/transaction-pool" }

--- a/substrate/utils/binary-merkle-tree/Cargo.toml
+++ b/substrate/utils/binary-merkle-tree/Cargo.toml
@@ -18,7 +18,7 @@ hash-db = { version = "0.16.0", default-features = false }
 
 [dev-dependencies]
 array-bytes = "6.1"
-env_logger = "0.9"
+env_logger = "0.11"
 sp-core = { path = "../../primitives/core" }
 sp-runtime = { path = "../../primitives/runtime" }
 

--- a/substrate/utils/frame/remote-externalities/Cargo.toml
+++ b/substrate/utils/frame/remote-externalities/Cargo.toml
@@ -26,7 +26,7 @@ sp-io = { path = "../../../primitives/io" }
 sp-runtime = { path = "../../../primitives/runtime" }
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 substrate-rpc-client = { path = "../rpc/client" }
-futures = "0.3"
+futures = "0.3.30"
 indicatif = "0.17.7"
 spinners = "4.1.0"
 tokio-retry = "0.3.0"

--- a/substrate/utils/frame/rpc/client/Cargo.toml
+++ b/substrate/utils/frame/rpc/client/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 jsonrpsee = { version = "0.22", features = ["ws-client"] }
 sc-rpc-api = { path = "../../../../client/rpc-api" }
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 serde = { workspace = true, default-features = true }
 sp-runtime = { path = "../../../../primitives/runtime" }
 log = { workspace = true, default-features = true }

--- a/substrate/utils/frame/rpc/support/Cargo.toml
+++ b/substrate/utils/frame/rpc/support/Cargo.toml
@@ -23,7 +23,7 @@ sc-rpc-api = { path = "../../../../client/rpc-api" }
 sp-storage = { path = "../../../../primitives/storage" }
 
 [dev-dependencies]
-scale-info = "2.10.0"
+scale-info = "2.11.1"
 jsonrpsee = { version = "0.22", features = ["jsonrpsee-types", "ws-client"] }
 tokio = "1.22.0"
 sp-core = { path = "../../../../primitives/core" }

--- a/substrate/utils/frame/rpc/support/Cargo.toml
+++ b/substrate/utils/frame/rpc/support/Cargo.toml
@@ -25,7 +25,7 @@ sp-storage = { path = "../../../../primitives/storage" }
 [dev-dependencies]
 scale-info = "2.11.1"
 jsonrpsee = { version = "0.22", features = ["jsonrpsee-types", "ws-client"] }
-tokio = "1.22.0"
+tokio = "1.37"
 sp-core = { path = "../../../../primitives/core" }
 sp-runtime = { path = "../../../../primitives/runtime" }
 frame-system = { path = "../../../../frame/system" }

--- a/substrate/utils/frame/rpc/system/Cargo.toml
+++ b/substrate/utils/frame/rpc/system/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.1" }
 jsonrpsee = { version = "0.22", features = ["client-core", "macros", "server"] }
-futures = "0.3.21"
+futures = "0.3.30"
 log = { workspace = true, default-features = true }
 frame-system-rpc-runtime-api = { path = "../../../../frame/system/rpc/runtime-api" }
 sc-rpc-api = { path = "../../../../client/rpc-api" }

--- a/substrate/utils/frame/rpc/system/Cargo.toml
+++ b/substrate/utils/frame/rpc/system/Cargo.toml
@@ -31,7 +31,7 @@ sp-runtime = { path = "../../../../primitives/runtime" }
 
 [dev-dependencies]
 sc-transaction-pool = { path = "../../../../client/transaction-pool" }
-tokio = "1.22.0"
+tokio = "1.37"
 assert_matches = "1.3.0"
 sp-tracing = { path = "../../../../primitives/tracing" }
 substrate-test-runtime-client = { path = "../../../../test-utils/runtime/client" }

--- a/substrate/utils/frame/try-runtime/cli/Cargo.toml
+++ b/substrate/utils/frame/try-runtime/cli/Cargo.toml
@@ -37,7 +37,7 @@ sp-weights = { path = "../../../../primitives/weights" }
 frame-try-runtime = { path = "../../../../frame/try-runtime", optional = true }
 substrate-rpc-client = { path = "../../rpc/client" }
 
-async-trait = "0.1.74"
+async-trait = "0.1.79"
 clap = { version = "4.5.3", features = ["derive"] }
 hex = { version = "0.4.3", default-features = false }
 log = { workspace = true, default-features = true }

--- a/substrate/utils/frame/try-runtime/cli/Cargo.toml
+++ b/substrate/utils/frame/try-runtime/cli/Cargo.toml
@@ -52,7 +52,7 @@ node-primitives = { path = "../../../../bin/node/primitives" }
 regex = "1.7.3"
 substrate-cli-test-utils = { path = "../../../../test-utils/cli" }
 tempfile = "3.1.0"
-tokio = "1.27.0"
+tokio = "1.37"
 
 [features]
 try-runtime = [

--- a/substrate/utils/wasm-builder/Cargo.toml
+++ b/substrate/utils/wasm-builder/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 build-helper = "0.1.1"
 cargo_metadata = "0.15.4"
 console = "0.15.8"
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.26.2", features = ["derive"] }
 tempfile = "3.1.0"
 toml = "0.8.8"
 walkdir = "2.4.0"

--- a/templates/minimal/node/Cargo.toml
+++ b/templates/minimal/node/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 jsonrpsee = { version = "0.22", features = ["server"] }
 serde_json = { workspace = true, default-features = true }

--- a/templates/minimal/pallets/template/Cargo.toml
+++ b/templates/minimal/pallets/template/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [
 	"derive",
 ], default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 frame = { path = "../../../../substrate/frame", default-features = false, features = [

--- a/templates/parachain/pallets/template/Cargo.toml
+++ b/templates/parachain/pallets/template/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 

--- a/templates/parachain/runtime/Cargo.toml
+++ b/templates/parachain/runtime/Cargo.toml
@@ -24,7 +24,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 ] }
 hex-literal = { version = "0.4.1", optional = true }
 log = { workspace = true }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 smallvec = "1.11.0"

--- a/templates/solochain/node/Cargo.toml
+++ b/templates/solochain/node/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
-futures = { version = "0.3.21", features = ["thread-pool"] }
+futures = { version = "0.3.30", features = ["thread-pool"] }
 serde_json = { workspace = true, default-features = true }
 jsonrpsee = { version = "0.22", features = ["server"] }
 

--- a/templates/solochain/pallets/template/Cargo.toml
+++ b/templates/solochain/pallets/template/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 

--- a/templates/solochain/runtime/Cargo.toml
+++ b/templates/solochain/runtime/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = [
 	"derive",
 ] }
-scale-info = { version = "2.10.0", default-features = false, features = [
+scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 	"serde",
 ] }


### PR DESCRIPTION
Working towards migrating the `parity-bridges-common` repo inside `polkadot-sdk`. This PR upgrades some dependencies in order to align them with the versions used in `parity-bridges-common`

Related to https://github.com/paritytech/parity-bridges-common/issues/2538