### PR TITLE
Added `mac-setup` script

### DIFF
--- a/.github/actions/set-up-mac/README.md
+++ b/.github/actions/set-up-mac/README.md
@@ -1,0 +1,15 @@
+# How to use
+
+```yml
+  set-image:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - id: set_image
+        run: cat .github/env >> $GITHUB_OUTPUT
+      - name: Install dependencies
+        uses: ./.github/actions/set-up-mac
+        with:
+          IMAGE: ${{ steps.set-image.outputs.IMAGE }}
+```

--- a/.github/actions/set-up-mac/action.yml
+++ b/.github/actions/set-up-mac/action.yml
@@ -1,0 +1,39 @@
+name: "Set up rust on mac"
+description: "Install the required tools for Mac runners"
+inputs:
+  IMAGE:
+    description: "Rust docker image"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install with Hombrew
+      shell: bash
+      run: brew install protobuf rustup openssl pkg-config zlib xz zstd llvm jq curl gcc make cmake
+    - name: Set version
+      shell: bash
+      run: |
+        VERSION=$(echo $IMAGE | sed -E 's/.*:bullseye-([^-]+)-.*/\1/')
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+      env:
+        IMAGE: ${{ inputs.IMAGE }}
+
+    - name: Install rustup
+      shell: bash
+      run: |
+        rustup-init -y
+        rustup install $VERSION
+        rustup default $VERSION
+
+    - name: MacOS Deps
+      shell: bash
+      run: |
+        rustup target add wasm32-unknown-unknown --toolchain $VERSION
+        rustup component add rust-src rustfmt clippy --toolchain $VERSION
+
+    - name: Check Rust
+      shell: bash
+      run: |
+        rustup show
+        rustup +nightly show

--- a/.github/actions/set-up-mac/action.yml
+++ b/.github/actions/set-up-mac/action.yml
@@ -16,6 +16,9 @@ runs:
         VERSION=$(echo $IMAGE | sed -E 's/.*:bullseye-([^-]+)-.*/\1/')
         echo $VERSION
         echo "VERSION=$VERSION" >> $GITHUB_ENV
+        NIGHTLY=$(echo $IMAGE | sed -E 's/.*([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')
+        echo $NIGHTLY
+        echo "NIGHTLY=$NIGHTLY" >> $GITHUB_ENV
       env:
         IMAGE: ${{ inputs.IMAGE }}
 
@@ -25,6 +28,7 @@ runs:
         rustup-init -y
         rustup install $VERSION
         rustup default $VERSION
+        rustup toolchain install "nightly-${NIGHTLY}"
 
     - name: MacOS Deps
       shell: bash


### PR DESCRIPTION
This is used for the steps that use the `macos` runner.

It installs the Rust version that we are using in the [`forklift` image](https://github.com/paritytech/polkadot-sdk/blob/master/.github/env).

To be used in #5386.