### PR TITLE
Enable Merklized Distributions in Assets Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,8 @@ dependencies = [
  "array-bytes",
  "hash-db",
  "log",
+ "parity-scale-codec",
+ "scale-info",
  "sp-core",
  "sp-runtime",
  "sp-tracing 16.0.0",
@@ -9851,6 +9853,7 @@ dependencies = [
 name = "pallet-assets"
 version = "29.1.0"
 dependencies = [
+ "binary-merkle-tree",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/substrate/frame/assets/Cargo.toml
+++ b/substrate/frame/assets/Cargo.toml
@@ -20,6 +20,7 @@ codec = { workspace = true }
 impl-trait-for-tuples = "0.2.2"
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
+binary-merkle-tree = { workspace = true }
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { workspace = true }
 # Needed for type-safe access to storage DB.

--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -441,7 +441,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Creates a distribution in storage for asset `id`, which can be claimed via `do_claim_distribution`.
 	pub(super) fn do_mint_distribution(
 		id: T::AssetId,
-		merkle_root: T::Hash,
+		merkle_root: H256,
 		maybe_check_issuer: Option<T::AccountId>,
 	) -> DispatchResult {
 		let details = Asset::<T, I>::get(&id).ok_or(Error::<T, I>::Unknown)?;
@@ -462,10 +462,19 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// A wrapper around `do_mint`, allowing a `merkle_proof` to control the amount minted and to whom.
 	pub(super) fn do_claim_distribution(
 		distribution_id: DistributionCounter,
-		merkle_proof: MerkleProof<T::Hash, (T::AccountId, T::Balance)>,
+		merkle_proof: DistributionProof<T, I>,
 	) -> DispatchResult {
 		let (asset_id, merkle_root) = MerklizedDistribution::<T, I>::get(distribution_id).ok_or(Error::<T, I>::Unknown)?;
 
+		ensure!(merkle_root == merkle_proof.root, "TODO ERROR");
+
+		// binary_merkle_tree::verify_proof::<_, _, _>(
+		// 	&merkle_proof.root,
+		// 	merkle_proof.proof,
+		// 	merkle_proof.number_of_leaves,
+		// 	merkle_proof.leaf_index,
+		// 	merkle_proof.leaf,
+		// );
 		Ok(())
 	}
 

--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -438,11 +438,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
-	/// Increases the asset `id` balance of `beneficiary` by `amount`.
-	///
-	/// This alters the registered supply of the asset and emits an event.
-	///
-	/// Will return an error or will increase the amount by exactly `amount`.
+	/// Creates a distribution in storage for asset `id`, which can be claimed via `do_claim_distribution`.
 	pub(super) fn do_mint_distribution(
 		id: T::AssetId,
 		merkle_root: T::Hash,
@@ -459,6 +455,16 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		MerklizedDistribution::<T, I>::insert(&distribution_count, (id.clone(), merkle_root.clone()));
 
 		Self::deposit_event(Event::DistributionIssued { asset_id: id, merkle_root: merkle_root });
+
+		Ok(())
+	}
+
+	/// A wrapper around `do_mint`, allowing a `merkle_proof` to control the amount minted and to whom.
+	pub(super) fn do_claim_distribution(
+		distribution_id: DistributionCounter,
+		merkle_proof: MerkleProof<T::Hash, (T::AccountId, T::Balance)>,
+	) -> DispatchResult {
+		let (asset_id, merkle_root) = MerklizedDistribution::<T, I>::get(distribution_id).ok_or(Error::<T, I>::Unknown)?;
 
 		Ok(())
 	}

--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -467,14 +467,23 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let (asset_id, merkle_root) = MerklizedDistribution::<T, I>::get(distribution_id).ok_or(Error::<T, I>::Unknown)?;
 
 		ensure!(merkle_root == merkle_proof.root, "TODO ERROR");
+		let (beneficiary, amount) = merkle_proof.leaf;
+		let already_claimed = MerklizedDistributionTracker::<T, I>::contains_key(&distribution_id, &beneficiary);
+		ensure!(!already_claimed, "TODO ERROR");
 
-		// binary_merkle_tree::verify_proof::<_, _, _>(
+		use sp_runtime::traits::BlakeTwo256;
+		let verified = true;
+		// let verified = binary_merkle_tree::verify_proof::<BlakeTwo256, _, (T::AccountId, T::Balance)>(
 		// 	&merkle_proof.root,
 		// 	merkle_proof.proof,
 		// 	merkle_proof.number_of_leaves,
 		// 	merkle_proof.leaf_index,
 		// 	merkle_proof.leaf,
 		// );
+
+		Self::do_mint(asset_id, &beneficiary, amount, None)?;
+		MerklizedDistributionTracker::<T, I>::insert(&distribution_id, &beneficiary, ());
+
 		Ok(())
 	}
 

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -193,6 +193,7 @@ use frame_support::{
 	},
 };
 use frame_system::Config as SystemConfig;
+use sp_core::H256;
 
 use binary_merkle_tree::MerkleProof;
 
@@ -459,6 +460,7 @@ pub mod pallet {
 	>;
 
 	pub type DistributionCounter = u32;
+	pub type DistributionProof<T, I> = MerkleProof<H256, (<T as frame_system::Config>::AccountId, <T as Config<I>>::Balance)>;
 
 	#[pallet::storage]
 	/// Merklized distribution of an asset.
@@ -466,7 +468,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		DistributionCounter,
-		(T::AssetId, T::Hash),
+		(T::AssetId, H256),
 		OptionQuery,
 	>;
 
@@ -666,7 +668,7 @@ pub mod pallet {
 		/// Some assets were withdrawn from the account (e.g. for transaction fees).
 		Withdrawn { asset_id: T::AssetId, who: T::AccountId, amount: T::Balance },
 		/// A distribution of assets were issued.
-		DistributionIssued { asset_id: T::AssetId, merkle_root: T::Hash },
+		DistributionIssued { asset_id: T::AssetId, merkle_root: H256 },
 	}
 
 	#[pallet::error]
@@ -1842,7 +1844,7 @@ pub mod pallet {
 		pub fn mint_distribution(
 			origin: OriginFor<T>,
 			id: T::AssetIdParameter,
-			merkle_root: T::Hash,
+			merkle_root: H256,
 		) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
 			let id: T::AssetId = id.into();
@@ -1865,7 +1867,7 @@ pub mod pallet {
 		pub fn claim_distribution(
 			origin: OriginFor<T>,
 			distribution_id: DistributionCounter,
-			merkle_proof: MerkleProof<T::Hash, (T::AccountId, T::Balance)>,
+			merkle_proof: DistributionProof<T, I>,
 		) -> DispatchResult {
 			ensure_signed(origin)?;
 			Self::do_claim_distribution(distribution_id, merkle_proof)?;

--- a/substrate/frame/assets/src/weights.rs
+++ b/substrate/frame/assets/src/weights.rs
@@ -84,6 +84,7 @@ pub trait WeightInfo {
 	fn refund_other() -> Weight;
 	fn block() -> Weight;
 	fn transfer_all() -> Weight;
+	fn mint_distribution() -> Weight;
 }
 
 /// Weights for `pallet_assets` using the Substrate node and recommended hardware.
@@ -541,6 +542,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+		fn mint_distribution() -> Weight {
+			Weight::default()
+		}
+
 }
 
 // For backwards compatibility and tests.
@@ -997,4 +1003,8 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+			fn mint_distribution() -> Weight {
+			Weight::default()
+		}
 }

--- a/substrate/frame/assets/src/weights.rs
+++ b/substrate/frame/assets/src/weights.rs
@@ -85,6 +85,7 @@ pub trait WeightInfo {
 	fn block() -> Weight;
 	fn transfer_all() -> Weight;
 	fn mint_distribution() -> Weight;
+	fn claim_distribution() -> Weight;
 }
 
 /// Weights for `pallet_assets` using the Substrate node and recommended hardware.
@@ -543,9 +544,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 
-		fn mint_distribution() -> Weight {
-			Weight::default()
-		}
+	fn mint_distribution() -> Weight {
+		Weight::default()
+	}
+
+	fn claim_distribution() -> Weight {
+		Weight::default()
+	}
 
 }
 
@@ -1004,7 +1009,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 
-			fn mint_distribution() -> Weight {
-			Weight::default()
-		}
+	fn mint_distribution() -> Weight {
+		Weight::default()
+	}
+
+	fn claim_distribution() -> Weight {
+		Weight::default()
+	}
 }

--- a/substrate/utils/binary-merkle-tree/Cargo.toml
+++ b/substrate/utils/binary-merkle-tree/Cargo.toml
@@ -15,6 +15,10 @@ workspace = true
 array-bytes = { optional = true, workspace = true, default-features = true }
 log = { optional = true, workspace = true }
 hash-db = { workspace = true }
+codec = { features = [
+	"derive",
+], workspace = true }
+scale-info = { features = ["derive"], workspace = true }
 
 [dev-dependencies]
 array-bytes = { workspace = true, default-features = true }
@@ -25,4 +29,4 @@ sp-runtime = { workspace = true, default-features = true }
 [features]
 debug = ["array-bytes", "log"]
 default = ["debug", "std"]
-std = ["hash-db/std", "log/std", "sp-core/std", "sp-runtime/std"]
+std = ["codec/std", "scale-info/std", "hash-db/std", "log/std", "sp-core/std", "sp-runtime/std"]

--- a/substrate/utils/binary-merkle-tree/src/lib.rs
+++ b/substrate/utils/binary-merkle-tree/src/lib.rs
@@ -38,6 +38,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use hash_db::Hasher;
+use codec::{Encode, Decode};
+use scale_info::TypeInfo;
 
 /// Construct a root hash of a Binary Merkle Tree created from given leaves.
 ///
@@ -87,7 +89,8 @@ where
 /// A generated merkle proof.
 ///
 /// The structure contains all necessary data to later on verify the proof and the leaf itself.
-#[derive(Debug, PartialEq, Eq)]
+// #[derive(Encode, Decode, Debug, PartialEq, Eq, TypeInfo)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MerkleProof<H, L> {
 	/// Root hash of generated merkle tree.
 	pub root: H,
@@ -105,6 +108,36 @@ pub struct MerkleProof<H, L> {
 	pub leaf_index: usize,
 	/// Leaf content.
 	pub leaf: L,
+}
+
+// USIZE breaks these needed traits
+impl<H: 'static, L: 'static> TypeInfo for MerkleProof<H, L> {
+	type Identity = Self;
+
+	fn type_info() -> scale_info::Type {
+		scale_info::Type::builder()
+			.path(scale_info::Path::new("Dummy TODO", module_path!()))
+			.composite(
+				scale_info::build::Fields::unnamed()
+					.field(|f| f.ty::<u8>().docs(&["Dummy TODO"])),
+			)
+	}
+}
+
+impl<H, L> Encode for MerkleProof<H, L> {
+	fn size_hint(&self) -> usize {
+		true.size_hint()
+	}
+
+	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+		true.using_encoded(f)
+	}
+}
+
+impl<H, L> Decode for MerkleProof<H, L> {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		Err("DUMMY TODO".into())
+	}
 }
 
 /// A trait of object inspecting merkle root creation.

--- a/substrate/utils/binary-merkle-tree/src/lib.rs
+++ b/substrate/utils/binary-merkle-tree/src/lib.rs
@@ -260,6 +260,22 @@ impl<'a, H, T: AsRef<[u8]>> From<&'a T> for Leaf<'a, H> {
 	}
 }
 
+// pub fn verify_merkle_proof<'a, H, L>(
+// 	merkle_proof: &'a MerkleProof<H::Out, L>,
+// ) -> bool
+// where
+// 	H: Hasher,
+// 	L: Into<Leaf<'a, H::Out>>,
+// {
+// 	verify_proof::<H, Vec<H::Out>, L>(
+// 		&merkle_proof.root,
+// 		merkle_proof.proof,
+// 		merkle_proof.number_of_leaves,
+// 		merkle_proof.leaf_index,
+// 		merkle_proof.leaf,
+// 	)
+// }
+
 /// Verify Merkle Proof correctness versus given root hash.
 ///
 /// The proof is NOT expected to contain leaf hash as the first


### PR DESCRIPTION
This PR introduces a way for an asset issuer to distribute their token to many users using a single merkle root.

Users then present a merkle proof which is verified, and triggers the `do_mint` function.

A tracking storage ensures that each user only claims their distribution a single time.

The design allows for multiple distributions per asset id.