### PR TITLE
Set rococo test-parachain to latest database version

### DIFF
--- a/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,
-	system_version: 0,
+	system_version: 1,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 6000;


### PR DESCRIPTION
It seems everything is already moved to database version 1, since we are using the test-parachain for some sTPS benchmarking let's move that to 1 as well to make sure we use the right db version and avoid this in the future.