### PR TITLE
chore: bump zombienet version

### DIFF
--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -1,7 +1,7 @@
 .zombienet-refs:
   extends: .build-refs
   variables:
-    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.103"
+    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.104"
     PUSHGATEWAY_URL: "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics"
     DEBUG: "zombie,zombie::network-node,zombie::kube::client::logs"
 


### PR DESCRIPTION
This version includes the latest release of pjs/api (https://github.com/polkadot-js/api/releases/tag/v11.1.1).
Thx!