### PR TITLE
Define `OpaqueValue`

### DIFF
--- a/substrate/primitives/consensus/beefy/src/lib.rs
+++ b/substrate/primitives/consensus/beefy/src/lib.rs
@@ -52,7 +52,10 @@ use core::fmt::{Debug, Display};
 use scale_info::TypeInfo;
 use sp_application_crypto::{AppCrypto, AppPublic, ByteArray, RuntimeAppPublic};
 use sp_core::H256;
-use sp_runtime::traits::{Hash, Keccak256, NumberFor};
+use sp_runtime::{
+	traits::{Hash, Keccak256, NumberFor},
+	OpaqueValue,
+};
 
 /// Key type for BEEFY module.
 pub const KEY_TYPE: sp_core::crypto::KeyTypeId = sp_application_crypto::key_types::BEEFY;
@@ -399,21 +402,7 @@ impl<AuthorityId> OnNewValidatorSet<AuthorityId> for () {
 /// the runtime API boundary this type is unknown and as such we keep this
 /// opaque representation, implementors of the runtime API will have to make
 /// sure that all usages of `OpaqueKeyOwnershipProof` refer to the same type.
-#[derive(Decode, Encode, PartialEq, TypeInfo)]
-pub struct OpaqueKeyOwnershipProof(Vec<u8>);
-impl OpaqueKeyOwnershipProof {
-	/// Create a new `OpaqueKeyOwnershipProof` using the given encoded
-	/// representation.
-	pub fn new(inner: Vec<u8>) -> OpaqueKeyOwnershipProof {
-		OpaqueKeyOwnershipProof(inner)
-	}
-
-	/// Try to decode this `OpaqueKeyOwnershipProof` into the given concrete key
-	/// ownership proof type.
-	pub fn decode<T: Decode>(self) -> Option<T> {
-		codec::Decode::decode(&mut &self.0[..]).ok()
-	}
-}
+pub type OpaqueKeyOwnershipProof = OpaqueValue;
 
 sp_api::decl_runtime_apis! {
 	/// API necessary for BEEFY voters.

--- a/substrate/primitives/consensus/grandpa/src/lib.rs
+++ b/substrate/primitives/consensus/grandpa/src/lib.rs
@@ -31,7 +31,7 @@ use scale_info::TypeInfo;
 use sp_keystore::KeystorePtr;
 use sp_runtime::{
 	traits::{Header as HeaderT, NumberFor},
-	ConsensusEngineId, RuntimeDebug,
+	ConsensusEngineId, OpaqueValue, RuntimeDebug,
 };
 
 /// The log target to be used by client code.
@@ -465,22 +465,7 @@ where
 /// the runtime API boundary this type is unknown and as such we keep this
 /// opaque representation, implementors of the runtime API will have to make
 /// sure that all usages of `OpaqueKeyOwnershipProof` refer to the same type.
-#[derive(Decode, Encode, PartialEq, TypeInfo)]
-pub struct OpaqueKeyOwnershipProof(Vec<u8>);
-
-impl OpaqueKeyOwnershipProof {
-	/// Create a new `OpaqueKeyOwnershipProof` using the given encoded
-	/// representation.
-	pub fn new(inner: Vec<u8>) -> OpaqueKeyOwnershipProof {
-		OpaqueKeyOwnershipProof(inner)
-	}
-
-	/// Try to decode this `OpaqueKeyOwnershipProof` into the given concrete key
-	/// ownership proof type.
-	pub fn decode<T: Decode>(self) -> Option<T> {
-		codec::Decode::decode(&mut &self.0[..]).ok()
-	}
-}
+pub type OpaqueKeyOwnershipProof = OpaqueValue;
 
 sp_api::decl_runtime_apis! {
 	/// APIs for integrating the GRANDPA finality gadget into runtimes.

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -1019,7 +1019,7 @@ impl OpaqueValue {
 	}
 
 	/// Try to decode this `OpaqueValue` into the given concrete type.
-	pub fn decode<T: Decode>(self) -> Option<T> {
+	pub fn decode<T: Decode>(&self) -> Option<T> {
 		Decode::decode(&mut &self.0[..]).ok()
 	}
 }

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -1009,6 +1009,21 @@ pub enum ExtrinsicInclusionMode {
 	OnlyInherents,
 }
 
+/// Simple blob that hold a value in an encoded form without committing to its type.
+#[derive(Decode, Encode, PartialEq, TypeInfo)]
+pub struct OpaqueValue(Vec<u8>);
+impl OpaqueValue {
+	/// Create a new `OpaqueValue` using the given encoded representation.
+	pub fn new(inner: Vec<u8>) -> OpaqueValue {
+		OpaqueValue(inner)
+	}
+
+	/// Try to decode this `OpaqueValue` into the given concrete type.
+	pub fn decode<T: Decode>(self) -> Option<T> {
+		Decode::decode(&mut &self.0[..]).ok()
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::traits::BlakeTwo256;


### PR DESCRIPTION
Define `OpaqueValue` and use it instead of `grandpa::OpaqueKeyOwnershipProof` and `beefy:OpaqueKeyOwnershipProof`

Related to https://github.com/paritytech/polkadot-sdk/pull/4522#discussion_r1608278279

We'll need to introduce a runtime API method that calls the `report_fork_voting_unsigned()` extrinsic. This method will need to receive the ancestry proof as a paramater. I'm still not sure, but there is a chance that we'll send the ancestry proof as an opaque type. 

So let's introduce this `OpaqueValue`. We can already use it to replace `grandpa::OpaqueKeyOwnershipProof` and `beefy:OpaqueKeyOwnershipProof` and maybe we'll need it for the ancestry proof as well. 