### PR TITLE
litep2p: Increment random walk metrics

### DIFF
--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -145,6 +145,9 @@ pub enum DiscoveryEvent {
 		/// Record.
 		record: Record,
 	},
+
+	/// Started a random Kademlia query.
+	RandomKademliaStarted,
 }
 
 /// Discovery.
@@ -456,6 +459,7 @@ impl Stream for Discovery {
 					match this.kademlia_handle.try_find_node(peer) {
 						Ok(query_id) => {
 							this.find_node_query_id = Some(query_id);
+							return Poll::Ready(Some(DiscoveryEvent::RandomKademliaStarted))
 						},
 						Err(()) => {
 							this.duration_to_next_find_query = cmp::min(

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -929,6 +929,12 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 								expires,
 							)
 						));
+					},
+
+					Some(DiscoveryEvent::RandomKademliaStarted) => {
+						if let Some(metrics) = self.metrics.as_ref() {
+							metrics.kademlia_random_queries_total.inc();
+						}
 					}
 				},
 				event = self.litep2p.next_event() => match event {


### PR DESCRIPTION
This PR exposes the `RandomKademliaStarted` event from the litep2p network backend, and then increments the appropriate metrics.

This is part of: https://github.com/paritytech/polkadot-sdk/issues/4681.
However, it is more of an effort to debug low peer count 

### Testing Done
- Started a node and fetched queries: `substrate_sub_libp2p_kademlia_random_queries_total` produces results for litep2p backend

cc @paritytech/networking 