### PR TITLE
Fix metrics not shutting down if there are open connections

### DIFF
--- a/prdoc/pr_6220.prdoc
+++ b/prdoc/pr_6220.prdoc
@@ -1,4 +1,4 @@
-title: Improve `CheckMetadataHash` transaction extension weight and logic
+title: Fix metrics not shutting down if there are open connections
 
 doc:
   - audience: Runtime Dev

--- a/prdoc/pr_6220.prdoc
+++ b/prdoc/pr_6220.prdoc
@@ -1,0 +1,10 @@
+title: Improve `CheckMetadataHash` transaction extension weight and logic
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Fix prometheus metrics not shutting down if there are open connections
+
+crates:
+- name: substrate-prometheus-endpoint
+  bump: patch

--- a/substrate/utils/prometheus/Cargo.toml
+++ b/substrate/utils/prometheus/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 http-body-util = { workspace = true }
 hyper = { features = ["http1", "server"], workspace = true }
-hyper-util = { features = ["server-auto", "tokio"], workspace = true }
+hyper-util = { features = ["server-auto", "server-graceful", "tokio"], workspace = true }
 log = { workspace = true, default-features = true }
 prometheus = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Fix prometheus metrics not shutting down if there are open connections. I fixed the same issue in the past but it broke again after a dependecy upgrade.

See also:

https://github.com/paritytech/polkadot-sdk/pull/1637

