### PR TITLE
XcmPaymentApi: take into account AH sufficient assets

### DIFF
--- a/substrate/frame/assets/src/functions.rs
+++ b/substrate/frame/assets/src/functions.rs
@@ -33,6 +33,11 @@ use DeadConsequence::*;
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	// Public immutables
 
+	pub fn sufficient_assets() -> impl Iterator<Item = T::AssetId> {
+		Asset::<T, I>::iter()
+			.filter_map(|(asset_id, details)| details.is_sufficient.then_some(asset_id))
+	}
+
 	/// Return the extra "sid-car" data for `id`/`who`, or `None` if the account doesn't exist.
 	pub fn adjust_extra(
 		id: T::AssetId,


### PR DESCRIPTION
# Description

This PR provides:
* The `sufficient_assets` function to the `pallet-assets`.
* Report all sufficient assets as acceptable as XCM execution fees in addition to the Relay's token
* Converting the native fees into the selected sufficient asset to be returned from the `query_weight_to_asset_fee`. 