### PR TITLE
re-export `XcmFeeToAccount`

### DIFF
--- a/polkadot/xcm/xcm-builder/src/lib.rs
+++ b/polkadot/xcm/xcm-builder/src/lib.rs
@@ -59,7 +59,7 @@ pub use currency_adapter::CurrencyAdapter;
 
 mod fee_handling;
 pub use fee_handling::{
-	deposit_or_burn_fee, HandleFee, SendXcmFeeToAccount, XcmFeeManagerFromComponents,
+	deposit_or_burn_fee, HandleFee, SendXcmFeeToAccount, XcmFeeManagerFromComponents, XcmFeeToAccount
 };
 
 mod filter_asset_location;


### PR DESCRIPTION
In #4959, `XcmFeeToAccount` was replaced with `SendXcmFeeToAccount`.

However, the deprecation should have happened on January 1 2025.

In that PR, we accidentally removed the re-exporting of `XcmFeeToAccount` from the `lib.rs` file, and it is no longer exported. 

If we want to keep `XcmFeeToAccount` till Jan 1 2025, we should re-export it