### PR TITLE
Add build options to the srtool build step

### DIFF
--- a/.github/workflows/release-30_publish_release_draft.yml
+++ b/.github/workflows/release-30_publish_release_draft.yml
@@ -26,6 +26,7 @@ jobs:
     uses: "./.github/workflows/release-srtool.yml"
     with:
        excluded_runtimes: "substrate-test bp cumulus-test kitchensink minimal-template parachain-template penpal polkadot-test seedling shell frame-try sp solochain-template"
+       build_opts: "--features metadata-hash"
 
   build-binaries:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-srtool.yml
+++ b/.github/workflows/release-srtool.yml
@@ -78,20 +78,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Prepare build options
+        run: |
+          BUILD_OPTIONS=""
+          if [[ ${{ matrix.chain }} == 'asset-hub-rococo' || ${{ matrix.chain }} == 'asset-hub-westend' || ${{ matrix.chain }} == 'rococo' || ${{ matrix.chain }} == 'westend' ]]; then
+            BUILD_OPTIONS=${{ inputs.build_opts }}
+          fi
+
+          echo "BUILD_OPTIONS=${BUILD_OPTIONS}" >> $GITHUB_ENV
+
       - name: Srtool build
-        if: ${{ matrix.chain != 'asset-hub-rococo' || matrix.chain != 'asset-hub-westend' || matrix.chain != 'rococo' || matrix.chain != 'westend' }}
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
-        with:
-          chain: ${{ matrix.chain }}
-          runtime_dir: ${{ matrix.runtime_dir }}
-
-      - name: Srtool build with options
-        if: ${{ matrix.chain == 'asset-hub-rococo' || matrix.chain == 'asset-hub-westend' || matrix.chain == 'rococo' || matrix.chain == 'westend' }}
-        id: srtool_build_with_opts
-        uses: chevdor/srtool-actions@v0.9.2
         env:
-          BUILD_OPTS: ${{ inputs.build_opts }}
+          BUILD_OPTS: ${{ github.env.BUILD_OPTIONS }}
         with:
           chain: ${{ matrix.chain }}
           runtime_dir: ${{ matrix.runtime_dir }}

--- a/.github/workflows/release-srtool.yml
+++ b/.github/workflows/release-srtool.yml
@@ -79,7 +79,16 @@ jobs:
           fetch-depth: 0
 
       - name: Srtool build
+        if: ${{ matrix.chain != 'asset-hub-rococo' || matrix.chain != 'asset-hub-westend' || matrix.chain != 'rococo' || matrix.chain != 'westend' }}
         id: srtool_build
+        uses: chevdor/srtool-actions@v0.9.2
+        with:
+          chain: ${{ matrix.chain }}
+          runtime_dir: ${{ matrix.runtime_dir }}
+
+      - name: Srtool build with options
+        if: ${{ matrix.chain == 'asset-hub-rococo' || matrix.chain == 'asset-hub-westend' || matrix.chain == 'rococo' || matrix.chain == 'westend' }}
+        id: srtool_build_with_opts
         uses: chevdor/srtool-actions@v0.9.2
         env:
           BUILD_OPTS: ${{ inputs.build_opts }}

--- a/.github/workflows/release-srtool.yml
+++ b/.github/workflows/release-srtool.yml
@@ -14,6 +14,8 @@ on:
     inputs:
       excluded_runtimes:
         type: string
+      build_opts:
+        type: string
     outputs:
       published_runtimes:
         value: ${{ jobs.find-runtimes.outputs.runtime }}
@@ -79,6 +81,8 @@ jobs:
       - name: Srtool build
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
+        env:
+          BUILD_OPTS: ${{ inputs.build_opts }}
         with:
           chain: ${{ matrix.chain }}
           runtime_dir: ${{ matrix.runtime_dir }}

--- a/.github/workflows/release-srtool.yml
+++ b/.github/workflows/release-srtool.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           BUILD_OPTIONS=""
           if [[ ${{ matrix.chain }} == 'asset-hub-rococo' || ${{ matrix.chain }} == 'asset-hub-westend' || ${{ matrix.chain }} == 'rococo' || ${{ matrix.chain }} == 'westend' ]]; then
-            BUILD_OPTIONS=${{ inputs.build_opts }}
+            BUILD_OPTIONS="${{ inputs.build_opts }}"
           fi
 
           echo "BUILD_OPTIONS=${BUILD_OPTIONS}" >> $GITHUB_ENV

--- a/.github/workflows/release-srtool.yml
+++ b/.github/workflows/release-srtool.yml
@@ -91,7 +91,7 @@ jobs:
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
         env:
-          BUILD_OPTS: ${{ github.env.BUILD_OPTIONS }}
+          BUILD_OPTS: ${{ env.BUILD_OPTIONS }}
         with:
           chain: ${{ matrix.chain }}
           runtime_dir: ${{ matrix.runtime_dir }}


### PR DESCRIPTION
This PR adds possibility to set BUILD_OPTIONS to the "Srtool Build"  step in the release pipeline while building runtimes.

Colses: https://github.com/paritytech/release-engineering/issues/213