### PR TITLE
prdoc: Require `bump` field

### DIFF
--- a/prdoc/pr_3286.prdoc
+++ b/prdoc/pr_3286.prdoc
@@ -14,3 +14,4 @@ doc:
 
 crates:
   - name: pallet-assets
+    bump: patch

--- a/prdoc/schema_user.json
+++ b/prdoc/schema_user.json
@@ -148,7 +148,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "bump"
         ]
       },
       "migration_db": {


### PR DESCRIPTION
Require to specify a `bump` for every modified crate.