### PR TITLE
define block hash provider and default impl using frame_system

### DIFF
--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1190,6 +1190,7 @@ impl pallet_mmr::Config for Runtime {
 	type OnNewRoot = pallet_beefy_mmr::DepositBeefyDigest<Runtime>;
 	type WeightInfo = ();
 	type LeafData = pallet_beefy_mmr::Pallet<Runtime>;
+	type BlockHashProvider = pallet_mmr::DefaultBlockHashProvider<Runtime>;
 }
 
 parameter_types! {

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -333,6 +333,7 @@ impl pallet_mmr::Config for Runtime {
 	type OnNewRoot = pallet_beefy_mmr::DepositBeefyDigest<Runtime>;
 	type WeightInfo = ();
 	type LeafData = pallet_beefy_mmr::Pallet<Runtime>;
+	type BlockHashProvider = pallet_mmr::DefaultBlockHashProvider<Runtime>;
 }
 
 /// MMR helper types.

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1602,6 +1602,7 @@ impl pallet_mmr::Config for Runtime {
 	type Hashing = Keccak256;
 	type LeafData = pallet_mmr::ParentNumberAndHash<Self>;
 	type OnNewRoot = pallet_beefy_mmr::DepositBeefyDigest<Runtime>;
+	type BlockHashProvider = pallet_mmr::DefaultBlockHashProvider<Runtime>;
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/beefy-mmr/src/mock.rs
+++ b/substrate/frame/beefy-mmr/src/mock.rs
@@ -90,6 +90,8 @@ impl pallet_mmr::Config for Test {
 
 	type OnNewRoot = pallet_beefy_mmr::DepositBeefyDigest<Test>;
 
+	type BlockHashProvider = pallet_mmr::DefaultBlockHashProvider<Test>;
+
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/merkle-mountain-range/src/lib.rs
+++ b/substrate/frame/merkle-mountain-range/src/lib.rs
@@ -103,6 +103,22 @@ impl<T: frame_system::Config> LeafDataProvider for ParentNumberAndHash<T> {
 	}
 }
 
+/// Block hash provider for a given block number.
+pub trait BlockHashProvider<BlockNumber, BlockHash>{
+	fn block_hash_for(block_number: BlockNumber) -> BlockHash;
+}
+
+/// Default implementation of BlockHashProvider using frame_system.
+pub struct DefaultBlockHashProvider<T: frame_system::Config>{
+	_phantom: sp_std::marker::PhantomData<T>,
+}
+
+impl<T: frame_system::Config> BlockHashProvider<BlockNumberFor<T>, T::Hash> for DefaultBlockHashProvider<T> {
+	fn block_hash_for(block_number: BlockNumberFor<T>) -> T::Hash {
+		frame_system::Pallet::<T>::block_hash(block_number)
+	}
+}
+
 pub trait WeightInfo {
 	fn on_initialize(peaks: NodeIndex) -> Weight;
 }
@@ -176,6 +192,9 @@ pub mod pallet {
 		/// digest (see [`frame_system::Pallet::deposit_log`]) to make it available for Light
 		/// Clients. Hook complexity should be `O(1)`.
 		type OnNewRoot: primitives::OnNewRoot<HashOf<Self, I>>;
+
+		/// Block hash provider for a given block number.
+		type BlockHashProvider: BlockHashProvider<BlockNumberFor<Self>, <Self as frame_system::Config>::Hash>;
 
 		/// Weights for this pallet.
 		type WeightInfo: WeightInfo;

--- a/substrate/frame/merkle-mountain-range/src/lib.rs
+++ b/substrate/frame/merkle-mountain-range/src/lib.rs
@@ -105,7 +105,7 @@ impl<T: frame_system::Config> LeafDataProvider for ParentNumberAndHash<T> {
 
 /// Block hash provider for a given block number.
 pub trait BlockHashProvider<BlockNumber, BlockHash> {
-	fn block_hash_for(block_number: BlockNumber) -> BlockHash;
+	fn block_hash(block_number: BlockNumber) -> BlockHash;
 }
 
 /// Default implementation of BlockHashProvider using frame_system.
@@ -116,7 +116,7 @@ pub struct DefaultBlockHashProvider<T: frame_system::Config> {
 impl<T: frame_system::Config> BlockHashProvider<BlockNumberFor<T>, T::Hash>
 	for DefaultBlockHashProvider<T>
 {
-	fn block_hash_for(block_number: BlockNumberFor<T>) -> T::Hash {
+	fn block_hash(block_number: BlockNumberFor<T>) -> T::Hash {
 		frame_system::Pallet::<T>::block_hash(block_number)
 	}
 }

--- a/substrate/frame/merkle-mountain-range/src/lib.rs
+++ b/substrate/frame/merkle-mountain-range/src/lib.rs
@@ -104,16 +104,18 @@ impl<T: frame_system::Config> LeafDataProvider for ParentNumberAndHash<T> {
 }
 
 /// Block hash provider for a given block number.
-pub trait BlockHashProvider<BlockNumber, BlockHash>{
+pub trait BlockHashProvider<BlockNumber, BlockHash> {
 	fn block_hash_for(block_number: BlockNumber) -> BlockHash;
 }
 
 /// Default implementation of BlockHashProvider using frame_system.
-pub struct DefaultBlockHashProvider<T: frame_system::Config>{
+pub struct DefaultBlockHashProvider<T: frame_system::Config> {
 	_phantom: sp_std::marker::PhantomData<T>,
 }
 
-impl<T: frame_system::Config> BlockHashProvider<BlockNumberFor<T>, T::Hash> for DefaultBlockHashProvider<T> {
+impl<T: frame_system::Config> BlockHashProvider<BlockNumberFor<T>, T::Hash>
+	for DefaultBlockHashProvider<T>
+{
 	fn block_hash_for(block_number: BlockNumberFor<T>) -> T::Hash {
 		frame_system::Pallet::<T>::block_hash(block_number)
 	}
@@ -194,7 +196,10 @@ pub mod pallet {
 		type OnNewRoot: primitives::OnNewRoot<HashOf<Self, I>>;
 
 		/// Block hash provider for a given block number.
-		type BlockHashProvider: BlockHashProvider<BlockNumberFor<Self>, <Self as frame_system::Config>::Hash>;
+		type BlockHashProvider: BlockHashProvider<
+			BlockNumberFor<Self>,
+			<Self as frame_system::Config>::Hash,
+		>;
 
 		/// Weights for this pallet.
 		type WeightInfo: WeightInfo;

--- a/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -29,7 +29,7 @@ use sp_std::prelude::*;
 use crate::{
 	mmr::{Node, NodeOf},
 	primitives::{self, NodeIndex},
-	Config, Nodes, NumberOfLeaves, Pallet, BlockHashProvider
+	BlockHashProvider, Config, Nodes, NumberOfLeaves, Pallet,
 };
 
 /// A marker type for runtime-specific storage implementation.

--- a/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -87,7 +87,7 @@ where
 		// Fall through to searching node using fork-specific key.
 		let ancestor_parent_block_num =
 			Pallet::<T, I>::leaf_index_to_parent_block_num(ancestor_leaf_idx, leaves);
-		let ancestor_parent_hash = T::BlockHashProvider::block_hash_for(ancestor_parent_block_num);
+		let ancestor_parent_hash = T::BlockHashProvider::block_hash(ancestor_parent_block_num);
 		let temp_key = Pallet::<T, I>::node_temp_offchain_key(pos, ancestor_parent_hash);
 		debug!(
 			target: "runtime::mmr::offchain",

--- a/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
+++ b/substrate/frame/merkle-mountain-range/src/mmr/storage.rs
@@ -29,7 +29,7 @@ use sp_std::prelude::*;
 use crate::{
 	mmr::{Node, NodeOf},
 	primitives::{self, NodeIndex},
-	Config, Nodes, NumberOfLeaves, Pallet,
+	Config, Nodes, NumberOfLeaves, Pallet, BlockHashProvider
 };
 
 /// A marker type for runtime-specific storage implementation.
@@ -87,7 +87,7 @@ where
 		// Fall through to searching node using fork-specific key.
 		let ancestor_parent_block_num =
 			Pallet::<T, I>::leaf_index_to_parent_block_num(ancestor_leaf_idx, leaves);
-		let ancestor_parent_hash = <frame_system::Pallet<T>>::block_hash(ancestor_parent_block_num);
+		let ancestor_parent_hash = T::BlockHashProvider::block_hash_for(ancestor_parent_block_num);
 		let temp_key = Pallet::<T, I>::node_temp_offchain_key(pos, ancestor_parent_hash);
 		debug!(
 			target: "runtime::mmr::offchain",

--- a/substrate/frame/merkle-mountain-range/src/mock.rs
+++ b/substrate/frame/merkle-mountain-range/src/mock.rs
@@ -44,6 +44,7 @@ impl Config for Test {
 	type Hashing = Keccak256;
 	type LeafData = Compact<Keccak256, (ParentNumberAndHash<Test>, LeafData)>;
 	type OnNewRoot = ();
+	type BlockHashProvider = DefaultBlockHashProvider<Test>;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
This PR introduces `BlockHashProvider` into `pallet_mmr::Config`
This type is used to get `block_hash` for a given `block_number` rather than directly using `frame_system::Pallet::block_hash`

The `DefaultBlockHashProvider` uses `frame_system::Pallet::block_hash` to get the `block_hash`

Closes: #4062