### PR TITLE
[Rococo<>Westend bridge] Allow any asset over the lane between the two Asset Hubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,6 +2252,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
  "frame-support",
+ "hex-literal",
  "pallet-asset-conversion",
  "pallet-assets",
  "pallet-balances",

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/genesis.rs
@@ -21,7 +21,7 @@ use sp_core::{sr25519, storage::Storage};
 use emulated_integration_tests_common::{
 	accounts, build_genesis_storage, collators, get_account_id_from_seed,
 	PenpalSiblingSovereignAccount, PenpalTeleportableAssetLocation, RESERVABLE_ASSET_ID,
-	SAFE_XCM_VERSION,
+	SAFE_XCM_VERSION, USDT_ID,
 };
 use parachains_common::{AccountId, Balance};
 
@@ -68,7 +68,10 @@ pub fn genesis() -> Storage {
 			..Default::default()
 		},
 		assets: asset_hub_rococo_runtime::AssetsConfig {
-			assets: vec![(RESERVABLE_ASSET_ID, AssetHubRococoAssetOwner::get(), true, ED)],
+			assets: vec![
+				(RESERVABLE_ASSET_ID, AssetHubRococoAssetOwner::get(), true, ED),
+				(USDT_ID, AssetHubRococoAssetOwner::get(), true, ED),
+			],
 			..Default::default()
 		},
 		foreign_assets: asset_hub_rococo_runtime::ForeignAssetsConfig {

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -51,10 +51,13 @@ pub const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
 
 type AccountPublic = <MultiSignature as Verify>::Signer;
 
-// This asset is added to AH as Asset and reserved transfer between Parachain and AH
+// (trust-backed) Asset registered on AH and reserve-transferred between Parachain and AH
 pub const RESERVABLE_ASSET_ID: u32 = 1;
-// This asset is added to AH as ForeignAsset and teleported between Penpal and AH
+// ForeignAsset registered on AH and teleported between Penpal and AH
 pub const TELEPORTABLE_ASSET_ID: u32 = 2;
+
+// USDT registered on AH as (trust-backed) Asset and reserve-transferred between Parachain and AH
+pub const USDT_ID: u32 = 1984;
 
 pub const PENPAL_ID: u32 = 2000;
 pub const ASSETS_PALLET_ID: u8 = 50;

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
@@ -20,7 +20,7 @@ use frame_support::{
 	sp_runtime::traits::Dispatchable,
 	traits::{
 		fungible::Inspect,
-		fungibles::{Create, Inspect as FungiblesInspect, Mutate},
+		fungibles::{Inspect as FungiblesInspect, Mutate},
 	},
 };
 use parachains_common::AccountId;
@@ -163,7 +163,7 @@ fn spend_roc_on_asset_hub() {
 #[test]
 fn create_and_claim_treasury_spend_in_usdt() {
 	const ASSET_ID: u32 = 1984;
-	const SPEND_AMOUNT: u128 = 1_000_000;
+	const SPEND_AMOUNT: u128 = 10_000_000;
 	// treasury location from a sibling parachain.
 	let treasury_location: Location = Location::new(1, PalletInstance(18));
 	// treasury account on a sibling parachain.
@@ -190,13 +190,7 @@ fn create_and_claim_treasury_spend_in_usdt() {
 	AssetHubRococo::execute_with(|| {
 		type Assets = <AssetHubRococo as AssetHubRococoPallet>::Assets;
 
-		// create an asset class and mint some assets to the treasury account.
-		assert_ok!(<Assets as Create<_>>::create(
-			ASSET_ID,
-			treasury_account.clone(),
-			true,
-			SPEND_AMOUNT / 2
-		));
+		// USDT created at genesis, mint some assets to the treasury account.
 		assert_ok!(<Assets as Mutate<_>>::mint_into(ASSET_ID, &treasury_account, SPEND_AMOUNT * 4));
 		// beneficiary has zero balance.
 		assert_eq!(<Assets as FungiblesInspect<_>>::balance(ASSET_ID, &alice,), 0u128,);

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
@@ -39,7 +39,8 @@ mod imports {
 	pub use parachains_common::AccountId;
 	pub use rococo_westend_system_emulated_network::{
 		asset_hub_rococo_emulated_chain::{
-			genesis::ED as ASSET_HUB_ROCOCO_ED, AssetHubRococoParaPallet as AssetHubRococoPallet,
+			genesis::{AssetHubRococoAssetOwner, ED as ASSET_HUB_ROCOCO_ED},
+			AssetHubRococoParaPallet as AssetHubRococoPallet,
 		},
 		asset_hub_westend_emulated_chain::{
 			genesis::ED as ASSET_HUB_WESTEND_ED, AssetHubWestendParaPallet as AssetHubWestendPallet,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/lib.rs
@@ -35,6 +35,7 @@ mod imports {
 		xcm_emulator::{
 			assert_expected_events, bx, Chain, Parachain as Para, RelayChain as Relay, TestExt,
 		},
+		ASSETS_PALLET_ID, USDT_ID,
 	};
 	pub use parachains_common::AccountId;
 	pub use rococo_westend_system_emulated_network::{

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
@@ -41,6 +41,11 @@ pub(crate) fn bridged_roc_at_ah_westend() -> Location {
 	Location::new(2, [GlobalConsensus(Rococo)])
 }
 
+// wWND
+pub(crate) fn bridged_wnd_at_ah_rococo() -> Location {
+	Location::new(2, [GlobalConsensus(Westend)])
+}
+
 // USDT and wUSDT
 pub(crate) fn usdt_at_ah_rococo() -> Location {
 	Location::new(0, [PalletInstance(ASSETS_PALLET_ID), GeneralIndex(USDT_ID.into())])
@@ -73,6 +78,12 @@ pub(crate) fn create_foreign_on_ah_westend(id: v3::Location, sufficient: bool) {
 	AssetHubWestend::force_create_foreign_asset(id, owner, sufficient, ASSET_MIN_BALANCE, vec![]);
 }
 
+pub(crate) fn foreign_balance_on_ah_rococo(id: v3::Location, who: &AccountId) -> u128 {
+	AssetHubRococo::execute_with(|| {
+		type Assets = <AssetHubRococo as AssetHubRococoPallet>::ForeignAssets;
+		<Assets as Inspect<_>>::balance(id, who)
+	})
+}
 pub(crate) fn foreign_balance_on_ah_westend(id: v3::Location, who: &AccountId) -> u128 {
 	AssetHubWestend::execute_with(|| {
 		type Assets = <AssetHubWestend as AssetHubWestendPallet>::ForeignAssets;
@@ -122,31 +133,6 @@ pub(crate) fn set_up_pool_with_wnd_on_ah_westend(foreign_asset: v3::Location) {
 			]
 		);
 	});
-}
-
-pub(crate) fn send_asset_from_asset_hub_rococo(
-	destination: Location,
-	(id, amount): (Location, u128),
-) -> DispatchResult {
-	let signed_origin =
-		<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get().into());
-
-	let beneficiary: Location =
-		AccountId32Junction { network: None, id: AssetHubWestendReceiver::get().into() }.into();
-
-	let assets: Assets = (id, amount).into();
-	let fee_asset_item = 0;
-
-	AssetHubRococo::execute_with(|| {
-		<AssetHubRococo as AssetHubRococoPallet>::PolkadotXcm::limited_reserve_transfer_assets(
-			signed_origin,
-			bx!(destination.into()),
-			bx!(beneficiary.into()),
-			bx!(assets.into()),
-			fee_asset_item,
-			WeightLimit::Unlimited,
-		)
-	})
 }
 
 pub(crate) fn send_assets_from_asset_hub_rococo(

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
@@ -59,6 +59,29 @@ pub(crate) fn send_asset_from_asset_hub_rococo(
 	})
 }
 
+pub(crate) fn send_assets_from_asset_hub_rococo(
+	destination: Location,
+	assets: Assets,
+	fee_idx: u32,
+) -> DispatchResult {
+	let signed_origin =
+		<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get().into());
+
+	let beneficiary: Location =
+		AccountId32Junction { network: None, id: AssetHubWestendReceiver::get().into() }.into();
+
+	AssetHubRococo::execute_with(|| {
+		<AssetHubRococo as AssetHubRococoPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+			signed_origin,
+			bx!(destination.into()),
+			bx!(beneficiary.into()),
+			bx!(assets.into()),
+			fee_idx,
+			WeightLimit::Unlimited,
+		)
+	})
+}
+
 pub(crate) fn assert_bridge_hub_rococo_message_accepted(expected_processed: bool) {
 	BridgeHubRococo::execute_with(|| {
 		type RuntimeEvent = <BridgeHubRococo as Chain>::RuntimeEvent;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
@@ -21,16 +21,10 @@ mod snowbridge;
 mod teleport;
 
 pub(crate) fn asset_hub_westend_location() -> Location {
-	Location::new(
-		2,
-		[GlobalConsensus(NetworkId::Westend), Parachain(AssetHubWestend::para_id().into())],
-	)
+	Location::new(2, [GlobalConsensus(Westend), Parachain(AssetHubWestend::para_id().into())])
 }
 pub(crate) fn bridge_hub_westend_location() -> Location {
-	Location::new(
-		2,
-		[GlobalConsensus(NetworkId::Westend), Parachain(BridgeHubWestend::para_id().into())],
-	)
+	Location::new(2, [GlobalConsensus(Westend), Parachain(BridgeHubWestend::para_id().into())])
 }
 
 // ROC and wROC
@@ -67,7 +61,7 @@ pub(crate) fn weth_at_asset_hubs() -> Location {
 	Location::new(
 		2,
 		[
-			GlobalConsensus(NetworkId::Ethereum { chain_id: snowbridge::CHAIN_ID }),
+			GlobalConsensus(Ethereum { chain_id: snowbridge::CHAIN_ID }),
 			AccountKey20 { network: None, key: snowbridge::WETH },
 		],
 	)
@@ -142,7 +136,6 @@ pub(crate) fn send_assets_from_asset_hub_rococo(
 ) -> DispatchResult {
 	let signed_origin =
 		<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get().into());
-
 	let beneficiary: Location =
 		AccountId32Junction { network: None, id: AssetHubWestendReceiver::get().into() }.into();
 

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
@@ -67,6 +67,16 @@ pub(crate) fn weth_at_asset_hubs() -> Location {
 	)
 }
 
+pub(crate) fn create_foreign_on_ah_rococo(
+	id: v3::Location,
+	sufficient: bool,
+	prefund_accounts: Vec<(AccountId, u128)>,
+) {
+	let owner = AssetHubRococo::account_id_of(ALICE);
+	let min = ASSET_MIN_BALANCE;
+	AssetHubRococo::force_create_foreign_asset(id, owner, sufficient, min, prefund_accounts);
+}
+
 pub(crate) fn create_foreign_on_ah_westend(id: v3::Location, sufficient: bool) {
 	let owner = AssetHubWestend::account_id_of(ALICE);
 	AssetHubWestend::force_create_foreign_asset(id, owner, sufficient, ASSET_MIN_BALANCE, vec![]);

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/send_xcm.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/send_xcm.rs
@@ -81,7 +81,11 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 
 	// send XCM from AssetHubRococo - fails - destination version not known
 	assert_err!(
-		send_asset_from_asset_hub_rococo(destination.clone(), (native_token.clone(), amount)),
+		send_assets_from_asset_hub_rococo(
+			destination.clone(),
+			(native_token.clone(), amount).into(),
+			0
+		),
 		DispatchError::Module(sp_runtime::ModuleError {
 			index: 31,
 			error: [1, 0, 0, 0],
@@ -98,9 +102,10 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 		newer_xcm_version,
 	);
 	// send XCM from AssetHubRococo - ok
-	assert_ok!(send_asset_from_asset_hub_rococo(
+	assert_ok!(send_assets_from_asset_hub_rococo(
 		destination.clone(),
-		(native_token.clone(), amount)
+		(native_token.clone(), amount).into(),
+		0,
 	));
 
 	// `ExportMessage` on local BridgeHub - fails - remote BridgeHub version not known
@@ -115,9 +120,10 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	);
 
 	// send XCM from AssetHubRococo - ok
-	assert_ok!(send_asset_from_asset_hub_rococo(
+	assert_ok!(send_assets_from_asset_hub_rococo(
 		destination.clone(),
-		(native_token.clone(), amount)
+		(native_token.clone(), amount).into(),
+		0,
 	));
 	assert_bridge_hub_rococo_message_accepted(true);
 	assert_bridge_hub_westend_message_received();

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -34,10 +34,10 @@ use sp_runtime::{DispatchError::Token, TokenError::FundsUnavailable};
 use testnet_parachains_constants::rococo::snowbridge::EthereumNetwork;
 
 const INITIAL_FUND: u128 = 5_000_000_000 * ROCOCO_ED;
-const CHAIN_ID: u64 = 11155111;
+pub const CHAIN_ID: u64 = 11155111;
 const TREASURY_ACCOUNT: [u8; 32] =
 	hex!("6d6f646c70792f74727372790000000000000000000000000000000000000000");
-const WETH: [u8; 20] = hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
+pub const WETH: [u8; 20] = hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
 const ETHEREUM_DESTINATION_ADDRESS: [u8; 20] = hex!("44a57ee2f2FCcb85FDa2B0B18EBD0D8D2333700e");
 const INSUFFICIENT_XCM_FEE: u128 = 1000;
 const XCM_FEE: u128 = 4_000_000_000;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
+hex-literal = { workspace = true, default-features = true }
 
 # Substrate
 frame-support = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
@@ -36,6 +36,7 @@ mod imports {
 		xcm_emulator::{
 			assert_expected_events, bx, Chain, Parachain as Para, RelayChain as Relay, TestExt,
 		},
+		ASSETS_PALLET_ID, USDT_ID,
 	};
 	pub use parachains_common::AccountId;
 	pub use rococo_westend_system_emulated_network::{

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/lib.rs
@@ -41,7 +41,8 @@ mod imports {
 	pub use parachains_common::AccountId;
 	pub use rococo_westend_system_emulated_network::{
 		asset_hub_rococo_emulated_chain::{
-			genesis::ED as ASSET_HUB_ROCOCO_ED, AssetHubRococoParaPallet as AssetHubRococoPallet,
+			genesis::{AssetHubRococoAssetOwner, ED as ASSET_HUB_ROCOCO_ED},
+			AssetHubRococoParaPallet as AssetHubRococoPallet,
 		},
 		asset_hub_westend_emulated_chain::{
 			genesis::ED as ASSET_HUB_WESTEND_ED, AssetHubWestendParaPallet as AssetHubWestendPallet,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 use crate::tests::*;
 
-fn send_asset_from_asset_hub_westend_to_asset_hub_rococo(id: Location, amount: u128) {
+fn send_assets_from_asset_hub_westend_to_asset_hub_rococo(assets: Assets, fee_idx: u32) {
 	let destination = asset_hub_rococo_location();
 
 	// fund the AHW's SA on BHW for paying bridge transport fees
@@ -25,7 +25,7 @@ fn send_asset_from_asset_hub_westend_to_asset_hub_rococo(id: Location, amount: u
 	BridgeHubWestend::force_xcm_version(bridge_hub_rococo_location(), XCM_VERSION);
 
 	// send message over bridge
-	assert_ok!(send_asset_from_asset_hub_westend(destination, (id, amount)));
+	assert_ok!(send_assets_from_asset_hub_westend(destination, assets, fee_idx));
 	assert_bridge_hub_westend_message_accepted(true);
 	assert_bridge_hub_rococo_message_received();
 }
@@ -103,76 +103,34 @@ fn send_asset_from_penpal_westend_through_local_asset_hub_to_rococo_asset_hub(
 
 #[test]
 fn send_wnds_from_asset_hub_westend_to_asset_hub_rococo() {
-	let wnd_at_asset_hub_westend: Location = Parent.into();
-	let wnd_at_asset_hub_rococo =
-		v3::Location::new(2, [v3::Junction::GlobalConsensus(v3::NetworkId::Westend)]);
-	let owner: AccountId = AssetHubRococo::account_id_of(ALICE);
-	AssetHubRococo::force_create_foreign_asset(
-		wnd_at_asset_hub_rococo,
-		owner,
-		true,
-		ASSET_MIN_BALANCE,
-		vec![],
-	);
+	let amount = ASSET_HUB_WESTEND_ED * 1_000;
+	let sender = AssetHubWestendSender::get();
+	let receiver = AssetHubRococoReceiver::get();
+	let wnd_at_asset_hub_westend = wnd_at_ah_westend();
+	let bridged_wnd_at_asset_hub_rococo = bridged_wnd_at_ah_rococo().try_into().unwrap();
+	create_foreign_on_ah_rococo(bridged_wnd_at_asset_hub_rococo, true);
+
+	set_up_pool_with_roc_on_ah_rococo(bridged_wnd_at_asset_hub_rococo);
+
+	////////////////////////////////////////////////////////////
+	// Let's first send over just some WNDs as a simple example
+	////////////////////////////////////////////////////////////
 	let sov_ahr_on_ahw = AssetHubWestend::sovereign_account_of_parachain_on_other_global_consensus(
 		Rococo,
 		AssetHubRococo::para_id(),
 	);
-
-	AssetHubRococo::execute_with(|| {
-		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
-
-		// setup a pool to pay xcm fees with `wnd_at_asset_hub_rococo` tokens
-		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::ForeignAssets::mint(
-			<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get()),
-			wnd_at_asset_hub_rococo.into(),
-			AssetHubRococoSender::get().into(),
-			3_000_000_000_000,
-		));
-
-		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::AssetConversion::create_pool(
-			<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get()),
-			Box::new(xcm::v3::Parent.into()),
-			Box::new(wnd_at_asset_hub_rococo),
-		));
-
-		assert_expected_events!(
-			AssetHubRococo,
-			vec![
-				RuntimeEvent::AssetConversion(pallet_asset_conversion::Event::PoolCreated { .. }) => {},
-			]
-		);
-
-		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::AssetConversion::add_liquidity(
-			<AssetHubRococo as Chain>::RuntimeOrigin::signed(AssetHubRococoSender::get()),
-			Box::new(xcm::v3::Parent.into()),
-			Box::new(wnd_at_asset_hub_rococo),
-			1_000_000_000_000,
-			2_000_000_000_000,
-			1,
-			1,
-			AssetHubRococoSender::get().into()
-		));
-
-		assert_expected_events!(
-			AssetHubRococo,
-			vec![
-				RuntimeEvent::AssetConversion(pallet_asset_conversion::Event::LiquidityAdded {..}) => {},
-			]
-		);
-	});
-
 	let wnds_in_reserve_on_ahw_before =
 		<AssetHubWestend as Chain>::account_data_of(sov_ahr_on_ahw.clone()).free;
-	let sender_wnds_before =
-		<AssetHubWestend as Chain>::account_data_of(AssetHubWestendSender::get()).free;
-	let receiver_wnds_before = AssetHubRococo::execute_with(|| {
-		type Assets = <AssetHubRococo as AssetHubRococoPallet>::ForeignAssets;
-		<Assets as Inspect<_>>::balance(wnd_at_asset_hub_rococo, &AssetHubRococoReceiver::get())
-	});
+	let sender_wnds_before = <AssetHubWestend as Chain>::account_data_of(sender.clone()).free;
+	let receiver_wnds_before =
+		foreign_balance_on_ah_rococo(bridged_wnd_at_asset_hub_rococo, &receiver);
 
-	let amount = ASSET_HUB_WESTEND_ED * 1_000;
-	send_asset_from_asset_hub_westend_to_asset_hub_rococo(wnd_at_asset_hub_westend, amount);
+	// send WNDs, use them for fees
+	let assets: Assets = (wnd_at_asset_hub_westend, amount).into();
+	let fee_index = 0;
+	send_assets_from_asset_hub_westend_to_asset_hub_rococo(assets, fee_index);
+
+	// verify expected events on final destination
 	AssetHubRococo::execute_with(|| {
 		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
 		assert_expected_events!(
@@ -180,8 +138,8 @@ fn send_wnds_from_asset_hub_westend_to_asset_hub_rococo() {
 			vec![
 				// issue WNDs on AHR
 				RuntimeEvent::ForeignAssets(pallet_assets::Event::Issued { asset_id, owner, .. }) => {
-					asset_id: *asset_id == wnd_at_asset_hub_rococo,
-					owner: *owner == AssetHubRococoReceiver::get(),
+					asset_id: *asset_id == bridged_wnd_at_asset_hub_rococo,
+					owner: *owner == receiver,
 				},
 				// message processed successfully
 				RuntimeEvent::MessageQueue(
@@ -191,12 +149,9 @@ fn send_wnds_from_asset_hub_westend_to_asset_hub_rococo() {
 		);
 	});
 
-	let sender_wnds_after =
-		<AssetHubWestend as Chain>::account_data_of(AssetHubWestendSender::get()).free;
-	let receiver_wnds_after = AssetHubRococo::execute_with(|| {
-		type Assets = <AssetHubRococo as AssetHubRococoPallet>::ForeignAssets;
-		<Assets as Inspect<_>>::balance(wnd_at_asset_hub_rococo, &AssetHubRococoReceiver::get())
-	});
+	let sender_wnds_after = <AssetHubWestend as Chain>::account_data_of(sender).free;
+	let receiver_wnds_after =
+		foreign_balance_on_ah_rococo(bridged_wnd_at_asset_hub_rococo, &receiver);
 	let wnds_in_reserve_on_ahw_after =
 		<AssetHubWestend as Chain>::account_data_of(sov_ahr_on_ahw).free;
 
@@ -211,15 +166,17 @@ fn send_wnds_from_asset_hub_westend_to_asset_hub_rococo() {
 #[test]
 fn send_rocs_from_asset_hub_westend_to_asset_hub_rococo() {
 	let prefund_amount = 10_000_000_000_000u128;
-	let roc_at_asset_hub_westend =
-		v3::Location::new(2, [v3::Junction::GlobalConsensus(v3::NetworkId::Rococo)]);
-	let owner: AccountId = AssetHubWestend::account_id_of(ALICE);
+	let sender = AssetHubWestendSender::get();
+	let receiver = AssetHubRococoReceiver::get();
+	let bridged_roc_at_asset_hub_westend = bridged_roc_at_ah_westend();
+	let bridged_roc_at_asset_hub_westend_v3 =
+		bridged_roc_at_asset_hub_westend.clone().try_into().unwrap();
 	AssetHubWestend::force_create_foreign_asset(
-		roc_at_asset_hub_westend,
-		owner,
+		bridged_roc_at_asset_hub_westend_v3,
+		AssetHubWestend::account_id_of(ALICE),
 		true,
 		ASSET_MIN_BALANCE,
-		vec![(AssetHubWestendSender::get(), prefund_amount)],
+		vec![(sender.clone(), prefund_amount)],
 	);
 
 	// fund the AHW's SA on AHR with the ROC tokens held in reserve
@@ -232,18 +189,16 @@ fn send_rocs_from_asset_hub_westend_to_asset_hub_rococo() {
 	let rocs_in_reserve_on_ahr_before =
 		<AssetHubRococo as Chain>::account_data_of(sov_ahw_on_ahr.clone()).free;
 	assert_eq!(rocs_in_reserve_on_ahr_before, prefund_amount);
-	let sender_rocs_before = AssetHubWestend::execute_with(|| {
-		type Assets = <AssetHubWestend as AssetHubWestendPallet>::ForeignAssets;
-		<Assets as Inspect<_>>::balance(roc_at_asset_hub_westend, &AssetHubWestendSender::get())
-	});
+
+	let sender_rocs_before =
+		foreign_balance_on_ah_westend(bridged_roc_at_asset_hub_westend_v3, &sender);
 	assert_eq!(sender_rocs_before, prefund_amount);
-	let receiver_rocs_before =
-		<AssetHubRococo as Chain>::account_data_of(AssetHubRococoReceiver::get()).free;
+	let receiver_rocs_before = <AssetHubRococo as Chain>::account_data_of(receiver.clone()).free;
 
 	let amount_to_send = ASSET_HUB_ROCOCO_ED * 1_000;
-	send_asset_from_asset_hub_westend_to_asset_hub_rococo(
-		roc_at_asset_hub_westend.try_into().unwrap(),
-		amount_to_send,
+	send_assets_from_asset_hub_westend_to_asset_hub_rococo(
+		(bridged_roc_at_asset_hub_westend, amount_to_send).into(),
+		0,
 	);
 	AssetHubRococo::execute_with(|| {
 		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
@@ -259,7 +214,7 @@ fn send_rocs_from_asset_hub_westend_to_asset_hub_rococo() {
 				},
 				// ROCs deposited to beneficiary
 				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, .. }) => {
-					who: *who == AssetHubRococoReceiver::get(),
+					who: *who == receiver,
 				},
 				// message processed successfully
 				RuntimeEvent::MessageQueue(
@@ -269,12 +224,9 @@ fn send_rocs_from_asset_hub_westend_to_asset_hub_rococo() {
 		);
 	});
 
-	let sender_rocs_after = AssetHubWestend::execute_with(|| {
-		type Assets = <AssetHubWestend as AssetHubWestendPallet>::ForeignAssets;
-		<Assets as Inspect<_>>::balance(roc_at_asset_hub_westend, &AssetHubWestendSender::get())
-	});
-	let receiver_rocs_after =
-		<AssetHubRococo as Chain>::account_data_of(AssetHubRococoReceiver::get()).free;
+	let sender_rocs_after =
+		foreign_balance_on_ah_westend(bridged_roc_at_asset_hub_westend_v3, &sender);
+	let receiver_rocs_after = <AssetHubRococo as Chain>::account_data_of(receiver).free;
 	let rocs_in_reserve_on_ahr_after =
 		<AssetHubRococo as Chain>::account_data_of(sov_ahw_on_ahr.clone()).free;
 
@@ -288,22 +240,13 @@ fn send_rocs_from_asset_hub_westend_to_asset_hub_rococo() {
 
 #[test]
 fn send_wnds_from_penpal_westend_through_asset_hub_westend_to_asset_hub_rococo() {
-	let wnd_at_westend_parachains: Location = Parent.into();
-	let wnd_at_asset_hub_rococo = Location::new(2, [Junction::GlobalConsensus(NetworkId::Westend)]);
-	let owner: AccountId = AssetHubRococo::account_id_of(ALICE);
-	AssetHubRococo::force_create_foreign_asset(
-		wnd_at_asset_hub_rococo.clone().try_into().unwrap(),
-		owner,
-		true,
-		ASSET_MIN_BALANCE,
-		vec![],
-	);
-	let sov_ahr_on_ahw = AssetHubWestend::sovereign_account_of_parachain_on_other_global_consensus(
-		Rococo,
-		AssetHubRococo::para_id(),
-	);
+	let wnd_at_westend_parachains = wnd_at_ah_westend();
+	let wnd_at_asset_hub_rococo = bridged_wnd_at_ah_rococo().try_into().unwrap();
+	create_foreign_on_ah_rococo(wnd_at_asset_hub_rococo, true);
 
 	let amount = ASSET_HUB_WESTEND_ED * 10_000_000;
+	let sender = PenpalBSender::get();
+	let receiver = AssetHubRococoReceiver::get();
 	let penpal_location = AssetHubWestend::sibling_location_of(PenpalB::para_id());
 	let sov_penpal_on_ahw = AssetHubWestend::sovereign_account_id_of(penpal_location);
 	// fund Penpal's sovereign account on AssetHub
@@ -312,26 +255,23 @@ fn send_wnds_from_penpal_westend_through_asset_hub_westend_to_asset_hub_rococo()
 	PenpalB::mint_foreign_asset(
 		<PenpalB as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
 		wnd_at_westend_parachains.clone(),
-		PenpalBSender::get(),
+		sender.clone(),
 		amount * 2,
 	);
 
+	let sov_ahr_on_ahw = AssetHubWestend::sovereign_account_of_parachain_on_other_global_consensus(
+		Rococo,
+		AssetHubRococo::para_id(),
+	);
 	let wnds_in_reserve_on_ahw_before =
 		<AssetHubWestend as Chain>::account_data_of(sov_ahr_on_ahw.clone()).free;
 	let sender_wnds_before = PenpalB::execute_with(|| {
 		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			wnd_at_westend_parachains.clone(),
-			&PenpalBSender::get(),
-		)
+		<ForeignAssets as Inspect<_>>::balance(wnd_at_westend_parachains.clone(), &sender)
 	});
-	let receiver_wnds_before = AssetHubRococo::execute_with(|| {
-		type Assets = <AssetHubRococo as AssetHubRococoPallet>::ForeignAssets;
-		<Assets as Inspect<_>>::balance(
-			wnd_at_asset_hub_rococo.clone().try_into().unwrap(),
-			&AssetHubRococoReceiver::get(),
-		)
-	});
+	let receiver_wnds_before = foreign_balance_on_ah_rococo(wnd_at_asset_hub_rococo, &receiver);
+
+	// Send WNDs over bridge
 	send_asset_from_penpal_westend_through_local_asset_hub_to_rococo_asset_hub(
 		wnd_at_westend_parachains.clone(),
 		amount,
@@ -345,7 +285,7 @@ fn send_wnds_from_penpal_westend_through_asset_hub_westend_to_asset_hub_rococo()
 				// issue WNDs on AHR
 				RuntimeEvent::ForeignAssets(pallet_assets::Event::Issued { asset_id, owner, .. }) => {
 					asset_id: *asset_id == wnd_at_westend_parachains.clone().try_into().unwrap(),
-					owner: *owner == AssetHubRococoReceiver::get(),
+					owner: owner == &receiver,
 				},
 				// message processed successfully
 				RuntimeEvent::MessageQueue(
@@ -357,15 +297,9 @@ fn send_wnds_from_penpal_westend_through_asset_hub_westend_to_asset_hub_rococo()
 
 	let sender_wnds_after = PenpalB::execute_with(|| {
 		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(wnd_at_westend_parachains, &PenpalBSender::get())
+		<ForeignAssets as Inspect<_>>::balance(wnd_at_westend_parachains, &sender)
 	});
-	let receiver_wnds_after = AssetHubRococo::execute_with(|| {
-		type Assets = <AssetHubRococo as AssetHubRococoPallet>::ForeignAssets;
-		<Assets as Inspect<_>>::balance(
-			wnd_at_asset_hub_rococo.try_into().unwrap(),
-			&AssetHubRococoReceiver::get(),
-		)
-	});
+	let receiver_wnds_after = foreign_balance_on_ah_rococo(wnd_at_asset_hub_rococo, &receiver);
 	let wnds_in_reserve_on_ahw_after =
 		<AssetHubWestend as Chain>::account_data_of(sov_ahr_on_ahw.clone()).free;
 

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
@@ -19,32 +19,130 @@ mod asset_transfers;
 mod send_xcm;
 mod teleport;
 
+mod snowbridge {
+	pub const CHAIN_ID: u64 = 11155111;
+	pub const WETH: [u8; 20] = hex_literal::hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
+}
+
 pub(crate) fn asset_hub_rococo_location() -> Location {
-	Location::new(
-		2,
-		[GlobalConsensus(NetworkId::Rococo), Parachain(AssetHubRococo::para_id().into())],
-	)
+	Location::new(2, [GlobalConsensus(Rococo), Parachain(AssetHubRococo::para_id().into())])
 }
 
 pub(crate) fn bridge_hub_rococo_location() -> Location {
+	Location::new(2, [GlobalConsensus(Rococo), Parachain(BridgeHubRococo::para_id().into())])
+}
+
+// WND and wWND
+pub(crate) fn wnd_at_ah_westend() -> Location {
+	Parent.into()
+}
+pub(crate) fn bridged_wnd_at_ah_rococo() -> Location {
+	Location::new(2, [GlobalConsensus(Westend)])
+}
+
+// wROC
+pub(crate) fn bridged_roc_at_ah_westend() -> Location {
+	Location::new(2, [GlobalConsensus(Rococo)])
+}
+
+// USDT and wUSDT
+pub(crate) fn usdt_at_ah_rococo() -> Location {
+	Location::new(2, [PalletInstance(ASSETS_PALLET_ID), GeneralIndex(USDT_ID.into())])
+}
+pub(crate) fn bridged_usdt_at_ah_westend() -> Location {
 	Location::new(
 		2,
-		[GlobalConsensus(NetworkId::Rococo), Parachain(BridgeHubRococo::para_id().into())],
+		[
+			GlobalConsensus(Rococo),
+			Parachain(AssetHubRococo::para_id().into()),
+			PalletInstance(ASSETS_PALLET_ID),
+			GeneralIndex(USDT_ID.into()),
+		],
 	)
 }
 
-pub(crate) fn send_asset_from_asset_hub_westend(
+// wETH has same relative location on both Rococo and Westend AssetHubs
+pub(crate) fn weth_at_asset_hubs() -> Location {
+	Location::new(
+		2,
+		[
+			GlobalConsensus(Ethereum { chain_id: snowbridge::CHAIN_ID }),
+			AccountKey20 { network: None, key: snowbridge::WETH },
+		],
+	)
+}
+
+pub(crate) fn create_foreign_on_ah_rococo(id: v3::Location, sufficient: bool) {
+	let owner = AssetHubRococo::account_id_of(ALICE);
+	AssetHubRococo::force_create_foreign_asset(id, owner, sufficient, ASSET_MIN_BALANCE, vec![]);
+}
+
+pub(crate) fn foreign_balance_on_ah_rococo(id: v3::Location, who: &AccountId) -> u128 {
+	AssetHubRococo::execute_with(|| {
+		type Assets = <AssetHubRococo as AssetHubRococoPallet>::ForeignAssets;
+		<Assets as Inspect<_>>::balance(id, who)
+	})
+}
+pub(crate) fn foreign_balance_on_ah_westend(id: v3::Location, who: &AccountId) -> u128 {
+	AssetHubWestend::execute_with(|| {
+		type Assets = <AssetHubWestend as AssetHubWestendPallet>::ForeignAssets;
+		<Assets as Inspect<_>>::balance(id, who)
+	})
+}
+
+// set up pool
+pub(crate) fn set_up_pool_with_roc_on_ah_rococo(foreign_asset: v3::Location) {
+	let roc: v3::Location = v3::Parent.into();
+	AssetHubRococo::execute_with(|| {
+		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
+		let owner = AssetHubRococoSender::get();
+		let signed_owner = <AssetHubRococo as Chain>::RuntimeOrigin::signed(owner.clone());
+
+		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::ForeignAssets::mint(
+			signed_owner.clone(),
+			foreign_asset.into(),
+			owner.clone().into(),
+			3_000_000_000_000,
+		));
+		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::AssetConversion::create_pool(
+			signed_owner.clone(),
+			Box::new(roc),
+			Box::new(foreign_asset),
+		));
+		assert_expected_events!(
+			AssetHubRococo,
+			vec![
+				RuntimeEvent::AssetConversion(pallet_asset_conversion::Event::PoolCreated { .. }) => {},
+			]
+		);
+		assert_ok!(<AssetHubRococo as AssetHubRococoPallet>::AssetConversion::add_liquidity(
+			signed_owner.clone(),
+			Box::new(roc),
+			Box::new(foreign_asset),
+			1_000_000_000_000,
+			2_000_000_000_000,
+			1,
+			1,
+			owner.into()
+		));
+		assert_expected_events!(
+			AssetHubRococo,
+			vec![
+				RuntimeEvent::AssetConversion(pallet_asset_conversion::Event::LiquidityAdded {..}) => {},
+			]
+		);
+	});
+}
+
+pub(crate) fn send_assets_from_asset_hub_westend(
 	destination: Location,
-	(id, amount): (Location, u128),
+	assets: Assets,
+	fee_idx: u32,
 ) -> DispatchResult {
 	let signed_origin =
 		<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get().into());
-
 	let beneficiary: Location =
 		AccountId32Junction { network: None, id: AssetHubRococoReceiver::get().into() }.into();
-
-	let assets: Assets = (id, amount).into();
-	let fee_asset_item = 0;
 
 	AssetHubWestend::execute_with(|| {
 		<AssetHubWestend as AssetHubWestendPallet>::PolkadotXcm::limited_reserve_transfer_assets(
@@ -52,7 +150,7 @@ pub(crate) fn send_asset_from_asset_hub_westend(
 			bx!(destination.into()),
 			bx!(beneficiary.into()),
 			bx!(assets.into()),
-			fee_asset_item,
+			fee_idx,
 			WeightLimit::Unlimited,
 		)
 	})

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
@@ -116,7 +116,7 @@ pub(crate) fn set_up_pool_with_roc_on_ah_rococo(asset: v3::Location, is_foreign:
 				3_000_000_000_000,
 			));
 		} else {
-			let asset_id = match asset.interior.clone().split_last() {
+			let asset_id = match asset.interior.split_last() {
 				(_, Some(v3::Junction::GeneralIndex(id))) => id as u32,
 				_ => unreachable!(),
 			};

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/send_xcm.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/send_xcm.rs
@@ -81,7 +81,11 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 
 	// send XCM from AssetHubWestend - fails - destination version not known
 	assert_err!(
-		send_asset_from_asset_hub_westend(destination.clone(), (native_token.clone(), amount)),
+		send_assets_from_asset_hub_westend(
+			destination.clone(),
+			(native_token.clone(), amount).into(),
+			0
+		),
 		DispatchError::Module(sp_runtime::ModuleError {
 			index: 31,
 			error: [1, 0, 0, 0],
@@ -98,9 +102,10 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 		newer_xcm_version,
 	);
 	// send XCM from AssetHubWestend - ok
-	assert_ok!(send_asset_from_asset_hub_westend(
+	assert_ok!(send_assets_from_asset_hub_westend(
 		destination.clone(),
-		(native_token.clone(), amount)
+		(native_token.clone(), amount).into(),
+		0
 	));
 
 	// `ExportMessage` on local BridgeHub - fails - remote BridgeHub version not known
@@ -115,9 +120,10 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	);
 
 	// send XCM from AssetHubWestend - ok
-	assert_ok!(send_asset_from_asset_hub_westend(
+	assert_ok!(send_assets_from_asset_hub_westend(
 		destination.clone(),
-		(native_token.clone(), amount)
+		(native_token.clone(), amount).into(),
+		0
 	));
 	assert_bridge_hub_westend_message_accepted(true);
 	assert_bridge_hub_rococo_message_received();

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
@@ -340,7 +340,7 @@ impl xcm_executor::Config for XcmConfig {
 	// held). Asset Hub may _act_ as a reserve location for ROC and assets created
 	// under `pallet-assets`. Users must use teleport where allowed (e.g. ROC with the Relay Chain).
 	type IsReserve = (
-		bridging::to_westend::IsTrustedBridgedReserveLocationForConcreteAsset,
+		bridging::to_westend::WestendAssetFromAssetHubWestend,
 		bridging::to_ethereum::IsTrustedBridgedReserveLocationForForeignAsset,
 	);
 	type IsTeleporter = TrustedTeleporters;
@@ -568,13 +568,11 @@ pub mod bridging {
 			);
 
 			pub const WestendNetwork: NetworkId = NetworkId::Westend;
-			pub AssetHubWestend: Location = Location::new(2, [GlobalConsensus(WestendNetwork::get()), Parachain(bp_asset_hub_westend::ASSET_HUB_WESTEND_PARACHAIN_ID)]);
-			pub WndLocation: Location = Location::new(2, [GlobalConsensus(WestendNetwork::get())]);
-
-			pub WndFromAssetHubWestend: (AssetFilter, Location) = (
-				Wild(AllOf { fun: WildFungible, id: AssetId(WndLocation::get()) }),
-				AssetHubWestend::get()
-			);
+			pub WestendEcosystem: Location = Location::new(2, [GlobalConsensus(WestendNetwork::get())]);
+			pub AssetHubWestend: Location = Location::new(2, [
+				GlobalConsensus(WestendNetwork::get()),
+				Parachain(bp_asset_hub_westend::ASSET_HUB_WESTEND_PARACHAIN_ID)
+			]);
 
 			/// Set up exporters configuration.
 			/// `Option<Asset>` represents static "base fee" which is used for total delivery fee calculation.
@@ -607,17 +605,9 @@ pub mod bridging {
 			}
 		}
 
-		/// Trusted reserve locations filter for `xcm_executor::Config::IsReserve`.
-		/// Locations from which the runtime accepts reserved assets.
-		pub type IsTrustedBridgedReserveLocationForConcreteAsset =
-			matching::IsTrustedBridgedReserveLocationForConcreteAsset<
-				UniversalLocation,
-				(
-					// allow receive WND from AssetHubWestend
-					xcm_builder::Case<WndFromAssetHubWestend>,
-					// and nothing else
-				),
-			>;
+		/// Allow any asset native to the Westend ecosystem if it comes from Westend Asset Hub.
+		pub type WestendAssetFromAssetHubWestend =
+			matching::RemoteAssetFromLocation<StartsWith<WestendEcosystem>, AssetHubWestend>;
 
 		impl Contains<RuntimeCall> for ToWestendXcmRouter {
 			fn contains(call: &RuntimeCall) -> bool {
@@ -672,7 +662,7 @@ pub mod bridging {
 		}
 
 		pub type IsTrustedBridgedReserveLocationForForeignAsset =
-			matching::IsForeignConcreteAsset<FromNetwork<UniversalLocation, EthereumNetwork>>;
+			IsForeignConcreteAsset<FromNetwork<UniversalLocation, EthereumNetwork>>;
 
 		impl Contains<(Location, Junction)> for UniversalAliases {
 			fn contains(alias: &(Location, Junction)) -> bool {

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
@@ -570,6 +570,7 @@ pub mod bridging {
 
 			pub const WestendNetwork: NetworkId = NetworkId::Westend;
 			pub WestendEcosystem: Location = Location::new(2, [GlobalConsensus(WestendNetwork::get())]);
+			pub WndLocation: Location = Location::new(2, [GlobalConsensus(WestendNetwork::get())]);
 			pub AssetHubWestend: Location = Location::new(2, [
 				GlobalConsensus(WestendNetwork::get()),
 				Parachain(bp_asset_hub_westend::ASSET_HUB_WESTEND_PARACHAIN_ID)

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/xcm_config.rs
@@ -337,8 +337,9 @@ impl xcm_executor::Config for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Asset Hub trusts only particular, pre-configured bridged locations from a different consensus
 	// as reserve locations (we trust the Bridge Hub to relay the message that a reserve is being
-	// held). Asset Hub may _act_ as a reserve location for ROC and assets created
-	// under `pallet-assets`. Users must use teleport where allowed (e.g. ROC with the Relay Chain).
+	// held). On Rococo Asset Hub, we allow Westend Asset Hub to act as reserve for any asset native
+	// to the Westend ecosystem. We also allow Ethereum contracts to act as reserves for the foreign
+	// assets identified by the same respective contracts locations.
 	type IsReserve = (
 		bridging::to_westend::WestendAssetFromAssetHubWestend,
 		bridging::to_ethereum::IsTrustedBridgedReserveLocationForForeignAsset,

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -571,6 +571,7 @@ pub mod bridging {
 			pub const RococoNetwork: NetworkId = NetworkId::Rococo;
 			pub const EthereumNetwork: NetworkId = NetworkId::Ethereum { chain_id: 11155111 };
 			pub RococoEcosystem: Location = Location::new(2, [GlobalConsensus(RococoNetwork::get())]);
+			pub RocLocation: Location = Location::new(2, [GlobalConsensus(RococoNetwork::get())]);
 			pub EthereumEcosystem: Location = Location::new(2, [GlobalConsensus(EthereumNetwork::get())]);
 			pub AssetHubRococo: Location = Location::new(2, [
 				GlobalConsensus(RococoNetwork::get()),

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -357,8 +357,8 @@ impl xcm_executor::Config for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Asset Hub trusts only particular, pre-configured bridged locations from a different consensus
 	// as reserve locations (we trust the Bridge Hub to relay the message that a reserve is being
-	// held). Asset Hub may _act_ as a reserve location for WND and assets created
-	// under `pallet-assets`. Users must use teleport where allowed (e.g. WND with the Relay Chain).
+	// held). On Westend Asset Hub, we allow Rococo Asset Hub to act as reserve for any asset native
+	// to the Rococo or Ethereum ecosystems.
 	type IsReserve = (bridging::to_rococo::RococoOrEthereumAssetFromAssetHubRococo,);
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;

--- a/cumulus/parachains/runtimes/assets/common/src/matching.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/matching.rs
@@ -98,22 +98,21 @@ impl<
 }
 
 /// Accept an asset if it is native to `AssetsAllowedNetworks` and it is coming from
-/// `RemoteAssetHubLocation`.
-pub struct RemoteAssetFromLocation<AssetsAllowedNetworks, RemoteAssetHubLocation>(
-	sp_std::marker::PhantomData<(AssetsAllowedNetworks, RemoteAssetHubLocation)>,
+/// `OriginLocation`.
+pub struct RemoteAssetFromLocation<AssetsAllowedNetworks, OriginLocation>(
+	sp_std::marker::PhantomData<(AssetsAllowedNetworks, OriginLocation)>,
 );
-impl<AssetsAllowedNetworks: Contains<Location>, RemoteAssetHubLocation: Get<Location>>
-	ContainsPair<Asset, Location>
-	for RemoteAssetFromLocation<AssetsAllowedNetworks, RemoteAssetHubLocation>
+impl<AssetsAllowedNetworks: Contains<Location>, OriginLocation: Get<Location>>
+	ContainsPair<Asset, Location> for RemoteAssetFromLocation<AssetsAllowedNetworks, OriginLocation>
 {
 	fn contains(asset: &Asset, origin: &Location) -> bool {
-		let remote_asset_hub = RemoteAssetHubLocation::get();
-		// ensure `origin` is `RemoteAssetHubLocation`
-		if !remote_asset_hub.eq(origin) {
+		let expected_origin = OriginLocation::get();
+		// ensure `origin` is expected `OriginLocation`
+		if !expected_origin.eq(origin) {
 			log::trace!(
 				target: "xcm::contains",
 				"RemoteAssetFromLocation asset: {:?}, origin: {:?} is not from expected {:?}",
-				asset, origin, remote_asset_hub,
+				asset, origin, expected_origin,
 			);
 			return false
 		} else {

--- a/prdoc/pr_4888.prdoc
+++ b/prdoc/pr_4888.prdoc
@@ -1,0 +1,35 @@
+title: "Allow any asset over the bridge lane between the two Asset Hubs"
+
+doc:
+  - audience: Runtime User
+    description: |
+      Allow all Rococo-native, Westend-native and Ethereum-native assets to flow over
+      the bridge between the Rococo and Westend AssetHubs.
+
+      On Rococo Asset Hub, we allow Westend Asset Hub to act as reserve for any asset
+      native to the Westend ecosystem.
+      We also allow Ethereum contracts to act as reserves for the foreign assets
+      identified by the same respective contracts locations (on the other side of Snowbridge).
+
+      On Westend Asset Hub, we allow Rococo Asset Hub to act as reserve for any asset
+      native to the Rococo or Ethereum ecosystems (practically providing Westend access
+      to Ethereum assets through double bridging: Ethereum <> Rococo <> Westend).
+
+crates:
+  - name: assets-common
+    bump: minor
+  - name: asset-hub-rococo-runtime
+    bump: minor
+  - name: asset-hub-westend-runtime
+    bump: minor
+  - name: asset-hub-rococo-emulated-chain
+    bump: minor
+  - name: asset-hub-rococo-integration-tests
+    bump: minor
+  - name: bridge-hub-rococo-integration-tests
+    bump: minor
+  - name: bridge-hub-westend-integration-tests
+    bump: minor
+  - name: emulated-integration-tests-common
+    bump: patch
+

--- a/prdoc/pr_4888.prdoc
+++ b/prdoc/pr_4888.prdoc
@@ -17,11 +17,11 @@ doc:
 
 crates:
   - name: assets-common
-    bump: minor
+    bump: major
   - name: asset-hub-rococo-runtime
-    bump: minor
+    bump: major
   - name: asset-hub-westend-runtime
-    bump: minor
+    bump: major
   - name: asset-hub-rococo-emulated-chain
     bump: minor
   - name: asset-hub-rococo-integration-tests
@@ -31,5 +31,5 @@ crates:
   - name: bridge-hub-westend-integration-tests
     bump: minor
   - name: emulated-integration-tests-common
-    bump: patch
+    bump: minor
 


### PR DESCRIPTION
On Westend Asset Hub, we allow Rococo Asset Hub to act as reserve for any asset native to the Rococo or Ethereum ecosystems (practically providing Westend access to Ethereum assets through double bridging: W<>R<>Eth).

On Rococo Asset Hub, we allow Westend Asset Hub to act as reserve for any asset native to the Westend ecosystem. We also allow Ethereum contracts to act as reserves for the foreign assets identified by the same respective contracts locations.

- [x] add emulated tests for various assets (native, trust-based, foreign/bridged) going AHR -> AHW,
- [x] add equivalent tests for the other direction AHW -> AHR.

This PR is a prerequisite to doing the same for Polkadot<>Kusama bridge.