### PR TITLE
Find author in old validator set on authorities change

### DIFF
--- a/substrate/frame/aura/src/lib.rs
+++ b/substrate/frame/aura/src/lib.rs
@@ -359,6 +359,21 @@ impl<T: Config> FindAuthor<u32> for Pallet<T> {
 
 		None
 	}
+
+	fn has_authorities_change<'a, I>(digests: I) -> bool
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])> + Clone,
+	{
+		for (id, mut data) in digests {
+			if id == AURA_ENGINE_ID {
+				if let Ok(ConsensusLog::AuthoritiesChange(_)) = ConsensusLog::decode(&mut data) {
+					return true;
+				}
+			}
+		}
+
+		false
+	}
 }
 
 /// We can not implement `FindAuthor` twice, because the compiler does not know if

--- a/substrate/frame/babe/src/lib.rs
+++ b/substrate/frame/babe/src/lib.rs
@@ -498,6 +498,21 @@ impl<T: Config> FindAuthor<u32> for Pallet<T> {
 
 		None
 	}
+
+	fn has_authorities_change<'a, I>(digests: I) -> bool
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])> + Clone,
+	{
+		for (id, mut data) in digests {
+			if id == BABE_ENGINE_ID {
+				if let Ok(ConsensusLog::NextEpochData(_)) = ConsensusLog::decode(&mut data) {
+					return true;
+				}
+			}
+		}
+
+		false
+	}
 }
 
 impl<T: Config> IsMember<AuthorityId> for Pallet<T> {

--- a/substrate/frame/support/src/traits/validation.rs
+++ b/substrate/frame/support/src/traits/validation.rs
@@ -56,13 +56,20 @@ pub trait FindAuthor<Author> {
 	/// Find the author of a block based on the pre-runtime digests.
 	fn find_author<'a, I>(digests: I) -> Option<Author>
 	where
-		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>;
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])> + Clone;
+
+	fn has_authorities_change<'a, I>(_digests: I) -> bool
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])> + Clone,
+	{
+		false
+	}
 }
 
 impl<A> FindAuthor<A> for () {
 	fn find_author<'a, I>(_: I) -> Option<A>
 	where
-		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])> + Clone,
 	{
 		None
 	}


### PR DESCRIPTION
Fixes #4923

Summary

* buffer validator set from the previous session
* check if authorities change presents in block digests (usually in the first block of a session?)
* find author in the previous set if authorities change presents

TODO

* [ ] use the old set if already available (but I couldn't find it)
* [ ] tests
* [ ] docs

@bkchr could you take a look?