### PR TITLE
adder-collator: add velocity measurement and make elastic scaling test more robust

### DIFF
--- a/polkadot/zombienet_tests/elastic_scaling/0001-basic-3cores-6s-blocks.zndsl
+++ b/polkadot/zombienet_tests/elastic_scaling/0001-basic-3cores-6s-blocks.zndsl
@@ -14,11 +14,13 @@ elastic-validator-4: reports node_roles is 4
 elastic-validator-0: js-script ./assign-core.js with "2000,0" return is 0 within 600 seconds
 elastic-validator-0: js-script ./assign-core.js with "2000,1" return is 0 within 600 seconds
 
-# Wait for 10 relay chain blocks 
+# Wait for 20 relay chain blocks 
 elastic-validator-0: reports substrate_block_height{status="best"} is at least 20 within 120 seconds
+
+# Non elastic parachain should progress normally
+some-parachain-1: count of log lines containing "BlockData { state: 24, add: 2 }" is 0 within 10 seconds
 
 # Parachain should progress with 3 blocks per relay chain block, so it's reasonable to expect state to be 
 # at least 50, assuming some tolerance 
-some-parachain: log line contains "BlockData { state: 50, add: 2 }" within 10 seconds
-some-parachain-1: count of log lines containing "BlockData { state: 24, add: 2 }" is 0 within 10 seconds
+some-parachain: log line contains "BlockData { state: 50, add: 2 }" within 20 seconds
 

--- a/polkadot/zombienet_tests/elastic_scaling/0001-basic-3cores-6s-blocks.zndsl
+++ b/polkadot/zombienet_tests/elastic_scaling/0001-basic-3cores-6s-blocks.zndsl
@@ -15,12 +15,14 @@ elastic-validator-0: js-script ./assign-core.js with "2000,0" return is 0 within
 elastic-validator-0: js-script ./assign-core.js with "2000,1" return is 0 within 600 seconds
 
 # Wait for 20 relay chain blocks 
-elastic-validator-0: reports substrate_block_height{status="best"} is at least 20 within 120 seconds
+elastic-validator-0: reports substrate_block_height{status="best"} is at least 20 within 600 seconds
 
 # Non elastic parachain should progress normally
-some-parachain-1: count of log lines containing "BlockData { state: 24, add: 2 }" is 0 within 10 seconds
+some-parachain-1: count of log lines containing "Parachain velocity: 1" is at least 9 within 20 seconds
+# Sanity
+some-parachain-1: count of log lines containing "Parachain velocity: 2" is 0 within 20 seconds
 
-# Parachain should progress with 3 blocks per relay chain block, so it's reasonable to expect state to be 
-# at least 50, assuming some tolerance 
-some-parachain: log line contains "BlockData { state: 50, add: 2 }" within 20 seconds
+# Parachain should progress 3 blocks per relay chain block ideally, however this measurement does 
+# `ceil()` on the actual velocity to account for CI overload.
+some-parachain: count of log lines containing "Parachain velocity: 3" is at least 9 within 20 seconds
 


### PR DESCRIPTION
Improves `adder-collator` to also compute the parachain velocity. The velocity is defined as number of parachain blocks progressing per relay chain block. 

In this test we're asserting that the elastic parachain always progresses by 3 blocks per RCB, while the non-elastic parachain progresses normally - 1 block per RCB. 