### PR TITLE
Remove unncessary call remove_from_peers_set

### DIFF
--- a/polkadot/node/network/bridge/src/validator_discovery.rs
+++ b/polkadot/node/network/bridge/src/validator_discovery.rs
@@ -88,16 +88,6 @@ impl<N: Network, AD: AuthorityDiscovery> Service<N, AD> {
 		{
 			gum::warn!(target: LOG_TARGET, err = ?e, "AuthorityDiscoveryService returned an invalid multiaddress");
 		}
-		// the addresses are known to be valid
-		//
-		// for peer-set management, the main protocol name should be used regardless of
-		// the negotiated version.
-		let _ = network_service
-			.remove_from_peers_set(
-				self.peerset_protocol_names.get_main_name(peer_set),
-				peers_to_remove,
-			)
-			.await;
 
 		network_service
 	}


### PR DESCRIPTION
... this is superfluous because set_reserved_peers implementation already calls this method here:
https://github.com/paritytech/polkadot-sdk/blob/cdb297b15ad9c1d952c0501afaf6b764e5fd147c/substrate/client/network/src/protocol_controller.rs#L571, so the call just ends producing this warnings whenever we manipulate the peers set.

```
Trying to remove unknown reserved node 12D3KooWRCePWvHoBbz9PSkw4aogtdVqkVDhiwpcHZCqh4hdPTXC from SetId(3)
peerset warnings (from different peers)
```