### PR TITLE
(PoC) XcmpQueue congestion support and dynamic fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,7 @@ version = "0.2.0"
 dependencies = [
  "bp-messages",
  "bp-runtime",
+ "bp-xcm-bridge-support",
  "frame-support",
  "parity-scale-codec",
  "scale-info",
@@ -2161,10 +2162,17 @@ dependencies = [
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
 dependencies = [
+ "bp-xcm-bridge-support",
  "parity-scale-codec",
  "scale-info",
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "bp-xcm-bridge-support"
+version = "0.6.0"
+dependencies = [
  "staging-xcm",
 ]
 
@@ -4437,7 +4445,7 @@ name = "cumulus-pallet-xcmp-queue"
 version = "0.7.0"
 dependencies = [
  "bounded-collections",
- "bp-xcm-bridge-hub-router",
+ "bp-xcm-bridge-hub",
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
 	"bridges/primitives/test-utils",
 	"bridges/primitives/xcm-bridge-hub",
 	"bridges/primitives/xcm-bridge-hub-router",
+	"bridges/primitives/xcm-bridge-support",
 	"bridges/relays/client-substrate",
 	"bridges/relays/equivocation",
 	"bridges/relays/finality",
@@ -649,6 +650,7 @@ bp-test-utils = { path = "bridges/primitives/test-utils", default-features = fal
 bp-westend = { path = "bridges/chains/chain-westend", default-features = false }
 bp-xcm-bridge-hub = { path = "bridges/primitives/xcm-bridge-hub", default-features = false }
 bp-xcm-bridge-hub-router = { path = "bridges/primitives/xcm-bridge-hub-router", default-features = false }
+bp-xcm-bridge-support = { path = "bridges/primitives/xcm-bridge-support", default-features = false }
 bridge-hub-common = { path = "cumulus/parachains/runtimes/bridge-hubs/common", default-features = false }
 bridge-hub-rococo-emulated-chain = { path = "cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo" }
 bridge-hub-rococo-runtime = { path = "cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo", default-features = false }

--- a/bridges/modules/xcm-bridge-hub/src/dispatcher.rs
+++ b/bridges/modules/xcm-bridge-hub/src/dispatcher.rs
@@ -25,7 +25,7 @@ use crate::{Config, Pallet, LOG_TARGET};
 
 use bp_messages::target_chain::{DispatchMessage, MessageDispatch};
 use bp_runtime::messages::MessageDispatchResult;
-use bp_xcm_bridge_hub::{LocalXcmChannelManager, XcmAsPlainPayload};
+use bp_xcm_bridge_hub::{XcmAsPlainPayload, XcmChannelStatusProvider};
 use codec::{Decode, Encode};
 use frame_support::{weights::Weight, CloneNoBound, EqNoBound, PartialEqNoBound};
 use pallet_bridge_messages::{Config as BridgeMessagesConfig, WeightInfoExt};

--- a/bridges/modules/xcm-bridge-hub/src/mock.rs
+++ b/bridges/modules/xcm-bridge-hub/src/mock.rs
@@ -415,10 +415,6 @@ impl TestLocalXcmChannelManager {
 impl LocalXcmChannelManager for TestLocalXcmChannelManager {
 	type Error = ();
 
-	fn is_congested(_with: &Location) -> bool {
-		frame_support::storage::unhashed::get_or_default(b"TestLocalXcmChannelManager.Congested")
-	}
-
 	fn suspend_bridge(_local_origin: &Location, _bridge: BridgeId) -> Result<(), Self::Error> {
 		frame_support::storage::unhashed::put(b"TestLocalXcmChannelManager.Suspended", &true);
 		Ok(())
@@ -430,9 +426,9 @@ impl LocalXcmChannelManager for TestLocalXcmChannelManager {
 	}
 }
 
-impl pallet_xcm_bridge_hub_router::XcmChannelStatusProvider for TestLocalXcmChannelManager {
-	fn is_congested(with: &Location) -> bool {
-		<Self as LocalXcmChannelManager>::is_congested(with)
+impl bp_xcm_bridge_hub::XcmChannelStatusProvider for TestLocalXcmChannelManager {
+	fn is_congested(_with: &Location) -> bool {
+		frame_support::storage::unhashed::get_or_default(b"TestLocalXcmChannelManager.Congested")
 	}
 }
 

--- a/bridges/primitives/xcm-bridge-hub-router/Cargo.toml
+++ b/bridges/primitives/xcm-bridge-hub-router/Cargo.toml
@@ -14,12 +14,12 @@ workspace = true
 codec = { features = ["bit-vec", "derive"], workspace = true }
 scale-info = { features = ["bit-vec", "derive"], workspace = true }
 
+# Bridge Dependencies
+bp-xcm-bridge-support = { workspace = true }
+
 # Substrate Dependencies
 sp-runtime = { workspace = true }
 sp-core = { workspace = true }
-
-# Polkadot Dependencies
-xcm = { workspace = true }
 
 [features]
 default = ["std"]
@@ -28,5 +28,4 @@ std = [
 	"scale-info/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"xcm/std",
 ]

--- a/bridges/primitives/xcm-bridge-hub-router/src/lib.rs
+++ b/bridges/primitives/xcm-bridge-hub-router/src/lib.rs
@@ -18,29 +18,14 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub use bp_xcm_bridge_support::XcmChannelStatusProvider;
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::{FixedU128, RuntimeDebug};
-use xcm::latest::prelude::Location;
 
 /// Minimal delivery fee factor.
 pub const MINIMAL_DELIVERY_FEE_FACTOR: FixedU128 = FixedU128::from_u32(1);
-
-/// XCM channel status provider that may report whether it is congested or not.
-///
-/// By channel we mean the physical channel that is used to deliver messages of one
-/// of the bridge queues.
-pub trait XcmChannelStatusProvider {
-	/// Returns true if the channel is currently congested.
-	fn is_congested(with: &Location) -> bool;
-}
-
-impl XcmChannelStatusProvider for () {
-	fn is_congested(_with: &Location) -> bool {
-		false
-	}
-}
 
 /// Current status of the bridge.
 #[derive(Clone, Decode, Encode, Eq, PartialEq, TypeInfo, MaxEncodedLen, RuntimeDebug)]

--- a/bridges/primitives/xcm-bridge-hub/Cargo.toml
+++ b/bridges/primitives/xcm-bridge-hub/Cargo.toml
@@ -18,6 +18,7 @@ serde = { features = ["alloc", "derive"], workspace = true }
 # Bridge Dependencies
 bp-messages = { workspace = true }
 bp-runtime = { workspace = true }
+bp-xcm-bridge-support = { workspace = true }
 
 # Substrate Dependencies
 sp-std = { workspace = true }

--- a/bridges/primitives/xcm-bridge-hub/src/lib.rs
+++ b/bridges/primitives/xcm-bridge-hub/src/lib.rs
@@ -21,6 +21,7 @@
 
 use bp_messages::LaneIdType;
 use bp_runtime::{AccountIdOf, BalanceOf, Chain};
+pub use bp_xcm_bridge_support::XcmChannelStatusProvider;
 pub use call_info::XcmBridgeHubCall;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
@@ -96,15 +97,9 @@ impl core::fmt::Debug for BridgeId {
 }
 
 /// Local XCM channel manager.
-pub trait LocalXcmChannelManager {
+pub trait LocalXcmChannelManager: bp_xcm_bridge_support::XcmChannelStatusProvider {
 	/// Error that may be returned when suspending/resuming the bridge.
 	type Error: sp_std::fmt::Debug;
-
-	/// Returns true if the channel with given location is currently congested.
-	///
-	/// The `with` is guaranteed to be in the same consensus. However, it may point to something
-	/// below the chain level - like the contract or pallet instance, for example.
-	fn is_congested(with: &Location) -> bool;
 
 	/// Suspend the bridge, opened by given origin.
 	///
@@ -121,10 +116,6 @@ pub trait LocalXcmChannelManager {
 
 impl LocalXcmChannelManager for () {
 	type Error = ();
-
-	fn is_congested(_with: &Location) -> bool {
-		false
-	}
 
 	fn suspend_bridge(_local_origin: &Location, _bridge: BridgeId) -> Result<(), Self::Error> {
 		Ok(())

--- a/bridges/primitives/xcm-bridge-support/Cargo.toml
+++ b/bridges/primitives/xcm-bridge-support/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bp-xcm-bridge-support"
+description = "Primitives for the xcm-like bridge."
+version = "0.6.0"
+authors.workspace = true
+edition.workspace = true
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Polkadot Dependencies
+xcm = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"xcm/std",
+]

--- a/bridges/primitives/xcm-bridge-support/src/lib.rs
+++ b/bridges/primitives/xcm-bridge-support/src/lib.rs
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Primitives for the xcm-like bridge.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use xcm::latest::prelude::Location;
+
+/// XCM channel status provider that may report whether it is congested or not.
+///
+/// By channel, we mean the physical channel that is used to deliver messages to/of one
+/// of the bridge queues.
+pub trait XcmChannelStatusProvider {
+	/// Returns true if the channel with given location is currently congested.
+	///
+	/// The `with` is guaranteed to be in the same consensus. However, it may point to something
+	/// below the chain level - like the contract or pallet instance, for example.
+	fn is_congested(with: &Location) -> bool;
+}
+
+impl XcmChannelStatusProvider for () {
+	fn is_congested(_with: &Location) -> bool {
+		false
+	}
+}

--- a/cumulus/pallets/xcmp-queue/Cargo.toml
+++ b/cumulus/pallets/xcmp-queue/Cargo.toml
@@ -37,7 +37,7 @@ frame-benchmarking = { optional = true, workspace = true }
 bounded-collections = { workspace = true }
 
 # Bridges
-bp-xcm-bridge-hub-router = { optional = true, workspace = true }
+bp-xcm-bridge-hub = { optional = true, workspace = true }
 
 [dev-dependencies]
 
@@ -53,7 +53,7 @@ cumulus-pallet-parachain-system = { workspace = true, default-features = true }
 default = ["std"]
 std = [
 	"bounded-collections/std",
-	"bp-xcm-bridge-hub-router?/std",
+	"bp-xcm-bridge-hub?/std",
 	"codec/std",
 	"cumulus-primitives-core/std",
 	"frame-benchmarking?/std",
@@ -96,4 +96,4 @@ try-runtime = [
 	"polkadot-runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
 ]
-bridging = ["bp-xcm-bridge-hub-router"]
+bridging = ["bp-xcm-bridge-hub"]

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
@@ -155,8 +155,8 @@ impl pallet_xcm_bridge_hub::Config<XcmOverBridgeHubWestendInstance> for Runtime 
 	type AllowWithoutBridgeDeposit =
 		RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>;
 
-	// TODO:(bridges-v2) - add `LocalXcmChannelManager` impl - https://github.com/paritytech/parity-bridges-common/issues/3047
-	type LocalXcmChannelManager = ();
+	type LocalXcmChannelManager =
+		cumulus_pallet_xcmp_queue::bridging::InAndOutXcmpChannelStatusProvider<Runtime>;
 	type BlobDispatcher = FromWestendMessageBlobDispatcher;
 }
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
@@ -184,8 +184,8 @@ impl pallet_xcm_bridge_hub::Config<XcmOverBridgeHubRococoInstance> for Runtime {
 	type AllowWithoutBridgeDeposit =
 		RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>;
 
-	// TODO:(bridges-v2) - add `LocalXcmChannelManager` impl - https://github.com/paritytech/parity-bridges-common/issues/3047
-	type LocalXcmChannelManager = ();
+	type LocalXcmChannelManager =
+		cumulus_pallet_xcmp_queue::bridging::InAndOutXcmpChannelStatusProvider<Runtime>;
 	type BlobDispatcher = FromRococoMessageBlobDispatcher;
 }
 


### PR DESCRIPTION
Closes: https://github.com/paritytech/polkadot-sdk/issues/5551

Provides additional support for reporting congestion and dynamic fees between parachains.

Essentially, it introduces a new `ChannelSignal::ReportCongestion(bool)` to the `XcmpQueue`, which can control the fee factor (`increase_fee_factor`, `decrease_fee_factor`).

_Note: This is a very rough draft._

## Description

TBD:  

## TODO

- [ ] add tests