### PR TITLE
Fix case in type in macro generation

### DIFF
--- a/substrate/frame/support/procedural/src/runtime/expand/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/expand/mod.rs
@@ -244,7 +244,7 @@ fn construct_runtime_final_expansion(
 		// Prevent UncheckedExtrinsic to print unused warning.
 		const _: () = {
 			#[allow(unused)]
-			type __hidden_use_of_unchecked_extrinsic = #unchecked_extrinsic;
+			type __HiddenUseOfUncheckedExtrinsic = #unchecked_extrinsic;
 		};
 
 		#[derive(


### PR DESCRIPTION
Generated type is not camel case this generate some warnings from IDE

label should be R0