### PR TITLE
Impl cfg macro with `sp-runtime/try-runtime` and `sp-runtime/runtime-benchmarks` feature available

### DIFF
--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -398,6 +398,7 @@ test-frame-ui:
   script:
     - time cargo test --locked -q --profile testnet -p frame-support-test --features=frame-feature-testing,no-metadata-docs,try-runtime,experimental
     - time cargo test --locked -q --profile testnet -p frame-support-test --features=frame-feature-testing,frame-feature-testing-2,no-metadata-docs,try-runtime,experimental
+    - time cargo test --locked -q --profile testnet -p sp-primitive-proc-macro
     - cat /cargo_target_dir/debug/.fingerprint/memory_units-759eddf317490d2b/lib-memory_units.json || true
 
 # This job runs all benchmarks defined in the `/bin/node/runtime` once to check that there are no errors.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20463,6 +20463,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
+ "sp-runtime-proc-macro",
  "sp-state-machine",
  "sp-std 14.0.0",
  "sp-tracing 16.0.0",
@@ -20573,6 +20574,18 @@ dependencies = [
  "sp-io",
  "sp-runtime-interface 24.0.0",
  "substrate-wasm-builder",
+]
+
+[[package]]
+name = "sp-runtime-proc-macro"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2 1.0.82",
+ "quote 1.0.36",
+ "rustversion",
+ "sp-runtime",
+ "syn 2.0.61",
+ "trybuild",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,6 +479,7 @@ members = [
 	"substrate/primitives/panic-handler",
 	"substrate/primitives/rpc",
 	"substrate/primitives/runtime",
+	"substrate/primitives/runtime/proc-macro",
 	"substrate/primitives/runtime-interface",
 	"substrate/primitives/runtime-interface/proc-macro",
 	"substrate/primitives/runtime-interface/test",
@@ -1243,6 +1244,7 @@ sp-offchain = { path = "substrate/primitives/offchain", default-features = false
 sp-panic-handler = { path = "substrate/primitives/panic-handler", default-features = false }
 sp-rpc = { path = "substrate/primitives/rpc", default-features = false }
 sp-runtime = { path = "substrate/primitives/runtime", default-features = false }
+sp-runtime-proc-macro = { path = "substrate/primitives/runtime/proc-macro", default-features = false }
 sp-runtime-interface = { path = "substrate/primitives/runtime-interface", default-features = false }
 sp-runtime-interface-proc-macro = { path = "substrate/primitives/runtime-interface/proc-macro", default-features = false }
 sp-runtime-interface-test-wasm = { path = "substrate/primitives/runtime-interface/test-wasm" }

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -35,6 +35,7 @@ sp-std = { workspace = true }
 sp-weights = { workspace = true }
 docify = { workspace = true }
 tracing = { workspace = true, features = ["log"], default-features = false }
+sp-runtime-proc-macro = { workspace = true }
 
 simple-mermaid = { version = "0.1.1", optional = true }
 

--- a/substrate/primitives/runtime/proc-macro/Cargo.toml
+++ b/substrate/primitives/runtime/proc-macro/Cargo.toml
@@ -27,6 +27,3 @@ proc-macro2 = { workspace = true }
 trybuild = { features = ["diff"], workspace = true }
 rustversion = { workspace = true }
 sp-runtime = { features = ["std"], workspace = true }
-
-[features]
-disable-ui-tests = []

--- a/substrate/primitives/runtime/proc-macro/Cargo.toml
+++ b/substrate/primitives/runtime/proc-macro/Cargo.toml
@@ -4,9 +4,9 @@ version = "1.0.0"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
-homepage = "https://substrate.io"
+homepage.workspace = true
 repository.workspace = true
-description = "Macros for declaring and implementing runtime apis."
+description = "Macros for substrate primitive runtime."
 documentation = "https://docs.rs/sp-api-proc-macro"
 
 [lints]

--- a/substrate/primitives/runtime/proc-macro/Cargo.toml
+++ b/substrate/primitives/runtime/proc-macro/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "sp-runtime-proc-macro"
+version = "1.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage = "https://substrate.io"
+repository.workspace = true
+description = "Macros for declaring and implementing runtime apis."
+documentation = "https://docs.rs/sp-api-proc-macro"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = { workspace = true }
+syn = { features = ["extra-traits", "fold", "full", "visit"], workspace = true }
+proc-macro2 = { workspace = true }
+
+[dev-dependencies]
+trybuild = { features = ["diff"], workspace = true }
+rustversion = { workspace = true }
+sp-runtime = { features = ["std"], workspace = true }
+
+[features]
+disable-ui-tests = []

--- a/substrate/primitives/runtime/proc-macro/src/lib.rs
+++ b/substrate/primitives/runtime/proc-macro/src/lib.rs
@@ -1,0 +1,204 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Proc macro for sp-runtime crate.
+
+mod replace_features;
+
+use replace_features::{ConfigurationPredicate, RuntimeFeature};
+
+// NOTE: Those macro are only provided in attribute macro style because implementing a proc_macro
+// which generates `#[cfg(feature = "some_features")]` is invalid, the compiler requires an item
+// after the attribute in the generated code.
+// `#![..]` cfg are also not supported because it is invalid to generate a `#![..]` macro call from
+// inside a macro.
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg` macro.
+///
+/// `#![..]` style macro call are not supported.
+///
+/// # Example
+///
+/// ```
+/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// fn some_function() {
+/// 	println!("try-runtime is enabled");
+/// }
+///
+/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// fn some_function() {
+/// 	println!("try-runtime and std are enabled");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn with_features_try_runtime_and_runtime_benchmarks(
+	args: proc_macro::TokenStream,
+	input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: true },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: true },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+	let input = proc_macro2::TokenStream::from(input);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		#[cfg(#args)]
+		#input
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg` macro.
+///
+/// `#![..]` style macro call are not supported.
+///
+/// # Example
+///
+/// ```
+/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// fn some_function() {
+/// 	println!("try-runtime is enabled");
+/// }
+///
+/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// fn some_function() {
+/// 	println!("try-runtime and std are enabled");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn with_features_try_runtime_and_not_runtime_benchmarks(
+	args: proc_macro::TokenStream,
+	input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: true },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: false },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+	let input = proc_macro2::TokenStream::from(input);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		#[cfg(#args)]
+		#input
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg` macro.
+///
+/// `#![..]` style macro call are not supported.
+///
+/// # Example
+///
+/// ```
+/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// fn some_function() {
+/// 	println!("try-runtime is enabled");
+/// }
+///
+/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// fn some_function() {
+/// 	println!("try-runtime and std are enabled");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn with_features_not_try_runtime_and_runtime_benchmarks(
+	args: proc_macro::TokenStream,
+	input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: false },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: true },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+	let input = proc_macro2::TokenStream::from(input);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		#[cfg(#args)]
+		#input
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg` macro.
+///
+/// `#![..]` style macro call are not supported.
+///
+/// # Example
+///
+/// ```
+/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// fn some_function() {
+/// 	println!("try-runtime is enabled");
+/// }
+///
+/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// fn some_function() {
+/// 	println!("try-runtime and std are enabled");
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn with_features_not_try_runtime_and_not_runtime_benchmarks(
+	args: proc_macro::TokenStream,
+	input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: false },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: false },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+	let input = proc_macro2::TokenStream::from(input);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		#[cfg(#args)]
+		#input
+	)
+	.into()
+}

--- a/substrate/primitives/runtime/proc-macro/src/lib.rs
+++ b/substrate/primitives/runtime/proc-macro/src/lib.rs
@@ -39,12 +39,12 @@ use replace_features::{ConfigurationPredicate, RuntimeFeature};
 /// # Example
 ///
 /// ```
-/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// #[sp_runtime::cfg_rt(feature = "sp-runtime/try-runtime")]
 /// fn some_function() {
 /// 	println!("try-runtime is enabled");
 /// }
 ///
-/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// #[sp_runtime::cfg_rt(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
 /// fn some_function() {
 /// 	println!("try-runtime and std are enabled");
 /// }
@@ -83,12 +83,12 @@ pub fn with_features_try_runtime_and_runtime_benchmarks(
 /// # Example
 ///
 /// ```
-/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// #[sp_runtime::cfg_rt(feature = "sp-runtime/try-runtime")]
 /// fn some_function() {
 /// 	println!("try-runtime is enabled");
 /// }
 ///
-/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// #[sp_runtime::cfg_rt(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
 /// fn some_function() {
 /// 	println!("try-runtime and std are enabled");
 /// }
@@ -127,12 +127,12 @@ pub fn with_features_try_runtime_and_not_runtime_benchmarks(
 /// # Example
 ///
 /// ```
-/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// #[sp_runtime::cfg_rt(feature = "sp-runtime/try-runtime")]
 /// fn some_function() {
 /// 	println!("try-runtime is enabled");
 /// }
 ///
-/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// #[sp_runtime::cfg_rt(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
 /// fn some_function() {
 /// 	println!("try-runtime and std are enabled");
 /// }
@@ -171,12 +171,12 @@ pub fn with_features_not_try_runtime_and_runtime_benchmarks(
 /// # Example
 ///
 /// ```
-/// #[sp_runtime::runtime_cfg(feature = "sp-runtime/try-runtime")]
+/// #[sp_runtime::cfg_rt(feature = "sp-runtime/try-runtime")]
 /// fn some_function() {
 /// 	println!("try-runtime is enabled");
 /// }
 ///
-/// #[sp_runtime::runtime_cfg(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
+/// #[sp_runtime::cfg_rt(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
 /// fn some_function() {
 /// 	println!("try-runtime and std are enabled");
 /// }
@@ -199,6 +199,162 @@ pub fn with_features_not_try_runtime_and_not_runtime_benchmarks(
 	quote::quote!(
 		#[cfg(#args)]
 		#input
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg!` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg!(..)` macro.
+///
+/// # Example
+///
+/// ```
+/// fn some_function() {
+/// 	if sp_runtime::cfg_rt_inline!(feature = "sp-runtime/try-runtime") {
+/// 		println!("try-runtime is enabled");
+/// 	}
+///
+/// 	if sp_runtime::cfg_rt_inline!(all(feature = "std", feature = "sp-runtime/runtime-benchmarks")) {
+/// 		println!("try-runtime and std are enabled");
+/// 	}
+/// }
+/// ```
+#[proc_macro]
+pub fn with_features_not_try_runtime_and_not_runtime_benchmarks_inline(
+	args: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: false },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: false },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		cfg!(#args)
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg!` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg!(..)` macro.
+///
+/// # Example
+///
+/// ```
+/// fn some_function() {
+/// 	if sp_runtime::cfg_rt_inline!(feature = "sp-runtime/try-runtime") {
+/// 		println!("try-runtime is enabled");
+/// 	}
+///
+/// 	if sp_runtime::cfg_rt_inline!(all(feature = "std", feature = "sp-runtime/runtime-benchmarks")) {
+/// 		println!("try-runtime and std are enabled");
+/// 	}
+/// }
+/// ```
+#[proc_macro]
+pub fn with_features_try_runtime_and_not_runtime_benchmarks_inline(
+	args: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: true },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: false },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		cfg!(#args)
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg!` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg!(..)` macro.
+///
+/// # Example
+///
+/// ```
+/// fn some_function() {
+/// 	if sp_runtime::cfg_rt_inline!(feature = "sp-runtime/try-runtime") {
+/// 		println!("try-runtime is enabled");
+/// 	}
+///
+/// 	if sp_runtime::cfg_rt_inline!(all(feature = "std", feature = "sp-runtime/runtime-benchmarks")) {
+/// 		println!("try-runtime and std are enabled");
+/// 	}
+/// }
+/// ```
+#[proc_macro]
+pub fn with_features_try_runtime_and_runtime_benchmarks_inline(
+	args: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: true },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: true },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		cfg!(#args)
+	)
+	.into()
+}
+
+// NOTE: This documentation is shown on the re-exported macro in the sp-runtime crate.
+// This doc is duplicated for each macro.
+/// Extended implementation of `cfg!` macro with access to `sp-runtime/try-runtime` and
+/// `sp-runtime/runtime-benchmarks` features.
+///
+/// Syntax is the same as `cfg!(..)` macro.
+///
+/// # Example
+///
+/// ```
+/// fn some_function() {
+/// 	if sp_runtime::cfg_rt_inline!(feature = "sp-runtime/try-runtime") {
+/// 		println!("try-runtime is enabled");
+/// 	}
+///
+/// 	if sp_runtime::cfg_rt_inline!(all(feature = "std", feature = "sp-runtime/runtime-benchmarks")) {
+/// 		println!("try-runtime and std are enabled");
+/// 	}
+/// }
+/// ```
+#[proc_macro]
+pub fn with_features_not_try_runtime_and_runtime_benchmarks_inline(
+	args: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+	let features = [
+		RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: false },
+		RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: true },
+	];
+
+	let mut args = syn::parse_macro_input!(args as ConfigurationPredicate);
+
+	args.replace_features(&features[..]);
+
+	quote::quote!(
+		cfg!(#args)
 	)
 	.into()
 }

--- a/substrate/primitives/runtime/proc-macro/src/replace_features.rs
+++ b/substrate/primitives/runtime/proc-macro/src/replace_features.rs
@@ -1,0 +1,288 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provides functions to deal with feature replacement in cfg-style macro.
+
+use syn::punctuated::Punctuated;
+
+mod kw {
+	syn::custom_keyword!(all);
+	syn::custom_keyword!(any);
+	syn::custom_keyword!(not);
+}
+
+/// Description of a runtime feature e.g. `sp-runtime/try-runtime` is enabled.
+pub struct RuntimeFeature {
+	pub name: String,
+	pub is_enabled: bool,
+}
+
+/// Syntax for `cfg`-style macro. E.g. `any(feature = "foo", bar)`.
+///
+/// This should be a full implementation of the `cfg` macro:
+/// https://doc.rust-lang.org/reference/conditional-compilation.html
+///
+///    Syntax
+///    ConfigurationPredicate :
+///          ConfigurationOption
+///       | ConfigurationAll
+///       | ConfigurationAny
+///       | ConfigurationNot
+///
+///    ConfigurationOption :
+///       IDENTIFIER (= (STRING_LITERAL | RAW_STRING_LITERAL))?
+///
+///    ConfigurationAll
+///       all ( ConfigurationPredicateList? )
+///
+///    ConfigurationAny
+///       any ( ConfigurationPredicateList? )
+///
+///    ConfigurationNot
+///       not ( ConfigurationPredicate )
+///
+///    ConfigurationPredicateList
+///       ConfigurationPredicate (, ConfigurationPredicate)* ,?
+///
+pub enum ConfigurationPredicate {
+	Option(ConfigurationOption),
+	All(ConfigurationList),
+	Any(ConfigurationList),
+	Not(ConfigurationNot),
+}
+
+/// E.g. `feature = "foo"`.
+pub struct ConfigurationOption {
+	ident: syn::Ident,
+	value: Option<(syn::Token![=], syn::LitStr)>,
+}
+
+/// E.g. `all(feature = "foo", bar)` or `any(feature = "foo", bar)`.
+pub struct ConfigurationList {
+	ident: syn::Ident,
+	predicates: Punctuated<ConfigurationPredicate, syn::Token![,]>,
+}
+
+/// E.g. `not(feature = "foo")`.
+pub struct ConfigurationNot {
+	ident: syn::Ident,
+	predicate: Box<ConfigurationPredicate>,
+}
+
+impl syn::parse::Parse for ConfigurationPredicate {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		if input.peek(kw::all) && input.peek2(syn::token::Paren) {
+			Ok(Self::All(input.parse()?))
+		} else if input.peek(kw::any) && input.peek2(syn::token::Paren) {
+			Ok(Self::Any(input.parse()?))
+		} else if input.peek(kw::not) && input.peek2(syn::token::Paren) {
+			Ok(Self::Not(input.parse()?))
+		} else if !input.peek(kw::not) &&!input.peek(kw::any) &&!input.peek(kw::all) && input.peek(syn::Ident) {
+			Ok(Self::Option(input.parse()?))
+		} else {
+			Err(input.error(
+				"Expected `all(..)`, `any(..)`, `not(..)`, `some_feature`, or `some_feature = ..`",
+			))
+		}
+	}
+}
+
+impl quote::ToTokens for ConfigurationPredicate {
+	fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+		match self {
+			ConfigurationPredicate::Option(option) => option.to_tokens(tokens),
+			ConfigurationPredicate::All(all) => all.to_tokens(tokens),
+			ConfigurationPredicate::Any(any) => any.to_tokens(tokens),
+			ConfigurationPredicate::Not(not) => not.to_tokens(tokens),
+		}
+	}
+}
+
+impl syn::parse::Parse for ConfigurationOption {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let ident: syn::Ident = input.parse()?;
+		let value = if input.peek(syn::Token![=]) {
+			let eq: syn::Token![=] = input.parse()?;
+			let value: syn::LitStr = input.parse()?;
+			Some((eq, value))
+		} else {
+			None
+		};
+
+		Ok(ConfigurationOption { ident, value })
+	}
+}
+
+impl quote::ToTokens for ConfigurationOption {
+	fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+		let ident = &self.ident;
+		let value = self.value.as_ref().map(|(eq, v)| quote::quote!(#eq #v));
+		tokens.extend(quote::quote!(#ident #value));
+	}
+}
+
+impl syn::parse::Parse for ConfigurationList {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let ident = input.parse()?;
+		let content;
+		syn::parenthesized!(content in input);
+		let predicates =
+			Punctuated::<ConfigurationPredicate, syn::Token![,]>::parse_terminated(&content)?;
+
+		if predicates.is_empty() {
+			return Err(content.error("Expected at least one predicate"));
+		}
+
+		Ok(ConfigurationList { ident, predicates })
+	}
+}
+
+impl quote::ToTokens for ConfigurationList {
+	fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+		let ident = &self.ident;
+		let predicates = &self.predicates;
+		tokens.extend(quote::quote!(#ident(#predicates)));
+	}
+}
+
+impl syn::parse::Parse for ConfigurationNot {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let ident = input.parse()?;
+		let content;
+		syn::parenthesized!(content in input);
+		let predicate: ConfigurationPredicate = content.parse()?;
+		Ok(ConfigurationNot { ident, predicate: Box::new(predicate) })
+	}
+}
+
+impl quote::ToTokens for ConfigurationNot {
+	fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+		let ident = &self.ident;
+		let predicate = &self.predicate;
+		tokens.extend(quote::quote!(#ident(#predicate)));
+	}
+}
+
+impl ConfigurationPredicate {
+	pub fn replace_features(&mut self, features: &[RuntimeFeature]) {
+		match self {
+			ConfigurationPredicate::All(ref mut list)
+			| ConfigurationPredicate::Any(ref mut list) => {
+				for predicate in &mut list.predicates {
+					predicate.replace_features(features);
+				}
+			},
+			ConfigurationPredicate::Not(ref mut not) => not.predicate.replace_features(features),
+			ConfigurationPredicate::Option(ref mut option) => {
+				if let Some((_, lit)) = &mut option.value {
+					if option.ident.to_string() == "feature" {
+						for feature in features {
+							if lit.value() == feature.name {
+								let false_predicate =
+									ConfigurationPredicate::All(ConfigurationList {
+										ident: syn::Ident::new("all", lit.span()),
+										predicates: FromIterator::from_iter([
+											ConfigurationPredicate::Option(ConfigurationOption {
+												ident: syn::Ident::new("target_endian", lit.span()),
+												value: Some((
+													Default::default(),
+													syn::LitStr::new("little", lit.span()),
+												)),
+											}),
+											ConfigurationPredicate::Option(ConfigurationOption {
+												ident: syn::Ident::new("target_endian", lit.span()),
+												value: Some((
+													Default::default(),
+													syn::LitStr::new("big", lit.span()),
+												)),
+											}),
+										]),
+									});
+
+								if feature.is_enabled {
+									*self = ConfigurationPredicate::Not(ConfigurationNot {
+										ident: syn::Ident::new("not", lit.span()),
+										predicate: Box::new(false_predicate),
+									});
+								} else {
+									*self = false_predicate;
+								}
+
+								return;
+							}
+						}
+					}
+				}
+			},
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use quote::ToTokens;
+
+	#[test]
+	fn test_replace() {
+		let input = quote::quote! {
+			any(feature = "sp-runtime/try-runtime", not(feature = "sp-runtime/runtime-benchmarks"))
+		};
+		let features = [
+			RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: true },
+			RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: false },
+		];
+		let expected = quote::quote! {
+			any(
+				not(all(target_endian = "little", target_endian = "big")),
+				not(
+					all(target_endian = "little", target_endian = "big")
+				)
+			)
+		};
+
+		let mut input: ConfigurationPredicate = syn::parse2(input).unwrap();
+		input.replace_features(&features[..]);
+
+		assert_eq!(input.to_token_stream().to_string(), expected.to_string());
+	}
+
+	#[test]
+	fn test_replace2() {
+		let input = quote::quote! {
+			any(foo, not(feature = "sp-runtime/runtime-benchmarks"), bar)
+		};
+		let features = [
+			RuntimeFeature { name: "sp-runtime/try-runtime".into(), is_enabled: true },
+			RuntimeFeature { name: "sp-runtime/runtime-benchmarks".into(), is_enabled: false },
+		];
+		let expected = quote::quote! {
+			any(
+				foo,
+				not(
+					all(target_endian = "little", target_endian = "big")
+				),
+				bar
+			)
+		};
+
+		let mut input: ConfigurationPredicate = syn::parse2(input).unwrap();
+		input.replace_features(&features[..]);
+
+		assert_eq!(input.to_token_stream().to_string(), expected.to_string());
+	}
+}

--- a/substrate/primitives/runtime/proc-macro/tests/replace_features.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/replace_features.rs
@@ -1,0 +1,118 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::*;
+
+// This function is placed so it will conflict with any code generating a funcion with the same
+// name.
+fn _should_not_compile() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(not(feature = "sp-runtime/runtime-benchmarks"))]
+fn _should_not_compile() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(not(feature = "sp-runtime/try-runtime"))]
+fn _should_not_compile() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature = "sp-runtime/try-runtime")]
+fn should_compile1() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature = "sp-runtime/runtime-benchmarks")]
+fn should_compile2() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(all(
+	feature = "sp-runtime/runtime-benchmarks",
+	feature = "sp-runtime/try-runtime"
+))]
+fn should_compile3() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(any(
+	not(feature = "sp-runtime/runtime-benchmarks"),
+	feature = "sp-runtime/try-runtime"
+))]
+fn should_compile4() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(any(
+	feature = "sp-runtime/runtime-benchmarks",
+	not(feature = "sp-runtime/try-runtime")
+))]
+fn should_compile5() {}
+
+#[with_features_not_try_runtime_and_runtime_benchmarks(not(
+	feature = "sp-runtime/runtime-benchmarks"
+))]
+fn _should_not_compile() {}
+
+#[with_features_not_try_runtime_and_runtime_benchmarks(not(not(
+	feature = "sp-runtime/try-runtime"
+)))]
+fn _should_not_compile() {}
+
+#[with_features_not_try_runtime_and_runtime_benchmarks(not(feature = "sp-runtime/try-runtime"))]
+fn should_compile6() {}
+
+#[with_features_not_try_runtime_and_runtime_benchmarks(feature = "sp-runtime/runtime-benchmarks")]
+fn should_compile7() {}
+
+#[with_features_not_try_runtime_and_not_runtime_benchmarks(not(not(
+	feature = "sp-runtime/runtime-benchmarks"
+)))]
+fn _should_not_compile() {}
+
+#[with_features_not_try_runtime_and_not_runtime_benchmarks(not(not(
+	feature = "sp-runtime/try-runtime"
+)))]
+fn _should_not_compile() {}
+
+#[with_features_not_try_runtime_and_not_runtime_benchmarks(not(
+	feature = "sp-runtime/try-runtime"
+))]
+fn should_compile8() {}
+
+#[with_features_not_try_runtime_and_not_runtime_benchmarks(not(
+	feature = "sp-runtime/runtime-benchmarks"
+))]
+fn should_compile9() {}
+
+#[with_features_try_runtime_and_not_runtime_benchmarks(not(not(
+	feature = "sp-runtime/runtime-benchmarks"
+)))]
+fn _should_not_compile() {}
+
+#[with_features_try_runtime_and_not_runtime_benchmarks(not(feature = "sp-runtime/try-runtime"))]
+fn _should_not_compile() {}
+
+#[with_features_try_runtime_and_not_runtime_benchmarks(feature = "sp-runtime/try-runtime")]
+fn should_compile10() {}
+
+#[with_features_try_runtime_and_not_runtime_benchmarks(not(
+	feature = "sp-runtime/runtime-benchmarks"
+))]
+fn should_compile11() {}
+
+fn main() {
+	should_compile1();
+	should_compile2();
+	should_compile3();
+	should_compile4();
+	should_compile5();
+	should_compile6();
+	should_compile7();
+	should_compile8();
+	should_compile9();
+	should_compile10();
+	should_compile11();
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input.stderr
@@ -1,0 +1,7 @@
+error: expected item after attributes
+  --> tests/ui/wrong_input.rs:20:1
+   |
+20 | sp_runtime_proc_macro::ttt! {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `sp_runtime_proc_macro::ttt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input.stderr
@@ -1,7 +1,0 @@
-error: expected item after attributes
-  --> tests/ui/wrong_input.rs:20:1
-   |
-20 | sp_runtime_proc_macro::ttt! {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `sp_runtime_proc_macro::ttt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input1.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input1.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks()]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input1.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input1.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, Expected `all(..)`, `any(..)`, `not(..)`, `SomeFeature`, or `feature = ..`
+  --> tests/ui/wrong_input1.rs:20:1
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks()]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `with_features_try_runtime_and_runtime_benchmarks` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input10.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input10.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(all())]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input10.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input10.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of input, Expected at least one predicate
+  --> tests/ui/wrong_input10.rs:20:56
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(all())]
+   |                                                        ^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input11.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input11.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(not())]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input11.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input11.stderr
@@ -1,0 +1,5 @@
+error: unexpected end of input, Expected `all(..)`, `any(..)`, `not(..)`, `SomeFeature`, or `feature = ..`
+  --> tests/ui/wrong_input11.rs:20:56
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(not())]
+   |                                                        ^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input12.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input12.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(not(foo, bar))]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input12.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input12.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input12.rs:20:59
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(not(foo, bar))]
+   |                                                           ^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input2.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input2.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(cfg(feature = "std"))]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input2.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input2.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input2.rs:20:55
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(cfg(feature = "std"))]
+   |                                                       ^^^^^^^^^^^^^^^^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input3.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input3.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature is "std")]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input3.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input3.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input3.rs:20:60
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(feature is "std")]
+   |                                                            ^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input4.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input4.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature "std")]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input4.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input4.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input4.rs:20:60
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(feature "std")]
+   |                                                            ^^^^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input5.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input5.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature = 3)]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input5.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input5.stderr
@@ -1,0 +1,5 @@
+error: expected string literal
+  --> tests/ui/wrong_input5.rs:20:62
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(feature = 3)]
+   |                                                              ^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input6.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input6.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature = "std" foo)]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input6.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input6.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input6.rs:20:68
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(feature = "std" foo)]
+   |                                                                    ^^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input7.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input7.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(nota(feature = "std"))]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input7.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input7.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input7.rs:20:56
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(nota(feature = "std"))]
+   |                                                        ^^^^^^^^^^^^^^^^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input8.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input8.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature("std"))]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input8.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input8.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> tests/ui/wrong_input8.rs:20:59
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(feature("std"))]
+   |                                                           ^^^^^^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input9.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input9.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+#[with_features_try_runtime_and_runtime_benchmarks(all[feature = "std"])]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input9.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_input9.stderr
@@ -1,0 +1,5 @@
+error: Expected `all(..)`, `any(..)`, `not(..)`, `SomeFeature`, or `feature = ..`
+  --> tests/ui/wrong_input9.rs:20:52
+   |
+20 | #[with_features_try_runtime_and_runtime_benchmarks(all[feature = "std"])]
+   |                                                    ^^^

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_usage.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_usage.rs
@@ -1,0 +1,26 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks;
+
+fn foo() {}
+
+#[with_features_try_runtime_and_runtime_benchmarks(feature = "sp-runtime/try-runtime")]
+fn foo() {}
+
+fn main() {
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui/wrong_usage.stderr
+++ b/substrate/primitives/runtime/proc-macro/tests/ui/wrong_usage.stderr
@@ -1,0 +1,10 @@
+error[E0428]: the name `foo` is defined multiple times
+  --> tests/ui/wrong_usage.rs:23:1
+   |
+20 | fn foo() {}
+   | -------- previous definition of the value `foo` here
+...
+23 | fn foo() {}
+   | ^^^^^^^^ `foo` redefined here
+   |
+   = note: `foo` must be defined only once in the value namespace of this module

--- a/substrate/primitives/runtime/proc-macro/tests/ui_tests.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui_tests.rs
@@ -1,0 +1,35 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "disable-ui-tests"))]
+#[test]
+fn pallet_ui() {
+	// Only run the ui tests when `RUN_UI_TESTS` is set.
+	if std::env::var("RUN_UI_TESTS").is_err() {
+		return;
+	}
+
+	// As trybuild is using `cargo check`, we don't need the real WASM binaries.
+	std::env::set_var("SKIP_WASM_BUILD", "1");
+
+	// Deny all warnings since we emit warnings as part of a Pallet's UI.
+	std::env::set_var("RUSTFLAGS", "--deny warnings");
+
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/ui/*.rs");
+}

--- a/substrate/primitives/runtime/proc-macro/tests/ui_tests.rs
+++ b/substrate/primitives/runtime/proc-macro/tests/ui_tests.rs
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
-#[cfg(not(feature = "disable-ui-tests"))]
 #[test]
 fn pallet_ui() {
 	// Only run the ui tests when `RUN_UI_TESTS` is set.

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -1172,6 +1172,61 @@ mod tests {
 			assert_eq!(sp_io::storage::get(b"b").unwrap(), vec![2u8; 33]);
 		});
 	}
+
+	// Function is used to test that macros below generate nothing.
+	fn _unique_function() {}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	#[runtime_cfg(not(feature = "runtime-benchmarks"))]
+	fn _unique_function() {}
+
+	#[cfg(feature = "try-runtime")]
+	#[runtime_cfg(not(feature = "try-runtime"))]
+	fn _unique_function() {}
+
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	#[runtime_cfg(feature = "runtime-benchmarks")]
+	fn _unique_function() {}
+
+	#[cfg(not(feature = "try-runtime"))]
+	#[runtime_cfg(feature = "try-runtime")]
+	fn _unique_function() {}
+
+	#[runtime_cfg(feature = "runtime-benchmarks")]
+	fn function_exist1() {}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	#[test]
+	fn test_function_exist1() {
+		function_exist1();
+	}
+
+	#[runtime_cfg(not(feature = "runtime-benchmarks"))]
+	fn function_exist1() {}
+
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	#[test]
+	fn test_function_exist1() {
+		function_exist1();
+	}
+
+	#[runtime_cfg(feature = "try-runtime")]
+	fn function_exist2() {}
+
+	#[cfg(feature = "try-runtime")]
+	#[test]
+	fn test_function_exist2() {
+		function_exist2();
+	}
+
+	#[runtime_cfg(not(feature = "try-runtime"))]
+	fn function_exist2() {}
+
+	#[cfg(not(feature = "try-runtime"))]
+	#[test]
+	fn test_function_exist2() {
+		function_exist2();
+	}
 }
 
 // NOTE: we have to test the sp_core stuff also from a different crate to check that the macro

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -1029,6 +1029,18 @@ impl OpaqueValue {
 	}
 }
 
+#[cfg(all(feature = "try-runtime", feature = "runtime-benchmarks"))]
+pub use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks as runtime_cfg;
+
+#[cfg(all(not(feature = "try-runtime"), feature = "runtime-benchmarks"))]
+pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_runtime_benchmarks as runtime_cfg;
+
+#[cfg(all(feature = "try-runtime", not(feature = "runtime-benchmarks")))]
+pub use sp_runtime_proc_macro::with_features_try_runtime_and_not_runtime_benchmarks as runtime_cfg;
+
+#[cfg(all(not(feature = "try-runtime"), not(feature = "runtime-benchmarks")))]
+pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_not_runtime_benchmarks as runtime_cfg;
+
 #[cfg(test)]
 mod tests {
 	use crate::traits::BlakeTwo256;

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -1030,16 +1030,28 @@ impl OpaqueValue {
 }
 
 #[cfg(all(feature = "try-runtime", feature = "runtime-benchmarks"))]
-pub use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks as runtime_cfg;
+pub use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks as cfg_rt;
 
 #[cfg(all(not(feature = "try-runtime"), feature = "runtime-benchmarks"))]
-pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_runtime_benchmarks as runtime_cfg;
+pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_runtime_benchmarks as cfg_rt;
 
 #[cfg(all(feature = "try-runtime", not(feature = "runtime-benchmarks")))]
-pub use sp_runtime_proc_macro::with_features_try_runtime_and_not_runtime_benchmarks as runtime_cfg;
+pub use sp_runtime_proc_macro::with_features_try_runtime_and_not_runtime_benchmarks as cfg_rt;
 
 #[cfg(all(not(feature = "try-runtime"), not(feature = "runtime-benchmarks")))]
-pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_not_runtime_benchmarks as runtime_cfg;
+pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_not_runtime_benchmarks as cfg_rt;
+
+#[cfg(all(feature = "try-runtime", feature = "runtime-benchmarks"))]
+pub use sp_runtime_proc_macro::with_features_try_runtime_and_runtime_benchmarks_inline as cfg_rt_inline;
+
+#[cfg(all(not(feature = "try-runtime"), feature = "runtime-benchmarks"))]
+pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_runtime_benchmarks_inline as cfg_rt_inline;
+
+#[cfg(all(feature = "try-runtime", not(feature = "runtime-benchmarks")))]
+pub use sp_runtime_proc_macro::with_features_try_runtime_and_not_runtime_benchmarks_inline as cfg_rt_inline;
+
+#[cfg(all(not(feature = "try-runtime"), not(feature = "runtime-benchmarks")))]
+pub use sp_runtime_proc_macro::with_features_not_try_runtime_and_not_runtime_benchmarks_inline as cfg_rt_inline;
 
 #[cfg(test)]
 mod tests {
@@ -1177,22 +1189,22 @@ mod tests {
 	fn _unique_function() {}
 
 	#[cfg(feature = "runtime-benchmarks")]
-	#[runtime_cfg(not(feature = "runtime-benchmarks"))]
+	#[cfg_rt(not(feature = "runtime-benchmarks"))]
 	fn _unique_function() {}
 
 	#[cfg(feature = "try-runtime")]
-	#[runtime_cfg(not(feature = "try-runtime"))]
+	#[cfg_rt(not(feature = "try-runtime"))]
 	fn _unique_function() {}
 
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	#[runtime_cfg(feature = "runtime-benchmarks")]
+	#[cfg_rt(feature = "runtime-benchmarks")]
 	fn _unique_function() {}
 
 	#[cfg(not(feature = "try-runtime"))]
-	#[runtime_cfg(feature = "try-runtime")]
+	#[cfg_rt(feature = "try-runtime")]
 	fn _unique_function() {}
 
-	#[runtime_cfg(feature = "runtime-benchmarks")]
+	#[cfg_rt(feature = "runtime-benchmarks")]
 	fn function_exist1() {}
 
 	#[cfg(feature = "runtime-benchmarks")]
@@ -1201,7 +1213,7 @@ mod tests {
 		function_exist1();
 	}
 
-	#[runtime_cfg(not(feature = "runtime-benchmarks"))]
+	#[cfg_rt(not(feature = "runtime-benchmarks"))]
 	fn function_exist1() {}
 
 	#[cfg(not(feature = "runtime-benchmarks"))]
@@ -1210,7 +1222,7 @@ mod tests {
 		function_exist1();
 	}
 
-	#[runtime_cfg(feature = "try-runtime")]
+	#[cfg_rt(feature = "try-runtime")]
 	fn function_exist2() {}
 
 	#[cfg(feature = "try-runtime")]
@@ -1219,13 +1231,73 @@ mod tests {
 		function_exist2();
 	}
 
-	#[runtime_cfg(not(feature = "try-runtime"))]
+	#[cfg_rt(not(feature = "try-runtime"))]
 	fn function_exist2() {}
 
 	#[cfg(not(feature = "try-runtime"))]
 	#[test]
 	fn test_function_exist2() {
 		function_exist2();
+	}
+
+	#[test]
+	fn test_inline() {
+		#[cfg(feature = "runtime-benchmarks")]
+		if cfg_rt_inline!(not(feature = "runtime-benchmarks")) {
+			unreachable!();
+		}
+
+		#[cfg(feature = "try-runtime")]
+		if cfg_rt_inline!(not(feature = "try-runtime")) {
+			unreachable!();
+		}
+
+		#[cfg(not(feature = "runtime-benchmarks"))]
+		if cfg_rt_inline!(feature = "runtime-benchmarks") {
+			unreachable!();
+		}
+
+		#[cfg(not(feature = "try-runtime"))]
+		if cfg_rt_inline!(feature = "try-runtime") {
+			unreachable!();
+		}
+	}
+
+
+	#[cfg(feature = "runtime-benchmarks")]
+	#[test]
+	fn test_inline_2() {
+		if cfg_rt_inline!(feature = "runtime-benchmarks") {
+		} else {
+			unreachable!();
+		}
+	}
+
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	#[test]
+	fn test_inline_2() {
+		if cfg_rt_inline!(not(feature = "runtime-benchmarks")) {
+		} else {
+			unreachable!();
+		}
+	}
+
+	#[cfg(feature = "try-runtime")]
+	#[test]
+	fn test_inline_3() {
+		if cfg_rt_inline!(feature = "try-runtime") {
+		} else {
+			unreachable!();
+		}
+	}
+
+	#[cfg(not(feature = "try-runtime"))]
+	#[test]
+	fn test_inline_3() {
+		if cfg_rt_inline!(not(feature = "try-runtime")) {
+		} else {
+			unreachable!();
+		}
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/paritytech/polkadot-sdk/issues/5101

Introduce a new macro in sp-runtime: `cfg_rt`.

this macro is same as `cfg` but allows 2 more feature: `sp-runtime/try-runtime` and `sp-runtime/runtime-benchmarks`.

This allows crate to use `sp-runtime` features and not having to declare any new features.

usage:

```rust
#[sp_runtime::cfg_rt(feature = "sp-runtime/try-runtime")]
fn some_function() {
	println!("try-runtime is enabled");
}
                                                                                            
#[sp_runtime::cfg_rt(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
fn some_function() {
	println!("try-runtime and std are enabled");
}
```

Also note that attribute macro on expression are not stable.

like this is invalid:
```rust
fn some_function() {
    #[sp_runtime::cfg_rt(all(feature = "std", feature = "sp-runtime/runtime-benchmarks"))]
    {}
}
```

Also alternative to `cfg!(..)` macro:
```rust
if sp_runtime::cfg_rt_inline!(feature = "sp-runtime/runtime-benchmarks") {
    // Some feature gated code
}
```