### PR TITLE
Adjust base value for statement-distribution regression tests

### DIFF
--- a/polkadot/node/network/statement-distribution/benches/statement-distribution-regression-bench.rs
+++ b/polkadot/node/network/statement-distribution/benches/statement-distribution-regression-bench.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), String> {
 		("Received from peers", 106.4000, 0.001),
 		("Sent to peers", 127.9100, 0.001),
 	]));
-	messages.extend(average_usage.check_cpu_usage(&[("statement-distribution", 0.0390, 0.1)]));
+	messages.extend(average_usage.check_cpu_usage(&[("statement-distribution", 0.0374, 0.1)]));
 
 	if messages.is_empty() {
 		Ok(())


### PR DESCRIPTION
A baseline for the statement-distribution regression test was set only in the beginning and now we see that the actual values a bit lower. 

<img width="1001" alt="image" src="https://github.com/user-attachments/assets/40b06eec-e38f-43ad-b437-89eca502aa66">

[Source](https://paritytech.github.io/polkadot-sdk/bench/statement-distribution-regression-bench)