### PR TITLE
Add support of block header pruning.

### DIFF
--- a/polkadot/node/test/service/src/lib.rs
+++ b/polkadot/node/test/service/src/lib.rs
@@ -198,7 +198,7 @@ pub fn node_config(
 		database: DatabaseSource::RocksDb { path: root.join("db"), cache_size: 128 },
 		trie_cache_maximum_size: Some(64 * 1024 * 1024),
 		state_pruning: Default::default(),
-		blocks_pruning: BlocksPruning::KeepFinalized,
+		blocks_pruning: BlocksPruning::KeepFinalized { prune_headers: false },
 		chain_spec: Box::new(spec),
 		wasm_method: WasmExecutionMethod::Compiled {
 			instantiation_strategy: WasmtimeInstantiationStrategy::PoolingCopyOnWrite,

--- a/prdoc/pr_4788.prdoc
+++ b/prdoc/pr_4788.prdoc
@@ -1,0 +1,13 @@
+title: Add block header pruning support.
+
+doc:
+  - audience: Node Dev
+    description: |
+      This PR adds block header pruning support and introduces the related CLI flag - `--prune-block-headers`
+
+crates:
+  - name: polkadot-test-service
+  - name: sc-cli
+  - name: sc-client-db
+  - name: sc-service
+  - name: substrate-test-utils

--- a/substrate/client/cli/src/config.rs
+++ b/substrate/client/cli/src/config.rs
@@ -262,7 +262,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	fn blocks_pruning(&self) -> Result<BlocksPruning> {
 		self.pruning_params()
 			.map(|x| x.blocks_pruning())
-			.unwrap_or_else(|| Ok(BlocksPruning::KeepFinalized))
+			.unwrap_or_else(|| Ok(BlocksPruning::KeepFinalized { prune_headers: false }))
 	}
 
 	/// Get the chain ID (string).

--- a/substrate/client/db/src/utils.rs
+++ b/substrate/client/db/src/utils.rs
@@ -23,7 +23,7 @@ use std::{fmt, fs, io, path::Path, sync::Arc};
 
 use log::{debug, info};
 
-use crate::{Database, DatabaseSource, DbHash};
+use crate::{columns, Database, DatabaseSource, DbHash};
 use codec::Decode;
 use sp_database::Transaction;
 use sp_runtime::{
@@ -463,6 +463,15 @@ pub fn read_header<Block: BlockT>(
 		},
 		None => Ok(None),
 	}
+}
+
+/// Drop a header from the database.
+pub fn remove_header<Block: BlockT>(
+	transaction: &mut Transaction<DbHash>,
+	db: &dyn Database<DbHash>,
+	id: BlockId<Block>,
+) -> sp_blockchain::Result<()> {
+	remove_from_db(transaction, db, columns::KEY_LOOKUP, columns::HEADER, id)
 }
 
 /// Read meta from the database.

--- a/substrate/client/service/test/src/lib.rs
+++ b/substrate/client/service/test/src/lib.rs
@@ -233,7 +233,7 @@ fn node_config<E: ChainSpecExtension + Clone + 'static + Send + Sync>(
 		database: DatabaseSource::RocksDb { path: root.join("db"), cache_size: 128 },
 		trie_cache_maximum_size: Some(16 * 1024 * 1024),
 		state_pruning: Default::default(),
-		blocks_pruning: BlocksPruning::KeepFinalized,
+		blocks_pruning: BlocksPruning::KeepFinalized { prune_headers: false },
 		chain_spec: Box::new((*spec).clone()),
 		wasm_method: Default::default(),
 		wasm_runtime_overrides: Default::default(),

--- a/substrate/test-utils/client/src/lib.rs
+++ b/substrate/test-utils/client/src/lib.rs
@@ -101,8 +101,10 @@ impl<Block: BlockT, ExecutorDispatch, G: GenesisInit>
 
 	/// Create new `TestClientBuilder` with default backend and storage chain mode
 	pub fn with_tx_storage(blocks_pruning: u32) -> Self {
-		let backend =
-			Arc::new(Backend::new_test_with_tx_storage(BlocksPruning::Some(blocks_pruning), 0));
+		let backend = Arc::new(Backend::new_test_with_tx_storage(
+			BlocksPruning::Some { blocks: blocks_pruning, prune_headers: false },
+			0,
+		));
 		Self::with_backend(backend)
 	}
 }


### PR DESCRIPTION
This PR follows https://github.com/paritytech/polkadot-sdk/pull/3962 and relates to https://github.com/paritytech/polkadot-sdk/issues/1570

The PR introduces `--prune-block-headers` flag to CLI that enables block header pruning along with block prunings when conditions (pruning mode, block finalization, etc) are met. The rationale behind the change is to reduce DB size by removing unnecessary data from the disk.

The flag goes to `prune_blocks` and `prune_displaced_branches` methods of the `sc-client-db` crate and enables the gathering of the affected hashes to prune, the hash collection is iterated with block header pruning (both from DB and metadata cache) in `try_commit_operation` as one of the final steps before the transaction commits. The initial implementation was simpler and pruned the block headers together with block pruning, however, `try_commit_operation` refreshes the cache after the block header pruning and before the transaction commit and thus keeps the block header in memory. 

Tests cover regular block header pruning and block header pruning on forks and reorgs.