### PR TITLE
[stable2409]: Backport #5688

### DIFF
--- a/polkadot/runtime/parachains/src/paras_inherent/benchmarking.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/benchmarking.rs
@@ -17,7 +17,7 @@
 use super::*;
 use crate::{inclusion, ParaId};
 use alloc::collections::btree_map::BTreeMap;
-use core::cmp::min;
+use core::cmp::{max, min};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
 
@@ -107,7 +107,7 @@ benchmarks! {
 	// of a single backed candidate.
 	enter_backed_candidates_variable {
 		let v in (BenchBuilder::<T>::fallback_min_backing_votes())
-			..(BenchBuilder::<T>::fallback_max_validators_per_core());
+			.. max(BenchBuilder::<T>::fallback_min_backing_votes() + 1, BenchBuilder::<T>::fallback_max_validators_per_core());
 
 		let cores_with_backed: BTreeMap<_, _>
 			= vec![(0, v)] // The backed candidate will have `v` validity votes.

--- a/prdoc/pr_5688.prdoc
+++ b/prdoc/pr_5688.prdoc
@@ -1,0 +1,10 @@
+title: "Fix `paras_inherent` benchmark"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Fixes the benchmark for relay chains like rococo-dev with `max_validators_per_core` value lower than 2.
+
+crates:
+- name: polkadot-runtime-parachains
+  bump: patch


### PR DESCRIPTION
As requested here: https://github.com/paritytech/polkadot-sdk/pull/5688#issuecomment-2352939516

I don't think it need to be backported to 2407, as the issue was not present there yet.