### PR TITLE
sc-beefy-consensus: Remove unneeded stream.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6222,9 +6222,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/prdoc/pr_4015.prdoc
+++ b/prdoc/pr_4015.prdoc
@@ -1,0 +1,14 @@
+title: Improve beefy networking code by forwarding data more directly
+
+doc:
+  - audience: Node Operator
+    description: |
+      Improve internal implementation of beefy to forward data directly to the
+      networking layer instead of first storing them internally. So, the
+      following error message should not appear again:
+      ```
+      The number of unprocessed messages in channel `mpsc_beefy_gossip_validator` exceeded 100000.
+      ```
+
+crates:
+  - name: sc-consensus-beefy

--- a/substrate/client/consensus/beefy/src/communication/gossip.rs
+++ b/substrate/client/consensus/beefy/src/communication/gossip.rs
@@ -511,15 +511,15 @@ pub(crate) mod tests {
 
 	impl NetworkPeers for TestNetwork {
 		fn set_authorized_peers(&self, _: std::collections::HashSet<PeerId>) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn set_authorized_only(&self, _: bool) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn add_known_address(&self, _: PeerId, _: sc_network::Multiaddr) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn report_peer(&self, peer_id: PeerId, cost_benefit: ReputationChange) {
@@ -527,30 +527,30 @@ pub(crate) mod tests {
 		}
 
 		fn peer_reputation(&self, _: &PeerId) -> i32 {
-			todo!()
+			unimplemented!()
 		}
 
 		fn disconnect_peer(&self, _: PeerId, _: sc_network::ProtocolName) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn accept_unreserved_peers(&self) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn deny_unreserved_peers(&self) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn add_reserved_peer(
 			&self,
 			_: sc_network::config::MultiaddrWithPeerId,
 		) -> Result<(), String> {
-			todo!()
+			unimplemented!()
 		}
 
 		fn remove_reserved_peer(&self, _: PeerId) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn set_reserved_peers(
@@ -558,7 +558,7 @@ pub(crate) mod tests {
 			_: sc_network::ProtocolName,
 			_: std::collections::HashSet<sc_network::Multiaddr>,
 		) -> Result<(), String> {
-			todo!()
+			unimplemented!()
 		}
 
 		fn add_peers_to_reserved_set(
@@ -566,7 +566,7 @@ pub(crate) mod tests {
 			_: sc_network::ProtocolName,
 			_: std::collections::HashSet<sc_network::Multiaddr>,
 		) -> Result<(), String> {
-			todo!()
+			unimplemented!()
 		}
 
 		fn remove_peers_from_reserved_set(
@@ -574,32 +574,32 @@ pub(crate) mod tests {
 			_: sc_network::ProtocolName,
 			_: Vec<PeerId>,
 		) -> Result<(), String> {
-			todo!()
+			unimplemented!()
 		}
 
 		fn sync_num_connected(&self) -> usize {
-			todo!()
+			unimplemented!()
 		}
 
 		fn peer_role(&self, _: PeerId, _: Vec<u8>) -> Option<sc_network::ObservedRole> {
-			todo!()
+			unimplemented!()
 		}
 	}
 
 	struct TestContext;
 	impl<B: sp_runtime::traits::Block> ValidatorContext<B> for TestContext {
 		fn broadcast_topic(&mut self, _topic: B::Hash, _force: bool) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn broadcast_message(&mut self, _topic: B::Hash, _message: Vec<u8>, _force: bool) {}
 
 		fn send_message(&mut self, _who: &sc_network::PeerId, _message: Vec<u8>) {
-			todo!()
+			unimplemented!()
 		}
 
 		fn send_topic(&mut self, _who: &sc_network::PeerId, _topic: B::Hash, _force: bool) {
-			todo!()
+			unimplemented!()
 		}
 	}
 

--- a/substrate/client/consensus/beefy/src/communication/gossip.rs
+++ b/substrate/client/consensus/beefy/src/communication/gossip.rs
@@ -28,10 +28,7 @@ use parking_lot::{Mutex, RwLock};
 use wasm_timer::Instant;
 
 use crate::{
-	communication::{
-		benefit, cost,
-		peers::{KnownPeers, PeerReport},
-	},
+	communication::{benefit, cost, peers::KnownPeers},
 	justification::{
 		proof_block_num_and_set_id, verify_with_validator_set, BeefyVersionedFinalityProof,
 	},
@@ -488,7 +485,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
 	use super::*;
-	use crate::keystore::BeefyKeystore;
+	use crate::{communication::peerrs::PeerReport, keystore::BeefyKeystore};
 	use sc_network_test::Block;
 	use sp_application_crypto::key_types::BEEFY as BEEFY_KEY_TYPE;
 	use sp_consensus_beefy::{

--- a/substrate/client/consensus/beefy/src/communication/gossip.rs
+++ b/substrate/client/consensus/beefy/src/communication/gossip.rs
@@ -485,7 +485,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
 	use super::*;
-	use crate::{communication::peerrs::PeerReport, keystore::BeefyKeystore};
+	use crate::{communication::peers::PeerReport, keystore::BeefyKeystore};
 	use sc_network_test::Block;
 	use sp_application_crypto::key_types::BEEFY as BEEFY_KEY_TYPE;
 	use sp_consensus_beefy::{

--- a/substrate/client/consensus/beefy/src/communication/gossip.rs
+++ b/substrate/client/consensus/beefy/src/communication/gossip.rs
@@ -18,14 +18,13 @@
 
 use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
-use sc_network::{PeerId, ReputationChange};
+use sc_network::{NetworkPeers, PeerId, ReputationChange};
 use sc_network_gossip::{MessageIntent, ValidationResult, Validator, ValidatorContext};
 use sp_runtime::traits::{Block, Hash, Header, NumberFor};
 
 use codec::{Decode, DecodeAll, Encode};
 use log::{debug, trace};
 use parking_lot::{Mutex, RwLock};
-use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use wasm_timer::Instant;
 
 use crate::{
@@ -223,7 +222,7 @@ impl<B: Block> Filter<B> {
 /// rejected/expired.
 ///
 ///All messaging is handled in a single BEEFY global topic.
-pub(crate) struct GossipValidator<B>
+pub(crate) struct GossipValidator<B, N>
 where
 	B: Block,
 {
@@ -232,26 +231,22 @@ where
 	gossip_filter: RwLock<Filter<B>>,
 	next_rebroadcast: Mutex<Instant>,
 	known_peers: Arc<Mutex<KnownPeers<B>>>,
-	report_sender: TracingUnboundedSender<PeerReport>,
+	network: Arc<N>,
 }
 
-impl<B> GossipValidator<B>
+impl<B, N> GossipValidator<B, N>
 where
 	B: Block,
 {
-	pub(crate) fn new(
-		known_peers: Arc<Mutex<KnownPeers<B>>>,
-	) -> (GossipValidator<B>, TracingUnboundedReceiver<PeerReport>) {
-		let (tx, rx) = tracing_unbounded("mpsc_beefy_gossip_validator", 100_000);
-		let val = GossipValidator {
+	pub(crate) fn new(known_peers: Arc<Mutex<KnownPeers<B>>>, network: Arc<N>) -> Self {
+		Self {
 			votes_topic: votes_topic::<B>(),
 			justifs_topic: proofs_topic::<B>(),
 			gossip_filter: RwLock::new(Filter::new()),
 			next_rebroadcast: Mutex::new(Instant::now() + REBROADCAST_AFTER),
 			known_peers,
-			report_sender: tx,
-		};
-		(val, rx)
+			network,
+		}
 	}
 
 	/// Update gossip validator filter.
@@ -265,9 +260,15 @@ where
 		);
 		self.gossip_filter.write().update(filter);
 	}
+}
 
+impl<B, N> GossipValidator<B, N>
+where
+	B: Block,
+	N: NetworkPeers,
+{
 	fn report(&self, who: PeerId, cost_benefit: ReputationChange) {
-		let _ = self.report_sender.unbounded_send(PeerReport { who, cost_benefit });
+		self.network.report_peer(who, cost_benefit);
 	}
 
 	fn validate_vote(
@@ -370,9 +371,10 @@ where
 	}
 }
 
-impl<B> Validator<B> for GossipValidator<B>
+impl<B, N> Validator<B> for GossipValidator<B, N>
 where
 	B: Block,
+	N: NetworkPeers + Send + Sync,
 {
 	fn peer_disconnected(&self, _context: &mut dyn ValidatorContext<B>, who: &PeerId) {
 		self.known_peers.lock().remove(who);
@@ -495,6 +497,95 @@ pub(crate) mod tests {
 	};
 	use sp_keystore::{testing::MemoryKeystore, Keystore};
 
+	pub(crate) struct TestNetwork {
+		report_sender: futures::channel::mpsc::UnboundedSender<PeerReport>,
+	}
+
+	impl TestNetwork {
+		pub fn new() -> (Self, futures::channel::mpsc::UnboundedReceiver<PeerReport>) {
+			let (tx, rx) = futures::channel::mpsc::unbounded();
+
+			(Self { report_sender: tx }, rx)
+		}
+	}
+
+	impl NetworkPeers for TestNetwork {
+		fn set_authorized_peers(&self, _: std::collections::HashSet<PeerId>) {
+			todo!()
+		}
+
+		fn set_authorized_only(&self, _: bool) {
+			todo!()
+		}
+
+		fn add_known_address(&self, _: PeerId, _: sc_network::Multiaddr) {
+			todo!()
+		}
+
+		fn report_peer(&self, peer_id: PeerId, cost_benefit: ReputationChange) {
+			let _ = self.report_sender.unbounded_send(PeerReport { who: peer_id, cost_benefit });
+		}
+
+		fn peer_reputation(&self, _: &PeerId) -> i32 {
+			todo!()
+		}
+
+		fn disconnect_peer(&self, _: PeerId, _: sc_network::ProtocolName) {
+			todo!()
+		}
+
+		fn accept_unreserved_peers(&self) {
+			todo!()
+		}
+
+		fn deny_unreserved_peers(&self) {
+			todo!()
+		}
+
+		fn add_reserved_peer(
+			&self,
+			_: sc_network::config::MultiaddrWithPeerId,
+		) -> Result<(), String> {
+			todo!()
+		}
+
+		fn remove_reserved_peer(&self, _: PeerId) {
+			todo!()
+		}
+
+		fn set_reserved_peers(
+			&self,
+			_: sc_network::ProtocolName,
+			_: std::collections::HashSet<sc_network::Multiaddr>,
+		) -> Result<(), String> {
+			todo!()
+		}
+
+		fn add_peers_to_reserved_set(
+			&self,
+			_: sc_network::ProtocolName,
+			_: std::collections::HashSet<sc_network::Multiaddr>,
+		) -> Result<(), String> {
+			todo!()
+		}
+
+		fn remove_peers_from_reserved_set(
+			&self,
+			_: sc_network::ProtocolName,
+			_: Vec<PeerId>,
+		) -> Result<(), String> {
+			todo!()
+		}
+
+		fn sync_num_connected(&self) -> usize {
+			todo!()
+		}
+
+		fn peer_role(&self, _: PeerId, _: Vec<u8>) -> Option<sc_network::ObservedRole> {
+			todo!()
+		}
+	}
+
 	struct TestContext;
 	impl<B: sp_runtime::traits::Block> ValidatorContext<B> for TestContext {
 		fn broadcast_topic(&mut self, _topic: B::Hash, _force: bool) {
@@ -560,8 +651,13 @@ pub(crate) mod tests {
 	fn should_validate_messages() {
 		let keys = vec![Keyring::<AuthorityId>::Alice.public()];
 		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 0).unwrap();
-		let (gv, mut report_stream) =
-			GossipValidator::<Block>::new(Arc::new(Mutex::new(KnownPeers::new())));
+
+		let (network, mut report_stream) = TestNetwork::new();
+
+		let gv = GossipValidator::<Block, _>::new(
+			Arc::new(Mutex::new(KnownPeers::new())),
+			Arc::new(network),
+		);
 		let sender = PeerId::random();
 		let mut context = TestContext;
 
@@ -574,7 +670,7 @@ pub(crate) mod tests {
 		let mut expected_report = PeerReport { who: sender, cost_benefit: expected_cost };
 		let res = gv.validate(&mut context, &sender, bad_encoding);
 		assert!(matches!(res, ValidationResult::Discard));
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// verify votes validation
 
@@ -585,14 +681,14 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded);
 		assert!(matches!(res, ValidationResult::Discard));
 		// nothing reported
-		assert!(report_stream.try_recv().is_err());
+		assert!(report_stream.try_next().is_err());
 
 		gv.update_filter(GossipFilterCfg { start: 0, end: 10, validator_set: &validator_set });
 		// nothing in cache first time
 		let res = gv.validate(&mut context, &sender, &encoded);
 		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
 		expected_report.cost_benefit = benefit::VOTE_MESSAGE;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// reject vote, voter not in validator set
 		let mut bad_vote = vote.clone();
@@ -601,7 +697,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &bad_vote);
 		assert!(matches!(res, ValidationResult::Discard));
 		expected_report.cost_benefit = cost::UNKNOWN_VOTER;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// reject if the round is not GRANDPA finalized
 		gv.update_filter(GossipFilterCfg { start: 1, end: 2, validator_set: &validator_set });
@@ -611,7 +707,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded);
 		assert!(matches!(res, ValidationResult::Discard));
 		expected_report.cost_benefit = cost::FUTURE_MESSAGE;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// reject if the round is not live anymore
 		gv.update_filter(GossipFilterCfg { start: 7, end: 10, validator_set: &validator_set });
@@ -621,7 +717,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded);
 		assert!(matches!(res, ValidationResult::Discard));
 		expected_report.cost_benefit = cost::OUTDATED_MESSAGE;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// now verify proofs validation
 
@@ -631,7 +727,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded_proof);
 		assert!(matches!(res, ValidationResult::Discard));
 		expected_report.cost_benefit = cost::OUTDATED_MESSAGE;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// accept next proof with good set_id
 		let proof = dummy_proof(7, &validator_set);
@@ -639,7 +735,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded_proof);
 		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
 		expected_report.cost_benefit = benefit::VALIDATED_PROOF;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// accept future proof with good set_id
 		let proof = dummy_proof(20, &validator_set);
@@ -647,7 +743,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded_proof);
 		assert!(matches!(res, ValidationResult::ProcessAndKeep(_)));
 		expected_report.cost_benefit = benefit::VALIDATED_PROOF;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// reject proof, future set_id
 		let bad_validator_set = ValidatorSet::<AuthorityId>::new(keys, 1).unwrap();
@@ -656,7 +752,7 @@ pub(crate) mod tests {
 		let res = gv.validate(&mut context, &sender, &encoded_proof);
 		assert!(matches!(res, ValidationResult::Discard));
 		expected_report.cost_benefit = cost::FUTURE_MESSAGE;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 
 		// reject proof, bad signatures (Bob instead of Alice)
 		let bad_validator_set =
@@ -667,14 +763,17 @@ pub(crate) mod tests {
 		assert!(matches!(res, ValidationResult::Discard));
 		expected_report.cost_benefit = cost::INVALID_PROOF;
 		expected_report.cost_benefit.value += cost::PER_SIGNATURE_CHECKED;
-		assert_eq!(report_stream.try_recv().unwrap(), expected_report);
+		assert_eq!(report_stream.try_next().unwrap().unwrap(), expected_report);
 	}
 
 	#[test]
 	fn messages_allowed_and_expired() {
 		let keys = vec![Keyring::Alice.public()];
 		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 0).unwrap();
-		let (gv, _) = GossipValidator::<Block>::new(Arc::new(Mutex::new(KnownPeers::new())));
+		let gv = GossipValidator::<Block, _>::new(
+			Arc::new(Mutex::new(KnownPeers::new())),
+			Arc::new(TestNetwork::new().0),
+		);
 		gv.update_filter(GossipFilterCfg { start: 0, end: 10, validator_set: &validator_set });
 		let sender = sc_network::PeerId::random();
 		let topic = Default::default();
@@ -751,7 +850,10 @@ pub(crate) mod tests {
 	fn messages_rebroadcast() {
 		let keys = vec![Keyring::Alice.public()];
 		let validator_set = ValidatorSet::<AuthorityId>::new(keys.clone(), 0).unwrap();
-		let (gv, _) = GossipValidator::<Block>::new(Arc::new(Mutex::new(KnownPeers::new())));
+		let gv = GossipValidator::<Block, _>::new(
+			Arc::new(Mutex::new(KnownPeers::new())),
+			Arc::new(TestNetwork::new().0),
+		);
 		gv.update_filter(GossipFilterCfg { start: 0, end: 10, validator_set: &validator_set });
 		let sender = sc_network::PeerId::random();
 		let topic = Default::default();

--- a/substrate/client/consensus/beefy/src/lib.rs
+++ b/substrate/client/consensus/beefy/src/lib.rs
@@ -68,7 +68,7 @@ pub mod import;
 pub mod justification;
 
 use crate::{
-	communication::{gossip::GossipValidator, peers::PeerReport},
+	communication::gossip::GossipValidator,
 	justification::BeefyVersionedFinalityProof,
 	keystore::BeefyKeystore,
 	metrics::VoterMetrics,
@@ -78,7 +78,6 @@ use crate::{
 pub use communication::beefy_protocol_name::{
 	gossip_protocol_name, justifications_protocol_name as justifs_protocol_name,
 };
-use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_runtime::generic::OpaqueDigestItemId;
 
 #[cfg(test)]
@@ -228,10 +227,9 @@ pub struct BeefyParams<B: Block, BE, C, N, P, R, S> {
 /// Helper object holding BEEFY worker communication/gossip components.
 ///
 /// These are created once, but will be reused if worker is restarted/reinitialized.
-pub(crate) struct BeefyComms<B: Block> {
+pub(crate) struct BeefyComms<B: Block, N> {
 	pub gossip_engine: GossipEngine<B>,
-	pub gossip_validator: Arc<GossipValidator<B>>,
-	pub gossip_report_stream: TracingUnboundedReceiver<PeerReport>,
+	pub gossip_validator: Arc<GossipValidator<B, N>>,
 	pub on_demand_justifications: OnDemandJustificationsEngine<B>,
 }
 
@@ -264,13 +262,13 @@ where
 	/// persisted state in AUX DB and latest chain information/progress.
 	///
 	/// Returns a sane `BeefyWorkerBuilder` that can build the `BeefyWorker`.
-	pub async fn async_initialize(
+	pub async fn async_initialize<N>(
 		backend: Arc<BE>,
 		runtime: Arc<R>,
 		key_store: BeefyKeystore<AuthorityId>,
 		metrics: Option<VoterMetrics>,
 		min_block_delta: u32,
-		gossip_validator: Arc<GossipValidator<B>>,
+		gossip_validator: Arc<GossipValidator<B, N>>,
 		finality_notifications: &mut Fuse<FinalityNotifications<B>>,
 		is_authority: bool,
 	) -> Result<Self, Error> {
@@ -298,15 +296,15 @@ where
 	}
 
 	/// Takes rest of missing pieces as params and builds the `BeefyWorker`.
-	pub fn build<P, S>(
+	pub fn build<P, S, N>(
 		self,
 		payload_provider: P,
 		sync: Arc<S>,
-		comms: BeefyComms<B>,
+		comms: BeefyComms<B, N>,
 		links: BeefyVoterLinks<B>,
 		pending_justifications: BTreeMap<NumberFor<B>, BeefyVersionedFinalityProof<B>>,
 		is_authority: bool,
-	) -> BeefyWorker<B, BE, P, R, S> {
+	) -> BeefyWorker<B, BE, P, R, S, N> {
 		BeefyWorker {
 			backend: self.backend,
 			runtime: self.runtime,
@@ -526,8 +524,8 @@ pub async fn start_beefy_gadget<B, BE, C, N, P, R, S>(
 	let known_peers = Arc::new(Mutex::new(KnownPeers::new()));
 	// Default votes filter is to discard everything.
 	// Validator is updated later with correct starting round and set id.
-	let (gossip_validator, gossip_report_stream) =
-		communication::gossip::GossipValidator::new(known_peers.clone());
+	let gossip_validator =
+		communication::gossip::GossipValidator::new(known_peers.clone(), network.clone());
 	let gossip_validator = Arc::new(gossip_validator);
 	let gossip_engine = GossipEngine::new(
 		network.clone(),
@@ -546,12 +544,7 @@ pub async fn start_beefy_gadget<B, BE, C, N, P, R, S>(
 		known_peers,
 		prometheus_registry.clone(),
 	);
-	let mut beefy_comms = BeefyComms {
-		gossip_engine,
-		gossip_validator,
-		gossip_report_stream,
-		on_demand_justifications,
-	};
+	let mut beefy_comms = BeefyComms { gossip_engine, gossip_validator, on_demand_justifications };
 
 	// We re-create and re-run the worker in this loop in order to quickly reinit and resume after
 	// select recoverable errors.
@@ -576,10 +569,6 @@ pub async fn start_beefy_gadget<B, BE, C, N, P, R, S>(
 							return
 						},
 					}
-				},
-				// Pump peer reports
-				_ = &mut beefy_comms.gossip_report_stream.next() => {
-					continue
 				},
 				// Pump gossip engine.
 				_ = &mut beefy_comms.gossip_engine => {

--- a/substrate/client/consensus/beefy/src/tests.rs
+++ b/substrate/client/consensus/beefy/src/tests.rs
@@ -23,8 +23,9 @@ use crate::{
 	beefy_block_import_and_links,
 	communication::{
 		gossip::{
-			proofs_topic, tests::sign_commitment, votes_topic, GossipFilterCfg, GossipMessage,
-			GossipValidator,
+			proofs_topic,
+			tests::{sign_commitment, TestNetwork},
+			votes_topic, GossipFilterCfg, GossipMessage, GossipValidator,
 		},
 		request_response::{on_demand_justifications_protocol_config, BeefyJustifsRequestHandler},
 	},
@@ -1450,7 +1451,7 @@ async fn gossipped_finality_proofs() {
 	let charlie = &mut net.peers[2];
 	let known_peers = Arc::new(Mutex::new(KnownPeers::<Block>::new()));
 	// Charlie will run just the gossip engine and not the full voter.
-	let (gossip_validator, _) = GossipValidator::new(known_peers);
+	let gossip_validator = GossipValidator::new(known_peers, Arc::new(TestNetwork::new().0));
 	let charlie_gossip_validator = Arc::new(gossip_validator);
 	charlie_gossip_validator.update_filter(GossipFilterCfg::<Block> {
 		start: 1,


### PR DESCRIPTION
The stream was just used to communicate from the validator the peer reports back to the gossip engine. Internally the gossip engine just forwards these reports to the networking engine. So, we can just do this directly.

The reporting stream was also pumped [in the worker behind the engine](https://github.com/paritytech/polkadot-sdk/blob/9d6261892814fa27c97881c0321c008d7340b54b/substrate/client/consensus/beefy/src/worker.rs#L939). This means if there was a lot of data incoming over the engine, the reporting stream was almost never processed and thus, it could have started to grow and we have seen issues around this.

Partly Closes: https://github.com/paritytech/polkadot-sdk/issues/3945