### PR TITLE
Add metric for time spent waiting in the execution queue

### DIFF
--- a/polkadot/node/core/pvf/src/execute/queue.rs
+++ b/polkadot/node/core/pvf/src/execute/queue.rs
@@ -562,6 +562,9 @@ fn assign(queue: &mut Queue, worker: Worker, job: ExecuteJob) {
 			thus claim_idle cannot return None;
 			qed.",
 	);
+	queue
+		.metrics
+		.observe_execution_queued_time(job.waiting_since.elapsed().as_millis() as u32);
 	let execution_timer = queue.metrics.time_execution();
 	queue.mux.push(
 		async move {


### PR DESCRIPTION
Add a metric to be able to understand the time jobs are waiting in the execution queue waiting for an available worker.
https://github.com/paritytech/polkadot-sdk/issues/4126