### PR TITLE
`fatxpool`: `LocalTransactionPool` implemented

### DIFF
--- a/prdoc/pr_6104.prdoc
+++ b/prdoc/pr_6104.prdoc
@@ -1,0 +1,10 @@
+title: "LocalTransactionPool implemented for fork aware transaction pool"
+
+doc:
+  - audience: Node Dev
+    description: |
+      LocalTransactionPool trait is implemented for fork aware transaction pool.
+
+crates:
+  - name: sc-transaction-pool
+    bump: minor

--- a/substrate/client/transaction-pool/benches/basics.rs
+++ b/substrate/client/transaction-pool/benches/basics.rs
@@ -91,6 +91,15 @@ impl ChainApi for TestApi {
 		})))
 	}
 
+	fn validate_transaction_blocking(
+		&self,
+		_at: <Self::Block as BlockT>::Hash,
+		_source: TransactionSource,
+		_uxt: Arc<<Self::Block as BlockT>::Extrinsic>,
+	) -> sc_transaction_pool_api::error::Result<TransactionValidity> {
+		unimplemented!();
+	}
+
 	fn block_id_to_number(
 		&self,
 		at: &BlockId<Self::Block>,

--- a/substrate/client/transaction-pool/src/common/api.rs
+++ b/substrate/client/transaction-pool/src/common/api.rs
@@ -162,6 +162,18 @@ where
 		.boxed()
 	}
 
+	/// Validates a transaction by calling into the runtime.
+	///
+	/// Same as `validate_transaction` but blocks the current thread when performing validation.
+	fn validate_transaction_blocking(
+		&self,
+		at: Block::Hash,
+		source: TransactionSource,
+		uxt: graph::ExtrinsicFor<Self>,
+	) -> error::Result<TransactionValidity> {
+		validate_transaction_blocking(&*self.client, at, source, uxt)
+	}
+
 	fn block_id_to_number(
 		&self,
 		at: &BlockId<Self::Block>,
@@ -271,29 +283,4 @@ where
 	log::trace!(target: LOG_TARGET, "[{h:?}] validate_transaction_blocking: at:{at:?} took:{:?}", s.elapsed());
 
 	result
-}
-
-impl<Client, Block> FullChainApi<Client, Block>
-where
-	Block: BlockT,
-	Client: ProvideRuntimeApi<Block>
-		+ BlockBackend<Block>
-		+ BlockIdTo<Block>
-		+ HeaderBackend<Block>
-		+ HeaderMetadata<Block, Error = sp_blockchain::Error>,
-	Client: Send + Sync + 'static,
-	Client::Api: TaggedTransactionQueue<Block>,
-{
-	/// Validates a transaction by calling into the runtime, same as
-	/// `validate_transaction` but blocks the current thread when performing
-	/// validation. Only implemented for `FullChainApi` since we can call into
-	/// the runtime locally.
-	pub fn validate_transaction_blocking(
-		&self,
-		at: Block::Hash,
-		source: TransactionSource,
-		uxt: graph::ExtrinsicFor<Self>,
-	) -> error::Result<TransactionValidity> {
-		validate_transaction_blocking(&*self.client, at, source, uxt)
-	}
 }

--- a/substrate/client/transaction-pool/src/common/tests.rs
+++ b/substrate/client/transaction-pool/src/common/tests.rs
@@ -156,6 +156,15 @@ impl ChainApi for TestApi {
 		futures::future::ready(Ok(res))
 	}
 
+	fn validate_transaction_blocking(
+		&self,
+		_at: <Self::Block as BlockT>::Hash,
+		_source: TransactionSource,
+		_uxt: Arc<<Self::Block as BlockT>::Extrinsic>,
+	) -> error::Result<TransactionValidity> {
+		unimplemented!();
+	}
+
 	/// Returns a block number given the block id.
 	fn block_id_to_number(
 		&self,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -237,11 +237,11 @@ where
 	pub(super) fn extend_unwatched(
 		&self,
 		source: TransactionSource,
-		xts: Vec<ExtrinsicFor<ChainApi>>,
+		xts: &[ExtrinsicFor<ChainApi>],
 	) -> Vec<Result<ExtrinsicHash<ChainApi>, ChainApi::Error>> {
 		let mut transactions = self.transactions.write();
 		let result = xts
-			.into_iter()
+			.iter()
 			.map(|xt| {
 				let hash = self.api.hash_and_length(&xt).0;
 				self.try_insert(
@@ -437,7 +437,7 @@ mod tx_mem_pool_tests {
 
 		let xts = (0..max + 1).map(|x| Arc::from(uxt(x as _))).collect::<Vec<_>>();
 
-		let results = mempool.extend_unwatched(TransactionSource::External, xts);
+		let results = mempool.extend_unwatched(TransactionSource::External, &xts);
 		assert!(results.iter().take(max).all(Result::is_ok));
 		assert!(matches!(
 			results.into_iter().last().unwrap().unwrap_err(),
@@ -455,7 +455,7 @@ mod tx_mem_pool_tests {
 		let mut xts = (0..max - 1).map(|x| Arc::from(uxt(x as _))).collect::<Vec<_>>();
 		xts.push(xts.iter().last().unwrap().clone());
 
-		let results = mempool.extend_unwatched(TransactionSource::External, xts);
+		let results = mempool.extend_unwatched(TransactionSource::External, &xts);
 		assert!(results.iter().take(max - 1).all(Result::is_ok));
 		assert!(matches!(
 			results.into_iter().last().unwrap().unwrap_err(),
@@ -471,7 +471,7 @@ mod tx_mem_pool_tests {
 
 		let xts = (0..max).map(|x| Arc::from(uxt(x as _))).collect::<Vec<_>>();
 
-		let results = mempool.extend_unwatched(TransactionSource::External, xts);
+		let results = mempool.extend_unwatched(TransactionSource::External, &xts);
 		assert!(results.iter().all(Result::is_ok));
 
 		let xt = Arc::from(uxt(98));
@@ -481,7 +481,7 @@ mod tx_mem_pool_tests {
 			sc_transaction_pool_api::error::Error::ImmediatelyDropped
 		));
 		let xt = Arc::from(uxt(99));
-		let mut result = mempool.extend_unwatched(TransactionSource::External, vec![xt]);
+		let mut result = mempool.extend_unwatched(TransactionSource::External, &[xt]);
 		assert!(matches!(
 			result.pop().unwrap().unwrap_err(),
 			sc_transaction_pool_api::error::Error::ImmediatelyDropped
@@ -498,7 +498,7 @@ mod tx_mem_pool_tests {
 		let xt0 = xts.iter().last().unwrap().clone();
 		let xt1 = xts.iter().next().unwrap().clone();
 
-		let results = mempool.extend_unwatched(TransactionSource::External, xts);
+		let results = mempool.extend_unwatched(TransactionSource::External, &xts);
 		assert!(results.iter().all(Result::is_ok));
 
 		let result = mempool.push_watched(TransactionSource::External, xt0);
@@ -506,7 +506,7 @@ mod tx_mem_pool_tests {
 			result.unwrap_err(),
 			sc_transaction_pool_api::error::Error::AlreadyImported(_)
 		));
-		let mut result = mempool.extend_unwatched(TransactionSource::External, vec![xt1]);
+		let mut result = mempool.extend_unwatched(TransactionSource::External, &[xt1]);
 		assert!(matches!(
 			result.pop().unwrap().unwrap_err(),
 			sc_transaction_pool_api::error::Error::AlreadyImported(_)
@@ -521,7 +521,7 @@ mod tx_mem_pool_tests {
 
 		let xts0 = (0..10).map(|x| Arc::from(uxt(x as _))).collect::<Vec<_>>();
 
-		let results = mempool.extend_unwatched(TransactionSource::External, xts0);
+		let results = mempool.extend_unwatched(TransactionSource::External, &xts0);
 		assert!(results.iter().all(Result::is_ok));
 
 		let xts1 = (0..5).map(|x| Arc::from(uxt(2 * x))).collect::<Vec<_>>();

--- a/substrate/client/transaction-pool/src/graph/pool.rs
+++ b/substrate/client/transaction-pool/src/graph/pool.rs
@@ -73,13 +73,24 @@ pub trait ChainApi: Send + Sync {
 		+ Send
 		+ 'static;
 
-	/// Verify extrinsic at given block.
+	/// Asynchronously verify extrinsic at given block.
 	fn validate_transaction(
 		&self,
 		at: <Self::Block as BlockT>::Hash,
 		source: TransactionSource,
 		uxt: ExtrinsicFor<Self>,
 	) -> Self::ValidationFuture;
+
+	/// Synchronously verify given extrinsic at given block.
+	///
+	/// Validates a transaction by calling into the runtime. Same as `validate_transaction` but
+	/// blocks the current thread when performing validation.
+	fn validate_transaction_blocking(
+		&self,
+		at: <Self::Block as BlockT>::Hash,
+		source: TransactionSource,
+		uxt: ExtrinsicFor<Self>,
+	) -> Result<TransactionValidity, Self::Error>;
 
 	/// Returns a block number given the block id.
 	fn block_id_to_number(

--- a/substrate/test-utils/runtime/transaction-pool/src/lib.rs
+++ b/substrate/test-utils/runtime/transaction-pool/src/lib.rs
@@ -450,6 +450,15 @@ impl ChainApi for TestApi {
 		ready(Ok(Ok(validity)))
 	}
 
+	fn validate_transaction_blocking(
+		&self,
+		_at: <Self::Block as BlockT>::Hash,
+		_source: TransactionSource,
+		_uxt: Arc<<Self::Block as BlockT>::Extrinsic>,
+	) -> Result<TransactionValidity, Error> {
+		unimplemented!();
+	}
+
 	fn block_id_to_number(
 		&self,
 		at: &BlockId<Self::Block>,


### PR DESCRIPTION
[`LocalTransactionPool` trait](https://github.com/paritytech/polkadot-sdk/blob/d5b96e9e7f24adc1799f8e426c5cb69b4f2dbf8a/substrate/client/transaction-pool/api/src/lib.rs#L408-L426) is now implemented for `ForkAwareTransactionPool`.

Closes #5493