### PR TITLE
Send PeerViewChange with high priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,12 +5434,14 @@ dependencies = [
 
 [[package]]
 name = "expander"
-version = "2.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
+checksum = "e2c470c71d91ecbd179935b24170459e926382eaaa86b590b78814e180d8a8e2"
 dependencies = [
  "blake2 0.10.6",
+ "file-guard",
  "fs-err",
+ "prettyplease 0.2.12",
  "proc-macro2 1.0.82",
  "quote 1.0.35",
  "syn 2.0.61",
@@ -5571,6 +5573,16 @@ name = "fiat-crypto"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+
+[[package]]
+name = "file-guard"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ef72acf95ec3d7dbf61275be556299490a245f017cf084bd23b4f68cf9407c"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "file-per-thread-logger"
@@ -9621,9 +9633,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestra"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92829eef0328a3d1cd22a02c0e51deb92a5362df3e7d21a4e9bdc38934694e66"
+checksum = "41f6bbacc8c189a3f2e45e0fd0436e5d97f194db888e721bdbc3973e7dbed4c2"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -9638,9 +9650,9 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1344346d5af32c95bbddea91b18a88cc83eac394192d20ef2fc4c40a74332355"
+checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
  "indexmap 2.2.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -855,7 +855,7 @@ num-rational = { version = "0.4.1" }
 num-traits = { version = "0.2.17", default-features = false }
 num_cpus = { version = "1.13.1" }
 once_cell = { version = "1.19.0" }
-orchestra = { version = "0.3.5", default-features = false }
+orchestra = { version = "0.4.0", default-features = false }
 pallet-alliance = { path = "substrate/frame/alliance", default-features = false }
 pallet-asset-conversion = { path = "substrate/frame/asset-conversion", default-features = false }
 pallet-asset-conversion-ops = { path = "substrate/frame/asset-conversion/ops", default-features = false }

--- a/polkadot/node/malus/src/interceptor.rs
+++ b/polkadot/node/malus/src/interceptor.rs
@@ -90,6 +90,10 @@ where
 	<OutgoingMessage as TryFrom<overseer::AllMessages>>::Error: std::fmt::Debug,
 {
 	async fn send_message(&mut self, msg: OutgoingMessage) {
+		self.send_message_with_priority::<overseer::NormalPriority>(msg).await;
+	}
+
+	async fn send_message_with_priority<P: Priority>(&mut self, msg: OutgoingMessage) {
 		let msg = <
 					<<Fil as MessageInterceptor<Sender>>::Message as overseer::AssociateOutgoing
 				>::OutgoingMessages as From<OutgoingMessage>>::from(msg);
@@ -103,7 +107,14 @@ where
 		}
 	}
 
-	fn try_send_message(&mut self, msg: OutgoingMessage) -> Result<(), TrySendError<OutgoingMessage>> {
+	fn try_send_message(
+		&mut self,
+		msg: OutgoingMessage,
+	) -> Result<(), polkadot_node_subsystem_util::metered::TrySendError<OutgoingMessage>> {
+		self.try_send_message_with_priority::<overseer::NormalPriority>(msg)
+	}
+
+	fn try_send_message_with_priority<P: Priority>(&mut self, msg: OutgoingMessage) -> Result<(), TrySendError<OutgoingMessage>> {
 		let msg = <
 				<<Fil as MessageInterceptor<Sender>>::Message as overseer::AssociateOutgoing
 			>::OutgoingMessages as From<OutgoingMessage>>::from(msg);

--- a/polkadot/node/network/availability-distribution/src/tests/state.rs
+++ b/polkadot/node/network/availability-distribution/src/tests/state.rs
@@ -216,7 +216,7 @@ impl TestState {
 		// Test will fail if this does not happen until timeout.
 		let mut remaining_stores = self.valid_chunks.len();
 
-		let TestSubsystemContextHandle { tx, mut rx } = harness.virtual_overseer;
+		let TestSubsystemContextHandle { tx, mut rx, .. } = harness.virtual_overseer;
 
 		// Spawning necessary as incoming queue can only hold a single item, we don't want to dead
 		// lock ;-)

--- a/polkadot/node/network/bridge/src/rx/mod.rs
+++ b/polkadot/node/network/bridge/src/rx/mod.rs
@@ -1140,7 +1140,12 @@ async fn dispatch_validation_events_to_all<I>(
 			if let Ok(event) = $event.focus() {
 				let has_high_priority = matches!(
 					event,
-					NetworkBridgeEvent::PeerConnected(..) | NetworkBridgeEvent::PeerViewChange(..)
+					// NetworkBridgeEvent::OurViewChange(..) must also be here,
+					// but it is sent via an unbounded channel.
+					// See https://github.com/paritytech/polkadot-sdk/issues/824
+					NetworkBridgeEvent::PeerConnected(..) |
+						NetworkBridgeEvent::PeerDisconnected(..) |
+						NetworkBridgeEvent::PeerViewChange(..)
 				);
 				let message = $message::from(event);
 				if has_high_priority {

--- a/polkadot/node/network/bridge/src/rx/mod.rs
+++ b/polkadot/node/network/bridge/src/rx/mod.rs
@@ -1138,7 +1138,10 @@ async fn dispatch_validation_events_to_all<I>(
 	macro_rules! send_message {
 		($event:expr, $message:ident) => {
 			if let Ok(event) = $event.focus() {
-				let has_high_priority = matches!(event, NetworkBridgeEvent::PeerViewChange(..));
+				let has_high_priority = matches!(
+					event,
+					NetworkBridgeEvent::PeerConnected(..) | NetworkBridgeEvent::PeerViewChange(..)
+				);
 				let message = $message::from(event);
 				if has_high_priority {
 					sender.send_message_with_priority::<overseer::HighPriority>(message).await;

--- a/polkadot/node/network/bridge/src/rx/mod.rs
+++ b/polkadot/node/network/bridge/src/rx/mod.rs
@@ -1135,13 +1135,25 @@ async fn dispatch_validation_events_to_all<I>(
 	I: IntoIterator<Item = NetworkBridgeEvent<net_protocol::VersionedValidationProtocol>>,
 	I::IntoIter: Send,
 {
+	macro_rules! send_message {
+		($event:expr, $message:ident) => {
+			if let Ok(event) = $event.focus() {
+				let has_high_priority = matches!(event, NetworkBridgeEvent::PeerViewChange(..));
+				let message = $message::from(event);
+				if has_high_priority {
+					sender.send_message_with_priority::<overseer::HighPriority>(message).await;
+				} else {
+					sender.send_message(message).await;
+				}
+			}
+		};
+	}
+
 	for event in events {
-		sender
-			.send_messages(event.focus().map(StatementDistributionMessage::from))
-			.await;
-		sender.send_messages(event.focus().map(BitfieldDistributionMessage::from)).await;
-		sender.send_messages(event.focus().map(ApprovalDistributionMessage::from)).await;
-		sender.send_messages(event.focus().map(GossipSupportMessage::from)).await;
+		send_message!(event, StatementDistributionMessage);
+		send_message!(event, BitfieldDistributionMessage);
+		send_message!(event, ApprovalDistributionMessage);
+		send_message!(event, GossipSupportMessage);
 	}
 }
 

--- a/polkadot/node/network/bridge/src/rx/tests.rs
+++ b/polkadot/node/network/bridge/src/rx/tests.rs
@@ -545,7 +545,10 @@ async fn assert_sends_validation_event_to_all(
 	event: NetworkBridgeEvent<net_protocol::VersionedValidationProtocol>,
 	virtual_overseer: &mut TestSubsystemContextHandle<NetworkBridgeRxMessage>,
 ) {
-	let is_peer_view_change = matches!(event, NetworkBridgeEvent::PeerViewChange(..));
+	let is_prioritized = matches!(
+		event,
+		NetworkBridgeEvent::PeerConnected(..) | NetworkBridgeEvent::PeerViewChange(..)
+	);
 
 	// Ordering must be consistent across:
 	// `fn dispatch_validation_event_to_all_unbounded`
@@ -579,10 +582,10 @@ async fn assert_sends_validation_event_to_all(
 	);
 
 	// Peer view changes sent with high priority.
-	if is_peer_view_change {
+	if is_prioritized {
 		assert_eq!(
 			virtual_overseer.message_counter.with_high_priority(),
-			if is_peer_view_change { 4 } else { 0 }
+			if is_prioritized { 4 } else { 0 }
 		);
 		virtual_overseer.message_counter.reset();
 	}

--- a/polkadot/node/network/bridge/src/rx/tests.rs
+++ b/polkadot/node/network/bridge/src/rx/tests.rs
@@ -975,6 +975,7 @@ fn peer_messages_sent_via_overseer() {
 			&mut virtual_overseer,
 		)
 		.await;
+		assert_eq!(virtual_overseer.message_counter.with_high_priority(), 12);
 		virtual_overseer
 	});
 }
@@ -1043,6 +1044,7 @@ fn peer_disconnect_from_just_one_peerset() {
 			&mut virtual_overseer,
 		)
 		.await;
+		assert_eq!(virtual_overseer.message_counter.with_high_priority(), 12);
 
 		// to show that we're still connected on the collation protocol, send a view update.
 

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -496,7 +496,7 @@ pub struct Overseer<SupportsParachains> {
 		RuntimeApiMessage,
 		ProspectiveParachainsMessage,
 		ChainApiMessage,
-	])]
+	], can_receive_priority_messages)]
 	statement_distribution: StatementDistribution,
 
 	#[subsystem(AvailabilityDistributionMessage, sends: [
@@ -525,7 +525,7 @@ pub struct Overseer<SupportsParachains> {
 		RuntimeApiMessage,
 		NetworkBridgeTxMessage,
 		ProvisionerMessage,
-	])]
+	], can_receive_priority_messages)]
 	bitfield_distribution: BitfieldDistribution,
 
 	#[subsystem(ProvisionerMessage, sends: [
@@ -581,7 +581,7 @@ pub struct Overseer<SupportsParachains> {
 	#[subsystem(blocking, message_capacity: 64000, ApprovalDistributionMessage, sends: [
 		NetworkBridgeTxMessage,
 		ApprovalVotingMessage,
-	])]
+	], can_receive_priority_messages)]
 	approval_distribution: ApprovalDistribution,
 
 	#[subsystem(blocking, ApprovalVotingMessage, sends: [
@@ -600,7 +600,7 @@ pub struct Overseer<SupportsParachains> {
 		NetworkBridgeRxMessage, // TODO <https://github.com/paritytech/polkadot/issues/5626>
 		RuntimeApiMessage,
 		ChainSelectionMessage,
-	])]
+	], can_receive_priority_messages)]
 	gossip_support: GossipSupport,
 
 	#[subsystem(blocking, message_capacity: 32000, DisputeCoordinatorMessage, sends: [

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -105,10 +105,11 @@ pub use polkadot_node_metrics::{
 
 pub use orchestra as gen;
 pub use orchestra::{
-	contextbounds, orchestra, subsystem, FromOrchestra, MapSubsystem, MessagePacket,
-	OrchestraError as OverseerError, SignalsReceived, Spawner, Subsystem, SubsystemContext,
-	SubsystemIncomingMessages, SubsystemInstance, SubsystemMeterReadouts, SubsystemMeters,
-	SubsystemSender, TimeoutExt, ToOrchestra, TrySendError,
+	contextbounds, orchestra, subsystem, FromOrchestra, HighPriority, MapSubsystem, MessagePacket,
+	NormalPriority, OrchestraError as OverseerError, Priority, PriorityLevel, SignalsReceived,
+	Spawner, Subsystem, SubsystemContext, SubsystemIncomingMessages, SubsystemInstance,
+	SubsystemMeterReadouts, SubsystemMeters, SubsystemSender, TimeoutExt, ToOrchestra,
+	TrySendError,
 };
 
 #[cfg(any(target_os = "linux", feature = "jemalloc-allocator"))]

--- a/polkadot/node/subsystem-test-helpers/src/lib.rs
+++ b/polkadot/node/subsystem-test-helpers/src/lib.rs
@@ -36,7 +36,7 @@ use std::{
 	convert::Infallible,
 	future::Future,
 	pin::Pin,
-	sync::Arc,
+	sync::{atomic::AtomicUsize, Arc},
 	task::{Context, Poll, Waker},
 	time::Duration,
 };
@@ -146,12 +146,13 @@ pub fn single_item_sink<T>() -> (SingleItemSink<T>, SingleItemStream<T>) {
 #[derive(Clone)]
 pub struct TestSubsystemSender {
 	tx: mpsc::UnboundedSender<AllMessages>,
+	message_counter: MessageCounter,
 }
 
 /// Construct a sender/receiver pair.
 pub fn sender_receiver() -> (TestSubsystemSender, mpsc::UnboundedReceiver<AllMessages>) {
 	let (tx, rx) = mpsc::unbounded();
-	(TestSubsystemSender { tx }, rx)
+	(TestSubsystemSender { tx, message_counter: MessageCounter::default() }, rx)
 }
 
 #[async_trait::async_trait]
@@ -161,6 +162,11 @@ where
 	OutgoingMessage: Send + 'static,
 {
 	async fn send_message(&mut self, msg: OutgoingMessage) {
+		self.send_message_with_priority::<overseer::NormalPriority>(msg).await;
+	}
+
+	async fn send_message_with_priority<P: overseer::Priority>(&mut self, msg: OutgoingMessage) {
+		self.message_counter.increment(P::priority());
 		self.tx.send(msg.into()).await.expect("test overseer no longer live");
 	}
 
@@ -168,6 +174,14 @@ where
 		&mut self,
 		msg: OutgoingMessage,
 	) -> Result<(), TrySendError<OutgoingMessage>> {
+		self.try_send_message_with_priority::<overseer::NormalPriority>(msg)
+	}
+
+	fn try_send_message_with_priority<P: overseer::Priority>(
+		&mut self,
+		msg: OutgoingMessage,
+	) -> Result<(), TrySendError<OutgoingMessage>> {
+		self.message_counter.increment(P::priority());
 		self.tx.unbounded_send(msg.into()).expect("test overseer no longer live");
 		Ok(())
 	}
@@ -277,6 +291,9 @@ pub struct TestSubsystemContextHandle<M> {
 
 	/// Direct access to the receiver.
 	pub rx: mpsc::UnboundedReceiver<AllMessages>,
+
+	/// Message counter over subsystems.
+	pub message_counter: MessageCounter,
 }
 
 impl<M> TestSubsystemContextHandle<M> {
@@ -322,6 +339,34 @@ pub fn make_subsystem_context<M, S>(
 	make_buffered_subsystem_context(spawner, 0)
 }
 
+/// Message counter over subsystems.
+#[derive(Default, Clone)]
+pub struct MessageCounter {
+	total: Arc<AtomicUsize>,
+	with_high_priority: Arc<AtomicUsize>,
+}
+
+impl MessageCounter {
+	/// Increment the message counter.
+	pub fn increment(&mut self, priority_level: overseer::PriorityLevel) {
+		self.total.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+		if matches!(priority_level, overseer::PriorityLevel::High) {
+			self.with_high_priority.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+		}
+	}
+
+	/// Reset the message counter.
+	pub fn reset(&mut self) {
+		self.total.store(0, std::sync::atomic::Ordering::SeqCst);
+		self.with_high_priority.store(0, std::sync::atomic::Ordering::SeqCst);
+	}
+
+	/// Get the messages with high priority count.
+	pub fn with_high_priority(&self) -> usize {
+		self.with_high_priority.load(std::sync::atomic::Ordering::SeqCst)
+	}
+}
+
 /// Make a test subsystem context with buffered overseer channel. Some tests (e.g.
 /// `dispute-coordinator`) create too many parallel operations and deadlock unless
 /// the channel is buffered. Usually `buffer_size=1` is enough.
@@ -331,15 +376,23 @@ pub fn make_buffered_subsystem_context<M, S>(
 ) -> (TestSubsystemContext<M, SpawnGlue<S>>, TestSubsystemContextHandle<M>) {
 	let (overseer_tx, overseer_rx) = mpsc::channel(buffer_size);
 	let (all_messages_tx, all_messages_rx) = mpsc::unbounded();
+	let message_counter = MessageCounter::default();
 
 	(
 		TestSubsystemContext {
-			tx: TestSubsystemSender { tx: all_messages_tx },
+			tx: TestSubsystemSender {
+				tx: all_messages_tx,
+				message_counter: message_counter.clone(),
+			},
 			rx: overseer_rx,
 			spawn: SpawnGlue(spawner),
 			message_buffer: VecDeque::new(),
 		},
-		TestSubsystemContextHandle { tx: overseer_tx, rx: all_messages_rx },
+		TestSubsystemContextHandle {
+			tx: overseer_tx,
+			rx: all_messages_rx,
+			message_counter: message_counter.clone(),
+		},
 	)
 }
 

--- a/prdoc/pr_4755.prdoc
+++ b/prdoc/pr_4755.prdoc
@@ -1,0 +1,24 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Send PeerViewChange with high priority
+
+doc:
+  - audience: Node Operator
+    description: |
+      - orchestra updated to 0.4.0
+      - PeerViewChange sent with high priority and should be processed first in a queue.
+      - To count them in tests added tracker to TestSender and TestOverseer. It acts more like a smoke test though.
+
+
+crates:
+  - name: polkadot-network-bridge
+    bump: minor
+  - name: polkadot-overseer
+    bump: patch
+  - name: polkadot-availability-distribution
+    bump: patch
+  - name: polkadot-test-malus
+    bump: patch
+  - name: polkadot-node-subsystem-test-helpers
+    bump: patch

--- a/prdoc/pr_4755.prdoc
+++ b/prdoc/pr_4755.prdoc
@@ -12,9 +12,9 @@ doc:
 
 
 crates:
-  - name: polkadot-network-bridge
-    bump: minor
   - name: polkadot-overseer
+    bump: minor
+  - name: polkadot-network-bridge
     bump: patch
   - name: polkadot-availability-distribution
     bump: patch

--- a/prdoc/pr_4755.prdoc
+++ b/prdoc/pr_4755.prdoc
@@ -4,9 +4,9 @@
 title: Send PeerViewChange with high priority
 
 doc:
-  - audience: Node Operator
+  - audience: Node Dev
     description: |
-      - orchestra updated to 0.4.0
+      - orchestra updated to 0.4.0, which introduces support for prioritizing system messages.
       - PeerViewChange sent with high priority and should be processed first in a queue.
       - To count them in tests added tracker to TestSender and TestOverseer. It acts more like a smoke test though.
 


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-sdk/issues/577

### Changed
- `orchestra` updated to 0.4.0
- `PeerViewChange` sent with high priority and should be processed first in a queue. 
- To count them in tests added tracker to TestSender and TestOverseer. It acts more like a smoke test though. 

### Testing on Versi

The changes were tested on Versi with two objectives:
1. Make sure the node functionality does not change.
2. See how the changes affect performance.

Test setup:
- 2.5 hours for each case
- 100 validators
- 50 parachains
- validatorsPerCore = 2
- neededApprovals = 100
- nDelayTranches = 89
- relayVrfModuloSamples = 50

During the test period, all nodes ran without any crashes, which satisfies the first objective.

To estimate the change in performance we used ToF charts. The graphs show that there are no spikes in the top as before. This proves that our hypothesis is correct. 

### Normalized charts with ToF
![image](https://github.com/user-attachments/assets/0d49d0db-8302-4a8c-a557-501856805ff5)
[Before](https://grafana.teleport.parity.io/goto/ZoR53ClSg?orgId=1)

![image](https://github.com/user-attachments/assets/9cc73784-7e45-49d9-8212-152373c05880)
[After](https://grafana.teleport.parity.io/goto/6ux5qC_IR?orgId=1)

### Conclusion

The prioritization of subsystem messages reduces the ToF of the networking subsystem, which helps faster propagation of gossip messages.