### PR TITLE
Add metric to measure the time it takes to gather enough assignments

### DIFF
--- a/polkadot/node/core/approval-voting/src/import.rs
+++ b/polkadot/node/core/approval-voting/src/import.rs
@@ -658,7 +658,7 @@ pub(crate) mod tests {
 			clock: Box::new(MockClock::default()),
 			assignment_criteria: Box::new(MockAssignmentCriteria::default()),
 			spans: HashMap::new(),
-			time_started_gathering_assignments: Default::default(),
+			per_block_assignments_gathering_times: Default::default(),
 		}
 	}
 

--- a/polkadot/node/core/approval-voting/src/import.rs
+++ b/polkadot/node/core/approval-voting/src/import.rs
@@ -607,7 +607,7 @@ pub(crate) mod tests {
 	use super::*;
 	use crate::{
 		approval_db::common::{load_block_entry, DbBackend},
-		RuntimeInfo, RuntimeInfoConfig,
+		RuntimeInfo, RuntimeInfoConfig, MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
 	};
 	use ::test_helpers::{dummy_candidate_receipt, dummy_hash};
 	use assert_matches::assert_matches;
@@ -622,6 +622,7 @@ pub(crate) mod tests {
 		node_features::FeatureIndex, ExecutorParams, Id as ParaId, IndexedVec, NodeFeatures,
 		SessionInfo, ValidatorId, ValidatorIndex,
 	};
+	use schnellru::{ByLength, LruMap};
 	pub(crate) use sp_consensus_babe::{
 		digests::{CompatibleDigestItem, PreDigest, SecondaryVRFPreDigest},
 		AllowedSlots, BabeEpochConfiguration, Epoch as BabeEpoch,
@@ -658,7 +659,9 @@ pub(crate) mod tests {
 			clock: Box::new(MockClock::default()),
 			assignment_criteria: Box::new(MockAssignmentCriteria::default()),
 			spans: HashMap::new(),
-			per_block_assignments_gathering_times: Default::default(),
+			per_block_assignments_gathering_times: LruMap::new(ByLength::new(
+				MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS,
+			)),
 		}
 	}
 

--- a/polkadot/node/core/approval-voting/src/import.rs
+++ b/polkadot/node/core/approval-voting/src/import.rs
@@ -658,6 +658,7 @@ pub(crate) mod tests {
 			clock: Box::new(MockClock::default()),
 			assignment_criteria: Box::new(MockAssignmentCriteria::default()),
 			spans: HashMap::new(),
+			time_started_gathering_assignments: Default::default(),
 		}
 	}
 

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -1028,6 +1028,14 @@ impl State {
 				let time_to_gather =
 					self.mark_gathered_enough_assignments(block_number, block_hash, candidate_hash);
 				if let Some(gathering_started) = time_to_gather.stage_start {
+					if gathering_started.elapsed().as_millis() > 6000 {
+						gum::trace!(
+							target: LOG_TARGET,
+							?block_hash,
+							?candidate_hash,
+							"Long assignment gathering time",
+						);
+					}
 					metrics.observe_assignment_gathering_time(
 						time_to_gather.stage,
 						gathering_started.elapsed().as_millis() as usize,

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -65,7 +65,7 @@ use sp_consensus::SyncOracle;
 use sp_consensus_slots::Slot;
 use std::time::Instant;
 
-// The maximum block we keep track of assignments gathering times, on normal operation
+// The max number of blocks we keep track of assignments gathering times. Normally,
 // this would never be reached because we prune the data on finalization, but we need
 // to also ensure the data is not growing unecessarily large.
 const MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS: u32 = 100;

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -960,10 +960,10 @@ impl State {
 			record.stage += 1;
 			gum::debug!(
 				target: LOG_TARGET,
-				"Started a new assignment gathering stage",
 				stage = ?record.stage,
 				?block_hash,
 				?candidate,
+				"Started a new assignment gathering stage",
 			);
 			record.stage_start = Some(Instant::now());
 		}

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -958,6 +958,13 @@ impl State {
 
 		if record.stage_start.is_none() {
 			record.stage += 1;
+			gum::debug!(
+				target: LOG_TARGET,
+				"Started a new assignment gathering stage",
+				stage = ?record.stage,
+				?block_hash,
+				?candidate,
+			);
 			record.stage_start = Some(Instant::now());
 		}
 

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -997,10 +997,10 @@ impl State {
 		}
 	}
 
-	fn cleanup_assignments_gathering_timestamp(&mut self, keep_greater_than: BlockNumber) {
+	fn cleanup_assignments_gathering_timestamp(&mut self, remove_lower_than: BlockNumber) {
 		while let Some((block_number, _)) = self.per_block_assignments_gathering_times.peek_oldest()
 		{
-			if *block_number < keep_greater_than {
+			if *block_number < remove_lower_than {
 				self.per_block_assignments_gathering_times.pop_oldest();
 			} else {
 				break

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -17,6 +17,10 @@
 use self::test_helpers::mock::new_leaf;
 use super::*;
 use crate::backend::V1ReadBackend;
+use overseer::prometheus::{
+	prometheus::{IntCounter, IntCounterVec},
+	Histogram, HistogramOpts, HistogramVec, Opts,
+};
 use polkadot_node_primitives::{
 	approval::{
 		v1::{
@@ -40,7 +44,7 @@ use polkadot_primitives::{
 	ApprovalVote, CandidateCommitments, CandidateEvent, CoreIndex, GroupIndex, Header,
 	Id as ParaId, IndexedVec, NodeFeatures, ValidationCode, ValidatorSignature,
 };
-use std::time::Duration;
+use std::{cmp::max, time::Duration};
 
 use assert_matches::assert_matches;
 use async_trait::async_trait;
@@ -5048,4 +5052,210 @@ fn subsystem_sends_pending_approvals_on_approval_restart() {
 
 		virtual_overseer
 	});
+}
+
+// Test we correctly update the timer when we mark the beginning of gathering assignments.
+#[test]
+fn test_gathering_assignments_statements() {
+	let mut state = State {
+		keystore: Arc::new(LocalKeystore::in_memory()),
+		slot_duration_millis: 6_000,
+		clock: Box::new(MockClock::default()),
+		assignment_criteria: Box::new(MockAssignmentCriteria::check_only(|_| Ok(0))),
+		spans: HashMap::new(),
+		time_started_gathering_assignments: Default::default(),
+	};
+
+	for i in 0..200i32 {
+		state.mark_begining_of_gathering_assignments(
+			i as u32,
+			Hash::repeat_byte(i as u8),
+			CandidateHash(Hash::repeat_byte(i as u8)),
+		);
+		assert!(
+			state.time_started_gathering_assignments.len() <=
+				MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS as usize
+		);
+
+		assert_eq!(
+			state.time_started_gathering_assignments.keys().min(),
+			Some(max(0, i - MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS as i32 + 1) as u32).as_ref()
+		)
+	}
+	assert_eq!(
+		state.time_started_gathering_assignments.len(),
+		MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS as usize
+	);
+
+	let nothing_changes = state.time_started_gathering_assignments.clone();
+
+	for i in 150..200i32 {
+		state.mark_begining_of_gathering_assignments(
+			i as u32,
+			Hash::repeat_byte(i as u8),
+			CandidateHash(Hash::repeat_byte(i as u8)),
+		);
+		assert_eq!(nothing_changes, state.time_started_gathering_assignments);
+	}
+
+	for i in 110..120 {
+		let block_hash = Hash::repeat_byte(i as u8);
+		let candidate_hash = CandidateHash(Hash::repeat_byte(i as u8));
+
+		state.mark_gathered_enough_assignments(i as u32, block_hash, candidate_hash);
+
+		assert!(state
+			.time_started_gathering_assignments
+			.get(&i)
+			.unwrap()
+			.get(&(block_hash, candidate_hash))
+			.unwrap()
+			.stage_start
+			.is_none());
+		state.mark_begining_of_gathering_assignments(i as u32, block_hash, candidate_hash);
+		let record = state
+			.time_started_gathering_assignments
+			.get(&i)
+			.unwrap()
+			.get(&(block_hash, candidate_hash))
+			.unwrap();
+
+		assert!(record.stage_start.is_some());
+		assert_eq!(record.stage, 1);
+	}
+}
+
+// Test we note the time we took to transition RequiredTranche  from Pending to Exact and
+// that we increase the stage when we transition from Exact to Pending.
+#[test]
+fn test_observe_assignment_gathering_status() {
+	let mut state = State {
+		keystore: Arc::new(LocalKeystore::in_memory()),
+		slot_duration_millis: 6_000,
+		clock: Box::new(MockClock::default()),
+		assignment_criteria: Box::new(MockAssignmentCriteria::check_only(|_| Ok(0))),
+		spans: HashMap::new(),
+		time_started_gathering_assignments: Default::default(),
+	};
+
+	let metrics_inner = MetricsInner {
+		imported_candidates_total: IntCounter::new("dummy", "dummy").unwrap(),
+		assignments_produced: Histogram::with_opts(HistogramOpts::new("dummy", "dummy")).unwrap(),
+		approvals_produced_total: IntCounterVec::new(Opts::new("dummy", "dummy"), &["dummy"])
+			.unwrap(),
+		no_shows_total: IntCounter::new("dummy", "dummy").unwrap(),
+		observed_no_shows: IntCounter::new("dummy", "dummy").unwrap(),
+		approved_by_one_third: IntCounter::new("dummy", "dummy").unwrap(),
+		wakeups_triggered_total: IntCounter::new("dummy", "dummy").unwrap(),
+		coalesced_approvals_buckets: Histogram::with_opts(HistogramOpts::new("dummy", "dummy"))
+			.unwrap(),
+		coalesced_approvals_delay: Histogram::with_opts(HistogramOpts::new("dummy", "dummy"))
+			.unwrap(),
+		candidate_approval_time_ticks: Histogram::with_opts(HistogramOpts::new("dummy", "dummy"))
+			.unwrap(),
+		block_approval_time_ticks: Histogram::with_opts(HistogramOpts::new("dummy", "dummy"))
+			.unwrap(),
+		time_db_transaction: Histogram::with_opts(HistogramOpts::new("dummy", "dummy")).unwrap(),
+		time_recover_and_approve: Histogram::with_opts(HistogramOpts::new("dummy", "dummy"))
+			.unwrap(),
+		candidate_signatures_requests_total: IntCounter::new("dummy", "dummy").unwrap(),
+		unapproved_candidates_in_unfinalized_chain: prometheus::Gauge::<prometheus::U64>::new(
+			"dummy", "dummy",
+		)
+		.unwrap(),
+		assignments_gathering_time_by_stage: HistogramVec::new(
+			HistogramOpts::new("test", "test"),
+			&["stage"],
+		)
+		.unwrap(),
+	};
+
+	let metrics = Metrics(Some(metrics_inner));
+	let block_hash = Hash::repeat_byte(1);
+	let candidate_hash = CandidateHash(Hash::repeat_byte(1));
+	let block_number = 1;
+
+	// Transition from Pending to Exact and check stage 0 time is recorded.
+	state.observe_assignment_gathering_status(
+		&metrics,
+		&RequiredTranches::Pending {
+			considered: 0,
+			next_no_show: None,
+			maximum_broadcast: 0,
+			clock_drift: 0,
+		},
+		block_hash,
+		block_number,
+		candidate_hash,
+	);
+
+	state.observe_assignment_gathering_status(
+		&metrics,
+		&RequiredTranches::Exact {
+			needed: 2,
+			tolerated_missing: 2,
+			next_no_show: None,
+			last_assignment_tick: None,
+		},
+		block_hash,
+		block_number,
+		candidate_hash,
+	);
+
+	let value = metrics
+		.0
+		.as_ref()
+		.unwrap()
+		.assignments_gathering_time_by_stage
+		.get_metric_with_label_values(&["0"])
+		.unwrap();
+
+	assert_eq!(value.get_sample_count(), 1);
+
+	// Transition from Exact to Pending to Exact and check stage 1 time is recorded.
+	state.observe_assignment_gathering_status(
+		&metrics,
+		&RequiredTranches::Pending {
+			considered: 0,
+			next_no_show: None,
+			maximum_broadcast: 0,
+			clock_drift: 0,
+		},
+		block_hash,
+		block_number,
+		candidate_hash,
+	);
+
+	state.observe_assignment_gathering_status(
+		&metrics,
+		&RequiredTranches::Exact {
+			needed: 2,
+			tolerated_missing: 2,
+			next_no_show: None,
+			last_assignment_tick: None,
+		},
+		block_hash,
+		block_number,
+		candidate_hash,
+	);
+
+	let value = metrics
+		.0
+		.as_ref()
+		.unwrap()
+		.assignments_gathering_time_by_stage
+		.get_metric_with_label_values(&["0"])
+		.unwrap();
+
+	assert_eq!(value.get_sample_count(), 1);
+
+	let value = metrics
+		.0
+		.as_ref()
+		.unwrap()
+		.assignments_gathering_time_by_stage
+		.get_metric_with_label_values(&["1"])
+		.unwrap();
+
+	assert_eq!(value.get_sample_count(), 1);
 }

--- a/polkadot/node/core/approval-voting/src/tests.rs
+++ b/polkadot/node/core/approval-voting/src/tests.rs
@@ -5063,7 +5063,7 @@ fn test_gathering_assignments_statements() {
 		clock: Box::new(MockClock::default()),
 		assignment_criteria: Box::new(MockAssignmentCriteria::check_only(|_| Ok(0))),
 		spans: HashMap::new(),
-		time_started_gathering_assignments: Default::default(),
+		per_block_assignments_gathering_times: Default::default(),
 	};
 
 	for i in 0..200i32 {
@@ -5073,21 +5073,21 @@ fn test_gathering_assignments_statements() {
 			CandidateHash(Hash::repeat_byte(i as u8)),
 		);
 		assert!(
-			state.time_started_gathering_assignments.len() <=
+			state.per_block_assignments_gathering_times.len() <=
 				MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS as usize
 		);
 
 		assert_eq!(
-			state.time_started_gathering_assignments.keys().min(),
+			state.per_block_assignments_gathering_times.keys().min(),
 			Some(max(0, i - MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS as i32 + 1) as u32).as_ref()
 		)
 	}
 	assert_eq!(
-		state.time_started_gathering_assignments.len(),
+		state.per_block_assignments_gathering_times.len(),
 		MAX_BLOCKS_WITH_ASSIGNMENT_TIMESTAMPS as usize
 	);
 
-	let nothing_changes = state.time_started_gathering_assignments.clone();
+	let nothing_changes = state.per_block_assignments_gathering_times.clone();
 
 	for i in 150..200i32 {
 		state.mark_begining_of_gathering_assignments(
@@ -5095,7 +5095,7 @@ fn test_gathering_assignments_statements() {
 			Hash::repeat_byte(i as u8),
 			CandidateHash(Hash::repeat_byte(i as u8)),
 		);
-		assert_eq!(nothing_changes, state.time_started_gathering_assignments);
+		assert_eq!(nothing_changes, state.per_block_assignments_gathering_times);
 	}
 
 	for i in 110..120 {
@@ -5105,7 +5105,7 @@ fn test_gathering_assignments_statements() {
 		state.mark_gathered_enough_assignments(i as u32, block_hash, candidate_hash);
 
 		assert!(state
-			.time_started_gathering_assignments
+			.per_block_assignments_gathering_times
 			.get(&i)
 			.unwrap()
 			.get(&(block_hash, candidate_hash))
@@ -5114,7 +5114,7 @@ fn test_gathering_assignments_statements() {
 			.is_none());
 		state.mark_begining_of_gathering_assignments(i as u32, block_hash, candidate_hash);
 		let record = state
-			.time_started_gathering_assignments
+			.per_block_assignments_gathering_times
 			.get(&i)
 			.unwrap()
 			.get(&(block_hash, candidate_hash))
@@ -5135,7 +5135,7 @@ fn test_observe_assignment_gathering_status() {
 		clock: Box::new(MockClock::default()),
 		assignment_criteria: Box::new(MockAssignmentCriteria::check_only(|_| Ok(0))),
 		spans: HashMap::new(),
-		time_started_gathering_assignments: Default::default(),
+		per_block_assignments_gathering_times: Default::default(),
 	};
 
 	let metrics_inner = MetricsInner {


### PR DESCRIPTION
To understand with high granularity how many assignment tranches are triggered before we concur that we have enough assignments. 

This metric is important because the triggering of an assignment creates a lot of work in the system for approving the candidate and gossiping the necessary messages.
