### PR TITLE
Use `Versioned*::from` instead of concrete `V*` when using `xcm::latest`

### DIFF
--- a/bridges/modules/xcm-bridge-hub-router/src/lib.rs
+++ b/bridges/modules/xcm-bridge-hub-router/src/lib.rs
@@ -655,8 +655,8 @@ mod tests {
 			assert_eq!(
 				XcmBridgeHubRouter::get_messages(),
 				vec![(
-					VersionedLocation::V5((Parent, Parachain(1002)).into()),
-					vec![VersionedXcm::V5(
+					VersionedLocation::from(Location::new(1, Parachain(1002))),
+					vec![VersionedXcm::from(
 						Xcm::builder()
 							.withdraw_asset((Parent, 1_002_000))
 							.buy_execution((Parent, 1_002_000), Unlimited)

--- a/bridges/modules/xcm-bridge-hub-router/src/mock.rs
+++ b/bridges/modules/xcm-bridge-hub-router/src/mock.rs
@@ -141,8 +141,8 @@ impl InspectMessageQueues for TestToBridgeHubSender {
 				.iter()
 				.map(|(location, message)| {
 					(
-						VersionedLocation::V5(location.clone()),
-						vec![VersionedXcm::V5(message.clone())],
+						VersionedLocation::from(location.clone()),
+						vec![VersionedXcm::from(message.clone())],
 					)
 				})
 				.collect()

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -1582,7 +1582,7 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 			.map(|encoded_message| VersionedXcm::<()>::decode(&mut &encoded_message[..]).unwrap())
 			.collect();
 
-		vec![(VersionedLocation::V5(Parent.into()), messages)]
+		vec![(VersionedLocation::from(Location::parent()), messages)]
 	}
 }
 

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -1036,7 +1036,7 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 				}
 
 				(
-					VersionedLocation::V5((Parent, Parachain(para_id.into())).into()),
+					VersionedLocation::from(Location::new(1, Parachain(para_id.into()))),
 					decoded_messages,
 				)
 			})

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -456,7 +456,7 @@ fn send_xcm_nested_works() {
 			XcmpQueue::take_outbound_messages(usize::MAX),
 			vec![(
 				HRMP_PARA_ID.into(),
-				(XcmpMessageFormat::ConcatenatedVersionedXcm, VersionedXcm::V5(good.clone()))
+				(XcmpMessageFormat::ConcatenatedVersionedXcm, VersionedXcm::from(good.clone()))
 					.encode(),
 			)]
 		);
@@ -512,7 +512,7 @@ fn hrmp_signals_are_prioritized() {
 		// Without a signal we get the messages in order:
 		let mut expected_msg = XcmpMessageFormat::ConcatenatedVersionedXcm.encode();
 		for _ in 0..31 {
-			expected_msg.extend(VersionedXcm::V5(message.clone()).encode());
+			expected_msg.extend(VersionedXcm::from(message.clone()).encode());
 		}
 
 		hypothetically!({
@@ -598,7 +598,7 @@ fn take_first_concatenated_xcm_good_recursion_depth_works() {
 	for _ in 0..MAX_XCM_DECODE_DEPTH - 1 {
 		good = Xcm(vec![SetAppendix(good)]);
 	}
-	let good = VersionedXcm::V5(good);
+	let good = VersionedXcm::from(good);
 
 	let page = good.encode();
 	assert_ok!(XcmpQueue::take_first_concatenated_xcm(&mut &page[..], &mut WeightMeter::new()));
@@ -611,7 +611,7 @@ fn take_first_concatenated_xcm_good_bad_depth_errors() {
 	for _ in 0..MAX_XCM_DECODE_DEPTH {
 		bad = Xcm(vec![SetAppendix(bad)]);
 	}
-	let bad = VersionedXcm::V5(bad);
+	let bad = VersionedXcm::from(bad);
 
 	let page = bad.encode();
 	assert_err!(
@@ -873,18 +873,18 @@ fn get_messages_works() {
 			queued_messages,
 			vec![
 				(
-					VersionedLocation::V5(other_destination),
+					VersionedLocation::from(other_destination),
 					vec![
-						VersionedXcm::V5(Xcm(vec![ClearOrigin])),
-						VersionedXcm::V5(Xcm(vec![ClearOrigin])),
+						VersionedXcm::from(Xcm(vec![ClearOrigin])),
+						VersionedXcm::from(Xcm(vec![ClearOrigin])),
 					],
 				),
 				(
-					VersionedLocation::V5(destination),
+					VersionedLocation::from(destination),
 					vec![
-						VersionedXcm::V5(Xcm(vec![ClearOrigin])),
-						VersionedXcm::V5(Xcm(vec![ClearOrigin])),
-						VersionedXcm::V5(Xcm(vec![ClearOrigin])),
+						VersionedXcm::from(Xcm(vec![ClearOrigin])),
+						VersionedXcm::from(Xcm(vec![ClearOrigin])),
+						VersionedXcm::from(Xcm(vec![ClearOrigin])),
 					],
 				),
 			],

--- a/cumulus/parachains/integration-tests/emulated/common/src/macros.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/macros.rs
@@ -495,7 +495,7 @@ macro_rules! test_can_estimate_and_pay_exact_fees {
 				let local_xcm_weight = Runtime::query_xcm_weight(local_xcm).unwrap();
 				local_execution_fees = Runtime::query_weight_to_asset_fee(
 					local_xcm_weight,
-					VersionedAssetId::V5(Location::parent().into()),
+					VersionedAssetId::from(AssetId(Location::parent())),
 				)
 				.unwrap();
 				// We filter the result to get only the messages we are interested in.
@@ -503,7 +503,7 @@ macro_rules! test_can_estimate_and_pay_exact_fees {
 					.forwarded_xcms
 					.iter()
 					.find(|(destination, _)| {
-						*destination == VersionedLocation::V5(Location::new(1, [Parachain(1000)]))
+						*destination == VersionedLocation::from(Location::new(1, [Parachain(1000)]))
 					})
 					.unwrap();
 				assert_eq!(messages_to_query.len(), 1);
@@ -517,7 +517,7 @@ macro_rules! test_can_estimate_and_pay_exact_fees {
 			// These are set in the AssetHub closure.
 			let mut intermediate_execution_fees = 0;
 			let mut intermediate_delivery_fees = 0;
-			let mut intermediate_remote_message = VersionedXcm::V5(Xcm::<()>(Vec::new()));
+			let mut intermediate_remote_message = VersionedXcm::from(Xcm::<()>(Vec::new()));
 			<$asset_hub as TestExt>::execute_with(|| {
 				type Runtime = <$asset_hub as Chain>::Runtime;
 				type RuntimeCall = <$asset_hub as Chain>::RuntimeCall;
@@ -526,13 +526,13 @@ macro_rules! test_can_estimate_and_pay_exact_fees {
 				let weight = Runtime::query_xcm_weight(remote_message.clone()).unwrap();
 				intermediate_execution_fees = Runtime::query_weight_to_asset_fee(
 					weight,
-					VersionedAssetId::V5(Location::new(1, []).into()),
+					VersionedAssetId::from(AssetId(Location::new(1, []))),
 				)
 				.unwrap();
 
 				// We have to do this to turn `VersionedXcm<()>` into `VersionedXcm<RuntimeCall>`.
 				let xcm_program =
-					VersionedXcm::V5(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
+					VersionedXcm::from(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
 
 				// Now we get the delivery fees to the final destination.
 				let result =
@@ -541,7 +541,7 @@ macro_rules! test_can_estimate_and_pay_exact_fees {
 					.forwarded_xcms
 					.iter()
 					.find(|(destination, _)| {
-						*destination == VersionedLocation::V5(Location::new(1, [Parachain(2001)]))
+						*destination == VersionedLocation::from(Location::new(1, [Parachain(2001)]))
 					})
 					.unwrap();
 				// There's actually two messages here.
@@ -565,7 +565,7 @@ macro_rules! test_can_estimate_and_pay_exact_fees {
 
 				let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
 				final_execution_fees =
-					Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::V5(Parent.into()))
+					Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::from(AssetId(Location::parent())))
 						.unwrap();
 			});
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/lib.rs
@@ -26,9 +26,7 @@ mod imports {
 	};
 
 	// Polkadot
-	pub use xcm::{
-		prelude::{AccountId32 as AccountId32Junction, *},
-	};
+	pub use xcm::prelude::{AccountId32 as AccountId32Junction, *};
 	pub use xcm_executor::traits::TransferType;
 
 	// Cumulus

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/lib.rs
@@ -28,7 +28,6 @@ mod imports {
 	// Polkadot
 	pub use xcm::{
 		prelude::{AccountId32 as AccountId32Junction, *},
-		v3,
 	};
 	pub use xcm_executor::traits::TransferType;
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
@@ -73,9 +73,10 @@ fn spend_roc_on_asset_hub() {
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
 				dest: bx!(VersionedLocation::from(asset_hub_location.clone())),
 				beneficiary: bx!(VersionedLocation::from(treasury_location)),
-				assets: bx!(VersionedAssets::from(Assets::from(
-					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }
-				))),
+				assets: bx!(VersionedAssets::from(Assets::from(Asset {
+					id: native_asset.clone().into(),
+					fun: treasury_balance.into()
+				}))),
 				fee_asset_item: 0,
 			})),
 		});

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
@@ -111,7 +111,10 @@ fn spend_roc_on_asset_hub() {
 		let native_asset = Location::parent();
 
 		let treasury_spend_call = RuntimeCall::Treasury(pallet_treasury::Call::<Runtime>::spend {
-			asset_kind: bx!(VersionedLocatableAsset::from((asset_hub_location.clone(), native_asset.into()))),
+			asset_kind: bx!(VersionedLocatableAsset::from((
+				asset_hub_location.clone(),
+				native_asset.into()
+			))),
 			amount: treasury_spend_balance,
 			beneficiary: bx!(VersionedLocation::from(alice_location)),
 			valid_from: None,
@@ -168,11 +171,12 @@ fn create_and_claim_treasury_spend_in_usdt() {
 	// treasury account on a sibling parachain.
 	let treasury_account =
 		ahr_xcm_config::LocationToAccountId::convert_location(&treasury_location).unwrap();
-	let asset_hub_location =
-		Location::new(0, Parachain(AssetHubRococo::para_id().into()));
+	let asset_hub_location = Location::new(0, Parachain(AssetHubRococo::para_id().into()));
 	let root = <Rococo as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.
-	let asset_kind: VersionedLocatableAsset = (asset_hub_location, AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into())).into();
+	let asset_kind: VersionedLocatableAsset =
+		(asset_hub_location, AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into()))
+			.into();
 	// treasury spend beneficiary.
 	let alice: AccountId = Rococo::account_id_of(ALICE);
 	let bob: AccountId = Rococo::account_id_of(BOB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
@@ -111,10 +111,7 @@ fn spend_roc_on_asset_hub() {
 		let native_asset = Location::parent();
 
 		let treasury_spend_call = RuntimeCall::Treasury(pallet_treasury::Call::<Runtime>::spend {
-			asset_kind: bx!(VersionedLocatableAsset::V5 {
-				location: asset_hub_location.clone(),
-				asset_id: native_asset.into(),
-			}),
+			asset_kind: bx!(VersionedLocatableAsset::from((asset_hub_location.clone(), native_asset.into()))),
 			amount: treasury_spend_balance,
 			beneficiary: bx!(VersionedLocation::from(alice_location)),
 			valid_from: None,
@@ -172,15 +169,10 @@ fn create_and_claim_treasury_spend_in_usdt() {
 	let treasury_account =
 		ahr_xcm_config::LocationToAccountId::convert_location(&treasury_location).unwrap();
 	let asset_hub_location =
-		v3::Location::new(0, v3::Junction::Parachain(AssetHubRococo::para_id().into()));
+		Location::new(0, Parachain(AssetHubRococo::para_id().into()));
 	let root = <Rococo as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.
-	let asset_kind = VersionedLocatableAsset::V3 {
-		location: asset_hub_location,
-		asset_id: v3::AssetId::Concrete(
-			(v3::Junction::PalletInstance(50), v3::Junction::GeneralIndex(USDT_ID.into())).into(),
-		),
-	};
+	let asset_kind: VersionedLocatableAsset = (asset_hub_location, AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into())).into();
 	// treasury spend beneficiary.
 	let alice: AccountId = Rococo::account_id_of(ALICE);
 	let bob: AccountId = Rococo::account_id_of(BOB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/treasury.rs
@@ -71,11 +71,11 @@ fn spend_roc_on_asset_hub() {
 		let teleport_call = RuntimeCall::Utility(pallet_utility::Call::<Runtime>::dispatch_as {
 			as_origin: bx!(RococoOriginCaller::system(RawOrigin::Signed(treasury_account))),
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
-				dest: bx!(VersionedLocation::V5(asset_hub_location.clone())),
-				beneficiary: bx!(VersionedLocation::V5(treasury_location)),
-				assets: bx!(VersionedAssets::V5(
-					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }.into()
-				)),
+				dest: bx!(VersionedLocation::from(asset_hub_location.clone())),
+				beneficiary: bx!(VersionedLocation::from(treasury_location)),
+				assets: bx!(VersionedAssets::from(Assets::from(
+					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }
+				))),
 				fee_asset_item: 0,
 			})),
 		});
@@ -115,7 +115,7 @@ fn spend_roc_on_asset_hub() {
 				asset_id: native_asset.into(),
 			}),
 			amount: treasury_spend_balance,
-			beneficiary: bx!(VersionedLocation::V5(alice_location)),
+			beneficiary: bx!(VersionedLocation::from(alice_location)),
 			valid_from: None,
 		});
 
@@ -173,7 +173,7 @@ fn create_and_claim_treasury_spend_in_usdt() {
 	let asset_hub_location =
 		v3::Location::new(0, v3::Junction::Parachain(AssetHubRococo::para_id().into()));
 	let root = <Rococo as Chain>::RuntimeOrigin::root();
-	// asset kind to be spend from the treasury.
+	// asset kind to be spent from the treasury.
 	let asset_kind = VersionedLocatableAsset::V3 {
 		location: asset_hub_location,
 		asset_id: v3::AssetId::Concrete(

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/xcm_fee_estimation.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/xcm_fee_estimation.rs
@@ -180,8 +180,9 @@ fn multi_hop_works() {
 		.unwrap();
 
 		// We have to do this to turn `VersionedXcm<()>` into `VersionedXcm<RuntimeCall>`.
-		let xcm_program =
-			VersionedXcm::from(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
+		let xcm_program = VersionedXcm::from(Xcm::<RuntimeCall>::from(
+			remote_message.clone().try_into().unwrap(),
+		));
 
 		// Now we get the delivery fees to the final destination.
 		let result =
@@ -213,9 +214,11 @@ fn multi_hop_works() {
 		type Runtime = <PenpalA as Chain>::Runtime;
 
 		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
-		final_execution_fees =
-			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::from(AssetId(Location::parent())))
-				.unwrap();
+		final_execution_fees = Runtime::query_weight_to_asset_fee(
+			weight,
+			VersionedAssetId::from(AssetId(Location::parent())),
+		)
+		.unwrap();
 	});
 
 	// Dry-running is done.

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/xcm_fee_estimation.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-rococo/src/tests/xcm_fee_estimation.rs
@@ -88,7 +88,7 @@ fn transfer_assets_para_to_para_through_ah_call(
 		dest: bx!(test.args.dest.into()),
 		assets: bx!(test.args.assets.clone().into()),
 		assets_transfer_type: bx!(TransferType::RemoteReserve(asset_hub_location.clone().into())),
-		remote_fees_id: bx!(VersionedAssetId::V5(AssetId(Location::new(1, [])))),
+		remote_fees_id: bx!(VersionedAssetId::from(AssetId(Location::new(1, [])))),
 		fees_transfer_type: bx!(TransferType::RemoteReserve(asset_hub_location.into())),
 		custom_xcm_on_dest: bx!(VersionedXcm::from(custom_xcm_on_dest)),
 		weight_limit: test.args.weight_limit,
@@ -139,7 +139,7 @@ fn multi_hop_works() {
 
 	// We get them from the PenpalA closure.
 	let mut delivery_fees_amount = 0;
-	let mut remote_message = VersionedXcm::V5(Xcm(Vec::new()));
+	let mut remote_message = VersionedXcm::from(Xcm(Vec::new()));
 	<PenpalA as TestExt>::execute_with(|| {
 		type Runtime = <PenpalA as Chain>::Runtime;
 		type OriginCaller = <PenpalA as Chain>::OriginCaller;
@@ -152,7 +152,7 @@ fn multi_hop_works() {
 			.forwarded_xcms
 			.iter()
 			.find(|(destination, _)| {
-				*destination == VersionedLocation::V5(Location::new(1, [Parachain(1000)]))
+				*destination == VersionedLocation::from(Location::new(1, [Parachain(1000)]))
 			})
 			.unwrap();
 		assert_eq!(messages_to_query.len(), 1);
@@ -166,7 +166,7 @@ fn multi_hop_works() {
 	// These are set in the AssetHub closure.
 	let mut intermediate_execution_fees = 0;
 	let mut intermediate_delivery_fees_amount = 0;
-	let mut intermediate_remote_message = VersionedXcm::V5(Xcm::<()>(Vec::new()));
+	let mut intermediate_remote_message = VersionedXcm::from(Xcm::<()>(Vec::new()));
 	<AssetHubRococo as TestExt>::execute_with(|| {
 		type Runtime = <AssetHubRococo as Chain>::Runtime;
 		type RuntimeCall = <AssetHubRococo as Chain>::RuntimeCall;
@@ -175,13 +175,13 @@ fn multi_hop_works() {
 		let weight = Runtime::query_xcm_weight(remote_message.clone()).unwrap();
 		intermediate_execution_fees = Runtime::query_weight_to_asset_fee(
 			weight,
-			VersionedAssetId::V5(Location::new(1, []).into()),
+			VersionedAssetId::from(AssetId(Location::new(1, []))),
 		)
 		.unwrap();
 
 		// We have to do this to turn `VersionedXcm<()>` into `VersionedXcm<RuntimeCall>`.
 		let xcm_program =
-			VersionedXcm::V5(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
+			VersionedXcm::from(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
 
 		// Now we get the delivery fees to the final destination.
 		let result =
@@ -190,7 +190,7 @@ fn multi_hop_works() {
 			.forwarded_xcms
 			.iter()
 			.find(|(destination, _)| {
-				*destination == VersionedLocation::V5(Location::new(1, [Parachain(2001)]))
+				*destination == VersionedLocation::from(Location::new(1, [Parachain(2001)]))
 			})
 			.unwrap();
 		// There's actually two messages here.
@@ -214,7 +214,7 @@ fn multi_hop_works() {
 
 		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
 		final_execution_fees =
-			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::V5(Parent.into()))
+			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::from(AssetId(Location::parent())))
 				.unwrap();
 	});
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/fellowship_treasury.rs
@@ -34,10 +34,7 @@ fn create_and_claim_treasury_spend() {
 	let asset_hub_location = Location::new(1, [Parachain(AssetHubWestend::para_id().into())]);
 	let root = <CollectivesWestend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.
-	let asset_kind = VersionedLocatableAsset::V5 {
-		location: asset_hub_location,
-		asset_id: AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into()),
-	};
+	let asset_kind: VersionedLocatableAsset = (asset_hub_location, AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into())).into();
 	// treasury spend beneficiary.
 	let alice: AccountId = Westend::account_id_of(ALICE);
 	let bob: AccountId = CollectivesWestend::account_id_of(BOB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/fellowship_treasury.rs
@@ -34,7 +34,9 @@ fn create_and_claim_treasury_spend() {
 	let asset_hub_location = Location::new(1, [Parachain(AssetHubWestend::para_id().into())]);
 	let root = <CollectivesWestend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.
-	let asset_kind: VersionedLocatableAsset = (asset_hub_location, AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into())).into();
+	let asset_kind: VersionedLocatableAsset =
+		(asset_hub_location, AssetId((PalletInstance(50), GeneralIndex(USDT_ID.into())).into()))
+			.into();
 	// treasury spend beneficiary.
 	let alice: AccountId = Westend::account_id_of(ALICE);
 	let bob: AccountId = CollectivesWestend::account_id_of(BOB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
@@ -33,10 +33,7 @@ fn create_and_claim_treasury_spend() {
 	let asset_hub_location = Location::new(0, Parachain(AssetHubWestend::para_id().into()));
 	let root = <Westend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.
-	let asset_kind = VersionedLocatableAsset::V5 {
-		location: asset_hub_location,
-		asset_id: AssetId([PalletInstance(50), GeneralIndex(USDT_ID.into())].into()),
-	};
+	let asset_kind: VersionedLocatableAsset = (asset_hub_location, AssetId([PalletInstance(50), GeneralIndex(USDT_ID.into())].into())).into();
 	// treasury spend beneficiary.
 	let alice: AccountId = Westend::account_id_of(ALICE);
 	let bob: AccountId = Westend::account_id_of(BOB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
@@ -33,7 +33,9 @@ fn create_and_claim_treasury_spend() {
 	let asset_hub_location = Location::new(0, Parachain(AssetHubWestend::para_id().into()));
 	let root = <Westend as Chain>::RuntimeOrigin::root();
 	// asset kind to be spent from the treasury.
-	let asset_kind: VersionedLocatableAsset = (asset_hub_location, AssetId([PalletInstance(50), GeneralIndex(USDT_ID.into())].into())).into();
+	let asset_kind: VersionedLocatableAsset =
+		(asset_hub_location, AssetId([PalletInstance(50), GeneralIndex(USDT_ID.into())].into()))
+			.into();
 	// treasury spend beneficiary.
 	let alice: AccountId = Westend::account_id_of(ALICE);
 	let bob: AccountId = Westend::account_id_of(BOB);

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/treasury.rs
@@ -32,7 +32,7 @@ fn create_and_claim_treasury_spend() {
 		ahw_xcm_config::LocationToAccountId::convert_location(&treasury_location).unwrap();
 	let asset_hub_location = Location::new(0, Parachain(AssetHubWestend::para_id().into()));
 	let root = <Westend as Chain>::RuntimeOrigin::root();
-	// asset kind to be spend from the treasury.
+	// asset kind to be spent from the treasury.
 	let asset_kind = VersionedLocatableAsset::V5 {
 		location: asset_hub_location,
 		asset_id: AssetId([PalletInstance(50), GeneralIndex(USDT_ID.into())].into()),

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/xcm_fee_estimation.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/xcm_fee_estimation.rs
@@ -89,7 +89,7 @@ fn transfer_assets_para_to_para_through_ah_call(
 		dest: bx!(test.args.dest.into()),
 		assets: bx!(test.args.assets.clone().into()),
 		assets_transfer_type: bx!(TransferType::RemoteReserve(asset_hub_location.clone().into())),
-		remote_fees_id: bx!(VersionedAssetId::V5(AssetId(Location::parent()))),
+		remote_fees_id: bx!(VersionedAssetId::from(AssetId(Location::parent()))),
 		fees_transfer_type: bx!(TransferType::RemoteReserve(asset_hub_location.into())),
 		custom_xcm_on_dest: bx!(VersionedXcm::from(custom_xcm_on_dest)),
 		weight_limit: test.args.weight_limit,
@@ -141,7 +141,7 @@ fn multi_hop_works() {
 
 	// We get them from the PenpalA closure.
 	let mut delivery_fees_amount = 0;
-	let mut remote_message = VersionedXcm::V5(Xcm(Vec::new()));
+	let mut remote_message = VersionedXcm::from(Xcm(Vec::new()));
 	<PenpalA as TestExt>::execute_with(|| {
 		type Runtime = <PenpalA as Chain>::Runtime;
 		type OriginCaller = <PenpalA as Chain>::OriginCaller;
@@ -154,7 +154,7 @@ fn multi_hop_works() {
 			.forwarded_xcms
 			.iter()
 			.find(|(destination, _)| {
-				*destination == VersionedLocation::V5(Location::new(1, [Parachain(1000)]))
+				*destination == VersionedLocation::from(Location::new(1, [Parachain(1000)]))
 			})
 			.unwrap();
 		assert_eq!(messages_to_query.len(), 1);
@@ -168,7 +168,7 @@ fn multi_hop_works() {
 	// These are set in the AssetHub closure.
 	let mut intermediate_execution_fees = 0;
 	let mut intermediate_delivery_fees_amount = 0;
-	let mut intermediate_remote_message = VersionedXcm::V5(Xcm::<()>(Vec::new()));
+	let mut intermediate_remote_message = VersionedXcm::from(Xcm::<()>(Vec::new()));
 	<AssetHubWestend as TestExt>::execute_with(|| {
 		type Runtime = <AssetHubWestend as Chain>::Runtime;
 		type RuntimeCall = <AssetHubWestend as Chain>::RuntimeCall;
@@ -177,13 +177,13 @@ fn multi_hop_works() {
 		let weight = Runtime::query_xcm_weight(remote_message.clone()).unwrap();
 		intermediate_execution_fees = Runtime::query_weight_to_asset_fee(
 			weight,
-			VersionedAssetId::V5(Location::new(1, []).into()),
+			VersionedAssetId::from(AssetId(Location::new(1, []))),
 		)
 		.unwrap();
 
 		// We have to do this to turn `VersionedXcm<()>` into `VersionedXcm<RuntimeCall>`.
 		let xcm_program =
-			VersionedXcm::V5(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
+			VersionedXcm::from(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
 
 		// Now we get the delivery fees to the final destination.
 		let result =
@@ -192,7 +192,7 @@ fn multi_hop_works() {
 			.forwarded_xcms
 			.iter()
 			.find(|(destination, _)| {
-				*destination == VersionedLocation::V5(Location::new(1, [Parachain(2001)]))
+				*destination == VersionedLocation::from(Location::new(1, [Parachain(2001)]))
 			})
 			.unwrap();
 		// There's actually two messages here.
@@ -216,7 +216,7 @@ fn multi_hop_works() {
 
 		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
 		final_execution_fees =
-			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::V5(Parent.into()))
+			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::from(Location::parent()))
 				.unwrap();
 	});
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/xcm_fee_estimation.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/xcm_fee_estimation.rs
@@ -182,8 +182,9 @@ fn multi_hop_works() {
 		.unwrap();
 
 		// We have to do this to turn `VersionedXcm<()>` into `VersionedXcm<RuntimeCall>`.
-		let xcm_program =
-			VersionedXcm::from(Xcm::<RuntimeCall>::from(remote_message.clone().try_into().unwrap()));
+		let xcm_program = VersionedXcm::from(Xcm::<RuntimeCall>::from(
+			remote_message.clone().try_into().unwrap(),
+		));
 
 		// Now we get the delivery fees to the final destination.
 		let result =

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -450,14 +450,14 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 			)),
 			fun: Fungible(WETH_AMOUNT),
 		}];
-		let multi_assets = VersionedAssets::V5(Assets::from(assets));
+		let multi_assets = VersionedAssets::from(Assets::from(assets));
 
-		let destination = VersionedLocation::V5(Location::new(
+		let destination = VersionedLocation::from(Location::new(
 			2,
 			[GlobalConsensus(Ethereum { chain_id: CHAIN_ID })],
 		));
 
-		let beneficiary = VersionedLocation::V5(Location::new(
+		let beneficiary = VersionedLocation::from(Location::new(
 			0,
 			[AccountKey20 { network: None, key: ETHEREUM_DESTINATION_ADDRESS.into() }],
 		));

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
@@ -221,14 +221,14 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 			)),
 			fun: Fungible(TOKEN_AMOUNT),
 		}];
-		let versioned_assets = VersionedAssets::V5(Assets::from(assets));
+		let versioned_assets = VersionedAssets::from(Assets::from(assets));
 
-		let destination = VersionedLocation::V5(Location::new(
+		let destination = VersionedLocation::from(Location::new(
 			2,
 			[GlobalConsensus(Ethereum { chain_id: CHAIN_ID })],
 		));
 
-		let beneficiary = VersionedLocation::V5(Location::new(
+		let beneficiary = VersionedLocation::from(Location::new(
 			0,
 			[AccountKey20 { network: None, key: ETHEREUM_DESTINATION_ADDRESS.into() }],
 		));

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
@@ -101,10 +101,7 @@ fn fellowship_treasury_spend() {
 		let native_asset = Location::parent();
 
 		let treasury_spend_call = RuntimeCall::Treasury(pallet_treasury::Call::<Runtime>::spend {
-			asset_kind: bx!(VersionedLocatableAsset::V5 {
-				location: asset_hub_location.clone(),
-				asset_id: native_asset.into(),
-			}),
+			asset_kind: bx!(VersionedLocatableAsset::from((asset_hub_location.clone(), native_asset.into()))),
 			amount: fellowship_treasury_balance,
 			beneficiary: bx!(VersionedLocation::from(fellowship_treasury_location)),
 			valid_from: None,
@@ -179,10 +176,7 @@ fn fellowship_treasury_spend() {
 
 		let fellowship_treasury_spend_call =
 			RuntimeCall::FellowshipTreasury(pallet_treasury::Call::<Runtime, Instance1>::spend {
-				asset_kind: bx!(VersionedLocatableAsset::V5 {
-					location: asset_hub_location,
-					asset_id: native_asset.into(),
-				}),
+				asset_kind: bx!(VersionedLocatableAsset::from((asset_hub_location, native_asset.into()))),
 				amount: fellowship_spend_balance,
 				beneficiary: bx!(VersionedLocation::from(alice_location)),
 				valid_from: None,

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
@@ -66,9 +66,10 @@ fn fellowship_treasury_spend() {
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
 				dest: bx!(VersionedLocation::from(asset_hub_location.clone())),
 				beneficiary: bx!(VersionedLocation::from(treasury_location)),
-				assets: bx!(VersionedAssets::from(Assets::from(
-					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }
-				))),
+				assets: bx!(VersionedAssets::from(Assets::from(Asset {
+					id: native_asset.clone().into(),
+					fun: treasury_balance.into()
+				}))),
 				fee_asset_item: 0,
 			})),
 		});
@@ -101,7 +102,10 @@ fn fellowship_treasury_spend() {
 		let native_asset = Location::parent();
 
 		let treasury_spend_call = RuntimeCall::Treasury(pallet_treasury::Call::<Runtime>::spend {
-			asset_kind: bx!(VersionedLocatableAsset::from((asset_hub_location.clone(), native_asset.into()))),
+			asset_kind: bx!(VersionedLocatableAsset::from((
+				asset_hub_location.clone(),
+				native_asset.into()
+			))),
 			amount: fellowship_treasury_balance,
 			beneficiary: bx!(VersionedLocation::from(fellowship_treasury_location)),
 			valid_from: None,
@@ -176,7 +180,10 @@ fn fellowship_treasury_spend() {
 
 		let fellowship_treasury_spend_call =
 			RuntimeCall::FellowshipTreasury(pallet_treasury::Call::<Runtime, Instance1>::spend {
-				asset_kind: bx!(VersionedLocatableAsset::from((asset_hub_location, native_asset.into()))),
+				asset_kind: bx!(VersionedLocatableAsset::from((
+					asset_hub_location,
+					native_asset.into()
+				))),
 				amount: fellowship_spend_balance,
 				beneficiary: bx!(VersionedLocation::from(alice_location)),
 				valid_from: None,

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
@@ -66,9 +66,9 @@ fn fellowship_treasury_spend() {
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
 				dest: bx!(VersionedLocation::from(asset_hub_location.clone())),
 				beneficiary: bx!(VersionedLocation::from(treasury_location)),
-				assets: bx!(VersionedAssets::from(
-					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }.into()
-				)),
+				assets: bx!(VersionedAssets::from(Assets::from(
+					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }
+				))),
 				fee_asset_item: 0,
 			})),
 		});

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship_treasury.rs
@@ -64,9 +64,9 @@ fn fellowship_treasury_spend() {
 		let teleport_call = RuntimeCall::Utility(pallet_utility::Call::<Runtime>::dispatch_as {
 			as_origin: bx!(WestendOriginCaller::system(RawOrigin::Signed(treasury_account))),
 			call: bx!(RuntimeCall::XcmPallet(pallet_xcm::Call::<Runtime>::teleport_assets {
-				dest: bx!(VersionedLocation::V5(asset_hub_location.clone())),
-				beneficiary: bx!(VersionedLocation::V5(treasury_location)),
-				assets: bx!(VersionedAssets::V5(
+				dest: bx!(VersionedLocation::from(asset_hub_location.clone())),
+				beneficiary: bx!(VersionedLocation::from(treasury_location)),
+				assets: bx!(VersionedAssets::from(
 					Asset { id: native_asset.clone().into(), fun: treasury_balance.into() }.into()
 				)),
 				fee_asset_item: 0,
@@ -106,7 +106,7 @@ fn fellowship_treasury_spend() {
 				asset_id: native_asset.into(),
 			}),
 			amount: fellowship_treasury_balance,
-			beneficiary: bx!(VersionedLocation::V5(fellowship_treasury_location)),
+			beneficiary: bx!(VersionedLocation::from(fellowship_treasury_location)),
 			valid_from: None,
 		});
 
@@ -184,7 +184,7 @@ fn fellowship_treasury_spend() {
 					asset_id: native_asset.into(),
 				}),
 				amount: fellowship_spend_balance,
-				beneficiary: bx!(VersionedLocation::V5(alice_location)),
+				beneficiary: bx!(VersionedLocation::from(alice_location)),
 				valid_from: None,
 			});
 

--- a/polkadot/runtime/common/src/impls.rs
+++ b/polkadot/runtime/common/src/impls.rs
@@ -142,6 +142,16 @@ pub enum VersionedLocatableAsset {
 	V5 { location: xcm::v5::Location, asset_id: xcm::v5::AssetId },
 }
 
+/// A conversion from latest xcm to `VersionedLocatableAsset`.
+impl From<(xcm::latest::Location, xcm::latest::AssetId)> for VersionedLocatableAsset {
+	fn from(value: (xcm::latest::Location, xcm::latest::AssetId)) -> Self {
+		VersionedLocatableAsset::V5 {
+			location: value.0,
+			asset_id: value.1,
+		}
+	}
+}
+
 /// Converts the [`VersionedLocatableAsset`] to the [`xcm_builder::LocatableAssetId`].
 pub struct LocatableAssetConverter;
 impl TryConvert<VersionedLocatableAsset, xcm_builder::LocatableAssetId>
@@ -239,17 +249,16 @@ pub mod benchmarks {
 	pub struct AssetRateArguments;
 	impl AssetKindFactory<VersionedLocatableAsset> for AssetRateArguments {
 		fn create_asset_kind(seed: u32) -> VersionedLocatableAsset {
-			VersionedLocatableAsset::V5 {
-				location: xcm::v5::Location::new(0, [xcm::v5::Junction::Parachain(seed)]),
-				asset_id: xcm::v5::Location::new(
+			(
+				Location::new(0, [Parachain(seed)]),
+				AssetId(Location::new(
 					0,
 					[
-						xcm::v5::Junction::PalletInstance(seed.try_into().unwrap()),
-						xcm::v5::Junction::GeneralIndex(seed.into()),
+						PalletInstance(seed.try_into().unwrap()),
+						GeneralIndex(seed.into()),
 					],
-				)
-				.into(),
-			}
+				))
+			).into()
 		}
 	}
 
@@ -264,25 +273,24 @@ pub mod benchmarks {
 		for TreasuryArguments<Parents, ParaId>
 	{
 		fn create_asset_kind(seed: u32) -> VersionedLocatableAsset {
-			VersionedLocatableAsset::V3 {
-				location: xcm::v3::Location::new(
+			(
+				Location::new(
 					Parents::get(),
-					[xcm::v3::Junction::Parachain(ParaId::get())],
+					[Junction::Parachain(ParaId::get())],
 				),
-				asset_id: xcm::v3::Location::new(
+				AssetId(Location::new(
 					0,
 					[
-						xcm::v3::Junction::PalletInstance(seed.try_into().unwrap()),
-						xcm::v3::Junction::GeneralIndex(seed.into()),
+						PalletInstance(seed.try_into().unwrap()),
+						GeneralIndex(seed.into()),
 					],
-				)
-				.into(),
-			}
+				)),
+			).into()
 		}
 		fn create_beneficiary(seed: [u8; 32]) -> VersionedLocation {
-			VersionedLocation::from(xcm::latest::Location::new(
+			VersionedLocation::from(Location::new(
 				0,
-				[xcm::latest::Junction::AccountId32 { network: None, id: seed }],
+				[AccountId32 { network: None, id: seed }],
 			))
 		}
 	}

--- a/polkadot/runtime/common/src/impls.rs
+++ b/polkadot/runtime/common/src/impls.rs
@@ -280,9 +280,9 @@ pub mod benchmarks {
 			}
 		}
 		fn create_beneficiary(seed: [u8; 32]) -> VersionedLocation {
-			VersionedLocation::V5(xcm::v5::Location::new(
+			VersionedLocation::from(xcm::latest::Location::new(
 				0,
-				[xcm::v5::Junction::AccountId32 { network: None, id: seed }],
+				[xcm::latest::Junction::AccountId32 { network: None, id: seed }],
 			))
 		}
 	}

--- a/polkadot/runtime/common/src/impls.rs
+++ b/polkadot/runtime/common/src/impls.rs
@@ -145,10 +145,7 @@ pub enum VersionedLocatableAsset {
 /// A conversion from latest xcm to `VersionedLocatableAsset`.
 impl From<(xcm::latest::Location, xcm::latest::AssetId)> for VersionedLocatableAsset {
 	fn from(value: (xcm::latest::Location, xcm::latest::AssetId)) -> Self {
-		VersionedLocatableAsset::V5 {
-			location: value.0,
-			asset_id: value.1,
-		}
+		VersionedLocatableAsset::V5 { location: value.0, asset_id: value.1 }
 	}
 }
 
@@ -253,12 +250,10 @@ pub mod benchmarks {
 				Location::new(0, [Parachain(seed)]),
 				AssetId(Location::new(
 					0,
-					[
-						PalletInstance(seed.try_into().unwrap()),
-						GeneralIndex(seed.into()),
-					],
-				))
-			).into()
+					[PalletInstance(seed.try_into().unwrap()), GeneralIndex(seed.into())],
+				)),
+			)
+				.into()
 		}
 	}
 
@@ -274,24 +269,16 @@ pub mod benchmarks {
 	{
 		fn create_asset_kind(seed: u32) -> VersionedLocatableAsset {
 			(
-				Location::new(
-					Parents::get(),
-					[Junction::Parachain(ParaId::get())],
-				),
+				Location::new(Parents::get(), [Junction::Parachain(ParaId::get())]),
 				AssetId(Location::new(
 					0,
-					[
-						PalletInstance(seed.try_into().unwrap()),
-						GeneralIndex(seed.into()),
-					],
+					[PalletInstance(seed.try_into().unwrap()), GeneralIndex(seed.into())],
 				)),
-			).into()
+			)
+				.into()
 		}
 		fn create_beneficiary(seed: [u8; 32]) -> VersionedLocation {
-			VersionedLocation::from(Location::new(
-				0,
-				[AccountId32 { network: None, id: seed }],
-			))
+			VersionedLocation::from(Location::new(0, [AccountId32 { network: None, id: seed }]))
 		}
 	}
 }

--- a/polkadot/runtime/common/src/xcm_sender.rs
+++ b/polkadot/runtime/common/src/xcm_sender.rs
@@ -157,7 +157,7 @@ impl<T: dmp::Config, W, P> InspectMessageQueues for ChildParachainRouter<T, W, P
 						message
 					})
 					.collect();
-				(VersionedLocation::V5(Parachain(para_id.into()).into()), decoded_messages)
+				(VersionedLocation::from(Location::from(Parachain(para_id.into()))), decoded_messages)
 			})
 			.collect()
 	}

--- a/polkadot/runtime/rococo/src/impls.rs
+++ b/polkadot/runtime/rococo/src/impls.rs
@@ -171,8 +171,8 @@ where
 		// send
 		let _ = <pallet_xcm::Pallet<Runtime>>::send(
 			RawOrigin::Root.into(),
-			Box::new(VersionedLocation::V5(destination)),
-			Box::new(VersionedXcm::V5(program)),
+			Box::new(VersionedLocation::from(destination)),
+			Box::new(VersionedXcm::from(program)),
 		)?;
 		Ok(())
 	}

--- a/polkadot/runtime/westend/src/impls.rs
+++ b/polkadot/runtime/westend/src/impls.rs
@@ -171,8 +171,8 @@ where
 		// send
 		let _ = <pallet_xcm::Pallet<Runtime>>::send(
 			RawOrigin::Root.into(),
-			Box::new(VersionedLocation::V5(destination)),
-			Box::new(VersionedXcm::V5(program)),
+			Box::new(VersionedLocation::from(destination)),
+			Box::new(VersionedXcm::from(program)),
 		)?;
 		Ok(())
 	}

--- a/polkadot/xcm/docs/src/cookbook/relay_token_transactor/tests.rs
+++ b/polkadot/xcm/docs/src/cookbook/relay_token_transactor/tests.rs
@@ -65,9 +65,9 @@ fn reserve_asset_transfers_work() {
 		let assets: Assets = (Here, 50u128 * CENTS as u128).into();
 		assert_ok!(relay_chain::XcmPallet::transfer_assets(
 			relay_chain::RuntimeOrigin::signed(ALICE),
-			Box::new(VersionedLocation::V5(destination.clone())),
-			Box::new(VersionedLocation::V5(beneficiary)),
-			Box::new(VersionedAssets::V5(assets)),
+			Box::new(VersionedLocation::from(destination.clone())),
+			Box::new(VersionedLocation::from(beneficiary)),
+			Box::new(VersionedAssets::from(assets)),
 			0,
 			WeightLimit::Unlimited,
 		));
@@ -101,9 +101,9 @@ fn reserve_asset_transfers_work() {
 		let assets: Assets = (Parent, 25u128 * CENTS as u128).into();
 		assert_ok!(parachain::XcmPallet::transfer_assets(
 			parachain::RuntimeOrigin::signed(BOB),
-			Box::new(VersionedLocation::V5(destination)),
-			Box::new(VersionedLocation::V5(beneficiary)),
-			Box::new(VersionedAssets::V5(assets)),
+			Box::new(VersionedLocation::from(destination)),
+			Box::new(VersionedLocation::from(beneficiary)),
+			Box::new(VersionedAssets::from(assets)),
 			0,
 			WeightLimit::Unlimited,
 		));

--- a/polkadot/xcm/pallet-xcm/src/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm/src/benchmarking.rs
@@ -382,8 +382,8 @@ benchmarks! {
 			asset.clone().into(),
 			&XcmContext { origin: None, message_id: [0u8; 32], topic: None }
 		);
-		let versioned_assets = VersionedAssets::V5(asset.into());
-	}: _<RuntimeOrigin<T>>(claim_origin.into(), Box::new(versioned_assets), Box::new(VersionedLocation::V5(claim_location)))
+		let versioned_assets = VersionedAssets::from(Assets::from(asset));
+	}: _<RuntimeOrigin<T>>(claim_origin.into(), Box::new(versioned_assets), Box::new(VersionedLocation::from(claim_location)))
 
 	impl_benchmark_test_suite!(
 		Pallet,

--- a/polkadot/xcm/pallet-xcm/src/tests/mod.rs
+++ b/polkadot/xcm/pallet-xcm/src/tests/mod.rs
@@ -509,9 +509,10 @@ fn claim_assets_works() {
 		assert_ok!(XcmPallet::claim_assets(
 			RuntimeOrigin::signed(ALICE),
 			Box::new(VersionedAssets::from(Assets::from((Here, SEND_AMOUNT)))),
-			Box::new(VersionedLocation::from(
-				Location::from(AccountId32 { network: None, id: ALICE.clone().into() })
-			)),
+			Box::new(VersionedLocation::from(Location::from(AccountId32 {
+				network: None,
+				id: ALICE.clone().into()
+			}))),
 		));
 		assert_eq!(Balances::total_balance(&ALICE), INITIAL_BALANCE);
 		assert_eq!(AssetTraps::<Test>::iter().collect::<Vec<_>>(), vec![]);

--- a/polkadot/xcm/pallet-xcm/src/tests/mod.rs
+++ b/polkadot/xcm/pallet-xcm/src/tests/mod.rs
@@ -478,14 +478,14 @@ fn claim_assets_works() {
 		// Even though assets are trapped, the extrinsic returns success.
 		assert_ok!(XcmPallet::execute(
 			RuntimeOrigin::signed(ALICE),
-			Box::new(VersionedXcm::V5(trapping_program)),
+			Box::new(VersionedXcm::from(trapping_program)),
 			BaseXcmWeight::get() * 2,
 		));
 		assert_eq!(Balances::total_balance(&ALICE), INITIAL_BALANCE - SEND_AMOUNT);
 
 		// Expected `AssetsTrapped` event info.
 		let source: Location = Junction::AccountId32 { network: None, id: ALICE.into() }.into();
-		let versioned_assets = VersionedAssets::V5(Assets::from((Here, SEND_AMOUNT)));
+		let versioned_assets = VersionedAssets::from(Assets::from((Here, SEND_AMOUNT)));
 		let hash = BlakeTwo256::hash_of(&(source.clone(), versioned_assets.clone()));
 
 		// Assets were indeed trapped.
@@ -508,9 +508,9 @@ fn claim_assets_works() {
 		// Now claim them with the extrinsic.
 		assert_ok!(XcmPallet::claim_assets(
 			RuntimeOrigin::signed(ALICE),
-			Box::new(VersionedAssets::V5((Here, SEND_AMOUNT).into())),
-			Box::new(VersionedLocation::V5(
-				AccountId32 { network: None, id: ALICE.clone().into() }.into()
+			Box::new(VersionedAssets::from(Assets::from((Here, SEND_AMOUNT)))),
+			Box::new(VersionedLocation::from(
+				Location::from(AccountId32 { network: None, id: ALICE.clone().into() })
 			)),
 		));
 		assert_eq!(Balances::total_balance(&ALICE), INITIAL_BALANCE);

--- a/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
+++ b/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
@@ -181,7 +181,7 @@ mod tests {
 
 		type Processor = ProcessXcmMessage<Junction, MockedExecutor, ()>;
 
-		let xcm = VersionedXcm::V5(xcm::latest::Xcm::<()>(vec![
+		let xcm = VersionedXcm::from(xcm::latest::Xcm::<()>(vec![
 			xcm::latest::Instruction::<()>::ClearOrigin,
 		]));
 		assert_err!(

--- a/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -242,7 +242,7 @@ fn query_response_fires() {
 		assert_eq!(
 			polkadot_test_runtime::Xcm::query(query_id),
 			Some(QueryStatus::Ready {
-				response: VersionedResponse::V5(Response::ExecutionResult(None)),
+				response: VersionedResponse::from(Response::ExecutionResult(None)),
 				at: 2u32.into()
 			}),
 		)

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -586,7 +586,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				// or the one used in BuyExecution
 				self.asset_used_in_buy_execution.as_ref()
 			})
-			// if it is different than what we need
+			// if it is different from what we need
 			.filter(|&id| asset_needed_for_fees.id.ne(id))
 		else {
 			// either nothing to swap or we're already holding the right asset


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/pull/5420

This PR includes some cleanup, as every time we upgrade XCM, we will need to rewrite all instances of `V5` to `V6`.