### PR TITLE
Add deprecation for Calls,Events,Errors,Pallet

### DIFF
--- a/prdoc/pr_4851.prdoc
+++ b/prdoc/pr_4851.prdoc
@@ -6,7 +6,7 @@ title: Add support for deprecation metadata in `RuntimeMetadataIr` entries.
 doc:
   - audience: Runtime Dev
     description: |
-      Adds `DeprecationStatus` enum to sp_metadata_ir.
+      Adds `DeprecationStatusIR` enum to sp_metadata_ir.
       Adds `deprecation_info` field to 
        - `RuntimeApiMetadataIR`
        - `RuntimeApiMethodMetadataIR`

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -58,12 +58,7 @@ pub fn expand_runtime_metadata(
 					#attr
 				}
 			});
-			let deprecation_info = {
-				let path = &decl.path;
-				let instance = decl.instance.as_ref().into_iter();
-
-				quote! { #path::Pallet::<#runtime #(, #path::#instance)*>::deprecation_info() }
-			};
+			let deprecation_info = expand_pallet_metadata_deprecation(runtime, decl);
 			quote! {
 				#attr
 				#scrate::__private::metadata_ir::PalletMetadataIR {
@@ -231,6 +226,13 @@ fn expand_pallet_metadata_events(
 	} else {
 		quote!(None)
 	}
+}
+
+fn expand_pallet_metadata_deprecation(runtime: &Ident, decl: &Pallet) -> TokenStream {
+	let path = &decl.path;
+	let instance = decl.instance.as_ref().into_iter();
+
+	quote! { #path::Pallet::<#runtime #(, #path::#instance)*>::deprecation_info() }
 }
 
 fn expand_pallet_metadata_constants(runtime: &Ident, decl: &Pallet) -> TokenStream {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -59,9 +59,12 @@ pub fn expand_runtime_metadata(
 					#attr
 				}
 			});
-			let deprecation_info =
-				crate::deprecation::get_deprecation(&quote! { #frame_support }, &decl.attrs)
-					.expect("Correctly parse deprecation attributes");
+			let deprecation_info = {
+				let path = &decl.path;
+				let instance = decl.instance.as_ref().into_iter();
+
+				quote! { #path::Pallet::<#runtime #(, #path::#instance)*>::deprecation_info() }
+			};
 			quote! {
 				#attr
 				#scrate::__private::metadata_ir::PalletMetadataIR {
@@ -224,9 +227,7 @@ fn expand_pallet_metadata_events(
 
 		quote! {
 			Some(
-				#scrate::__private::metadata_ir::PalletEventMetadataIR {
-					ty: #scrate::__private::scale_info::meta_type::<#pallet_event>()
-				}
+				#pallet_event::deprecation_info()
 			)
 		}
 	} else {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -28,7 +28,6 @@ pub fn expand_runtime_metadata(
 	extrinsic: &TokenStream,
 	system_path: &PalletPath,
 ) -> TokenStream {
-	let frame_support = crate::generate_access_from_frame_or_crate("frame-support").unwrap();
 	let pallets = pallet_declarations
 		.iter()
 		.filter_map(|pallet_declaration| {
@@ -47,7 +46,7 @@ pub fn expand_runtime_metadata(
 			let index = &decl.index;
 			let storage = expand_pallet_metadata_storage(&filtered_names, runtime, decl);
 			let calls = expand_pallet_metadata_calls(&filtered_names, runtime, decl);
-			let event = expand_pallet_metadata_events(&filtered_names, runtime, scrate, decl);
+			let event = expand_pallet_metadata_events(&filtered_names, runtime, decl);
 			let constants = expand_pallet_metadata_constants(runtime, decl);
 			let errors = expand_pallet_metadata_errors(runtime, decl);
 			let docs = expand_pallet_metadata_docs(runtime, decl);
@@ -207,7 +206,6 @@ fn expand_pallet_metadata_calls(
 fn expand_pallet_metadata_events(
 	filtered_names: &[&'static str],
 	runtime: &Ident,
-	scrate: &TokenStream,
 	decl: &Pallet,
 ) -> TokenStream {
 	if filtered_names.contains(&"Event") {
@@ -227,7 +225,7 @@ fn expand_pallet_metadata_events(
 
 		quote! {
 			Some(
-				#pallet_event::deprecation_info()
+				#pallet_event::event_metadata()
 			)
 		}
 	} else {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -225,7 +225,7 @@ fn expand_pallet_metadata_events(
 
 		quote! {
 			Some(
-				#pallet_event::event_metadata()
+				#pallet_event::event_metadata::<#pallet_event>()
 			)
 		}
 	} else {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -28,6 +28,7 @@ pub fn expand_runtime_metadata(
 	extrinsic: &TokenStream,
 	system_path: &PalletPath,
 ) -> TokenStream {
+	let frame_support = crate::generate_access_from_frame_or_crate("frame-support").unwrap();
 	let pallets = pallet_declarations
 		.iter()
 		.filter_map(|pallet_declaration| {
@@ -58,7 +59,9 @@ pub fn expand_runtime_metadata(
 					#attr
 				}
 			});
-
+			let deprecation_info =
+				crate::deprecation::get_deprecation(&quote! { #frame_support }, &decl.attrs)
+					.expect("Correctly parse deprecation attributes");
 			quote! {
 				#attr
 				#scrate::__private::metadata_ir::PalletMetadataIR {
@@ -70,6 +73,7 @@ pub fn expand_runtime_metadata(
 					constants: #constants,
 					error: #errors,
 					docs: #docs,
+					deprecation_info: #deprecation_info,
 				}
 			}
 		})

--- a/substrate/frame/support/procedural/src/construct_runtime/parse.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/parse.rs
@@ -607,6 +607,8 @@ pub struct Pallet {
 	pub cfg_pattern: Vec<cfg_expr::Expression>,
 	/// The doc literals
 	pub docs: Vec<syn::Expr>,
+	/// attributes
+	pub attrs: Vec<syn::Attribute>,
 }
 
 impl Pallet {
@@ -777,6 +779,7 @@ fn convert_pallets(pallets: Vec<PalletDeclaration>) -> syn::Result<PalletsConver
 				cfg_pattern,
 				pallet_parts,
 				docs: vec![],
+				attrs: pallet.attrs.clone(),
 			})
 		})
 		.collect::<Result<Vec<_>>>()?;

--- a/substrate/frame/support/procedural/src/deprecation.rs
+++ b/substrate/frame/support/procedural/src/deprecation.rs
@@ -163,7 +163,7 @@ pub fn get_deprecation_enum<'a>(
 pub fn variant_index_for_deprecation(index: u8, item: &Variant) -> u8 {
 	let index: u8 =
 		if let Some((_, Expr::Lit(ExprLit { lit: Lit::Int(num_lit), .. }))) = &item.discriminant {
-			num_lit.base10_parse::<u8>().map(|val| val).unwrap_or(index as u8)
+			num_lit.base10_parse::<u8>().unwrap_or(index as u8)
 		} else {
 			index as u8
 		};

--- a/substrate/frame/support/procedural/src/pallet/expand/call.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/call.rs
@@ -245,19 +245,11 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 			}
 		});
 
-	let deprecation = if let Some(call) = def.call.as_ref() {
-		crate::deprecation::get_deprecation_enum(
-			&quote::quote! {#frame_support},
-			call.attrs.as_ref(),
-			methods.iter().map(|item| (item.call_index as u8, item.attrs.as_ref())),
-		)
-	} else {
-		crate::deprecation::get_deprecation_enum(
-			&quote::quote! {#frame_support},
-			&[],
-			methods.iter().map(|item| (item.call_index as u8, item.attrs.as_ref())),
-		)
-	}
+	let deprecation = crate::deprecation::get_deprecation_enum(
+		&quote::quote! {#frame_support},
+		def.call.as_ref().map(|call| call.attrs.as_ref()).unwrap_or(&[]),
+		methods.iter().map(|item| (item.call_index as u8, item.attrs.as_ref())),
+	)
 	.unwrap_or_else(syn::Error::into_compile_error);
 
 	quote::quote_spanned!(span =>

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -102,12 +102,9 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 
 	let capture_docs = if cfg!(feature = "no-metadata-docs") { "never" } else { "always" };
 
-	let deprecation_status =
-		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &error.attrs)
-			.unwrap_or_else(syn::Error::into_compile_error);
-
-	let variants = crate::deprecation::get_deprecation_enum(
+	let deprecation = crate::deprecation::get_deprecation_enum(
 		&quote::quote! {#frame_support},
+		&error.attrs,
 		error_item
 			.variants
 			.iter()
@@ -208,8 +205,7 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 			pub fn error_metadata() -> #frame_support::__private::metadata_ir::PalletErrorMetadataIR {
 				#frame_support::__private::metadata_ir::PalletErrorMetadataIR {
 					ty: #frame_support::__private::scale_info::meta_type::<#error_ident<#type_use_gen>>(),
-					deprecation_info: #deprecation_status,
-					deprecated_variants: #variants
+					deprecation_info: #deprecation,
 				}
 			}
 		}

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -113,8 +113,9 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 	let variants: Vec<proc_macro2::TokenStream> = error_item
 		.variants
 		.iter()
-		.filter_map(|x| {
-			let key = x.ident.to_string();
+		.enumerate()
+		.filter_map(|(index, x)| {
+			let key = index;
 			let deprecation_status =
 				crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &x.attrs)
 					.expect("Correctly parse deprecation attributes");

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -217,7 +217,7 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 		impl<#type_impl_gen> #error_ident<#type_use_gen> #config_where_clause {
 			#[allow(dead_code)]
 			#[doc(hidden)]
-			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::PalletErrorMetadataIR {
+			pub fn error_metadata() -> #frame_support::__private::metadata_ir::PalletErrorMetadataIR {
 				#frame_support::__private::metadata_ir::PalletErrorMetadataIR {
 					ty: #frame_support::__private::scale_info::meta_type::<#error_ident<#type_use_gen>>(),
 					deprecation_info: #deprecation_status,

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -115,7 +115,7 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 		.iter()
 		.enumerate()
 		.filter_map(|(index, x)| {
-			let key = index;
+			let key = index as u8;
 			let deprecation_status =
 				crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &x.attrs)
 					.expect("Correctly parse deprecation attributes");

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -105,11 +105,11 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 	let deprecation = crate::deprecation::get_deprecation_enum(
 		&quote::quote! {#frame_support},
 		&error.attrs,
-		error_item
-			.variants
-			.iter()
-			.enumerate()
-			.map(|(index, item)| (index as u8, item.attrs.as_ref())),
+		error_item.variants.iter().enumerate().map(|(index, item)| {
+			let index = crate::deprecation::variant_index_for_deprecation(index as u8, item);
+
+			(index, item.attrs.as_ref())
+		}),
 	)
 	.unwrap_or_else(syn::Error::into_compile_error);
 

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -95,12 +95,9 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 		event_item.variants.push(variant);
 	}
 
-	let deprecation_status =
-		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &event.attrs)
-			.unwrap_or_else(syn::Error::into_compile_error);
-
-	let variants = crate::deprecation::get_deprecation_enum(
+	let deprecation = crate::deprecation::get_deprecation_enum(
 		&quote::quote! {#frame_support},
+		&event.attrs,
 		event_item
 			.variants
 			.iter()
@@ -190,8 +187,7 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 			pub fn event_metadata<W: #frame_support::__private::scale_info::TypeInfo + 'static>() -> #frame_support::__private::metadata_ir::PalletEventMetadataIR {
 				#frame_support::__private::metadata_ir::PalletEventMetadataIR {
 					ty: #frame_support::__private::scale_info::meta_type::<W>(),
-					deprecation_info: #deprecation_status,
-					deprecated_variants: #variants
+					deprecation_info: #deprecation,
 				}
 			}
 		}

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -199,7 +199,7 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 		impl<#event_impl_gen> #event_ident<#event_use_gen>  #event_where_clause {
 			#[allow(dead_code)]
 			#[doc(hidden)]
-			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::PalletEventMetadataIR {
+			pub fn event_metadata() -> #frame_support::__private::metadata_ir::PalletEventMetadataIR {
 				#frame_support::__private::metadata_ir::PalletEventMetadataIR {
 					ty: #frame_support::__private::scale_info::meta_type::<#event_ident<#event_use_gen>>(),
 					deprecation_info: #deprecation_status,

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -97,30 +97,18 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 
 	let deprecation_status =
 		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &event.attrs)
-			.expect("Correctly parse deprecation attributes");
+			.unwrap_or_else(syn::Error::into_compile_error);
 
-	let default_deprecation_info =
-		quote::quote! { #frame_support::__private::metadata_ir::DeprecationStatus::NotDeprecated }
-			.to_string();
+	let variants = crate::deprecation::get_deprecation_enum(
+		&quote::quote! {#frame_support},
+		event_item
+			.variants
+			.iter()
+			.enumerate()
+			.map(|(index, item)| (index as u8, item.attrs.as_ref())),
+	)
+	.unwrap_or_else(syn::Error::into_compile_error);
 
-	let variants: Vec<proc_macro2::TokenStream> = event_item
-		.variants
-		.iter()
-		.enumerate()
-		.filter_map(|(index, x)| {
-			let key = index as u8;
-			let deprecation_status =
-				crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &x.attrs)
-					.expect("Correctly parse deprecation attributes");
-			if deprecation_status.to_string() == default_deprecation_info {
-				None
-			} else {
-				Some(quote::quote! { (#key, #deprecation_status) })
-			}
-		})
-		.collect();
-
-	let variants = quote::quote! { #frame_support::__private::scale_info::prelude::collections::BTreeMap::from([#( #variants),*]) };
 	if get_doc_literals(&event_item.attrs).is_empty() {
 		event_item
 			.attrs

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -107,8 +107,9 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 	let variants: Vec<proc_macro2::TokenStream> = event_item
 		.variants
 		.iter()
-		.filter_map(|x| {
-			let key = x.ident.to_string();
+		.enumerate()
+		.filter_map(|(index, x)| {
+			let key = index;
 			let deprecation_status =
 				crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &x.attrs)
 					.expect("Correctly parse deprecation attributes");

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -108,7 +108,7 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 		.iter()
 		.enumerate()
 		.filter_map(|(index, x)| {
-			let key = index;
+			let key = index as u8;
 			let deprecation_status =
 				crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &x.attrs)
 					.expect("Correctly parse deprecation attributes");

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -196,7 +196,7 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 			fn from(_: #event_ident<#event_use_gen>) {}
 		}
 
-		impl<#event_impl_gen> #event_ident<#event_use_gen> #completed_where_clause {
+		impl<#event_impl_gen> #event_ident<#event_use_gen> #event_where_clause {
 			#[allow(dead_code)]
 			#[doc(hidden)]
 			pub fn event_metadata<W: #frame_support::__private::scale_info::TypeInfo + 'static>() -> #frame_support::__private::metadata_ir::PalletEventMetadataIR {

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -71,7 +71,6 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let event_use_gen = &event.gen_kind.type_use_gen(event.attr_span);
 	let event_impl_gen = &event.gen_kind.type_impl_gen(event.attr_span);
-
 	let event_item = {
 		let item = &mut def.item.content.as_mut().expect("Checked by def parser").1[event.index];
 		if let syn::Item::Enum(item) = item {
@@ -197,12 +196,12 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 			fn from(_: #event_ident<#event_use_gen>) {}
 		}
 
-		impl<#event_impl_gen> #event_ident<#event_use_gen>  #event_where_clause {
+		impl<#event_impl_gen> #event_ident<#event_use_gen> #completed_where_clause {
 			#[allow(dead_code)]
 			#[doc(hidden)]
-			pub fn event_metadata() -> #frame_support::__private::metadata_ir::PalletEventMetadataIR {
+			pub fn event_metadata<W: #frame_support::__private::scale_info::TypeInfo + 'static>() -> #frame_support::__private::metadata_ir::PalletEventMetadataIR {
 				#frame_support::__private::metadata_ir::PalletEventMetadataIR {
-					ty: #frame_support::__private::scale_info::meta_type::<#event_ident<#event_use_gen>>(),
+					ty: #frame_support::__private::scale_info::meta_type::<W>(),
 					deprecation_info: #deprecation_status,
 					deprecated_variants: #variants
 				}

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -98,11 +98,11 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 	let deprecation = crate::deprecation::get_deprecation_enum(
 		&quote::quote! {#frame_support},
 		&event.attrs,
-		event_item
-			.variants
-			.iter()
-			.enumerate()
-			.map(|(index, item)| (index as u8, item.attrs.as_ref())),
+		event_item.variants.iter().enumerate().map(|(index, item)| {
+			let index = crate::deprecation::variant_index_for_deprecation(index as u8, item);
+
+			(index, item.attrs.as_ref())
+		}),
 	)
 	.unwrap_or_else(syn::Error::into_compile_error);
 

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -290,7 +290,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		impl<#type_use_gen> #pallet_ident<#type_use_gen> {
 			#[allow(dead_code)]
 			#[doc(hidden)]
-			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::DeprecationStatus {
+			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::DeprecationStatusIR {
 				#deprecation_status
 			}
 		}

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -187,7 +187,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 	];
 	let deprecation_status =
 		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &def.item.attrs)
-			.expect("Correctly parse deprecation attributes");
+			.unwrap_or_else(syn::Error::into_compile_error);
 	quote::quote_spanned!(def.pallet_struct.attr_span =>
 		#pallet_error_metadata
 

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -83,7 +83,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 			impl<#type_impl_gen> #pallet_ident<#type_use_gen> #config_where_clause {
 				#[doc(hidden)]
 				pub fn error_metadata() -> Option<#frame_support::__private::metadata_ir::PalletErrorMetadataIR> {
-					Some(<#error_ident<#type_use_gen>>::deprecation_info())
+					Some(<#error_ident<#type_use_gen>>::error_metadata())
 				}
 			}
 		)

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -83,9 +83,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 			impl<#type_impl_gen> #pallet_ident<#type_use_gen> #config_where_clause {
 				#[doc(hidden)]
 				pub fn error_metadata() -> Option<#frame_support::__private::metadata_ir::PalletErrorMetadataIR> {
-					Some(#frame_support::__private::metadata_ir::PalletErrorMetadataIR {
-						ty: #frame_support::__private::scale_info::meta_type::<#error_ident<#type_use_gen>>()
-					})
+					Some(<#error_ident<#type_use_gen>>::deprecation_info())
 				}
 			}
 		)
@@ -187,7 +185,9 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 			}
 		}
 	];
-
+	let deprecation_status =
+		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &def.item.attrs)
+			.expect("Correctly parse deprecation attributes");
 	quote::quote_spanned!(def.pallet_struct.attr_span =>
 		#pallet_error_metadata
 
@@ -286,5 +286,14 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 
 		#storage_info
 		#whitelisted_storage_keys_impl
+
+		impl<#type_impl_gen> #pallet_ident<#type_use_gen>
+		#config_where_clause {
+			#[allow(dead_code)]
+			#[doc(hidden)]
+			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::DeprecationStatus {
+				#deprecation_status
+			}
+		}
 	)
 }

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -287,8 +287,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		#storage_info
 		#whitelisted_storage_keys_impl
 
-		impl<#type_impl_gen> #pallet_ident<#type_use_gen>
-		#config_where_clause {
+		impl<#type_use_gen> #pallet_ident<#type_use_gen> {
 			#[allow(dead_code)]
 			#[doc(hidden)]
 			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::DeprecationStatus {

--- a/substrate/frame/support/procedural/src/pallet/parse/call.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/call.rs
@@ -404,19 +404,18 @@ impl CallDef {
 					}
 
 					for (feeless_arg, arg) in feeless_check.inputs.iter().skip(1).zip(args.iter()) {
-						let feeless_arg_type = if let syn::Pat::Type(syn::PatType { ty, .. }) =
-							feeless_arg.clone()
-						{
-							if let syn::Type::Reference(pat) = *ty {
-								pat.elem.clone()
+						let feeless_arg_type =
+							if let syn::Pat::Type(syn::PatType { ty, .. }) = feeless_arg.clone() {
+								if let syn::Type::Reference(pat) = *ty {
+									pat.elem.clone()
+								} else {
+									let msg = "Invalid pallet::call, feeless_if closure argument must be a reference";
+									return Err(syn::Error::new(ty.span(), msg));
+								}
 							} else {
-								let msg = "Invalid pallet::call, feeless_if closure argument must be a reference";
-								return Err(syn::Error::new(ty.span(), msg));
-							}
-						} else {
-							let msg = "Invalid pallet::call, feeless_if closure argument must be a type ascription pattern";
-							return Err(syn::Error::new(feeless_arg.span(), msg));
-						};
+								let msg = "Invalid pallet::call, feeless_if closure argument must be a type ascription pattern";
+								return Err(syn::Error::new(feeless_arg.span(), msg));
+							};
 
 						if feeless_arg_type != arg.2 {
 							let msg =

--- a/substrate/frame/support/procedural/src/pallet/parse/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/error.rs
@@ -56,6 +56,8 @@ pub struct ErrorDef {
 	pub error: keyword::Error,
 	/// The span of the pallet::error attribute.
 	pub attr_span: proc_macro2::Span,
+	/// Attributes
+	pub attrs: Vec<syn::Attribute>,
 }
 
 impl ErrorDef {
@@ -110,6 +112,6 @@ impl ErrorDef {
 			})
 			.collect::<Result<_, _>>()?;
 
-		Ok(ErrorDef { attr_span, index, variants, instances, error })
+		Ok(ErrorDef { attr_span, index, variants, instances, error, attrs: item.attrs.clone() })
 	}
 }

--- a/substrate/frame/support/procedural/src/pallet/parse/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/event.rs
@@ -43,6 +43,8 @@ pub struct EventDef {
 	pub where_clause: Option<syn::WhereClause>,
 	/// The span of the pallet::event attribute.
 	pub attr_span: proc_macro2::Span,
+	/// event attributes
+	pub attrs: Vec<syn::Attribute>,
 }
 
 /// Attribute for a pallet's Event.
@@ -106,7 +108,7 @@ impl EventDef {
 		} else {
 			return Err(syn::Error::new(item.span(), "Invalid pallet::event, expected enum item"))
 		};
-
+		let attrs = item.attrs.clone();
 		let event_attrs: Vec<PalletEventDepositAttr> =
 			helper::take_item_pallet_attrs(&mut item.attrs)?;
 		let attr_info = PalletEventAttrInfo::from_attrs(event_attrs)?;
@@ -136,6 +138,15 @@ impl EventDef {
 
 		let event = syn::parse2::<keyword::Event>(item.ident.to_token_stream())?;
 
-		Ok(EventDef { attr_span, index, instances, deposit_event, event, gen_kind, where_clause })
+		Ok(EventDef {
+			attr_span,
+			index,
+			instances,
+			deposit_event,
+			event,
+			gen_kind,
+			where_clause,
+			attrs,
+		})
 	}
 }

--- a/substrate/frame/support/procedural/src/runtime/parse/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/parse/mod.rs
@@ -120,6 +120,7 @@ pub struct ExplicitAllPalletsDeclaration {
 	pub name: Ident,
 	pub pallets: Vec<Pallet>,
 }
+
 pub struct Def {
 	pub input: TokenStream2,
 	pub item: syn::ItemMod,

--- a/substrate/frame/support/procedural/src/runtime/parse/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/parse/mod.rs
@@ -120,7 +120,6 @@ pub struct ExplicitAllPalletsDeclaration {
 	pub name: Ident,
 	pub pallets: Vec<Pallet>,
 }
-
 pub struct Def {
 	pub input: TokenStream2,
 	pub item: syn::ItemMod,

--- a/substrate/frame/support/procedural/src/runtime/parse/pallet.rs
+++ b/substrate/frame/support/procedural/src/runtime/parse/pallet.rs
@@ -91,6 +91,7 @@ impl Pallet {
 			cfg_pattern,
 			pallet_parts,
 			docs,
+			attrs: item.attrs.clone(),
 		})
 	}
 }

--- a/substrate/frame/support/src/storage/types/counted_map.rs
+++ b/substrate/frame/support/src/storage/types/counted_map.rs
@@ -509,7 +509,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -1198,7 +1198,7 @@ mod test {
 	fn test_metadata() {
 		type A = CountedStorageMap<Prefix, Twox64Concat, u16, u32, ValueQuery, ADefault>;
 		let mut entries = vec![];
-		A::build_metadata(sp_metadata_ir::DeprecationStatus::NotDeprecated, vec![], &mut entries);
+		A::build_metadata(sp_metadata_ir::DeprecationStatusIR::NotDeprecated, vec![], &mut entries);
 		assert_eq!(
 			entries,
 			vec![
@@ -1212,7 +1212,7 @@ mod test {
 					},
 					default: 97u32.encode(),
 					docs: vec![],
-					deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+					deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				},
 				StorageEntryMetadataIR {
 					name: "counter_for_foo",
@@ -1224,7 +1224,7 @@ mod test {
 					} else {
 						vec!["Counter for the related counted storage map"]
 					},
-					deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+					deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				},
 			]
 		);

--- a/substrate/frame/support/src/storage/types/counted_nmap.rs
+++ b/substrate/frame/support/src/storage/types/counted_nmap.rs
@@ -633,7 +633,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -864,12 +864,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -886,7 +886,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -898,7 +898,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -910,7 +910,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -922,7 +922,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 				]
 			);
@@ -1125,12 +1125,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1150,7 +1150,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1162,7 +1162,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1177,7 +1177,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1189,7 +1189,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 				]
 			);
@@ -1423,12 +1423,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1449,7 +1449,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1461,7 +1461,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1477,7 +1477,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1489,7 +1489,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 				]
 			);

--- a/substrate/frame/support/src/storage/types/double_map.rs
+++ b/substrate/frame/support/src/storage/types/double_map.rs
@@ -733,7 +733,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -991,12 +991,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1016,7 +1016,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					},
 					StorageEntryMetadataIR {
 						name: "foo",
@@ -1031,7 +1031,7 @@ mod test {
 						},
 						default: 97u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					}
 				]
 			);

--- a/substrate/frame/support/src/storage/types/map.rs
+++ b/substrate/frame/support/src/storage/types/map.rs
@@ -491,7 +491,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -797,12 +797,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -819,7 +819,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					},
 					StorageEntryMetadataIR {
 						name: "foo",
@@ -831,7 +831,7 @@ mod test {
 						},
 						default: 97u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					}
 				]
 			);

--- a/substrate/frame/support/src/storage/types/mod.rs
+++ b/substrate/frame/support/src/storage/types/mod.rs
@@ -142,7 +142,7 @@ where
 pub trait StorageEntryMetadataBuilder {
 	/// Build into `entries` the storage metadata entries of a storage given some `docs`.
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		doc: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	);

--- a/substrate/frame/support/src/storage/types/nmap.rs
+++ b/substrate/frame/support/src/storage/types/nmap.rs
@@ -584,7 +584,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -825,12 +825,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -847,7 +847,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -859,7 +859,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					}
 				]
 			);
@@ -1035,12 +1035,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1060,7 +1060,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1075,7 +1075,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					}
 				]
 			);
@@ -1286,12 +1286,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1312,7 +1312,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1328,7 +1328,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					}
 				]
 			);

--- a/substrate/frame/support/src/storage/types/value.rs
+++ b/substrate/frame/support/src/storage/types/value.rs
@@ -278,7 +278,7 @@ where
 	OnEmpty: crate::traits::Get<QueryKind::Query> + 'static,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -421,12 +421,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -439,7 +439,7 @@ mod test {
 						ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<u32>()),
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					},
 					StorageEntryMetadataIR {
 						name: "foo",
@@ -447,7 +447,7 @@ mod test {
 						ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<u32>()),
 						default: 97u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					}
 				]
 			);

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -600,7 +600,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0, 0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::DeprecatedWithoutNote,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote,
 			},
 			StorageEntryMetadataIR {
 				name: "OptionLinkedMap",
@@ -612,7 +612,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 					note: "test",
 					since: None,
 				},
@@ -627,7 +627,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 					note: "test",
 					since: Some("test"),
 				},
@@ -642,7 +642,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 					note: "test",
 					since: None,
 				},
@@ -657,7 +657,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0, 0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "GenericDataDM",
@@ -669,7 +669,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "GenericData2DM",
@@ -681,7 +681,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "AppendableDM",
@@ -696,7 +696,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "Total",
@@ -704,7 +704,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<(u32, u32)>()),
 				default: vec![0, 0, 0, 0, 0, 0, 0, 0],
 				docs: vec![" Some running total."],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "Numbers",
@@ -716,7 +716,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![" Numbers to be added into the total."],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 		],
 	}
@@ -739,7 +739,7 @@ fn constant_metadata() {
 			ty: scale_info::meta_type::<()>(),
 			value: vec![],
 			docs: vec![],
-			deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+			deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 				note: "this constant is deprecated",
 				since: None
 			}

--- a/substrate/frame/support/src/tests/runtime.rs
+++ b/substrate/frame/support/src/tests/runtime.rs
@@ -123,6 +123,7 @@ mod runtime {
 	// Ensure that the runtime does not export the calls from the pallet
 	#[runtime::pallet_index(4)]
 	#[runtime::disable_call]
+	#[deprecated = "example"]
 	pub type PalletWithDisabledCall = pallet_with_disabled_call::Pallet<Runtime>;
 
 	// Ensure that the runtime does not export the unsigned calls from the pallet

--- a/substrate/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/undefined_event_part.stderr
@@ -34,3 +34,23 @@ help: consider importing one of these items
    |
 18 + use frame_system::Event;
    |
+
+error[E0433]: failed to resolve: could not find `Event` in `pallet`
+  --> tests/construct_runtime_ui/undefined_event_part.rs:66:1
+   |
+66 | / construct_runtime! {
+67 | |     pub struct Runtime
+68 | |     {
+69 | |         System: frame_system expanded::{}::{Pallet, Call, Storage, Config<T>, Event<T>},
+70 | |         Pallet: pallet expanded::{}::{Pallet, Event},
+71 | |     }
+72 | | }
+   | |_^ could not find `Event` in `pallet`
+   |
+   = note: this error originates in the macro `construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing one of these items
+   |
+18 + use frame_support_test::Event;
+   |
+18 + use frame_system::Event;
+   |

--- a/substrate/frame/support/test/tests/enum_deprecation.rs
+++ b/substrate/frame/support/test/tests/enum_deprecation.rs
@@ -1,0 +1,352 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#![allow(useless_deprecated, deprecated, clippy::deprecated_semver)]
+
+use std::collections::BTreeMap;
+
+use frame_support::{
+	derive_impl,
+	dispatch::Parameter,
+	dispatch_context::with_context,
+	parameter_types,
+	traits::{ConstU32, StorageVersion},
+	weights::Weight,
+	OrdNoBound, PartialOrdNoBound,
+};
+use scale_info::TypeInfo;
+
+use sp_runtime::DispatchError;
+
+parameter_types! {
+	/// Used to control if the storage version should be updated.
+	storage UpdateStorageVersion: bool = false;
+}
+
+pub struct SomeType1;
+impl From<SomeType1> for u64 {
+	fn from(_t: SomeType1) -> Self {
+		0u64
+	}
+}
+
+pub struct SomeType2;
+impl From<SomeType2> for u64 {
+	fn from(_t: SomeType2) -> Self {
+		100u64
+	}
+}
+
+pub struct SomeType3;
+impl From<SomeType3> for u64 {
+	fn from(_t: SomeType3) -> Self {
+		0u64
+	}
+}
+
+pub struct SomeType4;
+impl From<SomeType4> for u64 {
+	fn from(_t: SomeType4) -> Self {
+		0u64
+	}
+}
+
+pub trait SomeAssociation1 {
+	type _1: Parameter + codec::MaxEncodedLen + TypeInfo;
+}
+impl SomeAssociation1 for u64 {
+	type _1 = u64;
+}
+
+pub trait SomeAssociation2 {
+	type _2: Parameter + codec::MaxEncodedLen + TypeInfo;
+}
+impl SomeAssociation2 for u64 {
+	type _2 = u64;
+}
+
+#[frame_support::pallet]
+/// Pallet documentation
+// Comments should not be included in the pallet documentation
+#[pallet_doc("../../README.md")]
+#[doc = include_str!("../../README.md")]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use sp_runtime::DispatchResult;
+
+	pub(crate) const STORAGE_VERSION: StorageVersion = StorageVersion::new(10);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config
+	where
+		<Self as frame_system::Config>::AccountId: From<SomeType1> + SomeAssociation1,
+	{
+		/// Some comment
+		/// Some comment
+		#[pallet::constant]
+		type MyGetParam: Get<u32>;
+
+		/// Some comment
+		/// Some comment
+		#[pallet::constant]
+		type MyGetParam2: Get<u32>;
+
+		#[pallet::constant]
+		type MyGetParam3: Get<<Self::AccountId as SomeAssociation1>::_1>;
+
+		type Balance: Parameter + Default + TypeInfo;
+
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+	}
+
+	#[pallet::extra_constants]
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: From<SomeType1> + SomeAssociation1 + From<SomeType2>,
+	{
+		/// Some doc
+		/// Some doc
+		fn some_extra() -> T::AccountId {
+			SomeType2.into()
+		}
+
+		/// Some doc
+		fn some_extra_extra() -> T::AccountId {
+			SomeType1.into()
+		}
+
+		/// Some doc
+		#[pallet::constant_name(SomeExtraRename)]
+		fn some_extra_rename() -> T::AccountId {
+			SomeType1.into()
+		}
+	}
+
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	where
+		T::AccountId: From<SomeType2> + From<SomeType1> + SomeAssociation1,
+	{
+		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
+			let _ = T::AccountId::from(SomeType1); // Test for where clause
+			let _ = T::AccountId::from(SomeType2); // Test for where clause
+			Self::deposit_event(Event::B);
+			Weight::from_parts(10, 0)
+		}
+		fn on_finalize(_: BlockNumberFor<T>) {
+			let _ = T::AccountId::from(SomeType1); // Test for where clause
+			let _ = T::AccountId::from(SomeType2); // Test for where clause
+			Self::deposit_event(Event::A);
+		}
+		fn on_runtime_upgrade() -> Weight {
+			let _ = T::AccountId::from(SomeType1); // Test for where clause
+			let _ = T::AccountId::from(SomeType2); // Test for where clause
+			Self::deposit_event(Event::A);
+			Weight::from_parts(30, 0)
+		}
+		fn integrity_test() {
+			let _ = T::AccountId::from(SomeType1); // Test for where clause
+			let _ = T::AccountId::from(SomeType2); // Test for where clause
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: From<SomeType1> + From<SomeType2> + SomeAssociation1,
+	{
+		/// call foo_storage_layer doc comment put in metadata
+		#[pallet::call_index(1)]
+		#[pallet::weight({1})]
+		pub fn foo_storage_layer(
+			_origin: OriginFor<T>,
+			#[pallet::compact] foo: u32,
+		) -> DispatchResultWithPostInfo {
+			Self::deposit_event(Event::B);
+			if foo == 0 {
+				Err(Error::<T>::InsufficientProposersBalance)?;
+			}
+
+			Ok(().into())
+		}
+
+		#[pallet::call_index(4)]
+		#[pallet::weight({1})]
+		pub fn foo_index_out_of_order(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+
+		// Test for DispatchResult return type
+		#[pallet::call_index(2)]
+		#[pallet::weight({1})]
+		pub fn foo_no_post_info(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+
+		#[pallet::call_index(3)]
+		#[pallet::weight({1})]
+		pub fn check_for_dispatch_context(_origin: OriginFor<T>) -> DispatchResult {
+			with_context::<(), _>(|_| ()).ok_or_else(|| DispatchError::Unavailable)
+		}
+	}
+
+	#[pallet::error]
+	#[derive(PartialEq, Eq)]
+	pub enum Error<T> {
+		/// error doc comment put in metadata
+		InsufficientProposersBalance,
+		NonExistentStorageValue,
+		Code(u8),
+		#[codec(skip)]
+		Skipped(u128),
+		CompactU8(#[codec(compact)] u8),
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(fn deposit_event)]
+	pub enum Event<T: Config>
+	where
+		T::AccountId: SomeAssociation1 + From<SomeType1>,
+	{
+		#[deprecated = "second"]
+		A,
+		#[deprecated = "first"]
+		#[codec(index = 0)]
+		B,
+	}
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig<T: Config>
+	where
+		T::AccountId: From<SomeType1> + SomeAssociation1 + From<SomeType4>,
+	{
+		#[serde(skip)]
+		_config: sp_std::marker::PhantomData<T>,
+		_myfield: u32,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T>
+	where
+		T::AccountId: From<SomeType1> + SomeAssociation1 + From<SomeType4>,
+	{
+		fn build(&self) {
+			let _ = T::AccountId::from(SomeType1); // Test for where clause
+			let _ = T::AccountId::from(SomeType4); // Test for where clause
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		EqNoBound,
+		RuntimeDebugNoBound,
+		CloneNoBound,
+		PartialEqNoBound,
+		PartialOrdNoBound,
+		OrdNoBound,
+		Encode,
+		Decode,
+		TypeInfo,
+		MaxEncodedLen,
+	)]
+	pub struct Origin<T>(PhantomData<T>);
+}
+
+frame_support::parameter_types!(
+	pub const MyGetParam3: u32 = 12;
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type RuntimeCall = RuntimeCall;
+	type Hash = sp_runtime::testing::H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = sp_runtime::traits::IdentityLookup<Self::AccountId>;
+	type Block = Block;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+}
+impl pallet::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type MyGetParam = ConstU32<10>;
+	type MyGetParam2 = ConstU32<11>;
+	type MyGetParam3 = MyGetParam3;
+	type Balance = u64;
+}
+
+pub type Header = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic =
+	sp_runtime::testing::TestXt<RuntimeCall, frame_system::CheckNonZeroSender<Runtime>>;
+
+frame_support::construct_runtime!(
+	pub struct Runtime {
+		// Exclude part `Storage` in order not to check its metadata in tests.
+		System: frame_system exclude_parts { Pallet, Storage },
+		Example: pallet,
+
+	}
+);
+
+#[test]
+fn pallet_metadata() {
+	use sp_metadata_ir::{DeprecationInfoIR, DeprecationStatusIR};
+	let pallets = Runtime::metadata_ir().pallets;
+	let example = pallets[0].clone();
+	{
+		// Example pallet events are partially and fully deprecated
+		let meta = example.event.unwrap();
+		assert_eq!(
+			// Result should be this, but instead we get the result below
+			// see: https://github.com/paritytech/parity-scale-codec/issues/507
+			//
+			// DeprecationInfoIR::PartiallyDeprecated(BTreeMap::from([
+			// 	(codec::Compact(0), DeprecationStatusIR::Deprecated { note: "first", since: None
+			// }), 	(
+			// 		codec::Compact(1),
+			// 		DeprecationStatusIR::Deprecated { note: "second", since: None }
+			// 	)
+			// ])),
+			DeprecationInfoIR::PartiallyDeprecated(BTreeMap::from([(
+				codec::Compact(0),
+				DeprecationStatusIR::Deprecated { note: "first", since: None }
+			),])),
+			meta.deprecation_info
+		);
+	}
+}

--- a/substrate/frame/support/test/tests/instance.rs
+++ b/substrate/frame/support/test/tests/instance.rs
@@ -441,7 +441,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<u32>()),
 				default: vec![0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "Map",
@@ -453,7 +453,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: [0u8; 8].to_vec(),
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "DoubleMap",
@@ -465,7 +465,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: [0u8; 8].to_vec(),
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 		],
 	}

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2431,10 +2431,9 @@ fn post_runtime_upgrade_detects_storage_version_issues() {
 		// any storage version "enabled".
 		assert!(
 			ExecutiveWithUpgradePallet4::try_runtime_upgrade(UpgradeCheckSelect::PreAndPost)
-				.unwrap_err() ==
-				"On chain storage version set, while the pallet \
+				.unwrap_err() == "On chain storage version set, while the pallet \
 				doesn't have the `#[pallet::storage_version(VERSION)]` attribute."
-					.into()
+				.into()
 		);
 	});
 }

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2421,9 +2421,10 @@ fn post_runtime_upgrade_detects_storage_version_issues() {
 		// any storage version "enabled".
 		assert!(
 			ExecutiveWithUpgradePallet4::try_runtime_upgrade(UpgradeCheckSelect::PreAndPost)
-				.unwrap_err() == "On chain storage version set, while the pallet \
+				.unwrap_err() ==
+				"On chain storage version set, while the pallet \
 				doesn't have the `#[pallet::storage_version(VERSION)]` attribute."
-				.into()
+					.into()
 		);
 	});
 }

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2491,18 +2491,19 @@ fn test_error_feature_parsing() {
 fn pallet_metadata() {
 	use sp_metadata_ir::DeprecationStatus;
 	let pallets = Runtime::metadata_ir().pallets;
-
+	let example = pallets[0].clone();
+	let example2 = pallets[1].clone();
 	{
 		// Example2 pallet is deprecated
-		let meta = pallets[1].clone();
+		let meta = example2;
 		assert_eq!(
-			DeprecationStatus::Deprecated { note: "test", since: None },
-			meta.deprecation_info
+			&DeprecationStatus::Deprecated { note: "test", since: None },
+			&meta.deprecation_info
 		)
 	}
 	{
 		// Example pallet calls is fully and partially deprecated
-		let meta = pallets[0].calls.clone().unwrap();
+		let meta = &example.calls.unwrap();
 		assert_eq!(
 			DeprecationStatus::Deprecated { note: "test", since: None },
 			meta.deprecation_info
@@ -2514,7 +2515,7 @@ fn pallet_metadata() {
 	}
 	{
 		// Example pallet errors are partially and fully deprecated
-		let meta = pallets[0].error.clone().unwrap();
+		let meta = &example.error.unwrap();
 		assert_eq!(
 			DeprecationStatus::Deprecated { note: "test", since: None },
 			meta.deprecation_info
@@ -2526,7 +2527,7 @@ fn pallet_metadata() {
 	}
 	{
 		// Example pallet events are partially and fully deprecated
-		let meta = pallets[0].event.clone().unwrap();
+		let meta = example.event.unwrap();
 		assert_eq!(
 			DeprecationStatus::Deprecated { note: "test", since: None },
 			meta.deprecation_info

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2421,10 +2421,9 @@ fn post_runtime_upgrade_detects_storage_version_issues() {
 		// any storage version "enabled".
 		assert!(
 			ExecutiveWithUpgradePallet4::try_runtime_upgrade(UpgradeCheckSelect::PreAndPost)
-				.unwrap_err() ==
-				"On chain storage version set, while the pallet \
+				.unwrap_err() == "On chain storage version set, while the pallet \
 				doesn't have the `#[pallet::storage_version(VERSION)]` attribute."
-					.into()
+				.into()
 		);
 	});
 }

--- a/substrate/frame/support/test/tests/runtime_metadata.rs
+++ b/substrate/frame/support/test/tests/runtime_metadata.rs
@@ -19,7 +19,7 @@
 use frame_support::{derive_impl, traits::ConstU32};
 use scale_info::{form::MetaForm, meta_type};
 use sp_metadata_ir::{
-	DeprecationStatus, RuntimeApiMetadataIR, RuntimeApiMethodMetadataIR,
+	DeprecationStatusIR, RuntimeApiMetadataIR, RuntimeApiMethodMetadataIR,
 	RuntimeApiMethodParamMetadataIR,
 };
 use sp_runtime::traits::Block as BlockT;
@@ -134,7 +134,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 				RuntimeApiMethodMetadataIR {
 					name: "something_with_block",
@@ -144,7 +144,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<Block>(),
 					docs: maybe_docs(vec![" something_with_block."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 				RuntimeApiMethodMetadataIR {
 					name: "function_with_two_args",
@@ -160,7 +160,7 @@ fn runtime_metadata() {
 					],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::Deprecated {
+					deprecation_info: DeprecationStatusIR::Deprecated {
 						note: "example",
 						since: None,
 					}
@@ -170,7 +170,7 @@ fn runtime_metadata() {
 					inputs: vec![],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::Deprecated {
+					deprecation_info: DeprecationStatusIR::Deprecated {
 						note: "example",
 						since: Some("example"),
 					}
@@ -183,7 +183,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::Deprecated {
+					deprecation_info: DeprecationStatusIR::Deprecated {
 						                    note: "example",
 						                    since: None,
 						                }
@@ -194,7 +194,7 @@ fn runtime_metadata() {
 				"",
 				" Documentation on multiline.",
 			]),
-			deprecation_info: DeprecationStatus::DeprecatedWithoutNote,
+			deprecation_info: DeprecationStatusIR::DeprecatedWithoutNote,
 
 		},
 		RuntimeApiMetadataIR {
@@ -205,7 +205,7 @@ fn runtime_metadata() {
 					inputs: vec![],
 					output: meta_type::<sp_version::RuntimeVersion>(),
 					docs: maybe_docs(vec![" Returns the version of the runtime."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 				RuntimeApiMethodMetadataIR {
 					name: "execute_block",
@@ -215,7 +215,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<()>(),
 					docs: maybe_docs(vec![" Execute the given block."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 
 				},
 				RuntimeApiMethodMetadataIR {
@@ -226,13 +226,13 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<sp_runtime::ExtrinsicInclusionMode>(),
 					docs: maybe_docs(vec![" Initialize a block with the given header and return the runtime executive mode."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 			],
 			docs: maybe_docs(vec![
 				" The `Core` runtime api that every Substrate runtime needs to implement.",
 			]),
-			deprecation_info: DeprecationStatus::NotDeprecated,
+			deprecation_info: DeprecationStatusIR::NotDeprecated,
 		},
 	];
 

--- a/substrate/primitives/api/proc-macro/src/utils.rs
+++ b/substrate/primitives/api/proc-macro/src/utils.rs
@@ -313,7 +313,7 @@ fn parse_deprecated_meta(crate_: &TokenStream, attr: &syn::Attribute) -> Result<
 					} else {
 						quote! { None }
 					};
-					let doc = quote! { #crate_::metadata_ir::DeprecationStatus::Deprecated { note: #note, since: #since }};
+					let doc = quote! { #crate_::metadata_ir::DeprecationStatusIR::Deprecated { note: #note, since: #since }};
 					Ok(doc)
 				},
 			)
@@ -323,12 +323,12 @@ fn parse_deprecated_meta(crate_: &TokenStream, attr: &syn::Attribute) -> Result<
 			..
 		}) => {
 			// #[deprecated = "lit"]
-			let doc = quote! { #crate_::metadata_ir::DeprecationStatus::Deprecated { note: #lit, since: None } };
+			let doc = quote! { #crate_::metadata_ir::DeprecationStatusIR::Deprecated { note: #lit, since: None } };
 			Ok(doc)
 		},
 		Meta::Path(_) => {
 			// #[deprecated]
-			Ok(quote! { #crate_::metadata_ir::DeprecationStatus::DeprecatedWithoutNote })
+			Ok(quote! { #crate_::metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote })
 		},
 		_ => Err(Error::new(attr.span(), "Invalid deprecation attribute")),
 	}
@@ -340,7 +340,7 @@ pub fn get_deprecation(crate_: &TokenStream, attrs: &[syn::Attribute]) -> Result
 		.iter()
 		.find(|a| a.path().is_ident("deprecated"))
 		.map(|a| parse_deprecated_meta(&crate_, a))
-		.unwrap_or_else(|| Ok(quote! {#crate_::metadata_ir::DeprecationStatus::NotDeprecated}))
+		.unwrap_or_else(|| Ok(quote! {#crate_::metadata_ir::DeprecationStatusIR::NotDeprecated}))
 }
 
 #[cfg(test)]
@@ -404,23 +404,23 @@ mod tests {
 			parse_quote!(#[deprecated(note = #FIRST, since = #SECOND, extra = "Test")]);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[simple]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::DeprecatedWithoutNote }.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote }.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[simple_path]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: None } }.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: None } }.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[meta_list]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: None } }.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: None } }.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[meta_list_with_since]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[extra_fields]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
 		);
 	}
 }

--- a/substrate/primitives/api/test/tests/ui/deprecation_info.stderr
+++ b/substrate/primitives/api/test/tests/ui/deprecation_info.stderr
@@ -40,21 +40,6 @@ error: Invalid deprecation attribute: expected string literal
 24 |         #[deprecated = 5]
    |         ^
 
-error: malformed `deprecated` attribute input
-  --> tests/ui/deprecation_info.rs:24:3
-   |
-24 |         #[deprecated = 5]
-   |         ^^^^^^^^^^^^^^^^^
-   |
-help: the following are the possible correct uses
-   |
-24 |         #[deprecated = "reason"]
-   |
-24 |         #[deprecated(/*opt*/ since = "version", /*opt*/ note = "reason")]
-   |
-24 |         #[deprecated]
-   |
-
 error[E0541]: unknown meta item 'unknown_kw'
   --> tests/ui/deprecation_info.rs:20:16
    |

--- a/substrate/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
+++ b/substrate/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
@@ -53,11 +53,3 @@ note: associated function defined here
    |
 27 |         fn test(data: u64);
    |            ^^^^
-
-warning: unused variable: `data`
-  --> tests/ui/impl_incorrect_method_signature.rs:33:11
-   |
-33 |         fn test(data: String) {}
-   |                 ^^^^ help: if this is intentional, prefix it with an underscore: `_data`
-   |
-   = note: `#[warn(unused_variables)]` on by default

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -377,7 +377,7 @@ pub struct PalletEventMetadataIR<T: Form = MetaForm> {
 	/// Deprecation status of the event itself
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Deprecation status of the variants
-	pub deprecated_variants: BTreeMap<T::String, DeprecationStatus<T>>,
+	pub deprecated_variants: BTreeMap<usize, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletEventMetadataIR {
@@ -390,9 +390,8 @@ impl IntoPortable for PalletEventMetadataIR {
 				.deprecated_variants
 				.into_iter()
 				.map(|(k, v)| {
-					let key = k.into_portable(registry);
 					let value = v.into_portable(registry);
-					(key, value)
+					(k, value)
 				})
 				.collect(),
 			deprecation_info: self.deprecation_info.into_portable(registry),
@@ -437,7 +436,7 @@ pub struct PalletErrorMetadataIR<T: Form = MetaForm> {
 	/// Deprecation status of the error itself
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Deprecation status of the variants
-	pub deprecated_variants: BTreeMap<T::String, DeprecationStatus<T>>,
+	pub deprecated_variants: BTreeMap<usize, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletErrorMetadataIR {
@@ -450,9 +449,8 @@ impl IntoPortable for PalletErrorMetadataIR {
 				.deprecated_variants
 				.into_iter()
 				.map(|(k, v)| {
-					let key = k.into_portable(registry);
 					let value = v.into_portable(registry);
-					(key, value)
+					(k, value)
 				})
 				.collect(),
 			deprecation_info: self.deprecation_info.into_portable(registry),

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -346,7 +346,7 @@ pub struct PalletCallMetadataIR<T: Form = MetaForm> {
 	/// Deprecation status of the pallet call itself
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Deprecation status of the call indexes
-	pub deprecated_indexes: BTreeMap<usize, DeprecationStatus<T>>,
+	pub deprecated_indexes: BTreeMap<u8, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletCallMetadataIR {
@@ -377,7 +377,7 @@ pub struct PalletEventMetadataIR<T: Form = MetaForm> {
 	/// Deprecation status of the event itself
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Deprecation status of the variants
-	pub deprecated_variants: BTreeMap<usize, DeprecationStatus<T>>,
+	pub deprecated_variants: BTreeMap<u8, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletEventMetadataIR {
@@ -436,7 +436,7 @@ pub struct PalletErrorMetadataIR<T: Form = MetaForm> {
 	/// Deprecation status of the error itself
 	pub deprecation_info: DeprecationStatus<T>,
 	/// Deprecation status of the variants
-	pub deprecated_variants: BTreeMap<usize, DeprecationStatus<T>>,
+	pub deprecated_variants: BTreeMap<u8, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletErrorMetadataIR {

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -19,7 +19,7 @@ use codec::Encode;
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
-	IntoPortable, MetaType, Registry,
+	IntoPortable, Registry,
 };
 
 /// The intermediate representation for the runtime metadata.
@@ -140,8 +140,6 @@ pub struct PalletMetadataIR<T: Form = MetaForm> {
 	pub docs: Vec<T::String>,
 	/// Deprecation info
 	pub deprecation_info: DeprecationStatus<T>,
-	/// Deprecation info for events and errors
-	pub deprecation_table: BTreeMap<T::Type, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletMetadataIR {
@@ -158,15 +156,6 @@ impl IntoPortable for PalletMetadataIR {
 			index: self.index,
 			docs: registry.map_into_portable(self.docs),
 			deprecation_info: self.deprecation_info.into_portable(registry),
-			deprecation_table: self
-				.deprecation_table
-				.into_iter()
-				.map(|(k, v)| {
-					let key = registry.register_type(&k);
-					let value = v.into_portable(registry);
-					(key, value)
-				})
-				.collect(),
 		}
 	}
 }
@@ -354,19 +343,29 @@ impl IntoPortable for StorageEntryTypeIR {
 pub struct PalletCallMetadataIR<T: Form = MetaForm> {
 	/// The corresponding enum type for the pallet call.
 	pub ty: T::Type,
+	/// Deprecation status of the pallet call itself
+	pub deprecation_info: DeprecationStatus<T>,
+	/// Deprecation status of the call indexes
+	pub deprecated_indexes: BTreeMap<usize, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletCallMetadataIR {
 	type Output = PalletCallMetadataIR<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		PalletCallMetadataIR { ty: registry.register_type(&self.ty) }
-	}
-}
-
-impl From<MetaType> for PalletCallMetadataIR {
-	fn from(ty: MetaType) -> Self {
-		Self { ty }
+		PalletCallMetadataIR {
+			ty: registry.register_type(&self.ty),
+			deprecated_indexes: self
+				.deprecated_indexes
+				.into_iter()
+				.map(|(k, v)| {
+					let key = k;
+					let value = v.into_portable(registry);
+					(key, value)
+				})
+				.collect(),
+			deprecation_info: self.deprecation_info.into_portable(registry),
+		}
 	}
 }
 
@@ -375,19 +374,29 @@ impl From<MetaType> for PalletCallMetadataIR {
 pub struct PalletEventMetadataIR<T: Form = MetaForm> {
 	/// The Event type.
 	pub ty: T::Type,
+	/// Deprecation status of the event itself
+	pub deprecation_info: DeprecationStatus<T>,
+	/// Deprecation status of the variants
+	pub deprecated_variants: BTreeMap<T::String, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletEventMetadataIR {
 	type Output = PalletEventMetadataIR<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		PalletEventMetadataIR { ty: registry.register_type(&self.ty) }
-	}
-}
-
-impl From<MetaType> for PalletEventMetadataIR {
-	fn from(ty: MetaType) -> Self {
-		Self { ty }
+		PalletEventMetadataIR {
+			ty: registry.register_type(&self.ty),
+			deprecated_variants: self
+				.deprecated_variants
+				.into_iter()
+				.map(|(k, v)| {
+					let key = k.into_portable(registry);
+					let value = v.into_portable(registry);
+					(key, value)
+				})
+				.collect(),
+			deprecation_info: self.deprecation_info.into_portable(registry),
+		}
 	}
 }
 
@@ -425,19 +434,29 @@ impl IntoPortable for PalletConstantMetadataIR {
 pub struct PalletErrorMetadataIR<T: Form = MetaForm> {
 	/// The error type information.
 	pub ty: T::Type,
+	/// Deprecation status of the error itself
+	pub deprecation_info: DeprecationStatus<T>,
+	/// Deprecation status of the variants
+	pub deprecated_variants: BTreeMap<T::String, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletErrorMetadataIR {
 	type Output = PalletErrorMetadataIR<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
-		PalletErrorMetadataIR { ty: registry.register_type(&self.ty) }
-	}
-}
-
-impl From<MetaType> for PalletErrorMetadataIR {
-	fn from(ty: MetaType) -> Self {
-		Self { ty }
+		PalletErrorMetadataIR {
+			ty: registry.register_type(&self.ty),
+			deprecated_variants: self
+				.deprecated_variants
+				.into_iter()
+				.map(|(k, v)| {
+					let key = k.into_portable(registry);
+					let value = v.into_portable(registry);
+					(key, value)
+				})
+				.collect(),
+			deprecation_info: self.deprecation_info.into_portable(registry),
+		}
 	}
 }
 

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -18,7 +18,7 @@
 use codec::Encode;
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
-	prelude::vec::Vec,
+	prelude::{collections::BTreeMap, vec::Vec},
 	IntoPortable, MetaType, Registry,
 };
 
@@ -138,6 +138,10 @@ pub struct PalletMetadataIR<T: Form = MetaForm> {
 	pub index: u8,
 	/// Pallet documentation.
 	pub docs: Vec<T::String>,
+	/// Deprecation info
+	pub deprecation_info: DeprecationStatus<T>,
+	/// Deprecation info for events and errors
+	pub deprecation_table: BTreeMap<T::Type, DeprecationStatus<T>>,
 }
 
 impl IntoPortable for PalletMetadataIR {
@@ -153,6 +157,16 @@ impl IntoPortable for PalletMetadataIR {
 			error: self.error.map(|error| error.into_portable(registry)),
 			index: self.index,
 			docs: registry.map_into_portable(self.docs),
+			deprecation_info: self.deprecation_info.into_portable(registry),
+			deprecation_table: self
+				.deprecation_table
+				.into_iter()
+				.map(|(k, v)| {
+					let key = registry.register_type(&k);
+					let value = v.into_portable(registry);
+					(key, value)
+				})
+				.collect(),
 		}
 	}
 }


### PR DESCRIPTION
### Description: 
Adds support for `DeprecationStatus` info in `RuntimeMetadataIR` for Calls,Events,Errors and Pallet itself. 
depends on #4851.
####  Adds `deprecation_info` field to
- PalletCallMetadataIR
- PalletMetadataIR
- PalletEventMetadataIR
- PalletErrorMetadataIR
#### `deprecated_variants` for
- PalletEventMetadataIR
- PalletErrorMetadataIR
#### `deprecated_indexes` for
- PalletCallMetadataIR

There's also some test updates to make sure that deprecation attributes are getting propagated to the relevant structs.

see: [issue](https://github.com/paritytech/polkadot-sdk/issues/4098), Solution: A

### Notes 
The `deprecated_info` and `deprecated_variants/indexes` are done as separate fields for this mr. in next [PR](https://github.com/paritytech/polkadot-sdk/pull/4994) I refactored this as suggested into a single field.

### PS:
i used cargo +nightly fmt --all and cargo +nightly-2024-04-10 fmt --all and still getting line changes due to formatting, what's the correct incantation?