### PR TITLE
Implementations to allow easier unbricking of parachains

### DIFF
--- a/polkadot/runtime/common/src/assigned_slots/mod.rs
+++ b/polkadot/runtime/common/src/assigned_slots/mod.rs
@@ -719,6 +719,8 @@ mod tests {
 		type NextSessionRotation = crate::mock::TestNextSessionRotation;
 		type OnNewHead = ();
 		type AssignCoretime = ();
+		type UnbrickOrigin = EnsureRoot<Self::AccountId>;
+		type MinTimeToAllowUnbrick = ConstU32<5>;
 	}
 
 	impl parachains_shared::Config for Test {

--- a/polkadot/runtime/common/src/integration_tests.rs
+++ b/polkadot/runtime/common/src/integration_tests.rs
@@ -205,6 +205,8 @@ impl paras::Config for Test {
 	type NextSessionRotation = crate::mock::TestNextSessionRotation;
 	type OnNewHead = ();
 	type AssignCoretime = ();
+	type UnbrickOrigin = EnsureRoot<AccountId>;
+	type MinTimeToAllowUnbrick = ConstU32<5>;
 }
 
 parameter_types! {

--- a/polkadot/runtime/common/src/paras_registrar/mod.rs
+++ b/polkadot/runtime/common/src/paras_registrar/mod.rs
@@ -823,6 +823,8 @@ mod tests {
 		type NextSessionRotation = crate::mock::TestNextSessionRotation;
 		type OnNewHead = ();
 		type AssignCoretime = ();
+		type UnbrickOrigin = EnsureRoot<AccountId>;
+		type MinTimeToAllowUnbrick = frame_support::traits::ConstU32<5>;
 	}
 
 	impl configuration::Config for Test {
@@ -989,7 +991,7 @@ mod tests {
 			assert!(Parachains::is_parathread(para_id));
 			assert!(!Parachains::is_parachain(para_id));
 			// Deregister it
-			assert_ok!(Registrar::deregister(RuntimeOrigin::root(), para_id,));
+			assert_ok!(Registrar::deregister(RuntimeOrigin::root(), para_id));
 			run_to_session(START_SESSION_INDEX + 8);
 			// It is nothing
 			assert!(!Parachains::is_parathread(para_id));
@@ -1180,7 +1182,7 @@ mod tests {
 
 			run_to_session(START_SESSION_INDEX + 2);
 			assert!(Parachains::is_parathread(para_id));
-			assert_ok!(Registrar::deregister(RuntimeOrigin::root(), para_id,));
+			assert_ok!(Registrar::deregister(RuntimeOrigin::root(), para_id));
 			run_to_session(START_SESSION_INDEX + 4);
 			assert!(paras::Pallet::<Test>::lifecycle(para_id).is_none());
 			assert_eq!(Balances::reserved_balance(&1), 0);

--- a/polkadot/runtime/parachains/src/mock.rs
+++ b/polkadot/runtime/parachains/src/mock.rs
@@ -30,7 +30,7 @@ use polkadot_primitives::CoreIndex;
 
 use codec::Decode;
 use frame_support::{
-	assert_ok, derive_impl, parameter_types,
+	assert_ok, derive_impl, ord_parameter_types, parameter_types,
 	traits::{
 		Currency, ProcessMessage, ProcessMessageError, ValidatorSet, ValidatorSetWithIdentification,
 	},
@@ -38,7 +38,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_support_test::TestRandomness;
-use frame_system::limits;
+use frame_system::{limits, EnsureSignedBy};
 use polkadot_primitives::{
 	AuthorityDiscoveryId, Balance, BlockNumber, CandidateHash, Moment, SessionIndex, UpwardMessage,
 	ValidationCode, ValidatorIndex,
@@ -229,6 +229,10 @@ impl frame_support::traits::EstimateNextSessionRotation<u32> for TestNextSession
 	}
 }
 
+ord_parameter_types! {
+	pub const One: u64 = 1;
+}
+
 impl crate::paras::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = crate::paras::TestWeightInfo;
@@ -237,6 +241,8 @@ impl crate::paras::Config for Test {
 	type NextSessionRotation = TestNextSessionRotation;
 	type OnNewHead = ();
 	type AssignCoretime = ();
+	type UnbrickOrigin = EnsureSignedBy<One, AccountId>;
+	type MinTimeToAllowUnbrick = ConstU32<5>;
 }
 
 impl crate::dmp::Config for Test {}

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -978,6 +978,8 @@ impl parachains_paras::Config for Runtime {
 	type NextSessionRotation = Babe;
 	type OnNewHead = Registrar;
 	type AssignCoretime = CoretimeAssignmentProvider;
+	type UnbrickOrigin = EnsureNever<()>;
+	type MinTimeToAllowUnbrick = ConstU32<{ 2 * HOURS }>;
 }
 
 parameter_types! {

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -28,6 +28,7 @@ use alloc::{
 	vec::Vec,
 };
 use codec::Encode;
+use frame_system::{EnsureNever, EnsureRoot};
 use pallet_transaction_payment::FungibleAdapter;
 
 use polkadot_runtime_parachains::{
@@ -550,6 +551,8 @@ impl parachains_paras::Config for Runtime {
 	type NextSessionRotation = Babe;
 	type OnNewHead = ();
 	type AssignCoretime = ();
+	type UnbrickOrigin = EnsureRoot<AccountId>;
+	type MinTimeToAllowUnbrick = ConstU64<{ 2 * HOUR }>;
 }
 
 parameter_types! {

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1109,7 +1109,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				matches!(
 					c,
 					RuntimeCall::Staking(..) |
-						RuntimeCall::Session(..) | RuntimeCall::Utility(..) |
+						RuntimeCall::Session(..) |
+						RuntimeCall::Utility(..) |
 						RuntimeCall::FastUnstake(..) |
 						RuntimeCall::VoterList(..) |
 						RuntimeCall::NominationPools(..)
@@ -1209,6 +1210,8 @@ impl parachains_paras::Config for Runtime {
 	type NextSessionRotation = Babe;
 	type OnNewHead = ();
 	type AssignCoretime = CoretimeAssignmentProvider;
+	type UnbrickOrigin = EnsureRoot<AccountId>;
+	type MinTimeToAllowUnbrick = ConstU64<{ 2 * HOUR }>;
 }
 
 parameter_types! {


### PR DESCRIPTION
This Pull Request aims to implement the pallet components of the [Unbrick Collective](https://forum.polkadot.network/t/unbrick-collective/6931).

- [x] [Paras] Implement `unbrick` method
    The `Paras::unbrick` method allows a given origin to change the validation code or note a head for a para.
- [ ] [ParasRegistrar] Allow paras to delegate a manager
    This allows paras to opt-in for a delegated origin (i.e. `UnbrickCollective`) that can handle operations  to unbrick a para.
- [ ] [Whitelisted] Map between Dispatch Origin to Execution Origin.
  This allows using a single instance of `Whitelist` that executes calls to different origins depending on the caller origin, based on a mapping.