### PR TITLE
Introduce API for directly importing the state into the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18506,6 +18506,7 @@ dependencies = [
  "array-bytes",
  "criterion",
  "hash-db",
+ "hex",
  "kitchensink-runtime",
  "kvdb",
  "kvdb-memorydb",

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -590,6 +590,24 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	/// Returns state backend with post-state of given block.
 	fn state_at(&self, hash: Block::Hash) -> sp_blockchain::Result<Self::State>;
 
+	/// Import the state changes directly to the trie database.
+	///
+	/// # Arguments
+	///
+	/// - `at`: The block hash corresponding to the last available state before updating the trie database.
+	/// - `storage`: The storage changes reflecting the transition from the last local state to the target block's state being imported.
+	/// - `state_version`: The state version of the block identified by `at`.
+	///
+	/// # Returns
+	///
+	/// Returns the state root after importing the state.
+	fn commit_trie_changes(
+		&self,
+		at: Block::Hash,
+		storage: sp_runtime::Storage,
+		state_version: sp_runtime::StateVersion,
+	) -> sp_blockchain::Result<Block::Hash>;
+
 	/// Attempts to revert the chain by `n` blocks. If `revert_finalized` is set it will attempt to
 	/// revert past any finalized block, this is unsafe and can potentially leave the node in an
 	/// inconsistent state. All blocks higher than the best block are also reverted and not counting

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -594,8 +594,10 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	///
 	/// # Arguments
 	///
-	/// - `at`: The block hash corresponding to the last available state before updating the trie database.
-	/// - `storage`: The storage changes reflecting the transition from the last local state to the target block's state being imported.
+	/// - `at`: The block hash corresponding to the last available state before updating the trie
+	///   database.
+	/// - `storage`: The storage changes reflecting the transition from the last local state to the
+	///   target block's state being imported.
 	/// - `state_version`: The state version of the block identified by `at`.
 	///
 	/// # Returns

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -748,11 +748,11 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 
 	fn commit_trie_changes(
 		&self,
-		at: Block::Hash,
-		storage: sp_runtime::Storage,
-		state_version: sp_runtime::StateVersion,
+		_at: Block::Hash,
+		_storage: sp_runtime::Storage,
+		_state_version: sp_runtime::StateVersion,
 	) -> sp_blockchain::Result<Block::Hash> {
-		todo!()
+		unimplemented!("Not needed for in-mem backend")
 	}
 
 	fn revert(

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -192,7 +192,7 @@ impl<Block: BlockT> Blockchain<Block> {
 	pub fn equals_to(&self, other: &Self) -> bool {
 		// Check ptr equality first to avoid double read locks.
 		if ptr::eq(self, other) {
-			return true
+			return true;
 		}
 		self.canon_equals_to(other) && self.storage.read().blocks == other.storage.read().blocks
 	}
@@ -201,14 +201,14 @@ impl<Block: BlockT> Blockchain<Block> {
 	pub fn canon_equals_to(&self, other: &Self) -> bool {
 		// Check ptr equality first to avoid double read locks.
 		if ptr::eq(self, other) {
-			return true
+			return true;
 		}
 		let this = self.storage.read();
 		let other = other.storage.read();
-		this.hashes == other.hashes &&
-			this.best_hash == other.best_hash &&
-			this.best_number == other.best_number &&
-			this.genesis_hash == other.genesis_hash
+		this.hashes == other.hashes
+			&& this.best_hash == other.best_hash
+			&& this.best_number == other.best_number
+			&& this.genesis_hash == other.genesis_hash
 	}
 
 	/// Insert header CHT root.
@@ -307,7 +307,7 @@ impl<Block: BlockT> Blockchain<Block> {
 			if !stored_justifications.append(justification) {
 				return Err(sp_blockchain::Error::BadJustification(
 					"Duplicate consensus engine ID".into(),
-				))
+				));
 			}
 		} else {
 			*block_justifications = Some(Justifications::from(justification));
@@ -736,7 +736,7 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 
 	fn state_at(&self, hash: Block::Hash) -> sp_blockchain::Result<Self::State> {
 		if hash == Default::default() {
-			return Ok(Self::State::default())
+			return Ok(Self::State::default());
 		}
 
 		self.states
@@ -744,6 +744,15 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 			.get(&hash)
 			.cloned()
 			.ok_or_else(|| sp_blockchain::Error::UnknownBlock(format!("{}", hash)))
+	}
+
+	fn commit_trie_changes(
+		&self,
+		at: Block::Hash,
+		storage: sp_runtime::Storage,
+		state_version: sp_runtime::StateVersion,
+	) -> sp_blockchain::Result<Block::Hash> {
+		todo!()
 	}
 
 	fn revert(
@@ -783,7 +792,7 @@ impl<Block: BlockT> backend::LocalBackend<Block> for Backend<Block> {}
 /// Check that genesis storage is valid.
 pub fn check_genesis_storage(storage: &Storage) -> sp_blockchain::Result<()> {
 	if storage.top.iter().any(|(k, _)| well_known_keys::is_child_storage_key(k)) {
-		return Err(sp_blockchain::Error::InvalidState)
+		return Err(sp_blockchain::Error::InvalidState);
 	}
 
 	if storage
@@ -791,7 +800,7 @@ pub fn check_genesis_storage(storage: &Storage) -> sp_blockchain::Result<()> {
 		.keys()
 		.any(|child_key| !well_known_keys::is_child_storage_key(child_key))
 	{
-		return Err(sp_blockchain::Error::InvalidState)
+		return Err(sp_blockchain::Error::InvalidState);
 	}
 
 	Ok(())

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -205,10 +205,10 @@ impl<Block: BlockT> Blockchain<Block> {
 		}
 		let this = self.storage.read();
 		let other = other.storage.read();
-		this.hashes == other.hashes
-			&& this.best_hash == other.best_hash
-			&& this.best_number == other.best_number
-			&& this.genesis_hash == other.genesis_hash
+		this.hashes == other.hashes &&
+			this.best_hash == other.best_hash &&
+			this.best_number == other.best_number &&
+			this.genesis_hash == other.genesis_hash
 	}
 
 	/// Insert header CHT root.

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -40,6 +40,7 @@ sp-trie = { workspace = true, default-features = true }
 
 [dev-dependencies]
 criterion = { workspace = true, default-features = true }
+hex = { workspace = true }
 kvdb-rocksdb = { workspace = true }
 rand = { workspace = true, default-features = true }
 tempfile = { workspace = true }

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -37,6 +37,7 @@ mod parity_db;
 mod pinned_blocks_cache;
 mod record_stats_state;
 mod stats;
+mod trie_committer;
 #[cfg(any(feature = "rocksdb", test))]
 mod upgrade;
 mod utils;

--- a/substrate/client/db/src/trie_committer.rs
+++ b/substrate/client/db/src/trie_committer.rs
@@ -1,0 +1,64 @@
+use hash_db::{AsHashDB, HashDB, HashDBRef, Hasher, Prefix};
+use sp_state_machine::TrieBackendStorage;
+use sp_trie::{DBValue, PrefixedMemoryDB};
+
+pub(crate) struct Ephemeral<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> {
+	storage: &'a S,
+	overlay: &'a mut PrefixedMemoryDB<H>,
+}
+
+impl<'a, S: TrieBackendStorage<H>, H: Hasher> Ephemeral<'a, S, H> {
+	pub fn new(storage: &'a S, overlay: &'a mut PrefixedMemoryDB<H>) -> Self {
+		Ephemeral { storage, overlay }
+	}
+}
+
+impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> hash_db::HashDB<H, DBValue>
+	for Ephemeral<'a, S, H>
+{
+	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<DBValue> {
+		HashDB::get(self.overlay, key, prefix).or_else(|| {
+			self.storage.get(key, prefix).unwrap_or_else(|e| {
+				log::warn!(target: "trie", "Failed to read from DB: {}", e);
+				None
+			})
+		})
+	}
+
+	fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+		HashDB::get(self, key, prefix).is_some()
+	}
+
+	fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
+		HashDB::insert(self.overlay, prefix, value)
+	}
+
+	fn emplace(&mut self, key: H::Out, prefix: Prefix, value: DBValue) {
+		HashDB::emplace(self.overlay, key, prefix, value)
+	}
+
+	fn remove(&mut self, key: &H::Out, prefix: Prefix) {
+		HashDB::remove(self.overlay, key, prefix)
+	}
+}
+
+impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> HashDBRef<H, DBValue> for Ephemeral<'a, S, H> {
+	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<DBValue> {
+		HashDB::get(self, key, prefix)
+	}
+
+	fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
+		HashDB::contains(self, key, prefix)
+	}
+}
+
+impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> AsHashDB<H, DBValue>
+	for Ephemeral<'a, S, H>
+{
+	fn as_hash_db<'b>(&'b self) -> &'b (dyn HashDB<H, DBValue> + 'b) {
+		self
+	}
+	fn as_hash_db_mut<'b>(&'b mut self) -> &'b mut (dyn HashDB<H, DBValue> + 'b) {
+		self
+	}
+}

--- a/substrate/client/db/src/trie_committer.rs
+++ b/substrate/client/db/src/trie_committer.rs
@@ -1,23 +1,38 @@
+use crate::{columns, DbHash};
 use hash_db::{AsHashDB, HashDB, HashDBRef, Hasher, Prefix};
+use sp_database::{Change, Database, Transaction};
 use sp_state_machine::TrieBackendStorage;
-use sp_trie::{DBValue, PrefixedMemoryDB};
+use sp_trie::DBValue;
+use std::{marker::PhantomData, sync::Arc};
 
-pub(crate) struct Ephemeral<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> {
+/// [`TrieCommitter`] is responsible for committing trie state changes
+/// directly into the database, bypassing the in-memory intermediate storage
+/// (`PrefixedMemoryDB`).
+///
+/// This approach avoids potential OOM issues that can arise when dealing with
+/// large state imports, especially when importing the state downloaded from
+/// fast sync or warp sync.
+pub(crate) struct TrieCommitter<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> {
+	/// Old state storage backend.
 	storage: &'a S,
-	overlay: &'a mut PrefixedMemoryDB<H>,
+	/// Handle to the trie database where changes will be committed.
+	trie_database: Arc<dyn Database<DbHash>>,
+	_phantom: PhantomData<H>,
 }
 
-impl<'a, S: TrieBackendStorage<H>, H: Hasher> Ephemeral<'a, S, H> {
-	pub fn new(storage: &'a S, overlay: &'a mut PrefixedMemoryDB<H>) -> Self {
-		Ephemeral { storage, overlay }
+impl<'a, S: TrieBackendStorage<H>, H: Hasher> TrieCommitter<'a, S, H> {
+	pub fn new(storage: &'a S, trie_database: Arc<dyn Database<DbHash>>) -> Self {
+		Self { storage, trie_database, _phantom: Default::default() }
 	}
 }
 
 impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> hash_db::HashDB<H, DBValue>
-	for Ephemeral<'a, S, H>
+	for TrieCommitter<'a, S, H>
 {
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<DBValue> {
-		HashDB::get(self.overlay, key, prefix).or_else(|| {
+		let db_key = sp_trie::prefixed_key::<H>(key, prefix);
+
+		self.trie_database.get(columns::STATE, &db_key).or_else(|| {
 			self.storage.get(key, prefix).unwrap_or_else(|e| {
 				log::warn!(target: "trie", "Failed to read from DB: {}", e);
 				None
@@ -30,19 +45,31 @@ impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> hash_db::HashDB<H, DBValue>
 	}
 
 	fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
-		HashDB::insert(self.overlay, prefix, value)
+		let key = H::hash(value);
+
+		let db_key = sp_trie::prefixed_key::<H>(&key, prefix);
+		let tx = Transaction(vec![Change::Set(columns::STATE, db_key, value.to_vec())]);
+		self.trie_database.commit(tx).expect("TODO: handle unwrap properly");
+
+		key
 	}
 
 	fn emplace(&mut self, key: H::Out, prefix: Prefix, value: DBValue) {
-		HashDB::emplace(self.overlay, key, prefix, value)
+		let key = sp_trie::prefixed_key::<H>(&key, prefix);
+		let tx = Transaction(vec![Change::Set(columns::STATE, key, value)]);
+		self.trie_database.commit(tx).expect("TODO: handle unwrap properly");
 	}
 
 	fn remove(&mut self, key: &H::Out, prefix: Prefix) {
-		HashDB::remove(self.overlay, key, prefix)
+		let key = sp_trie::prefixed_key::<H>(&key, prefix);
+		let tx = Transaction(vec![Change::Remove(columns::STATE, key)]);
+		self.trie_database.commit(tx).expect("TODO: handle unwrap properly");
 	}
 }
 
-impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> HashDBRef<H, DBValue> for Ephemeral<'a, S, H> {
+impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> HashDBRef<H, DBValue>
+	for TrieCommitter<'a, S, H>
+{
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<DBValue> {
 		HashDB::get(self, key, prefix)
 	}
@@ -53,7 +80,7 @@ impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> HashDBRef<H, DBValue> for Eph
 }
 
 impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> AsHashDB<H, DBValue>
-	for Ephemeral<'a, S, H>
+	for TrieCommitter<'a, S, H>
 {
 	fn as_hash_db<'b>(&'b self) -> &'b (dyn HashDB<H, DBValue> + 'b) {
 		self

--- a/substrate/client/db/src/trie_committer.rs
+++ b/substrate/client/db/src/trie_committer.rs
@@ -30,6 +30,10 @@ impl<'a, S: 'a + TrieBackendStorage<H>, H: Hasher> hash_db::HashDB<H, DBValue>
 	for TrieCommitter<'a, S, H>
 {
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<DBValue> {
+		if prefix == sp_trie::EMPTY_PREFIX {
+			return Some([0u8].to_vec());
+		}
+
 		let db_key = sp_trie::prefixed_key::<H>(key, prefix);
 
 		self.trie_database.get(columns::STATE, &db_key).or_else(|| {

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -687,7 +687,11 @@ where
 						)?;
 						// TODO: local fast sync test.
 						// let state_root = operation.op.reset_storage(storage, state_version)?;
-						let state_root = self.backend.commit_trie_changes(parent_hash, storage, state_version)?;
+						let state_root = self.backend.commit_trie_changes(
+							parent_hash,
+							storage,
+							state_version,
+						)?;
 						if state_root != *import_headers.post().state_root() {
 							// State root mismatch when importing state. This should not happen in
 							// safe fast sync mode, but may happen in unsafe mode.

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -518,7 +518,7 @@ where
 		} = import_block;
 
 		if !intermediates.is_empty() {
-			return Err(Error::IncompletePipeline)
+			return Err(Error::IncompletePipeline);
 		}
 
 		let fork_choice = fork_choice.ok_or(Error::IncompletePipeline)?;
@@ -616,7 +616,7 @@ where
 			*import_headers.post().number() <= info.finalized_number &&
 			!gap_block
 		{
-			return Err(sp_blockchain::Error::NotInFinalizedChain)
+			return Err(sp_blockchain::Error::NotInFinalizedChain);
 		}
 
 		// this is a fairly arbitrary choice of where to draw the line on making notifications,
@@ -685,8 +685,6 @@ where
 							&storage,
 							&self.executor,
 						)?;
-						// TODO: local fast sync test.
-						// let state_root = operation.op.reset_storage(storage, state_version)?;
 						let state_root = self.backend.commit_trie_changes(
 							parent_hash,
 							storage,
@@ -696,7 +694,7 @@ where
 							// State root mismatch when importing state. This should not happen in
 							// safe fast sync mode, but may happen in unsafe mode.
 							warn!("Error importing state: State root mismatch.");
-							return Err(Error::InvalidStateRoot)
+							return Err(Error::InvalidStateRoot);
 						}
 						None
 					},
@@ -895,7 +893,7 @@ where
 
 				if import_block.header.state_root() != &gen_storage_changes.transaction_storage_root
 				{
-					return Err(Error::InvalidStateRoot)
+					return Err(Error::InvalidStateRoot);
 				}
 				Some(sc_consensus::StorageChanges::Changes(gen_storage_changes))
 			},
@@ -921,7 +919,7 @@ where
 				"Possible safety violation: attempted to re-finalize last finalized block {:?} ",
 				hash,
 			);
-			return Ok(())
+			return Ok(());
 		}
 
 		// Find tree route from last finalized to given block.
@@ -935,7 +933,7 @@ where
 				retracted, info.finalized_hash
 			);
 
-			return Err(sp_blockchain::Error::NotInFinalizedChain)
+			return Err(sp_blockchain::Error::NotInFinalizedChain);
 		}
 
 		// We may need to coercively update the best block if there is more than one
@@ -1019,7 +1017,7 @@ where
 				// since we won't be running the loop below which
 				// would also remove any closed sinks.
 				sinks.retain(|sink| !sink.is_closed());
-				return Ok(())
+				return Ok(());
 			},
 		};
 
@@ -1055,7 +1053,7 @@ where
 
 				self.every_import_notification_sinks.lock().retain(|sink| !sink.is_closed());
 
-				return Ok(())
+				return Ok(());
 			},
 		};
 
@@ -1154,7 +1152,7 @@ where
 			.as_ref()
 			.map_or(false, |importing| &hash == importing)
 		{
-			return Ok(BlockStatus::Queued)
+			return Ok(BlockStatus::Queued);
 		}
 
 		let hash_and_number = self.backend.blockchain().number(hash)?.map(|n| (hash, n));
@@ -1200,7 +1198,7 @@ where
 
 		let genesis_hash = self.backend.blockchain().info().genesis_hash;
 		if genesis_hash == target_hash {
-			return Ok(Vec::new())
+			return Ok(Vec::new());
 		}
 
 		let mut current_hash = target_hash;
@@ -1216,7 +1214,7 @@ where
 			current_hash = ancestor_hash;
 
 			if genesis_hash == current_hash {
-				break
+				break;
 			}
 
 			current = ancestor;
@@ -1301,7 +1299,7 @@ where
 		size_limit: usize,
 	) -> sp_blockchain::Result<Vec<(KeyValueStorageLevel, bool)>> {
 		if start_key.len() > MAX_NESTED_TRIE_DEPTH {
-			return Err(Error::Backend("Invalid start key.".to_string()))
+			return Err(Error::Backend("Invalid start key.".to_string()));
 		}
 		let state = self.state_at(hash)?;
 		let child_info = |storage_key: &Vec<u8>| -> sp_blockchain::Result<ChildInfo> {
@@ -1320,7 +1318,7 @@ where
 			{
 				Some((child_info(start_key)?, child_root))
 			} else {
-				return Err(Error::Backend("Invalid root start key.".to_string()))
+				return Err(Error::Backend("Invalid root start key.".to_string()));
 			}
 		} else {
 			None
@@ -1364,7 +1362,7 @@ where
 				let size = value.len() + next_key.len();
 				if total_size + size > size_limit && !entries.is_empty() {
 					complete = false;
-					break
+					break;
 				}
 				total_size += size;
 
@@ -1375,7 +1373,7 @@ where
 					child_roots.insert(value.clone());
 					switch_child_key = Some((next_key.clone(), value.clone()));
 					entries.push((next_key.clone(), value));
-					break
+					break;
 				}
 				entries.push((next_key.clone(), value));
 				current_key = next_key;
@@ -1395,12 +1393,12 @@ where
 					complete,
 				));
 				if !complete {
-					break
+					break;
 				}
 			} else {
 				result[0].0.key_values.extend(entries.into_iter());
 				result[0].1 = complete;
-				break
+				break;
 			}
 		}
 		Ok(result)
@@ -1805,7 +1803,7 @@ where
 		match self.block_rules.lookup(number, &hash) {
 			BlockLookupResult::KnownBad => {
 				trace!("Rejecting known bad block: #{} {:?}", number, hash);
-				return Ok(ImportResult::KnownBad)
+				return Ok(ImportResult::KnownBad);
 			},
 			BlockLookupResult::Expected(expected_hash) => {
 				trace!(
@@ -1814,7 +1812,7 @@ where
 					expected_hash,
 					number
 				);
-				return Ok(ImportResult::KnownBad)
+				return Ok(ImportResult::KnownBad);
 			},
 			BlockLookupResult::NotSpecial => {},
 		}

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -685,7 +685,9 @@ where
 							&storage,
 							&self.executor,
 						)?;
-						let state_root = operation.op.reset_storage(storage, state_version)?;
+						// TODO: local fast sync test.
+						// let state_root = operation.op.reset_storage(storage, state_version)?;
+						let state_root = self.backend.commit_trie_changes(parent_hash, storage, state_version)?;
 						if state_root != *import_headers.post().state_root() {
 							// State root mismatch when importing state. This should not happen in
 							// safe fast sync mode, but may happen in unsafe mode.


### PR DESCRIPTION
This new API commits the state directly to the underlying database, reducing the risk of OOM issues when importing large states into the node. More background on this can be found at https://github.com/paritytech/polkadot-sdk/issues/5862

This PR is an internal implementation change, replacing the `reset_storage()` function with the new `commit_trie_changes()` API in Client. The entire state still stays in the memory, which will be worked on after merging this PR.

I’ve successfully tested fast sync locally, and it works as expected. However, the unit test I added for this API has been failing since https://github.com/paritytech/polkadot-sdk/commit/3372d31406d112aaa1c1e560a5f43697875cd654. I’m submitting this PR to get early feedback on the overall approach and insights into the test failure before diving deeper into troubleshooting.

cc @bkchr 