### PR TITLE
Convince GitLab not to crop collapsed multiline strings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,8 +127,8 @@ default:
     - export PATH=$PATH:$(pwd)
     - >
       if [ "$FORKLIFT_BYPASS" != "true" ]; then
-      echo "FORKLIFT_BYPASS not set, creating alias cargo='forklift cargo'"
-      alias cargo="forklift cargo"
+      echo "FORKLIFT_BYPASS not set, creating alias cargo='forklift cargo'"; 
+      alias cargo="forklift cargo";
       fi
     #
     - echo "FL_FORKLIFT_VERSION ${FL_FORKLIFT_VERSION}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ default:
     - cp $FL_FORKLIFT_CONFIG ~/.forklift/config.toml
     - shopt -s expand_aliases
     - export PATH=$PATH:$(pwd)
-    - |
+    - >
       if [ "$FORKLIFT_BYPASS" != "true" ]; then
       echo "FORKLIFT_BYPASS not set, creating alias cargo='forklift cargo'"
       alias cargo="forklift cargo"

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -105,7 +105,7 @@ build-rustdoc:
     - mv ./target/doc ./crate-docs
     # Inject Simple Analytics (https://www.simpleanalytics.com/) privacy preserving tracker into
     # all .html files
-    - |
+    - >
       inject_simple_analytics() {
         local path="$1"
         local script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"

--- a/.gitlab/pipeline/build.yml
+++ b/.gitlab/pipeline/build.yml
@@ -107,24 +107,24 @@ build-rustdoc:
     # all .html files
     - >
       inject_simple_analytics() {
-        local path="$1"
-        local script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"
+        local path="$1";
+        local script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>";
 
         # Function that inject script into the head of an html file using sed.
         process_file() {
-            local file="$1"
-            echo "Adding Simple Analytics script to $file"
-            sed -i "s|</head>|$script_content</head>|" "$file"
-        }
-        export -f process_file
-        # xargs runs process_file in seperate shells without access to outer variables.
-        # to make script_content available inside process_file, export it as an env var here.
-        export script_content
+            local file="$1";
+            echo "Adding Simple Analytics script to $file";
+            sed -i "s|</head>|$script_content</head>|" "$file";
+        };
+        export -f process_file;
+        # xargs runs process_file in separate shells without access to outer variables.
+        # make script_content available inside process_file, export it as an env var here.
+        export script_content;
 
         # Modify .html files in parallel using xargs, otherwise it can take a long time.
-        find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {}
-      }
-      inject_simple_analytics "./crate-docs"
+        find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {};
+      };
+      inject_simple_analytics "./crate-docs";
     - echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
 
 build-implementers-guide:

--- a/.gitlab/pipeline/check.yml
+++ b/.gitlab/pipeline/check.yml
@@ -104,23 +104,19 @@ check-toml-format:
     - .docker-env
     - .test-pr-refs
   script:
-    - >
-      export RUST_LOG=remote-ext=debug,runtime=debug
-
-      echo "---------- Downloading try-runtime CLI ----------"
-      curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.4/try-runtime-x86_64-unknown-linux-musl -o try-runtime
-      chmod +x ./try-runtime
-      echo "Using try-runtime-cli version:"
-      ./try-runtime --version
-
-      echo "---------- Building ${PACKAGE} runtime ----------"
-      time cargo build --release --locked -p "$PACKAGE" --features try-runtime
-
-      echo "---------- Executing on-runtime-upgrade for ${NETWORK} ----------"
-      time ./try-runtime ${COMMAND_EXTRA_ARGS} \
+    - export RUST_LOG=remote-ext=debug,runtime=debug
+    - echo "---------- Downloading try-runtime CLI ----------"
+    - curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.4/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+    - chmod +x ./try-runtime
+    - echo "Using try-runtime-cli version:"
+    - ./try-runtime --version
+    - echo "---------- Building ${PACKAGE} runtime ----------"
+    - time cargo build --release --locked -p "$PACKAGE" --features try-runtime
+    - echo "---------- Executing on-runtime-upgrade for ${NETWORK} ----------"
+    - time ./try-runtime ${COMMAND_EXTRA_ARGS} \
           --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM" \
           on-runtime-upgrade --disable-spec-version-check --checks=all ${SUBCOMMAND_EXTRA_ARGS} live --uri ${URI}
-      sleep 5
+    - sleep 5
 
 # Check runtime migrations for Parity managed relay chains
 check-runtime-migration-westend:

--- a/.gitlab/pipeline/check.yml
+++ b/.gitlab/pipeline/check.yml
@@ -113,9 +113,10 @@ check-toml-format:
     - echo "---------- Building ${PACKAGE} runtime ----------"
     - time cargo build --release --locked -p "$PACKAGE" --features try-runtime
     - echo "---------- Executing on-runtime-upgrade for ${NETWORK} ----------"
-    - time ./try-runtime ${COMMAND_EXTRA_ARGS} \
-          --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM" \
-          on-runtime-upgrade --disable-spec-version-check --checks=all ${SUBCOMMAND_EXTRA_ARGS} live --uri ${URI}
+    - >
+      time ./try-runtime ${COMMAND_EXTRA_ARGS} \
+        --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM" \
+        on-runtime-upgrade --disable-spec-version-check --checks=all ${SUBCOMMAND_EXTRA_ARGS} live --uri ${URI}
     - sleep 5
 
 # Check runtime migrations for Parity managed relay chains

--- a/.gitlab/pipeline/check.yml
+++ b/.gitlab/pipeline/check.yml
@@ -104,7 +104,7 @@ check-toml-format:
     - .docker-env
     - .test-pr-refs
   script:
-    - |
+    - >
       export RUST_LOG=remote-ext=debug,runtime=debug
 
       echo "---------- Downloading try-runtime CLI ----------"
@@ -117,8 +117,8 @@ check-toml-format:
       time cargo build --release --locked -p "$PACKAGE" --features try-runtime
 
       echo "---------- Executing on-runtime-upgrade for ${NETWORK} ----------"
-      time ./try-runtime ${COMMAND_EXTRA_ARGS} \
-          --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM" \
+      time ./try-runtime ${COMMAND_EXTRA_ARGS}
+          --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM"
           on-runtime-upgrade --disable-spec-version-check --checks=all ${SUBCOMMAND_EXTRA_ARGS} live --uri ${URI}
       sleep 5
 

--- a/.gitlab/pipeline/check.yml
+++ b/.gitlab/pipeline/check.yml
@@ -117,8 +117,8 @@ check-toml-format:
       time cargo build --release --locked -p "$PACKAGE" --features try-runtime
 
       echo "---------- Executing on-runtime-upgrade for ${NETWORK} ----------"
-      time ./try-runtime ${COMMAND_EXTRA_ARGS}
-          --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM"
+      time ./try-runtime ${COMMAND_EXTRA_ARGS} \
+          --runtime ./target/release/wbuild/"$PACKAGE"/"$WASM" \
           on-runtime-upgrade --disable-spec-version-check --checks=all ${SUBCOMMAND_EXTRA_ARGS} live --uri ${URI}
       sleep 5
 

--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -115,15 +115,15 @@ trigger_workflow:
     - echo "Triggering workflow"
     - >
       for benchmark in $(ls charts/*.json); do
-        export bencmark_name=$(basename $benchmark)
-        echo "Benchmark: $bencmark_name"
-        export benchmark_dir=$(echo $bencmark_name | sed 's/\.json//')
+        export benchmark_name=$(basename $benchmark);
+        echo "Benchmark: $benchmark_name";
+        export benchmark_dir=$(echo $benchmark_name | sed 's/\.json//');
         curl -q -X POST \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: token $GITHUB_TOKEN" \
-               https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches \
-                -d '{"ref":"refs/heads/master","inputs":{"benchmark-data-dir-path":"'$benchmark_dir'","output-file-path":"'$bencmark_name'"}}'
-        sleep 300
+              https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches \
+              -d "{\"ref\":\"refs/heads/master\",\"inputs\":{\"benchmark-data-dir-path\":\"$benchmark_dir\",\"output-file-path\":\"$benchmark_name\"}}";
+        sleep 300;
       done
   allow_failure: true
 

--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -118,7 +118,10 @@ trigger_workflow:
         export bencmark_name=$(basename $benchmark)
         echo "Benchmark: $bencmark_name"
         export benchmark_dir=$(echo $bencmark_name | sed 's/\.json//')
-        curl -q -X POST
+        curl -q -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+               https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches \
               -H "Accept: application/vnd.github.v3+json"
               -H "Authorization: token $GITHUB_TOKEN"
                https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches

--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -113,15 +113,15 @@ trigger_workflow:
       artifacts: true
   script:
     - echo "Triggering workflow"
-    - |
+    - >
       for benchmark in $(ls charts/*.json); do
         export bencmark_name=$(basename $benchmark)
         echo "Benchmark: $bencmark_name"
         export benchmark_dir=$(echo $bencmark_name | sed 's/\.json//')
-        curl -q -X POST \
-              -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-               https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches \
+        curl -q -X POST
+              -H "Accept: application/vnd.github.v3+json"
+              -H "Authorization: token $GITHUB_TOKEN"
+               https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches
                 -d '{"ref":"refs/heads/master","inputs":{"benchmark-data-dir-path":"'$benchmark_dir'","output-file-path":"'$bencmark_name'"}}'
         sleep 300
       done

--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -122,9 +122,6 @@ trigger_workflow:
               -H "Accept: application/vnd.github.v3+json" \
               -H "Authorization: token $GITHUB_TOKEN" \
                https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches \
-              -H "Accept: application/vnd.github.v3+json"
-              -H "Authorization: token $GITHUB_TOKEN"
-               https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/actions/workflows/subsystem-benchmarks.yml/dispatches
                 -d '{"ref":"refs/heads/master","inputs":{"benchmark-data-dir-path":"'$benchmark_dir'","output-file-path":"'$bencmark_name'"}}'
         sleep 300
       done

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -23,19 +23,13 @@ test-linux-stable:
     - echo "Node index - ${CI_NODE_INDEX}. Total amount - ${CI_NODE_TOTAL}"
     # add experimental to features after https://github.com/paritytech/substrate/pull/14502 is merged
     # "upgrade_version_checks_should_work" is currently failing
+    - >
       time cargo nextest run \
         --workspace \
         --locked \
         --release \
         --no-fail-fast \
         --features try-runtime,experimental,riscv,ci-only-tests \
-    - >
-      time cargo nextest run
-        --workspace
-        --locked
-        --release
-        --no-fail-fast
-        --features try-runtime,experimental,riscv,ci-only-tests
         --partition count:${CI_NODE_INDEX}/${CI_NODE_TOTAL}
     # Upload tests results to Elasticsearch
     - echo "Upload test results to Elasticsearch"
@@ -93,19 +87,13 @@ test-linux-stable-runtime-benchmarks:
 #   script:
 #     # Build all but only execute 'runtime' tests.
 #     - echo "Node index - ${CI_NODE_INDEX}. Total amount - ${CI_NODE_TOTAL}"
+#     - >
 #       time cargo nextest run \
 #         --workspace \
 #         --locked \
 #         --release \
 #         --no-fail-fast \
 #         --features runtime-benchmarks,try-runtime \
-#     - >
-#       time cargo nextest run
-#         --workspace
-#         --locked
-#         --release
-#         --no-fail-fast
-#         --features runtime-benchmarks,try-runtime
 #         --partition count:${CI_NODE_INDEX}/${CI_NODE_TOTAL}
 #     # todo: add flacky-test collector
 

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -23,6 +23,12 @@ test-linux-stable:
     - echo "Node index - ${CI_NODE_INDEX}. Total amount - ${CI_NODE_TOTAL}"
     # add experimental to features after https://github.com/paritytech/substrate/pull/14502 is merged
     # "upgrade_version_checks_should_work" is currently failing
+      time cargo nextest run \
+        --workspace \
+        --locked \
+        --release \
+        --no-fail-fast \
+        --features try-runtime,experimental,riscv,ci-only-tests \
     - >
       time cargo nextest run
         --workspace
@@ -87,6 +93,12 @@ test-linux-stable-runtime-benchmarks:
 #   script:
 #     # Build all but only execute 'runtime' tests.
 #     - echo "Node index - ${CI_NODE_INDEX}. Total amount - ${CI_NODE_TOTAL}"
+#       time cargo nextest run \
+#         --workspace \
+#         --locked \
+#         --release \
+#         --no-fail-fast \
+#         --features runtime-benchmarks,try-runtime \
 #     - >
 #       time cargo nextest run
 #         --workspace

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -23,22 +23,22 @@ test-linux-stable:
     - echo "Node index - ${CI_NODE_INDEX}. Total amount - ${CI_NODE_TOTAL}"
     # add experimental to features after https://github.com/paritytech/substrate/pull/14502 is merged
     # "upgrade_version_checks_should_work" is currently failing
-    - |
-      time cargo nextest run \
-        --workspace \
-        --locked \
-        --release \
-        --no-fail-fast \
-        --features try-runtime,experimental,riscv,ci-only-tests \
+    - >
+      time cargo nextest run
+        --workspace
+        --locked
+        --release
+        --no-fail-fast
+        --features try-runtime,experimental,riscv,ci-only-tests
         --partition count:${CI_NODE_INDEX}/${CI_NODE_TOTAL}
     # Upload tests results to Elasticsearch
     - echo "Upload test results to Elasticsearch"
     - cat target/nextest/default/junit.xml | xq . > target/nextest/default/junit.json
-    - |
-      curl -v -XPOST --http1.1 \
-      -u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD} \
-      https://elasticsearch.parity-build.parity.io/unit-tests/_doc/${CI_JOB_ID} \
-      -H 'Content-Type: application/json' \
+    - >
+      curl -v -XPOST --http1.1
+      -u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}
+      https://elasticsearch.parity-build.parity.io/unit-tests/_doc/${CI_JOB_ID}
+      -H 'Content-Type: application/json'
       -d @target/nextest/default/junit.json || echo "failed to upload junit report"
     # run runtime-api tests with `enable-staging-api` feature on the 1st node
     - if [ ${CI_NODE_INDEX} == 1 ]; then time cargo nextest run -p sp-api-test --features enable-staging-api; fi
@@ -87,13 +87,13 @@ test-linux-stable-runtime-benchmarks:
 #   script:
 #     # Build all but only execute 'runtime' tests.
 #     - echo "Node index - ${CI_NODE_INDEX}. Total amount - ${CI_NODE_TOTAL}"
-#     - |
-#       time cargo nextest run \
-#         --workspace \
-#         --locked \
-#         --release \
-#         --no-fail-fast \
-#         --features runtime-benchmarks,try-runtime \
+#     - >
+#       time cargo nextest run
+#         --workspace
+#         --locked
+#         --release
+#         --no-fail-fast
+#         --features runtime-benchmarks,try-runtime
 #         --partition count:${CI_NODE_INDEX}/${CI_NODE_TOTAL}
 #     # todo: add flacky-test collector
 

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -35,10 +35,10 @@ test-linux-stable:
     - echo "Upload test results to Elasticsearch"
     - cat target/nextest/default/junit.xml | xq . > target/nextest/default/junit.json
     - >
-      curl -v -XPOST --http1.1
-      -u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}
-      https://elasticsearch.parity-build.parity.io/unit-tests/_doc/${CI_JOB_ID}
-      -H 'Content-Type: application/json'
+      curl -v -XPOST --http1.1 \
+      -u ${ELASTIC_USERNAME}:${ELASTIC_PASSWORD} \
+      https://elasticsearch.parity-build.parity.io/unit-tests/_doc/${CI_JOB_ID} \
+      -H 'Content-Type: application/json' \
       -d @target/nextest/default/junit.json || echo "failed to upload junit report"
     # run runtime-api tests with `enable-staging-api` feature on the 1st node
     - if [ ${CI_NODE_INDEX} == 1 ]; then time cargo nextest run -p sp-api-test --features enable-staging-api; fi


### PR DESCRIPTION
Use of `- >` instead of `- |` workarounds GitLab quirk when it crops collapsed multiline `script:` section commands in its CI job logs.
This PR also fixes `- |` based `script:` steps to behave properly after `- >` conversion.

Resolves https://github.com/paritytech/ci_cd/issues/972.