### PR TITLE
Implement `CheckMetadataHash` extension (#4274)

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           export CARGO_TARGET_DIR=target
           export RUSTFLAGS='-A warnings -A missing_docs'
+          export SKIP_WASM_BUILD=1
           if ! parity-publish --color always prdoc --since old --validate prdoc/pr_$PR.prdoc --toolchain nightly-2024-03-01 -v; then
             cat <<EOF
           👋 Hello developer! The SemVer information that you declared in the prdoc file did not match what the CI detected.

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -491,6 +491,17 @@ check-tracing:
     - time cargo test --locked --manifest-path ./substrate/primitives/tracing/Cargo.toml --no-default-features
     - time cargo test --locked --manifest-path ./substrate/primitives/tracing/Cargo.toml --no-default-features --features=with-tracing
 
+# Check that `westend-runtime` compiles with the `metadata-hash` feature enabled.
+check-metadata-hash:
+  stage: test
+  extends:
+    - .docker-env
+    - .common-refs
+    - .run-immediately
+    - .pipeline-stopper-artifacts
+  script:
+    - time cargo build --locked -p westend-runtime --features metadata-hash
+
 # more information about this job can be found here:
 # https://github.com/paritytech/substrate/pull/3778
 test-full-crypto-feature:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -894,6 +895,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "pallet-asset-conversion",
@@ -939,6 +941,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -5783,6 +5786,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata-hash-extension"
+version = "0.1.0"
+dependencies = [
+ "array-bytes",
+ "docify",
+ "frame-metadata",
+ "frame-support",
+ "frame-system",
+ "log",
+ "merkleized-metadata",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-runtime",
+ "sp-tracing 16.0.0",
+ "sp-transaction-pool",
+ "substrate-test-runtime-client",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "frame-omni-bencher"
 version = "0.1.0"
 dependencies = [
@@ -7238,6 +7262,7 @@ dependencies = [
  "frame-benchmarking-pallet-pov",
  "frame-election-provider-support",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -8348,6 +8373,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9029,6 +9068,7 @@ dependencies = [
 name = "node-testing"
 version = "3.0.0-dev"
 dependencies = [
+ "frame-metadata-hash-extension",
  "frame-system",
  "fs_extra",
  "futures",
@@ -11826,6 +11866,7 @@ dependencies = [
  "docify",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -13887,6 +13928,7 @@ dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "docify",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "kitchensink-runtime",
@@ -13988,6 +14030,7 @@ dependencies = [
  "env_logger 0.11.3",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -15748,6 +15791,7 @@ dependencies = [
  "bitvec",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-remote-externalities",
  "frame-support",
  "frame-system",
@@ -17750,6 +17794,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12ebca36cec2a3f983c46295b282b35e5f8496346fb859a8776dad5389e5389"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17774,6 +17841,12 @@ dependencies = [
  "quote 1.0.35",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -20161,6 +20234,7 @@ dependencies = [
  "criterion",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -20737,6 +20811,7 @@ version = "2.0.0"
 dependencies = [
  "array-bytes",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -20828,13 +20903,22 @@ dependencies = [
 name = "substrate-wasm-builder"
 version = "17.0.0"
 dependencies = [
+ "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
+ "sp-tracing 16.0.0",
+ "sp-version",
  "strum 0.26.2",
  "tempfile",
  "toml 0.8.8",
@@ -22761,6 +22845,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-remote-externalities",
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,6 +360,7 @@ members = [
 	"substrate/frame/membership",
 	"substrate/frame/merkle-mountain-range",
 	"substrate/frame/message-queue",
+	"substrate/frame/metadata-hash-extension",
 	"substrate/frame/migrations",
 	"substrate/frame/mixnet",
 	"substrate/frame/multisig",

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/Cargo.toml
@@ -18,6 +18,7 @@ assert_matches = "1.5.0"
 sp-runtime = { path = "../../../../../../../substrate/primitives/runtime", default-features = false }
 sp-keyring = { path = "../../../../../../../substrate/primitives/keyring", default-features = false }
 sp-core = { path = "../../../../../../../substrate/primitives/core", default-features = false }
+frame-metadata-hash-extension = { path = "../../../../../../../substrate/frame/metadata-hash-extension" }
 frame-support = { path = "../../../../../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../../../../../substrate/frame/system", default-features = false }
 pallet-balances = { path = "../../../../../../../substrate/frame/balances", default-features = false }

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/xcm_fee_estimation.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/xcm_fee_estimation.rs
@@ -324,6 +324,7 @@ fn construct_extrinsic_westend(
 		),
 		frame_system::CheckWeight::<Runtime>::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+		frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 	);
 	let raw_payload = westend_runtime::SignedPayload::new(call, extra).unwrap();
 	let signature = raw_payload.using_encoded(|payload| sender.sign(payload));

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/Cargo.toml
@@ -18,6 +18,7 @@ scale-info = { version = "2.11.1", default-features = false, features = ["derive
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false }
+frame-metadata-hash-extension = { path = "../../../../../substrate/frame/metadata-hash-extension", default-features = false }
 frame-support = { path = "../../../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../../../substrate/frame/system", default-features = false }
 frame-system-benchmarking = { path = "../../../../../substrate/frame/system/benchmarking", default-features = false, optional = true }
@@ -189,6 +190,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -248,7 +250,10 @@ std = [
 	"xcm/std",
 ]
 
+# Enable the metadata hash generation in the wasm builder.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["metadata-hash", "sp-api/disable-logging"]

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/build.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/build.rs
@@ -13,9 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "metadata-hash"), feature = "std"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::build_using_defaults();
+}
+
+#[cfg(all(feature = "metadata-hash", feature = "std"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("ROC", 12)
+		.build();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 1_012_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 15,
+	transaction_version: 16,
 	state_version: 1,
 };
 
@@ -970,6 +970,7 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_asset_conversion_tx_payment::ChargeAssetTxPayment<Runtime>,
 	cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml
@@ -18,6 +18,7 @@ scale-info = { version = "2.11.1", default-features = false, features = ["derive
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }
 frame-executive = { path = "../../../../../substrate/frame/executive", default-features = false }
+frame-metadata-hash-extension = { path = "../../../../../substrate/frame/metadata-hash-extension", default-features = false }
 frame-support = { path = "../../../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../../../substrate/frame/system", default-features = false }
 frame-system-benchmarking = { path = "../../../../../substrate/frame/system/benchmarking", default-features = false, optional = true }
@@ -189,6 +190,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -247,7 +249,10 @@ std = [
 	"xcm/std",
 ]
 
+# Enable the metadata hash generation in the wasm builder.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["metadata-hash", "sp-api/disable-logging"]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/build.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/build.rs
@@ -13,9 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "metadata-hash"), feature = "std"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::build_using_defaults();
+}
+
+#[cfg(all(feature = "metadata-hash", feature = "std"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("WND", 12)
+		.build();
 }
 
 #[cfg(not(feature = "std"))]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 1_012_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 15,
+	transaction_version: 16,
 	state_version: 1,
 };
 
@@ -965,6 +965,7 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_asset_conversion_tx_payment::ChargeAssetTxPayment<Runtime>,
 	cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/docs/sdk/Cargo.toml
+++ b/docs/sdk/Cargo.toml
@@ -38,6 +38,7 @@ frame-system = { path = "../../substrate/frame/system", default-features = false
 frame-support = { path = "../../substrate/frame/support", default-features = false }
 frame-executive = { path = "../../substrate/frame/executive", default-features = false }
 pallet-example-single-block-migrations = { path = "../../substrate/frame/examples/single-block-migrations" }
+frame-metadata-hash-extension = { path = "../../substrate/frame/metadata-hash-extension" }
 
 # Substrate Client
 sc-network = { path = "../../substrate/client/network" }

--- a/docs/sdk/src/guides/enable_metadata_hash.rs
+++ b/docs/sdk/src/guides/enable_metadata_hash.rs
@@ -1,0 +1,88 @@
+//! # Enable metadata hash verification
+//!
+//! This guide will teach you how to enable the metadata hash verification in your runtime.
+//!
+//! ## What is metadata hash verification?
+//!
+//! Each FRAME based runtime exposes metadata about itself. This metadata is used by consumers of
+//! the runtime to interpret the state, to construct transactions etc. Part of this metadata are the
+//! type information. These type information can be used to e.g. decode storage entries or to decode
+//! a transaction. So, the metadata is quite useful for wallets to interact with a FRAME based
+//! chain. Online wallets can fetch the metadata directly from any node of the chain they are
+//! connected to, but offline wallets can not do this. So, for the offline wallet to have access to
+//! the metadata it needs to be transferred and stored on the device. The problem is that the
+//! metadata has a size of several hundreds of kilobytes, which takes quite a while to transfer to
+//! these offline wallets and the internal storage of these devices is also not big enough to store
+//! the metadata for one or more networks. The next problem is that the offline wallet/user can not
+//! trust the metadata to be correct. It is very important for the metadata to be correct or
+//! otherwise an attacker could change them in a way that the offline wallet decodes a transaction
+//! in a different way than what it will be decoded to on chain. So, the user may signs an incorrect
+//! transaction leading to unexpecting behavior.
+//!
+//! The metadata hash verification circumvents the issues of the huge metadata and the need to trust
+//! some metadata blob to be correct. To generate a hash for the metadata, the metadata is chunked,
+//! these chunks are put into a merkle tree and then the root of this merkle tree is the "metadata
+//! hash". For a more technical explanation on how it works, see
+//! [RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html). At compile
+//! time the metadata hash is generated and "backed" into the runtime. This makes it extremely cheap
+//! for the runtime to verify on chain that the metadata hash is correct. By having the runtime
+//! verify the hash on chain, the user also doesn't need to trust the offchain metadata. If the
+//! metadata hash doesn't match the on chain metadata hash the transaction will be rejected. The
+//! metadata hash itself is added to the data of the transaction that is signed, this means the
+//! actual hash does not appear in the transaction. On chain the same procedure is repeated with the
+//! metadata hash that is known by the runtime and if the metadata hash doesn't match the signature
+//! verification will fail. As the metadata hash is actually the root of a merkle tree, the offline
+//! wallet can get proofs of individual types to decode a transaction. This means that the offline
+//! wallet does not require the entire metadata to be present on the device.
+//!
+//! ## Integrating metadata hash verification into your runtime
+//!
+//! The integration of the metadata hash verification is split into two parts, first the actual
+//! integration into the runtime and secondly the enabling of the metadata hash generation at
+//! compile time.
+//!
+//! ### Runtime integration
+//!
+//! From the runtime side only the
+//! [`CheckMetadataHash`](frame_metadata_hash_extension::CheckMetadataHash) needs to be added to the
+//! list of signed extension:
+#![doc = docify::embed!("../../templates/parachain/runtime/src/lib.rs", template_signed_extra)]
+//!
+//! > **Note:**
+//! >
+//! > Adding the signed extension changes the encoding of the transaction and adds one extra byte
+//! > per transaction!
+//!
+//! This signed extension will make sure to decode the requested `mode` and will add the metadata
+//! hash to the signed data depending on the requested `mode`. The `mode` gives the user/wallet
+//! control over deciding if the metadata hash should be verified or not. The metadata hash itself
+//! is drawn from the `RUNTIME_METADATA_HASH` environment variable. If the environment variable is
+//! not set, any transaction that requires the metadata hash is rejected with the error
+//! `CannotLookup`. This is a security measurement to prevent including invalid transactions.
+//!
+//! <div class="warning">
+//!
+//! The extension does not work with the native runtime, because the
+//! `RUNTIME_METADATA_HASH` environment variable is not set when building the
+//! `frame-metadata-hash-extension` crate.
+//!
+//! </div>
+//!
+//! ### Enable metadata hash generation
+//!
+//! The metadata hash generation needs to be enabled when building the wasm binary. The
+//! `substrate-wasm-builder` supports this out of the box:
+#![doc = docify::embed!("../../templates/parachain/runtime/build.rs", template_enable_metadata_hash)]
+//!
+//! > **Note:**
+//! >
+//! > The `metadata-hash` feature needs to be enabled for the `substrate-wasm-builder` to enable the
+//! > code for being able to generate the metadata hash. It is also recommended to put the metadata
+//! > hash generation behind a feature in the runtime as shown above. The reason behind is that it
+//! > adds a lot of code which increases the compile time and the generation itself also increases
+//! > the compile time. Thus, it is recommended to enable the feature only when the metadata hash is
+//! > required (e.g. for an on-chain build).
+//!
+//! The two parameters to `enable_metadata_hash` are the token symbol and the number of decimals of
+//! the primary token of the chain. These information are included for the wallets to show token
+//! related operations in a more user friendly way.

--- a/docs/sdk/src/guides/mod.rs
+++ b/docs/sdk/src/guides/mod.rs
@@ -26,3 +26,6 @@ pub mod xcm_enabled_parachain;
 
 /// How to enable storage weight reclaiming in a parachain node and runtime.
 pub mod enable_pov_reclaim;
+
+/// How to enable metadata hash verification in the runtime.
+pub mod enable_metadata_hash;

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -67,6 +67,7 @@ sp-version = { path = "../../../substrate/primitives/version" }
 pallet-babe = { path = "../../../substrate/frame/babe" }
 pallet-staking = { path = "../../../substrate/frame/staking" }
 pallet-transaction-payment-rpc-runtime-api = { path = "../../../substrate/frame/transaction-payment/rpc/runtime-api" }
+frame-metadata-hash-extension = { path = "../../../substrate/frame/metadata-hash-extension", optional = true }
 frame-system = { path = "../../../substrate/frame/system" }
 
 # Substrate Other
@@ -187,8 +188,18 @@ full-node = [
 ]
 
 # Configure the native runtimes to use.
-westend-native = ["bitvec", "westend-runtime", "westend-runtime-constants"]
-rococo-native = ["bitvec", "rococo-runtime", "rococo-runtime-constants"]
+westend-native = [
+	"bitvec",
+	"frame-metadata-hash-extension",
+	"westend-runtime",
+	"westend-runtime-constants",
+]
+rococo-native = [
+	"bitvec",
+	"frame-metadata-hash-extension",
+	"rococo-runtime",
+	"rococo-runtime-constants",
+]
 
 runtime-benchmarks = [
 	"frame-benchmarking-cli/runtime-benchmarks",

--- a/polkadot/node/service/src/benchmarking.rs
+++ b/polkadot/node/service/src/benchmarking.rs
@@ -201,6 +201,7 @@ fn westend_sign_call(
 		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
+		frame_metadata_hash_extension::CheckMetadataHash::<runtime::Runtime>::new(false),
 	);
 
 	let payload = runtime::SignedPayload::from_raw(
@@ -215,6 +216,7 @@ fn westend_sign_call(
 			(),
 			(),
 			(),
+			None,
 		),
 	);
 
@@ -253,6 +255,7 @@ fn rococo_sign_call(
 		frame_system::CheckNonce::<runtime::Runtime>::from(nonce),
 		frame_system::CheckWeight::<runtime::Runtime>::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::<runtime::Runtime>::from(0),
+		frame_metadata_hash_extension::CheckMetadataHash::<runtime::Runtime>::new(false),
 	);
 
 	let payload = runtime::SignedPayload::from_raw(
@@ -267,6 +270,7 @@ fn rococo_sign_call(
 			(),
 			(),
 			(),
+			None,
 		),
 	);
 

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -95,6 +95,7 @@ pallet-xcm-benchmarks = { path = "../../xcm/pallet-xcm-benchmarks", default-feat
 pallet-root-testing = { path = "../../../substrate/frame/root-testing", default-features = false }
 
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }
+frame-metadata-hash-extension = { path = "../../../substrate/frame/metadata-hash-extension", default-features = false }
 frame-try-runtime = { path = "../../../substrate/frame/try-runtime", default-features = false, optional = true }
 frame-system-benchmarking = { path = "../../../substrate/frame/system/benchmarking", default-features = false, optional = true }
 hex-literal = { version = "0.4.1" }
@@ -134,6 +135,7 @@ std = [
 	"block-builder-api/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -324,6 +326,9 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable the metadata hash generation in the wasm builder.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = ["rococo-runtime-constants/fast-runtime"]
 
@@ -332,4 +337,4 @@ runtime-metrics = ["runtime-parachains/runtime-metrics", "sp-io/with-tracing"]
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["metadata-hash", "sp-api/disable-logging"]

--- a/polkadot/runtime/rococo/build.rs
+++ b/polkadot/runtime/rococo/build.rs
@@ -14,13 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "metadata-hash"), feature = "std"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
 		.set_file_name("fast_runtime_binary.rs")
 		.enable_feature("fast-runtime")
+		.build();
+}
+
+#[cfg(all(feature = "metadata-hash", feature = "std"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("ROC", 12)
+		.build();
+
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.set_file_name("fast_runtime_binary.rs")
+		.enable_feature("fast-runtime")
+		.enable_metadata_hash("ROC", 12)
 		.build();
 }
 

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -643,7 +643,9 @@ where
 			frame_system::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+			frame_metadata_hash_extension::CheckMetadataHash::new(true),
 		);
+
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|e| {
 				log::warn!("Unable to create signed payload: {:?}", e);
@@ -1528,6 +1530,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -45,6 +45,7 @@ sp-npos-elections = { path = "../../../substrate/primitives/npos-elections", def
 
 frame-election-provider-support = { path = "../../../substrate/frame/election-provider-support", default-features = false }
 frame-executive = { path = "../../../substrate/frame/executive", default-features = false }
+frame-metadata-hash-extension = { path = "../../../substrate/frame/metadata-hash-extension", default-features = false }
 frame-support = { path = "../../../substrate/frame/support", default-features = false, features = ["experimental", "tuples-96"] }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }
 frame-system-rpc-runtime-api = { path = "../../../substrate/frame/system/rpc/runtime-api", default-features = false }
@@ -141,6 +142,7 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-election-provider-support/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -338,6 +340,9 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable the metadata hash generation in the wasm builder.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = []
 
@@ -346,4 +351,4 @@ runtime-metrics = ["runtime-parachains/runtime-metrics", "sp-io/with-tracing"]
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["metadata-hash", "sp-api/disable-logging"]

--- a/polkadot/runtime/westend/build.rs
+++ b/polkadot/runtime/westend/build.rs
@@ -14,8 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(all(not(feature = "metadata-hash"), feature = "std"))]
 fn main() {
-	WasmBuilder::build_using_defaults();
+	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }
+
+#[cfg(all(feature = "metadata-hash", feature = "std"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("WND", 12)
+		.build();
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -797,6 +797,7 @@ where
 			frame_system::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+			frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(true),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|e| {
@@ -1617,6 +1618,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 pub struct NominationPoolsMigrationV4OldPallet;

--- a/prdoc/pr_4274.prdoc
+++ b/prdoc/pr_4274.prdoc
@@ -1,0 +1,39 @@
+title: Introduce `CheckMetadataHash` signed extension
+
+doc:
+  - audience: Runtime Dev
+    description: |
+       Introduces the new `CheckMetadataHash` signed extension. This extension can be added to a
+       runtime to support verifying the metadata hash as described in
+       [RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html).
+       This removes the requirement for having a metadata portal and in general a centralized
+       authentication of the metadata. With this signed extension the runtime is able to verify
+       that the metadata used by the wallet was correct. This is mainly useful for offline wallets
+       which users need to trust any way, not that useful for online wallets.
+
+       There is a guide `generate_metadata_hash` for how to integrate this into a runtime that
+       should make it quite easy to integrate the signed extension.
+  - audience: Runtime User
+    description: |
+       This brings support for the new Ledger app and similar hardware wallets. These hardware
+       wallets will be able to decode the transaction using the metadata. The runtime will
+       ensure that the metadata used for this decoding process is correct and that the online
+       wallet did not tried to trick you.
+
+crates:
+  - name: substrate-wasm-builder
+    bump: minor
+  - name: sc-executor-wasmtime
+    bump: patch
+  - name: frame-metadata-hash-extension
+    bump: major
+  - name: polkadot-service
+    bump: none
+  - name: rococo-runtime
+    bump: major
+  - name: westend-runtime
+    bump: major
+  - name: asset-hub-rococo-runtime
+    bump: major
+  - name: asset-hub-westend-runtime
+    bump: major

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -99,6 +99,7 @@ sc-offchain = { path = "../../../client/offchain" }
 
 # frame dependencies
 frame-benchmarking = { path = "../../../frame/benchmarking" }
+frame-metadata-hash-extension = { path = "../../../frame/metadata-hash-extension" }
 frame-system = { path = "../../../frame/system" }
 frame-system-rpc-runtime-api = { path = "../../../frame/system/rpc/runtime-api" }
 pallet-assets = { path = "../../../frame/assets" }

--- a/substrate/bin/node/cli/benches/executor.rs
+++ b/substrate/bin/node/cli/benches/executor.rs
@@ -55,7 +55,7 @@ const HEAP_PAGES: u64 = 20;
 type TestExternalities<H> = CoreTestExternalities<H>;
 
 fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
-	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH)
+	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH, None)
 }
 
 fn new_test_ext(genesis_config: &RuntimeGenesisConfig) -> TestExternalities<BlakeTwo256> {

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -126,6 +126,7 @@ pub fn create_extrinsic(
 					kitchensink_runtime::Runtime,
 				>::from(tip, None),
 			),
+			frame_metadata_hash_extension::CheckMetadataHash::new(false),
 		);
 
 	let raw_payload = kitchensink_runtime::SignedPayload::from_raw(
@@ -140,6 +141,7 @@ pub fn create_extrinsic(
 			(),
 			(),
 			(),
+			None,
 		),
 	);
 	let signature = raw_payload.using_encoded(|e| sender.sign(e));
@@ -1041,6 +1043,7 @@ mod tests {
 				let tx_payment = pallet_skip_feeless_payment::SkipCheckIfFeeless::from(
 					pallet_asset_conversion_tx_payment::ChargeAssetTxPayment::from(0, None),
 				);
+				let metadata_hash = frame_metadata_hash_extension::CheckMetadataHash::new(false);
 				let extra = (
 					check_non_zero_sender,
 					check_spec_version,
@@ -1050,11 +1053,22 @@ mod tests {
 					check_nonce,
 					check_weight,
 					tx_payment,
+					metadata_hash,
 				);
 				let raw_payload = SignedPayload::from_raw(
 					function,
 					extra,
-					((), spec_version, transaction_version, genesis_hash, genesis_hash, (), (), ()),
+					(
+						(),
+						spec_version,
+						transaction_version,
+						genesis_hash,
+						genesis_hash,
+						(),
+						(),
+						(),
+						None,
+					),
 				);
 				let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
 				let (function, extra, _) = raw_payload.deconstruct();

--- a/substrate/bin/node/cli/tests/common.rs
+++ b/substrate/bin/node/cli/tests/common.rs
@@ -83,7 +83,7 @@ pub const TRANSACTION_VERSION: u32 = kitchensink_runtime::VERSION.transaction_ve
 pub type TestExternalities<H> = CoreTestExternalities<H>;
 
 pub fn sign(xt: CheckedExtrinsic) -> UncheckedExtrinsic {
-	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH)
+	node_testing::keyring::sign(xt, SPEC_VERSION, TRANSACTION_VERSION, GENESIS_HASH, None)
 }
 
 pub fn default_transfer_call() -> pallet_balances::Call<Runtime> {

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -58,6 +58,7 @@ sp-io = { path = "../../../primitives/io", default-features = false }
 frame-executive = { path = "../../../frame/executive", default-features = false }
 frame-benchmarking = { path = "../../../frame/benchmarking", default-features = false }
 frame-benchmarking-pallet-pov = { path = "../../../frame/benchmarking/pov", default-features = false }
+frame-metadata-hash-extension = { path = "../../../frame/metadata-hash-extension", default-features = false }
 frame-support = { path = "../../../frame/support", default-features = false, features = ["experimental", "tuples-96"] }
 frame-system = { path = "../../../frame/system", default-features = false }
 frame-system-benchmarking = { path = "../../../frame/system/benchmarking", default-features = false, optional = true }
@@ -159,6 +160,7 @@ std = [
 	"frame-benchmarking/std",
 	"frame-election-provider-support/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -436,3 +438,5 @@ experimental = [
 	"frame-system/experimental",
 	"pallet-example-tasks/experimental",
 ]
+
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]

--- a/substrate/bin/node/runtime/build.rs
+++ b/substrate/bin/node/runtime/build.rs
@@ -15,13 +15,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	#[cfg(feature = "std")]
-	{
-		substrate_wasm_builder::WasmBuilder::new()
-			.with_current_project()
-			.export_heap_base()
-			.import_memory()
-			.build();
-	}
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
 }
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("Test", 14)
+		.build()
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1434,6 +1434,7 @@ where
 					tip, None,
 				),
 			),
+			frame_metadata_hash_extension::CheckMetadataHash::new(false),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|e| {
@@ -2527,6 +2528,7 @@ pub type SignedExtra = (
 		Runtime,
 		pallet_asset_conversion_tx_payment::ChargeAssetTxPayment<Runtime>,
 	>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/substrate/bin/node/testing/Cargo.toml
+++ b/substrate/bin/node/testing/Cargo.toml
@@ -21,6 +21,7 @@ fs_extra = "1"
 futures = "0.3.30"
 log = { workspace = true, default-features = true }
 tempfile = "3.1.0"
+frame-metadata-hash-extension = { path = "../../../frame/metadata-hash-extension" }
 frame-system = { path = "../../../frame/system" }
 node-cli = { package = "staging-node-cli", path = "../cli" }
 node-primitives = { path = "../primitives" }

--- a/substrate/bin/node/testing/src/bench.rs
+++ b/substrate/bin/node/testing/src/bench.rs
@@ -571,6 +571,8 @@ impl BenchKeyring {
 					tx_version,
 					genesis_hash,
 					genesis_hash,
+					// metadata_hash
+					None::<()>,
 				);
 				let key = self.accounts.get(&signed).expect("Account id not found in keyring");
 				let signature = payload.using_encoded(|b| {

--- a/substrate/bin/node/testing/src/keyring.rs
+++ b/substrate/bin/node/testing/src/keyring.rs
@@ -82,6 +82,7 @@ pub fn signed_extra(nonce: Nonce, extra_fee: Balance) -> SignedExtra {
 		pallet_skip_feeless_payment::SkipCheckIfFeeless::from(
 			pallet_asset_conversion_tx_payment::ChargeAssetTxPayment::from(extra_fee, None),
 		),
+		frame_metadata_hash_extension::CheckMetadataHash::new(false),
 	)
 }
 
@@ -91,11 +92,19 @@ pub fn sign(
 	spec_version: u32,
 	tx_version: u32,
 	genesis_hash: [u8; 32],
+	metadata_hash: Option<[u8; 32]>,
 ) -> UncheckedExtrinsic {
 	match xt.signed {
 		Some((signed, extra)) => {
-			let payload =
-				(xt.function, extra.clone(), spec_version, tx_version, genesis_hash, genesis_hash);
+			let payload = (
+				xt.function,
+				extra.clone(),
+				spec_version,
+				tx_version,
+				genesis_hash,
+				genesis_hash,
+				metadata_hash,
+			);
 			let key = AccountKeyring::from_account_id(&signed).unwrap();
 			let signature =
 				payload

--- a/substrate/client/executor/wasmtime/src/lib.rs
+++ b/substrate/client/executor/wasmtime/src/lib.rs
@@ -41,3 +41,7 @@ pub use runtime::{
 	prepare_runtime_artifact, Config, DeterministicStackLimit, InstantiationStrategy, Semantics,
 	WasmtimeRuntime,
 };
+pub use sc_executor_common::{
+	runtime_blob::RuntimeBlob,
+	wasm_runtime::{HeapAllocStrategy, WasmModule},
+};

--- a/substrate/frame/metadata-hash-extension/Cargo.toml
+++ b/substrate/frame/metadata-hash-extension/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "frame-metadata-hash-extension"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "FRAME signed extension for verifying the metadata hash"
+
+[dependencies]
+array-bytes = "6.2.2"
+codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.1", default-features = false, features = ["derive", "serde"] }
+sp-runtime = { path = "../../primitives/runtime", default-features = false, features = ["serde"] }
+frame-support = { path = "../support", default-features = false }
+frame-system = { path = "../system", default-features = false }
+log = { workspace = true, default-features = false }
+docify = "0.2.8"
+
+[dev-dependencies]
+substrate-wasm-builder = { path = "../../utils/wasm-builder", features = ["metadata-hash"] }
+substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
+sp-api = { path = "../../primitives/api" }
+sp-transaction-pool = { path = "../../primitives/transaction-pool" }
+merkleized-metadata = "0.1.0"
+frame-metadata = { version = "16.0.0", features = ["current"] }
+sp-tracing = { path = "../../primitives/tracing" }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"scale-info/std",
+	"sp-runtime/std",
+]

--- a/substrate/frame/metadata-hash-extension/src/lib.rs
+++ b/substrate/frame/metadata-hash-extension/src/lib.rs
@@ -1,0 +1,168 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! The [`CheckMetadataHash`] signed extension.
+//!
+//! The extension for optionally checking the metadata hash. For information how it works and what
+//! it does exactly, see the docs of [`CheckMetadataHash`].
+//!
+//! # Integration
+//!
+//! As any signed extension you will need to add it to your runtime signed extensions:
+#![doc = docify::embed!("src/tests.rs", add_metadata_hash_extension)]
+//! As the extension requires the `RUNTIME_METADATA_HASH` environment variable to be present at
+//! compile time, it requires a little bit more setup. To have this environment variable available
+//! at compile time required to tell the `substrate-wasm-builder` to do so:
+#![doc = docify::embed!("src/tests.rs", enable_metadata_hash_in_wasm_builder)]
+//! As generating the metadata hash requires to compile the runtime twice, it is
+//! recommended to only enable the metadata hash generation when doing a build for a release or when
+//! you want to test this feature.
+
+extern crate alloc;
+/// For our tests
+extern crate self as frame_metadata_hash_extension;
+
+use codec::{Decode, Encode};
+use frame_support::DebugNoBound;
+use frame_system::Config;
+use scale_info::TypeInfo;
+use sp_runtime::{
+	traits::{DispatchInfoOf, SignedExtension},
+	transaction_validity::{TransactionValidityError, UnknownTransaction},
+};
+
+#[cfg(test)]
+mod tests;
+
+/// The mode of [`CheckMetadataHash`].
+#[derive(Decode, Encode, PartialEq, Debug, TypeInfo, Clone, Copy, Eq)]
+enum Mode {
+	Disabled,
+	Enabled,
+}
+
+/// Wrapper around the metadata hash and from where to get it from.
+#[derive(Default, Debug, PartialEq, Clone, Copy, Eq)]
+enum MetadataHash {
+	/// Fetch it from the `RUNTIME_METADATA_HASH` env variable at compile time.
+	#[default]
+	FetchFromEnv,
+	/// Use the given metadata hash.
+	Custom([u8; 32]),
+}
+
+impl MetadataHash {
+	/// Returns the metadata hash.
+	fn hash(&self) -> Option<[u8; 32]> {
+		match self {
+			Self::FetchFromEnv =>
+				option_env!("RUNTIME_METADATA_HASH").map(array_bytes::hex2array_unchecked),
+			Self::Custom(hash) => Some(*hash),
+		}
+	}
+}
+
+/// Extension for optionally verifying the metadata hash.
+///
+/// The metadata hash is cryptographical representation of the runtime metadata. This metadata hash
+/// is build as described in [RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html).
+/// This metadata hash should give users the confidence that what they build with an online wallet
+/// is the same they are signing with their offline wallet and then applying on chain. To ensure
+/// that the online wallet is not tricking the offline wallet into decoding and showing an incorrect
+/// extrinsic, the offline wallet will include the metadata hash into the additional signed data and
+/// the runtime will then do the same. If the metadata hash doesn't match, the signature
+/// verification will fail and thus, the transaction will be rejected. The RFC contains more details
+/// on how it works.
+///
+/// The extension adds one byte (the `mode`) to the size of the extrinsic. This one byte is
+/// controlling if the metadata hash should be added to the signed data or not. Mode `0` means that
+/// the metadata hash is not added and thus, `None` is added to the signed data. Mode `1` means that
+/// the metadata hash is added and thus, `Some(metadata_hash)` is added to the signed data. Further
+/// values of `mode` are reserved for future changes.
+///
+/// The metadata hash is read from the environment variable `RUNTIME_METADATA_HASH`. This
+/// environment variable is for example set by the `substrate-wasm-builder` when the feature for
+/// generating the metadata hash is enabled. If the environment variable is not set and `mode = 1`
+/// is passed, the transaction is rejected with [`UnknownTransaction::CannotLookup`].
+#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo, DebugNoBound)]
+#[scale_info(skip_type_params(T))]
+pub struct CheckMetadataHash<T> {
+	_phantom: core::marker::PhantomData<T>,
+	mode: Mode,
+	#[codec(skip)]
+	metadata_hash: MetadataHash,
+}
+
+impl<T> CheckMetadataHash<T> {
+	/// Creates new `SignedExtension` to check metadata hash.
+	pub fn new(enable: bool) -> Self {
+		Self {
+			_phantom: core::marker::PhantomData,
+			mode: if enable { Mode::Enabled } else { Mode::Disabled },
+			metadata_hash: MetadataHash::FetchFromEnv,
+		}
+	}
+
+	/// Create an instance that uses the given `metadata_hash`.
+	///
+	/// This is useful for testing the extension.
+	pub fn new_with_custom_hash(metadata_hash: [u8; 32]) -> Self {
+		Self {
+			_phantom: core::marker::PhantomData,
+			mode: Mode::Enabled,
+			metadata_hash: MetadataHash::Custom(metadata_hash),
+		}
+	}
+}
+
+impl<T: Config + Send + Sync> SignedExtension for CheckMetadataHash<T> {
+	type AccountId = T::AccountId;
+	type Call = <T as Config>::RuntimeCall;
+	type AdditionalSigned = Option<[u8; 32]>;
+	type Pre = ();
+	const IDENTIFIER: &'static str = "CheckMetadataHash";
+
+	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+		let signed = match self.mode {
+			Mode::Disabled => None,
+			Mode::Enabled => match self.metadata_hash.hash() {
+				Some(hash) => Some(hash),
+				None => return Err(UnknownTransaction::CannotLookup.into()),
+			},
+		};
+
+		log::debug!(
+			target: "runtime::metadata-hash",
+			"CheckMetadataHash::additional_signed => {:?}",
+			signed.as_ref().map(|h| array_bytes::bytes2hex("0x", h)),
+		);
+
+		Ok(signed)
+	}
+
+	fn pre_dispatch(
+		self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		info: &DispatchInfoOf<Self::Call>,
+		len: usize,
+	) -> Result<Self::Pre, TransactionValidityError> {
+		self.validate(who, call, info, len).map(|_| ())
+	}
+}

--- a/substrate/frame/metadata-hash-extension/src/tests.rs
+++ b/substrate/frame/metadata-hash-extension/src/tests.rs
@@ -1,0 +1,179 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::CheckMetadataHash;
+use codec::{Decode, Encode};
+use frame_metadata::RuntimeMetadataPrefixed;
+use frame_support::{
+	derive_impl,
+	pallet_prelude::{InvalidTransaction, TransactionValidityError},
+};
+use merkleized_metadata::{generate_metadata_digest, ExtraInfo};
+use sp_api::{Metadata, ProvideRuntimeApi};
+use sp_runtime::{
+	traits::{Extrinsic as _, SignedExtension},
+	transaction_validity::{TransactionSource, UnknownTransaction},
+};
+use sp_transaction_pool::runtime_api::TaggedTransactionQueue;
+use substrate_test_runtime_client::{
+	prelude::*,
+	runtime::{self, ExtrinsicBuilder},
+	DefaultTestClientBuilderExt, TestClientBuilder,
+};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+frame_support::construct_runtime! {
+	pub enum Test {
+		System: frame_system,
+	}
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type Block = Block;
+}
+
+#[test]
+fn rejects_when_no_metadata_hash_was_passed() {
+	let ext = CheckMetadataHash::<Test>::decode(&mut &1u8.encode()[..]).unwrap();
+	assert_eq!(Err(UnknownTransaction::CannotLookup.into()), ext.additional_signed());
+}
+
+#[test]
+fn rejects_unknown_mode() {
+	assert!(CheckMetadataHash::<Test>::decode(&mut &50u8.encode()[..]).is_err());
+}
+
+/// Generate the metadata hash for the `test-runtime`.
+fn generate_metadata_hash(metadata: RuntimeMetadataPrefixed) -> [u8; 32] {
+	let runtime_version = runtime::VERSION;
+	let base58_prefix = 0;
+
+	let extra_info = ExtraInfo {
+		spec_version: runtime_version.spec_version,
+		spec_name: runtime_version.spec_name.into(),
+		base58_prefix,
+		decimals: 10,
+		token_symbol: "TOKEN".into(),
+	};
+
+	generate_metadata_digest(&metadata.1, extra_info).unwrap().hash()
+}
+
+#[test]
+fn ensure_check_metadata_works_on_real_extrinsics() {
+	sp_tracing::try_init_simple();
+
+	let client = TestClientBuilder::new().build();
+	let runtime_api = client.runtime_api();
+	let best_hash = client.chain_info().best_hash;
+
+	let metadata = RuntimeMetadataPrefixed::decode(
+		&mut &runtime_api.metadata_at_version(best_hash, 15).unwrap().unwrap()[..],
+	)
+	.unwrap();
+
+	let valid_transaction = ExtrinsicBuilder::new_include_data(vec![1, 2, 3])
+		.metadata_hash(generate_metadata_hash(metadata))
+		.build();
+	// Ensure that the transaction is signed.
+	assert!(valid_transaction.is_signed().unwrap());
+
+	runtime_api
+		.validate_transaction(best_hash, TransactionSource::External, valid_transaction, best_hash)
+		.unwrap()
+		.unwrap();
+
+	// Including some random metadata hash should make the transaction invalid.
+	let invalid_transaction = ExtrinsicBuilder::new_include_data(vec![1, 2, 3])
+		.metadata_hash([10u8; 32])
+		.build();
+	// Ensure that the transaction is signed.
+	assert!(invalid_transaction.is_signed().unwrap());
+
+	assert_eq!(
+		TransactionValidityError::from(InvalidTransaction::BadProof),
+		runtime_api
+			.validate_transaction(
+				best_hash,
+				TransactionSource::External,
+				invalid_transaction,
+				best_hash
+			)
+			.unwrap()
+			.unwrap_err()
+	);
+}
+
+#[allow(unused)]
+mod docs {
+	use super::*;
+
+	#[docify::export]
+	mod add_metadata_hash_extension {
+		frame_support::construct_runtime! {
+			pub enum Runtime {
+				System: frame_system,
+			}
+		}
+
+		/// The `SignedExtension` to the basic transaction logic.
+		pub type SignedExtra = (
+			frame_system::CheckNonZeroSender<Runtime>,
+			frame_system::CheckSpecVersion<Runtime>,
+			frame_system::CheckTxVersion<Runtime>,
+			frame_system::CheckGenesis<Runtime>,
+			frame_system::CheckMortality<Runtime>,
+			frame_system::CheckNonce<Runtime>,
+			frame_system::CheckWeight<Runtime>,
+			// Add the `CheckMetadataHash` extension.
+			// The position in this list is not important, so we could also add it to beginning.
+			frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
+		);
+
+		/// In your runtime this will be your real address type.
+		type Address = ();
+		/// In your runtime this will be your real signature type.
+		type Signature = ();
+
+		/// Unchecked extrinsic type as expected by this runtime.
+		pub type UncheckedExtrinsic =
+			sp_runtime::generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+	}
+
+	// Put here to not have it in the docs as well.
+	#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+	impl frame_system::Config for add_metadata_hash_extension::Runtime {
+		type Block = Block;
+		type RuntimeEvent = add_metadata_hash_extension::RuntimeEvent;
+		type RuntimeOrigin = add_metadata_hash_extension::RuntimeOrigin;
+		type RuntimeCall = add_metadata_hash_extension::RuntimeCall;
+		type PalletInfo = add_metadata_hash_extension::PalletInfo;
+	}
+
+	#[docify::export]
+	fn enable_metadata_hash_in_wasm_builder() {
+		substrate_wasm_builder::WasmBuilder::init_with_defaults()
+			// Requires the `metadata-hash` feature to be activated.
+			// You need to pass the main token symbol and its number of decimals.
+			.enable_metadata_hash("TOKEN", 12)
+			// The runtime will be build twice and the second time the `RUNTIME_METADATA_HASH`
+			// environment variable will be set for the `CheckMetadataHash` extension.
+			.build()
+	}
+}

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -37,6 +37,7 @@ sp-runtime = { path = "../../primitives/runtime", default-features = false, feat
 pallet-babe = { path = "../../frame/babe", default-features = false }
 pallet-balances = { path = "../../frame/balances", default-features = false }
 frame-executive = { path = "../../frame/executive", default-features = false }
+frame-metadata-hash-extension = { path = "../../frame/metadata-hash-extension", default-features = false }
 frame-system = { path = "../../frame/system", default-features = false }
 frame-system-rpc-runtime-api = { path = "../../frame/system/rpc/runtime-api", default-features = false }
 pallet-timestamp = { path = "../../frame/timestamp", default-features = false }
@@ -67,7 +68,7 @@ serde = { features = ["alloc", "derive"], workspace = true }
 serde_json = { features = ["alloc"], workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { path = "../../utils/wasm-builder", optional = true }
+substrate-wasm-builder = { path = "../../utils/wasm-builder", optional = true, features = ["metadata-hash"] }
 
 [features]
 default = ["std"]
@@ -76,6 +77,7 @@ std = [
 	"array-bytes",
 	"codec/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
@@ -112,5 +114,6 @@ std = [
 	"substrate-wasm-builder",
 	"trie-db/std",
 ]
+
 # Special feature to disable logging
 disable-logging = ["sp-api/disable-logging"]

--- a/substrate/test-utils/runtime/build.rs
+++ b/substrate/test-utils/runtime/build.rs
@@ -25,6 +25,7 @@ fn main() {
 			// to this value by default. This is because some of our tests
 			// (`restoration_of_globals`) depend on the stack-size.
 			.append_to_rust_flags("-Clink-arg=-zstack-size=1048576")
+			.enable_metadata_hash("TOKEN", 10)
 			.import_memory()
 			.build();
 	}

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -149,7 +149,12 @@ pub type Signature = sr25519::Signature;
 pub type Pair = sp_core::sr25519::Pair;
 
 /// The SignedExtension to the basic transaction logic.
-pub type SignedExtra = (CheckNonce<Runtime>, CheckWeight<Runtime>, CheckSubstrateCall);
+pub type SignedExtra = (
+	CheckNonce<Runtime>,
+	CheckWeight<Runtime>,
+	CheckSubstrateCall,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
+);
 /// The payload being signed in transactions.
 pub type SignedPayload = sp_runtime::generic::SignedPayload<RuntimeCall, SignedExtra>;
 /// Unchecked extrinsic type as expected by this runtime.
@@ -494,14 +499,14 @@ impl_runtime_apis! {
 
 	impl sp_api::Metadata<Block> for Runtime {
 		fn metadata() -> OpaqueMetadata {
-			unimplemented!()
+			OpaqueMetadata::new(Runtime::metadata().into())
 		}
 
-		fn metadata_at_version(_version: u32) -> Option<OpaqueMetadata> {
-			unimplemented!()
+		fn metadata_at_version(version: u32) -> Option<OpaqueMetadata> {
+			Runtime::metadata_at_version(version)
 		}
 		fn metadata_versions() -> alloc::vec::Vec<u32> {
-			unimplemented!()
+			Runtime::metadata_versions()
 		}
 	}
 

--- a/substrate/utils/wasm-builder/Cargo.toml
+++ b/substrate/utils/wasm-builder/Cargo.toml
@@ -27,3 +27,34 @@ filetime = "0.2.16"
 wasm-opt = "0.116"
 parity-wasm = "0.45"
 polkavm-linker = { workspace = true }
+
+# Dependencies required for the `metadata-hash` feature.
+merkleized-metadata = { version = "0.1.0", optional = true }
+sc-executor = { path = "../../client/executor", optional = true }
+sp-core = { path = "../../primitives/core", optional = true }
+sp-io = { path = "../../primitives/io", optional = true }
+sp-version = { path = "../../primitives/version", optional = true }
+frame-metadata = { version = "16.0.0", features = ["current"], optional = true }
+codec = { package = "parity-scale-codec", version = "3.1.5", optional = true }
+array-bytes = { version = "6.1", optional = true }
+sp-tracing = { path = "../../primitives/tracing", optional = true }
+
+[features]
+# Enable support for generating the metadata hash.
+#
+# To generate the metadata hash the runtime is build once, executed to build the metadata and then
+# build a second time with the `RUNTIME_METADATA_HASH` environment variable set. The environment
+# variable then contains the hash and can be used inside the runtime.
+#
+# This pulls in quite a lot of dependencies and thus, is disabled by default.
+metadata-hash = [
+	"array-bytes",
+	"codec",
+	"frame-metadata",
+	"merkleized-metadata",
+	"sc-executor",
+	"sp-core",
+	"sp-io",
+	"sp-tracing",
+	"sp-version",
+]

--- a/substrate/utils/wasm-builder/src/builder.rs
+++ b/substrate/utils/wasm-builder/src/builder.rs
@@ -23,6 +23,13 @@ use std::{
 
 use crate::RuntimeTarget;
 
+/// Extra information when generating the `metadata-hash`.
+#[cfg(feature = "metadata-hash")]
+pub(crate) struct MetadataExtraInfo {
+	pub decimals: u8,
+	pub token_symbol: String,
+}
+
 /// Returns the manifest dir from the `CARGO_MANIFEST_DIR` env.
 fn get_manifest_dir() -> PathBuf {
 	env::var("CARGO_MANIFEST_DIR")
@@ -53,6 +60,8 @@ impl WasmBuilderSelectProject {
 			disable_runtime_version_section_check: false,
 			export_heap_base: false,
 			import_memory: false,
+			#[cfg(feature = "metadata-hash")]
+			enable_metadata_hash: None,
 		}
 	}
 
@@ -71,6 +80,8 @@ impl WasmBuilderSelectProject {
 				disable_runtime_version_section_check: false,
 				export_heap_base: false,
 				import_memory: false,
+				#[cfg(feature = "metadata-hash")]
+				enable_metadata_hash: None,
 			})
 		} else {
 			Err("Project path must point to the `Cargo.toml` of the project")
@@ -108,6 +119,10 @@ pub struct WasmBuilder {
 	export_heap_base: bool,
 	/// Whether `--import-memory` should be added to the link args (WASM-only).
 	import_memory: bool,
+
+	/// Whether to enable the metadata hash generation.
+	#[cfg(feature = "metadata-hash")]
+	enable_metadata_hash: Option<MetadataExtraInfo>,
 }
 
 impl WasmBuilder {
@@ -191,6 +206,22 @@ impl WasmBuilder {
 		self
 	}
 
+	/// Enable generation of the metadata hash.
+	///
+	/// This will compile the runtime once, fetch the metadata, build the metadata hash and
+	/// then compile again with the env `RUNTIME_METADATA_HASH` set. For more information
+	/// about the metadata hash see [RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html).
+	///
+	/// - `token_symbol`: The symbol of the main native token of the chain.
+	/// - `decimals`: The number of decimals of the main native token.
+	#[cfg(feature = "metadata-hash")]
+	pub fn enable_metadata_hash(mut self, token_symbol: impl Into<String>, decimals: u8) -> Self {
+		self.enable_metadata_hash =
+			Some(MetadataExtraInfo { token_symbol: token_symbol.into(), decimals });
+
+		self
+	}
+
 	/// Disable the check for the `runtime_version` wasm section.
 	///
 	/// By default the `wasm-builder` will ensure that the `runtime_version` section will
@@ -237,6 +268,8 @@ impl WasmBuilder {
 			self.features_to_enable,
 			self.file_name,
 			!self.disable_runtime_version_section_check,
+			#[cfg(feature = "metadata-hash")]
+			self.enable_metadata_hash,
 		);
 
 		// As last step we need to generate our `rerun-if-changed` stuff. If a build fails, we don't
@@ -311,6 +344,7 @@ fn build_project(
 	features_to_enable: Vec<String>,
 	wasm_binary_name: Option<String>,
 	check_for_runtime_version_section: bool,
+	#[cfg(feature = "metadata-hash")] enable_metadata_hash: Option<MetadataExtraInfo>,
 ) {
 	let cargo_cmd = match crate::prerequisites::check(target) {
 		Ok(cmd) => cmd,
@@ -328,6 +362,8 @@ fn build_project(
 		features_to_enable,
 		wasm_binary_name,
 		check_for_runtime_version_section,
+		#[cfg(feature = "metadata-hash")]
+		enable_metadata_hash,
 	);
 
 	let (wasm_binary, wasm_binary_bloaty) = if let Some(wasm_binary) = wasm_binary {

--- a/substrate/utils/wasm-builder/src/lib.rs
+++ b/substrate/utils/wasm-builder/src/lib.rs
@@ -116,6 +116,8 @@ use std::{
 use version::Version;
 
 mod builder;
+#[cfg(feature = "metadata-hash")]
+mod metadata_hash;
 mod prerequisites;
 mod version;
 mod wasm_project;
@@ -238,7 +240,7 @@ fn get_rustup_command(target: RuntimeTarget) -> Option<CargoCommand> {
 }
 
 /// Wraps a specific command which represents a cargo invocation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct CargoCommand {
 	program: String,
 	args: Vec<String>,
@@ -350,6 +352,7 @@ impl CargoCommand {
 }
 
 /// Wraps a [`CargoCommand`] and the version of `rustc` the cargo command uses.
+#[derive(Clone)]
 struct CargoCommandVersioned {
 	command: CargoCommand,
 	version: String,

--- a/substrate/utils/wasm-builder/src/metadata_hash.rs
+++ b/substrate/utils/wasm-builder/src/metadata_hash.rs
@@ -1,0 +1,132 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::builder::MetadataExtraInfo;
+use codec::{Decode, Encode};
+use frame_metadata::{RuntimeMetadata, RuntimeMetadataPrefixed};
+use merkleized_metadata::{generate_metadata_digest, ExtraInfo};
+use sc_executor::WasmExecutor;
+use sp_core::traits::{CallContext, CodeExecutor, RuntimeCode, WrappedRuntimeCode};
+use std::path::Path;
+
+/// The host functions that we provide when calling into the wasm file.
+///
+/// Any other host function will return an error.
+type HostFunctions = (
+	// The allocator functions.
+	sp_io::allocator::HostFunctions,
+	// Logging is good to have for debugging issues.
+	sp_io::logging::HostFunctions,
+	// Give access to the "state", actually the state will be empty, but some chains put constants
+	// into the state and this would panic at metadata generation. Thus, we give them an empty
+	// state to not panic.
+	sp_io::storage::HostFunctions,
+	// The hashing functions.
+	sp_io::hashing::HostFunctions,
+);
+
+/// Generate the metadata hash.
+///
+/// The metadata hash is generated as specced in
+/// [RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html).
+///
+/// Returns the metadata hash.
+pub fn generate_metadata_hash(wasm: &Path, extra_info: MetadataExtraInfo) -> [u8; 32] {
+	sp_tracing::try_init_simple();
+
+	let wasm = std::fs::read(wasm).expect("Wasm file was just created and should be readable.");
+
+	let executor = WasmExecutor::<HostFunctions>::builder()
+		.with_allow_missing_host_functions(true)
+		.build();
+
+	let runtime_code = RuntimeCode {
+		code_fetcher: &WrappedRuntimeCode(wasm.into()),
+		heap_pages: None,
+		// The hash is only used for caching and thus, not that important for our use case here.
+		hash: vec![1, 2, 3],
+	};
+
+	let metadata = executor
+		.call(
+			&mut sp_io::TestExternalities::default().ext(),
+			&runtime_code,
+			"Metadata_metadata_at_version",
+			&15u32.encode(),
+			CallContext::Offchain,
+		)
+		.0
+		.expect("`Metadata::metadata_at_version` should exist.");
+
+	let metadata = Option::<Vec<u8>>::decode(&mut &metadata[..])
+		.ok()
+		.flatten()
+		.expect("Metadata V15 support is required.");
+
+	let metadata = RuntimeMetadataPrefixed::decode(&mut &metadata[..])
+		.expect("Invalid encoded metadata?")
+		.1;
+
+	let runtime_version = executor
+		.call(
+			&mut sp_io::TestExternalities::default().ext(),
+			&runtime_code,
+			"Core_version",
+			&[],
+			CallContext::Offchain,
+		)
+		.0
+		.expect("`Core_version` should exist.");
+	let runtime_version = sp_version::RuntimeVersion::decode(&mut &runtime_version[..])
+		.expect("Invalid `RuntimeVersion` encoding");
+
+	let base58_prefix = extract_ss58_prefix(&metadata);
+
+	let extra_info = ExtraInfo {
+		spec_version: runtime_version.spec_version,
+		spec_name: runtime_version.spec_name.into(),
+		base58_prefix,
+		decimals: extra_info.decimals,
+		token_symbol: extra_info.token_symbol,
+	};
+
+	generate_metadata_digest(&metadata, extra_info)
+		.expect("Failed to generate the metadata digest")
+		.hash()
+}
+
+/// Extract the `SS58` from the constants in the given `metadata`.
+fn extract_ss58_prefix(metadata: &RuntimeMetadata) -> u16 {
+	let RuntimeMetadata::V15(ref metadata) = metadata else {
+		panic!("Metadata version 15 required")
+	};
+
+	let system = metadata
+		.pallets
+		.iter()
+		.find(|p| p.name == "System")
+		.expect("Each FRAME runtime has the `System` pallet; qed");
+
+	system
+		.constants
+		.iter()
+		.find_map(|c| {
+			(c.name == "SS58Prefix")
+				.then(|| u16::decode(&mut &c.value[..]).expect("SS58 is an `u16`; qed"))
+		})
+		.expect("`SS58PREFIX` exists in the `System` constants; qed")
+}

--- a/substrate/utils/wasm-builder/src/wasm_project.rs
+++ b/substrate/utils/wasm-builder/src/wasm_project.rs
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "metadata-hash")]
+use crate::builder::MetadataExtraInfo;
 use crate::{write_file_if_changed, CargoCommandVersioned, RuntimeTarget, OFFLINE};
 
 use build_helper::rerun_if_changed;
@@ -113,57 +115,103 @@ fn crate_metadata(cargo_manifest: &Path) -> Metadata {
 /// The path to the compact runtime binary and the bloaty runtime binary.
 pub(crate) fn create_and_compile(
 	target: RuntimeTarget,
-	project_cargo_toml: &Path,
+	orig_project_cargo_toml: &Path,
 	default_rustflags: &str,
 	cargo_cmd: CargoCommandVersioned,
 	features_to_enable: Vec<String>,
-	bloaty_blob_out_name_override: Option<String>,
+	blob_out_name_override: Option<String>,
 	check_for_runtime_version_section: bool,
+	#[cfg(feature = "metadata-hash")] enable_metadata_hash: Option<MetadataExtraInfo>,
 ) -> (Option<WasmBinary>, WasmBinaryBloaty) {
 	let runtime_workspace_root = get_wasm_workspace_root();
 	let runtime_workspace = runtime_workspace_root.join(target.build_subdirectory());
 
-	let crate_metadata = crate_metadata(project_cargo_toml);
+	let crate_metadata = crate_metadata(orig_project_cargo_toml);
 
 	let project = create_project(
 		target,
-		project_cargo_toml,
+		orig_project_cargo_toml,
 		&runtime_workspace,
 		&crate_metadata,
 		crate_metadata.workspace_root.as_ref(),
 		features_to_enable,
 	);
+	let wasm_project_cargo_toml = project.join("Cargo.toml");
 
 	let build_config = BuildConfiguration::detect(target, &project);
 
-	// Build the bloaty runtime blob
-	let raw_blob_path = build_bloaty_blob(
-		target,
-		&build_config.blob_build_profile,
-		&project,
-		default_rustflags,
-		cargo_cmd,
-	);
+	#[cfg(feature = "metadata-hash")]
+	let raw_blob_path = match enable_metadata_hash {
+		Some(extra_info) => {
+			// When the metadata hash is enabled we need to build the runtime twice.
+			let raw_blob_path = build_bloaty_blob(
+				target,
+				&build_config.blob_build_profile,
+				&project,
+				default_rustflags,
+				cargo_cmd.clone(),
+				None,
+			);
+
+			let hash = crate::metadata_hash::generate_metadata_hash(&raw_blob_path, extra_info);
+
+			build_bloaty_blob(
+				target,
+				&build_config.blob_build_profile,
+				&project,
+				default_rustflags,
+				cargo_cmd,
+				Some(hash),
+			)
+		},
+		None => build_bloaty_blob(
+			target,
+			&build_config.blob_build_profile,
+			&project,
+			default_rustflags,
+			cargo_cmd,
+			None,
+		),
+	};
+
+	// If the feature is not enabled, we only need to do it once.
+	#[cfg(not(feature = "metadata-hash"))]
+	let raw_blob_path = {
+		build_bloaty_blob(
+			target,
+			&build_config.blob_build_profile,
+			&project,
+			default_rustflags,
+			cargo_cmd,
+		)
+	};
+
+	let blob_name =
+		blob_out_name_override.unwrap_or_else(|| get_blob_name(target, &wasm_project_cargo_toml));
 
 	let (final_blob_binary, bloaty_blob_binary) = match target {
-		RuntimeTarget::Wasm => compile_wasm(
-			project_cargo_toml,
-			&project,
-			bloaty_blob_out_name_override,
-			check_for_runtime_version_section,
-			&build_config,
-		),
+		RuntimeTarget::Wasm => {
+			let out_path = project.join(format!("{blob_name}.wasm"));
+			fs::copy(raw_blob_path, &out_path).expect("copying the runtime blob should never fail");
+
+			maybe_compact_and_compress_wasm(
+				&wasm_project_cargo_toml,
+				&project,
+				WasmBinaryBloaty(out_path),
+				&blob_name,
+				check_for_runtime_version_section,
+				&build_config,
+			)
+		},
 		RuntimeTarget::Riscv => {
-			let out_name = bloaty_blob_out_name_override
-				.unwrap_or_else(|| get_blob_name(target, project_cargo_toml));
-			let out_path = project.join(format!("{out_name}.polkavm"));
+			let out_path = project.join(format!("{blob_name}.polkavm"));
 			fs::copy(raw_blob_path, &out_path).expect("copying the runtime blob should never fail");
 			(None, WasmBinaryBloaty(out_path))
 		},
 	};
 
 	generate_rerun_if_changed_instructions(
-		project_cargo_toml,
+		orig_project_cargo_toml,
 		&project,
 		&runtime_workspace,
 		final_blob_binary.as_ref(),
@@ -177,25 +225,14 @@ pub(crate) fn create_and_compile(
 	(final_blob_binary, bloaty_blob_binary)
 }
 
-fn compile_wasm(
-	project_cargo_toml: &Path,
+fn maybe_compact_and_compress_wasm(
+	wasm_project_cargo_toml: &Path,
 	project: &Path,
-	bloaty_blob_out_name_override: Option<String>,
+	bloaty_blob_binary: WasmBinaryBloaty,
+	blob_name: &str,
 	check_for_runtime_version_section: bool,
 	build_config: &BuildConfiguration,
 ) -> (Option<WasmBinary>, WasmBinaryBloaty) {
-	// Get the name of the bloaty runtime blob.
-	let bloaty_blob_default_name = get_blob_name(RuntimeTarget::Wasm, project_cargo_toml);
-	let bloaty_blob_out_name =
-		bloaty_blob_out_name_override.unwrap_or_else(|| bloaty_blob_default_name.clone());
-
-	let bloaty_blob_binary = copy_bloaty_blob(
-		&project,
-		&build_config.blob_build_profile,
-		&bloaty_blob_default_name,
-		&bloaty_blob_out_name,
-	);
-
 	// Try to compact and compress the bloaty blob, if the *outer* profile wants it.
 	//
 	// This is because, by default the inner profile will be set to `Release` even when the outer
@@ -203,15 +240,9 @@ fn compile_wasm(
 	// development activities.
 	let (compact_blob_path, compact_compressed_blob_path) =
 		if build_config.outer_build_profile.wants_compact() {
-			let compact_blob_path = compact_wasm(
-				&project,
-				&build_config.blob_build_profile,
-				project_cargo_toml,
-				&bloaty_blob_out_name,
-			);
-			let compact_compressed_blob_path = compact_blob_path
-				.as_ref()
-				.and_then(|p| try_compress_blob(&p.0, &bloaty_blob_out_name));
+			let compact_blob_path = compact_wasm(&project, blob_name, &bloaty_blob_binary);
+			let compact_compressed_blob_path =
+				compact_blob_path.as_ref().and_then(|p| try_compress_blob(&p.0, blob_name));
 			(compact_blob_path, compact_compressed_blob_path)
 		} else {
 			(None, None)
@@ -221,15 +252,12 @@ fn compile_wasm(
 		ensure_runtime_version_wasm_section_exists(bloaty_blob_binary.bloaty_path());
 	}
 
-	compact_blob_path
-		.as_ref()
-		.map(|wasm_binary| copy_blob_to_target_directory(project_cargo_toml, wasm_binary));
-
-	compact_compressed_blob_path.as_ref().map(|wasm_binary_compressed| {
-		copy_blob_to_target_directory(project_cargo_toml, wasm_binary_compressed)
-	});
-
 	let final_blob_binary = compact_compressed_blob_path.or(compact_blob_path);
+
+	final_blob_binary
+		.as_ref()
+		.map(|binary| copy_blob_to_target_directory(wasm_project_cargo_toml, binary));
+
 	(final_blob_binary, bloaty_blob_binary)
 }
 
@@ -347,12 +375,25 @@ fn get_crate_name(cargo_manifest: &Path) -> String {
 		.expect("Package name exists; qed")
 }
 
+/// Extract the `lib.name` from the given `Cargo.toml`.
+fn get_lib_name(cargo_manifest: &Path) -> Option<String> {
+	let cargo_toml: Table = toml::from_str(
+		&fs::read_to_string(cargo_manifest).expect("File exists as checked before; qed"),
+	)
+	.expect("Cargo manifest is a valid toml file; qed");
+
+	let lib = cargo_toml.get("lib").and_then(|t| t.as_table())?;
+
+	lib.get("name").and_then(|p| p.as_str()).map(ToOwned::to_owned)
+}
+
 /// Returns the name for the blob binary.
 fn get_blob_name(target: RuntimeTarget, cargo_manifest: &Path) -> String {
-	let crate_name = get_crate_name(cargo_manifest);
 	match target {
-		RuntimeTarget::Wasm => crate_name.replace('-', "_"),
-		RuntimeTarget::Riscv => crate_name,
+		RuntimeTarget::Wasm => get_lib_name(cargo_manifest)
+			.expect("The wasm project should have a `lib.name`; qed")
+			.replace('-', "_"),
+		RuntimeTarget::Riscv => get_crate_name(cargo_manifest),
 	}
 }
 
@@ -379,7 +420,6 @@ fn create_project_cargo_toml(
 	workspace_root_path: &Path,
 	crate_name: &str,
 	crate_path: &Path,
-	wasm_binary: &str,
 	enabled_features: impl Iterator<Item = String>,
 ) {
 	let mut workspace_toml: Table = toml::from_str(
@@ -443,7 +483,7 @@ fn create_project_cargo_toml(
 
 	if target == RuntimeTarget::Wasm {
 		let mut lib = Table::new();
-		lib.insert("name".into(), wasm_binary.into());
+		lib.insert("name".into(), crate_name.replace("-", "_").into());
 		lib.insert("crate-type".into(), vec!["cdylib".to_string()].into());
 		wasm_workspace_toml.insert("lib".into(), lib.into());
 	}
@@ -588,7 +628,6 @@ fn create_project(
 ) -> PathBuf {
 	let crate_name = get_crate_name(project_cargo_toml);
 	let crate_path = project_cargo_toml.parent().expect("Parent path exists; qed");
-	let wasm_binary = get_blob_name(target, project_cargo_toml);
 	let wasm_project_folder = wasm_workspace.join(&crate_name);
 
 	fs::create_dir_all(wasm_project_folder.join("src"))
@@ -610,7 +649,6 @@ fn create_project(
 		workspace_root_path,
 		&crate_name,
 		crate_path,
-		&wasm_binary,
 		enabled_features.into_iter(),
 	);
 
@@ -775,12 +813,15 @@ fn offline_build() -> bool {
 }
 
 /// Build the project and create the bloaty runtime blob.
+///
+/// Returns the path to the generated bloaty runtime blob.
 fn build_bloaty_blob(
 	target: RuntimeTarget,
 	blob_build_profile: &Profile,
 	project: &Path,
 	default_rustflags: &str,
 	cargo_cmd: CargoCommandVersioned,
+	#[cfg(feature = "metadata-hash")] metadata_hash: Option<[u8; 32]>,
 ) -> PathBuf {
 	let manifest_path = project.join("Cargo.toml");
 	let mut build_cmd = cargo_cmd.command();
@@ -819,6 +860,11 @@ fn build_bloaty_blob(
 		.env_remove("RUSTC")
 		// We don't want to call ourselves recursively
 		.env(crate::SKIP_BUILD_ENV, "");
+
+	#[cfg(feature = "metadata-hash")]
+	if let Some(hash) = metadata_hash {
+		build_cmd.env("RUNTIME_METADATA_HASH", array_bytes::bytes2hex("0x", &hash));
+	}
 
 	if super::color_output_enabled() {
 		build_cmd.arg("--color=always");
@@ -908,23 +954,16 @@ fn build_bloaty_blob(
 
 fn compact_wasm(
 	project: &Path,
-	inner_profile: &Profile,
-	cargo_manifest: &Path,
-	out_name: &str,
+	blob_name: &str,
+	bloaty_binary: &WasmBinaryBloaty,
 ) -> Option<WasmBinary> {
-	let default_out_name = get_blob_name(RuntimeTarget::Wasm, cargo_manifest);
-	let in_path = project
-		.join("target/wasm32-unknown-unknown")
-		.join(inner_profile.directory())
-		.join(format!("{}.wasm", default_out_name));
-
-	let wasm_compact_path = project.join(format!("{}.compact.wasm", out_name));
+	let wasm_compact_path = project.join(format!("{blob_name}.compact.wasm"));
 	let start = std::time::Instant::now();
 	wasm_opt::OptimizationOptions::new_opt_level_0()
 		.mvp_features_only()
 		.debug_info(true)
 		.add_pass(wasm_opt::Pass::StripDwarf)
-		.run(&in_path, &wasm_compact_path)
+		.run(bloaty_binary.bloaty_path(), &wasm_compact_path)
 		.expect("Failed to compact generated WASM binary.");
 	println!(
 		"{} {}",
@@ -932,22 +971,6 @@ fn compact_wasm(
 		colorize_info_message(format!("{:?}", start.elapsed()).as_str())
 	);
 	Some(WasmBinary(wasm_compact_path))
-}
-
-fn copy_bloaty_blob(
-	project: &Path,
-	inner_profile: &Profile,
-	in_name: &str,
-	out_name: &str,
-) -> WasmBinaryBloaty {
-	let in_path = project
-		.join("target/wasm32-unknown-unknown")
-		.join(inner_profile.directory())
-		.join(format!("{}.wasm", in_name));
-
-	let bloaty_path = project.join(format!("{}.wasm", out_name));
-	fs::copy(in_path, &bloaty_path).expect("Copying the bloaty file to the project dir.");
-	WasmBinaryBloaty(bloaty_path)
 }
 
 fn try_compress_blob(compact_blob_path: &Path, out_name: &str) -> Option<WasmBinary> {

--- a/templates/parachain/runtime/Cargo.toml
+++ b/templates/parachain/runtime/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
 substrate-wasm-builder = { path = "../../../substrate/utils/wasm-builder", optional = true }
+docify = "0.2.8"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
@@ -36,6 +37,7 @@ pallet-parachain-template = { path = "../pallets/template", default-features = f
 # Substrate / FRAME
 frame-benchmarking = { path = "../../../substrate/frame/benchmarking", default-features = false, optional = true }
 frame-executive = { path = "../../../substrate/frame/executive", default-features = false }
+frame-metadata-hash-extension = { path = "../../../substrate/frame/metadata-hash-extension", default-features = false }
 frame-support = { path = "../../../substrate/frame/support", default-features = false }
 frame-system = { path = "../../../substrate/frame/system", default-features = false }
 frame-system-benchmarking = { path = "../../../substrate/frame/system/benchmarking", default-features = false, optional = true }
@@ -106,6 +108,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -197,3 +200,16 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+# Enable the metadata hash generation.
+#
+# This is hidden behind a feature because it increases the compile time.
+# The wasm binary needs to be compiled twice, once to fetch the metadata,
+# generate the metadata hash and then a second time with the
+# `RUNTIME_METADATA_HASH` environment variable set for the `CheckMetadataHash`
+# extension.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
+# A convenience feature for enabling things when doing a build
+# for an on-chain release.
+on-chain-release-build = ["metadata-hash"]

--- a/templates/parachain/runtime/build.rs
+++ b/templates/parachain/runtime/build.rs
@@ -1,4 +1,12 @@
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+#[docify::export(template_enable_metadata_hash)]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("UNIT", 12)
+		.build();
+}
+
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::build_using_defaults();
 }

--- a/templates/parachain/runtime/src/lib.rs
+++ b/templates/parachain/runtime/src/lib.rs
@@ -86,6 +86,7 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	cumulus_primitives_storage_weight_reclaim::StorageWeightReclaim<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
This implements the `CheckMetadataHash` extension as described in [RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html).

Besides the signed extension, the `substrate-wasm-builder` is extended to support generating the metadata-hash.

Closes: https://github.com/paritytech/polkadot-sdk/issues/291

---------