### PR TITLE
Feature/asset ops traits

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
@@ -49,11 +49,12 @@ use testnet_parachains_constants::rococo::snowbridge::{
 };
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
-	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain,
-	DenyThenTry, DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, FrameTransactionalProcessor,
+	unique_instances::RecreateableInstanceAdapter, AccountId32Aliases,
+	AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain, DenyThenTry,
+	DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, FrameTransactionalProcessor,
 	FungibleAdapter, FungiblesAdapter, GlobalConsensusParachainConvertsFor, HashedDescription,
-	IsConcrete, LocalMint, NetworkExportTableItem, NoChecking, NonFungiblesAdapter,
+	InstancesOfClasses, IsConcrete, LocalMint, NetworkExportTableItem, NoChecking,
 	ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
 	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
 	SovereignPaidRemoteExporter, SovereignSignedViaLocation, StartsWith,
@@ -149,19 +150,11 @@ pub type UniquesConvertedConcreteId =
 	assets_common::UniquesConvertedConcreteId<UniquesPalletLocation>;
 
 /// Means for transacting unique assets.
-pub type UniquesTransactor = NonFungiblesAdapter<
-	// Use this non-fungibles implementation:
-	Uniques,
-	// This adapter will handle any non-fungible asset from the uniques pallet.
-	UniquesConvertedConcreteId,
-	// Convert an XCM Location into a local account id:
-	LocationToAccountId,
-	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+pub type UniquesTransactor = RecreateableInstanceAdapter<
 	AccountId,
-	// Does not check teleports.
-	NoChecking,
-	// The account to use for tracking teleports.
-	CheckingAccount,
+	LocationToAccountId,
+	InstancesOfClasses<UniquesConvertedConcreteId>,
+	Uniques,
 >;
 
 /// `AssetId`/`Balance` converter for `ForeignAssets`.

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -45,12 +45,12 @@ use polkadot_runtime_common::xcm_sender::ExponentialPrice;
 use sp_runtime::traits::{AccountIdConversion, ConvertInto};
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
-	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain,
-	DenyThenTry, DescribeFamily, DescribePalletTerminal, EnsureXcmOrigin,
-	FrameTransactionalProcessor, FungibleAdapter, FungiblesAdapter,
-	GlobalConsensusParachainConvertsFor, HashedDescription, IsConcrete, LocalMint,
-	NetworkExportTableItem, NoChecking, NonFungiblesAdapter, ParentAsSuperuser, ParentIsPreset,
+	unique_instances::RecreateableInstanceAdapter, AccountId32Aliases,
+	AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain, DenyThenTry, DescribeFamily,
+	DescribePalletTerminal, EnsureXcmOrigin, FrameTransactionalProcessor, FungibleAdapter,
+	FungiblesAdapter, GlobalConsensusParachainConvertsFor, HashedDescription, InstancesOfClasses,
+	IsConcrete, LocalMint, NetworkExportTableItem, NoChecking, ParentAsSuperuser, ParentIsPreset,
 	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, StartsWith,
 	StartsWithExplicitGlobalConsensus, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
@@ -142,19 +142,11 @@ pub type UniquesConvertedConcreteId =
 	assets_common::UniquesConvertedConcreteId<UniquesPalletLocation>;
 
 /// Means for transacting unique assets.
-pub type UniquesTransactor = NonFungiblesAdapter<
-	// Use this non-fungibles implementation:
-	Uniques,
-	// This adapter will handle any non-fungible asset from the uniques pallet.
-	UniquesConvertedConcreteId,
-	// Convert an XCM Location into a local account id:
-	LocationToAccountId,
-	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+pub type UniquesTransactor = RecreateableInstanceAdapter<
 	AccountId,
-	// Does not check teleports.
-	NoChecking,
-	// The account to use for tracking teleports.
-	CheckingAccount,
+	LocationToAccountId,
+	InstancesOfClasses<UniquesConvertedConcreteId>,
+	Uniques,
 >;
 
 /// `AssetId`/`Balance` converter for `ForeignAssets`.

--- a/polkadot/xcm/xcm-builder/src/asset_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/asset_conversion.rs
@@ -20,7 +20,9 @@ use frame_support::traits::{Contains, Get};
 use sp_runtime::traits::MaybeEquivalence;
 use sp_std::{marker::PhantomData, prelude::*, result};
 use xcm::latest::prelude::*;
-use xcm_executor::traits::{Error as MatchError, MatchesFungibles, MatchesNonFungibles};
+use xcm_executor::traits::{
+	Error as MatchError, MatchesFungibles, MatchesInstance, MatchesNonFungible, MatchesNonFungibles,
+};
 
 /// Converter struct implementing `AssetIdConversion` converting a numeric asset ID (must be
 /// `TryFrom/TryInto<u128>`) into a `GeneralIndex` junction, prefixed by some `Location` value.
@@ -149,6 +151,26 @@ impl<
 		let instance =
 			ConvertInstanceId::convert(instance).ok_or(MatchError::InstanceConversionFailed)?;
 		Ok((what, instance))
+	}
+}
+
+pub struct InstancesOfClasses<Matcher>(PhantomData<Matcher>);
+
+impl<ClassId, InstanceId, Matcher: MatchesNonFungibles<ClassId, InstanceId>>
+	MatchesInstance<(ClassId, InstanceId)> for InstancesOfClasses<Matcher>
+{
+	fn matches_instance(a: &Asset) -> result::Result<(ClassId, InstanceId), MatchError> {
+		Matcher::matches_nonfungibles(a)
+	}
+}
+
+pub struct ClasslessInstances<Matcher>(PhantomData<Matcher>);
+
+impl<InstanceId, Matcher: MatchesNonFungible<InstanceId>> MatchesInstance<InstanceId>
+	for ClasslessInstances<Matcher>
+{
+	fn matches_instance(a: &Asset) -> result::Result<InstanceId, MatchError> {
+		Matcher::matches_nonfungible(a).ok_or(MatchError::AssetNotHandled)
 	}
 }
 

--- a/polkadot/xcm/xcm-builder/src/lib.rs
+++ b/polkadot/xcm/xcm-builder/src/lib.rs
@@ -30,7 +30,8 @@ mod asset_conversion;
 #[allow(deprecated)]
 pub use asset_conversion::ConvertedConcreteAssetId;
 pub use asset_conversion::{
-	AsPrefixedGeneralIndex, ConvertedConcreteId, MatchedConvertedConcreteId,
+	AsPrefixedGeneralIndex, ClasslessInstances, ConvertedConcreteId, InstancesOfClasses,
+	MatchedConvertedConcreteId,
 };
 
 mod barriers;
@@ -90,6 +91,8 @@ pub use matches_token::IsConcrete;
 
 mod matcher;
 pub use matcher::{CreateMatcher, MatchXcm, Matcher};
+
+pub mod unique_instances;
 
 mod nonfungibles_adapter;
 pub use nonfungibles_adapter::{

--- a/polkadot/xcm/xcm-builder/src/unique_instances/backed_derivative.rs
+++ b/polkadot/xcm/xcm-builder/src/unique_instances/backed_derivative.rs
@@ -1,0 +1,172 @@
+use super::LOG_TARGET;
+use core::marker::PhantomData;
+use frame_support::traits::{
+	tokens::asset_ops::{
+		common_asset_kinds::{Class, Instance},
+		common_strategies::{DeriveIdFrom, FromTo, Owned},
+		AssetDefinition, Create, Transfer,
+	},
+	Get,
+};
+use xcm::latest::prelude::*;
+use xcm_executor::traits::{ConvertLocation, Error as MatchError, MatchesInstance, TransactAsset};
+
+/// The status of a derivative instance.
+pub enum DerivativeStatus<ClassId, InstanceId> {
+	/// The derivative can be deposited (created) in the given class.
+	DepositableIn(ClassId),
+
+	/// The derivative already exists and it has the given ID.
+	Exists(InstanceId),
+}
+
+/// The `BackedDerivativeInstanceAdapter` implements the `TransactAsset` for unique instances
+/// (NFT-like entities).
+///
+/// The adapter uses the following asset operations:
+/// * [`Create`] with the [`Owned`] strategy that uses the [`DeriveIdFrom`] id assignment.
+///     * The [`DeriveIdFrom`] accepts the value of the `Id` type retrieved from the class [asset
+///       definition](AssetDefinition)
+///     (`ClassDef` generic parameter, represents a class-like entity such as a collection of NFTs).
+/// * [`Transfer`] with [`FromTo`] strategy
+///
+/// This adapter assumes that a new asset can be created and an existing asset can be transferred.
+/// Also, the adapter assumes that the asset can't be destroyed.
+/// So, it transfers the asset to the `StashLocation` on withdrawal.
+///
+/// On deposit, the adapter consults the [`DerivativeStatus`] returned from the `Matcher`.
+/// If the asset is depositable in a certain class, it will be created within that class.
+/// Otherwise, if the asset exists, it will be transferred from the `StashLocation` to the
+/// beneficiary.
+///
+/// Transfers work as expected, transferring the asset from the `from` location to the beneficiary.
+///
+/// This adapter is meant to be used in non-reserve locations where derivatives
+/// can't be properly destroyed and then recreated.
+///
+/// For instance, an NFT engine on the chain (a pallet or a smart contract)
+/// can be incapable of recreating an NFT with the same ID.
+/// So, we can only create a derivative with a new ID.
+/// In this context, if we burn a derivative on withdrawal:
+/// 1. we could exhaust the ID space for derivatives
+/// 2. if "burning" means transferring to a special address (like the zero address in EVM),
+/// we also waste the active storage space for burned derivatives
+///
+/// To avoid that situation, the `StashLocation` is used to hold the withdrawn derivatives.
+///
+/// Also, this adapter can be used in the NFT engine that simply doesn't support burning NFTs.
+pub struct BackedDerivativeInstanceAdapter<
+	AccountId,
+	AccountIdConverter,
+	Matcher,
+	ClassDef,
+	InstanceOps,
+	StashLocation,
+>(PhantomData<(AccountId, AccountIdConverter, Matcher, ClassDef, InstanceOps, StashLocation)>);
+
+impl<AccountId, AccountIdConverter, Matcher, ClassDef, InstanceOps, StashLocation> TransactAsset
+	for BackedDerivativeInstanceAdapter<
+		AccountId,
+		AccountIdConverter,
+		Matcher,
+		ClassDef,
+		InstanceOps,
+		StashLocation,
+	> where
+	AccountIdConverter: ConvertLocation<AccountId>,
+	Matcher: MatchesInstance<DerivativeStatus<ClassDef::Id, InstanceOps::Id>>,
+	ClassDef: AssetDefinition<Class>,
+	for<'a> InstanceOps: AssetDefinition<Instance>
+		+ Create<Instance, Owned<'a, DeriveIdFrom<'a, ClassDef::Id, InstanceOps::Id>, AccountId>>
+		+ Transfer<Instance, FromTo<'a, AccountId>>,
+	StashLocation: Get<Location>,
+{
+	fn deposit_asset(what: &Asset, who: &Location, context: Option<&XcmContext>) -> XcmResult {
+		log::trace!(
+			target: LOG_TARGET,
+			"BackedDerivativeInstanceAdapter::deposit_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			context,
+		);
+
+		let derivative_status = Matcher::matches_instance(what)?;
+		let to = AccountIdConverter::convert_location(who)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+
+		let result = match derivative_status {
+			DerivativeStatus::DepositableIn(class_id) =>
+				InstanceOps::create(Owned::new(DeriveIdFrom::parent_id(&class_id), &to))
+					.map(|_id| ()),
+			DerivativeStatus::Exists(instance_id) => {
+				let from = AccountIdConverter::convert_location(&StashLocation::get())
+					.ok_or(MatchError::AccountIdConversionFailed)?;
+
+				InstanceOps::transfer(&instance_id, FromTo(&from, &to))
+			},
+		};
+
+		result.map_err(|e| XcmError::FailedToTransactAsset(e.into()))
+	}
+
+	fn withdraw_asset(
+		what: &Asset,
+		who: &Location,
+		maybe_context: Option<&XcmContext>,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		log::trace!(
+			target: LOG_TARGET,
+			"BackedDerivativeInstanceAdapter::withdraw_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			maybe_context,
+		);
+
+		let derivative_status = Matcher::matches_instance(what)?;
+		let from = AccountIdConverter::convert_location(who)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+
+		if let DerivativeStatus::Exists(instance_id) = derivative_status {
+			let to = AccountIdConverter::convert_location(&StashLocation::get())
+				.ok_or(MatchError::AccountIdConversionFailed)?;
+
+			InstanceOps::transfer(&instance_id, FromTo(&from, &to))
+				.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
+
+			Ok(what.clone().into())
+		} else {
+			Err(XcmError::NotWithdrawable)
+		}
+	}
+
+	fn internal_transfer_asset(
+		what: &Asset,
+		from: &Location,
+		to: &Location,
+		context: &XcmContext,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		log::trace!(
+			target: LOG_TARGET,
+			"BackedDerivativeInstanceAdapter::internal_transfer_asset what: {:?}, from: {:?}, to: {:?}, context: {:?}",
+			what,
+			from,
+			to,
+			context,
+		);
+
+		let derivative_status = Matcher::matches_instance(what)?;
+		let from = AccountIdConverter::convert_location(from)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+		let to = AccountIdConverter::convert_location(to)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+
+		if let DerivativeStatus::Exists(instance_id) = derivative_status {
+			InstanceOps::transfer(&instance_id, FromTo(&from, &to))
+				.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
+
+			Ok(what.clone().into())
+		} else {
+			Err(XcmError::NotWithdrawable)
+		}
+	}
+}

--- a/polkadot/xcm/xcm-builder/src/unique_instances/mod.rs
+++ b/polkadot/xcm/xcm-builder/src/unique_instances/mod.rs
@@ -1,0 +1,35 @@
+use frame_support::traits::tokens::asset_ops::{
+	common_asset_kinds::Instance, common_strategies::FromTo, Transfer,
+};
+use xcm::latest::prelude::*;
+use xcm_executor::traits::{ConvertLocation, Error as MatchError, MatchesInstance};
+
+const LOG_TARGET: &str = "xcm::unique_instances";
+
+pub mod backed_derivative;
+pub mod recreateable;
+pub mod transferable;
+
+pub use backed_derivative::*;
+pub use recreateable::*;
+pub use transferable::*;
+
+fn transfer_instance<
+	AccountId,
+	AccountIdConverter: ConvertLocation<AccountId>,
+	Matcher: MatchesInstance<InstanceTransfer::Id>,
+	InstanceTransfer: for<'a> Transfer<Instance, FromTo<'a, AccountId>>,
+>(
+	what: &Asset,
+	from: &Location,
+	to: &Location,
+) -> XcmResult {
+	let instance_id = Matcher::matches_instance(what)?;
+	let from =
+		AccountIdConverter::convert_location(from).ok_or(MatchError::AccountIdConversionFailed)?;
+	let to =
+		AccountIdConverter::convert_location(to).ok_or(MatchError::AccountIdConversionFailed)?;
+
+	InstanceTransfer::transfer(&instance_id, FromTo(&from, &to))
+		.map_err(|e| XcmError::FailedToTransactAsset(e.into()))
+}

--- a/polkadot/xcm/xcm-builder/src/unique_instances/recreateable.rs
+++ b/polkadot/xcm/xcm-builder/src/unique_instances/recreateable.rs
@@ -1,0 +1,109 @@
+use super::{transfer_instance, LOG_TARGET};
+use core::marker::PhantomData;
+use frame_support::traits::tokens::asset_ops::{
+	common_asset_kinds::Instance,
+	common_strategies::{FromTo, IfOwnedBy, Owned, PredefinedId},
+	AssetDefinition, Create, Destroy, Transfer,
+};
+use xcm::latest::prelude::*;
+use xcm_executor::traits::{ConvertLocation, Error as MatchError, MatchesInstance, TransactAsset};
+
+/// The `RecreateableInstanceAdapter` implements the `TransactAsset` for unique instances (NFT-like
+/// entities).
+/// The adapter uses the following asset operations:
+/// * [`Create`] with the [`Owned`] strategy that uses the [`PredefinedId`].
+/// The `Id` used is the one from the [asset's definition](AssetDefinition).
+/// * [`Transfer`] with [`FromTo`] strategy
+/// * [`Destroy`] with [`IfOwnedBy`] strategy
+///
+/// This adapter assumes that the asset can be safely destroyed
+/// without the loss of any important data. It will destroy the asset on withdrawal.
+/// Similarly, it assumes that the asset can be recreated with the same ID on deposit.
+///
+/// Transfers work without additional assumptions.
+///
+/// If the above assumptions are true,
+/// this adapter can be used both to work with the original instances in a reserve location
+/// and to work with derivatives in other locations.
+///
+/// Only the assets matched by `Matcher` are affected.
+/// If the `Matcher` recognizes the instance, it should return its `Id`.
+///
+/// Note on teleports:
+/// This adapter doesn't implement teleports at the moment since unique instances have associated
+/// data that should be teleported along.
+/// Currently, neither XCM has the ability to transfer such data
+/// nor a standard approach exists in the ecosystem for this use case.
+pub struct RecreateableInstanceAdapter<AccountId, AccountIdConverter, Matcher, InstanceOps>(
+	PhantomData<(AccountId, AccountIdConverter, Matcher, InstanceOps)>,
+);
+
+impl<AccountId, AccountIdConverter, Matcher, InstanceOps> TransactAsset
+	for RecreateableInstanceAdapter<AccountId, AccountIdConverter, Matcher, InstanceOps>
+where
+	AccountIdConverter: ConvertLocation<AccountId>,
+	Matcher: MatchesInstance<InstanceOps::Id>,
+	for<'a> InstanceOps: AssetDefinition<Instance>
+		+ Create<Instance, Owned<'a, PredefinedId<'a, InstanceOps::Id>, AccountId>>
+		+ Transfer<Instance, FromTo<'a, AccountId>>
+		+ Destroy<Instance, IfOwnedBy<'a, AccountId>>,
+{
+	fn deposit_asset(what: &Asset, who: &Location, context: Option<&XcmContext>) -> XcmResult {
+		log::trace!(
+			target: LOG_TARGET,
+			"RecreateableInstanceAdapter::deposit_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			context,
+		);
+
+		let instance_id = Matcher::matches_instance(what)?;
+		let who = AccountIdConverter::convert_location(who)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+
+		InstanceOps::create(Owned::new(PredefinedId(&instance_id), &who))
+			.map_err(|e| XcmError::FailedToTransactAsset(e.into()))
+	}
+
+	fn withdraw_asset(
+		what: &Asset,
+		who: &Location,
+		maybe_context: Option<&XcmContext>,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		log::trace!(
+			target: LOG_TARGET,
+			"RecreateableInstanceAdapter::withdraw_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			maybe_context,
+		);
+		let instance_id = Matcher::matches_instance(what)?;
+		let who = AccountIdConverter::convert_location(who)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+
+		InstanceOps::destroy(&instance_id, IfOwnedBy(&who))
+			.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
+
+		Ok(what.clone().into())
+	}
+
+	fn internal_transfer_asset(
+		what: &Asset,
+		from: &Location,
+		to: &Location,
+		context: &XcmContext,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		log::trace!(
+			target: LOG_TARGET,
+			"RecreateableInstanceAdapter::internal_transfer_asset what: {:?}, from: {:?}, to: {:?}, context: {:?}",
+			what,
+			from,
+			to,
+			context,
+		);
+
+		transfer_instance::<AccountId, AccountIdConverter, Matcher, InstanceOps>(what, from, to)?;
+
+		Ok(what.clone().into())
+	}
+}

--- a/polkadot/xcm/xcm-builder/src/unique_instances/transferable.rs
+++ b/polkadot/xcm/xcm-builder/src/unique_instances/transferable.rs
@@ -1,0 +1,108 @@
+use super::{transfer_instance, LOG_TARGET};
+use core::marker::PhantomData;
+use frame_support::traits::{
+	tokens::asset_ops::{common_asset_kinds::Instance, common_strategies::FromTo, Transfer},
+	Get,
+};
+use xcm::latest::prelude::*;
+use xcm_executor::traits::{ConvertLocation, MatchesInstance, TransactAsset};
+
+/// The `TransferableInstanceAdapter` implements the `TransactAsset` for unique instances (NFT-like
+/// entities).
+///
+/// The adapter uses only the [`Transfer`] asset operation with the [`FromTo`] strategy.
+///
+/// It is meant to be used when the asset can't be safely destroyed on withdrawal
+/// (i.e., the absence of the loss of important data can't be guaranteed when the asset is
+/// destroyed). Equivalently, this adapter may be used when the asset can't be recreated on deposit.
+///
+/// The adapter uses the `StashLocation` as the beneficiary to transfer the asset on withdrawal.
+/// On deposit, the asset will be transferred from the `StashLocation` to the beneficiary.
+///
+/// Transfers work as expected, transferring the asset from the `from` location to the beneficiary.
+///
+/// This adapter can be used only in a reserve location.
+/// It can't create new instances, hence it can't create derivatives.
+pub struct TransferableInstanceAdapter<
+	AccountId,
+	AccountIdConverter,
+	Matcher,
+	InstanceTransfer,
+	StashLocation,
+>(PhantomData<(AccountId, AccountIdConverter, Matcher, InstanceTransfer, StashLocation)>);
+
+impl<
+		AccountId,
+		AccountIdConverter: ConvertLocation<AccountId>,
+		Matcher: MatchesInstance<InstanceTransfer::Id>,
+		InstanceTransfer: for<'a> Transfer<Instance, FromTo<'a, AccountId>>,
+		StashLocation: Get<Location>,
+	> TransactAsset
+	for TransferableInstanceAdapter<
+		AccountId,
+		AccountIdConverter,
+		Matcher,
+		InstanceTransfer,
+		StashLocation,
+	>
+{
+	fn deposit_asset(what: &Asset, who: &Location, context: Option<&XcmContext>) -> XcmResult {
+		log::trace!(
+			target: LOG_TARGET,
+			"TransferableInstanceAdapter::deposit_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			context,
+		);
+
+		transfer_instance::<AccountId, AccountIdConverter, Matcher, InstanceTransfer>(
+			what,
+			&StashLocation::get(),
+			who,
+		)
+	}
+
+	fn withdraw_asset(
+		what: &Asset,
+		who: &Location,
+		maybe_context: Option<&XcmContext>,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		log::trace!(
+			target: LOG_TARGET,
+			"TransferableInstanceAdapter::withdraw_asset what: {:?}, who: {:?}, context: {:?}",
+			what,
+			who,
+			maybe_context,
+		);
+
+		transfer_instance::<AccountId, AccountIdConverter, Matcher, InstanceTransfer>(
+			what,
+			who,
+			&StashLocation::get(),
+		)?;
+
+		Ok(what.clone().into())
+	}
+
+	fn internal_transfer_asset(
+		what: &Asset,
+		from: &Location,
+		to: &Location,
+		context: &XcmContext,
+	) -> Result<xcm_executor::AssetsInHolding, XcmError> {
+		log::trace!(
+			target: LOG_TARGET,
+			"TransferableInstanceAdapter::internal_transfer_asset what: {:?}, from: {:?}, to: {:?}, context: {:?}",
+			what,
+			from,
+			to,
+			context,
+		);
+
+		transfer_instance::<AccountId, AccountIdConverter, Matcher, InstanceTransfer>(
+			what, from, to,
+		)?;
+
+		Ok(what.clone().into())
+	}
+}

--- a/polkadot/xcm/xcm-executor/src/traits/mod.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/mod.rs
@@ -35,7 +35,8 @@ mod filter_asset_location;
 pub use filter_asset_location::FilterAssetLocation;
 mod token_matching;
 pub use token_matching::{
-	Error, MatchesFungible, MatchesFungibles, MatchesNonFungible, MatchesNonFungibles,
+	Error, MatchesFungible, MatchesFungibles, MatchesInstance, MatchesNonFungible,
+	MatchesNonFungibles,
 };
 mod on_response;
 pub use on_response::{OnResponse, QueryHandler, QueryResponseStatus, VersionChangeNotifier};
@@ -58,9 +59,9 @@ pub mod prelude {
 	pub use super::{
 		export_xcm, validate_export, AssetExchange, AssetLock, ClaimAssets, ConvertOrigin,
 		DropAssets, Enact, Error, ExportXcm, FeeManager, FeeReason, LockError, MatchesFungible,
-		MatchesFungibles, MatchesNonFungible, MatchesNonFungibles, OnResponse, ProcessTransaction,
-		ShouldExecute, TransactAsset, VersionChangeNotifier, WeightBounds, WeightTrader,
-		WithOriginFilter,
+		MatchesFungibles, MatchesInstance, MatchesNonFungible, MatchesNonFungibles, OnResponse,
+		ProcessTransaction, ShouldExecute, TransactAsset, VersionChangeNotifier, WeightBounds,
+		WeightTrader, WithOriginFilter,
 	};
 	#[allow(deprecated)]
 	pub use super::{Identity, JustTry};

--- a/polkadot/xcm/xcm-executor/src/traits/token_matching.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/token_matching.rs
@@ -101,7 +101,22 @@ impl<AssetId, Instance> MatchesNonFungibles<AssetId, Instance> for Tuple {
 		for_tuples!( #(
 			match Tuple::matches_nonfungibles(a) { o @ Ok(_) => return o, _ => () }
 		)* );
-		log::trace!(target: "xcm::matches_non_fungibles", "did not match fungibles asset: {:?}", &a);
+		log::trace!(target: "xcm::matches_non_fungibles", "did not match non-fungibles asset: {:?}", &a);
+		Err(Error::AssetNotHandled)
+	}
+}
+
+pub trait MatchesInstance<Id> {
+	fn matches_instance(a: &Asset) -> result::Result<Id, Error>;
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl<Id> MatchesInstance<Id> for Tuple {
+	fn matches_instance(a: &Asset) -> result::Result<Id, Error> {
+		for_tuples!( #(
+			match Tuple::matches_instance(a) { o @ Ok(_) => return o, _ => () }
+		)* );
+		log::trace!(target: "xcm::matches_instance", "did not match an asset instance: {:?}", &a);
 		Err(Error::AssetNotHandled)
 	}
 }

--- a/substrate/frame/support/src/traits/tokens.rs
+++ b/substrate/frame/support/src/traits/tokens.rs
@@ -17,6 +17,7 @@
 
 //! Traits for working with tokens and their associated datastructures.
 
+pub mod asset_ops;
 pub mod currency;
 pub mod fungible;
 pub mod fungibles;

--- a/substrate/frame/support/src/traits/tokens/asset_ops.rs
+++ b/substrate/frame/support/src/traits/tokens/asset_ops.rs
@@ -1,0 +1,543 @@
+//! Abstract asset operations traits.
+//!
+//! The following operations are defined:
+//! * [`InspectMetadata`]
+//! * [`UpdateMetadata`]
+//! * [`Create`]
+//! * [`Transfer`]
+//! * [`Destroy`]
+//!
+//! Also, all the operations above (except the `Create` operation) use
+//! the [`AssetDefinition`] to retrieve the `Id` type of the asset.
+//!
+//! Each asset operation can be implemented for different asset kinds
+//! such as [`Class`](common_asset_kinds::Class) and [`Instance`](common_asset_kinds::Instance).
+//!
+//! Also, an asset operation can be implemented multiple times
+//! using different strategies associated with this operation.
+//!
+//! A strategy defines the operation behavior,
+//! may supply additional parameters,
+//! and may define a return value type of the operation.
+
+use crate::dispatch::DispatchResult;
+use core::marker::PhantomData;
+use sp_runtime::DispatchError;
+use sp_std::vec::Vec;
+
+/// Trait for defining an asset of a certain kind.
+/// The definition must provide the `Id` type to identify the asset.
+///
+/// The common asset kinds are:
+/// * The [`Class`](common_asset_kinds::Class) asset kind is of assets that resemble class-like
+/// entities. For example, a collection of non-fungible tokens belongs to this kind.
+/// * The [`Instance`](common_asset_kinds::Instance) asset kind is of assets that resemble concrete
+/// instances of something. For example, a non-fungible token (which may or may not be part of a
+/// certain class) belongs to this kind.
+///
+/// Other asset kinds can be defined.
+pub trait AssetDefinition<AssetKind> {
+	/// Type for identifying the asset.
+	type Id;
+}
+
+/// A strategy for use in the [`InspectMetadata`] implementations.
+///
+/// The common inspect strategies are:
+/// * [`Bytes`](common_strategies::Bytes)
+/// * [`Ownership`](common_strategies::Ownership)
+/// * [`CanCreate`](common_strategies::CanCreate)
+/// * [`CanTransfer`](common_strategies::CanTransfer)
+/// * [`CanDestroy`](common_strategies::CanDestroy)
+/// * [`CanUpdateMetadata`](common_strategies::CanUpdateMetadata)
+pub trait MetadataInspectStrategy {
+	/// The type to return from the [`InspectMetadata::inspect_metadata`] function.
+	type Value;
+}
+
+/// A trait representing the ability of a certain asset kind to **provide** its metadata
+/// information.
+///
+/// This trait can be implemented multiple times using different [`inspect
+/// strategies`](MetadataInspectStrategy).
+///
+/// An inspect strategy defines how the asset metadata is identified/retrieved
+/// and what [`Value`](MetadataInspectStrategy::Value) type is returned.
+pub trait InspectMetadata<AssetKind, Strategy: MetadataInspectStrategy>:
+	AssetDefinition<AssetKind>
+{
+	/// Inspect metadata information of the asset
+	/// using the given `id` and the inspect `strategy`.
+	///
+	/// The ID type is retrieved from the [`AssetDefinition`].
+	fn inspect_metadata(
+		id: &Self::Id,
+		strategy: Strategy,
+	) -> Result<Strategy::Value, DispatchError>;
+}
+
+/// A strategy for use in the [`UpdateMetadata`] implementations.
+///
+/// The common update strategies are:
+/// * [`Bytes`](common_strategies::Bytes)
+/// * [`CanCreate`](common_strategies::CanCreate)
+/// * [`CanTransfer`](common_strategies::CanTransfer)
+/// * [`CanDestroy`](common_strategies::CanDestroy)
+/// * [`CanUpdateMetadata`](common_strategies::CanUpdateMetadata)
+pub trait MetadataUpdateStrategy {
+	/// The type of metadata update to accept in the [`UpdateMetadata::update_metadata`] function.
+	type Update<'u>;
+}
+
+/// A trait representing the ability of a certain asset kind to **update** its metadata information.
+///
+/// This trait can be implemented multiple times using different [`update
+/// strategies`](MetadataUpdateStrategy).
+///
+/// An update strategy defines how the asset metadata is identified
+/// and what [`Update`](MetadataUpdateStrategy::Update) type is used.
+pub trait UpdateMetadata<AssetKind, Strategy: MetadataUpdateStrategy>:
+	AssetDefinition<AssetKind>
+{
+	/// Update metadata information of the asset
+	/// using the given `id`, the update `strategy`, and the `update` value.
+	///
+	/// The ID type is retrieved from the [`AssetDefinition`].
+	fn update_metadata(
+		id: &Self::Id,
+		strategy: Strategy,
+		update: Strategy::Update<'_>,
+	) -> DispatchResult;
+}
+
+/// A strategy for use in the [`Create`] implementations.
+///
+/// The common "create" strategies are:
+/// * [`Owned`](common_strategies::Owned)
+/// * [`Adminable`](common_strategies::Adminable)
+pub trait CreateStrategy {
+	/// This type represents successful asset creation.
+	/// It will be the return type of the [`Create::create`] function.
+	type Success;
+}
+
+/// An ID assignment approach to use in the "create" strategies.
+///
+/// The common ID assignments are:
+/// * [`AutoId`](common_strategies::AutoId)
+/// * [`PredefinedId`](common_strategies::PredefinedId)
+/// * [`DeriveIdFrom`](common_strategies::DeriveIdFrom)
+pub trait IdAssignment {
+	/// The reported ID type.
+	///
+	/// Examples:
+	/// * [`AutoId`](common_strategies::AutoId) returns ID of the newly created asset
+	/// * [`PredefinedId`](common_strategies::PredefinedId) returns `()` since the ID is already
+	///   defined
+	/// * [`DeriveIdFrom`](common_strategies::DeriveIdFrom) returns the derived ID
+	type ReportedId;
+}
+
+/// A trait representing the ability of a certain asset kind to be created.
+///
+/// This trait can be implemented multiple times using different [`"create"
+/// strategies`](CreateStrategy).
+///
+/// A create strategy defines all aspects of asset creation including how an asset ID is assigned.
+pub trait Create<AssetKind, Strategy: CreateStrategy> {
+	/// Create a new asset using the provided `strategy`.
+	fn create(strategy: Strategy) -> Result<Strategy::Success, DispatchError>;
+}
+
+/// A strategy for use in the [`Transfer`] implementations.
+///
+/// The common transfer strategies are:
+/// * [`JustTo`](common_strategies::JustTo)
+/// * [`FromTo`](common_strategies::FromTo)
+pub trait TransferStrategy {}
+
+/// A trait representing the ability of a certain asset kind to be transferred.
+///
+/// This trait can be implemented multiple times using different [`transfer
+/// strategies`](TransferStrategy).
+///
+/// A transfer strategy defines transfer parameters.
+pub trait Transfer<AssetKind, Strategy: TransferStrategy>: AssetDefinition<AssetKind> {
+	/// Transfer the asset identified by the given `id` using the provided `strategy`.
+	///
+	/// The ID type is retrieved from the [`AssetDefinition`].
+	fn transfer(id: &Self::Id, strategy: Strategy) -> DispatchResult;
+}
+
+/// A strategy for use in the [`Destroy`] implementations.
+///
+/// The common destroy strategies are:
+/// * [`JustDestroy`](common_strategies::JustDestroy)
+/// * [`IfOwnedBy`](common_strategies::IfOwnedBy)
+/// * [`WithWitness`](common_strategies::WithWitness)
+/// * [`IfOwnedByWithWitness`](common_strategies::IfOwnedByWithWitness)
+pub trait DestroyStrategy {
+	/// This type represents successful asset destruction.
+	/// It will be the return type of the [`Destroy::destroy`] function.
+	type Success;
+}
+
+/// A trait representing the ability of a certain asset kind to be destroyed.
+///
+/// This trait can be implemented multiple times using different [`destroy
+/// strategies`](DestroyStrategy).
+///
+/// A destroy strategy defines destroy parameters and the result value type.
+pub trait Destroy<AssetKind, Strategy: DestroyStrategy>: AssetDefinition<AssetKind> {
+	/// Destroy the asset identified by the given `id` using the provided `strategy`.
+	///
+	/// The ID type is retrieved from the [`AssetDefinition`].
+	fn destroy(id: &Self::Id, strategy: Strategy) -> Result<Strategy::Success, DispatchError>;
+}
+
+/// This modules contains the common asset kinds.
+pub mod common_asset_kinds {
+	/// The `Class` asset kind is of assets that resemble class-like entities.
+	/// For instance, a collection of non-fungible tokens is an asset of this kind.
+	pub struct Class;
+
+	/// The `Instance` asset kind represents assets resembling instances of something.
+	/// For instance, a single non-fungible token is an asset of this kind.
+	///
+	/// An instance asset is not necessarily bound to a class.
+	/// There could be "classless" instances.
+	pub struct Instance;
+}
+
+/// This modules contains the common asset ops strategies.
+pub mod common_strategies {
+	use super::*;
+
+	/// The `WithOrigin` is a strategy that accepts a runtime origin and the `Inner` strategy.
+	///
+	/// It is meant to be used when the origin check should be performed
+	/// in addition to the `Inner` strategy.
+	///
+	/// The `WithOrigin` implements any strategy that the `Inner` implements.
+	pub struct WithOrigin<RuntimeOrigin, Inner>(pub RuntimeOrigin, pub Inner);
+	impl<RuntimeOrigin, Inner: MetadataInspectStrategy> MetadataInspectStrategy
+		for WithOrigin<RuntimeOrigin, Inner>
+	{
+		type Value = Inner::Value;
+	}
+	impl<RuntimeOrigin, Inner: MetadataUpdateStrategy> MetadataUpdateStrategy
+		for WithOrigin<RuntimeOrigin, Inner>
+	{
+		type Update<'u> = Inner::Update<'u>;
+	}
+	impl<RuntimeOrigin, Inner: CreateStrategy> CreateStrategy for WithOrigin<RuntimeOrigin, Inner> {
+		type Success = Inner::Success;
+	}
+	impl<RuntimeOrigin, Inner: TransferStrategy> TransferStrategy for WithOrigin<RuntimeOrigin, Inner> {}
+	impl<RuntimeOrigin, Inner: DestroyStrategy> DestroyStrategy for WithOrigin<RuntimeOrigin, Inner> {
+		type Success = Inner::Success;
+	}
+
+	/// The `Bytes` strategy represents raw metadata bytes.
+	/// It is both an [inspect](MetadataInspectStrategy) and [update](MetadataUpdateStrategy)
+	/// metadata strategy.
+	///
+	/// * As the inspect strategy, it returns `Vec<u8>`.
+	/// * As the update strategy, it accepts `Option<&[u8]>`, where `None` means data removal.
+	///
+	/// By default, the `Bytes` identifies a byte blob associated with the asset (the only one
+	/// blob). However, a user can define several flavors of this strategy by supplying the `Flavor`
+	/// type. The `Flavor` type can also contain additional data (like a byte key) to identify a
+	/// certain byte data.
+	pub struct Bytes<Flavor = ()>(pub Flavor);
+	impl Default for Bytes<()> {
+		fn default() -> Self {
+			Self(())
+		}
+	}
+	impl<Flavor> MetadataInspectStrategy for Bytes<Flavor> {
+		type Value = Vec<u8>;
+	}
+	impl<Flavor> MetadataUpdateStrategy for Bytes<Flavor> {
+		type Update<'u> = Option<&'u [u8]>;
+	}
+
+	/// The `Ownership` [inspect](MetadataInspectStrategy) metadata strategy allows getting the
+	/// owner of an asset.
+	pub struct Ownership<Owner>(PhantomData<Owner>);
+	impl<Owner> Default for Ownership<Owner> {
+		fn default() -> Self {
+			Self(PhantomData)
+		}
+	}
+	impl<Owner> MetadataInspectStrategy for Ownership<Owner> {
+		type Value = Owner;
+	}
+
+	/// The `CanCreate` strategy represents the ability to create an asset.
+	/// It is both an [inspect](MetadataInspectStrategy) and [update](MetadataUpdateStrategy)
+	/// metadata strategy.
+	///
+	/// * As the inspect strategy, it returns `bool`.
+	/// * As the update strategy is accepts `bool`.
+	///
+	/// By default, this strategy means the ability to create an asset "in general".
+	/// However, a user can define several flavors of this strategy by supplying the `Flavor` type.
+	/// The `Flavor` type can add more details to the strategy.
+	/// For instance, "Can **a specific user** create an asset?".
+	pub struct CanCreate<Flavor = ()>(pub Flavor);
+	impl Default for CanCreate<()> {
+		fn default() -> Self {
+			Self(())
+		}
+	}
+	impl<Flavor> MetadataInspectStrategy for CanCreate<Flavor> {
+		type Value = bool;
+	}
+	impl<Flavor> MetadataUpdateStrategy for CanCreate<Flavor> {
+		type Update<'u> = bool;
+	}
+
+	/// The `CanTransfer` strategy represents the ability to transfer an asset.
+	/// It is both an [inspect](MetadataInspectStrategy) and [update](MetadataUpdateStrategy)
+	/// metadata strategy.
+	///
+	/// * As the inspect strategy, it returns `bool`.
+	/// * As the update strategy is accepts `bool`.
+	///
+	/// By default, this strategy means the ability to transfer an asset "in general".
+	/// However, a user can define several flavors of this strategy by supplying the `Flavor` type.
+	/// The `Flavor` type can add more details to the strategy.
+	/// For instance, "Can **a specific user** transfer an asset of **another user**?".
+	pub struct CanTransfer<Flavor = ()>(pub Flavor);
+	impl Default for CanTransfer<()> {
+		fn default() -> Self {
+			Self(())
+		}
+	}
+	impl<Flavor> MetadataInspectStrategy for CanTransfer<Flavor> {
+		type Value = bool;
+	}
+	impl<Flavor> MetadataUpdateStrategy for CanTransfer<Flavor> {
+		type Update<'u> = bool;
+	}
+
+	/// The `CanDestroy` strategy represents the ability to destroy an asset.
+	/// It is both an [inspect](MetadataInspectStrategy) and [update](MetadataUpdateStrategy)
+	/// metadata strategy.
+	///
+	/// * As the inspect strategy, it returns `bool`.
+	/// * As the update strategy is accepts `bool`.
+	///
+	/// By default, this strategy means the ability to destroy an asset "in general".
+	/// However, a user can define several flavors of this strategy by supplying the `Flavor` type.
+	/// The `Flavor` type can add more details to the strategy.
+	/// For instance, "Can **a specific user** destroy an asset of **another user**?".
+	pub struct CanDestroy<Flavor = ()>(pub Flavor);
+	impl Default for CanDestroy<()> {
+		fn default() -> Self {
+			Self(())
+		}
+	}
+	impl<Flavor> MetadataInspectStrategy for CanDestroy<Flavor> {
+		type Value = bool;
+	}
+	impl<Flavor> MetadataUpdateStrategy for CanDestroy<Flavor> {
+		type Update<'u> = bool;
+	}
+
+	/// The `CanUpdateMetadata` strategy represents the ability to update the metadata of an asset.
+	/// It is both an [inspect](MetadataInspectStrategy) and [update](MetadataUpdateStrategy)
+	/// metadata strategy.
+	///
+	/// * As the inspect strategy, it returns `bool`.
+	/// * As the update strategy is accepts `bool`.
+	///
+	/// By default, this strategy means the ability to update the metadata of an asset "in general".
+	/// However, a user can define several flavors of this strategy by supplying the `Flavor` type.
+	/// The `Flavor` type can add more details to the strategy.
+	/// For instance, "Can **a specific user** update the metadata of an asset **under a certain
+	/// key**?".
+	pub struct CanUpdateMetadata<Flavor = ()>(pub Flavor);
+	impl Default for CanUpdateMetadata<()> {
+		fn default() -> Self {
+			Self(())
+		}
+	}
+	impl<Flavor> MetadataInspectStrategy for CanUpdateMetadata<Flavor> {
+		type Value = bool;
+	}
+	impl<Flavor> MetadataUpdateStrategy for CanUpdateMetadata<Flavor> {
+		type Update<'u> = bool;
+	}
+
+	/// The `AutoId` is an ID assignment approach intended to be used in [`"create"
+	/// strategies`](CreateStrategy).
+	///
+	/// It accepts the `Id` type of the asset.
+	/// The "create" strategy should report the value of type `Id` upon successful asset creation.
+	pub struct AutoId<Id>(PhantomData<Id>);
+	impl<Id> AutoId<Id> {
+		pub fn new() -> Self {
+			Self(PhantomData)
+		}
+	}
+	impl<Id> IdAssignment for AutoId<Id> {
+		type ReportedId = Id;
+	}
+
+	/// The `PredefinedId` is an ID assignment approach intended to be used in [`"create"
+	/// strategies`](CreateStrategy).
+	///
+	/// It accepts a value of the `Id` type.
+	/// The "create" strategy should use the provided ID value to create a new asset.
+	pub struct PredefinedId<'a, Id>(pub &'a Id);
+	impl<'a, Id> IdAssignment for PredefinedId<'a, Id> {
+		type ReportedId = ();
+	}
+
+	/// The `DeriveIdFrom` is an ID assignment approach intended to be used in [`"create"
+	/// strategies`](CreateStrategy).
+	///
+	/// It accepts the `ParentId` and the `ChildId`.
+	/// The `ChildId` value should be computed by the "create" strategy using the `ParentId` value.
+	///
+	/// The "create" strategy should report the `ChildId` value upon successful asset creation.
+	///
+	/// An example of ID derivation is the creation of an NFT inside a collection using the
+	/// collection ID. The child ID in this case is the full ID of the NFT.
+	pub struct DeriveIdFrom<'a, ParentId, ChildId>(pub &'a ParentId, PhantomData<ChildId>);
+	impl<'a, ParentId, ChildId> DeriveIdFrom<'a, ParentId, ChildId> {
+		pub fn parent_id(primary_id: &'a ParentId) -> Self {
+			Self(primary_id, PhantomData)
+		}
+	}
+	impl<'a, ParentId, ChildId> IdAssignment for DeriveIdFrom<'a, ParentId, ChildId> {
+		type ReportedId = ChildId;
+	}
+
+	/// The `Owned` is a [`"create" strategy`](CreateStrategy).
+	///
+	/// It accepts:
+	/// * The [ID assignment](IdAssignment) approach
+	/// * The `owner`
+	/// * The optional `config`
+	/// * The optional creation `witness`
+	///
+	/// The [`Success`](CreateStrategy::Success) will contain
+	/// the [reported ID](IdAssignment::ReportedId) of the ID assignment approach.
+	pub struct Owned<'a, Assignment: IdAssignment, Owner, Config = (), Witness = ()> {
+		pub id_assignment: Assignment,
+		pub owner: &'a Owner,
+		pub config: &'a Config,
+		pub witness: &'a Witness,
+	}
+	impl<'a, Assignment: IdAssignment, Owner> Owned<'a, Assignment, Owner, (), ()> {
+		pub fn new(id_assignment: Assignment, owner: &'a Owner) -> Self {
+			Self { id_assignment, owner, config: &(), witness: &() }
+		}
+	}
+	impl<'a, Assignment: IdAssignment, Owner, Config> Owned<'a, Assignment, Owner, Config, ()> {
+		pub fn new_configured(
+			id_assignment: Assignment,
+			owner: &'a Owner,
+			config: &'a Config,
+		) -> Self {
+			Self { id_assignment, owner, config, witness: &() }
+		}
+	}
+	impl<'a, Assignment: IdAssignment, Owner, Config, Witness> CreateStrategy
+		for Owned<'a, Assignment, Owner, Config, Witness>
+	{
+		type Success = Assignment::ReportedId;
+	}
+
+	/// The `Adminable` is a [`"create" strategy`](CreateStrategy).
+	///
+	/// It accepts:
+	/// * The [ID assignment](IdAssignment) approach
+	/// * The `owner`
+	/// * The `admin`
+	/// * The optional `config`
+	/// * The optional creation `witness`
+	///
+	/// The [`Success`](CreateStrategy::Success) will contain
+	/// the [reported ID](IdAssignment::ReportedId) of the ID assignment approach.
+	pub struct Adminable<'a, Assignment: IdAssignment, Account, Config = (), Witness = ()> {
+		pub id_assignment: Assignment,
+		pub owner: &'a Account,
+		pub admin: &'a Account,
+		pub config: &'a Config,
+		pub witness: &'a Witness,
+	}
+	impl<'a, Assignment: IdAssignment, Account> Adminable<'a, Assignment, Account, (), ()> {
+		pub fn new(id_assignment: Assignment, owner: &'a Account, admin: &'a Account) -> Self {
+			Self { id_assignment, owner, admin, config: &(), witness: &() }
+		}
+	}
+	impl<'a, Assignment: IdAssignment, Account, Config> Adminable<'a, Assignment, Account, Config, ()> {
+		pub fn new_configured(
+			id_assignment: Assignment,
+			owner: &'a Account,
+			admin: &'a Account,
+			config: &'a Config,
+		) -> Self {
+			Self { id_assignment, owner, admin, config, witness: &() }
+		}
+	}
+	impl<'a, Assignment: IdAssignment, Account, Config, Witness> CreateStrategy
+		for Adminable<'a, Assignment, Account, Config, Witness>
+	{
+		type Success = Assignment::ReportedId;
+	}
+
+	/// The `JustTo` is a [`transfer strategy`](TransferStrategy).
+	///
+	/// It accepts the target of the transfer,
+	/// i.e., who will become the asset's owner after the transfer.
+	pub struct JustTo<'a, Owner>(pub &'a Owner);
+	impl<'a, Owner> TransferStrategy for JustTo<'a, Owner> {}
+
+	/// The `FromTo` is a [`transfer strategy`](TransferStrategy).
+	///
+	/// It accepts two parameters: `from` and `to` whom the asset should be transferred.
+	pub struct FromTo<'a, Owner>(pub &'a Owner, pub &'a Owner);
+	impl<'a, Owner> TransferStrategy for FromTo<'a, Owner> {}
+
+	/// The `JustDestroy` is a [`destroy strategy`](DestroyStrategy).
+	///
+	/// It represents an "unchecked" destruction of the asset.
+	pub struct JustDestroy;
+	impl DestroyStrategy for JustDestroy {
+		type Success = ();
+	}
+
+	/// The `IfOwnedBy` is a [`destroy strategy`](DestroyStrategy).
+	///
+	/// It accepts a possible owner of the asset.
+	/// If the provided entity owns the asset, it will be destroyed.
+	pub struct IfOwnedBy<'a, Owner>(pub &'a Owner);
+	impl<'a, Owner> DestroyStrategy for IfOwnedBy<'a, Owner> {
+		type Success = ();
+	}
+
+	/// The `WithWitness` is a [`destroy strategy`](DestroyStrategy).
+	///
+	/// It accepts a `Witness` to destroy an asset.
+	/// It will also return a `Witness` value upon destruction.
+	pub struct WithWitness<'a, Witness>(pub &'a Witness);
+	impl<'a, Witness> DestroyStrategy for WithWitness<'a, Witness> {
+		type Success = Witness;
+	}
+
+	/// The `IfOwnedByWithWitness` is a [`destroy strategy`](DestroyStrategy).
+	///
+	/// It is a combination of the [`IfOwnedBy`] and the [`WithWitness`] strategies.
+	pub struct IfOwnedByWithWitness<'a, Owner, Witness> {
+		pub owner: &'a Owner,
+		pub witness: &'a Witness,
+	}
+	impl<'a, Owner, Witness> DestroyStrategy for IfOwnedByWithWitness<'a, Owner, Witness> {
+		type Success = Witness;
+	}
+}

--- a/substrate/frame/uniques/src/impl_asset_ops/class.rs
+++ b/substrate/frame/uniques/src/impl_asset_ops/class.rs
@@ -1,0 +1,180 @@
+use crate::{asset_strategies::Attribute, *};
+use frame_support::{
+	dispatch::DispatchResult,
+	ensure,
+	traits::{
+		tokens::asset_ops::{
+			common_asset_kinds::Class,
+			common_strategies::{
+				Adminable, Bytes, IfOwnedByWithWitness, Ownership, PredefinedId, WithOrigin,
+				WithWitness,
+			},
+			AssetDefinition, Create, Destroy, InspectMetadata,
+		},
+		EnsureOrigin, Get,
+	},
+	BoundedSlice,
+};
+use frame_system::ensure_signed;
+use sp_runtime::DispatchError;
+
+impl<T: Config<I>, I: 'static> AssetDefinition<Class> for Pallet<T, I> {
+	type Id = T::CollectionId;
+}
+
+impl<T: Config<I>, I: 'static> InspectMetadata<Class, Ownership<T::AccountId>> for Pallet<T, I> {
+	fn inspect_metadata(
+		collection: &Self::Id,
+		_ownership: Ownership<T::AccountId>,
+	) -> Result<T::AccountId, DispatchError> {
+		Collection::<T, I>::get(collection)
+			.map(|a| a.owner)
+			.ok_or(Error::<T, I>::UnknownCollection.into())
+	}
+}
+
+impl<T: Config<I>, I: 'static> InspectMetadata<Class, Bytes> for Pallet<T, I> {
+	fn inspect_metadata(collection: &Self::Id, _bytes: Bytes) -> Result<Vec<u8>, DispatchError> {
+		CollectionMetadataOf::<T, I>::get(collection)
+			.map(|m| m.data.into())
+			.ok_or(Error::<T, I>::NoMetadata.into())
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> InspectMetadata<Class, Bytes<Attribute<'a>>> for Pallet<T, I> {
+	fn inspect_metadata(
+		collection: &Self::Id,
+		strategy: Bytes<Attribute>,
+	) -> Result<Vec<u8>, DispatchError> {
+		let Bytes(Attribute(attribute)) = strategy;
+
+		let attribute =
+			BoundedSlice::try_from(attribute).map_err(|_| Error::<T, I>::WrongAttribute)?;
+		crate::Attribute::<T, I>::get((collection, Option::<T::ItemId>::None, attribute))
+			.map(|a| a.0.into())
+			.ok_or(Error::<T, I>::AttributeNotFound.into())
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Create<Class, Adminable<'a, PredefinedId<'a, T::CollectionId>, T::AccountId>> for Pallet<T, I>
+{
+	fn create(
+		strategy: Adminable<PredefinedId<'a, T::CollectionId>, T::AccountId>,
+	) -> DispatchResult {
+		let Adminable { id_assignment: PredefinedId(collection), owner, admin, .. } = strategy;
+
+		Self::do_create_collection(
+			collection.clone(),
+			owner.clone(),
+			admin.clone(),
+			T::CollectionDeposit::get(),
+			false,
+			Event::Created {
+				collection: collection.clone(),
+				creator: owner.clone(),
+				owner: admin.clone(),
+			},
+		)
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Create<
+		Class,
+		WithOrigin<
+			T::RuntimeOrigin,
+			Adminable<'a, PredefinedId<'a, T::CollectionId>, T::AccountId>,
+		>,
+	> for Pallet<T, I>
+{
+	fn create(
+		strategy: WithOrigin<
+			T::RuntimeOrigin,
+			Adminable<PredefinedId<'a, T::CollectionId>, T::AccountId>,
+		>,
+	) -> DispatchResult {
+		let WithOrigin(
+			origin,
+			creation @ Adminable { id_assignment: PredefinedId(collection), owner, .. },
+		) = strategy;
+
+		let maybe_check_signer =
+			T::ForceOrigin::try_origin(origin).map(|_| None).or_else(|origin| {
+				T::CreateOrigin::ensure_origin(origin, &collection)
+					.map(Some)
+					.map_err(DispatchError::from)
+			})?;
+
+		if let Some(signer) = maybe_check_signer {
+			ensure!(signer == *owner, Error::<T, I>::NoPermission);
+		}
+
+		<Self as Create<_, _>>::create(creation)
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> Destroy<Class, WithWitness<'a, DestroyWitness>>
+	for Pallet<T, I>
+{
+	fn destroy(
+		collection: &Self::Id,
+		strategy: WithWitness<DestroyWitness>,
+	) -> Result<DestroyWitness, DispatchError> {
+		let WithWitness(witness) = strategy;
+
+		Self::do_destroy_collection(collection.clone(), *witness, None)
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Destroy<Class, WithOrigin<T::RuntimeOrigin, WithWitness<'a, DestroyWitness>>> for Pallet<T, I>
+{
+	fn destroy(
+		collection: &Self::Id,
+		strategy: WithOrigin<T::RuntimeOrigin, WithWitness<'a, DestroyWitness>>,
+	) -> Result<DestroyWitness, DispatchError> {
+		let WithOrigin(origin, destroy) = strategy;
+
+		T::ForceOrigin::ensure_origin(origin)?;
+
+		<Self as Destroy<_, _>>::destroy(collection, destroy)
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Destroy<Class, IfOwnedByWithWitness<'a, T::AccountId, DestroyWitness>> for Pallet<T, I>
+{
+	fn destroy(
+		collection: &Self::Id,
+		strategy: IfOwnedByWithWitness<T::AccountId, DestroyWitness>,
+	) -> Result<DestroyWitness, DispatchError> {
+		let IfOwnedByWithWitness { owner, witness } = strategy;
+
+		Self::do_destroy_collection(collection.clone(), *witness, Some(owner.clone()))
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Destroy<
+		Class,
+		WithOrigin<T::RuntimeOrigin, IfOwnedByWithWitness<'a, T::AccountId, DestroyWitness>>,
+	> for Pallet<T, I>
+{
+	fn destroy(
+		collection: &Self::Id,
+		strategy: WithOrigin<T::RuntimeOrigin, IfOwnedByWithWitness<T::AccountId, DestroyWitness>>,
+	) -> Result<DestroyWitness, DispatchError> {
+		let WithOrigin(origin, IfOwnedByWithWitness { owner, witness }) = strategy;
+		let maybe_check_owner = match T::ForceOrigin::try_origin(origin) {
+			Ok(_) => None,
+			Err(origin) => Some(ensure_signed(origin)?),
+		};
+
+		if let Some(signer) = maybe_check_owner {
+			ensure!(signer == *owner, Error::<T, I>::NoPermission);
+		}
+
+		Self::do_destroy_collection(collection.clone(), *witness, Some(owner.clone()))
+	}
+}

--- a/substrate/frame/uniques/src/impl_asset_ops/instance.rs
+++ b/substrate/frame/uniques/src/impl_asset_ops/instance.rs
@@ -1,0 +1,205 @@
+use crate::{asset_strategies::Attribute, *};
+use frame_support::{
+	dispatch::DispatchResult,
+	ensure,
+	traits::tokens::asset_ops::{
+		common_asset_kinds::Instance,
+		common_strategies::{
+			Bytes, CanTransfer, FromTo, IfOwnedBy, JustDestroy, JustTo, Owned, Ownership,
+			PredefinedId, WithOrigin,
+		},
+		AssetDefinition, Create, Destroy, InspectMetadata, Transfer,
+	},
+	BoundedSlice,
+};
+use frame_system::ensure_signed;
+use sp_runtime::DispatchError;
+
+impl<T: Config<I>, I: 'static> AssetDefinition<Instance> for Pallet<T, I> {
+	type Id = (T::CollectionId, T::ItemId);
+}
+
+impl<T: Config<I>, I: 'static> InspectMetadata<Instance, Ownership<T::AccountId>> for Pallet<T, I> {
+	fn inspect_metadata(
+		(collection, item): &Self::Id,
+		_ownership: Ownership<T::AccountId>,
+	) -> Result<T::AccountId, DispatchError> {
+		Item::<T, I>::get(collection, item)
+			.map(|a| a.owner)
+			.ok_or(Error::<T, I>::UnknownItem.into())
+	}
+}
+
+impl<T: Config<I>, I: 'static> InspectMetadata<Instance, Bytes> for Pallet<T, I> {
+	fn inspect_metadata(
+		(collection, item): &Self::Id,
+		_bytes: Bytes,
+	) -> Result<Vec<u8>, DispatchError> {
+		ItemMetadataOf::<T, I>::get(collection, item)
+			.map(|m| m.data.into())
+			.ok_or(Error::<T, I>::NoMetadata.into())
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> InspectMetadata<Instance, Bytes<Attribute<'a>>>
+	for Pallet<T, I>
+{
+	fn inspect_metadata(
+		(collection, item): &Self::Id,
+		strategy: Bytes<Attribute>,
+	) -> Result<Vec<u8>, DispatchError> {
+		let Bytes(Attribute(attribute)) = strategy;
+
+		let attribute =
+			BoundedSlice::try_from(attribute).map_err(|_| Error::<T, I>::WrongAttribute)?;
+		crate::Attribute::<T, I>::get((collection, Some(item), attribute))
+			.map(|a| a.0.into())
+			.ok_or(Error::<T, I>::AttributeNotFound.into())
+	}
+}
+
+impl<T: Config<I>, I: 'static> InspectMetadata<Instance, CanTransfer> for Pallet<T, I> {
+	fn inspect_metadata(
+		(collection, item): &Self::Id,
+		_can_transfer: CanTransfer,
+	) -> Result<bool, DispatchError> {
+		match (Collection::<T, I>::get(collection), Item::<T, I>::get(collection, item)) {
+			(Some(cd), Some(id)) => Ok(!cd.is_frozen && !id.is_frozen),
+			_ => Err(Error::<T, I>::UnknownItem.into()),
+		}
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Create<Instance, Owned<'a, PredefinedId<'a, (T::CollectionId, T::ItemId)>, T::AccountId>>
+	for Pallet<T, I>
+{
+	fn create(
+		strategy: Owned<PredefinedId<(T::CollectionId, T::ItemId)>, T::AccountId>,
+	) -> DispatchResult {
+		let Owned { id_assignment: PredefinedId((collection, item)), owner, .. } = strategy;
+
+		Self::do_mint(collection.clone(), *item, owner.clone(), |_| Ok(()))
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Create<
+		Instance,
+		WithOrigin<
+			T::RuntimeOrigin,
+			Owned<'a, PredefinedId<'a, (T::CollectionId, T::ItemId)>, T::AccountId>,
+		>,
+	> for Pallet<T, I>
+{
+	fn create(
+		strategy: WithOrigin<
+			T::RuntimeOrigin,
+			Owned<PredefinedId<(T::CollectionId, T::ItemId)>, T::AccountId>,
+		>,
+	) -> DispatchResult {
+		let WithOrigin(
+			origin,
+			Owned { id_assignment: PredefinedId((collection, item)), owner, .. },
+		) = strategy;
+
+		let signer = ensure_signed(origin)?;
+
+		Self::do_mint(collection.clone(), *item, owner.clone(), |collection_details| {
+			ensure!(collection_details.issuer == signer, Error::<T, I>::NoPermission);
+			Ok(())
+		})
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> Transfer<Instance, JustTo<'a, T::AccountId>> for Pallet<T, I> {
+	fn transfer((collection, item): &Self::Id, strategy: JustTo<T::AccountId>) -> DispatchResult {
+		let JustTo(dest) = strategy;
+
+		Self::do_transfer(collection.clone(), *item, dest.clone(), |_, _| Ok(()))
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Transfer<Instance, WithOrigin<T::RuntimeOrigin, JustTo<'a, T::AccountId>>> for Pallet<T, I>
+{
+	fn transfer(
+		(collection, item): &Self::Id,
+		strategy: WithOrigin<T::RuntimeOrigin, JustTo<T::AccountId>>,
+	) -> DispatchResult {
+		let WithOrigin(origin, JustTo(dest)) = strategy;
+
+		let signer = ensure_signed(origin)?;
+
+		Self::do_transfer(collection.clone(), *item, dest.clone(), |collection_details, details| {
+			if details.owner != signer && collection_details.admin != signer {
+				let approved = details.approved.take().map_or(false, |i| i == signer);
+				ensure!(approved, Error::<T, I>::NoPermission);
+			}
+			Ok(())
+		})
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> Transfer<Instance, FromTo<'a, T::AccountId>> for Pallet<T, I> {
+	fn transfer((collection, item): &Self::Id, strategy: FromTo<T::AccountId>) -> DispatchResult {
+		let FromTo(from, to) = strategy;
+
+		Self::do_transfer(collection.clone(), *item, to.clone(), |_, details| {
+			ensure!(details.owner == *from, Error::<T, I>::WrongOwner);
+			Ok(())
+		})
+	}
+}
+
+impl<T: Config<I>, I: 'static> Destroy<Instance, JustDestroy> for Pallet<T, I> {
+	fn destroy((collection, item): &Self::Id, _strategy: JustDestroy) -> DispatchResult {
+		Self::do_burn(collection.clone(), *item, |_, _| Ok(()))
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> Destroy<Instance, WithOrigin<T::RuntimeOrigin, JustDestroy>>
+	for Pallet<T, I>
+{
+	fn destroy(
+		id @ (collection, item): &Self::Id,
+		strategy: WithOrigin<T::RuntimeOrigin, JustDestroy>,
+	) -> DispatchResult {
+		let WithOrigin(origin, JustDestroy) = strategy;
+		let details =
+			Item::<T, I>::get(collection, item).ok_or(Error::<T, I>::UnknownCollection)?;
+
+		<Self as Destroy<_, _>>::destroy(id, WithOrigin(origin, IfOwnedBy(&details.owner)))
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static> Destroy<Instance, IfOwnedBy<'a, T::AccountId>> for Pallet<T, I> {
+	fn destroy((collection, item): &Self::Id, strategy: IfOwnedBy<T::AccountId>) -> DispatchResult {
+		let IfOwnedBy(who) = strategy;
+
+		Self::do_burn(collection.clone(), *item, |_, d| {
+			ensure!(d.owner == *who, Error::<T, I>::NoPermission);
+			Ok(())
+		})
+	}
+}
+
+impl<'a, T: Config<I>, I: 'static>
+	Destroy<Instance, WithOrigin<T::RuntimeOrigin, IfOwnedBy<'a, T::AccountId>>> for Pallet<T, I>
+{
+	fn destroy(
+		(collection, item): &Self::Id,
+		strategy: WithOrigin<T::RuntimeOrigin, IfOwnedBy<T::AccountId>>,
+	) -> DispatchResult {
+		let WithOrigin(origin, IfOwnedBy(who)) = strategy;
+
+		let signer = ensure_signed(origin)?;
+
+		Self::do_burn(collection.clone(), *item, |collection_details, details| {
+			let is_permitted = collection_details.admin == signer || details.owner == signer;
+			ensure!(is_permitted, Error::<T, I>::NoPermission);
+			ensure!(*who == details.owner, Error::<T, I>::WrongOwner);
+			Ok(())
+		})
+	}
+}

--- a/substrate/frame/uniques/src/impl_asset_ops/mod.rs
+++ b/substrate/frame/uniques/src/impl_asset_ops/mod.rs
@@ -1,0 +1,2 @@
+mod class;
+mod instance;

--- a/substrate/frame/uniques/src/lib.rs
+++ b/substrate/frame/uniques/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mock;
 mod tests;
 
 mod functions;
+mod impl_asset_ops;
 mod impl_nonfungibles;
 mod types;
 
@@ -420,6 +421,14 @@ pub mod pallet {
 		NotForSale,
 		/// The provided bid is too low.
 		BidTooLow,
+		/// No metadata is found.
+		NoMetadata,
+		/// Wrong metadata key/value bytes supplied.
+		WrongMetadata,
+		/// An attribute is not found.
+		AttributeNotFound,
+		/// Wrong attribute key/value bytes supplied.
+		WrongAttribute,
 	}
 
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {

--- a/substrate/frame/uniques/src/types.rs
+++ b/substrate/frame/uniques/src/types.rs
@@ -131,3 +131,7 @@ pub struct ItemMetadata<DepositBalance, StringLimit: Get<u32>> {
 	/// Whether the item metadata may be changed by a non Force origin.
 	pub(super) is_frozen: bool,
 }
+
+pub mod asset_strategies {
+	pub struct Attribute<'a>(pub &'a [u8]);
+}


### PR DESCRIPTION
This PR introduces a new set of traits that represent different asset operations in a granular and abstract way. The main aim of the PR is to provide a granular general interface for non-fungible collections and tokens.

This is the PR I mentioned in the https://github.com/paritytech/polkadot-sdk/issues/4073 issue.

The new `asset_ops` module is added to `frame_support::traits::tokens`.
It defines the following operations on assets:
* InspectMetadata
* UpdateMetadata
* Create
* Transfer
* Destroy

Also, it defines the `AssetDefinition` trait used by all the above operations to retrieve the `Id` type of the asset (except the `Create` operation).

Each asset operation can be implemented for different asset kinds (for instance, one asset kind is a collection of NFTs and another kind is an individual non-fungible token).

Also, each operation can be implemented multiple times using different strategies associated with this operation.

For details, see the following (best viewed in the same order):
* doc comments in `substrate/frame/support/src/traits/tokens/asset_ops.rs`
* the example implementation in the `pallet-uniques`
* new XCM adapters
    * their doc comments
    * the use of the `RecreateableInstanceAdapter` for `pallet-uniques` in Rococo and Westend.

----

To keep this PR simple, it doesn't contain implementation for `pallet-nfts` and `pallet-nft-fractionalization`.
However, you can examine such implementation in [the separate PR opened in the fork](https://github.com/UniqueNetwork/polkadot-sdk/pull/8).
It also includes using the `TransferableInstanceAdapter` for `pallet-nfts` in Rococo and Westend.

Note: the `RecreateableInstanceAdapter` can't be used with `pallet-nfts` because this pallet [may burn data along with the NFT](https://github.com/paritytech/polkadot-sdk/blob/8b4cfda7589325d1a34f70b3770ab494a9d4052c/substrate/frame/nfts/src/features/create_delete_item.rs#L240-L241), so the NFT can't be fully recreated.
