### PR TITLE
Add missing features in templates' node packages

### DIFF
--- a/templates/minimal/README.md
+++ b/templates/minimal/README.md
@@ -42,7 +42,7 @@ packages required to compile this template - please take note of the Rust compil
 🔨 Use the following command to build the node without launching it:
 
 ```sh
-cargo build --package minimal-template-node --release
+cargo build --release
 ```
 
 🐳 Alternatively, build the docker image:

--- a/templates/minimal/node/Cargo.toml
+++ b/templates/minimal/node/Cargo.toml
@@ -57,4 +57,7 @@ minimal-template-runtime = { workspace = true }
 substrate-build-script-utils = { workspace = true, default-features = true }
 
 [features]
-default = []
+default = ["std"]
+std = [
+	"minimal-template-runtime/std",
+]

--- a/templates/parachain/README.md
+++ b/templates/parachain/README.md
@@ -44,7 +44,7 @@ packages required to compile this template - please take note of the Rust compil
 🔨 Use the following command to build the node without launching it:
 
 ```sh
-cargo build --package parachain-template-node --release
+cargo build --release
 ```
 
 🐳 Alternatively, build the docker image:

--- a/templates/parachain/node/Cargo.toml
+++ b/templates/parachain/node/Cargo.toml
@@ -79,7 +79,10 @@ color-print = { workspace = true }
 substrate-build-script-utils = { workspace = true, default-features = true }
 
 [features]
-default = []
+default = ["std"]
+std = [
+	"parachain-template-runtime/std",
+]
 runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",
 	"frame-benchmarking-cli/runtime-benchmarks",

--- a/templates/parachain/node/Cargo.toml
+++ b/templates/parachain/node/Cargo.toml
@@ -82,6 +82,8 @@ substrate-build-script-utils = { workspace = true, default-features = true }
 default = ["std"]
 std = [
 	"parachain-template-runtime/std",
+	"log/std",
+	"xcm/std"
 ]
 runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",

--- a/templates/parachain/node/Cargo.toml
+++ b/templates/parachain/node/Cargo.toml
@@ -81,9 +81,9 @@ substrate-build-script-utils = { workspace = true, default-features = true }
 [features]
 default = ["std"]
 std = [
-	"parachain-template-runtime/std",
 	"log/std",
-	"xcm/std"
+	"parachain-template-runtime/std",
+	"xcm/std",
 ]
 runtime-benchmarks = [
 	"cumulus-primitives-core/runtime-benchmarks",

--- a/templates/solochain/README.md
+++ b/templates/solochain/README.md
@@ -28,7 +28,7 @@ installation](#alternatives-installations) options.
 Use the following command to build the node without launching it:
 
 ```sh
-cargo build --package solochain-template-node --release
+cargo build --release
 ```
 
 ### Embedded Docs

--- a/templates/solochain/node/Cargo.toml
+++ b/templates/solochain/node/Cargo.toml
@@ -66,7 +66,10 @@ solochain-template-runtime = { workspace = true }
 substrate-build-script-utils = { workspace = true, default-features = true }
 
 [features]
-default = []
+default = ["std"]
+std = [
+	"solochain-template-runtime/std",
+]
 # Dependencies that are only required if runtime benchmarking should be build.
 runtime-benchmarks = [
 	"frame-benchmarking-cli/runtime-benchmarks",


### PR DESCRIPTION
Corrects the issue we had [here](https://github.com/paritytech/polkadot-sdk-parachain-template/pull/10), in which `cargo build --release` worked but `cargo build --package parachain-template-node --release` failed with missing features.

The command has been added to CI to make sure it works, but at the same we're changing it in the readme to just `cargo build --release` for simplification.

Labeling silent because those packages are un-published as part of the regular release process.