### PR TITLE
Asset Hub: auto incremented asset id for trust backed assets

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -266,7 +266,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Freezer = AssetsFreezer;
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_local::WeightInfo<Runtime>;
-	type CallbackHandle = ();
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
 	#[cfg(feature = "runtime-benchmarks")]
@@ -1019,6 +1019,12 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	frame_support::migrations::RemovePallet<StateTrieMigrationName, RocksDbWeight>,
+	// unreleased
+	pallet_assets::migration::next_asset_id::SetNextAssetId<
+		ConstU32<50_000_000>,
+		Runtime,
+		TrustBackedAssetsInstance,
+	>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -263,7 +263,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type Freezer = AssetsFreezer;
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_local::WeightInfo<Runtime>;
-	type CallbackHandle = ();
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type RemoveItemsLimit = ConstU32<1000>;
 	#[cfg(feature = "runtime-benchmarks")]
@@ -1021,6 +1021,12 @@ pub type Migrations = (
 	// unreleased
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
+	// unreleased
+	pallet_assets::migration::next_asset_id::SetNextAssetId<
+		ConstU32<50_000_000>,
+		Runtime,
+		TrustBackedAssetsInstance,
+	>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );

--- a/prdoc/pr_5687.prdoc
+++ b/prdoc/pr_5687.prdoc
@@ -1,0 +1,24 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "Westend/Rococo Asset Hub: auto incremented asset id for trust backed assets"
+
+doc:
+  - audience: Runtime User
+    description: |
+      Setup auto incremented asset id to `50_000_000` for trust backed assets.
+
+      ### Migration
+      This change does not break the API but introduces a new constraint. It implements 
+      an auto-incremented ID strategy for Trust-Backed Assets (50 pallet instance indexes on both 
+      networks), starting at ID 50,000,000. Each new asset must be created with an ID that is one 
+      greater than the last asset created. The next ID can be fetched from the `NextAssetId` 
+      storage item of the assets pallet. An empty `NextAssetId` storage item indicates no 
+      constraint on the next asset ID and can serve as a feature flag for this release.
+
+
+crates:
+  - name: asset-hub-rococo-runtime
+    bump: major
+  - name: asset-hub-westend-runtime
+    bump: major


### PR DESCRIPTION
Setup auto incremented asset id to `50_000_000` for trust backed assets.

In order to align with Polkadot/Kusama Asset Hub - https://github.com/polkadot-fellows/runtimes/pull/414
The next closes existing assets IDs in Rococo is `69_696_969`, in Westend is `88_228_866`.

### Migration
**Stakeholders**: all clients providing asset creation functionality on Westend/Rococo Asset Hub

This change does not break the API but introduces a new constraint. It implements an auto-incremented ID strategy for Trust-Backed Assets (50 pallet instance indexes on both networks), starting at ID 50,000,000. Each new asset must be created with an ID that is one greater than the last asset created. The next ID can be fetched from the `NextAssetId` storage item of the assets pallet. An empty `NextAssetId` storage item indicates no constraint on the next asset ID and can serve as a feature flag for this release.