### PR TITLE
Backport xcmpayment-fee tests from polkadot-fellows repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-executor",
+ "xcm-runtime-apis",
 ]
 
 [[package]]

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/Cargo.toml
@@ -28,6 +28,7 @@ pallet-utility = { workspace = true }
 xcm = { workspace = true }
 pallet-xcm = { workspace = true }
 xcm-executor = { workspace = true }
+xcm-runtime-apis = { workspace = true, default-features = true }
 polkadot-runtime-common = { workspace = true, default-features = true }
 rococo-runtime-constants = { workspace = true, default-features = true }
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/mod.rs
@@ -21,3 +21,4 @@ mod set_xcm_versions;
 mod swap;
 mod teleport;
 mod treasury;
+mod xcm_fee_estimation;


### PR DESCRIPTION
# Description
This is continue of the work to backport `emulated-integration-tests-common`, if you want to understand the full context start with reading [#4930](https://github.com/paritytech/polkadot-sdk/pull/4930)