### PR TITLE
Fixes validation for `SkipCheckIfFeeless` extension

### DIFF
--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs
@@ -43,7 +43,7 @@ use frame_support::{
 use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_runtime::{
 	traits::{DispatchInfoOf, PostDispatchInfoOf, SignedExtension},
-	transaction_validity::TransactionValidityError,
+	transaction_validity::{TransactionValidity, TransactionValidityError, ValidTransaction},
 };
 
 #[cfg(test)]
@@ -120,6 +120,20 @@ where
 
 	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
 		self.0.additional_signed()
+	}
+
+	fn validate(
+		&self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		info: &DispatchInfoOf<Self::Call>,
+		len: usize,
+	) -> TransactionValidity {
+		if call.is_feeless(&<T as frame_system::Config>::RuntimeOrigin::signed(who.clone())) {
+			Ok(ValidTransaction::default())
+		} else {
+			self.0.validate(who, call, info, len)
+		}
 	}
 
 	fn pre_dispatch(

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/mock.rs
@@ -33,6 +33,7 @@ impl Config for Runtime {
 
 parameter_types! {
 	pub static PreDispatchCount: u32 = 0;
+	pub static ValidateCount: u32 = 0;
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
@@ -47,6 +48,18 @@ impl SignedExtension for DummyExtension {
 	fn additional_signed(&self) -> sp_std::result::Result<(), TransactionValidityError> {
 		Ok(())
 	}
+
+	fn validate(
+		&self,
+		_who: &Self::AccountId,
+		_call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		ValidateCount::mutate(|c| *c += 1);
+		Ok(Default::default())
+	}
+
 	fn pre_dispatch(
 		self,
 		_who: &Self::AccountId,

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/tests.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use super::*;
-use crate::mock::{pallet_dummy::Call, DummyExtension, PreDispatchCount, Runtime, RuntimeCall};
+use crate::mock::{
+	pallet_dummy::Call, DummyExtension, PreDispatchCount, Runtime, RuntimeCall, ValidateCount,
+};
 use frame_support::dispatch::DispatchInfo;
 
 #[test]
@@ -30,4 +32,21 @@ fn skip_feeless_payment_works() {
 		.pre_dispatch(&0, &call, &DispatchInfo::default(), 0)
 		.unwrap();
 	assert_eq!(PreDispatchCount::get(), 1);
+}
+
+#[test]
+fn validate_works() {
+	assert_eq!(ValidateCount::get(), 0);
+
+	let call = RuntimeCall::DummyPallet(Call::<Runtime>::aux { data: 1 });
+	SkipCheckIfFeeless::<Runtime, DummyExtension>::from(DummyExtension)
+		.validate(&0, &call, &DispatchInfo::default(), 0)
+		.unwrap();
+	assert_eq!(ValidateCount::get(), 1);
+
+	let call = RuntimeCall::DummyPallet(Call::<Runtime>::aux { data: 0 });
+	SkipCheckIfFeeless::<Runtime, DummyExtension>::from(DummyExtension)
+		.validate(&0, &call, &DispatchInfo::default(), 0)
+		.unwrap();
+	assert_eq!(ValidateCount::get(), 1);
 }


### PR DESCRIPTION
During validation, `SkipCheckIfFeeless` should check if the call is `feeless` and delegate to the wrapped extension if not.