### PR TITLE
Fix migrations for pallet-xcm

### DIFF
--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1805,6 +1805,8 @@ pub mod migrations {
 			MaxAgentsToMigrate,
 		>,
 		parachains_shared::migration::MigrateToV1<Runtime>,
+		// permanent
+		pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	);
 }
 


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/pull/4826

## Description

TBD:

## TODO
- [ ] create tracking issue for `polkadot-fellows`
- [x] Add missing `MigrateToLatestXcmVersion` for westend
- [ ] fix pallet-xcm `Queries`
  - fails for Westend https://github.com/paritytech/polkadot-sdk/actions/runs/11381324568/job/31662577532?pr=6092 
  - `V2` was removed from `Versioned*` stuff, but we have a live data with V2 e.g. Queries - e.g. Kusama or Polkadot relay chains
```
VersionNotifier: {
        origin: {
          V2: {
            parents: 0
            interior: {
              X1: {
                Parachain: 2,124
              }
            }
          }
        }
        isActive: true
      } 
```
![image](https://github.com/user-attachments/assets/f59f761b-46a7-4def-8aea-45c4e41c0a00)
- [ ] fix also for `RemoteLockedFungibles` 
- [ ] fix also for `LockedFungibles`
- [ ]  what about `RecordedXcm`?


