### PR TITLE
Remove not-audited warning

### DIFF
--- a/prdoc/pr_5114.prdoc
+++ b/prdoc/pr_5114.prdoc
@@ -1,0 +1,16 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "Remove not-audited warning"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Pallets `tx-pause` and `safe-mode` have passed audit, this just removes a warning in the docs
+      to not use them.
+
+crates:
+  - name: pallet-safe-mode
+    bump: patch
+  - name: pallet-tx-pause
+    bump: patch

--- a/substrate/frame/safe-mode/src/lib.rs
+++ b/substrate/frame/safe-mode/src/lib.rs
@@ -19,10 +19,6 @@
 //!
 //! Trigger for stopping all extrinsics outside of a specific whitelist.
 //!
-//! ## WARNING
-//!
-//! NOT YET AUDITED. DO NOT USE IN PRODUCTION.
-//!
 //! ## Pallet API
 //!
 //! See the [`pallet`] module for more information about the interfaces this pallet exposes,

--- a/substrate/frame/tx-pause/src/lib.rs
+++ b/substrate/frame/tx-pause/src/lib.rs
@@ -19,10 +19,6 @@
 //!
 //! Allows dynamic, chain-state-based pausing and unpausing of specific extrinsics via call filters.
 //!
-//! ## WARNING
-//!
-//! NOT YET AUDITED. DO NOT USE IN PRODUCTION.
-//!
 //! ## Pallet API
 //!
 //! See the [`pallet`] module for more information about the interfaces this pallet exposes,


### PR DESCRIPTION
Pallet tx-pause and safe-mode are both audited, see: #4445
