### PR TITLE
Bridge: added subcommand to relay single parachain header

### DIFF
--- a/bridges/relays/lib-substrate-relay/src/cli/relay_parachains.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_parachains.rs
@@ -18,6 +18,8 @@
 
 use async_std::sync::Mutex;
 use async_trait::async_trait;
+use bp_polkadot_core::BlockNumber as RelayBlockNumber;
+use bp_runtime::HeaderIdProvider;
 use parachains_relay::parachains_loop::{AvailableHeader, SourceClient, TargetClient};
 use relay_substrate_client::Parachain;
 use relay_utils::metrics::{GlobalMetrics, StandaloneMetric};
@@ -49,6 +51,21 @@ pub struct RelayParachainsParams {
 	only_free_headers: bool,
 	#[structopt(flatten)]
 	prometheus_params: PrometheusParams,
+}
+
+/// Single parachains head relaying params.
+#[derive(StructOpt)]
+pub struct RelayParachainHeadParams {
+	#[structopt(flatten)]
+	source: SourceConnectionParams,
+	#[structopt(flatten)]
+	target: TargetConnectionParams,
+	#[structopt(flatten)]
+	target_sign: TargetSigningParams,
+	/// Prove parachain head at that relay block number. This relay header must be previously
+	/// proved to the target chain.
+	#[structopt(long)]
+	at_relay_block: RelayBlockNumber,
 }
 
 /// Trait used for relaying parachains finality between 2 chains.
@@ -93,5 +110,39 @@ where
 		)
 		.await
 		.map_err(|e| anyhow::format_err!("{}", e))
+	}
+
+	/// Relay single parachain head. No checks are made to ensure that transaction will succeed.
+	async fn relay_parachain_head(data: RelayParachainHeadParams) -> anyhow::Result<()> {
+		let source_chain_client = data.source.into_client::<Self::SourceRelay>().await?;
+		let at_relay_block = source_chain_client
+			.header_by_number(data.at_relay_block)
+			.await
+			.map_err(|e| anyhow::format_err!("{}", e))?
+			.id();
+
+		let source_client = ParachainsSource::<Self::ParachainFinality>::new(
+			source_chain_client.clone(),
+			Arc::new(Mutex::new(AvailableHeader::Missing)),
+		);
+
+		let target_transaction_params = TransactionParams {
+			signer: data.target_sign.to_keypair::<Self::Target>()?,
+			mortality: data.target_sign.target_transactions_mortality,
+		};
+		let target_chain_client = data.target.into_client::<Self::Target>().await?;
+		let target_client = ParachainsTarget::<Self::ParachainFinality>::new(
+			source_chain_client,
+			target_chain_client,
+			target_transaction_params,
+		);
+
+		parachains_relay::parachains_loop::relay_single_head(
+			source_client,
+			target_client,
+			at_relay_block,
+		)
+		.await
+		.map_err(|_| anyhow::format_err!("The command has failed"))
 	}
 }

--- a/bridges/relays/lib-substrate-relay/src/parachains/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/parachains/mod.rs
@@ -19,14 +19,8 @@
 
 use async_trait::async_trait;
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
-use pallet_bridge_parachains::{
-	Call as BridgeParachainsCall, Config as BridgeParachainsConfig, RelayBlockHash,
-	RelayBlockHasher, RelayBlockNumber,
-};
 use parachains_relay::ParachainsPipeline;
-use relay_substrate_client::{
-	CallOf, Chain, ChainWithTransactions, HeaderIdOf, Parachain, RelayChain,
-};
+use relay_substrate_client::{CallOf, ChainWithTransactions, HeaderIdOf, Parachain, RelayChain};
 use std::{fmt::Debug, marker::PhantomData};
 
 pub mod source;
@@ -73,38 +67,4 @@ pub trait SubmitParachainHeadsCallBuilder<P: SubstrateParachainsPipeline>:
 		parachain_heads_proof: ParaHeadsProof,
 		is_free_execution_expected: bool,
 	) -> CallOf<P::TargetChain>;
-}
-
-/// Building `submit_parachain_heads` call when you have direct access to the target
-/// chain runtime.
-pub struct DirectSubmitParachainHeadsCallBuilder<P, R, I> {
-	_phantom: PhantomData<(P, R, I)>,
-}
-
-impl<P, R, I> SubmitParachainHeadsCallBuilder<P> for DirectSubmitParachainHeadsCallBuilder<P, R, I>
-where
-	P: SubstrateParachainsPipeline,
-	P::SourceRelayChain: Chain<Hash = RelayBlockHash, BlockNumber = RelayBlockNumber>,
-	R: BridgeParachainsConfig<I> + Send + Sync,
-	I: 'static + Send + Sync,
-	R::BridgedChain: bp_runtime::Chain<
-		BlockNumber = RelayBlockNumber,
-		Hash = RelayBlockHash,
-		Hasher = RelayBlockHasher,
-	>,
-	CallOf<P::TargetChain>: From<BridgeParachainsCall<R, I>>,
-{
-	fn build_submit_parachain_heads_call(
-		at_relay_block: HeaderIdOf<P::SourceRelayChain>,
-		parachains: Vec<(ParaId, ParaHash)>,
-		parachain_heads_proof: ParaHeadsProof,
-		_is_free_execution_expected: bool,
-	) -> CallOf<P::TargetChain> {
-		BridgeParachainsCall::<R, I>::submit_parachain_heads {
-			at_relay_block: (at_relay_block.0, at_relay_block.1),
-			parachains,
-			parachain_heads_proof,
-		}
-		.into()
-	}
 }


### PR DESCRIPTION
Related to https://github.com/paritytech/parity-bridges-common/issues/2962
Relay companion: https://github.com/paritytech/parity-bridges-common/pull/2978

Example usage:
```
./target/release/substrate-relay relay-parachain-head rococo-to-bridge-hub-westend \
    --source-host localhost --source-port 9942 \
    --target-host localhost --target-port 8945 --target-signer //Alice \
    --at-relay-block 61
```