### PR TITLE
Bring reference_hardware.json inline with machine used for weights

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/src/machine/reference_hardware.json
+++ b/substrate/utils/frame/benchmarking-cli/src/machine/reference_hardware.json
@@ -1,7 +1,7 @@
 [
 	{
 		"metric": "Blake2256",
-		"minimum": 783.27
+		"minimum": 968.31
 	},
 	{
 		"metric": "Sr25519Verify",


### PR DESCRIPTION
Since https://github.com/paritytech/substrate/pull/13548 optimization, `Blake2256` is faster with about 20%, that means that there is a difference of ~20% between the benchmark values we ask validators to run against and the machine we use for generating the weights.

So if all validators, just barely pass the benchmarks our weights are potentially underestimated with about ~20%, so let's bring this two in sync.

## Results

Generated on machine from here: https://github.com/paritytech/devops/pull/3210
```
+----------+----------------+-------------+-------------+-------------------+
| Category | Function       | Score       | Minimum     | Result            |
+===========================================================================+
| CPU      | BLAKE2-256     | 968.31 MiBs | 783.27 MiBs | ✅ Pass (123.6 %) |
|----------+----------------+-------------+-------------+-------------------|
| CPU      | SR25519-Verify | 583.67 KiBs | 560.67 KiBs | ✅ Pass (104.1 %) |
|----------+----------------+-------------+-------------+-------------------|
| Memory   | Copy           | 12.21 GiBs  | 11.49 GiBs  | ✅ Pass (106.3 %) |
```

Discovered and discussed here: https://github.com/paritytech/polkadot-sdk/pull/5127#issuecomment-2258423469 