### PR TITLE
bitfield_distribution: Move on blocking pool and use custom capacity

### DIFF
--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -521,7 +521,7 @@ pub struct Overseer<SupportsParachains> {
 	])]
 	bitfield_signing: BitfieldSigning,
 
-	#[subsystem(BitfieldDistributionMessage, sends: [
+	#[subsystem(blocking, message_capacity: 8192, BitfieldDistributionMessage, sends: [
 		RuntimeApiMessage,
 		NetworkBridgeTxMessage,
 		ProvisionerMessage,

--- a/prdoc/pr_5787.prdoc
+++ b/prdoc/pr_5787.prdoc
@@ -1,0 +1,13 @@
+title: "Move bitfield_distribution to blocking task pool and set capacity to 8192"
+
+doc:
+  - audience: Node Dev
+    description: |
+      This is moving bitfield_distribution to the blocking task pool because it does cpu
+      intensive work and to make it snappier. Additionally, also increase the message
+      capacity of the subsystem to make sure the queue does not get full if there is a
+      burst of messages.
+
+crates:
+  - name: polkadot-overseer
+    bump: patch


### PR DESCRIPTION
## Description

Details and rationale explained here: https://github.com/paritytech/polkadot-sdk/issues/5657#issuecomment-2363076080

Fixes: https://github.com/paritytech/polkadot-sdk/issues/5657