### PR TITLE
[FRAME] fix: Do not emit `Issued { amount: 0 }` event

### DIFF
--- a/prdoc/pr_5946.prdoc
+++ b/prdoc/pr_5946.prdoc
@@ -1,0 +1,15 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "[FRAME] fix: Do not emit `Issued { amount: 0 }` event"
+
+doc:
+  - audience:
+    - Runtime Dev
+    - Runtime User
+    description: |
+      Filter out `Issued` events in `pallet-balances` module when its balance amount is zero.
+
+crates:
+  - name: pallet-balances
+    bump: patch

--- a/substrate/frame/balances/src/impl_fungible.rs
+++ b/substrate/frame/balances/src/impl_fungible.rs
@@ -354,7 +354,9 @@ impl<T: Config<I>, I: 'static> fungible::Balanced<T::AccountId> for Pallet<T, I>
 		Self::deposit_event(Event::<T, I>::Withdraw { who: who.clone(), amount });
 	}
 	fn done_issue(amount: Self::Balance) {
-		Self::deposit_event(Event::<T, I>::Issued { amount });
+		if !amount.is_zero() {
+			Self::deposit_event(Event::<T, I>::Issued { amount });
+		}
 	}
 	fn done_rescind(amount: Self::Balance) {
 		Self::deposit_event(Event::<T, I>::Rescinded { amount });


### PR DESCRIPTION
closes #5942

Couldn't find any emissions of `Event::Issued` without amount check other than in this PR.

Currently, we have;

https://github.com/paritytech/polkadot-sdk/blob/4bda956d2c635c3926578741a19fbcc3de69cbb8/substrate/frame/balances/src/impl_currency.rs#L212-L220

and

https://github.com/paritytech/polkadot-sdk/blob/4bda956d2c635c3926578741a19fbcc3de69cbb8/substrate/frame/balances/src/impl_currency.rs#L293-L306