### PR TITLE
[To be merged in another PR]: small improvment on top of transaction extension PR

### DIFF
--- a/bridges/bin/runtime-common/src/extensions.rs
+++ b/bridges/bin/runtime-common/src/extensions.rs
@@ -274,11 +274,9 @@ macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
 	($call:ty, $account_id:ty, $($filter_call:ty),*) => {
 		#[derive(Clone, codec::Decode, Default, codec::Encode, Eq, PartialEq, sp_runtime::RuntimeDebug, scale_info::TypeInfo)]
 		pub struct BridgeRejectObsoleteHeadersAndMessages;
-		impl sp_runtime::traits::TransactionExtensionBase for BridgeRejectObsoleteHeadersAndMessages {
+		impl sp_runtime::traits::TransactionExtension<$call> for BridgeRejectObsoleteHeadersAndMessages {
 			const IDENTIFIER: &'static str = "BridgeRejectObsoleteHeadersAndMessages";
 			type Implicit = ();
-		}
-		impl sp_runtime::traits::TransactionExtension<$call> for BridgeRejectObsoleteHeadersAndMessages {
 			type Pre = Option<(
 				$account_id,
 				( $(

--- a/bridges/chains/chain-polkadot-bulletin/src/lib.rs
+++ b/bridges/chains/chain-polkadot-bulletin/src/lib.rs
@@ -39,7 +39,7 @@ use frame_system::limits;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{Dispatchable, TransactionExtensionBase},
+	traits::{Dispatchable},
 	transaction_validity::TransactionValidityError,
 	Perbill, StateVersion,
 };
@@ -96,19 +96,16 @@ pub type TransactionExtensionSchema = GenericTransactionExtension<(
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
 pub struct TransactionExtension(TransactionExtensionSchema);
 
-impl TransactionExtensionBase for TransactionExtension {
-	const IDENTIFIER: &'static str = "Not needed.";
-	type Implicit = <TransactionExtensionSchema as TransactionExtensionBase>::Implicit;
-
-	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
-		<TransactionExtensionSchema as TransactionExtensionBase>::implicit(&self.0)
-	}
-}
-
 impl<C> sp_runtime::traits::TransactionExtension<C> for TransactionExtension
 where
 	C: Dispatchable,
 {
+	const IDENTIFIER: &'static str = "Not needed.";
+	type Implicit = <TransactionExtensionSchema as sp_runtime::traits::TransactionExtension<C>>::Implicit;
+
+	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
+		<TransactionExtensionSchema as sp_runtime::traits::TransactionExtension<C>>::implicit(&self.0)
+	}
 	type Pre = ();
 	type Val = ();
 

--- a/bridges/modules/relayers/src/extension/mod.rs
+++ b/bridges/modules/relayers/src/extension/mod.rs
@@ -45,7 +45,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
 		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, PostDispatchInfoOf,
-		TransactionExtension, TransactionExtensionBase, ValidateResult, Zero,
+		TransactionExtension, ValidateResult, Zero,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransactionBuilder},
 	DispatchResult, RuntimeDebug,
@@ -125,6 +125,7 @@ where
 		+ TransactionPaymentConfig,
 	C: ExtensionConfig<Runtime = R, Reward = R::Reward>,
 	R::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+	<R::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<R::AccountId> + Clone,
 	<R as TransactionPaymentConfig>::OnChargeTransaction:
 		OnChargeTransaction<R, Balance = R::Reward>,
 {
@@ -265,21 +266,6 @@ where
 	}
 }
 
-impl<R, C> TransactionExtensionBase for BridgeRelayersTransactionExtension<R, C>
-where
-	Self: 'static + Send + Sync,
-	R: RelayersConfig
-		+ BridgeMessagesConfig<C::BridgeMessagesPalletInstance>
-		+ TransactionPaymentConfig,
-	C: ExtensionConfig<Runtime = R, Reward = R::Reward>,
-	R::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
-	<R as TransactionPaymentConfig>::OnChargeTransaction:
-		OnChargeTransaction<R, Balance = R::Reward>,
-{
-	const IDENTIFIER: &'static str = C::IdProvider::STR;
-	type Implicit = ();
-}
-
 impl<R, C> TransactionExtension<R::RuntimeCall> for BridgeRelayersTransactionExtension<R, C>
 where
 	Self: 'static + Send + Sync,
@@ -292,6 +278,8 @@ where
 	<R as TransactionPaymentConfig>::OnChargeTransaction:
 		OnChargeTransaction<R, Balance = R::Reward>,
 {
+	const IDENTIFIER: &'static str = C::IdProvider::STR;
+	type Implicit = ();
 	type Pre = Option<PreDispatchData<R::AccountId, C::RemoteGrandpaChainBlockNumber>>;
 	type Val = Option<ExtensionCallInfo<C::RemoteGrandpaChainBlockNumber>>;
 

--- a/bridges/primitives/runtime/src/extensions.rs
+++ b/bridges/primitives/runtime/src/extensions.rs
@@ -21,7 +21,7 @@ use impl_trait_for_tuples::impl_for_tuples;
 use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{Dispatchable, TransactionExtension, TransactionExtensionBase},
+	traits::{Dispatchable, TransactionExtension},
 	transaction_validity::TransactionValidityError,
 };
 use sp_std::{fmt::Debug, marker::PhantomData};
@@ -123,8 +123,9 @@ impl<S: TransactionExtensionSchema> GenericTransactionExtension<S> {
 	}
 }
 
-impl<S> TransactionExtensionBase for GenericTransactionExtension<S>
+impl<S, C> TransactionExtension<C> for GenericTransactionExtension<S>
 where
+	C: Dispatchable,
 	S: TransactionExtensionSchema,
 	S::Payload: Send + Sync,
 	S::Implicit: Send + Sync,
@@ -142,14 +143,6 @@ where
 				frame_support::unsigned::UnknownTransaction::Custom(0xFF),
 			))
 	}
-}
-impl<S, C> TransactionExtension<C> for GenericTransactionExtension<S>
-where
-	C: Dispatchable,
-	S: TransactionExtensionSchema,
-	S::Payload: Send + Sync,
-	S::Implicit: Send + Sync,
-{
 	type Pre = ();
 	type Val = ();
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -1475,7 +1475,7 @@ mod tests {
 	use codec::Encode;
 	use sp_runtime::{
 		generic::Era,
-		traits::{TransactionExtensionBase, Zero},
+		traits::{TransactionExtension, Zero},
 	};
 
 	#[test]
@@ -1515,8 +1515,8 @@ mod tests {
                 );
                 assert_eq!(payload.encode().split_last().unwrap().1, bhr_indirect_payload.encode());
                 assert_eq!(
-                    payload.implicit().unwrap().encode().split_last().unwrap().1,
-                    bhr_indirect_payload.implicit().unwrap().encode()
+                    TxExtension::implicit(&payload).unwrap().encode().split_last().unwrap().1,
+                    sp_runtime::traits::TransactionExtension::<RuntimeCall>::implicit(&bhr_indirect_payload).unwrap().encode()
                 )
             }
         });

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -1321,7 +1321,7 @@ mod tests {
 	use codec::Encode;
 	use sp_runtime::{
 		generic::Era,
-		traits::{TransactionExtensionBase, Zero},
+		traits::{TransactionExtension, Zero},
 	};
 
 	#[test]
@@ -1359,8 +1359,8 @@ mod tests {
                 );
                 assert_eq!(payload.encode().split_last().unwrap().1, bh_indirect_payload.encode());
                 assert_eq!(
-                    payload.implicit().unwrap().encode().split_last().unwrap().1,
-                    bh_indirect_payload.implicit().unwrap().encode()
+                    TxExtension::implicit(&payload).unwrap().encode().split_last().unwrap().1,
+                    sp_runtime::traits::TransactionExtension::<RuntimeCall>::implicit(&bh_indirect_payload).unwrap().encode()
                 )
             }
         });

--- a/cumulus/parachains/runtimes/starters/shell/src/lib.rs
+++ b/cumulus/parachains/runtimes/starters/shell/src/lib.rs
@@ -45,7 +45,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
 		AccountIdLookup, BlakeTwo256, Block as BlockT, DispatchInfoOf, OriginOf,
-		TransactionExtension, TransactionExtensionBase, ValidateResult,
+		TransactionExtension, ValidateResult,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -279,12 +279,9 @@ construct_runtime! {
 #[derive(Eq, PartialEq, Clone, Default, sp_core::RuntimeDebug, Encode, Decode, TypeInfo)]
 pub struct DisallowSigned;
 
-impl TransactionExtensionBase for DisallowSigned {
+impl TransactionExtension<RuntimeCall> for DisallowSigned {
 	const IDENTIFIER: &'static str = "DisallowSigned";
 	type Implicit = ();
-}
-
-impl TransactionExtension<RuntimeCall> for DisallowSigned {
 	type Val = ();
 	type Pre = ();
 	fn validate(

--- a/cumulus/primitives/storage-weight-reclaim/src/lib.rs
+++ b/cumulus/primitives/storage-weight-reclaim/src/lib.rs
@@ -33,7 +33,6 @@ use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
 		DispatchInfoOf, Dispatchable, PostDispatchInfoOf, TransactionExtension,
-		TransactionExtensionBase,
 	},
 	transaction_validity::TransactionValidityError,
 	DispatchResult,
@@ -126,15 +125,12 @@ impl<T: Config + Send + Sync> core::fmt::Debug for StorageWeightReclaim<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for StorageWeightReclaim<T> {
-	const IDENTIFIER: &'static str = "StorageWeightReclaim";
-	type Implicit = ();
-}
-
 impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for StorageWeightReclaim<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 {
+	const IDENTIFIER: &'static str = "StorageWeightReclaim";
+	type Implicit = ();
 	type Val = ();
 	type Pre = Option<u64>;
 

--- a/docs/sdk/src/reference_docs/extrinsic_encoding.rs
+++ b/docs/sdk/src/reference_docs/extrinsic_encoding.rs
@@ -202,7 +202,7 @@
 //!
 //! The bytes representing `call_data` and `transaction_extensions_extra` can be obtained as
 //! descibed above. `transaction_extensions_implicit` is constructed by SCALE encoding the
-//! ["implicit" data][sp_runtime::traits::TransactionExtensionBase::Implicit] for each transaction
+//! ["implicit" data][sp_runtime::traits::TransactionExtension::Implicit] for each transaction
 //! extension that the chain is using, in order.
 //!
 //! Once we've concatenated those together, we hash the result using a Blake2 256bit hasher.

--- a/docs/sdk/src/reference_docs/transaction_extensions.rs
+++ b/docs/sdk/src/reference_docs/transaction_extensions.rs
@@ -64,7 +64,7 @@ pub mod transaction_extensions_example {
 	use scale_info::TypeInfo;
 	use sp_runtime::{
 		impl_tx_ext_default,
-		traits::{Dispatchable, TransactionExtension, TransactionExtensionBase},
+		traits::{Dispatchable, TransactionExtension},
 		transaction_validity::TransactionValidityError,
 	};
 
@@ -73,12 +73,9 @@ pub mod transaction_extensions_example {
 	#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 	pub struct AddToPayload(pub u32);
 
-	impl TransactionExtensionBase for AddToPayload {
+	impl<Call: Dispatchable> TransactionExtension<Call> for AddToPayload {
 		const IDENTIFIER: &'static str = "AddToPayload";
 		type Implicit = ();
-	}
-
-	impl<Call: Dispatchable> TransactionExtension<Call> for AddToPayload {
 		type Pre = ();
 		type Val = ();
 
@@ -91,16 +88,13 @@ pub mod transaction_extensions_example {
 	#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
 	pub struct AddToSignaturePayload;
 
-	impl TransactionExtensionBase for AddToSignaturePayload {
+	impl<Call: Dispatchable> TransactionExtension<Call> for AddToSignaturePayload {
 		const IDENTIFIER: &'static str = "AddToSignaturePayload";
 		type Implicit = u32;
 
 		fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
 			Ok(1234)
 		}
-	}
-
-	impl<Call: Dispatchable> TransactionExtension<Call> for AddToSignaturePayload {
 		type Pre = ();
 		type Val = ();
 

--- a/polkadot/runtime/common/src/claims.rs
+++ b/polkadot/runtime/common/src/claims.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
 		AsAuthorizedOrigin, AsSystemOriginSigner, CheckedSub, DispatchInfoOf, Dispatchable,
-		TransactionExtension, TransactionExtensionBase, Zero,
+		TransactionExtension, Zero,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction,
@@ -625,20 +625,14 @@ where
 	}
 }
 
-impl<T: Config> TransactionExtensionBase for PrevalidateAttests<T>
-where
-	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>,
-{
-	const IDENTIFIER: &'static str = "PrevalidateAttests";
-	type Implicit = ();
-}
-
 impl<T: Config> TransactionExtension<T::RuntimeCall> for PrevalidateAttests<T>
 where
 	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>,
 	<<T as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		AsSystemOriginSigner<T::AccountId> + AsAuthorizedOrigin + Clone,
 {
+	const IDENTIFIER: &'static str = "PrevalidateAttests";
+	type Implicit = ();
 	type Pre = ();
 	type Val = ();
 

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -626,8 +626,6 @@ impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for R
 where
 	RuntimeCall: From<LocalCall>,
 {
-	type SignaturePayload = UncheckedSignaturePayload;
-
 	fn create_signed_transaction<
 		C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>,
 	>(

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -417,8 +417,6 @@ impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for R
 where
 	RuntimeCall: From<LocalCall>,
 {
-	type SignaturePayload = UncheckedSignaturePayload;
-
 	fn create_signed_transaction<
 		C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>,
 	>(

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -894,8 +894,6 @@ impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for R
 where
 	RuntimeCall: From<LocalCall>,
 {
-	type SignaturePayload = UncheckedSignaturePayload;
-
 	fn create_signed_transaction<
 		C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>,
 	>(

--- a/prdoc/pr_2280.prdoc
+++ b/prdoc/pr_2280.prdoc
@@ -48,7 +48,7 @@ doc:
           contextual data that is injected into the transaction extension logic. It is unused in
           instances migrated from `SignedExtension`.
         - Extensions now track the weight they consume during valdiation, preparation and
-          post-dispatch through the `TransactionExtensionBase::weight` function.
+          post-dispatch through the `TransactionExtension::weight` function.
         - `TestXt` was removed and its usage in tests was replaced with `UncheckedExtrinsic`
           instances.
 

--- a/prdoc/pr_2280.prdoc
+++ b/prdoc/pr_2280.prdoc
@@ -48,7 +48,7 @@ doc:
           contextual data that is injected into the transaction extension logic. It is unused in
           instances migrated from `SignedExtension`.
         - Extensions now track the weight they consume during valdiation, preparation and
-          post-dispatch through the `TransactionExtension::weight` function.
+          post-dispatch through the `TransactionExtensionBase::weight` function.
         - `TestXt` was removed and its usage in tests was replaced with `UncheckedExtrinsic`
           instances.
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1456,8 +1456,6 @@ impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for R
 where
 	RuntimeCall: From<LocalCall>,
 {
-	type SignaturePayload = UncheckedSignaturePayload;
-
 	fn create_signed_transaction<
 		C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>,
 	>(

--- a/substrate/frame/examples/authorization-tx-extension/src/extensions.rs
+++ b/substrate/frame/examples/authorization-tx-extension/src/extensions.rs
@@ -23,7 +23,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
-		DispatchInfoOf, IdentifyAccount, OriginOf, TransactionExtension, TransactionExtensionBase,
+		DispatchInfoOf, IdentifyAccount, OriginOf, TransactionExtension,
 		ValidateResult, Verify,
 	},
 	transaction_validity::{InvalidTransaction, ValidTransaction},
@@ -75,25 +75,6 @@ impl<T: Config, Signer, Signature> fmt::Debug for AuthorizeCoownership<T, Signer
 	}
 }
 
-impl<T: Config + Send + Sync, Signer, Signature> TransactionExtensionBase
-	for AuthorizeCoownership<T, Signer, Signature>
-where
-	Signer: Clone + Eq + PartialEq + Encode + Decode + TypeInfo + Send + Sync + 'static,
-	Signature: Verify<Signer = Signer>
-		+ Clone
-		+ Eq
-		+ PartialEq
-		+ Encode
-		+ Decode
-		+ TypeInfo
-		+ Send
-		+ Sync
-		+ 'static,
-{
-	const IDENTIFIER: &'static str = "AuthorizeCoownership";
-	type Implicit = ();
-}
-
 impl<T: Config + Send + Sync, Signer, Signature> TransactionExtension<T::RuntimeCall>
 	for AuthorizeCoownership<T, Signer, Signature>
 where
@@ -118,6 +99,8 @@ where
 		+ Sync
 		+ 'static,
 {
+	const IDENTIFIER: &'static str = "AuthorizeCoownership";
+	type Implicit = ();
 	type Val = ();
 	type Pre = ();
 

--- a/substrate/frame/examples/authorization-tx-extension/src/tests.rs
+++ b/substrate/frame/examples/authorization-tx-extension/src/tests.rs
@@ -26,7 +26,7 @@ use frame_support::{
 };
 use sp_keyring::AccountKeyring;
 use sp_runtime::{
-	traits::{Applyable, Checkable, IdentityLookup, TransactionExtensionBase},
+	traits::{Applyable, Checkable, IdentityLookup, TransactionExtension},
 	MultiSignature, MultiSigner,
 };
 

--- a/substrate/frame/examples/basic/src/lib.rs
+++ b/substrate/frame/examples/basic/src/lib.rs
@@ -71,7 +71,7 @@ use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
 		Bounded, DispatchInfoOf, OriginOf, SaturatedConversion, Saturating, TransactionExtension,
-		TransactionExtensionBase, ValidateResult,
+		ValidateResult,
 	},
 	transaction_validity::{InvalidTransaction, ValidTransaction},
 };
@@ -489,15 +489,13 @@ impl<T: Config + Send + Sync> core::fmt::Debug for WatchDummy<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for WatchDummy<T> {
-	const IDENTIFIER: &'static str = "WatchDummy";
-	type Implicit = ();
-}
 impl<T: Config + Send + Sync> TransactionExtension<<T as frame_system::Config>::RuntimeCall>
 	for WatchDummy<T>
 where
 	<T as frame_system::Config>::RuntimeCall: IsSubType<Call<T>>,
 {
+	const IDENTIFIER: &'static str = "WatchDummy";
+	type Implicit = ();
 	type Pre = ();
 	type Val = ();
 

--- a/substrate/frame/examples/offchain-worker/src/tests.rs
+++ b/substrate/frame/examples/offchain-worker/src/tests.rs
@@ -103,8 +103,6 @@ impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for T
 where
 	RuntimeCall: From<LocalCall>,
 {
-	type SignaturePayload = (u64, (), ());
-
 	fn create_signed_transaction<
 		C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>,
 	>(

--- a/substrate/frame/metadata-hash-extension/src/lib.rs
+++ b/substrate/frame/metadata-hash-extension/src/lib.rs
@@ -44,7 +44,7 @@ use frame_system::Config;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{TransactionExtension, TransactionExtensionBase},
+	traits::{TransactionExtension},
 	transaction_validity::{TransactionValidityError, UnknownTransaction},
 };
 
@@ -132,7 +132,7 @@ impl<T> CheckMetadataHash<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckMetadataHash<T> {
+impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckMetadataHash<T> {
 	const IDENTIFIER: &'static str = "CheckMetadataHash";
 	type Implicit = Option<[u8; 32]>;
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
@@ -152,8 +152,6 @@ impl<T: Config + Send + Sync> TransactionExtensionBase for CheckMetadataHash<T> 
 
 		Ok(signed)
 	}
-}
-impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckMetadataHash<T> {
 	type Val = ();
 	type Pre = ();
 

--- a/substrate/frame/metadata-hash-extension/src/tests.rs
+++ b/substrate/frame/metadata-hash-extension/src/tests.rs
@@ -25,7 +25,7 @@ use frame_support::{
 use merkleized_metadata::{generate_metadata_digest, ExtraInfo};
 use sp_api::{Metadata, ProvideRuntimeApi};
 use sp_runtime::{
-	traits::{ExtrinsicLike, TransactionExtensionBase},
+	traits::{ExtrinsicLike, TransactionExtension},
 	transaction_validity::{TransactionSource, UnknownTransaction},
 };
 use sp_transaction_pool::runtime_api::TaggedTransactionQueue;

--- a/substrate/frame/sudo/src/extension.rs
+++ b/substrate/frame/sudo/src/extension.rs
@@ -24,7 +24,7 @@ use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
 		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, TransactionExtension,
-		TransactionExtensionBase,
+
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionValidityError, UnknownTransaction,
@@ -69,10 +69,6 @@ impl<T: Config + Send + Sync> CheckOnlySudoAccount<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckOnlySudoAccount<T> {
-	const IDENTIFIER: &'static str = "CheckOnlySudoAccount";
-	type Implicit = ();
-}
 impl<T: Config + Send + Sync> TransactionExtension<<T as frame_system::Config>::RuntimeCall>
 	for CheckOnlySudoAccount<T>
 where
@@ -80,6 +76,8 @@ where
 	<<T as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		AsSystemOriginSigner<T::AccountId> + Clone,
 {
+	const IDENTIFIER: &'static str = "CheckOnlySudoAccount";
+	type Implicit = ();
 	type Pre = ();
 	type Val = ();
 

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -129,7 +129,7 @@ pub fn expand_runtime_metadata(
 								.map(|meta| #scrate::__private::metadata_ir::TransactionExtensionMetadataIR {
 									identifier: meta.identifier,
 									ty: meta.ty,
-									implicit: meta.additional_signed,
+									implicit: meta.implicit,
 								})
 								.collect(),
 					},

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -123,7 +123,7 @@ pub fn expand_runtime_metadata(
 						extensions: <
 								<
 									#extrinsic as #scrate::sp_runtime::traits::ExtrinsicMetadata
-								>::SignedExtensions as #scrate::sp_runtime::traits::TransactionExtensionBase
+								>::SignedExtensions as #scrate::sp_runtime::traits::TransactionExtension::<<#runtime as #system_path::Config>::RuntimeCall> // TODO TODO: double check
 							>::metadata()
 								.into_iter()
 								.map(|meta| #scrate::__private::metadata_ir::TransactionExtensionMetadataIR {

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -28,7 +28,6 @@ use sp_runtime::{
 	generic::{CheckedExtrinsic, UncheckedExtrinsic},
 	traits::{
 		Dispatchable, ExtensionPostDispatchWeightHandler, RefundWeight, TransactionExtension,
-		TransactionExtensionBase,
 	},
 	DispatchError, RuntimeDebug,
 };
@@ -385,7 +384,6 @@ impl<Address, Call: Dispatchable, Signature, Extension: TransactionExtension<Cal
 	for UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Call: GetDispatchInfo + Dispatchable,
-	Extension: TransactionExtensionBase,
 {
 	fn get_dispatch_info(&self) -> DispatchInfo {
 		let mut info = self.function.get_dispatch_info();
@@ -399,7 +397,6 @@ impl<AccountId, Call: Dispatchable, Extension: TransactionExtension<Call>> GetDi
 	for CheckedExtrinsic<AccountId, Call, Extension>
 where
 	Call: GetDispatchInfo,
-	Extension: TransactionExtensionBase,
 {
 	fn get_dispatch_info(&self) -> DispatchInfo {
 		let mut info = self.function.get_dispatch_info();
@@ -1205,7 +1202,6 @@ mod test_extensions {
 		impl_tx_ext_default,
 		traits::{
 			DispatchInfoOf, Dispatchable, OriginOf, PostDispatchInfoOf, TransactionExtension,
-			TransactionExtensionBase,
 		},
 		transaction_validity::TransactionValidityError,
 	};
@@ -1217,11 +1213,9 @@ mod test_extensions {
 	#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 	pub struct HalfCostIf(pub bool);
 
-	impl TransactionExtensionBase for HalfCostIf {
+	impl<RuntimeCall: Dispatchable> TransactionExtension<RuntimeCall> for HalfCostIf {
 		const IDENTIFIER: &'static str = "HalfCostIf";
 		type Implicit = ();
-	}
-	impl<RuntimeCall: Dispatchable> TransactionExtension<RuntimeCall> for HalfCostIf {
 		type Val = ();
 		type Pre = bool;
 
@@ -1261,14 +1255,12 @@ mod test_extensions {
 	#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 	pub struct FreeIfUnder(pub u64);
 
-	impl TransactionExtensionBase for FreeIfUnder {
-		const IDENTIFIER: &'static str = "FreeIfUnder";
-		type Implicit = ();
-	}
 	impl<RuntimeCall: Dispatchable> TransactionExtension<RuntimeCall> for FreeIfUnder
 	where
 		RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo>,
 	{
+		const IDENTIFIER: &'static str = "FreeIfUnder";
+		type Implicit = ();
 		type Val = ();
 		type Pre = u64;
 
@@ -1309,11 +1301,9 @@ mod test_extensions {
 	#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 	pub struct ActualWeightIs(pub u64);
 
-	impl TransactionExtensionBase for ActualWeightIs {
+	impl<RuntimeCall: Dispatchable> TransactionExtension<RuntimeCall> for ActualWeightIs {
 		const IDENTIFIER: &'static str = "ActualWeightIs";
 		type Implicit = ();
-	}
-	impl<RuntimeCall: Dispatchable> TransactionExtension<RuntimeCall> for ActualWeightIs {
 		type Val = ();
 		type Pre = u64;
 

--- a/substrate/frame/support/src/transaction_extensions.rs
+++ b/substrate/frame/support/src/transaction_extensions.rs
@@ -24,8 +24,8 @@ use sp_io::hashing::blake2_256;
 use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
-		transaction_extension::TransactionExtensionBase, DispatchInfoOf, Dispatchable,
-		IdentifyAccount, TransactionExtension, Verify,
+		transaction_extension::TransactionExtension, DispatchInfoOf, Dispatchable,
+		IdentifyAccount, Verify,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
 };
@@ -57,16 +57,6 @@ where
 	}
 }
 
-impl<V: Verify> TransactionExtensionBase for VerifyMultiSignature<V>
-where
-	V: Codec + Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
-	<V::Signer as IdentifyAccount>::AccountId:
-		Codec + Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
-{
-	const IDENTIFIER: &'static str = "VerifyMultiSignature";
-	type Implicit = ();
-}
-
 impl<V: Verify, Call: Dispatchable + Encode> TransactionExtension<Call> for VerifyMultiSignature<V>
 where
 	V: Codec + Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
@@ -74,6 +64,8 @@ where
 		Codec + Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo,
 	<Call as Dispatchable>::RuntimeOrigin: From<Option<<V::Signer as IdentifyAccount>::AccountId>>,
 {
+	const IDENTIFIER: &'static str = "VerifyMultiSignature";
+	type Implicit = ();
 	type Val = ();
 	type Pre = ();
 	impl_tx_ext_default!(Call; prepare);

--- a/substrate/frame/system/src/extensions/check_genesis.rs
+++ b/substrate/frame/system/src/extensions/check_genesis.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{TransactionExtension, TransactionExtensionBase, Zero},
+	traits::{TransactionExtension, Zero},
 	transaction_validity::TransactionValidityError,
 };
 
@@ -53,14 +53,12 @@ impl<T: Config + Send + Sync> CheckGenesis<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckGenesis<T> {
+impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckGenesis<T> {
 	const IDENTIFIER: &'static str = "CheckGenesis";
 	type Implicit = T::Hash;
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
 		Ok(<Pallet<T>>::block_hash(BlockNumberFor::<T>::zero()))
 	}
-}
-impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckGenesis<T> {
 	type Val = ();
 	type Pre = ();
 	fn weight(&self, _: &T::RuntimeCall) -> sp_weights::Weight {

--- a/substrate/frame/system/src/extensions/check_mortality.rs
+++ b/substrate/frame/system/src/extensions/check_mortality.rs
@@ -22,7 +22,7 @@ use sp_runtime::{
 	generic::Era,
 	impl_tx_ext_default,
 	traits::{
-		DispatchInfoOf, SaturatedConversion, TransactionExtension, TransactionExtensionBase,
+		DispatchInfoOf, SaturatedConversion, TransactionExtension,
 		ValidateResult,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
@@ -59,7 +59,7 @@ impl<T: Config + Send + Sync> core::fmt::Debug for CheckMortality<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckMortality<T> {
+impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckMortality<T> {
 	const IDENTIFIER: &'static str = "CheckMortality";
 	type Implicit = T::Hash;
 
@@ -72,8 +72,6 @@ impl<T: Config + Send + Sync> TransactionExtensionBase for CheckMortality<T> {
 			Ok(<Pallet<T>>::block_hash(n))
 		}
 	}
-}
-impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckMortality<T> {
 	type Pre = ();
 	type Val = ();
 

--- a/substrate/frame/system/src/extensions/check_non_zero_sender.rs
+++ b/substrate/frame/system/src/extensions/check_non_zero_sender.rs
@@ -23,7 +23,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
 	traits::{
-		transaction_extension::TransactionExtensionBase, DispatchInfoOf, TransactionExtension,
+		DispatchInfoOf, TransactionExtension,
 	},
 	transaction_validity::InvalidTransaction,
 };
@@ -52,11 +52,9 @@ impl<T: Config + Send + Sync> CheckNonZeroSender<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckNonZeroSender<T> {
+impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckNonZeroSender<T> {
 	const IDENTIFIER: &'static str = "CheckNonZeroSender";
 	type Implicit = ();
-}
-impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckNonZeroSender<T> {
 	type Val = ();
 	type Pre = ();
 

--- a/substrate/frame/system/src/extensions/check_nonce.rs
+++ b/substrate/frame/system/src/extensions/check_nonce.rs
@@ -23,7 +23,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
 		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, One, TransactionExtension,
-		TransactionExtensionBase, ValidateResult, Zero,
+		ValidateResult, Zero,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionLongevity, TransactionValidityError, ValidTransaction,
@@ -66,15 +66,13 @@ impl<T: Config> core::fmt::Debug for CheckNonce<T> {
 	}
 }
 
-impl<T: Config> TransactionExtensionBase for CheckNonce<T> {
-	const IDENTIFIER: &'static str = "CheckNonce";
-	type Implicit = ();
-}
 impl<T: Config> TransactionExtension<T::RuntimeCall> for CheckNonce<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
 	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
 {
+	const IDENTIFIER: &'static str = "CheckNonce";
+	type Implicit = ();
 	type Val = Option<(T::AccountId, T::Nonce)>;
 	type Pre = ();
 

--- a/substrate/frame/system/src/extensions/check_spec_version.rs
+++ b/substrate/frame/system/src/extensions/check_spec_version.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{transaction_extension::TransactionExtensionBase, TransactionExtension},
+	traits::{TransactionExtension},
 	transaction_validity::TransactionValidityError,
 };
 
@@ -53,16 +53,14 @@ impl<T: Config + Send + Sync> CheckSpecVersion<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckSpecVersion<T> {
+impl<T: Config + Send + Sync> TransactionExtension<<T as Config>::RuntimeCall>
+	for CheckSpecVersion<T>
+{
 	const IDENTIFIER: &'static str = "CheckSpecVersion";
 	type Implicit = u32;
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
 		Ok(<Pallet<T>>::runtime_version().spec_version)
 	}
-}
-impl<T: Config + Send + Sync> TransactionExtension<<T as Config>::RuntimeCall>
-	for CheckSpecVersion<T>
-{
 	type Val = ();
 	type Pre = ();
 	fn weight(&self, _: &<T as Config>::RuntimeCall) -> sp_weights::Weight {

--- a/substrate/frame/system/src/extensions/check_tx_version.rs
+++ b/substrate/frame/system/src/extensions/check_tx_version.rs
@@ -20,7 +20,7 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
-	traits::{transaction_extension::TransactionExtensionBase, TransactionExtension},
+	traits::{TransactionExtension},
 	transaction_validity::TransactionValidityError,
 };
 
@@ -53,16 +53,14 @@ impl<T: Config + Send + Sync> CheckTxVersion<T> {
 	}
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckTxVersion<T> {
+impl<T: Config + Send + Sync> TransactionExtension<<T as Config>::RuntimeCall>
+	for CheckTxVersion<T>
+{
 	const IDENTIFIER: &'static str = "CheckTxVersion";
 	type Implicit = u32;
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
 		Ok(<Pallet<T>>::runtime_version().transaction_version)
 	}
-}
-impl<T: Config + Send + Sync> TransactionExtension<<T as Config>::RuntimeCall>
-	for CheckTxVersion<T>
-{
 	type Val = ();
 	type Pre = ();
 	fn weight(&self, _: &<T as Config>::RuntimeCall) -> sp_weights::Weight {

--- a/substrate/frame/system/src/extensions/check_weight.rs
+++ b/substrate/frame/system/src/extensions/check_weight.rs
@@ -25,7 +25,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
 		DispatchInfoOf, Dispatchable, PostDispatchInfoOf, TransactionExtension,
-		TransactionExtensionBase, ValidateResult,
+		ValidateResult,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
 	DispatchResult,
@@ -208,14 +208,12 @@ where
 	Ok(all_weight)
 }
 
-impl<T: Config + Send + Sync> TransactionExtensionBase for CheckWeight<T> {
-	const IDENTIFIER: &'static str = "CheckWeight";
-	type Implicit = ();
-}
 impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckWeight<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 {
+	const IDENTIFIER: &'static str = "CheckWeight";
+	type Implicit = ();
 	type Pre = ();
 	type Val = u32; /* next block length */
 

--- a/substrate/frame/system/src/offchain.rs
+++ b/substrate/frame/system/src/offchain.rs
@@ -61,7 +61,7 @@ use codec::Encode;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	app_crypto::RuntimeAppPublic,
-	traits::{ExtrinsicLike, IdentifyAccount, One, SignaturePayload},
+	traits::{ExtrinsicLike, IdentifyAccount, One},
 	RuntimeDebug,
 };
 
@@ -474,9 +474,6 @@ pub trait CreateTransaction<LocalCall>: CreateTransactionBase<LocalCall> {
 pub trait CreateSignedTransaction<LocalCall>:
 	CreateTransactionBase<LocalCall> + SigningTypes
 {
-	/// TODO: revisit this, currently here for metadata purposes.
-	type SignaturePayload: SignaturePayload;
-
 	/// Attempt to create signed extrinsic data that encodes call from given account.
 	///
 	/// Runtime implementation is free to construct the payload to sign and the signature

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -55,7 +55,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
 		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, RefundWeight,
-		TransactionExtension, TransactionExtensionBase, ValidateResult, Zero,
+		TransactionExtension, ValidateResult, Zero,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
 };
@@ -250,16 +250,6 @@ impl<T: Config> core::fmt::Debug for ChargeAssetTxPayment<T> {
 	}
 }
 
-impl<T: Config> TransactionExtensionBase for ChargeAssetTxPayment<T>
-where
-	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
-	BalanceOf<T>: Send + Sync + From<u64>,
-	T::AssetId: Send + Sync,
-{
-	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
-	type Implicit = ();
-}
-
 impl<T: Config> TransactionExtension<T::RuntimeCall> for ChargeAssetTxPayment<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
@@ -267,6 +257,8 @@ where
 	T::AssetId: Send + Sync,
 	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
 {
+	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
+	type Implicit = ();
 	type Val = (
 		// tip
 		BalanceOf<T>,

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
@@ -53,7 +53,7 @@ use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
 		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, RefundWeight,
-		TransactionExtension, TransactionExtensionBase, Zero,
+		TransactionExtension, Zero,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
 };
@@ -262,17 +262,6 @@ impl<T: Config> core::fmt::Debug for ChargeAssetTxPayment<T> {
 	}
 }
 
-impl<T: Config> TransactionExtensionBase for ChargeAssetTxPayment<T>
-where
-	AssetBalanceOf<T>: Send + Sync,
-	BalanceOf<T>: Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>>,
-	ChargeAssetIdOf<T>: Send + Sync,
-	Credit<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
-{
-	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
-	type Implicit = ();
-}
-
 impl<T: Config> TransactionExtension<T::RuntimeCall> for ChargeAssetTxPayment<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
@@ -282,6 +271,8 @@ where
 	Credit<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
 	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
 {
+	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
+	type Implicit = ();
 	type Val = (
 		// tip
 		BalanceOf<T>,

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs
@@ -46,7 +46,7 @@ use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_runtime::{
 	traits::{
 		DispatchInfoOf, OriginOf, PostDispatchInfoOf, TransactionExtension,
-		TransactionExtensionBase, ValidateResult,
+		ValidateResult,
 	},
 	transaction_validity::TransactionValidityError,
 };
@@ -116,8 +116,10 @@ pub enum Intermediate<T, O> {
 }
 use Intermediate::*;
 
-impl<T: Config + Send + Sync, S: TransactionExtensionBase> TransactionExtensionBase
-	for SkipCheckIfFeeless<T, S>
+impl<T: Config + Send + Sync, S: TransactionExtension<T::RuntimeCall>>
+	TransactionExtension<T::RuntimeCall> for SkipCheckIfFeeless<T, S>
+where
+	T::RuntimeCall: CheckIfFeeless<Origin = frame_system::pallet_prelude::OriginFor<T>>,
 {
 	// From the outside this extension should be "invisible", because it just extends the wrapped
 	// extension with an extra check in `pre_dispatch` and `post_dispatch`. Thus, we should forward
@@ -129,13 +131,6 @@ impl<T: Config + Send + Sync, S: TransactionExtensionBase> TransactionExtensionB
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
 		self.0.implicit()
 	}
-}
-
-impl<T: Config + Send + Sync, S: TransactionExtension<T::RuntimeCall>>
-	TransactionExtension<T::RuntimeCall> for SkipCheckIfFeeless<T, S>
-where
-	T::RuntimeCall: CheckIfFeeless<Origin = frame_system::pallet_prelude::OriginFor<T>>,
-{
 	type Val = Intermediate<S::Val, <OriginOf<T::RuntimeCall> as OriginTrait>::PalletsOrigin>;
 	type Pre = Intermediate<S::Pre, <OriginOf<T::RuntimeCall> as OriginTrait>::PalletsOrigin>;
 

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/mock.rs
@@ -42,11 +42,9 @@ parameter_types! {
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 pub struct DummyExtension;
 
-impl TransactionExtensionBase for DummyExtension {
+impl TransactionExtension<RuntimeCall> for DummyExtension {
 	const IDENTIFIER: &'static str = "DummyExtension";
 	type Implicit = ();
-}
-impl TransactionExtension<RuntimeCall> for DummyExtension {
 	type Val = ();
 	type Pre = ();
 

--- a/substrate/frame/transaction-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/src/benchmarking.rs
@@ -38,7 +38,6 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	T: Config,
 	T::RuntimeOrigin: AsAuthorizedOrigin,
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
-    BalanceOf<T>: Send + Sync + From<u64>,
 )]
 mod benchmarks {
 	use super::*;
@@ -48,7 +47,7 @@ mod benchmarks {
 		let caller: T::AccountId = account("caller", 0, 0);
 		<T::OnChargeTransaction as OnChargeTransaction<T>>::endow_account(
 			&caller,
-			<T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance() * 1000.into(),
+			<T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance() * 1000u32.into(),
 		);
 		let tip = <T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance();
 		let ext: ChargeTransactionPayment<T> = ChargeTransactionPayment::from(tip);

--- a/substrate/frame/transaction-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/src/lib.rs
@@ -62,7 +62,7 @@ pub use payment::*;
 use sp_runtime::{
 	traits::{
 		Convert, DispatchInfoOf, Dispatchable, One, PostDispatchInfoOf, SaturatedConversion,
-		Saturating, TransactionExtension, TransactionExtensionBase, Zero,
+		Saturating, TransactionExtension, Zero,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionPriority, TransactionValidityError, ValidTransaction,
@@ -850,16 +850,12 @@ impl<T: Config> core::fmt::Debug for ChargeTransactionPayment<T> {
 	}
 }
 
-impl<T: Config> TransactionExtensionBase for ChargeTransactionPayment<T> {
-	const IDENTIFIER: &'static str = "ChargeTransactionPayment";
-	type Implicit = ();
-}
-
 impl<T: Config> TransactionExtension<T::RuntimeCall> for ChargeTransactionPayment<T>
 where
-	BalanceOf<T>: Send + Sync + From<u64>,
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 {
+	const IDENTIFIER: &'static str = "ChargeTransactionPayment";
+	type Implicit = ();
 	type Val = (
 		// tip
 		BalanceOf<T>,

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -20,9 +20,8 @@
 use crate::{
 	generic::{CheckedExtrinsic, ExtrinsicFormat},
 	traits::{
-		self, transaction_extension::TransactionExtensionBase, Checkable, Dispatchable,
+		self, transaction_extension::TransactionExtension, Checkable, Dispatchable,
 		ExtrinsicLike, ExtrinsicMetadata, IdentifyAccount, MaybeDisplay, Member, SignaturePayload,
-		TransactionExtension,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic,
@@ -568,7 +567,7 @@ impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extension: Decode> se
 /// Note that the payload that we sign to produce unchecked extrinsic signature
 /// is going to be different than the `SignaturePayload` - so the thing the extrinsic
 /// actually contains.
-pub struct SignedPayload<Call: Dispatchable, Extension: TransactionExtensionBase>(
+pub struct SignedPayload<Call: Dispatchable, Extension: TransactionExtension<Call>>(
 	(Call, Extension, Extension::Implicit),
 	ExtrinsicVersion,
 );
@@ -576,7 +575,7 @@ pub struct SignedPayload<Call: Dispatchable, Extension: TransactionExtensionBase
 impl<Call, Extension> SignedPayload<Call, Extension>
 where
 	Call: Encode + Dispatchable,
-	Extension: TransactionExtensionBase,
+	Extension: TransactionExtension<Call>,
 {
 	/// Create new `SignedPayload`.
 	///
@@ -610,7 +609,7 @@ where
 impl<Call, Extension> Encode for SignedPayload<Call, Extension>
 where
 	Call: Encode + Dispatchable,
-	Extension: TransactionExtensionBase,
+	Extension: TransactionExtension<Call>,
 {
 	/// Get an encoded version of this `blake2_256`-hashed payload.
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
@@ -631,7 +630,7 @@ where
 impl<Call, Extension> EncodeLike for SignedPayload<Call, Extension>
 where
 	Call: Encode + Dispatchable,
-	Extension: TransactionExtensionBase,
+	Extension: TransactionExtension<Call>,
 {
 }
 
@@ -819,11 +818,9 @@ mod tests {
 	// NOTE: this is demonstration. One can simply use `()` for testing.
 	#[derive(Debug, Encode, Decode, Clone, Eq, PartialEq, Ord, PartialOrd, TypeInfo)]
 	struct DummyExtension;
-	impl TransactionExtensionBase for DummyExtension {
+	impl TransactionExtension<TestCall> for DummyExtension {
 		const IDENTIFIER: &'static str = "DummyExtension";
 		type Implicit = ();
-	}
-	impl TransactionExtension<TestCall> for DummyExtension {
 		type Val = ();
 		type Pre = ();
 		impl_tx_ext_default!(TestCall; validate prepare);

--- a/substrate/primitives/runtime/src/traits/mod.rs
+++ b/substrate/primitives/runtime/src/traits/mod.rs
@@ -54,7 +54,7 @@ use std::str::FromStr;
 
 pub mod transaction_extension;
 pub use transaction_extension::{
-	DispatchTransaction, TransactionExtension, TransactionExtensionBase,
+	DispatchTransaction, TransactionExtension,
 	TransactionExtensionMetadata, ValidateResult,
 };
 

--- a/substrate/primitives/runtime/src/traits/mod.rs
+++ b/substrate/primitives/runtime/src/traits/mod.rs
@@ -1706,7 +1706,7 @@ pub trait SignedExtension:
 		sp_std::vec![TransactionExtensionMetadata {
 			identifier: Self::IDENTIFIER,
 			ty: scale_info::meta_type::<Self>(),
-			additional_signed: scale_info::meta_type::<Self::AdditionalSigned>()
+			implicit: scale_info::meta_type::<Self::AdditionalSigned>()
 		}]
 	}
 

--- a/substrate/primitives/runtime/src/traits/transaction_extension/as_transaction_extension.rs
+++ b/substrate/primitives/runtime/src/traits/transaction_extension/as_transaction_extension.rs
@@ -47,7 +47,10 @@ impl<SE: SignedExtension> From<SE> for AsTransactionExtension<SE> {
 	}
 }
 
-impl<SE: SignedExtension> TransactionExtensionBase for AsTransactionExtension<SE> {
+impl<SE: SignedExtension> TransactionExtension<SE::Call> for AsTransactionExtension<SE>
+where
+	<SE::Call as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<SE::AccountId> + Clone,
+{
 	const IDENTIFIER: &'static str = SE::IDENTIFIER;
 	type Implicit = SE::AdditionalSigned;
 
@@ -57,12 +60,6 @@ impl<SE: SignedExtension> TransactionExtensionBase for AsTransactionExtension<SE
 	fn metadata() -> Vec<TransactionExtensionMetadata> {
 		SE::metadata()
 	}
-}
-
-impl<SE: SignedExtension> TransactionExtension<SE::Call> for AsTransactionExtension<SE>
-where
-	<SE::Call as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<SE::AccountId> + Clone,
-{
 	type Val = ();
 	type Pre = SE::Pre;
 

--- a/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs
+++ b/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs
@@ -462,8 +462,6 @@ pub struct TransactionExtensionMetadata {
 
 #[impl_for_tuples(1, 12)]
 impl<Call: Dispatchable> TransactionExtension<Call> for Tuple {
-	for_tuples!( where #( Tuple: TransactionExtension<Call> )* );
-
 	const IDENTIFIER: &'static str = "Use `metadata()`!";
 	for_tuples!( type Implicit = ( #( Tuple::Implicit ),* ); );
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {

--- a/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs
+++ b/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs
@@ -82,8 +82,7 @@ pub trait TransactionExtensionBase:
 		sp_std::vec![TransactionExtensionMetadata {
 			identifier: Self::IDENTIFIER,
 			ty: scale_info::meta_type::<Self>(),
-			// TODO: Metadata-v16: Rename to "implicit"
-			additional_signed: scale_info::meta_type::<Self::Implicit>()
+			implicit: scale_info::meta_type::<Self::Implicit>()
 		}]
 	}
 }
@@ -463,8 +462,7 @@ pub struct TransactionExtensionMetadata {
 	/// The type of the [`TransactionExtension`].
 	pub ty: MetaType,
 	/// The type of the [`TransactionExtension`] additional signed data for the payload.
-	// TODO: Rename "implicit"
-	pub additional_signed: MetaType,
+	pub implicit: MetaType,
 }
 
 #[impl_for_tuples(1, 12)]

--- a/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs
+++ b/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs
@@ -45,48 +45,6 @@ pub use dispatch_transaction::DispatchTransaction;
 pub type ValidateResult<Val, Call> =
 	Result<(ValidTransaction, Val, OriginOf<Call>), TransactionValidityError>;
 
-/// Base for [TransactionExtension]s; this contains the associated types and does not require any
-/// generic parameterization.
-pub trait TransactionExtensionBase:
-	Codec + Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo
-{
-	/// Unique identifier of this signed extension.
-	///
-	/// This will be exposed in the metadata to identify the signed extension used in an extrinsic.
-	const IDENTIFIER: &'static str;
-
-	/// Any additional data which was known at the time of transaction construction and can be
-	/// useful in authenticating the transaction. This is determined dynamically in part from the
-	/// on-chain environment using the `implicit` function and not directly contained in the
-	/// transaction itself and therefore is considered "implicit".
-	type Implicit: Codec + StaticTypeInfo;
-
-	/// Determine any additional data which was known at the time of transaction construction and
-	/// can be useful in authenticating the transaction. The expected usage of this is to include in
-	/// any data which is signed and verified as part of transaction validation. Also perform any
-	/// pre-signature-verification checks and return an error if needed.
-	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
-		use crate::transaction_validity::InvalidTransaction::IndeterminateImplicit;
-		Ok(Self::Implicit::decode(&mut &[][..]).map_err(|_| IndeterminateImplicit)?)
-	}
-
-	/// Returns the metadata for this extension.
-	///
-	/// As a [`TransactionExtension`] can be a tuple of [`TransactionExtension`]s we need to return
-	/// a `Vec` that holds the metadata of each one. Each individual `TransactionExtension` must
-	/// return *exactly* one [`TransactionExtensionMetadata`].
-	///
-	/// This method provides a default implementation that returns a vec containing a single
-	/// [`TransactionExtensionMetadata`].
-	fn metadata() -> Vec<TransactionExtensionMetadata> {
-		sp_std::vec![TransactionExtensionMetadata {
-			identifier: Self::IDENTIFIER,
-			ty: scale_info::meta_type::<Self>(),
-			implicit: scale_info::meta_type::<Self::Implicit>()
-		}]
-	}
-}
-
 /// Means by which a transaction may be extended. This type embodies both the data and the logic
 /// that should be additionally associated with the transaction. It should be plain old data.
 ///
@@ -124,7 +82,7 @@ pub trait TransactionExtensionBase:
 ///
 /// ## Default implementations
 ///
-/// Of the 6 functions in this trait along with `TransactionExtensionBase`, 2 of them must return a
+/// Of the 6 functions in this trait along with `TransactionExtension`, 2 of them must return a
 /// value of an associated type on success, with only `implicit` having a default implementation.
 /// This means that default implementations cannot be provided for `validate` and `prepare`.
 /// However, a macro is provided [impl_tx_ext_default](crate::impl_tx_ext_default) which is capable
@@ -155,7 +113,7 @@ pub trait TransactionExtensionBase:
 /// the input to the next extension in the pipeline.
 ///
 /// This ordered composition happens with all datatypes ([Val](TransactionExtension::Val),
-/// [Pre](TransactionExtension::Pre) and [Implicit](TransactionExtensionBase::Implicit)) as well as
+/// [Pre](TransactionExtension::Pre) and [Implicit](TransactionExtension::Implicit)) as well as
 /// all functions. There are important consequences stemming from how the composition affects the
 /// meaning of the `origin` and `implication` parameters as well as the results. Whereas the
 /// [prepare](TransactionExtension::prepare) and
@@ -181,7 +139,7 @@ pub trait TransactionExtensionBase:
 /// returned. It is expressed to the [validate](TransactionExtension::validate) function only as the
 /// `implication` argument which implements the [Encode] trait. A transaction extension may define
 /// its own implications through its own fields and the
-/// [implicit](TransactionExtensionBase::implicit) function. This is only utilized by extensions
+/// [implicit](TransactionExtension::implicit) function. This is only utilized by extensions
 /// which preceed it in a pipeline or, if the transaction is an old-school signed transaction, the
 /// underlying transaction verification logic.
 ///
@@ -197,7 +155,44 @@ pub trait TransactionExtensionBase:
 /// transaction payment and refunds should be at the end of the pipeline in order to capture the
 /// correct amount of weight used during the call. This is because one canot know the actual weight
 /// of an extension after post dispatch without running the post dispatch ahead of time.
-pub trait TransactionExtension<Call: Dispatchable>: TransactionExtensionBase {
+pub trait TransactionExtension<Call: Dispatchable>: Codec + Debug + Sync + Send + Clone + Eq + PartialEq + StaticTypeInfo
+{
+	/// Unique identifier of this signed extension.
+	///
+	/// This will be exposed in the metadata to identify the signed extension used in an extrinsic.
+	const IDENTIFIER: &'static str;
+
+	/// Any additional data which was known at the time of transaction construction and can be
+	/// useful in authenticating the transaction. This is determined dynamically in part from the
+	/// on-chain environment using the `implicit` function and not directly contained in the
+	/// transaction itself and therefore is considered "implicit".
+	type Implicit: Codec + StaticTypeInfo;
+
+	/// Determine any additional data which was known at the time of transaction construction and
+	/// can be useful in authenticating the transaction. The expected usage of this is to include in
+	/// any data which is signed and verified as part of transaction validation. Also perform any
+	/// pre-signature-verification checks and return an error if needed.
+	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
+		use crate::transaction_validity::InvalidTransaction::IndeterminateImplicit;
+		Ok(Self::Implicit::decode(&mut &[][..]).map_err(|_| IndeterminateImplicit)?)
+	}
+
+	/// Returns the metadata for this extension.
+	///
+	/// As a [`TransactionExtension`] can be a tuple of [`TransactionExtension`]s we need to return
+	/// a `Vec` that holds the metadata of each one. Each individual `TransactionExtension` must
+	/// return *exactly* one [`TransactionExtensionMetadata`].
+	///
+	/// This method provides a default implementation that returns a vec containing a single
+	/// [`TransactionExtensionMetadata`].
+	fn metadata() -> Vec<TransactionExtensionMetadata> {
+		sp_std::vec![TransactionExtensionMetadata {
+			identifier: Self::IDENTIFIER,
+			ty: scale_info::meta_type::<Self>(),
+			implicit: scale_info::meta_type::<Self::Implicit>()
+		}]
+	}
+
 	/// The type that encodes information that can be passed from validate to prepare.
 	type Val;
 
@@ -466,8 +461,9 @@ pub struct TransactionExtensionMetadata {
 }
 
 #[impl_for_tuples(1, 12)]
-impl TransactionExtensionBase for Tuple {
-	for_tuples!( where #( Tuple: TransactionExtensionBase )* );
+impl<Call: Dispatchable> TransactionExtension<Call> for Tuple {
+	for_tuples!( where #( Tuple: TransactionExtension<Call> )* );
+
 	const IDENTIFIER: &'static str = "Use `metadata()`!";
 	for_tuples!( type Implicit = ( #( Tuple::Implicit ),* ); );
 	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
@@ -478,11 +474,7 @@ impl TransactionExtensionBase for Tuple {
 		for_tuples!( #( ids.extend(Tuple::metadata()); )* );
 		ids
 	}
-}
 
-#[impl_for_tuples(1, 12)]
-impl<Call: Dispatchable> TransactionExtension<Call> for Tuple {
-	for_tuples!( where #( Tuple: TransactionExtension<Call> )* );
 	for_tuples!( type Val = ( #( Tuple::Val ),* ); );
 	for_tuples!( type Pre = ( #( Tuple::Pre ),* ); );
 
@@ -573,15 +565,12 @@ impl<Call: Dispatchable> TransactionExtension<Call> for Tuple {
 	}
 }
 
-impl TransactionExtensionBase for () {
+impl<Call: Dispatchable> TransactionExtension<Call> for () {
 	const IDENTIFIER: &'static str = "UnitTransactionExtension";
 	type Implicit = ();
 	fn implicit(&self) -> sp_std::result::Result<Self::Implicit, TransactionValidityError> {
 		Ok(())
 	}
-}
-
-impl<Call: Dispatchable> TransactionExtension<Call> for () {
 	type Val = ();
 	type Pre = ();
 	fn weight(&self, _call: &Call) -> Weight {

--- a/substrate/test-utils/runtime/src/extrinsic.rs
+++ b/substrate/test-utils/runtime/src/extrinsic.rs
@@ -27,7 +27,7 @@ use frame_system::{CheckNonce, CheckWeight};
 use sp_core::crypto::Pair as TraitPair;
 use sp_keyring::AccountKeyring;
 use sp_runtime::{
-	generic::Preamble, traits::TransactionExtensionBase, transaction_validity::TransactionPriority,
+	generic::Preamble, traits::TransactionExtension, transaction_validity::TransactionPriority,
 	Perbill,
 };
 

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -277,11 +277,9 @@ impl sp_runtime::traits::Dispatchable for CheckSubstrateCall {
 	}
 }
 
-impl sp_runtime::traits::TransactionExtensionBase for CheckSubstrateCall {
+impl sp_runtime::traits::TransactionExtension<RuntimeCall> for CheckSubstrateCall {
 	const IDENTIFIER: &'static str = "CheckSubstrateCall";
 	type Implicit = ();
-}
-impl sp_runtime::traits::TransactionExtension<RuntimeCall> for CheckSubstrateCall {
 	type Pre = ();
 	type Val = ();
 	impl_tx_ext_default!(RuntimeCall; prepare);


### PR DESCRIPTION
* rename metadata stuff from `additional_signed` to `implicit` (doesn't break metadata, only temporary representation in the code)
* removed some unused associated type `SignaturePayload`
* remove `From<u64>` from transaction payment transaction extension
* remove `TransactionExtensionBase`, merged into `TransactionExtension`