### PR TITLE
Simplify bridges relayer cli configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23882,7 +23882,6 @@ dependencies = [
  "rbtag",
  "relay-substrate-client",
  "relay-utils",
- "rustc-hex",
  "scale-info",
  "sp-consensus-grandpa",
  "sp-core 28.0.0",

--- a/bridges/relays/lib-substrate-relay/Cargo.toml
+++ b/bridges/relays/lib-substrate-relay/Cargo.toml
@@ -22,7 +22,6 @@ num-traits = { workspace = true, default-features = true }
 rbtag = { workspace = true }
 structopt = { workspace = true }
 strum = { features = ["derive"], workspace = true, default-features = true }
-rustc-hex = { workspace = true }
 thiserror = { workspace = true }
 
 # Bridge dependencies

--- a/bridges/relays/lib-substrate-relay/src/cli/bridge.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/bridge.rs
@@ -23,12 +23,9 @@ use crate::{
 	parachains::SubstrateParachainsPipeline,
 };
 use bp_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
-use codec::{Codec, EncodeLike};
-use messages_relay::Labeled;
 use relay_substrate_client::{
 	Chain, ChainWithRuntimeVersion, ChainWithTransactions, Parachain, RelayChain,
 };
-use std::fmt::Debug;
 
 /// Minimal bridge representation that can be used from the CLI.
 /// It connects a source chain to a target chain.
@@ -102,22 +99,7 @@ where
 /// Bridge representation that can be used from the CLI for relaying messages.
 pub trait MessagesCliBridge: CliBridgeBase {
 	/// The Source -> Destination messages synchronization pipeline.
-	type MessagesLane: SubstrateMessageLane<
-		SourceChain = Self::Source,
-		TargetChain = Self::Target,
-		LaneId = Self::LaneId,
-	>;
-	/// Lane identifier type.
-	type LaneId: Clone
-		+ Copy
-		+ Debug
-		+ Codec
-		+ EncodeLike
-		+ Send
-		+ Sync
-		+ Labeled
-		+ TryFrom<Vec<u8>>
-		+ Default;
+	type MessagesLane: SubstrateMessageLane<SourceChain = Self::Source, TargetChain = Self::Target>;
 
 	/// Optional messages delivery transaction limits that the messages relay is going
 	/// to use. If it returns `None`, limits are estimated using `TransactionPayment` API
@@ -128,4 +110,5 @@ pub trait MessagesCliBridge: CliBridgeBase {
 }
 
 /// An alias for lane identifier type.
-pub type MessagesLaneIdOf<B> = <B as MessagesCliBridge>::LaneId;
+pub type MessagesLaneIdOf<B> =
+	<<B as MessagesCliBridge>::MessagesLane as SubstrateMessageLane>::LaneId;

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_headers_and_messages/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_headers_and_messages/mod.rs
@@ -339,7 +339,7 @@ where
 
 		// Need 2x capacity since we consider both directions for each lane
 		let mut message_relays =
-			Vec::with_capacity(lanes_l2r.len().saturating_add(lanes_r2l.len()) * 2);
+			Vec::with_capacity(lanes_l2r.len().saturating_add(lanes_r2l.len()));
 		for lane in lanes_l2r {
 			let left_to_right_messages =
 				crate::messages::run::<<Self::L2R as MessagesCliBridge>::MessagesLane, _, _>(

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_headers_and_messages/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_headers_and_messages/mod.rs
@@ -320,7 +320,9 @@ where
 				_,
 				Self::Right,
 				MessagesLaneIdOf<Self::L2R>,
-			>(common.left.client.clone(), &common.metrics_params, &common.left.accounts, &lanes_l2r)
+			>(
+				common.left.client.clone(), &common.metrics_params, &common.left.accounts, &lanes_l2r
+			)
 			.await?;
 			crate::messages::metrics::add_relay_balances_metrics::<
 				_,

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_headers_and_messages/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_headers_and_messages/mod.rs
@@ -31,7 +31,6 @@ pub mod relay_to_relay;
 pub mod relay_to_parachain;
 
 use async_trait::async_trait;
-use codec::{Codec, EncodeLike};
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 use structopt::StructOpt;
 
@@ -47,7 +46,6 @@ use crate::{
 	HeadersToRelay, TaggedAccount, TransactionParams,
 };
 use bp_runtime::BalanceOf;
-use messages_relay::Labeled;
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, Chain, ChainWithBalances, ChainWithMessages,
 	ChainWithRuntimeVersion, ChainWithTransactions,
@@ -239,20 +237,9 @@ where
 		+ ChainWithRuntimeVersion;
 
 	/// Left to Right bridge.
-	type L2R: MessagesCliBridge<Source = Self::Left, Target = Self::Right, LaneId = Self::LaneId>;
+	type L2R: MessagesCliBridge<Source = Self::Left, Target = Self::Right>;
 	/// Right to Left bridge
-	type R2L: MessagesCliBridge<Source = Self::Right, Target = Self::Left, LaneId = Self::LaneId>;
-	/// Lane identifier type.
-	type LaneId: Clone
-		+ Copy
-		+ Debug
-		+ Codec
-		+ EncodeLike
-		+ Send
-		+ Sync
-		+ Labeled
-		+ TryFrom<Vec<u8>>
-		+ Default;
+	type R2L: MessagesCliBridge<Source = Self::Right, Target = Self::Left>;
 
 	/// Construct new bridge.
 	fn new(params: <Self::Base as Full2WayBridgeBase>::Params) -> anyhow::Result<Self>;
@@ -303,7 +290,7 @@ where
 			self.mut_base().start_on_demand_headers_relayers().await?;
 
 		// add balance-related metrics
-		let lanes: Vec<Self::LaneId> = self
+		let lanes_l2r: Vec<MessagesLaneIdOf<Self::L2R>> = self
 			.base()
 			.common()
 			.shared
@@ -312,28 +299,46 @@ where
 			.cloned()
 			.map(HexLaneId::try_convert)
 			.collect::<Result<Vec<_>, HexLaneId>>()
-			.expect("");
+			.map_err(|e| {
+				anyhow::format_err!("Conversion failed for L2R lanes with error: {:?}!", e)
+			})?;
+		let lanes_r2l: Vec<MessagesLaneIdOf<Self::R2L>> = self
+			.base()
+			.common()
+			.shared
+			.lane
+			.iter()
+			.cloned()
+			.map(HexLaneId::try_convert)
+			.collect::<Result<Vec<_>, HexLaneId>>()
+			.map_err(|e| {
+				anyhow::format_err!("Conversion failed for R2L lanes with error: {:?}!", e)
+			})?;
 		{
 			let common = self.mut_base().mut_common();
 			crate::messages::metrics::add_relay_balances_metrics::<
 				_,
 				Self::Right,
 				MessagesLaneIdOf<Self::L2R>,
-			>(common.left.client.clone(), &common.metrics_params, &common.left.accounts, &lanes)
+			>(common.left.client.clone(), &common.metrics_params, &common.left.accounts, &lanes_l2r)
 			.await?;
 			crate::messages::metrics::add_relay_balances_metrics::<
 				_,
 				Self::Left,
 				MessagesLaneIdOf<Self::R2L>,
 			>(
-				common.right.client.clone(), &common.metrics_params, &common.right.accounts, &lanes
+				common.right.client.clone(),
+				&common.metrics_params,
+				&common.right.accounts,
+				&lanes_r2l,
 			)
 			.await?;
 		}
 
 		// Need 2x capacity since we consider both directions for each lane
-		let mut message_relays = Vec::with_capacity(lanes.len() * 2);
-		for lane in lanes {
+		let mut message_relays =
+			Vec::with_capacity(lanes_l2r.len().saturating_add(lanes_r2l.len()) * 2);
+		for lane in lanes_l2r {
 			let left_to_right_messages =
 				crate::messages::run::<<Self::L2R as MessagesCliBridge>::MessagesLane, _, _>(
 					self.left_to_right().messages_relay_params(
@@ -346,7 +351,8 @@ where
 				.map_err(|e| anyhow::format_err!("{}", e))
 				.boxed();
 			message_relays.push(left_to_right_messages);
-
+		}
+		for lane in lanes_r2l {
 			let right_to_left_messages =
 				crate::messages::run::<<Self::R2L as MessagesCliBridge>::MessagesLane, _, _>(
 					self.right_to_left().messages_relay_params(


### PR DESCRIPTION
This PR removes the requirement to set the `LaneId` in the relayer CLI configuration where it was not really necessary.