### PR TITLE
xcm-emlator: Use `BlockNumberFor` instead of `parachains_common::BlockNumber=u32` (#4434)

### DIFF
--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -32,7 +32,9 @@ pub use frame_support::{
 	},
 	weights::{Weight, WeightMeter},
 };
-pub use frame_system::{Config as SystemConfig, Pallet as SystemPallet};
+pub use frame_system::{
+	pallet_prelude::BlockNumberFor, Config as SystemConfig, Pallet as SystemPallet,
+};
 pub use pallet_balances::AccountData;
 pub use sp_arithmetic::traits::Bounded;
 pub use sp_core::{blake2_256, parameter_types, sr25519, storage::Storage, Pair};
@@ -49,7 +51,7 @@ pub use cumulus_primitives_core::{
 pub use cumulus_primitives_parachain_inherent::ParachainInherentData;
 pub use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 pub use pallet_message_queue::{Config as MessageQueueConfig, Pallet as MessageQueuePallet};
-pub use parachains_common::{AccountId, Balance, BlockNumber};
+pub use parachains_common::{AccountId, Balance};
 pub use polkadot_primitives;
 pub use polkadot_runtime_parachains::inclusion::{AggregateMessageOrigin, UmpQueueId};
 
@@ -643,7 +645,7 @@ macro_rules! decl_test_parachains {
 							.clone()
 						);
 						<Self as Chain>::System::initialize(&block_number, &parent_head_data.hash(), &Default::default());
-						<<Self as Parachain>::ParachainSystem as Hooks<$crate::BlockNumber>>::on_initialize(block_number);
+						<<Self as Parachain>::ParachainSystem as Hooks<$crate::BlockNumberFor<Self::Runtime>>>::on_initialize(block_number);
 
 						let _ = <Self as Parachain>::ParachainSystem::set_validation_data(
 							<Self as Chain>::RuntimeOrigin::none(),


### PR DESCRIPTION
Cherry-picked from `master` (#4434). Context: https://github.com/paritytech/polkadot-sdk/issues/4428.

I don't see any other way than opening other PRs for each of the released branches with this fix. If you guys have an alternative proposal, I am all ears. Otherwise, I'll go ahead and open the other ones once this gets merged.