### PR TITLE
Change sorted list types and simplify type conversions in stake-tracker

### DIFF
--- a/substrate/frame/staking/src/migrations/single_block.rs
+++ b/substrate/frame/staking/src/migrations/single_block.rs
@@ -406,7 +406,7 @@ pub mod v9 {
 				let weight_of_cached = Pallet::<T>::weight_of_fn();
 				for (v, _) in Validators::<T>::iter() {
 					let weight = weight_of_cached(&v);
-					let _ = T::VoterList::on_insert(v.clone(), weight).map_err(|err| {
+					let _ = T::VoterList::on_insert(v.clone(), weight.into()).map_err(|err| {
 						log!(warn, "failed to insert {:?} into VoterList: {:?}", v, err)
 					});
 				}
@@ -488,7 +488,7 @@ pub mod v8 {
 
 			let migrated = T::VoterList::unsafe_regenerate(
 				Nominators::<T>::iter().map(|(id, _)| id),
-				Pallet::<T>::weight_of_fn(),
+				Pallet::<T>::active_stake_of_fn(),
 			);
 
 			StorageVersion::<T>::put(ObsoleteReleases::V8_0_0);

--- a/substrate/frame/staking/src/migrations/v13_stake_tracker/mod.rs
+++ b/substrate/frame/staking/src/migrations/v13_stake_tracker/mod.rs
@@ -116,6 +116,11 @@ impl<T: Config, W: weights::WeightInfo> SteppedMigration for MigrationV13<T, W> 
 					}
 				}
 
+				let _ = T::VoterList::on_update(
+					&nominator,
+					Pallet::<T>::stake(&nominator).defensive_unwrap_or_default().active,
+				);
+
 				// progress cursor.
 				cursor = Some(nominator)
 			} else {

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -20,7 +20,7 @@
 use crate::{self as pallet_staking, *};
 use frame_election_provider_support::{
 	bounds::{ElectionBounds, ElectionBoundsBuilder},
-	onchain, SequentialPhragmen, SortedListProvider, VoteWeight,
+	onchain, SequentialPhragmen, SortedListProvider,
 };
 use frame_support::{
 	assert_ok, derive_impl,
@@ -209,13 +209,12 @@ impl OnUnbalanced<NegativeImbalanceOf<Test>> for RewardRemainderMock {
 	}
 }
 
-const VOTER_THRESHOLDS: [sp_npos_elections::VoteWeight; 9] =
-	[10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000];
+const VOTER_THRESHOLDS: [Balance; 9] = [10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000];
 
 const TARGET_THRESHOLDS: [Balance; 9] = [100, 200, 300, 400, 500, 600, 1_000, 2_000, 10_000];
 
 parameter_types! {
-	pub static VoterBagThresholds: &'static [sp_npos_elections::VoteWeight] = &VOTER_THRESHOLDS;
+	pub static VoterBagThresholds: &'static [Balance] = &VOTER_THRESHOLDS;
 	pub static TargetBagThresholds: &'static [Balance] = &TARGET_THRESHOLDS;
 	pub static HistoryDepth: u32 = 80;
 	pub static MaxExposurePageSize: u32 = 64;
@@ -233,7 +232,7 @@ impl pallet_bags_list::Config<VoterBagsListInstance> for Test {
 	// Staking is the source of truth for voter bags list, since they are not kept up to date.
 	type ScoreProvider = Staking;
 	type BagThresholds = VoterBagThresholds;
-	type Score = VoteWeight;
+	type Score = Balance;
 }
 
 type TargetBagsListInstance = pallet_bags_list::Instance2;
@@ -1147,7 +1146,7 @@ pub(crate) fn ensure_on_staking_updates_emitted(
 	EventsEmitted::set(vec![]);
 }
 
-pub(crate) fn voters_and_targets() -> (Vec<(AccountId, VoteWeight)>, Vec<(AccountId, Balance)>) {
+pub(crate) fn voters_and_targets() -> (Vec<(AccountId, Balance)>, Vec<(AccountId, Balance)>) {
 	(
 		VoterBagsList::iter()
 			.map(|v| (v, VoterBagsList::get_score(&v).unwrap()))

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -18,9 +18,7 @@
 //! Staking FRAME Pallet.
 
 use codec::Codec;
-use frame_election_provider_support::{
-	ElectionProvider, ElectionProviderBase, SortedListProvider, VoteWeight,
-};
+use frame_election_provider_support::{ElectionProvider, ElectionProviderBase, SortedListProvider};
 use frame_support::{
 	pallet_prelude::*,
 	traits::{
@@ -230,7 +228,7 @@ pub mod pallet {
 		/// chilled.
 		///
 		/// Invariant: what comes out of this list will always be an active nominator.
-		type VoterList: SortedListProvider<Self::AccountId, Score = VoteWeight>;
+		type VoterList: SortedListProvider<Self::AccountId, Score = BalanceOf<Self>>;
 
 		/// Something that provides a sorted list of targets (aka electable and chilled
 		/// validators), used for NPoS election.
@@ -1603,10 +1601,10 @@ pub mod pallet {
 			let stash = ledger.stash.clone();
 			let final_unlocking = ledger.unlocking.len();
 
-			// NOTE: ledger must be updated prior to calling `Self::weight_of`.
+			let active_stake = ledger.active;
 			ledger.update()?;
 			if T::VoterList::contains(&stash) {
-				let _ = T::VoterList::on_update(&stash, Self::weight_of(&stash)).defensive();
+				let _ = T::VoterList::on_update(&stash, active_stake).defensive();
 			}
 
 			let removed_chunks = 1u32 // for the case where the last iterated chunk is not removed


### PR DESCRIPTION
Changes the voter and sorted lists score types. 

- Target list score from `Balance` to `ExtendedBalance`: for safety.
- Voter list score from `VoteWeight` to `Balance`: to avoid conversions to vote weight. (can we do this though? what if the vote weight is > u64)

This way, the conversion to `VoteWeight` (which requires the a call to `T::Currency::total_issuance`) is reduced to a minimum and never required at the stake-tracker level. The target list score is `ExtendedBalance` for safety, as the approvals stakes with unbounded nominations may overflow u64.

Note that the end of the day, the voter and target lists are used to keep stakers sorted by stake/approval stakes.

Converting the voter score from `VoteWeight` to `Balance` requires a migration since vote_weight(account) != active_stake(account)`