### PR TITLE
make polkadot-parachain startup errors pretty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13846,6 +13846,7 @@ dependencies = [
  "bridge-hub-westend-runtime",
  "clap 4.5.11",
  "collectives-westend-runtime",
+ "color-eyre",
  "color-print",
  "contracts-rococo-runtime",
  "coretime-rococo-runtime",

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 async-trait = { workspace = true }
 clap = { features = ["derive"], workspace = true }
 codec = { workspace = true, default-features = true }
+color-eyre = { workspace = true }
 color-print = { workspace = true }
 futures = { workspace = true }
 hex-literal = { workspace = true, default-features = true }

--- a/cumulus/polkadot-parachain/src/main.rs
+++ b/cumulus/polkadot-parachain/src/main.rs
@@ -50,6 +50,7 @@ mod fake_runtime_api;
 mod rpc;
 mod service;
 
-fn main() -> sc_cli::Result<()> {
-	command::run()
+fn main() -> color_eyre::eyre::Result<()> {
+	color_eyre::install()?;
+	Ok(command::run()?)
 }

--- a/prdoc/pr_5214.prdoc
+++ b/prdoc/pr_5214.prdoc
@@ -1,0 +1,11 @@
+title: make polkadot-parachain startup errors pretty
+
+doc:
+  - audience: Node Operator
+    description: |
+      Changed the format of how polkadot-parachain prints the startup errors to include
+      the full displayable context.
+
+crates:
+  - name: polkadot-parachain-bin
+    bump: minor


### PR DESCRIPTION
The errors on polkadot-parachain are not printed with their full display context(what is marked with `#[error(`) because main  returns plain Result and the error will be shown in its  Debug format, that's not consistent with how the polkadot binary behave and is not user friendly since it does not tell them why they got the error. 

Fix it by using `color_eyre` as polkadot already does it. 

Fixes: https://github.com/paritytech/polkadot-sdk/issues/5211

## Output before
```
Error: NetworkKeyNotFound("/acala/data/Collator2/chains/mandala-tc9/network/secret_ed25519")
```

## Output after
```
Error: 
   0: Starting an authorithy without network key in /home/alexggh/.local/share/polkadot-parachain/chains/asset-hub-kusama/network/secret_ed25519.
      
       This is not a safe operation because other authorities in the network may depend on your node having a stable identity.
      
       Otherwise these other authorities may not being able to reach you.
      
       If it is the first time running your node you could use one of the following methods:
      
       1. [Preferred] Separately generate the key with: <NODE_BINARY> key generate-node-key --base-path <YOUR_BASE_PATH>
      
       2. [Preferred] Separately generate the key with: <NODE_BINARY> key generate-node-key --file <YOUR_PATH_TO_NODE_KEY>
      
       3. [Preferred] Separately generate the key with: <NODE_BINARY> key generate-node-key --default-base-path
      
       4. [Unsafe] Pass --unsafe-force-node-key-generation and make sure you remove it for subsequent node restarts

```