### PR TITLE
update cmd timeout

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -283,7 +283,7 @@ jobs:
     env:
       JOB_NAME: "cmd"
     runs-on: ${{ needs.set-image.outputs.RUNNER }}
-    timeout-minutes: 1800 # 30 hours as it could take a long time to run all the runtimes/pallets
+    timeout-minutes: 4320 # 72 hours -> 3 days; as it could take a long time to run all the runtimes/pallets
     container:
       image: ${{ needs.set-image.outputs.IMAGE }}
     steps:


### PR DESCRIPTION
30 hrs -> 72 hours
as it has stopped by timeout here https://github.com/paritytech/polkadot-sdk/actions/runs/11299872333/job/31431758932