### PR TITLE
Dry run xcms on bridge hubs to get forwarded xcms across the P<>K bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11034,6 +11034,8 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-std 14.0.0",
  "sp-trie 29.0.0",
+ "staging-xcm",
+ "staging-xcm-builder",
 ]
 
 [[package]]

--- a/bridges/modules/messages/Cargo.toml
+++ b/bridges/modules/messages/Cargo.toml
@@ -15,18 +15,22 @@ codec = { workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 
-# Bridge dependencies
+# Bridge dependencies.
 bp-header-chain = { workspace = true }
 bp-messages = { workspace = true }
 bp-runtime = { workspace = true }
 
-# Substrate Dependencies
+# Substrate dependencies.
 frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-trie = { optional = true, workspace = true }
+
+# Polkadot dependencies.
+xcm = { workspace = true, package = "staging-xcm" }
+xcm-builder = { workspace = true, package = "staging-xcm-builder" }
 
 [dev-dependencies]
 bp-runtime = { features = ["test-helpers"], workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
@@ -538,8 +538,10 @@ fn send_back_wnds_from_penpal_rococo_through_asset_hub_rococo_to_asset_hub_weste
 #[test]
 fn dry_run_transfer_to_westend_sends_xcm_to_bridge_hub() {
 	test_dry_run_transfer_across_pk_bridge!(
+		Westend,
 		AssetHubRococo,
 		BridgeHubRococo,
-		asset_hub_westend_location()
+		asset_hub_westend_location(),
+		bridge_hub_westend_location()
 	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
@@ -558,8 +558,10 @@ fn send_back_rocs_from_penpal_westend_through_asset_hub_westend_to_asset_hub_roc
 #[test]
 fn dry_run_transfer_to_rococo_sends_xcm_to_bridge_hub() {
 	test_dry_run_transfer_across_pk_bridge!(
+		Rococo,
 		AssetHubWestend,
 		BridgeHubWestend,
-		asset_hub_rococo_location()
+		asset_hub_rococo_location(),
+		bridge_hub_rococo_location()
 	);
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -868,7 +868,7 @@ impl_runtime_apis! {
 		}
 
 		fn dry_run_xcm(origin_location: VersionedLocation, xcm: VersionedXcm<RuntimeCall>) -> Result<XcmDryRunEffects<RuntimeEvent>, XcmDryRunApiError> {
-			PolkadotXcm::dry_run_xcm::<Runtime, xcm_config::XcmRouter, RuntimeCall, xcm_config::XcmConfig>(origin_location, xcm)
+			PolkadotXcm::dry_run_xcm::<Runtime, (xcm_config::XcmRouter, BridgeWestendMessages), RuntimeCall, xcm_config::XcmConfig>(origin_location, xcm)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -800,7 +800,7 @@ impl_runtime_apis! {
 		}
 
 		fn dry_run_xcm(origin_location: VersionedLocation, xcm: VersionedXcm<RuntimeCall>) -> Result<XcmDryRunEffects<RuntimeEvent>, XcmDryRunApiError> {
-			PolkadotXcm::dry_run_xcm::<Runtime, xcm_config::XcmRouter, RuntimeCall, xcm_config::XcmConfig>(origin_location, xcm)
+			PolkadotXcm::dry_run_xcm::<Runtime, (xcm_config::XcmRouter, BridgeRococoMessages), RuntimeCall, xcm_config::XcmConfig>(origin_location, xcm)
 		}
 	}
 

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -2528,7 +2528,10 @@ impl<T: Config> Pallet<T> {
 			XcmDryRunApiError::VersionedConversionFailed
 		})?;
 		let mut hash = xcm.using_encoded(sp_io::hashing::blake2_256);
-		frame_system::Pallet::<Runtime>::reset_events(); // To make sure we only record events from current call.
+		// Clear other messages in queues...
+		Router::clear_messages();
+		// ...and reset events to make sure we only record events from current call.
+		frame_system::Pallet::<Runtime>::reset_events();
 		let result = xcm_executor::XcmExecutor::<XcmConfig>::prepare_and_execute(
 			origin_location,
 			xcm,


### PR DESCRIPTION
The DryRunApi did not return any forwarded xcms when used on bridge hubs.
This PR completes the story of dry running an XCM across the P<>K bridge.

The tests `dry_run_transfer_to_westend_sends_xcm_to_bridge_hub` and `dry_run_transfer_to_rococo_sends_xcm_to_bridge_hub` show how you can start from Asset Hub on one side of the bridge and get the message that will be executed on the Asset Hub on the other side.
These two tests use the `test_dry_run_transfer_across_pk_bridge` macro.

The most important implementation is `InspectMessageQueues` for pallet bridge messages.
