### PR TITLE
Stabilize elastic-pov-recovery zombienet test

### DIFF
--- a/cumulus/zombienet/tests/0009-elastic_pov_recovery.toml
+++ b/cumulus/zombienet/tests/0009-elastic_pov_recovery.toml
@@ -1,6 +1,14 @@
 [settings]
 timeout = 1000
 
+[relaychain.default_resources]
+limits = { memory = "4G", cpu = "2" }
+requests = { memory = "2G", cpu = "1" }
+
+[parachain.default_resources]
+limits = { memory = "4G", cpu = "2" }
+requests = { memory = "2G", cpu = "1" }
+
 [relaychain.genesis.runtimeGenesis.patch.configuration.config.async_backing_params]
   max_candidate_depth = 6
   allowed_ancestry_len = 3
@@ -32,17 +40,17 @@ id = 2100
 chain = "elastic-scaling"
 add_to_genesis = false
 
-  # Slot based authoring with 3 cores and 2s slot duration
-  [[parachains.collators]]
-  name = "collator-elastic"
-  image = "{{COL_IMAGE}}"
-  command = "test-parachain"
-  args = ["--disable-block-announcements", "-laura=trace,runtime=info,cumulus-consensus=trace,consensus::common=trace,parachain::collation-generation=trace,parachain::collator-protocol=trace,parachain=debug", "--force-authoring", "--experimental-use-slot-based"]
-
   # run 'recovery-target' as a parachain full node
   [[parachains.collators]]
   name = "recovery-target"
   validator = false # full node
   image = "{{COL_IMAGE}}"
   command = "test-parachain"
-  args = ["-lparachain::availability=trace,sync=debug,parachain=debug,cumulus-pov-recovery=debug,cumulus-consensus=debug", "--disable-block-announcements", "--bootnodes {{'collator-elastic'|zombie('multiAddress')}}", "--in-peers 0", "--out-peers 0", "--", "--reserved-only", "--reserved-nodes {{'alice'|zombie('multiAddress')}}"]
+  args = ["-lparachain::availability=trace,sync=debug,parachain=debug,cumulus-pov-recovery=debug,cumulus-consensus=debug", "--disable-block-announcements", "--in-peers 0", "--out-peers 0", "--", "--reserved-only", "--reserved-nodes {{'alice'|zombie('multiAddress')}}"]
+
+  # Slot based authoring with 3 cores and 2s slot duration
+  [[parachains.collators]]
+  name = "collator-elastic"
+  image = "{{COL_IMAGE}}"
+  command = "test-parachain"
+  args = ["--disable-block-announcements", "-laura=trace,runtime=info,cumulus-consensus=trace,consensus::common=trace,parachain::collation-generation=trace,parachain::collator-protocol=trace,parachain=debug", "--force-authoring", "--experimental-use-slot-based"]

--- a/cumulus/zombienet/tests/0009-elastic_pov_recovery.toml
+++ b/cumulus/zombienet/tests/0009-elastic_pov_recovery.toml
@@ -31,7 +31,11 @@ command = "polkadot"
 
   [[relaychain.node_groups]]
   name = "validator"
-  args = ["-lruntime=debug,parachain=trace",  "--reserved-only", "--reserved-nodes {{'alice'|zombie('multiAddress')}}"]
+  args = [
+    "-lruntime=debug,parachain=trace",
+    "--reserved-only",
+    "--reserved-nodes {{'alice'|zombie('multiAddress')}}"
+  ]
   count = 8
 
 # Slot based authoring with 3 cores and 2s slot duration
@@ -46,11 +50,23 @@ add_to_genesis = false
   validator = false # full node
   image = "{{COL_IMAGE}}"
   command = "test-parachain"
-  args = ["-lparachain::availability=trace,sync=debug,parachain=debug,cumulus-pov-recovery=debug,cumulus-consensus=debug", "--disable-block-announcements", "--in-peers 0", "--out-peers 0", "--", "--reserved-only", "--reserved-nodes {{'alice'|zombie('multiAddress')}}"]
+  args = [
+    "-lparachain::availability=trace,sync=debug,parachain=debug,cumulus-pov-recovery=debug,cumulus-consensus=debug",
+    "--disable-block-announcements",
+    "--in-peers 0",
+    "--out-peers 0",
+    "--",
+    "--reserved-only",
+    "--reserved-nodes {{'alice'|zombie('multiAddress')}}"]
 
   # Slot based authoring with 3 cores and 2s slot duration
   [[parachains.collators]]
   name = "collator-elastic"
   image = "{{COL_IMAGE}}"
   command = "test-parachain"
-  args = ["--disable-block-announcements", "-laura=trace,runtime=info,cumulus-consensus=trace,consensus::common=trace,parachain::collation-generation=trace,parachain::collator-protocol=trace,parachain=debug", "--force-authoring", "--experimental-use-slot-based"]
+  args = [
+    "-laura=trace,runtime=info,cumulus-consensus=trace,consensus::common=trace,parachain::collation-generation=trace,parachain::collator-protocol=trace,parachain=debug",
+    "--disable-block-announcements",
+    "--force-authoring",
+    "--experimental-use-slot-based"
+  ]


### PR DESCRIPTION
We should start the `recovery-target` node first, then the `collator-elastic` node. Also increases the resources available to these pods.