### PR TITLE
Add symlinks for code of conduct and contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+docs/contributor/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+docs/contributor/CONTRIBUTING.md


### PR DESCRIPTION
Addresses [this](https://github.com/paritytech/eng-automation/issues/10#issuecomment-2286391379).

> Another side note is the checkmarks in https://github.com/paritytech/polkadot-sdk/community. It seems like even though we have `CONTRIBUTING.md` in `/docs` it is not picked up in this list. I am not even sure what is the benefit of following these standards, but it is probably for the best to do it. 