### PR TITLE
Add docs for the common binaries exported from Polkadot SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/paritytec
 * Other Resources:
   * [Polkadot Wiki -> Build](https://wiki.polkadot.network/docs/build-guide)
 
+## Binaries
+
+This repo provides the source code to a number of useful binaries used throughout Polkadot SDK development. The most commonly used are:
+
+- `polkadot`: A node for the main Polkadot Relay Chain.
+- `polkadot-parachain`: A node for a generic Parachain. Can be combined with a custom chain specification to launch a custom Parachain.
+- `chain-spec-builder`: A tool to generate a custom chain specification. Can be combined with a Polkadot-SDK compatible Wasm runtime to build a custom chain specification.
+
+You can find released binaries for Linux in our [latest releases](https://github.com/paritytech/polkadot-sdk/releases/).
+
+For other platforms, you can compile the binaries yourself with:
+
+```bash
+cargo install --git https://github.com/paritytech/polkadot-sdk/ --tag polkadot-stable2407 polkadot polkadot-parachain-bin staging-chain-spec-builder
+```
+
 ## 🚀 Releases
 
 > [!NOTE]


### PR DESCRIPTION
This PR updates the main `README` file to introduce a simple command to install the most commonly used binaries from the `Polkadot SDK` used for development.

In many cases, as a developer using the Polkadot SDK, these are the main things you would want to access from the `polkadot-sdk` repo, so I think it is key to highlight how you can easily get those binaries.