### PR TITLE
Update review-trigger.yml

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -32,6 +32,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           github.event.action == 'synchronize' && 
           github.event.sender.login == github.event.pull_request.user.login && 
+          github.event.pull_request.author_association != 'CONTRIBUTOR' && 
           github.event.pull_request.author_association != 'MEMBER'
         run: |
           # We get the list of reviewers who approved the PR


### PR DESCRIPTION
Followup after https://github.com/paritytech/polkadot-sdk/pull/3431
Per https://stackoverflow.com/questions/63188674/github-actions-detect-author-association and https://michaelheap.com/github-actions-check-permission/
looks like just checking NOT a MEMBER is not correct, Not a CONTRIBUTORs check should be included