### PR TITLE
[ci] Migrate checks to GHA

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -97,7 +98,8 @@ jobs:
           cd substrate/primitives/keyring
           ./check-features-variants.sh
           cd -
-
+  # name of this job must be unique across all workflows
+  # otherwise GitHub will mark all these jobs as required
   confirm-required-checks-passed:
     runs-on: ubuntu-latest
     name: All checks passed

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: checks
+name: Checks
 
 on:
   push:
@@ -98,7 +98,7 @@ jobs:
           ./check-features-variants.sh
           cd -
 
-  confirm-required-jobs-passed:
+  confirm-required-checks-passed:
     runs-on: ubuntu-latest
     name: All checks passed
     # If any new job gets added, be sure to add it to this array

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,29 +14,38 @@ concurrency:
 permissions: {}
 
 jobs:
-  changes:
-    # TODO: remove once migration is complete or this workflow is fully stable
-    if: contains(github.event.label.name, 'GHA-migration')
-    permissions:
-      pull-requests: read
-    uses: ./.github/workflows/reusable-check-changed-files.yml
+  # temporary disabled because currently doesn't work in merge queue
+  # changes:
+  #   permissions:
+  #     pull-requests: read
+  #   uses: ./.github/workflows/reusable-check-changed-files.yml
   set-image:
     # GitHub Actions allows using 'env' in a container context.
     # However, env variables don't work for forks: https://github.com/orgs/community/discussions/44322
     # This workaround sets the container image for each job using 'set-image' job output.
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
+      RUNNER: ${{ steps.set_runner.outputs.RUNNER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - id: set_image
         run: cat .github/env >> $GITHUB_OUTPUT
+      # By default we use spot machines that can be terminated at any time.
+      # Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
+      - id: set_runner
+        run: |
+          # Run merge queues on persistent runners
+          if [[ $GITHUB_REF_NAME == *"gh-readonly-queue"* ]]; then
+            echo "RUNNER=arc-runners-polkadot-sdk-beefy-persistent" >> $GITHUB_OUTPUT
+          else
+            echo "RUNNER=arc-runners-polkadot-sdk-beefy" >> $GITHUB_OUTPUT
+          fi
   cargo-clippy:
-    runs-on: arc-runners-polkadot-sdk-beefy
-    needs: [set-image, changes] # , build-frame-omni-bencher ]
-    if: ${{ needs.changes.outputs.rust }}
+    runs-on: ${{ needs.set-image.outputs.RUNNER }}
+    needs: [set-image]
+    # if: ${{ needs.changes.outputs.rust }}
     timeout-minutes: 40
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -50,9 +59,9 @@ jobs:
           forklift cargo clippy --all-targets --locked --workspace
           forklift cargo clippy --all-targets --all-features --locked --workspace
   check-try-runtime:
-    runs-on: arc-runners-polkadot-sdk-beefy
-    needs: [set-image, changes] # , build-frame-omni-bencher ]
-    if: ${{ needs.changes.outputs.rust }}
+    runs-on: ${{ needs.set-image.outputs.RUNNER }}
+    needs: [set-image]
+    # if: ${{ needs.changes.outputs.rust }}
     timeout-minutes: 40
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -69,9 +78,9 @@ jobs:
           forklift cargo check --locked --all --features try-runtime,experimental
   # check-core-crypto-features works fast without forklift
   check-core-crypto-features:
-    runs-on: arc-runners-polkadot-sdk-beefy
-    needs: [set-image, changes] # , build-frame-omni-bencher ]
-    if: ${{ needs.changes.outputs.rust }}
+    runs-on: ${{ needs.set-image.outputs.RUNNER }}
+    needs: [set-image]
+    # if: ${{ needs.changes.outputs.rust }}
     timeout-minutes: 30
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -88,3 +97,11 @@ jobs:
           cd substrate/primitives/keyring
           ./check-features-variants.sh
           cd -
+
+  confirm-required-jobs-passed:
+    runs-on: ubuntu-latest
+    name: All checks passed
+    # If any new job gets added, be sure to add it to this array
+    needs: [cargo-clippy, check-try-runtime, check-core-crypto-features]
+    steps:
+      - run: echo '### Good job! All the tests passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,4 +104,4 @@ jobs:
     # If any new job gets added, be sure to add it to this array
     needs: [cargo-clippy, check-try-runtime, check-core-crypto-features]
     steps:
-      - run: echo '### Good job! All the tests passed 🚀' >> $GITHUB_STEP_SUMMARY
+      - run: echo '### Good job! All the checks passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
             echo "RUNNER=arc-runners-polkadot-sdk-beefy" >> $GITHUB_OUTPUT
           fi
 
+  # This job runs all benchmarks defined in the `/bin/node/runtime` once to check that there are no errors.
   quick-benchmarks:
     needs: [set-image]
     # if: ${{ needs.changes.outputs.rust }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,17 +5,18 @@ on:
     branches:
       - master
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  changes:
-    permissions:
-      pull-requests: read
-    uses: ./.github/workflows/reusable-check-changed-files.yml
+  # disabled because currently doesn't work in merge queue
+  # changes:
+  #   permissions:
+  #     pull-requests: read
+  #   uses: ./.github/workflows/reusable-check-changed-files.yml
 
   set-image:
     # GitHub Actions allows using 'env' in a container context.
@@ -24,16 +25,27 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
+      RUNNER: ${{ steps.set_runner.outputs.RUNNER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - id: set_image
         run: cat .github/env >> $GITHUB_OUTPUT
+      # By default we use spot machines that can be terminated at any time.
+      # Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
+      - id: set_runner
+        run: |
+          # Run merge queues on persistent runners
+          if [[ $GITHUB_REF_NAME == *"gh-readonly-queue"* ]]; then
+            echo "RUNNER=arc-runners-polkadot-sdk-beefy-persistent" >> $GITHUB_OUTPUT
+          else
+            echo "RUNNER=arc-runners-polkadot-sdk-beefy" >> $GITHUB_OUTPUT
+          fi
 
   quick-benchmarks:
-    needs: [ set-image, changes ]
-    if: ${{ needs.changes.outputs.rust }}
-    runs-on: arc-runners-polkadot-sdk-beefy
+    needs: [set-image]
+    # if: ${{ needs.changes.outputs.rust }}
+    runs-on: ${{ needs.set-image.outputs.RUNNER }}
     timeout-minutes: 60
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -46,13 +58,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: script
-        run: time forklift cargo run --locked --release -p staging-node-cli --bin substrate-node --features runtime-benchmarks -- benchmark pallet --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1 --quiet
+        run: forklift cargo run --locked --release -p staging-node-cli --bin substrate-node --features runtime-benchmarks -- benchmark pallet --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1 --quiet
 
   # cf https://github.com/paritytech/polkadot-sdk/issues/1652
   test-syscalls:
-    needs: [ set-image, changes ]
-    if: ${{ needs.changes.outputs.rust }}
-    runs-on: arc-runners-polkadot-sdk-beefy
+    needs: [set-image]
+    # if: ${{ needs.changes.outputs.rust }}
+    runs-on: ${{ needs.set-image.outputs.RUNNER }}
     timeout-minutes: 60
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -63,21 +75,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: script
+        id: test
         run: |
+          exit 1 # test on_failure
           forklift cargo build --locked --profile production --target x86_64-unknown-linux-musl --bin polkadot-execute-worker --bin polkadot-prepare-worker
           cd polkadot/scripts/list-syscalls
           ./list-syscalls.rb ../../../target/x86_64-unknown-linux-musl/production/polkadot-execute-worker --only-used-syscalls | diff -u execute-worker-syscalls -
           ./list-syscalls.rb ../../../target/x86_64-unknown-linux-musl/production/polkadot-prepare-worker --only-used-syscalls | diff -u prepare-worker-syscalls -
-    # todo:
-    # after_script:
-    # - if [[ "$CI_JOB_STATUS" == "failed" ]]; then
-    #   printf "The x86_64 syscalls used by the worker binaries have changed. Please review if this is expected and update polkadot/scripts/list-syscalls/*-worker-syscalls as needed.\n";
-    #   fi
+      - name: on_failure
+        if: steps.test.conclusion == 'failure'
+        run: |
+          echo "The x86_64 syscalls used by the worker binaries have changed. Please review if this is expected and update polkadot/scripts/list-syscalls/*-worker-syscalls as needed." >> $GITHUB_STEP_SUMMARY
 
   cargo-check-all-benches:
-    needs: [ set-image, changes ]
-    if: ${{ needs.changes.outputs.rust }}
-    runs-on: arc-runners-polkadot-sdk-beefy
+    needs: [set-image]
+    # if: ${{ needs.changes.outputs.rust }}
+    runs-on: ${{ needs.set-image.outputs.RUNNER }}
     timeout-minutes: 60
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
@@ -87,4 +100,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: script
-        run: time forklift cargo check --all --benches
+        run: forklift cargo check --all --benches

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
           ./list-syscalls.rb ../../../target/x86_64-unknown-linux-musl/production/polkadot-execute-worker --only-used-syscalls | diff -u execute-worker-syscalls -
           ./list-syscalls.rb ../../../target/x86_64-unknown-linux-musl/production/polkadot-prepare-worker --only-used-syscalls | diff -u prepare-worker-syscalls -
       - name: on_failure
-        if: steps.test.conclusion == 'failure'
+        if: failure() && steps.test.outcome == 'failure'
         run: |
           echo "The x86_64 syscalls used by the worker binaries have changed. Please review if this is expected and update polkadot/scripts/list-syscalls/*-worker-syscalls as needed." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,6 @@ jobs:
       - name: script
         id: test
         run: |
-          exit 1 # test on_failure
           forklift cargo build --locked --profile production --target x86_64-unknown-linux-musl --bin polkadot-execute-worker --bin polkadot-prepare-worker
           cd polkadot/scripts/list-syscalls
           ./list-syscalls.rb ../../../target/x86_64-unknown-linux-musl/production/polkadot-execute-worker --only-used-syscalls | diff -u execute-worker-syscalls -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,11 +340,6 @@ cancel-pipeline-check-tracing:
   needs:
     - job: check-tracing
 
-cancel-pipeline-cargo-clippy:
-  extends: .cancel-pipeline-template
-  needs:
-    - job: cargo-clippy
-
 cancel-pipeline-build-linux-stable:
   extends: .cancel-pipeline-template
   needs:
@@ -369,16 +364,6 @@ cancel-pipeline-test-frame-ui:
   extends: .cancel-pipeline-template
   needs:
     - job: test-frame-ui
-
-cancel-pipeline-quick-benchmarks:
-  extends: .cancel-pipeline-template
-  needs:
-    - job: quick-benchmarks
-
-cancel-pipeline-check-try-runtime:
-  extends: .cancel-pipeline-template
-  needs:
-    - job: check-try-runtime
 
 cancel-pipeline-test-frame-examples-compile-to-wasm:
   extends: .cancel-pipeline-template

--- a/.gitlab/pipeline/check.yml
+++ b/.gitlab/pipeline/check.yml
@@ -1,29 +1,3 @@
-cargo-clippy:
-  stage: check
-  extends:
-    - .docker-env
-    - .common-refs
-    - .pipeline-stopper-artifacts
-  variables:
-    RUSTFLAGS: "-D warnings"
-  script:
-    - SKIP_WASM_BUILD=1 cargo clippy --all-targets --locked --workspace --quiet
-    - SKIP_WASM_BUILD=1 cargo clippy --all-targets --all-features --locked --workspace --quiet
-
-check-try-runtime:
-  stage: check
-  extends:
-    - .docker-env
-    - .common-refs
-  script:
-    - time cargo check --locked --all --features try-runtime
-    # this is taken from cumulus
-    # Check that parachain-template will compile with `try-runtime` feature flag.
-    - time cargo check --locked -p parachain-template-node --features try-runtime
-    # add after https://github.com/paritytech/substrate/pull/14502 is merged
-    # experimental code may rely on try-runtime and vice-versa
-    - time cargo check --locked --all --features try-runtime,experimental
-
 # from substrate
 # not sure if it's needed in monorepo
 check-dependency-rules:
@@ -121,19 +95,3 @@ check-runtime-migration-rococo:
     WASM: "rococo_runtime.compact.compressed.wasm"
     URI: "wss://try-runtime-rococo.polkadot.io:443"
     SUBCOMMAND_EXTRA_ARGS: "--no-weight-warnings"
-
-check-core-crypto-features:
-  stage: check
-  extends:
-    - .docker-env
-    - .common-refs
-  script:
-    - pushd substrate/primitives/core
-    - ./check-features-variants.sh
-    - popd
-    - pushd substrate/primitives/application-crypto
-    - ./check-features-variants.sh
-    - popd
-    - pushd substrate/primitives/keyring
-    - ./check-features-variants.sh
-    - popd

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -403,23 +403,6 @@ test-frame-ui:
     - time cargo test --locked -q --profile testnet --manifest-path substrate/primitives/runtime-interface/Cargo.toml
     - cat /cargo_target_dir/debug/.fingerprint/memory_units-759eddf317490d2b/lib-memory_units.json || true
 
-# This job runs all benchmarks defined in the `/bin/node/runtime` once to check that there are no errors.
-quick-benchmarks:
-  stage: test
-  extends:
-    - .docker-env
-    - .common-refs
-    - .run-immediately
-  variables:
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: "-C debug-assertions -D warnings"
-    RUST_BACKTRACE: "full"
-    WASM_BUILD_NO_COLOR: 1
-    WASM_BUILD_RUSTFLAGS: "-C debug-assertions -D warnings"
-  script:
-    - time cargo run --locked --release -p staging-node-cli --bin substrate-node --features runtime-benchmarks --quiet -- benchmark pallet --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1 --quiet
-
 quick-benchmarks-omni:
   stage: test
   extends:


### PR DESCRIPTION
PR migrates jobs `quick-benchmarks`, `cargo-clippy`, `check-try-runtime` and `check-core-crypto-features` from Gitlab to GitHub

cc https://github.com/paritytech/ci_cd/issues/1006