### PR TITLE
[subsystem-bench] Adjust approval-voting-regression-bench

### DIFF
--- a/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
+++ b/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
@@ -77,12 +77,12 @@ fn main() -> Result<(), String> {
 	// We expect no variance for received and sent
 	// but use 0.001 because we operate with floats
 	messages.extend(average_usage.check_network_usage(&[
-		("Received from peers", 52942.4600, 0.001),
-		("Sent to peers", 63547.0330, 0.001),
+		("Received from peers", 52941.6071, 0.001),
+		("Sent to peers", 63810.1859, 0.001),
 	]));
 	messages.extend(average_usage.check_cpu_usage(&[
-		("approval-distribution", 7.4075, 0.1),
-		("approval-voting", 9.9873, 0.1),
+		("approval-distribution", 6.3912, 0.1),
+		("approval-voting", 10.0578, 0.1),
 	]));
 
 	if messages.is_empty() {


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/5081

After last changes in approval subsystem and their benchmarks base values need to be updated