### PR TITLE
sc-tracing: enable env-filter feature

### DIFF
--- a/substrate/client/tracing/Cargo.toml
+++ b/substrate/client/tracing/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 tracing = "0.1.29"
 tracing-log = "0.1.3"
-tracing-subscriber = { workspace = true, features = ["parking_lot", "env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "parking_lot"] }
 sc-client-api = { path = "../api" }
 sc-tracing-proc-macro = { path = "proc-macro" }
 sp-api = { path = "../../primitives/api" }

--- a/substrate/client/tracing/Cargo.toml
+++ b/substrate/client/tracing/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 tracing = "0.1.29"
 tracing-log = "0.1.3"
-tracing-subscriber = { workspace = true, features = ["parking_lot"] }
+tracing-subscriber = { workspace = true, features = ["parking_lot", "env-filter"] }
 sc-client-api = { path = "../api" }
 sc-tracing-proc-macro = { path = "proc-macro" }
 sp-api = { path = "../../primitives/api" }


### PR DESCRIPTION
This crate uses this feature however it appears to still work without this feature enabled. I believe this is due to feature unification of the workspace. Some other crate enables this feature so it also ends up enabled here. But when this crate is pushed to crates.io and compiled individualy it fails to compile.