### PR TITLE
rustls: Disable logging again

### DIFF
--- a/prdoc/pr_4541.prdoc
+++ b/prdoc/pr_4541.prdoc
@@ -12,5 +12,5 @@ doc:
       anymore.
 
 crates:
-  - name: sc-clig
+  - name: sc-cli
     bump: patch

--- a/prdoc/pr_4541.prdoc
+++ b/prdoc/pr_4541.prdoc
@@ -14,3 +14,4 @@ doc:
 crates:
   - name: sc-cli
     bump: patch
+    validate: false

--- a/prdoc/pr_4541.prdoc
+++ b/prdoc/pr_4541.prdoc
@@ -1,0 +1,16 @@
+title: "Remove warning about `BadCertificate` Version 2"
+
+doc:
+  - audience: Node Operator
+    description: |
+      The node was printing the following warning from time to time:
+      ```
+      Sending fatal alert BadCertificate
+      ```
+
+      This is not an user error and thus, the warning will now not be printed
+      anymore.
+
+crates:
+  - name: sc-clig
+    bump: patch

--- a/prdoc/pr_4541.prdoc
+++ b/prdoc/pr_4541.prdoc
@@ -12,6 +12,5 @@ doc:
       anymore.
 
 crates:
-  - name: sc-cli
+  - name: sc-tracing
     bump: patch
-    validate: false

--- a/substrate/client/tracing/src/logging/mod.rs
+++ b/substrate/client/tracing/src/logging/mod.rs
@@ -142,8 +142,13 @@ where
 			parse_default_directive("libp2p_mdns::behaviour::iface=off")
 				.expect("provided directive is valid"),
 		)
+		// Disable annoying log messages from rustls
 		.add_directive(
 			parse_default_directive("rustls::common_state=off")
+				.expect("provided directive is valid"),
+		)
+		.add_directive(
+			parse_default_directive("rustls::conn=off")
 				.expect("provided directive is valid"),
 		);
 

--- a/substrate/client/tracing/src/logging/mod.rs
+++ b/substrate/client/tracing/src/logging/mod.rs
@@ -148,8 +148,7 @@ where
 				.expect("provided directive is valid"),
 		)
 		.add_directive(
-			parse_default_directive("rustls::conn=off")
-				.expect("provided directive is valid"),
+			parse_default_directive("rustls::conn=off").expect("provided directive is valid"),
 		);
 
 	if let Ok(lvl) = std::env::var("RUST_LOG") {


### PR DESCRIPTION
We are actually using an older version, where the log line is in a different file.