### PR TITLE
Do not enforce network key presence for collators

### DIFF
--- a/polkadot/cli/src/command.rs
+++ b/polkadot/cli/src/command.rs
@@ -153,6 +153,11 @@ impl SubstrateCli for Cli {
 			},
 		})
 	}
+
+	// Enforce the presence of a network key if the node is started as an authorithy.
+	fn enforce_network_key_exists_when_authority(&self) -> bool {
+		true
+	}
 }
 
 fn set_default_ss58_version(spec: &Box<dyn polkadot_service::ChainSpec>) {

--- a/substrate/client/cli/src/config.rs
+++ b/substrate/client/cli/src/config.rs
@@ -437,11 +437,15 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	///
 	/// By default this is retrieved from `NodeKeyParams` if it is available. Otherwise its
 	/// `NodeKeyConfig::default()`.
-	fn node_key(&self, net_config_dir: &PathBuf) -> Result<NodeKeyConfig> {
+	fn node_key(
+		&self,
+		net_config_dir: &PathBuf,
+		require_key_for_authority: bool,
+	) -> Result<NodeKeyConfig> {
 		let is_dev = self.is_dev()?;
 		let role = self.role(is_dev)?;
 		self.node_key_params()
-			.map(|x| x.node_key(net_config_dir, role, is_dev))
+			.map(|x| x.node_key(net_config_dir, role, is_dev, require_key_for_authority))
 			.unwrap_or_else(|| Ok(Default::default()))
 	}
 
@@ -490,7 +494,8 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 				Database::ParityDb
 			},
 		);
-		let node_key = self.node_key(&net_config_dir)?;
+		let node_key =
+			self.node_key(&net_config_dir, cli.enforce_network_key_exists_when_authority())?;
 		let role = self.role(is_dev)?;
 		let max_runtime_instances = self.max_runtime_instances()?.unwrap_or(8);
 		let is_validator = role.is_authority();

--- a/substrate/client/cli/src/lib.rs
+++ b/substrate/client/cli/src/lib.rs
@@ -250,4 +250,9 @@ pub trait SubstrateCli: Sized {
 		command.init(&Self::support_url(), &Self::impl_version(), logger_hook, &config)?;
 		Runner::new(config, tokio_runtime, signals)
 	}
+
+	/// Returns if a node should enforce the presence of a node key for authorities.
+	fn enforce_network_key_exists_when_authority(&self) -> bool {
+		false
+	}
 }


### PR DESCRIPTION
Because of https://github.com/paritytech/polkadot-sdk/blob/299aacb56f4f11127b194d12692b00066e91ac92/cumulus/client/cli/src/lib.rs#L318 https://github.com/paritytech/polkadot-sdk/pull/3852 wrongly enforces that the network key is present for collators started with polkadot-parachain binary, instead of generating it on the fly.

That is not necessary and created some small friction for collators, since they have to pass `--unsafe-force-node-key-generation` or generate the key with the `generate-node-key` command.

This PR fixes that since the change was intended to apply only for relaychain authorithies.
Triggered by: https://matrix.to/#/!gTDxPnCbETlSLiqWfc:matrix.org/$Y9hLdT0z2TZCtskIcsIrD3kQm3XE5nga4b4LbGWsh-8?via=web3.foundation&via=matrix.org&via=parity.io
