### PR TITLE
Cross chain pure proxy replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,8 @@ name = "collectives-westend-integration-tests"
 version = "1.0.0"
 dependencies = [
  "assert_matches",
+ "asset-hub-westend-runtime",
+ "collectives-westend-runtime",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
@@ -2882,6 +2884,7 @@ dependencies = [
  "pallet-assets",
  "pallet-balances",
  "pallet-message-queue",
+ "pallet-proxy",
  "pallet-treasury",
  "pallet-utility",
  "pallet-xcm",

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/lib.rs
@@ -50,6 +50,7 @@ decl_test_parachains! {
 			ForeignAssets: asset_hub_westend_runtime::ForeignAssets,
 			PoolAssets: asset_hub_westend_runtime::PoolAssets,
 			AssetConversion: asset_hub_westend_runtime::AssetConversion,
+			Proxy: asset_hub_westend_runtime::Proxy,
 		}
 	},
 }

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/collectives/collectives-westend/src/lib.rs
@@ -45,6 +45,7 @@ decl_test_parachains! {
 			Balances: collectives_westend_runtime::Balances,
 			FellowshipTreasury: collectives_westend_runtime::FellowshipTreasury,
 			AssetRate: collectives_westend_runtime::AssetRate,
+			Proxy: collectives_westend_runtime::Proxy,
 		}
 	},
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/Cargo.toml
@@ -23,6 +23,7 @@ pallet-assets = { workspace = true }
 pallet-treasury = { workspace = true }
 pallet-message-queue = { workspace = true }
 pallet-utility = { workspace = true }
+pallet-proxy = { workspace = true }
 
 # Polkadot
 polkadot-runtime-common = { workspace = true, default-features = true }
@@ -38,3 +39,5 @@ cumulus-pallet-xcmp-queue = { workspace = true }
 cumulus-pallet-parachain-system = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
 westend-system-emulated-network = { workspace = true }
+asset-hub-westend-runtime = { workspace = true }
+collectives-westend-runtime = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/mod.rs
@@ -14,3 +14,4 @@
 // limitations under the License.
 
 mod fellowship_treasury;
+mod proxy;

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/proxy.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/proxy.rs
@@ -68,7 +68,7 @@ fn cross_chain_pure_proxy() {
 			<Balances as Inspect<_>>::minimum_balance() * 100
 		));
 
-		let transfer_proxy_call = RuntimeCall::Proxy(pallet_proxy::Call::<Runtime>::add_proxy {
+		let add_proxy_call = RuntimeCall::Proxy(pallet_proxy::Call::<Runtime>::add_proxy {
 			delegate: alice.clone().into(),
 			proxy_type: CollectivesProxyType::Any,
 			delay: 0,
@@ -78,7 +78,7 @@ fn cross_chain_pure_proxy() {
 			RuntimeOrigin::signed(bob.clone()),
 			pure.clone().into(),
 			None,
-			bx!(transfer_proxy_call),
+			bx!(add_proxy_call),
 		));
 
 		let events = CollectivesWestend::events();
@@ -149,7 +149,7 @@ fn cross_chain_pure_proxy() {
 		type AssetHubBalances = <AssetHubWestend as AssetHubWestendPallet>::Balances;
 
 		// Add proxy call to be executed on the Asset Hub on behalf of the pure account.
-		let transfer_proxy_call =
+		let add_proxy_call =
 			AssetHubRuntimeCall::Proxy(pallet_proxy::Call::<AssetHubRuntime>::add_proxy {
 				delegate: alice.clone().into(),
 				proxy_type: AssetHubProxyType::Any,
@@ -176,7 +176,7 @@ fn cross_chain_pure_proxy() {
 				Transact {
 					origin_kind: OriginKind::SovereignAccount,
 					require_weight_at_most: Weight::from_parts(1_000_000_000, 10_000),
-					call: transfer_proxy_call.encode().into(),
+					call: add_proxy_call.encode().into(),
 				},
 			]))),
 		});

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/proxy.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/proxy.rs
@@ -1,0 +1,239 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::*;
+use asset_hub_westend_runtime::{
+	xcm_config::LocationToAccountId as AssetHubLocationToAccountId, ProxyType as AssetHubProxyType,
+};
+use codec::Encode;
+use collectives_westend_runtime::ProxyType as CollectivesProxyType;
+use frame_support::{
+	assert_ok,
+	traits::fungible::{Inspect, Mutate},
+};
+use xcm_executor::traits::ConvertLocation;
+
+#[test]
+fn cross_chain_pure_proxy() {
+	// proxy of the pure account.
+	let alice = Westend::account_id_of("Alice");
+	// spawner of the pure account, delegates to the pure account to Alice.
+	let bob = Westend::account_id_of("Bob");
+
+	// Bob creates a pure account on Collectives Chain.
+	let pure = CollectivesWestend::execute_with(|| {
+		type Proxy = <CollectivesWestend as CollectivesWestendPallet>::Proxy;
+		type RuntimeOrigin = <CollectivesWestend as Chain>::RuntimeOrigin;
+		type RuntimeEvent = <CollectivesWestend as Chain>::RuntimeEvent;
+
+		assert_ok!(Proxy::create_pure(
+			RuntimeOrigin::signed(bob.clone()),
+			CollectivesProxyType::Any,
+			0,
+			0
+		));
+
+		let events = CollectivesWestend::events();
+		match events.iter().last() {
+			Some(RuntimeEvent::Proxy(pallet_proxy::Event::PureCreated { pure, .. })) =>
+				pure.clone(),
+			_ => panic!("Expected PureCreated event"),
+		}
+	});
+
+	// Bob adds Alice as a proxy to the pure account on Collectives Chain.
+	CollectivesWestend::execute_with(|| {
+		type Proxy = <CollectivesWestend as CollectivesWestendPallet>::Proxy;
+		type Balances = <CollectivesWestend as CollectivesWestendPallet>::Balances;
+		type Runtime = <CollectivesWestend as Chain>::Runtime;
+		type RuntimeOrigin = <CollectivesWestend as Chain>::RuntimeOrigin;
+		type RuntimeEvent = <CollectivesWestend as Chain>::RuntimeEvent;
+		type RuntimeCall = <CollectivesWestend as Chain>::RuntimeCall;
+
+		// fund pure account for a deposit required for adding Alice as a proxy.
+		assert_ok!(<Balances as Mutate<_>>::mint_into(
+			&pure,
+			<Balances as Inspect<_>>::minimum_balance() * 100
+		));
+
+		let transfer_proxy_call = RuntimeCall::Proxy(pallet_proxy::Call::<Runtime>::add_proxy {
+			delegate: alice.clone().into(),
+			proxy_type: CollectivesProxyType::Any,
+			delay: 0,
+		});
+
+		assert_ok!(Proxy::proxy(
+			RuntimeOrigin::signed(bob.clone()),
+			pure.clone().into(),
+			None,
+			bx!(transfer_proxy_call),
+		));
+
+		let events = CollectivesWestend::events();
+		match events.iter().rev().nth(1) {
+			Some(RuntimeEvent::Proxy(pallet_proxy::Event::ProxyAdded {
+				delegator,
+				delegatee,
+				..
+			})) => {
+				assert_eq!(*delegator, pure);
+				assert_eq!(*delegatee, alice);
+			},
+			_ => panic!("Expected PureCreated event"),
+		}
+	});
+
+	// Alice sends the XCM program from Collectives to the Asset Hub on behalf of a pure account,
+	// aiming to add herself as a proxy to that same pure account.
+	//
+	// Given that the XCM program on the Asset Hub will execute with the origin set as
+	// location(1, [Parachain(1001), pure]) after descending the origin, it's necessary to
+	// pre-fund that account to cover execution fees.
+	// Additionally, the pure account on the Asset Hub requires funding for the deposit needed
+	// to add Alice as a proxy.
+	//
+	// TODO: We can eliminate the need for additional funding on the Asset Hub by teleporting
+	// some assets from the Collectives to the Asset Hub. These assets would be placed in a holding
+	// registry for the actual XCM program execution and can be used for fee payments and deposit.
+	// This could be achieved with a call like `xcm_pallet::transfer_assets_using_type_and_then`.
+	// However, the current version of xcm-executor is not suitable for our case, as it requires to
+	// clear the origin (using the ClearOrigin instruction) after receiving teleported/reserve
+	// assets and before executing any following XCM program. A potential solution could involve
+	// allowing the use of the `DescendOrigin` instruction in certain scenarios, instead of
+	// `ClearOrigin`.
+
+	AssetHubWestend::execute_with(|| {
+		type Balances = <AssetHubWestend as AssetHubWestendPallet>::Balances;
+
+		let ah_pure = AssetHubLocationToAccountId::convert_location(&Location::new(
+			1,
+			[
+				Parachain(1001),
+				AccountId32 { network: Some(NetworkId::Westend), id: pure.clone().into() },
+			],
+		))
+		.unwrap();
+
+		assert_ok!(<Balances as Mutate<_>>::mint_into(
+			&ah_pure,
+			<Balances as Inspect<_>>::minimum_balance() * 100
+		));
+
+		assert_ok!(<Balances as Mutate<_>>::mint_into(
+			&pure,
+			<Balances as Inspect<_>>::minimum_balance() * 100
+		));
+	});
+
+	// Alice sends the XCM program from Collectives to the Asset Hub.
+	CollectivesWestend::execute_with(|| {
+		type Proxy = <CollectivesWestend as CollectivesWestendPallet>::Proxy;
+		type Runtime = <CollectivesWestend as Chain>::Runtime;
+		type RuntimeOrigin = <CollectivesWestend as Chain>::RuntimeOrigin;
+		type RuntimeEvent = <CollectivesWestend as Chain>::RuntimeEvent;
+		type RuntimeCall = <CollectivesWestend as Chain>::RuntimeCall;
+		type AssetHubRuntime = <AssetHubWestend as Chain>::Runtime;
+		type AssetHubRuntimeCall = <AssetHubWestend as Chain>::RuntimeCall;
+		type AssetHubBalances = <AssetHubWestend as AssetHubWestendPallet>::Balances;
+
+		// Add proxy call to be executed on the Asset Hub on behalf of the pure account.
+		let transfer_proxy_call =
+			AssetHubRuntimeCall::Proxy(pallet_proxy::Call::<AssetHubRuntime>::add_proxy {
+				delegate: alice.clone().into(),
+				proxy_type: AssetHubProxyType::Any,
+				delay: 0,
+			});
+
+		let asset_hub_location = Location::new(1, Parachain(1000));
+		let fee_asset = Asset {
+			id: Location::parent().into(),
+			fun: (<AssetHubBalances as Inspect<_>>::minimum_balance() * 20).into(),
+		};
+
+		// XCM send call to be commanded by pure account on Collectives.
+		let send_xcm = RuntimeCall::PolkadotXcm(pallet_xcm::Call::<Runtime>::send {
+			dest: bx!(VersionedLocation::V4(asset_hub_location)),
+			message: bx!(VersionedXcm::V4(Xcm(vec![
+				WithdrawAsset(fee_asset.clone().into()),
+				BuyExecution { weight_limit: Unlimited, fees: fee_asset },
+				// we replace `Location(1, [Parachain(1001), pure])` by Location(0, [pure])
+				AliasOrigin(Location::new(
+					0,
+					AccountId32 { network: None, id: pure.clone().into() }
+				)),
+				Transact {
+					origin_kind: OriginKind::SovereignAccount,
+					require_weight_at_most: Weight::from_parts(1_000_000_000, 10_000),
+					call: transfer_proxy_call.encode().into(),
+				},
+			]))),
+		});
+
+		// Alice proxies the XCM send call.
+		assert_ok!(Proxy::proxy(
+			RuntimeOrigin::signed(alice.clone()),
+			pure.clone().into(),
+			None,
+			bx!(send_xcm),
+		));
+
+		let events = CollectivesWestend::events();
+		match events.iter().last() {
+			Some(RuntimeEvent::Proxy(pallet_proxy::Event::ProxyExecuted { result: Ok(()) })) => (),
+			_ => panic!("Expected ProxyExecuted event"),
+		}
+	});
+
+	AssetHubWestend::execute_with(|| {
+		type Proxy = <AssetHubWestend as AssetHubWestendPallet>::Proxy;
+		type Balances = <AssetHubWestend as AssetHubWestendPallet>::Balances;
+		type Runtime = <AssetHubWestend as Chain>::Runtime;
+		type RuntimeOrigin = <AssetHubWestend as Chain>::RuntimeOrigin;
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
+		type RuntimeCall = <AssetHubWestend as Chain>::RuntimeCall;
+
+		let events = AssetHubWestend::events();
+		match events.iter().last() {
+			Some(RuntimeEvent::MessageQueue(pallet_message_queue::Event::Processed {
+				success: true,
+				..
+			})) => (),
+			_ => panic!("Expected MessageQueue::Processed event"),
+		}
+
+		let bob_init_balance = <Balances as Inspect<_>>::balance(&bob);
+		let transfer_amount = <Balances as Inspect<_>>::minimum_balance() * 10;
+
+		// Alice transfers some funds from pure account on Asset Hub.
+
+		let transfer_call =
+			RuntimeCall::Balances(pallet_balances::Call::<Runtime>::transfer_keep_alive {
+				dest: bob.clone().into(),
+				value: transfer_amount,
+			});
+
+		assert_ok!(Proxy::proxy(
+			RuntimeOrigin::signed(alice.clone()),
+			pure.clone().into(),
+			None,
+			bx!(transfer_call),
+		));
+
+		assert_eq!(
+			<Balances as Inspect<_>>::total_balance(&bob),
+			bob_init_balance + transfer_amount,
+		);
+	});
+}

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
@@ -223,8 +223,8 @@ impl<Call> XcmWeightInfo<Call> for AssetHubWestendXcmWeight<Call> {
 		XcmGeneric::<Runtime>::clear_topic()
 	}
 	fn alias_origin(_: &Location) -> Weight {
-		// XCM Executor does not currently support alias origin operations
-		Weight::MAX
+		// TODO: replace with actual weight
+		Weight::from_parts(1, 1)
 	}
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/xcm_config.rs
@@ -225,7 +225,8 @@ impl xcm_executor::Config for XcmConfig {
 
 /// Converts a local signed origin into an XCM location.
 /// Forms the basis for local origins sending/executing XCMs.
-pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
+pub type LocalOriginToLocation =
+	(SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>, FellowsToPlurality);
 
 pub type PriceForParentDelivery =
 	ExponentialPrice<FeeAssetId, BaseDeliveryFee, TransactionByteFee, ParachainSystem>;
@@ -250,7 +251,7 @@ pub type FellowsToPlurality = OriginToPluralityVoice<RuntimeOrigin, Fellows, Fel
 impl pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	// We only allow the Fellows to send messages.
-	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, FellowsToPlurality>;
+	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
 	// We support local origins dispatching XCM executions.
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;


### PR DESCRIPTION
Attempt to fix https://github.com/paritytech/polkadot-sdk/issues/3288

This PR explores a method to replicate a pure account and its proxy relations from the chain where the pure account was created to some remote chain.

Pure accounts are keyless accounts (only a public key is known) that are created with a proxy account to control them. The same pure account cannot be created on another chain, so to replicate the same relationship, it should be copied via XCM.

The solution demonstrated in the PR is based on alias origins (the `AliasOrigin` XCM instruction). It establishes a relationship where any account such as `Location{ parent: {a}, X2(Parachain({b}), AccountId32({c})) }` from an authorized chain has its alias on the authorizing chain with the same account ID: `Location{ parent: 0, X1(AccountId32({c})) }`. 

Refer to `cross_chain_pure_proxy` test for example and `SystemAccountId32Aliases` type for alias configuration example. 

Con: the authorizing chain assumes risks if the authorized chain is compromised.

### Alternative solution allowing replication only for pure proxy
An extension pallet for the proxy pallet sends an XCM program to a remote chain on behalf of itself to replicate a pure proxy. This pallet will be authorized by the same proxy extension pallet on a receiving chain to perform replication. To replicate a pure proxy a caller must provide a witness data (preimage of the pure account: spawner, block, ext index, index) and the pure proxy must exist within original proxy pallet. The receiving chain can check the witness data and accept the replication of the pure proxy (with same account ids as on the source chain). 

Con: users/clients have to provide a witness data 