### PR TITLE
Minor clean up

### DIFF
--- a/prdoc/pr_5284.prdoc
+++ b/prdoc/pr_5284.prdoc
@@ -9,4 +9,4 @@ doc:
 
 crates:
   - name: sp-runtime
-    bump: patch
+    bump: none

--- a/prdoc/pr_5284.prdoc
+++ b/prdoc/pr_5284.prdoc
@@ -1,0 +1,12 @@
+title: Minor clean up
+author: conr2d
+topic: runtime
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Refactor `MultiSignature` and `MultiSigner` code to reduce verbosity.
+
+crates:
+  - name: sp-runtime
+    bump: patch

--- a/prdoc/pr_5284.prdoc
+++ b/prdoc/pr_5284.prdoc
@@ -2,11 +2,6 @@ title: Minor clean up
 author: conr2d
 topic: runtime
 
-doc:
-  - audience: Runtime Dev
-    description: |
-      Refactor `MultiSignature` and `MultiSigner` code to reduce verbosity.
-
 crates:
   - name: sp-runtime
     bump: none

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -449,7 +449,7 @@ impl std::fmt::Display for MultiSigner {
 impl Verify for MultiSignature {
 	type Signer = MultiSigner;
 	fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId32) -> bool {
-		let who: &[u8; 32] = signer.as_ref();
+		let who: [u8; 32] = *signer.as_ref();
 		match self {
 			Self::Ed25519(sig) => sig.verify(msg, &who.into()),
 			Self::Sr25519(sig) => sig.verify(msg, &who.into()),

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -438,10 +438,10 @@ impl TryFrom<MultiSigner> for ecdsa::Public {
 #[cfg(feature = "std")]
 impl std::fmt::Display for MultiSigner {
 	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match *self {
-			Self::Ed25519(ref who) => write!(fmt, "ed25519: {}", who),
-			Self::Sr25519(ref who) => write!(fmt, "sr25519: {}", who),
-			Self::Ecdsa(ref who) => write!(fmt, "ecdsa: {}", who),
+		match self {
+			Self::Ed25519(who) => write!(fmt, "ed25519: {}", who),
+			Self::Sr25519(who) => write!(fmt, "sr25519: {}", who),
+			Self::Ecdsa(who) => write!(fmt, "ecdsa: {}", who),
 		}
 	}
 }

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -449,23 +449,14 @@ impl std::fmt::Display for MultiSigner {
 impl Verify for MultiSignature {
 	type Signer = MultiSigner;
 	fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId32) -> bool {
-		match (self, signer) {
-			(Self::Ed25519(ref sig), who) => match ed25519::Public::from_slice(who.as_ref()) {
-				Ok(signer) => sig.verify(msg, &signer),
-				Err(()) => false,
-			},
-			(Self::Sr25519(ref sig), who) => match sr25519::Public::from_slice(who.as_ref()) {
-				Ok(signer) => sig.verify(msg, &signer),
-				Err(()) => false,
-			},
-			(Self::Ecdsa(ref sig), who) => {
+		let who: &[u8; 32] = signer.as_ref();
+		match (self, *who) {
+			(Self::Ed25519(sig), who) => sig.verify(msg, &who.into()),
+			(Self::Sr25519(sig), who) => sig.verify(msg, &who.into()),
+			(Self::Ecdsa(sig), who) => {
 				let m = sp_io::hashing::blake2_256(msg.get());
-				match sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m) {
-					Ok(pubkey) =>
-						&sp_io::hashing::blake2_256(pubkey.as_ref()) ==
-							<dyn AsRef<[u8; 32]>>::as_ref(who),
-					_ => false,
-				}
+				sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m)
+					.map_or(false, |pubkey| sp_io::hashing::blake2_256(&pubkey) == who)
 			},
 		}
 	}

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -450,10 +450,10 @@ impl Verify for MultiSignature {
 	type Signer = MultiSigner;
 	fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId32) -> bool {
 		let who: &[u8; 32] = signer.as_ref();
-		match (self, *who) {
-			(Self::Ed25519(sig), who) => sig.verify(msg, &who.into()),
-			(Self::Sr25519(sig), who) => sig.verify(msg, &who.into()),
-			(Self::Ecdsa(sig), who) => {
+		match self {
+			Self::Ed25519(sig) => sig.verify(msg, &who.into()),
+			Self::Sr25519(sig) => sig.verify(msg, &who.into()),
+			Self::Ecdsa(sig) => {
 				let m = sp_io::hashing::blake2_256(msg.get());
 				sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m)
 					.map_or(false, |pubkey| sp_io::hashing::blake2_256(&pubkey) == who)


### PR DESCRIPTION
This PR performs minor code cleanup to reduce verbosity. Since the compiler has already optimized out indirect calls in the existing code, these changes improve readability but do not affect performance.