### PR TITLE
Bridge: check submit_finality_proof limits before submission

### DIFF
--- a/bridges/relays/client-substrate/src/error.rs
+++ b/bridges/relays/client-substrate/src/error.rs
@@ -17,6 +17,7 @@
 //! Substrate node RPC errors.
 
 use crate::SimpleRuntimeVersion;
+use bp_header_chain::SubmitFinalityProofCallExtras;
 use bp_polkadot_core::parachains::ParaId;
 use jsonrpsee::core::ClientError as RpcError;
 use relay_utils::MaybeConnectionError;
@@ -128,6 +129,12 @@ pub enum Error {
 		expected: SimpleRuntimeVersion,
 		/// Actual runtime version.
 		actual: SimpleRuntimeVersion,
+	},
+	/// Finality proof submission exceeds size and/or weight limits.
+	#[error("Finality proof submission exceeds limits: {extras:?}")]
+	FinalityProofWeightLimitExceeded {
+		/// Finality proof submission extras.
+		extras: SubmitFinalityProofCallExtras,
 	},
 	/// Custom logic error.
 	#[error("{0}")]

--- a/bridges/relays/lib-substrate-relay/src/finality_base/engine.rs
+++ b/bridges/relays/lib-substrate-relay/src/finality_base/engine.rs
@@ -23,9 +23,8 @@ use bp_header_chain::{
 		verify_and_optimize_justification, GrandpaEquivocationsFinder, GrandpaJustification,
 		JustificationVerificationContext,
 	},
-	max_expected_submit_finality_proof_arguments_size, AuthoritySet, ConsensusLogReader,
-	FinalityProof, FindEquivocations, GrandpaConsensusLogReader, HeaderFinalityInfo,
-	HeaderGrandpaInfo, StoredHeaderGrandpaInfo,
+	AuthoritySet, ConsensusLogReader, FinalityProof, FindEquivocations, GrandpaConsensusLogReader,
+	HeaderFinalityInfo, HeaderGrandpaInfo, StoredHeaderGrandpaInfo, SubmitFinalityProofCallExtras,
 };
 use bp_runtime::{BasicOperatingMode, HeaderIdProvider, OperatingMode};
 use codec::{Decode, Encode};
@@ -36,21 +35,8 @@ use relay_substrate_client::{
 };
 use sp_consensus_grandpa::{AuthorityList as GrandpaAuthoritiesSet, GRANDPA_ENGINE_ID};
 use sp_core::{storage::StorageKey, Bytes};
-use sp_runtime::{scale_info::TypeInfo, traits::Header, ConsensusEngineId, SaturatedConversion};
+use sp_runtime::{scale_info::TypeInfo, traits::Header, ConsensusEngineId};
 use std::{fmt::Debug, marker::PhantomData};
-
-/// Result of checking maximal expected call size.
-pub enum MaxExpectedCallSizeCheck {
-	/// Size is ok and call will be refunded.
-	Ok,
-	/// The call size exceeds the maximal expected and relayer will only get partial refund.
-	Exceeds {
-		/// Actual call size.
-		call_size: u32,
-		/// Maximal expected call size.
-		max_call_size: u32,
-	},
-}
 
 /// Finality engine, used by the Substrate chain.
 #[async_trait]
@@ -129,12 +115,11 @@ pub trait Engine<C: Chain>: Send {
 	) -> Result<Self::FinalityVerificationContext, SubstrateError>;
 
 	/// Checks whether the given `header` and its finality `proof` fit the maximal expected
-	/// call size limit. If result is `MaxExpectedCallSizeCheck::Exceeds { .. }`, this
-	/// submission won't be fully refunded and relayer will spend its own funds on that.
-	fn check_max_expected_call_size(
+	/// call limits (size and weight).
+	fn check_max_expected_call_limits(
 		header: &C::Header,
 		proof: &Self::FinalityProof,
-	) -> MaxExpectedCallSizeCheck;
+	) -> SubmitFinalityProofCallExtras;
 
 	/// Prepare initialization data for the finality bridge pallet.
 	async fn prepare_initialization_data(
@@ -245,22 +230,11 @@ impl<C: ChainWithGrandpa> Engine<C> for Grandpa<C> {
 		})
 	}
 
-	fn check_max_expected_call_size(
+	fn check_max_expected_call_limits(
 		header: &C::Header,
 		proof: &Self::FinalityProof,
-	) -> MaxExpectedCallSizeCheck {
-		let is_mandatory = Self::ConsensusLogReader::schedules_authorities_change(header.digest());
-		let call_size: u32 =
-			header.encoded_size().saturating_add(proof.encoded_size()).saturated_into();
-		let max_call_size = max_expected_submit_finality_proof_arguments_size::<C>(
-			is_mandatory,
-			proof.commit.precommits.len().saturated_into(),
-		);
-		if call_size > max_call_size {
-			MaxExpectedCallSizeCheck::Exceeds { call_size, max_call_size }
-		} else {
-			MaxExpectedCallSizeCheck::Ok
-		}
+	) -> SubmitFinalityProofCallExtras {
+		bp_header_chain::submit_finality_proof_limits_extras::<C>(header, proof)
 	}
 
 	/// Prepare initialization data for the GRANDPA verifier pallet.

--- a/bridges/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/bridges/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -16,9 +16,7 @@
 
 //! On-demand Substrate -> Substrate header finality relay.
 
-use crate::{
-	finality::SubmitFinalityProofCallBuilder, finality_base::engine::MaxExpectedCallSizeCheck,
-};
+use crate::finality::SubmitFinalityProofCallBuilder;
 
 use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;
@@ -156,22 +154,21 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 
 			// now we have the header and its proof, but we want to minimize our losses, so let's
 			// check if we'll get the full refund for submitting this header
-			let check_result = P::FinalityEngine::check_max_expected_call_size(&header, &proof);
-			if let MaxExpectedCallSizeCheck::Exceeds { call_size, max_call_size } = check_result {
+			let check_result = P::FinalityEngine::check_max_expected_call_limits(&header, &proof);
+			if check_result.is_weight_limit_exceeded || check_result.extra_size != 0 {
 				iterations += 1;
 				current_required_header = header_id.number().saturating_add(One::one());
 				if iterations < MAX_ITERATIONS {
 					log::debug!(
 						target: "bridge",
-						"[{}] Requested to prove {} head {:?}. Selected to prove {} head {:?}. But it is too large: {} vs {}. \
+						"[{}] Requested to prove {} head {:?}. Selected to prove {} head {:?}. But it exceeds limits: {:?}. \
 						Going to select next header",
 						self.relay_task_name,
 						P::SourceChain::NAME,
 						required_header,
 						P::SourceChain::NAME,
 						header_id,
-						call_size,
-						max_call_size,
+						check_result,
 					);
 
 					continue;


### PR DESCRIPTION
closes https://github.com/paritytech/parity-bridges-common/issues/2982
closes https://github.com/paritytech/parity-bridges-common/issues/2730

The main change is in the bridges/relays/lib-substrate-relay/src/finality/target.rs, changes in other files are just moving the code 

~I haven't been able to run zn tests locally - don't know why, but it keeps failing for me locally with: `
Error running script: /home/svyatonik/dev/polkadot-sdk/bridges/testing/framework/js-helpers/wait-hrmp-channel-opened.js 	 Error: Timeout(300), "custom-js /home/svyatonik/dev/polkadot-sdk/bridges/testing/framework/js-helpers/wait-hrmp-channel-opened.js within 300 secs" didn't complete on time.`~ The issue was an obsolete `polkadot-js-api` binary - did `yarn global upgrade` and it is ok now