### PR TITLE
[ci] Use default gh runners for small workloads

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-licenses:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       LICENSES: "'Apache-2.0' 'GPL-3.0-only' 'GPL-3.0-or-later WITH Classpath-exception-2.0'"

--- a/.github/workflows/checks-quick.yml
+++ b/.github/workflows/checks-quick.yml
@@ -19,7 +19,7 @@ jobs:
     # GitHub Actions allows using 'env' in a container context.
     # However, env variables don't work for forks: https://github.com/orgs/community/discussions/44322
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
@@ -29,7 +29,7 @@ jobs:
       - id: set_image
         run: cat .github/env >> $GITHUB_OUTPUT
   fmt:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [set-image]
     container:
@@ -39,11 +39,8 @@ jobs:
       - name: Cargo fmt
         run: cargo +nightly fmt --all -- --check
   check-dependency-rules:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
-    # needs: [set-image]
-    # container:
-    #   image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: check dependency rules
@@ -51,7 +48,7 @@ jobs:
           cd substrate/
           ../.gitlab/ensure-deps.sh
   check-rust-feature-propagation:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [set-image]
     container:
@@ -61,7 +58,7 @@ jobs:
       - name: run zepter
         run: zepter run check
   test-rust-features:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [set-image]
     container:
@@ -71,7 +68,7 @@ jobs:
       - name: run rust features
         run: bash .gitlab/rust-features.sh .
   check-toml-format:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [set-image]
     container:
@@ -83,7 +80,7 @@ jobs:
           taplo format --check --config .config/taplo.toml
           echo "Please run `taplo format --config .config/taplo.toml` to fix any toml formatting issues"
   check-workspace:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.0 (22. Sep 2023)
@@ -98,7 +95,7 @@ jobs:
           "substrate/frame/contracts/fixtures/build"
           "substrate/frame/contracts/fixtures/contracts/common"
   check-markdown:
-    runs-on: arc-runners-polkadot-sdk
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout sources


### PR DESCRIPTION
`ubuntu-latest` are free for public repo so it's better (and cheaper) to use them for small jobs