### PR TITLE
Look further in `ClaimQueue` during collation generation

### DIFF
--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -419,7 +419,7 @@ async fn distribute_collation<Context>(
 
 	// Determine which core(s) the para collated-on is assigned to.
 	// If it is not scheduled then ignore the message.
-	let (our_cores, num_cores) =
+	let (our_cores, num_cores) =	//TODO: Use claimqueue here?
 		match determine_cores(ctx.sender(), id, candidate_relay_parent, relay_parent_mode).await? {
 			(cores, _num_cores) if cores.is_empty() => {
 				gum::warn!(


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot-sdk/issues/1797

Implementation for https://github.com/paritytech/polkadot-sdk/issues/1797#issuecomment-1991099502

When generating a collation the first two elements from the `ClaimQueue` are examined:
* depth 0 - this is the `ParaId` scheduled next. As suggested in the linked comment we will build a collation for this slot on startup or if our `ParaId` was not scheduled for two (or more) slots. Providing a collation for depth 0 will probably time out on the first try but the collation will be ready for the retry,
* depth 1 - this is the most relevant slot from collation generation point of view. As discussed providing collation for depth 0 is challenging so we also prepare one more collation for the next slot if our `ParaId` is scheduled there.

To keep track of the work done in previous iterations of the `collation-generation` run loop a  `HashSet` is passed to `handle_new_activations`. It persist all work scheduled in the current iteration and is overwritten on the next iteration. I used this instead of a `bool` indicating if this is a first iteration or not (as suggested in the comment) because I want to cover the case when the collator's `ParaId` has not been scheduled for two consecutive `ClaimQueue` slots.

This PR is still work in progress. 

TODOS:
- [ ] Collect feedback on the initial approach
- [ ] Fix compilation errors in unit tests.
- [ ] Write new unit tests.
- [ ] Write end-to-end test.
