### PR TITLE
Adjust sync templates flow to use new release branch

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -21,7 +21,9 @@ on:
       crate_release_version:
         description: 'A release version to use, e.g. 1.9.0'
         required: true
-
+      stable_release_branch:
+        description: 'Stable release branch, e.g. stable2407'
+        required: true
 
 jobs:
   sync-templates:
@@ -44,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: polkadot-sdk
-          ref: "release-crates-io-v${{ github.event.inputs.crate_release_version }}"
+          ref: "${{ github.event.inputs.stable_release_branch }}"
       - name: Generate a token for the template repository
         id: app_token
         uses: actions/create-github-app-token@v1.9.3

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -18,9 +18,6 @@ on:
   # A manual dispatch for now - automatic on releases later.
   workflow_dispatch:
     inputs:
-      crate_release_version:
-        description: 'A release version to use, e.g. 1.9.0'
-        required: true
       stable_release_branch:
         description: 'Stable release branch, e.g. stable2407'
         required: true
@@ -125,7 +122,7 @@ jobs:
           cp -r polkadot-sdk/templates/${{ matrix.template }}/* "${{ env.template-path }}/"
 
       - name: Run psvm on monorepo workspace dependencies
-        run: psvm -o -v ${{ github.event.inputs.crate_release_version }} -p ./Cargo.toml
+        run: psvm -o -v ${{ github.event.inputs.stable_release_branch }} -p ./Cargo.toml
         working-directory: polkadot-sdk/
       - name: Copy over required workspace dependencies
         run: |
@@ -166,12 +163,12 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           add-paths: |
             ./*
-          title: "[Don't merge] Update the ${{ matrix.template }} template to ${{ github.event.inputs.crate_release_version }}"
+          title: "[Don't merge] Update the ${{ matrix.template }} template to ${{ github.event.inputs.stable_release_branch }}"
           body: "The template has NOT been successfully built and needs to be inspected."
-          branch: "update-template/${{ github.event.inputs.crate_release_version }}"
+          branch: "update-template/${{ github.event.inputs.stable_release_branch }}"
       - name: Push changes
         run: |
           git add -A .
-          git commit --allow-empty -m "Update to ${{ github.event.inputs.crate_release_version }} triggered by ${{ github.event_name }}"
+          git commit --allow-empty -m "Update to ${{ github.event.inputs.stable_release_branch }} triggered by ${{ github.event_name }}"
           git push
         working-directory: "${{ env.template-path }}"

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -71,8 +71,8 @@ jobs:
 
       # 2. Yanking the template out of the monorepo workspace.
 
-      - name: Use psvm to replace git references with released creates.
-        run: find . -type f -name 'Cargo.toml' -exec psvm -o -v ${{ github.event.inputs.crate_release_version }} -p {} \;
+      - name: Replace dev-dependencies path references with workspace references
+        run: find . -type f -name 'Cargo.toml' -exec sed -i'' -E "s/path = \"\.\.\/.*\"/workspace = true/g" {} \; 
         working-directory: polkadot-sdk/templates/${{ matrix.template }}/
       - name: Create a new workspace Cargo.toml
         run: |


### PR DESCRIPTION
As the release branch name changed starting from this release, this PR adds it to the sync templates flow so that checkout step worked properly.