### PR TITLE
Support `pallet-assets` sufficients as account providers

### DIFF
--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -77,6 +77,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				ExistenceReason::DepositFrom(depositor.clone(), deposit)
 			}
 		} else if d.is_sufficient {
+			// this only bumps account 'sufficients', but 'providers' is still zero
 			frame_system::Pallet::<T>::inc_sufficients(who);
 			d.sufficients.saturating_inc();
 			ExistenceReason::Sufficient
@@ -150,6 +151,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			if amount < details.min_balance {
 				return DepositConsequence::BelowMinimum
 			}
+			// for non-sufficient assets, the account must be able to accrue consumers
 			if !details.is_sufficient && !frame_system::Pallet::<T>::can_accrue_consumers(who, 2) {
 				return DepositConsequence::CannotCreate
 			}

--- a/substrate/frame/assets/src/tests.rs
+++ b/substrate/frame/assets/src/tests.rs
@@ -47,6 +47,22 @@ fn asset_account_counts(asset_id: u32) -> (u32, u32) {
 }
 
 #[test]
+fn holding_sufficient_asset_should_act_as_ED_for_account() {
+	new_test_ext().execute_with(|| {
+		let sufficient_id = 42;
+		let not_sufficient_id = 23;
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), sufficient_id, 1, true, 10));
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), not_sufficient_id, 1, false, 10));
+		assert_eq!(asset_ids(), vec![23, 42, 999]);
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), sufficient_id, 1, 100));
+
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(1), not_sufficient_id, 1, 100)); // <-- this fails
+		                                                                         // with "CannotCreate"
+	});
+}
+
+#[test]
 fn transfer_should_never_burn() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, false, 1));

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -1677,6 +1677,8 @@ impl<T: Config> Pallet<T> {
 	/// True if the account has at least one provider reference and adding `amount` consumer
 	/// references would not take it above the the maximum.
 	pub fn can_accrue_consumers(who: &T::AccountId, amount: u32) -> bool {
+		// frame-system only allows accruing consumers iff `providers > 0`, which is not the case
+		// for accounts holding only sufficient assets (but no DOT)...
 		let a = Account::<T>::get(who);
 		match a.consumers.checked_add(amount) {
 			Some(c) => a.providers > 0 && c <= T::MaxConsumers::max_consumers(),


### PR DESCRIPTION
Example scenario: on AssetHub we should be able to allow accounts to be created and to **hold non-sufficient assets** even without holding DOT ED, as long as they hold _other_ sufficient assets (e.g. USDT or USDC).

This is not possible now though because `pallet-assets` "sufficient" assets do not act as account providers..

This PR is meant to explore options to make that possible.

The first commit showcases a very simple UT failing because of above.
The second commit comments on the relevant functions that currently allow an account to exist with only e.g. USDT, but do not allow same account to hold any other non-sufficient asset.