### PR TITLE
Fixing token-economics dead link

### DIFF
--- a/substrate/frame/transaction-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/src/lib.rs
@@ -135,7 +135,7 @@ type BalanceOf<T> = <<T as Config>::OnChargeTransaction as OnChargeTransaction<T
 /// Meaning that fees can change by around ~23% per day, given extreme congestion.
 ///
 /// More info can be found at:
-/// <https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html>
+/// <https://research.web3.foundation/Polkadot/overview/token-economics>
 pub struct TargetedFeeAdjustment<T, S, V, M, X>(core::marker::PhantomData<(T, S, V, M, X)>);
 
 /// Something that can convert the current multiplier to the next one.


### PR DESCRIPTION
The page [2-token-economics](https://research.web3.foundation/en/latest/polkadot/overview/2-token-economics.html) is a dead link, replacing it with [token-economics](https://research.web3.foundation/Polkadot/overview/token-economics).