### PR TITLE
Predicate route table by Xcm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21044,6 +21044,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-std 14.0.0",
  "staging-xcm",
+ "staging-xcm-builder",
  "staging-xcm-executor",
 ]
 

--- a/bridges/snowbridge/primitives/router/Cargo.toml
+++ b/bridges/snowbridge/primitives/router/Cargo.toml
@@ -24,6 +24,7 @@ sp-std = { workspace = true }
 
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
+xcm-builder = { workspace = true }
 
 snowbridge-core = { workspace = true }
 
@@ -43,6 +44,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
 ]
@@ -50,5 +52,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"snowbridge-core/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 ]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -494,7 +494,10 @@ pub type XcmRouter = WithUniqueTopic<(
 	// Router which wraps and sends xcm to BridgeHub to be delivered to the Ethereum
 	// GlobalConsensus
 	SovereignPaidRemoteExporter<
-		bridging::to_ethereum::EthereumNetworkExportTable,
+		(
+			bridging::to_ethereum::EthereumNetworkExportTableV2,
+			bridging::to_ethereum::EthereumNetworkExportTable,
+		),
 		XcmpQueue,
 		UniversalLocation,
 	>,
@@ -666,7 +669,9 @@ pub mod bridging {
 			/// Needs to be more than fee calculated from DefaultFeeConfig FeeConfigRecord in snowbridge:parachain/pallets/outbound-queue/src/lib.rs
 			/// Polkadot uses 10 decimals, Kusama,Rococo,Westend 12 decimals.
 			pub const DefaultBridgeHubEthereumBaseFee: Balance = 2_750_872_500_000;
+			pub const DefaultBridgeHubEthereumBaseFeeV2: Balance = 4_000_000_000;
 			pub storage BridgeHubEthereumBaseFee: Balance = DefaultBridgeHubEthereumBaseFee::get();
+			pub storage BridgeHubEthereumBaseFeeV2: Balance = DefaultBridgeHubEthereumBaseFeeV2::get();
 			pub SiblingBridgeHubWithEthereumInboundQueueInstance: Location = Location::new(
 				1,
 				[
@@ -689,6 +694,18 @@ pub mod bridging {
 				),
 			];
 
+			pub BridgeTableV2: sp_std::vec::Vec<NetworkExportTableItem> = sp_std::vec![
+				NetworkExportTableItem::new(
+					EthereumNetwork::get(),
+					Some(sp_std::vec![Junctions::Here]),
+					SiblingBridgeHub::get(),
+					Some((
+						XcmBridgeHubRouterFeeAssetId::get(),
+						BridgeHubEthereumBaseFeeV2::get(),
+					).into())
+				),
+			];
+
 			/// Universal aliases
 			pub UniversalAliases: BTreeSet<(Location, Junction)> = BTreeSet::from_iter(
 				sp_std::vec![
@@ -699,7 +716,17 @@ pub mod bridging {
 			pub EthereumBridgeTable: sp_std::vec::Vec<NetworkExportTableItem> = sp_std::vec::Vec::new().into_iter()
 				.chain(BridgeTable::get())
 				.collect();
+
+			pub EthereumBridgeTableV2: sp_std::vec::Vec<NetworkExportTableItem> = sp_std::vec::Vec::new().into_iter()
+				.chain(BridgeTableV2::get())
+				.collect();
 		}
+
+		pub type EthereumNetworkExportTableV2 =
+			snowbridge_router_primitives::outbound::XcmFilterExporter<
+				xcm_builder::NetworkExportTable<EthereumBridgeTableV2>,
+				snowbridge_router_primitives::outbound::XcmForSnowbridgeV2,
+			>;
 
 		pub type EthereumNetworkExportTable = xcm_builder::NetworkExportTable<EthereumBridgeTable>;
 


### PR DESCRIPTION
### Context

Idea from @alistair-singh. The [ExporterFor](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/xcm-builder/src/universal_exports.rs#L92) trait returns the fee to be charged to the user when exporting to Ethereum on Asset Hub. This trait exposes the XCM as message parameter that can be used to select an exporter. On Asset Hub this is configured with [NetworkExportTable](https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/xcm/xcm-builder/src/universal_exports.rs#L153) struct implementation. However this implementation ignores the message parameter. We need to modify this implementation so that it contains another field, a predicate which accepts Xcm<()> -> bool which acts as the filter. We can then modify the existing record in the [BridgeTable](https://github.com/paritytech/polkadot-sdk/blob/master/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs#L680) to have a predicate which matches V1 XCM. And add a new record in the bridge table that matches V2 XCM. Each record can then be configured with a different fee.

The predicate for V1 XCM will look for
```
WithdrawAsset(...) or ReserveAssetDeposited # For erc20 and PNA respectively
ClearOrigin
BuyExecution
```
The predicate for V2 XCM will look for
```
WithdrawAsset or ReserveAssetDeposited or TeleportedAssetRevceived or * 
PayFees(fees)
ALiasOrigin
```