### PR TITLE
sp-core: Improve docs generated by `generate_feature_enabled_macro`

### DIFF
--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -430,6 +430,7 @@ pub const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
 macro_rules! generate_feature_enabled_macro {
 	( $macro_name:ident, $feature_name:meta, $d:tt ) => {
 		$crate::paste::paste!{
+			///
 			#[cfg($feature_name)]
 			#[macro_export]
 			macro_rules! [<_ $macro_name>] {
@@ -438,6 +439,7 @@ macro_rules! generate_feature_enabled_macro {
 				}
 			}
 
+			///
  			#[cfg(not($feature_name))]
 			#[macro_export]
 			macro_rules! [<_ $macro_name>] {
@@ -454,7 +456,8 @@ macro_rules! generate_feature_enabled_macro {
 			/// // Will add the code depending on the feature being enabled or not.
 			#[doc = concat!(stringify!($macro_name), "!( println!(\"Hello\") )")]
 			/// ```
-			pub use [<_ $macro_name>] as $macro_name;
+			// https://github.com/rust-lang/rust/pull/52234			
+ 			pub use [<_ $macro_name>] as $macro_name;
 		}
 	};
 }

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -430,16 +430,6 @@ pub const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
 macro_rules! generate_feature_enabled_macro {
 	( $macro_name:ident, $feature_name:meta, $d:tt ) => {
 		$crate::paste::paste!{
-			/// Enable/disable the given code depending on
-			#[doc = concat!("`", stringify!($feature_name), "`")]
-			/// being enabled for the crate or not.
-			///
-			/// # Example
-			///
-			/// ```nocompile
-			/// // Will add the code depending on the feature being enabled or not.
-			#[doc = concat!(stringify!($macro_name), "!( println!(\"Hello\") )")]
-			/// ```
 			#[cfg($feature_name)]
 			#[macro_export]
 			macro_rules! [<_ $macro_name>] {
@@ -448,6 +438,12 @@ macro_rules! generate_feature_enabled_macro {
 				}
 			}
 
+ 			#[cfg(not($feature_name))]
+			#[macro_export]
+			macro_rules! [<_ $macro_name>] {
+				( $d ( $d input:tt )* ) => {};
+			}
+
 			/// Enable/disable the given code depending on
 			#[doc = concat!("`", stringify!($feature_name), "`")]
 			/// being enabled for the crate or not.
@@ -458,14 +454,6 @@ macro_rules! generate_feature_enabled_macro {
 			/// // Will add the code depending on the feature being enabled or not.
 			#[doc = concat!(stringify!($macro_name), "!( println!(\"Hello\") )")]
 			/// ```
-			#[cfg(not($feature_name))]
-			#[macro_export]
-			macro_rules! [<_ $macro_name>] {
-				( $d ( $d input:tt )* ) => {};
-			}
-
-			// Work around for: <https://github.com/rust-lang/rust/pull/52234>
-			#[doc(hidden)]
 			pub use [<_ $macro_name>] as $macro_name;
 		}
 	};


### PR DESCRIPTION
Now: 
![image](https://github.com/paritytech/polkadot-sdk/assets/5718007/01545872-e21b-48b9-9913-4b940ff3f361)

Before:
![image](https://github.com/paritytech/polkadot-sdk/assets/5718007/09ae9fa4-eca8-43f7-a083-a4555e392610)


We sadly can not remove the `_macro_name`, but this way we at least show the correct macro plus docs.