### PR TITLE
Updated review-bot to obtain number from event

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -13,15 +13,15 @@ jobs:
     steps:
       - name: Extract content of artifact
         id: number
-        uses: Bullrich/extract-text-from-artifact@v1.0.0
+        uses: Bullrich/extract-text-from-artifact@v1.0.1
         with:
           artifact-name: pr_number
       - name: Generate token
         id: app_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1.9.3
         with:
-          app_id: ${{ secrets.REVIEW_APP_ID }}
-          private_key: ${{ secrets.REVIEW_APP_KEY }}
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
         uses: paritytech/review-bot@v2.4.0
         with:

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: master
     steps:
-      - name: Extract content of artifact
-        id: number
-        uses: Bullrich/extract-text-from-artifact@v1.0.1
-        with:
-          artifact-name: pr_number
       - name: Generate token
         id: app_token
         uses: actions/create-github-app-token@v1.9.3
@@ -28,5 +23,6 @@ jobs:
           repo-token: ${{ steps.app_token.outputs.token }}
           team-token: ${{ steps.app_token.outputs.token }}
           checks-token: ${{ steps.app_token.outputs.token }}
-          pr-number: ${{ steps.number.outputs.content }}
+          # This is extracted from the triggering event
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           request-reviewers: true

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -45,7 +45,7 @@ jobs:
 
           # We request them to review again
           echo $REVIEWERS | gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers --input -
-          
+
           echo "::error::Project needs to be reviewed again"
           exit 1
         env:
@@ -53,22 +53,8 @@ jobs:
       - name: Comment requirements
         # If the previous step failed and github-actions hasn't commented yet we comment instructions
         if: failure() && !contains(fromJson(steps.comments.outputs.bodies), 'Review required! Latest push from author must always be reviewed')
-        run: |          
+        run: |
           gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "Review required! Latest push from author must always be reviewed"
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENTS: ${{ steps.comments.outputs.users }}
-      - name: Get PR number
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          echo "Saving PR number: $PR_NUMBER"
-          mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v4.3.3
-        name: Save PR number
-        with:
-          name: pr_number
-          path: pr/
-          if-no-files-found: error
-          retention-days: 5

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -65,9 +65,10 @@ jobs:
           echo "Saving PR number: $PR_NUMBER"
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.3
         name: Save PR number
         with:
           name: pr_number
           path: pr/
+          if-no-files-found: error
           retention-days: 5


### PR DESCRIPTION
It seems that `review-trigger` is not uploading the artifact that is used by `review-bot`, so I changed the PR-Number to be obtained by the previous event that triggered this action.

I also took the liberty to replace `tibdex/github-app-token` for `actions/create-github-app-token` which is GitHub's official app.