### PR TITLE
Rename QueueEvent::StartWork

### DIFF
--- a/polkadot/node/core/pvf/src/execute/queue.rs
+++ b/polkadot/node/core/pvf/src/execute/queue.rs
@@ -143,7 +143,7 @@ impl Workers {
 
 enum QueueEvent {
 	Spawn(IdleWorker, WorkerHandle, ExecuteJob),
-	StartWork(
+	FinishWork(
 		Worker,
 		Result<WorkerInterfaceResponse, WorkerInterfaceError>,
 		ArtifactId,
@@ -333,7 +333,7 @@ async fn handle_mux(queue: &mut Queue, event: QueueEvent) {
 		QueueEvent::Spawn(idle, handle, job) => {
 			handle_worker_spawned(queue, idle, handle, job);
 		},
-		QueueEvent::StartWork(worker, outcome, artifact_id, result_tx) => {
+		QueueEvent::FinishWork(worker, outcome, artifact_id, result_tx) => {
 			handle_job_finish(queue, worker, outcome, artifact_id, result_tx).await;
 		},
 	}
@@ -615,7 +615,7 @@ fn assign(queue: &mut Queue, worker: Worker, job: ExecuteJob) {
 				job.pov,
 			)
 			.await;
-			QueueEvent::StartWork(worker, result, job.artifact.id, job.result_tx)
+			QueueEvent::FinishWork(worker, result, job.artifact.id, job.result_tx)
 		}
 		.boxed(),
 	);

--- a/prdoc/pr_6015.prdoc
+++ b/prdoc/pr_6015.prdoc
@@ -3,19 +3,8 @@ doc:
 - audience:
   - Node Dev
   description: |-
-    # Description
+    When we send `QueueEvent::StartWork`, we have already completed the execution. Therefore, `QueueEvent::FinishWork` is a better match.
 
-    When we send `QueueEvent::StartWork`, we have already completed the execution. This may be a leftover of a previous logic change. Currently, the name is misleading, so it would be better to rename it to `FinishWork`.
-
-    https://github.com/paritytech/polkadot-sdk/blob/c52675efdc05e181ddcec72d3bd425dc0a89d622/polkadot/node/core/pvf/src/execute/queue.rs#L632-L646
-
-    https://github.com/paritytech/polkadot-sdk/blob/c52675efdc05e181ddcec72d3bd425dc0a89d622/polkadot/node/core/pvf/src/execute/queue.rs#L361-L363
-
-    Fixes https://github.com/paritytech/polkadot-sdk/issues/5910
-
-    ## Integration
-
-    Shouldn't affect downstream projects.
 crates:
 - name: polkadot-node-core-pvf
   bump: patch

--- a/prdoc/pr_6015.prdoc
+++ b/prdoc/pr_6015.prdoc
@@ -1,7 +1,6 @@
 title: Rename QueueEvent::StartWork
 doc:
-- audience:
-  - Node Dev
+- audience: Node Dev
   description: |-
     When we send `QueueEvent::StartWork`, we have already completed the execution. Therefore, `QueueEvent::FinishWork` is a better match.
 

--- a/prdoc/pr_6015.prdoc
+++ b/prdoc/pr_6015.prdoc
@@ -1,0 +1,21 @@
+title: Rename QueueEvent::StartWork
+doc:
+- audience:
+  - Node Dev
+  description: |-
+    # Description
+
+    When we send `QueueEvent::StartWork`, we have already completed the execution. This may be a leftover of a previous logic change. Currently, the name is misleading, so it would be better to rename it to `FinishWork`.
+
+    https://github.com/paritytech/polkadot-sdk/blob/c52675efdc05e181ddcec72d3bd425dc0a89d622/polkadot/node/core/pvf/src/execute/queue.rs#L632-L646
+
+    https://github.com/paritytech/polkadot-sdk/blob/c52675efdc05e181ddcec72d3bd425dc0a89d622/polkadot/node/core/pvf/src/execute/queue.rs#L361-L363
+
+    Fixes https://github.com/paritytech/polkadot-sdk/issues/5910
+
+    ## Integration
+
+    Shouldn't affect downstream projects.
+crates:
+- name: polkadot-node-core-pvf
+  bump: patch


### PR DESCRIPTION
# Description

When we send `QueueEvent::StartWork`, we have already completed the execution. This may be a leftover of a previous logic change. Currently, the name is misleading, so it would be better to rename it to `FinishWork`.

https://github.com/paritytech/polkadot-sdk/blob/c52675efdc05e181ddcec72d3bd425dc0a89d622/polkadot/node/core/pvf/src/execute/queue.rs#L632-L646

https://github.com/paritytech/polkadot-sdk/blob/c52675efdc05e181ddcec72d3bd425dc0a89d622/polkadot/node/core/pvf/src/execute/queue.rs#L361-L363

Fixes https://github.com/paritytech/polkadot-sdk/issues/5910

## Integration

Shouldn't affect downstream projects.

