### PR TITLE
Make `PendingConfigs` storage item public

### DIFF
--- a/polkadot/runtime/parachains/src/configuration.rs
+++ b/polkadot/runtime/parachains/src/configuration.rs
@@ -557,7 +557,7 @@ pub mod pallet {
 	/// The list is sorted ascending by session index. Also, this list can only contain at most
 	/// 2 items: for the next session and for the `scheduled_session`.
 	#[pallet::storage]
-	pub(crate) type PendingConfigs<T: Config> =
+	pub type PendingConfigs<T: Config> =
 		StorageValue<_, Vec<(SessionIndex, HostConfiguration<BlockNumberFor<T>>)>, ValueQuery>;
 
 	/// If this is set, then the configuration setters will bypass the consistency checks. This

--- a/prdoc/pr_5467.prdoc
+++ b/prdoc/pr_5467.prdoc
@@ -7,4 +7,4 @@ doc:
 
 crates:
   - name: polkadot-runtime-parachains
-    bump: none
+    bump: minor

--- a/prdoc/pr_5467.prdoc
+++ b/prdoc/pr_5467.prdoc
@@ -1,0 +1,10 @@
+title: Make PendingConfigs storage item public
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Make PendingConfigs storage item in polkadot's configuration crate public.
+
+crates:
+  - name: polkadot-runtime-parachains
+    bump: none


### PR DESCRIPTION
## Description
This PR changes `PendingConfigs` storage item's visibility from crate to public. This enable us to read it in our runtime.