### PR TITLE
Backport #5369 to v1.14: Always include UnpaidExecution, not just when revenue is nonzero

### DIFF
--- a/polkadot/runtime/parachains/src/coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/coretime/mod.rs
@@ -358,7 +358,10 @@ fn mk_coretime_call<T: Config>(call: crate::coretime::CoretimeCalls) -> Instruct
 
 fn do_notify_revenue<T: Config>(when: BlockNumber, raw_revenue: Balance) -> Result<(), XcmError> {
 	let dest = Junction::Parachain(T::BrokerId::get()).into_location();
-	let mut message = Vec::new();
+	let mut message = vec![Instruction::UnpaidExecution {
+		weight_limit: WeightLimit::Unlimited,
+		check_origin: None,
+	}];
 	let asset = Asset { id: AssetId(Location::here()), fun: Fungible(raw_revenue) };
 	let dummy_xcm_context = XcmContext { origin: None, message_id: [0; 32], topic: None };
 
@@ -383,10 +386,6 @@ fn do_notify_revenue<T: Config>(when: BlockNumber, raw_revenue: Balance) -> Resu
 
 		message.extend(
 			[
-				Instruction::UnpaidExecution {
-					weight_limit: WeightLimit::Unlimited,
-					check_origin: None,
-				},
 				ReceiveTeleportedAsset(assets_reanchored),
 				DepositAsset {
 					assets: Wild(AllCounted(1)),

--- a/prdoc/pr_5370.prdoc
+++ b/prdoc/pr_5370.prdoc
@@ -1,0 +1,15 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fix failing XCM from relay to Coretime Chain when revenue is zero
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      The coretime assigner now always includes UnpaidExecution when calling `notify_revenue` via a
+      `Transact`, not just when revenue is nonzero. This fixes an issue where the XCM would fail to
+      process on the receiving side.
+
+crates:
+  - name: polkadot-runtime-parachains
+    bump: patch


### PR DESCRIPTION
Full details in #5369 