### PR TITLE
[CI] Fix prdoc command

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # Take a snapshot at 5am when most SDK devs are not working.
+  schedule:
+    - cron: '0 5 * * *'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/command-prdoc.yml
+++ b/.github/workflows/command-prdoc.yml
@@ -43,9 +43,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  set-image:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE: ${{ steps.set_image.outputs.IMAGE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - id: set_image
+        run: cat .github/env >> $GITHUB_OUTPUT
   cmd-prdoc:
+    needs: [set-image]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    container:
+      image: ${{ needs.set-image.outputs.IMAGE }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Changes:
- Run the prdoc command in a docker container since otherwise the set-up-gh script wont work.
- Take try-runtime snapshot at night to avoid spamming the node with snapshot jobs at day.
