### PR TITLE
Bridge: fix zombienet tests

### DIFF
--- a/bridges/testing/environments/rococo-westend/bridges_rococo_westend.sh
+++ b/bridges/testing/environments/rococo-westend/bridges_rococo_westend.sh
@@ -177,6 +177,7 @@ function run_finality_relay() {
         --only-free-headers \
         --source-host localhost \
         --source-port 9942 \
+        --source-version-mode Auto \
         --target-host localhost \
         --target-port 8945 \
         --target-version-mode Auto \
@@ -188,6 +189,7 @@ function run_finality_relay() {
         --only-free-headers \
         --source-host localhost \
         --source-port 9945 \
+        --source-version-mode Auto \
         --target-host localhost \
         --target-port 8943 \
         --target-version-mode Auto \
@@ -203,6 +205,7 @@ function run_parachains_relay() {
         --only-free-headers \
         --source-host localhost \
         --source-port 9942 \
+        --source-version-mode Auto \
         --target-host localhost \
         --target-port 8945 \
         --target-version-mode Auto \
@@ -214,6 +217,7 @@ function run_parachains_relay() {
         --only-free-headers \
         --source-host localhost \
         --source-port 9945 \
+        --source-version-mode Auto \
         --target-host localhost \
         --target-port 8943 \
         --target-version-mode Auto \


### PR DESCRIPTION
Due to recent bump of Rococo/Westend versions + the fact that https://github.com/paritytech/parity-bridges-common/pull/2894 has finally reached this repo, tests now fail, because we've started checking all client versions (even source) unless we specify `--source-version-mode Auto` in CLI arguments. This looks like an overkill, but all those version checks will be fixed by https://github.com/paritytech/polkadot-sdk/pull/4256, so now it makes sense just to add this CLI option. We also need to propagate it to running relays eventually.