### PR TITLE
Remove unnecessary cloning

### DIFF
--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -182,7 +182,7 @@ impl From<MultiRemovalResults> for KillStorageResult {
 pub trait Storage {
 	/// Returns the data for `key` in the storage or `None` if the key can not be found.
 	fn get(&self, key: &[u8]) -> Option<bytes::Bytes> {
-		self.storage(key).map(|s| bytes::Bytes::from(s.to_vec()))
+		self.storage(key).map(bytes::Bytes::from)
 	}
 
 	/// Get `key` from storage, placing the value into `value_out` and return the number of


### PR DESCRIPTION
Seems like Externalities already [return a vector](https://github.com/paritytech/polkadot-sdk/blob/ffbce2a817ec2e7c8b7ce49f7ed6794584f19667/substrate/primitives/externalities/src/lib.rs#L86), so calling `to_vec` on a vector just results in an unneeded copying. 