### PR TITLE
Add stable-rc tags to the docker images

### DIFF
--- a/.github/scripts/common/lib.sh
+++ b/.github/scripts/common/lib.sh
@@ -462,7 +462,7 @@ function get_polkadot_node_version_from_code() {
 
 validate_stable_tag() {
     tag="$1"
-    pattern='^stable[0-9]+(-[0-9]+)?$'
+    pattern="^stable[0-9]{4}(-[0-9]+)?(-rc[0-9]+)?$"
 
     if [[ $tag =~ $pattern ]]; then
         echo $tag

--- a/.github/scripts/common/lib.sh
+++ b/.github/scripts/common/lib.sh
@@ -242,6 +242,7 @@ fetch_release_artifacts() {
 # - GITHUB_TOKEN
 # - REPO in the form paritytech/polkadot
 fetch_release_artifacts_from_s3() {
+  BINARY=$1
   echo "Version    : $VERSION"
   echo "Repo       : $REPO"
   echo "Binary     : $BINARY"

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -215,8 +215,20 @@ jobs:
           echo "release=${release}" >> $GITHUB_OUTPUT
           echo "stable=${{ needs.validate-inputs.outputs.stable_tag }}" >> $GITHUB_OUTPUT
 
-      - name: Build Injected Container image for polkadot rc or chain-spec-builder
-        if: ${{ env.BINARY == 'polkadot' || env.BINARY == 'chain-spec-builder' }}
+      - name: Build Injected Container image for polkadot rc
+        if: ${{ env.BINARY == 'polkadot' }}
+        env:
+          ARTIFACTS_FOLDER: release-artifacts
+          IMAGE_NAME: ${{ env.BINARY }}
+          OWNER: ${{ env.DOCKER_OWNER }}
+          TAGS: ${{ join(steps.fetch_rc_refs.outputs.*, ',') || join(steps.fetch_release_refs.outputs.*, ',') }}
+        run: |
+          ls -al
+          echo "Building container for $BINARY"
+          ./docker/scripts/polkadot/build-injected.sh $ARTIFACTS_FOLDER
+
+      - name: Build Injected Container image chain-spec-builder
+        if: ${{ env.BINARY == 'chain-spec-builder' }}
         env:
           ARTIFACTS_FOLDER: release-artifacts
           IMAGE_NAME: ${{ env.BINARY }}

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Validate inputs
         id: validate_inputs
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       #TODO: this step will be needed when automated triggering will work
         #this step runs only if the workflow is triggered automatically when new release is published
@@ -134,8 +134,8 @@ jobs:
           . ./.github/scripts/common/lib.sh
 
           VERSION="${{ needs.validate-inputs.outputs.VERSION }}"
-          if [[ $inpust.binary == 'polkadot' ]]; then
-            bins=( polkadot polkadot-prepare-worker polkadot-execute-worker )
+          if [[ $BINARY == 'polkadot' ]]; then
+            bins=(polkadot polkadot-prepare-worker polkadot-execute-worker)
             for bin in "${bins[@]}"; do
               fetch_release_artifacts_from_s3 $bin
             done
@@ -166,7 +166,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -234,7 +234,7 @@ jobs:
           ./docker/scripts/polkadot/build-injected.sh $ARTIFACTS_FOLDER
 
       - name: Build Injected Container image chain-spec-builder
-        if: ${{ env.BINARY == 'polkadot' || env.BINARY == 'chain-spec-builder' }}
+        if: ${{ env.BINARY == 'chain-spec-builder' }}
         env:
           ARTIFACTS_FOLDER: release-artifacts
           IMAGE_NAME: ${{ env.BINARY }}
@@ -321,7 +321,7 @@ jobs:
     environment: release
     steps:
       - name: Checkout sources
-        uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -194,8 +194,8 @@ jobs:
         run: |
           . ./.github/scripts/common/lib.sh
 
-          release="release-${{ needs.validate-inputs.outputs.RELEASE_ID }}" && \
-          echo "release=${release}" >> $GITHUB_OUTPUT
+          version="${{ needs.validate-inputs.outputs.VERSION }}" && \
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
           commit=$(git rev-parse --short HEAD) && \
           echo "commit=${commit}" >> $GITHUB_OUTPUT
@@ -262,7 +262,15 @@ jobs:
           echo "Building container for $BINARY"
           ./docker/scripts/build-injected.sh
 
-      - name: Login to Dockerhub
+      - name: Login to Dockerhub to publish polkadot
+        if: ${{ env.BINARY == 'polkadot' }}
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.POLKADOT_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.POLKADOT_DOCKERHUB_TOKEN }}
+
+      - name: Login to Dockerhub to puiblish polkadot-parachain/chain-spec-builder
+        if: ${{ env.BINARY == 'polkadot-parachain' || env.BINARY == 'chain-spec-builder' }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.CUMULUS_DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -194,8 +194,8 @@ jobs:
         run: |
           . ./.github/scripts/common/lib.sh
 
-          version="${{ needs.validate-inputs.outputs.VERSION }}" && \
-          echo "version=${version}" >> $GITHUB_OUTPUT
+          release="${{ needs.validate-inputs.outputs.VERSION }}" && \
+          echo "release=${release}" >> $GITHUB_OUTPUT
 
           commit=$(git rev-parse --short HEAD) && \
           echo "commit=${commit}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -134,7 +134,14 @@ jobs:
           . ./.github/scripts/common/lib.sh
 
           VERSION="${{ needs.validate-inputs.outputs.VERSION }}"
-          fetch_release_artifacts_from_s3
+          if [[ $BINARY == 'polkadot' ]]; then
+            bins=(polkadot polkadot-prepare-worker polkadot-execute-worker)
+            for bin in "${bins[@]}"; do
+              fetch_release_artifacts_from_s3 $bin
+            done
+          else
+            fetch_release_artifacts_from_s3 $BINARY
+          fi
 
       - name: Fetch chain-spec-builder rc artifacts or release artifacts based on release id
         #this step runs only if the workflow is triggered manually and only for chain-spec-builder

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -134,7 +134,7 @@ jobs:
           . ./.github/scripts/common/lib.sh
 
           VERSION="${{ needs.validate-inputs.outputs.VERSION }}"
-          if [[ $BINARY == 'polkadot' ]]; then
+          if [[ ${{ inputs.binary }} == 'polkadot' ]]; then
             bins=(polkadot polkadot-prepare-worker polkadot-execute-worker)
             for bin in "${bins[@]}"; do
               fetch_release_artifacts_from_s3 $bin

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -194,15 +194,14 @@ jobs:
         run: |
           . ./.github/scripts/common/lib.sh
 
-          release="${{ needs.validate-inputs.outputs.VERSION }}" && \
+          release="${{ needs.validate-inputs.outputs.stable_tag }}" && \
           echo "release=${release}" >> $GITHUB_OUTPUT
 
           commit=$(git rev-parse --short HEAD) && \
           echo "commit=${commit}" >> $GITHUB_OUTPUT
 
-          tag=$(git name-rev --tags --name-only $(git rev-parse HEAD)) && \
-          [ "${tag}" != "undefined" ] && echo "tag=${tag}" >> $GITHUB_OUTPUT || \
-          echo "No tag, doing without"
+          tag="${{ needs.validate-inputs.outputs.version }}" && \
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
 
       - name: Fetch release tags
         working-directory: release-artifacts

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -134,8 +134,8 @@ jobs:
           . ./.github/scripts/common/lib.sh
 
           VERSION="${{ needs.validate-inputs.outputs.VERSION }}"
-          if [[ $BINARY == 'polkadot' ]]; then
-            bins=(polkadot polkadot-prepare-worker polkadot-execute-worker)
+          if [[ $inpust.binary == 'polkadot' ]]; then
+            bins=( polkadot polkadot-prepare-worker polkadot-execute-worker )
             for bin in "${bins[@]}"; do
               fetch_release_artifacts_from_s3 $bin
             done
@@ -235,7 +235,7 @@ jobs:
           ./docker/scripts/polkadot/build-injected.sh $ARTIFACTS_FOLDER
 
       - name: Build Injected Container image chain-spec-builder
-        if: ${{ env.BINARY == 'chain-spec-builder' }}
+        if: ${{ env.BINARY == 'polkadot' || env.BINARY == 'chain-spec-builder' }}
         env:
           ARTIFACTS_FOLDER: release-artifacts
           IMAGE_NAME: ${{ env.BINARY }}

--- a/docker/dockerfiles/polkadot/polkadot_injected.Dockerfile
+++ b/docker/dockerfiles/polkadot/polkadot_injected.Dockerfile
@@ -1,0 +1,52 @@
+FROM docker.io/parity/base-bin
+
+# metadata
+ARG VCS_REF
+ARG BUILD_DATE
+ARG IMAGE_NAME
+# That can be a single one or a comma separated list
+ARG BINARY=polkadot
+
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="parity/polkadot" \
+	io.parity.image.description="Polkadot: a platform for web3. This is the official Parity image with an injected binary." \
+	io.parity.image.source="https://github.com/paritytech/polkadot-sdk/blob/${VCS_REF}/docker/dockerfiles/polkadot/polkadot_injected.Dockerfile" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}" \
+	io.parity.image.documentation="https://github.com/paritytech/polkadot-sdk/"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+USER root
+WORKDIR /app
+
+# add polkadot and polkadot-*-worker binaries to the docker image
+COPY bin/* /usr/local/bin/
+COPY entrypoint.sh .
+
+
+RUN chmod -R a+rx "/usr/local/bin"; \
+		mkdir -p /data /polkadot/.local/share && \
+		chown -R parity:parity /data && \
+		ln -s /data /polkadot/.local/share/polkadot
+
+USER parity
+
+# check if executable works in this container
+RUN /usr/local/bin/polkadot --version
+RUN /usr/local/bin/polkadot-prepare-worker --version
+RUN /usr/local/bin/polkadot-execute-worker --version
+
+
+EXPOSE 30333 9933 9944 9615
+VOLUME ["/polkadot"]
+
+ENV BINARY=${BINARY}
+
+# ENTRYPOINT
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+# We call the help by default
+CMD ["--help"]

--- a/docker/scripts/build-injected.sh
+++ b/docker/scripts/build-injected.sh
@@ -40,7 +40,7 @@ VCS_REF=${VCS_REF:-01234567}
 echo "Using engine: $ENGINE"
 echo "Using Dockerfile: $DOCKERFILE"
 echo "Using context: $CONTEXT"
-echo "Building ${IMAGE}:latest container image for ${BINARY} v${VERSION} from ${ARTIFACTS_FOLDER} hang on!"
+echo "Building ${IMAGE}:latest container image for ${BINARY} ${VERSION} from ${ARTIFACTS_FOLDER} hang on!"
 echo "ARTIFACTS_FOLDER=$ARTIFACTS_FOLDER"
 echo "CONTEXT=$CONTEXT"
 

--- a/docker/scripts/polkadot/build-injected.sh
+++ b/docker/scripts/polkadot/build-injected.sh
@@ -9,5 +9,6 @@ PROJECT_ROOT=`git rev-parse --show-toplevel`
 
 export BINARY=polkadot,polkadot-execute-worker,polkadot-prepare-worker
 export ARTIFACTS_FOLDER=$1
+export DOCKERFILE="docker/dockerfiles/polkadot/polkadot_injected.Dockerfile"
 
 $PROJECT_ROOT/docker/scripts/build-injected.sh


### PR DESCRIPTION
This PR adds the `stableYYMM-rcX` or `stableYYMM-X-rcX` tags to the docker images, so that they could be published with the new tag naming scheme.

Closes: https://github.com/paritytech/release-engineering/issues/224