### PR TITLE
peerstore: Clarify peer report warnings

### DIFF
--- a/prdoc/pr_5407.prdoc
+++ b/prdoc/pr_5407.prdoc
@@ -1,0 +1,17 @@
+title: Prepare PVFs if node is a validator in the next session
+
+doc:
+  - audience: [Node Operator, Node Dev]
+    description: |
+      This PR aims to remove the noise caused by the peer store's reputation system.
+      A warning was emitted each time a reputation was reported for a banned peer,
+      regardless of the reputation being positive. This has led in the past to
+      situations where it was hard to identify the actual reason of the ban and
+      caused noise for node operators.
+
+      The `Banned, disconnecting.` warning is logged only when the peer is banned.
+      Other misbehaves are logged as `Misbehaved during the ban threshold`.
+
+crates:
+  - name: sc-network
+

--- a/prdoc/pr_5407.prdoc
+++ b/prdoc/pr_5407.prdoc
@@ -14,4 +14,4 @@ doc:
 
 crates:
   - name: sc-network
-
+    bump: patch

--- a/substrate/client/network/src/litep2p/peerstore.rs
+++ b/substrate/client/network/src/litep2p/peerstore.rs
@@ -209,6 +209,16 @@ impl PeerStoreProvider for PeerstoreHandle {
 		);
 
 		if !peer_info.is_banned() {
+			if was_banned {
+				log::info!(
+					target: LOG_TARGET,
+					"Peer {} is now unbanned: {:+} to {}. Reason: {}.",
+					peer_id,
+					change.value,
+					peer_reputation,
+					change.reason,
+				);
+			}
 			return;
 		}
 

--- a/substrate/client/network/src/litep2p/peerstore.rs
+++ b/substrate/client/network/src/litep2p/peerstore.rs
@@ -192,38 +192,53 @@ impl PeerStoreProvider for PeerstoreHandle {
 	}
 
 	/// Adjust peer reputation.
-	fn report_peer(&self, peer: PeerId, reputation_change: ReputationChange) {
+	fn report_peer(&self, peer_id: PeerId, change: ReputationChange) {
 		let mut lock = self.0.lock();
+		let peer_info = lock.peers.entry(peer_id).or_default();
+		let was_banned = peer_info.is_banned();
+		peer_info.add_reputation(change.value);
+		let peer_reputation = peer_info.reputation;
 
-		log::trace!(target: LOG_TARGET, "report peer {reputation_change:?}");
+		log::trace!(
+			target: LOG_TARGET,
+			"Report {}: {:+} to {}. Reason: {}.",
+			peer_id,
+			change.value,
+			peer_reputation,
+			change.reason,
+		);
 
-		match lock.peers.get_mut(&peer) {
-			Some(info) => {
-				info.add_reputation(reputation_change.value);
-			},
-			None => {
-				lock.peers.insert(
-					peer,
-					PeerInfo {
-						reputation: reputation_change.value,
-						last_updated: Instant::now(),
-						role: None,
-					},
-				);
-			},
+		if !peer_info.is_banned() {
+			return;
 		}
 
-		if lock
-			.peers
-			.get(&peer)
-			.expect("peer exist since it was just modified; qed")
-			.is_banned()
-		{
-			log::warn!(target: LOG_TARGET, "{peer:?} banned, disconnecting, reason: {}", reputation_change.reason);
+		// Peer is currently banned, disconnect it from all protocols.
+		lock.protocols.iter().for_each(|handle| handle.disconnect_peer(peer_id.into()));
 
-			for sender in &lock.protocols {
-				sender.disconnect_peer(peer);
-			}
+		// The peer is banned for the first time.
+		if !was_banned {
+			log::warn!(
+				target: LOG_TARGET,
+				"Report {}: {:+} to {}. Reason: {}. Banned, disconnecting.",
+				peer_id,
+				change.value,
+				peer_reputation,
+				change.reason,
+			);
+			return;
+		}
+
+		// The peer was already banned and it got another negative report.
+		// This may happen during a batch report.
+		if change.value < 0 {
+			log::warn!(
+				target: LOG_TARGET,
+				"Report {}: {:+} to {}. Reason: {}. Misbehaved during the ban threshold.",
+				peer_id,
+				change.value,
+				peer_reputation,
+				change.reason,
+			);
 		}
 	}
 

--- a/substrate/client/network/src/litep2p/peerstore.rs
+++ b/substrate/client/network/src/litep2p/peerstore.rs
@@ -231,7 +231,7 @@ impl PeerStoreProvider for PeerstoreHandle {
 		// The peer was already banned and it got another negative report.
 		// This may happen during a batch report.
 		if change.value < 0 {
-			log::warn!(
+			log::debug!(
 				target: LOG_TARGET,
 				"Report {}: {:+} to {}. Reason: {}. Misbehaved during the ban threshold.",
 				peer_id,

--- a/substrate/client/network/src/peer_store.rs
+++ b/substrate/client/network/src/peer_store.rs
@@ -273,6 +273,16 @@ impl PeerStoreInner {
 		);
 
 		if !peer_info.is_banned() {
+			if was_banned {
+				log::info!(
+					target: LOG_TARGET,
+					"Peer {} is now unbanned: {:+} to {}. Reason: {}.",
+					peer_id,
+					change.value,
+					peer_info.reputation,
+					change.reason,
+				);
+			}
 			return;
 		}
 

--- a/substrate/client/network/src/peer_store.rs
+++ b/substrate/client/network/src/peer_store.rs
@@ -295,7 +295,7 @@ impl PeerStoreInner {
 		// The peer was already banned and it got another negative report.
 		// This may happen during a batch report.
 		if change.value < 0 {
-			log::warn!(
+			log::debug!(
 				target: LOG_TARGET,
 				"Report {}: {:+} to {}. Reason: {}. Misbehaved during the ban threshold.",
 				peer_id,

--- a/substrate/client/network/src/peer_store.rs
+++ b/substrate/client/network/src/peer_store.rs
@@ -260,11 +260,27 @@ impl PeerStoreInner {
 
 	fn report_peer(&mut self, peer_id: PeerId, change: ReputationChange) {
 		let peer_info = self.peers.entry(peer_id).or_default();
+		let was_banned = peer_info.is_banned();
 		peer_info.add_reputation(change.value);
 
-		if peer_info.is_banned() {
-			self.protocols.iter().for_each(|handle| handle.disconnect_peer(peer_id.into()));
+		log::trace!(
+			target: LOG_TARGET,
+			"Report {}: {:+} to {}. Reason: {}.",
+			peer_id,
+			change.value,
+			peer_info.reputation,
+			change.reason,
+		);
 
+		if !peer_info.is_banned() {
+			return;
+		}
+
+		// Peer is currently banned, disconnect it from all protocols.
+		self.protocols.iter().for_each(|handle| handle.disconnect_peer(peer_id.into()));
+
+		// The peer is banned for the first time.
+		if !was_banned {
 			log::warn!(
 				target: LOG_TARGET,
 				"Report {}: {:+} to {}. Reason: {}. Banned, disconnecting.",
@@ -273,10 +289,15 @@ impl PeerStoreInner {
 				peer_info.reputation,
 				change.reason,
 			);
-		} else {
-			log::trace!(
+			return;
+		}
+
+		// The peer was already banned and it got another negative report.
+		// This may happen during a batch report.
+		if change.value < 0 {
+			log::warn!(
 				target: LOG_TARGET,
-				"Report {}: {:+} to {}. Reason: {}.",
+				"Report {}: {:+} to {}. Reason: {}. Misbehaved during the ban threshold.",
 				peer_id,
 				change.value,
 				peer_info.reputation,


### PR DESCRIPTION
This PR aims to make the logging from the peer store a bit more clear.

In the past, we aggressively produced warning logs from the peer store component, even in cases where the reputation change was not malicious. This has led to an extensive number of logs, as well to node operator confusion. 

In this PR, we produce a warning message if:
- The peer crosses the banned threshold for the first time. This is the actual reason of a ban
- The peer misbehaves again while being banned. This may happen during a batch peer report

cc @paritytech/networking 

Part of: https://github.com/paritytech/polkadot-sdk/issues/5379.