### PR TITLE
[dnm-testing] litep2p/experimental: Enable WebRTC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "litep2p"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/litep2p?branch=lexnv/update-webrtc-crate#eaec7ceb50d658243509e704a9ee6e792f4ecef7"
+source = "git+https://github.com/paritytech/litep2p?branch=lexnv/test-webrtc#c132bb32c430a01ea7128ce1aa726ea9d188673b"
 dependencies = [
  "async-trait",
  "bs58 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,7 +1393,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "ring 0.1.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sp-ark-bls12-381",
  "sp-ark-ed-on-bls12-381-bandersnatch",
  "zeroize",
@@ -2421,9 +2421,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bzip2-sys"
@@ -5073,7 +5073,7 @@ dependencies = [
  "ed25519 2.2.2",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle 2.5.0",
  "zeroize",
 ]
@@ -5103,7 +5103,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "hex",
  "rand_core 0.6.4",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -5483,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fastrlp"
@@ -7341,7 +7341,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -7772,7 +7772,7 @@ dependencies = [
  "multihash 0.17.0",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "zeroize",
 ]
@@ -7797,7 +7797,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "smallvec",
  "thiserror",
  "uint",
@@ -7855,7 +7855,7 @@ dependencies = [
  "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "snow",
  "static_assertions",
  "thiserror",
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "litep2p"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/litep2p?branch=master#b142c9eb611fb2fe78d2830266a3675b37299ceb"
+source = "git+https://github.com/paritytech/litep2p?branch=lexnv/update-webrtc-crate#eaec7ceb50d658243509e704a9ee6e792f4ecef7"
 dependencies = [
  "async-trait",
  "bs58 0.4.0",
@@ -8217,7 +8217,7 @@ dependencies = [
  "ring 0.16.20",
  "rustls 0.20.8",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "simple-dns",
  "smallvec",
  "snow",
@@ -8753,7 +8753,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive 0.8.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "unsigned-varint",
 ]
@@ -8770,7 +8770,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive 0.8.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "unsigned-varint",
 ]
@@ -8800,7 +8800,7 @@ dependencies = [
  "ripemd",
  "serde",
  "sha1",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "strobe-rs",
 ]
@@ -12554,7 +12554,7 @@ checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -17898,7 +17898,7 @@ dependencies = [
  "merlin",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle 2.5.0",
  "zeroize",
 ]
@@ -17933,9 +17933,9 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f64cef148d3295c730c3cb340b0b252a4d570b1c7d4bf0808f88540b0a888bc"
+checksum = "97a4f06d93f32c3d835893e3ba8f953f9e0ccadfed414e95e595dec947fdb075"
 dependencies = [
  "bytes",
  "crc",
@@ -18311,9 +18311,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -18571,7 +18571,7 @@ dependencies = [
  "schnorrkel 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "siphasher",
  "slab",
@@ -18638,7 +18638,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring 0.16.20",
  "rustc_version 0.4.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle 2.5.0",
 ]
 
@@ -19486,7 +19486,7 @@ dependencies = [
  "byteorder",
  "criterion 0.4.0",
  "digest 0.10.7",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "sp-crypto-hashing-proc-macro",
  "twox-hash",
@@ -19907,7 +19907,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -20451,17 +20451,17 @@ dependencies = [
 
 [[package]]
 name = "str0m"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48572247f422dcbe68630c973f8296fbd5157119cd36a3223e48bf83d47727"
+checksum = "6706347e49b13373f7ddfafad47df7583ed52083d6fc8a594eb2c80497ef959d"
 dependencies = [
  "combine",
  "crc",
+ "fastrand 2.0.2",
  "hmac 0.12.1",
  "once_cell",
  "openssl",
  "openssl-sys",
- "rand 0.8.5",
  "sctp-proto",
  "serde",
  "sha-1 0.10.1",
@@ -20604,7 +20604,7 @@ dependencies = [
  "pbkdf2",
  "rustc-hex",
  "schnorrkel 0.11.4",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -21135,7 +21135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand 2.0.2",
  "redox_syscall 0.4.1",
  "rustix 0.38.21",
  "windows-sys 0.48.0",
@@ -21305,9 +21305,9 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
@@ -21334,9 +21334,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2 1.0.75",
  "quote 1.0.35",
@@ -22306,7 +22306,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "thiserror",
  "zeroize",
@@ -22624,7 +22624,7 @@ dependencies = [
  "log",
  "rustix 0.36.15",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "toml 0.5.11",
  "windows-sys 0.45.0",
  "zstd 0.11.2+zstd.1.5.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8190,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "litep2p"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/litep2p?branch=lexnv/test-webrtc#c132bb32c430a01ea7128ce1aa726ea9d188673b"
+source = "git+https://github.com/paritytech/litep2p?branch=lexnv/test-webrtc#a1603d878a0dbfa8de1ebf497c5e268cd9a26504"
 dependencies = [
  "async-trait",
  "bs58 0.4.0",

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -59,7 +59,7 @@ sp-blockchain = { path = "../../primitives/blockchain" }
 sp-core = { path = "../../primitives/core" }
 sp-runtime = { path = "../../primitives/runtime" }
 wasm-timer = "0.2"
-litep2p = { git = "https://github.com/paritytech/litep2p", branch = "lexnv/update-webrtc-crate" }
+litep2p = { git = "https://github.com/paritytech/litep2p", branch = "lexnv/test-webrtc" }
 once_cell = "1.18.0"
 void = "1.0.2"
 schnellru = "0.2.1"

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -59,7 +59,7 @@ sp-blockchain = { path = "../../primitives/blockchain" }
 sp-core = { path = "../../primitives/core" }
 sp-runtime = { path = "../../primitives/runtime" }
 wasm-timer = "0.2"
-litep2p = { git = "https://github.com/paritytech/litep2p", branch = "master" }
+litep2p = { git = "https://github.com/paritytech/litep2p", branch = "lexnv/update-webrtc-crate" }
 once_cell = "1.18.0"
 void = "1.0.2"
 schnellru = "0.2.1"

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -462,7 +462,10 @@ impl Stream for Discovery {
 					"`GET_RECORD` succeeded for {query_id:?}: {record:?}",
 				);
 
-				return Poll::Ready(Some(DiscoveryEvent::GetRecordSuccess { query_id, record }));
+				return Poll::Ready(Some(DiscoveryEvent::GetRecordSuccess {
+					query_id,
+					record: record.record,
+				}));
 			},
 			Poll::Ready(Some(KademliaEvent::PutRecordSucess { query_id, key: _ })) =>
 				return Poll::Ready(Some(DiscoveryEvent::PutRecordSuccess { query_id })),

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -360,6 +360,8 @@ impl Litep2pNetworkBackend {
 				// to the same Protocol::WebRTC variant. This is a limitation of the multiaddr
 				// crate.
 				(Some(Protocol::Udp(_)), Some(Protocol::WebRTC)) => {
+					log::info!(target: LOG_TARGET, "using webrtc protocol {addr:?}");
+
 					webrtc_addresses.push(addr.clone());
 				},
 

--- a/substrate/client/network/types/Cargo.toml
+++ b/substrate/client/network/types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sc-network-types"
 [dependencies]
 bs58 = "0.4.0"
 libp2p-identity = { version = "0.1.3", features = ["ed25519", "peerid"] }
-litep2p = { git = "https://github.com/paritytech/litep2p", branch = "master" }
+litep2p = { git = "https://github.com/paritytech/litep2p", branch = "lexnv/update-webrtc-crate" }
 multiaddr = "0.17.0"
 multihash = { version = "0.17.0", default-features = false, features = ["identity", "multihash-impl", "sha2", "std"] }
 rand = "0.8.5"

--- a/substrate/client/network/types/Cargo.toml
+++ b/substrate/client/network/types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sc-network-types"
 [dependencies]
 bs58 = "0.4.0"
 libp2p-identity = { version = "0.1.3", features = ["ed25519", "peerid"] }
-litep2p = { git = "https://github.com/paritytech/litep2p", branch = "lexnv/update-webrtc-crate" }
+litep2p = { git = "https://github.com/paritytech/litep2p", branch = "lexnv/test-webrtc" }
 multiaddr = "0.17.0"
 multihash = { version = "0.17.0", default-features = false, features = ["identity", "multihash-impl", "sha2", "std"] }
 rand = "0.8.5"

--- a/substrate/client/transaction-pool/src/graph/validated_pool.rs
+++ b/substrate/client/transaction-pool/src/graph/validated_pool.rs
@@ -237,7 +237,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 		{
 			log::debug!(
 				target: LOG_TARGET,
-				"Enforcing limits ({}/{}kB ready, {}/{}kB future",
+				"Enforcing limits ({}/{}kB ready, {}/{}kB future)",
 				ready_limit.count,
 				ready_limit.total_bytes / 1024,
 				future_limit.count,

--- a/substrate/primitives/crypto/hashing/Cargo.toml
+++ b/substrate/primitives/crypto/hashing/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 blake2b_simd = { version = "1.0.1", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 digest = { version = "0.10.3", default-features = false }
-sha2 = { version = "0.10.7", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 sha3 = { version = "0.10.0", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false, features = ["digest_0_10"] }
 

--- a/substrate/primitives/statement-store/Cargo.toml
+++ b/substrate/primitives/statement-store/Cargo.toml
@@ -33,7 +33,7 @@ x25519-dalek = { version = "2.0", optional = true, features = ["static_secrets"]
 curve25519-dalek = { version = "4.1.1", optional = true }
 aes-gcm = { version = "0.10", optional = true }
 hkdf = { version = "0.12.0", optional = true }
-sha2 = { version = "0.10.7", optional = true }
+sha2 = { version = "0.10.8", optional = true }
 rand = { version = "0.8.5", features = ["small_rng"], optional = true }
 
 [features]

--- a/substrate/utils/substrate-bip39/Cargo.toml
+++ b/substrate/utils/substrate-bip39/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 hmac = "0.12.1"
 pbkdf2 = { version = "0.12.2", default-features = false }
 schnorrkel = { version = "0.11.4", default-features = false }
-sha2 = { version = "0.10.7", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 zeroize = { version = "1.4.3", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR enables the litep2p WebRTC transport layer that was recently merged to the litep2p crate, thanks to @altonen and @dmitry-markin for the huge heavy lifting there!
- https://github.com/paritytech/litep2p/pull/51

This PR relies on a branch of litep2p, which we hope soon to merge. The branch updates the interval str0m crate to the latest version, which contains among other bug fixes a fix to increment the channel ID of webRTC connections. 
- https://github.com/paritytech/litep2p/pull/95

Please note that webRTC is still an unstable feature and other problems may appear during testing.
It would be of great help to our efforts to stabilize this to report back any issues to https://github.com/paritytech/litep2p.
To check this functionality, use the following to enable litep2p `--network-backend litep2p`

cc @paritytech/networking 
