### PR TITLE
[WIP] Changes client memory allocation limits when executing in the offchain context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18911,6 +18911,7 @@ version = "0.29.0"
 dependencies = [
  "polkavm 0.9.3",
  "sc-allocator 23.0.0",
+ "sp-core 28.0.0",
  "sp-maybe-compressed-blob 11.0.0",
  "sp-wasm-interface 20.0.0",
  "thiserror",
@@ -18938,6 +18939,7 @@ dependencies = [
  "log",
  "polkavm 0.9.3",
  "sc-executor-common 0.29.0",
+ "sp-core 28.0.0",
  "sp-wasm-interface 20.0.0",
 ]
 
@@ -18969,6 +18971,7 @@ dependencies = [
  "sc-allocator 23.0.0",
  "sc-executor-common 0.29.0",
  "sc-runtime-test",
+ "sp-core 28.0.0",
  "sp-io 30.0.0",
  "sp-runtime-interface 24.0.0",
  "sp-wasm-interface 20.0.0",

--- a/polkadot/node/core/pvf/common/src/executor_interface.rs
+++ b/polkadot/node/core/pvf/common/src/executor_interface.rs
@@ -27,7 +27,10 @@ use sc_executor_common::{
 	wasm_runtime::{HeapAllocStrategy, WasmModule as _},
 };
 use sc_executor_wasmtime::{Config, DeterministicStackLimit, Semantics, WasmtimeRuntime};
-use sp_core::storage::{ChildInfo, TrackedStorageKey};
+use sp_core::{
+	storage::{ChildInfo, TrackedStorageKey},
+	traits::CallContext,
+};
 use sp_externalities::MultiRemovalResults;
 use std::any::{Any, TypeId};
 
@@ -98,7 +101,7 @@ pub const DEFAULT_CONFIG: Config = Config {
 
 /// Executes the given PVF in the form of a compiled artifact and returns the result of
 /// execution upon success.
-///
+//
 /// # Safety
 ///
 /// The caller must ensure that the compiled artifact passed here was:
@@ -119,7 +122,7 @@ pub unsafe fn execute_artifact(
 
 	match sc_executor::with_externalities_safe(&mut ext, || {
 		let runtime = create_runtime_from_artifact_bytes(compiled_artifact_blob, executor_params)?;
-		runtime.new_instance()?.call("validate_block", params)
+		runtime.new_instance()?.call("validate_block", params, CallContext::Onchain)
 	}) {
 		Ok(Ok(ok)) => Ok(ok),
 		Ok(Err(err)) | Err(err) => Err(err),

--- a/substrate/client/allocator/src/freeing_bump.rs
+++ b/substrate/client/allocator/src/freeing_bump.rs
@@ -425,6 +425,14 @@ impl FreeingBumpHeapAllocator {
 			),
 		};
 
+		log::debug!(
+			target: LOG_TARGET,
+			"Allocator instantiated for {:?} context with {} max allocation ({} max orders).",
+			context,
+			max_allocation,
+			max_orders
+		);
+
 		FreeingBumpHeapAllocator {
 			original_heap_base: aligned_heap_base,
 			bumper: aligned_heap_base,

--- a/substrate/client/executor/common/Cargo.toml
+++ b/substrate/client/executor/common/Cargo.toml
@@ -20,6 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 thiserror = { workspace = true }
 wasm-instrument = { workspace = true, default-features = true }
 sc-allocator = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
 sp-maybe-compressed-blob = { workspace = true, default-features = true }
 sp-wasm-interface = { workspace = true, default-features = true }
 polkavm = { workspace = true }

--- a/substrate/client/executor/common/src/wasm_runtime.rs
+++ b/substrate/client/executor/common/src/wasm_runtime.rs
@@ -21,6 +21,7 @@
 use crate::error::Error;
 
 pub use sc_allocator::AllocationStats;
+use sp_core::traits::CallContext;
 
 /// Default heap allocation strategy.
 pub const DEFAULT_HEAP_ALLOC_STRATEGY: HeapAllocStrategy =
@@ -46,8 +47,8 @@ pub trait WasmInstance: Send {
 	/// Before execution, instance is reset.
 	///
 	/// Returns the encoded result on success.
-	fn call(&mut self, method: &str, data: &[u8]) -> Result<Vec<u8>, Error> {
-		self.call_with_allocation_stats(method, data).0
+	fn call(&mut self, method: &str, data: &[u8], context: CallContext) -> Result<Vec<u8>, Error> {
+		self.call_with_allocation_stats(method, data, context).0
 	}
 
 	/// Call a method on this WASM instance.
@@ -59,6 +60,7 @@ pub trait WasmInstance: Send {
 		&mut self,
 		method: &str,
 		data: &[u8],
+		context: CallContext,
 	) -> (Result<Vec<u8>, Error>, Option<AllocationStats>);
 
 	/// Call an exported method on this WASM instance.
@@ -66,8 +68,13 @@ pub trait WasmInstance: Send {
 	/// Before execution, instance is reset.
 	///
 	/// Returns the encoded result on success.
-	fn call_export(&mut self, method: &str, data: &[u8]) -> Result<Vec<u8>, Error> {
-		self.call(method.into(), data)
+	fn call_export(
+		&mut self,
+		method: &str,
+		data: &[u8],
+		context: CallContext,
+	) -> Result<Vec<u8>, Error> {
+		self.call(method.into(), data, context)
 	}
 }
 

--- a/substrate/client/executor/polkavm/Cargo.toml
+++ b/substrate/client/executor/polkavm/Cargo.toml
@@ -20,4 +20,5 @@ log = { workspace = true }
 polkavm = { workspace = true }
 
 sc-executor-common = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
 sp-wasm-interface = { workspace = true, default-features = true }

--- a/substrate/client/executor/polkavm/src/lib.rs
+++ b/substrate/client/executor/polkavm/src/lib.rs
@@ -21,6 +21,7 @@ use sc_executor_common::{
 	error::{Error, WasmError},
 	wasm_runtime::{AllocationStats, WasmInstance, WasmModule},
 };
+use sp_core::traits::CallContext;
 use sp_wasm_interface::{
 	Function, FunctionContext, HostFunctions, Pointer, Value, ValueType, WordSize,
 };
@@ -42,6 +43,7 @@ impl WasmInstance for Instance {
 		&mut self,
 		name: &str,
 		raw_data: &[u8],
+		_context: CallContext,
 	) -> (Result<Vec<u8>, Error>, Option<AllocationStats>) {
 		let Some(method_index) = self.0.module().lookup_export(name) else {
 			return (

--- a/substrate/client/executor/src/integration_tests/mod.rs
+++ b/substrate/client/executor/src/integration_tests/mod.rs
@@ -99,6 +99,7 @@ fn call_in_wasm<E: Externalities>(
 		true,
 		function,
 		call_data,
+		Default::default(),
 	)
 }
 
@@ -424,6 +425,7 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 			true,
 			"test_allocate_vec",
 			&16777216_u32.encode(),
+			Default::default(),
 		)
 		.unwrap_err();
 
@@ -463,13 +465,17 @@ fn returns_mutable_static(wasm_method: WasmExecutionMethod) {
 		mk_test_runtime(wasm_method, HeapAllocStrategy::Dynamic { maximum_pages: Some(1024) });
 
 	let mut instance = runtime.new_instance().unwrap();
-	let res = instance.call_export("returns_mutable_static", &[0]).unwrap();
+	let res = instance
+		.call_export("returns_mutable_static", &[0], Default::default())
+		.unwrap();
 	assert_eq!(33, u64::decode(&mut &res[..]).unwrap());
 
 	// We expect that every invocation will need to return the initial
 	// value plus one. If the value increases more than that then it is
 	// a sign that the wasm runtime preserves the memory content.
-	let res = instance.call_export("returns_mutable_static", &[0]).unwrap();
+	let res = instance
+		.call_export("returns_mutable_static", &[0], Default::default())
+		.unwrap();
 	assert_eq!(33, u64::decode(&mut &res[..]).unwrap());
 }
 
@@ -479,13 +485,17 @@ fn returns_mutable_static_bss(wasm_method: WasmExecutionMethod) {
 		mk_test_runtime(wasm_method, HeapAllocStrategy::Dynamic { maximum_pages: Some(1024) });
 
 	let mut instance = runtime.new_instance().unwrap();
-	let res = instance.call_export("returns_mutable_static_bss", &[0]).unwrap();
+	let res = instance
+		.call_export("returns_mutable_static_bss", &[0], Default::default())
+		.unwrap();
 	assert_eq!(1, u64::decode(&mut &res[..]).unwrap());
 
 	// We expect that every invocation will need to return the initial
 	// value plus one. If the value increases more than that then it is
 	// a sign that the wasm runtime preserves the memory content.
-	let res = instance.call_export("returns_mutable_static_bss", &[0]).unwrap();
+	let res = instance
+		.call_export("returns_mutable_static_bss", &[0], Default::default())
+		.unwrap();
 	assert_eq!(1, u64::decode(&mut &res[..]).unwrap());
 }
 
@@ -510,11 +520,13 @@ fn restoration_of_globals(wasm_method: WasmExecutionMethod) {
 	let mut instance = runtime.new_instance().unwrap();
 
 	// On the first invocation we allocate approx. 768KB (75%) of stack and then trap.
-	let res = instance.call_export("allocates_huge_stack_array", &true.encode());
+	let res =
+		instance.call_export("allocates_huge_stack_array", &true.encode(), Default::default());
 	assert!(res.is_err());
 
 	// On the second invocation we allocate yet another 768KB (75%) of stack
-	let res = instance.call_export("allocates_huge_stack_array", &false.encode());
+	let res =
+		instance.call_export("allocates_huge_stack_array", &false.encode(), Default::default());
 	assert!(res.is_ok());
 }
 
@@ -539,6 +551,7 @@ fn parallel_execution(wasm_method: WasmExecutionMethod) {
 							true,
 							"test_twox_128",
 							&[0],
+							Default::default(),
 						)
 						.unwrap(),
 					array_bytes::hex2bytes_unchecked("99e9d85137db46ef4bbea33613baafd5").encode()
@@ -609,7 +622,7 @@ fn allocate_two_gigabyte(wasm_method: WasmExecutionMethod) {
 	let runtime = mk_test_runtime(wasm_method, HeapAllocStrategy::Dynamic { maximum_pages: None });
 
 	let mut instance = runtime.new_instance().unwrap();
-	let res = instance.call_export("allocate_two_gigabyte", &[0]).unwrap();
+	let res = instance.call_export("allocate_two_gigabyte", &[0], Default::default()).unwrap();
 	assert_eq!(10 * 1024 * 1024 * 205, u32::decode(&mut &res[..]).unwrap());
 }
 
@@ -683,10 +696,14 @@ fn memory_is_cleared_between_invocations(wasm_method: WasmExecutionMethod) {
 	.unwrap();
 
 	let mut instance = runtime.new_instance().unwrap();
-	let res = instance.call_export("returns_no_bss_mutable_static", &[0]).unwrap();
+	let res = instance
+		.call_export("returns_no_bss_mutable_static", &[0], Default::default())
+		.unwrap();
 	assert_eq!(1, u64::decode(&mut &res[..]).unwrap());
 
-	let res = instance.call_export("returns_no_bss_mutable_static", &[0]).unwrap();
+	let res = instance
+		.call_export("returns_no_bss_mutable_static", &[0], Default::default())
+		.unwrap();
 	assert_eq!(1, u64::decode(&mut &res[..]).unwrap());
 }
 

--- a/substrate/client/executor/src/lib.rs
+++ b/substrate/client/executor/src/lib.rs
@@ -84,6 +84,7 @@ mod tests {
 				true,
 				"test_empty_return",
 				&[],
+				Default::default(),
 			)
 			.unwrap();
 		assert_eq!(res, vec![0u8; 0]);

--- a/substrate/client/executor/wasmtime/Cargo.toml
+++ b/substrate/client/executor/wasmtime/Cargo.toml
@@ -31,6 +31,7 @@ wasmtime = { features = [
 	"pooling-allocator",
 ], workspace = true }
 anyhow = { workspace = true }
+sp-core = { workspace = true, default-features = true }
 sc-allocator = { workspace = true, default-features = true }
 sc-executor-common = { workspace = true, default-features = true }
 sp-runtime-interface = { workspace = true, default-features = true }

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -408,6 +408,7 @@ macro_rules! impl_maybe_marker_std_or_serde {
 /// The maximum number of bytes that can be allocated at one time by onchain execution calls.
 // The maximum possible allocation size was chosen rather arbitrary, 32 MiB should be enough for
 // everybody.
+// TODO(gpestana); consider rename to MAX_POSSIBLE_ALLOCATION_ONCHAIN.
 pub const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
 
 /// The maximum number of bytes that can be allocated at one time by offchain execution calls.

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -405,10 +405,13 @@ macro_rules! impl_maybe_marker_std_or_serde {
 	}
 }
 
-/// The maximum number of bytes that can be allocated at one time.
+/// The maximum number of bytes that can be allocated at one time by onchain execution calls.
 // The maximum possible allocation size was chosen rather arbitrary, 32 MiB should be enough for
 // everybody.
 pub const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
+
+/// The maximum number of bytes that can be allocated at one time by offchain execution calls.
+pub const MAX_POSSIBLE_ALLOCATION_OFFCHAIN: u32 = 2147483648; // 2^31 bytes, 2 GiB
 
 /// Generates a macro for checking if a certain feature is enabled.
 ///

--- a/substrate/primitives/core/src/traits.rs
+++ b/substrate/primitives/core/src/traits.rs
@@ -36,6 +36,12 @@ pub enum CallContext {
 	Onchain,
 }
 
+impl Default for CallContext {
+	fn default() -> Self {
+		Self::Onchain
+	}
+}
+
 /// Code execution engine.
 pub trait CodeExecutor: Sized + Send + Sync + ReadRuntimeVersion + Clone + 'static {
 	/// Externalities error type.


### PR DESCRIPTION
This PR refactors the client allocator to allocate up to 2GiB of memory when running in the offchain context, instead of limiting the allocation to 32MiB as nowadays. This refactor allows for the generation of large chainspecs and memory intensive offchain-worker computation, which is important for staking as the size of the election snapshots increase. 

The `context: CallContext` enum variant in the executor is passed down to the wasm instance, which then instantiates the allocator with the limits corresponding to the call context.