### PR TITLE
Use 0.1.0 as minimum version for crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-common"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10479,7 +10479,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-parameters"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -18707,7 +18707,7 @@ dependencies = [
 
 [[package]]
 name = "sp-crypto-hashing"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -18721,7 +18721,7 @@ dependencies = [
 
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "quote",
  "sp-crypto-hashing",

--- a/cumulus/parachains/runtimes/bridge-hubs/common/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-hub-common"
-version = "0.0.0"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 description = "Bridge hub common utilities"

--- a/substrate/frame/parameters/Cargo.toml
+++ b/substrate/frame/parameters/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-parameters"
 description = "Pallet to store and configure parameters."
 repository.workspace = true
 license = "Apache-2.0"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Acala Developers", "Parity Technologies <admin@parity.io>"]
 edition.workspace = true
 

--- a/substrate/primitives/crypto/hashing/Cargo.toml
+++ b/substrate/primitives/crypto/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-crypto-hashing"
-version = "0.0.0"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"

--- a/substrate/primitives/crypto/hashing/proc-macro/Cargo.toml
+++ b/substrate/primitives/crypto/hashing/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-crypto-hashing-proc-macro"
-version = "0.0.0"
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"


### PR DESCRIPTION
CI will be enforcing this with next parity-publish release