### PR TITLE
Implement Proof Of Possession capability for all public key crypto types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21844,6 +21844,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0",
+ "sp-crypto-pubkeycrypto-proc-macro",
  "sp-debug-derive 14.0.0",
  "sp-externalities 0.25.0",
  "sp-runtime-interface 24.0.0",
@@ -22106,6 +22107,19 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote 1.0.37",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "sp-crypto-pubkeycrypto"
+version = "28.0.0"
+
+[[package]]
+name = "sp-crypto-pubkeycrypto-proc-macro"
+version = "0.1.0"
+dependencies = [
+ "quote 1.0.37",
+ "sp-crypto-hashing 0.1.0",
  "syn 2.0.79",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -469,6 +469,8 @@ members = [
 	"substrate/primitives/crypto/ec-utils",
 	"substrate/primitives/crypto/hashing",
 	"substrate/primitives/crypto/hashing/proc-macro",
+	"substrate/primitives/crypto/pubkeycrypto",
+	"substrate/primitives/crypto/pubkeycrypto/proc-macro",
 	"substrate/primitives/database",
 	"substrate/primitives/debug-derive",
 	"substrate/primitives/externalities",
@@ -1240,6 +1242,8 @@ sp-consensus-slots = { path = "substrate/primitives/consensus/slots", default-fe
 sp-core = { path = "substrate/primitives/core", default-features = false }
 sp-core-hashing = { default-features = false, path = "substrate/deprecated/hashing" }
 sp-core-hashing-proc-macro = { default-features = false, path = "substrate/deprecated/hashing/proc-macro" }
+sp-crypto-pubkeycrypto = {default-features = false, path = "substrate/primitives/crypto/pubkeycrypto"}
+sp-crypto-pubkeycrypto-proc-macro = {default-features = false, path = "substrate/primitives/crypto/pubkeycrypto/proc-macro"}
 sp-crypto-ec-utils = { default-features = false, path = "substrate/primitives/crypto/ec-utils" }
 sp-crypto-hashing = { path = "substrate/primitives/crypto/hashing", default-features = false }
 sp-crypto-hashing-proc-macro = { path = "substrate/primitives/crypto/hashing/proc-macro", default-features = false }

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -42,6 +42,7 @@ sp-std = { workspace = true }
 sp-debug-derive = { workspace = true }
 sp-storage = { workspace = true }
 sp-externalities = { optional = true, workspace = true }
+sp-crypto-pubkeycrypto-proc-macro=  { workspace = true }
 futures = { optional = true, workspace = true }
 dyn-clonable = { optional = true, workspace = true }
 thiserror = { optional = true, workspace = true }

--- a/substrate/primitives/core/src/bandersnatch.rs
+++ b/substrate/primitives/core/src/bandersnatch.rs
@@ -24,8 +24,10 @@
 use crate::crypto::VrfSecret;
 use crate::crypto::{
 	ByteArray, CryptoType, CryptoTypeId, DeriveError, DeriveJunction, Pair as TraitPair,
-	PublicBytes, SecretStringError, SignatureBytes, UncheckedFrom, VrfPublic,
+	ProofOfPossessionGenerator, ProofOfPossessionVerifier, PublicBytes, SecretStringError,
+	SignatureBytes, UncheckedFrom, VrfPublic,
 };
+use sp_crypto_pubkeycrypto_proc_macro::ProofOfPossession;
 
 use bandersnatch_vrfs::{CanonicalSerialize, SecretKey};
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
@@ -75,7 +77,7 @@ impl CryptoType for Signature {
 type Seed = [u8; SEED_SERIALIZED_SIZE];
 
 /// Bandersnatch secret key.
-#[derive(Clone)]
+#[derive(Clone, ProofOfPossession)]
 pub struct Pair {
 	secret: SecretKey,
 	seed: Seed,

--- a/substrate/primitives/core/src/bls.rs
+++ b/substrate/primitives/core/src/bls.rs
@@ -32,7 +32,7 @@ use alloc::vec::Vec;
 
 use w3f_bls::{
 	DoublePublicKey, DoublePublicKeyScheme, DoubleSignature, EngineBLS, Keypair, Message,
-	SecretKey, SerializableToBytes, TinyBLS381,
+	ProofOfPossession, SecretKey, SerializableToBytes, TinyBLS381,
 };
 
 /// BLS-377 specialized types

--- a/substrate/primitives/core/src/ecdsa.rs
+++ b/substrate/primitives/core/src/ecdsa.rs
@@ -18,9 +18,12 @@
 //! Simple ECDSA secp256k1 API.
 
 use crate::crypto::{
-	CryptoType, CryptoTypeId, DeriveError, DeriveJunction, Pair as TraitPair, PublicBytes,
-	SecretStringError, SignatureBytes,
+	CryptoType, CryptoTypeId, DeriveError, DeriveJunction, Pair as TraitPair,
+	ProofOfPossessionGenerator, ProofOfPossessionVerifier, PublicBytes, SecretStringError,
+	SignatureBytes,
 };
+
+use sp_crypto_pubkeycrypto_proc_macro::ProofOfPossession;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -154,7 +157,7 @@ fn derive_hard_junction(secret_seed: &Seed, cc: &[u8; 32]) -> Seed {
 }
 
 /// A key pair.
-#[derive(Clone)]
+#[derive(Clone, ProofOfPossession)]
 pub struct Pair {
 	public: Public,
 	secret: SecretKey,

--- a/substrate/primitives/core/src/ed25519.rs
+++ b/substrate/primitives/core/src/ed25519.rs
@@ -19,10 +19,12 @@
 
 use crate::crypto::{
 	ByteArray, CryptoType, CryptoTypeId, DeriveError, DeriveJunction, Pair as TraitPair,
-	PublicBytes, SecretStringError, SignatureBytes,
+	ProofOfPossessionGenerator, ProofOfPossessionVerifier, PublicBytes, SecretStringError,
+	SignatureBytes,
 };
 
 use ed25519_zebra::{SigningKey, VerificationKey};
+use sp_crypto_pubkeycrypto_proc_macro::ProofOfPossession;
 
 use alloc::vec::Vec;
 
@@ -50,7 +52,7 @@ pub type Public = PublicBytes<PUBLIC_KEY_SERIALIZED_SIZE, Ed25519Tag>;
 pub type Signature = SignatureBytes<SIGNATURE_SERIALIZED_SIZE, Ed25519Tag>;
 
 /// A key pair.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, ProofOfPossession)]
 pub struct Pair {
 	public: VerificationKey,
 	secret: SigningKey,

--- a/substrate/primitives/core/src/sr25519.rs
+++ b/substrate/primitives/core/src/sr25519.rs
@@ -23,8 +23,11 @@
 #[cfg(feature = "serde")]
 use crate::crypto::Ss58Codec;
 use crate::crypto::{
-	CryptoBytes, DeriveError, DeriveJunction, Pair as TraitPair, SecretStringError,
+	CryptoBytes, DeriveError, DeriveJunction, Pair as TraitPair, ProofOfPossessionGenerator,
+	ProofOfPossessionVerifier, SecretStringError,
 };
+use sp_crypto_pubkeycrypto_proc_macro::ProofOfPossession;
+
 use alloc::vec::Vec;
 #[cfg(feature = "full_crypto")]
 use schnorrkel::signing_context;
@@ -145,6 +148,7 @@ impl From<schnorrkel::Signature> for Signature {
 }
 
 /// An Schnorrkel/Ristretto x25519 ("sr25519") key pair.
+#[derive(ProofOfPossession)]
 pub struct Pair(Keypair);
 
 impl Clone for Pair {

--- a/substrate/primitives/crypto/pubkeycrypto/Cargo.toml
+++ b/substrate/primitives/crypto/pubkeycrypto/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "sp-crypto-pubkeycrypto"
+authors.workspace = true
+edition.workspace = true
+version = "28.0.0"
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "A crate for all implementations of public key cryptography in Substrate (currently in primitive/core.)"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+
+# full crypto
+
+
+[dev-dependencies]
+
+
+
+[lib]
+bench = false
+
+
+[features]
+default = ["std"]
+
+std = []
+
+# Serde support without relying on std features.
+serde = [
+
+]
+
+# This feature enables all crypto primitives for `no_std` builds like microcontrollers
+# or Intel SGX.
+# For the regular wasm runtime builds this should not be used.
+full_crypto = [
+]
+

--- a/substrate/primitives/crypto/pubkeycrypto/proc-macro/Cargo.toml
+++ b/substrate/primitives/crypto/pubkeycrypto/proc-macro/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sp-crypto-pubkeycrypto-proc-macro"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "Procedural macros for deriving public key crypto implementations."
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = { workspace = true }
+syn = { features = ["full", "parsing"], workspace = true }
+sp-crypto-hashing = { workspace = true }

--- a/substrate/primitives/crypto/pubkeycrypto/proc-macro/src/impls.rs
+++ b/substrate/primitives/crypto/pubkeycrypto/proc-macro/src/impls.rs
@@ -1,0 +1,124 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+
+use proc_macro::TokenStream;
+
+pub(super) struct InputBytes(pub Vec<u8>);
+
+pub(super) struct MultipleInputBytes(pub Vec<Vec<u8>>);
+
+impl MultipleInputBytes {
+	pub(super) fn concatenated(mut self) -> Vec<u8> {
+		if self.0.is_empty() {
+			Vec::new()
+		} else {
+			let mut result = core::mem::take(&mut self.0[0]);
+			for other in self.0[1..].iter_mut() {
+				result.append(other);
+			}
+			result
+		}
+	}
+}
+
+impl Parse for InputBytes {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		match syn::ExprArray::parse(input) {
+			Ok(array) => {
+				let mut bytes = Vec::<u8>::new();
+				for expr in array.elems.iter() {
+					match expr {
+						syn::Expr::Lit(lit) => match &lit.lit {
+							syn::Lit::Int(b) => bytes.push(b.base10_parse()?),
+							syn::Lit::Byte(b) => bytes.push(b.value()),
+							_ =>
+								return Err(syn::Error::new(
+									input.span(),
+									"Expected array of u8 elements.".to_string(),
+								)),
+						},
+						_ =>
+							return Err(syn::Error::new(
+								input.span(),
+								"Expected array of u8 elements.".to_string(),
+							)),
+					}
+				}
+				return Ok(InputBytes(bytes))
+			},
+			Err(_e) => (),
+		}
+		// use rust names as a vec of their utf8 bytecode.
+		match syn::Ident::parse(input) {
+			Ok(ident) => return Ok(InputBytes(ident.to_string().as_bytes().to_vec())),
+			Err(_e) => (),
+		}
+		Ok(InputBytes(syn::LitByteStr::parse(input)?.value()))
+	}
+}
+
+impl Parse for MultipleInputBytes {
+	fn parse(input: ParseStream) -> syn::Result<Self> {
+		let elts =
+			syn::punctuated::Punctuated::<InputBytes, syn::token::Comma>::parse_terminated(input)?;
+		Ok(MultipleInputBytes(elts.into_iter().map(|elt| elt.0).collect()))
+	}
+}
+
+pub(super) fn twox_64(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::twox_64(bytes.as_slice()))
+}
+
+pub(super) fn twox_128(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::twox_128(bytes.as_slice()))
+}
+
+pub(super) fn blake2b_512(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::blake2_512(bytes.as_slice()))
+}
+
+pub(super) fn blake2b_256(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::blake2_256(bytes.as_slice()))
+}
+
+pub(super) fn blake2b_64(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::blake2_64(bytes.as_slice()))
+}
+
+pub(super) fn keccak_256(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::keccak_256(bytes.as_slice()))
+}
+
+pub(super) fn keccak_512(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::keccak_512(bytes.as_slice()))
+}
+
+pub(super) fn sha2_256(bytes: Vec<u8>) -> TokenStream {
+	bytes_to_array(sp_crypto_hashing::sha2_256(bytes.as_slice()))
+}
+
+fn bytes_to_array(bytes: impl IntoIterator<Item = u8>) -> TokenStream {
+	let bytes = bytes.into_iter();
+
+	quote!(
+		[ #( #bytes ),* ]
+	)
+	.into()
+}

--- a/substrate/primitives/crypto/pubkeycrypto/proc-macro/src/lib.rs
+++ b/substrate/primitives/crypto/pubkeycrypto/proc-macro/src/lib.rs
@@ -1,0 +1,42 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Macros to implement internals of public key crypto modules
+//!
+use proc_macro::{TokenStream};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+/// Implement Proof of Possession  Generation and Verificition for Crypto Pair type
+#[proc_macro_derive(ProofOfPossession)]
+pub fn derive_proof_of_possession(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Get the name of the struct or enum to implement the trait for
+    let name = input.ident;
+
+    // Generate the implementation for the trait
+    let expanded = quote! {
+	#[cfg(feature = "full_crypto")]
+        impl ProofOfPossessionGenerator for #name {}
+        impl ProofOfPossessionVerifier for #name {}	
+    };
+
+    // Convert the quote output to a TokenStream
+    TokenStream::from(expanded)
+}

--- a/substrate/primitives/crypto/pubkeycrypto/src/lib.rs
+++ b/substrate/primitives/crypto/pubkeycrypto/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn it_works() {}
+}


### PR DESCRIPTION
# Description
- Implement `ProofOfPossession` traits with default implementation.
- Implement their derive macro in a new proc-macro crate in `pubkeycrypto` create which eventually should contains all pubkey crypto scheme as recommended by #1975
- Derive ProofOfPossession for all pubkey crypto type beside BLS.

- TODO: Implement Nugget BLS proof of possession which should certifies that the unique secret key known to the prover is used to generate both public keys in G1 and G2.
- TODO: Implement sign Host function for BLS12-381 necessary to be able to generate proof of possion through runtime.
- TODO: Implement generation and verification of proof of possession functions in all RuntimeApp and RuntimeAppPublic s.

✄ -----------------------------------------------------------------------------

# Checklist

* [X] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!

✄ -----------------------------------------------------------------------------
