### PR TITLE
Hide `tuplex` dependency and re-export by macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,6 @@ dependencies = [
  "static_assertions",
  "substrate-wasm-builder",
  "testnet-parachains-constants",
- "tuplex",
  "xcm-fee-payment-runtime-api",
 ]
 
@@ -2261,7 +2260,6 @@ dependencies = [
  "static_assertions",
  "substrate-wasm-builder",
  "testnet-parachains-constants",
- "tuplex",
  "westend-runtime-constants",
  "xcm-fee-payment-runtime-api",
 ]

--- a/bridges/bin/runtime-common/src/extensions/check_obsolete_extension.rs
+++ b/bridges/bin/runtime-common/src/extensions/check_obsolete_extension.rs
@@ -36,6 +36,9 @@ use sp_runtime::{
 	transaction_validity::{TransactionPriority, TransactionValidity, ValidTransactionBuilder},
 };
 
+// Re-export to avoid include tuplex dependency everywhere
+pub use tuplex;
+
 /// A duplication of the `FilterCall` trait.
 ///
 /// We need this trait in order to be able to implement it for the messages pallet,
@@ -313,7 +316,7 @@ macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
 				info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
 				len: usize,
 			) -> Result<Self::Pre, sp_runtime::transaction_validity::TransactionValidityError> {
-				use tuplex::PushBack;
+				use $crate::extensions::check_obsolete_extension::tuplex::PushBack;
 				let to_post_dispatch = ();
 				$(
 					let (from_validate, call_filter_validity) = <
@@ -336,7 +339,7 @@ macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
 				len: usize,
 				result: &sp_runtime::DispatchResult,
 			) -> Result<(), sp_runtime::transaction_validity::TransactionValidityError> {
-				use tuplex::PopFront;
+				use $crate::extensions::check_obsolete_extension::tuplex::PopFront;
 				let Some((relayer, to_post_dispatch)) = to_post_dispatch else { return Ok(()) };
 				let has_failed = result.is_err();
 				$(

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -22,7 +22,6 @@ scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
 ] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
-tuplex = { version = "0.1", default-features = false }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }
@@ -218,7 +217,6 @@ std = [
 	"sp-version/std",
 	"substrate-wasm-builder",
 	"testnet-parachains-constants/std",
-	"tuplex/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm-fee-payment-runtime-api/std",

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
@@ -18,7 +18,6 @@ hex-literal = { version = "0.4.1" }
 log = { workspace = true }
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 serde = { optional = true, features = ["derive"], workspace = true, default-features = true }
-tuplex = { version = "0.1", default-features = false }
 
 # Substrate
 frame-benchmarking = { path = "../../../../../substrate/frame/benchmarking", default-features = false, optional = true }
@@ -182,7 +181,6 @@ std = [
 	"sp-version/std",
 	"substrate-wasm-builder",
 	"testnet-parachains-constants/std",
-	"tuplex/std",
 	"westend-runtime-constants/std",
 	"xcm-builder/std",
 	"xcm-executor/std",


### PR DESCRIPTION
Addressing comment: https://github.com/paritytech/polkadot-sdk/pull/4102/files#r1635502496