### PR TITLE
sp-wasm-interface: `wasmtime` should not be enabled by `std`

### DIFF
--- a/substrate/primitives/wasm-interface/Cargo.toml
+++ b/substrate/primitives/wasm-interface/Cargo.toml
@@ -25,5 +25,5 @@ anyhow = { version = "1.0.81", optional = true }
 
 [features]
 default = ["std"]
-std = ["codec/std", "log/std", "wasmtime"]
+std = ["codec/std", "log/std"]
 wasmtime = ["anyhow", "dep:wasmtime"]


### PR DESCRIPTION
Closes: https://github.com/paritytech/polkadot-sdk/issues/3909