### PR TITLE
net/litep2p: Propagate ValuePut events to the network backend

### DIFF
--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -851,6 +851,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 									"`PUT_VALUE` for {key:?} ({query_id:?}) succeeded",
 								);
 
+								self.event_streams.send(Event::Dht(
+									DhtEvent::ValuePut(libp2p::kad::RecordKey::new(&key))
+								));
+
 								if let Some(ref metrics) = self.metrics {
 									metrics
 										.kademlia_query_duration


### PR DESCRIPTION
The `DhtEvent::ValuePut` was not propagated back to the higher levels.

This PR ensures we'll send the ValuePut event similarly to `DhtEvent::ValuePutFailed`

### Next Steps
- [ ] A bit more testing

Thanks @alexggh for catching this 🙏 

cc @paritytech/networking 