### PR TITLE
net/discovery: Remove legacy `/kad` protocol

### DIFF
--- a/substrate/client/network/src/discovery.rs
+++ b/substrate/client/network/src/discovery.rs
@@ -319,9 +319,6 @@ pub struct DiscoveryBehaviour {
 	/// to these peers.
 	records_to_publish: HashMap<QueryId, Record>,
 	/// The chain based kademlia protocol name (including genesis hash and fork id).
-	///
-	/// Remove when all nodes are upgraded to genesis hash and fork ID-based Kademlia:
-	/// <https://github.com/paritytech/polkadot-sdk/issues/504>.
 	kademlia_protocol: Option<StreamProtocol>,
 }
 
@@ -381,10 +378,6 @@ impl DiscoveryBehaviour {
 			}
 
 			// The supported protocols must include the chain-based Kademlia protocol.
-			//
-			// Extract the chain-based Kademlia protocol from `kademlia.protocol_name()`
-			// when all nodes are upgraded to genesis hash and fork ID-based Kademlia:
-			// https://github.com/paritytech/polkadot-sdk/issues/504.
 			if !supported_protocols.iter().any(|p| {
 				p == self
 					.kademlia_protocol

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -19,7 +19,7 @@
 //! libp2p-related discovery code for litep2p backend.
 
 use crate::{
-	config::{NetworkConfiguration, ProtocolId},
+	config::NetworkConfiguration,
 	peer_store::PeerStoreProvider,
 };
 
@@ -231,7 +231,6 @@ impl Discovery {
 		config: &NetworkConfiguration,
 		genesis_hash: Hash,
 		fork_id: Option<&str>,
-		protocol_id: &ProtocolId,
 		known_peers: HashMap<PeerId, Vec<Multiaddr>>,
 		listen_addresses: Arc<RwLock<HashSet<Multiaddr>>>,
 		_peerstore_handle: Arc<dyn PeerStoreProvider>,

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -207,11 +207,6 @@ pub struct Discovery {
 	duration_to_next_find_query: Duration,
 }
 
-/// Legacy (fallback) Kademlia protocol name based on `protocol_id`.
-fn legacy_kademlia_protocol_name(id: &ProtocolId) -> ProtocolName {
-	ProtocolName::from(format!("/{}/kad", id.as_ref()))
-}
-
 /// Kademlia protocol name based on `genesis_hash` and `fork_id`.
 fn kademlia_protocol_name<Hash: AsRef<[u8]>>(
 	genesis_hash: Hash,
@@ -261,7 +256,6 @@ impl Discovery {
 		let (kademlia_config, kademlia_handle) = {
 			let protocol_names = vec![
 				kademlia_protocol_name(genesis_hash.clone(), fork_id),
-				legacy_kademlia_protocol_name(protocol_id),
 			];
 
 			KademliaConfigBuilder::new()

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -543,7 +543,6 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 				&network_config,
 				params.genesis_hash,
 				params.fork_id.as_deref(),
-				&params.protocol_id,
 				known_addresses.clone(),
 				Arc::clone(&listen_addresses),
 				Arc::clone(&peer_store_handle),

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -519,11 +519,7 @@ where
 						.collect::<Vec<_>>(),
 				);
 				config.discovery_limit(u64::from(network_config.default_peers_set.out_peers) + 15);
-				config.with_kademlia(
-					params.genesis_hash,
-					params.fork_id.as_deref(),
-					&params.protocol_id,
-				);
+				config.with_kademlia(params.genesis_hash, params.fork_id.as_deref());
 				config.with_dht_random_walk(network_config.enable_dht_random_walk);
 				config.allow_non_globals_in_dht(network_config.allow_non_globals_in_dht);
 				config.use_kademlia_disjoint_query_paths(


### PR DESCRIPTION
This PR removes the legacy `/kad` kademlia protocol.

Instead, nodes use the genesis based kademlia protocol for the discovery process.

Part of:
- https://github.com/paritytech/polkadot-sdk/issues/504

cc @paritytech/networking 