### PR TITLE
Remove the need to wait for target block header in warp sync implementation

### DIFF
--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -28,10 +28,7 @@ use cumulus_relay_chain_interface::{RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::{
 	build_minimal_relay_chain_node_light_client, build_minimal_relay_chain_node_with_rpc,
 };
-use futures::{
-	channel::{mpsc, oneshot},
-	FutureExt, StreamExt,
-};
+use futures::{channel::mpsc, StreamExt};
 use polkadot_primitives::{CollatorPair, OccupiedCoreAssumption};
 use sc_client_api::{
 	Backend as BackendT, BlockBackend, BlockchainEvents, Finalizer, ProofProvider, UsageProvider,
@@ -43,7 +40,7 @@ use sc_consensus::{
 use sc_network::{config::SyncMode, service::traits::NetworkService, NetworkBackend};
 use sc_network_sync::SyncingService;
 use sc_network_transactions::TransactionsHandlerController;
-use sc_service::{Configuration, NetworkStarter, SpawnTaskHandle, TaskManager, WarpSyncParams};
+use sc_service::{Configuration, NetworkStarter, SpawnTaskHandle, TaskManager, WarpSyncConfig};
 use sc_telemetry::{log, TelemetryWorkerHandle};
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::ProvideRuntimeApi;
@@ -467,12 +464,19 @@ where
 {
 	let warp_sync_params = match parachain_config.network.sync_mode {
 		SyncMode::Warp => {
-			let target_block = warp_sync_get::<Block, RCInterface>(
-				para_id,
-				relay_chain_interface.clone(),
-				spawn_handle.clone(),
-			);
-			Some(WarpSyncParams::WaitForTarget(target_block))
+			log::debug!(target: LOG_TARGET_SYNC, "waiting for announce block...");
+
+			let target_block =
+				wait_for_finalized_para_head::<Block, _>(para_id, relay_chain_interface.clone())
+					.await
+					.inspect_err(|e| {
+						log::error!(
+							target: LOG_TARGET_SYNC,
+							"Unable to determine parachain target block {:?}",
+							e
+						);
+					})?;
+			Some(WarpSyncConfig::WithTarget(target_block))
 		},
 		_ => None,
 	};
@@ -500,67 +504,37 @@ where
 		spawn_handle,
 		import_queue,
 		block_announce_validator_builder: Some(Box::new(move |_| block_announce_validator)),
-		warp_sync_params,
+		warp_sync_config: warp_sync_params,
 		block_relay: None,
 		metrics,
 	})
 }
 
-/// Creates a new background task to wait for the relay chain to sync up and retrieve the parachain
-/// header
-fn warp_sync_get<B, RCInterface>(
-	para_id: ParaId,
-	relay_chain_interface: RCInterface,
-	spawner: SpawnTaskHandle,
-) -> oneshot::Receiver<<B as BlockT>::Header>
-where
-	B: BlockT + 'static,
-	RCInterface: RelayChainInterface + 'static,
-{
-	let (sender, receiver) = oneshot::channel::<B::Header>();
-	spawner.spawn(
-		"cumulus-parachain-wait-for-target-block",
-		None,
-		async move {
-			log::debug!(
-				target: LOG_TARGET_SYNC,
-				"waiting for announce block in a background task...",
-			);
-
-			let _ = wait_for_finalized_para_head::<B, _>(sender, para_id, relay_chain_interface)
-				.await
-				.map_err(|e| {
-					log::error!(
-						target: LOG_TARGET_SYNC,
-						"Unable to determine parachain target block {:?}",
-						e
-					)
-				});
-		}
-		.boxed(),
-	);
-
-	receiver
-}
-
 /// Waits for the relay chain to have finished syncing and then gets the parachain header that
 /// corresponds to the last finalized relay chain block.
 async fn wait_for_finalized_para_head<B, RCInterface>(
-	sender: oneshot::Sender<<B as BlockT>::Header>,
 	para_id: ParaId,
 	relay_chain_interface: RCInterface,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+) -> sc_service::error::Result<<B as BlockT>::Header>
 where
 	B: BlockT + 'static,
 	RCInterface: RelayChainInterface + Send + 'static,
 {
-	let mut imported_blocks = relay_chain_interface.import_notification_stream().await?.fuse();
-	while imported_blocks.next().await.is_some() {
-		let is_syncing = relay_chain_interface.is_major_syncing().await.map_err(|e| {
-			Box::<dyn std::error::Error + Send + Sync>::from(format!(
-				"Unable to determine sync status. {e}"
+	let mut imported_blocks = relay_chain_interface
+		.import_notification_stream()
+		.await
+		.map_err(|error| {
+			sc_service::Error::Other(format!(
+				"Relay chain import notification stream error when waiting for parachain head: \
+				{error}"
 			))
-		})?;
+		})?
+		.fuse();
+	while imported_blocks.next().await.is_some() {
+		let is_syncing = relay_chain_interface
+			.is_major_syncing()
+			.await
+			.map_err(|e| format!("Unable to determine sync status: {e}"))?;
 
 		if !is_syncing {
 			let relay_chain_best_hash = relay_chain_interface
@@ -586,8 +560,7 @@ where
 				finalized_header.number(),
 				finalized_header.hash()
 			);
-			let _ = sender.send(finalized_header);
-			return Ok(())
+			return Ok(finalized_header)
 		}
 	}
 

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -764,7 +764,7 @@ pub fn new_full<
 ) -> Result<NewFull, Error> {
 	use polkadot_availability_recovery::FETCH_CHUNKS_THRESHOLD;
 	use polkadot_node_network_protocol::request_response::IncomingRequest;
-	use sc_network_sync::WarpSyncParams;
+	use sc_network_sync::WarpSyncConfig;
 
 	let is_offchain_indexing_enabled = config.offchain_worker.indexing_enabled;
 	let role = config.role.clone();
@@ -1037,7 +1037,7 @@ pub fn new_full<
 			spawn_handle: task_manager.spawn_handle(),
 			import_queue,
 			block_announce_validator_builder: None,
-			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			warp_sync_config: Some(WarpSyncConfig::WithProvider(warp_sync)),
 			block_relay: None,
 			metrics,
 		})?;

--- a/prdoc/pr_5431.prdoc
+++ b/prdoc/pr_5431.prdoc
@@ -1,0 +1,20 @@
+title: Remove the need to wait for target block header in warp sync implementation
+
+doc:
+  - audience: Node Dev
+    description: |
+      Previously warp sync needed to wait for target block header of the relay chain to become available before warp
+      sync can start, which resulted in cumbersome APIs. Parachain initialization was refactored to initialize warp sync
+      with target block header from the very beginning, improving and simplifying sync API.
+
+crates:
+  - name: sc-service
+    bump: major
+  - name: sc-network-sync
+    bump: major
+  - name: polkadot-service
+    bump: major
+  - name: cumulus-client-service
+    bump: major
+  - name: sc-informant
+    bump: major

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -37,7 +37,7 @@ use sc_consensus_babe::{self, SlotProportion};
 use sc_network::{
 	event::Event, service::traits::NetworkService, NetworkBackend, NetworkEventStream,
 };
-use sc_network_sync::{strategy::warp::WarpSyncParams, SyncingService};
+use sc_network_sync::{strategy::warp::WarpSyncConfig, SyncingService};
 use sc_service::{config::Configuration, error::Error as ServiceError, RpcHandlers, TaskManager};
 use sc_statement_store::Store as StatementStore;
 use sc_telemetry::{Telemetry, TelemetryWorker};
@@ -517,7 +517,7 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 			spawn_handle: task_manager.spawn_handle(),
 			import_queue,
 			block_announce_validator_builder: None,
-			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			warp_sync_config: Some(WarpSyncConfig::WithProvider(warp_sync)),
 			block_relay: None,
 			metrics,
 		})?;

--- a/substrate/client/informant/src/display.rs
+++ b/substrate/client/informant/src/display.rs
@@ -101,17 +101,9 @@ impl<B: BlockT> InformantDisplay<B> {
 					_,
 					Some(WarpSyncProgress { phase: WarpSyncPhase::DownloadingBlocks(n), .. }),
 				) if !sync_status.is_major_syncing() => ("⏩", "Block history".into(), format!(", #{}", n)),
-				(
-					_,
-					_,
-					Some(WarpSyncProgress { phase: WarpSyncPhase::AwaitingTargetBlock, .. }),
-				) => ("⏩", "Waiting for pending target block".into(), "".into()),
 				// Handle all phases besides the two phases we already handle above.
 				(_, _, Some(warp))
-					if !matches!(
-						warp.phase,
-						WarpSyncPhase::AwaitingTargetBlock | WarpSyncPhase::DownloadingBlocks(_)
-					) =>
+					if !matches!(warp.phase, WarpSyncPhase::DownloadingBlocks(_)) =>
 					(
 						"⏩",
 						"Warping".into(),

--- a/substrate/client/network/sync/src/lib.rs
+++ b/substrate/client/network/sync/src/lib.rs
@@ -19,7 +19,7 @@
 //! Blockchain syncing implementation in Substrate.
 
 pub use service::syncing_service::SyncingService;
-pub use strategy::warp::{WarpSyncParams, WarpSyncPhase, WarpSyncProgress};
+pub use strategy::warp::{WarpSyncConfig, WarpSyncPhase, WarpSyncProgress};
 pub use types::{SyncEvent, SyncEventStream, SyncState, SyncStatus, SyncStatusProvider};
 
 mod block_announce_validator;

--- a/substrate/client/network/sync/src/strategy/warp.rs
+++ b/substrate/client/network/sync/src/strategy/warp.rs
@@ -26,7 +26,6 @@ use crate::{
 	LOG_TARGET,
 };
 use codec::{Decode, Encode};
-use futures::channel::oneshot;
 use log::{debug, error, trace};
 use sc_network_common::sync::message::{
 	BlockAnnounce, BlockAttributes, BlockData, BlockRequest, Direction, FromBlock,
@@ -104,8 +103,6 @@ mod rep {
 pub enum WarpSyncPhase<Block: BlockT> {
 	/// Waiting for peers to connect.
 	AwaitingPeers { required_peers: usize },
-	/// Waiting for target block to be received.
-	AwaitingTargetBlock,
 	/// Downloading and verifying grandpa warp proofs.
 	DownloadingWarpProofs,
 	/// Downloading target block.
@@ -125,7 +122,6 @@ impl<Block: BlockT> fmt::Display for WarpSyncPhase<Block> {
 		match self {
 			Self::AwaitingPeers { required_peers } =>
 				write!(f, "Waiting for {required_peers} peers to be connected"),
-			Self::AwaitingTargetBlock => write!(f, "Waiting for target block to be received"),
 			Self::DownloadingWarpProofs => write!(f, "Downloading finality proofs"),
 			Self::DownloadingTargetBlock => write!(f, "Downloading target block"),
 			Self::DownloadingState => write!(f, "Downloading state"),
@@ -145,37 +141,14 @@ pub struct WarpSyncProgress<Block: BlockT> {
 	pub total_bytes: u64,
 }
 
-/// The different types of warp syncing, passed to `build_network`.
-pub enum WarpSyncParams<Block: BlockT> {
-	/// Standard warp sync for the chain.
-	WithProvider(Arc<dyn WarpSyncProvider<Block>>),
-	/// Skip downloading proofs and wait for a header of the state that should be downloaded.
-	///
-	/// It is expected that the header provider ensures that the header is trusted.
-	WaitForTarget(oneshot::Receiver<<Block as BlockT>::Header>),
-}
-
 /// Warp sync configuration as accepted by [`WarpSync`].
 pub enum WarpSyncConfig<Block: BlockT> {
 	/// Standard warp sync for the chain.
 	WithProvider(Arc<dyn WarpSyncProvider<Block>>),
-	/// Skip downloading proofs and wait for a header of the state that should be downloaded.
+	/// Skip downloading proofs and use provided header of the state that should be downloaded.
 	///
 	/// It is expected that the header provider ensures that the header is trusted.
-	WaitForTarget,
-}
-
-impl<Block: BlockT> WarpSyncParams<Block> {
-	/// Split `WarpSyncParams` into `WarpSyncConfig` and warp sync target block header receiver.
-	pub fn split(
-		self,
-	) -> (WarpSyncConfig<Block>, Option<oneshot::Receiver<<Block as BlockT>::Header>>) {
-		match self {
-			WarpSyncParams::WithProvider(provider) =>
-				(WarpSyncConfig::WithProvider(provider), None),
-			WarpSyncParams::WaitForTarget(rx) => (WarpSyncConfig::WaitForTarget, Some(rx)),
-		}
-	}
+	WithTarget(<Block as BlockT>::Header),
 }
 
 /// Warp sync phase used by warp sync state machine.
@@ -189,9 +162,6 @@ enum Phase<B: BlockT> {
 		last_hash: B::Hash,
 		warp_sync_provider: Arc<dyn WarpSyncProvider<B>>,
 	},
-	/// Waiting for target block to be set externally if we skip warp proofs downloading,
-	/// and start straight from the target block (used by parachains warp sync).
-	PendingTargetBlock,
 	/// Downloading target block.
 	TargetBlock(B::Header),
 	/// Warp sync is complete.
@@ -274,7 +244,7 @@ where
 		let phase = match warp_sync_config {
 			WarpSyncConfig::WithProvider(warp_sync_provider) =>
 				Phase::WaitingForPeers { warp_sync_provider },
-			WarpSyncConfig::WaitForTarget => Phase::PendingTargetBlock,
+			WarpSyncConfig::WithTarget(target_header) => Phase::TargetBlock(target_header),
 		};
 
 		Self {
@@ -287,20 +257,6 @@ where
 			actions: Vec::new(),
 			result: None,
 		}
-	}
-
-	/// Set target block externally in case we skip warp proof downloading.
-	pub fn set_target_block(&mut self, header: B::Header) {
-		let Phase::PendingTargetBlock = self.phase else {
-			error!(
-				target: LOG_TARGET,
-				"Attempt to set warp sync target block in invalid phase.",
-			);
-			debug_assert!(false);
-			return
-		};
-
-		self.phase = Phase::TargetBlock(header);
 	}
 
 	/// Notify that a new peer has connected.
@@ -592,10 +548,6 @@ where
 				phase: WarpSyncPhase::DownloadingTargetBlock,
 				total_bytes: self.total_proof_bytes,
 			},
-			Phase::PendingTargetBlock { .. } => WarpSyncProgress {
-				phase: WarpSyncPhase::AwaitingTargetBlock,
-				total_bytes: self.total_proof_bytes,
-			},
 			Phase::Complete => WarpSyncProgress {
 				phase: WarpSyncPhase::Complete,
 				total_bytes: self.total_proof_bytes + self.total_state_bytes,
@@ -614,14 +566,12 @@ where
 			state: match &self.phase {
 				Phase::WaitingForPeers { .. } => SyncState::Downloading { target: Zero::zero() },
 				Phase::WarpProof { .. } => SyncState::Downloading { target: Zero::zero() },
-				Phase::PendingTargetBlock => SyncState::Downloading { target: Zero::zero() },
 				Phase::TargetBlock(header) => SyncState::Downloading { target: *header.number() },
 				Phase::Complete => SyncState::Idle,
 			},
 			best_seen_block: match &self.phase {
 				Phase::WaitingForPeers { .. } => None,
 				Phase::WarpProof { .. } => None,
-				Phase::PendingTargetBlock => None,
 				Phase::TargetBlock(header) => Some(*header.number()),
 				Phase::Complete => None,
 			},
@@ -759,7 +709,13 @@ mod test {
 	#[test]
 	fn warp_sync_to_target_for_db_with_finalized_state_is_noop() {
 		let client = mock_client_with_state();
-		let config = WarpSyncConfig::WaitForTarget;
+		let config = WarpSyncConfig::WithTarget(<Block as BlockT>::Header::new(
+			1,
+			Default::default(),
+			Default::default(),
+			Default::default(),
+			Default::default(),
+		));
 		let mut warp_sync = WarpSync::new(Arc::new(client), config);
 
 		// Warp sync instantly finishes
@@ -785,7 +741,13 @@ mod test {
 	#[test]
 	fn warp_sync_to_target_for_empty_db_doesnt_finish_instantly() {
 		let client = mock_client_without_state();
-		let config = WarpSyncConfig::WaitForTarget;
+		let config = WarpSyncConfig::WithTarget(<Block as BlockT>::Header::new(
+			1,
+			Default::default(),
+			Default::default(),
+			Default::default(),
+			Default::default(),
+		));
 		let mut warp_sync = WarpSync::new(Arc::new(client), config);
 
 		// No actions are emitted.
@@ -936,7 +898,13 @@ mod test {
 		}
 
 		// Manually set to another phase.
-		warp_sync.phase = Phase::PendingTargetBlock;
+		warp_sync.phase = Phase::TargetBlock(<Block as BlockT>::Header::new(
+			1,
+			Default::default(),
+			Default::default(),
+			Default::default(),
+			Default::default(),
+		));
 
 		// No request is made.
 		assert!(warp_sync.warp_proof_request().is_none());
@@ -1193,7 +1161,7 @@ mod test {
 			.unwrap()
 			.block;
 		let target_header = target_block.header().clone();
-		let config = WarpSyncConfig::WaitForTarget;
+		let config = WarpSyncConfig::WithTarget(target_header);
 		let mut warp_sync = WarpSync::new(client, config);
 
 		// Make sure we have enough peers to make a request.
@@ -1201,10 +1169,6 @@ mod test {
 			warp_sync.add_peer(PeerId::random(), Hash::random(), best_number);
 		}
 
-		// No actions generated so far.
-		assert_eq!(warp_sync.actions().count(), 0);
-
-		warp_sync.set_target_block(target_header);
 		assert!(matches!(warp_sync.phase, Phase::TargetBlock(_)));
 
 		let (_peer_id, request) = warp_sync.target_block_request().unwrap();

--- a/substrate/client/network/test/src/lib.rs
+++ b/substrate/client/network/test/src/lib.rs
@@ -34,7 +34,7 @@ use std::{
 	time::Duration,
 };
 
-use futures::{channel::oneshot, future::BoxFuture, pin_mut, prelude::*};
+use futures::{future::BoxFuture, pin_mut, prelude::*};
 use libp2p::PeerId;
 use log::trace;
 use parking_lot::Mutex;
@@ -67,7 +67,7 @@ use sc_network_sync::{
 	service::{network::NetworkServiceProvider, syncing_service::SyncingService},
 	state_request_handler::StateRequestHandler,
 	strategy::warp::{
-		AuthorityList, EncodedProof, SetId, VerificationResult, WarpSyncParams, WarpSyncProvider,
+		AuthorityList, EncodedProof, SetId, VerificationResult, WarpSyncConfig, WarpSyncProvider,
 	},
 	warp_request_handler,
 };
@@ -701,7 +701,7 @@ pub struct FullPeerConfig {
 	/// Enable transaction indexing.
 	pub storage_chain: bool,
 	/// Optional target block header to sync to
-	pub target_block: Option<<Block as BlockT>::Header>,
+	pub target_header: Option<<Block as BlockT>::Header>,
 	/// Force genesis even in case of warp & light state sync.
 	pub force_genesis: bool,
 }
@@ -865,13 +865,9 @@ pub trait TestNetFactory: Default + Sized + Send {
 
 		let warp_sync = Arc::new(TestWarpSyncProvider(client.clone()));
 
-		let warp_sync_params = match config.target_block {
-			Some(target_block) => {
-				let (sender, receiver) = oneshot::channel::<<Block as BlockT>::Header>();
-				let _ = sender.send(target_block);
-				WarpSyncParams::WaitForTarget(receiver)
-			},
-			_ => WarpSyncParams::WithProvider(warp_sync.clone()),
+		let warp_sync_config = match config.target_header {
+			Some(target_header) => WarpSyncConfig::WithTarget(target_header),
+			_ => WarpSyncConfig::WithProvider(warp_sync.clone()),
 		};
 
 		let warp_protocol_config = {
@@ -919,7 +915,7 @@ pub trait TestNetFactory: Default + Sized + Send {
 				protocol_id.clone(),
 				&fork_id,
 				block_announce_validator,
-				Some(warp_sync_params),
+				Some(warp_sync_config),
 				chain_sync_network_handle,
 				import_queue.service(),
 				block_relay_params.downloader,

--- a/substrate/client/network/test/src/sync.rs
+++ b/substrate/client/network/test/src/sync.rs
@@ -1298,7 +1298,7 @@ async fn warp_sync_to_target_block() {
 
 	net.add_full_peer_with_config(FullPeerConfig {
 		sync_mode: SyncMode::Warp,
-		target_block: Some(target_block),
+		target_header: Some(target_block),
 		..Default::default()
 	});
 

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -55,7 +55,7 @@ use sc_network_sync::{
 	block_relay_protocol::BlockRelayParams, block_request_handler::BlockRequestHandler,
 	engine::SyncingEngine, service::network::NetworkServiceProvider,
 	state_request_handler::StateRequestHandler,
-	warp_request_handler::RequestHandler as WarpSyncRequestHandler, SyncingService, WarpSyncParams,
+	warp_request_handler::RequestHandler as WarpSyncRequestHandler, SyncingService, WarpSyncConfig,
 };
 use sc_rpc::{
 	author::AuthorApiServer,
@@ -756,8 +756,8 @@ pub struct BuildNetworkParams<
 	/// A block announce validator builder.
 	pub block_announce_validator_builder:
 		Option<Box<dyn FnOnce(Arc<TCl>) -> Box<dyn BlockAnnounceValidator<TBl> + Send> + Send>>,
-	/// Optional warp sync params.
-	pub warp_sync_params: Option<WarpSyncParams<TBl>>,
+	/// Optional warp sync config.
+	pub warp_sync_config: Option<WarpSyncConfig<TBl>>,
 	/// User specified block relay params. If not specified, the default
 	/// block request handler will be used.
 	pub block_relay: Option<BlockRelayParams<TBl, TNet>>,
@@ -801,12 +801,12 @@ where
 		spawn_handle,
 		import_queue,
 		block_announce_validator_builder,
-		warp_sync_params,
+		warp_sync_config,
 		block_relay,
 		metrics,
 	} = params;
 
-	if warp_sync_params.is_none() && config.network.sync_mode.is_warp() {
+	if warp_sync_config.is_none() && config.network.sync_mode.is_warp() {
 		return Err("Warp sync enabled, but no warp sync provider configured.".into())
 	}
 
@@ -869,8 +869,8 @@ where
 		(protocol_config, config_name)
 	};
 
-	let (warp_sync_protocol_config, warp_request_protocol_name) = match warp_sync_params.as_ref() {
-		Some(WarpSyncParams::WithProvider(warp_with_provider)) => {
+	let (warp_sync_protocol_config, warp_request_protocol_name) = match warp_sync_config.as_ref() {
+		Some(WarpSyncConfig::WithProvider(warp_with_provider)) => {
 			// Allow both outgoing and incoming requests.
 			let (handler, protocol_config) = WarpSyncRequestHandler::new::<_, TNet>(
 				protocol_id.clone(),
@@ -939,7 +939,7 @@ where
 		protocol_id.clone(),
 		&config.chain_spec.fork_id().map(ToOwned::to_owned),
 		block_announce_validator,
-		warp_sync_params,
+		warp_sync_config,
 		chain_sync_network_handle,
 		import_queue.service(),
 		block_downloader,

--- a/substrate/client/service/src/lib.rs
+++ b/substrate/client/service/src/lib.rs
@@ -82,7 +82,7 @@ pub use sc_chain_spec::{
 
 pub use sc_consensus::ImportQueue;
 pub use sc_executor::NativeExecutionDispatch;
-pub use sc_network_sync::WarpSyncParams;
+pub use sc_network_sync::WarpSyncConfig;
 #[doc(hidden)]
 pub use sc_network_transactions::config::{TransactionImport, TransactionImportFuture};
 pub use sc_rpc::{

--- a/templates/minimal/node/src/service.rs
+++ b/templates/minimal/node/src/service.rs
@@ -138,7 +138,7 @@ pub fn new_full<Network: sc_network::NetworkBackend<Block, <Block as BlockT>::Ha
 			import_queue,
 			net_config,
 			block_announce_validator_builder: None,
-			warp_sync_params: None,
+			warp_sync_config: None,
 			block_relay: None,
 			metrics,
 		})?;

--- a/templates/solochain/node/src/service.rs
+++ b/templates/solochain/node/src/service.rs
@@ -4,7 +4,7 @@ use futures::FutureExt;
 use sc_client_api::{Backend, BlockBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_consensus_grandpa::SharedVoterState;
-use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncParams};
+use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncConfig};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use solochain_template_runtime::{self, apis::RuntimeApi, opaque::Block};
@@ -175,7 +175,7 @@ pub fn new_full<
 			spawn_handle: task_manager.spawn_handle(),
 			import_queue,
 			block_announce_validator_builder: None,
-			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			warp_sync_config: Some(WarpSyncConfig::WithProvider(warp_sync)),
 			block_relay: None,
 			metrics,
 		})?;


### PR DESCRIPTION
I'm not sure if this is exactly what https://github.com/paritytech/polkadot-sdk/issues/3537 meant, but I think it should be fine to wait for relay chain before initializing parachain node fully, which removed the need for background task and extra hacks throughout the stack just to know where warp sync should start.

Previously there were both `WarpSyncParams` and `WarpSyncConfig`, but there was no longer any point in having two data structures, so I simplified it to just `WarpSyncConfig`.

Fixes https://github.com/paritytech/polkadot-sdk/issues/3537