### PR TITLE
Frame Metadata Deprecation: Refactor enum a bit

### DIFF
--- a/prdoc/pr_4851.prdoc
+++ b/prdoc/pr_4851.prdoc
@@ -6,7 +6,7 @@ title: Add support for deprecation metadata in `RuntimeMetadataIr` entries.
 doc:
   - audience: Runtime Dev
     description: |
-      Adds `DeprecationStatus` enum to sp_metadata_ir.
+      Adds `DeprecationStatusIR` enum to sp_metadata_ir.
       Adds `deprecation_info` field to 
        - `RuntimeApiMetadataIR`
        - `RuntimeApiMethodMetadataIR`

--- a/substrate/frame/support/procedural/src/deprecation.rs
+++ b/substrate/frame/support/procedural/src/deprecation.rs
@@ -124,7 +124,7 @@ pub fn get_deprecation_enum<'a>(
 				.iter()
 				.find(|a| a.path().is_ident("deprecated"))
 				.map(|x| x.span())
-				.expect("this can never fail");
+				.expect("this can never fail, because we have found the deprecated attribute above; qed");
 			Err(Error::new(span, "Invalid deprecation usage. Either deprecate variants/call indexes or the type as a whole"))
 		},
 	}

--- a/substrate/frame/support/procedural/src/deprecation.rs
+++ b/substrate/frame/support/procedural/src/deprecation.rs
@@ -102,7 +102,7 @@ pub fn get_deprecation_enum<'a>(
 
 	let children = children_attrs
 		.filter_map(|(key, attributes)| {
-			let key = key as u8;
+			let key = quote::quote! { #path::__private::codec::Compact(#key as u8) };
 			let deprecation_status = parse_deprecation(path, attributes).transpose();
 			deprecation_status.map(|item| item.map(|item| quote::quote! { (#key, #item) }))
 		})

--- a/substrate/frame/support/procedural/src/deprecation.rs
+++ b/substrate/frame/support/procedural/src/deprecation.rs
@@ -49,7 +49,7 @@ fn parse_deprecated_meta(path: &TokenStream, attr: &syn::Attribute) -> Result<To
 					} else {
 						quote! { None }
 					};
-					let doc = quote! { #path::__private::metadata_ir::DeprecationStatus::Deprecated { note: #note, since: #since }};
+					let doc = quote! { #path::__private::metadata_ir::DeprecationStatusIR::Deprecated { note: #note, since: #since }};
 					Ok(doc)
 				},
 			)
@@ -59,12 +59,12 @@ fn parse_deprecated_meta(path: &TokenStream, attr: &syn::Attribute) -> Result<To
 			..
 		}) => {
 			// #[deprecated = "lit"]
-			let doc = quote! { #path::__private::metadata_ir::DeprecationStatus::Deprecated { note: #lit, since: None } };
+			let doc = quote! { #path::__private::metadata_ir::DeprecationStatusIR::Deprecated { note: #lit, since: None } };
 			Ok(doc)
 		},
 		Meta::Path(_) => {
 			// #[deprecated]
-			Ok(quote! { #path::__private::metadata_ir::DeprecationStatus::DeprecatedWithoutNote })
+			Ok(quote! { #path::__private::metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote })
 		},
 		_ => Err(Error::new(attr.span(), "Invalid deprecation attribute")),
 	}
@@ -77,14 +77,15 @@ pub fn get_deprecation(path: &TokenStream, attrs: &[syn::Attribute]) -> Result<T
 		.find(|a| a.path().is_ident("deprecated"))
 		.map(|a| parse_deprecated_meta(path, a))
 		.unwrap_or_else(|| {
-			Ok(quote! {#path::__private::metadata_ir::DeprecationStatus::NotDeprecated})
+			Ok(quote! {#path::__private::metadata_ir::DeprecationStatusIR::NotDeprecated})
 		})
 }
 
 /// collects deprecation attribute if its present for enum-like types
 pub fn get_deprecation_enum<'a>(
 	path: &TokenStream,
-	attrs: impl Iterator<Item = (u8, &'a [syn::Attribute])>,
+	parent_attrs: &[syn::Attribute],
+	children_attrs: impl Iterator<Item = (u8, &'a [syn::Attribute])>,
 ) -> Result<TokenStream> {
 	fn parse_deprecation(
 		path: &TokenStream,
@@ -97,15 +98,34 @@ pub fn get_deprecation_enum<'a>(
 			.unwrap_or_else(|| Ok(None))
 	}
 
-	let children = attrs
+	let parent_deprecation = parse_deprecation(path, parent_attrs)?;
+
+	let children = children_attrs
 		.filter_map(|(key, attributes)| {
 			let key = key as u8;
 			let deprecation_status = parse_deprecation(path, attributes).transpose();
 			deprecation_status.map(|item| item.map(|item| quote::quote! { (#key, #item) }))
 		})
 		.collect::<Result<Vec<TokenStream>>>()?;
-
-	Ok(
-		quote::quote! { #path::__private::scale_info::prelude::collections::BTreeMap::from([#( #children),*]) },
-	)
+	match (parent_deprecation, children.as_slice()) {
+		(None, []) =>
+			Ok(quote::quote! { #path::__private::metadata_ir::DeprecationInfoIR::NotDeprecated }),
+		(None, _) => {
+			let children = quote::quote! { #path::__private::scale_info::prelude::collections::BTreeMap::from([#( #children),*]) };
+			Ok(
+				quote::quote! { #path::__private::metadata_ir::DeprecationInfoIR::PartiallyDeprecated(#children) },
+			)
+		},
+		(Some(depr), []) => Ok(
+			quote::quote! { #path::__private::metadata_ir::DeprecationInfoIR::FullyDeprecated(#depr) },
+		),
+		(Some(_), _) => {
+			let span = parent_attrs
+				.iter()
+				.find(|a| a.path().is_ident("deprecated"))
+				.map(|x| x.span())
+				.expect("this can never fail");
+			Err(Error::new(span, "Invalid deprecation usage. Either deprecate variants/call indexes or the type as a whole"))
+		},
+	}
 }

--- a/substrate/frame/support/procedural/src/pallet/expand/call.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/call.rs
@@ -245,19 +245,19 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 			}
 		});
 
-	let deprecation_status = if let Some(call) = def.call.as_ref() {
-		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &call.attrs)
+	let deprecation = if let Some(call) = def.call.as_ref() {
+		crate::deprecation::get_deprecation_enum(
+			&quote::quote! {#frame_support},
+			call.attrs.as_ref(),
+			methods.iter().map(|item| (item.call_index as u8, item.attrs.as_ref())),
+		)
 	} else {
-		Ok(
-			quote::quote! { #frame_support::__private::metadata_ir::DeprecationStatus::NotDeprecated },
+		crate::deprecation::get_deprecation_enum(
+			&quote::quote! {#frame_support},
+			&[],
+			methods.iter().map(|item| (item.call_index as u8, item.attrs.as_ref())),
 		)
 	}
-	.unwrap_or_else(syn::Error::into_compile_error);
-
-	let indexes = crate::deprecation::get_deprecation_enum(
-		&quote::quote! {#frame_support},
-		methods.iter().map(|item| (item.call_index as u8, item.attrs.as_ref())),
-	)
 	.unwrap_or_else(syn::Error::into_compile_error);
 
 	quote::quote_spanned!(span =>

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -102,12 +102,9 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 
 	let capture_docs = if cfg!(feature = "no-metadata-docs") { "never" } else { "always" };
 
-	let deprecation_status =
-		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &error.attrs)
-			.unwrap_or_else(syn::Error::into_compile_error);
-
-	let variants = crate::deprecation::get_deprecation_enum(
+	let deprecation = crate::deprecation::get_deprecation_enum(
 		&quote::quote! {#frame_support},
+		&error.attrs,
 		error_item
 			.variants
 			.iter()
@@ -115,6 +112,7 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 			.map(|(index, item)| (index as u8, item.attrs.as_ref())),
 	)
 	.unwrap_or_else(syn::Error::into_compile_error);
+
 	// derive TypeInfo for error metadata
 	error_item.attrs.push(syn::parse_quote! {
 		#[derive(

--- a/substrate/frame/support/procedural/src/pallet/expand/event.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/event.rs
@@ -95,12 +95,9 @@ pub fn expand_event(def: &mut Def) -> proc_macro2::TokenStream {
 		event_item.variants.push(variant);
 	}
 
-	let deprecation_status =
-		crate::deprecation::get_deprecation(&quote::quote! {#frame_support}, &event.attrs)
-			.unwrap_or_else(syn::Error::into_compile_error);
-
-	let variants = crate::deprecation::get_deprecation_enum(
+	let deprecation = crate::deprecation::get_deprecation_enum(
 		&quote::quote! {#frame_support},
+		&event.attrs,
 		event_item
 			.variants
 			.iter()

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -290,7 +290,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		impl<#type_use_gen> #pallet_ident<#type_use_gen> {
 			#[allow(dead_code)]
 			#[doc(hidden)]
-			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::DeprecationStatus {
+			pub fn deprecation_info() -> #frame_support::__private::metadata_ir::DeprecationStatusIR {
 				#deprecation_status
 			}
 		}

--- a/substrate/frame/support/src/storage/types/counted_map.rs
+++ b/substrate/frame/support/src/storage/types/counted_map.rs
@@ -509,7 +509,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -1198,7 +1198,7 @@ mod test {
 	fn test_metadata() {
 		type A = CountedStorageMap<Prefix, Twox64Concat, u16, u32, ValueQuery, ADefault>;
 		let mut entries = vec![];
-		A::build_metadata(sp_metadata_ir::DeprecationStatus::NotDeprecated, vec![], &mut entries);
+		A::build_metadata(sp_metadata_ir::DeprecationStatusIR::NotDeprecated, vec![], &mut entries);
 		assert_eq!(
 			entries,
 			vec![
@@ -1212,7 +1212,7 @@ mod test {
 					},
 					default: 97u32.encode(),
 					docs: vec![],
-					deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+					deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				},
 				StorageEntryMetadataIR {
 					name: "counter_for_foo",
@@ -1224,7 +1224,7 @@ mod test {
 					} else {
 						vec!["Counter for the related counted storage map"]
 					},
-					deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+					deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				},
 			]
 		);

--- a/substrate/frame/support/src/storage/types/counted_nmap.rs
+++ b/substrate/frame/support/src/storage/types/counted_nmap.rs
@@ -633,7 +633,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -864,12 +864,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -886,7 +886,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -898,7 +898,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -910,7 +910,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -922,7 +922,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 				]
 			);
@@ -1125,12 +1125,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1150,7 +1150,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1162,7 +1162,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1177,7 +1177,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1189,7 +1189,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 				]
 			);
@@ -1423,12 +1423,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1449,7 +1449,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1461,7 +1461,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1477,7 +1477,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1489,7 +1489,7 @@ mod test {
 						} else {
 							vec!["Counter for the related counted storage map"]
 						},
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 				]
 			);

--- a/substrate/frame/support/src/storage/types/double_map.rs
+++ b/substrate/frame/support/src/storage/types/double_map.rs
@@ -733,7 +733,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -991,12 +991,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1016,7 +1016,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					},
 					StorageEntryMetadataIR {
 						name: "foo",
@@ -1031,7 +1031,7 @@ mod test {
 						},
 						default: 97u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					}
 				]
 			);

--- a/substrate/frame/support/src/storage/types/map.rs
+++ b/substrate/frame/support/src/storage/types/map.rs
@@ -491,7 +491,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -797,12 +797,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -819,7 +819,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					},
 					StorageEntryMetadataIR {
 						name: "foo",
@@ -831,7 +831,7 @@ mod test {
 						},
 						default: 97u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					}
 				]
 			);

--- a/substrate/frame/support/src/storage/types/mod.rs
+++ b/substrate/frame/support/src/storage/types/mod.rs
@@ -142,7 +142,7 @@ where
 pub trait StorageEntryMetadataBuilder {
 	/// Build into `entries` the storage metadata entries of a storage given some `docs`.
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		doc: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	);

--- a/substrate/frame/support/src/storage/types/nmap.rs
+++ b/substrate/frame/support/src/storage/types/nmap.rs
@@ -584,7 +584,7 @@ where
 	MaxValues: Get<Option<u32>>,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -825,12 +825,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -847,7 +847,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -859,7 +859,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					}
 				]
 			);
@@ -1035,12 +1035,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1060,7 +1060,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1075,7 +1075,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					}
 				]
 			);
@@ -1286,12 +1286,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -1312,7 +1312,7 @@ mod test {
 						},
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					},
 					StorageEntryMetadataIR {
 						name: "Foo",
@@ -1328,7 +1328,7 @@ mod test {
 						},
 						default: 98u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 					}
 				]
 			);

--- a/substrate/frame/support/src/storage/types/value.rs
+++ b/substrate/frame/support/src/storage/types/value.rs
@@ -278,7 +278,7 @@ where
 	OnEmpty: crate::traits::Get<QueryKind::Query> + 'static,
 {
 	fn build_metadata(
-		deprecation_status: sp_metadata_ir::DeprecationStatus,
+		deprecation_status: sp_metadata_ir::DeprecationStatusIR,
 		docs: Vec<&'static str>,
 		entries: &mut Vec<StorageEntryMetadataIR>,
 	) {
@@ -421,12 +421,12 @@ mod test {
 
 			let mut entries = vec![];
 			A::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
 			AValueQueryWithAnOnEmpty::build_metadata(
-				sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 				vec![],
 				&mut entries,
 			);
@@ -439,7 +439,7 @@ mod test {
 						ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<u32>()),
 						default: Option::<u32>::None.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					},
 					StorageEntryMetadataIR {
 						name: "foo",
@@ -447,7 +447,7 @@ mod test {
 						ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<u32>()),
 						default: 97u32.encode(),
 						docs: vec![],
-						deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated
+						deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated
 					}
 				]
 			);

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -600,7 +600,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0, 0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::DeprecatedWithoutNote,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote,
 			},
 			StorageEntryMetadataIR {
 				name: "OptionLinkedMap",
@@ -612,7 +612,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 					note: "test",
 					since: None,
 				},
@@ -627,7 +627,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 					note: "test",
 					since: Some("test"),
 				},
@@ -642,7 +642,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 					note: "test",
 					since: None,
 				},
@@ -657,7 +657,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0, 0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "GenericDataDM",
@@ -669,7 +669,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "GenericData2DM",
@@ -681,7 +681,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "AppendableDM",
@@ -696,7 +696,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "Total",
@@ -704,7 +704,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<(u32, u32)>()),
 				default: vec![0, 0, 0, 0, 0, 0, 0, 0],
 				docs: vec![" Some running total."],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "Numbers",
@@ -716,7 +716,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: vec![0],
 				docs: vec![" Numbers to be added into the total."],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 		],
 	}
@@ -739,7 +739,7 @@ fn constant_metadata() {
 			ty: scale_info::meta_type::<()>(),
 			value: vec![],
 			docs: vec![],
-			deprecation_info: sp_metadata_ir::DeprecationStatus::Deprecated {
+			deprecation_info: sp_metadata_ir::DeprecationStatusIR::Deprecated {
 				note: "this constant is deprecated",
 				since: None
 			}

--- a/substrate/frame/support/test/tests/instance.rs
+++ b/substrate/frame/support/test/tests/instance.rs
@@ -441,7 +441,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				ty: StorageEntryTypeIR::Plain(scale_info::meta_type::<u32>()),
 				default: vec![0, 0, 0, 0],
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "Map",
@@ -453,7 +453,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: [0u8; 8].to_vec(),
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 			StorageEntryMetadataIR {
 				name: "DoubleMap",
@@ -465,7 +465,7 @@ fn expected_metadata() -> PalletStorageMetadataIR {
 				},
 				default: [0u8; 8].to_vec(),
 				docs: vec![],
-				deprecation_info: sp_metadata_ir::DeprecationStatus::NotDeprecated,
+				deprecation_info: sp_metadata_ir::DeprecationStatusIR::NotDeprecated,
 			},
 		],
 	}

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2428,10 +2428,9 @@ fn post_runtime_upgrade_detects_storage_version_issues() {
 		// any storage version "enabled".
 		assert!(
 			ExecutiveWithUpgradePallet4::try_runtime_upgrade(UpgradeCheckSelect::PreAndPost)
-				.unwrap_err() ==
-				"On chain storage version set, while the pallet \
+				.unwrap_err() == "On chain storage version set, while the pallet \
 				doesn't have the `#[pallet::storage_version(VERSION)]` attribute."
-					.into()
+				.into()
 		);
 	});
 }

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2429,10 +2429,9 @@ fn post_runtime_upgrade_detects_storage_version_issues() {
 		// any storage version "enabled".
 		assert!(
 			ExecutiveWithUpgradePallet4::try_runtime_upgrade(UpgradeCheckSelect::PreAndPost)
-				.unwrap_err() ==
-				"On chain storage version set, while the pallet \
+				.unwrap_err() == "On chain storage version set, while the pallet \
 				doesn't have the `#[pallet::storage_version(VERSION)]` attribute."
-					.into()
+				.into()
 		);
 	});
 }

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -2428,9 +2428,10 @@ fn post_runtime_upgrade_detects_storage_version_issues() {
 		// any storage version "enabled".
 		assert!(
 			ExecutiveWithUpgradePallet4::try_runtime_upgrade(UpgradeCheckSelect::PreAndPost)
-				.unwrap_err() == "On chain storage version set, while the pallet \
+				.unwrap_err() ==
+				"On chain storage version set, while the pallet \
 				doesn't have the `#[pallet::storage_version(VERSION)]` attribute."
-				.into()
+					.into()
 		);
 	});
 }
@@ -2501,7 +2502,7 @@ fn pallet_metadata() {
 		let meta = &example.calls.unwrap();
 		assert_eq!(
 			DeprecationInfoIR::PartiallyDeprecated(BTreeMap::from([(
-				0,
+				codec::Compact(0),
 				DeprecationStatusIR::Deprecated { note: "test", since: None }
 			)])),
 			meta.deprecation_info
@@ -2512,7 +2513,7 @@ fn pallet_metadata() {
 		let meta = &example.error.unwrap();
 		assert_eq!(
 			DeprecationInfoIR::PartiallyDeprecated(BTreeMap::from([(
-				2,
+				codec::Compact(2),
 				DeprecationStatusIR::Deprecated { note: "test", since: None }
 			)])),
 			meta.deprecation_info

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -296,7 +296,6 @@ pub mod pallet {
 		/// event doc comment put in metadata
 		Proposed(<T as frame_system::Config>::AccountId),
 		Spending(BalanceOf<T>),
-		#[deprecated = "test"]
 		Something(u32),
 		SomethingElse(<T::AccountId as SomeAssociation1>::_1),
 	}
@@ -2486,14 +2485,14 @@ fn test_error_feature_parsing() {
 
 #[test]
 fn pallet_metadata() {
-	use sp_metadata_ir::{DeprecationInfo, DeprecationStatus};
+	use sp_metadata_ir::{DeprecationInfoIR, DeprecationStatusIR};
 	let pallets = Runtime::metadata_ir().pallets;
 	let example = pallets[0].clone();
 	let example2 = pallets[1].clone();
 	{
 		// Example2 pallet is deprecated
 		assert_eq!(
-			&DeprecationStatus::Deprecated { note: "test", since: None },
+			&DeprecationStatusIR::Deprecated { note: "test", since: None },
 			&example2.deprecation_info
 		)
 	}
@@ -2501,9 +2500,9 @@ fn pallet_metadata() {
 		// Example pallet calls is fully and partially deprecated
 		let meta = &example.calls.unwrap();
 		assert_eq!(
-			DeprecationInfo::PartiallyDeprecated(BTreeMap::from([(
+			DeprecationInfoIR::PartiallyDeprecated(BTreeMap::from([(
 				0,
-				DeprecationStatus::Deprecated { note: "test", since: None }
+				DeprecationStatusIR::Deprecated { note: "test", since: None }
 			)])),
 			meta.deprecation_info
 		)
@@ -2512,9 +2511,9 @@ fn pallet_metadata() {
 		// Example pallet errors are partially and fully deprecated
 		let meta = &example.error.unwrap();
 		assert_eq!(
-			DeprecationInfo::PartiallyDeprecated(BTreeMap::from([(
+			DeprecationInfoIR::PartiallyDeprecated(BTreeMap::from([(
 				2,
-				DeprecationStatus::Deprecated { note: "test", since: None }
+				DeprecationStatusIR::Deprecated { note: "test", since: None }
 			)])),
 			meta.deprecation_info
 		)
@@ -2523,7 +2522,7 @@ fn pallet_metadata() {
 		// Example pallet events are partially and fully deprecated
 		let meta = example.event.unwrap();
 		assert_eq!(
-			DeprecationInfo::FullyDeprecated(DeprecationStatus::Deprecated {
+			DeprecationInfoIR::FullyDeprecated(DeprecationStatusIR::Deprecated {
 				note: "test",
 				since: None
 			}),
@@ -2533,6 +2532,6 @@ fn pallet_metadata() {
 	{
 		// Example2 pallet events are not deprecated
 		let meta = example2.event.unwrap();
-		assert_eq!(DeprecationInfo::NotDeprecated, meta.deprecation_info);
+		assert_eq!(DeprecationInfoIR::NotDeprecated, meta.deprecation_info);
 	}
 }

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -208,7 +208,6 @@ pub mod pallet {
 	}
 
 	#[pallet::call]
-	#[deprecated = "test"]
 	impl<T: Config> Pallet<T>
 	where
 		T::AccountId: From<SomeType1> + From<SomeType3> + SomeAssociation1,
@@ -274,7 +273,6 @@ pub mod pallet {
 
 	#[pallet::error]
 	#[derive(PartialEq, Eq)]
-	#[deprecated = "test"]
 	pub enum Error<T> {
 		/// error doc comment put in metadata
 		InsufficientProposersBalance,
@@ -2489,52 +2487,53 @@ fn test_error_feature_parsing() {
 
 #[test]
 fn pallet_metadata() {
-	use sp_metadata_ir::DeprecationStatus;
+	use sp_metadata_ir::{DeprecationInfo, DeprecationStatus};
 	let pallets = Runtime::metadata_ir().pallets;
 	let example = pallets[0].clone();
 	let example2 = pallets[1].clone();
 	{
 		// Example2 pallet is deprecated
-		let meta = example2;
 		assert_eq!(
 			&DeprecationStatus::Deprecated { note: "test", since: None },
-			&meta.deprecation_info
+			&example2.deprecation_info
 		)
 	}
 	{
 		// Example pallet calls is fully and partially deprecated
 		let meta = &example.calls.unwrap();
 		assert_eq!(
-			DeprecationStatus::Deprecated { note: "test", since: None },
+			DeprecationInfo::PartiallyDeprecated(BTreeMap::from([(
+				0,
+				DeprecationStatus::Deprecated { note: "test", since: None }
+			)])),
 			meta.deprecation_info
-		);
-		assert_eq!(
-			BTreeMap::from([(0, DeprecationStatus::Deprecated { note: "test", since: None })]),
-			meta.deprecated_indexes
 		)
 	}
 	{
 		// Example pallet errors are partially and fully deprecated
 		let meta = &example.error.unwrap();
 		assert_eq!(
-			DeprecationStatus::Deprecated { note: "test", since: None },
+			DeprecationInfo::PartiallyDeprecated(BTreeMap::from([(
+				2,
+				DeprecationStatus::Deprecated { note: "test", since: None }
+			)])),
 			meta.deprecation_info
-		);
-		assert_eq!(
-			BTreeMap::from([(2, DeprecationStatus::Deprecated { note: "test", since: None })]),
-			meta.deprecated_variants
 		)
 	}
 	{
 		// Example pallet events are partially and fully deprecated
 		let meta = example.event.unwrap();
 		assert_eq!(
-			DeprecationStatus::Deprecated { note: "test", since: None },
+			DeprecationInfo::FullyDeprecated(DeprecationStatus::Deprecated {
+				note: "test",
+				since: None
+			}),
 			meta.deprecation_info
 		);
-		assert_eq!(
-			BTreeMap::from([(2, DeprecationStatus::Deprecated { note: "test", since: None })]),
-			meta.deprecated_variants
-		)
+	}
+	{
+		// Example2 pallet events are not deprecated
+		let meta = example2.event.unwrap();
+		assert_eq!(DeprecationInfo::NotDeprecated, meta.deprecation_info);
 	}
 }

--- a/substrate/frame/support/test/tests/runtime_metadata.rs
+++ b/substrate/frame/support/test/tests/runtime_metadata.rs
@@ -19,7 +19,7 @@
 use frame_support::{derive_impl, traits::ConstU32};
 use scale_info::{form::MetaForm, meta_type};
 use sp_metadata_ir::{
-	DeprecationStatus, RuntimeApiMetadataIR, RuntimeApiMethodMetadataIR,
+	DeprecationStatusIR, RuntimeApiMetadataIR, RuntimeApiMethodMetadataIR,
 	RuntimeApiMethodParamMetadataIR,
 };
 use sp_runtime::traits::Block as BlockT;
@@ -134,7 +134,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 				RuntimeApiMethodMetadataIR {
 					name: "something_with_block",
@@ -144,7 +144,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<Block>(),
 					docs: maybe_docs(vec![" something_with_block."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 				RuntimeApiMethodMetadataIR {
 					name: "function_with_two_args",
@@ -160,7 +160,7 @@ fn runtime_metadata() {
 					],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::Deprecated {
+					deprecation_info: DeprecationStatusIR::Deprecated {
 						note: "example",
 						since: None,
 					}
@@ -170,7 +170,7 @@ fn runtime_metadata() {
 					inputs: vec![],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::Deprecated {
+					deprecation_info: DeprecationStatusIR::Deprecated {
 						note: "example",
 						since: Some("example"),
 					}
@@ -183,7 +183,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<()>(),
 					docs: vec![],
-					deprecation_info: DeprecationStatus::Deprecated {
+					deprecation_info: DeprecationStatusIR::Deprecated {
 						                    note: "example",
 						                    since: None,
 						                }
@@ -194,7 +194,7 @@ fn runtime_metadata() {
 				"",
 				" Documentation on multiline.",
 			]),
-			deprecation_info: DeprecationStatus::DeprecatedWithoutNote,
+			deprecation_info: DeprecationStatusIR::DeprecatedWithoutNote,
 
 		},
 		RuntimeApiMetadataIR {
@@ -205,7 +205,7 @@ fn runtime_metadata() {
 					inputs: vec![],
 					output: meta_type::<sp_version::RuntimeVersion>(),
 					docs: maybe_docs(vec![" Returns the version of the runtime."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 				RuntimeApiMethodMetadataIR {
 					name: "execute_block",
@@ -215,7 +215,7 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<()>(),
 					docs: maybe_docs(vec![" Execute the given block."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 
 				},
 				RuntimeApiMethodMetadataIR {
@@ -226,13 +226,13 @@ fn runtime_metadata() {
 					}],
 					output: meta_type::<sp_runtime::ExtrinsicInclusionMode>(),
 					docs: maybe_docs(vec![" Initialize a block with the given header and return the runtime executive mode."]),
-					deprecation_info: DeprecationStatus::NotDeprecated,
+					deprecation_info: DeprecationStatusIR::NotDeprecated,
 				},
 			],
 			docs: maybe_docs(vec![
 				" The `Core` runtime api that every Substrate runtime needs to implement.",
 			]),
-			deprecation_info: DeprecationStatus::NotDeprecated,
+			deprecation_info: DeprecationStatusIR::NotDeprecated,
 		},
 	];
 

--- a/substrate/primitives/api/proc-macro/src/utils.rs
+++ b/substrate/primitives/api/proc-macro/src/utils.rs
@@ -313,7 +313,7 @@ fn parse_deprecated_meta(crate_: &TokenStream, attr: &syn::Attribute) -> Result<
 					} else {
 						quote! { None }
 					};
-					let doc = quote! { #crate_::metadata_ir::DeprecationStatus::Deprecated { note: #note, since: #since }};
+					let doc = quote! { #crate_::metadata_ir::DeprecationStatusIR::Deprecated { note: #note, since: #since }};
 					Ok(doc)
 				},
 			)
@@ -323,12 +323,12 @@ fn parse_deprecated_meta(crate_: &TokenStream, attr: &syn::Attribute) -> Result<
 			..
 		}) => {
 			// #[deprecated = "lit"]
-			let doc = quote! { #crate_::metadata_ir::DeprecationStatus::Deprecated { note: #lit, since: None } };
+			let doc = quote! { #crate_::metadata_ir::DeprecationStatusIR::Deprecated { note: #lit, since: None } };
 			Ok(doc)
 		},
 		Meta::Path(_) => {
 			// #[deprecated]
-			Ok(quote! { #crate_::metadata_ir::DeprecationStatus::DeprecatedWithoutNote })
+			Ok(quote! { #crate_::metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote })
 		},
 		_ => Err(Error::new(attr.span(), "Invalid deprecation attribute")),
 	}
@@ -340,7 +340,7 @@ pub fn get_deprecation(crate_: &TokenStream, attrs: &[syn::Attribute]) -> Result
 		.iter()
 		.find(|a| a.path().is_ident("deprecated"))
 		.map(|a| parse_deprecated_meta(&crate_, a))
-		.unwrap_or_else(|| Ok(quote! {#crate_::metadata_ir::DeprecationStatus::NotDeprecated}))
+		.unwrap_or_else(|| Ok(quote! {#crate_::metadata_ir::DeprecationStatusIR::NotDeprecated}))
 }
 
 #[cfg(test)]
@@ -404,23 +404,23 @@ mod tests {
 			parse_quote!(#[deprecated(note = #FIRST, since = #SECOND, extra = "Test")]);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[simple]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::DeprecatedWithoutNote }.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::DeprecatedWithoutNote }.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[simple_path]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: None } }.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: None } }.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[meta_list]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: None } }.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: None } }.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[meta_list_with_since]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
 		);
 		assert_eq!(
 			get_deprecation(&quote! { crate }, &[extra_fields]).unwrap().to_string(),
-			quote! { crate::metadata_ir::DeprecationStatus::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
+			quote! { crate::metadata_ir::DeprecationStatusIR::Deprecated { note: #FIRST, since: Some(#SECOND) }}.to_string()
 		);
 	}
 }

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -495,7 +495,7 @@ impl IntoPortable for DeprecationStatusIR {
 	}
 }
 /// Deprecation info for an enums/errors/calls.
-/// Denotes full/partial deprecation of the typ
+/// Denotes full/partial deprecation of the type
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 pub enum DeprecationInfoIR<T: Form = MetaForm> {
 	/// Type is not deprecated

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use codec::Encode;
+use codec::{Compact, Encode};
 use scale_info::{
 	form::{Form, MetaForm, PortableForm},
 	prelude::{collections::BTreeMap, vec::Vec},
@@ -505,7 +505,7 @@ pub enum DeprecationInfoIR<T: Form = MetaForm> {
 	/// Entry is partially deprecated.
 	/// For Errors and Events this means that only some of the variants are deprecated
 	/// For Calls only certain call indexes are deprecated
-	PartiallyDeprecated(BTreeMap<u8, DeprecationStatusIR<T>>),
+	PartiallyDeprecated(BTreeMap<Compact<u8>, DeprecationStatusIR<T>>),
 }
 impl IntoPortable for DeprecationInfoIR {
 	type Output = DeprecationInfoIR<PortableForm>;

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -53,7 +53,7 @@ pub struct RuntimeApiMetadataIR<T: Form = MetaForm> {
 	/// Trait documentation.
 	pub docs: Vec<T::String>,
 	/// Deprecation info
-	pub deprecation_info: DeprecationStatus<T>,
+	pub deprecation_info: DeprecationStatusIR<T>,
 }
 
 impl IntoPortable for RuntimeApiMetadataIR {
@@ -81,7 +81,7 @@ pub struct RuntimeApiMethodMetadataIR<T: Form = MetaForm> {
 	/// Method documentation.
 	pub docs: Vec<T::String>,
 	/// Deprecation info
-	pub deprecation_info: DeprecationStatus<T>,
+	pub deprecation_info: DeprecationStatusIR<T>,
 }
 
 impl IntoPortable for RuntimeApiMethodMetadataIR {
@@ -139,7 +139,7 @@ pub struct PalletMetadataIR<T: Form = MetaForm> {
 	/// Pallet documentation.
 	pub docs: Vec<T::String>,
 	/// Deprecation info
-	pub deprecation_info: DeprecationStatus<T>,
+	pub deprecation_info: DeprecationStatusIR<T>,
 }
 
 impl IntoPortable for PalletMetadataIR {
@@ -255,7 +255,7 @@ pub struct StorageEntryMetadataIR<T: Form = MetaForm> {
 	/// Storage entry documentation.
 	pub docs: Vec<T::String>,
 	/// Deprecation info
-	pub deprecation_info: DeprecationStatus<T>,
+	pub deprecation_info: DeprecationStatusIR<T>,
 }
 
 impl IntoPortable for StorageEntryMetadataIR {
@@ -344,7 +344,7 @@ pub struct PalletCallMetadataIR<T: Form = MetaForm> {
 	/// The corresponding enum type for the pallet call.
 	pub ty: T::Type,
 	/// Deprecation status of the pallet call
-	pub deprecation_info: DeprecationInfo<T>,
+	pub deprecation_info: DeprecationInfoIR<T>,
 }
 
 impl IntoPortable for PalletCallMetadataIR {
@@ -364,7 +364,7 @@ pub struct PalletEventMetadataIR<T: Form = MetaForm> {
 	/// The Event type.
 	pub ty: T::Type,
 	/// Deprecation info of the event
-	pub deprecation_info: DeprecationInfo<T>,
+	pub deprecation_info: DeprecationInfoIR<T>,
 }
 
 impl IntoPortable for PalletEventMetadataIR {
@@ -390,7 +390,7 @@ pub struct PalletConstantMetadataIR<T: Form = MetaForm> {
 	/// Documentation of the constant.
 	pub docs: Vec<T::String>,
 	/// Deprecation info
-	pub deprecation_info: DeprecationStatus<T>,
+	pub deprecation_info: DeprecationStatusIR<T>,
 }
 
 impl IntoPortable for PalletConstantMetadataIR {
@@ -413,7 +413,7 @@ pub struct PalletErrorMetadataIR<T: Form = MetaForm> {
 	/// The error type information.
 	pub ty: T::Type,
 	/// Deprecation info
-	pub deprecation_info: DeprecationInfo<T>,
+	pub deprecation_info: DeprecationInfoIR<T>,
 }
 
 impl IntoPortable for PalletErrorMetadataIR {
@@ -466,7 +466,7 @@ impl IntoPortable for OuterEnumsIR {
 
 /// Deprecation status for an entry inside MetadataIR
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
-pub enum DeprecationStatus<T: Form = MetaForm> {
+pub enum DeprecationStatusIR<T: Form = MetaForm> {
 	/// Entry is not deprecated
 	NotDeprecated,
 	/// Deprecated without a note.
@@ -479,47 +479,47 @@ pub enum DeprecationStatus<T: Form = MetaForm> {
 		since: Option<T::String>,
 	},
 }
-impl IntoPortable for DeprecationStatus {
-	type Output = DeprecationStatus<PortableForm>;
+impl IntoPortable for DeprecationStatusIR {
+	type Output = DeprecationStatusIR<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		match self {
 			Self::Deprecated { note, since } => {
 				let note = note.into_portable(registry);
 				let since = since.map(|x| x.into_portable(registry));
-				DeprecationStatus::Deprecated { note, since }
+				DeprecationStatusIR::Deprecated { note, since }
 			},
-			Self::DeprecatedWithoutNote => DeprecationStatus::DeprecatedWithoutNote,
-			Self::NotDeprecated => DeprecationStatus::NotDeprecated,
+			Self::DeprecatedWithoutNote => DeprecationStatusIR::DeprecatedWithoutNote,
+			Self::NotDeprecated => DeprecationStatusIR::NotDeprecated,
 		}
 	}
 }
 /// Deprecation info for an enums/errors/calls.
 /// Denotes full/partial deprecation of the typ
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
-pub enum DeprecationInfo<T: Form = MetaForm> {
+pub enum DeprecationInfoIR<T: Form = MetaForm> {
 	/// Type is not deprecated
 	NotDeprecated,
 	/// Entry is fully deprecated.
-	FullyDeprecated(DeprecationStatus<T>),
+	FullyDeprecated(DeprecationStatusIR<T>),
 	/// Entry is partially deprecated.
 	/// For Errors and Events this means that only some of the variants are deprecated
-	/// For Calls oncly certain call indexes are deprecated
-	PartiallyDeprecated(BTreeMap<u8, DeprecationStatus<T>>),
+	/// For Calls only certain call indexes are deprecated
+	PartiallyDeprecated(BTreeMap<u8, DeprecationStatusIR<T>>),
 }
-impl IntoPortable for DeprecationInfo {
-	type Output = DeprecationInfo<PortableForm>;
+impl IntoPortable for DeprecationInfoIR {
+	type Output = DeprecationInfoIR<PortableForm>;
 
 	fn into_portable(self, registry: &mut Registry) -> Self::Output {
 		match self {
 			Self::PartiallyDeprecated(entries) => {
 				let entries =
 					entries.into_iter().map(|(k, entry)| (k, entry.into_portable(registry)));
-				DeprecationInfo::PartiallyDeprecated(entries.collect())
+				DeprecationInfoIR::PartiallyDeprecated(entries.collect())
 			},
 			Self::FullyDeprecated(deprecation) =>
-				DeprecationInfo::FullyDeprecated(deprecation.into_portable(registry)),
-			Self::NotDeprecated => DeprecationInfo::NotDeprecated,
+				DeprecationInfoIR::FullyDeprecated(deprecation.into_portable(registry)),
+			Self::NotDeprecated => DeprecationInfoIR::NotDeprecated,
 		}
 	}
 }


### PR DESCRIPTION
### Description
This is  PR following a suggestion from previous PR to refactor some definitions.
> Could we group the deprecation infos? Some initial idea would be:
> 
> ```rust
> enum DeprecationMetadataIr {
>     Fully(DeprecationStatusIr),
>     Partially(BTreeMap<usize, DeprecationStatusIr<T>>),
> }
> ```
> 
> I would also rename the `DeprecationStatus` to `DeprecationStatusIR` sometime, since we'll need to convert this to a frame_metadata::DeprecationStatus

see [link](https://github.com/paritytech/polkadot-sdk/pull/4948#discussion_r1666430304)


depends on #4948 