### PR TITLE
Update docker image for bridges substrate-relay

### DIFF
--- a/docker/dockerfiles/bridges_zombienet_tests_injected.Dockerfile
+++ b/docker/dockerfiles/bridges_zombienet_tests_injected.Dockerfile
@@ -1,7 +1,7 @@
 # this image is built on top of existing Zombienet image
 ARG ZOMBIENET_IMAGE
 # this image uses substrate-relay image built elsewhere
-ARG SUBSTRATE_RELAY_IMAGE=docker.io/paritytech/substrate-relay:v1.6.10
+ARG SUBSTRATE_RELAY_IMAGE=docker.io/paritytech/substrate-relay:v1.7.0
 
 # metadata
 ARG VCS_REF


### PR DESCRIPTION
This PR updates the substrate-relay version for the bridges' Zombienet tests.