### PR TITLE
Github Actions workflow to automatically sync critical forks

### DIFF
--- a/.github/workflows/fork-sync-action.yml
+++ b/.github/workflows/fork-sync-action.yml
@@ -1,0 +1,20 @@
+# This Workflow is not supposed to run in the paritytech/polkadot-sdk repo.
+# This Workflow is supposed to run only in the forks of the repo, 
+# paritytech-release/polkadot-sdk specifically,
+# to automatically maintain the critical fork synced with the upstream.
+# This Workflow should be always disabled in the paritytech/polkadot-sdk repo.
+
+name: Sync the forked repo with the upstream
+on:
+  schedule:
+    - cron: "0 0/4 * * *"
+  workflow_dispatch:
+
+jobs:
+     job_sync_branches:
+      uses: paritytech-release/sync-workflows/.github/workflows/sync-with-upstream.yml@latest
+      with:
+        fork_writer_app_id: ${{ vars.UPSTREAM_CONTENT_SYNC_APP_ID}}
+        fork_owner: ${{ vars.RELEASE_ORG}}
+      secrets:
+        fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}


### PR DESCRIPTION
This Workflow is not supposed to run in the paritytech/polkadot-sdk repo. This Workflow is supposed to run only in the forks of the repo, in `paritytech-release/polkadot-sdk` specifically, to automatically maintain the critical fork synced with the upstream. This Workflow should be always disabled in the paritytech/polkadot-sdk repo.