### PR TITLE
rpc2: Finalized event doesn't indicate that the best block changes

### DIFF
--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head_follow.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head_follow.rs
@@ -32,7 +32,7 @@ use futures::{
 };
 use futures_util::future::Either;
 use jsonrpsee::SubscriptionSink;
-use log::{debug, error};
+use log::debug;
 use sc_client_api::{
 	Backend, BlockBackend, BlockImportNotification, BlockchainEvents, FinalityNotification,
 };

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head_follow.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head_follow.rs
@@ -572,7 +572,7 @@ where
 					// The information from `.info()` is updated from the DB as the last
 					// step of the finalization and it should be up to date.
 					// If the info is outdated, there is nothing the RPC can do for now.
-					error!(
+					debug!(
 						target: LOG_TARGET,
 						"[follow][id={:?}] Client does not contain different best block",
 						self.sub_id,


### PR DESCRIPTION
We should not print a warning if the best block stays the same between two finality events. There is no requirement that this changes. For sure this doesn't need to be an error message.