### PR TITLE
[CI] Create Audited command

### DIFF
--- a/.github/commands-readme.md
+++ b/.github/commands-readme.md
@@ -8,12 +8,14 @@ To run an action, you need to go to the [_actions tab_](https://github.com/parit
 
 The current available command actions are:
 
+- [Command Audit](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-audit.yml)
 - [Command FMT](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-fmt.yml)
 - [Command Update UI](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-update-ui.yml)
 - [Command Sync](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-sync.yml)
 - [Command Bench](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-bench.yml)
 - [Command Bench All](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-bench-all.yml)
 - [Command Bench Overhead](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-bench-overhead.yml)
+
 
 You need to select the action, and click on the dropdown that says: `Run workflow`. It is located in the upper right.
 
@@ -34,6 +36,18 @@ You can use [`gh cli`](https://cli.github.com/) to run the commands too. Refers 
 The number of the pull request. Required so the action can fetch the correct branch and comment if it fails.
 
 ## Action configurations
+
+### Audit
+
+This action can be used to mark a Pull Request as audited or trivial. It is intended to be used either by developers or auditors to advance the `audited` tag.
+
+It needs to be used exactly in the order of unaudited Pull Requests that you can see [here](https://github.com/paritytech/polkadot-sdk/compare/audited...master). Only the top Pull Request number will work. After that, the next one can be marked as audited.
+
+You can use the following [`gh cli`](https://cli.github.com/) inside the repo:
+
+```bash
+gh workflow run command-audit.yml -f pr=1000
+```
 
 ### FMT
 

--- a/.github/workflows/command-audit.yml
+++ b/.github/workflows/command-audit.yml
@@ -1,0 +1,67 @@
+name: Command Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Number of the audited Pull Request
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  TAG: audited
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Download repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gh cli
+        run: |
+          wget -q https://github.com/cli/cli/releases/download/v2.51.0/gh_2.51.0_linux_amd64.tar.gz -O gh.tar.gz && \
+          tar -xzf gh.tar.gz && mv gh_2.51.0_linux_amd64/bin/gh /usr/local/bin/gh && rm gh.tar.gz
+          chmod +x /usr/local/bin/gh
+
+      - name: Extract Merge Commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MERGE_COMMIT=$(gh pr view ${{ inputs.pr }} --json mergeCommit --jq '.mergeCommit.oid')
+          echo "MERGE_COMMIT=$MERGE_COMMIT" >> $GITHUB_ENV
+      
+      - name: Check Commit
+        run: |
+          # Check that the parent of the MERGE_COMMIT is the '$TAG' tag.
+          git fetch origin refs/tags/$TAG:refs/tags/$TAG
+          
+          MERGE_COMMIT_PARENT=$(git rev-parse $MERGE_COMMIT^)
+          AUDITED_TAG=$(git rev-parse $TAG)
+
+          if [ "$MERGE_COMMIT_PARENT" != "$AUDITED_TAG" ]; then
+            echo "The parent of the merge commit is not the $TAG tag. Commit not audited: $MERGE_COMMIT_PARENT"
+            exit 1
+          fi
+
+      - name: Force Push the audited tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git tag -f $TAG $MERGE_COMMIT
+          git push origin $TAG --force
+
+      - name: Report success
+        run: gh pr comment ${{ inputs.pr }} --body "This Merge Request has been marked as audited or trivial by @${{ github.actor }} via <a href=\"$RUN\">CI</a>."
+        env:
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ github.token }}

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -20,3 +20,9 @@ production networks. If in doubt, ask in chat or in the Merge Request.
 2. Set status to Backlog
 3. Assign priority, considering the universe of PRs currently in the backlog
 4. Add the component
+
+## Marking a Pull Request as audited or trivial
+
+The [audit command](../.github/commands-readme.md) can be used to mark a Pull Request as audited or trivial. It is intended to be used by auditors or developers.
+
+This command advances the `audited` tag by exactly one commit. It therefore needs to be used on the Pull Requests exactly in the order being shown [here](https://github.com/paritytech/polkadot-sdk/compare/audited...master).


### PR DESCRIPTION
Creates a new bot that can be used to advance the `audited` tag by the next commit in [this](https://github.com/paritytech/polkadot-sdk/compare/audited...master) list.

## Example

With the new release process, audits need to happen in the order that merge requests got merged into master (or earlier, if the developers want to get feedback from the auditors).  

You can therefore see the audit TODO list when listing [all commits](https://github.com/paritytech/polkadot-sdk/compare/audited...master) that are on `master`, but not yet on the `audited` tag:

![Screenshot 2024-07-30 at 23 15 24](https://github.com/user-attachments/assets/c3adfe55-16ed-4f19-a644-886e189239b0)

Now when the next audit happens and concludes that `Fix landlock presence test` is safe to deploy, you click [here](https://github.com/paritytech/polkadot-sdk/actions/workflows/command-audit.yml) (TODO fixup link after merge) and enter the Merge Request number:

![Screenshot 2024-07-30 at 23 18 17](https://github.com/user-attachments/assets/fabac104-90e0-4e00-9f8a-80d901114201)

This will then advance the `audited` that and include this change in the next release.  
If a change is found to be _not_ safe to deploy, it may either be reverted or hotfixed. All intermediate commits between the faulty commit and the fix (or reversion) need to be audited and the `audited` tag be advanced in bulk (TODO add this to the action).