### PR TITLE
Allow concurrent header metadata reads

### DIFF
--- a/substrate/primitives/blockchain/src/header_metadata.rs
+++ b/substrate/primitives/blockchain/src/header_metadata.rs
@@ -284,7 +284,7 @@ impl<Block: BlockT> Default for HeaderMetadataCache<Block> {
 
 impl<Block: BlockT> HeaderMetadataCache<Block> {
 	pub fn header_metadata(&self, hash: Block::Hash) -> Option<CachedHeaderMetadata<Block>> {
-		self.cache.write().get(&hash).cloned()
+		self.cache.read().get(&hash).cloned()
 	}
 
 	pub fn insert_header_metadata(&self, hash: Block::Hash, metadata: CachedHeaderMetadata<Block>) {

--- a/substrate/primitives/blockchain/src/header_metadata.rs
+++ b/substrate/primitives/blockchain/src/header_metadata.rs
@@ -284,7 +284,7 @@ impl<Block: BlockT> Default for HeaderMetadataCache<Block> {
 
 impl<Block: BlockT> HeaderMetadataCache<Block> {
 	pub fn header_metadata(&self, hash: Block::Hash) -> Option<CachedHeaderMetadata<Block>> {
-		self.cache.read().get(&hash).cloned()
+		self.cache.read().peek(&hash).cloned()
 	}
 
 	pub fn insert_header_metadata(&self, hash: Block::Hash, metadata: CachedHeaderMetadata<Block>) {


### PR DESCRIPTION
Looked like a bug to me that defeated the purpose of using `RwLock`