### PR TITLE
Paseo ss58Format chain spec update

### DIFF
--- a/polkadot/node/service/chain-specs/paseo.json
+++ b/polkadot/node/service/chain-specs/paseo.json
@@ -26,7 +26,7 @@
   "telemetryEndpoints": null,
   "protocolId": "pas",
   "properties": {
-    "ss58Format": 42,
+    "ss58Format": 0,
     "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },


### PR DESCRIPTION
After the runtime upgrade to version 1.3.0, Paseo’s ss58 account format was unified with Polkadot’s standard by setting `"ss58Format": 0`.

This pull request is a straightforward update to the chain specification in the Polkadot node. It ensures that when RPC calls invoke `system.properties()`, the correct ss58 format value is retrieved.