### PR TITLE
Remove staking controller account logic from pallets & runtimes

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/genesis.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/genesis.rs
@@ -84,9 +84,7 @@ pub fn genesis() -> Storage {
 			minimum_validator_count: 1,
 			stakers: validators::initial_authorities()
 				.iter()
-				.map(|x| {
-					(x.0.clone(), x.1.clone(), STASH, westend_runtime::StakerStatus::Validator)
-				})
+				.map(|x| (x.0.clone(), STASH, westend_runtime::StakerStatus::Validator))
 				.collect(),
 			invulnerables: validators::initial_authorities().iter().map(|x| x.0.clone()).collect(),
 			force_era: pallet_staking::Forcing::ForceNone,

--- a/polkadot/runtime/common/src/try_runtime.rs
+++ b/polkadot/runtime/common/src/try_runtime.rs
@@ -34,7 +34,7 @@ where
 	let mut unstaked_err = 0;
 	let mut unstaked_slashed = 0;
 
-	let all_stakers = Ledger::<T>::iter().map(|(ctrl, l)| (ctrl, l.stash)).collect::<BTreeSet<_>>();
+	let all_stakers = Ledger::<T>::iter().map(|(_, l)| l.stash).collect::<BTreeSet<_>>();
 	let mut all_exposed = BTreeSet::new();
 	ErasStakers::<T>::iter().for_each(|(_, val, expo)| {
 		all_exposed.insert(val);
@@ -43,7 +43,7 @@ where
 
 	let eligible = all_stakers
 		.iter()
-		.filter_map(|(ctrl, stash)| all_exposed.contains(stash).then_some(ctrl))
+		.filter(|stash| all_exposed.contains(stash))
 		.collect::<Vec<_>>();
 
 	log::info!(

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -364,7 +364,6 @@ impl pallet_staking::Config for Runtime {
 	type TargetList = pallet_staking::UseValidatorsMap<Runtime>;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type MaxUnlockingChunks = frame_support::traits::ConstU32<32>;
-	type MaxControllersInDeprecationBatch = ConstU32<5900>;
 	type HistoryDepth = frame_support::traits::ConstU32<84>;
 	type BenchmarkingConfig = polkadot_runtime_common::StakingBenchmarkingConfig;
 	type EventListeners = ();

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -722,7 +722,6 @@ parameter_types! {
 	// of nominators.
 	pub const MaxNominators: u32 = 64;
 	pub const MaxNominations: u32 = <NposCompactSolution16 as frame_election_provider_support::NposSolution>::LIMIT as u32;
-	pub const MaxControllersInDeprecationBatch: u32 = 751;
 }
 
 impl pallet_staking::Config for Runtime {
@@ -749,7 +748,6 @@ impl pallet_staking::Config for Runtime {
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<{ MaxNominations::get() }>;
 	type MaxUnlockingChunks = frame_support::traits::ConstU32<32>;
 	type HistoryDepth = frame_support::traits::ConstU32<84>;
-	type MaxControllersInDeprecationBatch = MaxControllersInDeprecationBatch;
 	type BenchmarkingConfig = polkadot_runtime_common::StakingBenchmarkingConfig;
 	type EventListeners = (NominationPools, DelegatedStaking);
 	type WeightInfo = weights::pallet_staking::WeightInfo<Runtime>;

--- a/polkadot/runtime/westend/src/weights/pallet_staking.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_staking.rs
@@ -318,36 +318,6 @@ impl<T: frame_system::Config> pallet_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
-	/// Storage: `Staking::Ledger` (r:1 w:0)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Bonded` (r:1 w:0)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Payee` (r:1 w:1)
-	/// Proof: `Staking::Payee` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
-	fn update_payee() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `932`
-		//  Estimated: `4556`
-		// Minimum execution time: 23_428_000 picoseconds.
-		Weight::from_parts(24_080_000, 0)
-			.saturating_add(Weight::from_parts(0, 4556))
-			.saturating_add(T::DbWeight::get().reads(3))
-			.saturating_add(T::DbWeight::get().writes(1))
-	}
-	/// Storage: `Staking::Bonded` (r:1 w:1)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Ledger` (r:2 w:2)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	fn set_controller() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `865`
-		//  Estimated: `8122`
-		// Minimum execution time: 21_159_000 picoseconds.
-		Weight::from_parts(21_706_000, 0)
-			.saturating_add(Weight::from_parts(0, 8122))
-			.saturating_add(T::DbWeight::get().reads(3))
-			.saturating_add(T::DbWeight::get().writes(3))
-	}
 	/// Storage: `Staking::ValidatorCount` (r:0 w:1)
 	/// Proof: `Staking::ValidatorCount` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn set_validator_count() -> Weight {
@@ -405,26 +375,6 @@ impl<T: frame_system::Config> pallet_staking::WeightInfo for WeightInfo<T> {
 			// Standard Error: 67
 			.saturating_add(Weight::from_parts(11_785, 0).saturating_mul(v.into()))
 			.saturating_add(T::DbWeight::get().writes(1))
-	}
-	/// Storage: `Staking::Ledger` (r:1502 w:1502)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Bonded` (r:751 w:751)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Payee` (r:751 w:0)
-	/// Proof: `Staking::Payee` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
-	/// The range of component `i` is `[0, 751]`.
-	fn deprecate_controller_batch(i: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `680 + i * (227 ±0)`
-		//  Estimated: `990 + i * (7132 ±0)`
-		// Minimum execution time: 4_321_000 picoseconds.
-		Weight::from_parts(4_407_000, 0)
-			.saturating_add(Weight::from_parts(0, 990))
-			// Standard Error: 37_239
-			.saturating_add(Weight::from_parts(21_300_598, 0).saturating_mul(i.into()))
-			.saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(i.into())))
-			.saturating_add(T::DbWeight::get().writes((3_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_parts(0, 7132).saturating_mul(i.into()))
 	}
 	/// Storage: `Staking::SlashingSpans` (r:1 w:1)
 	/// Proof: `Staking::SlashingSpans` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/prdoc/pr_4574.prdoc
+++ b/prdoc/pr_4574.prdoc
@@ -1,0 +1,36 @@
+title: Remove staking controller account logic from codebase.
+
+doc:
+  - audience: Runtime Dev
+    description:
+       Removes controller account logic from the pallets and runtimes.
+
+crates:
+  - name: pallet-staking
+    bump: minor
+  - name: pallet-babe
+    bump: patch
+  - name: pallet-fast-unstake
+    bump: minor
+  - name: pallet-grandpa
+    bump: patch
+  - name: pallet-beefy 
+    bump: patch
+  - name: pallet-delegated-staking
+    bump: patch
+  - name: pallet-nomination-pools-benchmarking
+    bump: patch
+  - name: pallet-offences-benchmarking
+    bump: patch
+  - name: pallet-session-benchmarking
+    bump: patch
+  - name: pallet-root-offences
+    bump: patch
+  - name: pallet-nomination-pools
+    bump: patch
+  - name: sp-staking
+    bump: patch
+  - name: polkadot-runtime-common
+    bump: patch
+  - name: westend-runtime
+    bump: patch

--- a/substrate/bin/node/cli/src/chain_spec.rs
+++ b/substrate/bin/node/cli/src/chain_spec.rs
@@ -305,7 +305,7 @@ fn configure_accounts(
 	)>,
 	Vec<AccountId>,
 	usize,
-	Vec<(AccountId, AccountId, Balance, StakerStatus<AccountId>)>,
+	Vec<(AccountId, Balance, StakerStatus<AccountId>)>,
 ) {
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
@@ -338,7 +338,7 @@ fn configure_accounts(
 	let mut rng = rand::thread_rng();
 	let stakers = initial_authorities
 		.iter()
-		.map(|x| (x.0.clone(), x.0.clone(), stash, StakerStatus::Validator))
+		.map(|x| (x.0.clone(), stash, StakerStatus::Validator))
 		.chain(initial_nominators.iter().map(|x| {
 			use rand::{seq::SliceRandom, Rng};
 			let limit = (MaxNominations::get() as usize).min(initial_authorities.len());
@@ -349,7 +349,7 @@ fn configure_accounts(
 				.into_iter()
 				.map(|choice| choice.0.clone())
 				.collect::<Vec<_>>();
-			(x.clone(), x.clone(), stash, StakerStatus::Nominator(nominations))
+			(x.clone(), stash, StakerStatus::Nominator(nominations))
 		}))
 		.collect::<Vec<_>>();
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -652,7 +652,6 @@ parameter_types! {
 	pub const SlashDeferDuration: sp_staking::EraIndex = 24 * 7; // 1/4 the bonding duration.
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
 	pub const MaxNominators: u32 = 64;
-	pub const MaxControllersInDeprecationBatch: u32 = 5900;
 	pub OffchainRepeat: BlockNumber = 5;
 	pub HistoryDepth: u32 = 84;
 }
@@ -694,7 +693,6 @@ impl pallet_staking::Config for Runtime {
 	// This a placeholder, to be introduced in the next PR as an instance of bags-list
 	type TargetList = pallet_staking::UseValidatorsMap<Self>;
 	type MaxUnlockingChunks = ConstU32<32>;
-	type MaxControllersInDeprecationBatch = MaxControllersInDeprecationBatch;
 	type HistoryDepth = HistoryDepth;
 	type EventListeners = NominationPools;
 	type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;

--- a/substrate/bin/node/testing/src/genesis.rs
+++ b/substrate/bin/node/testing/src/genesis.rs
@@ -58,9 +58,9 @@ pub fn config_endowed(extra_endowed: Vec<AccountId>) -> RuntimeGenesisConfig {
 		},
 		staking: StakingConfig {
 			stakers: vec![
-				(dave(), dave(), 111 * DOLLARS, StakerStatus::Validator),
-				(eve(), eve(), 100 * DOLLARS, StakerStatus::Validator),
-				(ferdie(), ferdie(), 100 * DOLLARS, StakerStatus::Validator),
+				(dave(), 111 * DOLLARS, StakerStatus::Validator),
+				(eve(), 100 * DOLLARS, StakerStatus::Validator),
+				(ferdie(), 100 * DOLLARS, StakerStatus::Validator),
 			],
 			validator_count: 3,
 			minimum_validator_count: 0,

--- a/substrate/frame/babe/src/mock.rs
+++ b/substrate/frame/babe/src/mock.rs
@@ -325,7 +325,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AuthorityId>) -> sp_io::Tes
 
 	// controllers are same as stash
 	let stakers: Vec<_> = (0..authorities.len())
-		.map(|i| (i as u64, i as u64, 10_000, pallet_staking::StakerStatus::<u64>::Validator))
+		.map(|i| (i as u64, 10_000, pallet_staking::StakerStatus::<u64>::Validator))
 		.collect();
 
 	let staking_config = pallet_staking::GenesisConfig::<Test> {

--- a/substrate/frame/beefy/src/mock.rs
+++ b/substrate/frame/beefy/src/mock.rs
@@ -284,9 +284,8 @@ impl ExtBuilder {
 			.assimilate_storage(&mut t)
 			.unwrap();
 
-		// controllers are same as stash
 		let stakers: Vec<_> = (0..self.authorities.len())
-			.map(|i| (i as u64, i as u64, 10_000, pallet_staking::StakerStatus::<u64>::Validator))
+			.map(|i| (i as u64, 10_000, pallet_staking::StakerStatus::<u64>::Validator))
 			.collect();
 
 		let staking_config = pallet_staking::GenesisConfig::<Test> {

--- a/substrate/frame/delegated-staking/src/mock.rs
+++ b/substrate/frame/delegated-staking/src/mock.rs
@@ -194,18 +194,15 @@ impl ExtBuilder {
 		let stakers = vec![
 			(
 				GENESIS_VALIDATOR,
-				GENESIS_VALIDATOR,
 				1000,
 				sp_staking::StakerStatus::<AccountId>::Validator,
 			),
 			(
 				GENESIS_NOMINATOR_ONE,
-				GENESIS_NOMINATOR_ONE,
 				100,
 				sp_staking::StakerStatus::<AccountId>::Nominator(vec![1]),
 			),
 			(
-				GENESIS_NOMINATOR_TWO,
 				GENESIS_NOMINATOR_TWO,
 				200,
 				sp_staking::StakerStatus::<AccountId>::Nominator(vec![1]),

--- a/substrate/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
+++ b/substrate/frame/election-provider-multi-phase/test-staking-e2e/src/mock.rs
@@ -381,27 +381,27 @@ pub struct StakingExtBuilder {
 	min_validator_bond: Balance,
 	status: BTreeMap<AccountId, StakerStatus<AccountId>>,
 	stakes: BTreeMap<AccountId, Balance>,
-	stakers: Vec<(AccountId, AccountId, Balance, StakerStatus<AccountId>)>,
+	stakers: Vec<(AccountId, Balance, StakerStatus<AccountId>)>,
 }
 
 impl Default for StakingExtBuilder {
 	fn default() -> Self {
 		let stakers = vec![
-			// (stash, ctrl, stake, status)
+			// (stash, stake, status)
 			// these two will be elected in the default test where we elect 2.
-			(11, 11, 1000, StakerStatus::<AccountId>::Validator),
-			(21, 21, 1000, StakerStatus::<AccountId>::Validator),
+			(11, 1000, StakerStatus::<AccountId>::Validator),
+			(21, 1000, StakerStatus::<AccountId>::Validator),
 			// loser validators if validator_count() is default.
-			(31, 31, 500, StakerStatus::<AccountId>::Validator),
-			(41, 41, 1500, StakerStatus::<AccountId>::Validator),
-			(51, 51, 1500, StakerStatus::<AccountId>::Validator),
-			(61, 61, 1500, StakerStatus::<AccountId>::Validator),
-			(71, 71, 1500, StakerStatus::<AccountId>::Validator),
-			(81, 81, 1500, StakerStatus::<AccountId>::Validator),
-			(91, 91, 1500, StakerStatus::<AccountId>::Validator),
-			(101, 101, 500, StakerStatus::<AccountId>::Validator),
+			(31, 500, StakerStatus::<AccountId>::Validator),
+			(41, 1500, StakerStatus::<AccountId>::Validator),
+			(51, 1500, StakerStatus::<AccountId>::Validator),
+			(61, 1500, StakerStatus::<AccountId>::Validator),
+			(71, 1500, StakerStatus::<AccountId>::Validator),
+			(81, 1500, StakerStatus::<AccountId>::Validator),
+			(91, 1500, StakerStatus::<AccountId>::Validator),
+			(101, 500, StakerStatus::<AccountId>::Validator),
 			// an idle validator
-			(201, 201, 1000, StakerStatus::<AccountId>::Idle),
+			(201, 1000, StakerStatus::<AccountId>::Idle),
 		];
 
 		Self {
@@ -479,18 +479,6 @@ impl Default for BalancesExtBuilder {
 			(2, 20),
 			(3, 300),
 			(4, 400),
-			// controllers (still used in some tests. Soon to be deprecated).
-			(10, 100),
-			(20, 100),
-			(30, 100),
-			(40, 100),
-			(50, 100),
-			(60, 100),
-			(70, 100),
-			(80, 100),
-			(90, 100),
-			(100, 100),
-			(200, 100),
 			// stashes
 			(11, 1000),
 			(21, 2000),
@@ -541,7 +529,7 @@ impl ExtBuilder {
 
 		let mut stakers = self.staking_builder.stakers.clone();
 		self.staking_builder.status.clone().into_iter().for_each(|(stash, status)| {
-			let (_, _, _, ref mut prev_status) = stakers
+			let (_, _, ref mut prev_status) = stakers
 				.iter_mut()
 				.find(|s| s.0 == stash)
 				.expect("set_status staker should exist; qed");
@@ -549,7 +537,7 @@ impl ExtBuilder {
 		});
 		// replaced any of the stakes if needed.
 		self.staking_builder.stakes.clone().into_iter().for_each(|(stash, stake)| {
-			let (_, _, ref mut prev_stake, _) = stakers
+			let (_, ref mut prev_stake, _) = stakers
 				.iter_mut()
 				.find(|s| s.0 == stash)
 				.expect("set_stake staker should exits; qed.");

--- a/substrate/frame/fast-unstake/src/mock.rs
+++ b/substrate/frame/fast-unstake/src/mock.rs
@@ -160,19 +160,13 @@ pub(crate) fn fast_unstake_events_since_last_call() -> Vec<super::Event<Runtime>
 }
 
 pub struct ExtBuilder {
-	unexposed: Vec<(AccountId, AccountId, Balance)>,
+	unexposed: Vec<(AccountId, Balance)>,
 }
 
 impl Default for ExtBuilder {
 	fn default() -> Self {
 		Self {
-			unexposed: vec![
-				(1, 1, 7 + 100),
-				(3, 3, 7 + 100),
-				(5, 5, 7 + 100),
-				(7, 7, 7 + 100),
-				(9, 9, 7 + 100),
-			],
+			unexposed: vec![(1, 7 + 100), (3, 7 + 100), (5, 7 + 100), (7, 7 + 100), (9, 7 + 100)],
 		}
 	}
 }
@@ -222,7 +216,7 @@ impl ExtBuilder {
 				.unexposed
 				.clone()
 				.into_iter()
-				.map(|(stash, _, balance)| (stash, balance * 2))
+				.map(|(stash, balance)| (stash, balance * 2))
 				.chain(validators_range.clone().map(|x| (x, 7 + 100)))
 				.chain(nominators_range.clone().map(|x| (x, 7 + 100)))
 				.collect::<Vec<_>>(),
@@ -233,9 +227,11 @@ impl ExtBuilder {
 			stakers: self
 				.unexposed
 				.into_iter()
-				.map(|(x, y, z)| (x, y, z, pallet_staking::StakerStatus::Nominator(vec![42])))
-				.chain(validators_range.map(|x| (x, x, 100, StakerStatus::Validator)))
-				.chain(nominators_range.map(|x| (x, x, 100, StakerStatus::Nominator(vec![x]))))
+				.map(|(stash, balance)| {
+					(stash, balance, pallet_staking::StakerStatus::Nominator(vec![42]))
+				})
+				.chain(validators_range.map(|x| (x, 100, StakerStatus::Validator)))
+				.chain(nominators_range.map(|x| (x, 100, StakerStatus::Nominator(vec![x]))))
 				.collect::<Vec<_>>(),
 			..Default::default()
 		}

--- a/substrate/frame/fast-unstake/src/tests.rs
+++ b/substrate/frame/fast-unstake/src/tests.rs
@@ -36,7 +36,7 @@ fn test_setup_works() {
 fn register_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		ErasToCheckPerBlock::<T>::put(1);
-		// Controller account registers for fast unstake.
+		// Stash account registers for fast unstake.
 		assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(1)));
 		// Ensure stash is in the queue.
 		assert_ne!(Queue::<T>::get(1), None);
@@ -50,7 +50,7 @@ fn register_insufficient_funds_fails() {
 		ErasToCheckPerBlock::<T>::put(1);
 		<T as Config>::Currency::make_free_balance_be(&1, 3);
 
-		// Controller account registers for fast unstake.
+		// Stash account registers for fast unstake.
 		assert_noop!(
 			FastUnstake::register_fast_unstake(RuntimeOrigin::signed(1)),
 			BalancesError::<T, _>::InsufficientBalance,
@@ -82,7 +82,7 @@ fn cannot_register_if_not_bonded() {
 		// Attempt to fast unstake.
 		assert_noop!(
 			FastUnstake::register_fast_unstake(RuntimeOrigin::signed(2)),
-			Error::<T>::NotController
+			Error::<T>::NotStash
 		);
 	});
 }
@@ -110,7 +110,7 @@ fn cannot_register_if_head() {
 			stashes: bounded_vec![(1, Deposit::get())],
 			checked: bounded_vec![],
 		});
-		// Controller attempts to register
+		// Stash attempts to register
 		assert_noop!(
 			FastUnstake::register_fast_unstake(RuntimeOrigin::signed(1)),
 			Error::<T>::AlreadyHead
@@ -139,11 +139,11 @@ fn deregister_works() {
 
 		assert_eq!(<T as Config>::Currency::reserved_balance(&1), 0);
 
-		// Controller account registers for fast unstake.
+		// Stash account registers for fast unstake.
 		assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(1)));
 		assert_eq!(<T as Config>::Currency::reserved_balance(&1), Deposit::get());
 
-		// Controller then changes mind and deregisters.
+		// Stash then changes mind and deregisters.
 		assert_ok!(FastUnstake::deregister(RuntimeOrigin::signed(1)));
 		assert_eq!(<T as Config>::Currency::reserved_balance(&1), 0);
 
@@ -163,13 +163,13 @@ fn deregister_disabled_fails() {
 }
 
 #[test]
-fn cannot_deregister_if_not_controller() {
+fn cannot_deregister_if_not_stash() {
 	ExtBuilder::default().build_and_execute(|| {
 		ErasToCheckPerBlock::<T>::put(1);
-		// Controller (same as stash) account registers for fast unstake.
+		// Stash registers for fast unstake.
 		assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(1)));
 		// Another account tries to deregister.
-		assert_noop!(FastUnstake::deregister(RuntimeOrigin::signed(2)), Error::<T>::NotController);
+		assert_noop!(FastUnstake::deregister(RuntimeOrigin::signed(2)), Error::<T>::NotStash);
 	});
 }
 
@@ -177,7 +177,7 @@ fn cannot_deregister_if_not_controller() {
 fn cannot_deregister_if_not_queued() {
 	ExtBuilder::default().build_and_execute(|| {
 		ErasToCheckPerBlock::<T>::put(1);
-		// Controller tries to deregister without first registering
+		// Stash tries to deregister without first registering
 		assert_noop!(FastUnstake::deregister(RuntimeOrigin::signed(1)), Error::<T>::NotQueued);
 	});
 }
@@ -186,14 +186,14 @@ fn cannot_deregister_if_not_queued() {
 fn cannot_deregister_already_head() {
 	ExtBuilder::default().build_and_execute(|| {
 		ErasToCheckPerBlock::<T>::put(1);
-		// Controller attempts to register, should fail
+		// Stash attempts to register, should fail
 		assert_ok!(FastUnstake::register_fast_unstake(RuntimeOrigin::signed(1)));
 		// Insert some Head item for stash.
 		Head::<T>::put(UnstakeRequest {
 			stashes: bounded_vec![(1, Deposit::get())],
 			checked: bounded_vec![],
 		});
-		// Controller attempts to deregister
+		// Stash attempts to deregister
 		assert_noop!(FastUnstake::deregister(RuntimeOrigin::signed(1)), Error::<T>::AlreadyHead);
 	});
 }

--- a/substrate/frame/grandpa/src/mock.rs
+++ b/substrate/frame/grandpa/src/mock.rs
@@ -241,7 +241,7 @@ pub fn new_test_ext_raw_authorities(authorities: AuthorityList) -> sp_io::TestEx
 
 	// controllers are the same as stash
 	let stakers: Vec<_> = (0..authorities.len())
-		.map(|i| (i as u64, i as u64, 10_000, pallet_staking::StakerStatus::<u64>::Validator))
+		.map(|i| (i as u64, 10_000, pallet_staking::StakerStatus::<u64>::Validator))
 		.collect();
 
 	let staking_config = pallet_staking::GenesisConfig::<Test> {

--- a/substrate/frame/nomination-pools/src/mock.rs
+++ b/substrate/frame/nomination-pools/src/mock.rs
@@ -184,7 +184,7 @@ impl sp_staking::StakingInterface for StakingMock {
 		Nominations::get()
 	}
 
-	fn stash_by_ctrl(_controller: &Self::AccountId) -> Result<Self::AccountId, DispatchError> {
+	fn stash(_who: &Self::AccountId) -> Result<Self::AccountId, DispatchError> {
 		unimplemented!("method currently not used in testing")
 	}
 

--- a/substrate/frame/root-offences/src/mock.rs
+++ b/substrate/frame/root-offences/src/mock.rs
@@ -200,11 +200,6 @@ impl ExtBuilder {
 
 		pallet_balances::GenesisConfig::<Test> {
 			balances: vec![
-				// controllers (still used in some tests. Soon to be deprecated).
-				(10, self.balance_factor * 50),
-				(20, self.balance_factor * 50),
-				(30, self.balance_factor * 50),
-				(40, self.balance_factor * 50),
 				// stashes
 				(11, self.balance_factor * 1000),
 				(21, self.balance_factor * 1000),
@@ -216,14 +211,14 @@ impl ExtBuilder {
 		.unwrap();
 
 		let stakers = vec![
-			// (stash, ctrl, stake, status)
+			// (stash, stake, status)
 			// these two will be elected in the default test where we elect 2.
-			(11, 11, 1000, StakerStatus::<AccountId>::Validator),
-			(21, 21, 1000, StakerStatus::<AccountId>::Validator),
+			(11, 1000, StakerStatus::<AccountId>::Validator),
+			(21, 1000, StakerStatus::<AccountId>::Validator),
 			// a loser validator
-			(31, 31, 500, StakerStatus::<AccountId>::Validator),
+			(31, 500, StakerStatus::<AccountId>::Validator),
 			// an idle validator
-			(41, 41, 1000, StakerStatus::<AccountId>::Idle),
+			(41, 1000, StakerStatus::<AccountId>::Idle),
 		];
 
 		let _ = pallet_staking::GenesisConfig::<Test> {

--- a/substrate/frame/session/benchmarking/src/inner.rs
+++ b/substrate/frame/session/benchmarking/src/inner.rs
@@ -55,32 +55,30 @@ benchmarks! {
 			true,
 			RewardDestination::Staked,
 		)?;
-		let v_controller = pallet_staking::Pallet::<T>::bonded(&v_stash).ok_or("not stash")?;
+		let v_stash = pallet_staking::Pallet::<T>::bonded(&v_stash).ok_or("not stash")?;
 
 		let keys = T::Keys::decode(&mut TrailingZeroInput::zeroes()).unwrap();
 		let proof: Vec<u8> = vec![0,1,2,3];
-		// Whitelist controller account from further DB operations.
-		let v_controller_key = frame_system::Account::<T>::hashed_key_for(&v_controller);
-		frame_benchmarking::benchmarking::add_to_whitelist(v_controller_key.into());
-	}: _(RawOrigin::Signed(v_controller), keys, proof)
+		// Whitelist stash account from further DB operations.
+		let v_stash_key = frame_system::Account::<T>::hashed_key_for(&v_stash);
+		frame_benchmarking::benchmarking::add_to_whitelist(v_stash_key.into());
+	}: _(RawOrigin::Signed(v_stash), keys, proof)
 
 	purge_keys {
 		let n = MaxNominationsOf::<T>::get();
 		let (v_stash, _) = create_validator_with_nominators::<T>(
 			n,
 			MaxNominationsOf::<T>::get(),
-			false,
-			true,
 			RewardDestination::Staked,
 		)?;
-		let v_controller = pallet_staking::Pallet::<T>::bonded(&v_stash).ok_or("not stash")?;
+		let v_stash = pallet_staking::Pallet::<T>::bonded(&v_stash).ok_or("not stash")?;
 		let keys = T::Keys::decode(&mut TrailingZeroInput::zeroes()).unwrap();
 		let proof: Vec<u8> = vec![0,1,2,3];
-		Session::<T>::set_keys(RawOrigin::Signed(v_controller.clone()).into(), keys, proof)?;
-		// Whitelist controller account from further DB operations.
-		let v_controller_key = frame_system::Account::<T>::hashed_key_for(&v_controller);
-		frame_benchmarking::benchmarking::add_to_whitelist(v_controller_key.into());
-	}: _(RawOrigin::Signed(v_controller))
+		Session::<T>::set_keys(RawOrigin::Signed(v_stash.clone()).into(), keys, proof)?;
+		// Whitelist stash account from further DB operations.
+		let v_stash_key = frame_system::Account::<T>::hashed_key_for(&v_stash);
+		frame_benchmarking::benchmarking::add_to_whitelist(v_stash_key.into());
+	}: _(RawOrigin::Signed(v_stash))
 
 	#[extra]
 	check_membership_proof_current_session {
@@ -129,7 +127,7 @@ fn check_membership_proof_setup<T: Config>(
 		use rand::{RngCore, SeedableRng};
 
 		let validator = T::Lookup::lookup(who).unwrap();
-		let controller = pallet_staking::Pallet::<T>::bonded(&validator).unwrap();
+		let stash = pallet_staking::Pallet::<T>::bonded(&validator).unwrap();
 
 		let keys = {
 			let mut keys = [0u8; 128];
@@ -146,7 +144,7 @@ fn check_membership_proof_setup<T: Config>(
 		let keys: T::Keys = Decode::decode(&mut &keys[..]).unwrap();
 		let proof: Vec<u8> = vec![];
 
-		Session::<T>::set_keys(RawOrigin::Signed(controller).into(), keys, proof).unwrap();
+		Session::<T>::set_keys(RawOrigin::Signed(stash).into(), keys, proof).unwrap();
 	}
 
 	Pallet::<T>::on_initialize(frame_system::pallet_prelude::BlockNumberFor::<T>::one());

--- a/substrate/frame/staking/README.md
+++ b/substrate/frame/staking/README.md
@@ -51,9 +51,6 @@ issues instructions on how funds shall be used.
 An account can become a bonded stash account using the
 [`bond`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.bond) call.
 
-Stash accounts can update their associated controller back to their stash account using the
-[`set_controller`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.set_controller) call.
-
 Note: Controller accounts are being deprecated in favor of proxy accounts, so it is no longer possible to set a unique
 address for a stash's controller.
 

--- a/substrate/frame/staking/src/benchmarking.rs
+++ b/substrate/frame/staking/src/benchmarking.rs
@@ -25,7 +25,6 @@ use codec::Decode;
 use frame_election_provider_support::{bounds::DataProviderBounds, SortedListProvider};
 use frame_support::{
 	pallet_prelude::*,
-	storage::bounded_vec::BoundedVec,
 	traits::{Currency, Get, Imbalance, UnfilteredDispatchable},
 };
 use sp_runtime::{
@@ -66,12 +65,10 @@ pub fn add_slashing_spans<T: Config>(who: &T::AccountId, spans: u32) {
 
 // This function clears all existing validators and nominators from the set, and generates one new
 // validator being nominated by n nominators, and returns the validator stash account and the
-// nominators' stash and controller. It also starts an era and creates pending payouts.
+// nominators' stash. It also starts an era and creates pending payouts.
 pub fn create_validator_with_nominators<T: Config>(
 	n: u32,
 	upper_bound: u32,
-	dead_controller: bool,
-	unique_controller: bool,
 	destination: RewardDestination<T::AccountId>,
 ) -> Result<(T::AccountId, Vec<(T::AccountId, T::AccountId)>), &'static str> {
 	// Clean up any existing state.
@@ -79,15 +76,11 @@ pub fn create_validator_with_nominators<T: Config>(
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
-	let (v_stash, v_controller) = if unique_controller {
-		create_unique_stash_controller::<T>(0, 100, destination.clone(), false)?
-	} else {
-		create_stash_controller::<T>(0, 100, destination.clone())?
-	};
+	let v_stash = create_stash::<T>(0, 100, destination.clone())?;
 
 	let validator_prefs =
 		ValidatorPrefs { commission: Perbill::from_percent(50), ..Default::default() };
-	Staking::<T>::validate(RawOrigin::Signed(v_controller).into(), validator_prefs)?;
+	Staking::<T>::validate(RawOrigin::Signed(v_stash.clone()).into(), validator_prefs)?;
 	let stash_lookup = T::Lookup::unlookup(v_stash.clone());
 
 	points_total += 10;
@@ -98,17 +91,14 @@ pub fn create_validator_with_nominators<T: Config>(
 
 	// Give the validator n nominators, but keep total users in the system the same.
 	for i in 0..upper_bound {
-		let (n_stash, n_controller) = if !dead_controller {
-			create_stash_controller::<T>(u32::MAX - i, 100, destination.clone())?
-		} else {
-			create_unique_stash_controller::<T>(u32::MAX - i, 100, destination.clone(), true)?
-		};
+		let n_stash = create_stash::<T>(u32::MAX - i, 100, destination.clone())?;
+
 		if i < n {
 			Staking::<T>::nominate(
-				RawOrigin::Signed(n_controller.clone()).into(),
+				RawOrigin::Signed(n_stash.clone()).into(),
 				vec![stash_lookup.clone()],
 			)?;
-			nominators.push((n_stash, n_controller));
+			nominators.push((n_stash.clone(), n_stash));
 		}
 	}
 
@@ -143,8 +133,6 @@ pub fn create_validator_with_nominators<T: Config>(
 struct ListScenario<T: Config> {
 	/// Stash that is expected to be moved.
 	origin_stash1: T::AccountId,
-	/// Controller of the Stash that is expected to be moved.
-	origin_controller1: T::AccountId,
 	dest_weight: BalanceOf<T>,
 }
 
@@ -172,24 +160,24 @@ impl<T: Config> ListScenario<T> {
 
 		// create accounts with the origin weight
 
-		let (origin_stash1, origin_controller1) = create_stash_controller_with_balance::<T>(
+		let origin_stash1 = create_stash_with_balance::<T>(
 			USER_SEED + 2,
 			origin_weight,
 			RewardDestination::Staked,
 		)?;
 		Staking::<T>::nominate(
-			RawOrigin::Signed(origin_controller1.clone()).into(),
+			RawOrigin::Signed(origin_stash1.clone()).into(),
 			// NOTE: these don't really need to be validators.
 			vec![T::Lookup::unlookup(account("random_validator", 0, SEED))],
 		)?;
 
-		let (_origin_stash2, origin_controller2) = create_stash_controller_with_balance::<T>(
+		let origin_stash2 = create_stash_with_balance::<T>(
 			USER_SEED + 3,
 			origin_weight,
 			RewardDestination::Staked,
 		)?;
 		Staking::<T>::nominate(
-			RawOrigin::Signed(origin_controller2).into(),
+			RawOrigin::Signed(origin_stash2).into(),
 			vec![T::Lookup::unlookup(account("random_validator", 0, SEED))],
 		)?;
 
@@ -203,17 +191,14 @@ impl<T: Config> ListScenario<T> {
 			T::CurrencyToVote::to_currency(dest_weight_as_vote as u128, total_issuance);
 
 		// create an account with the worst case destination weight
-		let (_dest_stash1, dest_controller1) = create_stash_controller_with_balance::<T>(
-			USER_SEED + 1,
-			dest_weight,
-			RewardDestination::Staked,
-		)?;
+		let dest_stash1 =
+			create_stash_with_balance::<T>(USER_SEED + 1, dest_weight, RewardDestination::Staked)?;
 		Staking::<T>::nominate(
-			RawOrigin::Signed(dest_controller1).into(),
+			RawOrigin::Signed(dest_stash1).into(),
 			vec![T::Lookup::unlookup(account("random_validator", 0, SEED))],
 		)?;
 
-		Ok(ListScenario { origin_stash1, origin_controller1, dest_weight })
+		Ok(ListScenario { origin_stash1, dest_weight })
 	}
 }
 
@@ -227,7 +212,6 @@ benchmarks! {
 		whitelist_account!(stash);
 	}: _(RawOrigin::Signed(stash.clone()), amount, reward_destination)
 	verify {
-		assert!(Bonded::<T>::contains_key(stash.clone()));
 		assert!(Ledger::<T>::contains_key(stash));
 	}
 
@@ -245,16 +229,15 @@ benchmarks! {
 		let max_additional = scenario.dest_weight - origin_weight;
 
 		let stash = scenario.origin_stash1.clone();
-		let controller = scenario.origin_controller1;
 		let original_bonded: BalanceOf<T>
-			= Ledger::<T>::get(&controller).map(|l| l.active).ok_or("ledger not created after")?;
+			= Ledger::<T>::get(&stash).map(|l| l.active).ok_or("ledger not created after")?;
 
 		let _ = T::Currency::deposit_into_existing(&stash, max_additional).unwrap();
 
 		whitelist_account!(stash);
-	}: _(RawOrigin::Signed(stash), max_additional)
+	}: _(RawOrigin::Signed(stash.clone()), max_additional)
 	verify {
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created after")?;
+		let ledger = Ledger::<T>::get(&stash).ok_or("ledger not created after")?;
 		let new_bonded: BalanceOf<T> = ledger.active;
 		assert!(original_bonded < new_bonded);
 	}
@@ -273,15 +256,14 @@ benchmarks! {
 		let scenario = ListScenario::<T>::new(origin_weight, false)?;
 
 		let stash = scenario.origin_stash1.clone();
-		let controller = scenario.origin_controller1.clone();
 		let amount = origin_weight - scenario.dest_weight;
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
+		let ledger = Ledger::<T>::get(&stash).ok_or("ledger not created before")?;
 		let original_bonded: BalanceOf<T> = ledger.active;
 
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller.clone()), amount)
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash.clone()), amount)
 	verify {
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created after")?;
+		let ledger = Ledger::<T>::get(&stash).ok_or("ledger not created after")?;
 		let new_bonded: BalanceOf<T> = ledger.active;
 		assert!(original_bonded > new_bonded);
 	}
@@ -290,17 +272,17 @@ benchmarks! {
 	withdraw_unbonded_update {
 		// Slashing Spans
 		let s in 0 .. MAX_SPANS;
-		let (stash, controller) = create_stash_controller::<T>(0, 100, RewardDestination::Staked)?;
+		let stash = create_stash::<T>(0, 100, RewardDestination::Staked)?;
 		add_slashing_spans::<T>(&stash, s);
 		let amount = T::Currency::minimum_balance() * 5u32.into(); // Half of total
-		Staking::<T>::unbond(RawOrigin::Signed(controller.clone()).into(), amount)?;
+		Staking::<T>::unbond(RawOrigin::Signed(stash.clone()).into(), amount)?;
 		CurrentEra::<T>::put(EraIndex::max_value());
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
+		let ledger = Ledger::<T>::get(&stash).ok_or("ledger not created before")?;
 		let original_total: BalanceOf<T> = ledger.total;
-		whitelist_account!(controller);
-	}: withdraw_unbonded(RawOrigin::Signed(controller.clone()), s)
+		whitelist_account!(stash);
+	}: withdraw_unbonded(RawOrigin::Signed(stash.clone()), s)
 	verify {
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created after")?;
+		let ledger = Ledger::<T>::get(&stash).ok_or("ledger not created after")?;
 		let new_total: BalanceOf<T> = ledger.total;
 		assert!(original_total > new_total);
 	}
@@ -317,26 +299,25 @@ benchmarks! {
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
-		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1;
 		add_slashing_spans::<T>(&stash, s);
 		assert!(T::VoterList::contains(&stash));
 
 		let ed = T::Currency::minimum_balance();
-		let mut ledger = Ledger::<T>::get(&controller).unwrap();
+		let mut ledger = Ledger::<T>::get(&stash).unwrap();
 		ledger.active = ed - One::one();
-		Ledger::<T>::insert(&controller, ledger);
+		Ledger::<T>::insert(&stash, ledger);
 		CurrentEra::<T>::put(EraIndex::max_value());
 
-		whitelist_account!(controller);
-	}: withdraw_unbonded(RawOrigin::Signed(controller.clone()), s)
+		whitelist_account!(stash);
+	}: withdraw_unbonded(RawOrigin::Signed(stash.clone()), s)
 	verify {
-		assert!(!Ledger::<T>::contains_key(controller));
+		assert!(!Ledger::<T>::contains_key(stash));
 		assert!(!T::VoterList::contains(&stash));
 	}
 
 	validate {
-		let (stash, controller) = create_stash_controller::<T>(
+		let stash = create_stash::<T>(
 			MaxNominationsOf::<T>::get() - 1,
 			100,
 			RewardDestination::Staked,
@@ -345,8 +326,8 @@ benchmarks! {
 		assert!(!T::VoterList::contains(&stash));
 
 		let prefs = ValidatorPrefs::default();
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller), prefs)
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash), prefs)
 	verify {
 		assert!(Validators::<T>::contains_key(&stash));
 		assert!(T::VoterList::contains(&stash));
@@ -364,7 +345,7 @@ benchmarks! {
 		let rest_of_validators = create_validators_with_seed::<T>(MaxNominationsOf::<T>::get() - 1, 100, 415)?;
 
 		// this is the validator that will be kicking.
-		let (stash, controller) = create_stash_controller::<T>(
+		let stash = create_stash::<T>(
 			MaxNominationsOf::<T>::get() - 1,
 			100,
 			RewardDestination::Staked,
@@ -372,14 +353,14 @@ benchmarks! {
 		let stash_lookup = T::Lookup::unlookup(stash.clone());
 
 		// they start validating.
-		Staking::<T>::validate(RawOrigin::Signed(controller.clone()).into(), Default::default())?;
+		Staking::<T>::validate(RawOrigin::Signed(stash.clone()).into(), Default::default())?;
 
 		// we now create the nominators. there will be `k` of them; each will nominate all
 		// validators. we will then kick each of the `k` nominators from the main validator.
 		let mut nominator_stashes = Vec::with_capacity(k as usize);
 		for i in 0 .. k {
 			// create a nominator stash.
-			let (n_stash, n_controller) = create_stash_controller::<T>(
+			let n_stash = create_stash::<T>(
 				MaxNominationsOf::<T>::get() + i,
 				100,
 				RewardDestination::Staked,
@@ -391,7 +372,7 @@ benchmarks! {
 			// optimisations/pessimisations.
 			nominations.insert(i as usize % (nominations.len() + 1), stash_lookup.clone());
 			// then we nominate.
-			Staking::<T>::nominate(RawOrigin::Signed(n_controller.clone()).into(), nominations)?;
+			Staking::<T>::nominate(RawOrigin::Signed(n_stash.clone()).into(), nominations)?;
 
 			nominator_stashes.push(n_stash);
 		}
@@ -406,8 +387,8 @@ benchmarks! {
 			.map(|n| T::Lookup::unlookup(n.clone()))
 			.collect::<Vec<_>>();
 
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller), kicks)
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash), kicks)
 	verify {
 		// all nominators now should *not* be nominating our validator...
 		for n in nominator_stashes.iter() {
@@ -427,7 +408,7 @@ benchmarks! {
 		// setup a worst case list scenario. Note we don't care about the destination position, because
 		// we are just doing an insert into the origin position.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
-		let (stash, controller) = create_stash_controller_with_balance::<T>(
+		let stash = create_stash_with_balance::<T>(
 			SEED + MaxNominationsOf::<T>::get() + 1, // make sure the account does not conflict with others
 			origin_weight,
 			RewardDestination::Staked,
@@ -437,8 +418,8 @@ benchmarks! {
 		assert!(!T::VoterList::contains(&stash));
 
 		let validators = create_validators::<T>(n, 100).unwrap();
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller), validators)
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash), validators)
 	verify {
 		assert!(Nominators::<T>::contains_key(&stash));
 		assert!(T::VoterList::contains(&stash))
@@ -453,48 +434,23 @@ benchmarks! {
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
-		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1;
 		assert!(T::VoterList::contains(&stash));
 
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller))
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash))
 	verify {
 		assert!(!T::VoterList::contains(&stash));
 	}
 
 	set_payee {
-		let (stash, controller) = create_stash_controller::<T>(USER_SEED, 100, RewardDestination::Staked)?;
+		let stash = create_stash::<T>(USER_SEED, 100, RewardDestination::Staked)?;
+		let new_payee = create_funded_user::<T>("new_payee", USER_SEED + 4, 100);
 		assert_eq!(Payee::<T>::get(&stash), Some(RewardDestination::Staked));
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller.clone()), RewardDestination::Account(controller.clone()))
-	verify {
-		assert_eq!(Payee::<T>::get(&stash), Some(RewardDestination::Account(controller)));
-	}
-
-	update_payee {
-		let (stash, controller) = create_stash_controller::<T>(USER_SEED, 100, RewardDestination::Staked)?;
-		Payee::<T>::insert(&stash, {
-			#[allow(deprecated)]
-			RewardDestination::Controller
-		});
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller.clone()), controller.clone())
-	verify {
-		assert_eq!(Payee::<T>::get(&stash), Some(RewardDestination::Account(controller)));
-	}
-
-	set_controller {
-		let (stash, ctlr) = create_unique_stash_controller::<T>(9000, 100, RewardDestination::Staked, false)?;
-		// ensure `ctlr` is the currently stored controller.
-		assert!(!Ledger::<T>::contains_key(&stash));
-		assert!(Ledger::<T>::contains_key(&ctlr));
-		assert_eq!(Bonded::<T>::get(&stash), Some(ctlr.clone()));
-
 		whitelist_account!(stash);
-	}: _(RawOrigin::Signed(stash.clone()))
+	}: _(RawOrigin::Signed(stash.clone()), RewardDestination::Account(new_payee.clone()))
 	verify {
-		assert!(Ledger::<T>::contains_key(&stash));
+		assert_eq!(Payee::<T>::get(&stash), Some(RewardDestination::Account(new_payee)));
 	}
 
 	set_validator_count {
@@ -525,39 +481,6 @@ benchmarks! {
 		assert_eq!(Invulnerables::<T>::get().len(), v as usize);
 	}
 
-	deprecate_controller_batch {
-		// We pass a dynamic number of controllers to the benchmark, up to
-		// `MaxControllersInDeprecationBatch`.
-		let i in 0 .. T::MaxControllersInDeprecationBatch::get();
-
-		let mut controllers: Vec<_> = vec![];
-		let mut stashes: Vec<_> = vec![];
-		for n in 0..i as u32 {
-			let (stash, controller) = create_unique_stash_controller::<T>(
-				n,
-				100,
-				RewardDestination::Staked,
-				false
-			)?;
-			controllers.push(controller);
-			stashes.push(stash);
-		}
-		let bounded_controllers: BoundedVec<_, T::MaxControllersInDeprecationBatch> =
-			BoundedVec::try_from(controllers.clone()).unwrap();
-	}: _(RawOrigin::Root, bounded_controllers)
-	verify {
-		for n in 0..i as u32 {
-			let stash = &stashes[n as usize];
-			let controller = &controllers[n as usize];
-			// Ledger no longer keyed by controller.
-			assert_eq!(Ledger::<T>::get(controller), None);
-			// Bonded now maps to the stash.
-			assert_eq!(Bonded::<T>::get(stash), Some(stash.clone()));
-			// Ledger is now keyed by stash.
-			assert_eq!(Ledger::<T>::get(stash).unwrap().stash, *stash);
-		}
-	}
-
 	force_unstake {
 		// Slashing Spans
 		let s in 0 .. MAX_SPANS;
@@ -569,14 +492,12 @@ benchmarks! {
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
-		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1;
 		assert!(T::VoterList::contains(&stash));
 		add_slashing_spans::<T>(&stash, s);
-
 	}: _(RawOrigin::Root, stash.clone(), s)
 	verify {
-		assert!(!Ledger::<T>::contains_key(&controller));
+		assert!(!Ledger::<T>::contains_key(&stash));
 		assert!(!T::VoterList::contains(&stash));
 	}
 
@@ -601,8 +522,6 @@ benchmarks! {
 		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxExposurePageSize::get() as u32,
-			false,
-			true,
 			RewardDestination::Staked,
 		)?;
 
@@ -664,19 +583,18 @@ benchmarks! {
 		};
 
 		let stash = scenario.origin_stash1.clone();
-		let controller = scenario.origin_controller1;
-		let mut staking_ledger = Ledger::<T>::get(controller.clone()).unwrap();
+		let mut staking_ledger = Ledger::<T>::get(stash.clone()).unwrap();
 
 		for _ in 0 .. l {
 			staking_ledger.unlocking.try_push(unlock_chunk.clone()).unwrap()
 		}
-		Ledger::<T>::insert(controller.clone(), staking_ledger.clone());
+		Ledger::<T>::insert(stash.clone(), staking_ledger.clone());
 		let original_bonded: BalanceOf<T> = staking_ledger.active;
 
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller.clone()), rebond_amount)
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash.clone()), rebond_amount)
 	verify {
-		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created after")?;
+		let ledger = Ledger::<T>::get(&stash).ok_or("ledger not created after")?;
 		let new_bonded: BalanceOf<T> = ledger.active;
 		assert!(original_bonded < new_bonded);
 	}
@@ -691,7 +609,6 @@ benchmarks! {
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
-		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1;
 
 		add_slashing_spans::<T>(&stash, s);
@@ -699,15 +616,14 @@ benchmarks! {
 			stash.clone(),
 			T::Currency::minimum_balance() - One::one(),
 		);
-		Ledger::<T>::insert(&controller, l);
+		Ledger::<T>::insert(&stash, l);
 
 		assert!(Bonded::<T>::contains_key(&stash));
 		assert!(T::VoterList::contains(&stash));
 
-		whitelist_account!(controller);
-	}: _(RawOrigin::Signed(controller), stash.clone(), s)
+		whitelist_account!(stash);
+	}: _(RawOrigin::Signed(stash), stash.clone(), s)
 	verify {
-		assert!(!Bonded::<T>::contains_key(&stash));
 		assert!(!T::VoterList::contains(&stash));
 	}
 
@@ -783,8 +699,8 @@ benchmarks! {
 	#[extra]
 	do_slash {
 		let l in 1 .. T::MaxUnlockingChunks::get() as u32;
-		let (stash, controller) = create_stash_controller::<T>(0, 100, RewardDestination::Staked)?;
-		let mut staking_ledger = Ledger::<T>::get(controller.clone()).unwrap();
+		let stash = create_stash::<T>(0, 100, RewardDestination::Staked)?;
+		let mut staking_ledger = Ledger::<T>::get(stash.clone()).unwrap();
 		let unlock_chunk = UnlockChunk::<BalanceOf<T>> {
 			value: 1u32.into(),
 			era: EraIndex::zero(),
@@ -792,7 +708,7 @@ benchmarks! {
 		for _ in 0 .. l {
 			staking_ledger.unlocking.try_push(unlock_chunk.clone()).unwrap();
 		}
-		Ledger::<T>::insert(controller, staking_ledger);
+		Ledger::<T>::insert(stash.clone(), staking_ledger);
 		let slash_amount = T::Currency::minimum_balance() * 10u32.into();
 		let balance_before = T::Currency::free_balance(&stash);
 	}: {
@@ -895,7 +811,6 @@ benchmarks! {
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
-		let controller = scenario.origin_controller1.clone();
 		let stash = scenario.origin_stash1;
 		assert!(T::VoterList::contains(&stash));
 
@@ -921,11 +836,11 @@ benchmarks! {
 		clear_validators_and_nominators::<T>();
 
 		// Create a validator with a commission of 50%
-		let (stash, controller) =
-			create_stash_controller::<T>(1, 1, RewardDestination::Staked)?;
+		let stash =
+			create_stash::<T>(1, 1, RewardDestination::Staked)?;
 		let validator_prefs =
 			ValidatorPrefs { commission: Perbill::from_percent(50), ..Default::default() };
-		Staking::<T>::validate(RawOrigin::Signed(controller).into(), validator_prefs)?;
+		Staking::<T>::validate(RawOrigin::Signed(stash.clone()).into(), validator_prefs)?;
 
 		// Sanity check
 		assert_eq!(
@@ -953,9 +868,9 @@ benchmarks! {
 	}
 
 	restore_ledger {
-		let (stash, controller) = create_stash_controller::<T>(0, 100, RewardDestination::Staked)?;
+		let stash = create_stash::<T>(0, 100, RewardDestination::Staked)?;
 		// corrupt ledger.
-		Ledger::<T>::remove(controller);
+		Ledger::<T>::remove(stash.clone());
 	}: _(RawOrigin::Root, stash.clone(), None, None, None)
 	verify {
 		assert_eq!(Staking::<T>::inspect_bond_state(&stash), Ok(LedgerIntegrityState::Ok));
@@ -1009,8 +924,6 @@ mod tests {
 			let (validator_stash, nominators) = create_validator_with_nominators::<Test>(
 				n,
 				<<Test as Config>::MaxExposurePageSize as Get<_>>::get(),
-				false,
-				false,
 				RewardDestination::Staked,
 			)
 			.unwrap();
@@ -1037,11 +950,9 @@ mod tests {
 		ExtBuilder::default().build_and_execute(|| {
 			let n = 10;
 
-			let (validator_stash, _nominators) = create_validator_with_nominators::<Test>(
+			let (validator_stash, _) = create_validator_with_nominators::<Test>(
 				n,
 				<<Test as Config>::MaxExposurePageSize as Get<_>>::get(),
-				false,
-				false,
 				RewardDestination::Staked,
 			)
 			.unwrap();

--- a/substrate/frame/staking/src/ledger.rs
+++ b/substrate/frame/staking/src/ledger.rs
@@ -31,10 +31,7 @@
 //! performed through the methods exposed by the [`StakingLedger`] implementation in order to ensure
 //! state consistency.
 
-use frame_support::{
-	defensive, ensure,
-	traits::{Defensive, LockableCurrency},
-};
+use frame_support::{defensive, ensure, traits::LockableCurrency};
 use sp_staking::{StakingAccount, StakingInterface};
 
 use crate::{
@@ -229,30 +226,6 @@ impl<T: Config> StakingLedger<T> {
 		}
 
 		<Payee<T>>::insert(&self.stash, payee);
-		Ok(())
-	}
-
-	/// Sets the ledger controller to its stash.
-	pub(crate) fn set_controller_to_stash(self) -> Result<(), Error<T>> {
-		let controller = self.controller.as_ref()
-            .defensive_proof("Ledger's controller field didn't exist. The controller should have been fetched using StakingLedger.")
-            .ok_or(Error::<T>::NotController)?;
-
-		ensure!(self.stash != *controller, Error::<T>::AlreadyPaired);
-
-		// check if the ledger's stash is a controller of another ledger.
-		if let Some(bonded_ledger) = Ledger::<T>::get(&self.stash) {
-			// there is a ledger bonded by the stash. In this case, the stash of the bonded ledger
-			// should be the same as the ledger's stash. Otherwise fail to prevent data
-			// inconsistencies. See <https://github.com/paritytech/polkadot-sdk/pull/3639> for more
-			// details.
-			ensure!(bonded_ledger.stash == self.stash, Error::<T>::BadState);
-		}
-
-		<Ledger<T>>::remove(&controller);
-		<Ledger<T>>::insert(&self.stash, &self);
-		<Bonded<T>>::insert(&self.stash, &self.stash);
-
 		Ok(())
 	}
 

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -40,8 +40,7 @@
 //!   producing blocks or guaranteeing finality of the chain.
 //! - Nominating: The process of placing staked funds behind one or more validators in order to
 //!   share in any reward, and punishment, they take.
-//! - Stash account: The account holding an owner's funds used for staking.
-//! - Controller account (being deprecated): The account that controls an owner's funds for staking.
+//! - Stash account: The account holding and controlling an owner's funds used for staking.
 //! - Era: A (whole) number of sessions, which is the period that the validator set (and each
 //!   validator's active nominator set) is recalculated and where rewards are paid out.
 //! - Slash: The punishment of a staker by reducing its funds.
@@ -62,8 +61,7 @@
 //! Almost any interaction with the Staking pallet requires a process of _**bonding**_ (also known
 //! as being a _staker_). To become *bonded*, a fund-holding register known as the _stash account_,
 //! which holds some or all of the funds that become frozen in place as part of the staking process.
-//! The controller account, which this pallet now assigns the stash account to, issues instructions
-//! on how funds shall be used.
+//! The stash account issues instructions on how funds shall be used.
 //!
 //! An account can become a bonded stash account using the [`bond`](Call::bond) call.
 //!
@@ -249,11 +247,11 @@
 //!
 //! Any funds already placed into stash can be the target of the following operations:
 //!
-//! The controller account can free a portion (or all) of the funds using the
-//! [`unbond`](Call::unbond) call. Note that the funds are not immediately accessible. Instead, a
-//! duration denoted by [`Config::BondingDuration`] (in number of eras) must pass until the funds
-//! can actually be removed. Once the `BondingDuration` is over, the
-//! [`withdraw_unbonded`](Call::withdraw_unbonded) call can be used to actually withdraw the funds.
+//! The stash account can free a portion (or all) of the funds using the [`unbond`](Call::unbond)
+//! call. Note that the funds are not immediately accessible. Instead, a duration denoted by
+//! [`Config::BondingDuration`] (in number of eras) must pass until the funds can actually be
+//! removed. Once the `BondingDuration` is over, the [`withdraw_unbonded`](Call::withdraw_unbonded)
+//! call can be used to actually withdraw the funds.
 //!
 //! Note that there is a limitation to the number of fund-chunks that can be scheduled to be
 //! unlocked in the future via [`unbond`](Call::unbond). In case this maximum

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -39,7 +39,7 @@ use sp_runtime::{
 
 use sp_staking::{
 	EraIndex, Page, SessionIndex,
-	StakingAccount::{self, Controller, Stash},
+	StakingAccount::{self, Stash},
 	StakingInterface,
 };
 
@@ -282,9 +282,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxUnlockingChunks: Get<u32>;
 
-		/// The maximum amount of controller accounts that can be deprecated in one call.
-		type MaxControllersInDeprecationBatch: Get<u32>;
-
 		/// Something that listens to staking updates and performs actions based on the data it
 		/// receives.
 		///
@@ -340,7 +337,6 @@ pub mod pallet {
 			type NextNewSession = ();
 			type MaxExposurePageSize = ConstU32<64>;
 			type MaxUnlockingChunks = ConstU32<32>;
-			type MaxControllersInDeprecationBatch = ConstU32<100>;
 			type EventListeners = ();
 			type DisablingStrategy = crate::UpToLimitDisablingStrategy;
 			#[cfg(feature = "std")]
@@ -367,7 +363,7 @@ pub mod pallet {
 	#[pallet::unbounded]
 	pub type Invulnerables<T: Config> = StorageValue<_, Vec<T::AccountId>, ValueQuery>;
 
-	/// Map from all locked "stash" accounts to the controller account.
+	/// Map from all locked "stash" accounts to the now-deprecated controller account.
 	///
 	/// TWOX-NOTE: SAFE since `AccountId` is a secure hash.
 	#[pallet::storage]
@@ -393,6 +389,7 @@ pub mod pallet {
 
 	/// Map from all (unlocked) "controller" accounts to the info regarding the staking.
 	///
+	/// TODO: Map ledgers from "stash" accounts instead of controllers.
 	/// Note: All the reads and mutations to this storage *MUST* be done through the methods exposed
 	/// by [`StakingLedger`] to ensure data and lock consistency.
 	#[pallet::storage]
@@ -744,8 +741,7 @@ pub mod pallet {
 		pub force_era: Forcing,
 		pub slash_reward_fraction: Perbill,
 		pub canceled_payout: BalanceOf<T>,
-		pub stakers:
-			Vec<(T::AccountId, T::AccountId, BalanceOf<T>, crate::StakerStatus<T::AccountId>)>,
+		pub stakers: Vec<(T::AccountId, BalanceOf<T>, crate::StakerStatus<T::AccountId>)>,
 		pub min_nominator_bond: BalanceOf<T>,
 		pub min_validator_bond: BalanceOf<T>,
 		pub max_validator_count: Option<u32>,
@@ -770,7 +766,7 @@ pub mod pallet {
 				MaxNominatorsCount::<T>::put(x);
 			}
 
-			for &(ref stash, _, balance, ref status) in &self.stakers {
+			for &(ref stash, balance, ref status) in &self.stakers {
 				crate::log!(
 					trace,
 					"inserting genesis staker: {:?} => {:?} => {:?}",
@@ -861,8 +857,6 @@ pub mod pallet {
 		SnapshotTargetsSizeExceeded { size: u32 },
 		/// A new force era mode was set.
 		ForceEra { mode: Forcing },
-		/// Report of a controller batch deprecation.
-		ControllerBatchDeprecated { failures: u32 },
 	}
 
 	#[pallet::error]
@@ -988,8 +982,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		/// Take the origin account as a stash and lock up `value` of its balance. `controller` will
-		/// be the account that controls it.
+		/// Take the origin account as a stash and lock up `value` of its balance.
 		///
 		/// `value` must be more than the `minimum_balance` specified by `T::Currency`.
 		///
@@ -1017,11 +1010,6 @@ pub mod pallet {
 				return Err(Error::<T>::AlreadyBonded.into())
 			}
 
-			// An existing controller cannot become a stash.
-			if StakingLedger::<T>::is_bonded(StakingAccount::Controller(stash.clone())) {
-				return Err(Error::<T>::AlreadyPaired.into())
-			}
-
 			// Reject a bond which is considered to be _dust_.
 			if value < T::Currency::minimum_balance() {
 				return Err(Error::<T>::InsufficientBond.into())
@@ -1044,7 +1032,7 @@ pub mod pallet {
 		/// Add some extra amount that have appeared in the stash `free_balance` into the balance up
 		/// for staking.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the stash, not the controller.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// Use this if there are additional funds in your stash account that you wish to bond.
 		/// Unlike [`bond`](Self::bond) or [`unbond`](Self::unbond) this function does not impose
@@ -1069,7 +1057,7 @@ pub mod pallet {
 		/// period ends. If this leaves an amount actively bonded less than
 		/// T::Currency::minimum_balance(), then it is increased to the full amount.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// Once the unlock period is done, you can call `withdraw_unbonded` to actually move
 		/// the funds out of management ready for transfer.
@@ -1092,17 +1080,16 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] value: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
-			let controller = ensure_signed(origin)?;
-			let unlocking =
-				Self::ledger(Controller(controller.clone())).map(|l| l.unlocking.len())?;
+			let stash = ensure_signed(origin)?;
+			let unlocking = Self::ledger(Stash(stash.clone())).map(|l| l.unlocking.len())?;
 
 			// if there are no unlocking chunks available, try to withdraw chunks older than
 			// `BondingDuration` to proceed with the unbonding.
 			let maybe_withdraw_weight = {
 				if unlocking == T::MaxUnlockingChunks::get() as usize {
 					let real_num_slashing_spans =
-						Self::slashing_spans(&controller).map_or(0, |s| s.iter().count());
-					Some(Self::do_withdraw_unbonded(&controller, real_num_slashing_spans as u32)?)
+					Self::slashing_spans(&stash).map_or(0, |s| s.iter().count());
+					Some(Self::do_withdraw_unbonded(&stash, real_num_slashing_spans as u32)?)
 				} else {
 					None
 				}
@@ -1110,7 +1097,7 @@ pub mod pallet {
 
 			// we need to fetch the ledger again because it may have been mutated in the call
 			// to `Self::do_withdraw_unbonded` above.
-			let mut ledger = Self::ledger(Controller(controller))?;
+			let mut ledger = Self::ledger(Stash(stash))?;
 			let mut value = value.min(ledger.active);
 			let stash = ledger.stash.clone();
 
@@ -1180,7 +1167,7 @@ pub mod pallet {
 		/// This essentially frees up that balance to be used by the stash account to do whatever
 		/// it wants.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// Emits `Withdrawn`.
 		///
@@ -1204,23 +1191,23 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			num_slashing_spans: u32,
 		) -> DispatchResultWithPostInfo {
-			let controller = ensure_signed(origin)?;
+			let stash = ensure_signed(origin)?;
 
-			let actual_weight = Self::do_withdraw_unbonded(&controller, num_slashing_spans)?;
+			let actual_weight = Self::do_withdraw_unbonded(&stash, num_slashing_spans)?;
 			Ok(Some(actual_weight).into())
 		}
 
-		/// Declare the desire to validate for the origin controller.
+		/// Declare the desire to validate for the given stash.
 		///
 		/// Effects will be felt at the beginning of the next era.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::validate())]
 		pub fn validate(origin: OriginFor<T>, prefs: ValidatorPrefs) -> DispatchResult {
-			let controller = ensure_signed(origin)?;
+			let stash = ensure_signed(origin)?;
 
-			let ledger = Self::ledger(Controller(controller))?;
+			let ledger = Self::ledger(Stash(stash))?;
 
 			ensure!(ledger.active >= MinValidatorBond::<T>::get(), Error::<T>::InsufficientBond);
 			let stash = &ledger.stash;
@@ -1248,11 +1235,11 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Declare the desire to nominate `targets` for the origin controller.
+		/// Declare the desire to nominate `targets` for a stash.
 		///
 		/// Effects will be felt at the beginning of the next era.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// ## Complexity
 		/// - The transaction's complexity is proportional to the size of `targets` (N)
@@ -1264,9 +1251,9 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			targets: Vec<AccountIdLookupOf<T>>,
 		) -> DispatchResult {
-			let controller = ensure_signed(origin)?;
+			let stash = ensure_signed(origin)?;
 
-			let ledger = Self::ledger(StakingAccount::Controller(controller.clone()))?;
+			let ledger = Self::ledger(Stash(stash))?;
 
 			ensure!(ledger.active >= MinNominatorBond::<T>::get(), Error::<T>::InsufficientBond);
 			let stash = &ledger.stash;
@@ -1324,7 +1311,7 @@ pub mod pallet {
 		///
 		/// Effects will be felt at the beginning of the next era.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// ## Complexity
 		/// - Independent of the arguments. Insignificant complexity.
@@ -1333,19 +1320,19 @@ pub mod pallet {
 		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::chill())]
 		pub fn chill(origin: OriginFor<T>) -> DispatchResult {
-			let controller = ensure_signed(origin)?;
+			let stash = ensure_signed(origin)?;
 
-			let ledger = Self::ledger(StakingAccount::Controller(controller))?;
+			let ledger = Self::ledger(StakingAccount::Stash(stash))?;
 
 			Self::chill_stash(&ledger.stash);
 			Ok(())
 		}
 
-		/// (Re-)set the payment target for a controller.
+		/// (Re-)set the payment target for a stash.
 		///
 		/// Effects will be felt instantly (as soon as this function is completed successfully).
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// ## Complexity
 		/// - O(1)
@@ -1359,8 +1346,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			payee: RewardDestination<T::AccountId>,
 		) -> DispatchResult {
-			let controller = ensure_signed(origin)?;
-			let ledger = Self::ledger(Controller(controller.clone()))?;
+			let stash = ensure_signed(origin)?;
+			let ledger = Self::ledger(Stash(stash.clone()))?;
 
 			ensure!(
 				(payee != {
@@ -1375,40 +1362,6 @@ pub mod pallet {
 				.defensive_proof("ledger was retrieved from storage, thus its bonded; qed.")?;
 
 			Ok(())
-		}
-
-		/// (Re-)sets the controller of a stash to the stash itself. This function previously
-		/// accepted a `controller` argument to set the controller to an account other than the
-		/// stash itself. This functionality has now been removed, now only setting the controller
-		/// to the stash, if it is not already.
-		///
-		/// Effects will be felt instantly (as soon as this function is completed successfully).
-		///
-		/// The dispatch origin for this call must be _Signed_ by the stash, not the controller.
-		///
-		/// ## Complexity
-		/// O(1)
-		/// - Independent of the arguments. Insignificant complexity.
-		/// - Contains a limited number of reads.
-		/// - Writes are limited to the `origin` account key.
-		#[pallet::call_index(8)]
-		#[pallet::weight(T::WeightInfo::set_controller())]
-		pub fn set_controller(origin: OriginFor<T>) -> DispatchResult {
-			let stash = ensure_signed(origin)?;
-
-			Self::ledger(StakingAccount::Stash(stash.clone())).map(|ledger| {
-				let controller = ledger.controller()
-                    .defensive_proof("Ledger's controller field didn't exist. The controller should have been fetched using StakingLedger.")
-                    .ok_or(Error::<T>::NotController)?;
-
-				if controller == stash {
-					// Stash is already its own controller.
-					return Err(Error::<T>::AlreadyPaired.into())
-				}
-
-				let _ = ledger.set_controller_to_stash()?;
-				Ok(())
-			})?
 		}
 
 		/// Sets the ideal number of validators.
@@ -1635,7 +1588,7 @@ pub mod pallet {
 
 		/// Rebond a portion of the stash scheduled to be unlocked.
 		///
-		/// The dispatch origin must be signed by the controller.
+		/// The dispatch origin must be signed by the stash.
 		///
 		/// ## Complexity
 		/// - Time complexity: O(L), where L is unlocking chunks
@@ -1646,8 +1599,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			#[pallet::compact] value: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
-			let controller = ensure_signed(origin)?;
-			let ledger = Self::ledger(Controller(controller))?;
+			let stash = ensure_signed(origin)?;
+			let ledger = Self::ledger(Stash(stash))?;
 			ensure!(!ledger.unlocking.is_empty(), Error::<T>::NoUnlockChunk);
 
 			let initial_unlocking = ledger.unlocking.len() as u32;
@@ -1725,7 +1678,7 @@ pub mod pallet {
 		///
 		/// Effects will be felt at the beginning of the next era.
 		///
-		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		/// The dispatch origin for this call must be _Signed_ by the stash.
 		///
 		/// - `who`: A list of nominator stash accounts who are nominating this validator which
 		///   should no longer be nominating this validator.
@@ -1735,8 +1688,8 @@ pub mod pallet {
 		#[pallet::call_index(21)]
 		#[pallet::weight(T::WeightInfo::kick(who.len() as u32))]
 		pub fn kick(origin: OriginFor<T>, who: Vec<AccountIdLookupOf<T>>) -> DispatchResult {
-			let controller = ensure_signed(origin)?;
-			let ledger = Self::ledger(Controller(controller))?;
+			let signed = ensure_signed(origin)?;
+			let ledger = &Self::ledger(Stash(signed))?;
 			let stash = &ledger.stash;
 
 			for nom_stash in who
@@ -1816,19 +1769,19 @@ pub mod pallet {
 			config_op_exp!(MaxStakedRewards<T>, max_staked_rewards);
 			Ok(())
 		}
-		/// Declare a `controller` to stop participating as either a validator or nominator.
+		/// Declare a `stash` to stop participating as either a validator or nominator.
 		///
 		/// Effects will be felt at the beginning of the next era.
 		///
 		/// The dispatch origin for this call must be _Signed_, but can be called by anyone.
 		///
-		/// If the caller is the same as the controller being targeted, then no further checks are
+		/// If the caller is the same as the stash being targeted, then no further checks are
 		/// enforced, and this function behaves just like `chill`.
 		///
-		/// If the caller is different than the controller being targeted, the following conditions
+		/// If the caller is different than the stash being targeted, the following conditions
 		/// must be met:
 		///
-		/// * `controller` must belong to a nominator who has become non-decodable,
+		/// * `stash` must belong to a nominator who has become non-decodable,
 		///
 		/// Or:
 		///
@@ -1848,16 +1801,10 @@ pub mod pallet {
 			// Anyone can call this function.
 			let caller = ensure_signed(origin)?;
 			let ledger = Self::ledger(Stash(stash.clone()))?;
-			let controller = ledger
-				.controller()
-				.defensive_proof(
-					"Ledger's controller field didn't exist. The controller should have been fetched using StakingLedger.",
-				)
-				.ok_or(Error::<T>::NotController)?;
 
 			// In order for one user to chill another user, the following conditions must be met:
 			//
-			// * `controller` belongs to a nominator who has become non-decodable,
+			// * `stash` belongs to a nominator who has become non-decodable,
 			//
 			// Or
 			//
@@ -1869,14 +1816,14 @@ pub mod pallet {
 			//   determine this is a person that should be chilled because they have not met the
 			//   threshold bond required.
 			//
-			// Otherwise, if caller is the same as the controller, this is just like `chill`.
+			// Otherwise, if caller is the same as the stash, this is just like `chill`.
 
 			if Nominators::<T>::contains_key(&stash) && Nominators::<T>::get(&stash).is_none() {
 				Self::chill_stash(&stash);
 				return Ok(())
 			}
 
-			if caller != controller {
+			if caller != stash {
 				let threshold = ChillThreshold::<T>::get().ok_or(Error::<T>::CannotChillOther)?;
 				let min_active_bond = if Nominators::<T>::contains_key(&stash) {
 					let max_nominator_count =
@@ -1971,83 +1918,6 @@ pub mod pallet {
 			Self::do_payout_stakers_by_page(validator_stash, era, page)
 		}
 
-		/// Migrates an account's `RewardDestination::Controller` to
-		/// `RewardDestination::Account(controller)`.
-		///
-		/// Effects will be felt instantly (as soon as this function is completed successfully).
-		///
-		/// This will waive the transaction fee if the `payee` is successfully migrated.
-		#[pallet::call_index(27)]
-		#[pallet::weight(T::WeightInfo::update_payee())]
-		pub fn update_payee(
-			origin: OriginFor<T>,
-			controller: T::AccountId,
-		) -> DispatchResultWithPostInfo {
-			let _ = ensure_signed(origin)?;
-			let ledger = Self::ledger(StakingAccount::Controller(controller.clone()))?;
-
-			ensure!(
-				(Payee::<T>::get(&ledger.stash) == {
-					#[allow(deprecated)]
-					Some(RewardDestination::Controller)
-				}),
-				Error::<T>::NotController
-			);
-
-			let _ = ledger
-				.set_payee(RewardDestination::Account(controller))
-				.defensive_proof("ledger should have been previously retrieved from storage.")?;
-
-			Ok(Pays::No.into())
-		}
-
-		/// Updates a batch of controller accounts to their corresponding stash account if they are
-		/// not the same. Ignores any controller accounts that do not exist, and does not operate if
-		/// the stash and controller are already the same.
-		///
-		/// Effects will be felt instantly (as soon as this function is completed successfully).
-		///
-		/// The dispatch origin must be `T::AdminOrigin`.
-		#[pallet::call_index(28)]
-		#[pallet::weight(T::WeightInfo::deprecate_controller_batch(controllers.len() as u32))]
-		pub fn deprecate_controller_batch(
-			origin: OriginFor<T>,
-			controllers: BoundedVec<T::AccountId, T::MaxControllersInDeprecationBatch>,
-		) -> DispatchResultWithPostInfo {
-			T::AdminOrigin::ensure_origin(origin)?;
-
-			// Ignore controllers that do not exist or are already the same as stash.
-			let filtered_batch_with_ledger: Vec<_> = controllers
-				.iter()
-				.filter_map(|controller| {
-					let ledger = Self::ledger(StakingAccount::Controller(controller.clone()));
-					ledger.ok().map_or(None, |ledger| {
-						// If the controller `RewardDestination` is still the deprecated
-						// `Controller` variant, skip deprecating this account.
-						let payee_deprecated = Payee::<T>::get(&ledger.stash) == {
-							#[allow(deprecated)]
-							Some(RewardDestination::Controller)
-						};
-
-						if ledger.stash != *controller && !payee_deprecated {
-							Some(ledger)
-						} else {
-							None
-						}
-					})
-				})
-				.collect();
-
-			// Update unique pairs.
-			let mut failures = 0;
-			for ledger in filtered_batch_with_ledger {
-				let _ = ledger.clone().set_controller_to_stash().map_err(|_| failures += 1);
-			}
-			Self::deposit_event(Event::<T>::ControllerBatchDeprecated { failures });
-
-			Ok(Some(T::WeightInfo::deprecate_controller_batch(controllers.len() as u32)).into())
-		}
-
 		/// Restores the state of a ledger which is in an inconsistent state.
 		///
 		/// The requirements to restore a ledger are the following:
@@ -2064,7 +1934,6 @@ pub mod pallet {
 		pub fn restore_ledger(
 			origin: OriginFor<T>,
 			stash: T::AccountId,
-			maybe_controller: Option<T::AccountId>,
 			maybe_total: Option<BalanceOf<T>>,
 			maybe_unlocking: Option<BoundedVec<UnlockChunk<BalanceOf<T>>, T::MaxUnlockingChunks>>,
 		) -> DispatchResult {
@@ -2078,7 +1947,7 @@ pub mod pallet {
 
 			let (new_controller, new_total) = match Self::inspect_bond_state(&stash) {
 				Ok(LedgerIntegrityState::Corrupted) => {
-					let new_controller = maybe_controller.unwrap_or(stash.clone());
+					let new_controller = stash.clone();
 
 					let new_total = if let Some(total) = maybe_total {
 						let new_total = total.min(stash_balance);

--- a/substrate/frame/staking/src/testing_utils.rs
+++ b/substrate/frame/staking/src/testing_utils.rs
@@ -69,73 +69,28 @@ pub fn create_funded_user_with_balance<T: Config>(
 	user
 }
 
-/// Create a stash and controller pair.
-pub fn create_stash_controller<T: Config>(
+/// Create a stash.
+pub fn create_stash<T: Config>(
 	n: u32,
 	balance_factor: u32,
 	destination: RewardDestination<T::AccountId>,
-) -> Result<(T::AccountId, T::AccountId), &'static str> {
+) -> Result<T::AccountId, &'static str> {
 	let staker = create_funded_user::<T>("stash", n, balance_factor);
 	let amount =
 		T::Currency::minimum_balance().max(1u64.into()) * (balance_factor / 10).max(1).into();
 	Staking::<T>::bond(RawOrigin::Signed(staker.clone()).into(), amount, destination)?;
-	Ok((staker.clone(), staker))
+	Ok(staker)
 }
 
-/// Create a unique stash and controller pair.
-pub fn create_unique_stash_controller<T: Config>(
-	n: u32,
-	balance_factor: u32,
-	destination: RewardDestination<T::AccountId>,
-	dead_controller: bool,
-) -> Result<(T::AccountId, T::AccountId), &'static str> {
-	let stash = create_funded_user::<T>("stash", n, balance_factor);
-
-	let controller = if dead_controller {
-		create_funded_user::<T>("controller", n, 0)
-	} else {
-		create_funded_user::<T>("controller", n, balance_factor)
-	};
-	let amount = T::Currency::minimum_balance() * (balance_factor / 10).max(1).into();
-	Staking::<T>::bond(RawOrigin::Signed(stash.clone()).into(), amount, destination)?;
-
-	// update ledger to be a *different* controller to stash
-	if let Some(l) = Ledger::<T>::take(&stash) {
-		<Ledger<T>>::insert(&controller, l);
-	}
-	// update bonded account to be unique controller
-	<Bonded<T>>::insert(&stash, &controller);
-
-	Ok((stash, controller))
-}
-
-/// Create a stash and controller pair with fixed balance.
-pub fn create_stash_controller_with_balance<T: Config>(
+/// Create a stash account with a fixed balance.
+pub fn create_stash_with_balance<T: Config>(
 	n: u32,
 	balance: crate::BalanceOf<T>,
 	destination: RewardDestination<T::AccountId>,
-) -> Result<(T::AccountId, T::AccountId), &'static str> {
+) -> Result<T::AccountId, &'static str> {
 	let staker = create_funded_user_with_balance::<T>("stash", n, balance);
 	Staking::<T>::bond(RawOrigin::Signed(staker.clone()).into(), balance, destination)?;
-	Ok((staker.clone(), staker))
-}
-
-/// Create a stash and controller pair, where payouts go to a dead payee account. This is used to
-/// test worst case payout scenarios.
-pub fn create_stash_and_dead_payee<T: Config>(
-	n: u32,
-	balance_factor: u32,
-) -> Result<(T::AccountId, T::AccountId), &'static str> {
-	let staker = create_funded_user::<T>("stash", n, 0);
-	// payee has no funds
-	let payee = create_funded_user::<T>("payee", n, 0);
-	let amount = T::Currency::minimum_balance() * (balance_factor / 10).max(1).into();
-	Staking::<T>::bond(
-		RawOrigin::Signed(staker.clone()).into(),
-		amount,
-		RewardDestination::Account(payee),
-	)?;
-	Ok((staker.clone(), staker))
+	Ok(staker)
 }
 
 /// create `max` validators.
@@ -154,11 +109,10 @@ pub fn create_validators_with_seed<T: Config>(
 ) -> Result<Vec<AccountIdLookupOf<T>>, &'static str> {
 	let mut validators: Vec<AccountIdLookupOf<T>> = Vec::with_capacity(max as usize);
 	for i in 0..max {
-		let (stash, controller) =
-			create_stash_controller::<T>(i + seed, balance_factor, RewardDestination::Staked)?;
+		let stash = create_stash::<T>(i + seed, balance_factor, RewardDestination::Staked)?;
 		let validator_prefs =
 			ValidatorPrefs { commission: Perbill::from_percent(50), ..Default::default() };
-		Staking::<T>::validate(RawOrigin::Signed(controller).into(), validator_prefs)?;
+		Staking::<T>::validate(RawOrigin::Signed(stash.clone()).into(), validator_prefs)?;
 		let stash_lookup = T::Lookup::unlookup(stash);
 		validators.push(stash_lookup);
 	}
@@ -195,11 +149,10 @@ pub fn create_validators_with_nominators_for_era<T: Config>(
 	// Create validators
 	for i in 0..validators {
 		let balance_factor = if randomize_stake { rng.next_u32() % 255 + 10 } else { 100u32 };
-		let (v_stash, v_controller) =
-			create_stash_controller::<T>(i, balance_factor, RewardDestination::Staked)?;
+		let v_stash = create_stash::<T>(i, balance_factor, RewardDestination::Staked)?;
 		let validator_prefs =
 			ValidatorPrefs { commission: Perbill::from_percent(50), ..Default::default() };
-		Staking::<T>::validate(RawOrigin::Signed(v_controller.clone()).into(), validator_prefs)?;
+		Staking::<T>::validate(RawOrigin::Signed(v_stash.clone()).into(), validator_prefs)?;
 		let stash_lookup = T::Lookup::unlookup(v_stash.clone());
 		validators_stash.push(stash_lookup.clone());
 	}
@@ -210,8 +163,7 @@ pub fn create_validators_with_nominators_for_era<T: Config>(
 	// Create nominators
 	for j in 0..nominators {
 		let balance_factor = if randomize_stake { rng.next_u32() % 255 + 10 } else { 100u32 };
-		let (_n_stash, n_controller) =
-			create_stash_controller::<T>(u32::MAX - j, balance_factor, RewardDestination::Staked)?;
+		let n_stash = create_stash::<T>(u32::MAX - j, balance_factor, RewardDestination::Staked)?;
 
 		// Have them randomly validate
 		let mut available_validators = validator_chosen.clone();
@@ -223,10 +175,7 @@ pub fn create_validators_with_nominators_for_era<T: Config>(
 			let validator = available_validators.remove(selected);
 			selected_validators.push(validator);
 		}
-		Staking::<T>::nominate(
-			RawOrigin::Signed(n_controller.clone()).into(),
-			selected_validators,
-		)?;
+		Staking::<T>::nominate(RawOrigin::Signed(n_stash.clone()).into(), selected_validators)?;
 	}
 
 	ValidatorCount::<T>::put(validators);

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -101,7 +101,7 @@ fn set_staking_configs_works() {
 #[test]
 fn force_unstake_works() {
 	ExtBuilder::default().build_and_execute(|| {
-		// Account 11 (also controller) is stashed and locked
+		// Account 11 is stashed and locked
 		assert_eq!(Staking::bonded(&11), Some(11));
 		// Adds 2 slashing spans
 		add_slash(&11);
@@ -129,7 +129,7 @@ fn force_unstake_works() {
 #[test]
 fn kill_stash_works() {
 	ExtBuilder::default().build_and_execute(|| {
-		// Account 11 (also controller) is stashed and locked
+		// Account 11 is stashed and locked
 		assert_eq!(Staking::bonded(&11), Some(11));
 		// Adds 2 slashing spans
 		add_slash(&11);
@@ -148,9 +148,9 @@ fn kill_stash_works() {
 fn basic_setup_works() {
 	// Verifies initial conditions of mock
 	ExtBuilder::default().build_and_execute(|| {
-		// Account 11 is stashed and locked, and is the controller
+		// Account 11 is stashed and locked.
 		assert_eq!(Staking::bonded(&11), Some(11));
-		// Account 21 is stashed and locked and is the controller
+		// Account 21 is stashed and locked.
 		assert_eq!(Staking::bonded(&21), Some(21));
 		// Account 1 is not a stashed
 		assert_eq!(Staking::bonded(&1), None);
@@ -228,58 +228,9 @@ fn basic_setup_works() {
 		// Initial Era and session
 		assert_eq!(active_era(), 0);
 
-		// Account 10 has `balance_factor` free balance
-		assert_eq!(Balances::free_balance(10), 1);
-		assert_eq!(Balances::free_balance(10), 1);
-
 		// New era is not being forced
 		assert_eq!(Staking::force_era(), Forcing::NotForcing);
 	});
-}
-
-#[test]
-fn change_controller_works() {
-	ExtBuilder::default().build_and_execute(|| {
-		let (stash, controller) = testing_utils::create_unique_stash_controller::<Test>(
-			0,
-			100,
-			RewardDestination::Staked,
-			false,
-		)
-		.unwrap();
-
-		// ensure `stash` and `controller` are bonded as stash controller pair.
-		assert_eq!(Staking::bonded(&stash), Some(controller));
-
-		// `controller` can control `stash` who is initially a validator.
-		assert_ok!(Staking::chill(RuntimeOrigin::signed(controller)));
-
-		// sets controller back to `stash`.
-		assert_ok!(Staking::set_controller(RuntimeOrigin::signed(stash)));
-		assert_eq!(Staking::bonded(&stash), Some(stash));
-		mock::start_active_era(1);
-
-		// fetch the ledger from storage and check if the controller is correct.
-		let ledger = Staking::ledger(StakingAccount::Stash(stash)).unwrap();
-		assert_eq!(ledger.controller(), Some(stash));
-
-		// same if we fetch the ledger by controller.
-		let ledger = Staking::ledger(StakingAccount::Controller(stash)).unwrap();
-		assert_eq!(ledger.controller, Some(stash));
-		assert_eq!(ledger.controller(), Some(stash));
-
-		// the raw storage ledger's controller is always `None`. however, we can still fetch the
-		// correct controller with `ledger.controller()`.
-		let raw_ledger = <Ledger<Test>>::get(&stash).unwrap();
-		assert_eq!(raw_ledger.controller, None);
-
-		// `controller` is no longer in control. `stash` is now controller.
-		assert_noop!(
-			Staking::validate(RuntimeOrigin::signed(controller), ValidatorPrefs::default()),
-			Error::<Test>::NotController,
-		);
-		assert_ok!(Staking::validate(RuntimeOrigin::signed(stash), ValidatorPrefs::default()));
-	})
 }
 
 #[test]
@@ -291,18 +242,13 @@ fn change_controller_already_paired_once_stash() {
 		// 11 is initially a validator.
 		assert_ok!(Staking::chill(RuntimeOrigin::signed(11)));
 
-		// Controller cannot change once matching with stash.
-		assert_noop!(
-			Staking::set_controller(RuntimeOrigin::signed(11)),
-			Error::<Test>::AlreadyPaired
-		);
 		assert_eq!(Staking::bonded(&11), Some(11));
 		mock::start_active_era(1);
 
 		// 10 is no longer in control.
 		assert_noop!(
 			Staking::validate(RuntimeOrigin::signed(10), ValidatorPrefs::default()),
-			Error::<Test>::NotController,
+			Error::<Test>::NotStash,
 		);
 		assert_ok!(Staking::validate(RuntimeOrigin::signed(11), ValidatorPrefs::default()));
 	})
@@ -425,7 +371,7 @@ fn rewards_should_work() {
 fn staking_should_work() {
 	ExtBuilder::default().nominate(false).build_and_execute(|| {
 		// remember + compare this along with the test.
-		assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 		// put some money in account that we'll use.
 		for i in 1..5 {
@@ -434,7 +380,7 @@ fn staking_should_work() {
 
 		// --- Block 2:
 		start_session(2);
-		// add a new candidate for being a validator. account 3 controlled by 4.
+		// add a new candidate for being a validator.
 		assert_ok!(Staking::bond(RuntimeOrigin::signed(3), 1500, RewardDestination::Account(3)));
 		assert_ok!(Staking::validate(RuntimeOrigin::signed(3), ValidatorPrefs::default()));
 		assert_ok!(Session::set_keys(
@@ -444,13 +390,13 @@ fn staking_should_work() {
 		));
 
 		// No effects will be seen so far.
-		assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 		// --- Block 3:
 		start_session(3);
 
 		// No effects will be seen so far. Era has not been yet triggered.
-		assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 		// --- Block 4: the validators will now be queued.
 		start_session(4);
@@ -462,21 +408,21 @@ fn staking_should_work() {
 		// --- Block 6: the validators will now be changed.
 		start_session(6);
 
-		assert_eq_uvec!(validator_controllers(), vec![21, 3]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 3]);
 		// --- Block 6: Unstake 4 as a validator, freeing up the balance stashed in 3
 		// 4 will chill
 		Staking::chill(RuntimeOrigin::signed(3)).unwrap();
 
 		// --- Block 7: nothing. 3 is still there.
 		start_session(7);
-		assert_eq_uvec!(validator_controllers(), vec![21, 3]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 3]);
 
 		// --- Block 8:
 		start_session(8);
 
 		// --- Block 9: 4 will not be a validator.
 		start_session(9);
-		assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 		// Note: the stashed value of 4 is still lock
 		assert_eq!(
@@ -532,12 +478,12 @@ fn less_than_needed_candidates_works() {
 		.build_and_execute(|| {
 			assert_eq!(Staking::validator_count(), 4);
 			assert_eq!(Staking::minimum_validator_count(), 1);
-			assert_eq_uvec!(validator_controllers(), vec![31, 21, 11]);
+			assert_eq_uvec!(validator_stashes(), vec![31, 21, 11]);
 
 			mock::start_active_era(1);
 
 			// Previous set is selected. NO election algorithm is even executed.
-			assert_eq_uvec!(validator_controllers(), vec![31, 21, 11]);
+			assert_eq_uvec!(validator_stashes(), vec![31, 21, 11]);
 
 			// But the exposure is updated in a simple way. No external votes exists.
 			// This is purely self-vote.
@@ -555,7 +501,7 @@ fn no_candidate_emergency_condition() {
 		.nominate(false)
 		.build_and_execute(|| {
 			// initial validators
-			assert_eq_uvec!(validator_controllers(), vec![11, 21, 31, 41]);
+			assert_eq_uvec!(validator_stashes(), vec![11, 21, 31, 41]);
 			let prefs = ValidatorPrefs { commission: Perbill::one(), ..Default::default() };
 			Validators::<Test>::insert(11, prefs.clone());
 
@@ -579,7 +525,7 @@ fn no_candidate_emergency_condition() {
 
 			// Previous ones are elected. chill is not effective in active era (as era hasn't
 			// changed)
-			assert_eq_uvec!(validator_controllers(), vec![11, 21, 31, 41]);
+			assert_eq_uvec!(validator_stashes(), vec![11, 21, 31, 41]);
 			// The chill is still pending.
 			assert!(!Validators::<Test>::contains_key(11));
 			// No new era is created.
@@ -596,13 +542,13 @@ fn nominating_and_rewards_should_work() {
 		.set_status(31, StakerStatus::Idle)
 		.build_and_execute(|| {
 			// initial validators.
-			assert_eq_uvec!(validator_controllers(), vec![41, 21]);
+			assert_eq_uvec!(validator_stashes(), vec![41, 21]);
 
 			// re-validate with 11 and 31.
 			assert_ok!(Staking::validate(RuntimeOrigin::signed(11), Default::default()));
 			assert_ok!(Staking::validate(RuntimeOrigin::signed(31), Default::default()));
 
-			// Set payee to controller.
+			// Set payee to the stash.
 			assert_ok!(Staking::set_payee(RuntimeOrigin::signed(11), RewardDestination::Stash));
 			assert_ok!(Staking::set_payee(RuntimeOrigin::signed(21), RewardDestination::Stash));
 			assert_ok!(Staking::set_payee(RuntimeOrigin::signed(31), RewardDestination::Stash));
@@ -633,7 +579,7 @@ fn nominating_and_rewards_should_work() {
 			mock::start_active_era(1);
 
 			// 10 and 20 have more votes, they will be chosen.
-			assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+			assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 			// old validators must have already received some rewards.
 			let initial_balance_41 = Balances::total_balance(&41);
@@ -781,16 +727,11 @@ fn double_staking_should_fail() {
 	// should test (in the same order):
 	// * an account already bonded as stash cannot be stashed again.
 	// * an account already bonded as stash cannot nominate.
-	// * an account already bonded as controller can nominate.
 	ExtBuilder::default().try_state(false).build_and_execute(|| {
 		let arbitrary_value = 5;
-		let (stash, controller) = testing_utils::create_unique_stash_controller::<Test>(
-			0,
-			arbitrary_value,
-			RewardDestination::Staked,
-			false,
-		)
-		.unwrap();
+		let stash =
+			testing_utils::create_stash::<Test>(0, arbitrary_value, RewardDestination::Staked)
+				.unwrap();
 
 		// 4 = not used so far,  stash => not allowed.
 		assert_noop!(
@@ -801,32 +742,22 @@ fn double_staking_should_fail() {
 			),
 			Error::<Test>::AlreadyBonded,
 		);
-		// stash => attempting to nominate should fail.
-		assert_noop!(
-			Staking::nominate(RuntimeOrigin::signed(stash), vec![1]),
-			Error::<Test>::NotController
-		);
-		// controller => nominating should work.
-		assert_ok!(Staking::nominate(RuntimeOrigin::signed(controller), vec![1]));
+		// stash => nominating should work.
+		assert_ok!(Staking::nominate(RuntimeOrigin::signed(stash), vec![1]));
 	});
 }
 
 #[test]
-fn double_controlling_attempt_should_fail() {
+fn double_stash_attempt_should_fail() {
 	// should test (in the same order):
-	// * an account already bonded as controller CANNOT be reused as the controller of another
-	//   account.
+	// * a stash already bonded CANNOT be reused as the stash of another account.
 	ExtBuilder::default().try_state(false).build_and_execute(|| {
 		let arbitrary_value = 5;
-		let (stash, _) = testing_utils::create_unique_stash_controller::<Test>(
-			0,
-			arbitrary_value,
-			RewardDestination::Staked,
-			false,
-		)
-		.unwrap();
+		let stash =
+			testing_utils::create_stash::<Test>(0, arbitrary_value, RewardDestination::Staked)
+				.unwrap();
 
-		// Note that controller (same as stash) is reused => no-op.
+		// Note that stash is reused => no-op.
 		assert_noop!(
 			Staking::bond(
 				RuntimeOrigin::signed(stash),
@@ -994,7 +925,7 @@ fn cannot_transfer_staked_balance() {
 		assert_eq!(Staking::bonded(&11), Some(11));
 		// Confirm account 11 has some free balance
 		assert_eq!(Balances::free_balance(11), 1000);
-		// Confirm account 11 (via controller) is totally staked
+		// Confirm account 11 is totally staked
 		assert_eq!(Staking::eras_stakers(active_era(), &11).total, 1000);
 		// Confirm account 11 cannot transfer as a result
 		assert_noop!(
@@ -1019,7 +950,7 @@ fn cannot_transfer_staked_balance_2() {
 		assert_eq!(Staking::bonded(&21), Some(21));
 		// Confirm account 21 has some free balance
 		assert_eq!(Balances::free_balance(21), 2000);
-		// Confirm account 21 (via controller) is totally staked
+		// Confirm account 21 is totally staked
 		assert_eq!(Staking::eras_stakers(active_era(), &21).total, 1000);
 		// Confirm account 21 can transfer at most 1000
 		assert_noop!(
@@ -1038,7 +969,7 @@ fn cannot_reserve_staked_balance() {
 		assert_eq!(Staking::bonded(&11), Some(11));
 		// Confirm account 11 has some free balance
 		assert_eq!(Balances::free_balance(11), 1000);
-		// Confirm account 11 (via controller 10) is totally staked
+		// Confirm account 11 is totally staked
 		assert_eq!(Staking::eras_stakers(active_era(), &11).own, 1000);
 		// Confirm account 11 cannot reserve as a result
 		assert_noop!(Balances::reserve(&11, 1), BalancesError::<Test, _>::LiquidityRestrictions);
@@ -1129,10 +1060,10 @@ fn reward_destination_works() {
 		// (era 1, page 0) is claimed
 		assert_eq!(Staking::claimed_rewards(1, &11), vec![0]);
 
-		// Change RewardDestination to Account
+		// Change RewardDestination to Account 11
 		<Payee<Test>>::insert(&11, RewardDestination::Account(11));
 
-		// Check controller balance
+		// Check reward destination balance
 		assert_eq!(Balances::free_balance(11), 23150);
 
 		// Compute total payout now for whole duration as other parameter won't change
@@ -1144,7 +1075,7 @@ fn reward_destination_works() {
 
 		// Check that RewardDestination is Account(11)
 		assert_eq!(Staking::payee(11.into()), Some(RewardDestination::Account(11)));
-		// Check that reward went to the controller account
+		// Check that reward went to the correct account
 		assert_eq!(Balances::free_balance(11), recorded_stash_balance + total_payout_2);
 		// Check that amount at stake is NOT increased
 		assert_eq!(
@@ -1224,7 +1155,7 @@ fn bond_extra_works() {
 		// Give account 11 some large free balance greater than total
 		let _ = Balances::make_free_balance_be(&11, 1000000);
 
-		// Call the bond_extra function from controller, add only 100
+		// Call the bond_extra function, add only 100
 		assert_ok!(Staking::bond_extra(RuntimeOrigin::signed(11), 100));
 		// There should be 100 more `total` and `active` in the ledger
 		assert_eq!(
@@ -1978,7 +1909,7 @@ fn switching_roles() {
 			assert_ok!(Staking::set_payee(RuntimeOrigin::signed(*i), RewardDestination::Stash));
 		}
 
-		assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+		assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 		// put some money in account that we'll use.
 		for i in 1..7 {
@@ -2004,7 +1935,7 @@ fn switching_roles() {
 		mock::start_active_era(1);
 
 		// with current nominators 11 and 5 have the most stake
-		assert_eq_uvec!(validator_controllers(), vec![5, 11]);
+		assert_eq_uvec!(validator_stashes(), vec![5, 11]);
 
 		// 2 decides to be a validator. Consequences:
 		assert_ok!(Staking::validate(RuntimeOrigin::signed(1), ValidatorPrefs::default()));
@@ -2022,7 +1953,7 @@ fn switching_roles() {
 
 		mock::start_active_era(2);
 
-		assert_eq_uvec!(validator_controllers(), vec![1, 21]);
+		assert_eq_uvec!(validator_stashes(), vec![1, 21]);
 	});
 }
 
@@ -2030,7 +1961,6 @@ fn switching_roles() {
 fn wrong_vote_is_moot() {
 	ExtBuilder::default()
 		.add_staker(
-			61,
 			61,
 			500,
 			StakerStatus::Nominator(vec![
@@ -2043,7 +1973,7 @@ fn wrong_vote_is_moot() {
 			mock::start_active_era(1);
 
 			// new validators
-			assert_eq_uvec!(validator_controllers(), vec![21, 11]);
+			assert_eq_uvec!(validator_stashes(), vec![21, 11]);
 
 			// our new voter is taken into account
 			assert!(Staking::eras_stakers(active_era(), &11).others.iter().any(|i| i.who == 61));
@@ -2132,7 +2062,7 @@ fn bond_with_little_staked_value_bounded() {
 			mock::make_all_reward_payment(0);
 
 			// 1 is elected.
-			assert_eq_uvec!(validator_controllers(), vec![21, 11, 1]);
+			assert_eq_uvec!(validator_stashes(), vec![21, 11, 1]);
 			assert_eq!(Staking::eras_stakers(active_era(), &2).total, 0);
 
 			// Old ones are rewarded.
@@ -2150,7 +2080,7 @@ fn bond_with_little_staked_value_bounded() {
 			mock::start_active_era(2);
 			mock::make_all_reward_payment(1);
 
-			assert_eq_uvec!(validator_controllers(), vec![21, 11, 1]);
+			assert_eq_uvec!(validator_stashes(), vec![21, 11, 1]);
 			assert_eq!(Staking::eras_stakers(active_era(), &2).total, 0);
 
 			// 2 is now rewarded.
@@ -2274,11 +2204,11 @@ fn bond_with_duplicate_vote_should_be_ignored_by_election_provider_elected() {
 fn new_era_elects_correct_number_of_validators() {
 	ExtBuilder::default().nominate(true).validator_count(1).build_and_execute(|| {
 		assert_eq!(Staking::validator_count(), 1);
-		assert_eq!(validator_controllers().len(), 1);
+		assert_eq!(validator_stashes().len(), 1);
 
 		Session::on_initialize(System::block_number());
 
-		assert_eq!(validator_controllers().len(), 1);
+		assert_eq!(validator_stashes().len(), 1);
 	})
 }
 
@@ -2299,7 +2229,7 @@ fn phragmen_should_not_overflow() {
 
 		mock::start_active_era(1);
 
-		assert_eq_uvec!(validator_controllers(), vec![3, 5]);
+		assert_eq_uvec!(validator_stashes(), vec![3, 5]);
 
 		// We can safely convert back to values within [u64, u128].
 		assert!(Staking::eras_stakers(active_era(), &3).total > Votes::max_value() as Balance);
@@ -3958,7 +3888,7 @@ fn test_multi_page_payout_stakers_by_page() {
 		RewardOnUnbalanceWasCalled::set(false);
 		System::reset_events();
 
-		let controller_balance_before_p0_payout = Balances::free_balance(&11);
+		let balance_before_p0_payout = Balances::free_balance(&11);
 		// Payout rewards for first exposure page
 		assert_ok!(Staking::payout_stakers_by_page(RuntimeOrigin::signed(1337), 11, 1, 0));
 
@@ -3972,14 +3902,14 @@ fn test_multi_page_payout_stakers_by_page() {
 			]
 		));
 
-		let controller_balance_after_p0_payout = Balances::free_balance(&11);
+		let balance_after_p0_payout = Balances::free_balance(&11);
 
 		// verify rewards have been paid out but still some left
 		assert!(pallet_balances::TotalIssuance::<Test>::get() > pre_payout_total_issuance);
 		assert!(pallet_balances::TotalIssuance::<Test>::get() < pre_payout_total_issuance + payout);
 
 		// verify the validator has been rewarded
-		assert!(controller_balance_after_p0_payout > controller_balance_before_p0_payout);
+		assert!(balance_after_p0_payout > balance_before_p0_payout);
 
 		// Payout the second and last page of nominators
 		assert_ok!(Staking::payout_stakers_by_page(RuntimeOrigin::signed(1337), 11, 1, 1));
@@ -3996,7 +3926,7 @@ fn test_multi_page_payout_stakers_by_page() {
 			]
 		));
 		// verify the validator was not rewarded the second time
-		assert_eq!(Balances::free_balance(&11), controller_balance_after_p0_payout);
+		assert_eq!(Balances::free_balance(&11), balance_after_p0_payout);
 
 		// verify all rewards have been paid out
 		assert_eq_error_rate!(
@@ -4178,7 +4108,7 @@ fn test_multi_page_payout_stakers_backward_compatible() {
 		let pre_payout_total_issuance = pallet_balances::TotalIssuance::<Test>::get();
 		RewardOnUnbalanceWasCalled::set(false);
 
-		let controller_balance_before_p0_payout = Balances::free_balance(&11);
+		let balance_before_p0_payout = Balances::free_balance(&11);
 		// Payout rewards for first exposure page
 		assert_ok!(Staking::payout_stakers(RuntimeOrigin::signed(1337), 11, 1));
 		// page 0 is claimed
@@ -4187,14 +4117,14 @@ fn test_multi_page_payout_stakers_backward_compatible() {
 			Error::<Test>::AlreadyClaimed.with_weight(err_weight)
 		);
 
-		let controller_balance_after_p0_payout = Balances::free_balance(&11);
+		let balance_after_p0_payout = Balances::free_balance(&11);
 
 		// verify rewards have been paid out but still some left
 		assert!(pallet_balances::TotalIssuance::<Test>::get() > pre_payout_total_issuance);
 		assert!(pallet_balances::TotalIssuance::<Test>::get() < pre_payout_total_issuance + payout);
 
 		// verify the validator has been rewarded
-		assert!(controller_balance_after_p0_payout > controller_balance_before_p0_payout);
+		assert!(balance_after_p0_payout > balance_before_p0_payout);
 
 		// This should payout the second and last page of nominators
 		assert_ok!(Staking::payout_stakers(RuntimeOrigin::signed(1337), 11, 1));
@@ -4206,7 +4136,7 @@ fn test_multi_page_payout_stakers_backward_compatible() {
 		);
 
 		// verify the validator was not rewarded the second time
-		assert_eq!(Balances::free_balance(&11), controller_balance_after_p0_payout);
+		assert_eq!(Balances::free_balance(&11), balance_after_p0_payout);
 
 		// verify all rewards have been paid out
 		assert_eq_error_rate!(
@@ -4216,8 +4146,7 @@ fn test_multi_page_payout_stakers_backward_compatible() {
 		);
 		assert!(RewardOnUnbalanceWasCalled::get());
 
-		// verify all nominators of validator 11 are paid out, including the validator
-		// Validator payout goes to controller.
+		// verify all nominators of validator 11 are paid out, including the validator.
 		assert!(Balances::free_balance(&11) > balance);
 		for i in 0..100 {
 			assert!(Balances::free_balance(&(1000 + i)) > balance + i as Balance);
@@ -4582,10 +4511,10 @@ fn test_commission_paid_across_pages() {
 		// Payout rewards for first exposure page
 		assert_ok!(Staking::payout_stakers_by_page(RuntimeOrigin::signed(1337), 11, 1, 0));
 
-		let controller_balance_after_p0_payout = Balances::free_balance(&11);
+		let balance_after_p0_payout = Balances::free_balance(&11);
 
 		// some commission is paid
-		assert!(initial_balance < controller_balance_after_p0_payout);
+		assert!(initial_balance < balance_after_p0_payout);
 
 		// payout all pages
 		for i in 1..4 {
@@ -4845,7 +4774,7 @@ fn payout_to_any_account_works() {
 		// Create a validator:
 		bond_validator(11, balance); // Default(64)
 
-		// Create a stash/controller pair
+		// Create a stash
 		bond_nominator(1234, 100, vec![11]);
 
 		// Update payout location
@@ -5137,9 +5066,9 @@ mod election_data_provider {
 	fn set_minimum_active_stake_is_correct() {
 		ExtBuilder::default()
 			.nominate(false)
-			.add_staker(61, 61, 2_000, StakerStatus::<AccountId>::Nominator(vec![21]))
-			.add_staker(71, 71, 10, StakerStatus::<AccountId>::Nominator(vec![21]))
-			.add_staker(81, 81, 50, StakerStatus::<AccountId>::Nominator(vec![21]))
+			.add_staker(61, 2_000, StakerStatus::<AccountId>::Nominator(vec![21]))
+			.add_staker(71, 10, StakerStatus::<AccountId>::Nominator(vec![21]))
+			.add_staker(81, 50, StakerStatus::<AccountId>::Nominator(vec![21]))
 			.build_and_execute(|| {
 				// default bounds are unbounded.
 				assert_ok!(<Staking as ElectionDataProvider>::electing_voters(
@@ -5204,7 +5133,7 @@ mod election_data_provider {
 		ExtBuilder::default()
 			.has_stakers(true)
 			.nominate(true)
-			.add_staker(61, 61, 2_000, StakerStatus::<AccountId>::Nominator(vec![21]))
+			.add_staker(61, 2_000, StakerStatus::<AccountId>::Nominator(vec![21]))
 			.build_and_execute(|| {
 				assert_eq!(Staking::weight_of(&101), 500);
 				let voters = <Staking as ElectionDataProvider>::electing_voters(
@@ -5266,18 +5195,15 @@ mod election_data_provider {
 			// ppl, but then lower the MaxNomination limit.
 			.add_staker(
 				61,
-				61,
 				2_000,
 				StakerStatus::<AccountId>::Nominator(vec![21, 22, 23, 24, 25]),
 			)
 			.add_staker(
 				71,
-				71,
 				2_000,
 				StakerStatus::<AccountId>::Nominator(vec![21, 22, 23, 24, 25]),
 			)
 			.add_staker(
-				81,
 				81,
 				2_000,
 				StakerStatus::<AccountId>::Nominator(vec![21, 22, 23, 24, 25]),
@@ -5429,7 +5355,6 @@ mod election_data_provider {
 			.nominate(false)
 			.add_staker(
 				61,
-				60,
 				300, // 300 bond has 16 nomination quota.
 				StakerStatus::<AccountId>::Nominator(vec![21, 22, 23, 24, 25]),
 			)
@@ -5458,12 +5383,11 @@ mod election_data_provider {
 			.nominate(false)
 			.add_staker(
 				71,
-				70,
 				333,
 				StakerStatus::<AccountId>::Nominator(vec![16, 15, 14, 13, 12, 11, 10]),
 			)
 			.build_and_execute(|| {
-				// nominations of controller 70 won't be added due to voter size limit exceeded.
+				// nominations of stash 70 won't be added due to voter size limit exceeded.
 				let bounds = ElectionBoundsBuilder::default().voters_size(100.into()).build();
 				assert_eq!(
 					Staking::electing_voters(bounds.voters)
@@ -5819,23 +5743,16 @@ fn capped_stakers_works() {
 		// can create `max - validator_count` validators
 		let mut some_existing_validator = AccountId::default();
 		for i in 0..max - validator_count {
-			let (_, controller) = testing_utils::create_stash_controller::<Test>(
-				i + 10_000_000,
-				100,
-				RewardDestination::Stash,
-			)
-			.unwrap();
-			assert_ok!(Staking::validate(
-				RuntimeOrigin::signed(controller),
-				ValidatorPrefs::default()
-			));
-			some_existing_validator = controller;
+			let stash =
+				testing_utils::create_stash::<Test>(i + 10_000_000, 100, RewardDestination::Stash)
+					.unwrap();
+			assert_ok!(Staking::validate(RuntimeOrigin::signed(stash), ValidatorPrefs::default()));
+			some_existing_validator = stash;
 		}
 
 		// but no more
-		let (_, last_validator) =
-			testing_utils::create_stash_controller::<Test>(1337, 100, RewardDestination::Stash)
-				.unwrap();
+		let last_validator =
+			testing_utils::create_stash::<Test>(1337, 100, RewardDestination::Stash).unwrap();
 
 		assert_noop!(
 			Staking::validate(RuntimeOrigin::signed(last_validator), ValidatorPrefs::default()),
@@ -5845,23 +5762,17 @@ fn capped_stakers_works() {
 		// same with nominators
 		let mut some_existing_nominator = AccountId::default();
 		for i in 0..max - nominator_count {
-			let (_, controller) = testing_utils::create_stash_controller::<Test>(
-				i + 20_000_000,
-				100,
-				RewardDestination::Stash,
-			)
-			.unwrap();
-			assert_ok!(Staking::nominate(RuntimeOrigin::signed(controller), vec![1]));
-			some_existing_nominator = controller;
+			let stash =
+				testing_utils::create_stash::<Test>(i + 20_000_000, 100, RewardDestination::Stash)
+					.unwrap();
+			assert_ok!(Staking::nominate(RuntimeOrigin::signed(stash), vec![1]));
+			some_existing_nominator = stash;
 		}
 
 		// one more is too many.
-		let (_, last_nominator) = testing_utils::create_stash_controller::<Test>(
-			30_000_000,
-			100,
-			RewardDestination::Stash,
-		)
-		.unwrap();
+		let last_nominator =
+			testing_utils::create_stash::<Test>(30_000_000, 100, RewardDestination::Stash).unwrap();
+
 		assert_noop!(
 			Staking::nominate(RuntimeOrigin::signed(last_nominator), vec![1]),
 			Error::<Test>::TooManyNominators
@@ -5951,8 +5862,8 @@ fn min_commission_works() {
 fn change_of_absolute_max_nominations() {
 	use frame_election_provider_support::ElectionDataProvider;
 	ExtBuilder::default()
-		.add_staker(61, 61, 10, StakerStatus::Nominator(vec![1]))
-		.add_staker(71, 71, 10, StakerStatus::Nominator(vec![1, 2, 3]))
+		.add_staker(61, 10, StakerStatus::Nominator(vec![1]))
+		.add_staker(71, 10, StakerStatus::Nominator(vec![1, 2, 3]))
 		.balance_factor(10)
 		.build_and_execute(|| {
 			// pre-condition
@@ -6049,10 +5960,10 @@ fn change_of_absolute_max_nominations() {
 fn nomination_quota_max_changes_decoding() {
 	use frame_election_provider_support::ElectionDataProvider;
 	ExtBuilder::default()
-		.add_staker(60, 61, 10, StakerStatus::Nominator(vec![1]))
-		.add_staker(70, 71, 10, StakerStatus::Nominator(vec![1, 2, 3]))
-		.add_staker(30, 330, 10, StakerStatus::Nominator(vec![1, 2, 3, 4]))
-		.add_staker(50, 550, 10, StakerStatus::Nominator(vec![1, 2, 3, 4]))
+		.add_staker(60, 10, StakerStatus::Nominator(vec![1]))
+		.add_staker(70, 10, StakerStatus::Nominator(vec![1, 2, 3]))
+		.add_staker(30, 10, StakerStatus::Nominator(vec![1, 2, 3, 4]))
+		.add_staker(50, 10, StakerStatus::Nominator(vec![1, 2, 3, 4]))
 		.balance_factor(10)
 		.build_and_execute(|| {
 			// pre-condition.
@@ -6449,8 +6360,8 @@ fn reducing_max_unlocking_chunks_abrupt() {
 		// when max unlocking chunks is reduced abruptly to a low value
 		MaxUnlockingChunks::set(1);
 		// then unbond, rebond ops are blocked with ledger in corrupt state
-		assert_noop!(Staking::unbond(RuntimeOrigin::signed(3), 20), Error::<Test>::NotController);
-		assert_noop!(Staking::rebond(RuntimeOrigin::signed(3), 100), Error::<Test>::NotController);
+		assert_noop!(Staking::unbond(RuntimeOrigin::signed(3), 20), Error::<Test>::NotController); // TODO: use `NotStash` once variant is removed from ledeger.
+		assert_noop!(Staking::rebond(RuntimeOrigin::signed(3), 100), Error::<Test>::NotController); // TODO: use `NotStash` once variant is removed from ledeger.
 
 		// reset the ledger corruption
 		MaxUnlockingChunks::set(2);
@@ -7052,29 +6963,6 @@ mod staking_interface {
 				assert_eq!(Balances::balance_locked(STAKING_ID, &11), 0);
 			});
 	}
-
-	#[test]
-	fn status() {
-		ExtBuilder::default().build_and_execute(|| {
-			// stash of a validator is identified as a validator
-			assert_eq!(Staking::status(&11).unwrap(), StakerStatus::Validator);
-			// .. but not the controller.
-			assert!(Staking::status(&10).is_err());
-
-			// stash of nominator is identified as a nominator
-			assert_eq!(Staking::status(&101).unwrap(), StakerStatus::Nominator(vec![11, 21]));
-			// .. but not the controller.
-			assert!(Staking::status(&100).is_err());
-
-			// stash of chilled is identified as a chilled
-			assert_eq!(Staking::status(&41).unwrap(), StakerStatus::Idle);
-			// .. but not the controller.
-			assert!(Staking::status(&40).is_err());
-
-			// random other account.
-			assert!(Staking::status(&42).is_err());
-		})
-	}
 }
 
 mod staking_unchecked {
@@ -7387,7 +7275,7 @@ mod staking_unchecked {
 
 			// recover the ledger won't work for virtual staker
 			assert_noop!(
-				Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None, None),
+				Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None),
 				Error::<Test>::VirtualStakerNotAllowed
 			);
 
@@ -7395,7 +7283,7 @@ mod staking_unchecked {
 			<VirtualStakers<Test>>::remove(333);
 
 			// try restore again
-			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None, None));
+			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None));
 		})
 	}
 }
@@ -7406,17 +7294,17 @@ mod ledger {
 	fn paired_account_works() {
 		ExtBuilder::default().try_state(false).build_and_execute(|| {
 			assert_ok!(Staking::bond(
-				RuntimeOrigin::signed(10),
+				RuntimeOrigin::signed(61),
 				100,
-				RewardDestination::Account(10)
+				RewardDestination::Account(61)
 			));
 
-			assert_eq!(<Bonded<Test>>::get(&10), Some(10));
+			assert_eq!(<Bonded<Test>>::get(&61), Some(61));
 			assert_eq!(
-				StakingLedger::<Test>::paired_account(StakingAccount::Controller(10)),
-				Some(10)
+				StakingLedger::<Test>::paired_account(StakingAccount::Controller(61)),
+				Some(61)
 			);
-			assert_eq!(StakingLedger::<Test>::paired_account(StakingAccount::Stash(10)), Some(10));
+			assert_eq!(StakingLedger::<Test>::paired_account(StakingAccount::Stash(61)), Some(61));
 
 			assert_eq!(<Bonded<Test>>::get(&42), None);
 			assert_eq!(StakingLedger::<Test>::paired_account(StakingAccount::Controller(42)), None);
@@ -7547,28 +7435,6 @@ mod ledger {
 	}
 
 	#[test]
-	fn bond_controller_cannot_be_stash_works() {
-		ExtBuilder::default().build_and_execute(|| {
-			let (stash, controller) = testing_utils::create_unique_stash_controller::<Test>(
-				0,
-				10,
-				RewardDestination::Staked,
-				false,
-			)
-			.unwrap();
-
-			assert_eq!(Bonded::<Test>::get(stash), Some(controller));
-			assert_eq!(Ledger::<Test>::get(controller).map(|l| l.stash), Some(stash));
-
-			// existing controller should not be able become a stash.
-			assert_noop!(
-				Staking::bond(RuntimeOrigin::signed(controller), 10, RewardDestination::Staked),
-				Error::<Test>::AlreadyPaired,
-			);
-		})
-	}
-
-	#[test]
 	fn is_bonded_works() {
 		ExtBuilder::default().build_and_execute(|| {
 			assert!(!StakingLedger::<Test>::is_bonded(StakingAccount::Stash(42)));
@@ -7596,281 +7462,6 @@ mod ledger {
 				Error::<Test>::ControllerDeprecated
 			);
 			assert_eq!(Payee::<Test>::get(&11), Some(RewardDestination::Staked));
-		})
-	}
-
-	#[test]
-	#[allow(deprecated)]
-	fn update_payee_migration_works() {
-		ExtBuilder::default().build_and_execute(|| {
-			// migrate a `Controller` variant to `Account` variant.
-			Payee::<Test>::insert(11, RewardDestination::Controller);
-			assert_eq!(Payee::<Test>::get(&11), Some(RewardDestination::Controller));
-			assert_ok!(Staking::update_payee(RuntimeOrigin::signed(11), 11));
-			assert_eq!(Payee::<Test>::get(&11), Some(RewardDestination::Account(11)));
-
-			// Do not migrate a variant if not `Controller`.
-			Payee::<Test>::insert(21, RewardDestination::Stash);
-			assert_eq!(Payee::<Test>::get(&21), Some(RewardDestination::Stash));
-			assert_noop!(
-				Staking::update_payee(RuntimeOrigin::signed(11), 21),
-				Error::<Test>::NotController
-			);
-			assert_eq!(Payee::<Test>::get(&21), Some(RewardDestination::Stash));
-		})
-	}
-
-	#[test]
-	fn deprecate_controller_batch_works_full_weight() {
-		ExtBuilder::default().try_state(false).build_and_execute(|| {
-			// Given:
-
-			let start = 1001;
-			let mut controllers: Vec<_> = vec![];
-			for n in start..(start + MaxControllersInDeprecationBatch::get()).into() {
-				let ctlr: u64 = n.into();
-				let stash: u64 = (n + 10000).into();
-
-				Ledger::<Test>::insert(
-					ctlr,
-					StakingLedger {
-						controller: None,
-						total: (10 + ctlr).into(),
-						active: (10 + ctlr).into(),
-						..StakingLedger::default_from(stash)
-					},
-				);
-				Bonded::<Test>::insert(stash, ctlr);
-				Payee::<Test>::insert(stash, RewardDestination::Staked);
-
-				controllers.push(ctlr);
-			}
-
-			// When:
-
-			let bounded_controllers: BoundedVec<
-				_,
-				<Test as Config>::MaxControllersInDeprecationBatch,
-			> = BoundedVec::try_from(controllers).unwrap();
-
-			// Only `AdminOrigin` can sign.
-			assert_noop!(
-				Staking::deprecate_controller_batch(
-					RuntimeOrigin::signed(2),
-					bounded_controllers.clone()
-				),
-				BadOrigin
-			);
-
-			let result =
-				Staking::deprecate_controller_batch(RuntimeOrigin::root(), bounded_controllers);
-			assert_ok!(result);
-			assert_eq!(
-				result.unwrap().actual_weight.unwrap(),
-				<Test as Config>::WeightInfo::deprecate_controller_batch(
-					<Test as Config>::MaxControllersInDeprecationBatch::get()
-				)
-			);
-
-			// Then:
-
-			for n in start..(start + MaxControllersInDeprecationBatch::get()).into() {
-				let ctlr: u64 = n.into();
-				let stash: u64 = (n + 10000).into();
-
-				// Ledger no longer keyed by controller.
-				assert_eq!(Ledger::<Test>::get(ctlr), None);
-				// Bonded now maps to the stash.
-				assert_eq!(Bonded::<Test>::get(stash), Some(stash));
-
-				// Ledger is now keyed by stash.
-				let ledger_updated = Ledger::<Test>::get(stash).unwrap();
-				assert_eq!(ledger_updated.stash, stash);
-
-				// Check `active` and `total` values match the original ledger set by controller.
-				assert_eq!(ledger_updated.active, (10 + ctlr).into());
-				assert_eq!(ledger_updated.total, (10 + ctlr).into());
-			}
-		})
-	}
-
-	#[test]
-	fn deprecate_controller_batch_works_half_weight() {
-		ExtBuilder::default().build_and_execute(|| {
-			// Given:
-
-			let start = 1001;
-			let mut controllers: Vec<_> = vec![];
-			for n in start..(start + MaxControllersInDeprecationBatch::get()).into() {
-				let ctlr: u64 = n.into();
-
-				// Only half of entries are unique pairs.
-				let stash: u64 = if n % 2 == 0 { (n + 10000).into() } else { ctlr };
-
-				Ledger::<Test>::insert(
-					ctlr,
-					StakingLedger { controller: None, ..StakingLedger::default_from(stash) },
-				);
-				Bonded::<Test>::insert(stash, ctlr);
-				Payee::<Test>::insert(stash, RewardDestination::Staked);
-
-				controllers.push(ctlr);
-			}
-
-			// When:
-			let bounded_controllers: BoundedVec<
-				_,
-				<Test as Config>::MaxControllersInDeprecationBatch,
-			> = BoundedVec::try_from(controllers.clone()).unwrap();
-
-			let result =
-				Staking::deprecate_controller_batch(RuntimeOrigin::root(), bounded_controllers);
-			assert_ok!(result);
-			assert_eq!(
-				result.unwrap().actual_weight.unwrap(),
-				<Test as Config>::WeightInfo::deprecate_controller_batch(controllers.len() as u32)
-			);
-
-			// Then:
-
-			for n in start..(start + MaxControllersInDeprecationBatch::get()).into() {
-				let unique_pair = n % 2 == 0;
-				let ctlr: u64 = n.into();
-				let stash: u64 = if unique_pair { (n + 10000).into() } else { ctlr };
-
-				// Side effect of migration for unique pair.
-				if unique_pair {
-					assert_eq!(Ledger::<Test>::get(ctlr), None);
-				}
-				// Bonded maps to the stash.
-				assert_eq!(Bonded::<Test>::get(stash), Some(stash));
-
-				// Ledger is keyed by stash.
-				let ledger_updated = Ledger::<Test>::get(stash).unwrap();
-				assert_eq!(ledger_updated.stash, stash);
-			}
-		})
-	}
-
-	#[test]
-	fn deprecate_controller_batch_skips_unmigrated_controller_payees() {
-		ExtBuilder::default().try_state(false).build_and_execute(|| {
-			// Given:
-
-			let stash: u64 = 1000;
-			let ctlr: u64 = 1001;
-
-			Ledger::<Test>::insert(
-				ctlr,
-				StakingLedger { controller: None, ..StakingLedger::default_from(stash) },
-			);
-			Bonded::<Test>::insert(stash, ctlr);
-			#[allow(deprecated)]
-			Payee::<Test>::insert(stash, RewardDestination::Controller);
-
-			// When:
-
-			let bounded_controllers: BoundedVec<
-				_,
-				<Test as Config>::MaxControllersInDeprecationBatch,
-			> = BoundedVec::try_from(vec![ctlr]).unwrap();
-
-			let result =
-				Staking::deprecate_controller_batch(RuntimeOrigin::root(), bounded_controllers);
-			assert_ok!(result);
-			assert_eq!(
-				result.unwrap().actual_weight.unwrap(),
-				<Test as Config>::WeightInfo::deprecate_controller_batch(1 as u32)
-			);
-
-			// Then:
-
-			// Esure deprecation did not happen.
-			assert_eq!(Ledger::<Test>::get(ctlr).is_some(), true);
-
-			// Bonded still keyed by controller.
-			assert_eq!(Bonded::<Test>::get(stash), Some(ctlr));
-
-			// Ledger is still keyed by controller.
-			let ledger_updated = Ledger::<Test>::get(ctlr).unwrap();
-			assert_eq!(ledger_updated.stash, stash);
-		})
-	}
-
-	#[test]
-	fn deprecate_controller_batch_with_bad_state_ok() {
-		ExtBuilder::default().has_stakers(false).nominate(false).build_and_execute(|| {
-			setup_double_bonded_ledgers();
-
-			// now let's deprecate all the controllers for all the existing ledgers.
-			let bounded_controllers: BoundedVec<
-				_,
-				<Test as Config>::MaxControllersInDeprecationBatch,
-			> = BoundedVec::try_from(vec![333, 444, 555, 777]).unwrap();
-
-			assert_ok!(Staking::deprecate_controller_batch(
-				RuntimeOrigin::root(),
-				bounded_controllers
-			));
-
-			assert_eq!(
-				*staking_events().last().unwrap(),
-				Event::ControllerBatchDeprecated { failures: 0 }
-			);
-		})
-	}
-
-	#[test]
-	fn deprecate_controller_batch_with_bad_state_failures() {
-		ExtBuilder::default().has_stakers(false).try_state(false).build_and_execute(|| {
-			setup_double_bonded_ledgers();
-
-			// now let's deprecate all the controllers for all the existing ledgers.
-			let bounded_controllers: BoundedVec<
-				_,
-				<Test as Config>::MaxControllersInDeprecationBatch,
-			> = BoundedVec::try_from(vec![777, 555, 444, 333]).unwrap();
-
-			assert_ok!(Staking::deprecate_controller_batch(
-				RuntimeOrigin::root(),
-				bounded_controllers
-			));
-
-			assert_eq!(
-				*staking_events().last().unwrap(),
-				Event::ControllerBatchDeprecated { failures: 2 }
-			);
-		})
-	}
-
-	#[test]
-	fn set_controller_with_bad_state_ok() {
-		ExtBuilder::default().has_stakers(false).nominate(false).build_and_execute(|| {
-			setup_double_bonded_ledgers();
-
-			// in this case, setting controller works due to the ordering of the calls.
-			assert_ok!(Staking::set_controller(RuntimeOrigin::signed(333)));
-			assert_ok!(Staking::set_controller(RuntimeOrigin::signed(444)));
-			assert_ok!(Staking::set_controller(RuntimeOrigin::signed(555)));
-		})
-	}
-
-	#[test]
-	fn set_controller_with_bad_state_fails() {
-		ExtBuilder::default().has_stakers(false).try_state(false).build_and_execute(|| {
-			setup_double_bonded_ledgers();
-
-			// setting the controller of ledger associated with stash 555 fails since its stash is a
-			// controller of another ledger.
-			assert_noop!(
-				Staking::set_controller(RuntimeOrigin::signed(555)),
-				Error::<Test>::BadState
-			);
-			assert_noop!(
-				Staking::set_controller(RuntimeOrigin::signed(444)),
-				Error::<Test>::BadState
-			);
-			assert_ok!(Staking::set_controller(RuntimeOrigin::signed(333)));
 		})
 	}
 }
@@ -8063,7 +7654,7 @@ mod ledger_recovery {
 			assert!(Staking::do_try_state(System::block_number()).is_err());
 
 			// recover the ledger bonded by 333 stash.
-			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None, None));
+			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None));
 
 			// try-state checks are ok now.
 			assert_ok!(Staking::do_try_state(System::block_number()));
@@ -8107,20 +7698,19 @@ mod ledger_recovery {
 			assert!(Staking::do_try_state(System::block_number()).is_err());
 
 			// recover the ledger bonded by 333 stash.
-			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None, None));
+			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None));
 
 			// for the try-state checks to pass, we also need to recover the stash 444 which is
 			// corrupted too by proxy of kill(333). Currently, both the lock and the ledger of 444
 			// have been cleared so we need to provide the new amount to restore the ledger.
 			assert_noop!(
-				Staking::restore_ledger(RuntimeOrigin::root(), 444, None, None, None),
+				Staking::restore_ledger(RuntimeOrigin::root(), 444, None, None),
 				Error::<Test>::CannotRestoreLedger
 			);
 
 			assert_ok!(Staking::restore_ledger(
 				RuntimeOrigin::root(),
 				444,
-				None,
 				Some(total_444_before_corruption),
 				None,
 			));
@@ -8163,7 +7753,7 @@ mod ledger_recovery {
 			assert_ok!(StakingLedger::<Test>::kill(&444));
 
 			// recover the ledger bonded by 333 stash.
-			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None, None));
+			assert_ok!(Staking::restore_ledger(RuntimeOrigin::root(), 333, None, None));
 
 			// 444 does not need recover in this case since it's been killed successfully.
 			assert_eq!(Staking::inspect_bond_state(&444), Err(Error::<Test>::NotStash));
@@ -8219,7 +7809,6 @@ mod ledger_recovery {
 			assert_ok!(Staking::restore_ledger(
 				RuntimeOrigin::root(),
 				333,
-				None,
 				Some(lock_333_before + 30),
 				None
 			));
@@ -8228,7 +7817,7 @@ mod ledger_recovery {
 			// of sync. in which case, we need to explicitly set the ledger's lock and amount,
 			// otherwise the ledger recover will fail.
 			assert_noop!(
-				Staking::restore_ledger(RuntimeOrigin::root(), 444, None, None, None),
+				Staking::restore_ledger(RuntimeOrigin::root(), 444, None, None),
 				Error::<Test>::CannotRestoreLedger
 			);
 
@@ -8236,7 +7825,6 @@ mod ledger_recovery {
 			assert_ok!(Staking::restore_ledger(
 				RuntimeOrigin::root(),
 				444,
-				None,
 				Some(lock_444_before + 40),
 				None
 			));

--- a/substrate/frame/staking/src/weights.rs
+++ b/substrate/frame/staking/src/weights.rs
@@ -61,14 +61,11 @@ pub trait WeightInfo {
 	fn nominate(n: u32, ) -> Weight;
 	fn chill() -> Weight;
 	fn set_payee() -> Weight;
-	fn update_payee() -> Weight;
-	fn set_controller() -> Weight;
 	fn set_validator_count() -> Weight;
 	fn force_no_eras() -> Weight;
 	fn force_new_era() -> Weight;
 	fn force_new_era_always() -> Weight;
 	fn set_invulnerables(v: u32, ) -> Weight;
-	fn deprecate_controller_batch(i: u32, ) -> Weight;
 	fn force_unstake(s: u32, ) -> Weight;
 	fn cancel_deferred_slash(s: u32, ) -> Weight;
 	fn payout_stakers_alive_staked(n: u32, ) -> Weight;
@@ -348,34 +345,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Staking::Ledger` (r:1 w:0)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Bonded` (r:1 w:0)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Payee` (r:1 w:1)
-	/// Proof: `Staking::Payee` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
-	fn update_payee() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `969`
-		//  Estimated: `4556`
-		// Minimum execution time: 23_705_000 picoseconds.
-		Weight::from_parts(24_409_000, 4556)
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	/// Storage: `Staking::Bonded` (r:1 w:1)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Ledger` (r:2 w:2)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	fn set_controller() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `902`
-		//  Estimated: `8122`
-		// Minimum execution time: 23_479_000 picoseconds.
-		Weight::from_parts(24_502_000, 8122)
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
-	}
 	/// Storage: `Staking::ValidatorCount` (r:0 w:1)
 	/// Proof: `Staking::ValidatorCount` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn set_validator_count() -> Weight {
@@ -428,25 +397,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 30
 			.saturating_add(Weight::from_parts(10_058, 0).saturating_mul(v.into()))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	/// Storage: `Staking::Ledger` (r:11800 w:11800)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Bonded` (r:5900 w:5900)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Payee` (r:5900 w:0)
-	/// Proof: `Staking::Payee` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
-	/// The range of component `i` is `[0, 5900]`.
-	fn deprecate_controller_batch(i: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `1746 + i * (229 ±0)`
-		//  Estimated: `990 + i * (7132 ±0)`
-		// Minimum execution time: 5_300_000 picoseconds.
-		Weight::from_parts(5_437_000, 990)
-			// Standard Error: 66_261
-			.saturating_add(Weight::from_parts(30_172_457, 0).saturating_mul(i.into()))
-			.saturating_add(T::DbWeight::get().reads((4_u64).saturating_mul(i.into())))
-			.saturating_add(T::DbWeight::get().writes((3_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_parts(0, 7132).saturating_mul(i.into()))
 	}
 	/// Storage: `Staking::SlashingSpans` (r:1 w:1)
 	/// Proof: `Staking::SlashingSpans` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1098,34 +1048,6 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	/// Storage: `Staking::Ledger` (r:1 w:0)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Bonded` (r:1 w:0)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Payee` (r:1 w:1)
-	/// Proof: `Staking::Payee` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
-	fn update_payee() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `969`
-		//  Estimated: `4556`
-		// Minimum execution time: 23_705_000 picoseconds.
-		Weight::from_parts(24_409_000, 4556)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
-	}
-	/// Storage: `Staking::Bonded` (r:1 w:1)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Ledger` (r:2 w:2)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	fn set_controller() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `902`
-		//  Estimated: `8122`
-		// Minimum execution time: 23_479_000 picoseconds.
-		Weight::from_parts(24_502_000, 8122)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
-	}
 	/// Storage: `Staking::ValidatorCount` (r:0 w:1)
 	/// Proof: `Staking::ValidatorCount` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn set_validator_count() -> Weight {
@@ -1178,25 +1100,6 @@ impl WeightInfo for () {
 			// Standard Error: 30
 			.saturating_add(Weight::from_parts(10_058, 0).saturating_mul(v.into()))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
-	}
-	/// Storage: `Staking::Ledger` (r:11800 w:11800)
-	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Bonded` (r:5900 w:5900)
-	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-	/// Storage: `Staking::Payee` (r:5900 w:0)
-	/// Proof: `Staking::Payee` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
-	/// The range of component `i` is `[0, 5900]`.
-	fn deprecate_controller_batch(i: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `1746 + i * (229 ±0)`
-		//  Estimated: `990 + i * (7132 ±0)`
-		// Minimum execution time: 5_300_000 picoseconds.
-		Weight::from_parts(5_437_000, 990)
-			// Standard Error: 66_261
-			.saturating_add(Weight::from_parts(30_172_457, 0).saturating_mul(i.into()))
-			.saturating_add(RocksDbWeight::get().reads((4_u64).saturating_mul(i.into())))
-			.saturating_add(RocksDbWeight::get().writes((3_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_parts(0, 7132).saturating_mul(i.into()))
 	}
 	/// Storage: `Staking::SlashingSpans` (r:1 w:1)
 	/// Proof: `Staking::SlashingSpans` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/substrate/primitives/staking/src/lib.rs
+++ b/substrate/primitives/staking/src/lib.rs
@@ -189,13 +189,9 @@ pub trait StakingInterface {
 	/// The minimum amount required to bond in order to set validation intentions.
 	fn minimum_validator_bond() -> Self::Balance;
 
-	/// Return a stash account that is controlled by a `controller`.
-	///
-	/// ## Note
-	///
-	/// The controller abstraction is not permanent and might go away. Avoid using this as much as
-	/// possible.
-	fn stash_by_ctrl(controller: &Self::AccountId) -> Result<Self::AccountId, DispatchError>;
+	/// Return a stash account of a ledger associated with the provided account, `Err` if not a
+	/// staker.
+	fn stash(who: &Self::AccountId) -> Result<Self::AccountId, DispatchError>;
 
 	/// Number of eras that staked funds must remain bonded for.
 	fn bonding_duration() -> EraIndex;


### PR DESCRIPTION
This PR removes controller logic from pallets & chain specs. Tracking issue: https://github.com/paritytech/polkadot-sdk/issues/2500

### Prerequisites before merging

This PR should be merged once the following tasks have been completed:

- [ ] `restore_ledger` has been executed on Polkadot, that fixes corrupt ledger state items.
- [ ] `update_payee` has been executed on Polkadot, migrating all `RewardDestination::Controller` entries to `RewardDestination::Account(controller)` entries.
- [ ] `deprecate_controller_batch` calls have been executed on Kusama and Polkadot, that updates all unique controllers to the corresponding stash address.

Once these prerequisites have been completed, it will be safe to bump the staking pallet with the updates of this PR.

---
### Pre-merge checklist
- [x] Update prdoc with more detailed changes.
- [ ] Re-generate `staking` benchmarks.
- [ ] Notify CI team of changes.
---

### Controller deprecation

- [x] Remove `deprecate_controller_batch` call from staking pallet and `MaxControllersInDeprecationBatch` across codebase.
- [x] Remove `set_controller` call from staking pallet.
- [x] Update `staking` calls that require `controller` as origin to be `stash` instead.
- [x] Remove `update_payee` call from staking pallet.
- [x] Remove `maybe_controller` param from `restore_ledger`.
- [x] Tidy up `testing_utils` to not provide controller accounts.
- [x] Update tests to not consider controller accounts. https://github.com/paritytech/polkadot-sdk/pull/4574/commits/ddb8256a03fc3d389edf5f993d289dd66257c6c7
- [x] Remove controller account associated data from mocks and chain specs. https://github.com/paritytech/polkadot-sdk/pull/4574/commits/714f2f9ba3bf92f1196988cd4bc761c1e5467854, https://github.com/paritytech/polkadot-sdk/pull/4574/commits/ce82d9859f794bd395e98b676ca5e6f6ed75e1ee
- [x] Update `fast-unstake` calls that require `controller` as origin to be `stash` instead.
- [x] Ensure high level pallet docs no longer mention controller accounts, but mention proxies.
- [ ] Draw down usage of `Bonded` storage.
- [ ] Remove controller related tests (restore ledger tests).
- [ ] Remove `StakingAccount::Controller` from staking ledger.
- [ ] Explore migration to remove `Bonded` storage.