### PR TITLE
Stabilize elastic-scaling pov-recovery test

### DIFF
--- a/cumulus/zombienet/tests/0002-pov_recovery.zndsl
+++ b/cumulus/zombienet/tests/0002-pov_recovery.zndsl
@@ -2,7 +2,9 @@ Description: PoV recovery test
 Network: ./0002-pov_recovery.toml
 Creds: config
 
-# wait 20 blocks and register parachain
+# Wait 20 blocks and register parachain. This part is important for pov-recovery.
+# We need to make sure that the recovering node is able to see all relay-chain
+# notifications containing the candidates to recover.
 validator-3: reports block height is at least 20 within 250 seconds
 validator-0: js-script ./register-para.js with "2000" within 240 seconds
 validator-0: parachain 2000 is registered within 300 seconds

--- a/cumulus/zombienet/tests/0009-elastic_pov_recovery.toml
+++ b/cumulus/zombienet/tests/0009-elastic_pov_recovery.toml
@@ -30,7 +30,7 @@ command = "polkadot"
 [[parachains]]
 id = 2100
 chain = "elastic-scaling"
-add_to_genesis = true
+add_to_genesis = false
 
   # Slot based authoring with 3 cores and 2s slot duration
   [[parachains.collators]]

--- a/cumulus/zombienet/tests/0009-elastic_pov_recovery.zndsl
+++ b/cumulus/zombienet/tests/0009-elastic_pov_recovery.zndsl
@@ -6,10 +6,12 @@ alice: is up
 collator-elastic: is up
 
 # configure relay chain
-alice: js-script ./assign-core.js with "2100,0" return is 0 within 600 seconds
-alice: js-script ./assign-core.js with "2100,1" return is 0 within 600 seconds
+alice: js-script ./assign-core.js with "2100,0" return is 0 within 200 seconds
+alice: js-script ./assign-core.js with "2100,1" return is 0 within 200 seconds
 
-# wait 20 blocks and register parachain
+# Wait 20 blocks and register parachain. This part is important for pov-recovery.
+# We need to make sure that the recovering node is able to see all relay-chain
+# notifications containing the candidates to recover.
 alice: reports block height is at least 20 within 250 seconds
 alice: js-script ./register-para.js with "2100" within 240 seconds
 alice: parachain 2100 is registered within 300 seconds

--- a/cumulus/zombienet/tests/0009-elastic_pov_recovery.zndsl
+++ b/cumulus/zombienet/tests/0009-elastic_pov_recovery.zndsl
@@ -5,12 +5,15 @@ Creds: config
 alice: is up
 collator-elastic: is up
 
-# wait 20 blocks and register parachain
-alice: reports block height is at least 20 within 250 seconds
-
 # configure relay chain
 alice: js-script ./assign-core.js with "2100,0" return is 0 within 600 seconds
 alice: js-script ./assign-core.js with "2100,1" return is 0 within 600 seconds
+
+# wait 20 blocks and register parachain
+alice: reports block height is at least 20 within 250 seconds
+alice: js-script ./register-para.js with "2100" within 240 seconds
+alice: parachain 2100 is registered within 300 seconds
+
 
 # check block production
 collator-elastic: reports block height is at least 40 within 225 seconds


### PR DESCRIPTION
Timing issues in container startup have made this test flaky. We now wait for 20 and then register the parachain. 
This makes sure that the parachain node has the ability to see all relay chain notifications it needs.