### PR TITLE
`polkadot-parachain`: Unify asset-hub authoring codepath with general AURA

### DIFF
--- a/cumulus/polkadot-parachain/src/command.rs
+++ b/cumulus/polkadot-parachain/src/command.rs
@@ -725,25 +725,17 @@ async fn start_node<Network: sc_network::NetworkBackend<Block, Hash>>(
 		.map(|r| r.0)
 		.map_err(Into::into),
 
-		Runtime::AssetHub => crate::service::start_asset_hub_lookahead_node::<
-			RuntimeApi,
-			AuraId,
-			Network,
-		>(config, polkadot_config, collator_options, id, hwbench)
-		.await
-		.map(|r| r.0)
-		.map_err(Into::into),
-
-		Runtime::Collectives => crate::service::start_generic_aura_lookahead_node::<Network>(
-			config,
-			polkadot_config,
-			collator_options,
-			id,
-			hwbench,
-		)
-		.await
-		.map(|r| r.0)
-		.map_err(Into::into),
+		Runtime::AssetHub | Runtime::Collectives =>
+			crate::service::start_generic_aura_lookahead_node::<Network>(
+				config,
+				polkadot_config,
+				collator_options,
+				id,
+				hwbench,
+			)
+			.await
+			.map(|r| r.0)
+			.map_err(Into::into),
 
 		Runtime::Seedling | Runtime::Shell => crate::service::start_shell_node::<Network>(
 			config,

--- a/cumulus/polkadot-parachain/src/service.rs
+++ b/cumulus/polkadot-parachain/src/service.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-use codec::Decode;
 use cumulus_client_cli::CollatorOptions;
 use cumulus_client_collator::service::CollatorService;
 use cumulus_client_consensus_aura::collators::lookahead::{self as aura, Params as AuraParams};
@@ -45,7 +44,7 @@ pub use parachains_common::{AccountId, AuraId, Balance, Block, Hash, Nonce};
 use cumulus_client_consensus_relay_chain::Verifier as RelayChainVerifier;
 use futures::prelude::*;
 use prometheus_endpoint::Registry;
-use sc_client_api::Backend as ClientApiBackend;
+use sc_client_api::BlockchainEvents;
 use sc_consensus::{
 	import_queue::{BasicQueue, Verifier as VerifierT},
 	BlockImportParams, ImportQueue,
@@ -55,14 +54,10 @@ use sc_network::{config::FullNetworkConfiguration, service::traits::NetworkBacke
 use sc_network_sync::SyncingService;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
-use sp_api::{ConstructRuntimeApi, ProvideRuntimeApi};
-use sp_blockchain::HeaderBackend;
-use sp_core::traits::SpawnEssentialNamed;
+use sp_api::{ApiExt, ConstructRuntimeApi, ProvideRuntimeApi};
+use sp_consensus_aura::AuraApi;
 use sp_keystore::KeystorePtr;
-use sp_runtime::{
-	app_crypto::AppCrypto,
-	traits::{Block as BlockT, Header as HeaderT},
-};
+use sp_runtime::{app_crypto::AppCrypto, traits::Header as HeaderT};
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use polkadot_primitives::CollatorPair;
@@ -423,7 +418,7 @@ pub async fn start_rococo_parachain_node<Net: NetworkBackend<Block, Hash>>(
 		para_id,
 		build_parachain_rpc_extensions::<FakeRuntimeApi>,
 		build_aura_import_queue,
-		start_lookahead_aura_consensus,
+		start_lookahead_aura_consensus::<_, AuraId>,
 		hwbench,
 	)
 	.await
@@ -600,7 +595,7 @@ pub async fn start_generic_aura_lookahead_node<Net: NetworkBackend<Block, Hash>>
 		para_id,
 		build_parachain_rpc_extensions::<FakeRuntimeApi>,
 		build_relay_to_aura_import_queue::<_, AuraId>,
-		start_lookahead_aura_consensus,
+		start_lookahead_aura_consensus::<_, AuraId>,
 		hwbench,
 	)
 	.await
@@ -635,107 +630,40 @@ where
 		para_id,
 		build_parachain_rpc_extensions::<RuntimeApi>,
 		build_relay_to_aura_import_queue::<_, AuraId>,
-		|client,
-		 block_import,
-		 prometheus_registry,
-		 telemetry,
-		 task_manager,
-		 relay_chain_interface,
-		 transaction_pool,
-		 sync_oracle,
-		 keystore,
-		 relay_chain_slot_duration,
-		 para_id,
-		 collator_key,
-		 overseer_handle,
-		 announce_block,
-		 backend| {
-			let relay_chain_interface2 = relay_chain_interface.clone();
-
-			let collator_service = CollatorService::new(
-				client.clone(),
-				Arc::new(task_manager.spawn_handle()),
-				announce_block,
-				client.clone(),
-			);
-
-			let spawner = task_manager.spawn_handle();
-
-			let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
-				spawner,
-				client.clone(),
-				transaction_pool,
-				prometheus_registry,
-				telemetry.clone(),
-			);
-
-			let collation_future = Box::pin(async move {
-				// Start collating with the `shell` runtime while waiting for an upgrade to an Aura
-				// compatible runtime.
-				let mut request_stream = cumulus_client_collator::relay_chain_driven::init(
-					collator_key.clone(),
-					para_id,
-					overseer_handle.clone(),
-				)
-				.await;
-				while let Some(request) = request_stream.next().await {
-					let pvd = request.persisted_validation_data().clone();
-					let last_head_hash =
-						match <Block as BlockT>::Header::decode(&mut &pvd.parent_head.0[..]) {
-							Ok(header) => header.hash(),
-							Err(e) => {
-								log::error!("Could not decode the head data: {e}");
-								request.complete(None);
-								continue
-							},
-						};
-
-					// Check if we have upgraded to an Aura compatible runtime and transition if
-					// necessary.
-					if client.runtime_api().has_aura_api(last_head_hash) {
-						// Respond to this request before transitioning to Aura.
-						request.complete(None);
-						break
-					}
-				}
-
-				// Move to Aura consensus.
-				let proposer = Proposer::new(proposer_factory);
-
-				let params = AuraParams {
-					create_inherent_data_providers: move |_, ()| async move { Ok(()) },
-					block_import,
-					para_client: client.clone(),
-					para_backend: backend,
-					relay_client: relay_chain_interface2,
-					code_hash_provider: move |block_hash| {
-						client.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
-					},
-					sync_oracle,
-					keystore,
-					collator_key,
-					para_id,
-					overseer_handle,
-					relay_chain_slot_duration,
-					proposer,
-					collator_service,
-					authoring_duration: Duration::from_millis(1500),
-					reinitialize: true, /* we need to always re-initialize for asset-hub moving
-					                     * to aura */
-				};
-
-				aura::run::<Block, <AuraId as AppCrypto>::Pair, _, _, _, _, _, _, _, _, _>(params)
-					.await
-			});
-
-			let spawner = task_manager.spawn_essential_handle();
-			spawner.spawn_essential("cumulus-asset-hub-collator", None, collation_future);
-
-			Ok(())
-		},
+		start_lookahead_aura_consensus::<RuntimeApi, AuraId>,
 		hwbench,
 	)
 	.await
+}
+
+/// Wait for the Aura runtime API to appear on chain.
+/// This is useful for chains that started out without Aura. Components that
+/// are depending on Aura functionality will wait until Aura appears in the runtime.
+async fn wait_for_aura<RuntimeApi, AuraId>(client: Arc<ParachainClient<RuntimeApi>>)
+where
+	RuntimeApi: ConstructNodeRuntimeApi<Block, ParachainClient<RuntimeApi>>,
+	RuntimeApi::RuntimeApi: AuraRuntimeApi<Block, AuraId>,
+	AuraId: AuraIdT + Sync,
+{
+	let finalized_hash = client.chain_info().finalized_hash;
+	if client
+		.runtime_api()
+		.has_api::<dyn AuraApi<Block, AuraId>>(finalized_hash)
+		.unwrap_or(false)
+	{
+		return;
+	};
+
+	let mut stream = client.finality_notification_stream();
+	while let Some(notification) = stream.next().await {
+		let has_aura_api = client
+			.runtime_api()
+			.has_api::<dyn AuraApi<Block, AuraId>>(notification.hash)
+			.unwrap_or(false);
+		if has_aura_api {
+			return;
+		}
+	}
 }
 
 /// Start relay-chain consensus that is free for all. Everyone can submit a block, the relay-chain
@@ -811,7 +739,7 @@ fn start_relay_chain_consensus(
 }
 
 /// Start consensus using the lookahead aura collator.
-fn start_lookahead_aura_consensus<RuntimeApi>(
+fn start_lookahead_aura_consensus<RuntimeApi, AuraId>(
 	client: Arc<ParachainClient<RuntimeApi>>,
 	block_import: ParachainBlockImport<RuntimeApi>,
 	prometheus_registry: Option<&Registry>,
@@ -831,12 +759,8 @@ fn start_lookahead_aura_consensus<RuntimeApi>(
 where
 	RuntimeApi: ConstructNodeRuntimeApi<Block, ParachainClient<RuntimeApi>>,
 	RuntimeApi::RuntimeApi: AuraRuntimeApi<Block, AuraId>,
+	AuraId: AuraIdT + Sync,
 {
-	let info = backend.blockchain().info();
-	if !client.runtime_api().has_aura_api(info.finalized_hash) {
-		return Err(sc_service::error::Error::Other("Missing aura runtime APIs".to_string()));
-	}
-
 	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 		task_manager.spawn_handle(),
 		client.clone(),
@@ -858,8 +782,11 @@ where
 		para_client: client.clone(),
 		para_backend: backend,
 		relay_client: relay_chain_interface,
-		code_hash_provider: move |block_hash| {
-			client.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
+		code_hash_provider: {
+			let client = client.clone();
+			move |block_hash| {
+				client.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
+			}
 		},
 		sync_oracle,
 		keystore,
@@ -873,7 +800,10 @@ where
 		reinitialize: false,
 	};
 
-	let fut = aura::run::<Block, <AuraId as AppCrypto>::Pair, _, _, _, _, _, _, _, _, _>(params);
+	let fut = async move {
+		wait_for_aura(client).await;
+		aura::run::<Block, <AuraId as AppCrypto>::Pair, _, _, _, _, _, _, _, _, _>(params).await;
+	};
 	task_manager.spawn_essential_handle().spawn("aura", None, fut);
 
 	Ok(())
@@ -897,7 +827,7 @@ pub async fn start_basic_lookahead_node<Net: NetworkBackend<Block, Hash>>(
 		para_id,
 		|_, _, _, _| Ok(RpcModule::new(())),
 		build_relay_to_aura_import_queue::<_, AuraId>,
-		start_lookahead_aura_consensus,
+		start_lookahead_aura_consensus::<_, AuraId>,
 		hwbench,
 	)
 	.await
@@ -919,7 +849,7 @@ pub async fn start_contracts_rococo_node<Net: NetworkBackend<Block, Hash>>(
 		para_id,
 		build_contracts_rpc_extensions,
 		build_aura_import_queue,
-		start_lookahead_aura_consensus,
+		start_lookahead_aura_consensus::<_, AuraId>,
 		hwbench,
 	)
 	.await

--- a/prdoc/pr_4932.prdoc
+++ b/prdoc/pr_4932.prdoc
@@ -1,0 +1,15 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Remove relay-chain consensus authoring support for asset-hub chains from polkadot-parachain.
+
+doc:
+  - audience: Node Operator
+    description: |
+        The polkadot-parachain node had special handling for asset-hub parachains. They started out
+        using relay-chain consensus and later migrated to Aura as soon as it became available. The codepath for authoring
+        with relay chain consensus has been removed, since all asset hub chains have long migrated.
+
+crates:
+  - name: polkadot-parachain-bin
+    bump: major


### PR DESCRIPTION
Recently thought about the special handling we have for asset-hub chains. They started with relay chain consensus and transitioned to AURA at some point. However, nobody should be authoring with relay chain consensus on these chains anymore, the transition is long done.

I propose to remove this special handling, allowing us to unify one more execution path.