### PR TITLE
Enforce the batched calls limit recursively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,6 +2135,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 14.0.0",
  "sp-tracing 16.0.0",
+ "sp-utility",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -2293,6 +2294,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 14.0.0",
  "sp-trie",
+ "sp-utility",
  "staging-xcm",
  "staging-xcm-builder",
  "static_assertions",
@@ -9943,6 +9945,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 14.0.0",
  "sp-tracing 16.0.0",
+ "sp-utility",
  "staging-xcm",
  "staging-xcm-builder",
  "wasm-instrument",
@@ -10983,6 +10986,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",
+ "sp-utility",
 ]
 
 [[package]]
@@ -11110,6 +11114,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",
+ "sp-utility",
 ]
 
 [[package]]
@@ -11514,6 +11519,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",
+ "sp-utility",
 ]
 
 [[package]]
@@ -11533,6 +11539,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",
+ "sp-utility",
 ]
 
 [[package]]
@@ -11569,6 +11576,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",
+ "sp-utility",
 ]
 
 [[package]]
@@ -15835,6 +15843,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 14.0.0",
  "sp-trie",
+ "sp-utility",
  "sp-version",
  "staging-xcm",
  "thiserror",
@@ -20383,6 +20392,17 @@ dependencies = [
  "trie-db",
  "trie-root",
  "trie-standardmap",
+]
+
+[[package]]
+name = "sp-utility"
+version = "13.0.0"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-std 14.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -489,6 +489,7 @@ members = [
 	"substrate/primitives/transaction-pool",
 	"substrate/primitives/transaction-storage-proof",
 	"substrate/primitives/trie",
+	"substrate/primitives/utility",
 	"substrate/primitives/version",
 	"substrate/primitives/version/proc-macro",
 	"substrate/primitives/wasm-interface",

--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -45,6 +45,7 @@ sp-io = { path = "../../../substrate/primitives/io", default-features = false }
 sp-runtime = { path = "../../../substrate/primitives/runtime", default-features = false }
 sp-std = { path = "../../../substrate/primitives/std", default-features = false }
 sp-trie = { path = "../../../substrate/primitives/trie", default-features = false }
+sp-utility = { path = "../../../substrate/primitives/utility", default-features = false }
 
 # Polkadot dependencies
 xcm = { package = "staging-xcm", path = "../../../polkadot/xcm", default-features = false }
@@ -83,6 +84,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-trie/std",
+	"sp-utility/std",
 	"tuplex/std",
 	"xcm-builder/std",
 	"xcm/std",

--- a/bridges/bin/runtime-common/src/extensions/refund_relayer_extension.rs
+++ b/bridges/bin/runtime-common/src/extensions/refund_relayer_extension.rs
@@ -54,6 +54,7 @@ use sp_runtime::{
 	DispatchResult, FixedPointOperand, RuntimeDebug,
 };
 use sp_std::{marker::PhantomData, vec, vec::Vec};
+use sp_utility::CallsBatch;
 
 type AccountIdOf<R> = <R as frame_system::Config>::AccountId;
 // without this typedef rustfmt fails with internal err
@@ -629,7 +630,8 @@ where
 
 	fn expand_call(call: &CallOf<Runtime>) -> Vec<&CallOf<Runtime>> {
 		match call.is_sub_type() {
-			Some(UtilityCall::<Runtime>::batch_all { ref calls }) if calls.len() <= 3 =>
+			Some(UtilityCall::<Runtime>::batch_all { calls: CallsBatch(calls) })
+				if calls.len() <= 3 =>
 				calls.iter().collect(),
 			Some(_) => vec![],
 			None => vec![call],
@@ -780,7 +782,8 @@ where
 
 	fn expand_call(call: &CallOf<Runtime>) -> Vec<&CallOf<Runtime>> {
 		match call.is_sub_type() {
-			Some(UtilityCall::<Runtime>::batch_all { ref calls }) if calls.len() <= 2 =>
+			Some(UtilityCall::<Runtime>::batch_all { calls: CallsBatch(calls) })
+				if calls.len() <= 2 =>
 				calls.iter().collect(),
 			Some(_) => vec![],
 			None => vec![call],
@@ -1179,10 +1182,10 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_parachain_head_call(parachain_head_at_relay_header_number),
 				message_delivery_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1191,10 +1194,10 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_parachain_head_call(parachain_head_at_relay_header_number),
 				message_confirmation_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1203,10 +1206,10 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call(relay_header_number),
 				message_delivery_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1215,10 +1218,10 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call_ex(relay_header_number),
 				message_delivery_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1227,10 +1230,10 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call(relay_header_number),
 				message_confirmation_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1239,10 +1242,10 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call_ex(relay_header_number),
 				message_confirmation_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1252,11 +1255,11 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call(relay_header_number),
 				submit_parachain_head_call(parachain_head_at_relay_header_number),
 				message_delivery_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1266,11 +1269,11 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call_ex(relay_header_number),
 				submit_parachain_head_call_ex(parachain_head_at_relay_header_number),
 				message_delivery_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1280,11 +1283,11 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call(relay_header_number),
 				submit_parachain_head_call(parachain_head_at_relay_header_number),
 				message_confirmation_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -1294,11 +1297,11 @@ pub(crate) mod tests {
 		best_message: MessageNonce,
 	) -> RuntimeCall {
 		RuntimeCall::Utility(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				submit_relay_header_call_ex(relay_header_number),
 				submit_parachain_head_call_ex(parachain_head_at_relay_header_number),
 				message_confirmation_call(best_message),
-			],
+			]),
 		})
 	}
 
@@ -2093,7 +2096,7 @@ pub(crate) mod tests {
 			initialize_environment(100, 100, 100);
 
 			let call = RuntimeCall::Utility(UtilityCall::batch_all {
-				calls: vec![
+				calls: CallsBatch(vec![
 					RuntimeCall::BridgeParachains(ParachainsCall::submit_parachain_heads {
 						at_relay_block: (100, RelayBlockHash::default()),
 						parachains: vec![
@@ -2106,7 +2109,7 @@ pub(crate) mod tests {
 						parachain_heads_proof: ParaHeadsProof { storage_proof: vec![] },
 					}),
 					message_delivery_call(200),
-				],
+				]),
 			});
 
 			assert_eq!(run_pre_dispatch(call), Ok(None),);

--- a/bridges/relays/client-substrate/Cargo.toml
+++ b/bridges/relays/client-substrate/Cargo.toml
@@ -50,6 +50,7 @@ sp-rpc = { path = "../../../substrate/primitives/rpc" }
 sp-runtime = { path = "../../../substrate/primitives/runtime" }
 sp-std = { path = "../../../substrate/primitives/std" }
 sp-trie = { path = "../../../substrate/primitives/trie" }
+sp-utility = { path = "../../../substrate/primitives/utility" }
 sp-version = { path = "../../../substrate/primitives/version" }
 
 # Polkadot Dependencies

--- a/bridges/relays/client-substrate/src/chain.rs
+++ b/bridges/relays/client-substrate/src/chain.rs
@@ -34,6 +34,7 @@ use sp_runtime::{
 	traits::{Block as BlockT, Member},
 	ConsensusEngineId, EncodedJustification,
 };
+use sp_utility::CallsBatch;
 use std::{fmt::Debug, time::Duration};
 
 /// Substrate-based chain from minimal relay-client point of view.
@@ -269,7 +270,7 @@ where
 	<R as pallet_utility::Config>::RuntimeCall: From<pallet_utility::Call<R>>,
 {
 	fn build_batch_call(calls: Vec<C::Call>) -> C::Call {
-		pallet_utility::Call::batch_all { calls }.into()
+		pallet_utility::Call::batch_all { calls: CallsBatch(calls) }.into()
 	}
 }
 

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml
@@ -23,6 +23,7 @@ sp-keyring = { path = "../../../../../substrate/primitives/keyring" }
 sp-runtime = { path = "../../../../../substrate/primitives/runtime", default-features = false }
 sp-std = { path = "../../../../../substrate/primitives/std", default-features = false }
 sp-tracing = { path = "../../../../../substrate/primitives/tracing" }
+sp-utility = { path = "../../../../../substrate/primitives/utility" }
 pallet-balances = { path = "../../../../../substrate/frame/balances", default-features = false }
 pallet-utility = { path = "../../../../../substrate/frame/utility", default-features = false }
 pallet-timestamp = { path = "../../../../../substrate/frame/timestamp", default-features = false }
@@ -82,6 +83,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_grandpa_chain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_grandpa_chain.rs
@@ -44,6 +44,7 @@ use parachains_runtimes_test_utils::{
 use sp_core::Get;
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::Header as HeaderT, AccountId32};
+use sp_utility::CallsBatch;
 use xcm::latest::prelude::*;
 
 /// Helper trait to test bridges with remote GRANDPA chain.
@@ -421,7 +422,7 @@ pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 			let relay_chain_header_hash = relay_chain_header.hash();
 			vec![(
 				pallet_utility::Call::<RuntimeHelper::Runtime>::batch_all {
-					calls: vec![
+					calls: CallsBatch(vec![
 						BridgeGrandpaCall::<RuntimeHelper::Runtime, RuntimeHelper::GPI>::submit_finality_proof {
 							finality_target: Box::new(relay_chain_header),
 							justification: grandpa_justification,
@@ -432,7 +433,7 @@ pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 							messages_count: 1,
 							dispatch_weight: Weight::from_parts(1000000000, 0),
 						}.into(),
-					],
+					]),
 				}
 				.into(),
 				Box::new((

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_parachain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/from_parachain.rs
@@ -45,6 +45,7 @@ use parachains_runtimes_test_utils::{
 use sp_core::Get;
 use sp_keyring::AccountKeyring::*;
 use sp_runtime::{traits::Header as HeaderT, AccountId32};
+use sp_utility::CallsBatch;
 use xcm::latest::prelude::*;
 
 /// Helper trait to test bridges with remote parachain.
@@ -506,7 +507,7 @@ pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 			let relay_chain_header_number = *relay_chain_header.number();
 			vec![(
 				pallet_utility::Call::<RuntimeHelper::Runtime>::batch_all {
-					calls: vec![
+					calls: CallsBatch(vec![
 						BridgeGrandpaCall::<RuntimeHelper::Runtime, RuntimeHelper::GPI>::submit_finality_proof {
 							finality_target: Box::new(relay_chain_header),
 							justification: grandpa_justification,
@@ -522,7 +523,7 @@ pub fn complex_relay_extrinsic_works<RuntimeHelper>(
 							messages_count: 1,
 							dispatch_weight: Weight::from_parts(1000000000, 0),
 						}.into(),
-					],
+					]),
 				}
 				.into(),
 				Box::new((

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_data/from_grandpa_chain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_data/from_grandpa_chain.rs
@@ -44,6 +44,7 @@ use bp_header_chain::{justification::GrandpaJustification, ChainWithGrandpa};
 use bp_messages::{DeliveredMessages, InboundLaneData, UnrewardedRelayer};
 use bp_runtime::HashOf;
 use sp_runtime::DigestItem;
+use sp_utility::CallsBatch;
 
 /// Prepare a batch call with bridged GRANDPA finality and message proof.
 pub fn make_complex_relayer_delivery_batch<Runtime, GPI, MPI>(
@@ -78,7 +79,7 @@ where
 		dispatch_weight: Weight::from_parts(1000000000, 0),
 	};
 	pallet_utility::Call::<Runtime>::batch_all {
-		calls: vec![submit_grandpa.into(), submit_message.into()],
+		calls: CallsBatch(vec![submit_grandpa.into(), submit_message.into()]),
 	}
 }
 
@@ -117,7 +118,7 @@ where
 			relayers_state,
 		};
 	pallet_utility::Call::<Runtime>::batch_all {
-		calls: vec![submit_grandpa.into(), submit_message_delivery_proof.into()],
+		calls: CallsBatch(vec![submit_grandpa.into(), submit_message_delivery_proof.into()]),
 	}
 }
 

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_data/from_parachain.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_data/from_parachain.rs
@@ -47,6 +47,7 @@ use bp_header_chain::{justification::GrandpaJustification, ChainWithGrandpa};
 use bp_messages::{DeliveredMessages, InboundLaneData, MessageNonce, UnrewardedRelayer};
 use bp_polkadot_core::parachains::{ParaHash, ParaHead, ParaHeadsProof, ParaId};
 use sp_runtime::SaturatedConversion;
+use sp_utility::CallsBatch;
 
 /// Prepare a batch call with relay finality proof, parachain head proof and message proof.
 pub fn make_complex_relayer_delivery_batch<Runtime, GPI, PPI, MPI, InboundRelayer>(
@@ -98,7 +99,11 @@ pub fn make_complex_relayer_delivery_batch<Runtime, GPI, PPI, MPI, InboundRelaye
 		dispatch_weight: Weight::from_parts(1000000000, 0),
 	};
 	pallet_utility::Call::<Runtime>::batch_all {
-		calls: vec![submit_grandpa.into(), submit_para_head.into(), submit_message.into()],
+		calls: CallsBatch(vec![
+			submit_grandpa.into(),
+			submit_para_head.into(),
+			submit_message.into(),
+		]),
 	}
 }
 
@@ -151,11 +156,11 @@ where
 			relayers_state,
 		};
 	pallet_utility::Call::<Runtime>::batch_all {
-		calls: vec![
+		calls: CallsBatch(vec![
 			submit_grandpa.into(),
 			submit_para_head.into(),
 			submit_message_delivery_proof.into(),
-		],
+		]),
 	}
 }
 

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -76,6 +76,7 @@ pallet-assets = { path = "../assets" }
 pallet-proxy = { path = "../proxy" }
 sp-keystore = { path = "../../primitives/keystore" }
 sp-tracing = { path = "../../primitives/tracing" }
+sp-utility = { path = "../../primitives/utility" }
 
 [features]
 default = ["std"]
@@ -100,6 +101,7 @@ std = [
 	"sp-keystore/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 	"wasm-instrument?/std",
 	"wasmi/std",
 	"xcm-builder/std",

--- a/substrate/frame/contracts/src/exec.rs
+++ b/substrate/frame/contracts/src/exec.rs
@@ -1655,6 +1655,7 @@ mod tests {
 	use pallet_contracts_uapi::ReturnFlags;
 	use pretty_assertions::assert_eq;
 	use sp_runtime::{traits::Hash, DispatchError};
+	use sp_utility::CallsBatch;
 	use std::{cell::RefCell, collections::hash_map::HashMap, rc::Rc};
 
 	type System = frame_system::Pallet<Test>;
@@ -3199,7 +3200,7 @@ mod tests {
 
 			// as part of a patch: return is OK (but it interrupted the batch)
 			assert_ok!(ctx.ext.call_runtime(RuntimeCall::Utility(UtilCall::batch {
-				calls: vec![allowed_call.clone(), forbidden_call, allowed_call]
+				calls: CallsBatch(vec![allowed_call.clone(), forbidden_call, allowed_call])
 			})),);
 
 			// the transfer wasn't performed

--- a/substrate/frame/proxy/Cargo.toml
+++ b/substrate/frame/proxy/Cargo.toml
@@ -16,8 +16,12 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["max-encoded-len"] }
-scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
+	"max-encoded-len",
+] }
+scale-info = { version = "2.11.1", default-features = false, features = [
+	"derive",
+] }
 frame-benchmarking = { path = "../benchmarking", default-features = false, optional = true }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
@@ -29,6 +33,7 @@ sp-std = { path = "../../primitives/std", default-features = false }
 pallet-balances = { path = "../balances" }
 pallet-utility = { path = "../utility" }
 sp-core = { path = "../../primitives/core" }
+sp-utility = { path = "../../primitives/utility", default-features = false }
 
 [features]
 default = ["std"]
@@ -44,6 +49,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/proxy/src/tests.rs
+++ b/substrate/frame/proxy/src/tests.rs
@@ -29,6 +29,7 @@ use frame_support::{
 };
 use sp_core::H256;
 use sp_runtime::{traits::BlakeTwo256, BuildStorage, DispatchError, RuntimeDebug};
+use sp_utility::CallsBatch;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -348,7 +349,8 @@ fn filtering_works() {
 			ProxyEvent::ProxyExecuted { result: Err(SystemError::CallFiltered.into()) }.into(),
 		);
 
-		let call = Box::new(RuntimeCall::Utility(UtilityCall::batch { calls: vec![*inner] }));
+		let call =
+			Box::new(RuntimeCall::Utility(UtilityCall::batch { calls: CallsBatch(vec![*inner]) }));
 		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(2), 1, None, call.clone()));
 		expect_events(vec![
 			UtilityEvent::BatchCompleted.into(),
@@ -370,7 +372,8 @@ fn filtering_works() {
 			ProxyType::Any,
 			0,
 		)));
-		let call = Box::new(RuntimeCall::Utility(UtilityCall::batch { calls: vec![*inner] }));
+		let call =
+			Box::new(RuntimeCall::Utility(UtilityCall::batch { calls: CallsBatch(vec![*inner]) }));
 		assert_ok!(Proxy::proxy(RuntimeOrigin::signed(2), 1, None, call.clone()));
 		expect_events(vec![
 			UtilityEvent::BatchCompleted.into(),

--- a/substrate/frame/safe-mode/Cargo.toml
+++ b/substrate/frame/safe-mode/Cargo.toml
@@ -31,6 +31,7 @@ pallet-proxy = { path = "../proxy", default-features = false, optional = true }
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }
 sp-io = { path = "../../primitives/io" }
+sp-utility = { path = "../../primitives/utility", default-features = false }
 pallet-balances = { path = "../balances" }
 pallet-utility = { path = "../utility" }
 pallet-proxy = { path = "../proxy" }
@@ -52,6 +53,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/safe-mode/src/tests.rs
+++ b/substrate/frame/safe-mode/src/tests.rs
@@ -24,6 +24,7 @@ use crate::mock::{RuntimeCall, *};
 
 use frame_support::{assert_err, assert_noop, assert_ok, hypothetically_ok, traits::Currency};
 use sp_runtime::traits::Dispatchable;
+use sp_utility::CallsBatch;
 
 #[test]
 fn fails_to_filter_calls_to_safe_mode_pallet() {
@@ -151,8 +152,9 @@ fn can_filter_balance_calls_when_activated() {
 #[test]
 fn can_filter_balance_in_batch_when_activated() {
 	new_test_ext().execute_with(|| {
-		let batch_call =
-			RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call_transfer()] });
+		let batch_call = RuntimeCall::Utility(pallet_utility::Call::batch {
+			calls: CallsBatch(vec![call_transfer()]),
+		});
 
 		assert_ok!(batch_call.clone().dispatch(RuntimeOrigin::signed(0)));
 

--- a/substrate/frame/treasury/Cargo.toml
+++ b/substrate/frame/treasury/Cargo.toml
@@ -34,8 +34,9 @@ sp-core = { path = "../../primitives/core", default-features = false, optional =
 
 [dev-dependencies]
 sp-io = { path = "../../primitives/io" }
-pallet-utility = { path = "../utility" }
+sp-utility = { path = "../../primitives/utility", default-features = false }
 sp-core = { path = "../../primitives/core", default-features = false }
+pallet-utility = { path = "../utility" }
 
 [features]
 default = ["std"]
@@ -52,6 +53,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 ]
 runtime-benchmarks = [
 	"dep:sp-core",

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -24,6 +24,7 @@ use sp_runtime::{
 	traits::{BadOrigin, Dispatchable, IdentityLookup},
 	BuildStorage,
 };
+use sp_utility::CallsBatch;
 
 use frame_support::{
 	assert_err_ignore_postinfo, assert_noop, assert_ok, derive_impl,
@@ -665,19 +666,19 @@ fn spending_local_in_batch_respects_max_total() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Respect the `max_total` for the given origin.
 		assert_ok!(RuntimeCall::from(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				RuntimeCall::from(TreasuryCall::spend_local { amount: 2, beneficiary: 100 }),
 				RuntimeCall::from(TreasuryCall::spend_local { amount: 2, beneficiary: 101 })
-			]
+			])
 		})
 		.dispatch(RuntimeOrigin::signed(10)));
 
 		assert_err_ignore_postinfo!(
 			RuntimeCall::from(UtilityCall::batch_all {
-				calls: vec![
+				calls: CallsBatch(vec![
 					RuntimeCall::from(TreasuryCall::spend_local { amount: 2, beneficiary: 100 }),
 					RuntimeCall::from(TreasuryCall::spend_local { amount: 4, beneficiary: 101 })
-				]
+				])
 			})
 			.dispatch(RuntimeOrigin::signed(10)),
 			Error::<Test, _>::InsufficientPermission
@@ -690,7 +691,7 @@ fn spending_in_batch_respects_max_total() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Respect the `max_total` for the given origin.
 		assert_ok!(RuntimeCall::from(UtilityCall::batch_all {
-			calls: vec![
+			calls: CallsBatch(vec![
 				RuntimeCall::from(TreasuryCall::spend {
 					asset_kind: Box::new(1),
 					amount: 1,
@@ -703,13 +704,13 @@ fn spending_in_batch_respects_max_total() {
 					beneficiary: Box::new(101),
 					valid_from: None,
 				})
-			]
+			])
 		})
 		.dispatch(RuntimeOrigin::signed(10)));
 
 		assert_err_ignore_postinfo!(
 			RuntimeCall::from(UtilityCall::batch_all {
-				calls: vec![
+				calls: CallsBatch(vec![
 					RuntimeCall::from(TreasuryCall::spend {
 						asset_kind: Box::new(1),
 						amount: 2,
@@ -722,7 +723,7 @@ fn spending_in_batch_respects_max_total() {
 						beneficiary: Box::new(101),
 						valid_from: None,
 					})
-				]
+				])
 			})
 			.dispatch(RuntimeOrigin::signed(10)),
 			Error::<Test, _>::InsufficientPermission

--- a/substrate/frame/tx-pause/Cargo.toml
+++ b/substrate/frame/tx-pause/Cargo.toml
@@ -30,6 +30,7 @@ pallet-proxy = { path = "../proxy", default-features = false, optional = true }
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }
 sp-io = { path = "../../primitives/io" }
+sp-utility = { path = "../../primitives/utility", default-features = false }
 pallet-balances = { path = "../balances" }
 pallet-utility = { path = "../utility" }
 pallet-proxy = { path = "../proxy" }
@@ -49,6 +50,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/tx-pause/src/tests.rs
+++ b/substrate/frame/tx-pause/src/tests.rs
@@ -22,6 +22,7 @@ use crate::mock::{RuntimeCall, *};
 
 use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_runtime::DispatchError;
+use sp_utility::CallsBatch;
 
 // GENERAL SUCCESS/POSITIVE TESTS ---------------------
 
@@ -50,8 +51,9 @@ fn can_pause_all_calls_in_pallet_except_on_whitelist() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(call_transfer(1, 1).dispatch(RuntimeOrigin::signed(0)));
 
-		let batch_call =
-			RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call_transfer(1, 1)] });
+		let batch_call = RuntimeCall::Utility(pallet_utility::Call::batch {
+			calls: CallsBatch(vec![call_transfer(1, 1)]),
+		});
 		assert_ok!(batch_call.clone().dispatch(RuntimeOrigin::signed(0)));
 
 		assert_ok!(TxPause::pause(
@@ -90,8 +92,9 @@ fn can_unpause_specific_call() {
 #[test]
 fn can_filter_balance_in_batch_when_paused() {
 	new_test_ext().execute_with(|| {
-		let batch_call =
-			RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call_transfer(1, 1)] });
+		let batch_call = RuntimeCall::Utility(pallet_utility::Call::batch {
+			calls: CallsBatch(vec![call_transfer(1, 1)]),
+		});
 
 		assert_ok!(TxPause::pause(
 			RuntimeOrigin::signed(mock::PauseOrigin::get()),
@@ -149,8 +152,9 @@ fn fails_to_pause_unpausable_call_when_other_call_is_paused() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(call_transfer(1, 1).dispatch(RuntimeOrigin::signed(0)));
 
-		let batch_call =
-			RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![call_transfer(1, 1)] });
+		let batch_call = RuntimeCall::Utility(pallet_utility::Call::batch {
+			calls: CallsBatch(vec![call_transfer(1, 1)]),
+		});
 		assert_ok!(batch_call.clone().dispatch(RuntimeOrigin::signed(0)));
 
 		assert_ok!(TxPause::pause(

--- a/substrate/frame/utility/Cargo.toml
+++ b/substrate/frame/utility/Cargo.toml
@@ -25,6 +25,7 @@ sp-core = { path = "../../primitives/core", default-features = false }
 sp-io = { path = "../../primitives/io", default-features = false }
 sp-runtime = { path = "../../primitives/runtime", default-features = false }
 sp-std = { path = "../../primitives/std", default-features = false }
+sp-utility = { path = "../../primitives/utility", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { path = "../balances" }
@@ -49,6 +50,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-utility/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/utility/src/benchmarking.rs
+++ b/substrate/frame/utility/src/benchmarking.rs
@@ -39,7 +39,7 @@ benchmarks! {
 			calls.push(call);
 		}
 		let caller = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller), calls)
+	}: _(RawOrigin::Signed(caller), CallsBatch(calls))
 	verify {
 		assert_last_event::<T>(Event::BatchCompleted.into())
 	}
@@ -60,7 +60,7 @@ benchmarks! {
 			calls.push(call);
 		}
 		let caller = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller), calls)
+	}: _(RawOrigin::Signed(caller), CallsBatch(calls))
 	verify {
 		assert_last_event::<T>(Event::BatchCompleted.into())
 	}
@@ -81,7 +81,7 @@ benchmarks! {
 			calls.push(call);
 		}
 		let caller = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller), calls)
+	}: _(RawOrigin::Signed(caller), CallsBatch(calls))
 	verify {
 		assert_last_event::<T>(Event::BatchCompleted.into())
 	}

--- a/substrate/primitives/utility/Cargo.toml
+++ b/substrate/primitives/utility/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "sp-utility"
+version = "13.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository.workspace = true
+description = "Primitives for the utility pallet."
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
+environmental = { version = "1.1.4", default-features = false }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
+sp-core = { path = "../../primitives/core", default-features = false }
+sp-std = { path = "../../primitives/std", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"environmental/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-std/std",
+]

--- a/substrate/primitives/utility/src/lib.rs
+++ b/substrate/primitives/utility/src/lib.rs
@@ -1,0 +1,46 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
+
+//! A crate which contains primitives that are useful for the utility pallet.
+
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use sp_std::vec::Vec;
+
+/// Align the call size to 1KB. As we are currently compiling the runtime for native/wasm
+/// the `size_of` of the `Call` can be different. To ensure that this doesn't lead to
+/// mismatches between native/wasm or to different metadata for the same runtime, we
+/// align the call size. The value is chosen big enough to hopefully never reach it.
+pub const CALL_ALIGN: u32 = 1024;
+
+/// The limit on the number of batched calls.
+pub fn batched_calls_limit<Call>() -> u32 {
+	let allocator_limit = sp_core::MAX_POSSIBLE_ALLOCATION;
+	let call_size =
+		((sp_std::mem::size_of::<Call>() as u32 + CALL_ALIGN - 1) / CALL_ALIGN) * CALL_ALIGN;
+	// The margin to take into account vec doubling capacity.
+	let margin_factor = 3;
+
+	allocator_limit / margin_factor / call_size
+}
+
+/// Helper struct containing a batch of calls.
+#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo)]
+pub struct CallsBatch<Call>(pub Vec<Call>);


### PR DESCRIPTION
Enforce the `batched_calls_limit()` recursively so that the entire batch including the nested calls fits inside the limit.