### PR TITLE
Dependabot: Group all CI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     directory: "/"
     labels: ["A1-insubstantial", "R0-silent"]
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       # We assume these crates to be semver abiding and can therefore group them together.
       known_good_semver:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: '/'
     labels: ["A1-insubstantial", "R0-silent"]
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      ci_dependencies:
+        patterns:
+        - "*"
   # Update Rust dependencies:
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
Dependabot is going a bit crazy lately and spamming up a lot of merge requests. Going to group all the CI deps into one and reducing the frequency to weekly.  
Maybe we can do some more aggressive batching for the Rust deps as well.
