### PR TITLE
Introduce connected_peers() API

### DIFF
--- a/prdoc/pr_4400.prdoc
+++ b/prdoc/pr_4400.prdoc
@@ -1,0 +1,10 @@
+title: Introduce connected_peers() API to sc-network
+
+doc:
+  - audience: Node Dev
+    description: |
+      The new change exposes a list of the currently connected peers to use in other parts of the system. A list of PeerId will be used by request-response protocol operations.
+
+crates:
+  - name: sc-network
+    bump: patch


### PR DESCRIPTION
This PR adds `connected_peers` API to Substrate Network (`sc-network` crate). The new API exports a list of the currently connected peers. It's helpful when we need to issue custom requests (libp2p request-response protocol) to some peer because the upstream protocol uses `PeerId` to target a specific peer. Actually, `request-response` protocol is able to initiate a new connection when we pass PeerId (it tries to obtain the address) but for this use-case we expose currently connected peers only. 