### PR TITLE
Add a way to fetch the relay state proof

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -966,7 +966,7 @@ pub mod pallet {
 						provides: vec![hash.as_ref().to_vec()],
 						longevity: TransactionLongevity::max_value(),
 						propagate: true,
-					});
+					})
 				}
 			}
 			if let Call::set_validation_data { .. } = call {

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -271,7 +271,7 @@ pub mod pallet {
 						false,
 						"host configuration is promised to set until `on_finalize`; qed",
 					);
-					return;
+					return
 				},
 			};
 
@@ -286,7 +286,7 @@ pub mod pallet {
 						"relevant messaging state is promised to be set until `on_finalize`; \
 							qed",
 					);
-					return;
+					return
 				},
 			};
 
@@ -307,7 +307,7 @@ pub mod pallet {
 							"relevant messaging state is promised to be set until `on_finalize`; \
 								qed",
 						);
-						return (0, 0);
+						return (0, 0)
 					},
 				};
 
@@ -970,7 +970,7 @@ pub mod pallet {
 				}
 			}
 			if let Call::set_validation_data { .. } = call {
-				return Ok(Default::default());
+				return Ok(Default::default())
 			}
 			Err(InvalidTransaction::Call.into())
 		}
@@ -1042,7 +1042,7 @@ impl<T: Config> GetChannelInfo for Pallet<T> {
 		let channels = match RelevantMessagingState::<T>::get() {
 			None => {
 				log::warn!("calling `get_channel_status` with no RelevantMessagingState?!");
-				return ChannelStatus::Closed;
+				return ChannelStatus::Closed
 			},
 			Some(d) => d.egress_channels,
 		};
@@ -1059,7 +1059,7 @@ impl<T: Config> GetChannelInfo for Pallet<T> {
 		let meta = &channels[index].1;
 		if meta.msg_count + 1 > meta.max_capacity {
 			// The channel is at its capacity. Skip it for now.
-			return ChannelStatus::Full;
+			return ChannelStatus::Full
 		}
 		let max_size_now = meta.max_total_size - meta.total_size;
 		let max_size_ever = meta.max_message_size;
@@ -1562,7 +1562,7 @@ impl<T: Config> Pallet<T> {
 		// However, changing this setting is expected to be rare.
 		if let Some(cfg) = HostConfiguration::<T>::get() {
 			if message_len > cfg.max_upward_message_size as usize {
-				return Err(MessageSendError::TooBig);
+				return Err(MessageSendError::TooBig)
 			}
 			let threshold =
 				cfg.max_upward_queue_size.saturating_div(ump_constants::THRESHOLD_FACTOR);


### PR DESCRIPTION
With the removal of public getters there is now no way of fetching the relay state proof injected as in parachain-system. This is useful to read certain well-known keys from other pallets (e.g., CURRENT_BLOCK_RANDOMNESS or any other)