### PR TITLE
wasm-builder: Make it easier to build a WASM binary

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/build.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/build.rs
@@ -15,11 +15,7 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/build.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/build.rs
@@ -15,11 +15,7 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/build.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/build.rs
@@ -15,11 +15,7 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/build.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/build.rs
@@ -15,11 +15,7 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/build.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/build.rs
@@ -16,9 +16,5 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	WasmBuilder::build_using_defaults();
 }

--- a/cumulus/parachains/runtimes/testing/penpal/build.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/build.rs
@@ -16,11 +16,7 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/build.rs
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/build.rs
@@ -15,11 +15,7 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/test/runtime/build.rs
+++ b/cumulus/test/runtime/build.rs
@@ -18,16 +18,10 @@
 fn main() {
 	use substrate_wasm_builder::WasmBuilder;
 
-	WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build();
+	WasmBuilder::build_using_defaults();
 
-	WasmBuilder::new()
-		.with_current_project()
+	WasmBuilder::init_with_defaults()
 		.enable_feature("increment-spec-version")
-		.import_memory()
 		.set_file_name("wasm_binary_spec_version_incremented.rs")
 		.build();
 }

--- a/polkadot/runtime/rococo/build.rs
+++ b/polkadot/runtime/rococo/build.rs
@@ -16,18 +16,11 @@
 
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.import_memory()
-		.export_heap_base()
-		.build();
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
 		.set_file_name("fast_runtime_binary.rs")
 		.enable_feature("fast-runtime")
-		.import_memory()
-		.export_heap_base()
 		.build();
 }
 

--- a/polkadot/runtime/test-runtime/build.rs
+++ b/polkadot/runtime/test-runtime/build.rs
@@ -17,9 +17,5 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.import_memory()
-		.export_heap_base()
-		.build()
+	WasmBuilder::build_using_defaults();
 }

--- a/polkadot/runtime/westend/build.rs
+++ b/polkadot/runtime/westend/build.rs
@@ -17,9 +17,5 @@
 use substrate_wasm_builder::WasmBuilder;
 
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.import_memory()
-		.export_heap_base()
-		.build()
+	WasmBuilder::build_using_defaults();
 }

--- a/prdoc/pr_4177.prdoc
+++ b/prdoc/pr_4177.prdoc
@@ -1,0 +1,12 @@
+title: "wasm-builder: Make it easier to build a WASM binary"
+
+doc:
+  - audience: Runtime Dev, Node Dev
+    description: |
+      Combines all the recommended calls of the `WasmBuilder` into
+      `build_using_defaults()` or `init_with_defaults()` if more changes are required.
+      Otherwise the interface doesn't change and users can still continue to use
+      the "old" interface.
+
+crates:
+  - name: substrate-wasm-builder

--- a/prdoc/pr_4177.prdoc
+++ b/prdoc/pr_4177.prdoc
@@ -1,7 +1,7 @@
 title: "wasm-builder: Make it easier to build a WASM binary"
 
 doc:
-  - audience: Runtime Dev, Node Dev
+  - audience: [Runtime Dev, Node Dev]
     description: |
       Combines all the recommended calls of the `WasmBuilder` into
       `build_using_defaults()` or `init_with_defaults()` if more changes are required.

--- a/substrate/utils/wasm-builder/src/builder.rs
+++ b/substrate/utils/wasm-builder/src/builder.rs
@@ -120,7 +120,7 @@ impl WasmBuilder {
 	///
 	/// This is the same as calling:
 	/// ```no_run
-	/// WasmBuilder::new()
+	/// substrate_wasm_builder::WasmBuilder::new()
 	///    .with_current_project()
 	///    .import_memory()
 	///    .export_heap_base()
@@ -140,10 +140,10 @@ impl WasmBuilder {
 	///
 	/// This is the same as calling:
 	/// ```no_run
-	/// WasmBuilder::new()
+	/// substrate_wasm_builder::WasmBuilder::new()
 	///    .with_current_project()
 	///    .import_memory()
-	///    .export_heap_base()
+	///    .export_heap_base();
 	/// ```
 	pub fn init_with_defaults() -> Self {
 		WasmBuilder::new().with_current_project().import_memory().export_heap_base()

--- a/substrate/utils/wasm-builder/src/builder.rs
+++ b/substrate/utils/wasm-builder/src/builder.rs
@@ -146,10 +146,7 @@ impl WasmBuilder {
 	///    .export_heap_base()
 	/// ```
 	pub fn init_with_defaults() -> Self {
-		WasmBuilder::new()
-			.with_current_project()
-			.import_memory()
-			.export_heap_base()
+		WasmBuilder::new().with_current_project().import_memory().export_heap_base()
 	}
 
 	/// Enable exporting `__heap_base` as global variable in the WASM binary.

--- a/substrate/utils/wasm-builder/src/builder.rs
+++ b/substrate/utils/wasm-builder/src/builder.rs
@@ -116,6 +116,42 @@ impl WasmBuilder {
 		WasmBuilderSelectProject { _ignore: () }
 	}
 
+	/// Build the WASM binary using the recommended default values.
+	///
+	/// This is the same as calling:
+	/// ```no_run
+	/// WasmBuilder::new()
+	///    .with_current_project()
+	///    .import_memory()
+	///    .export_heap_base()
+	///    .build();
+	/// ```
+	pub fn build_using_defaults() {
+		WasmBuilder::new()
+			.with_current_project()
+			.import_memory()
+			.export_heap_base()
+			.build();
+	}
+
+	/// Init the wasm builder with the recommended default values.
+	///
+	/// In contrast to [`Self::build_using_defaults`] it does not build the WASM binary directly.
+	///
+	/// This is the same as calling:
+	/// ```no_run
+	/// WasmBuilder::new()
+	///    .with_current_project()
+	///    .import_memory()
+	///    .export_heap_base()
+	/// ```
+	pub fn init_with_defaults() -> Self {
+		WasmBuilder::new()
+			.with_current_project()
+			.import_memory()
+			.export_heap_base()
+	}
+
 	/// Enable exporting `__heap_base` as global variable in the WASM binary.
 	///
 	/// This adds `-Clink-arg=--export=__heap_base` to `RUST_FLAGS`.

--- a/substrate/utils/wasm-builder/src/lib.rs
+++ b/substrate/utils/wasm-builder/src/lib.rs
@@ -33,15 +33,9 @@
 //! use substrate_wasm_builder::WasmBuilder;
 //!
 //! fn main() {
-//!     WasmBuilder::new()
-//!         // Tell the builder to build the project (crate) this `build.rs` is part of.
-//!         .with_current_project()
-//!         // Make sure to export the `heap_base` global, this is required by Substrate
-//!         .export_heap_base()
-//!         // Build the Wasm file so that it imports the memory (need to be provided by at instantiation)
-//!         .import_memory()
-//!         // Build it.
-//!         .build()
+//!     // Builds the WASM binary using the recommended defaults.
+//!     // If you need more control, you can call `new` or `init_with_defaults`.
+//!     WasmBuilder::build_using_defaults();
 //! }
 //! ```
 //!

--- a/templates/minimal/runtime/build.rs
+++ b/templates/minimal/runtime/build.rs
@@ -18,10 +18,6 @@
 fn main() {
 	#[cfg(feature = "std")]
 	{
-		substrate_wasm_builder::WasmBuilder::new()
-			.with_current_project()
-			.export_heap_base()
-			.import_memory()
-			.build();
+		substrate_wasm_builder::WasmBuilder::build_using_defaults();
 	}
 }

--- a/templates/parachain/runtime/build.rs
+++ b/templates/parachain/runtime/build.rs
@@ -1,10 +1,6 @@
 #[cfg(feature = "std")]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
 
 /// The wasm builder is deactivated when compiling

--- a/templates/solochain/runtime/build.rs
+++ b/templates/solochain/runtime/build.rs
@@ -1,10 +1,6 @@
 fn main() {
 	#[cfg(feature = "std")]
 	{
-		substrate_wasm_builder::WasmBuilder::new()
-			.with_current_project()
-			.export_heap_base()
-			.import_memory()
-			.build();
+		substrate_wasm_builder::WasmBuilder::build_using_defaults();
 	}
 }


### PR DESCRIPTION
Basically combines all the recommended calls into one `build_using_defaults()` call or `init_with_defaults()` when there are some custom changes required.