### PR TITLE
txWatch: Stabilize txWatch to version 1

### DIFF
--- a/substrate/client/rpc-spec-v2/src/transaction/api.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/api.rs
@@ -33,8 +33,8 @@ pub trait TransactionApi<Hash: Clone> {
 	///
 	/// This method is unstable and subject to change in the future.
 	#[subscription(
-		name = "transactionWatch_unstable_submitAndWatch" => "transactionWatch_unstable_watchEvent",
-		unsubscribe = "transactionWatch_unstable_unwatch",
+		name = "transactionWatch_v1_submitAndWatch" => "transactionWatch_v1_watchEvent",
+		unsubscribe = "transactionWatch_v1_unwatch",
 		item = TransactionEvent<Hash>,
 	)]
 	fn submit_and_watch(&self, bytes: Bytes);

--- a/substrate/client/rpc-spec-v2/src/transaction/tests/transaction_tests.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/tests/transaction_tests.rs
@@ -38,7 +38,7 @@ async fn tx_invalid_bytes() {
 
 	// This should not rely on the tx pool state.
 	let mut sub = tx_api
-		.subscribe_unbounded("transactionWatch_unstable_submitAndWatch", rpc_params![&"0xdeadbeef"])
+		.subscribe_unbounded("transactionWatch_v1_submitAndWatch", rpc_params![&"0xdeadbeef"])
 		.await
 		.unwrap();
 
@@ -56,7 +56,7 @@ async fn tx_in_finalized() {
 	let xt = hex_string(&uxt.encode());
 
 	let mut sub = tx_api
-		.subscribe_unbounded("transactionWatch_unstable_submitAndWatch", rpc_params![&xt])
+		.subscribe_unbounded("transactionWatch_v1_submitAndWatch", rpc_params![&xt])
 		.await
 		.unwrap();
 
@@ -95,7 +95,7 @@ async fn tx_with_pruned_best_block() {
 	let xt = hex_string(&uxt.encode());
 
 	let mut sub = tx_api
-		.subscribe_unbounded("transactionWatch_unstable_submitAndWatch", rpc_params![&xt])
+		.subscribe_unbounded("transactionWatch_v1_submitAndWatch", rpc_params![&xt])
 		.await
 		.unwrap();
 


### PR DESCRIPTION
This PR stabilizes the txBroadcast API to version 1.

Needs from spec:
- https://github.com/paritytech/json-rpc-interface-spec/pull/153 
- https://github.com/paritytech/json-rpc-interface-spec/pull/154


cc @paritytech/subxt-team 