### PR TITLE
Fix: dust unbonded for zero existential deposit

### DIFF
--- a/prdoc/pr_4364.prdoc
+++ b/prdoc/pr_4364.prdoc
@@ -1,0 +1,10 @@
+title: Fix: dust unbonded for zero existential deposit
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      When a staker unbonds and withdraws, it is possible that their stash will contain less currency than the existential deposit. If that happens, their stash is reaped. But if the existential deposit is zero, the reap is not triggered. This PR adjusts pallet_staking to reap a stash in the special case that the stash value is zero and the existential deposit is zero.
+
+crates:
+  - name: pallet-staking
+    bump: patch

--- a/prdoc/pr_4364.prdoc
+++ b/prdoc/pr_4364.prdoc
@@ -1,4 +1,4 @@
-title: Fix: dust unbonded for zero existential deposit
+title: Fix dust unbonded for zero existential deposit
 
 doc:
   - audience: Runtime Dev

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -198,8 +198,9 @@ impl<T: Config> Pallet<T> {
 		}
 		let new_total = ledger.total;
 
+		let ed = T::Currency::minimum_balance();
 		let used_weight =
-			if ledger.unlocking.is_empty() && ledger.active < T::Currency::minimum_balance() {
+			if ledger.unlocking.is_empty() && (ledger.active < ed || ledger.active == 0u32.into()) {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
 				// left. We can now safely remove all staking-related information.

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -200,7 +200,7 @@ impl<T: Config> Pallet<T> {
 
 		let ed = T::Currency::minimum_balance();
 		let used_weight =
-			if ledger.unlocking.is_empty() && (ledger.active < ed || ledger.active == 0u32.into()) {
+			if ledger.unlocking.is_empty() && (ledger.active < ed || ledger.active.is_zero()) {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
 				// left. We can now safely remove all staking-related information.

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -1644,9 +1644,9 @@ pub mod pallet {
 			let origin_balance = T::Currency::total_balance(&stash);
 			let ledger_total = Self::ledger(Stash(stash.clone())).map(|l| l.total).unwrap_or_default();
 			let reapable = origin_balance < ed ||
-				origin_balance == 0u32.into() ||
+				origin_balance.is_zero() ||
 				ledger_total < ed ||
-				ledger_total == 0u32.into();
+				ledger_total.is_zero();
 			ensure!(reapable, Error::<T>::FundedTarget);
 
 			// Remove all staking-related information and lock.

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -938,7 +938,8 @@ pub mod pallet {
 		/// - Three extra DB entries.
 		///
 		/// NOTE: Two of the storage writes (`Self::bonded`, `Self::payee`) are _never_ cleaned
-		/// unless the `origin` falls below _existential deposit_ (or equal to 0) and gets removed as dust.
+		/// unless the `origin` falls below _existential deposit_ (or equal to 0) and gets removed
+		/// as dust.
 		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::bond())]
 		pub fn bond(
@@ -1642,7 +1643,8 @@ pub mod pallet {
 
 			let ed = T::Currency::minimum_balance();
 			let origin_balance = T::Currency::total_balance(&stash);
-			let ledger_total = Self::ledger(Stash(stash.clone())).map(|l| l.total).unwrap_or_default();
+			let ledger_total =
+				Self::ledger(Stash(stash.clone())).map(|l| l.total).unwrap_or_default();
 			let reapable = origin_balance < ed ||
 				origin_balance.is_zero() ||
 				ledger_total < ed ||

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -938,7 +938,7 @@ pub mod pallet {
 		/// - Three extra DB entries.
 		///
 		/// NOTE: Two of the storage writes (`Self::bonded`, `Self::payee`) are _never_ cleaned
-		/// unless the `origin` falls below _existential deposit_ and gets removed as dust.
+		/// unless the `origin` falls below _existential deposit_ (or equal to 0) and gets removed as dust.
 		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::bond())]
 		pub fn bond(

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -1932,6 +1932,44 @@ fn reap_stash_works() {
 }
 
 #[test]
+fn reap_stash_works_with_existential_deposit_zero() {
+	ExtBuilder::default()
+		.existential_deposit(0)
+		.balance_factor(10)
+		.build_and_execute(|| {
+			// given
+			assert_eq!(Balances::balance_locked(STAKING_ID, &11), 10 * 1000);
+			assert_eq!(Staking::bonded(&11), Some(11));
+
+			assert!(<Ledger<Test>>::contains_key(&11));
+			assert!(<Bonded<Test>>::contains_key(&11));
+			assert!(<Validators<Test>>::contains_key(&11));
+			assert!(<Payee<Test>>::contains_key(&11));
+
+			// stash is not reapable
+			assert_noop!(
+				Staking::reap_stash(RuntimeOrigin::signed(20), 11, 0),
+				Error::<Test>::FundedTarget
+			);
+
+			// no easy way to cause an account to go below ED, we tweak their staking ledger
+			// instead.
+			Ledger::<Test>::insert(11, StakingLedger::<Test>::new(11, 0));
+
+			// reap-able
+			assert_ok!(Staking::reap_stash(RuntimeOrigin::signed(20), 11, 0));
+
+			// then
+			assert!(!<Ledger<Test>>::contains_key(&11));
+			assert!(!<Bonded<Test>>::contains_key(&11));
+			assert!(!<Validators<Test>>::contains_key(&11));
+			assert!(!<Payee<Test>>::contains_key(&11));
+			// lock is removed.
+			assert_eq!(Balances::balance_locked(STAKING_ID, &11), 0);
+		});
+}
+
+#[test]
 fn switching_roles() {
 	// Test that it should be possible to switch between roles (nominator, validator, idle) with
 	// minimal overhead.
@@ -6950,6 +6988,59 @@ mod staking_interface {
 				RuntimeOrigin::signed(11),
 				num_slashing_spans as u32
 			));
+		});
+	}
+
+	#[test]
+	fn do_withdraw_unbonded_can_kill_stash_with_existential_deposit_zero() {
+		ExtBuilder::default()
+			.existential_deposit(0)
+			.nominate(false)
+			.build_and_execute(|| {
+			// Initial state of 11
+			assert_eq!(Staking::bonded(&11), Some(11));
+			assert_eq!(
+				Staking::ledger(11.into()).unwrap(),
+				StakingLedgerInspect {
+					stash: 11,
+					total: 1000,
+					active: 1000,
+					unlocking: Default::default(),
+					legacy_claimed_rewards: bounded_vec![],
+				}
+			);
+			assert_eq!(
+				Staking::eras_stakers(active_era(), &11),
+				Exposure { total: 1000, own: 1000, others: vec![] }
+			);
+
+			// Unbond all of the funds in stash.
+			Staking::chill(RuntimeOrigin::signed(11));
+			Staking::unbond(RuntimeOrigin::signed(11), 1000).unwrap();
+			assert_eq!(
+				Staking::ledger(11.into()).unwrap(),
+				StakingLedgerInspect {
+					stash: 11,
+					total: 1000,
+					active: 0,
+					unlocking: bounded_vec![UnlockChunk { value: 1000, era: 3 }],
+					legacy_claimed_rewards: bounded_vec![],
+				},
+			);
+
+			// trigger future era.
+			mock::start_active_era(3);
+
+			// withdraw unbonded
+			assert_ok!(Staking::withdraw_unbonded(RuntimeOrigin::signed(11), 0));
+
+			// empty stash has been reaped
+			assert!(!<Ledger<Test>>::contains_key(&11));
+			assert!(!<Bonded<Test>>::contains_key(&11));
+			assert!(!<Validators<Test>>::contains_key(&11));
+			assert!(!<Payee<Test>>::contains_key(&11));
+			// lock is removed.
+			assert_eq!(Balances::balance_locked(STAKING_ID, &11), 0);
 		});
 	}
 

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -7015,7 +7015,7 @@ mod staking_interface {
 			);
 
 			// Unbond all of the funds in stash.
-			Staking::chill(RuntimeOrigin::signed(11));
+			Staking::chill(RuntimeOrigin::signed(11)).unwrap();
 			Staking::unbond(RuntimeOrigin::signed(11), 1000).unwrap();
 			assert_eq!(
 				Staking::ledger(11.into()).unwrap(),

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -6997,51 +6997,51 @@ mod staking_interface {
 			.existential_deposit(0)
 			.nominate(false)
 			.build_and_execute(|| {
-			// Initial state of 11
-			assert_eq!(Staking::bonded(&11), Some(11));
-			assert_eq!(
-				Staking::ledger(11.into()).unwrap(),
-				StakingLedgerInspect {
-					stash: 11,
-					total: 1000,
-					active: 1000,
-					unlocking: Default::default(),
-					legacy_claimed_rewards: bounded_vec![],
-				}
-			);
-			assert_eq!(
-				Staking::eras_stakers(active_era(), &11),
-				Exposure { total: 1000, own: 1000, others: vec![] }
-			);
+				// Initial state of 11
+				assert_eq!(Staking::bonded(&11), Some(11));
+				assert_eq!(
+					Staking::ledger(11.into()).unwrap(),
+					StakingLedgerInspect {
+						stash: 11,
+						total: 1000,
+						active: 1000,
+						unlocking: Default::default(),
+						legacy_claimed_rewards: bounded_vec![],
+					}
+				);
+				assert_eq!(
+					Staking::eras_stakers(active_era(), &11),
+					Exposure { total: 1000, own: 1000, others: vec![] }
+				);
 
-			// Unbond all of the funds in stash.
-			Staking::chill(RuntimeOrigin::signed(11)).unwrap();
-			Staking::unbond(RuntimeOrigin::signed(11), 1000).unwrap();
-			assert_eq!(
-				Staking::ledger(11.into()).unwrap(),
-				StakingLedgerInspect {
-					stash: 11,
-					total: 1000,
-					active: 0,
-					unlocking: bounded_vec![UnlockChunk { value: 1000, era: 3 }],
-					legacy_claimed_rewards: bounded_vec![],
-				},
-			);
+				// Unbond all of the funds in stash.
+				Staking::chill(RuntimeOrigin::signed(11)).unwrap();
+				Staking::unbond(RuntimeOrigin::signed(11), 1000).unwrap();
+				assert_eq!(
+					Staking::ledger(11.into()).unwrap(),
+					StakingLedgerInspect {
+						stash: 11,
+						total: 1000,
+						active: 0,
+						unlocking: bounded_vec![UnlockChunk { value: 1000, era: 3 }],
+						legacy_claimed_rewards: bounded_vec![],
+					},
+				);
 
-			// trigger future era.
-			mock::start_active_era(3);
+				// trigger future era.
+				mock::start_active_era(3);
 
-			// withdraw unbonded
-			assert_ok!(Staking::withdraw_unbonded(RuntimeOrigin::signed(11), 0));
+				// withdraw unbonded
+				assert_ok!(Staking::withdraw_unbonded(RuntimeOrigin::signed(11), 0));
 
-			// empty stash has been reaped
-			assert!(!<Ledger<Test>>::contains_key(&11));
-			assert!(!<Bonded<Test>>::contains_key(&11));
-			assert!(!<Validators<Test>>::contains_key(&11));
-			assert!(!<Payee<Test>>::contains_key(&11));
-			// lock is removed.
-			assert_eq!(Balances::balance_locked(STAKING_ID, &11), 0);
-		});
+				// empty stash has been reaped
+				assert!(!<Ledger<Test>>::contains_key(&11));
+				assert!(!<Bonded<Test>>::contains_key(&11));
+				assert!(!<Validators<Test>>::contains_key(&11));
+				assert!(!<Payee<Test>>::contains_key(&11));
+				// lock is removed.
+				assert_eq!(Balances::balance_locked(STAKING_ID, &11), 0);
+			});
 	}
 
 	#[test]


### PR DESCRIPTION
When a staker unbonds and withdraws, it is possible that their stash will contain less currency than the existential deposit. If that happens, their stash is reaped. But if the existential deposit is zero, the reap is not triggered. This PR adjusts `pallet_staking` to reap a stash in the special case that the stash value is zero and the existential deposit is zero.

This change is important for blockchains built on substrate that require an existential deposit of zero, becuase it conserves valued storage space.

There are two places in which ledgers are checked to determine if their value is less than the existential deposit and they should be reaped: in the methods `do_withdraw_unbonded` and `reap_stash`. When the check is made, the condition `ledger_total == 0` is also checked. If `ledger_total` is zero, then it must be below any existential deposit greater than zero and equal to an existential deposit of 0.

I added a new test for each method to confirm the change behaves as expected.

Closes https://github.com/paritytech/polkadot-sdk/issues/4340