### PR TITLE
Fix Stuck Collator Funds

### DIFF
--- a/cumulus/pallets/collator-selection/Cargo.toml
+++ b/cumulus/pallets/collator-selection/Cargo.toml
@@ -27,6 +27,7 @@ sp-staking = { path = "../../../substrate/primitives/staking", default-features 
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }
 pallet-authorship = { path = "../../../substrate/frame/authorship", default-features = false }
+pallet-balances = { path = "../../../substrate/frame/balances", default-features = false }
 pallet-session = { path = "../../../substrate/frame/session", default-features = false }
 
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }
@@ -38,7 +39,6 @@ sp-tracing = { path = "../../../substrate/primitives/tracing" }
 sp-runtime = { path = "../../../substrate/primitives/runtime" }
 pallet-timestamp = { path = "../../../substrate/frame/timestamp" }
 sp-consensus-aura = { path = "../../../substrate/primitives/consensus/aura" }
-pallet-balances = { path = "../../../substrate/frame/balances" }
 pallet-aura = { path = "../../../substrate/frame/aura" }
 
 [features]
@@ -59,6 +59,7 @@ std = [
 	"frame-system/std",
 	"log/std",
 	"pallet-authorship/std",
+	"pallet-balances/std",
 	"pallet-session/std",
 	"rand/std",
 	"scale-info/std",

--- a/cumulus/pallets/collator-selection/src/lib.rs
+++ b/cumulus/pallets/collator-selection/src/lib.rs
@@ -121,7 +121,7 @@ pub mod pallet {
 	use sp_std::vec::Vec;
 
 	/// The in-code storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	type BalanceOf<T> =
 		<<T as Config>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -55,7 +55,7 @@ pub mod v2 {
 	impl<T: Config + pallet_balances::Config> UncheckedOnRuntimeUpgrade for UncheckedMigrationToV2<T> {
 		fn on_runtime_upgrade() -> Weight {
 			let mut weight = Weight::zero();
-			let mut count: u32 = 0;
+			let mut count: u64 = 0;
 			// candidates who exist under the old `Candidates` key
 			let candidates = Candidates::<T>::take();
 
@@ -86,7 +86,7 @@ pub mod v2 {
 					count.saturating_inc();
 				}
 				weight.saturating_accrue(
-					<<T as pallet_balances::Config>::WeightInfo as pallet_balances::WeightInfo>::force_unreserve(),
+					<<T as pallet_balances::Config>::WeightInfo as pallet_balances::WeightInfo>::force_unreserve() * count,
 				);
 			}
 

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -29,6 +29,8 @@ pub mod v2 {
 		traits::{Currency, ReservableCurrency},
 	};
 	use sp_runtime::traits::{Saturating, Zero};
+	#[cfg(feature = "try-runtime")]
+	use sp_std::vec::Vec;
 
 	#[storage_alias]
 	pub type Candidates<T: Config> = StorageValue<

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -81,7 +81,7 @@ pub mod v2 {
 					if err > Zero::zero() {
 						log::info!(
 							target: LOG_TARGET,
-							"{:?} balance was unable to be unreserved from {}",
+							"{:?} balance was unable to be unreserved from {:?}",
 							err, &candidate.who,
 						);
 					}
@@ -222,14 +222,17 @@ mod tests {
 			Balances::make_free_balance_be(&one, 100u64);
 			Balances::make_free_balance_be(&two, 100u64);
 			Balances::make_free_balance_be(&three, 100u64);
+
 			// Reservations: 10 for the "old" candidacy and 10 for the "new"
 			Balances::reserve(&one, 10u64).unwrap(); // old
 			Balances::reserve(&two, 20u64).unwrap(); // old + new
 			Balances::reserve(&three, 10u64).unwrap(); // new
+
 			// Candidate info
 			let candidate_one = CandidateInfo { who: one, deposit };
 			let candidate_two = CandidateInfo { who: two, deposit };
 			let candidate_three = CandidateInfo { who: three, deposit };
+
 			// Storage lists
 			let bounded_candidates =
 				BoundedVec::<CandidateInfo<u64, u64>, ConstU32<20>>::try_from(vec![
@@ -243,9 +246,11 @@ mod tests {
 					candidate_three.clone(),
 				])
 				.expect("it works");
+
 			// Set storage
 			Candidates::<Test>::put(bounded_candidates);
 			CandidateList::<Test>::put(bounded_candidate_list.clone());
+
 			// Sanity check
 			assert_eq!(Balances::free_balance(one), 90);
 			assert_eq!(Balances::free_balance(two), 80);
@@ -281,12 +286,15 @@ mod tests {
 			// Set balance to 100
 			Balances::make_free_balance_be(&one, 100u64);
 			Balances::make_free_balance_be(&two, 100u64);
+
 			// Reservations
 			Balances::reserve(&one, 10u64).unwrap(); // old
 			Balances::reserve(&two, 10u64).unwrap(); // old
+
 			// Candidate info
 			let candidate_one = CandidateInfo { who: one, deposit };
 			let candidate_two = CandidateInfo { who: two, deposit };
+
 			// Storage lists
 			let bounded_candidates =
 				BoundedVec::<CandidateInfo<u64, u64>, ConstU32<20>>::try_from(vec![
@@ -294,8 +302,10 @@ mod tests {
 					candidate_two.clone(),
 				])
 				.expect("it works");
+
 			// Set storage
 			Candidates::<Test>::put(bounded_candidates.clone());
+
 			// Sanity check
 			assert_eq!(Balances::free_balance(one), 90);
 			assert_eq!(Balances::free_balance(two), 90);

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -52,7 +52,7 @@ pub mod v2 {
 
 	/// Migrate to V2.
 	pub struct UncheckedMigrationToV2<T>(sp_std::marker::PhantomData<T>);
-	impl<T: Config> UncheckedOnRuntimeUpgrade for UncheckedMigrationToV2<T> {
+	impl<T: Config + pallet_balances::Config> UncheckedOnRuntimeUpgrade for UncheckedMigrationToV2<T> {
 		fn on_runtime_upgrade() -> Weight {
 			let mut weight = Weight::zero();
 			let mut count: u32 = 0;
@@ -85,11 +85,8 @@ pub mod v2 {
 					}
 					count.saturating_inc();
 				}
-				// conservative benchmarks from `force_unreserve`
 				weight.saturating_accrue(
-					Weight::from_parts(20_000_000, 4_000)
-						.saturating_add(T::DbWeight::get().reads_writes(1, 1))
-						.saturating_mul(count.into()),
+					<<T as pallet_balances::Config>::WeightInfo as pallet_balances::WeightInfo>::force_unreserve(),
 				);
 			}
 

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -20,7 +20,7 @@ use super::*;
 use frame_support::traits::{OnRuntimeUpgrade, UncheckedOnRuntimeUpgrade};
 use log;
 
-/// Migrate to v2. Should have been part of https://github.com/paritytech/polkadot-sdk/pull/1340
+/// Migrate to v2. Should have been part of <https://github.com/paritytech/polkadot-sdk/pull/1340>.
 pub mod v2 {
 	use super::*;
 	use frame_support::{
@@ -51,8 +51,6 @@ pub mod v2 {
 	>;
 
 	/// Migrate to V2.
-	///
-	/// Note: This should have been in https://github.com/paritytech/polkadot-sdk/pull/1340.
 	pub struct UncheckedMigrationToV2<T>(sp_std::marker::PhantomData<T>);
 	impl<T: Config> UncheckedOnRuntimeUpgrade for UncheckedMigrationToV2<T> {
 		fn on_runtime_upgrade() -> Weight {

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -85,9 +85,14 @@ pub mod v2 {
 							err, &candidate.who,
 						);
 					}
-					// weight.saturating_accrue(<T as pallet_balances::Config>::WeightInfo::force_unreserve());
 					count.saturating_inc();
 				}
+				// conservative benchmarks from `force_unreserve`
+				weight.saturating_accrue(
+					Weight::from_parts(20_000_000, 4_000)
+						.saturating_add(T::DbWeight::get().reads_writes(1, 1))
+						.saturating_mul(count.into()),
+				);
 			}
 
 			log::info!(

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -93,7 +93,7 @@ pub mod v2 {
 					count,
 				);
 				// 1 read/write for storage version
-				weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+				weight.saturating_accrue(T::DbWeight::get().reads_writes(3, 2));
 				weight
 			} else {
 				log::info!(

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -77,7 +77,7 @@ pub mod v2 {
 				for candidate in candidates {
 					let err = T::Currency::unreserve(&candidate.who, candidate.deposit);
 					if err > Zero::zero() {
-						log::info!(
+						log::error!(
 							target: LOG_TARGET,
 							"{:?} balance was unable to be unreserved from {:?}",
 							err, &candidate.who,
@@ -86,7 +86,7 @@ pub mod v2 {
 					count.saturating_inc();
 				}
 				weight.saturating_accrue(
-					<<T as pallet_balances::Config>::WeightInfo as pallet_balances::WeightInfo>::force_unreserve() * count,
+					<<T as pallet_balances::Config>::WeightInfo as pallet_balances::WeightInfo>::force_unreserve().saturating_mul(count.into()),
 				);
 			}
 

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -79,14 +79,13 @@ pub mod v2 {
 					// `CandidateList`. So, let's just refund the old ones and assume they have
 					// already started participating in the new system.
 					for candidate in candidates {
-						let _err = T::Currency::unreserve(&candidate.who, candidate.deposit);
+						let _err = T::Currency::unreserve(&candidate.who, candidate.deposit).defensive();
 						count.saturating_inc();
 					}
 					// TODO: set each accrue to weight of `unreserve`
 					weight.saturating_accrue(T::DbWeight::get().reads_writes(0, count as u64));
 				}
 
-				StorageVersion::new(2).put::<Pallet<T>>();
 				log::info!(
 					target: LOG_TARGET,
 					"Unreserved locked bond of {} candidates, upgraded storage to version 2",
@@ -118,8 +117,6 @@ pub mod v2 {
 				"after migration, the candidates map should be empty"
 			);
 
-			let on_chain_version = Pallet::<T>::on_chain_storage_version();
-			frame_support::ensure!(on_chain_version >= 1, "must_upgrade");
 
 			Ok(())
 		}

--- a/cumulus/pallets/collator-selection/src/migration.rs
+++ b/cumulus/pallets/collator-selection/src/migration.rs
@@ -88,6 +88,26 @@ pub mod v2 {
 				T::DbWeight::get().reads(1)
 			}
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
+			let number_of_candidates = Candidates::<T>::get().to_vec().len();
+			Ok((number_of_candidates as u32).encode())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(_number_of_candidates: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+			let new_number_of_candidates = Candidates::<T>::get().to_vec().len();
+			assert_eq!(
+				new_number_of_candidates, 0 as usize,
+				"after migration, the candidates map should be empty"
+			);
+
+			let on_chain_version = Pallet::<T>::on_chain_storage_version();
+			frame_support::ensure!(on_chain_version >= 1, "must_upgrade");
+
+			Ok(())
+		}
 	}
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -973,10 +973,10 @@ pub type UncheckedExtrinsic =
 /// Migrations to apply on runtime upgrade.
 #[allow(deprecated)]
 pub type Migrations = (
-	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
 	InitStorageVersions,
 	// unreleased
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -963,7 +963,7 @@ pub type Migrations = (
 	// v9420
 	pallet_nfts::migration::v1::MigrateToV1<Runtime>,
 	// unreleased
-	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	// unreleased
 	pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
 	// unreleased

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -139,7 +139,7 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
-	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
 	InitStorageVersions,
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -118,7 +118,7 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
-	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
 	InitStorageVersions,
 	// unreleased

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -722,7 +722,7 @@ pub type UncheckedExtrinsic =
 /// `OnRuntimeUpgrade`. Included migrations must be idempotent.
 type Migrations = (
 	// unreleased
-	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	// unreleased
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	// permanent

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -98,6 +98,8 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v2::MigrationToV2<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v3::MigrationToV3<Runtime>,

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -108,6 +108,7 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	pallet_broker::migration::MigrateV0ToV1<Runtime>,
 	// permanent

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -108,6 +108,7 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	pallet_broker::migration::MigrateV0ToV1<Runtime>,
 	// permanent

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -102,6 +102,7 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -102,6 +102,7 @@ pub type UncheckedExtrinsic =
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
+	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );

--- a/prdoc/pr_4229.prdoc
+++ b/prdoc/pr_4229.prdoc
@@ -1,0 +1,10 @@
+title: "Fix Stuck Collator Funds"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Fixes stuck collator funds by providing a migration that should have been in PR 1340.
+
+crates:
+  - name: pallet-collator-selection
+    bump: patch


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/4206

In #1340 one of the storage types was changed from `Candidates` to `CandidateList`. Since the actual key includes the hash of this value, all of the candidates stored here are (a) "missing" and (b) unable to unreserve their candidacy bond.

This migration kills the storage values and refunds the deposit held for each candidate.