### PR TITLE
fix link check

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -18,7 +18,10 @@ accept = [
 	"429",
 ]
 
-exclude_path = ["./target", "./prdoc"]
+exclude_path = [
+	"./prdoc",
+	"./target",
+]
 
 exclude = [
 	# Place holders (no need to fix these):

--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -18,7 +18,7 @@ accept = [
 	"429",
 ]
 
-exclude_path = ["./target"]
+exclude_path = ["./target", "./prdoc"]
 
 exclude = [
 	# Place holders (no need to fix these):
@@ -53,5 +53,4 @@ exclude = [
 	"https://etherscan.io/block/11090290",
 	"https://subscan.io/",
 	"https://substrate.stackexchange.com/.*",
-	"https://github.com/paritytech/devops/.*",
 ]

--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -53,4 +53,5 @@ exclude = [
 	"https://etherscan.io/block/11090290",
 	"https://subscan.io/",
 	"https://substrate.stackexchange.com/.*",
+	"https://github.com/paritytech/devops/.*",
 ]


### PR DESCRIPTION
PR Doc #5443 broke the link checker because it includes a link to this private repo:

https://github.com/paritytech/devops/issues/3502

This PR adds the `prdoc` folder to the excluded paths of the link checker to ensure that historical PR Docs do not break the pipeline.

I think this makes sense over whitelisting the github link because we probably expect that in a long enough time period, links from old PR docs will start to break, but I don't think we intend to update those  old PR docs, or start whitelisting lots of urls.