### PR TITLE
Deprecate `dmp-queue` pallet

### DIFF
--- a/cumulus/pallets/dmp-queue/src/lib.rs
+++ b/cumulus/pallets/dmp-queue/src/lib.rs
@@ -21,6 +21,7 @@
 //! from the runtime once `Completed` was emitted.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(deprecated)] // The pallet itself is deprecated.
 
 use migration::*;
 pub use pallet::*;
@@ -38,6 +39,9 @@ pub type MaxDmpMessageLenOf<T> =
 	<<T as Config>::DmpSink as frame_support::traits::HandleMessage>::MaxMessageLen;
 
 #[frame_support::pallet]
+#[deprecated(
+	note = "`cumulus-pallet-dmp-queue` will be removed after November 2024. It can be removed once its lazy migration completed. See <https://github.com/paritytech/polkadot-sdk/pull/1246>."
+)]
 pub mod pallet {
 	use super::*;
 	use frame_support::{pallet_prelude::*, traits::HandleMessage, weights::WeightMeter};

--- a/prdoc/pr_4475.prdoc
+++ b/prdoc/pr_4475.prdoc
@@ -1,0 +1,10 @@
+title: "Deprecate dmp-queue pallet"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Schedule the DMP queue pallet for deletion. It is not needed anymore sine https://github.com/paritytech/polkadot-sdk/pull/1246.
+
+crates:
+  - name: cumulus-pallet-dmp-queue
+    bump: minor


### PR DESCRIPTION
`cumulus-pallet-dmp-queue` is not needed anymore since https://github.com/paritytech/polkadot-sdk/pull/1246.

The only logic that remains in the pallet is a lazy migration in the [`on_idle`](https://github.com/paritytech/polkadot-sdk/blob/8d62c13b2541920c37fb9d9ca733fcce91e96573/cumulus/pallets/dmp-queue/src/lib.rs#L158) hook.