### PR TITLE
bridge tests: send bridged assets from random parachain to bridged asset hub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,6 +2077,7 @@ dependencies = [
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
+ "penpal-runtime",
  "rococo-system-emulated-network",
  "rococo-westend-system-emulated-network",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,6 @@ name = "asset-hub-rococo-integration-tests"
 version = "1.0.0"
 dependencies = [
  "assert_matches",
- "asset-hub-rococo-runtime",
  "asset-test-utils",
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
@@ -819,9 +818,7 @@ dependencies = [
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "penpal-runtime",
  "polkadot-runtime-common",
- "rococo-runtime",
  "rococo-runtime-constants",
  "rococo-system-emulated-network",
  "sp-runtime",
@@ -933,7 +930,6 @@ name = "asset-hub-westend-integration-tests"
 version = "1.0.0"
 dependencies = [
  "assert_matches",
- "asset-hub-westend-runtime",
  "asset-test-utils",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -951,14 +947,12 @@ dependencies = [
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "penpal-runtime",
  "polkadot-runtime-common",
  "sp-core",
  "sp-keyring",
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-executor",
- "westend-runtime",
  "westend-system-emulated-network",
  "xcm-runtime-apis",
 ]
@@ -2063,8 +2057,6 @@ dependencies = [
 name = "bridge-hub-rococo-integration-tests"
 version = "1.0.0"
 dependencies = [
- "asset-hub-rococo-runtime",
- "bridge-hub-rococo-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
  "frame-support",
@@ -2077,7 +2069,6 @@ dependencies = [
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
- "penpal-runtime",
  "rococo-system-emulated-network",
  "rococo-westend-system-emulated-network",
  "scale-info",
@@ -2249,7 +2240,6 @@ dependencies = [
 name = "bridge-hub-westend-integration-tests"
 version = "1.0.0"
 dependencies = [
- "bridge-hub-westend-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
  "frame-support",
@@ -2894,8 +2884,6 @@ name = "collectives-westend-integration-tests"
 version = "1.0.0"
 dependencies = [
  "assert_matches",
- "asset-hub-westend-runtime",
- "collectives-westend-runtime",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
@@ -2914,7 +2902,6 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-executor",
  "testnet-parachains-constants",
- "westend-runtime",
  "westend-runtime-constants",
  "westend-system-emulated-network",
 ]
@@ -12572,9 +12559,7 @@ dependencies = [
  "pallet-message-queue",
  "parachains-common",
  "parity-scale-codec",
- "people-rococo-runtime",
  "polkadot-runtime-common",
- "rococo-runtime",
  "rococo-runtime-constants",
  "rococo-system-emulated-network",
  "sp-runtime",
@@ -12673,12 +12658,10 @@ dependencies = [
  "pallet-message-queue",
  "parachains-common",
  "parity-scale-codec",
- "people-westend-runtime",
  "polkadot-runtime-common",
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-executor",
- "westend-runtime",
  "westend-runtime-constants",
  "westend-system-emulated-network",
 ]

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use asset_hub_rococo_runtime;
+
 pub mod genesis;
 
 // Substrate

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use asset_hub_westend_runtime;
+
 pub mod genesis;
 
 // Substrate

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo/src/lib.rs
@@ -15,6 +15,11 @@
 
 pub mod genesis;
 
+pub use bridge_hub_rococo_runtime::{
+	xcm_config::XcmConfig as BridgeHubRococoXcmConfig, EthereumBeaconClient, EthereumInboundQueue,
+	RuntimeOrigin as BridgeHubRococoRuntimeOrigin,
+};
+
 // Substrate
 use frame_support::traits::OnInitialize;
 

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-westend/src/lib.rs
@@ -15,6 +15,8 @@
 
 pub mod genesis;
 
+pub use bridge_hub_westend_runtime::xcm_config::XcmConfig as BridgeHubWestendXcmConfig;
+
 // Substrate
 use frame_support::traits::OnInitialize;
 

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/collectives/collectives-westend/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use collectives_westend_runtime;
+
 pub mod genesis;
 
 // Substrate

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/people/people-rococo/src/lib.rs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+pub use people_rococo_runtime;
 
 pub mod genesis;
 

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/people/people-westend/src/lib.rs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+pub use people_westend_runtime;
 
 pub mod genesis;
 

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use penpal_runtime::{self, xcm_config::RelayNetworkId as PenpalRelayNetworkId};
+
 mod genesis;
 pub use genesis::{genesis, PenpalAssetOwner, PenpalSudoAccount, ED, PARA_ID_A, PARA_ID_B};
-pub use penpal_runtime::xcm_config::{
-	CustomizableAssetFromSystemAssetHub, RelayNetworkId as PenpalRelayNetworkId,
-};
 
 // Substrate
 use frame_support::traits::OnInitialize;

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/lib.rs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+pub use rococo_runtime;
 
 pub mod genesis;
 

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/lib.rs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+pub use westend_runtime;
 
 pub mod genesis;
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/Cargo.toml
@@ -28,7 +28,6 @@ pallet-utility = { workspace = true }
 xcm = { workspace = true }
 pallet-xcm = { workspace = true }
 xcm-executor = { workspace = true }
-rococo-runtime = { workspace = true }
 polkadot-runtime-common = { workspace = true, default-features = true }
 rococo-runtime-constants = { workspace = true, default-features = true }
 
@@ -36,7 +35,5 @@ rococo-runtime-constants = { workspace = true, default-features = true }
 asset-test-utils = { workspace = true, default-features = true }
 cumulus-pallet-parachain-system = { workspace = true }
 parachains-common = { workspace = true, default-features = true }
-asset-hub-rococo-runtime = { workspace = true, default-features = true }
-penpal-runtime = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
 rococo-system-emulated-network = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/lib.rs
@@ -46,32 +46,42 @@ mod imports {
 	pub use parachains_common::Balance;
 	pub use rococo_system_emulated_network::{
 		asset_hub_rococo_emulated_chain::{
+			asset_hub_rococo_runtime::{
+				xcm_config::{
+					self as ahr_xcm_config, TokenLocation as RelayLocation,
+					XcmConfig as AssetHubRococoXcmConfig,
+				},
+				AssetConversionOrigin as AssetHubRococoAssetConversionOrigin,
+			},
 			genesis::{AssetHubRococoAssetOwner, ED as ASSET_HUB_ROCOCO_ED},
 			AssetHubRococoParaPallet as AssetHubRococoPallet,
 		},
 		penpal_emulated_chain::{
+			penpal_runtime::xcm_config::{
+				CustomizableAssetFromSystemAssetHub as PenpalCustomizableAssetFromSystemAssetHub,
+				LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
+				LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
+			},
 			PenpalAParaPallet as PenpalAPallet, PenpalAssetOwner,
 			PenpalBParaPallet as PenpalBPallet, ED as PENPAL_ED,
 		},
-		rococo_emulated_chain::{genesis::ED as ROCOCO_ED, RococoRelayPallet as RococoPallet},
+		rococo_emulated_chain::{
+			genesis::ED as ROCOCO_ED,
+			rococo_runtime::{
+				governance as rococo_governance,
+				xcm_config::{
+					UniversalLocation as RococoUniversalLocation, XcmConfig as RococoXcmConfig,
+				},
+				OriginCaller as RococoOriginCaller,
+			},
+			RococoRelayPallet as RococoPallet,
+		},
 		AssetHubRococoPara as AssetHubRococo, AssetHubRococoParaReceiver as AssetHubRococoReceiver,
 		AssetHubRococoParaSender as AssetHubRococoSender, BridgeHubRococoPara as BridgeHubRococo,
 		BridgeHubRococoParaReceiver as BridgeHubRococoReceiver, PenpalAPara as PenpalA,
 		PenpalAParaReceiver as PenpalAReceiver, PenpalAParaSender as PenpalASender,
 		PenpalBPara as PenpalB, PenpalBParaReceiver as PenpalBReceiver, RococoRelay as Rococo,
 		RococoRelayReceiver as RococoReceiver, RococoRelaySender as RococoSender,
-	};
-
-	// Runtimes
-	pub use asset_hub_rococo_runtime::xcm_config::{
-		TokenLocation as RelayLocation, XcmConfig as AssetHubRococoXcmConfig,
-	};
-	pub use penpal_runtime::xcm_config::{
-		LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
-		LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
-	};
-	pub use rococo_runtime::xcm_config::{
-		UniversalLocation as RococoUniversalLocation, XcmConfig as RococoXcmConfig,
 	};
 
 	pub const ASSET_ID: u32 = 3;

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/hybrid_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/hybrid_transfers.rs
@@ -170,7 +170,7 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		assert_ok!(<PenpalA as Chain>::System::set_storage(
 			<PenpalA as Chain>::RuntimeOrigin::root(),
 			vec![(
-				penpal_runtime::xcm_config::CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Westend)]).encode(),
 			)],
 		));
@@ -300,7 +300,7 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 		assert_ok!(<PenpalA as Chain>::System::set_storage(
 			<PenpalA as Chain>::RuntimeOrigin::root(),
 			vec![(
-				penpal_runtime::xcm_config::CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Westend)]).encode(),
 			)],
 		));
@@ -454,7 +454,7 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		assert_ok!(<PenpalB as Chain>::System::set_storage(
 			<PenpalB as Chain>::RuntimeOrigin::root(),
 			vec![(
-				penpal_runtime::xcm_config::CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Westend)]).encode(),
 			)],
 		));

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/swap.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/swap.rs
@@ -17,10 +17,7 @@ use crate::imports::*;
 
 #[test]
 fn swap_locally_on_chain_using_local_assets() {
-	let asset_native = Box::new(
-		v3::Location::try_from(asset_hub_rococo_runtime::xcm_config::TokenLocation::get())
-			.expect("conversion works"),
-	);
+	let asset_native = Box::new(v3::Location::try_from(RelayLocation::get()).unwrap());
 	let asset_one = Box::new(v3::Location::new(
 		0,
 		[
@@ -230,12 +227,12 @@ fn swap_locally_on_chain_using_foreign_assets() {
 
 #[test]
 fn cannot_create_pool_from_pool_assets() {
-	let asset_native = asset_hub_rococo_runtime::xcm_config::TokenLocation::get();
-	let mut asset_one = asset_hub_rococo_runtime::xcm_config::PoolAssetsPalletLocation::get();
+	let asset_native = RelayLocation::get();
+	let mut asset_one = ahr_xcm_config::PoolAssetsPalletLocation::get();
 	asset_one.append_with(GeneralIndex(ASSET_ID.into())).expect("pool assets");
 
 	AssetHubRococo::execute_with(|| {
-		let pool_owner_account_id = asset_hub_rococo_runtime::AssetConversionOrigin::get();
+		let pool_owner_account_id = AssetHubRococoAssetConversionOrigin::get();
 
 		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::PoolAssets::create(
 			<AssetHubRococo as Chain>::RuntimeOrigin::signed(pool_owner_account_id.clone()),
@@ -255,8 +252,8 @@ fn cannot_create_pool_from_pool_assets() {
 		assert_matches::assert_matches!(
 			<AssetHubRococo as AssetHubRococoPallet>::AssetConversion::create_pool(
 				<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get()),
-				Box::new(v3::Location::try_from(asset_native).expect("conversion works")),
-				Box::new(v3::Location::try_from(asset_one).expect("conversion works")),
+				Box::new(v3::Location::try_from(asset_native).unwrap()),
+				Box::new(v3::Location::try_from(asset_one).unwrap()),
 			),
 			Err(DispatchError::Module(ModuleError{index: _, error: _, message})) => assert_eq!(message, Some("Unknown"))
 		);
@@ -265,9 +262,7 @@ fn cannot_create_pool_from_pool_assets() {
 
 #[test]
 fn pay_xcm_fee_with_some_asset_swapped_for_native() {
-	let asset_native =
-		v3::Location::try_from(asset_hub_rococo_runtime::xcm_config::TokenLocation::get())
-			.expect("conversion works");
+	let asset_native = v3::Location::try_from(RelayLocation::get()).unwrap();
 	let asset_one = xcm::v3::Location {
 		parents: 0,
 		interior: [

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
@@ -25,7 +25,6 @@ use frame_support::{
 };
 use parachains_common::AccountId;
 use polkadot_runtime_common::impls::VersionedLocatableAsset;
-use rococo_runtime::OriginCaller;
 use rococo_runtime_constants::currency::GRAND;
 use xcm_executor::traits::ConvertLocation;
 
@@ -67,7 +66,7 @@ fn spend_roc_on_asset_hub() {
 		let treasury_location: Location = (Parent, PalletInstance(18)).into();
 
 		let teleport_call = RuntimeCall::Utility(pallet_utility::Call::<Runtime>::dispatch_as {
-			as_origin: bx!(OriginCaller::system(RawOrigin::Signed(treasury_account))),
+			as_origin: bx!(RococoOriginCaller::system(RawOrigin::Signed(treasury_account))),
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
 				dest: bx!(VersionedLocation::V4(asset_hub_location.clone())),
 				beneficiary: bx!(VersionedLocation::V4(treasury_location)),
@@ -99,7 +98,7 @@ fn spend_roc_on_asset_hub() {
 		// Fund Alice account from Rococo Treasury account on Asset Hub.
 
 		let treasury_origin: RuntimeOrigin =
-			rococo_runtime::governance::pallet_custom_origins::Origin::Treasurer.into();
+			rococo_governance::pallet_custom_origins::Origin::Treasurer.into();
 
 		let alice_location: Location =
 			[Junction::AccountId32 { network: None, id: Rococo::account_id_of(ALICE).into() }]
@@ -168,10 +167,7 @@ fn create_and_claim_treasury_spend_in_usdt() {
 	let treasury_location: Location = Location::new(1, PalletInstance(18));
 	// treasury account on a sibling parachain.
 	let treasury_account =
-		asset_hub_rococo_runtime::xcm_config::LocationToAccountId::convert_location(
-			&treasury_location,
-		)
-		.unwrap();
+		ahr_xcm_config::LocationToAccountId::convert_location(&treasury_location).unwrap();
 	let asset_hub_location =
 		v3::Location::new(0, v3::Junction::Parachain(AssetHubRococo::para_id().into()));
 	let root = <Rococo as Chain>::RuntimeOrigin::root();

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/Cargo.toml
@@ -35,12 +35,9 @@ xcm = { workspace = true }
 xcm-executor = { workspace = true }
 pallet-xcm = { workspace = true }
 xcm-runtime-apis = { workspace = true }
-westend-runtime = { workspace = true }
 
 # Cumulus
 parachains-common = { workspace = true, default-features = true }
-penpal-runtime = { workspace = true }
-asset-hub-westend-runtime = { workspace = true }
 asset-test-utils = { workspace = true, default-features = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
 cumulus-pallet-parachain-system = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/lib.rs
@@ -46,15 +46,33 @@ mod imports {
 	pub use parachains_common::{AccountId, Balance};
 	pub use westend_system_emulated_network::{
 		asset_hub_westend_emulated_chain::{
+			asset_hub_westend_runtime::{
+				xcm_config::{
+					self as ahw_xcm_config, WestendLocation as RelayLocation,
+					XcmConfig as AssetHubWestendXcmConfig,
+				},
+				AssetConversionOrigin as AssetHubWestendAssetConversionOrigin,
+			},
 			genesis::{AssetHubWestendAssetOwner, ED as ASSET_HUB_WESTEND_ED},
 			AssetHubWestendParaPallet as AssetHubWestendPallet,
 		},
 		collectives_westend_emulated_chain::CollectivesWestendParaPallet as CollectivesWestendPallet,
 		penpal_emulated_chain::{
+			penpal_runtime::xcm_config::{
+				CustomizableAssetFromSystemAssetHub as PenpalCustomizableAssetFromSystemAssetHub,
+				LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
+				LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
+			},
 			PenpalAParaPallet as PenpalAPallet, PenpalAssetOwner,
 			PenpalBParaPallet as PenpalBPallet,
 		},
-		westend_emulated_chain::{genesis::ED as WESTEND_ED, WestendRelayPallet as WestendPallet},
+		westend_emulated_chain::{
+			genesis::ED as WESTEND_ED,
+			westend_runtime::xcm_config::{
+				UniversalLocation as WestendUniversalLocation, XcmConfig as WestendXcmConfig,
+			},
+			WestendRelayPallet as WestendPallet,
+		},
 		AssetHubWestendPara as AssetHubWestend,
 		AssetHubWestendParaReceiver as AssetHubWestendReceiver,
 		AssetHubWestendParaSender as AssetHubWestendSender,
@@ -64,18 +82,6 @@ mod imports {
 		PenpalAParaReceiver as PenpalAReceiver, PenpalAParaSender as PenpalASender,
 		PenpalBPara as PenpalB, PenpalBParaReceiver as PenpalBReceiver, WestendRelay as Westend,
 		WestendRelayReceiver as WestendReceiver, WestendRelaySender as WestendSender,
-	};
-
-	// Runtimes
-	pub use asset_hub_westend_runtime::xcm_config::{
-		WestendLocation as RelayLocation, XcmConfig as AssetHubWestendXcmConfig,
-	};
-	pub use penpal_runtime::xcm_config::{
-		LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
-		LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
-	};
-	pub use westend_runtime::xcm_config::{
-		UniversalLocation as WestendUniversalLocation, XcmConfig as WestendXcmConfig,
 	};
 
 	pub const ASSET_ID: u32 = 3;

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/fellowship_treasury.rs
@@ -28,10 +28,7 @@ fn create_and_claim_treasury_spend() {
 		Location::new(1, [Parachain(CollectivesWestend::para_id().into()), PalletInstance(65)]);
 	// treasury account on a sibling parachain.
 	let treasury_account =
-		asset_hub_westend_runtime::xcm_config::LocationToAccountId::convert_location(
-			&treasury_location,
-		)
-		.unwrap();
+		ahw_xcm_config::LocationToAccountId::convert_location(&treasury_location).unwrap();
 	let asset_hub_location = Location::new(1, [Parachain(AssetHubWestend::para_id().into())]);
 	let root = <CollectivesWestend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/hybrid_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/hybrid_transfers.rs
@@ -170,7 +170,7 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		assert_ok!(<PenpalA as Chain>::System::set_storage(
 			<PenpalA as Chain>::RuntimeOrigin::root(),
 			vec![(
-				penpal_runtime::xcm_config::CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Rococo)]).encode(),
 			)],
 		));
@@ -300,7 +300,7 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 		assert_ok!(<PenpalA as Chain>::System::set_storage(
 			<PenpalA as Chain>::RuntimeOrigin::root(),
 			vec![(
-				penpal_runtime::xcm_config::CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Rococo)]).encode(),
 			)],
 		));
@@ -455,7 +455,7 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		assert_ok!(<PenpalB as Chain>::System::set_storage(
 			<PenpalB as Chain>::RuntimeOrigin::root(),
 			vec![(
-				penpal_runtime::xcm_config::CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Rococo)]).encode(),
 			)],
 		));

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/swap.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/swap.rs
@@ -17,10 +17,8 @@ use crate::imports::*;
 
 #[test]
 fn swap_locally_on_chain_using_local_assets() {
-	let asset_native = Box::new(
-		v3::Location::try_from(asset_hub_westend_runtime::xcm_config::WestendLocation::get())
-			.expect("conversion works"),
-	);
+	let asset_native =
+		Box::new(v3::Location::try_from(RelayLocation::get()).expect("conversion works"));
 	let asset_one = Box::new(v3::Location {
 		parents: 0,
 		interior: [
@@ -229,12 +227,12 @@ fn swap_locally_on_chain_using_foreign_assets() {
 
 #[test]
 fn cannot_create_pool_from_pool_assets() {
-	let asset_native = asset_hub_westend_runtime::xcm_config::WestendLocation::get();
-	let mut asset_one = asset_hub_westend_runtime::xcm_config::PoolAssetsPalletLocation::get();
+	let asset_native = RelayLocation::get();
+	let mut asset_one = ahw_xcm_config::PoolAssetsPalletLocation::get();
 	asset_one.append_with(GeneralIndex(ASSET_ID.into())).expect("pool assets");
 
 	AssetHubWestend::execute_with(|| {
-		let pool_owner_account_id = asset_hub_westend_runtime::AssetConversionOrigin::get();
+		let pool_owner_account_id = AssetHubWestendAssetConversionOrigin::get();
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::PoolAssets::create(
 			<AssetHubWestend as Chain>::RuntimeOrigin::signed(pool_owner_account_id.clone()),
@@ -264,9 +262,7 @@ fn cannot_create_pool_from_pool_assets() {
 
 #[test]
 fn pay_xcm_fee_with_some_asset_swapped_for_native() {
-	let asset_native =
-		v3::Location::try_from(asset_hub_westend_runtime::xcm_config::WestendLocation::get())
-			.expect("conversion works");
+	let asset_native = v3::Location::try_from(RelayLocation::get()).expect("conversion works");
 	let asset_one = xcm::v3::Location {
 		parents: 0,
 		interior: [

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
@@ -27,10 +27,7 @@ fn create_and_claim_treasury_spend() {
 	let treasury_location: Location = Location::new(1, PalletInstance(37));
 	// treasury account on a sibling parachain.
 	let treasury_account =
-		asset_hub_westend_runtime::xcm_config::LocationToAccountId::convert_location(
-			&treasury_location,
-		)
-		.unwrap();
+		ahw_xcm_config::LocationToAccountId::convert_location(&treasury_location).unwrap();
 	let asset_hub_location = Location::new(0, Parachain(AssetHubWestend::para_id().into()));
 	let root = <Westend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spend from the treasury.

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
@@ -36,11 +36,12 @@ pallet-bridge-messages = { workspace = true }
 parachains-common = { workspace = true, default-features = true }
 testnet-parachains-constants = { features = ["rococo"], workspace = true, default-features = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
-bridge-hub-rococo-runtime = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
+asset-hub-rococo-runtime = { workspace = true }
+bridge-hub-rococo-runtime = { workspace = true }
+penpal-runtime = { workspace = true }
 rococo-westend-system-emulated-network = { workspace = true }
 rococo-system-emulated-network = { workspace = true }
-asset-hub-rococo-runtime = { workspace = true }
 
 # Snowbridge
 snowbridge-core = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/Cargo.toml
@@ -33,15 +33,12 @@ xcm-executor = { workspace = true }
 pallet-bridge-messages = { workspace = true }
 
 # Cumulus
-parachains-common = { workspace = true, default-features = true }
-testnet-parachains-constants = { features = ["rococo"], workspace = true, default-features = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
-asset-hub-rococo-runtime = { workspace = true }
-bridge-hub-rococo-runtime = { workspace = true }
-penpal-runtime = { workspace = true }
-rococo-westend-system-emulated-network = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
 rococo-system-emulated-network = { workspace = true }
+rococo-westend-system-emulated-network = { workspace = true }
+testnet-parachains-constants = { features = ["rococo"], workspace = true, default-features = true }
 
 # Snowbridge
 snowbridge-core = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
@@ -38,6 +38,7 @@ mod imports {
 		ASSETS_PALLET_ID, USDT_ID,
 	};
 	pub use parachains_common::AccountId;
+	pub use penpal_runtime::xcm_config::UniversalLocation as PenpalUniversalLocation;
 	pub use rococo_westend_system_emulated_network::{
 		asset_hub_rococo_emulated_chain::{
 			genesis::{AssetHubRococoAssetOwner, ED as ASSET_HUB_ROCOCO_ED},

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
@@ -38,9 +38,9 @@ mod imports {
 		ASSETS_PALLET_ID, USDT_ID,
 	};
 	pub use parachains_common::AccountId;
-	pub use penpal_runtime::xcm_config::UniversalLocation as PenpalUniversalLocation;
 	pub use rococo_westend_system_emulated_network::{
 		asset_hub_rococo_emulated_chain::{
+			asset_hub_rococo_runtime::xcm_config as ahr_xcm_config,
 			genesis::{AssetHubRococoAssetOwner, ED as ASSET_HUB_ROCOCO_ED},
 			AssetHubRococoParaPallet as AssetHubRococoPallet,
 		},
@@ -48,9 +48,17 @@ mod imports {
 			genesis::ED as ASSET_HUB_WESTEND_ED, AssetHubWestendParaPallet as AssetHubWestendPallet,
 		},
 		bridge_hub_rococo_emulated_chain::{
-			genesis::ED as BRIDGE_HUB_ROCOCO_ED, BridgeHubRococoParaPallet as BridgeHubRococoPallet,
+			genesis::ED as BRIDGE_HUB_ROCOCO_ED,
+			BridgeHubRococoParaPallet as BridgeHubRococoPallet, BridgeHubRococoRuntimeOrigin,
+			BridgeHubRococoXcmConfig, EthereumBeaconClient, EthereumInboundQueue,
 		},
-		penpal_emulated_chain::{PenpalAParaPallet as PenpalAPallet, PenpalAssetOwner},
+		penpal_emulated_chain::{
+			penpal_runtime::xcm_config::{
+				CustomizableAssetFromSystemAssetHub as PenpalCustomizableAssetFromSystemAssetHub,
+				UniversalLocation as PenpalUniversalLocation,
+			},
+			PenpalAParaPallet as PenpalAPallet, PenpalAssetOwner,
+		},
 		rococo_emulated_chain::{genesis::ED as ROCOCO_ED, RococoRelayPallet as RococoPallet},
 		AssetHubRococoPara as AssetHubRococo, AssetHubRococoParaReceiver as AssetHubRococoReceiver,
 		AssetHubRococoParaSender as AssetHubRococoSender, AssetHubWestendPara as AssetHubWestend,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
@@ -277,7 +277,7 @@ fn send_back_wnds_from_asset_hub_rococo_to_asset_hub_westend() {
 	assert_eq!(sender_wnds_before, prefund_amount);
 	let receiver_wnds_before = <AssetHubWestend as Chain>::account_data_of(receiver.clone()).free;
 
-	// send WNDs, use them for fees
+	// send back WNDs, use them for fees
 	send_assets_over_bridge(|| {
 		let destination = asset_hub_westend_location();
 		let assets: Assets = (wnd_at_asset_hub_rococo, amount_to_send).into();
@@ -351,7 +351,7 @@ fn send_rocs_from_penpal_rococo_through_asset_hub_rococo_to_asset_hub_westend() 
 		let fees_id: AssetId = roc_at_rococo_parachains.clone().into();
 		let fees_transfer_type = TransferType::RemoteReserve(local_asset_hub.into());
 		let beneficiary: Location =
-			AccountId32Junction { network: None, id: AssetHubWestendReceiver::get().into() }.into();
+			AccountId32Junction { network: None, id: receiver.clone().into() }.into();
 		let custom_xcm_on_dest = Xcm::<()>(vec![DepositAsset {
 			assets: Wild(AllCounted(assets.len() as u32)),
 			beneficiary,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -13,12 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::imports::*;
-use bridge_hub_rococo_runtime::{EthereumBeaconClient, EthereumInboundQueue, RuntimeOrigin};
 use codec::{Decode, Encode};
 use emulated_integration_tests_common::xcm_emulator::ConvertLocation;
 use frame_support::pallet_prelude::TypeInfo;
 use hex_literal::hex;
-use rococo_system_emulated_network::penpal_emulated_chain::CustomizableAssetFromSystemAssetHub;
 use rococo_westend_system_emulated_network::BridgeHubRococoParaSender as BridgeHubRococoSender;
 use snowbridge_core::{inbound::InboundQueueFixture, outbound::OperatingMode};
 use snowbridge_pallet_inbound_queue_fixtures::{
@@ -64,7 +62,7 @@ pub fn send_inbound_message(fixture: InboundQueueFixture) -> DispatchResult {
 	)
 	.unwrap();
 	EthereumInboundQueue::submit(
-		RuntimeOrigin::signed(BridgeHubRococoSender::get()),
+		BridgeHubRococoRuntimeOrigin::signed(BridgeHubRococoSender::get()),
 		fixture.message,
 	)
 }
@@ -298,7 +296,7 @@ fn send_token_from_ethereum_to_penpal() {
 		assert_ok!(<PenpalA as Chain>::System::set_storage(
 			<PenpalA as Chain>::RuntimeOrigin::root(),
 			vec![(
-				CustomizableAssetFromSystemAssetHub::key().to_vec(),
+				PenpalCustomizableAssetFromSystemAssetHub::key().to_vec(),
 				Location::new(2, [GlobalConsensus(Ethereum { chain_id: CHAIN_ID })]).encode(),
 			)],
 		));
@@ -379,7 +377,7 @@ fn send_token_from_ethereum_to_penpal() {
 /// - returning the token to Ethereum
 #[test]
 fn send_weth_asset_from_asset_hub_to_ethereum() {
-	use asset_hub_rococo_runtime::xcm_config::bridging::to_ethereum::DefaultBridgeHubEthereumBaseFee;
+	use ahr_xcm_config::bridging::to_ethereum::DefaultBridgeHubEthereumBaseFee;
 	let assethub_location = BridgeHubRococo::sibling_location_of(AssetHubRococo::para_id());
 	let assethub_sovereign = BridgeHubRococo::sovereign_account_id_of(assethub_location);
 

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/teleport.rs
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tests::*;
-use bridge_hub_rococo_runtime::xcm_config::XcmConfig;
+use crate::imports::*;
 
 #[test]
 fn teleport_to_other_system_parachains_works() {
@@ -22,9 +21,9 @@ fn teleport_to_other_system_parachains_works() {
 	let native_asset: Assets = (Parent, amount).into();
 
 	test_parachain_is_trusted_teleporter!(
-		BridgeHubRococo,      // Origin
-		XcmConfig,            // XCM configuration
-		vec![AssetHubRococo], // Destinations
+		BridgeHubRococo,          // Origin
+		BridgeHubRococoXcmConfig, // XCM configuration
+		vec![AssetHubRococo],     // Destinations
 		(native_asset, amount)
 	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
@@ -30,8 +30,7 @@ xcm-executor = { workspace = true }
 pallet-bridge-messages = { workspace = true }
 
 # Cumulus
-parachains-common = { workspace = true, default-features = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
-bridge-hub-westend-runtime = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
 rococo-westend-system-emulated-network = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
@@ -49,7 +49,7 @@ mod imports {
 		},
 		bridge_hub_westend_emulated_chain::{
 			genesis::ED as BRIDGE_HUB_WESTEND_ED,
-			BridgeHubWestendParaPallet as BridgeHubWestendPallet,
+			BridgeHubWestendParaPallet as BridgeHubWestendPallet, BridgeHubWestendXcmConfig,
 		},
 		penpal_emulated_chain::{PenpalAssetOwner, PenpalBParaPallet as PenpalBPallet},
 		westend_emulated_chain::WestendRelayPallet as WestendPallet,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
@@ -51,7 +51,10 @@ mod imports {
 			genesis::ED as BRIDGE_HUB_WESTEND_ED,
 			BridgeHubWestendParaPallet as BridgeHubWestendPallet, BridgeHubWestendXcmConfig,
 		},
-		penpal_emulated_chain::{PenpalAssetOwner, PenpalBParaPallet as PenpalBPallet},
+		penpal_emulated_chain::{
+			penpal_runtime::xcm_config::UniversalLocation as PenpalUniversalLocation,
+			PenpalAssetOwner, PenpalBParaPallet as PenpalBPallet,
+		},
 		westend_emulated_chain::WestendRelayPallet as WestendPallet,
 		AssetHubRococoPara as AssetHubRococo, AssetHubRococoParaReceiver as AssetHubRococoReceiver,
 		AssetHubRococoParaSender as AssetHubRococoSender, AssetHubWestendPara as AssetHubWestend,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/teleport.rs
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tests::*;
-use bridge_hub_westend_runtime::xcm_config::XcmConfig;
+use crate::imports::*;
 
 #[test]
 fn teleport_to_other_system_parachains_works() {
@@ -22,9 +21,9 @@ fn teleport_to_other_system_parachains_works() {
 	let native_asset: Assets = (Parent, amount).into();
 
 	test_parachain_is_trusted_teleporter!(
-		BridgeHubWestend,      // Origin
-		XcmConfig,             // XCM configuration
-		vec![AssetHubWestend], // Destinations
+		BridgeHubWestend,          // Origin
+		BridgeHubWestendXcmConfig, // XCM configuration
+		vec![AssetHubWestend],     // Destinations
 		(native_asset, amount)
 	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/Cargo.toml
@@ -29,14 +29,11 @@ polkadot-runtime-common = { workspace = true, default-features = true }
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
 pallet-xcm = { workspace = true }
-westend-runtime = { workspace = true }
 westend-runtime-constants = { workspace = true, default-features = true }
 
 # Cumulus
 parachains-common = { workspace = true, default-features = true }
 testnet-parachains-constants = { features = ["westend"], workspace = true, default-features = true }
-asset-hub-westend-runtime = { workspace = true }
-collectives-westend-runtime = { workspace = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
 cumulus-pallet-parachain-system = { workspace = true }
 emulated-integration-tests-common = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/lib.rs
@@ -19,9 +19,18 @@ pub use emulated_integration_tests_common::xcm_emulator::{
 	assert_expected_events, bx, Chain, RelayChain as Relay, TestExt,
 };
 pub use westend_system_emulated_network::{
-	asset_hub_westend_emulated_chain::AssetHubWestendParaPallet as AssetHubWestendPallet,
-	collectives_westend_emulated_chain::CollectivesWestendParaPallet as CollectivesWestendPallet,
-	westend_emulated_chain::WestendRelayPallet as WestendPallet,
+	asset_hub_westend_emulated_chain::{
+		asset_hub_westend_runtime::xcm_config::LocationToAccountId as AssetHubLocationToAccountId,
+		AssetHubWestendParaPallet as AssetHubWestendPallet,
+	},
+	collectives_westend_emulated_chain::{
+		collectives_westend_runtime::fellowship as collectives_fellowship,
+		CollectivesWestendParaPallet as CollectivesWestendPallet,
+	},
+	westend_emulated_chain::{
+		westend_runtime::{governance as westend_governance, OriginCaller as WestendOriginCaller},
+		WestendRelayPallet as WestendPallet,
+	},
 	AssetHubWestendPara as AssetHubWestend, CollectivesWestendPara as CollectivesWestend,
 	WestendRelay as Westend,
 };

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
@@ -14,14 +14,12 @@
 // limitations under the License.
 
 use crate::*;
-use asset_hub_westend_runtime::xcm_config::LocationToAccountId as AssetHubLocationToAccountId;
 use emulated_integration_tests_common::accounts::ALICE;
 use frame_support::{
 	assert_ok, dispatch::RawOrigin, instances::Instance1, sp_runtime::traits::Dispatchable,
 	traits::fungible::Inspect,
 };
 use polkadot_runtime_common::impls::VersionedLocatableAsset;
-use westend_runtime::OriginCaller;
 use westend_runtime_constants::currency::UNITS;
 use xcm_executor::traits::ConvertLocation;
 
@@ -65,7 +63,7 @@ fn fellowship_treasury_spend() {
 		let treasury_location: Location = (Parent, PalletInstance(37)).into();
 
 		let teleport_call = RuntimeCall::Utility(pallet_utility::Call::<Runtime>::dispatch_as {
-			as_origin: bx!(OriginCaller::system(RawOrigin::Signed(treasury_account))),
+			as_origin: bx!(WestendOriginCaller::system(RawOrigin::Signed(treasury_account))),
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
 				dest: bx!(VersionedLocation::V4(asset_hub_location.clone())),
 				beneficiary: bx!(VersionedLocation::V4(treasury_location)),
@@ -97,7 +95,7 @@ fn fellowship_treasury_spend() {
 		// Fund Fellowship Treasury from Westend Treasury.
 
 		let treasury_origin: RuntimeOrigin =
-			westend_runtime::governance::pallet_custom_origins::Origin::Treasurer.into();
+			westend_governance::pallet_custom_origins::Origin::Treasurer.into();
 		let fellowship_treasury_location: Location =
 			Location::new(1, [Parachain(1001), PalletInstance(65)]);
 		let asset_hub_location: Location = [Parachain(1000)].into();
@@ -170,8 +168,7 @@ fn fellowship_treasury_spend() {
 		// Fund Alice account from Fellowship Treasury.
 
 		let fellows_origin: RuntimeOrigin =
-			collectives_westend_runtime::fellowship::pallet_fellowship_origins::Origin::Fellows
-				.into();
+			collectives_fellowship::pallet_fellowship_origins::Origin::Fellows.into();
 		let asset_hub_location: Location = (Parent, Parachain(1000)).into();
 		let native_asset = Location::parent();
 

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/Cargo.toml
@@ -11,22 +11,20 @@ publish = false
 codec = { workspace = true }
 
 # Substrate
-sp-runtime = { workspace = true }
 frame-support = { workspace = true }
 pallet-balances = { workspace = true }
 pallet-message-queue = { workspace = true }
 pallet-identity = { workspace = true }
+sp-runtime = { workspace = true }
 
 # Polkadot
+polkadot-runtime-common = { workspace = true, default-features = true }
+rococo-runtime-constants = { workspace = true, default-features = true }
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
-rococo-runtime = { workspace = true }
-rococo-runtime-constants = { workspace = true, default-features = true }
-polkadot-runtime-common = { workspace = true, default-features = true }
 
 # Cumulus
 asset-test-utils = { workspace = true, default-features = true }
-parachains-common = { workspace = true, default-features = true }
-people-rococo-runtime = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
 rococo-system-emulated-network = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/lib.rs
@@ -37,9 +37,19 @@ mod imports {
 	pub use parachains_common::Balance;
 	pub use rococo_system_emulated_network::{
 		people_rococo_emulated_chain::{
-			genesis::ED as PEOPLE_ROCOCO_ED, PeopleRococoParaPallet as PeopleRococoPallet,
+			genesis::ED as PEOPLE_ROCOCO_ED,
+			people_rococo_runtime::{people, xcm_config::XcmConfig as PeopleRococoXcmConfig},
+			PeopleRococoParaPallet as PeopleRococoPallet,
 		},
-		rococo_emulated_chain::{genesis::ED as ROCOCO_ED, RococoRelayPallet as RococoPallet},
+		rococo_emulated_chain::{
+			genesis::ED as ROCOCO_ED,
+			rococo_runtime::{
+				xcm_config::XcmConfig as RococoXcmConfig, BasicDeposit, ByteDeposit,
+				MaxAdditionalFields, MaxSubAccounts, RuntimeOrigin as RococoOrigin,
+				SubAccountDeposit,
+			},
+			RococoRelayPallet as RococoPallet,
+		},
 		PeopleRococoPara as PeopleRococo, PeopleRococoParaReceiver as PeopleRococoReceiver,
 		PeopleRococoParaSender as PeopleRococoSender, RococoRelay as Rococo,
 		RococoRelayReceiver as RococoReceiver, RococoRelaySender as RococoSender,

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/tests/reap_identity.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/tests/reap_identity.rs
@@ -42,13 +42,9 @@ use crate::imports::*;
 use frame_support::BoundedVec;
 use pallet_balances::Event as BalancesEvent;
 use pallet_identity::{legacy::IdentityInfo, Data, Event as IdentityEvent};
-use people_rococo_runtime::people::{
+use people::{
 	BasicDeposit as BasicDepositParachain, ByteDeposit as ByteDepositParachain,
 	IdentityInfo as IdentityInfoParachain, SubAccountDeposit as SubAccountDepositParachain,
-};
-use rococo_runtime::{
-	BasicDeposit, ByteDeposit, MaxAdditionalFields, MaxSubAccounts, RuntimeOrigin as RococoOrigin,
-	SubAccountDeposit,
 };
 use rococo_runtime_constants::currency::*;
 use rococo_system_emulated_network::{

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/tests/teleport.rs
@@ -155,9 +155,7 @@ fn limited_teleport_native_assets_from_relay_to_system_para_works() {
 	let delivery_fees = Rococo::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<RococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(
-			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
-		)
+		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
 
 	let sender_balance_after = test.sender.balance;
@@ -206,9 +204,7 @@ fn limited_teleport_native_assets_back_from_system_para_to_relay_works() {
 	let delivery_fees = PeopleRococo::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleRococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(
-			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
-		)
+		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
 
 	// Sender's balance is reduced
@@ -252,9 +248,7 @@ fn limited_teleport_native_assets_from_system_para_to_relay_fails() {
 	let delivery_fees = PeopleRococo::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleRococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(
-			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
-		)
+		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
 
 	// Sender's balance is reduced

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-rococo/src/tests/teleport.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 use crate::imports::*;
-use people_rococo_runtime::xcm_config::XcmConfig as PeopleRococoXcmConfig;
-use rococo_runtime::xcm_config::XcmConfig as RococoXcmConfig;
 
 fn relay_origin_assertions(t: RelayToSystemParaTest) {
 	type RuntimeEvent = <Rococo as Chain>::RuntimeEvent;
@@ -157,7 +155,9 @@ fn limited_teleport_native_assets_from_relay_to_system_para_works() {
 	let delivery_fees = Rococo::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<RococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
+		>(
+			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
+		)
 	});
 
 	let sender_balance_after = test.sender.balance;
@@ -206,7 +206,9 @@ fn limited_teleport_native_assets_back_from_system_para_to_relay_works() {
 	let delivery_fees = PeopleRococo::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleRococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
+		>(
+			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
+		)
 	});
 
 	// Sender's balance is reduced
@@ -250,7 +252,9 @@ fn limited_teleport_native_assets_from_system_para_to_relay_fails() {
 	let delivery_fees = PeopleRococo::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleRococoXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
+		>(
+			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
+		)
 	});
 
 	// Sender's balance is reduced

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/Cargo.toml
@@ -11,22 +11,20 @@ publish = false
 codec = { workspace = true }
 
 # Substrate
-sp-runtime = { workspace = true }
 frame-support = { workspace = true }
 pallet-balances = { workspace = true }
 pallet-message-queue = { workspace = true }
 pallet-identity = { workspace = true }
+sp-runtime = { workspace = true }
 
 # Polkadot
+polkadot-runtime-common = { workspace = true, default-features = true }
+westend-runtime-constants = { workspace = true, default-features = true }
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
-westend-runtime = { workspace = true }
-westend-runtime-constants = { workspace = true, default-features = true }
-polkadot-runtime-common = { workspace = true, default-features = true }
 
 # Cumulus
 asset-test-utils = { workspace = true, default-features = true }
-parachains-common = { workspace = true, default-features = true }
-people-westend-runtime = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
 westend-system-emulated-network = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/lib.rs
@@ -35,10 +35,21 @@ mod imports {
 	};
 	pub use parachains_common::Balance;
 	pub use westend_system_emulated_network::{
+		self,
 		people_westend_emulated_chain::{
-			genesis::ED as PEOPLE_WESTEND_ED, PeopleWestendParaPallet as PeopleWestendPallet,
+			genesis::ED as PEOPLE_WESTEND_ED,
+			people_westend_runtime::{people, xcm_config::XcmConfig as PeopleWestendXcmConfig},
+			PeopleWestendParaPallet as PeopleWestendPallet,
 		},
-		westend_emulated_chain::{genesis::ED as WESTEND_ED, WestendRelayPallet as WestendPallet},
+		westend_emulated_chain::{
+			genesis::ED as WESTEND_ED,
+			westend_runtime::{
+				xcm_config::XcmConfig as WestendXcmConfig, BasicDeposit, ByteDeposit,
+				MaxAdditionalFields, MaxSubAccounts, RuntimeOrigin as WestendOrigin,
+				SubAccountDeposit,
+			},
+			WestendRelayPallet as WestendPallet,
+		},
 		PeopleWestendPara as PeopleWestend, PeopleWestendParaReceiver as PeopleWestendReceiver,
 		PeopleWestendParaSender as PeopleWestendSender, WestendRelay as Westend,
 		WestendRelayReceiver as WestendReceiver, WestendRelaySender as WestendSender,

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/tests/reap_identity.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/tests/reap_identity.rs
@@ -42,13 +42,9 @@ use crate::imports::*;
 use frame_support::BoundedVec;
 use pallet_balances::Event as BalancesEvent;
 use pallet_identity::{legacy::IdentityInfo, Data, Event as IdentityEvent};
-use people_westend_runtime::people::{
+use people::{
 	BasicDeposit as BasicDepositParachain, ByteDeposit as ByteDepositParachain,
 	IdentityInfo as IdentityInfoParachain, SubAccountDeposit as SubAccountDepositParachain,
-};
-use westend_runtime::{
-	BasicDeposit, ByteDeposit, MaxAdditionalFields, MaxSubAccounts, RuntimeOrigin as WestendOrigin,
-	SubAccountDeposit,
 };
 use westend_runtime_constants::currency::*;
 use westend_system_emulated_network::{

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/tests/teleport.rs
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 use crate::imports::*;
-use people_westend_runtime::xcm_config::XcmConfig as PeopleWestendXcmConfig;
-use westend_runtime::xcm_config::XcmConfig as WestendXcmConfig;
 
 fn relay_origin_assertions(t: RelayToSystemParaTest) {
 	type RuntimeEvent = <Westend as Chain>::RuntimeEvent;
@@ -157,7 +155,9 @@ fn limited_teleport_native_assets_from_relay_to_system_para_works() {
 	let delivery_fees = Westend::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<WestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
+		>(
+			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
+		)
 	});
 
 	let sender_balance_after = test.sender.balance;
@@ -206,7 +206,9 @@ fn limited_teleport_native_assets_back_from_system_para_to_relay_works() {
 	let delivery_fees = PeopleWestend::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleWestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
+		>(
+			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
+		)
 	});
 
 	// Sender's balance is reduced
@@ -250,7 +252,9 @@ fn limited_teleport_native_assets_from_system_para_to_relay_fails() {
 	let delivery_fees = PeopleWestend::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleWestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
+		>(
+			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
+		)
 	});
 
 	// Sender's balance is reduced

--- a/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/tests/teleport.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/people/people-westend/src/tests/teleport.rs
@@ -155,9 +155,7 @@ fn limited_teleport_native_assets_from_relay_to_system_para_works() {
 	let delivery_fees = Westend::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<WestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(
-			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
-		)
+		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
 
 	let sender_balance_after = test.sender.balance;
@@ -206,9 +204,7 @@ fn limited_teleport_native_assets_back_from_system_para_to_relay_works() {
 	let delivery_fees = PeopleWestend::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleWestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(
-			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
-		)
+		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
 
 	// Sender's balance is reduced
@@ -252,9 +248,7 @@ fn limited_teleport_native_assets_from_system_para_to_relay_fails() {
 	let delivery_fees = PeopleWestend::execute_with(|| {
 		xcm_helpers::teleport_assets_delivery_fees::<
 			<PeopleWestendXcmConfig as xcm_executor::Config>::XcmSender,
-		>(
-			test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest
-		)
+		>(test.args.assets.clone(), 0, test.args.weight_limit, test.args.beneficiary, test.args.dest)
 	});
 
 	// Sender's balance is reduced


### PR DESCRIPTION
- Send bridged WNDs: Penpal Rococo -> AH Rococo -> AH Westend
- Send bridged ROCs: Penpal Westend -> AH Westend -> AH Rococo

The tests send both ROCs and WNDs, for each direction the native asset is only used to pay for the transport fees on the local AssetHub, and are not sent over the bridge.

Including the native asset won't be necessary anymore once we get #4375.