### PR TITLE
approval-distribution: Fix preallocation of ApprovalEntries

### DIFF
--- a/polkadot/node/network/approval-distribution/src/lib.rs
+++ b/polkadot/node/network/approval-distribution/src/lib.rs
@@ -161,7 +161,7 @@ impl ApprovalEntry {
 		Self {
 			validator_index: assignment.validator,
 			assignment,
-			approvals: HashMap::with_capacity(candidates.len()),
+			approvals: HashMap::new(),
 			assignment_claimed_candidates: candidates,
 			routing_info,
 		}

--- a/prdoc/pr_5411.prdoc
+++ b/prdoc/pr_5411.prdoc
@@ -1,0 +1,3 @@
+crates:
+  - name: polkadot-approval-distribution
+    bump: none


### PR DESCRIPTION
We preallocated the approvals field in the ApprovalEntry by up to a factor of two in the worse conditions, since we can't have more than 6 approvals and candidates.len() will return 20 if you have just the 20th bit set. 
This adds to a lot of wasted memory because we have an ApprovalEntry for each assignment we received

This was discovered while running rust jemalloc-profiling with the steps from here: https://www.magiroux.com/rust-jemalloc-profiling/

Just with this optimisation approvals subsystem-benchmark memory usage on the worst case scenario is reduced from 6.1GiB to 2.4 GiB, even cpu usage of approval-distribution decreases by 4-5%.