### PR TITLE
Bridges - add version guarding for standalone relaying of parachains and messages

### DIFF
--- a/bridges/relays/lib-substrate-relay/src/cli/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/mod.rs
@@ -20,7 +20,6 @@ use rbtag::BuildInfo;
 use sp_runtime::traits::TryConvert;
 use std::str::FromStr;
 use structopt::StructOpt;
-use strum::{EnumString, VariantNames};
 
 pub mod bridge;
 pub mod chain_schema;
@@ -137,17 +136,6 @@ where
 			.map(ExplicitOrMaximal::Explicit)
 			.map_err(|e| format!("Failed to parse '{e:?}'. Expected 'max' or explicit value"))
 	}
-}
-
-#[doc = "Runtime version params."]
-#[derive(StructOpt, Debug, PartialEq, Eq, Clone, Copy, EnumString, VariantNames)]
-pub enum RuntimeVersionType {
-	/// Auto query version from chain
-	Auto,
-	/// Custom `spec_version` and `transaction_version`
-	Custom,
-	/// Read version from bundle dependencies directly.
-	Bundle,
 }
 
 #[cfg(test)]

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_headers.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_headers.rs
@@ -96,6 +96,7 @@ pub trait HeadersRelayer: RelayToRelayHeadersCliBridge {
 			signer: target_sign,
 			mortality: target_transactions_mortality,
 		};
+
 		Self::Finality::start_relay_guards(&target_client, target_client.can_start_version_guard())
 			.await?;
 

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_messages.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_messages.rs
@@ -121,6 +121,8 @@ where
 			anyhow::format_err!("Invalid laneId: {:?}!", invalid_lane_id)
 		})?;
 
+		Self::start_relay_guards(&target_client, target_client.can_start_version_guard()).await?;
+
 		crate::messages::run::<Self::MessagesLane, _, _>(MessagesRelayParams {
 			source_client,
 			source_transaction_params: TransactionParams {
@@ -215,5 +217,19 @@ where
 			lane_id,
 		)
 		.await
+	}
+
+	/// Add relay guards if required.
+	async fn start_relay_guards(
+		target_client: &impl Client<Self::Target>,
+		enable_version_guard: bool,
+	) -> relay_substrate_client::Result<()> {
+		if enable_version_guard {
+			relay_substrate_client::guard::abort_on_spec_version_change(
+				target_client.clone(),
+				target_client.simple_runtime_version().await?.spec_version,
+			);
+		}
+		Ok(())
 	}
 }

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_parachains.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_parachains.rs
@@ -32,6 +32,7 @@ use crate::{
 		chain_schema::*,
 		DefaultClient, PrometheusParams,
 	},
+	finality::SubstrateFinalitySyncPipeline,
 	parachains::{source::ParachainsSource, target::ParachainsTarget, ParachainsPipelineAdapter},
 	TransactionParams,
 };
@@ -103,6 +104,9 @@ where
 		let metrics_params: relay_utils::metrics::MetricsParams =
 			data.prometheus_params.into_metrics_params()?;
 		GlobalMetrics::new()?.register_and_spawn(&metrics_params.registry)?;
+
+		Self::RelayFinality::start_relay_guards(target_client.target_client(), target_client.target_client().can_start_version_guard())
+			.await?;
 
 		parachains_relay::parachains_loop::run(
 			source_client,

--- a/bridges/relays/lib-substrate-relay/src/cli/relay_parachains.rs
+++ b/bridges/relays/lib-substrate-relay/src/cli/relay_parachains.rs
@@ -105,8 +105,11 @@ where
 			data.prometheus_params.into_metrics_params()?;
 		GlobalMetrics::new()?.register_and_spawn(&metrics_params.registry)?;
 
-		Self::RelayFinality::start_relay_guards(target_client.target_client(), target_client.target_client().can_start_version_guard())
-			.await?;
+		Self::RelayFinality::start_relay_guards(
+			target_client.target_client(),
+			target_client.target_client().can_start_version_guard(),
+		)
+		.await?;
 
 		parachains_relay::parachains_loop::run(
 			source_client,

--- a/bridges/relays/parachains/src/parachains_loop.rs
+++ b/bridges/relays/parachains/src/parachains_loop.rs
@@ -177,6 +177,14 @@ pub async fn run<P: ParachainsPipeline>(
 where
 	P::SourceRelayChain: Chain<BlockNumber = RelayBlockNumber>,
 {
+	log::info!(
+		target: "bridge",
+		"Starting {} -> {} finality proof relay: relaying (only_free_headers: {:?}) headers",
+		P::SourceParachain::NAME,
+		P::TargetChain::NAME,
+		only_free_headers,
+	);
+
 	let exit_signal = exit_signal.shared();
 	relay_utils::relay_loop(source_client, target_client)
 		.with_metrics(metrics_params)


### PR DESCRIPTION
This PR adds the ability to start version guarding when performing standalone relaying of messages and parachains.

## Follow-up
- decouple and simplify `fn start_relay_guards`: https://github.com/paritytech/polkadot-sdk/issues/5923