### PR TITLE
Fix broken windows build

### DIFF
--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -57,7 +57,7 @@ type UncheckedSignaturePayload<Address, Signature, Extra> = (Address, Signature,
 /// could in principle be any other interaction. Transactions are either signed or unsigned. A
 /// sensible transaction pool should ensure that only transactions that are worthwhile are
 /// considered for block-building.
-#[cfg_attr(feature = "std", doc = simple_mermaid::mermaid!("../../docs/mermaid/extrinsics.mmd"))]
+#[cfg_attr(all(feature = "std", not(windows)), doc = simple_mermaid::mermaid!("../../docs/mermaid/extrinsics.mmd"))]
 /// This type is by no means enforced within Substrate, but given its genericness, it is highly
 /// likely that for most use-cases it will suffice. Thus, the encoding of this type will dictate
 /// exactly what bytes should be sent to a runtime to transact with it.


### PR DESCRIPTION
Fixes #4625.

Specifically, the `cfg` attribute `windows` refers to the compile target and not the build environment, and in the case of cross-compilation, the build environment and target can differ. However, the line modified is related to documentation generation, so there should be no critical issue with this change.