### PR TITLE
fixed GrandpaConsensusLogReader::find_scheduled_change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "29.0.0"
+version = "29.0.2"
 dependencies = [
  "aquamarine",
  "array-bytes 6.1.0",
@@ -9135,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "29.0.0"
+version = "29.0.1"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9311,7 +9311,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10605,7 +10605,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "29.0.0"
+version = "29.0.2"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/bridges/primitives/header-chain/src/lib.rs
+++ b/bridges/primitives/header-chain/src/lib.rs
@@ -32,7 +32,9 @@ use core::{clone::Clone, cmp::Eq, default::Default, fmt::Debug};
 use frame_support::PalletError;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_consensus_grandpa::{AuthorityList, ConsensusLog, SetId, GRANDPA_ENGINE_ID};
+use sp_consensus_grandpa::{
+	AuthorityList, ConsensusLog, ScheduledChange, SetId, GRANDPA_ENGINE_ID,
+};
 use sp_runtime::{traits::Header as HeaderT, Digest, RuntimeDebug};
 use sp_std::{boxed::Box, vec::Vec};
 
@@ -147,24 +149,23 @@ pub struct GrandpaConsensusLogReader<Number>(sp_std::marker::PhantomData<Number>
 
 impl<Number: Codec> GrandpaConsensusLogReader<Number> {
 	/// Find and return scheduled (regular) change digest item.
-	pub fn find_scheduled_change(
-		digest: &Digest,
-	) -> Option<sp_consensus_grandpa::ScheduledChange<Number>> {
+	pub fn find_scheduled_change(digest: &Digest) -> Option<ScheduledChange<Number>> {
+		use sp_runtime::generic::OpaqueDigestItemId;
+		let id = OpaqueDigestItemId::Consensus(&GRANDPA_ENGINE_ID);
+
+		let filter_log = |log: ConsensusLog<Number>| match log {
+			ConsensusLog::ScheduledChange(change) => Some(change),
+			_ => None,
+		};
+
 		// find the first consensus digest with the right ID which converts to
 		// the right kind of consensus log.
-		digest
-			.convert_first(|log| log.consensus_try_to(&GRANDPA_ENGINE_ID))
-			.and_then(|log| match log {
-				ConsensusLog::ScheduledChange(change) => Some(change),
-				_ => None,
-			})
+		digest.convert_first(|l| l.try_to(id).and_then(filter_log))
 	}
 
 	/// Find and return forced change digest item. Or light client can't do anything
 	/// with forced changes, so we can't accept header with the forced change digest.
-	pub fn find_forced_change(
-		digest: &Digest,
-	) -> Option<(Number, sp_consensus_grandpa::ScheduledChange<Number>)> {
+	pub fn find_forced_change(digest: &Digest) -> Option<(Number, ScheduledChange<Number>)> {
 		// find the first consensus digest with the right ID which converts to
 		// the right kind of consensus log.
 		digest
@@ -336,7 +337,7 @@ mod tests {
 	use super::*;
 	use bp_runtime::ChainId;
 	use frame_support::weights::Weight;
-	use sp_runtime::{testing::H256, traits::BlakeTwo256, MultiSignature};
+	use sp_runtime::{testing::H256, traits::BlakeTwo256, DigestItem, MultiSignature};
 
 	struct TestChain;
 
@@ -373,6 +374,37 @@ mod tests {
 		assert!(
 			max_expected_submit_finality_proof_arguments_size::<TestChain>(true, 100) >
 				max_expected_submit_finality_proof_arguments_size::<TestChain>(false, 100),
+		);
+	}
+
+	#[test]
+	fn find_scheduled_change_works() {
+		let scheduled_change = ScheduledChange { next_authorities: vec![], delay: 0 };
+
+		// first
+		let mut digest = Digest::default();
+		digest.push(DigestItem::Consensus(
+			GRANDPA_ENGINE_ID,
+			ConsensusLog::ScheduledChange(scheduled_change.clone()).encode(),
+		));
+		assert_eq!(
+			GrandpaConsensusLogReader::find_scheduled_change(&digest),
+			Some(scheduled_change.clone())
+		);
+
+		// not first
+		let mut digest = Digest::default();
+		digest.push(DigestItem::Consensus(
+			GRANDPA_ENGINE_ID,
+			ConsensusLog::<u64>::OnDisabled(0).encode(),
+		));
+		digest.push(DigestItem::Consensus(
+			GRANDPA_ENGINE_ID,
+			ConsensusLog::ScheduledChange(scheduled_change.clone()).encode(),
+		));
+		assert_eq!(
+			GrandpaConsensusLogReader::find_scheduled_change(&digest),
+			Some(scheduled_change.clone())
 		);
 	}
 }

--- a/prdoc/pr_4209.prdoc
+++ b/prdoc/pr_4209.prdoc
@@ -1,0 +1,14 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fixed GrandpaConsensusLogReader::find_scheduled_change
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      This PR fixes the issue with authorities set change digest item search
+      in the bridges code. The issue happens when there are multiple consensus
+      digest items in the same header digest.
+
+crates:
+ - name: bp-header-chain


### PR DESCRIPTION
We'll need to prepare a hotfix `1.2.2` release for fellowship runtimes
We need to republish `bp-header-chain` with minor version bump. Should I do it here manually or it happens automatically? @Morganamilo 