### PR TITLE
Update CODEOWNERS and review-bot for new contracts pallet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,8 +64,8 @@
 /substrate/primitives/merkle-mountain-range/ @acatangiu
 
 # Contracts
-/substrate/frame/contracts/ @athei @pgherveou @paritytech/docs-audit
-/substrate/frame/revive/ @athei @pgherveou @paritytech/docs-audit
+/substrate/frame/contracts/ @paritytech/smart-contracts @paritytech/docs-audit
+/substrate/frame/revive/ @paritytech/smart-contracts @paritytech/docs-audit
 
 # NPoS and election
 /substrate/frame/election-provider-multi-phase/ @paritytech/staking-core @paritytech/docs-audit

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -29,7 +29,7 @@ rules:
       # excluding files from 'Runtime files' and 'CI files' rules
       exclude:
         - ^cumulus/parachains/common/src/[^/]+\.rs$
-        - ^substrate/frame/(?!.*(nfts/.*|uniques/.*|babe/.*|grandpa/.*|beefy|merkle-mountain-range/.*|contracts/.*|election|nomination-pools/.*|staking/.*|aura/.*))
+        - ^substrate/frame/(?!.*(nfts/.*|uniques/.*|babe/.*|grandpa/.*|beefy|merkle-mountain-range/.*|contracts/.*|revive/.*|election|nomination-pools/.*|staking/.*|aura/.*))
         - ^\.gitlab-ci\.yml
         - ^docker/.*
         - ^\.github/.*
@@ -56,7 +56,7 @@ rules:
   - name: FRAME coders substrate
     condition:
       include:
-        - ^substrate/frame/(?!.*(nfts/.*|uniques/.*|babe/.*|grandpa/.*|beefy|merkle-mountain-range/.*|contracts/.*|election|nomination-pools/.*|staking/.*|aura/.*))
+        - ^substrate/frame/(?!.*(nfts/.*|uniques/.*|babe/.*|grandpa/.*|beefy|merkle-mountain-range/.*|contracts/.*|revive/.*|election|nomination-pools/.*|staking/.*|aura/.*))
     type: "and"
     reviewers:
       - minApprovals: 2
@@ -65,6 +65,17 @@ rules:
       - minApprovals: 1
         teams:
           - frame-coders
+
+  # Smart Contracts
+  - name: Smart Contracts
+    type: basic
+    condition:
+      include:
+        - ^substrate/frame/contracts/.*
+        - ^substrate/frame/revive/.*
+    minApprovals: 2
+    teams:
+      - smart-contracts
 
   # Protection of THIS file
   - name: Review Bot


### PR DESCRIPTION
Created a new @paritytech/smart-contracts team that is now referenced in the review bot config and CODEOWNERS file. Also excluded the new pallet in the other review bot rules.