### PR TITLE
Bridge: fixed relayer version metric value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15472,6 +15472,7 @@ dependencies = [
  "jsonpath_lib",
  "log",
  "num-traits",
+ "parking_lot 0.12.1",
  "serde_json",
  "sp-runtime",
  "substrate-prometheus-endpoint",

--- a/bridges/relays/lib-substrate-relay/src/cli/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/mod.rs
@@ -125,14 +125,13 @@ impl PrometheusParams {
 			None
 		};
 
-		let relay_version = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
+		let relay_version = relay_utils::initialize::RELAYER_VERSION
+			.lock()
+			.clone()
+			.unwrap_or_else(|| "unknown".to_string());
 		let relay_commit = SubstrateRelayBuildInfo::get_git_commit();
-		relay_utils::metrics::MetricsParams::new(
-			metrics_address,
-			relay_version.into(),
-			relay_commit,
-		)
-		.map_err(|e| anyhow::format_err!("{:?}", e))
+		relay_utils::metrics::MetricsParams::new(metrics_address, relay_version, relay_commit)
+			.map_err(|e| anyhow::format_err!("{:?}", e))
 	}
 }
 

--- a/bridges/relays/utils/Cargo.toml
+++ b/bridges/relays/utils/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.30"
 jsonpath_lib = "0.3"
 log = { workspace = true }
 num-traits = "0.2"
+parking_lot = "0.12.1"
 serde_json = { workspace = true, default-features = true }
 sysinfo = "0.30"
 time = { version = "0.3", features = ["formatting", "local-offset", "std"] }

--- a/bridges/relays/utils/src/initialize.rs
+++ b/bridges/relays/utils/src/initialize.rs
@@ -16,7 +16,12 @@
 
 //! Relayer initialization functions.
 
+use parking_lot::Mutex;
 use std::{cell::RefCell, fmt::Display, io::Write};
+
+/// Relayer version that is provided as metric. Must be set by a binary
+/// (get if with `option_env!("CARGO_PKG_VERSION")` from a binary package code).
+pub static RELAYER_VERSION: Mutex<Option<String>> = Mutex::new(None);
 
 async_std::task_local! {
 	pub(crate) static LOOP_NAME: RefCell<String> = RefCell::new(String::default());

--- a/bridges/relays/utils/src/initialize.rs
+++ b/bridges/relays/utils/src/initialize.rs
@@ -20,7 +20,7 @@ use parking_lot::Mutex;
 use std::{cell::RefCell, fmt::Display, io::Write};
 
 /// Relayer version that is provided as metric. Must be set by a binary
-/// (get if with `option_env!("CARGO_PKG_VERSION")` from a binary package code).
+/// (get it with `option_env!("CARGO_PKG_VERSION")` from a binary package code).
 pub static RELAYER_VERSION: Mutex<Option<String>> = Mutex::new(None);
 
 async_std::task_local! {


### PR DESCRIPTION
Before relayer crates have been moved + merged, the `MetricsParams` type has been created from a `substrate-relay` crate (binary) and hence it has been setting the `substrate_relay_build_info` metic value properly - to the binary version. Now it is created from the `substrate-relay-helper` crate, which has the fixed (it isn't published) version `0.1.0`, so our relay provides incorrect metric value. This 'breaks' our monitoring tools - we see that all relayers have that incorrect version, which is not cool.

The idea is to have a global static variable (shame on me) that is initialized by the binary during initialization like we do with the logger initialization already. Was considering some alternative options:
- adding a separate argument to every relayer subcommand and propagating it to the `MetricsParams::new()` causes a lot of changes and introduces even more noise to the binary code, which is supposed to be as small as possible in the new design. But I could do that if team thinks it is better;
- adding a `structopt(skip) pub relayer_version: RelayerVersion` argument to all subcommand params won't work, because it will be initialized by default and `RelayerVersion` needs to reside in some util crate (not the binary), so it'll have the wrong value again.