### PR TITLE
Backport #5427

### DIFF
--- a/polkadot/statement-table/src/generic.rs
+++ b/polkadot/statement-table/src/generic.rs
@@ -477,10 +477,7 @@ impl<Ctx: Context> Table<Ctx> {
 		if !context.is_member_of(&from, &votes.group_id) {
 			let sig = match vote {
 				ValidityVote::Valid(s) => s,
-				ValidityVote::Issued(_) => panic!(
-					"implicit issuance vote only cast from `import_candidate` after \
-							checking group membership of issuer; qed"
-				),
+				ValidityVote::Issued(s) => s,
 			};
 
 			return Err(Misbehavior::UnauthorizedStatement(UnauthorizedStatement {


### PR DESCRIPTION
`validity_vote` function is also called from `import_statement` not only from `import_candidate`. The proof still holds if we assume seconded statements always come before valid statements, which should be the case but is not actually enforced by this module at all. On top of this the proof is not local.