### PR TITLE
feat: reduce coupling between salary and core-fellowship pallet

### DIFF
--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
@@ -223,6 +223,7 @@ impl pallet_core_fellowship::Config<AmbassadorCoreInstance> for Runtime {
 	type FastPromoteOrigin = Self::PromoteOrigin;
 	type EvidenceSize = ConstU32<65536>;
 	type MaxRank = ConstU32<9>;
+	type PayoutPeriodDuration = ConstU32<1>;
 }
 
 pub type AmbassadorSalaryInstance = pallet_salary::Instance2;

--- a/substrate/frame/core-fellowship/src/migration.rs
+++ b/substrate/frame/core-fellowship/src/migration.rs
@@ -84,8 +84,13 @@ impl<T: Config<I>, I: 'static> UncheckedOnRuntimeUpgrade for MigrateToV1<T, I> {
 		let old_value = v0::Params::<T, I>::take();
 		// Write the new value to storage
 		let new = crate::ParamsType {
-			active_salary: BoundedVec::defensive_truncate_from(old_value.active_salary.to_vec()),
-			passive_salary: BoundedVec::defensive_truncate_from(old_value.passive_salary.to_vec()),
+			active_salary_per_period: BoundedVec::defensive_truncate_from(
+				old_value.active_salary.to_vec(),
+			),
+			passive_salary_per_period: BoundedVec::defensive_truncate_from(
+				old_value.passive_salary.to_vec(),
+			),
+			payout_period_duration: old_value.payout_period,
 			demotion_period: BoundedVec::defensive_truncate_from(
 				old_value.demotion_period.to_vec(),
 			),

--- a/substrate/frame/salary/src/lib.rs
+++ b/substrate/frame/salary/src/lib.rs
@@ -392,6 +392,12 @@ pub mod pallet {
 		pub fn cycle_period() -> BlockNumberFor<T> {
 			T::RegistrationPeriod::get() + T::PayoutPeriod::get()
 		}
+		fn calculate_periods_to_pay(last_payout: BlockNumberFor<T>, now: BlockNumberFor<T>) -> u32 {
+			// TODO: retrieve payout period from core-fellowship config?
+			let payout_period = T::PayoutPeriod::get();
+			let elapsed = now.saturating_sub(last_payout);
+			(elapsed / payout_period) as u32
+		}
 		fn do_payout(who: T::AccountId, beneficiary: T::AccountId) -> DispatchResult {
 			let mut status = Status::<T, I>::get().ok_or(Error::<T, I>::NotStarted)?;
 			let mut claimant = Claimant::<T, I>::get(&who).ok_or(Error::<T, I>::NotInducted)?;
@@ -418,7 +424,9 @@ pub mod pallet {
 				Nothing | Attempted { .. } if claimant.last_active < status.cycle_index => {
 					// Not registered for this cycle. Pay from whatever is left.
 					let rank = T::Members::rank_of(&who).ok_or(Error::<T, I>::NotMember)?;
-					let ideal_payout = T::Salary::get_salary(rank, &who);
+					let salary_per_period = T::Salary::get_salary(rank, &who);
+					let periods_to_pay = Self::calculate_periods_to_pay(status.cycle_start, now);
+					let ideal_payout = salary_per_period.saturating_mul(periods_to_pay.into());
 
 					let pot = status
 						.budget


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/3617

## Description

Introduce a new parameter to define the salary of rank for a specific duration (currently in number of blocks), in the `core-fellowship` pallet. This enables other pallets using this salary information to derive the actual "salary" to give after a certain amount of blocks have passed. 

Specifically, for the `salary` pallet, we can now independently calculate the salary to distribute based on the difference in cycles, without having to know what "duration" means in `core-fellowship`

Perhaps it might be useful to define an auxiliary type to facilitate conversion between "duration" and "cycles"