### PR TITLE
[ci] Divide subsystem-regression-tests into 2 jobs

### DIFF
--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -70,9 +70,9 @@ publish-subsystem-benchmarks:
     - .kubernetes-env
     - .publish-gh-pages-refs
   needs:
-    - job: subsystem-regression-tests-recovery
+    - job: subsystem-benchmark-availability-recovery
       artifacts: true
-    - job: subsystem-regression-tests-distribution
+    - job: subsystem-benchmark-availability-distribution
       artifacts: true
     - job: publish-rustdoc
       artifacts: false
@@ -111,9 +111,9 @@ trigger_workflow:
   needs:
     - job: publish-subsystem-benchmarks
       artifacts: false
-    - job: subsystem-regression-tests-recovery
+    - job: subsystem-benchmark-availability-recovery
       artifacts: true
-    - job: subsystem-regression-tests-distribution
+    - job: subsystem-benchmark-availability-distribution
       artifacts: true
   script:
     - echo "Triggering workflow"

--- a/.gitlab/pipeline/publish.yml
+++ b/.gitlab/pipeline/publish.yml
@@ -70,7 +70,9 @@ publish-subsystem-benchmarks:
     - .kubernetes-env
     - .publish-gh-pages-refs
   needs:
-    - job: subsystem-regression-tests
+    - job: subsystem-regression-tests-recovery
+      artifacts: true
+    - job: subsystem-regression-tests-distribution
       artifacts: true
     - job: publish-rustdoc
       artifacts: false
@@ -109,7 +111,9 @@ trigger_workflow:
   needs:
     - job: publish-subsystem-benchmarks
       artifacts: false
-    - job: subsystem-regression-tests
+    - job: subsystem-regression-tests-recovery
+      artifacts: true
+    - job: subsystem-regression-tests-distribution
       artifacts: true
   script:
     - echo "Triggering workflow"

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -511,12 +511,12 @@ test-syscalls:
       fi
   allow_failure: false # this rarely triggers in practice
 
-subsystem-regression-tests:
+subsystem-regression-tests-recovery:
   stage: test
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     when: always
-    expire_in: 1 days
+    expire_in: 1 hour
     paths:
       - charts/
   extends:
@@ -525,6 +525,23 @@ subsystem-regression-tests:
     - .run-immediately
   script:
     - cargo bench --profile=testnet -p polkadot-availability-recovery --bench availability-recovery-regression-bench --features subsystem-benchmarks
+  tags:
+    - benchmark
+  allow_failure: true
+
+subsystem-regression-tests-distribution:
+  stage: test
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    when: always
+    expire_in: 1 hour
+    paths:
+      - charts/
+  extends:
+    - .docker-env
+    - .common-refs
+    - .run-immediately
+  script:
     - cargo bench --profile=testnet -p polkadot-availability-distribution --bench availability-distribution-regression-bench --features subsystem-benchmarks
   tags:
     - benchmark

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -511,7 +511,7 @@ test-syscalls:
       fi
   allow_failure: false # this rarely triggers in practice
 
-subsystem-regression-tests-recovery:
+subsystem-benchmark-availability-recovery:
   stage: test
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
@@ -529,7 +529,7 @@ subsystem-regression-tests-recovery:
     - benchmark
   allow_failure: true
 
-subsystem-regression-tests-distribution:
+subsystem-benchmark-availability-distribution:
   stage: test
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"


### PR DESCRIPTION
Currently `subsystem-regression-tests` job fails if the first benchmarks fail and there is no result for the second benchmark.  Also dividing the job makes the pipeline faster (currently it's a longest job)

cc https://github.com/paritytech/ci_cd/issues/969
cc @AndreiEres 