### PR TITLE
Removes production configs for `derive_impl` and updates system config

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -53,7 +53,7 @@ use sp_version::RuntimeVersion;
 use codec::{Decode, Encode, MaxEncodedLen};
 use cumulus_primitives_core::ParaId;
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	ord_parameter_types, parameter_types,
@@ -157,7 +157,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
@@ -173,6 +172,21 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -35,7 +35,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	ord_parameter_types, parameter_types,
@@ -159,7 +159,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
@@ -175,6 +174,21 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -65,7 +65,7 @@ use sp_version::RuntimeVersion;
 
 use cumulus_primitives_core::ParaId;
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -249,8 +249,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
@@ -279,6 +277,21 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -59,7 +59,7 @@ use bridge_hub_common::{
 	AggregateMessageOrigin,
 };
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -223,8 +223,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
@@ -253,6 +251,21 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -65,7 +65,7 @@ use sp_version::RuntimeVersion;
 use codec::{Decode, Encode, MaxEncodedLen};
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -162,7 +162,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
@@ -179,6 +178,20 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<0>;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -46,7 +46,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -175,7 +175,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
@@ -191,6 +190,21 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<42>;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -36,7 +36,7 @@ pub mod xcm_config;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -177,7 +177,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
@@ -205,6 +204,21 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -36,7 +36,7 @@ pub mod xcm_config;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -176,7 +176,6 @@ parameter_types! {
 }
 
 // Configure FRAME pallets to include in runtime.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
@@ -204,6 +203,21 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -64,7 +64,7 @@ use sp_version::RuntimeVersion;
 
 use cumulus_primitives_core::AggregateMessageOrigin;
 pub use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -146,7 +146,6 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type AccountId = AccountId;
 	type Nonce = Nonce;
@@ -159,6 +158,24 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = frame_support::traits::Everything;
+	type DbWeight = ();
+	type AccountData = frame_system::AccountInfo<Self::Nonce, ()>;
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -25,7 +25,7 @@ pub mod xcm_config;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -166,7 +166,6 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BaseCallFilter = Everything;
 	type BlockWeights = RuntimeBlockWeights;
@@ -183,6 +182,20 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -25,7 +25,7 @@ pub mod xcm_config;
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{
-	construct_runtime, derive_impl,
+	construct_runtime,
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
@@ -166,7 +166,6 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BaseCallFilter = Everything;
 	type BlockWeights = RuntimeBlockWeights;
@@ -183,6 +182,20 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = ConstU32<16>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeTask = RuntimeTask;
+	type PalletInfo = PalletInfo;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -184,7 +184,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -298,7 +298,7 @@ impl pallet_safe_mode::Config for Runtime {
 	type WeightInfo = pallet_safe_mode::weights::SubstrateWeight<Runtime>;
 }
 
-#[derive_impl(frame_system::config_preludes::SolochainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BaseCallFilter = InsideBoth<SafeMode, TxPause>;
 	type BlockWeights = RuntimeBlockWeights;

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -262,7 +262,7 @@ pub mod pallet {
 	/// Default implementations of [`DefaultConfig`], which can be used to implement [`Config`].
 	pub mod config_preludes {
 		use super::{inject_runtime_type, DefaultConfig};
-		use frame_support::{derive_impl, traits::Get};
+		use frame_support::traits::Get;
 
 		/// A predefined adapter that covers `BlockNumberFor<T>` for `Config::Block::BlockNumber` of
 		/// the types `u32`, `u64`, and `u128`.
@@ -290,7 +290,7 @@ pub mod pallet {
 			type Hash = sp_core::hash::H256;
 			type Hashing = sp_runtime::traits::BlakeTwo256;
 			type AccountId = u64;
-			type Lookup = sp_runtime::traits::IdentityLookup<u64>;
+			type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
 			type MaxConsumers = frame_support::traits::ConstU32<16>;
 			type AccountData = ();
 			type OnNewAccount = ();
@@ -320,121 +320,6 @@ pub mod pallet {
 			type PostInherents = ();
 			type PostTransactions = ();
 		}
-
-		/// Default configurations of this pallet in a solochain environment.
-		///
-		/// ## Considerations:
-		///
-		/// By default, this type makes the following choices:
-		///
-		/// * Use a normal 32 byte account id, with a [`DefaultConfig::Lookup`] that implies no
-		///   'account-indexing' pallet is being used.
-		/// * Given that we don't know anything about the existence of a currency system in scope,
-		///   an [`DefaultConfig::AccountData`] is chosen that has no addition data. Overwrite this
-		///   if you use `pallet-balances` or similar.
-		/// * Make sure to overwrite [`DefaultConfig::Version`].
-		/// * 2s block time, and a default 5mb block size is used.
-		pub struct SolochainDefaultConfig;
-
-		#[frame_support::register_default_impl(SolochainDefaultConfig)]
-		impl DefaultConfig for SolochainDefaultConfig {
-			/// The default type for storing how many extrinsics an account has signed.
-			type Nonce = u32;
-
-			/// The default type for hashing blocks and tries.
-			type Hash = sp_core::hash::H256;
-
-			/// The default hashing algorithm used.
-			type Hashing = sp_runtime::traits::BlakeTwo256;
-
-			/// The default identifier used to distinguish between accounts.
-			type AccountId = sp_runtime::AccountId32;
-
-			/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-			type Lookup = sp_runtime::traits::AccountIdLookup<Self::AccountId, ()>;
-
-			/// The maximum number of consumers allowed on a single account. Using 128 as default.
-			type MaxConsumers = frame_support::traits::ConstU32<128>;
-
-			/// The default data to be stored in an account.
-			type AccountData = crate::AccountInfo<Self::Nonce, ()>;
-
-			/// What to do if a new account is created.
-			type OnNewAccount = ();
-
-			/// What to do if an account is fully reaped from the system.
-			type OnKilledAccount = ();
-
-			/// Weight information for the extrinsics of this pallet.
-			type SystemWeightInfo = ();
-
-			/// This is used as an identifier of the chain.
-			type SS58Prefix = ();
-
-			/// Version of the runtime.
-			type Version = ();
-
-			/// Block & extrinsics weights: base values and limits.
-			type BlockWeights = ();
-
-			/// The maximum length of a block (in bytes).
-			type BlockLength = ();
-
-			/// The weight of database operations that the runtime can invoke.
-			type DbWeight = ();
-
-			/// The ubiquitous event type injected by `construct_runtime!`.
-			#[inject_runtime_type]
-			type RuntimeEvent = ();
-
-			/// The ubiquitous origin type injected by `construct_runtime!`.
-			#[inject_runtime_type]
-			type RuntimeOrigin = ();
-
-			/// The aggregated dispatch type available for extrinsics, injected by
-			/// `construct_runtime!`.
-			#[inject_runtime_type]
-			type RuntimeCall = ();
-
-			/// The aggregated Task type, injected by `construct_runtime!`.
-			#[inject_runtime_type]
-			type RuntimeTask = ();
-
-			/// Converts a module to the index of the module, injected by `construct_runtime!`.
-			#[inject_runtime_type]
-			type PalletInfo = ();
-
-			/// The basic call filter to use in dispatchable. Supports everything as the default.
-			type BaseCallFilter = frame_support::traits::Everything;
-
-			/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
-			/// Using 256 as default.
-			type BlockHashCount = TestBlockHashCount<frame_support::traits::ConstU32<256>>;
-
-			/// The set code logic, just the default since we're not a parachain.
-			type OnSetCode = ();
-			type SingleBlockMigrations = ();
-			type MultiBlockMigrator = ();
-			type PreInherents = ();
-			type PostInherents = ();
-			type PostTransactions = ();
-		}
-
-		/// Default configurations of this pallet in a relay-chain environment.
-		pub struct RelayChainDefaultConfig;
-
-		/// It currently uses the same configuration as `SolochainDefaultConfig`.
-		#[derive_impl(SolochainDefaultConfig as DefaultConfig, no_aggregated_types)]
-		#[frame_support::register_default_impl(RelayChainDefaultConfig)]
-		impl DefaultConfig for RelayChainDefaultConfig {}
-
-		/// Default configurations of this pallet in a parachain environment.
-		pub struct ParaChainDefaultConfig;
-
-		/// It currently uses the same configuration as `SolochainDefaultConfig`.
-		#[derive_impl(SolochainDefaultConfig as DefaultConfig, no_aggregated_types)]
-		#[frame_support::register_default_impl(ParaChainDefaultConfig)]
-		impl DefaultConfig for ParaChainDefaultConfig {}
 	}
 
 	/// System configuration trait. Implemented by runtime.

--- a/templates/minimal/runtime/src/lib.rs
+++ b/templates/minimal/runtime/src/lib.rs
@@ -127,7 +127,7 @@ parameter_types! {
 }
 
 /// Implements the types required for the system pallet.
-#[derive_impl(frame_system::config_preludes::SolochainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type Block = Block;
 	type Version = Version;

--- a/templates/parachain/runtime/src/configs/mod.rs
+++ b/templates/parachain/runtime/src/configs/mod.rs
@@ -92,9 +92,9 @@ parameter_types! {
 }
 
 /// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
-/// [`ParaChainDefaultConfig`](`struct@frame_system::config_preludes::ParaChainDefaultConfig`),
+/// [`TestDefaultConfig`](`struct@frame_system::config_preludes::TestDefaultConfig`),
 /// but overridden as needed.
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;

--- a/templates/solochain/runtime/src/lib.rs
+++ b/templates/solochain/runtime/src/lib.rs
@@ -146,9 +146,9 @@ parameter_types! {
 }
 
 /// The default types are being injected by [`derive_impl`](`frame_support::derive_impl`) from
-/// [`SoloChainDefaultConfig`](`struct@frame_system::config_preludes::SolochainDefaultConfig`),
+/// [`TestDefaultConfig`](`struct@frame_system::config_preludes::TestDefaultConfig`),
 /// but overridden as needed.
-#[derive_impl(frame_system::config_preludes::SolochainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The block type for the runtime.
 	type Block = Block;


### PR DESCRIPTION
This PR adds the following changes:
1. As discussed in the [forum post](https://forum.polkadot.network/t/seeking-feedback-on-derive-impl-for-default-configurations-in-pallet-templates/7584), this PR removes the usage of `derive_impl` from production runtimes. Consequently, it removes `SolochainDefaultConfig`, `ParachainDefaultConfig` and `RelaychainDefaultConfig`. `TestDefaultConfig` would continue to be used in test runtimes and templates.
2. As @seadanda suggested [here](https://github.com/paritytech/polkadot-sdk/pull/4642#discussion_r1620258444), this PR updates the default for `Lookup` to `sp_runtime::traits::IdentityLookup<Self::AccountId>` to avoid the need to override in most cases.