### PR TITLE
pallet assets: Fix errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9571,7 +9571,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "29.0.0"
+version = "29.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/prdoc/pr_4118.prdoc
+++ b/prdoc/pr_4118.prdoc
@@ -1,4 +1,4 @@
-title: pallet assets: minor improvement on errors returned for some calls
+title: "pallet assets: minor improvement on errors returned for some calls"
 
 doc:
   - audience: Runtime Dev

--- a/prdoc/pr_4118.prdoc
+++ b/prdoc/pr_4118.prdoc
@@ -4,6 +4,9 @@ doc:
   - audience: Runtime Dev
     description: |
       Some calls in pallet assets have better errors. No new error is introduced, only more sensible choice are made.
+  - audience: Runtime User
+    description: |
+      Some calls in pallet assets have better errors. No new error is introduced, only more sensible choice are made.
 
 crates:
   - name: pallet-assets

--- a/prdoc/pr_4118.prdoc
+++ b/prdoc/pr_4118.prdoc
@@ -1,0 +1,10 @@
+title: pallet assets: minor improvement on errors returned for some calls
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Some calls in pallet assets have better errors. No new error is introduced, only more sensible choice are made.
+
+crates:
+  - name: pallet-assets
+    bump: minor

--- a/substrate/frame/assets/Cargo.toml
+++ b/substrate/frame/assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-assets"
-version = "29.0.0"
+version = "29.1.0"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"

--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -491,7 +491,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 		ensure!(
 			d.status == AssetStatus::Live || d.status == AssetStatus::Frozen,
-			Error::<T, I>::AssetNotLive
+			Error::<T, I>::IncorrectStatus
 		);
 
 		let actual = Self::decrease_balance(id.clone(), target, amount, f, |actual, details| {

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -1113,7 +1113,7 @@ pub mod pallet {
 
 			Asset::<T, I>::try_mutate(id.clone(), |maybe_details| {
 				let details = maybe_details.as_mut().ok_or(Error::<T, I>::Unknown)?;
-				ensure!(details.status == AssetStatus::Live, Error::<T, I>::LiveAsset);
+				ensure!(details.status == AssetStatus::Live, Error::<T, I>::AssetNotLive);
 				ensure!(origin == details.owner, Error::<T, I>::NoPermission);
 				if details.owner == owner {
 					return Ok(())

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -987,7 +987,7 @@ pub mod pallet {
 			let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(
 				d.status == AssetStatus::Live || d.status == AssetStatus::Frozen,
-				Error::<T, I>::AssetNotLive
+				Error::<T, I>::IncorrectStatus
 			);
 			ensure!(origin == d.freezer, Error::<T, I>::NoPermission);
 			let who = T::Lookup::lookup(who)?;
@@ -1024,7 +1024,7 @@ pub mod pallet {
 			let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(
 				details.status == AssetStatus::Live || details.status == AssetStatus::Frozen,
-				Error::<T, I>::AssetNotLive
+				Error::<T, I>::IncorrectStatus
 			);
 			ensure!(origin == details.admin, Error::<T, I>::NoPermission);
 			let who = T::Lookup::lookup(who)?;
@@ -1669,7 +1669,7 @@ pub mod pallet {
 			let d = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
 			ensure!(
 				d.status == AssetStatus::Live || d.status == AssetStatus::Frozen,
-				Error::<T, I>::AssetNotLive
+				Error::<T, I>::IncorrectStatus
 			);
 			ensure!(origin == d.freezer, Error::<T, I>::NoPermission);
 			let who = T::Lookup::lookup(who)?;


### PR DESCRIPTION
`LiveAsset` is an error to be returned when an asset is not supposed to be live.
And `AssetNotLive` is an error to be returned when an asset is supposed to be live, I don't think frozen qualifies as live.