### PR TITLE
fix: change visibility of `state_cache_size` in `import_params`

### DIFF
--- a/substrate/client/cli/src/params/import_params.rs
+++ b/substrate/client/cli/src/params/import_params.rs
@@ -83,7 +83,7 @@ pub struct ImportParams {
 
 	/// DEPRECATED: switch to `--trie-cache-size`.
 	#[arg(long)]
-	state_cache_size: Option<usize>,
+	pub state_cache_size: Option<usize>,
 }
 
 impl ImportParams {


### PR DESCRIPTION
This allows the struct to be constructed outside of this crate.

Use case: Instantiating the struct from other sources e.g. environment variables