### PR TITLE
Tx Payment: (tests check) drop ED requirements for tx payments with exchangeable asset 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11427,6 +11427,7 @@ version = "28.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-assets",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",

--- a/substrate/frame/transaction-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/Cargo.toml
@@ -31,6 +31,7 @@ sp-std = { path = "../../primitives/std", default-features = false }
 [dev-dependencies]
 serde_json = { workspace = true, default-features = true }
 pallet-balances = { path = "../balances" }
+pallet-assets = { path = "../assets" }
 
 [features]
 default = ["std"]
@@ -39,6 +40,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
+	"pallet-assets/std",
 	"scale-info/std",
 	"serde",
 	"sp-core/std",

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
@@ -37,7 +37,6 @@ use frame_support::{
 use frame_system as system;
 use frame_system::{EnsureRoot, EnsureSignedBy};
 use pallet_asset_conversion::{Ascending, Chain, WithFirstAsset};
-use pallet_transaction_payment::FungibleAdapter;
 use sp_core::H256;
 use sp_runtime::{
 	traits::{AccountIdConversion, BlakeTwo256, IdentityLookup, SaturatedConversion},

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
@@ -176,7 +176,9 @@ impl OnUnbalanced<fungible::Credit<<Runtime as frame_system::Config>::AccountId,
 #[derive_impl(pallet_transaction_payment::config_preludes::TestDefaultConfig)]
 impl pallet_transaction_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees>;
+	// type OnChargeTransaction = FungibleAdapter<Balances, DealWithFees>;
+	type OnChargeTransaction =
+		pallet_transaction_payment::FungiblesAdapter<NativeAndAssets, Native, (), ()>;
 	type WeightToFee = WeightToFee;
 	type LengthToFee = TransactionByteFee;
 	type FeeMultiplierUpdate = ();
@@ -249,12 +251,14 @@ pub type PoolIdToAccountId = pallet_asset_conversion::AccountIdConverter<
 	(NativeOrWithId<u32>, NativeOrWithId<u32>),
 >;
 
+type NativeAndAssets = UnionOf<Balances, Assets, NativeFromLeft, NativeOrWithId<u32>, AccountId>;
+
 impl pallet_asset_conversion::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
 	type HigherPrecisionBalance = u128;
 	type AssetKind = NativeOrWithId<u32>;
-	type Assets = UnionOf<Balances, Assets, NativeFromLeft, NativeOrWithId<u32>, AccountId>;
+	type Assets = NativeAndAssets;
 	type PoolId = (Self::AssetKind, Self::AssetKind);
 	type PoolLocator = Chain<
 		WithFirstAsset<Native, AccountId, NativeOrWithId<u32>, PoolIdToAccountId>,
@@ -279,5 +283,6 @@ impl pallet_asset_conversion::Config for Runtime {
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Fungibles = Assets;
-	type OnChargeAssetTransaction = AssetConversionAdapter<Balances, AssetConversion, Native>;
+	// type OnChargeAssetTransaction = AssetConversionAdapter<Balances, AssetConversion, Native>;
+	type OnChargeAssetTransaction = SwapCreditAdapter<Native, AssetConversion>;
 }

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
@@ -261,11 +261,13 @@ where
 		) {
 			Ok((fee_credit, change)) => (fee_credit, change),
 			Err((credit_in, _)) => {
+				// The swap should not error since the price quote was successful.
 				let _ = T::Assets::resolve(who, credit_in).defensive();
 				return Err(InvalidTransaction::Payment.into())
 			},
 		};
 
+		// Should be always zero since the exact price was quoted before.
 		ensure!(change.peek().is_zero(), InvalidTransaction::Payment);
 
 		Ok((Some(fee_credit), fee, asset_fee))

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
@@ -369,7 +369,7 @@ where
 			post_info,
 			corrected_fee,
 			tip,
-			fee.into(),
+			Some(fee),
 		)
 		.map(|_| fee_in_asset)
 	}

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/payment.rs
@@ -304,7 +304,7 @@ where
 			// Deposit the refund before the swap to ensure it can be processed.
 			let debt = match T::Assets::deposit(
 				asset_id.clone(),
-				&who,
+				who,
 				refund_asset_amount,
 				Precision::BestEffort,
 			) {
@@ -331,10 +331,7 @@ where
 							// credit.
 							_ => return Err(InvalidTransaction::Payment.into()),
 						};
-						(
-							fee_paid,
-							initial_asset_consumed.saturating_sub(refund_asset_amount.into()),
-						)
+						(fee_paid, initial_asset_consumed.saturating_sub(refund_asset_amount))
 					},
 					// The error should not occur since swap was quoted before.
 					Err((refund, _)) => {

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
@@ -239,7 +239,7 @@ fn transaction_payment_in_asset_possible() {
 			let fee_in_asset = input_quote.unwrap();
 			assert_eq!(Assets::balance(asset_id, caller), balance);
 
-			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
+			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
 				.pre_dispatch(&caller, CALL, &info_from_weight(WEIGHT_5), len)
 				.unwrap();
 			// assert that native balance is not used
@@ -263,7 +263,6 @@ fn transaction_payment_in_asset_possible() {
 			));
 
 			assert_eq!(Assets::balance(asset_id, caller), balance - fee_in_asset);
-			assert_eq!(TipUnbalancedAmount::get(), 0);
 			assert_eq!(FeeUnbalancedAmount::get(), fee_in_native);
 		});
 }
@@ -297,7 +296,7 @@ fn transaction_payment_in_asset_fails_if_no_pool_for_that_asset() {
 			assert_eq!(Assets::balance(asset_id, caller), balance);
 
 			let len = 10;
-			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id)).pre_dispatch(
+			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into())).pre_dispatch(
 				&caller,
 				CALL,
 				&info_from_weight(WEIGHT_5),
@@ -352,7 +351,7 @@ fn transaction_payment_without_fee() {
 			assert_eq!(input_quote, Some(201));
 
 			let fee_in_asset = input_quote.unwrap();
-			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
+			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
 				.pre_dispatch(&caller, CALL, &info_from_weight(WEIGHT_5), len)
 				.unwrap();
 
@@ -429,7 +428,7 @@ fn asset_transaction_payment_with_tip_and_refund() {
 			assert_eq!(input_quote, Some(1206));
 
 			let fee_in_asset = input_quote.unwrap();
-			let pre = ChargeAssetTxPayment::<Runtime>::from(tip, Some(asset_id))
+			let pre = ChargeAssetTxPayment::<Runtime>::from(tip, Some(asset_id.into()))
 				.pre_dispatch(&caller, CALL, &info_from_weight(WEIGHT_100), len)
 				.unwrap();
 			assert_eq!(Assets::balance(asset_id, caller), balance - fee_in_asset);
@@ -458,8 +457,7 @@ fn asset_transaction_payment_with_tip_and_refund() {
 				&Ok(())
 			));
 
-			assert_eq!(TipUnbalancedAmount::get(), tip);
-			assert_eq!(FeeUnbalancedAmount::get(), expected_fee);
+			assert_eq!(FeeUnbalancedAmount::get(), expected_fee + tip);
 
 			// caller should get refunded
 			assert_eq!(
@@ -521,7 +519,7 @@ fn payment_from_account_with_only_assets() {
 			.unwrap();
 			assert_eq!(fee_in_asset, 201);
 
-			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
+			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
 				.pre_dispatch(&caller, CALL, &info_from_weight(WEIGHT_5), len)
 				.unwrap();
 			assert_eq!(Balances::free_balance(caller), 0);
@@ -540,7 +538,6 @@ fn payment_from_account_with_only_assets() {
 			assert_eq!(Assets::balance(asset_id, caller), balance - fee_in_asset + refund);
 			assert_eq!(Balances::free_balance(caller), 0);
 
-			assert_eq!(TipUnbalancedAmount::get(), 0);
 			assert_eq!(FeeUnbalancedAmount::get(), fee_in_native);
 		});
 }
@@ -580,7 +577,7 @@ fn converted_fee_is_never_zero_if_input_fee_is_not() {
 
 			// there will be no conversion when the fee is zero
 			{
-				let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
+				let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
 					.pre_dispatch(&caller, CALL, &info_from_pays(Pays::No), len)
 					.unwrap();
 				// `Pays::No` implies there are no fees
@@ -606,7 +603,7 @@ fn converted_fee_is_never_zero_if_input_fee_is_not() {
 			)
 			.unwrap();
 
-			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
+			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
 				.pre_dispatch(&caller, CALL, &info_from_weight(Weight::from_parts(weight, 0)), len)
 				.unwrap();
 			assert_eq!(Assets::balance(asset_id, caller), balance - fee_in_asset);
@@ -656,7 +653,7 @@ fn post_dispatch_fee_is_zero_if_pre_dispatch_fee_is_zero() {
 			// calculated fee is greater than 0
 			assert!(fee > 0);
 
-			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
+			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id.into()))
 				.pre_dispatch(&caller, CALL, &info_from_pays(Pays::No), len)
 				.unwrap();
 			// `Pays::No` implies no pre-dispatch fees

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
@@ -512,30 +512,23 @@ fn payment_from_account_with_only_assets() {
 			let len = 10;
 
 			let fee_in_native = base_weight + weight + len as u64;
-			let ed = Balances::minimum_balance();
 			let fee_in_asset = AssetConversion::quote_price_tokens_for_exact_tokens(
 				NativeOrWithId::WithId(asset_id),
 				NativeOrWithId::Native,
-				fee_in_native + ed,
+				fee_in_native,
 				true,
 			)
 			.unwrap();
-			assert_eq!(fee_in_asset, 301);
+			assert_eq!(fee_in_asset, 201);
 
 			let pre = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id))
 				.pre_dispatch(&caller, CALL, &info_from_weight(WEIGHT_5), len)
 				.unwrap();
-			assert_eq!(Balances::free_balance(caller), ed);
+			assert_eq!(Balances::free_balance(caller), 0);
 			// check that fee was charged in the given asset
 			assert_eq!(Assets::balance(asset_id, caller), balance - fee_in_asset);
 
-			let refund = AssetConversion::quote_price_exact_tokens_for_tokens(
-				NativeOrWithId::Native,
-				NativeOrWithId::WithId(asset_id),
-				ed,
-				true,
-			)
-			.unwrap();
+			let refund = 0;
 
 			assert_ok!(ChargeAssetTxPayment::<Runtime>::post_dispatch(
 				Some(pre),

--- a/substrate/frame/transaction-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/src/mock.rs
@@ -221,7 +221,4 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
-	pallet_assets::runtime_benchmarks_enabled! {
-		type BenchmarkHelper = ();
-	}
 }

--- a/substrate/frame/transaction-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/src/mock.rs
@@ -185,10 +185,10 @@ impl OnUnbalanced<fungibles::Credit<<Runtime as frame_system::Config>::AccountId
 }
 
 type NativeAndAssets =
-	fungible::UnionOf<Balances, Assets, NativeFromLeft, NativeOrWithId<u64>, u64>;
+	fungible::UnionOf<Balances, Assets, NativeFromLeft, NativeOrWithId<u32>, u64>;
 
 parameter_types! {
-	pub Native: NativeOrWithId::<u64> = NativeOrWithId::<u64>::Native;
+	pub Native: NativeOrWithId::<u32> = NativeOrWithId::<u32>::Native;
 }
 
 impl Config for Runtime {
@@ -205,8 +205,8 @@ impl Config for Runtime {
 impl pallet_assets::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = u64;
-	type AssetId = u64;
-	type AssetIdParameter = codec::Compact<u64>;
+	type AssetId = u32;
+	type AssetIdParameter = codec::Compact<u32>;
 	type Currency = Balances;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<u64>>;
 	type ForceOrigin = EnsureRoot<u64>;
@@ -221,4 +221,7 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
+	pallet_assets::runtime_benchmarks_enabled! {
+		type BenchmarkHelper = ();
+	}
 }

--- a/substrate/frame/transaction-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/src/tests.rs
@@ -150,7 +150,6 @@ fn signed_extension_transaction_payment_work() {
 			));
 			assert_eq!(Balances::free_balance(1), 100 - 5 - 5 - 10);
 			assert_eq!(FeeUnbalancedAmount::get(), 5 + 5 + 10);
-			assert_eq!(TipUnbalancedAmount::get(), 0);
 
 			FeeUnbalancedAmount::mutate(|a| *a = 0);
 
@@ -167,8 +166,7 @@ fn signed_extension_transaction_payment_work() {
 				&Ok(())
 			));
 			assert_eq!(Balances::free_balance(2), 200 - 5 - 10 - 50 - 5);
-			assert_eq!(FeeUnbalancedAmount::get(), 5 + 10 + 50);
-			assert_eq!(TipUnbalancedAmount::get(), 5);
+			assert_eq!(FeeUnbalancedAmount::get(), 5 + 10 + 50 + 5);
 		});
 }
 


### PR DESCRIPTION
Use Credit Swaps for transaction payments involving assets exchangeable for the native asset to bypass the need for Existential Deposit (ED).

This PR includes implementations of two types proposed to the runtimes, available here - [link](https://github.com/polkadot-fellows/runtimes/pull/310). These types are designed to avoid any breaking changes to the pallets and can be proposed to the runtime without requiring a library version upgrade.

The current version of the PR is intended to assess the correctness of the new types against the existing tests built for types implementing the same protocol.

I believe that with some breaking changes, the solution can be further improved, potentially eliminating the need for an implementation like `FungiblesAdapter` of the `OnChargeTransaction` trait. However, implementing such changes would require additional time and cannot be integrated for the next runtime release.

Target implementation with breaking changes: https://github.com/paritytech/polkadot-sdk/pull/4488