### PR TITLE
Backport #5392

### DIFF
--- a/polkadot/node/network/dispute-distribution/src/receiver/mod.rs
+++ b/polkadot/node/network/dispute-distribution/src/receiver/mod.rs
@@ -66,9 +66,12 @@ use self::{
 
 const COST_INVALID_REQUEST: Rep = Rep::CostMajor("Received message could not be decoded.");
 const COST_INVALID_SIGNATURE: Rep = Rep::Malicious("Signatures were invalid.");
-const COST_INVALID_IMPORT: Rep =
-	Rep::Malicious("Import was deemed invalid by dispute-coordinator.");
 const COST_NOT_A_VALIDATOR: Rep = Rep::CostMajor("Reporting peer was not a validator.");
+
+/// Invalid imports can be caused by flooding, e.g. by a disabled validator.
+const COST_INVALID_IMPORT: Rep =
+	Rep::CostMinor("Import was deemed invalid by dispute-coordinator.");
+
 /// Mildly punish peers exceeding their rate limit.
 ///
 /// For honest peers this should rarely happen, but if it happens we would not want to disconnect

--- a/prdoc/pr_5392.prdoc
+++ b/prdoc/pr_5392.prdoc
@@ -1,0 +1,11 @@
+title: "Don't disconnect disabled nodes sending us dispute messages"
+
+doc:
+  - audience: Node Operator
+    description: |
+        No longer disconnect peers which we consider disabled when raising
+        disputes as this will affect the approval process and thus finality.
+
+crates:
+  - name: polkadot-dispute-distribution
+    bump: patch


### PR DESCRIPTION
There are numerous reasons for invalid imports, most of them would likely be caused by bugs. On the other side, dispute distribution handles all connections fairly, thus there is little harm in keeping a problematic connection open.

---------