### PR TITLE
Fix `decision` from `UpToLimitDisablingStrategy` 

### DIFF
--- a/polkadot/zombienet_tests/functional/0010-validator-disabling.toml
+++ b/polkadot/zombienet_tests/functional/0010-validator-disabling.toml
@@ -21,7 +21,7 @@ requests = { memory = "2G", cpu = "1" }
   [[relaychain.node_groups]]
   name = "honest-validator"
   count = 3
-  args = ["-lparachain=debug"]
+  args = ["-lparachain=debug,runtime::staking=debug"]
 
   [[relaychain.node_groups]]
   image = "{{MALUS_IMAGE}}"

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -1285,20 +1285,33 @@ impl<T: Config, const DISABLING_LIMIT_FACTOR: usize> DisablingStrategy<T>
 
 		// We don't disable more than the limit
 		if currently_disabled.len() >= Self::disable_limit(active_set.len()) {
+			log!(
+				debug,
+				"Won't disable: reached disabling limit {:?}",
+				Self::disable_limit(active_set.len())
+			);
 			return None
 		}
 
 		// We don't disable for offences in previous eras
-		if Pallet::<T>::current_era().unwrap_or_default() > slash_era {
+		if ActiveEra::<T>::get().map(|e| e.index).unwrap_or_default() > slash_era {
+			log!(
+				debug,
+				"Won't disable: current_era {:?} > slash_era {:?}",
+				Pallet::<T>::current_era().unwrap_or_default(),
+				slash_era
+			);
 			return None
 		}
 
 		let offender_idx = if let Some(idx) = active_set.iter().position(|i| i == offender_stash) {
 			idx as u32
 		} else {
-			// offender not found in the active set, do nothing
+			log!(debug, "Won't disable: offender not in active set",);
 			return None
 		};
+
+		log!(debug, "Will disable {:?}", offender_idx);
 
 		Some(offender_idx)
 	}

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -7958,7 +7958,9 @@ mod ledger_recovery {
 }
 
 mod byzantine_threshold_disabling_strategy {
-	use crate::{tests::Test, CurrentEra, DisablingStrategy, UpToLimitDisablingStrategy};
+	use crate::{
+		tests::Test, ActiveEra, ActiveEraInfo, DisablingStrategy, UpToLimitDisablingStrategy,
+	};
 	use sp_staking::EraIndex;
 
 	// Common test data - the stash of the offending validator, the era of the offence and the
@@ -7973,7 +7975,7 @@ mod byzantine_threshold_disabling_strategy {
 		sp_io::TestExternalities::default().execute_with(|| {
 			let initially_disabled = vec![];
 			pallet_session::Validators::<Test>::put(ACTIVE_SET.to_vec());
-			CurrentEra::<Test>::put(2);
+			ActiveEra::<Test>::put(ActiveEraInfo { index: 2, start: None });
 
 			let disable_offender =
 				<UpToLimitDisablingStrategy as DisablingStrategy<Test>>::decision(


### PR DESCRIPTION
`CurrentEra` in staking pallet is actually the latest planned era. The actual current era is `ActiveEra`.