### PR TITLE
Fix extrinsics count logging in frame-system

### DIFF
--- a/prdoc/pr_4461.prdoc
+++ b/prdoc/pr_4461.prdoc
@@ -1,0 +1,9 @@
+title: Fix extrinsics count logging in frame-system
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Fixes the issue of the number of extrinsics in the block always being 0 in the log of frame-system.
+
+crates:
+  - name: frame-system

--- a/prdoc/pr_4461.prdoc
+++ b/prdoc/pr_4461.prdoc
@@ -7,3 +7,4 @@ doc:
 
 crates:
   - name: frame-system
+    bump: patch 

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -1780,7 +1780,7 @@ impl<T: Config> Pallet<T> {
 			"[{:?}] {} extrinsics, length: {} (normal {}%, op: {}%, mandatory {}%) / normal weight:\
 			 {} ({}%) op weight {} ({}%) / mandatory weight {} ({}%)",
 			Self::block_number(),
-			Self::extrinsic_index().unwrap_or_default(),
+			Self::extrinsic_count(),
 			Self::all_extrinsics_len(),
 			sp_runtime::Percent::from_rational(
 				Self::all_extrinsics_len(),


### PR DESCRIPTION
The storage item ExtrinsicIndex is already taken before the `finalize()` in `note_finished_extrinsics()`, rendering it's always 0 in the log. This commit fixes it by using the proper API for extrinsics count.