### PR TITLE
Fix favicon link to fix CI

### DIFF
--- a/docs/sdk/src/lib.rs
+++ b/docs/sdk/src/lib.rs
@@ -25,7 +25,7 @@
 #![doc = simple_mermaid::mermaid!("../../mermaid/IA.mmd")]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
-#![doc(html_favicon_url = "https://polkadot.network/favicon-32x32.png")]
+#![doc(html_favicon_url = "https://polkadot.com/favicon.ico")]
 #![doc(
 	html_logo_url = "https://europe1.discourse-cdn.com/standard21/uploads/polkadot2/original/1X/eb57081e2bb7c39e5fcb1a98b443e423fa4448ae.svg"
 )]


### PR DESCRIPTION
The polkadot.network website was recently refreshed and the `favicon-32x32.png` was removed. It was linked in some docs and so the docs have been updated to point to a working favicon on the new website.

Previously the lychee link checker was failing on all PRs.