### PR TITLE
Make `--state-version` in storage benchmark command self-descriptive

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/src/storage/cmd.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/storage/cmd.rs
@@ -55,6 +55,13 @@ pub struct StorageCmd {
 	pub params: StorageParams,
 }
 
+#[derive(clap::ValueEnum, Clone, Default, Debug, Serialize, PartialEq)]
+enum StateVersionFlag {
+	#[default]
+	V0,
+	V1,
+}
+
 /// Parameters for modifying the benchmark behaviour and the post processing of the results.
 #[derive(Debug, Default, Serialize, Clone, PartialEq, Args)]
 pub struct StorageParams {
@@ -96,10 +103,12 @@ pub struct StorageParams {
 	#[arg(long, default_value_t = 1)]
 	pub warmups: u32,
 
-	/// The `StateVersion` to use. Substrate `--dev` should use `V1` and Polkadot `V0`.
+	/// The `StateVersion` to use.
+	///
+	/// Substrate `--dev` should use `v1` and Polkadot `v0`.
 	/// Selecting the wrong version can corrupt the DB.
-	#[arg(long, value_parser = clap::value_parser!(u8).range(0..=1))]
-	pub state_version: u8,
+	#[arg(long, value_enum)]
+	pub state_version: StateVersionFlag,
 
 	/// Trie cache size in bytes.
 	///
@@ -166,9 +175,8 @@ impl StorageCmd {
 	/// Returns the specified state version.
 	pub(crate) fn state_version(&self) -> StateVersion {
 		match self.params.state_version {
-			0 => StateVersion::V0,
-			1 => StateVersion::V1,
-			_ => unreachable!("Clap set to only allow 0 and 1"),
+			StateVersionFlag::V0 => StateVersion::V0,
+			StateVersionFlag::V1 => StateVersion::V1,
 		}
 	}
 


### PR DESCRIPTION
> Substrate `--dev` should use `V1` and Polkadot `V0`. Selecting the wrong version can corrupt the DB.

Given the help message above, I thought I should use `--state-version V0` but it turned out `--state-version 0` was expected, which is misleading. This commit fixes it by adding an enum for specifying the StateVersion, making the rendered help message accurate and self-descriptive.

```
      --state-version <STATE_VERSION>
          The `StateVersion` to use.

          Substrate `--dev` should use `v1` and Polkadot `v0`. Selecting the wrong version can corrupt the DB.

          [possible values: v0, v1]
```