### PR TITLE
Remove unused feature gated code from the minimal template

### DIFF
--- a/templates/minimal/node/src/command.rs
+++ b/templates/minimal/node/src/command.rs
@@ -23,9 +23,6 @@ use crate::{
 use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
 
-#[cfg(feature = "try-runtime")]
-use try_runtime_cli::block_building_info::timestamp_with_aura_info;
-
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
 		"Substrate Node".into()

--- a/templates/minimal/node/src/service.rs
+++ b/templates/minimal/node/src/service.rs
@@ -27,11 +27,6 @@ use std::sync::Arc;
 
 use crate::cli::Consensus;
 
-#[cfg(feature = "runtime-benchmarks")]
-type HostFunctions =
-	(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions);
-
-#[cfg(not(feature = "runtime-benchmarks"))]
 type HostFunctions = sp_io::SubstrateHostFunctions;
 
 #[docify::export]


### PR DESCRIPTION
- Progresses https://github.com/paritytech/polkadot-sdk/issues/5226

There is no actual `try-runtime` or `runtime-benchmarks` functionality in the minimal template at the moment.
