### PR TITLE
Fix zombienet bridges test

### DIFF
--- a/bridges/testing/environments/rococo-westend/bridges_rococo_westend.sh
+++ b/bridges/testing/environments/rococo-westend/bridges_rococo_westend.sh
@@ -270,7 +270,7 @@ case "$1" in
           "//Alice" \
           1000 \
           "ws://127.0.0.1:9910" \
-          "$(jq --null-input '{ "parents": 2, "interior": { "X1": { "GlobalConsensus": "Westend" } } }')" \
+          "$(jq --null-input '{ "parents": 2, "interior": { "X1": [{ "GlobalConsensus": "Westend" }] } }')" \
           "$GLOBAL_CONSENSUS_WESTEND_SOVEREIGN_ACCOUNT" \
           10000000000 \
           true
@@ -329,7 +329,7 @@ case "$1" in
           "//Alice" \
           1000 \
           "ws://127.0.0.1:9010" \
-          "$(jq --null-input '{ "parents": 2, "interior": { "X1": { "GlobalConsensus": "Rococo" } } }')" \
+          "$(jq --null-input '{ "parents": 2, "interior": { "X1": [{ "GlobalConsensus": "Rococo" }] } }')" \
           "$GLOBAL_CONSENSUS_ROCOCO_SOVEREIGN_ACCOUNT" \
           10000000000 \
           true

--- a/bridges/testing/framework/js-helpers/wrapped-assets-balance.js
+++ b/bridges/testing/framework/js-helpers/wrapped-assets-balance.js
@@ -8,7 +8,7 @@ async function run(nodeName, networkInfo, args) {
     const bridgedNetworkName = args[2];
     while (true) {
         const foreignAssetAccount = await api.query.foreignAssets.account(
-            { parents: 2, interior: { X1: { GlobalConsensus: bridgedNetworkName } } },
+            { parents: 2, interior: { X1: [{ GlobalConsensus: bridgedNetworkName }] } },
             accountAddress
         );
         if (foreignAssetAccount.isSome) {


### PR DESCRIPTION
After https://github.com/paritytech/polkadot-sdk/pull/4129, a zombienet bridge test was broken.
This is because XCMv4 locations have an array in the `interior` field, which also has to appear in PJS.