### PR TITLE
[BUG|Crowdloan] Start Period can't be the current

### DIFF
--- a/polkadot/runtime/common/src/crowdloan/mod.rs
+++ b/polkadot/runtime/common/src/crowdloan/mod.rs
@@ -398,7 +398,7 @@ pub mod pallet {
 
 			// Can't start a crowdloan for a lease period that already passed.
 			if let Some((current_lease_period, _)) = T::Auctioneer::lease_period_index(now) {
-				ensure!(first_period >= current_lease_period, Error::<T>::FirstPeriodInPast);
+				ensure!(first_period > current_lease_period, Error::<T>::FirstPeriodInPast);
 			}
 
 			// There should not be an existing fund.

--- a/polkadot/runtime/common/src/crowdloan/mod.rs
+++ b/polkadot/runtime/common/src/crowdloan/mod.rs
@@ -396,8 +396,9 @@ pub mod pallet {
 			};
 			ensure!(adjusted_lease_period_at_end <= first_period, Error::<T>::EndTooFarInFuture);
 
-			// Validate the starting period for a crowdloan. 
-			// A crowdloan cannot be initiated for a lease period that has already begun or is in the past.
+			// Validate the starting period for a crowdloan.
+			// A crowdloan cannot be initiated for a lease period that has already begun or is in
+			// the past.
 			if let Some((current_lease_period, _)) = T::Auctioneer::lease_period_index(now) {
 				ensure!(first_period > current_lease_period, Error::<T>::FirstPeriodInPast);
 			}

--- a/polkadot/runtime/common/src/crowdloan/mod.rs
+++ b/polkadot/runtime/common/src/crowdloan/mod.rs
@@ -396,7 +396,8 @@ pub mod pallet {
 			};
 			ensure!(adjusted_lease_period_at_end <= first_period, Error::<T>::EndTooFarInFuture);
 
-			// Can't start a crowdloan for a lease period that already passed.
+			// Validate the starting period for a crowdloan. 
+			// A crowdloan cannot be initiated for a lease period that has already begun or is in the past.
 			if let Some((current_lease_period, _)) = T::Auctioneer::lease_period_index(now) {
 				ensure!(first_period > current_lease_period, Error::<T>::FirstPeriodInPast);
 			}


### PR DESCRIPTION
This PR addresses a critical bug in the validation logic for the start period of crowdloans within the Polkadot runtime. The issue allowed for the creation of crowdloans that could overlap with current lease periods, leading to unexpected behavior in auction participation.

#### Context
The bug has directly impacted real-world operations, as evidenced by the recent difficulties faced by the LAOS Network. They initiated a crowdloan for paraid = 3370 with the intent to participate in Auction 68. Due to the incorrect setting of the first lease period as 16, the same as the current period at the time, contributions were not recognized as valid bids for the auction. This issue has prompted [Referendum 716](https://polkadot.polkassembly.io/referenda/716) titled "Correcting LAOS Network's Crowdloan Lease Start Period for Auction Eligibility", proposed by a member of the LAOS Chain Foundation.

#### Changes Made:
- Updated the inline comments to clearly explain the necessity of setting the first lease period strictly after the current lease period.
- Modified the validation check from `>=` to `>` to ensure crowdloans are only initiated for future lease periods, thus preventing similar issues in future auctions.

#### Impact of the Bug:
- At time of writing 330 participants contributed for Auction 68, with a total of 95000 DOT collected. These contributions failed to be recognized due to the bug.
- A corrective action proposed in Referendum 716 suggests adjusting the first_period parameter from 16 to 17 to align with auction eligibility requirements. This measure, if implemented timely, will salvage the contributions for the last three auctions of the batch (71 to 73).

This bug fix is critical to maintain the integrity and reliability of the crowdloan and auction processes in the Polkadot network, ensuring that contributions are accurately processed and recognized in future auctions.