### PR TITLE
[Assets] Check for `ContainsFreezes` on `dead_account`

### DIFF
--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -688,6 +688,8 @@ pub mod pallet {
 		CallbackFailed,
 		/// The asset ID must be equal to the [`NextAssetId`].
 		BadAssetId,
+		/// The asset cannot be destroyed because some accounts for this asset contain freezes.
+		ContainsFreezes,
 	}
 
 	#[pallet::call(weight(<T as Config<I>>::WeightInfo))]


### PR DESCRIPTION
A [conversation](https://github.com/paritytech/polkadot-sdk/pull/4530#discussion_r1751972808) from #4530 (pointed out by @muharem initially, then followed up by @pandres95 and @joepetrowski) found that accounts could be destroyed without considering whether freezes do exist.

This behaviour is unexpected, as freezes should only be removed from the external systems which set them in first place.

This patch ensures that accounts cannot die unless they don't have freezes in place.