### PR TITLE
Deprecate `para_id()` from `CoreState` in polkadot primitives

### DIFF
--- a/polkadot/node/core/prospective-parachains/src/tests.rs
+++ b/polkadot/node/core/prospective-parachains/src/tests.rs
@@ -1797,7 +1797,10 @@ fn persists_pending_availability_candidate() {
 	test_state.availability_cores = test_state
 		.availability_cores
 		.into_iter()
-		.filter(|core| core.para_id().map_or(false, |id| id == para_id))
+		.filter(|core| match core {
+			CoreState::Scheduled(scheduled_core) => scheduled_core.para_id == para_id,
+			_ => false,
+		})
 		.collect();
 	assert_eq!(test_state.availability_cores.len(), 1);
 
@@ -1896,7 +1899,10 @@ fn backwards_compatible() {
 	test_state.availability_cores = test_state
 		.availability_cores
 		.into_iter()
-		.filter(|core| core.para_id().map_or(false, |id| id == para_id))
+		.filter(|core| match core {
+			CoreState::Scheduled(scheduled_core) => scheduled_core.para_id == para_id,
+			_ => false,
+		})
 		.collect();
 	assert_eq!(test_state.availability_cores.len(), 1);
 

--- a/polkadot/node/core/provisioner/src/tests.rs
+++ b/polkadot/node/core/provisioner/src/tests.rs
@@ -921,7 +921,7 @@ mod select_candidates {
 				descriptor.para_id = if let Scheduled(scheduled_core) = &mock_cores[i] {
 					scheduled_core.para_id
 				} else {
-					panic!("`moc_cores` is not initialized with `Scheduled`?")
+					panic!("`mock_cores` is not initialized with `Scheduled`?")
 				};
 				descriptor.persisted_validation_data_hash = empty_hash;
 				descriptor.pov_hash = Hash::from_low_u64_be(i as u64);

--- a/polkadot/node/core/provisioner/src/tests.rs
+++ b/polkadot/node/core/provisioner/src/tests.rs
@@ -918,7 +918,11 @@ mod select_candidates {
 		let committed_receipts: Vec<_> = (0..mock_cores.len())
 			.map(|i| {
 				let mut descriptor = dummy_candidate_descriptor(dummy_hash());
-				descriptor.para_id = mock_cores[i].para_id().unwrap();
+				descriptor.para_id = if let Scheduled(scheduled_core) = &mock_cores[i] {
+					scheduled_core.para_id
+				} else {
+					panic!("`moc_cores` is not initialized with `Scheduled`?")
+				};
 				descriptor.persisted_validation_data_hash = empty_hash;
 				descriptor.pov_hash = Hash::from_low_u64_be(i as u64);
 				CommittedCandidateReceipt {

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -705,10 +705,9 @@ pub(crate) async fn handle_active_leaves_update<Context>(
 		});
 
 		let groups_per_para = determine_groups_per_para(
-			ctx.sender(),
-			new_relay_parent,
 			availability_cores,
 			group_rotation_info,
+			&maybe_claim_queue,
 			max_candidate_depth,
 		)
 		.await;
@@ -2159,24 +2158,11 @@ async fn provide_candidate_to_grid<Context>(
 
 // Utility function to populate per relay parent `ParaId` to `GroupIndex` mappings.
 async fn determine_groups_per_para(
-	sender: &mut impl overseer::StatementDistributionSenderTrait,
-	relay_parent: Hash,
 	availability_cores: Vec<CoreState>,
 	group_rotation_info: GroupRotationInfo,
+	maybe_claim_queue: &Option<ClaimQueueSnapshot>,
 	max_candidate_depth: usize,
 ) -> HashMap<ParaId, Vec<GroupIndex>> {
-	let maybe_claim_queue = fetch_claim_queue(sender, relay_parent)
-			.await
-			.unwrap_or_else(|err| {
-				gum::debug!(
-					target: LOG_TARGET,
-					?relay_parent,
-					?err,
-					"determine_groups_per_para: `claim_queue` API not available, falling back to iterating availability cores"
-				);
-				None
-			});
-
 	let n_cores = availability_cores.len();
 
 	// Determine the core indices occupied by each para at the current relay parent. To support

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -777,7 +777,7 @@ fn find_active_validator_state(
 	} else {
 		availability_cores
 			.get(core_index.0 as usize)
-			.map(|core_state| match core_state {
+			.and_then(|core_state| match core_state {
 				CoreState::Scheduled(scheduled_core) => Some(scheduled_core.para_id),
 				CoreState::Occupied(occupied_core) if max_candidate_depth >= 1 => occupied_core
 					.next_up_on_available
@@ -785,7 +785,6 @@ fn find_active_validator_state(
 					.map(|scheduled_core| scheduled_core.para_id),
 				CoreState::Free | CoreState::Occupied(_) => None,
 			})
-			.flatten()
 	};
 	let group_validators = groups.get(our_group)?.to_owned();
 

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -772,7 +772,7 @@ fn find_active_validator_state(
 	let our_group = groups.by_validator_index(validator_index)?;
 
 	let core_index = group_rotation_info.core_for_group(our_group, availability_cores.len());
-	let core_assignment = if let Some(claim_queue) = maybe_claim_queue {
+	let para_assigned_to_core = if let Some(claim_queue) = maybe_claim_queue {
 		claim_queue.get_claim_for(core_index, 0)
 	} else {
 		availability_cores
@@ -792,7 +792,7 @@ fn find_active_validator_state(
 		active: Some(ActiveValidatorState {
 			index: validator_index,
 			group: our_group,
-			assignment: core_assignment,
+			assignment: para_assigned_to_core,
 			cluster_tracker: ClusterTracker::new(group_validators, seconding_limit)
 				.expect("group is non-empty because we are in it; qed"),
 		}),

--- a/polkadot/primitives/src/v7/mod.rs
+++ b/polkadot/primitives/src/v7/mod.rs
@@ -1086,15 +1086,6 @@ pub enum CoreState<H = Hash, N = BlockNumber> {
 }
 
 impl<N> CoreState<N> {
-	/// If this core state has a `para_id`, return it.
-	pub fn para_id(&self) -> Option<Id> {
-		match self {
-			Self::Occupied(ref core) => Some(core.para_id()),
-			Self::Scheduled(core) => Some(core.para_id),
-			Self::Free => None,
-		}
-	}
-
 	/// Is this core state `Self::Occupied`?
 	pub fn is_occupied(&self) -> bool {
 		matches!(self, Self::Occupied(_))

--- a/polkadot/primitives/src/v7/mod.rs
+++ b/polkadot/primitives/src/v7/mod.rs
@@ -1086,6 +1086,18 @@ pub enum CoreState<H = Hash, N = BlockNumber> {
 }
 
 impl<N> CoreState<N> {
+	/// If this core state has a `para_id`, return it.
+	#[deprecated(
+		note = "`para_id` will be removed. Use `ClaimQueue` to query the scheduled `para_id` instead."
+	)]
+	pub fn para_id(&self) -> Option<Id> {
+		match self {
+			Self::Occupied(ref core) => core.next_up_on_available.as_ref().map(|n| n.para_id),
+			Self::Scheduled(core) => Some(core.para_id),
+			Self::Free => None,
+		}
+	}
+
 	/// Is this core state `Self::Occupied`?
 	pub fn is_occupied(&self) -> bool {
 		matches!(self, Self::Occupied(_))

--- a/polkadot/primitives/src/v7/mod.rs
+++ b/polkadot/primitives/src/v7/mod.rs
@@ -1086,7 +1086,10 @@ pub enum CoreState<H = Hash, N = BlockNumber> {
 }
 
 impl<N> CoreState<N> {
-	/// If this core state has a `para_id`, return it.
+	/// Returns the scheduled `ParaId` for the core or `None` if nothing is scheduled.
+	///
+	/// This function is deprecated. `ClaimQueue` should be used to obtain the scheduled `ParaId`s
+	/// for each core.
 	#[deprecated(
 		note = "`para_id` will be removed. Use `ClaimQueue` to query the scheduled `para_id` instead."
 	)]

--- a/prdoc/pr_3979.prdoc
+++ b/prdoc/pr_3979.prdoc
@@ -1,19 +1,20 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: Remove `para_id()` from `CoreState` in polkadot primitives
+title: Deprecate `para_id()` from `CoreState` in polkadot primitives
 
 doc:
   - audience: "Node Dev"
     description: |
-     The motivation is that `para_id()` can be misused with Coretime which allows two parachains (A,B) to share a 
-     core at an arbitrary relay chain block. This happens when a candidate of parachain A is pending availability 
-     while parachain B is scheduled on the same core. In such a case the removed `para_id()` function would always
-     return the id of A. Implementers should now use the `ClaimQueue` to query the scheduled `para_id`.
+     The motivation is that the old implementation of `para_id()` can be misused with Coretime which allows two
+     parachains (A,B) to share a core at an arbitrary relay chain block. This happens when a candidate of parachain A
+     is pending availability while parachain B is scheduled on the same core. In such a case the deprecated `para_id()`
+     function would always return the id of A. This behavior is fixed by always returning the scheduled `ParaId` for
+     occupied cores. But nevertheless implementers should prefer using the `ClaimQueue` to query the scheduled `para_id`.
 
 crates:
   - name: polkadot-primitives
-    bump: major
+    bump: minor
   - name: polkadot-statement-distribution
     bump: minor
   - name: cumulus-client-consensus-aura

--- a/prdoc/pr_3979.prdoc
+++ b/prdoc/pr_3979.prdoc
@@ -6,11 +6,9 @@ title: Deprecate `para_id()` from `CoreState` in polkadot primitives
 doc:
   - audience: "Node Dev"
     description: |
-     The motivation is that the old implementation of `para_id()` can be misused with Coretime which allows two
-     parachains (A,B) to share a core at an arbitrary relay chain block. This happens when a candidate of parachain A
-     is pending availability while parachain B is scheduled on the same core. In such a case the deprecated `para_id()`
-     function would always return the id of A. This behavior is fixed by always returning the scheduled `ParaId` for
-     occupied cores. But nevertheless implementers should prefer using the `ClaimQueue` to query the scheduled `para_id`.
+     `CoreState`'s `para_id()` function is getting deprecated in favour of direct usage of the
+     `ClaimQueue`. This is the preferred approach because it provides a better view on what is
+     scheduled on each core.
 
 crates:
   - name: polkadot-primitives

--- a/prdoc/pr_3979.prdoc
+++ b/prdoc/pr_3979.prdoc
@@ -1,0 +1,19 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Remove `para_id()` from `CoreState` in polkadot primitives
+
+doc:
+  - audience: "Node Dev"
+    description: |
+      With Coretime there is no more a static 1:1 mapping between core index and para id. This
+      mapping should be obtained from the scheduler/claimqueue on block by block basis. This change
+      removes `para_id()` from `CoreState` as it doesn't serve its purpose anymore.
+
+crates:
+  - name: polkadot-primitives
+    bump: major
+  - name: polkadot-statement-distribution
+    bump: minor
+  - name: cumulus-client-consensus-aura
+    bump: minor

--- a/prdoc/pr_3979.prdoc
+++ b/prdoc/pr_3979.prdoc
@@ -6,9 +6,10 @@ title: Remove `para_id()` from `CoreState` in polkadot primitives
 doc:
   - audience: "Node Dev"
     description: |
-      With Coretime there is no more a static 1:1 mapping between core index and para id. This
-      mapping should be obtained from the scheduler/claimqueue on block by block basis. This change
-      removes `para_id()` from `CoreState` as it doesn't serve its purpose anymore.
+     The motivation is that `para_id()` can be misused with Coretime which allows two parachains (A,B) to share a 
+     core at an arbitrary relay chain block. This happens when a candidate of parachain A is pending availability 
+     while parachain B is scheduled on the same core. In such a case the removed `para_id()` function would always
+     return the id of A. Implementers should now use the `ClaimQueue` to query the scheduled `para_id`.
 
 crates:
   - name: polkadot-primitives


### PR DESCRIPTION
With Coretime enabled we can no longer assume there is a static 1:1 mapping between core index and para id. This mapping should be obtained from the scheduler/claimqueue on block by block basis.

This PR modifies `para_id()` (from `CoreState`) to return the scheduled `ParaId` for occupied cores and removes its usages in the code.

Closes https://github.com/paritytech/polkadot-sdk/issues/3948