### PR TITLE
Fix mmr zombienet test

### DIFF
--- a/polkadot/zombienet_tests/functional/0003-mmr-generate-and-verify-proof.js
+++ b/polkadot/zombienet_tests/functional/0003-mmr-generate-and-verify-proof.js
@@ -3,9 +3,9 @@ const common = require('./0003-common.js');
 async function run(nodeName, networkInfo, nodeNames) {
   const apis = await common.getApis(networkInfo, nodeNames);
 
-  const proof = await apis[nodeName].rpc.mmr.generateProof([1, 9, 20]);
-
-  const root = await apis[nodeName].rpc.mmr.root()
+  let at = await apis[nodeName].rpc.chain.getBlockHash(21);
+  const root = await apis[nodeName].rpc.mmr.root(at);
+  const proof = await apis[nodeName].rpc.mmr.generateProof([1, 9, 20], 21, at);
 
   const proofVerifications = await Promise.all(
     Object.values(apis).map(async (api) => {


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/4309

If a new block is generated between these 2 lines:

```
  const proof = await apis[nodeName].rpc.mmr.generateProof([1, 9, 20]);

  const root = await apis[nodeName].rpc.mmr.root()
```

we will try to verify a proof for the previous block with the mmr root at the current block. Which will fail.

So we generate the proof and get the mmr root at block 21 for consistency.