### PR TITLE
[ci] Disable cargo-hfuzz, disable cargo-doc

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -17,13 +17,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   preflight:
     uses: ./.github/workflows/reusable-preflight.yml
 
   # More info can be found here: https://github.com/paritytech/polkadot/pull/5865
   check-runtime-migration:
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     # We need to set this to rather long to allow the snapshot to be created, but the average time
     # should be much lower.
     timeout-minutes: 60

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,14 +15,13 @@ concurrency:
 permissions: {}
 
 jobs:
-
   preflight:
     uses: ./.github/workflows/reusable-preflight.yml
 
   cargo-clippy:
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     needs: [preflight]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     timeout-minutes: 40
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -38,7 +37,7 @@ jobs:
   check-try-runtime:
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     needs: [preflight]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     timeout-minutes: 40
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -57,7 +56,7 @@ jobs:
   check-core-crypto-features:
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     needs: [preflight]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     timeout-minutes: 30
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,15 +9,17 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   preflight:
+    if: contains(github.event.label.name, 'GHA-migration')
     uses: ./.github/workflows/reusable-preflight.yml
 
   test-rustdoc:
-    runs-on: arc-runners-polkadot-sdk-beefy
+    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     needs: [preflight]
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -38,7 +40,8 @@ jobs:
           RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
 
   build-rustdoc:
-    runs-on: arc-runners-polkadot-sdk-beefy
+    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     needs: [preflight, test-rustdoc]
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -104,6 +104,10 @@ jobs:
     if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1/2, 2/2]
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     env:
@@ -115,7 +119,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: script
-        run: forklift cargo nextest run --workspace --locked --release --no-fail-fast --cargo-quiet --features experimental,riscv,ci-only-tests
+        run: |
+          forklift cargo nextest run --workspace \
+                   --locked \
+                   --release \
+                   --no-fail-fast \
+                   --cargo-quiet \
+                   --features experimental,riscv,ci-only-tests \
+                   --partition count:${{ matrix.partition }}
 
   confirm-required-jobs-passed:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -13,13 +13,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   preflight:
     uses: ./.github/workflows/reusable-preflight.yml
 
   test-linux-stable-int:
     needs: [preflight]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
     container:
@@ -40,7 +39,7 @@ jobs:
   # https://github.com/paritytech/ci_cd/issues/864
   test-linux-stable-runtime-benchmarks:
     needs: [preflight]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
     container:
@@ -58,7 +57,7 @@ jobs:
 
   test-linux-stable:
     needs: [preflight]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ matrix.runners }}
     timeout-minutes: 60
     strategy:
@@ -98,6 +97,26 @@ jobs:
         if: ${{ matrix.partition == '1/3' }}
         run: forklift cargo nextest run -p sp-api-test --features enable-staging-api
 
+  # some tests do not run with `try-runtime` feature enabled
+  # https://github.com/paritytech/polkadot-sdk/pull/4251#discussion_r1624282143
+  test-linux-stable-no-try-runtime:
+    needs: [preflight]
+    if: ${{ needs.preflight.outputs.changes_rust }}
+    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    timeout-minutes: 60
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    env:
+      RUST_TOOLCHAIN: stable
+      # Enable debug assertions since we are running optimized builds for testing
+      # but still want to have debug assertions.
+      RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: script
+        run: forklift cargo nextest run --workspace --locked --release --no-fail-fast --cargo-quiet --features experimental,riscv,ci-only-tests
+
   confirm-required-jobs-passed:
     runs-on: ubuntu-latest
     name: All tests passed
@@ -107,6 +126,7 @@ jobs:
         test-linux-stable-int,
         test-linux-stable-runtime-benchmarks,
         test-linux-stable,
+        test-linux-stable-no-try-runtime,
       ]
     if: always() && !cancelled()
     steps:

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -104,10 +104,10 @@ jobs:
     if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1/2, 2/2]
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     partition: [1/2, 2/2]
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     env:
@@ -125,8 +125,8 @@ jobs:
                    --release \
                    --no-fail-fast \
                    --cargo-quiet \
-                   --features experimental,riscv,ci-only-tests \
-                   --partition count:${{ matrix.partition }}
+                   --features experimental,riscv,ci-only-tests # \
+                   # --partition count:${{ matrix.partition }}
 
   confirm-required-jobs-passed:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -97,37 +97,6 @@ jobs:
         if: ${{ matrix.partition == '1/3' }}
         run: forklift cargo nextest run -p sp-api-test --features enable-staging-api
 
-  # some tests do not run with `try-runtime` feature enabled
-  # https://github.com/paritytech/polkadot-sdk/pull/4251#discussion_r1624282143
-  test-linux-stable-no-try-runtime:
-    needs: [preflight]
-    if: ${{ needs.preflight.outputs.changes_rust }}
-    runs-on: ${{ needs.preflight.outputs.RUNNER }}
-    timeout-minutes: 60
-    # strategy:
-    #   fail-fast: false
-    #   matrix:
-    #     partition: [1/2, 2/2]
-    container:
-      image: ${{ needs.preflight.outputs.IMAGE }}
-    env:
-      RUST_TOOLCHAIN: stable
-      # Enable debug assertions since we are running optimized builds for testing
-      # but still want to have debug assertions.
-      RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: script
-        run: |
-          forklift cargo nextest run --workspace \
-                   --locked \
-                   --release \
-                   --no-fail-fast \
-                   --cargo-quiet \
-                   --features experimental,riscv,ci-only-tests # \
-                   # --partition count:${{ matrix.partition }}
-
   confirm-required-jobs-passed:
     runs-on: ubuntu-latest
     name: All tests passed
@@ -137,7 +106,6 @@ jobs:
         test-linux-stable-int,
         test-linux-stable-runtime-benchmarks,
         test-linux-stable,
-        test-linux-stable-no-try-runtime,
       ]
     if: always() && !cancelled()
     steps:

--- a/.github/workflows/tests-misc.yml
+++ b/.github/workflows/tests-misc.yml
@@ -22,6 +22,7 @@ jobs:
   test-full-crypto-feature:
     needs: [preflight]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     timeout-minutes: 60
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -46,6 +47,7 @@ jobs:
     # into one job
     needs: [preflight, test-full-crypto-feature]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     env:
@@ -67,6 +69,7 @@ jobs:
     timeout-minutes: 60
     needs: [preflight]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     env:
@@ -95,6 +98,7 @@ jobs:
     timeout-minutes: 20
     needs: [preflight, test-frame-examples-compile-to-wasm]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     env:
@@ -194,6 +198,7 @@ jobs:
     needs: [preflight]
     timeout-minutes: 30
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     steps:
@@ -226,6 +231,7 @@ jobs:
     timeout-minutes: 20
     needs: [preflight, test-node-metrics]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     steps:
@@ -241,6 +247,7 @@ jobs:
     timeout-minutes: 20
     needs: [preflight, check-tracing]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     steps:
@@ -251,50 +258,52 @@ jobs:
         run: |
           forklift cargo build --locked -p westend-runtime --features metadata-hash
 
-  cargo-hfuzz:
-    timeout-minutes: 20
-    needs: [preflight, check-metadata-hash]
-    runs-on: ${{ needs.preflight.outputs.RUNNER }}
-    container:
-      image: ${{ needs.preflight.outputs.IMAGE }}
-    env:
-      # max 10s per iteration, 60s per file
-      HFUZZ_RUN_ARGS: |
-        --exit_upon_crash
-        --exit_code_upon_crash 1
-        --timeout 10
-        --run_time 60
+  # disabled until https://github.com/paritytech/polkadot-sdk/issues/5812 is resolved
+  # cargo-hfuzz:
+  #   timeout-minutes: 20
+  #   needs: [preflight, check-metadata-hash]
+  #   runs-on: ${{ needs.preflight.outputs.RUNNER }}
+  #   container:
+  #     image: ${{ needs.preflight.outputs.IMAGE }}
+  #   env:
+  #     # max 10s per iteration, 60s per file
+  #     HFUZZ_RUN_ARGS: |
+  #       --exit_upon_crash
+  #       --exit_code_upon_crash 1
+  #       --timeout 10
+  #       --run_time 60
 
-      # use git version of honggfuzz-rs until v0.5.56 is out, we need a few recent changes:
-      # https://github.com/rust-fuzz/honggfuzz-rs/pull/75 to avoid breakage on debian
-      # https://github.com/rust-fuzz/honggfuzz-rs/pull/81 fix to the above pr
-      # https://github.com/rust-fuzz/honggfuzz-rs/pull/82 fix for handling absolute CARGO_TARGET_DIR
-      HFUZZ_BUILD_ARGS: |
-        --config=patch.crates-io.honggfuzz.git="https://github.com/altaua/honggfuzz-rs"
-        --config=patch.crates-io.honggfuzz.rev="205f7c8c059a0d98fe1cb912cdac84f324cb6981"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  #     # use git version of honggfuzz-rs until v0.5.56 is out, we need a few recent changes:
+  #     # https://github.com/rust-fuzz/honggfuzz-rs/pull/75 to avoid breakage on debian
+  #     # https://github.com/rust-fuzz/honggfuzz-rs/pull/81 fix to the above pr
+  #     # https://github.com/rust-fuzz/honggfuzz-rs/pull/82 fix for handling absolute CARGO_TARGET_DIR
+  #     HFUZZ_BUILD_ARGS: |
+  #       --config=patch.crates-io.honggfuzz.git="https://github.com/altaua/honggfuzz-rs"
+  #       --config=patch.crates-io.honggfuzz.rev="205f7c8c059a0d98fe1cb912cdac84f324cb6981"
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: Run honggfuzz
-        run: |
-          cd substrate/primitives/arithmetic/fuzzer
-          forklift cargo hfuzz build
-          for target in $(cargo read-manifest | jq -r '.targets | .[] | .name');
-          do
-            forklift cargo hfuzz run "$target" || { printf "fuzzing failure for %s\n" "$target"; exit 1; };
-          done
+  #     - name: Run honggfuzz
+  #       run: |
+  #         cd substrate/primitives/arithmetic/fuzzer
+  #         forklift cargo hfuzz build
+  #         for target in $(cargo read-manifest | jq -r '.targets | .[] | .name');
+  #         do
+  #           forklift cargo hfuzz run "$target" || { printf "fuzzing failure for %s\n" "$target"; exit 1; };
+  #         done
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4.3.6
-        with:
-          path: substrate/primitives/arithmetic/fuzzer/hfuzz_workspace/
-          name: hfuzz-${{ github.sha }}
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4.3.6
+  #       with:
+  #         path: substrate/primitives/arithmetic/fuzzer/hfuzz_workspace/
+  #         name: hfuzz-${{ github.sha }}
 
   cargo-check-each-crate:
     timeout-minutes: 140
     needs: [preflight]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     env:
@@ -322,6 +331,7 @@ jobs:
     timeout-minutes: 30
     needs: [preflight]
     runs-on: ${{ needs.preflight.outputs.RUNNER_MACOS }}
+    if: ${{ needs.preflight.outputs.changes_rust }}
     env:
       SKIP_WASM_BUILD: 1
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,21 +5,20 @@ on:
     branches:
       - master
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-
   preflight:
     uses: ./.github/workflows/reusable-preflight.yml
 
   # This job runs all benchmarks defined in the `/bin/node/runtime` once to check that there are no errors.
   quick-benchmarks:
-    needs: [ preflight ]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    needs: [preflight]
+    if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
     container:
@@ -37,8 +36,8 @@ jobs:
 
   # cf https://github.com/paritytech/polkadot-sdk/issues/1652
   test-syscalls:
-    needs: [ preflight ]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    needs: [preflight]
+    if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
     container:
@@ -61,10 +60,9 @@ jobs:
         run: |
           echo "The x86_64 syscalls used by the worker binaries have changed. Please review if this is expected and update polkadot/scripts/list-syscalls/*-worker-syscalls as needed." >> $GITHUB_STEP_SUMMARY
 
-
   cargo-check-all-benches:
-    needs: [ preflight ]
-    # if: ${{ needs.preflight.outputs.changes_rust }}
+    needs: [preflight]
+    if: ${{ needs.preflight.outputs.changes_rust }}
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     timeout-minutes: 60
     container:

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -110,6 +110,30 @@ test-linux-stable-codecov:
         codecovcli -v do-upload -f target/coverage/result/report-${CI_NODE_INDEX}.lcov --disable-search -t ${CODECOV_TOKEN} -r paritytech/polkadot-sdk --commit-sha ${CI_COMMIT_SHA} --fail-on-error --git-service github;
       fi
 
+# some tests do not run with `try-runtime` feature enabled
+# https://github.com/paritytech/polkadot-sdk/pull/4251#discussion_r1624282143
+test-linux-stable-no-try-runtime:
+  stage: test
+  extends:
+    - .docker-env
+    - .common-refs
+    - .run-immediately
+    - .pipeline-stopper-artifacts
+  variables:
+    RUST_TOOLCHAIN: stable
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
+  script:
+    - >
+      time cargo nextest run \
+        --workspace \
+        --locked \
+        --release \
+        --no-fail-fast \
+        --cargo-quiet \
+        --features experimental,riscv,ci-only-tests
+
 test-doc:
   stage: test
   extends:

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -110,30 +110,6 @@ test-linux-stable-codecov:
         codecovcli -v do-upload -f target/coverage/result/report-${CI_NODE_INDEX}.lcov --disable-search -t ${CODECOV_TOKEN} -r paritytech/polkadot-sdk --commit-sha ${CI_COMMIT_SHA} --fail-on-error --git-service github;
       fi
 
-# some tests do not run with `try-runtime` feature enabled
-# https://github.com/paritytech/polkadot-sdk/pull/4251#discussion_r1624282143
-test-linux-stable-no-try-runtime:
-  stage: test
-  extends:
-    - .docker-env
-    - .common-refs
-    - .run-immediately
-    - .pipeline-stopper-artifacts
-  variables:
-    RUST_TOOLCHAIN: stable
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
-  script:
-    - >
-      time cargo nextest run \
-        --workspace \
-        --locked \
-        --release \
-        --no-fail-fast \
-        --cargo-quiet \
-        --features experimental,riscv,ci-only-tests
-
 test-doc:
   stage: test
   extends:

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -112,6 +112,7 @@ test-linux-stable-codecov:
 
 # some tests do not run with `try-runtime` feature enabled
 # https://github.com/paritytech/polkadot-sdk/pull/4251#discussion_r1624282143
+# Move to github after https://github.com/paritytech/ci_cd/issues/1056 is fixed
 test-linux-stable-no-try-runtime:
   stage: test
   extends:


### PR DESCRIPTION
Changes in PR:
- disabled cargo-hfuzz until [the issue](https://github.com/paritytech/polkadot-sdk/issues/5812) is fixed.
- enabled condition to skip jobs when no rust files are changed