### PR TITLE
Update epoch duration in babe

### DIFF
--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -1590,7 +1590,7 @@ where
 					viable_epoch.as_ref().start_slot,
 				);
 
-				let next_epoch = viable_epoch.increment((next_epoch_descriptor, epoch_config));
+				let next_epoch = viable_epoch.increment((next_epoch_descriptor.clone(), epoch_config.clone()));
 
 				let mut current_viable_epoch = viable_epoch.into_cloned();
 				current_viable_epoch.as_mut().epoch_index -= 1;
@@ -1599,7 +1599,7 @@ where
 					.start_slot
 					.saturating_sub(Slot::from(current_viable_epoch.as_ref().duration));
 				let current_epoch = current_viable_epoch
-					.increment((next_epoch_descriptor.clone(), epoch_config.clone()));
+					.increment((next_epoch_descriptor, epoch_config));
 
 				log!(
 					target: LOG_TARGET,

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -1533,6 +1533,18 @@ where
 					})?
 					.into_cloned();
 
+				let epoch_duration_changed =
+					viable_epoch.as_ref().duration != self.config.epoch_length;
+				if epoch_duration_changed {
+					warn!(
+						target: LOG_TARGET,
+						"👶 Epoch duration changed: from {} to {}",
+						viable_epoch.as_ref().duration,
+						self.config.epoch_length
+					);
+					viable_epoch.as_mut().duration = self.config.epoch_length;
+				}
+
 				let epoch_config = next_config_digest
 					.map(Into::into)
 					.unwrap_or_else(|| viable_epoch.as_ref().config.clone());
@@ -1577,18 +1589,6 @@ where
 					slot,
 					viable_epoch.as_ref().start_slot,
 				);
-
-				let epoch_duration_changed =
-					viable_epoch.as_ref().duration != self.config.epoch_length;
-				if epoch_duration_changed {
-					warn!(
-						target: LOG_TARGET,
-						"👶 Epoch duration changed: from {} to {}",
-						viable_epoch.as_ref().duration,
-						self.config.epoch_length
-					);
-					viable_epoch.as_mut().duration = self.config.epoch_length;
-				}
 
 				let next_epoch = viable_epoch.increment((next_epoch_descriptor, epoch_config));
 

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -1580,10 +1580,10 @@ where
 
 				if viable_epoch.as_ref().duration != self.config.epoch_length {
 					warn!(
-					    target: LOG_TARGET,
-					    "👶 Epoch duration changed: from {} to {}",
-					    viable_epoch.as_ref().duration,
-					    self.config.epoch_length
+						target: LOG_TARGET,
+						"👶 Epoch duration changed: from {} to {}",
+						viable_epoch.as_ref().duration,
+						self.config.epoch_length
 					);
 					viable_epoch.as_mut().duration = self.config.epoch_length;
 				}

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -1578,6 +1578,16 @@ where
 					viable_epoch.as_ref().start_slot,
 				);
 
+				if viable_epoch.as_ref().duration != self.config.epoch_length {
+					warn!(
+					    target: LOG_TARGET,
+					    "👶 Epoch duration changed: from {} to {}",
+					    viable_epoch.as_ref().duration,
+					    self.config.epoch_length
+					);
+					viable_epoch.as_mut().duration = self.config.epoch_length;
+				}
+
 				let next_epoch = viable_epoch.increment((next_epoch_descriptor, epoch_config));
 
 				log!(

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -1533,18 +1533,6 @@ where
 					})?
 					.into_cloned();
 
-				let epoch_duration_changed =
-					viable_epoch.as_ref().duration != self.config.epoch_length;
-				if epoch_duration_changed {
-					warn!(
-						target: LOG_TARGET,
-						"👶 Epoch duration changed: from {} to {}",
-						viable_epoch.as_ref().duration,
-						self.config.epoch_length
-					);
-					viable_epoch.as_mut().duration = self.config.epoch_length;
-				}
-
 				let epoch_config = next_config_digest
 					.map(Into::into)
 					.unwrap_or_else(|| viable_epoch.as_ref().config.clone());
@@ -1578,6 +1566,18 @@ where
 						target: LOG_TARGET,
 						"👶 Epoch(s) skipped: from {} to {}", prev_index, epoch.epoch_index,
 					);
+				}
+
+				let epoch_duration_changed =
+					viable_epoch.as_ref().duration != self.config.epoch_length;
+				if epoch_duration_changed {
+					warn!(
+						target: LOG_TARGET,
+						"👶 Epoch duration changed: from {} to {}",
+						viable_epoch.as_ref().duration,
+						self.config.epoch_length
+					);
+					viable_epoch.as_mut().duration = self.config.epoch_length;
 				}
 
 				log!(


### PR DESCRIPTION
Our chain uses babe and grandpa consensus. 
The original `EpochDuration` is 4 hours, and `ExpectedBlockTime` is 30s, so the epoch duration is 4 * 60 * 60 / 30 = 480 blocks.

Now we use runtime upgrade to adjust `ExpectedBlockTime` to 6s, so the epoch duration is 4 * 60 * 60 / 6 = 2400 blocks.

After the runtime upgrade, restart the node, but find that `next_epoch` is still calculated according to 480, resulting in an error:

```
2024-07-21 14:45:12 🔖 Pre-sealed block for proposal at 1043. Hash now 0xf21b4b9c2ce7deb034d5aece5dde5227946a291dce1ed666437bcedcde4c1e79, previously 0x9082e389741dc15ba0e8b3c9c8ced8552cee1da10fef91503ed3cf607cee9ffc.
2024-07-21 14:45:12 first_in_epoch: true, next_epoch_digest: None, next_config_digest: None
2024-07-21 14:45:12 Error with block built on 0xb6962e59402cb2bfe4bf35616ab4101e7d0df979f15f322a0bc92633b9d250b5: Import failed: Expected epoch change to happen at 0xf21b4b9c2ce7deb034d5aece5dde5227946a291dce1ed666437bcedcde4c1e79, s286928852
```