### PR TITLE
Update getting-started.sh to install the specific rust version specified in .github/env file

### DIFF
--- a/scripts/getting-started.sh
+++ b/scripts/getting-started.sh
@@ -109,13 +109,14 @@ else
     exit 1
 fi
 
-# Check if rust is installed
+# Check if rust is installed, if not, install the version defined in the .github/env file
 if command -v rustc >/dev/null 2>&1; then
     echo "\n✅︎🦀 Rust already installed."
 else
     if prompt_default_yes "\n🦀 Rust is not installed. Install it?"; then
         echo "🦀 Installing via rustup."
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        version=`cat ../.github/env | grep IMAGE | cut -d'-' -f3`
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/?version=$version | sh
     else
         echo "Aborting."
         exit 1


### PR DESCRIPTION
# Description

Add a means to fetch and install the expected rust version defined in [.github/env](https://github.com/paritytech/polkadot-sdk/blob/master/.github/env).

## Integration

The implementation tightly relies on the standardized naming convention used in the currently used `docker.io/paritytech/ci-unified:bullseye-X.YY.Z-etc`.

## Review Notes
Since the `bullseye` naming convention is always followed by dash delimiters, a workaround would be to grep and cut the specific version.  If this naming convention ever changes in any way that would add or remove a dash before the version occurs in the string, then the cut used to fetch the version would have to be modified as well.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!
