### PR TITLE
[Bot] Use correct token in backport bot

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -33,9 +33,11 @@ jobs:
         with:
           target_branches: stable2407 stable2409
           merge_commits: skip
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }} # FAIL-CI this token wont trigger CI
           pull_description: |
             Backport #${pull_number} into `${target_branch}` (cc @${pull_author}).
+
+            See the [BACKPORT.md](https://github.com/paritytech/polkadot-sdk/blob/master/docs/BACKPORT.md) for an explanation on how to trigger this bot.
 
             <!--
               # To be used by other automation, do not modify:

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -27,13 +27,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.CMD_BOT_APP_ID }}
+          private_key: ${{ secrets.CMD_BOT_APP_KEY }}
+
       - name: Create backport pull requests
         uses: korthout/backport-action@v3
         id: backport
         with:
           target_branches: stable2407 stable2409
           merge_commits: skip
-          github_token: ${{ secrets.GITHUB_TOKEN }} # FAIL-CI this token wont trigger CI
+          github_token: ${{ steps.generate_token.outputs.token }}
           pull_description: |
             Backport #${pull_number} into `${target_branch}` from ${pull_author}.
 

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -35,9 +35,9 @@ jobs:
           merge_commits: skip
           github_token: ${{ secrets.GITHUB_TOKEN }} # FAIL-CI this token wont trigger CI
           pull_description: |
-            Backport #${pull_number} into `${target_branch}` (cc @${pull_author}).
+            Backport #${pull_number} into `${target_branch}` from ${pull_author}.
 
-            See the [BACKPORT.md](https://github.com/paritytech/polkadot-sdk/blob/master/docs/BACKPORT.md) for an explanation on how to trigger this bot.
+            See the [documentation](https://github.com/paritytech/polkadot-sdk/blob/master/docs/BACKPORT.md) on how to use this bot.
 
             <!--
               # To be used by other automation, do not modify:
@@ -49,6 +49,7 @@ jobs:
             {
               "conflict_resolution": "draft_commit_conflicts"
             }
+          copy_assignees: true
 
       - name: Label Backports
         if: ${{ steps.backport.outputs.created_pull_numbers != '' }}
@@ -65,4 +66,22 @@ jobs:
                 labels: ['A3-backport']
               });
               console.log(`Added A3-backport label to PR #${pullNumber}`);
+            }
+
+      - name: Request Review
+        if: ${{ steps.backport.outputs.created_pull_numbers != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullNumbers = '${{ steps.backport.outputs.created_pull_numbers }}'.split(' ');
+            const reviewer = '${{ github.event.pull_request.user.login }}';
+            
+            for (const pullNumber of pullNumbers) {
+              await github.pulls.createReviewRequest({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parseInt(pullNumber),
+                reviewers: [ reviewer ]
+              });
+              console.log(`Requested review from ${reviewer} for PR #${pullNumber}`);
             }


### PR DESCRIPTION
The backport bot does currently not trigger the CI when opening a MR, like here: https://github.com/paritytech/polkadot-sdk/pull/5651  
Devs need to push an empty commit manually. Now using a token that will also trigger the CI.
