### PR TITLE
Add more logs for AcceptanceCheckErr

### DIFF
--- a/prdoc/pr_5513.prdoc
+++ b/prdoc/pr_5513.prdoc
@@ -1,0 +1,10 @@
+title: Add more logs to trace AcceptanceCheckErr
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      `Debug` was derived on `AcceptanceCheckErr` to print the error. This PR adds more logs to trace the error.
+
+crates:
+  - name: polkadot-runtime-parachains
+    bump: patch


### PR DESCRIPTION
# Description

The error message should be logged out when the check method returns an error.

Because specific information is lost when `UmpAcceptanceCheckErr`, `ProcessedDownwardMessagesAcceptanceErr`, `HrmpWatermarkAcceptanceErr`, `OutboundHrmpAcceptanceErr` are converted to `AcceptanceCheckErr`, a log is added to each check.

## Integration

## Review Notes

# Checklist

* [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)