### PR TITLE
Fix mismatched types due to incompatible version of ethabi-decode v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5757,9 +5757,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi-decode"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9af52ec57c5147716872863c2567c886e7d62f539465b94352dbc0108fe5293"
+checksum = "52029c4087f9f01108f851d0d02df9c21feb5660a19713466724b7f95bd2d773"
 dependencies = [
  "ethereum-types",
  "tiny-keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -741,7 +741,7 @@ enumn = { version = "0.1.13" }
 env_logger = { version = "0.11.2" }
 environmental = { version = "1.1.4", default-features = false }
 equivocation-detector = { path = "bridges/relays/equivocation" }
-ethabi = { version = "1.0.0", default-features = false, package = "ethabi-decode" }
+ethabi = { version = "1.1.0", default-features = false, package = "ethabi-decode" }
 ethbloom = { version = "0.14.1", default-features = false }
 ethereum-types = { version = "0.15.1", default-features = false }
 exit-future = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -741,7 +741,7 @@ enumn = { version = "0.1.13" }
 env_logger = { version = "0.11.2" }
 environmental = { version = "1.1.4", default-features = false }
 equivocation-detector = { path = "bridges/relays/equivocation" }
-ethabi = { version = "1.1.0", default-features = false, package = "ethabi-decode" }
+ethabi = { version = "2.0.0", default-features = false, package = "ethabi-decode" }
 ethbloom = { version = "0.14.1", default-features = false }
 ethereum-types = { version = "0.15.1", default-features = false }
 exit-future = { version = "0.2.0" }


### PR DESCRIPTION
# Description

This issue is related to #5870, but this issue won't happen in the `polkadot-sdk` since `ethabi-decode@1.1.0` was specified in `cargo.lock`.

```
  error[E0308]: mismatched types
     --> /Users/orochi/.cargo/git/checkouts/polkadot-sdk-dd2bf11f1ce49c06/d1c115b/bridges/snowbridge/primitives/core/src/outbound.rs:313:20
      |
  313 | ...                   Token::Uint(U256::from(*amount)),
      |                       ----------- ^^^^^^^^^^^^^^^^^^^ expected `ethabi_decode::U256`, found `sp_core::U256`
      |                       |
      |                       arguments to this enum variant are incorrect
      |
      = note: `sp_core::U256` and `ethabi_decode::U256` have similar names, but are actually distinct types
  note: `sp_core::U256` is defined in crate `primitive_types`
     --> /Users/orochi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/primitive-types-0.13.1/src/lib.rs:44:1
      |
  44  | / construct_uint! {
  45  | |     /// 256-bit unsigned integer.
  46  | |     #[cfg_attr(feature = "scale-info", derive(TypeInfo))]
  47  | |     pub struct U256(4);
  48  | | }
      | |_^
  note: `ethabi_decode::U256` is defined in crate `primitive_types`
     --> /Users/orochi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/primitive-types-0.12.2/src/lib.rs:38:1
```

## Integration

N/A

## Review Notes

I changed `ethabi-decode` to match the version in the lock file.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

