### PR TITLE
Bump PoV request timeout

### DIFF
--- a/polkadot/node/network/protocol/src/request_response/mod.rs
+++ b/polkadot/node/network/protocol/src/request_response/mod.rs
@@ -123,10 +123,12 @@ const DEFAULT_REQUEST_TIMEOUT_CONNECTED: Duration = Duration::from_secs(1);
 /// Timeout for requesting availability chunks.
 pub const CHUNK_REQUEST_TIMEOUT: Duration = DEFAULT_REQUEST_TIMEOUT_CONNECTED;
 
-/// This timeout is based on what seems sensible from a time budget perspective, considering 6
-/// second block time. This is going to be tough, if we have multiple forks and large PoVs, but we
-/// only have so much time.
-const POV_REQUEST_TIMEOUT_CONNECTED: Duration = Duration::from_millis(1200);
+/// This timeout is based on the following parameters, assuming we use asynchronous backing with no
+/// time budget within a relay block:
+/// - 500 Mbit/s networking speed
+/// - 10 MB PoV
+/// - 10 parallel executions
+const POV_REQUEST_TIMEOUT_CONNECTED: Duration = Duration::from_millis(2000);
 
 /// We want timeout statement requests fast, so we don't waste time on slow nodes. Responders will
 /// try their best to either serve within that timeout or return an error immediately. (We need to

--- a/prdoc/pr_5924.prdoc
+++ b/prdoc/pr_5924.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Bump PoV request timeout
+
+doc:
+  - audience: Node Dev
+    description: |
+      With asynchronous backing and PoV size 10MB, we can increase the PoV request timeout from 1.2s to 2s.
+
+crates:
+  - name: polkadot-node-network-protocol
+    bump: patch


### PR DESCRIPTION
# Description

We previously set the PoV request timeout to 1.2s based on synchronous backing, which allowed for 5 PoVs per relay block. With asynchronous backing, we no longer have a time budget and can increase the value to 2s.

Fixes https://github.com/paritytech/polkadot-sdk/issues/5885

## Integration

This PR shouldn't affect downstream projects.

## Review Notes

This PR can be followed by experiments with Gluttons on Kusama to confirm that the timeout is sufficient.
