### PR TITLE
[Backport] Fix parity-publish (#5670)

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: install parity-publish
         # Set the target dir to cache the build.
-        run: CARGO_TARGET_DIR=./target/ cargo install parity-publish@0.8.0 -q
+        run: CARGO_TARGET_DIR=./target/ cargo install parity-publish@0.8.0 --locked -q
 
       - name: check semver
         run: |

--- a/.github/workflows/publish-check-crates.yml
+++ b/.github/workflows/publish-check-crates.yml
@@ -20,7 +20,7 @@ jobs:
           cache-on-failure: true
 
       - name: install parity-publish
-        run: cargo install parity-publish@0.8.0
+        run: cargo install parity-publish@0.8.0 --locked -q
 
       - name: parity-publish check
         run: parity-publish --color always check --allow-unpublished

--- a/.github/workflows/publish-claim-crates.yml
+++ b/.github/workflows/publish-claim-crates.yml
@@ -18,7 +18,7 @@ jobs:
           cache-on-failure: true
 
       - name: install parity-publish
-        run: cargo install parity-publish@0.8.0
+        run: cargo install parity-publish@0.8.0 --locked -q
 
       - name: parity-publish claim
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17311,7 +17311,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "array-bytes",
  "criterion",


### PR DESCRIPTION
Backport of the fix that prevents `parity-publish`  from failing during installation.