### PR TITLE
[Westend] Parameterises minimum era inflation to treasury

### DIFF
--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -705,7 +705,6 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 		let yearly_emission = fixed_inflation_rate.saturating_mul_int(fixed_total_issuance);
 
 		let era_emission = relative_era_len.saturating_mul_int(yearly_emission);
-		// 15% to treasury, as per Polkadot ref 1139.
 		let to_treasury = MinTreasuryEraInflation::get().saturating_mul_int(era_emission);
 		let to_stakers = era_emission.saturating_sub(to_treasury);
 

--- a/polkadot/runtime/westend/src/tests.rs
+++ b/polkadot/runtime/westend/src/tests.rs
@@ -28,6 +28,12 @@ use xcm_runtime_apis::conversions::LocationToAccountHelper;
 
 const MILLISECONDS_PER_HOUR: u64 = 60 * 60 * 1000;
 
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut ext = sp_io::TestExternalities::new(Default::default());
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}
+
 #[test]
 fn remove_keys_weight_is_sensible() {
 	use polkadot_runtime_common::crowdloan::WeightInfo;
@@ -318,91 +324,105 @@ fn location_conversion_works() {
 
 #[test]
 fn staking_inflation_correct_single_era() {
-	let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-		123, // ignored
-		456, // ignored
-		MILLISECONDS_PER_HOUR,
-	);
+	new_test_ext().execute_with(|| {
+		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+			123, // ignored
+			456, // ignored
+			MILLISECONDS_PER_HOUR,
+		);
 
-	assert_relative_eq!(to_stakers as f64, (4_046 * CENTS) as f64, max_relative = 0.01);
-	assert_relative_eq!(to_treasury as f64, (714 * CENTS) as f64, max_relative = 0.01);
-	// Total per hour is ~47.6 WND
-	assert_relative_eq!(
-		(to_stakers as f64 + to_treasury as f64),
-		(4_760 * CENTS) as f64,
-		max_relative = 0.001
-	);
+		assert_relative_eq!(to_stakers as f64, (4_046 * CENTS) as f64, max_relative = 0.01);
+		assert_relative_eq!(to_treasury as f64, (714 * CENTS) as f64, max_relative = 0.01);
+		// Total per hour is ~47.6 WND
+		assert_relative_eq!(
+			(to_stakers as f64 + to_treasury as f64),
+			(4_760 * CENTS) as f64,
+			max_relative = 0.001
+		);
+	})
 }
 
 #[test]
 fn staking_inflation_correct_longer_era() {
-	// Twice the era duration means twice the emission:
-	let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-		123, // ignored
-		456, // ignored
-		2 * MILLISECONDS_PER_HOUR,
-	);
+	new_test_ext().execute_with(|| {
+		// Twice the era duration means twice the emission:
+		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+			123, // ignored
+			456, // ignored
+			2 * MILLISECONDS_PER_HOUR,
+		);
 
-	assert_relative_eq!(to_stakers as f64, (4_046 * CENTS) as f64 * 2.0, max_relative = 0.001);
-	assert_relative_eq!(to_treasury as f64, (714 * CENTS) as f64 * 2.0, max_relative = 0.001);
+		assert_relative_eq!(to_stakers as f64, (4_046 * CENTS) as f64 * 2.0, max_relative = 0.001);
+		assert_relative_eq!(to_treasury as f64, (714 * CENTS) as f64 * 2.0, max_relative = 0.001);
+	})
 }
 
 #[test]
 fn staking_inflation_correct_whole_year() {
-	let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-		123,                                        // ignored
-		456,                                        // ignored
-		(36525 * 24 * MILLISECONDS_PER_HOUR) / 100, // 1 year
-	);
+	new_test_ext().execute_with(|| {
+		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+			123,                                        // ignored
+			456,                                        // ignored
+			(36525 * 24 * MILLISECONDS_PER_HOUR) / 100, // 1 year
+		);
 
-	// Our yearly emissions is about 417k WND:
-	let yearly_emission = 417_307 * UNITS;
-	assert_relative_eq!(
-		to_stakers as f64 + to_treasury as f64,
-		yearly_emission as f64,
-		max_relative = 0.001
-	);
+		// Our yearly emissions is about 417k WND:
+		let yearly_emission = 417_307 * UNITS;
+		assert_relative_eq!(
+			to_stakers as f64 + to_treasury as f64,
+			yearly_emission as f64,
+			max_relative = 0.001
+		);
 
-	assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.001);
-	assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.001);
+		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.001);
+		assert_relative_eq!(
+			to_treasury as f64,
+			yearly_emission as f64 * 0.15,
+			max_relative = 0.001
+		);
+	})
 }
 
 // 10 years into the future, our values do not overflow.
 #[test]
 fn staking_inflation_correct_not_overflow() {
-	let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-		123,                                       // ignored
-		456,                                       // ignored
-		(36525 * 24 * MILLISECONDS_PER_HOUR) / 10, // 10 years
-	);
-	let initial_ti: i128 = 5_216_342_402_773_185_773;
-	let projected_total_issuance = (to_stakers as i128 + to_treasury as i128) + initial_ti;
+	new_test_ext().execute_with(|| {
+		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+			123,                                       // ignored
+			456,                                       // ignored
+			(36525 * 24 * MILLISECONDS_PER_HOUR) / 10, // 10 years
+		);
+		let initial_ti: i128 = 5_216_342_402_773_185_773;
+		let projected_total_issuance = (to_stakers as i128 + to_treasury as i128) + initial_ti;
 
-	// In 2034, there will be about 9.39 million WND in existence.
-	assert_relative_eq!(
-		projected_total_issuance as f64,
-		(9_390_000 * UNITS) as f64,
-		max_relative = 0.001
-	);
+		// In 2034, there will be about 9.39 million WND in existence.
+		assert_relative_eq!(
+			projected_total_issuance as f64,
+			(9_390_000 * UNITS) as f64,
+			max_relative = 0.001
+		);
+	})
 }
 
 // Print percent per year, just as convenience.
 #[test]
 fn staking_inflation_correct_print_percent() {
-	let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-		123,                                        // ignored
-		456,                                        // ignored
-		(36525 * 24 * MILLISECONDS_PER_HOUR) / 100, // 1 year
-	);
-	let yearly_emission = to_stakers + to_treasury;
-	let mut ti: i128 = 5_216_342_402_773_185_773;
+	new_test_ext().execute_with(|| {
+		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+			123,                                        // ignored
+			456,                                        // ignored
+			(36525 * 24 * MILLISECONDS_PER_HOUR) / 100, // 1 year
+		);
+		let yearly_emission = to_stakers + to_treasury;
+		let mut ti: i128 = 5_216_342_402_773_185_773;
 
-	for y in 0..10 {
-		let new_ti = ti + yearly_emission as i128;
-		let inflation = 100.0 * (new_ti - ti) as f64 / ti as f64;
-		println!("Year {y} inflation: {inflation}%");
-		ti = new_ti;
+		for y in 0..10 {
+			let new_ti = ti + yearly_emission as i128;
+			let inflation = 100.0 * (new_ti - ti) as f64 / ti as f64;
+			println!("Year {y} inflation: {inflation}%");
+			ti = new_ti;
 
-		assert!(inflation <= 8.0 && inflation > 2.0, "sanity check");
-	}
+			assert!(inflation <= 8.0 && inflation > 2.0, "sanity check");
+		}
+	})
 }

--- a/prdoc/pr_6165.prdoc
+++ b/prdoc/pr_6165.prdoc
@@ -1,0 +1,11 @@
+title: Parameterises Westend minimum era infaltion to treasury
+
+doc:
+  - audience: Runtime User
+    description: |
+      Parameterises the minimum era inflation percentage that should be automatically minted into
+      the treasury. This parameterisation exposes the config directly to governance.
+
+crates:
+  - name: westend-runtime
+    bump: patch


### PR DESCRIPTION
Parameterises the minimum era inflation percentage that should be automatically minted into the treasury. This parameterisation exposes the config directly to governance through the params pallet (root origin required).

Related to https://github.com/paritytech/polkadot-sdk/issues/6158