### PR TITLE
Bump fatality crate to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5362,20 +5362,19 @@ dependencies = [
 
 [[package]]
 name = "fatality"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ecdc33d04db74fc23db9f54f6f314c61d29f810d58ba423d0c204888365458"
+checksum = "ec6f82451ff7f0568c6181287189126d492b5654e30a788add08027b6363d019"
 dependencies = [
  "fatality-proc-macro",
- "syn 2.0.61",
  "thiserror",
 ]
 
 [[package]]
 name = "fatality-proc-macro"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac67b350787fd4a934752e30ddb45569da000e14bf3e499224302778b7a918ab"
+checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
  "indexmap 2.2.3",
@@ -5383,7 +5382,6 @@ dependencies = [
  "proc-macro2 1.0.82",
  "quote 1.0.35",
  "syn 2.0.61",
- "thiserror",
 ]
 
 [[package]]

--- a/polkadot/node/core/backing/Cargo.toml
+++ b/polkadot/node/core/backing/Cargo.toml
@@ -21,7 +21,7 @@ statement-table = { package = "polkadot-statement-table", path = "../../../state
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 gum = { package = "tracing-gum", path = "../../gum" }
 thiserror = { workspace = true }
-fatality = "0.1.0"
+fatality = "0.1.1"
 schnellru = "0.2.1"
 
 [dev-dependencies]

--- a/polkadot/node/core/dispute-coordinator/Cargo.toml
+++ b/polkadot/node/core/dispute-coordinator/Cargo.toml
@@ -16,7 +16,7 @@ parity-scale-codec = "3.6.1"
 kvdb = "0.13.0"
 thiserror = { workspace = true }
 schnellru = "0.2.1"
-fatality = "0.1.0"
+fatality = "0.1.1"
 
 polkadot-primitives = { path = "../../../primitives" }
 polkadot-node-primitives = { path = "../../primitives" }

--- a/polkadot/node/core/prospective-parachains/Cargo.toml
+++ b/polkadot/node/core/prospective-parachains/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.30"
 gum = { package = "tracing-gum", path = "../../gum" }
 parity-scale-codec = "3.6.4"
 thiserror = { workspace = true }
-fatality = "0.1.0"
+fatality = "0.1.1"
 bitvec = "1"
 
 polkadot-primitives = { path = "../../../primitives" }

--- a/polkadot/node/core/provisioner/Cargo.toml
+++ b/polkadot/node/core/provisioner/Cargo.toml
@@ -19,7 +19,7 @@ polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 futures-timer = "3.0.2"
-fatality = "0.1.0"
+fatality = "0.1.1"
 schnellru = "0.2.1"
 
 [dev-dependencies]

--- a/polkadot/node/network/availability-distribution/Cargo.toml
+++ b/polkadot/node/network/availability-distribution/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { workspace = true }
 rand = "0.8.5"
 derive_more = "0.99.17"
 schnellru = "0.2.1"
-fatality = "0.1.0"
+fatality = "0.1.1"
 
 [dev-dependencies]
 polkadot-node-subsystem-test-helpers = { path = "../../subsystem-test-helpers" }

--- a/polkadot/node/network/availability-recovery/Cargo.toml
+++ b/polkadot/node/network/availability-recovery/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.30"
 tokio = "1.37"
 schnellru = "0.2.1"
 rand = "0.8.5"
-fatality = "0.1.0"
+fatality = "0.1.1"
 thiserror = { workspace = true }
 async-trait = "0.1.79"
 gum = { package = "tracing-gum", path = "../../gum" }

--- a/polkadot/node/network/bridge/Cargo.toml
+++ b/polkadot/node/network/bridge/Cargo.toml
@@ -24,7 +24,7 @@ polkadot-node-subsystem = { path = "../../subsystem" }
 polkadot-overseer = { path = "../../overseer" }
 parking_lot = "0.12.1"
 bytes = "1"
-fatality = "0.1.0"
+fatality = "0.1.1"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -24,7 +24,7 @@ polkadot-node-network-protocol = { path = "../protocol" }
 polkadot-node-primitives = { path = "../../primitives" }
 polkadot-node-subsystem-util = { path = "../../subsystem-util" }
 polkadot-node-subsystem = { path = "../../subsystem" }
-fatality = "0.1.0"
+fatality = "0.1.1"
 thiserror = { workspace = true }
 tokio-util = "0.7.1"
 

--- a/polkadot/node/network/dispute-distribution/Cargo.toml
+++ b/polkadot/node/network/dispute-distribution/Cargo.toml
@@ -25,7 +25,7 @@ sc-network = { path = "../../../../substrate/client/network" }
 sp-application-crypto = { path = "../../../../substrate/primitives/application-crypto" }
 sp-keystore = { path = "../../../../substrate/primitives/keystore" }
 thiserror = { workspace = true }
-fatality = "0.1.0"
+fatality = "0.1.1"
 schnellru = "0.2.1"
 indexmap = "2.0.0"
 

--- a/polkadot/node/network/protocol/Cargo.toml
+++ b/polkadot/node/network/protocol/Cargo.toml
@@ -24,7 +24,7 @@ sp-runtime = { path = "../../../../substrate/primitives/runtime" }
 strum = { version = "0.26.2", features = ["derive"] }
 futures = "0.3.30"
 thiserror = { workspace = true }
-fatality = "0.1.0"
+fatality = "0.1.1"
 rand = "0.8"
 derive_more = "0.99"
 gum = { package = "tracing-gum", path = "../../gum" }

--- a/polkadot/node/network/statement-distribution/Cargo.toml
+++ b/polkadot/node/network/statement-distribution/Cargo.toml
@@ -24,7 +24,7 @@ arrayvec = "0.7.4"
 indexmap = "2.0.0"
 parity-scale-codec = { version = "3.6.1", default-features = false, features = ["derive"] }
 thiserror = { workspace = true }
-fatality = "0.1.0"
+fatality = "0.1.1"
 bitvec = "1"
 
 [dev-dependencies]

--- a/polkadot/node/subsystem-util/Cargo.toml
+++ b/polkadot/node/subsystem-util/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.12.1"
 pin-project = "1.0.9"
 rand = "0.8.5"
 thiserror = { workspace = true }
-fatality = "0.1.0"
+fatality = "0.1.1"
 gum = { package = "tracing-gum", path = "../gum" }
 derive_more = "0.99.17"
 schnellru = "0.2.1"


### PR DESCRIPTION
... to get rid of the macro debug logs like this from build output
```
[/home/alexggh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fatality-proc-macro-0.1.0/src/types.rs:171:23] input = TokenStream [
    Literal {
        kind: Str,
        symbol: "Error while accessing runtime information",
        suffix: None,
        span: #0 bytes(6943..6986),
    },
]
```