### PR TITLE
Add best block indicator to informant message + print parent block on import  message

### DIFF
--- a/substrate/client/informant/src/lib.rs
+++ b/substrate/client/informant/src/lib.rs
@@ -187,10 +187,12 @@ where
 				last_blocks.pop_front();
 			}
 
+			let best_indicator = if n.is_new_best { "🌟" } else { "✨" };
 			info!(
 				target: "substrate",
-				"✨ Imported #{} ({})",
+				"{best_indicator} Imported #{} ({} -> {})",
 				format.print_with_color(Colour::White.bold(), n.header.number()),
+				n.header.parent_hash(),
 				n.hash,
 			);
 		}


### PR DESCRIPTION
Sometimes you need to debug some issues just by the logs and reconstruct what happened.
In these scenarios it would be nice to know if a block was imported as best block, and what it parent was.
So here I propose to change the output of the informant to this:

```
2024-04-05 20:38:22.004  INFO ⋮substrate: [Parachain] ✨ Imported #18 (0xe7b3…4555 -> 0xbd6f…ced7)    
2024-04-05 20:38:24.005  INFO ⋮substrate: [Parachain] ✨ Imported #19 (0xbd6f…ced7 -> 0x4dd0…d81f)    
2024-04-05 20:38:24.011  INFO ⋮substrate: [jobless-children-5352] 🌟 Imported #42 (0xed2e…27fc -> 0x718f…f30e)    
2024-04-05 20:38:26.005  INFO ⋮substrate: [Parachain] ✨ Imported #20 (0x4dd0…d81f -> 0x6e85…e2b8)    
2024-04-05 20:38:28.004  INFO ⋮substrate: [Parachain] 🌟 Imported #21 (0x6e85…e2b8 -> 0xad53…2a97)    
2024-04-05 20:38:30.004  INFO ⋮substrate: [Parachain] 🌟 Imported #22 (0xad53…2a97 -> 0xa874…890f)    
```
