### PR TITLE
fix js oom `js-scripts`

### DIFF
--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -9,6 +9,7 @@
     RUN_IN_CI: "1"
     KUBERNETES_CPU_REQUEST: "512m"
     KUBERNETES_MEMORY_REQUEST: "1Gi"
+    NODE_OPTIONS="--max_old_space_size=4096"
   timeout: 60m
 
 include:


### PR DESCRIPTION
Fix `oom` failures (`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`), like:

https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/7602589
https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/7602594