### PR TITLE
Update async-channel/async-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,15 +1146,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.5.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
- "async-lock 2.8.0",
  "async-task",
  "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite 1.13.0",
+ "fastrand 2.1.0",
+ "futures-lite 2.0.0",
  "slab",
 ]
 
@@ -1183,16 +1182,16 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "async-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
  "blocking",
- "futures-lite 1.13.0",
+ "futures-lite 2.0.0",
  "once_cell",
 ]
 
@@ -1335,20 +1334,20 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
 dependencies = [
  "async-attributes",
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 1.13.0",
+ "futures-lite 2.0.0",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -1802,17 +1801,15 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.3.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 1.9.0",
- "async-lock 2.8.0",
+ "async-channel 2.3.1",
  "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
- "futures-lite 1.13.0",
- "log",
+ "futures-io",
+ "futures-lite 2.0.0",
+ "piper",
 ]
 
 [[package]]
@@ -6923,9 +6920,9 @@ checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -13816,6 +13813,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.1.0",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,12 +1134,11 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2776ead772134d55b62dd45e59a79e21612d85d0af729b8b7d3967d601a62a"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -1303,7 +1302,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel 2.3.0",
+ "async-channel 2.3.1",
  "async-io 2.3.3",
  "async-lock 3.4.0",
  "async-signal",
@@ -3322,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -14094,7 +14093,7 @@ name = "polkadot-dispute-distribution"
 version = "7.0.0"
 dependencies = [
  "assert_matches",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "async-trait",
  "derive_more",
  "fatality",
@@ -14736,7 +14735,7 @@ dependencies = [
 name = "polkadot-node-network-protocol"
 version = "7.0.0"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "async-trait",
  "bitvec",
  "derive_more",
@@ -15861,7 +15860,7 @@ version = "7.0.0"
 dependencies = [
  "arrayvec 0.7.4",
  "assert_matches",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "bitvec",
  "fatality",
  "futures",
@@ -18719,7 +18718,7 @@ name = "sc-consensus-beefy"
 version = "13.0.0"
 dependencies = [
  "array-bytes",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "async-trait",
  "fnv",
  "futures",
@@ -19169,7 +19168,7 @@ version = "0.34.0"
 dependencies = [
  "array-bytes",
  "assert_matches",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "async-trait",
  "asynchronous-codec",
  "bytes",
@@ -19273,7 +19272,7 @@ name = "sc-network-light"
 version = "0.33.0"
 dependencies = [
  "array-bytes",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "futures",
  "log",
  "parity-scale-codec",
@@ -19293,7 +19292,7 @@ name = "sc-network-statement"
 version = "0.16.0"
 dependencies = [
  "array-bytes",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "futures",
  "log",
  "parity-scale-codec",
@@ -19312,7 +19311,7 @@ name = "sc-network-sync"
 version = "0.33.0"
 dependencies = [
  "array-bytes",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "async-trait",
  "fork-tree",
  "futures",
@@ -19668,7 +19667,7 @@ name = "sc-service-test"
 version = "2.0.0"
 dependencies = [
  "array-bytes",
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "fdlimit",
  "futures",
  "log",
@@ -19892,7 +19891,7 @@ dependencies = [
 name = "sc-utils"
 version = "14.0.0"
 dependencies = [
- "async-channel 1.9.0",
+ "async-channel 2.3.1",
  "futures",
  "futures-timer",
  "log",
@@ -20738,7 +20737,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
- "async-channel 2.3.0",
+ "async-channel 2.3.1",
  "async-executor",
  "async-fs 2.1.2",
  "async-io 2.3.3",
@@ -20909,7 +20908,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5496f2d116b7019a526b1039ec2247dd172b8670633b1a64a614c9ea12c9d8c7"
 dependencies = [
- "async-channel 2.3.0",
+ "async-channel 2.3.1",
  "async-lock 3.4.0",
  "base64 0.21.7",
  "blake2-rfc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -612,7 +612,7 @@ asset-hub-westend-emulated-chain = { path = "cumulus/parachains/integration-test
 asset-hub-westend-runtime = { path = "cumulus/parachains/runtimes/assets/asset-hub-westend" }
 asset-test-utils = { path = "cumulus/parachains/runtimes/assets/test-utils", default-features = false }
 assets-common = { path = "cumulus/parachains/runtimes/assets/common", default-features = false }
-async-channel = { version = "1.8.0" }
+async-channel = { version = "2.3.1" }
 async-std = { version = "1.9.0" }
 async-trait = { version = "0.1.79" }
 asynchronous-codec = { version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -812,7 +812,7 @@ integer-sqrt = { version = "0.1.2" }
 ip_network = { version = "0.4.1" }
 is-terminal = { version = "0.4.9" }
 is_executable = { version = "1.0.1" }
-isahc = { version = "1.2" }
+isahc = { version = "1.7.2" }
 itertools = { version = "0.11" }
 jemalloc_pprof = { version = "0.4" }
 jobserver = { version = "0.1.26" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -613,7 +613,7 @@ asset-hub-westend-runtime = { path = "cumulus/parachains/runtimes/assets/asset-h
 asset-test-utils = { path = "cumulus/parachains/runtimes/assets/test-utils", default-features = false }
 assets-common = { path = "cumulus/parachains/runtimes/assets/common", default-features = false }
 async-channel = { version = "2.3.1" }
-async-std = { version = "1.9.0" }
+async-std = { version = "1.13.0" }
 async-trait = { version = "0.1.79" }
 asynchronous-codec = { version = "0.6" }
 backoff = { version = "0.4" }

--- a/polkadot/node/network/protocol/src/request_response/incoming/mod.rs
+++ b/polkadot/node/network/protocol/src/request_response/incoming/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, pin::Pin};
 
 use futures::{channel::oneshot, StreamExt};
 
@@ -58,7 +58,7 @@ where
 		req_protocol_names: &ReqProtocolNames,
 	) -> (IncomingRequestReceiver<Req>, N::RequestResponseProtocolConfig) {
 		let (raw, cfg) = Req::PROTOCOL.get_config::<B, N>(req_protocol_names);
-		(IncomingRequestReceiver { raw, phantom: PhantomData {} }, cfg)
+		(IncomingRequestReceiver { raw: Box::pin(raw), phantom: PhantomData {} }, cfg)
 	}
 
 	/// Create new `IncomingRequest`.
@@ -206,7 +206,7 @@ pub struct OutgoingResponse<Response> {
 ///
 /// Takes care of decoding and handling of invalid encoded requests.
 pub struct IncomingRequestReceiver<Req> {
-	raw: async_channel::Receiver<netconfig::IncomingRequest>,
+	raw: Pin<Box<async_channel::Receiver<netconfig::IncomingRequest>>>,
 	phantom: PhantomData<Req>,
 }
 

--- a/substrate/client/consensus/beefy/src/communication/request_response/incoming_requests_handler.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/incoming_requests_handler.rs
@@ -27,7 +27,7 @@ use sc_network::{
 use sc_network_types::PeerId;
 use sp_consensus_beefy::BEEFY_ENGINE_ID;
 use sp_runtime::traits::Block;
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, pin::Pin, sync::Arc};
 
 use crate::{
 	communication::{
@@ -100,12 +100,12 @@ impl<B: Block> IncomingRequest<B> {
 ///
 /// Takes care of decoding and handling of invalid encoded requests.
 pub(crate) struct IncomingRequestReceiver {
-	raw: async_channel::Receiver<netconfig::IncomingRequest>,
+	raw: Pin<Box<async_channel::Receiver<netconfig::IncomingRequest>>>,
 }
 
 impl IncomingRequestReceiver {
 	pub fn new(inner: async_channel::Receiver<netconfig::IncomingRequest>) -> Self {
-		Self { raw: inner }
+		Self { raw: Box::pin(inner) }
 	}
 
 	/// Try to receive the next incoming request.

--- a/substrate/client/network/src/bitswap/mod.rs
+++ b/substrate/client/network/src/bitswap/mod.rs
@@ -37,7 +37,7 @@ use schema::bitswap::{
 	Message as BitswapMessage,
 };
 use sp_runtime::traits::Block as BlockT;
-use std::{io, sync::Arc, time::Duration};
+use std::{io, pin::Pin, sync::Arc, time::Duration};
 use unsigned_varint::encode as varint_encode;
 
 mod schema;
@@ -95,7 +95,7 @@ impl Prefix {
 /// Bitswap request handler
 pub struct BitswapRequestHandler<B> {
 	client: Arc<dyn BlockBackend<B> + Send + Sync>,
-	request_receiver: async_channel::Receiver<IncomingRequest>,
+	request_receiver: Pin<Box<async_channel::Receiver<IncomingRequest>>>,
 }
 
 impl<B: BlockT> BitswapRequestHandler<B> {
@@ -112,7 +112,7 @@ impl<B: BlockT> BitswapRequestHandler<B> {
 			inbound_queue: Some(tx),
 		};
 
-		(Self { client, request_receiver }, config)
+		(Self { client, request_receiver: Box::pin(request_receiver) }, config)
 	}
 
 	/// Run [`BitswapRequestHandler`].

--- a/substrate/client/utils/src/mpsc.rs
+++ b/substrate/client/utils/src/mpsc.rs
@@ -27,6 +27,7 @@ use async_channel::{Receiver, Sender};
 use futures::{
 	stream::{FusedStream, Stream},
 	task::{Context, Poll},
+	StreamExt,
 };
 use log::error;
 use sp_arithmetic::traits::SaturatedConversion;
@@ -67,7 +68,7 @@ impl<T> Clone for TracingUnboundedSender<T> {
 /// measure when a message is polled.
 #[derive(Debug)]
 pub struct TracingUnboundedReceiver<T> {
-	inner: Receiver<T>,
+	inner: Pin<Box<Receiver<T>>>,
 	name: &'static str,
 }
 
@@ -86,7 +87,7 @@ pub fn tracing_unbounded<T>(
 		warning_fired: Arc::new(AtomicBool::new(false)),
 		creation_backtrace: Arc::new(Backtrace::force_capture()),
 	};
-	let receiver = TracingUnboundedReceiver { inner: r, name: name.into() };
+	let receiver = TracingUnboundedReceiver { inner: Box::pin(r), name: name.into() };
 	(sender, receiver)
 }
 
@@ -189,7 +190,7 @@ impl<T> Stream for TracingUnboundedReceiver<T> {
 
 	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
 		let s = self.get_mut();
-		match Pin::new(&mut s.inner).poll_next(cx) {
+		match s.inner.poll_next_unpin(cx) {
 			Poll::Ready(msg) => {
 				if msg.is_some() {
 					UNBOUNDED_CHANNELS_COUNTER.with_label_values(&[s.name, RECEIVED_LABEL]).inc();


### PR DESCRIPTION
Relatively trivial PR, just updated `async-channel` to new major version and tried to get rid of old version by updating `async-std`, though it didn't help and there are other dependencies still relying on old version of `async-channel` here upstream, but downstream users will be able to remove it in some cases, which is already a good thing.

The biggest change in new major version of `async-channel` is that it no longer implements `Unpin`, so had to do `Pin<Box<T>>` in a few places.

Not sure if this needs prdoc since changes are trivial and mostly internal.