### PR TITLE
pallet-collator-selection: correctly register weight in `new_session`

### DIFF
--- a/cumulus/pallets/collator-selection/src/lib.rs
+++ b/cumulus/pallets/collator-selection/src/lib.rs
@@ -972,7 +972,7 @@ pub mod pallet {
 			let result = Self::assemble_collators();
 
 			frame_system::Pallet::<T>::register_extra_weight_unchecked(
-				T::WeightInfo::new_session(candidates_len_before, removed),
+				T::WeightInfo::new_session(removed, candidates_len_before),
 				DispatchClass::Mandatory,
 			);
 			Some(result)

--- a/prdoc/pr_5430.prdoc
+++ b/prdoc/pr_5430.prdoc
@@ -1,7 +1,7 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: pallet-collator-staking: ese correctly the `WeightInfo` call for `new_session`
+title: "pallet-collator-staking: use correctly the `WeightInfo` call for `new_session`"
 
 doc:
   - audience: Runtime Dev

--- a/prdoc/pr_5430.prdoc
+++ b/prdoc/pr_5430.prdoc
@@ -9,5 +9,5 @@ doc:
       - Fixes an incorrect usage of the `WeightInfo` trait for `new_session`.
 
 crates:
-    - name: pallet-collator-selection
-      bump: minor
+  - name: pallet-collator-selection
+    bump: minor

--- a/prdoc/pr_5430.prdoc
+++ b/prdoc/pr_5430.prdoc
@@ -1,7 +1,7 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: "pallet-collator-staking: use correctly the `WeightInfo` call for `new_session`"
+title: "pallet-collator-selection: use correctly the `WeightInfo` call for `new_session`"
 
 doc:
   - audience: Runtime Dev

--- a/prdoc/pr_5430.prdoc
+++ b/prdoc/pr_5430.prdoc
@@ -1,7 +1,7 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: "pallet-collator-selection: use correctly the `WeightInfo` call for `new_session`"
+title: "pallet-collator-selection: correctly register weight in `new_session`"
 
 doc:
   - audience: Runtime Dev
@@ -10,4 +10,4 @@ doc:
 
 crates:
   - name: pallet-collator-selection
-    bump: minor
+    bump: patch

--- a/prdoc/pr_5430.prdoc
+++ b/prdoc/pr_5430.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: pallet-collator-staking: ese correctly the `WeightInfo` call for `new_session`
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      - Fixes an incorrect usage of the `WeightInfo` trait for `new_session`.
+
+crates:
+    - name: pallet-collator-selection
+      bump: minor


### PR DESCRIPTION
The `pallet-collator-selection` is not correctly using the weight for the [new_session](https://github.com/blockdeep/pallet-collator-staking/blob/main/src/benchmarking.rs#L350-L353) function.

The first parameter is the removed candidates, and the second one the original number of candidates before the removal, but both values are swapped.