### PR TITLE
Adds example for custom default configs

### DIFF
--- a/substrate/frame/support/src/tests/custom_default_config.rs
+++ b/substrate/frame/support/src/tests/custom_default_config.rs
@@ -1,0 +1,63 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Config;
+use crate::{derive_impl, pallet_prelude::inject_runtime_type};
+use static_assertions::assert_type_eq_all;
+
+#[docify::export]
+pub mod custom_config_prelude {
+	use super::*;
+
+	pub trait CustomDefaultConfigProvider {
+		type AccountId;
+		type RuntimeOrigin;
+		type RuntimeCall;
+		type RuntimeTask;
+	}
+
+	pub struct CustomDefaultConfig;
+
+	#[crate::register_default_impl(CustomDefaultConfig)]
+	impl CustomDefaultConfigProvider for CustomDefaultConfig {
+		type AccountId = u16;
+		#[inject_runtime_type]
+		type RuntimeOrigin = ();
+		#[inject_runtime_type]
+		type RuntimeCall = ();
+		#[inject_runtime_type]
+		type RuntimeTask = ();
+	}
+}
+
+#[docify::export]
+#[test]
+fn derive_impl_works_with_custom_default_config() {
+	struct DummyRuntime;
+
+	#[derive_impl(custom_config_prelude::CustomDefaultConfig, no_aggregated_types)]
+	impl Config for DummyRuntime {
+		type BaseCallFilter = frame_support::traits::Everything;
+		type Block = super::Block;
+		type DbWeight = ();
+		type PalletInfo = super::PalletInfo;
+	}
+
+	assert_type_eq_all!(<DummyRuntime as Config>::AccountId, u16);
+	assert_type_eq_all!(<DummyRuntime as Config>::RuntimeOrigin, ());
+	assert_type_eq_all!(<DummyRuntime as Config>::RuntimeCall, ());
+}

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -26,6 +26,7 @@ use sp_runtime::{generic, traits::BlakeTwo256, BuildStorage};
 
 pub use self::frame_system::{pallet_prelude::*, Config, Pallet};
 
+mod custom_default_config;
 mod inject_runtime_type;
 mod runtime;
 mod storage_alias;


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-sdk/issues/4827

This PR provides an example to create custom default configs for any pallet that could be created externally and shared across runtimes. Such a paradigm can be used in https://github.com/paritytech/polkadot-sdk/pull/4056.

It requires the following:
1. A trait that carries those configuration parameters for a pallet that should be shared across runtimes
2. An implementation of that trait registered via `register_default_impl`
3. Usage of `derive_impl` at the actual impl site pointing to this default implementation