### PR TITLE
[CI] Fix backport bot

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
   issues: write
+  actions: write # It may have to backport changes to the CI as well.
 
 jobs:
   backport:


### PR DESCRIPTION
Seems to also need actions permission otherwise it error when trying to backport a change to the yml files liker [here](https://github.com/paritytech/polkadot-sdk/actions/runs/11143649431/job/30969199054).
