### PR TITLE
FRAME: utility dispatch_as_account call

### DIFF
--- a/bridges/bin/runtime-common/src/mock.rs
+++ b/bridges/bin/runtime-common/src/mock.rs
@@ -154,7 +154,7 @@ impl frame_system::Config for TestRuntime {
 impl pallet_utility::Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = ();
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -429,7 +429,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/pallet_utility.rs
@@ -99,4 +99,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 1_745
 			.saturating_add(Weight::from_parts(6_562_902, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -408,7 +408,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_utility.rs
@@ -98,4 +98,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 3_765
 			.saturating_add(Weight::from_parts(6_028_416, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -490,7 +490,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_utility.rs
@@ -98,4 +98,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 1_601
 			.saturating_add(Weight::from_parts(5_138_293, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -452,7 +452,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/pallet_utility.rs
@@ -99,4 +99,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 1_601
 			.saturating_add(Weight::from_parts(5_138_293, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -250,7 +250,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_utility.rs
@@ -98,4 +98,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 1_395
 			.saturating_add(Weight::from_parts(5_000_971, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -260,7 +260,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -420,7 +420,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/pallet_utility.rs
@@ -99,4 +99,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 1_621
 			.saturating_add(Weight::from_parts(3_312_302, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -420,7 +420,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/pallet_utility.rs
@@ -99,4 +99,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 740
 			.saturating_add(Weight::from_parts(2_800_888, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -388,7 +388,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/pallet_utility.rs
@@ -96,4 +96,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 3_915
 			.saturating_add(Weight::from_parts(4_372_646, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -388,7 +388,7 @@ impl pallet_multisig::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/pallet_utility.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/pallet_utility.rs
@@ -96,4 +96,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 7_605
 			.saturating_add(Weight::from_parts(4_306_193, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -629,7 +629,7 @@ impl pallet_identity::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/rococo/src/weights/pallet_utility.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_utility.rs
@@ -96,4 +96,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 3_924
 			.saturating_add(Weight::from_parts(4_604_529, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -844,7 +844,7 @@ impl pallet_identity::Config for Runtime {
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 

--- a/polkadot/runtime/westend/src/weights/pallet_utility.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_utility.rs
@@ -99,4 +99,13 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 			// Standard Error: 2_817
 			.saturating_add(Weight::from_parts(5_113_539, 0).saturating_mul(c.into()))
 	}
+	// TODO: Should be regenerated. Current weight copied from `dispatch_as` call.
+	fn dispatch_as_account() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 9_255_000 picoseconds.
+		Weight::from_parts(9_683_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
+	}
 }

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -328,7 +328,7 @@ impl pallet_example_mbm::Config for Runtime {}
 impl pallet_utility::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
 }
 

--- a/substrate/frame/contracts/src/tests.rs
+++ b/substrate/frame/contracts/src/tests.rs
@@ -365,7 +365,7 @@ impl pallet_timestamp::Config for Test {
 impl pallet_utility::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/proxy/src/tests.rs
+++ b/substrate/frame/proxy/src/tests.rs
@@ -58,7 +58,7 @@ impl pallet_balances::Config for Test {
 impl pallet_utility::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/safe-mode/src/mock.rs
+++ b/substrate/frame/safe-mode/src/mock.rs
@@ -88,7 +88,7 @@ impl pallet_balances::Config for Test {
 impl pallet_utility::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -79,7 +79,7 @@ impl pallet_balances::Config for Test {
 impl pallet_utility::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/tx-pause/src/mock.rs
+++ b/substrate/frame/tx-pause/src/mock.rs
@@ -86,7 +86,7 @@ impl pallet_balances::Config for Test {
 impl pallet_utility::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
+	type OriginToAccount = ();
 	type WeightInfo = ();
 }
 

--- a/substrate/frame/utility/src/weights.rs
+++ b/substrate/frame/utility/src/weights.rs
@@ -56,6 +56,7 @@ pub trait WeightInfo {
 	fn batch_all(c: u32, ) -> Weight;
 	fn dispatch_as() -> Weight;
 	fn force_batch(c: u32, ) -> Weight;
+	fn dispatch_as_account() -> Weight;
 }
 
 /// Weights for `pallet_utility` using the Substrate node and recommended hardware.
@@ -125,6 +126,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(Weight::from_parts(4_955_816, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 	}
+	// TODO: regenerate weights, copied from `dispatch_as`
+	fn dispatch_as_account() -> Weight {
+		Weight::from_parts(7_452_000, 0)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -192,5 +197,9 @@ impl WeightInfo for () {
 			// Standard Error: 4_988
 			.saturating_add(Weight::from_parts(4_955_816, 0).saturating_mul(c.into()))
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
+	}
+	// TODO: regenerate weights, copied from `dispatch_as`
+	fn dispatch_as_account() -> Weight {
+		Weight::from_parts(7_452_000, 0)
 	}
 }


### PR DESCRIPTION
Introduce `dispatch_as_account` call to utility pallet.

The call useful when calls from the batch needs to be commanded by some pallet's origin (e.g. permissioned schedule call), and the inner call (e.g. transfer) should be dispatched from a sovereign account (as signed).
Real use case: https://github.com/paritytech/polkadot-sdk/pull/2939;

Example:
In the example scheduler schedule operation is permissioned 
``` 
xcm::Transact {
  origin_kind: Xcm / SovereignAccount 
  call: batch_all(
    pallet_scheduler(
      schedule(
        ...
        call: transfer(from: Treasurer, to: Alice, ...)
      )
    ),
  transfer(from: Treasurer, to: Alice, ... )
  )
}
```
Possible Solutions:
1. origin_kind = SovereignAccount && white list `Treasurer` sovereign account for schedule.
2. origin_kind = Xcm && use something like `dispatch_as_account`

I am in favor of (1) solution. But I am keeping this PR for discussions for now.