### PR TITLE
Migrated `docs` scripts to GitHub actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,12 +99,12 @@ jobs:
           rm -rf book/
           rm -rf ${REF_NAME}
         env:
-          REF_NAME: ${{ github.head_ref }}
+          REF_NAME: ${{ github.head_ref || github.ref_name }}
       - name: Download rustdocs
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.sha }}-doc
-          path: ${{ github.head_ref }}
+          path: ${{ github.head_ref || github.ref_name }}
       - name: Download guide
         uses: actions/download-artifact@v4
         with:
@@ -118,8 +118,8 @@ jobs:
         with:
           github-token: ${{ github.token }}
           push-branch: "gh-pages"
-          commit-message: "___Updated docs for ${{ github.head_ref }}___"
+          commit-message: "___Updated docs for ${{ github.head_ref || github.ref_name }}___"
           force-add: "true"
-          files: ${{ github.head_ref }}/ book/
+          files: ${{ github.head_ref || github.ref_name }}/ book/
           name: devops-parity
           email: devops-team@parity.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+  push:
+    branches: [master]
 
 name: Test Docs
 
@@ -83,6 +85,7 @@ jobs:
           if-no-files-found: error
 
   publish-rustdoc:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - id: set_image
         run: cat .github/env >> $GITHUB_OUTPUT
   test-rustdoc:
-    runs-on: arc-runners-beefy-stg
+    runs-on: arc-runners-polkadot-sdk-beefy
     needs: [set-image]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -26,7 +26,7 @@ jobs:
         env:
           SKIP_WASM_BUILD: 1
   test-doc:
-    runs-on: arc-runners-beefy-stg
+    runs-on: arc-runners-polkadot-sdk-beefy
     needs: [set-image, test-rustdoc]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -37,7 +37,7 @@ jobs:
           RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
 
   build-rustdoc:
-    runs-on: arc-runners-beefy-stg
+    runs-on: arc-runners-polkadot-sdk-beefy
     needs: [set-image]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [master]
 
-name: Test Docs
+name: Docs
 
 jobs:
   set-image:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -95,13 +95,17 @@ jobs:
   publish-rustdoc:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    environment: subsystem-benchmarks
     needs: [build-rustdoc, build-implementers-guide]
     steps:
       - uses: actions/checkout@v4
         with:
           ref: gh-pages
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.POLKADOTSDK_GHPAGES_APP_ID }}
+          private-key: ${{ secrets.POLKADOTSDK_GHPAGES_APP_KEY }}
       - name: Ensure destination dir does not exist
         run: |
           rm -rf book/
@@ -121,10 +125,10 @@ jobs:
       - run: mkdir -p book
       - name: Move book files
         run: mv /tmp/book/html/* book/
-      - name: push
+      - name: Push to GH-Pages branch
         uses: github-actions-x/commit@v2.9
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           push-branch: "gh-pages"
           commit-message: "___Updated docs for ${{ github.head_ref || github.ref_name }}___"
           force-add: "true"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,9 @@ jobs:
   set-image:
     # GitHub Actions allows using 'env' in a container context.
     # However, env variables don't work for forks: https://github.com/orgs/community/discussions/44322
-    # This workaround sets the container image for each job using 'set-image' job output.  
+    # This workaround sets the container image for each job using 'set-image' job output.
     # TODO: remove once migration is complete or this workflow is fully stable
-    if: contains(github.event.label.name, 'GHA-migration')
+    if: contains(github.event.label.name, 'GHA-migration') || contains(github.event.pull_request.labels.*.name, 'GHA-migration')
     runs-on: ubuntu-latest
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+name: Docs
+
 on:
   push:
     branches:
@@ -5,8 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   merge_group:
-
-name: Docs
 
 jobs:
   set-image:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,20 @@
 on:
-  pull_request:
   push:
-    branches: [master]
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
+  merge_group:
 
 name: Docs
 
 jobs:
   set-image:
+    # GitHub Actions allows using 'env' in a container context.
+    # However, env variables don't work for forks: https://github.com/orgs/community/discussions/44322
+    # This workaround sets the container image for each job using 'set-image' job output.  
+    # TODO: remove once migration is complete or this workflow is fully stable
+    if: contains(github.event.label.name, 'GHA-migration')
     runs-on: ubuntu-latest
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
@@ -22,28 +30,28 @@ jobs:
       image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - uses: actions/checkout@v4
-      - run: time cargo doc --workspace --all-features --no-deps
+      - run: forklift cargo doc --workspace --all-features --no-deps
         env:
           SKIP_WASM_BUILD: 1
   test-doc:
-    runs-on: arc-runners-polkadot-sdk-beefy
-    needs: [set-image, test-rustdoc]
-    container:
-      image: ${{ needs.set-image.outputs.IMAGE }}
-    steps:
-      - uses: actions/checkout@v4
-      - run: time cargo test --doc --workspace
-        env:
-          RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-
-  build-rustdoc:
     runs-on: arc-runners-polkadot-sdk-beefy
     needs: [set-image]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - uses: actions/checkout@v4
-      - run: time cargo doc --all-features --workspace --no-deps
+      - run: forklift cargo test --doc --workspace
+        env:
+          RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+
+  build-rustdoc:
+    runs-on: arc-runners-polkadot-sdk-beefy
+    needs: [set-image, test-rustdoc]
+    container:
+      image: ${{ needs.set-image.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: forklift cargo doc --all-features --workspace --no-deps
         env:
           SKIP_WASM_BUILD: 1
           RUSTDOCFLAGS: "-Dwarnings --default-theme=ayu --html-in-header ./docs/sdk/assets/header.html --extend-css ./docs/sdk/assets/theme.css --html-after-content ./docs/sdk/assets/after-content.html"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
   merge_group:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   set-image:
     # GitHub Actions allows using 'env' in a container context.

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -62,14 +62,14 @@ jobs:
         id: extract_branch
         shell: bash
         run: |
-          sanitized_branch=$(echo "$BRANCH_NAME" | tr '/' '_')
-          echo "Sanitized branch name is $sanitized_branch"
-          echo "sanitized_ref=$sanitized_ref" >> $GITHUB_OUTPUT
+          export sanitized_ref=$(echo "$BRANCH_NAME" | tr '/' '_')
+          echo "Sanitized branch name is $sanitized_ref"
+          echo "REFERENCE=$sanitized_ref" >> $GITHUB_OUTPUT
         env:
           BRANCH_NAME: "${{ github.head_ref }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: "${{ steps.extract_branch.outputs.sanitized_ref }}-doc"
+          name: ${{ steps.extract_branch.outputs.REFERENCE }}-doc
           path: ./crate-docs/
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -52,22 +52,7 @@ jobs:
           script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"
           path="./crate-docs"
 
-          inject_simple_analytics() {
-            local path="$1";
-            local script_content="$2";
-
-            process_file() {
-              local file="$1";
-              echo "Adding Simple Analytics script to $file";
-              sed -i "s|</head>|$script_content</head>|" "$file";
-            }
-            export -f process_file;
-            export script_content="$script_content";
-
-            find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {};
-          }
-
-          inject_simple_analytics "$path" "$script_content"
+          find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'file="{}"; echo "Adding Simple Analytics script to $file"; sed -i "s|</head>|$script_content</head>|" "$file";'
       - run: echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -54,9 +54,17 @@ jobs:
 
           find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'file="{}"; echo "Adding Simple Analytics script to $file"; sed -i "s|</head>|$script_content</head>|" "$file";'
       - run: echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
+      - name: Sanitize branch name
+        shell: bash
+        run: |
+          sanitized_branch=$(echo "$BRANCH_NAME" | tr '/' '_')
+          echo "sanitized_ref=$sanitized_ref" >> $GITHUB_ENV
+        env:
+          BRANCH_NAME: "${{ github.head_ref }}"
+        id: extract_branch
       - uses: actions/upload-artifact@v4
         with:
-          name: "${{ github.workflow }}_${{ github.head_ref }}-doc"
+          name: "${{ env.sanitized_ref }}-doc"
           path: ./crate-docs/
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -58,18 +58,9 @@ jobs:
 
           inject_simple_analytics "$docs_dir" "$script_content"
       - run: echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
-      - name: Sanitize branch name
-        id: extract_branch
-        shell: bash
-        run: |
-          export sanitized_ref=$(echo "$BRANCH_NAME" | tr '/' '_')
-          echo "Sanitized branch name is $sanitized_ref"
-          echo "REFERENCE=$sanitized_ref" >> $GITHUB_OUTPUT
-        env:
-          BRANCH_NAME: "${{ github.head_ref }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.extract_branch.outputs.REFERENCE }}-doc
+          name: ${{ github.sha }}-doc
           path: ./crate-docs/
           retention-days: 1
           if-no-files-found: error
@@ -84,3 +75,9 @@ jobs:
       - run: mdbook build ./polkadot/roadmap/implementers-guide
       - run: mkdir -p artifacts
       - run: mv polkadot/roadmap/implementers-guide/book artifacts/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}-guide
+          path: ./artifacts/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -76,8 +76,6 @@ jobs:
 
   build-implementers-guide:
     runs-on: ubuntu-latest
-    container:
-      image: paritytech/mdbook-utils:e14aae4a-20221123
     steps:
       - uses: actions/checkout@v4
       - run: mdbook build ./polkadot/roadmap/implementers-guide

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: time cargo doc --workspace --all-features --no-deps
+        env:
+          SKIP_WASM_BUILD: 1
   test-doc:
     runs-on: arc-runners-beefy-stg
     needs: [set-image, test-rustdoc]
@@ -29,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: time cargo test --doc --workspace
+        env:
+          RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+
   build-rustdoc:
     runs-on: arc-runners-beefy-stg
     needs: [set-image]

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -29,3 +29,44 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: time cargo test --doc --workspace
+  build-rustdoc:
+    runs-on: arc-runners-beefy-stg
+    needs: [set-image]
+    container:
+      image: ${{ needs.set-image.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: time cargo doc --all-features --workspace --no-deps
+        env:
+          SKIP_WASM_BUILD: 1
+          RUSTDOCFLAGS: "-Dwarnings --default-theme=ayu --html-in-header ./docs/sdk/assets/header.html --extend-css ./docs/sdk/assets/theme.css --html-after-content ./docs/sdk/assets/after-content.html"
+      - run: rm -f ./target/doc/.lock
+      - run: mv ./target/doc ./crate-docs
+      - name: Inject Simple Analytics script
+        run: |
+          script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"
+          path="./crate-docs"
+
+          inject_simple_analytics() {
+            local path="$1";
+            local script_content="$2";
+
+            process_file() {
+              local file="$1";
+              echo "Adding Simple Analytics script to $file";
+              sed -i "s|</head>|$script_content</head>|" "$file";
+            }
+            export -f process_file;
+            export script_content="$script_content";
+
+            find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'process_file "$@"' _ {};
+          }
+
+          inject_simple_analytics "$path" "$script_content"
+      - run: echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "${{ github.workflow }}_${{ github.head_ref }}-doc"
+          path: ./crate-docs/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -59,13 +59,14 @@ jobs:
           inject_simple_analytics "$docs_dir" "$script_content"
       - run: echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
       - name: Sanitize branch name
+        id: extract_branch
         shell: bash
         run: |
           sanitized_branch=$(echo "$BRANCH_NAME" | tr '/' '_')
+          echo "Sanitized branch name is $sanitized_branch"
           echo "sanitized_ref=$sanitized_ref" >> $GITHUB_OUTPUT
         env:
           BRANCH_NAME: "${{ github.head_ref }}"
-        id: extract_branch
       - uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.extract_branch.outputs.sanitized_ref }}-doc"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -81,3 +81,42 @@ jobs:
           path: ./artifacts/
           retention-days: 1
           if-no-files-found: error
+
+  publish-rustdoc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [build-rustdoc, build-implementers-guide]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Ensure destination dir does not exist
+        run: |
+          rm -rf book/
+          rm -rf ${REF_NAME}
+        env:
+          REF_NAME: ${{ github.head_ref }}
+      - name: Download rustdocs
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.sha }}-doc
+          path: ${{ github.head_ref }}
+      - name: Download guide
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.sha }}-guide
+          path: /tmp
+      - run: mkdir -p book
+      - name: Move book files
+        run: mv /tmp/book/html/* book/
+      - name: push
+        uses: github-actions-x/commit@v2.9
+        with:
+          github-token: ${{ github.token }}
+          push-branch: "gh-pages"
+          commit-message: "___Updated docs for ${{ github.head_ref }}___"
+          force-add: "true"
+          files: ${{ github.head_ref }}/ book/
+          name: devops-parity
+          email: devops-team@parity.io

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -14,7 +14,7 @@ jobs:
       - id: set_image
         run: cat .github/env >> $GITHUB_OUTPUT
   test-rustdoc:
-    runs-on: ubuntu-latest
+    runs-on: arc-runners-beefy-stg
     needs: [set-image]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: time cargo doc --workspace --all-features --no-deps
   test-doc:
-    runs-on: ubuntu-latest
+    runs-on: arc-runners-beefy-stg
     needs: [set-image, test-rustdoc]
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,31 @@
+on:
+  pull_request:
+
+name: Test Docs
+
+jobs:
+  set-image:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE: ${{ steps.set_image.outputs.IMAGE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - id: set_image
+        run: cat .github/env >> $GITHUB_OUTPUT
+  test-rustdoc:
+    runs-on: ubuntu-latest
+    needs: [set-image]
+    container:
+      image: ${{ needs.set-image.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: time cargo doc --workspace --all-features --no-deps
+  test-doc:
+    runs-on: ubuntu-latest
+    needs: [set-image, test-rustdoc]
+    container:
+      image: ${{ needs.set-image.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: time cargo test --doc --workspace

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -58,13 +58,13 @@ jobs:
         shell: bash
         run: |
           sanitized_branch=$(echo "$BRANCH_NAME" | tr '/' '_')
-          echo "sanitized_ref=$sanitized_ref" >> $GITHUB_ENV
+          echo "sanitized_ref=$sanitized_ref" >> $GITHUB_OUTPUT
         env:
           BRANCH_NAME: "${{ github.head_ref }}"
         id: extract_branch
       - uses: actions/upload-artifact@v4
         with:
-          name: "${{ env.sanitized_ref }}-doc"
+          name: "${{ steps.extract_branch.outputs.sanitized_ref }}-doc"
           path: ./crate-docs/
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -76,9 +76,11 @@ jobs:
 
   build-implementers-guide:
     runs-on: ubuntu-latest
+    container:
+      image: paritytech/mdbook-utils:e14aae4a-20221123
+      options: --user root
     steps:
       - uses: actions/checkout@v4
-      - run: cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed
       - run: mdbook build ./polkadot/roadmap/implementers-guide
       - run: mkdir -p artifacts
       - run: mv polkadot/roadmap/implementers-guide/book artifacts/

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -73,3 +73,13 @@ jobs:
           path: ./crate-docs/
           retention-days: 1
           if-no-files-found: error
+
+  build-implementers-guide:
+    runs-on: ubuntu-latest
+    container:
+      image: paritytech/mdbook-utils:e14aae4a-20221123
+    steps:
+      - uses: actions/checkout@v4
+      - run: mdbook build ./polkadot/roadmap/implementers-guide
+      - run: mkdir -p artifacts
+      - run: mv polkadot/roadmap/implementers-guide/book artifacts/

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: cargo install mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed
       - run: mdbook build ./polkadot/roadmap/implementers-guide
       - run: mkdir -p artifacts
       - run: mv polkadot/roadmap/implementers-guide/book artifacts/

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -50,9 +50,13 @@ jobs:
       - name: Inject Simple Analytics script
         run: |
           script_content="<script async defer src=\"https://apisa.parity.io/latest.js\"></script><noscript><img src=\"https://apisa.parity.io/latest.js\" alt=\"\" referrerpolicy=\"no-referrer-when-downgrade\" /></noscript>"
-          path="./crate-docs"
+          docs_dir="./crate-docs"
 
-          find "$path" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'file="{}"; echo "Adding Simple Analytics script to $file"; sed -i "s|</head>|$script_content</head>|" "$file";'
+          inject_simple_analytics() {
+            find "$1" -name '*.html' | xargs -I {} -P "$(nproc)" bash -c 'file="{}"; echo "Adding Simple Analytics script to $file"; sed -i "s|</head>|'"$2"'</head>|" "$file";'
+          }
+
+          inject_simple_analytics "$docs_dir" "$script_content"
       - run: echo "<meta http-equiv=refresh content=0;url=polkadot_sdk_docs/index.html>" > ./crate-docs/index.html
       - name: Sanitize branch name
         shell: bash


### PR DESCRIPTION
Migrated the following scripts to GHA
- test-doc
- test-rustdoc
- build-rustdoc
- build-implementers-guide
- publish-rustdoc (only runs when `master` is modified)

Resolves paritytech/ci_cd#1016

---

Some questions I have:
- Should I remove the equivalent scripts from the `gitlab-ci` files?