### PR TITLE
review-bot: reverted #4271 and added `workflow_dispatch`

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           app-id: ${{ secrets.REVIEW_APP_ID }}
           private-key: ${{ secrets.REVIEW_APP_KEY }}
+      - name: Extract content of artifact
+        if: ${{ !inputs.pr-number }}
+        id: number
+        uses: Bullrich/extract-text-from-artifact@v1.0.1
+        with:
+          artifact-name: pr_number
       - name: "Evaluates PR reviews and assigns reviewers"
         uses: paritytech/review-bot@v2.4.0
         with:
@@ -30,7 +36,7 @@ jobs:
           team-token: ${{ steps.app_token.outputs.token }}
           checks-token: ${{ steps.app_token.outputs.token }}
           # This is extracted from the triggering event
-          pr-number: ${{ inputs.pr-number || github.event.workflow_run.pull_requests[0].number }}
+          pr-number: ${{ inputs.pr-number || steps.number.outputs.content }}
           request-reviewers: true
       - name: Log payload
         if: ${{ failure() || runner.debug }}

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -5,6 +5,12 @@ on:
       - Review-Trigger
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "Number of the PR to evaluate"
+        required: true
+        type: number
 
 jobs:
   review-approvals:
@@ -24,5 +30,5 @@ jobs:
           team-token: ${{ steps.app_token.outputs.token }}
           checks-token: ${{ steps.app_token.outputs.token }}
           # This is extracted from the triggering event
-          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr-number: ${{ inputs.pr-number || github.event.workflow_run.pull_requests[0].number }}
           request-reviewers: true

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -32,3 +32,8 @@ jobs:
           # This is extracted from the triggering event
           pr-number: ${{ inputs.pr-number || github.event.workflow_run.pull_requests[0].number }}
           request-reviewers: true
+      - name: Log payload
+        if: ${{ failure() || runner.debug }}
+        run: echo "::debug::$payload"
+        env:
+          payload: ${{ toJson(github.event) }}

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -58,3 +58,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENTS: ${{ steps.comments.outputs.users }}
+      - name: Get PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Saving PR number: $PR_NUMBER"
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v4
+        name: Save PR number
+        with:
+          name: pr_number
+          path: pr/
+          retention-days: 5


### PR DESCRIPTION
This PR includes two changes:
- added `workflow_dispatch` to review bot
- reverted #4271

### Added `workflow_dispatch` to review bot
This allows us, in the case that review-bot fails for some fork reasons, to trigger it manually ensuring that we can overcame the problem with the multiple actions while we look for a solution.

<img width="342" alt="image" src="https://github.com/paritytech/polkadot-sdk/assets/8524599/f432f91b-829a-4da4-b4ca-54cc4fe280c8">

### Reverted #4271
Unfortunately, the changes added in #4271 do not work in forks.

Here is a lengthy discussion of many individuals facing the same problem as me:
- [GitHub Action `pull_request` attribute empty in `workflow_run` event object for PR from forked repo #25220](https://github.com/orgs/community/discussions/25220)

So I had to revert it (but I updated the dependencies to latest).

#### Miscellaneous changes

I added a debug log at the end of review bot in case it fails so we can easily debug it without having to make a lot of boilerplate and forks to duplicate the environment.