### PR TITLE
Benchmark pov overhead

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/src/extrinsic/bench.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/extrinsic/bench.rs
@@ -156,12 +156,6 @@ where
 			ext_builder
 		} else {
 			let proof_size = builder.estimate_block_size(true) - builder.estimate_block_size(false);
-			println!(
-				"HEYYYY: {}, with: {}, without: {}",
-				proof_size,
-				builder.estimate_block_size(true),
-				builder.estimate_block_size(false)
-			);
 			return Ok((builder.build()?.block, None, proof_size as u64))
 		};
 

--- a/substrate/utils/frame/benchmarking-cli/src/overhead/cmd.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/overhead/cmd.rs
@@ -120,16 +120,23 @@ impl OverheadCmd {
 
 		// per-block execution overhead
 		{
-			let stats = bench.bench_block()?;
+			let (stats, proof_size) = bench.bench_block()?;
 			info!("Per-block execution overhead [ns]:\n{:?}", stats);
-			let template = TemplateData::new(BenchmarkType::Block, &cfg, &self.params, &stats)?;
+			let template =
+				TemplateData::new(BenchmarkType::Block, &cfg, &self.params, &stats, proof_size)?;
 			template.write(&self.params.weight.weight_path)?;
 		}
 		// per-extrinsic execution overhead
 		{
-			let stats = bench.bench_extrinsic(ext_builder)?;
+			let (stats, proof_size) = bench.bench_extrinsic(ext_builder)?;
 			info!("Per-extrinsic execution overhead [ns]:\n{:?}", stats);
-			let template = TemplateData::new(BenchmarkType::Extrinsic, &cfg, &self.params, &stats)?;
+			let template = TemplateData::new(
+				BenchmarkType::Extrinsic,
+				&cfg,
+				&self.params,
+				&stats,
+				proof_size,
+			)?;
 			template.write(&self.params.weight.weight_path)?;
 		}
 

--- a/substrate/utils/frame/benchmarking-cli/src/overhead/template.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/overhead/template.rs
@@ -18,6 +18,7 @@
 //! Converts a benchmark result into [`TemplateData`] and writes
 //! it into the `weights.hbs` template.
 
+use frame_support::pallet_prelude::Weight;
 use sc_cli::Result;
 use sc_service::Configuration;
 
@@ -59,8 +60,10 @@ pub(crate) struct TemplateData {
 	params: OverheadParams,
 	/// Stats about the benchmark result.
 	stats: Stats,
-	/// The resulting weight in ns.
-	weight: u64,
+	/// The resulting ref time weight.
+	ref_time: u64,
+	/// The size of the proof weight.
+	proof_size: u64,
 }
 
 impl TemplateData {
@@ -70,8 +73,9 @@ impl TemplateData {
 		cfg: &Configuration,
 		params: &OverheadParams,
 		stats: &Stats,
+		proof_size: u64,
 	) -> Result<Self> {
-		let weight = params.weight.calc_weight(stats)?;
+		let ref_time = params.weight.calc_weight(stats)?;
 		let header = params
 			.header
 			.as_ref()
@@ -91,7 +95,8 @@ impl TemplateData {
 			args: env::args().collect::<Vec<String>>(),
 			params: params.clone(),
 			stats: stats.clone(),
-			weight,
+			ref_time,
+			proof_size: params.bench.enable_proof_size.then(|| proof_size).unwrap_or(0),
 		})
 	}
 

--- a/substrate/utils/frame/benchmarking-cli/src/overhead/weights.hbs
+++ b/substrate/utils/frame/benchmarking-cli/src/overhead/weights.hbs
@@ -18,9 +18,9 @@ use sp_weights::{constants::WEIGHT_REF_TIME_PER_NANOS, Weight};
 
 parameter_types! {
 	{{#if (eq short_name "block")}}
-	/// Time to execute an empty block.
+	/// Weight fo executing an empty block.
 	{{else}}
-	/// Time to execute a NO-OP extrinsic, for example `System::remark`.
+	/// Weight of executing a NO-OP extrinsic, for example `System::remark`.
 	{{/if}}
 	/// Calculated by multiplying the *{{params.weight.weight_metric}}* with `{{params.weight.weight_mul}}` and adding `{{params.weight.weight_add}}`.
 	///
@@ -35,7 +35,7 @@ parameter_types! {
 	///   95th: {{underscore stats.p95}}
 	///   75th: {{underscore stats.p75}}
 	pub const {{long_name}}Weight: Weight =
-		Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul({{underscore weight}}), 0);
+		Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul({{underscore ref_time}}), {{underscore proof_size}});
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add PoV benchmarking to the Block and Extrinsic base weight.  
This is a makeshift solution until we have the Transaction Extension benchmarking, so not sure if it is needed.

About the approach: the proof is measure when building the block, but building and importing has the same proof AFAIK so it should be fine.

Draft until we decided if we want this.