### PR TITLE
ci: Paused `cmd-action` commenter

### DIFF
--- a/.github/workflows/command-inform.yml
+++ b/.github/workflows/command-inform.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, 'bot ')
+    # Temporary disable the bot until the new command bot works properly
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, 'bot ') && false
     steps:
     - name: Inform that the new command exist
       uses: actions/github-script@v7


### PR DESCRIPTION
Paused the action which comments on every command starting with `bot ` until we can fix all the commands which are not working.