### PR TITLE
Syncing strategy refactoring

### DIFF
--- a/prdoc/pr_5469.prdoc
+++ b/prdoc/pr_5469.prdoc
@@ -1,0 +1,11 @@
+title: Syncing strategy refactoring
+
+doc:
+  - audience: Node Dev
+    description: |
+      Mostly internal changes to syncing strategies that is a step towards making them configurable/extensible in the
+      future. It is unlikely that external developers will need to change their code.
+
+crates:
+  - name: sc-network-sync
+    bump: major

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -33,7 +33,7 @@ use crate::{
 	},
 	strategy::{
 		warp::{EncodedProof, WarpProofRequest, WarpSyncConfig},
-		StrategyKey, SyncingAction, SyncingConfig, SyncingStrategy,
+		PolkadotSyncingStrategy, StrategyKey, SyncingAction, SyncingConfig,
 	},
 	types::{
 		BadPeer, ExtendedPeerInfo, OpaqueStateRequest, OpaqueStateResponse, PeerRequest, SyncEvent,
@@ -189,7 +189,7 @@ pub struct Peer<B: BlockT> {
 
 pub struct SyncingEngine<B: BlockT, Client> {
 	/// Syncing strategy.
-	strategy: SyncingStrategy<B, Client>,
+	strategy: PolkadotSyncingStrategy<B, Client>,
 
 	/// Blockchain client.
 	client: Arc<Client>,
@@ -397,7 +397,8 @@ where
 			);
 
 		// Initialize syncing strategy.
-		let strategy = SyncingStrategy::new(syncing_config, client.clone(), warp_sync_config)?;
+		let strategy =
+			PolkadotSyncingStrategy::new(syncing_config, client.clone(), warp_sync_config)?;
 
 		let block_announce_protocol_name = block_announce_config.protocol_name().clone();
 		let (tx, service_rx) = tracing_unbounded("mpsc_chain_sync", 100_000);
@@ -710,7 +711,7 @@ where
 						number,
 					)
 				},
-				// Nothing to do, this is handled internally by `SyncingStrategy`.
+				// Nothing to do, this is handled internally by `PolkadotSyncingStrategy`.
 				SyncingAction::Finished => {},
 			}
 		}

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -33,7 +33,7 @@ use crate::{
 	},
 	strategy::{
 		warp::{EncodedProof, WarpProofRequest, WarpSyncConfig},
-		PolkadotSyncingStrategy, StrategyKey, SyncingAction, SyncingConfig,
+		PolkadotSyncingStrategy, StrategyKey, SyncingAction, SyncingConfig, SyncingStrategy,
 	},
 	types::{
 		BadPeer, ExtendedPeerInfo, OpaqueStateRequest, OpaqueStateResponse, PeerRequest, SyncEvent,

--- a/substrate/client/network/sync/src/strategy.rs
+++ b/substrate/client/network/sync/src/strategy.rs
@@ -186,44 +186,6 @@ where
 		+ Sync
 		+ 'static,
 {
-	/// Initialize a new syncing strategy.
-	pub fn new(
-		config: SyncingConfig,
-		client: Arc<Client>,
-		warp_sync_config: Option<WarpSyncConfig<B>>,
-	) -> Result<Self, ClientError> {
-		if let SyncMode::Warp = config.mode {
-			let warp_sync_config = warp_sync_config
-				.expect("Warp sync configuration must be supplied in warp sync mode.");
-			let warp_sync = WarpSync::new(client.clone(), warp_sync_config);
-			Ok(Self {
-				config,
-				client,
-				warp: Some(warp_sync),
-				state: None,
-				chain_sync: None,
-				peer_best_blocks: Default::default(),
-			})
-		} else {
-			let chain_sync = ChainSync::new(
-				chain_sync_mode(config.mode),
-				client.clone(),
-				config.max_parallel_downloads,
-				config.max_blocks_per_request,
-				config.metrics_registry.as_ref(),
-				std::iter::empty(),
-			)?;
-			Ok(Self {
-				config,
-				client,
-				warp: None,
-				state: None,
-				chain_sync: Some(chain_sync),
-				peer_best_blocks: Default::default(),
-			})
-		}
-	}
-
 	/// Notify that a new peer has connected.
 	pub fn add_peer(&mut self, peer_id: PeerId, best_hash: B::Hash, best_number: NumberFor<B>) {
 		self.peer_best_blocks.insert(peer_id, (best_hash, best_number));
@@ -475,6 +437,44 @@ where
 		}
 
 		Ok(actions)
+	}
+
+	/// Initialize a new syncing strategy.
+	pub fn new(
+		config: SyncingConfig,
+		client: Arc<Client>,
+		warp_sync_config: Option<WarpSyncConfig<B>>,
+	) -> Result<Self, ClientError> {
+		if let SyncMode::Warp = config.mode {
+			let warp_sync_config = warp_sync_config
+				.expect("Warp sync configuration must be supplied in warp sync mode.");
+			let warp_sync = WarpSync::new(client.clone(), warp_sync_config);
+			Ok(Self {
+				config,
+				client,
+				warp: Some(warp_sync),
+				state: None,
+				chain_sync: None,
+				peer_best_blocks: Default::default(),
+			})
+		} else {
+			let chain_sync = ChainSync::new(
+				chain_sync_mode(config.mode),
+				client.clone(),
+				config.max_parallel_downloads,
+				config.max_blocks_per_request,
+				config.metrics_registry.as_ref(),
+				std::iter::empty(),
+			)?;
+			Ok(Self {
+				config,
+				client,
+				warp: None,
+				state: None,
+				chain_sync: Some(chain_sync),
+				peer_best_blocks: Default::default(),
+			})
+		}
 	}
 
 	/// Proceed with the next strategy if the active one finished.

--- a/substrate/client/network/sync/src/strategy.rs
+++ b/substrate/client/network/sync/src/strategy.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! [`SyncingStrategy`] is a proxy between [`crate::engine::SyncingEngine`]
+//! [`PolkadotSyncingStrategy`] is a proxy between [`crate::engine::SyncingEngine`]
 //! and specific syncing algorithms.
 
 pub mod chain_sync;
@@ -104,7 +104,7 @@ pub enum SyncingAction<B: BlockT> {
 		number: NumberFor<B>,
 		justifications: Justifications,
 	},
-	/// Strategy finished. Nothing to do, this is handled by `SyncingStrategy`.
+	/// Strategy finished. Nothing to do, this is handled by `PolkadotSyncingStrategy`.
 	Finished,
 }
 
@@ -158,8 +158,8 @@ impl<B: BlockT> From<ChainSyncAction<B>> for SyncingAction<B> {
 	}
 }
 
-/// Proxy to specific syncing strategies.
-pub struct SyncingStrategy<B: BlockT, Client> {
+/// Proxy to specific syncing strategies used in Polkadot.
+pub struct PolkadotSyncingStrategy<B: BlockT, Client> {
 	/// Initial syncing configuration.
 	config: SyncingConfig,
 	/// Client used by syncing strategies.
@@ -171,11 +171,11 @@ pub struct SyncingStrategy<B: BlockT, Client> {
 	/// `ChainSync` strategy.`
 	chain_sync: Option<ChainSync<B, Client>>,
 	/// Connected peers and their best blocks used to seed a new strategy when switching to it in
-	/// [`SyncingStrategy::proceed_to_next`].
+	/// [`PolkadotSyncingStrategy::proceed_to_next`].
 	peer_best_blocks: HashMap<PeerId, (B::Hash, NumberFor<B>)>,
 }
 
-impl<B: BlockT, Client> SyncingStrategy<B, Client>
+impl<B: BlockT, Client> PolkadotSyncingStrategy<B, Client>
 where
 	B: BlockT,
 	Client: HeaderBackend<B>

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -233,50 +233,6 @@ pub enum ChainSyncMode {
 	},
 }
 
-/// The main data structure which contains all the state for a chains
-/// active syncing strategy.
-pub struct ChainSync<B: BlockT, Client> {
-	/// Chain client.
-	client: Arc<Client>,
-	/// The active peers that we are using to sync and their PeerSync status
-	peers: HashMap<PeerId, PeerSync<B>>,
-	disconnected_peers: DisconnectedPeers,
-	/// A `BlockCollection` of blocks that are being downloaded from peers
-	blocks: BlockCollection<B>,
-	/// The best block number in our queue of blocks to import
-	best_queued_number: NumberFor<B>,
-	/// The best block hash in our queue of blocks to import
-	best_queued_hash: B::Hash,
-	/// Current mode (full/light)
-	mode: ChainSyncMode,
-	/// Any extra justification requests.
-	extra_justifications: ExtraRequests<B>,
-	/// A set of hashes of blocks that are being downloaded or have been
-	/// downloaded and are queued for import.
-	queue_blocks: HashSet<B::Hash>,
-	/// Fork sync targets.
-	fork_targets: HashMap<B::Hash, ForkTarget<B>>,
-	/// A set of peers for which there might be potential block requests
-	allowed_requests: AllowedRequests,
-	/// Maximum number of peers to ask the same blocks in parallel.
-	max_parallel_downloads: u32,
-	/// Maximum blocks per request.
-	max_blocks_per_request: u32,
-	/// Total number of downloaded blocks.
-	downloaded_blocks: usize,
-	/// State sync in progress, if any.
-	state_sync: Option<StateSync<B, Client>>,
-	/// Enable importing existing blocks. This is used used after the state download to
-	/// catch up to the latest state while re-importing blocks.
-	import_existing: bool,
-	/// Gap download process.
-	gap_sync: Option<GapSync<B>>,
-	/// Pending actions.
-	actions: Vec<ChainSyncAction<B>>,
-	/// Prometheus metrics.
-	metrics: Option<Metrics>,
-}
-
 /// All the data we have about a Peer that we are trying to sync with
 #[derive(Debug, Clone)]
 pub(crate) struct PeerSync<B: BlockT> {
@@ -344,6 +300,50 @@ impl<B: BlockT> PeerSyncState<B> {
 	pub fn is_available(&self) -> bool {
 		matches!(self, Self::Available)
 	}
+}
+
+/// The main data structure which contains all the state for a chains
+/// active syncing strategy.
+pub struct ChainSync<B: BlockT, Client> {
+	/// Chain client.
+	client: Arc<Client>,
+	/// The active peers that we are using to sync and their PeerSync status
+	peers: HashMap<PeerId, PeerSync<B>>,
+	disconnected_peers: DisconnectedPeers,
+	/// A `BlockCollection` of blocks that are being downloaded from peers
+	blocks: BlockCollection<B>,
+	/// The best block number in our queue of blocks to import
+	best_queued_number: NumberFor<B>,
+	/// The best block hash in our queue of blocks to import
+	best_queued_hash: B::Hash,
+	/// Current mode (full/light)
+	mode: ChainSyncMode,
+	/// Any extra justification requests.
+	extra_justifications: ExtraRequests<B>,
+	/// A set of hashes of blocks that are being downloaded or have been
+	/// downloaded and are queued for import.
+	queue_blocks: HashSet<B::Hash>,
+	/// Fork sync targets.
+	fork_targets: HashMap<B::Hash, ForkTarget<B>>,
+	/// A set of peers for which there might be potential block requests
+	allowed_requests: AllowedRequests,
+	/// Maximum number of peers to ask the same blocks in parallel.
+	max_parallel_downloads: u32,
+	/// Maximum blocks per request.
+	max_blocks_per_request: u32,
+	/// Total number of downloaded blocks.
+	downloaded_blocks: usize,
+	/// State sync in progress, if any.
+	state_sync: Option<StateSync<B, Client>>,
+	/// Enable importing existing blocks. This is used used after the state download to
+	/// catch up to the latest state while re-importing blocks.
+	import_existing: bool,
+	/// Gap download process.
+	gap_sync: Option<GapSync<B>>,
+	/// Pending actions.
+	actions: Vec<ChainSyncAction<B>>,
+	/// Prometheus metrics.
+	metrics: Option<Metrics>,
 }
 
 impl<B, Client> ChainSync<B, Client>


### PR DESCRIPTION
This is a step towards https://github.com/paritytech/polkadot-sdk/issues/5333

The commits with code moving (but no other changes) and actual changes are separated for easier review.

Essentially this results in `SyncingStrategy` trait replacing struct (which is renamed to `PolkadotSyncingStrategy`, open for better name suggestions). Technically it is already possible to replace `PolkadotSyncingStrategy<B, Client>` with `Box<dyn SyncingStrategy<B>` in syncing engine, but I decided to postpone such change until we actually have an ability to customize it. It should also be possible to swap `PolkadotSyncingStrategy` with just `ChainSync` that only supports regular full sync from genesis (it also implements `SyncingStrategy` trait).

While extracted trait still has a lot of non-generic stuff in it like exposed knowledge of warp sync and `StrategyKey` with hardcoded set of options, I believe this is a step in the right direction and will address those in upcoming PRs.

With https://github.com/paritytech/polkadot-sdk/pull/5431 that landed earlier warp sync configuration is more straightforward, but there are still numerous things interleaved that will take some time to abstract away nicely and expose in network config for developers. For now this is an internal change even though data structures are technically public and require major version bump.