### PR TITLE
[ci] Remove quick-benchmarks-omni from GitLab

### DIFF
--- a/.github/workflows/check-frame-omni-bencher.yml
+++ b/.github/workflows/check-frame-omni-bencher.yml
@@ -86,14 +86,14 @@ jobs:
           forklift cargo build --release --locked -p $PACKAGE_NAME -p frame-omni-bencher --features=${{ matrix.runtime.bench_features }} --quiet
           echo "Running short benchmarking for PACKAGE_NAME=$PACKAGE_NAME and RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
           ls -lrt $RUNTIME_BLOB_PATH
-          
+
           cmd="./target/release/frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1 $FLAGS"
           echo "Running command: $cmd"
           eval "$cmd"
   confirm-frame-omni-benchers-passed:
     runs-on: ubuntu-latest
     name: All benchmarks passed
-    needs: run-frame-omni-bencher
+    needs: [quick-benchmarks-omni, run-frame-omni-bencher]
     if: always() && !cancelled()
     steps:
       - run: |

--- a/.gitlab/pipeline/test.yml
+++ b/.gitlab/pipeline/test.yml
@@ -136,20 +136,3 @@ test-rustdoc:
     SKIP_WASM_BUILD: 1
   script:
     - time cargo doc --workspace --all-features --no-deps
-
-quick-benchmarks-omni:
-  stage: test
-  extends:
-    - .docker-env
-    - .common-refs
-    - .run-immediately
-  variables:
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: "-C debug-assertions"
-    RUST_BACKTRACE: "full"
-    WASM_BUILD_NO_COLOR: 1
-    WASM_BUILD_RUSTFLAGS: "-C debug-assertions"
-  script:
-    - time cargo build --locked --quiet --release -p asset-hub-westend-runtime --features runtime-benchmarks
-    - time cargo run --locked --release -p frame-omni-bencher --quiet -- v1 benchmark pallet --runtime target/release/wbuild/asset-hub-westend-runtime/asset_hub_westend_runtime.compact.compressed.wasm --all --steps 2 --repeat 1 --quiet


### PR DESCRIPTION
The `quick-benchmarks-omni` job was moved to GHA (can be found [here](https://github.com/paritytech/polkadot-sdk/blob/439b31ef9bbdf0e0709bbab4804a9590b48ba8f0/.github/workflows/check-frame-omni-bencher.yml#L22)) but hasn't been removed from GitLab . PR fixes it and makes the check required.