### PR TITLE
Improve Create release draft workflow + templates for the free notes and docker images sections in the notes

### DIFF
--- a/.github/workflows/release-30_publish_release_draft.yml
+++ b/.github/workflows/release-30_publish_release_draft.yml
@@ -132,6 +132,7 @@ jobs:
   post_to_matrix:
     runs-on: ubuntu-latest
     needs: publish-release-draft
+    environment: release
     strategy:
       matrix:
         channel:

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -48,5 +48,3 @@ jobs:
             Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
 
             -----
-
-            ${{github.event.release.body}}

--- a/scripts/release/build-changelogs.sh
+++ b/scripts/release/build-changelogs.sh
@@ -51,7 +51,7 @@ for tuple in "${aud_desc_array[@]}"; do
 
     echo "Processing audience: $audience ($audience_id)"
     export TARGET_AUDIENCE="$audience"
-    export AUDIENCE_DESC="**These changes are relevant to:** $description"
+    export AUDIENCE_DESC="**ℹ️ These changes are relevant to:** $description"
 
     tera -t "${TEMPLATE_AUDIENCE}" --env --env-key env "${CONTEXT_JSON}" > "$OUTPUT/relnote_${audience_id}.md"
     cat "$OUTPUT/relnote_${audience_id}.md" >> "$PROJECT_ROOT/scripts/release/templates/changelog.md"

--- a/scripts/release/templates/_free_notes.md.tera
+++ b/scripts/release/templates/_free_notes.md.tera
@@ -1,0 +1,10 @@
+
+{# This file uses the Markdown format with additional templating such as this comment. -#}
+{# Such a comment will not show up in the rendered release notes. -#}
+{# The content of this file (if any) will be inserted at the top of the release notes -#}
+{# and generated for each new release candidate. -#}
+{# Ensure you leave an empty line at both top and bottom of this file. -#}
+
+<!-- Such a comment will be rendered but remain invisible in the rendered markdown -->
+<!-- Edit below this line -->
+<!-- Edit above this line -->

--- a/scripts/release/templates/docker_image.md.tera
+++ b/scripts/release/templates/docker_image.md.tera
@@ -1,10 +1,10 @@
 
 ## Docker images
 
-The docker images for the `polkadot` node binary and the `polkadot-parachain` binary can be found at Docker hub:
+The docker images for the `polkadot` node binary and the `polkadot-parachain` binary can be found at Docker hub (will be available a few minutes after the release has been published):
 - [Polkadot image](https://hub.docker.com/r/parity/polkadot/tags?page=1&ordering=last_updated)
 - [Polkadot-Parachain image](https://hub.docker.com/r/parity/polkadot-parachain/tags?page=1&ordering=last_updated)
-(Will be available a few minutes after the release has been published).
+
 
 You may also pull it with:
 

--- a/scripts/release/templates/docker_image.md.tera
+++ b/scripts/release/templates/docker_image.md.tera
@@ -1,0 +1,20 @@
+
+## Docker image
+
+The docker image for the `polkadot` polkadot node binary can be found at [Docker hub](https://hub.docker.com/r/parity/polkadot/tags?page=1&ordering=last_updated)
+(It will be available a few minutes after the release has been published).
+
+The docker image for the `polkadot-parachain` binary can be found at [Docker hub](https://hub.docker.com/r/parity/polkadot-parachain/tags?page=1&ordering=last_updated).
+(It will be available a few minutes after the release has been published).
+
+You may also pull it with:
+
+```
+docker pull parity/polkadot:latest
+```
+
+or
+
+```
+docker pull parity/polkadot-parachain:latest
+```

--- a/scripts/release/templates/docker_image.md.tera
+++ b/scripts/release/templates/docker_image.md.tera
@@ -1,11 +1,10 @@
 
-## Docker image
+## Docker images
 
-The docker image for the `polkadot` polkadot node binary can be found at [Docker hub](https://hub.docker.com/r/parity/polkadot/tags?page=1&ordering=last_updated)
-(It will be available a few minutes after the release has been published).
-
-The docker image for the `polkadot-parachain` binary can be found at [Docker hub](https://hub.docker.com/r/parity/polkadot-parachain/tags?page=1&ordering=last_updated).
-(It will be available a few minutes after the release has been published).
+The docker images for the `polkadot` node binary and the `polkadot-parachain` binary can be found at Docker hub:
+- [Polkadot image](https://hub.docker.com/r/parity/polkadot/tags?page=1&ordering=last_updated)
+- [Polkadot-Parachain image](https://hub.docker.com/r/parity/polkadot-parachain/tags?page=1&ordering=last_updated)
+(Will be available a few minutes after the release has been published).
 
 You may also pull it with:
 

--- a/scripts/release/templates/template.md.tera
+++ b/scripts/release/templates/template.md.tera
@@ -2,8 +2,14 @@
 
 This release contains the changes from `{{ env.REF1 | replace(from="refs/tags/", to="") }}` to `{{ env.REF2 | replace(from="refs/tags/", to="") }}`.
 
+{# -- Manual free notes section -- #}
+{% include "_free_notes.md.tera" -%}
+
+{# -- Automatic section -- #}
 {% include "changes.md.tera" -%}
 
 {% include "compiler.md.tera" -%}
 
 {% include "runtimes.md.tera" -%}
+
+{% include "docker_image.md.tera" -%}


### PR DESCRIPTION
This PR has the following changes:

- New templates for the free notes and docker images sections in the release notes. There is going to be a section for the manual additions to the release notes + a section with the links to the docker images for `polkadot` and `polkadot-parachain` binaries at the end of the release draft.
- Fix for matrix section in the Create release draft flow (adds the release environment variable)
- Reduction of the message which is posted to the announcement chats, as the current one with the full release notes text is too big.