### PR TITLE
add notices to the implementer's guide docs that changed for elastic scaling

### DIFF
--- a/polkadot/roadmap/implementers-guide/src/node/backing/candidate-backing.md
+++ b/polkadot/roadmap/implementers-guide/src/node/backing/candidate-backing.md
@@ -1,5 +1,9 @@
 # Candidate Backing
 
+> NOTE: This module has suffered changes for the elastic scaling implementation. As a result, parts of this document may
+be out of date and will be updated at a later time. Issue tracking the update:
+https://github.com/paritytech/polkadot-sdk/issues/3699
+
 The Candidate Backing subsystem ensures every parablock considered for relay block inclusion has been seconded by at
 least one validator, and approved by a quorum. Parablocks for which not enough validators will assert correctness are
 discarded. If the block later proves invalid, the initial backers are slashable; this gives Polkadot a rational threat

--- a/polkadot/roadmap/implementers-guide/src/node/backing/prospective-parachains.md
+++ b/polkadot/roadmap/implementers-guide/src/node/backing/prospective-parachains.md
@@ -1,5 +1,9 @@
 # Prospective Parachains
 
+> NOTE: This module has suffered changes for the elastic scaling implementation. As a result, parts of this document may
+be out of date and will be updated at a later time. Issue tracking the update:
+https://github.com/paritytech/polkadot-sdk/issues/3699
+
 ## Overview
 
 **Purpose:** Tracks and handles prospective parachain fragments and informs

--- a/polkadot/roadmap/implementers-guide/src/node/collators/collator-protocol.md
+++ b/polkadot/roadmap/implementers-guide/src/node/collators/collator-protocol.md
@@ -1,5 +1,9 @@
 # Collator Protocol
 
+> NOTE: This module has suffered changes for the elastic scaling implementation. As a result, parts of this document may
+be out of date and will be updated at a later time. Issue tracking the update:
+https://github.com/paritytech/polkadot-sdk/issues/3699
+
 The Collator Protocol implements the network protocol by which collators and validators communicate. It is used by
 collators to distribute collations to validators and used by validators to accept collations by collators.
 

--- a/polkadot/roadmap/implementers-guide/src/node/utility/provisioner.md
+++ b/polkadot/roadmap/implementers-guide/src/node/utility/provisioner.md
@@ -1,5 +1,9 @@
 # Provisioner
 
+> NOTE: This module has suffered changes for the elastic scaling implementation. As a result, parts of this document may
+be out of date and will be updated at a later time. Issue tracking the update:
+https://github.com/paritytech/polkadot-sdk/issues/3699
+
 Relay chain block authorship authority is governed by BABE and is beyond the scope of the Overseer and the rest of the
 subsystems. That said, ultimately the block author needs to select a set of backable parachain candidates and other
 consensus data, and assemble a block from them. This subsystem is responsible for providing the necessary data to all

--- a/polkadot/roadmap/implementers-guide/src/runtime/inclusion.md
+++ b/polkadot/roadmap/implementers-guide/src/runtime/inclusion.md
@@ -1,5 +1,9 @@
 # Inclusion Pallet
 
+> NOTE: This module has suffered changes for the elastic scaling implementation. As a result, parts of this document may
+be out of date and will be updated at a later time. Issue tracking the update:
+https://github.com/paritytech/polkadot-sdk/issues/3699
+
 The inclusion module is responsible for inclusion and availability of scheduled parachains. It also manages the UMP
 dispatch queue of each parachain.
 

--- a/polkadot/roadmap/implementers-guide/src/runtime/parainherent.md
+++ b/polkadot/roadmap/implementers-guide/src/runtime/parainherent.md
@@ -1,5 +1,9 @@
 # `ParaInherent`
 
+> NOTE: This module has suffered changes for the elastic scaling implementation. As a result, parts of this document may
+be out of date and will be updated at a later time. Issue tracking the update:
+https://github.com/paritytech/polkadot-sdk/issues/3699
+
 This module is responsible for providing all data given to the runtime by the block author to the various parachains
 modules. The entry-point is mandatory, in that it must be invoked exactly once within every block, and it is also
 "inherent", in that it is provided with no origin by the block author. The data within it carries its own


### PR DESCRIPTION
The update is tracked by: https://github.com/paritytech/polkadot-sdk/issues/3699

However, this is not worth doing at this point since it will change in the future for phase 2 of the implementation.

Still, it's useful to let people know that the information is not the most up to date.