### PR TITLE
Parameters benchmarkings

### DIFF
--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -193,7 +193,12 @@ pub mod pallet {
 	}
 
 	/// Stored parameters.
+	/// 
+	/// ## Storage Whitelist
+	/// Since we account for all parameters read weight for each block,
+	/// don't double count it in other pallet benchmarks
 	#[pallet::storage]
+	#[pallet::whitelist_storage]
 	pub type Parameters<T: Config> =
 		StorageMap<_, Blake2_128Concat, KeyOf<T>, ValueOf<T>, OptionQuery>;
 

--- a/substrate/frame/parameters/src/lib.rs
+++ b/substrate/frame/parameters/src/lib.rs
@@ -167,6 +167,15 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
+			let items = Parameters::<T>::iter().count() as u64;
+
+			Weight::zero().saturating_add(T::DbWeight::get().reads(items))
+		}
+	}
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {


### PR DESCRIPTION
Account for all parameters read weight on every block, and whitelist the parameters storage so the weight is not double counted.