### PR TITLE
fixed cmd bot commenting not working

### DIFF
--- a/.github/workflows/command-inform.yml
+++ b/.github/workflows/command-inform.yml
@@ -7,9 +7,15 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, 'bot ')
     steps:
     - name: Inform that the new command exist
-      if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, 'bot ') }}
-      run: gh pr comment ${{ github.event.issue.number }} --body 'We are migrating this bot to be a GitHub Action<br/><br/>Please, see the <a href="https://github.com/paritytech/polkadot-sdk/blob/master/.github/commands-readme.md">documentation on how to use it</a>'
-      env:
-        GH_TOKEN: ${{ github.token }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'We are migrating the command bot to be a GitHub Action<br/><br/>Please, see the <a href="https://github.com/paritytech/polkadot-sdk/blob/master/.github/commands-readme.md">documentation on how to use it</a>'
+          })


### PR DESCRIPTION
Fixed the mentioned issue: https://github.com/paritytech/command-bot/issues/113#issuecomment-2222277552

Now it will properly comment when the old bot gets triggered.