### PR TITLE
Fix occasional `alloc` not found error in `format_runtime_string!`

### DIFF
--- a/prdoc/pr_5632.prdoc
+++ b/prdoc/pr_5632.prdoc
@@ -1,7 +1,7 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: [sp-runtime] fix macro hygiene for format_runtime_string!
+title: Fix `alloc` not found error in `format_runtime_string!`
 
 doc:
   - audience: Runtime Dev

--- a/prdoc/pr_5632.prdoc
+++ b/prdoc/pr_5632.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: [sp-runtime] fix macro hygiene for format_runtime_string!
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Fixes the macro hygiene in the `format_runtime_string!` macro to fix the `alloc` not found build error.
+
+crates:
+  - name: sp-runtime
+    bump: patch

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -49,7 +49,7 @@
 extern crate alloc;
 
 #[doc(hidden)]
-pub use alloc::{vec::Vec, format};
+pub use alloc::{format, vec::Vec};
 #[doc(hidden)]
 pub use codec;
 #[doc(hidden)]

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -72,6 +72,10 @@ pub use sp_core::storage::StateVersion;
 #[cfg(feature = "std")]
 pub use sp_core::storage::{Storage, StorageChild};
 
+// format is used in a runtime_string.rs macro.
+// Hence, we re-export it for proper macro hygene.
+pub use alloc::format;
+
 use sp_core::{
 	crypto::{self, ByteArray, FromEntropy},
 	ecdsa, ed25519,
@@ -79,8 +83,6 @@ use sp_core::{
 	sr25519,
 };
 
-#[cfg(all(not(feature = "std"), feature = "serde"))]
-use alloc::format;
 use alloc::vec;
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -72,8 +72,9 @@ pub use sp_core::storage::StateVersion;
 #[cfg(feature = "std")]
 pub use sp_core::storage::{Storage, StorageChild};
 
-// format is used in a runtime_string.rs macro.
-// Hence, we re-export it for proper macro hygene.
+// `format!` is used in a runtime_string.rs macro.
+// Hence, we re-export it at the crate root for
+// proper macro hygene.
 pub use alloc::format;
 
 use sp_core::{

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -49,7 +49,7 @@
 extern crate alloc;
 
 #[doc(hidden)]
-pub use alloc::vec::Vec;
+pub use alloc::{vec::Vec, format};
 #[doc(hidden)]
 pub use codec;
 #[doc(hidden)]
@@ -71,11 +71,6 @@ pub use sp_application_crypto as app_crypto;
 pub use sp_core::storage::StateVersion;
 #[cfg(feature = "std")]
 pub use sp_core::storage::{Storage, StorageChild};
-
-// `format!` is used in a runtime_string.rs macro.
-// Hence, we re-export it at the crate root for
-// proper macro hygene.
-pub use alloc::format;
 
 use sp_core::{
 	crypto::{self, ByteArray, FromEntropy},

--- a/substrate/primitives/runtime/src/runtime_string.rs
+++ b/substrate/primitives/runtime/src/runtime_string.rs
@@ -50,7 +50,7 @@ macro_rules! format_runtime_string {
 		}
 		#[cfg(not(feature = "std"))]
 		{
-			sp_runtime::RuntimeString::Owned(alloc::format!($($args)*).as_bytes().to_vec())
+			sp_runtime::RuntimeString::Owned($crate::format!($($args)*).as_bytes().to_vec())
 		}
 	}};
 }


### PR DESCRIPTION
The macro hygiene for the `format_runtime_string!` macro was broken since https://github.com/paritytech/polkadot-sdk/pull/5010, which resulted in the following build error under certain circumstances:

```console
  error[E0433]: failed to resolve: use of undeclared crate or module `alloc`
      --> /home/clang/.cargo/registry/src/index.crates.io-6f17d22bba15001f/frame-benchmarking-36.0.0/src/v1.rs:1738:2
       |
  1738 | /     sp_runtime::format_runtime_string!(
  1739 | |         "\n* Pallet: {}\n\
  1740 | |         * Benchmark: {}\n\
  1741 | |         * Components: {:?}\n\
  ...    |
  1750 | |         error_message,
  1751 | |     )
       | |_____^ use of undeclared crate or module `alloc`
       |
       = note: this error originates in the macro `sp_runtime::format_runtime_string` (in Nightly builds, run with -Z macro-backtrace for more info)

  For more information about this error, try `rustc --explain E0433`.
```

This bug has been known already, but hasn't been fixed so far, see https://github.com/paritytech/polkadot-sdk/issues/5213 and https://substrate.stackexchange.com/questions/11786/use-of-undeclared-crate-or-module-alloc-when-upgrade-to-v1-13-0.

I have made a mini rust crate that can reproduce the bug, and it also shows that this PR will fix the issue: https://github.com/clangenb/sp-runtime-string-test.