### PR TITLE
`polkadot-node-core-pvf-common`: Fix test compilation error

### DIFF
--- a/polkadot/node/core/pvf/common/Cargo.toml
+++ b/polkadot/node/core/pvf/common/Cargo.toml
@@ -42,6 +42,8 @@ seccompiler = "0.4.0"
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 tempfile = { workspace = true }
 
 [features]


### PR DESCRIPTION
This crate only uses `tempfile` on linux but includes it unconditionally in its `Cargo.toml`. It also sets `#![deny(unused_crate_dependencies)]`. This leads to an hard error to anything that is not Linux.

This PR fixes this error. I am wondering why CI didn't catch that. Shouldn't the test at least be compiled (but not run) on macOS?