### PR TITLE
Re: fix warnings with latest rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -543,7 +543,7 @@ default-members = [
 [workspace.lints.rust]
 suspicious_double_ref_op = { level = "allow", priority = 2 }
 # `substrate_runtime` is a common `cfg` condition name used in the repo.
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(substrate_runtime)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(substrate_runtime)'] }
 
 [workspace.lints.clippy]
 all = { level = "allow", priority = 0 }


### PR DESCRIPTION
I made mistake on previous PR https://github.com/paritytech/polkadot-sdk/pull/5150. It disabled all unexpected cfgs instead of just allowing `substrate_runtime` condition.

In this PR: unexpected cfgs other than `substrate_runtime` are still checked. and some warnings appear about them