### PR TITLE
Update subsystem-benchmark params

### DIFF
--- a/polkadot/node/network/availability-distribution/benches/availability-distribution-regression-bench.rs
+++ b/polkadot/node/network/availability-distribution/benches/availability-distribution-regression-bench.rs
@@ -31,7 +31,7 @@ use polkadot_subsystem_bench::{
 };
 use std::io::Write;
 
-const BENCH_COUNT: usize = 5;
+const BENCH_COUNT: usize = 30;
 
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
@@ -40,8 +40,6 @@ fn main() -> Result<(), String> {
 	config.n_cores = 10;
 	config.n_validators = 500;
 	config.num_blocks = 3;
-	config.connectivity = 100;
-	config.latency = None;
 	config.generate_pov_sizes();
 	let state = TestState::new(&config);
 
@@ -79,9 +77,9 @@ fn main() -> Result<(), String> {
 		("Sent to peers", 18480.0, 0.001),
 	]));
 	messages.extend(average_usage.check_cpu_usage(&[
-		("availability-distribution", 0.012, 0.05),
-		("availability-store", 0.153, 0.05),
-		("bitfield-distribution", 0.026, 0.05),
+		("availability-distribution", 0.012, 0.1),
+		("availability-store", 0.153, 0.1),
+		("bitfield-distribution", 0.026, 0.1),
 	]));
 
 	if messages.is_empty() {

--- a/polkadot/node/network/availability-recovery/benches/availability-recovery-regression-bench.rs
+++ b/polkadot/node/network/availability-recovery/benches/availability-recovery-regression-bench.rs
@@ -32,7 +32,7 @@ use polkadot_subsystem_bench::{
 };
 use std::io::Write;
 
-const BENCH_COUNT: usize = 5;
+const BENCH_COUNT: usize = 30;
 
 fn main() -> Result<(), String> {
 	let mut messages = vec![];
@@ -40,8 +40,6 @@ fn main() -> Result<(), String> {
 	let options = DataAvailabilityReadOptions { fetch_from_backers: true };
 	let mut config = TestConfiguration::default();
 	config.num_blocks = 3;
-	config.connectivity = 100;
-	config.latency = None;
 	config.generate_pov_sizes();
 
 	let state = TestState::new(&config);
@@ -76,7 +74,7 @@ fn main() -> Result<(), String> {
 		("Received from peers", 307200.000, 0.001),
 		("Sent to peers", 1.667, 0.001),
 	]));
-	messages.extend(average_usage.check_cpu_usage(&[("availability-recovery", 11.500, 0.05)]));
+	messages.extend(average_usage.check_cpu_usage(&[("availability-recovery", 11.500, 0.10)]));
 
 	if messages.is_empty() {
 		Ok(())


### PR DESCRIPTION
- Returns latency (with it, results are more stable)
- The threshold is weakened
- Increased number of runs