### PR TITLE
Update the template synchronization script

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -90,7 +90,13 @@ jobs:
               "runtime",
           ]
           resolver = "2"
+
+          [workspace.dependencies]
+          
           EOF
+
+          echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\" }" >> Cargo.toml
+          echo "$(toml get -r ./pallets/template/Cargo.toml 'package.name') = { path = \"./pallets/template\" }" >> Cargo.toml
         shell: bash
         working-directory: polkadot-sdk/templates/${{ matrix.template }}/
       - name: Update workspace configuration
@@ -116,9 +122,12 @@ jobs:
       - name: Copy over the new changes
         run: |
           cp -r polkadot-sdk/templates/${{ matrix.template }}/* "${{ env.template-path }}/"
+
+      - name: Run psvm on monorepo workspace dependencies
+        run: psvm -o -v ${{ github.event.inputs.crate_release_version }} -p ./Cargo.toml
+        working-directory: polkadot-sdk/
       - name: Copy over required workspace dependencies
         run: |
-          echo -e "\n[workspace.dependencies]" >> Cargo.toml
           set +e
           # If a workspace dependency is required..
           while cargo tree --depth 1 --prefix none --no-dedupe 2>&1 | grep 'was not found in `workspace.dependencies`'; do

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -94,8 +94,8 @@ jobs:
           [workspace.dependencies]
           EOF
 
-          echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\" }" >> Cargo.toml
-          echo "$(toml get -r ./pallets/template/Cargo.toml 'package.name') = { path = \"./pallets/template\" }" >> Cargo.toml
+          echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\", default-features = false }" >> Cargo.toml
+          echo "$(toml get -r ./pallets/template/Cargo.toml 'package.name') = { path = \"./pallets/template\", default-features = false }" >> Cargo.toml
         shell: bash
         working-directory: polkadot-sdk/templates/${{ matrix.template }}/
       - name: Update workspace configuration

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -92,7 +92,6 @@ jobs:
           resolver = "2"
 
           [workspace.dependencies]
-          
           EOF
 
           echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\" }" >> Cargo.toml


### PR DESCRIPTION
There are slight changes required, after https://github.com/paritytech/polkadot-sdk/pull/4716.

In order to follow the convention in the templates, we need to specify the internal template dependencies (runtime and a pallet) in the main `Cargo.toml`.

Additionally, there are now dependencies with `path` in the main `Cargo.toml`, so we add a step with `psvm` to change those references to crate versions.