### PR TITLE
Bridge: check bridge GRANDPA pallet call limits from signed extension

### DIFF
--- a/bridges/modules/grandpa/src/lib.rs
+++ b/bridges/modules/grandpa/src/lib.rs
@@ -504,6 +504,9 @@ pub mod pallet {
 		/// The submitter wanted free execution, but the difference between best known and
 		/// bundled header numbers is below the `FreeHeadersInterval`.
 		BelowFreeHeaderInterval,
+		/// The header (and its finality) submission overflows hardcoded chain limits: size
+		/// and/or weight are larger than expected.
+		HeaderOverflowLimits,
 	}
 
 	/// Called when new free header is imported.


### PR DESCRIPTION
silent, because it'll be deployed with the https://github.com/paritytech/polkadot-sdk/pull/4102, where this code has been introduced

I've planned originally to avoid doing that check in the runtime code, because it **may be** checked offchain. But actually, the check is quite cheap and we could do that onchain too.