### PR TITLE
network/tx: Ban peers with tx that fail to decode

### DIFF
--- a/substrate/client/network/transactions/src/lib.rs
+++ b/substrate/client/network/transactions/src/lib.rs
@@ -368,7 +368,8 @@ where
 				{
 					self.on_transactions(peer, m);
 				} else {
-					warn!(target: "sub-libp2p", "Failed to decode transactions list");
+					warn!(target: "sub-libp2p", "Failed to decode transactions list from peer {peer}");
+					self.network.report_peer(peer, rep::BAD_TRANSACTION);
 				}
 			},
 		}


### PR DESCRIPTION
A malicious peer can submit random bytes on transaction protocol.
In this case, the peer is not disconnected or reported back to the peerstore.

This PR ensures the peer's reputation is properly reported.

Discovered during testing:
- https://github.com/paritytech/polkadot-sdk/pull/4977


cc @paritytech/networking 