### PR TITLE
Backport timestamp logging fix

### DIFF
--- a/prdoc/pr_5055.prdoc
+++ b/prdoc/pr_5055.prdoc
@@ -1,0 +1,11 @@
+title: Only log error in `UnixTime::now` call of the pallet-timestamp implementation if called at genesis
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      This minor patch re-introduces a check to ensure that the `UnixTime::now` implementation in the timestamp only
+      logs an error if called at the genesis block.
+
+crates:
+- name: pallet-timestamp
+  bump: minor

--- a/prdoc/pr_5055.prdoc
+++ b/prdoc/pr_5055.prdoc
@@ -8,4 +8,4 @@ doc:
 
 crates:
 - name: pallet-timestamp
-  bump: minor
+  bump: patch

--- a/substrate/frame/timestamp/src/lib.rs
+++ b/substrate/frame/timestamp/src/lib.rs
@@ -368,10 +368,12 @@ impl<T: Config> UnixTime for Pallet<T> {
 		// `sp_timestamp::InherentDataProvider`.
 		let now = Now::<T>::get();
 
-		log::error!(
-			target: "runtime::timestamp",
-			"`pallet_timestamp::UnixTime::now` is called at genesis, invalid value returned: 0",
-		);
+		if now == T::Moment::zero() {
+			log::error!(
+				target: "runtime::timestamp",
+				"`pallet_timestamp::UnixTime::now` is called at genesis, invalid value returned: 0",
+			);
+		}
 
 		core::time::Duration::from_millis(now.saturated_into::<u64>())
 	}


### PR DESCRIPTION
https://github.com/paritytech/polkadot-sdk/commit/03c45b910331214c5b4f9cc88244b684e8a97e42