### PR TITLE
ADD CORRECTED PATH FOR `extrinsics.mmd`

### DIFF
--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -58,7 +58,7 @@ type UncheckedSignaturePayload<Address, Signature, Extra> = (Address, Signature,
 /// could in principle be any other interaction. Transactions are either signed or unsigned. A
 /// sensible transaction pool should ensure that only transactions that are worthwhile are
 /// considered for block-building.
-#[cfg_attr(all(feature = "std", not(windows)), doc = simple_mermaid::mermaid!("../../docs/mermaid/extrinsics.mmd"))]
+#[cfg_attr(all(feature = "std", not(windows)), doc = simple_mermaid::mermaid!("../../../../../docs/mermaid/extrinsics.mmd"))]
 /// This type is by no means enforced within Substrate, but given its genericness, it is highly
 /// likely that for most use-cases it will suffice. Thus, the encoding of this type will dictate
 /// exactly what bytes should be sent to a runtime to transact with it.


### PR DESCRIPTION
This PR corrects the documentation path for the `extrinsics.mmd` file referenced in `unchecked_extrinsics.rs`.

The original code was referencing the file path incorrectly. The correct path is now provided as follows:

```rust
#[cfg_attr(all(feature = "std", not(windows)), doc = simple_mermaid::mermaid!("../../../../../docs/mermaid/extrinsics.mmd"))]
```

The file structure for the relevant files is as follows:

```plaintext
substrate-sdk/
├── docs/
│   └── mermaid/
│       └── extrinsics.mmd
└── substrate/
    └── primitives/
        └── runtime/
            └── src/
                └── generic/
                    └── unchecked_extrinsics.rs
```

- **Correct File Location:** `../../../../../docs/mermaid/extrinsics.mmd`
- **Reference Location in Code:** `substrate-sdk/substrate/primitives/runtime/src/generic/unchecked_extrinsics.rs`

This ensures that the documentation will correctly render the Mermaid diagram from the specified location in the code.
