### PR TITLE
Update pallet_staking benchmarks for zero existential deposit

### DIFF
--- a/substrate/frame/staking/src/benchmarking.rs
+++ b/substrate/frame/staking/src/benchmarking.rs
@@ -133,6 +133,7 @@ pub fn create_validator_with_nominators<T: Config>(
 
 	// Create reward pool
 	let total_payout = asset::existential_deposit::<T>()
+		.max(1u32.into())
 		.saturating_mul(upper_bound.into())
 		.saturating_mul(1000u32.into());
 	<ErasValidatorReward<T>>::insert(current_era, total_payout);
@@ -242,7 +243,7 @@ mod benchmarks {
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());
 
 		// setup the worst case list scenario.
 
@@ -308,7 +309,7 @@ mod benchmarks {
 	) -> Result<(), BenchmarkError> {
 		let (stash, controller) = create_stash_controller::<T>(0, 100, RewardDestination::Staked)?;
 		add_slashing_spans::<T>(&stash, s);
-		let amount = asset::existential_deposit::<T>() * 5u32.into(); // Half of total
+		let amount = asset::existential_deposit::<T>().max(1u32.into()) * 5u32.into(); // Half of total
 		Staking::<T>::unbond(RawOrigin::Signed(controller.clone()).into(), amount)?;
 		CurrentEra::<T>::put(EraIndex::max_value());
 		let ledger = Ledger::<T>::get(&controller).ok_or("ledger not created before")?;
@@ -334,7 +335,7 @@ mod benchmarks {
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());;
 
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
@@ -459,7 +460,7 @@ mod benchmarks {
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());;
 
 		// setup a worst case list scenario. Note we don't care about the destination position,
 		// because we are just doing an insert into the origin position.
@@ -492,7 +493,7 @@ mod benchmarks {
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());;
 
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
@@ -653,7 +654,7 @@ mod benchmarks {
 		// Clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());;
 
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
@@ -791,7 +792,7 @@ mod benchmarks {
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());;
 
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
@@ -1045,7 +1046,7 @@ mod benchmarks {
 		// clean up any existing state.
 		clear_validators_and_nominators::<T>();
 
-		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
+		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>()).max(1u32.into());;
 
 		// setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.

--- a/substrate/frame/staking/src/testing_utils.rs
+++ b/substrate/frame/staking/src/testing_utils.rs
@@ -53,7 +53,7 @@ pub fn create_funded_user<T: Config>(
 	balance_factor: u32,
 ) -> T::AccountId {
 	let user = account(string, n, SEED);
-	let balance = asset::existential_deposit::<T>() * balance_factor.into();
+	let balance = asset::existential_deposit::<T>().max(1u32.into()) * balance_factor.into();
 	let _ = asset::set_stakeable_balance::<T>(&user, balance);
 	user
 }


### PR DESCRIPTION
# Description

This PR update pallet_staking benchmarks to allow for the case where existential deposit is set to 0.

## Integration

No additional effort is required to integrate this change.

## Review Notes

I simply added "1" in cases where existential deposit is used, to ensure that the value is never 0. In general, the tests do not need to depend on existential deposit. That amount is arbitrary. So adding 1 should not cause any issues, and no issues were observed.