### PR TITLE
[ci] Run `test-linux-stable-int` on self-hosted GitHub Runners

### DIFF
--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -1,4 +1,4 @@
-name: test-linux-stable-int
+name: test-github-actions
 
 on:
   pull_request:
@@ -26,3 +26,18 @@ jobs:
         uses: actions/checkout@v4
       - name: script
         run: WASM_BUILD_NO_COLOR=1 time cargo test -p staging-node-cli --release --locked -- --ignored
+  quick-benchmarks:
+    runs-on: arc-runners-polkadot-sdk
+    timeout-minutes: 30
+    container:
+      image: "docker.io/paritytech/ci-unified:bullseye-1.75.0-2024-01-22-v20240109"
+    env:
+      RUSTFLAGS: "-C debug-assertions -D warnings"
+      RUST_BACKTRACE: "full"
+      WASM_BUILD_NO_COLOR: 1
+      WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: script
+        run: time cargo run --locked --release -p staging-node-cli --bin substrate-node --features runtime-benchmarks --quiet -- benchmark pallet --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1 --quiet

--- a/.github/workflows/test-linux-stable-int.yml
+++ b/.github/workflows/test-linux-stable-int.yml
@@ -1,0 +1,28 @@
+name: test-linux-stable-int
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-linux-stable-int:
+    runs-on: arc-runners-polkadot-sdk
+    timeout-minutes: 30
+    container:
+      image: "docker.io/paritytech/ci-unified:bullseye-1.75.0-2024-01-22-v20240109"
+    env:
+      RUSTFLAGS: "-C debug-assertions -D warnings"
+      RUST_BACKTRACE: 1
+      WASM_BUILD_NO_COLOR: 1
+      WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
+      # Ensure we run the UI tests.
+      RUN_UI_TESTS: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: script
+        run: WASM_BUILD_NO_COLOR=1 time cargo test -p staging-node-cli --release --locked -- --ignored


### PR DESCRIPTION
PR adds `test-linux-stable-int` and `quick-benchmarks` as github action jobs. It's a copy of `test-linux-stable-int`  and `quick-benchmarks` from gitlab ci and now it's needed to make a stress test for self-hosted github runners. `test-linux-stable-int`  and `quick-benchmarks` in gitlab are still `Required` whereas this workflow is allowed to fail.

cc https://github.com/paritytech/infrastructure/issues/46