### PR TITLE
sc-network-types: implement `From<IpAddr> for Multiaddr`

### DIFF
--- a/substrate/client/network/types/src/multiaddr.rs
+++ b/substrate/client/network/types/src/multiaddr.rs
@@ -22,6 +22,7 @@ use litep2p::types::multiaddr::{
 };
 use std::{
 	fmt::{self, Debug, Display},
+	net::{IpAddr, Ipv4Addr, Ipv6Addr},
 	str::FromStr,
 };
 
@@ -99,6 +100,27 @@ impl From<LiteP2pMultiaddr> for Multiaddr {
 impl From<Multiaddr> for LiteP2pMultiaddr {
 	fn from(multiaddr: Multiaddr) -> Self {
 		multiaddr.multiaddr
+	}
+}
+
+impl From<IpAddr> for Multiaddr {
+	fn from(v: IpAddr) -> Multiaddr {
+		match v {
+			IpAddr::V4(a) => a.into(),
+			IpAddr::V6(a) => a.into(),
+		}
+	}
+}
+
+impl From<Ipv4Addr> for Multiaddr {
+	fn from(v: Ipv4Addr) -> Multiaddr {
+		Protocol::Ip4(v).into()
+	}
+}
+
+impl From<Ipv6Addr> for Multiaddr {
+	fn from(v: Ipv6Addr) -> Multiaddr {
+		Protocol::Ip6(v).into()
 	}
 }
 

--- a/substrate/client/network/types/src/multiaddr/protocol.rs
+++ b/substrate/client/network/types/src/multiaddr/protocol.rs
@@ -20,7 +20,7 @@ use crate::multihash::Multihash;
 use litep2p::types::multiaddr::Protocol as LiteP2pProtocol;
 use std::{
 	borrow::Cow,
-	net::{Ipv4Addr, Ipv6Addr},
+	net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
 /// [`Protocol`] describes all possible multiaddress protocols.
@@ -58,6 +58,30 @@ pub enum Protocol<'a> {
 	Utp,
 	Ws(Cow<'a, str>),
 	Wss(Cow<'a, str>),
+}
+
+impl<'a> From<IpAddr> for Protocol<'a> {
+	#[inline]
+	fn from(addr: IpAddr) -> Self {
+		match addr {
+			IpAddr::V4(addr) => Protocol::Ip4(addr),
+			IpAddr::V6(addr) => Protocol::Ip6(addr),
+		}
+	}
+}
+
+impl<'a> From<Ipv4Addr> for Protocol<'a> {
+	#[inline]
+	fn from(addr: Ipv4Addr) -> Self {
+		Protocol::Ip4(addr)
+	}
+}
+
+impl<'a> From<Ipv6Addr> for Protocol<'a> {
+	#[inline]
+	fn from(addr: Ipv6Addr) -> Self {
+		Protocol::Ip6(addr)
+	}
 }
 
 impl<'a> From<LiteP2pProtocol<'a>> for Protocol<'a> {


### PR DESCRIPTION
Add `From` implementation used by downstream project.

Ref. https://github.com/paritytech/polkadot-sdk/pull/4198#discussion_r1648676102

CC @nazar-pc 