### PR TITLE
A more relaxed way to define `DefaultConfig` for pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14641,6 +14641,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
  "sp-offchain",

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -160,7 +160,10 @@ impl frame_system::Config for Runtime {
 	type BlockLength = RuntimeBlockLength;
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+	type AccountData = frame_system::AccountInfo<<Self as frame_system::Config>::Nonce, ()>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type SystemWeightInfo = weights::frame_system::WeightInfo<Self>;
+	type DbWeight = RocksDbWeight;
 }
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/weights/mod.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/weights/mod.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 pub mod cumulus_pallet_parachain_system;
+pub mod frame_system;
 pub mod pallet_glutton;
 pub mod pallet_message_queue;
 pub mod pallet_timestamp;

--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -203,7 +203,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;

--- a/docs/sdk/src/reference_docs/chain_spec_runtime/src/runtime.rs
+++ b/docs/sdk/src/reference_docs/chain_spec_runtime/src/runtime.rs
@@ -81,7 +81,7 @@ parameter_types! {
 }
 
 /// Implements the types required for the system pallet.
-#[derive_impl(frame_system::config_preludes::SolochainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type Block = Block;
 	type Version = Version;

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -149,7 +149,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-#[derive_impl(frame_system::config_preludes::RelayChainDefaultConfig)]
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type BlockWeights = BlockWeights;
 	type BlockLength = BlockLength;

--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -46,6 +46,7 @@ sp-consensus-aura = { optional = true, workspace = true }
 sp-consensus-grandpa = { optional = true, workspace = true }
 sp-inherents = { optional = true, workspace = true }
 sp-storage = { optional = true, workspace = true }
+sp-genesis-builder ={ optional = true, workspace = true }
 
 frame-executive = { optional = true, workspace = true }
 frame-system-rpc-runtime-api = { optional = true, workspace = true }
@@ -77,6 +78,7 @@ runtime = [
 	"sp-storage",
 	"sp-transaction-pool",
 	"sp-version",
+	"sp-genesis-builder",
 
 	"frame-executive",
 	"frame-system-rpc-runtime-api",
@@ -106,6 +108,7 @@ std = [
 	"sp-storage/std",
 	"sp-transaction-pool?/std",
 	"sp-version?/std",
+	"sp-genesis-builder?/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -204,6 +204,12 @@ pub mod runtime {
 		/// Macro to implement runtime APIs.
 		pub use sp_api::impl_runtime_apis;
 
+		/// Some types often used in `impl_runtime_apis`
+		pub use frame_support::genesis_builder_helper::*;
+		pub use sp_core::OpaqueMetadata;
+		pub use sp_inherents::{CheckInherentsResult, InherentData};
+		pub use sp_runtime::{ApplyExtrinsicResult, ExtrinsicInclusionMode};
+
 		#[cfg(feature = "std")]
 		pub use sp_version::NativeVersion;
 	}
@@ -215,7 +221,7 @@ pub mod runtime {
 	/// A non-testing runtime should have this enabled, as such:
 	///
 	/// ```
-	/// use polkadot_sdk_frame::runtime::{prelude::*, apis::{*,}};
+	/// use polkadot_sdk_frame::runtime::{prelude::*, apis};
 	/// ```
 	// TODO: This is because of wildcard imports, and it should be not needed once we can avoid
 	// that. Imports like that are needed because we seem to need some unknown types in the macro
@@ -223,16 +229,12 @@ pub mod runtime {
 	// moved to file similarly.
 	#[allow(ambiguous_glob_reexports)]
 	pub mod apis {
-		// Types often used in the runtime APIs.
-		pub use sp_core::OpaqueMetadata;
-		pub use sp_inherents::{CheckInherentsResult, InherentData};
-		pub use sp_runtime::{ApplyExtrinsicResult, ExtrinsicInclusionMode};
-
 		pub use frame_system_rpc_runtime_api::*;
 		pub use sp_api::{self, *};
 		pub use sp_block_builder::*;
 		pub use sp_consensus_aura::*;
 		pub use sp_consensus_grandpa::*;
+		pub use sp_genesis_builder::*;
 		pub use sp_offchain::*;
 		pub use sp_session::runtime_api::*;
 		pub use sp_transaction_pool::runtime_api::*;

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -341,7 +341,8 @@ pub mod pallet {
 
 		/// A marker type to signal that a certain associated type of `DefaultConfig` needs ot be
 		/// overwritten.
-		pub struct you_cannot_use_derive_impl_on_this_type_please_override_it;
+		#[allow(non_camel_case_types)]
+		pub struct you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 		#[frame_support::register_default_impl(SolochainDefaultConfig)]
 		impl DefaultConfig for SolochainDefaultConfig {
@@ -364,7 +365,7 @@ pub mod pallet {
 			type MaxConsumers = frame_support::traits::ConstU32<128>;
 
 			/// The default data to be stored in an account.
-			type AccountData = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type AccountData = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// What to do if a new account is created.
 			type OnNewAccount = ();
@@ -373,22 +374,22 @@ pub mod pallet {
 			type OnKilledAccount = ();
 
 			/// Weight information for the extrinsics of this pallet.]
-			type SystemWeightInfo = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type SystemWeightInfo = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// This is used as an identifier of the chain.
-			type SS58Prefix = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type SS58Prefix = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// Version of the runtime.
-			type Version = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type Version = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// Block & extrinsics weights: base values and limits.
-			type BlockWeights = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type BlockWeights = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// The maximum length of a block (in bytes).
-			type BlockLength = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type BlockLength = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// The weight of database operations that the runtime can invoke.
-			type DbWeight = you_cannot_use_derive_impl_on_this_type_please_override_it;
+			type DbWeight = you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it;
 
 			/// The ubiquitous event type injected by `construct_runtime!`.
 			#[inject_runtime_type]

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -339,6 +339,10 @@ pub mod pallet {
 		/// * 2s block time, and a default 5mb block size is used.
 		pub struct SolochainDefaultConfig;
 
+		/// A marker type to signal that a certain associated type of `DefaultConfig` needs ot be
+		/// overwritten.
+		pub struct you_cannot_use_derive_impl_on_this_type_please_override_it;
+
 		#[frame_support::register_default_impl(SolochainDefaultConfig)]
 		impl DefaultConfig for SolochainDefaultConfig {
 			/// The default type for storing how many extrinsics an account has signed.
@@ -360,7 +364,7 @@ pub mod pallet {
 			type MaxConsumers = frame_support::traits::ConstU32<128>;
 
 			/// The default data to be stored in an account.
-			type AccountData = crate::AccountInfo<Self::Nonce, ()>;
+			type AccountData = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// What to do if a new account is created.
 			type OnNewAccount = ();
@@ -368,23 +372,23 @@ pub mod pallet {
 			/// What to do if an account is fully reaped from the system.
 			type OnKilledAccount = ();
 
-			/// Weight information for the extrinsics of this pallet.
-			type SystemWeightInfo = ();
+			/// Weight information for the extrinsics of this pallet.]
+			type SystemWeightInfo = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// This is used as an identifier of the chain.
-			type SS58Prefix = ();
+			type SS58Prefix = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// Version of the runtime.
-			type Version = ();
+			type Version = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// Block & extrinsics weights: base values and limits.
-			type BlockWeights = ();
+			type BlockWeights = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// The maximum length of a block (in bytes).
-			type BlockLength = ();
+			type BlockLength = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// The weight of database operations that the runtime can invoke.
-			type DbWeight = ();
+			type DbWeight = you_cannot_use_derive_impl_on_this_type_please_override_it;
 
 			/// The ubiquitous event type injected by `construct_runtime!`.
 			#[inject_runtime_type]
@@ -467,10 +471,12 @@ pub mod pallet {
 
 		/// Block & extrinsics weights: base values and limits.
 		#[pallet::constant]
+		#[pallet::no_default_bounds]
 		type BlockWeights: Get<limits::BlockWeights>;
 
 		/// The maximum length of a block (in bytes).
 		#[pallet::constant]
+		#[pallet::no_default_bounds]
 		type BlockLength: Get<limits::BlockLength>;
 
 		/// The `RuntimeOrigin` type used by dispatchable calls.
@@ -551,10 +557,12 @@ pub mod pallet {
 
 		/// The weight of runtime database operations the runtime can invoke.
 		#[pallet::constant]
+		#[pallet::no_default_bounds]
 		type DbWeight: Get<RuntimeDbWeight>;
 
 		/// Get the chain's in-code version.
 		#[pallet::constant]
+		#[pallet::no_default_bounds]
 		type Version: Get<RuntimeVersion>;
 
 		/// Provides information about the pallet setup in the runtime.
@@ -568,6 +576,7 @@ pub mod pallet {
 
 		/// Data to be associated with an account (other than nonce/transaction counter, which this
 		/// pallet does regardless).
+		#[pallet::no_default_bounds]
 		type AccountData: Member + FullCodec + Clone + Default + TypeInfo + MaxEncodedLen;
 
 		/// Handler for when a new account has just been created.
@@ -578,6 +587,7 @@ pub mod pallet {
 		/// All resources should be cleaned up associated with the given account.
 		type OnKilledAccount: OnKilledAccount<Self::AccountId>;
 
+		#[pallet::no_default_bounds]
 		type SystemWeightInfo: WeightInfo;
 
 		/// The designated SS58 prefix of this chain.
@@ -586,6 +596,7 @@ pub mod pallet {
 		/// that the runtime should know about the prefix in order to make use of it as
 		/// an identifier of the chain.
 		#[pallet::constant]
+		#[pallet::no_default_bounds]
 		type SS58Prefix: Get<u16>;
 
 		/// What to do if the runtime wants to change the code to something new.

--- a/templates/minimal/runtime/src/lib.rs
+++ b/templates/minimal/runtime/src/lib.rs
@@ -30,7 +30,7 @@ use frame::{
 	deps::frame_support::{
 		genesis_builder_helper::{build_state, get_preset},
 		runtime,
-		weights::{FixedFee, NoFee},
+		weights::{constants::RocksDbWeight, FixedFee, NoFee},
 	},
 	prelude::*,
 	runtime::{
@@ -136,6 +136,12 @@ impl frame_system::Config for Runtime {
 	type Version = Version;
 	// Use the account data from the balances pallet
 	type AccountData = pallet_balances::AccountData<<Runtime as pallet_balances::Config>::Balance>;
+	// You would probably want to override these before ever using this template in production.
+	type SystemWeightInfo = ();
+	type DbWeight = RocksDbWeight;
+	type SS58Prefix = ();
+	type BlockLength = ();
+	type BlockWeights = ();
 }
 
 // Implements the types required for the balances pallet.

--- a/templates/parachain/runtime/src/configs/mod.rs
+++ b/templates/parachain/runtime/src/configs/mod.rs
@@ -123,6 +123,10 @@ impl frame_system::Config for Runtime {
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	/// The weight information of this pallet.
+	///
+	/// TODO: override this before deploying this pallet.
+	type SystemWeightInfo = ();
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/templates/solochain/runtime/src/configs/mod.rs
+++ b/templates/solochain/runtime/src/configs/mod.rs
@@ -88,6 +88,10 @@ impl frame_system::Config for Runtime {
 	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
 	type SS58Prefix = SS58Prefix;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	/// The weight information of this pallet.
+	///
+	/// TODO: you want to provide real type before deploying this to production.
+	type SystemWeightInfo = ();
 }
 
 impl pallet_aura::Config for Runtime {


### PR DESCRIPTION
The underlying problem is this: 

In a given pallet, we want to provide defaults for (usually) all `type`s in `TestDefaultConfig`, but for `SolochainDefaultConfig` and such, we might want to provide defaults in only a subset of them. 

https://github.com/paritytech/polkadot-sdk/pull/4689 and https://github.com/paritytech/polkadot-sdk/pull/4965 and https://github.com/paritytech/polkadot-sdk/pull/4056 have all faces this issue one way or another. 

What I have done here is a simple and near zero effort way to fix this. The compromise is that we use a bit more type-safety, but as long as we have at least one test for usage of each `register_default_impl`, we are good. 

The trick is to mark a type that is ambiguous as `#[no_default_bound]`. Then, we can provide a default that actually works in `TestDefaultConfig`, and one that does not in production. 

The error message will look something like this: 

```
  error[E0277]: the trait bound `you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it: polkadot_sdk_frame::prelude::Get<RuntimeDbWeight>` is not satisfied
     --> /Users/kianenigma/Desktop/Parity/polkadot-sdk-2/templates/minimal/runtime/src/lib.rs:133:1
      |
  133 | #[derive_impl(frame_system::config_preludes::SolochainDefaultConfig)]
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `polkadot_sdk_frame::prelude::Get<RuntimeDbWeight>` is not implemented for `you_cannot_use_derive_impl_on_the_associated_type_raising_this_error_please_override_it`
      |
      = help: the following other types implement trait `polkadot_sdk_frame::prelude::Get<T>`:
                <Version as polkadot_sdk_frame::prelude::Get<_I>>
                <NextFeeMultiplierOnEmpty as polkadot_sdk_frame::prelude::Get<FixedU128>>
                <GetDefault as polkadot_sdk_frame::prelude::Get<T>>
                <ConstBool<T> as polkadot_sdk_frame::prelude::Get<bool>>
                <ConstBool<T> as polkadot_sdk_frame::prelude::Get<core::option::Option<bool>>>
                <ConstU8<T> as polkadot_sdk_frame::prelude::Get<u8>>
                <ConstU8<T> as polkadot_sdk_frame::prelude::Get<core::option::Option<u8>>>
                <ConstU16<T> as polkadot_sdk_frame::prelude::Get<u16>>
              and 29 others
  note: required by a bound in `polkadot_sdk_frame::prelude::frame_system::Config::DbWeight`
     --> /Users/kianenigma/Desktop/Parity/polkadot-sdk-2/substrate/frame/system/src/lib.rs:562:18
      |
  562 |         type DbWeight: Get<RuntimeDbWeight>;
      |                        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `Config::DbWeight`
      = note: this error originates in the attribute macro `derive_impl` which comes from the expansion of the macro `frame::deps::frame_support::macro_magic::forward_tokens_verbatim` (in Nightly builds, run with -Z macro-backtrace for more info)
```