### PR TITLE
Bump authoring duration for async backing to 2s.

### DIFF
--- a/cumulus/polkadot-parachain/src/service.rs
+++ b/cumulus/polkadot-parachain/src/service.rs
@@ -832,7 +832,7 @@ where
 				relay_chain_slot_duration,
 				proposer: Proposer::new(proposer_factory),
 				collator_service,
-				authoring_duration: Duration::from_millis(1500),
+				authoring_duration: Duration::from_millis(2000),
 				reinitialize: false,
 			},
 		};

--- a/docs/sdk/src/guides/async_backing_guide.rs
+++ b/docs/sdk/src/guides/async_backing_guide.rs
@@ -174,7 +174,7 @@
 //!    - In the `para_client` field, pass in a cloned para client rather than the original
 //!    - Add a `para_backend` parameter after `para_client`, passing in our para backend
 //!    - Provide a `code_hash_provider` closure like that shown below
-//!    - Increase `authoring_duration` from 500 milliseconds to 1500
+//!    - Increase `authoring_duration` from 500 milliseconds to 2000
 //! ```ignore
 //! let params = AuraParams {
 //!     ..
@@ -185,7 +185,7 @@
 //!         client.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
 //!     },
 //!     ..
-//!     authoring_duration: Duration::from_millis(1500),
+//!     authoring_duration: Duration::from_millis(2000),
 //!     ..
 //! };
 //! ```

--- a/prdoc/pr_5195.prdoc
+++ b/prdoc/pr_5195.prdoc
@@ -1,0 +1,9 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Bump Aura authoring duration to 2s.
+
+doc:
+  - audience: Node Dev
+    description: |
+      This PR bumps the Aura authoring duration in the asynchronous backing guide to 2s in order to make better use of the provided coretime.

--- a/prdoc/pr_5195.prdoc
+++ b/prdoc/pr_5195.prdoc
@@ -6,4 +6,10 @@ title: Bump Aura authoring duration to 2s.
 doc:
   - audience: Node Dev
     description: |
-      This PR bumps the Aura authoring duration in the asynchronous backing guide to 2s in order to make better use of the provided coretime.
+      This PR bumps the Aura authoring duration in the asynchronous backing
+      guide and the polkadot-parachain service file to 2s in order to make
+      better use of the provided coretime.
+
+crates:
+  - name: polkadot-parachain-bin
+    bump: patch


### PR DESCRIPTION
Should be safe on all production network. 

I noticed that Paseo needs to be updated, it is lacking behind in a couple of things.

Execution environment parameters should be updated to those of Polkadot:

```
[
      {
        MaxMemoryPages: 8,192
      }
      {
        PvfExecTimeout: [
          Backing
          2,500
        ]
      }
      {
        PvfExecTimeout: [
          Approval
          15,000
        ]
      }
    ]
  ]
  ```
  
