### PR TITLE
Bridges: added helper function to relay single GRANDPA proof + header

### DIFF
--- a/bridges/relays/lib-substrate-relay/src/cli/relay_headers.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_headers.rs
@@ -19,7 +19,10 @@
 use async_trait::async_trait;
 use structopt::StructOpt;
 
-use relay_utils::metrics::{GlobalMetrics, StandaloneMetric};
+use relay_utils::{
+	metrics::{GlobalMetrics, StandaloneMetric},
+	UniqueSaturatedInto,
+};
 
 use crate::{
 	cli::{bridge::*, chain_schema::*, PrometheusParams},
@@ -46,6 +49,21 @@ pub struct RelayHeadersParams {
 	target_sign: TargetSigningParams,
 	#[structopt(flatten)]
 	prometheus_params: PrometheusParams,
+}
+
+/// Single header relaying params.
+#[derive(StructOpt)]
+pub struct RelayHeaderParams {
+	#[structopt(flatten)]
+	source: SourceConnectionParams,
+	#[structopt(flatten)]
+	target: TargetConnectionParams,
+	#[structopt(flatten)]
+	target_sign: TargetSigningParams,
+	/// Number of the source chain header that we want to relay. It must have a persistent
+	/// storage proof at the [`Self::source`] node, otherwise the command will fail.
+	#[structopt(long)]
+	number: u128,
 }
 
 impl RelayHeadersParams {
@@ -86,6 +104,25 @@ pub trait HeadersRelayer: RelayToRelayHeadersCliBridge {
 			headers_to_relay,
 			target_transactions_params,
 			metrics_params,
+		)
+		.await
+	}
+
+	/// Relay single header. No any check are made to ensure that transaction will succeed.
+	async fn relay_header(data: RelayHeaderParams) -> anyhow::Result<()> {
+		let source_client = data.source.into_client::<Self::Source>().await?;
+		let target_client = data.target.into_client::<Self::Target>().await?;
+		let target_transactions_mortality = data.target_sign.target_transactions_mortality;
+		let target_sign = data.target_sign.to_keypair::<Self::Target>()?;
+
+		crate::finality::relay_single_header::<Self::Finality>(
+			source_client,
+			target_client,
+			crate::TransactionParams {
+				signer: target_sign,
+				mortality: target_transactions_mortality,
+			},
+			data.number.unique_saturated_into(),
 		)
 		.await
 	}

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_headers.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_headers.rs
@@ -108,7 +108,7 @@ pub trait HeadersRelayer: RelayToRelayHeadersCliBridge {
 		.await
 	}
 
-	/// Relay single header. No any check are made to ensure that transaction will succeed.
+	/// Relay single header. No checks are made to ensure that transaction will succeed.
 	async fn relay_header(data: RelayHeaderParams) -> anyhow::Result<()> {
 		let source_client = data.source.into_client::<Self::Source>().await?;
 		let target_client = data.target.into_client::<Self::Target>().await?;

--- a/bridges/relays/lib-substrate-relay/src/finality/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/finality/mod.rs
@@ -277,7 +277,7 @@ pub async fn run<P: SubstrateFinalitySyncPipeline>(
 	.map_err(|e| anyhow::format_err!("{}", e))
 }
 
-/// Relay single header. No any check are made to ensure that transaction will succeed.
+/// Relay single header. No checks are made to ensure that transaction will succeed.
 pub async fn relay_single_header<P: SubstrateFinalitySyncPipeline>(
 	source_client: Client<P::SourceChain>,
 	target_client: Client<P::TargetChain>,

--- a/bridges/relays/lib-substrate-relay/src/finality/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/finality/mod.rs
@@ -25,13 +25,15 @@ use crate::{
 
 use async_trait::async_trait;
 use bp_header_chain::justification::{GrandpaJustification, JustificationVerificationContext};
-use finality_relay::{FinalityPipeline, FinalitySyncPipeline, HeadersToRelay};
+use finality_relay::{
+	FinalityPipeline, FinalitySyncPipeline, HeadersToRelay, SourceClient, TargetClient,
+};
 use pallet_bridge_grandpa::{Call as BridgeGrandpaCall, Config as BridgeGrandpaConfig};
 use relay_substrate_client::{
 	transaction_stall_timeout, AccountIdOf, AccountKeyPairOf, BlockNumberOf, CallOf, Chain,
 	ChainWithTransactions, Client, HashOf, HeaderOf, SyncHeader,
 };
-use relay_utils::metrics::MetricsParams;
+use relay_utils::{metrics::MetricsParams, TrackedTransactionStatus, TransactionTracker};
 use sp_core::Pair;
 use std::{fmt::Debug, marker::PhantomData};
 
@@ -273,4 +275,35 @@ pub async fn run<P: SubstrateFinalitySyncPipeline>(
 	)
 	.await
 	.map_err(|e| anyhow::format_err!("{}", e))
+}
+
+/// Relay single header. No any check are made to ensure that transaction will succeed.
+pub async fn relay_single_header<P: SubstrateFinalitySyncPipeline>(
+	source_client: Client<P::SourceChain>,
+	target_client: Client<P::TargetChain>,
+	transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
+	header_number: BlockNumberOf<P::SourceChain>,
+) -> anyhow::Result<()> {
+	let finality_source = SubstrateFinalitySource::<P>::new(source_client, None);
+	let (header, proof) = finality_source.header_and_finality_proof(header_number).await?;
+	let Some(proof) = proof else {
+		return Err(anyhow::format_err!(
+			"Unable to submit {} header #{} to {}: no finality proof",
+			P::SourceChain::NAME,
+			header_number,
+			P::TargetChain::NAME,
+		));
+	};
+
+	let finality_target = SubstrateFinalityTarget::<P>::new(target_client, transaction_params);
+	let tx_tracker = finality_target.submit_finality_proof(header, proof, false).await?;
+	match tx_tracker.wait().await {
+		TrackedTransactionStatus::Finalized(_) => Ok(()),
+		TrackedTransactionStatus::Lost => Err(anyhow::format_err!(
+			"Transaction with {} header #{} is considered lost at {}",
+			P::SourceChain::NAME,
+			header_number,
+			P::TargetChain::NAME,
+		)),
+	}
 }


### PR DESCRIPTION
related to https://github.com/paritytech/parity-bridges-common/issues/2962
silent, because the actual code for subcommand is added in the `parity-bridges-common` repo, where binary lives