### PR TITLE
Update approval-voting-regression-bench

### DIFF
--- a/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
+++ b/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
@@ -77,8 +77,8 @@ fn main() -> Result<(), String> {
 	// We expect no variance for received and sent
 	// but use 0.001 because we operate with floats
 	messages.extend(average_usage.check_network_usage(&[
-		("Received from peers", 52941.6071, 0.001),
-		("Sent to peers", 63810.1859, 0.001),
+		("Received from peers", 52941.6071, 0.01),
+		("Sent to peers", 63810.1859, 0.01),
 	]));
 	messages.extend(average_usage.check_cpu_usage(&[
 		("approval-distribution", 6.3912, 0.1),

--- a/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
+++ b/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
@@ -74,8 +74,9 @@ fn main() -> Result<(), String> {
 	.map_err(|e| e.to_string())?;
 	println!("{}", average_usage);
 
-	// We expect no variance for received and sent
-	// but use 0.01 because we operate with floats
+	// We expect some small variance for received and sent because the
+	// test messages are generated at every benchmark run and they contain
+	// random data so use 0.01 as the accepted variance.
 	messages.extend(average_usage.check_network_usage(&[
 		("Received from peers", 52941.6071, 0.01),
 		("Sent to peers", 63995.2200, 0.01),

--- a/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
+++ b/polkadot/node/core/approval-voting/benches/approval-voting-regression-bench.rs
@@ -75,10 +75,10 @@ fn main() -> Result<(), String> {
 	println!("{}", average_usage);
 
 	// We expect no variance for received and sent
-	// but use 0.001 because we operate with floats
+	// but use 0.01 because we operate with floats
 	messages.extend(average_usage.check_network_usage(&[
 		("Received from peers", 52941.6071, 0.01),
-		("Sent to peers", 63810.1859, 0.01),
+		("Sent to peers", 63995.2200, 0.01),
 	]));
 	messages.extend(average_usage.check_cpu_usage(&[
 		("approval-distribution", 6.3912, 0.1),


### PR DESCRIPTION
The accepted divergence rate of 1/1000 is excessive and leads to false positives especially after https://github.com/paritytech/polkadot-sdk/pull/4772 and https://github.com/paritytech/polkadot-sdk/pull/5042, so let's increase it to 1/100 since we do have some randomness in the system and there is no point in being that strict.

Fixes: https://github.com/paritytech/polkadot-sdk/issues/5463