### PR TITLE
node-inspect: do not depend on rocksdb

### DIFF
--- a/substrate/bin/node/inspect/Cargo.toml
+++ b/substrate/bin/node/inspect/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 clap = { version = "4.5.3", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.12" }
 thiserror = { workspace = true }
-sc-cli = { path = "../../../client/cli" }
+sc-cli = { path = "../../../client/cli", default-features = false }
 sc-client-api = { path = "../../../client/api" }
 sc-service = { path = "../../../client/service", default-features = false }
 sp-blockchain = { path = "../../../primitives/blockchain" }


### PR DESCRIPTION
The crate `sc-cli` otherwise enables the `rocksdb` feature.