### PR TITLE
chain-spec: minor clarification on the genesis config patch

### DIFF
--- a/substrate/client/chain-spec/src/lib.rs
+++ b/substrate/client/chain-spec/src/lib.rs
@@ -172,6 +172,12 @@
 //!   </tbody>
 //! </table>
 //!
+//! The main purpose of the `RuntimeGenesisConfig` patch is to:
+//! - minimize the maintenance effort when RuntimeGenesisConfig is changed in the future (e.g. new pallets added to
+//!   the runtime or pallet's genesis config changed),
+//! - increase the readability - it only contains the relevant fields,
+//! - allow to apply numerous changes in distinct domains (e.g. for zombienet).
+//!
 //! For production or long-lasting blockchains, using the `raw` format in the chain specification is
 //! recommended. Only the `raw` format guarantees that storage root hash will remain unchanged when
 //! the `RuntimeGenesisConfig` format changes due to software upgrade.

--- a/substrate/client/chain-spec/src/lib.rs
+++ b/substrate/client/chain-spec/src/lib.rs
@@ -173,8 +173,8 @@
 //! </table>
 //!
 //! The main purpose of the `RuntimeGenesisConfig` patch is to:
-//! - minimize the maintenance effort when RuntimeGenesisConfig is changed in the future (e.g. new pallets added to
-//!   the runtime or pallet's genesis config changed),
+//! - minimize the maintenance effort when RuntimeGenesisConfig is changed in the future (e.g. new
+//!   pallets added to the runtime or pallet's genesis config changed),
 //! - increase the readability - it only contains the relevant fields,
 //! - allow to apply numerous changes in distinct domains (e.g. for zombienet).
 //!


### PR DESCRIPTION
Added minor clarification on the genesis config patch ([link](https://substrate.stackexchange.com/questions/11813/in-the-genesis-config-what-does-the-patch-key-do/11825#11825))