### PR TITLE
Add riscv feature to the cumulus node

### DIFF
--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -108,3 +108,6 @@ fast-runtime = [
 	"coretime-rococo-runtime/fast-runtime",
 	"coretime-westend-runtime/fast-runtime",
 ]
+# needs to be passed down to runtimes using pallet_revive later
+# for now we just add it so that the benchbot can start using it
+riscv = []


### PR DESCRIPTION
Needed so that the bench-bot can start using this feature. Once we add pallet_revive to westend the bench bot will work.

https://github.com/paritytech/command-bot-scripts/pull/73