### PR TITLE
[ci] Increase timeout for check-runtime-migration workflow

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -34,7 +34,7 @@ jobs:
   # rococo and westend are disabled for now (no access to parity-chains.parity.io)
   check-runtime-migration:
     runs-on: arc-runners-polkadot-sdk-beefy
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [set-image]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}


### PR DESCRIPTION
`[check-runtime-migration` now takes more than 30 minutes. Quick fix with increased timeout.