### PR TITLE
[CI] Cache try-runtime check

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -133,7 +133,7 @@ jobs:
           path: |
             snapshot.raw
             ${{ steps.get-date.outputs.today }}
-          key: try-runtime-snapshot-${{ matrix.network }}-daily
+          key: try-runtime-snapshot-${{ matrix.network }}-daily-${{ steps.get-date.outputs.today }}
         
       - name: Build Runtime
         run: |

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -138,5 +138,5 @@ jobs:
           echo "---------- Executing on-runtime-upgrade for ${{ matrix.network }} ----------"
           time ./try-runtime ${{ matrix.command_extra_args }} \
               --runtime ./target/release/wbuild/${{ matrix.package }}/${{ matrix.wasm }} \
-              on-runtime-upgrade --disable-spec-version-check --checks=all ${{ matrix.subcommand_extra_args }} live --uri ${{ matrix.uri }}
+              on-runtime-upgrade --disable-spec-version-check --checks=all ${{ matrix.subcommand_extra_args }} snap -p snapshot.raw
           sleep 5

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -106,7 +106,7 @@ jobs:
         shell: bash
 
       - name: Download Snapshot
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           # We use a file-name as key here to avoid creating one snapshot per network per day, which
           # could result in a lot of old snapshots being kept around.
@@ -136,6 +136,16 @@ jobs:
           touch ${{ steps.get-date.outputs.today }}
 
           ./try-runtime create-snapshot --uri ${{ matrix.uri }} snapshot.raw
+      
+        # Upload the snapshot ASAP to prevent other jobs from also creating snapshots. Its not a
+        # problem, but a waste of time.
+      - name: Upload Snapshot
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            snapshot.raw
+            ${{ steps.get-date.outputs.today }}
+          key: try-runtime-snapshot-${{ matrix.network }}-daily
         
       - name: Build Runtime
         run: |

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -99,6 +99,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Download CLI
+        run: |
+          curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.7.0/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+          chmod +x ./try-runtime
+          echo "Using try-runtime-cli version:"
+          ./try-runtime --version
+
       - name: Get Date
         id: get-date
         run: |
@@ -108,37 +115,18 @@ jobs:
       - name: Download Snapshot
         uses: actions/cache/restore@v4
         with:
-          # We use a file-name as key here to avoid creating one snapshot per network per day, which
-          # could result in a lot of old snapshots being kept around.
-          path: |
-            snapshot.raw
-            ${{ steps.get-date.outputs.today }}
-          key: try-runtime-snapshot-${{ matrix.network }}-daily
-      
-      - name: Delete Stale Snapshot
-        if: ${{ hashFiles(steps.get-date.outputs.today) == '' }}
-        run: |
-          echo "No or stale snapshot for today (${{ steps.get-date.outputs.today }}); deleting."
-          rm -f snapshot.raw
-      
-      - name: Download CLI
-        run: |
-          echo "---------- Downloading try-runtime CLI ----------"
-          curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.4/try-runtime-x86_64-unknown-linux-musl -o try-runtime
-          chmod +x ./try-runtime
-          echo "Using try-runtime-cli version:"
-          ./try-runtime --version
+          path: snapshot.raw
+          key: try-runtime-snapshot-${{ matrix.network }}-daily-${{ steps.get-date.outputs.today }}
 
-      - name: Create Snapshot
+      - name: Create Snapshot If Not Exists
         if: ${{ hashFiles('snapshot.raw') == '' }}
         run: |
           echo "Creating new snapshot for today (${{ steps.get-date.outputs.today }})"
-          touch ${{ steps.get-date.outputs.today }}
-
           ./try-runtime create-snapshot --uri ${{ matrix.uri }} snapshot.raw
       
-        # Upload the snapshot ASAP to prevent other jobs from also creating snapshots. Its not a
-        # problem, but a waste of time.
+      # Upload the snapshot ASAP to prevent other jobs from also creating snapshots. Its not a
+      # problem, but a waste of time. If two jobs try to upload to a key, only one will acquire the
+      # key with write permission. Luckily this only emits a warning and doesn't fail the job.
       - name: Upload Snapshot
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -116,10 +116,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: snapshot.raw
-          key: try-runtime-snapshot-${{ matrix.network }}-${{ steps.get-date.outputs.today }}-wip
+          key: try-runtime-snapshot-${{ matrix.network }}-${{ steps.get-date.outputs.today }}
           save-always: true
 
-      - name: Create Snapshot If Not Exists
+      - name: Create Snapshot If Stale
         if: ${{ hashFiles('snapshot.raw') == '' }}
         run: |
           echo "Creating new snapshot for today (${{ steps.get-date.outputs.today }})"

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: snapshot.raw
-          key: try-runtime-snapshot-${{ matrix.network }}-daily-${{ steps.get-date.outputs.today }}
+          key: try-runtime-snapshot-${{ matrix.network }}-${{ steps.get-date.outputs.today }}-wip
 
       - name: Create Snapshot If Not Exists
         if: ${{ hashFiles('snapshot.raw') == '' }}

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           path: snapshot.raw
           key: try-runtime-snapshot-${{ matrix.network }}-${{ steps.get-date.outputs.today }}-wip
+          save-always: true
 
       - name: Create Snapshot If Not Exists
         if: ${{ hashFiles('snapshot.raw') == '' }}

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -135,7 +135,7 @@ jobs:
           echo "Creating new snapshot for today (${{ steps.get-date.outputs.today }})"
           touch ${{ steps.get-date.outputs.today }}
 
-          try-runtime create-snapshot --uri ${{ matrix.uri }} snapshot.raw
+          ./try-runtime create-snapshot --uri ${{ matrix.uri }} snapshot.raw
         
       - name: Build Runtime
         run: |

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -113,7 +113,7 @@ jobs:
         shell: bash
 
       - name: Download Snapshot
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: snapshot.raw
           key: try-runtime-snapshot-${{ matrix.network }}-daily-${{ steps.get-date.outputs.today }}
@@ -123,18 +123,7 @@ jobs:
         run: |
           echo "Creating new snapshot for today (${{ steps.get-date.outputs.today }})"
           ./try-runtime create-snapshot --uri ${{ matrix.uri }} snapshot.raw
-      
-      # Upload the snapshot ASAP to prevent other jobs from also creating snapshots. Its not a
-      # problem, but a waste of time. If two jobs try to upload to a key, only one will acquire the
-      # key with write permission. Luckily this only emits a warning and doesn't fail the job.
-      - name: Upload Snapshot
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            snapshot.raw
-            ${{ steps.get-date.outputs.today }}
-          key: try-runtime-snapshot-${{ matrix.network }}-daily-${{ steps.get-date.outputs.today }}
-        
+
       - name: Build Runtime
         run: |
           echo "---------- Building ${{ matrix.package }} runtime ----------"

--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -27,7 +29,9 @@ jobs:
   # rococo and westend are disabled for now (no access to parity-chains.parity.io)
   check-runtime-migration:
     runs-on: arc-runners-polkadot-sdk-beefy
-    timeout-minutes: 40
+    # We need to set this to rather long to allow the snapshot to be created, but the average time
+    # should be much lower.
+    timeout-minutes: 60
     needs: [set-image]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -94,19 +98,54 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: script
-        run: |
-          echo "Running ${{ matrix.network }} runtime migration check"
-          export RUST_LOG=remote-ext=debug,runtime=debug
 
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "today=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Download Snapshot
+        uses: actions/cache@v4
+        with:
+          # We use a file-name as key here to avoid creating one snapshot per network per day, which
+          # could result in a lot of old snapshots being kept around.
+          path: |
+            snapshot.raw
+            ${{ steps.get-date.outputs.today }}
+          key: try-runtime-snapshot-${{ matrix.network }}-daily
+      
+      - name: Delete Stale Snapshot
+        if: ${{ hashFiles(steps.get-date.outputs.today) == '' }}
+        run: |
+          echo "No or stale snapshot for today (${{ steps.get-date.outputs.today }}); deleting."
+          rm -f snapshot.raw
+      
+      - name: Download CLI
+        run: |
           echo "---------- Downloading try-runtime CLI ----------"
           curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.4/try-runtime-x86_64-unknown-linux-musl -o try-runtime
           chmod +x ./try-runtime
           echo "Using try-runtime-cli version:"
           ./try-runtime --version
 
+      - name: Create Snapshot
+        if: ${{ hashFiles('snapshot.raw') == '' }}
+        run: |
+          echo "Creating new snapshot for today (${{ steps.get-date.outputs.today }})"
+          touch ${{ steps.get-date.outputs.today }}
+
+          try-runtime create-snapshot --uri ${{ matrix.uri }} snapshot.raw
+        
+      - name: Build Runtime
+        run: |
           echo "---------- Building ${{ matrix.package }} runtime ----------"
-          time forklift cargo build --release --locked -p ${{ matrix.package }} --features try-runtime
+          time forklift cargo build --release --locked -p ${{ matrix.package }} --features try-runtime -q
+
+      - name: Run Check
+        run: |
+          echo "Running ${{ matrix.network }} runtime migration check"
+          export RUST_LOG=remote-ext=debug,runtime=debug
 
           echo "---------- Executing on-runtime-upgrade for ${{ matrix.network }} ----------"
           time ./try-runtime ${{ matrix.command_extra_args }} \


### PR DESCRIPTION
Adds a snapshot step to the try-runtime check that tries to download a cached snapshot.  
The cache is valid for the current day and is otherwise re-created.

Check is now only limited by build time and docker startup.

![Screenshot 2024-07-30 at 02 02 58](https://github.com/user-attachments/assets/0773e9b9-4a52-4572-a891-74b9d725ba70)

![Screenshot 2024-07-30 at 02 02 20](https://github.com/user-attachments/assets/4685ef17-a04c-4bdc-9d61-311d0010f71c)

