### PR TITLE
sp-api: Use macro to detect if `frame-metadata` is enabled

### DIFF
--- a/substrate/primitives/api/Cargo.toml
+++ b/substrate/primitives/api/Cargo.toml
@@ -68,4 +68,4 @@ std = [
 disable-logging = ["log/max_level_off"]
 # Do not report the documentation in the metadata.
 no-metadata-docs = ["sp-api-proc-macro/no-metadata-docs"]
-frame-metadata = ["sp-api-proc-macro/frame-metadata", "sp-metadata-ir"]
+frame-metadata = ["sp-metadata-ir"]

--- a/substrate/primitives/api/proc-macro/Cargo.toml
+++ b/substrate/primitives/api/proc-macro/Cargo.toml
@@ -35,4 +35,3 @@ assert_matches = "1.3.0"
 default = ["std"]
 std = ["blake2/std"]
 no-metadata-docs = []
-frame-metadata = []

--- a/substrate/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -193,10 +193,7 @@ fn generate_runtime_decls(decls: &[ItemTrait]) -> Result<TokenStream> {
 			get_api_version(&found_attributes).map(|v| generate_runtime_api_version(v as u32))?;
 		let id = generate_runtime_api_id(&decl.ident.to_string());
 
-		#[cfg(feature = "frame-metadata")]
 		let metadata = crate::runtime_metadata::generate_decl_runtime_metadata(&decl);
-		#[cfg(not(feature = "frame-metadata"))]
-		let metadata = quote!();
 
 		let trait_api_version = get_api_version(&found_attributes)?;
 

--- a/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -821,10 +821,7 @@ fn impl_runtime_apis_impl_inner(api_impls: &[ItemImpl]) -> Result<TokenStream> {
 	let wasm_interface = generate_wasm_interface(api_impls)?;
 	let api_impls_for_runtime_api = generate_api_impl_for_runtime_api(api_impls)?;
 
-	#[cfg(feature = "frame-metadata")]
 	let runtime_metadata = crate::runtime_metadata::generate_impl_runtime_metadata(api_impls)?;
-	#[cfg(not(feature = "frame-metadata"))]
-	let runtime_metadata = quote!();
 
 	let impl_ = quote!(
 		#base_runtime_api

--- a/substrate/primitives/api/proc-macro/src/lib.rs
+++ b/substrate/primitives/api/proc-macro/src/lib.rs
@@ -25,7 +25,6 @@ mod common;
 mod decl_runtime_apis;
 mod impl_runtime_apis;
 mod mock_impl_runtime_apis;
-#[cfg(feature = "frame-metadata")]
 mod runtime_metadata;
 mod utils;
 

--- a/substrate/primitives/api/proc-macro/src/runtime_metadata.rs
+++ b/substrate/primitives/api/proc-macro/src/runtime_metadata.rs
@@ -164,15 +164,17 @@ pub fn generate_decl_runtime_metadata(decl: &ItemTrait) -> TokenStream2 {
 	let (impl_generics, _, where_clause) = generics.split_for_impl();
 
 	quote!(
-		#( #attrs )*
-		#[inline(always)]
-		pub fn runtime_metadata #impl_generics () -> #crate_::metadata_ir::RuntimeApiMetadataIR
-		#where_clause
-		{
-			#crate_::metadata_ir::RuntimeApiMetadataIR {
-				name: #trait_name,
-				methods: #crate_::vec![ #( #methods, )* ],
-				docs: #docs,
+		#crate_::frame_metadata_enabled! {
+			#( #attrs )*
+			#[inline(always)]
+			pub fn runtime_metadata #impl_generics () -> #crate_::metadata_ir::RuntimeApiMetadataIR
+				#where_clause
+			{
+				#crate_::metadata_ir::RuntimeApiMetadataIR {
+					name: #trait_name,
+					methods: #crate_::vec![ #( #methods, )* ],
+					docs: #docs,
+				}
 			}
 		}
 	)
@@ -255,14 +257,16 @@ pub fn generate_impl_runtime_metadata(impls: &[ItemImpl]) -> Result<TokenStream2
 	// `construct_runtime!` is called.
 
 	Ok(quote!(
-		#[doc(hidden)]
-		trait InternalImplRuntimeApis {
-			#[inline(always)]
-			fn runtime_metadata(&self) -> #crate_::vec::Vec<#crate_::metadata_ir::RuntimeApiMetadataIR> {
-				#crate_::vec![ #( #metadata, )* ]
+		#crate_::frame_metadata_enabled! {
+			#[doc(hidden)]
+			trait InternalImplRuntimeApis {
+				#[inline(always)]
+				fn runtime_metadata(&self) -> #crate_::vec::Vec<#crate_::metadata_ir::RuntimeApiMetadataIR> {
+					#crate_::vec![ #( #metadata, )* ]
+				}
 			}
+			#[doc(hidden)]
+			impl InternalImplRuntimeApis for #runtime_name {}
 		}
-		#[doc(hidden)]
-		impl InternalImplRuntimeApis for #runtime_name {}
 	))
 }

--- a/substrate/primitives/api/proc-macro/src/utils.rs
+++ b/substrate/primitives/api/proc-macro/src/utils.rs
@@ -261,7 +261,6 @@ pub fn versioned_trait_name(trait_ident: &Ident, version: u64) -> Ident {
 }
 
 /// Extract the documentation from the provided attributes.
-#[cfg(feature = "frame-metadata")]
 pub fn get_doc_literals(attrs: &[syn::Attribute]) -> Vec<syn::Lit> {
 	use quote::ToTokens;
 	attrs
@@ -277,7 +276,6 @@ pub fn get_doc_literals(attrs: &[syn::Attribute]) -> Vec<syn::Lit> {
 }
 
 /// Filters all attributes except the cfg ones.
-#[cfg(feature = "frame-metadata")]
 pub fn filter_cfg_attributes(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
 	attrs.iter().filter(|a| a.path().is_ident("cfg")).cloned().collect()
 }

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -838,3 +838,4 @@ decl_runtime_apis! {
 
 sp_core::generate_feature_enabled_macro!(std_enabled, feature = "std", $);
 sp_core::generate_feature_enabled_macro!(std_disabled, not(feature = "std"), $);
+sp_core::generate_feature_enabled_macro!(frame_metadata_enabled, feature = "frame-metadata", $);


### PR DESCRIPTION
While `sp-api-proc-macro` isn't used directly and thus, it should have the same features enabled as `sp-api`. However, I have seen issues around `frame-metadata` not being enabled for `sp-api`, but for `sp-api-proc-macro`. This can be prevented by using the `frame_metadata_enabled` macro from `sp-api` that ensures we have the same feature set between both crates.