### PR TITLE
fix prospective parachains test to use shuffled candidate list

### DIFF
--- a/polkadot/node/core/prospective-parachains/src/fragment_chain/tests.rs
+++ b/polkadot/node/core/prospective-parachains/src/fragment_chain/tests.rs
@@ -1433,7 +1433,7 @@ fn test_find_ancestor_path_and_find_backable_chain() {
 	// Now back all candidates. Back them in a random order. The result should always be the same.
 	let mut candidates_shuffled = candidates.clone();
 	candidates_shuffled.shuffle(&mut thread_rng());
-	for candidate in candidates.iter() {
+	for candidate in candidates_shuffled.iter() {
 		chain.candidate_backed(candidate);
 		storage.mark_backed(candidate);
 	}

--- a/prdoc/pr_5880.prdoc
+++ b/prdoc/pr_5880.prdoc
@@ -1,0 +1,11 @@
+title: Fix prospective parachains test to use shuffled candidate list
+
+doc:
+  - audience: Node Dev
+    description: |
+        Fix prospective parachains test to use shuffled candidate list.
+        Resolves https://github.com/paritytech/polkadot-sdk/issues/5617.
+
+crates:
+  - name: polkadot-node-core-prospective-parachains
+    bump: none


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/5617