### PR TITLE
Include RUNTIME_METADATA_HASH in cache key

### DIFF
--- a/.forklift/config.toml
+++ b/.forklift/config.toml
@@ -10,6 +10,9 @@ jobsBlackList = []
 logLevel = "warn"
 threadsCount = 6
 
+[cache]
+extraEnv = ["RUNTIME_METADATA_HASH"]
+
 [metrics]
 enabled = true
 pushEndpoint = "placeholder"


### PR DESCRIPTION
Add RUNTIME_METADATA_HASH variable to [`cache.extraEnv`](https://github.com/paritytech/forklift/tree/0.12.4?tab=readme-ov-file#cache) in config.toml (setting available from forklift 0.12.4)