### PR TITLE
Bridge: drop subscriptions when they are no longer required

### DIFF
--- a/bridges/relays/client-substrate/src/client.rs
+++ b/bridges/relays/client-substrate/src/client.rs
@@ -882,6 +882,7 @@ impl<T: DeserializeOwned> Subscription<T> {
 			item_type,
 		);
 
+let (cancel_sender, cancel_receiver) = futures::channel::oneshot::channel::<()>(); // TODO: remove me
 		futures::pin_mut!(subscription, cancel_receiver);
 		loop {
 			match futures::future::select(subscription.next(), &mut cancel_receiver).await {

--- a/bridges/relays/client-substrate/src/client.rs
+++ b/bridges/relays/client-substrate/src/client.rs
@@ -79,6 +79,8 @@ pub fn is_ancient_block<N: From<u32> + PartialOrd + Saturating>(block: N, best: 
 /// Opaque justifications subscription type.
 pub struct Subscription<T>(
 	pub(crate) Mutex<futures::channel::mpsc::Receiver<Option<T>>>,
+	// The following field is not explicitly used by the code. But when it is dropped,
+	// the bakground task receives a shutdown signal.
 	#[allow(dead_code)] pub(crate) futures::channel::oneshot::Sender<()>,
 );
 
@@ -856,6 +858,7 @@ impl<T: DeserializeOwned> Subscription<T> {
 			match item {
 				Some(item) => Some((item, Some(this))),
 				None => {
+					// let's make it explicit here
 					let _ = this.1.send(());
 					None
 				},

--- a/bridges/relays/client-substrate/src/transaction_tracker.rs
+++ b/bridges/relays/client-substrate/src/transaction_tracker.rs
@@ -306,12 +306,13 @@ mod tests {
 		TrackedTransactionStatus<HeaderIdOf<TestChain>>,
 		InvalidationStatus<HeaderIdOf<TestChain>>,
 	)> {
+		let (cancel_sender, _cancel_receiver) = futures::channel::oneshot::channel();
 		let (mut sender, receiver) = futures::channel::mpsc::channel(1);
 		let tx_tracker = TransactionTracker::<TestChain, TestEnvironment>::new(
 			TestEnvironment(Ok(HeaderId(0, Default::default()))),
 			Duration::from_secs(0),
 			Default::default(),
-			Subscription(async_std::sync::Mutex::new(receiver)),
+			Subscription(async_std::sync::Mutex::new(receiver), cancel_sender),
 		);
 
 		let wait_for_stall_timeout = futures::future::pending();
@@ -428,12 +429,13 @@ mod tests {
 
 	#[async_std::test]
 	async fn lost_on_timeout_when_waiting_for_invalidation_status() {
+		let (cancel_sender, _cancel_receiver) = futures::channel::oneshot::channel();
 		let (_sender, receiver) = futures::channel::mpsc::channel(1);
 		let tx_tracker = TransactionTracker::<TestChain, TestEnvironment>::new(
 			TestEnvironment(Ok(HeaderId(0, Default::default()))),
 			Duration::from_secs(0),
 			Default::default(),
-			Subscription(async_std::sync::Mutex::new(receiver)),
+			Subscription(async_std::sync::Mutex::new(receiver), cancel_sender),
 		);
 
 		let wait_for_stall_timeout = futures::future::ready(()).shared();


### PR DESCRIPTION
The bridge relay is **not** using `tokio`, while `jsonrpsee` does. To make it work together, we are spawning a separate tokio task for every jsonrpsee subscription, which holds a subscription reference. It looks like we are not stopping those tasks when we no longer need it and when there are more than `1024` active subscriptions, `jsonrpsee` stops opening new subscriptions. This PR adds an `cancel` signal that is sent to the background task when we no longer need a subscription.