### PR TITLE
Update stake plus network key for collectives polkadot boot node

### DIFF
--- a/cumulus/parachains/chain-specs/collectives-polkadot.json
+++ b/cumulus/parachains/chain-specs/collectives-polkadot.json
@@ -8,7 +8,7 @@
     "/dns/polkadot-collectives-connect-ew6-0.polkadot.io/tcp/443/wss/p2p/12D3KooWLDZT5gAjMtC8fojiCwiz17SC61oeX2C7GWBCqqf9TwVD",
     "/dns/polkadot-collectives-connect-ew6-1.polkadot.io/tcp/443/wss/p2p/12D3KooWC9BwKMDyRUTXsE7teSmoKMgbyxqAp3zi2MTGRJR5nhCL",
     "/dns/collectives-polkadot.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWKLVfjCpW2syecz39UPe4QkJhwME9HUehBvf8oRcT4kot",
-    "/dns/collectives-polkadot.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWBCewTdMPoXNvs1ky1VLidMdS28Jnh8fNbCP81FYiQHn4",
+    "/dns/collectives-polkadot.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWQGy6gckVQXC8skjC4Z9HybvjzxM7Ejc9hC2SHbq1uCv7",
     "/dns/boot.metaspan.io/tcp/16072/p2p/12D3KooWJWTTu2t2yg5bFRH6tjEpfzKwZir5R9JRRjQpgFPXdDfp",
     "/dns/boot.metaspan.io/tcp/16076/wss/p2p/12D3KooWJWTTu2t2yg5bFRH6tjEpfzKwZir5R9JRRjQpgFPXdDfp",
     "/dns/boot.gatotech.network/tcp/33120/p2p/12D3KooWGZsa9tSeLQ1VeC996e1YsCPuyRYMipHQuXikPjcKcpVQ",


### PR DESCRIPTION
# Description

Update the chain specs for collectives polkadot to include an accurate network key for the stake plus boot node. 

## Integration

N/A

## Review Notes

Very simple PR
