### PR TITLE
Run subsystem-benchmark without network latency

### DIFF
--- a/polkadot/node/network/availability-distribution/benches/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/benches/availability-distribution-regression-bench.rs
@@ -31,7 +31,7 @@ use polkadot_subsystem_bench::{
 };
 use std::io::Write;
 
-const BENCH_COUNT: usize = 50;
+const BENCH_COUNT: usize = 5;
 
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
@@ -40,6 +40,8 @@ fn main() -> Result<(), String> {
 	config.n_cores = 10;
 	config.n_validators = 500;
 	config.num_blocks = 3;
+	config.connectivity = 100;
+	config.latency = None;
 	config.generate_pov_sizes();
 	let state = TestState::new(&config);
 

--- a/polkadot/node/network/availability-recovery/benches/availability-recovery-regression-bench.rs
+++ b/polkadot/node/network/availability-recovery/benches/availability-recovery-regression-bench.rs
@@ -32,7 +32,7 @@ use polkadot_subsystem_bench::{
 };
 use std::io::Write;
 
-const BENCH_COUNT: usize = 50;
+const BENCH_COUNT: usize = 5;
 
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
@@ -40,6 +40,8 @@ fn main() -> Result<(), String> {
 	let options = DataAvailabilityReadOptions { fetch_from_backers: true };
 	let mut config = TestConfiguration::default();
 	config.num_blocks = 3;
+	config.connectivity = 100;
+	config.latency = None;
 	config.generate_pov_sizes();
 
 	let state = TestState::new(&config);

--- a/polkadot/node/subsystem-bench/src/lib/network.rs
+++ b/polkadot/node/subsystem-bench/src/lib/network.rs
@@ -474,19 +474,17 @@ impl EmulatedPeer {
 	pub async fn send_message(&mut self, message: NetworkMessage) {
 		self.tx_limiter.reap(message.size()).await;
 
-		if self.latency_ms == 0 {
-			self.to_node.unbounded_send(message).expect("Sending to the node never fails");
-		} else {
-			let to_node = self.to_node.clone();
-			let latency_ms = std::time::Duration::from_millis(self.latency_ms as u64);
+		let to_node = self.to_node.clone();
+		let latency_ms = std::time::Duration::from_millis(self.latency_ms as u64);
 
-			// Emulate RTT latency
-			self.spawn_handle
-				.spawn("peer-latency-emulator", "test-environment", async move {
+		self.spawn_handle
+			.spawn("peer-latency-emulator", "test-environment", async move {
+				// Emulate RTT latency
+				if !latency_ms.is_zero() {
 					tokio::time::sleep(latency_ms).await;
-					to_node.unbounded_send(message).expect("Sending to the node never fails");
-				});
-		}
+				}
+				to_node.unbounded_send(message).expect("Sending to the node never fails");
+			});
 	}
 
 	/// Returns the rx bandwidth limiter.


### PR DESCRIPTION
Implements the idea from https://github.com/paritytech/polkadot-sdk/pull/3899
- Removed latencies
- Number of runs reduced from 50 to 5, according to local runs it's quite enough
- Network message always sends in a spawned task even if latency is zero. Without it, CPU time sometimes spikes. 