### PR TITLE
txBroadcast: Stabilize to version 1

### DIFF
--- a/substrate/client/rpc-spec-v2/src/transaction/api.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/api.rs
@@ -47,7 +47,7 @@ pub trait TransactionBroadcastApi {
 	/// # Unstable
 	///
 	/// This method is unstable and subject to change in the future.
-	#[method(name = "transaction_unstable_broadcast")]
+	#[method(name = "transaction_v1_broadcast")]
 	fn broadcast(&self, bytes: Bytes) -> RpcResult<Option<String>>;
 
 	/// Broadcast an extrinsic to the chain.
@@ -55,6 +55,6 @@ pub trait TransactionBroadcastApi {
 	/// # Unstable
 	///
 	/// This method is unstable and subject to change in the future.
-	#[method(name = "transaction_unstable_stop")]
+	#[method(name = "transaction_v1_stop")]
 	fn stop_broadcast(&self, operation_id: String) -> Result<(), ErrorBroadcast>;
 }


### PR DESCRIPTION
This PR stabilizes the txBroadcast API to version 1.

Ideally needs:
- https://github.com/paritytech/polkadot-sdk/pull/4050
- https://github.com/paritytech/polkadot-sdk/pull/3772

cc @paritytech/subxt-team 