### PR TITLE
Make the PR template a default for new PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,1 +1,0 @@
-../../docs/contributor/PULL_REQUEST_TEMPLATE.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+../docs/contributor/PULL_REQUEST_TEMPLATE.md

--- a/docs/contributor/PULL_REQUEST_TEMPLATE.md
+++ b/docs/contributor/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@ possibly integration.*
 # Checklist
 
 * [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
-* [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
+* [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
   required)
     * External contributors: ask maintainers to put the right label on your PR.
 * [ ] I have made corresponding changes to the documentation (if applicable)

--- a/docs/contributor/PULL_REQUEST_TEMPLATE.md
+++ b/docs/contributor/PULL_REQUEST_TEMPLATE.md
@@ -33,8 +33,9 @@ possibly integration.*
 # Checklist
 
 * [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
-* [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
-  required)
+* [ ] My PR follows the [labeling requirements](
+https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
+) of this project (at minimum one label for `T` required)
     * External contributors: ask maintainers to put the right label on your PR.
 * [ ] I have made corresponding changes to the documentation (if applicable)
 * [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)


### PR DESCRIPTION
A follow-up to https://github.com/paritytech/polkadot-sdk/pull/5447

Instead of having an option to select a PR template (like is the case with issues), this change will make the one PR template we have the default, it will show up for every new PR.

Also updated one link so it works properly in the PR body.