### PR TITLE
[Bot] Fix backport bot

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
+  issues: write
 
 jobs:
   backport:


### PR DESCRIPTION
Apparently changing the GH Token made it lose permission... error from here: https://github.com/paritytech/polkadot-sdk/actions/runs/10815755374/job/30005387859

From this list it looks like comment creation should be allowed by adding issues to the list: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token