### PR TITLE
Snowbridge - Ethereum Client - Reject finalized updates without a sync committee in next store period

### DIFF
--- a/bridges/snowbridge/parachain/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/parachain/pallets/ethereum-client/src/lib.rs
@@ -121,6 +121,7 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T> {
 		SkippedSyncCommitteePeriod,
+		SyncCommitteeUpdateRequired,
 		/// Attested header is older than latest finalized header.
 		IrrelevantUpdate,
 		NotBootstrapped,
@@ -393,6 +394,7 @@ pub mod pallet {
 
 			// Verify update is relevant.
 			let update_attested_period = compute_period(update.attested_header.slot);
+			let update_finalized_period = compute_period(update.finalized_header.slot);
 			let update_has_next_sync_committee = !<NextSyncCommittee<T>>::exists() &&
 				(update.next_sync_committee_update.is_some() &&
 					update_attested_period == store_period);
@@ -467,6 +469,11 @@ pub mod pallet {
 						update.attested_header.state_root
 					),
 					Error::<T>::InvalidSyncCommitteeMerkleProof
+				);
+			} else {
+				ensure!(
+					update_finalized_period == store_period,
+					Error::<T>::SyncCommitteeUpdateRequired
 				);
 			}
 

--- a/bridges/snowbridge/parachain/pallets/ethereum-client/src/tests.rs
+++ b/bridges/snowbridge/parachain/pallets/ethereum-client/src/tests.rs
@@ -451,13 +451,14 @@ fn submit_update_with_sync_committee_in_current_period() {
 }
 
 #[test]
-fn submit_update_in_next_period() {
+fn reject_submit_update_in_next_period() {
 	let checkpoint = Box::new(load_checkpoint_update_fixture());
 	let sync_committee_update = Box::new(load_sync_committee_update_fixture());
 	let update = Box::new(load_next_finalized_header_update_fixture());
 	let sync_committee_period = compute_period(sync_committee_update.finalized_header.slot);
 	let next_sync_committee_period = compute_period(update.finalized_header.slot);
 	assert_eq!(sync_committee_period + 1, next_sync_committee_period);
+	let next_sync_committee_update = Box::new(load_next_sync_committee_update_fixture());
 
 	new_tester().execute_with(|| {
 		assert_ok!(EthereumBeaconClient::process_checkpoint_update(&checkpoint));
@@ -465,6 +466,17 @@ fn submit_update_in_next_period() {
 			RuntimeOrigin::signed(1),
 			sync_committee_update.clone()
 		));
+		// check an update in the next period is rejected
+		assert_err!(
+			EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update.clone()),
+			Error::<Test>::SyncCommitteeUpdateRequired
+		);
+		// submit update with next sync committee
+		assert_ok!(EthereumBeaconClient::submit(
+			RuntimeOrigin::signed(1),
+			next_sync_committee_update
+		));
+		// check same header in the next period can now be submitted successfully
 		assert_ok!(EthereumBeaconClient::submit(RuntimeOrigin::signed(1), update.clone()));
 		let block_root: H256 = update.finalized_header.clone().hash_tree_root().unwrap();
 		assert!(<FinalizedBeaconState<Test>>::contains_key(block_root));

--- a/prdoc/pr_4478.prdoc
+++ b/prdoc/pr_4478.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Snowbridge - Ethereum Client - Reject finalized updates without a sync committee in next store period
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Bug fix in the Ethereum light client that stalls the light client when an update in the next sync committee period is received without receiving the next sync committee update in the next period.
+
+crates:
+  - name: snowbridge-pallet-ethereum-client
+    bump: patch


### PR DESCRIPTION
This is a cherry-pick from master of [https://github.com/paritytech/polkadot-sdk/pull/3790 and https://github.com/paritytech/polkadot-sdk/pull/3727](https://github.com/paritytech/polkadot-sdk/pull/4478)

Expected patches for (1.7.0):
snowbridge-pallet-ethereum-client