### PR TITLE
wip/PoC: Enrich metadata custom types with essential types for chain communications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,8 +1629,6 @@ dependencies = [
 [[package]]
 name = "bounded-collections"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32385ecb91a31bddaf908e8dcf4a15aef1bcd3913cc03ebfad02ff6d568abc1"
 dependencies = [
  "log",
  "parity-scale-codec",

--- a/cumulus/pallets/collator-selection/src/weights.rs
+++ b/cumulus/pallets/collator-selection/src/weights.rs
@@ -40,6 +40,7 @@ pub trait WeightInfo {
 }
 
 /// Weights for pallet_collator_selection using the Substrate node and recommended hardware.
+#[derive(scale_info::TypeInfo)]
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn set_invulnerables(b: u32) -> Weight {

--- a/cumulus/pallets/xcmp-queue/Cargo.toml
+++ b/cumulus/pallets/xcmp-queue/Cargo.toml
@@ -34,7 +34,7 @@ cumulus-primitives-core = { path = "../../primitives/core", default-features = f
 
 # Optional import for benchmarking
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }
-bounded-collections = { version = "0.2.0", default-features = false }
+bounded-collections = { path = "/home/lexnv/workspace/parity-common/bounded-collections", default-features = false }
 
 # Bridges
 bp-xcm-bridge-hub-router = { path = "../../../bridges/primitives/xcm-bridge-hub-router", default-features = false, optional = true }

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1678,8 +1678,13 @@ cumulus_pallet_parachain_system::register_validate_block! {
 
 parameter_types! {
 	// The deposit configuration for the singed migration. Specially if you want to allow any signed account to do the migration (see `SignedFilter`, these deposits should be high)
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationSignedDepositPerItem: Balance = CENTS;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationSignedDepositBase: Balance = 2_000 * CENTS;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationMaxKeyLen: u32 = 512;
 }
 

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -544,6 +544,7 @@ parameter_types! {
 	pub WestendTreasuryAccount: AccountId = WESTEND_TREASURY_PALLET_ID.into_account_truncating();
 	// The number of blocks a member must wait between giving a retirement notice and retiring.
 	// Supposed to be greater than time required to `kick_member` with alliance motion.
+	#[derive(scale_info::TypeInfo)]
 	pub const AllianceRetirementPeriod: BlockNumber = (90 * DAYS) + ALLIANCE_MOTION_DURATION;
 }
 

--- a/polkadot/parachain/Cargo.toml
+++ b/polkadot/parachain/Cargo.toml
@@ -21,7 +21,8 @@ sp-core = { path = "../../substrate/primitives/core", default-features = false, 
 sp-weights = { path = "../../substrate/primitives/weights", default-features = false }
 polkadot-core-primitives = { path = "../core-primitives", default-features = false }
 derive_more = "0.99.11"
-bounded-collections = { version = "0.2.0", default-features = false, features = ["serde"] }
+
+bounded-collections = { path = "/home/lexnv/workspace/parity-common/bounded-collections", default-features = false, features = ["serde"] }
 
 # all optional crates.
 serde = { features = ["alloc", "derive"], workspace = true }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -344,6 +344,7 @@ impl pallet_preimage::Config for Runtime {
 
 parameter_types! {
 	pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
+	#[derive(scale_info::TypeInfo)]
 	pub ReportLongevity: u64 = EpochDurationInBlocks::get() as u64 * 10;
 }
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1367,8 +1367,13 @@ impl pallet_root_testing::Config for Runtime {
 
 parameter_types! {
 	// The deposit configuration for the singed migration. Specially if you want to allow any signed account to do the migration (see `SignedFilter`, these deposits should be high)
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationSignedDepositPerItem: Balance = 1 * CENTS;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationSignedDepositBase: Balance = 20 * CENTS * 100;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationMaxKeyLen: u32 = 512;
 }
 

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 array-bytes = "6.1"
-bounded-collections = { version = "0.2.0", default-features = false, features = ["serde"] }
+bounded-collections = { path = "/home/lexnv/workspace/parity-common/bounded-collections", default-features = false, features = ["serde"] }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"] }
 impl-trait-for-tuples = "0.2.2"
 log = { workspace = true }

--- a/polkadot/xcm/pallet-xcm/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-bounded-collections = { version = "0.2.0", default-features = false }
+bounded-collections = { path = "/home/lexnv/workspace/parity-common/bounded-collections", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }

--- a/substrate/bin/node/runtime/src/impls.rs
+++ b/substrate/bin/node/runtime/src/impls.rs
@@ -55,6 +55,7 @@ impl HandleCredit<AccountId, Assets> for CreditToBlockAuthor {
 	}
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct AllianceIdentityVerifier;
 impl IdentityVerifier<AccountId> for AllianceIdentityVerifier {
 	fn has_required_identities(who: &AccountId) -> bool {

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -489,6 +489,8 @@ parameter_types! {
 	//       Attempting to do so will brick block production.
 	pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
 	pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const ReportLongevity: u64 =
 		BondingDuration::get() as u64 * SessionsPerEra::get() as u64 * EpochDuration::get();
 }
@@ -1954,8 +1956,13 @@ impl pallet_whitelist::Config for Runtime {
 }
 
 parameter_types! {
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationSignedDepositPerItem: Balance = 1 * CENTS;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationSignedDepositBase: Balance = 20 * DOLLARS;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const MigrationMaxKeyLen: u32 = 512;
 }
 
@@ -1978,8 +1985,13 @@ impl pallet_state_trie_migration::Config for Runtime {
 const ALLIANCE_MOTION_DURATION_IN_BLOCKS: BlockNumber = 5 * DAYS;
 
 parameter_types! {
+	#[derive(scale_info::TypeInfo)]
 	pub const AllianceMotionDuration: BlockNumber = ALLIANCE_MOTION_DURATION_IN_BLOCKS;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const AllianceMaxProposals: u32 = 100;
+
+	#[derive(scale_info::TypeInfo)]
 	pub const AllianceMaxMembers: u32 = 100;
 }
 
@@ -1999,6 +2011,7 @@ impl pallet_collective::Config<AllianceCollective> for Runtime {
 
 parameter_types! {
 	pub const MaxFellows: u32 = AllianceMaxMembers::get();
+	#[derive(scale_info::TypeInfo)]
 	pub const MaxAllies: u32 = 100;
 	pub const AllyDeposit: Balance = 10 * DOLLARS;
 	pub const RetirementPeriod: BlockNumber = ALLIANCE_MOTION_DURATION_IN_BLOCKS + (1 * DAYS);
@@ -2065,6 +2078,7 @@ impl pallet_statement::Config for Runtime {
 }
 
 parameter_types! {
+	#[derive(scale_info::TypeInfo)]
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * RuntimeBlockWeights::get().max_block;
 }
 
@@ -2087,6 +2101,7 @@ parameter_types! {
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct IntoAuthor;
 impl OnUnbalanced<Credit<AccountId, Balances>> for IntoAuthor {
 	fn on_nonzero_unbalanced(credit: Credit<AccountId, Balances>) {
@@ -2100,6 +2115,7 @@ parameter_types! {
 	pub storage CoretimeRevenue: Option<(BlockNumber, Balance)> = None;
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct CoretimeProvider;
 impl CoretimeInterface for CoretimeProvider {
 	type AccountId = AccountId;
@@ -2206,6 +2222,7 @@ impl Default for RuntimeParameters {
 	}
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct DynamicParametersManagerOrigin;
 impl EnsureOriginWithArg<RuntimeOrigin, RuntimeParametersKey> for DynamicParametersManagerOrigin {
 	type Success = ();
@@ -2336,6 +2353,7 @@ mod runtime {
 	pub type Offences = pallet_offences;
 
 	#[runtime::pallet_index(26)]
+	#[derive(scale_info::TypeInfo)]
 	pub type Historical = pallet_session_historical;
 
 	#[runtime::pallet_index(27)]

--- a/substrate/frame/alliance/src/mock.rs
+++ b/substrate/frame/alliance/src/mock.rs
@@ -154,6 +154,7 @@ impl Verify for AccountU64 {
 	}
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct AllianceIdentityVerifier;
 impl IdentityVerifier<AccountId> for AllianceIdentityVerifier {
 	fn has_required_identities(who: &AccountId) -> bool {
@@ -213,6 +214,7 @@ impl ProposalProvider<AccountId, H256, RuntimeCall> for AllianceProposalProvider
 
 parameter_types! {
 	pub const MaxFellows: u32 = MaxMembers::get();
+	#[derive(scale_info::TypeInfo)]
 	pub const MaxAllies: u32 = 100;
 	pub const AllyDeposit: u64 = 25;
 	pub const RetirementPeriod: BlockNumber = MOTION_DURATION_IN_BLOCKS + 1;

--- a/substrate/frame/babe/src/equivocation.rs
+++ b/substrate/frame/babe/src/equivocation.rs
@@ -104,6 +104,7 @@ impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 /// - On-chain validity checks and processing are mostly delegated to the user provided generic
 ///   types implementing `KeyOwnerProofSystem` and `ReportOffence` traits.
 /// - Offence reporter for unsigned transactions is fetched via the the authorship pallet.
+#[derive(scale_info::TypeInfo)]
 pub struct EquivocationReportSystem<T, R, P, L>(sp_std::marker::PhantomData<(T, R, P, L)>);
 
 impl<T, R, P, L>

--- a/substrate/frame/beefy/src/equivocation.rs
+++ b/substrate/frame/beefy/src/equivocation.rs
@@ -119,6 +119,7 @@ where
 /// - On-chain validity checks and processing are mostly delegated to the user provided generic
 ///   types implementing `KeyOwnerProofSystem` and `ReportOffence` traits.
 /// - Offence reporter for unsigned transactions is fetched via the the authorship pallet.
+#[derive(scale_info::TypeInfo)]
 pub struct EquivocationReportSystem<T, R, P, L>(sp_std::marker::PhantomData<(T, R, P, L)>);
 
 /// Equivocation evidence convenience alias.

--- a/substrate/frame/contracts/src/lib.rs
+++ b/substrate/frame/contracts/src/lib.rs
@@ -508,6 +508,7 @@ pub mod pallet {
 		}
 
 		/// A type providing default configurations for this pallet in testing environment.
+		#[derive(scale_info::TypeInfo)]
 		pub struct TestDefaultConfig;
 
 		impl<Output, BlockNumber> Randomness<Output, BlockNumber> for TestDefaultConfig {

--- a/substrate/frame/executive/src/tests.rs
+++ b/substrate/frame/executive/src/tests.rs
@@ -398,6 +398,7 @@ parameter_types! {
 	pub static SystemCallbacksCalled: u32 = 0;
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct MockedSystemCallbacks;
 impl PreInherents for MockedSystemCallbacks {
 	fn pre_inherents() {

--- a/substrate/frame/grandpa/src/equivocation.rs
+++ b/substrate/frame/grandpa/src/equivocation.rs
@@ -114,6 +114,7 @@ impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 /// - On-chain validity checks and processing are mostly delegated to the user provided generic
 ///   types implementing `KeyOwnerProofSystem` and `ReportOffence` traits.
 /// - Offence reporter for unsigned transactions is fetched via the the authorship pallet.
+#[derive(scale_info::TypeInfo)]
 pub struct EquivocationReportSystem<T, R, P, L>(sp_std::marker::PhantomData<(T, R, P, L)>);
 
 impl<T, R, P, L>

--- a/substrate/frame/migrations/src/lib.rs
+++ b/substrate/frame/migrations/src/lib.rs
@@ -346,6 +346,7 @@ pub mod pallet {
 
 		frame_support::parameter_types! {
 			/// Maximal weight per block that can be spent on migrations in tests.
+			#[derive(scale_info::TypeInfo)]
 			pub TestMaxServiceWeight: Weight = <<TestDefaultConfig as frame_system::DefaultConfig>::BlockWeights as Get<BlockWeights>>::get().max_block.div(2);
 		}
 

--- a/substrate/frame/multisig/src/tests.rs
+++ b/substrate/frame/multisig/src/tests.rs
@@ -53,6 +53,7 @@ impl pallet_balances::Config for Test {
 	type AccountStore = System;
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct TestBaseCallFilter;
 impl Contains<RuntimeCall> for TestBaseCallFilter {
 	fn contains(c: &RuntimeCall) -> bool {

--- a/substrate/frame/proxy/src/tests.rs
+++ b/substrate/frame/proxy/src/tests.rs
@@ -102,6 +102,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 		self == &ProxyType::Any || self == o
 	}
 }
+
+#[derive(scale_info::TypeInfo)]
 pub struct BaseFilter;
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(c: &RuntimeCall) -> bool {

--- a/substrate/frame/referenda/src/mock.rs
+++ b/substrate/frame/referenda/src/mock.rs
@@ -48,6 +48,7 @@ frame_support::construct_runtime!(
 );
 
 // Test that a fitlered call can be dispatched.
+#[derive(scale_info::TypeInfo)]
 pub struct BaseFilter;
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {

--- a/substrate/frame/scheduler/src/mock.rs
+++ b/substrate/frame/scheduler/src/mock.rs
@@ -123,6 +123,7 @@ frame_support::construct_runtime!(
 );
 
 // Scheduler must dispatch with root and no filter, this tests base filter is indeed not used.
+#[derive(scale_info::TypeInfo)]
 pub struct BaseFilter;
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(call: &RuntimeCall) -> bool {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -181,6 +181,18 @@ pub fn expand_runtime_metadata(
 								"Signature".into(),
 								signature_ty,
 							),
+							(
+								"Hash".into(),
+								#scrate::__private::scale_info::meta_type::<
+										<#runtime as #system_path::Config>::Hash
+									>(),
+							),
+							(
+								"Hashing".into(),
+								#scrate::__private::scale_info::meta_type::<
+										<#runtime as #system_path::Config>::Hashing
+									>(),
+							),
 							#maybe_asset_id
 						]
 						.into_iter()

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -27,6 +27,7 @@ pub fn expand_runtime_metadata(
 	scrate: &TokenStream,
 	extrinsic: &TokenStream,
 	system_path: &PalletPath,
+	assets_path: Option<PalletPath>,
 ) -> TokenStream {
 	let pallets = pallet_declarations
 		.iter()
@@ -74,6 +75,19 @@ pub fn expand_runtime_metadata(
 			}
 		})
 		.collect::<Vec<_>>();
+
+	let asset_id = if let Some(assets_path) = assets_path {
+		quote! {
+			(
+				"AssetId".into(),
+				#scrate::__private::scale_info::meta_type::<
+						<#runtime as #assets_path::Config>::AssetId
+					>(),
+			),
+		}
+	} else {
+		quote! {}
+	};
 
 	quote! {
 		impl #runtime {
@@ -155,6 +169,7 @@ pub fn expand_runtime_metadata(
 										<#runtime as #system_path::Config>::AccountId
 									>(),
 							),
+							#asset_id
 						]
 						.into_iter()
 						.collect(),

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -149,6 +149,12 @@ pub fn expand_runtime_metadata(
 										<#runtime as #system_path::Config>::RuntimeCall
 									>(),
 							),
+							(
+								"AccountId".into(),
+								#scrate::__private::scale_info::meta_type::<
+										<#runtime as #system_path::Config>::AccountId
+									>(),
+							),
 						]
 						.into_iter()
 						.collect(),

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -140,6 +140,18 @@ pub fn expand_runtime_metadata(
 							>(),
 						event_enum_ty: #scrate::__private::scale_info::meta_type::<RuntimeEvent>(),
 						error_enum_ty: #scrate::__private::scale_info::meta_type::<RuntimeError>(),
+					},
+					custom_types: #scrate::__private::metadata_ir::CustomMetadataIR {
+						map: [
+							(
+								"CallEnumTy".into(),
+								#scrate::__private::scale_info::meta_type::<
+										<#runtime as #system_path::Config>::RuntimeCall
+									>(),
+							),
+						]
+						.into_iter()
+						.collect(),
 					}
 				}
 			}

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -52,6 +52,7 @@ pub fn expand_runtime_metadata(
 			let constants = expand_pallet_metadata_constants(runtime, decl);
 			let errors = expand_pallet_metadata_errors(runtime, decl);
 			let docs = expand_pallet_metadata_docs(runtime, decl);
+			let associated_types = expand_pallet_metadata_associated_types(runtime, decl);
 			let attr = decl.cfg_pattern.iter().fold(TokenStream::new(), |acc, pattern| {
 				let attr = TokenStream::from_str(&format!("#[cfg({})]", pattern.original()))
 					.expect("was successfully parsed before; qed");
@@ -72,6 +73,7 @@ pub fn expand_runtime_metadata(
 					constants: #constants,
 					error: #errors,
 					docs: #docs,
+					associated_types: #associated_types,
 				}
 			}
 		})
@@ -310,5 +312,14 @@ fn expand_pallet_metadata_docs(runtime: &Ident, decl: &Pallet) -> TokenStream {
 
 	quote! {
 		#path::Pallet::<#runtime #(, #path::#instance)*>::pallet_documentation_metadata()
+	}
+}
+
+fn expand_pallet_metadata_associated_types(runtime: &Ident, decl: &Pallet) -> TokenStream {
+	let path = &decl.path;
+	let instance = decl.instance.as_ref().into_iter();
+
+	quote! {
+		#path::Pallet::<#runtime #(, #path::#instance)*>::pallet_associated_types_metadata()
 	}
 }

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -28,6 +28,7 @@ pub fn expand_runtime_metadata(
 	extrinsic: &TokenStream,
 	system_path: &PalletPath,
 	assets_pallet: Option<&Pallet>,
+	header: &TokenStream,
 ) -> TokenStream {
 	let pallets = pallet_declarations
 		.iter()
@@ -192,6 +193,10 @@ pub fn expand_runtime_metadata(
 								#scrate::__private::scale_info::meta_type::<
 										<#runtime as #system_path::Config>::Hashing
 									>(),
+							),
+							(
+								"Header".into(),
+								#scrate::__private::scale_info::meta_type::<#header>(),
 							),
 							#maybe_asset_id
 						]

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -173,6 +173,10 @@ pub fn expand_runtime_metadata(
 										<#runtime as #system_path::Config>::AccountId
 									>(),
 							),
+							(
+								"Address".into(),
+								address_ty,
+							),
 							#maybe_asset_id
 						]
 						.into_iter()

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -163,12 +163,6 @@ pub fn expand_runtime_metadata(
 					custom_types: #scrate::__private::metadata_ir::CustomMetadataIR {
 						map: [
 							(
-								"CallEnumTy".into(),
-								#scrate::__private::scale_info::meta_type::<
-										<#runtime as #system_path::Config>::RuntimeCall
-									>(),
-							),
-							(
 								"AccountId".into(),
 								#scrate::__private::scale_info::meta_type::<
 										<#runtime as #system_path::Config>::AccountId

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -177,6 +177,10 @@ pub fn expand_runtime_metadata(
 								"Address".into(),
 								address_ty,
 							),
+							(
+								"Signature".into(),
+								signature_ty,
+							),
 							#maybe_asset_id
 						]
 						.into_iter()

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/origin.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/origin.rs
@@ -103,6 +103,7 @@ pub fn expand_outer_origin(
 		///
 		#[doc = #doc_string]
 		#[derive(Clone)]
+		#[derive(#scrate::__private::scale_info::TypeInfo)]
 		pub struct RuntimeOrigin {
 			pub caller: OriginCaller,
 			filter: #scrate::__private::sp_std::rc::Rc<Box<dyn Fn(&<#runtime as #system_path::Config>::RuntimeCall) -> bool>>,

--- a/substrate/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/mod.rs
@@ -398,6 +398,7 @@ fn construct_runtime_final_expansion(
 	let frame_system = generate_access_from_frame_or_crate("frame-system")?;
 	let block = quote!(<#name as #frame_system::Config>::Block);
 	let unchecked_extrinsic = quote!(<#block as #scrate::sp_runtime::traits::Block>::Extrinsic);
+	let header = quote!(<#block as #scrate::sp_runtime::traits::Block>::Header);
 
 	let outer_event =
 		expand::expand_outer_enum(&name, &pallets, &scrate, expand::OuterEnumType::Event)?;
@@ -417,6 +418,7 @@ fn construct_runtime_final_expansion(
 		&unchecked_extrinsic,
 		&system_pallet.path,
 		assets_pallet,
+		&header,
 	);
 	let outer_config = expand::expand_outer_config(&name, &pallets, &scrate);
 	let inherent =

--- a/substrate/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/mod.rs
@@ -416,7 +416,7 @@ fn construct_runtime_final_expansion(
 		&scrate,
 		&unchecked_extrinsic,
 		&system_pallet.path,
-		assets_pallet.map(|pallet| pallet.path.clone()),
+		assets_pallet,
 	);
 	let outer_config = expand::expand_outer_config(&name, &pallets, &scrate);
 	let inherent =

--- a/substrate/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/mod.rs
@@ -226,6 +226,10 @@ use syn::{spanned::Spanned, Ident, Result};
 
 /// The fixed name of the system pallet.
 const SYSTEM_PALLET_NAME: &str = "System";
+/// The fixed name of the ForeignAssets pallet.
+const FOREIGN_ASSETS_PALLET_NAME: &str = "ForeignAssets";
+/// The fixed name of the Assets pallet.
+const ASSETS_PALLET_NAME: &str = "Assets";
 
 /// Implementation of `construct_runtime` macro. Either expand to some code which will call
 /// `construct_runtime` again, or expand to the final runtime definition.
@@ -365,6 +369,12 @@ fn construct_runtime_final_expansion(
 		))
 	}
 
+	// Find either the foreign assets pallet or the local assets pallet in this order.
+	let assets_pallet = pallets
+		.iter()
+		.find(|decl| decl.name == FOREIGN_ASSETS_PALLET_NAME)
+		.or_else(|| pallets.iter().find(|decl| decl.name == ASSETS_PALLET_NAME));
+
 	let features = pallets
 		.iter()
 		.filter_map(|decl| {
@@ -406,6 +416,7 @@ fn construct_runtime_final_expansion(
 		&scrate,
 		&unchecked_extrinsic,
 		&system_pallet.path,
+		assets_pallet.map(|pallet| pallet.path.clone()),
 	);
 	let outer_config = expand::expand_outer_config(&name, &pallets, &scrate);
 	let inherent =

--- a/substrate/frame/support/procedural/src/pallet/expand/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/config.rs
@@ -125,16 +125,17 @@ pub fn expand_config_metadata(def: &Def) -> proc_macro2::TokenStream {
 		let no_docs = vec![];
 		let doc = if cfg!(feature = "no-metadata-docs") { &no_docs } else { &metadata.doc };
 
-		quote::quote!({
-			#( #cfgs ) *
-			#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR {
-				name: #ident_str,
-				ty: #frame_support::__private::scale_info::meta_type::<
-						<T as Config #trait_use_gen>::#ident
-					>(),
-				docs: #frame_support::__private::sp_std::vec![ #( #doc ),* ],
-			}
-		})
+		quote::quote!(
+			#( #cfgs ) * {
+				#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR {
+					name: #ident_str,
+					ty: #frame_support::__private::scale_info::meta_type::<
+							<T as Config #trait_use_gen>::#ident
+						>(),
+					docs: #frame_support::__private::sp_std::vec![ #( #doc ),* ],
+				}
+			},
+		)
 	});
 
 	quote::quote!(
@@ -144,7 +145,7 @@ pub fn expand_config_metadata(def: &Def) -> proc_macro2::TokenStream {
 			pub fn pallet_associated_types_metadata()
 				-> #frame_support::__private::sp_std::vec::Vec<#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR>
 			{
-				#frame_support::__private::sp_std::vec![ #( #types ),* ]
+				#frame_support::__private::sp_std::vec![ #( #types )* ]
 			}
 		}
 	)

--- a/substrate/frame/support/procedural/src/pallet/expand/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/config.rs
@@ -113,11 +113,20 @@ pub fn expand_config_metadata(def: &Def) -> proc_macro2::TokenStream {
 	let types = def.config.associated_types_metadata.iter().map(|metadata| {
 		let ident = &metadata.ident;
 		let ident_str = format!("{}", ident);
+		let cfgs = &metadata.cfg;
+
+		if ident == "BenchmarkHelper" {
+			println!();
+			println!();
+			println!();
+			println!(" cfg {:?}", cfgs);
+		}
 
 		let no_docs = vec![];
 		let doc = if cfg!(feature = "no-metadata-docs") { &no_docs } else { &metadata.doc };
 
 		quote::quote!({
+			#( #cfgs ) *
 			#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR {
 				name: #ident_str,
 				ty: #frame_support::__private::scale_info::meta_type::<

--- a/substrate/frame/support/procedural/src/pallet/expand/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/config.rs
@@ -115,12 +115,12 @@ pub fn expand_config_metadata(def: &Def) -> proc_macro2::TokenStream {
 		let ident_str = format!("{}", ident);
 		let cfgs = &metadata.cfg;
 
-		if ident == "BenchmarkHelper" {
-			println!();
-			println!();
-			println!();
-			println!(" cfg {:?}", cfgs);
-		}
+		// if ident == "BenchmarkHelper" {
+		// 	println!();
+		// 	println!();
+		// 	println!();
+		// 	println!(" cfg {:?}", cfgs);
+		// }
 
 		let no_docs = vec![];
 		let doc = if cfg!(feature = "no-metadata-docs") { &no_docs } else { &metadata.doc };

--- a/substrate/frame/support/procedural/src/pallet/expand/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/config.rs
@@ -99,7 +99,7 @@ Consequently, a runtime that wants to include this pallet must implement this tr
 /// Generate the metadata for the associated types of the config trait.
 ///
 /// Implements the `pallet_associated_types_metadata` function for the pallet.
-pub fn expand_config_metadata(def: &mut Def) -> proc_macro2::TokenStream {
+pub fn expand_config_metadata(def: &Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let type_impl_gen = &def.type_impl_generics(proc_macro2::Span::call_site());
 	let type_use_gen = &def.type_use_generics(proc_macro2::Span::call_site());
@@ -121,7 +121,7 @@ pub fn expand_config_metadata(def: &mut Def) -> proc_macro2::TokenStream {
 			#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR {
 				name: #ident_str,
 				ty: #frame_support::__private::scale_info::meta_type::<
-						<<T as Config #trait_use_gen>::#ident
+						<T as Config #trait_use_gen>::#ident
 					>(),
 				docs: #frame_support::__private::sp_std::vec![ #( #doc ),* ],
 			}

--- a/substrate/frame/support/procedural/src/pallet/expand/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/config.rs
@@ -95,3 +95,48 @@ Consequently, a runtime that wants to include this pallet must implement this tr
 		_ => Default::default(),
 	}
 }
+
+/// Generate the metadata for the associated types of the config trait.
+///
+/// Implements the `pallet_associated_types_metadata` function for the pallet.
+pub fn expand_config_metadata(def: &mut Def) -> proc_macro2::TokenStream {
+	let frame_support = &def.frame_support;
+	let type_impl_gen = &def.type_impl_generics(proc_macro2::Span::call_site());
+	let type_use_gen = &def.type_use_generics(proc_macro2::Span::call_site());
+	let pallet_ident = &def.pallet_struct.pallet;
+	let trait_use_gen = &def.trait_use_generics(proc_macro2::Span::call_site());
+
+	let mut where_clauses = vec![&def.config.where_clause];
+	where_clauses.extend(def.extra_constants.iter().map(|d| &d.where_clause));
+	let completed_where_clause = super::merge_where_clauses(&where_clauses);
+
+	let types = def.config.associated_types_metadata.iter().map(|metadata| {
+		let ident = &metadata.ident;
+		let ident_str = format!("{}", ident);
+
+		let no_docs = vec![];
+		let doc = if cfg!(feature = "no-metadata-docs") { &no_docs } else { &metadata.doc };
+
+		quote::quote!({
+			#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR {
+				name: #ident_str,
+				ty: #frame_support::__private::scale_info::meta_type::<
+						<<T as Config #trait_use_gen>::#ident
+					>(),
+				docs: #frame_support::__private::sp_std::vec![ #( #doc ),* ],
+			}
+		})
+	});
+
+	quote::quote!(
+		impl<#type_impl_gen> #pallet_ident<#type_use_gen> #completed_where_clause {
+
+			#[doc(hidden)]
+			pub fn pallet_associated_types_metadata()
+				-> #frame_support::__private::sp_std::vec::Vec<#frame_support::__private::metadata_ir::PalletAssociatedTypesMetadataIR>
+			{
+				#frame_support::__private::sp_std::vec![ #( #types ),* ]
+			}
+		}
+	)
+}

--- a/substrate/frame/support/procedural/src/pallet/expand/constants.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/constants.rs
@@ -30,8 +30,7 @@ struct ConstDef {
 	pub metadata_name: Option<syn::Ident>,
 }
 
-///
-/// * Impl fn module_constant_metadata for pallet.
+/// Implement the `pallet_constants_metadata` function for the pallet.
 pub fn expand_constants(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let type_impl_gen = &def.type_impl_generics(proc_macro2::Span::call_site());

--- a/substrate/frame/support/procedural/src/pallet/expand/mod.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/mod.rs
@@ -60,6 +60,7 @@ pub fn expand(mut def: Def) -> proc_macro2::TokenStream {
 	let constants = constants::expand_constants(&mut def);
 	let pallet_struct = pallet_struct::expand_pallet_struct(&mut def);
 	let config = config::expand_config(&mut def);
+	let associated_types = config::expand_config_metadata(&def);
 	let call = call::expand_call(&mut def);
 	let tasks = tasks::expand_tasks(&mut def);
 	let error = error::expand_error(&mut def);
@@ -101,6 +102,7 @@ storage item. Otherwise, all storage items are listed among [*Type Definitions*]
 		#constants
 		#pallet_struct
 		#config
+		#associated_types
 		#call
 		#tasks
 		#error

--- a/substrate/frame/support/procedural/src/pallet/parse/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/config.rs
@@ -334,9 +334,7 @@ impl ConfigDef {
 		item: &mut syn::Item,
 		enable_default: bool,
 	) -> syn::Result<Self> {
-		let item = if let syn::Item::Trait(item) = item {
-			item
-		} else {
+		let syn::Item::Trait(item) = item else {
 			let msg = "Invalid pallet::config, expected trait definition";
 			return Err(syn::Error::new(item.span(), msg))
 		};

--- a/substrate/frame/support/procedural/src/pallet/parse/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/config.rs
@@ -55,6 +55,8 @@ pub struct ConfigDef {
 	pub has_instance: bool,
 	/// Const associated type.
 	pub consts_metadata: Vec<ConstMetadataDef>,
+	/// Associated types exposed to metadata.
+	pub associated_types_metadata: Vec<AssociatedTypeMetadataDef>,
 	/// Whether the trait has the associated type `Event`, note that those bounds are
 	/// checked:
 	/// * `IsType<Self as frame_system::Config>::RuntimeEvent`
@@ -124,6 +126,23 @@ impl TryFrom<&syn::TraitItemType> for ConstMetadataDef {
 			.expect("Internal error: replacing `Self` by `T` should result in valid type");
 
 		Ok(Self { ident, type_, doc })
+	}
+}
+
+/// Input definition for an associated type in pallet config.
+pub struct AssociatedTypeMetadataDef {
+	/// Name of the associated type.
+	pub ident: syn::Ident,
+	/// The doc associated
+	pub doc: Vec<syn::Expr>,
+}
+
+impl From<&syn::TraitItemType> for AssociatedTypeMetadataDef {
+	fn from(trait_ty: &syn::TraitItemType) -> Self {
+		let ident = trait_ty.ident.clone();
+		let doc = get_doc_literals(&trait_ty.attrs);
+
+		Self { ident, doc }
 	}
 }
 
@@ -375,6 +394,7 @@ impl ConfigDef {
 
 		let mut has_event_type = false;
 		let mut consts_metadata = vec![];
+		let mut associated_types_metadata = vec![];
 		let mut default_sub_trait = if enable_default {
 			Some(DefaultTrait {
 				items: Default::default(),
@@ -414,7 +434,7 @@ impl ConfigDef {
 						if !enable_default {
 							return Err(syn::Error::new(
 								pallet_attr._bracket.span.join(),
-								"`#[pallet:no_default]` can only be used if `#[pallet::config(with_default)]` \
+								"`#[pallet::no_default]` can only be used if `#[pallet::config(with_default)]` \
 								has been specified"
 							))
 						}
@@ -443,6 +463,12 @@ impl ConfigDef {
 						}
 						already_no_default_bounds = true;
 					},
+				}
+			}
+
+			if !is_event && !already_constant {
+				if let syn::TraitItem::Type(ref ty) = trait_item {
+					associated_types_metadata.push(AssociatedTypeMetadataDef::from(ty));
 				}
 			}
 
@@ -488,6 +514,7 @@ impl ConfigDef {
 			index,
 			has_instance,
 			consts_metadata,
+			associated_types_metadata,
 			has_event_type,
 			where_clause,
 			attr_span,

--- a/substrate/frame/support/procedural/src/pallet/parse/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/config.rs
@@ -223,55 +223,55 @@ fn check_event_type(
 	trait_item: &syn::TraitItem,
 	trait_has_instance: bool,
 ) -> syn::Result<bool> {
-	if let syn::TraitItem::Type(type_) = trait_item {
-		if type_.ident == "RuntimeEvent" {
-			// Check event has no generics
-			if !type_.generics.params.is_empty() || type_.generics.where_clause.is_some() {
-				let msg = "Invalid `type RuntimeEvent`, associated type `RuntimeEvent` is reserved and must have\
+	let syn::TraitItem::Type(type_) = trait_item else { return Ok(false) };
+
+	if type_.ident != "RuntimeEvent" {
+		return Ok(false)
+	}
+
+	// Check event has no generics
+	if !type_.generics.params.is_empty() || type_.generics.where_clause.is_some() {
+		let msg =
+			"Invalid `type RuntimeEvent`, associated type `RuntimeEvent` is reserved and must have\
 					no generics nor where_clause";
-				return Err(syn::Error::new(trait_item.span(), msg))
-			}
+		return Err(syn::Error::new(trait_item.span(), msg))
+	}
 
-			// Check bound contains IsType and From
-			let has_is_type_bound = type_.bounds.iter().any(|s| {
-				syn::parse2::<IsTypeBoundEventParse>(s.to_token_stream())
-					.map_or(false, |b| has_expected_system_config(b.0, frame_system))
-			});
+	// Check bound contains IsType and From
+	let has_is_type_bound = type_.bounds.iter().any(|s| {
+		syn::parse2::<IsTypeBoundEventParse>(s.to_token_stream())
+			.map_or(false, |b| has_expected_system_config(b.0, frame_system))
+	});
 
-			if !has_is_type_bound {
-				let msg = "Invalid `type RuntimeEvent`, associated type `RuntimeEvent` is reserved and must \
-					bound: `IsType<<Self as frame_system::Config>::RuntimeEvent>`".to_string();
-				return Err(syn::Error::new(type_.span(), msg))
-			}
+	if !has_is_type_bound {
+		let msg =
+			"Invalid `type RuntimeEvent`, associated type `RuntimeEvent` is reserved and must \
+					bound: `IsType<<Self as frame_system::Config>::RuntimeEvent>`"
+				.to_string();
+		return Err(syn::Error::new(type_.span(), msg))
+	}
 
-			let from_event_bound = type_
-				.bounds
-				.iter()
-				.find_map(|s| syn::parse2::<FromEventParse>(s.to_token_stream()).ok());
+	let from_event_bound = type_
+		.bounds
+		.iter()
+		.find_map(|s| syn::parse2::<FromEventParse>(s.to_token_stream()).ok());
 
-			let from_event_bound = if let Some(b) = from_event_bound {
-				b
-			} else {
-				let msg = "Invalid `type RuntimeEvent`, associated type `RuntimeEvent` is reserved and must \
-					bound: `From<Event>` or `From<Event<Self>>` or `From<Event<Self, I>>`";
-				return Err(syn::Error::new(type_.span(), msg))
-			};
+	let Some(from_event_bound) = from_event_bound else {
+		let msg =
+			"Invalid `type RuntimeEvent`, associated type `RuntimeEvent` is reserved and must \
+				bound: `From<Event>` or `From<Event<Self>>` or `From<Event<Self, I>>`";
+		return Err(syn::Error::new(type_.span(), msg))
+	};
 
-			if from_event_bound.is_generic && (from_event_bound.has_instance != trait_has_instance)
-			{
-				let msg = "Invalid `type RuntimeEvent`, associated type `RuntimeEvent` bounds inconsistent \
+	if from_event_bound.is_generic && (from_event_bound.has_instance != trait_has_instance) {
+		let msg =
+			"Invalid `type RuntimeEvent`, associated type `RuntimeEvent` bounds inconsistent \
 					`From<Event..>`. Config and generic Event must be both with instance or \
 					without instance";
-				return Err(syn::Error::new(type_.span(), msg))
-			}
-
-			Ok(true)
-		} else {
-			Ok(false)
-		}
-	} else {
-		Ok(false)
+		return Err(syn::Error::new(type_.span(), msg))
 	}
+
+	Ok(true)
 }
 
 /// Check that the path to `frame_system::Config` is valid, this is that the path is just

--- a/substrate/frame/support/procedural/src/pallet/parse/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/config.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use super::helper;
-use frame_support_procedural_tools::{get_doc_literals, is_using_frame_crate};
+use frame_support_procedural_tools::{get_cfg_attributes, get_doc_literals, is_using_frame_crate};
 use quote::ToTokens;
 use syn::{spanned::Spanned, token, Token};
 
@@ -135,14 +135,17 @@ pub struct AssociatedTypeMetadataDef {
 	pub ident: syn::Ident,
 	/// The doc associated
 	pub doc: Vec<syn::Expr>,
+	/// The cfg associated.
+	pub cfg: Vec<syn::Attribute>,
 }
 
 impl From<&mut syn::TraitItemType> for AssociatedTypeMetadataDef {
 	fn from(trait_ty: &mut syn::TraitItemType) -> Self {
 		let ident = trait_ty.ident.clone();
 		let doc = get_doc_literals(&trait_ty.attrs);
+		let cfg = get_cfg_attributes(&trait_ty.attrs);
 
-		Self { ident, doc }
+		Self { ident, doc, cfg }
 	}
 }
 

--- a/substrate/frame/support/procedural/src/pallet/parse/helper.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/helper.rs
@@ -55,16 +55,16 @@ pub(crate) fn take_first_item_pallet_attr<Attr>(
 where
 	Attr: syn::parse::Parse,
 {
-	let attrs = if let Some(attrs) = item.mut_item_attrs() { attrs } else { return Ok(None) };
+	let Some(attrs) = item.mut_item_attrs() else { return Ok(None) };
 
-	if let Some(index) = attrs.iter().position(|attr| {
+	let Some(index) = attrs.iter().position(|attr| {
 		attr.path().segments.first().map_or(false, |segment| segment.ident == "pallet")
-	}) {
-		let pallet_attr = attrs.remove(index);
-		Ok(Some(syn::parse2(pallet_attr.into_token_stream())?))
-	} else {
-		Ok(None)
-	}
+	}) else {
+		return Ok(None)
+	};
+
+	let pallet_attr = attrs.remove(index);
+	Ok(Some(syn::parse2(pallet_attr.into_token_stream())?))
 }
 
 /// Take all the pallet attributes (e.g. attribute like `#[pallet..]`) and decode them to `Attr`

--- a/substrate/frame/support/procedural/src/pallet/parse/mod.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/mod.rs
@@ -116,6 +116,7 @@ impl Def {
 						index,
 						item,
 						with_default,
+						&frame_support,
 					)?),
 				Some(PalletAttr::Pallet(span)) if pallet_struct.is_none() => {
 					let p = pallet_struct::PalletStructDef::try_from(span, index, item)?;

--- a/substrate/frame/support/procedural/src/runtime/expand/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/expand/mod.rs
@@ -39,6 +39,10 @@ use syn::{Ident, Result};
 
 /// The fixed name of the system pallet.
 const SYSTEM_PALLET_NAME: &str = "System";
+/// The fixed name of the ForeignAssets pallet.
+const FOREIGN_ASSETS_PALLET_NAME: &str = "ForeignAssets";
+/// The fixed name of the Assets pallet.
+const ASSETS_PALLET_NAME: &str = "Assets";
 
 pub fn expand(def: Def, legacy_ordering: bool) -> TokenStream2 {
 	let input = def.input;
@@ -143,6 +147,12 @@ fn construct_runtime_final_expansion(
 		))
 	}
 
+	// Find either the foreign assets pallet or the local assets pallet in this order.
+	let assets_pallet = pallets
+		.iter()
+		.find(|decl| decl.name == FOREIGN_ASSETS_PALLET_NAME)
+		.or_else(|| pallets.iter().find(|decl| decl.name == ASSETS_PALLET_NAME));
+
 	let features = pallets
 		.iter()
 		.filter_map(|decl| {
@@ -230,6 +240,7 @@ fn construct_runtime_final_expansion(
 		&scrate,
 		&unchecked_extrinsic,
 		&system_pallet.path,
+		assets_pallet,
 	);
 	let outer_config = expand::expand_outer_config(&name, &pallets, &scrate);
 	let inherent =

--- a/substrate/frame/support/procedural/src/runtime/expand/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/expand/mod.rs
@@ -176,6 +176,7 @@ fn construct_runtime_final_expansion(
 	let frame_system = generate_access_from_frame_or_crate("frame-system")?;
 	let block = quote!(<#name as #frame_system::Config>::Block);
 	let unchecked_extrinsic = quote!(<#block as #scrate::sp_runtime::traits::Block>::Extrinsic);
+	let header = quote!(<#block as #scrate::sp_runtime::traits::Block>::Header);
 
 	let mut dispatch = None;
 	let mut outer_event = None;
@@ -241,6 +242,7 @@ fn construct_runtime_final_expansion(
 		&unchecked_extrinsic,
 		&system_pallet.path,
 		assets_pallet,
+		&header,
 	);
 	let outer_config = expand::expand_outer_config(&name, &pallets, &scrate);
 	let inherent =

--- a/substrate/frame/support/procedural/tools/src/lib.rs
+++ b/substrate/frame/support/procedural/tools/src/lib.rs
@@ -163,3 +163,17 @@ pub fn get_doc_literals(attrs: &[syn::Attribute]) -> Vec<syn::Expr> {
 		})
 		.collect()
 }
+
+/// Return all cfg attributes literals found.
+pub fn get_cfg_attributes(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
+	attrs
+		.iter()
+		.filter_map(|attr| {
+			if let syn::Meta::List(meta) = &attr.meta {
+				meta.path.get_ident().filter(|ident| *ident == "cfg").map(|_| attr.clone())
+			} else {
+				None
+			}
+		})
+		.collect()
+}

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -692,7 +692,7 @@ mod weight_tests {
 			type Block: Parameter + sp_runtime::traits::Block;
 			type AccountId;
 			type Balance;
-			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
+			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall> + scale_info::TypeInfo;
 			type RuntimeOrigin;
 			type RuntimeCall;
 			type RuntimeTask;

--- a/substrate/frame/support/src/migrations.rs
+++ b/substrate/frame/support/src/migrations.rs
@@ -476,6 +476,7 @@ pub trait FailedMigrationHandler {
 /// Do now allow any transactions to be processed after a runtime upgrade failed.
 ///
 /// This is **not a sane default**, since it prevents governance intervention.
+#[derive(scale_info::TypeInfo)]
 pub struct FreezeChainOnFailedMigration;
 
 impl FailedMigrationHandler for FreezeChainOnFailedMigration {

--- a/substrate/frame/support/src/storage/generator/mod.rs
+++ b/substrate/frame/support/src/storage/generator/mod.rs
@@ -60,7 +60,7 @@ mod tests {
 		pub trait Config: 'static {
 			type Block: sp_runtime::traits::Block;
 			type AccountId;
-			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
+			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall> + scale_info::TypeInfo;
 			type RuntimeOrigin;
 			type RuntimeCall;
 			type RuntimeTask;

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -68,7 +68,7 @@ pub mod frame_system {
 		type Block: Parameter + sp_runtime::traits::Block;
 		type AccountId;
 		#[pallet::no_default_bounds]
-		type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
+		type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall> + scale_info::TypeInfo;
 		#[pallet::no_default_bounds]
 		type RuntimeOrigin;
 		#[pallet::no_default_bounds]

--- a/substrate/frame/support/src/traits/members.rs
+++ b/substrate/frame/support/src/traits/members.rs
@@ -76,6 +76,7 @@ impl<A, B, CA: Contains<A>, CB: Contains<B>> ContainsPair<A, B> for FromContains
 }
 
 /// A [`Contains`] implementation that contains every value.
+#[derive(scale_info::TypeInfo)]
 pub enum Everything {}
 impl<T> Contains<T> for Everything {
 	fn contains(_: &T) -> bool {
@@ -102,6 +103,7 @@ impl<A, B> ContainsPair<A, B> for Nothing {
 }
 
 /// A [`Contains`] implementation that contains everything except the values in `Exclude`.
+#[derive(scale_info::TypeInfo)]
 pub struct EverythingBut<Exclude>(PhantomData<Exclude>);
 impl<T, Exclude: Contains<T>> Contains<T> for EverythingBut<Exclude> {
 	fn contains(t: &T) -> bool {
@@ -132,6 +134,7 @@ impl<A, B, These: ContainsPair<A, B>, Except: ContainsPair<A, B>> ContainsPair<A
 
 /// A [`Contains`] implementation which contains all members of `These` which are also members of
 /// `Those`.
+#[derive(scale_info::TypeInfo)]
 pub struct InsideBoth<These, Those>(PhantomData<(These, Those)>);
 impl<T, These: Contains<T>, Those: Contains<T>> Contains<T> for InsideBoth<These, Those> {
 	fn contains(t: &T) -> bool {

--- a/substrate/frame/support/test/src/lib.rs
+++ b/substrate/frame/support/test/src/lib.rs
@@ -44,7 +44,8 @@ pub mod pallet {
 		/// The account type.
 		type AccountId: Parameter + Member + MaxEncodedLen;
 		/// The basic call filter to use in Origin.
-		type BaseCallFilter: frame_support::traits::Contains<Self::RuntimeCall>;
+		type BaseCallFilter: frame_support::traits::Contains<Self::RuntimeCall>
+			+ scale_info::TypeInfo;
 		/// The runtime origin type.
 		type RuntimeOrigin: Into<Result<RawOrigin<Self::AccountId>, Self::RuntimeOrigin>>
 			+ From<RawOrigin<Self::AccountId>>;

--- a/substrate/frame/support/test/tests/origin.rs
+++ b/substrate/frame/support/test/tests/origin.rs
@@ -145,6 +145,7 @@ pub mod module {
 	}
 }
 
+#[derive(scale_info::TypeInfo)]
 pub struct BaseCallFilter;
 impl Contains<RuntimeCall> for BaseCallFilter {
 	fn contains(c: &RuntimeCall) -> bool {

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -1220,6 +1220,7 @@ impl<
 }
 
 /// Ensure the origin is any `Signed` origin.
+#[derive(scale_info::TypeInfo)]
 pub struct EnsureSigned<AccountId>(sp_std::marker::PhantomData<AccountId>);
 impl<O: Into<Result<RawOrigin<AccountId>, O>> + From<RawOrigin<AccountId>>, AccountId: Decode>
 	EnsureOrigin<O> for EnsureSigned<AccountId>

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -448,7 +448,7 @@ pub mod pallet {
 		/// [`frame_support::traits::EverythingBut`] et al. The default would be
 		/// [`frame_support::traits::Everything`].
 		#[pallet::no_default_bounds]
-		type BaseCallFilter: Contains<Self::RuntimeCall>;
+		type BaseCallFilter: Contains<Self::RuntimeCall> + scale_info::TypeInfo;
 
 		/// Block & extrinsics weights: base values and limits.
 		#[pallet::constant]

--- a/substrate/frame/utility/src/tests.rs
+++ b/substrate/frame/utility/src/tests.rs
@@ -205,6 +205,7 @@ impl pallet_collective::Config<CouncilCollective> for Test {
 
 impl example::Config for Test {}
 
+#[derive(scale_info::TypeInfo)]
 pub struct TestBaseCallFilter;
 impl Contains<RuntimeCall> for TestBaseCallFilter {
 	fn contains(c: &RuntimeCall) -> bool {

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -20,7 +20,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1", default-features = 
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 log = { workspace = true }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }
-bounded-collections = { version = "0.2.0", default-features = false }
+bounded-collections = { path = "/home/lexnv/workspace/parity-common/bounded-collections", default-features = false }
 primitive-types = { version = "0.12.0", default-features = false, features = ["codec", "scale-info"] }
 impl-serde = { version = "0.4.0", default-features = false, optional = true }
 hash-db = { version = "0.16.0", default-features = false }

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -134,6 +134,8 @@ pub struct PalletMetadataIR<T: Form = MetaForm> {
 	pub index: u8,
 	/// Pallet documentation.
 	pub docs: Vec<T::String>,
+	/// Pallet associated types metadata.
+	pub associated_types: Vec<PalletAssociatedTypesMetadataIR<T>>,
 }
 
 impl IntoPortable for PalletMetadataIR {
@@ -149,6 +151,7 @@ impl IntoPortable for PalletMetadataIR {
 			error: self.error.map(|error| error.into_portable(registry)),
 			index: self.index,
 			docs: registry.map_into_portable(self.docs),
+			associated_types: registry.map_into_portable(self.associated_types),
 		}
 	}
 }

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -417,6 +417,29 @@ impl IntoPortable for PalletConstantMetadataIR {
 	}
 }
 
+/// Metadata about one pallet associated type.
+#[derive(Clone, PartialEq, Eq, Encode, Debug)]
+pub struct PalletAssociatedTypesMetadataIR<T: Form = MetaForm> {
+	/// Name of the pallet associated type.
+	pub name: T::String,
+	/// Type of the pallet associated type.
+	pub ty: T::Type,
+	/// Documentation of the associated type.
+	pub docs: Vec<T::String>,
+}
+
+impl IntoPortable for PalletAssociatedTypesMetadataIR {
+	type Output = PalletAssociatedTypesMetadataIR<PortableForm>;
+
+	fn into_portable(self, registry: &mut Registry) -> Self::Output {
+		PalletAssociatedTypesMetadataIR {
+			name: self.name.into_portable(registry),
+			ty: registry.register_type(&self.ty),
+			docs: registry.map_into_portable(self.docs),
+		}
+	}
+}
+
 /// Metadata about a pallet error.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 pub struct PalletErrorMetadataIR<T: Form = MetaForm> {

--- a/substrate/primitives/metadata-ir/src/v14.rs
+++ b/substrate/primitives/metadata-ir/src/v14.rs
@@ -51,7 +51,7 @@ impl From<PalletMetadataIR> for PalletMetadata {
 			constants: ir.constants.into_iter().map(Into::into).collect(),
 			error: ir.error.map(Into::into),
 			index: ir.index,
-			// Note: ir.docs not part of v14.
+			// Note: ir.docs and ir.associated_types are not part of v14.
 		}
 	}
 }

--- a/substrate/primitives/metadata-ir/src/v15.rs
+++ b/substrate/primitives/metadata-ir/src/v15.rs
@@ -17,17 +17,16 @@
 
 //! Convert the IR to V15 metadata.
 
-use crate::OuterEnumsIR;
-
 use super::types::{
-	ExtrinsicMetadataIR, MetadataIR, PalletMetadataIR, RuntimeApiMetadataIR,
-	RuntimeApiMethodMetadataIR, RuntimeApiMethodParamMetadataIR, SignedExtensionMetadataIR,
+	CustomMetadataIR, ExtrinsicMetadataIR, MetadataIR, OuterEnumsIR, PalletMetadataIR,
+	RuntimeApiMetadataIR, RuntimeApiMethodMetadataIR, RuntimeApiMethodParamMetadataIR,
+	SignedExtensionMetadataIR,
 };
 
 use frame_metadata::v15::{
-	CustomMetadata, ExtrinsicMetadata, OuterEnums, PalletMetadata, RuntimeApiMetadata,
-	RuntimeApiMethodMetadata, RuntimeApiMethodParamMetadata, RuntimeMetadataV15,
-	SignedExtensionMetadata,
+	CustomMetadata, CustomValueMetadata, ExtrinsicMetadata, OuterEnums, PalletMetadata,
+	RuntimeApiMetadata, RuntimeApiMethodMetadata, RuntimeApiMethodParamMetadata,
+	RuntimeMetadataV15, SignedExtensionMetadata,
 };
 
 impl From<MetadataIR> for RuntimeMetadataV15 {
@@ -38,9 +37,8 @@ impl From<MetadataIR> for RuntimeMetadataV15 {
 			ir.ty,
 			ir.apis.into_iter().map(Into::into).collect(),
 			ir.outer_enums.into(),
-			// Substrate does not collect yet the custom metadata fields.
 			// This allows us to extend the V15 easily.
-			CustomMetadata { map: Default::default() },
+			ir.custom_types.into(),
 		)
 	}
 }
@@ -116,6 +114,18 @@ impl From<OuterEnumsIR> for OuterEnums {
 			call_enum_ty: ir.call_enum_ty,
 			event_enum_ty: ir.event_enum_ty,
 			error_enum_ty: ir.error_enum_ty,
+		}
+	}
+}
+
+impl From<CustomMetadataIR> for CustomMetadata {
+	fn from(ir: CustomMetadataIR) -> Self {
+		CustomMetadata {
+			map: ir
+				.map
+				.into_iter()
+				.map(|(name, ty)| (name, CustomValueMetadata { ty, value: Default::default() }))
+				.collect(),
 		}
 	}
 }

--- a/substrate/primitives/metadata-ir/src/v15.rs
+++ b/substrate/primitives/metadata-ir/src/v15.rs
@@ -81,6 +81,7 @@ impl From<PalletMetadataIR> for PalletMetadata {
 			error: ir.error.map(Into::into),
 			index: ir.index,
 			docs: ir.docs,
+			// Note: ir.associated_types are not part of v15.
 		}
 	}
 }

--- a/substrate/primitives/runtime/src/traits.rs
+++ b/substrate/primitives/runtime/src/traits.rs
@@ -226,7 +226,7 @@ pub trait StaticLookup {
 }
 
 /// A lookup implementation returning the input value.
-#[derive(Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, scale_info::TypeInfo)]
 pub struct IdentityLookup<T>(PhantomData<T>);
 impl<T: Codec + Clone + PartialEq + Debug + TypeInfo> StaticLookup for IdentityLookup<T> {
 	type Source = T;
@@ -248,6 +248,7 @@ impl<T> Lookup for IdentityLookup<T> {
 }
 
 /// A lookup implementation returning the `AccountId` from a `MultiAddress`.
+#[derive(scale_info::TypeInfo)]
 pub struct AccountIdLookup<AccountId, AccountIndex>(PhantomData<(AccountId, AccountIndex)>);
 impl<AccountId, AccountIndex> StaticLookup for AccountIdLookup<AccountId, AccountIndex>
 where

--- a/substrate/primitives/weights/Cargo.toml
+++ b/substrate/primitives/weights/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-bounded-collections = { version = "0.2.0", default-features = false }
+bounded-collections = { path = "/home/lexnv/workspace/parity-common/bounded-collections", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }


### PR DESCRIPTION

This PR enriches the metadata's custom types via captured types needed by users to communicate with the chain.
Ideally, this will naturally evolve into a strongly typed metadata V16.

Subxt relies on a preset called `Config` to interact with the chain.
This `Config` present contains types such as `AccountId`, `Hasher` and more needed to craft transactions.
Subxt has implemented a `SubstrateConfig` and `PolkadotConfig`.

This is the subxt [config](https://github.com/paritytech/subxt/pull/1566/files#diff-88a79c5a0c04b7ac18e28856b68cb3be44b4bae69e832344415a3fc50941ef5bR14-R35) that can be almost entirely replaced by metadata types.

The end goal of this PoC is to remove as many types needed by those configs and rely on the metadata provided information instead.


For more details, see https://github.com/paritytech/subxt/pull/1566. 