### PR TITLE
rustls: Disable logging

### DIFF
--- a/prdoc/pr_4426.prdoc
+++ b/prdoc/pr_4426.prdoc
@@ -1,0 +1,15 @@
+title: "Remove warning about `BadCertificate`"
+
+doc:
+  - audience: Node Operator
+    description: |
+      The node was printing the following warning from time to time:
+      ```
+      Sending fatal alert BadCertificate
+      ```
+
+      This is not an user error and thus, the warning will now not be printed
+      anymore.
+
+crates:
+  - name: sc-cli

--- a/substrate/client/tracing/src/logging/mod.rs
+++ b/substrate/client/tracing/src/logging/mod.rs
@@ -141,6 +141,10 @@ where
 		.add_directive(
 			parse_default_directive("libp2p_mdns::behaviour::iface=off")
 				.expect("provided directive is valid"),
+		)
+		.add_directive(
+			parse_default_directive("rustls::common_state=off")
+				.expect("provided directive is valid"),
 		);
 
 	if let Ok(lvl) = std::env::var("RUST_LOG") {


### PR DESCRIPTION
Disable logging of rustls to get rid off the following log lines:
```
Sending fatal alert BadCertificate
```

Upstream also removed them: https://github.com/rustls/rustls/pull/1278


Closes: https://github.com/paritytech/polkadot-sdk/issues/3252