### PR TITLE
On keys deregistered hook

### DIFF
--- a/substrate/frame/session/src/lib.rs
+++ b/substrate/frame/session/src/lib.rs
@@ -143,13 +143,17 @@ pub use weights::WeightInfo;
 
 /// Decides whether the session should be ended.
 pub trait ShouldEndSession<BlockNumber> {
-	/// Return `true` if the session should be ended.
+	// Return `true` if the session should be ended.
 	fn should_end_session(now: BlockNumber) -> bool;
 }
 
 /// Hook to be applied when an account deregisters keys
 pub trait OnKeysDeregistered<AccountId> {
 	fn on_keys_deregisterd(account: AccountId);
+}
+
+impl<AccountId> OnKeysDeregistered<AccountId> for () {
+	fn on_keys_deregisterd(_account: AccountId) {}
 }
 
 /// Ends the session after a fixed period of blocks.

--- a/substrate/frame/session/src/lib.rs
+++ b/substrate/frame/session/src/lib.rs
@@ -143,7 +143,7 @@ pub use weights::WeightInfo;
 
 /// Decides whether the session should be ended.
 pub trait ShouldEndSession<BlockNumber> {
-	// Return `true` if the session should be ended.
+	/// Return `true` if the session should be ended.
 	fn should_end_session(now: BlockNumber) -> bool;
 }
 

--- a/substrate/frame/session/src/lib.rs
+++ b/substrate/frame/session/src/lib.rs
@@ -666,7 +666,7 @@ impl<T: Config> Pallet<T> {
 			let mut now_session_keys = session_keys.iter();
 			let mut check_next_changed = |keys: &T::Keys| {
 				if changed {
-					return;
+					return
 				}
 				// since a new validator set always leads to `changed` starting
 				// as true, we can ensure that `now_session_keys` and `next_validators`
@@ -702,14 +702,14 @@ impl<T: Config> Pallet<T> {
 	/// Disable the validator of index `i`, returns `false` if the validator was already disabled.
 	pub fn disable_index(i: u32) -> bool {
 		if i >= Validators::<T>::decode_len().unwrap_or(0) as u32 {
-			return false;
+			return false
 		}
 
 		<DisabledValidators<T>>::mutate(|disabled| {
 			if let Err(index) = disabled.binary_search(&i) {
 				disabled.insert(index, i);
 				T::SessionHandler::on_disabled(i);
-				return true;
+				return true
 			}
 
 			false
@@ -824,7 +824,7 @@ impl<T: Config> Pallet<T> {
 
 			if let Some(old) = old_keys.as_ref().map(|k| k.get_raw(*id)) {
 				if key == old {
-					continue;
+					continue
 				}
 
 				Self::clear_key_owner(*id, old);


### PR DESCRIPTION
Just initial draft on the idea of having a hook that is applied after session-keys are purged. This would allow to wire it with, e.g., pallet-invulnerables to immediately remove the invulnerable whose keys have been purged.

I want to capture initial opinions before I move on with this PR 