### PR TITLE
Enable approval-voting-parallel by default on kusama

### DIFF
--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -759,13 +759,12 @@ pub fn new_full<
 		Some(backoff)
 	};
 
-	// Running approval voting in parallel is enabled by default on all networks except Polkadot and
-	// Kusama, unless explicitly enabled by the commandline option.
+	// Running approval voting in parallel is enabled by default on all networks except Polkadot
+	// unless explicitly enabled by the commandline option.
 	// This is meant to be temporary until we have enough confidence in the new system to enable it
 	// by default on all networks.
-	let enable_approval_voting_parallel = (!config.chain_spec.is_kusama() &&
-		!config.chain_spec.is_polkadot()) ||
-		enable_approval_voting_parallel;
+	let enable_approval_voting_parallel =
+		!config.chain_spec.is_polkadot() || enable_approval_voting_parallel;
 
 	let disable_grandpa = config.disable_grandpa;
 	let name = config.network.node_name.clone();

--- a/prdoc/pr_6218.prdoc
+++ b/prdoc/pr_6218.prdoc
@@ -1,0 +1,9 @@
+title: Enable approval-voting-parallel by default on kusama
+
+doc:
+  - audience: Node Dev
+    description: |
+        Enable approval-voting-parallel by default on kusama
+crates:
+  - name: polkadot-service
+    bump: patch


### PR DESCRIPTION
The approval-voting-parallel introduced with https://github.com/paritytech/polkadot-sdk/pull/4849 has been tested on `versi` and approximately 3 weeks on parity's existing kusama nodes https://github.com/paritytech/devops/issues/3583, things worked as expected, so enable it by default on all kusama nodes in the next release.

The next step will be enabling by default on polkadot if no issue arrises while running on kusama.