### PR TITLE
litep2p/peerstore: Fix bump last updated time

### DIFF
--- a/substrate/client/network/src/litep2p/peerstore.rs
+++ b/substrate/client/network/src/litep2p/peerstore.rs
@@ -85,6 +85,11 @@ impl PeerInfo {
 		self.reputation < BANNED_THRESHOLD
 	}
 
+	fn add_reputation(&mut self, increment: i32) {
+		self.reputation = self.reputation.saturating_add(increment);
+		self.bump_last_updated();
+	}
+
 	fn decay_reputation(&mut self, seconds_passed: u64) {
 		// Note that decaying the reputation value happens "on its own",
 		// so we don't do `bump_last_updated()`.
@@ -102,6 +107,10 @@ impl PeerInfo {
 				break
 			}
 		}
+	}
+
+	fn bump_last_updated(&mut self) {
+		self.last_updated = Instant::now();
 	}
 }
 
@@ -169,7 +178,7 @@ impl PeerStoreProvider for PeerstoreHandle {
 
 		match lock.peers.get_mut(&peer) {
 			Some(info) => {
-				info.reputation = info.reputation.saturating_add(reputation_change.value);
+				info.add_reputation(reputation_change.value);
 			},
 			None => {
 				lock.peers.insert(


### PR DESCRIPTION
This PR bumps the last time of a reputation update of a peer.
Doing so ensures the peer remains in the peerstore for longer than 1 hour.

Libp2p updates the `last_updated` field as well.

Small summary for the peerstore:
- A: when peers are reported the `last_updated` time is set to current time (not done before this PR)
- B: peers that were not updated for 1 hour are removed from the peerstore
- the reputation of the peers is decaying to zero over time
- peers are reported with a reputation change (positive or negative depending on the behavior)

Because, (A) was not updating the `last_updated` time, we might lose the reputation of peers that are constantly updated after 1hour because of (B). 

cc @paritytech/networking 


