### PR TITLE
Fix TrustedQueryApi Error

### DIFF
--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -9,7 +9,6 @@
     RUN_IN_CI: "1"
     KUBERNETES_CPU_REQUEST: "512m"
     KUBERNETES_MEMORY_REQUEST: "1Gi"
-    NODE_OPTIONS: "--max-old-space-size=8192"
   timeout: 60m
 
 include:

--- a/polkadot/xcm/xcm-runtime-apis/src/trusted_query.rs
+++ b/polkadot/xcm/xcm-runtime-apis/src/trusted_query.rs
@@ -44,9 +44,7 @@ sp_api::decl_runtime_apis! {
 #[derive(Copy, Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo)]
 pub enum Error {
 	/// Converting a versioned Asset structure from one version to another failed.
-	#[codec(index = 1)]
 	VersionedAssetConversionFailed,
 	/// Converting a versioned Location structure from one version to another failed.
-	#[codec(index = 1)]
 	VersionedLocationConversionFailed,
 }


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/6161

This seems to fix the `JavaScript heap out of memory` error encountered in the bridge zombienet tests lately. 

This is just a partial fix, since we also need to address https://github.com/paritytech/polkadot-sdk/issues/6133 in order to fully fix the bridge zombienet tests