### PR TITLE
beefy: Increment metric and add extra log details

### DIFF
--- a/substrate/client/consensus/beefy/src/communication/peers.rs
+++ b/substrate/client/consensus/beefy/src/communication/peers.rs
@@ -75,6 +75,11 @@ impl<B: Block> KnownPeers<B> {
 	pub fn contains(&self, peer: &PeerId) -> bool {
 		self.live.contains_key(peer)
 	}
+
+	/// Number of peers in the set.
+	pub fn len(&self) -> usize {
+		self.live.len()
+	}
 }
 
 #[cfg(test)]

--- a/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -253,6 +253,10 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 				if let Some(peer) = self.try_next_peer(None) {
 					self.request_from_peer(peer, req_info);
 				} else {
+					metric_inc!(
+						self.metrics,
+						beefy_on_demand_justification_no_peer_to_request_from
+					);
 					warn!(
 						target: BEEFY_SYNC_LOG_TARGET,
 						"🥩 ran out of peers to request justif #{block:?} from, in flight err: {err:?}"

--- a/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -257,9 +257,12 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 						self.metrics,
 						beefy_on_demand_justification_no_peer_to_request_from
 					);
+
+					let num_cache = self.peers_cache.len();
+					let num_live = self.live_peers.lock().len();
 					warn!(
 						target: BEEFY_SYNC_LOG_TARGET,
-						"🥩 ran out of peers to request justif #{block:?} from, in flight err: {err:?}"
+						"🥩 ran out of peers to request justif #{block:?} from num_cache={num_cache} num_live={num_live} err={err:?}",
 					);
 				}
 				// Report peer based on error type.

--- a/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -98,17 +98,12 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 		}
 	}
 
-	/// Returns the next peer from the peers cache, if available.
-	///
-	/// If the optional block number if provided, the peers cache is
-	/// repopulated from the live peers that have voted on higher block numbers.
-	fn try_next_peer(&mut self, reset_cache: Option<NumberFor<B>>) -> Option<PeerId> {
+	fn reset_peers_cache_for_block(&mut self, block: NumberFor<B>) {
+		self.peers_cache = self.live_peers.lock().further_than(block);
+	}
+
+	fn try_next_peer(&mut self) -> Option<PeerId> {
 		let live = self.live_peers.lock();
-
-		if let Some(reset) = reset_cache {
-			self.peers_cache = live.further_than(reset);
-		}
-
 		while let Some(peer) = self.peers_cache.pop_front() {
 			if live.contains(&peer) {
 				return Some(peer);
@@ -147,10 +142,11 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 		if matches!(self.state, State::AwaitingResponse(_, _, _)) {
 			return;
 		}
+		self.reset_peers_cache_for_block(block);
 
 		// Start the requests engine - each unsuccessful received response will automatically
 		// trigger a new request to the next peer in the `peers_cache` until there are none left.
-		if let Some(peer) = self.try_next_peer(Some(block)) {
+		if let Some(peer) = self.try_next_peer() {
 			self.request_from_peer(peer, RequestInfo { block, active_set });
 		} else {
 			metric_inc!(self.metrics, beefy_on_demand_justification_no_peer_to_request_from);
@@ -250,7 +246,7 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 		match self.process_response(&peer, &req_info, resp) {
 			Err(err) => {
 				// No valid justification received, try next peer in our set.
-				if let Some(peer) = self.try_next_peer(None) {
+				if let Some(peer) = self.try_next_peer() {
 					self.request_from_peer(peer, req_info);
 				} else {
 					metric_inc!(

--- a/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -255,7 +255,7 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 				} else {
 					warn!(
 						target: BEEFY_SYNC_LOG_TARGET,
-						"🥩 ran out of peers to request justif #{:?} from", block
+						"🥩 ran out of peers to request justif #{block:?} from, in flight err: {err:?}"
 					);
 				}
 				// Report peer based on error type.
@@ -269,7 +269,7 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 				metric_inc!(self.metrics, beefy_on_demand_justification_good_proof);
 				debug!(
 					target: BEEFY_SYNC_LOG_TARGET,
-					"🥩 received valid on-demand justif #{:?} from {:?}", block, peer
+					"🥩 received valid on-demand justif #{block:?} from {peer:?}",
 				);
 				let peer_report = PeerReport { who: peer, cost_benefit: benefit::VALIDATED_PROOF };
 				ResponseInfo::ValidProof(proof, peer_report)

--- a/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -101,7 +101,7 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 	/// Returns the next peer from the peers cache, if available.
 	///
 	/// If the optional block number if provided, the peers cache is
-	/// repopulated from the live peers that have vother on higher block numbers.
+	/// repopulated from the live peers that have voted on higher block numbers.
 	fn try_next_peer(&mut self, reset_cache: Option<NumberFor<B>>) -> Option<PeerId> {
 		let live = self.live_peers.lock();
 


### PR DESCRIPTION
This PR increments the beefy metric wrt no peers to query justification from.
The metric is incremented when we submit a request to a known peer, however that peer failed to provide a valid response, and there are no further peers to query.

While at it, add a few extra details to identify the number of active peers and cached peers, together with the request error

Part of:
- https://github.com/paritytech/polkadot-sdk/issues/4985
- https://github.com/paritytech/polkadot-sdk/issues/4925


