### PR TITLE
Transact without specifying weight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23491,7 +23491,6 @@ dependencies = [
  "bounded-collections",
  "derivative",
  "environmental",
- "frame-support",
  "hex",
  "hex-literal",
  "impl-trait-for-tuples",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23491,6 +23491,7 @@ dependencies = [
  "bounded-collections",
  "derivative",
  "environmental",
+ "frame-support",
  "hex",
  "hex-literal",
  "impl-trait-for-tuples",

--- a/bridges/snowbridge/primitives/router/src/inbound/mod.rs
+++ b/bridges/snowbridge/primitives/router/src/inbound/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 
 use codec::{Decode, Encode};
 use core::marker::PhantomData;
-use frame_support::{traits::tokens::Balance as BalanceT, weights::Weight, PalletError};
+use frame_support::{traits::tokens::Balance as BalanceT, PalletError};
 use scale_info::TypeInfo;
 use snowbridge_core::TokenId;
 use sp_core::{Get, RuntimeDebug, H160, H256};
@@ -279,7 +279,6 @@ where
 			// Call create_asset on foreign assets pallet.
 			Transact {
 				origin_kind: OriginKind::Xcm,
-				require_weight_at_most: Weight::from_parts(400_000_000, 8_000),
 				call: (
 					create_call_index,
 					asset_id,

--- a/cumulus/parachains/integration-tests/emulated/common/src/macros.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/macros.rs
@@ -698,7 +698,7 @@ macro_rules! test_xcm_fee_querying_apis_work_for_asset_hub {
 				));
 
 				type Runtime = <$asset_hub as Chain>::Runtime;
-				let acceptable_payment_assets = Runtime::query_acceptable_payment_assets(4).unwrap();
+				let acceptable_payment_assets = Runtime::query_acceptable_payment_assets(XCM_VERSION).unwrap();
 				assert_eq!(acceptable_payment_assets, vec![
 					VersionedAssetId::from(AssetId(wnd.clone())),
 					VersionedAssetId::from(AssetId(usdt.clone())),

--- a/cumulus/parachains/integration-tests/emulated/common/src/xcm_helpers.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/xcm_helpers.rs
@@ -27,12 +27,11 @@ pub fn xcm_transact_paid_execution(
 	beneficiary: AccountId,
 ) -> VersionedXcm<()> {
 	let weight_limit = WeightLimit::Unlimited;
-	let require_weight_at_most = Weight::from_parts(1000000000, 200000);
 
 	VersionedXcm::from(Xcm(vec![
 		WithdrawAsset(fees.clone().into()),
 		BuyExecution { fees, weight_limit },
-		Transact { require_weight_at_most, origin_kind, call },
+		Transact { origin_kind, call },
 		RefundSurplus,
 		DepositAsset {
 			assets: All.into(),
@@ -50,12 +49,11 @@ pub fn xcm_transact_unpaid_execution(
 	origin_kind: OriginKind,
 ) -> VersionedXcm<()> {
 	let weight_limit = WeightLimit::Unlimited;
-	let require_weight_at_most = Weight::from_parts(1000000000, 200000);
 	let check_origin = None;
 
 	VersionedXcm::from(Xcm(vec![
 		UnpaidExecution { weight_limit, check_origin },
-		Transact { require_weight_at_most, origin_kind, call },
+		Transact { origin_kind, call },
 	]))
 }
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/send.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/send.rs
@@ -24,7 +24,7 @@ fn send_transact_as_superuser_from_relay_to_asset_hub_works() {
 		ASSET_MIN_BALANCE,
 		true,
 		AssetHubWestendSender::get().into(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(144_759_000, 3675)),
 	)
 }
 
@@ -121,7 +121,7 @@ fn send_xcm_from_para_to_asset_hub_paying_fee_with_sufficient_asset() {
 		ASSET_MIN_BALANCE,
 		true,
 		para_sovereign_account.clone(),
-		Some(Weight::from_parts(1_019_445_000, 200_000)),
+		Some(Weight::from_parts(144_759_000, 3675)),
 		ASSET_MIN_BALANCE * 1000000000,
 	);
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/set_xcm_versions.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/set_xcm_versions.rs
@@ -67,10 +67,7 @@ fn system_para_sets_relay_xcm_supported_version() {
 	AssetHubWestend::execute_with(|| {
 		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
-		AssetHubWestend::assert_dmp_queue_complete(Some(Weight::from_parts(
-			115_688_000,
-			0,
-		)));
+		AssetHubWestend::assert_dmp_queue_complete(Some(Weight::from_parts(115_688_000, 0)));
 
 		assert_expected_events!(
 			AssetHubWestend,

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/set_xcm_versions.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/set_xcm_versions.rs
@@ -68,8 +68,8 @@ fn system_para_sets_relay_xcm_supported_version() {
 		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
 		AssetHubWestend::assert_dmp_queue_complete(Some(Weight::from_parts(
-			1_019_210_000,
-			200_000,
+			115_688_000,
+			0,
 		)));
 
 		assert_expected_events!(

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -84,10 +84,7 @@ fn create_agent() {
 	let remote_xcm = VersionedXcm::from(Xcm(vec![
 		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 		DescendOrigin(Parachain(origin_para).into()),
-		Transact {
-			origin_kind: OriginKind::Xcm,
-			call: create_agent_call.encode().into(),
-		},
+		Transact { origin_kind: OriginKind::Xcm, call: create_agent_call.encode().into() },
 	]));
 
 	// Rococo Global Consensus
@@ -141,10 +138,7 @@ fn create_channel() {
 	let create_agent_xcm = VersionedXcm::from(Xcm(vec![
 		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 		DescendOrigin(Parachain(origin_para).into()),
-		Transact {
-			origin_kind: OriginKind::Xcm,
-			call: create_agent_call.encode().into(),
-		},
+		Transact { origin_kind: OriginKind::Xcm, call: create_agent_call.encode().into() },
 	]));
 
 	let create_channel_call =
@@ -153,10 +147,7 @@ fn create_channel() {
 	let create_channel_xcm = VersionedXcm::from(Xcm(vec![
 		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 		DescendOrigin(Parachain(origin_para).into()),
-		Transact {
-			origin_kind: OriginKind::Xcm,
-			call: create_channel_call.encode().into(),
-		},
+		Transact { origin_kind: OriginKind::Xcm, call: create_channel_call.encode().into() },
 	]));
 
 	// Rococo Global Consensus

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -85,7 +85,6 @@ fn create_agent() {
 		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 		DescendOrigin(Parachain(origin_para).into()),
 		Transact {
-			require_weight_at_most: 3000000000.into(),
 			origin_kind: OriginKind::Xcm,
 			call: create_agent_call.encode().into(),
 		},
@@ -143,7 +142,6 @@ fn create_channel() {
 		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 		DescendOrigin(Parachain(origin_para).into()),
 		Transact {
-			require_weight_at_most: 3000000000.into(),
 			origin_kind: OriginKind::Xcm,
 			call: create_agent_call.encode().into(),
 		},
@@ -156,7 +154,6 @@ fn create_channel() {
 		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 		DescendOrigin(Parachain(origin_para).into()),
 		Transact {
-			require_weight_at_most: 3000000000.into(),
 			origin_kind: OriginKind::Xcm,
 			call: create_channel_call.encode().into(),
 		},

--- a/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend/src/tests/fellowship.rs
@@ -36,7 +36,6 @@ fn fellows_whitelist_call() {
 				UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 				Transact {
 					origin_kind: OriginKind::Xcm,
-					require_weight_at_most: Weight::from_parts(5_000_000_000, 500_000),
 					call: WestendCall::Whitelist(
 						pallet_whitelist::Call::<WestendRuntime>::whitelist_call { call_hash }
 					)

--- a/cumulus/parachains/pallets/ping/src/lib.rs
+++ b/cumulus/parachains/pallets/ping/src/lib.rs
@@ -108,7 +108,6 @@ pub mod pallet {
 					(Parent, Junction::Parachain(para.into())).into(),
 					Xcm(vec![Transact {
 						origin_kind: OriginKind::Native,
-						require_weight_at_most: Weight::from_parts(1_000, 1_000),
 						call: <T as Config>::RuntimeCall::from(Call::<T>::ping {
 							seq,
 							payload: payload.clone().to_vec(),
@@ -209,7 +208,6 @@ pub mod pallet {
 				(Parent, Junction::Parachain(para.into())).into(),
 				Xcm(vec![Transact {
 					origin_kind: OriginKind::Native,
-					require_weight_at_most: Weight::from_parts(1_000, 1_000),
 					call: <T as Config>::RuntimeCall::from(Call::<T>::pong {
 						seq,
 						payload: payload.clone(),

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1414,7 +1414,7 @@ impl_runtime_apis! {
 			// We also accept all assets in a pool with the native token.
 			let assets_in_pool_with_native = assets_common::get_assets_in_pool_with::<
 				Runtime,
-				xcm::v4::Location
+				xcm::v5::Location
 			>(&native_token).map_err(|()| XcmPaymentApiError::VersionedConversionFailed)?.into_iter();
 			acceptable_assets.extend(assets_in_pool_with_native);
 			PolkadotXcm::query_acceptable_payment_assets(xcm_version, acceptable_assets)
@@ -1431,7 +1431,7 @@ impl_runtime_apis! {
 				Ok(asset_id) => {
 					let assets_in_pool_with_this_asset: Vec<_> = assets_common::get_assets_in_pool_with::<
 						Runtime,
-						xcm::v4::Location
+						xcm::v5::Location
 					>(&asset_id.0).map_err(|()| XcmPaymentApiError::VersionedConversionFailed)?;
 					if assets_in_pool_with_this_asset
 						.into_iter()

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
@@ -86,7 +86,6 @@ impl<Call> XcmWeightInfo<Call> for AssetHubRococoXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
@@ -84,10 +84,7 @@ impl<Call> XcmWeightInfo<Call> for AssetHubRococoXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1526,7 +1526,7 @@ impl_runtime_apis! {
 			// We also accept all assets in a pool with the native token.
 			let assets_in_pool_with_native = assets_common::get_assets_in_pool_with::<
 				Runtime,
-				xcm::v4::Location
+				xcm::v5::Location
 			>(&native_token).map_err(|()| XcmPaymentApiError::VersionedConversionFailed)?.into_iter();
 			acceptable_assets.extend(assets_in_pool_with_native);
 			PolkadotXcm::query_acceptable_payment_assets(xcm_version, acceptable_assets)
@@ -1544,7 +1544,7 @@ impl_runtime_apis! {
 					// We recognize assets in a pool with the native one.
 					let assets_in_pool_with_this_asset: Vec<_> = assets_common::get_assets_in_pool_with::<
 						Runtime,
-						xcm::v4::Location
+						xcm::v5::Location
 					>(&asset_id.0).map_err(|()| XcmPaymentApiError::VersionedConversionFailed)?;
 					if assets_in_pool_with_this_asset
 						.into_iter()

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
@@ -85,7 +85,6 @@ impl<Call> XcmWeightInfo<Call> for AssetHubWestendXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
@@ -83,10 +83,7 @@ impl<Call> XcmWeightInfo<Call> for AssetHubWestendXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
@@ -1202,10 +1202,7 @@ pub fn create_and_manage_foreign_assets_for_local_consensus_parachain_assets_wor
 			let xcm = Xcm(vec![
 				WithdrawAsset(buy_execution_fee.clone().into()),
 				BuyExecution { fees: buy_execution_fee.clone(), weight_limit: Unlimited },
-				Transact {
-					origin_kind: OriginKind::Xcm,
-					call: foreign_asset_create.into(),
-				},
+				Transact { origin_kind: OriginKind::Xcm, call: foreign_asset_create.into() },
 				Transact {
 					origin_kind: OriginKind::SovereignAccount,
 					call: foreign_asset_set_metadata.into(),
@@ -1318,10 +1315,7 @@ pub fn create_and_manage_foreign_assets_for_local_consensus_parachain_assets_wor
 			let xcm = Xcm(vec![
 				WithdrawAsset(buy_execution_fee.clone().into()),
 				BuyExecution { fees: buy_execution_fee.clone(), weight_limit: Unlimited },
-				Transact {
-					origin_kind: OriginKind::Xcm,
-					call: foreign_asset_create.into(),
-				},
+				Transact { origin_kind: OriginKind::Xcm, call: foreign_asset_create.into() },
 				ExpectTransactStatus(MaybeErrorCode::from(DispatchError::BadOrigin.encode())),
 			]);
 

--- a/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/assets/test-utils/src/test_cases.rs
@@ -1204,17 +1204,14 @@ pub fn create_and_manage_foreign_assets_for_local_consensus_parachain_assets_wor
 				BuyExecution { fees: buy_execution_fee.clone(), weight_limit: Unlimited },
 				Transact {
 					origin_kind: OriginKind::Xcm,
-					require_weight_at_most: Weight::from_parts(40_000_000_000, 8000),
 					call: foreign_asset_create.into(),
 				},
 				Transact {
 					origin_kind: OriginKind::SovereignAccount,
-					require_weight_at_most: Weight::from_parts(20_000_000_000, 8000),
 					call: foreign_asset_set_metadata.into(),
 				},
 				Transact {
 					origin_kind: OriginKind::SovereignAccount,
-					require_weight_at_most: Weight::from_parts(20_000_000_000, 8000),
 					call: foreign_asset_set_team.into(),
 				},
 				ExpectTransactStatus(MaybeErrorCode::Success),
@@ -1323,7 +1320,6 @@ pub fn create_and_manage_foreign_assets_for_local_consensus_parachain_assets_wor
 				BuyExecution { fees: buy_execution_fee.clone(), weight_limit: Unlimited },
 				Transact {
 					origin_kind: OriginKind::Xcm,
-					require_weight_at_most: Weight::from_parts(20_000_000_000, 8000),
 					call: foreign_asset_create.into(),
 				},
 				ExpectTransactStatus(MaybeErrorCode::from(DispatchError::BadOrigin.encode())),

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -86,7 +86,6 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -84,10 +84,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
@@ -87,7 +87,6 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubWestendXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
@@ -85,10 +85,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubWestendXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
@@ -129,10 +129,8 @@ pub fn initialize_bridge_by_governance_works<Runtime, GrandpaPalletInstance>(
 		});
 
 		// execute XCM with Transacts to `initialize bridge` as governance does
-		assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
-			initialize_call.encode(),
-		)
-		.ensure_complete());
+		assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(initialize_call.encode(),)
+			.ensure_complete());
 
 		// check mode after
 		assert_eq!(

--- a/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/test-utils/src/test_cases/mod.rs
@@ -131,7 +131,6 @@ pub fn initialize_bridge_by_governance_works<Runtime, GrandpaPalletInstance>(
 		// execute XCM with Transacts to `initialize bridge` as governance does
 		assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
 			initialize_call.encode(),
-			initialize_call.get_dispatch_info().call_weight,
 		)
 		.ensure_complete());
 
@@ -172,7 +171,6 @@ pub fn change_bridge_grandpa_pallet_mode_by_governance_works<Runtime, GrandpaPal
 			// execute XCM with Transacts to `initialize bridge` as governance does
 			assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
 				set_operating_mode_call.encode(),
-				set_operating_mode_call.get_dispatch_info().call_weight,
 			)
 			.ensure_complete());
 
@@ -225,7 +223,6 @@ pub fn change_bridge_parachains_pallet_mode_by_governance_works<Runtime, Paracha
 			// execute XCM with Transacts to `initialize bridge` as governance does
 			assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
 				set_operating_mode_call.encode(),
-				set_operating_mode_call.get_dispatch_info().call_weight,
 			)
 			.ensure_complete());
 
@@ -278,7 +275,6 @@ pub fn change_bridge_messages_pallet_mode_by_governance_works<Runtime, MessagesP
 			// execute XCM with Transacts to `initialize bridge` as governance does
 			assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
 				set_operating_mode_call.encode(),
-				set_operating_mode_call.get_dispatch_info().call_weight,
 			)
 			.ensure_complete());
 

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/coretime.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/coretime.rs
@@ -134,7 +134,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: Weight::from_parts(1000000000, 200000),
 				call: request_core_count_call.encode().into(),
 			},
 		]);
@@ -164,7 +163,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: Weight::from_parts(1000000000, 200000),
 				call: request_revenue_info_at_call.encode().into(),
 			},
 		]);
@@ -193,7 +191,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: Weight::from_parts(1000000000, 200000),
 				call: credit_account_call.encode().into(),
 			},
 		]);
@@ -258,7 +255,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: Weight::from_parts(1_000_000_000, 200000),
 				call: assign_core_call.encode().into(),
 			},
 		]);

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
@@ -86,7 +86,6 @@ impl<Call> XcmWeightInfo<Call> for CoretimeRococoXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
@@ -84,10 +84,7 @@ impl<Call> XcmWeightInfo<Call> for CoretimeRococoXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/coretime.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/coretime.rs
@@ -127,12 +127,6 @@ impl CoretimeInterface for CoretimeAllocator {
 		use crate::coretime::CoretimeProviderCalls::RequestCoreCount;
 		let request_core_count_call = RelayRuntimePallets::Coretime(RequestCoreCount(count));
 
-		// Weight for `request_core_count` from westend benchmarks:
-		// `ref_time` = 7889000 + (3 * 25000000) + (1 * 100000000) = 182889000
-		// `proof_size` = 1636
-		// Add 5% to each component and round to 2 significant figures.
-		let call_weight = Weight::from_parts(190_000_000, 1700);
-
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
 				weight_limit: WeightLimit::Unlimited,
@@ -140,7 +134,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: call_weight,
 				call: request_core_count_call.encode().into(),
 			},
 		]);
@@ -170,7 +163,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: Weight::from_parts(1000000000, 200000),
 				call: request_revenue_info_at_call.encode().into(),
 			},
 		]);
@@ -199,7 +191,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: Weight::from_parts(1000000000, 200000),
 				call: credit_account_call.encode().into(),
 			},
 		]);
@@ -224,12 +215,6 @@ impl CoretimeInterface for CoretimeAllocator {
 		end_hint: Option<RCBlockNumberOf<Self>>,
 	) {
 		use crate::coretime::CoretimeProviderCalls::AssignCore;
-
-		// Weight for `assign_core` from westend benchmarks:
-		// `ref_time` = 10177115 + (1 * 25000000) + (2 * 100000000) + (57600 * 13932) = 937660315
-		// `proof_size` = 3612
-		// Add 5% to each component and round to 2 significant figures.
-		let call_weight = Weight::from_parts(980_000_000, 3800);
 
 		// The relay chain currently only allows `assign_core` to be called with a complete mask
 		// and only ever with increasing `begin`. The assignments must be truncated to avoid
@@ -270,7 +255,6 @@ impl CoretimeInterface for CoretimeAllocator {
 			},
 			Instruction::Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: call_weight,
 				call: assign_core_call.encode().into(),
 			},
 		]);

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
@@ -85,7 +85,6 @@ impl<Call> XcmWeightInfo<Call> for CoretimeWestendXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
@@ -83,10 +83,7 @@ impl<Call> XcmWeightInfo<Call> for CoretimeWestendXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
@@ -83,10 +83,7 @@ impl<Call> XcmWeightInfo<Call> for PeopleRococoXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
@@ -85,7 +85,6 @@ impl<Call> XcmWeightInfo<Call> for PeopleRococoXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
@@ -85,7 +85,6 @@ impl<Call> XcmWeightInfo<Call> for PeopleWestendXcmWeight<Call> {
 	}
 	fn transact(
 		_origin_type: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<Call>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
@@ -83,10 +83,7 @@ impl<Call> XcmWeightInfo<Call> for PeopleWestendXcmWeight<Call> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_type: &OriginKind,
-		_call: &DoubleEncoded<Call>,
-	) -> Weight {
+	fn transact(_origin_type: &OriginKind, _call: &DoubleEncoded<Call>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -445,10 +445,7 @@ impl<
 		// prepare xcm as governance will do
 		let xcm = Xcm(vec![
 			UnpaidExecution { weight_limit: Unlimited, check_origin: None },
-			Transact {
-				origin_kind: OriginKind::Superuser,
-				call: call.into(),
-			},
+			Transact { origin_kind: OriginKind::Superuser, call: call.into() },
 			ExpectTransactStatus(MaybeErrorCode::Success),
 		]);
 
@@ -472,10 +469,7 @@ impl<
 		let xcm = Xcm(vec![
 			WithdrawAsset(buy_execution_fee.clone().into()),
 			BuyExecution { fees: buy_execution_fee.clone(), weight_limit: Unlimited },
-			Transact {
-				origin_kind: OriginKind::Xcm,
-				call: call.encode().into(),
-			},
+			Transact { origin_kind: OriginKind::Xcm, call: call.encode().into() },
 			ExpectTransactStatus(MaybeErrorCode::Success),
 		]);
 

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -441,13 +441,12 @@ impl<
 		AllPalletsWithoutSystem,
 	> RuntimeHelper<Runtime, AllPalletsWithoutSystem>
 {
-	pub fn execute_as_governance(call: Vec<u8>, require_weight_at_most: Weight) -> Outcome {
+	pub fn execute_as_governance(call: Vec<u8>) -> Outcome {
 		// prepare xcm as governance will do
 		let xcm = Xcm(vec![
 			UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 			Transact {
 				origin_kind: OriginKind::Superuser,
-				require_weight_at_most,
 				call: call.into(),
 			},
 			ExpectTransactStatus(MaybeErrorCode::Success),
@@ -475,7 +474,6 @@ impl<
 			BuyExecution { fees: buy_execution_fee.clone(), weight_limit: Unlimited },
 			Transact {
 				origin_kind: OriginKind::Xcm,
-				require_weight_at_most: call.get_dispatch_info().call_weight,
 				call: call.encode().into(),
 			},
 			ExpectTransactStatus(MaybeErrorCode::Success),

--- a/cumulus/parachains/runtimes/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/test_cases.rs
@@ -72,15 +72,9 @@ pub fn change_storage_constant_by_governance_works<Runtime, StorageConstant, Sto
 					)],
 				});
 
-			// estimate - storing just 1 value
-			use frame_system::WeightInfo;
-			let require_weight_at_most =
-				<Runtime as frame_system::Config>::SystemWeightInfo::set_storage(1);
-
 			// execute XCM with Transact to `set_storage` as governance does
 			assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
 				set_storage_call,
-				require_weight_at_most
 			)
 			.ensure_complete());
 
@@ -127,17 +121,9 @@ pub fn set_storage_keys_by_governance_works<Runtime>(
 			items: storage_items.clone(),
 		});
 
-		// estimate - storing just 1 value
-		use frame_system::WeightInfo;
-		let require_weight_at_most =
-			<Runtime as frame_system::Config>::SystemWeightInfo::set_storage(
-				storage_items.len().try_into().unwrap(),
-			);
-
 		// execute XCM with Transact to `set_storage` as governance does
 		assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
 			kill_storage_call,
-			require_weight_at_most
 		)
 		.ensure_complete());
 	});

--- a/cumulus/parachains/runtimes/test-utils/src/test_cases.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/test_cases.rs
@@ -73,10 +73,8 @@ pub fn change_storage_constant_by_governance_works<Runtime, StorageConstant, Sto
 				});
 
 			// execute XCM with Transact to `set_storage` as governance does
-			assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
-				set_storage_call,
-			)
-			.ensure_complete());
+			assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(set_storage_call,)
+				.ensure_complete());
 
 			// check delivery reward constant after (stored)
 			assert_eq!(StorageConstant::get(), new_storage_constant_value);
@@ -122,10 +120,9 @@ pub fn set_storage_keys_by_governance_works<Runtime>(
 		});
 
 		// execute XCM with Transact to `set_storage` as governance does
-		assert_ok!(RuntimeHelper::<Runtime>::execute_as_governance(
-			kill_storage_call,
-		)
-		.ensure_complete());
+		assert_ok!(
+			RuntimeHelper::<Runtime>::execute_as_governance(kill_storage_call,).ensure_complete()
+		);
 	});
 	runtime.execute_with(|| {
 		assert_storage();

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -62,7 +62,7 @@ mod v_coretime {
 
 	impl<
 			T: Config,
-			SendXcm: xcm::v5::SendXcm,
+			SendXcm: xcm::latest::SendXcm,
 			LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 			const TIMESLICE_PERIOD: u32,
 		> MigrateToCoretime<T, SendXcm, LegacyLease, TIMESLICE_PERIOD>
@@ -95,7 +95,7 @@ mod v_coretime {
 
 	impl<
 			T: Config + crate::dmp::Config,
-			SendXcm: xcm::v5::SendXcm,
+			SendXcm: xcm::latest::SendXcm,
 			LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 			const TIMESLICE_PERIOD: u32,
 		> OnRuntimeUpgrade for MigrateToCoretime<T, SendXcm, LegacyLease, TIMESLICE_PERIOD>
@@ -157,7 +157,7 @@ mod v_coretime {
 	// NOTE: Also migrates `num_cores` config value in configuration::ActiveConfig.
 	fn migrate_to_coretime<
 		T: Config,
-		SendXcm: xcm::v5::SendXcm,
+		SendXcm: xcm::latest::SendXcm,
 		LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 		const TIMESLICE_PERIOD: u32,
 	>() -> Weight {
@@ -215,7 +215,7 @@ mod v_coretime {
 
 	fn migrate_send_assignments_to_coretime_chain<
 		T: Config,
-		SendXcm: xcm::v5::SendXcm,
+		SendXcm: xcm::latest::SendXcm,
 		LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 		const TIMESLICE_PERIOD: u32,
 	>() -> result::Result<(), SendError> {

--- a/polkadot/runtime/parachains/src/coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/coretime/mod.rs
@@ -106,7 +106,7 @@ pub mod pallet {
 
 	use crate::configuration;
 	use sp_runtime::traits::TryConvert;
-	use xcm::v5::InteriorLocation;
+	use xcm::latest::InteriorLocation;
 	use xcm_executor::traits::TransactAsset;
 
 	use super::*;

--- a/polkadot/runtime/parachains/src/coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/coretime/mod.rs
@@ -136,11 +136,6 @@ pub mod pallet {
 		type AssetTransactor: TransactAsset;
 		/// AccountId to Location converter
 		type AccountToLocation: for<'a> TryConvert<&'a Self::AccountId, Location>;
-
-		/// Maximum weight for any XCM transact call that should be executed on the coretime chain.
-		///
-		/// Basically should be `max_weight(set_leases, reserve, notify_core_count)`.
-		type MaxXcmTransactWeight: Get<Weight>;
 	}
 
 	#[pallet::event]
@@ -338,7 +333,6 @@ impl<T: Config> OnNewSession<BlockNumberFor<T>> for Pallet<T> {
 fn mk_coretime_call<T: Config>(call: crate::coretime::CoretimeCalls) -> Instruction<()> {
 	Instruction::Transact {
 		origin_kind: OriginKind::Superuser,
-		require_weight_at_most: T::MaxXcmTransactWeight::get(),
 		call: BrokerRuntimePallets::Broker(call).encode().into(),
 	}
 }

--- a/polkadot/runtime/parachains/src/mock.rs
+++ b/polkadot/runtime/parachains/src/mock.rs
@@ -31,6 +31,7 @@ use polkadot_primitives::CoreIndex;
 use codec::Decode;
 use frame_support::{
 	assert_ok, derive_impl, parameter_types,
+	dispatch::GetDispatchInfo,
 	traits::{
 		Currency, ProcessMessage, ProcessMessageError, ValidatorSet, ValidatorSetWithIdentification,
 	},
@@ -261,7 +262,7 @@ thread_local! {
 /// versions in the `VERSION_WRAPPER`.
 pub struct TestUsesOnlyStoredVersionWrapper;
 impl WrapVersion for TestUsesOnlyStoredVersionWrapper {
-	fn wrap_version<RuntimeCall>(
+	fn wrap_version<RuntimeCall: Decode + GetDispatchInfo>(
 		dest: &Location,
 		xcm: impl Into<VersionedXcm<RuntimeCall>>,
 	) -> Result<VersionedXcm<RuntimeCall>, ()> {
@@ -422,7 +423,6 @@ impl assigner_coretime::Config for Test {}
 
 parameter_types! {
 	pub const BrokerId: u32 = 10u32;
-	pub MaxXcmTransactWeight: Weight = Weight::from_parts(10_000_000, 10_000);
 }
 
 pub struct BrokerPot;
@@ -439,7 +439,6 @@ impl coretime::Config for Test {
 	type BrokerId = BrokerId;
 	type WeightInfo = crate::coretime::TestWeightInfo;
 	type SendXcm = DummyXcmSender;
-	type MaxXcmTransactWeight = MaxXcmTransactWeight;
 	type BrokerPotLocation = BrokerPot;
 	type AssetTransactor = ();
 	type AccountToLocation = ();

--- a/polkadot/runtime/parachains/src/mock.rs
+++ b/polkadot/runtime/parachains/src/mock.rs
@@ -30,8 +30,9 @@ use polkadot_primitives::CoreIndex;
 
 use codec::Decode;
 use frame_support::{
-	assert_ok, derive_impl, parameter_types,
+	assert_ok, derive_impl,
 	dispatch::GetDispatchInfo,
+	parameter_types,
 	traits::{
 		Currency, ProcessMessage, ProcessMessageError, ValidatorSet, ValidatorSetWithIdentification,
 	},

--- a/polkadot/runtime/rococo/src/impls.rs
+++ b/polkadot/runtime/rococo/src/impls.rs
@@ -160,10 +160,7 @@ where
 					.into(),
 			},
 			// Poke the deposit to reserve the appropriate amount on the parachain.
-			Transact {
-				origin_kind: OriginKind::Superuser,
-				call: poke.encode().into(),
-			},
+			Transact { origin_kind: OriginKind::Superuser, call: poke.encode().into() },
 		]);
 
 		// send

--- a/polkadot/runtime/rococo/src/impls.rs
+++ b/polkadot/runtime/rococo/src/impls.rs
@@ -21,7 +21,7 @@ use core::marker::PhantomData;
 use frame_support::pallet_prelude::DispatchResult;
 use frame_system::RawOrigin;
 use polkadot_primitives::Balance;
-use polkadot_runtime_common::identity_migrator::{OnReapIdentity, WeightInfo};
+use polkadot_runtime_common::identity_migrator::OnReapIdentity;
 use rococo_runtime_constants::currency::*;
 use xcm::{latest::prelude::*, VersionedLocation, VersionedXcm};
 use xcm_executor::traits::TransactAsset;
@@ -88,10 +88,7 @@ where
 	AccountId: Into<[u8; 32]> + Clone + Encode,
 {
 	fn on_reap_identity(who: &AccountId, fields: u32, subs: u32) -> DispatchResult {
-		use crate::{
-			impls::IdentityMigratorCalls::PokeDeposit,
-			weights::polkadot_runtime_common_identity_migrator::WeightInfo as MigratorWeights,
-		};
+		use crate::impls::IdentityMigratorCalls::PokeDeposit;
 
 		let total_to_send = Self::calculate_remote_deposit(fields, subs);
 

--- a/polkadot/runtime/rococo/src/impls.rs
+++ b/polkadot/runtime/rococo/src/impls.rs
@@ -144,7 +144,6 @@ where
 				.into();
 
 		let poke = PeopleRuntimePallets::<AccountId>::IdentityMigrator(PokeDeposit(who.clone()));
-		let remote_weight_limit = MigratorWeights::<Runtime>::poke_deposit().saturating_mul(2);
 
 		// Actual program to execute on People Chain.
 		let program: Xcm<()> = Xcm(vec![
@@ -163,7 +162,6 @@ where
 			// Poke the deposit to reserve the appropriate amount on the parachain.
 			Transact {
 				origin_kind: OriginKind::Superuser,
-				require_weight_at_most: remote_weight_limit,
 				call: poke.encode().into(),
 			},
 		]);

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1114,7 +1114,6 @@ impl coretime::Config for Runtime {
 		xcm_config::ThisNetwork,
 		<Runtime as frame_system::Config>::AccountId,
 	>;
-	type MaxXcmTransactWeight = MaxXcmTransactWeight;
 }
 
 parameter_types! {

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1090,7 +1090,6 @@ impl parachains_scheduler::Config for Runtime {
 parameter_types! {
 	pub const BrokerId: u32 = BROKER_ID;
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
-	pub MaxXcmTransactWeight: Weight = Weight::from_parts(200_000_000, 20_000);
 }
 
 pub struct BrokerPot;

--- a/polkadot/runtime/rococo/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/rococo/src/weights/xcm/mod.rs
@@ -113,7 +113,6 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for RococoXcmWeight<RuntimeCall> {
 	}
 	fn transact(
 		_origin_kind: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<RuntimeCall>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/polkadot/runtime/rococo/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/rococo/src/weights/xcm/mod.rs
@@ -111,10 +111,7 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for RococoXcmWeight<RuntimeCall> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmBalancesWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_kind: &OriginKind,
-		_call: &DoubleEncoded<RuntimeCall>,
-	) -> Weight {
+	fn transact(_origin_kind: &OriginKind, _call: &DoubleEncoded<RuntimeCall>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -94,7 +94,7 @@ use sp_staking::SessionIndex;
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use xcm::v5::{Assets, InteriorLocation, Location, SendError, SendResult, SendXcm, XcmHash};
+use xcm::latest::{Assets, InteriorLocation, Location, SendError, SendResult, SendXcm, XcmHash};
 
 pub use pallet_balances::Call as BalancesCall;
 #[cfg(feature = "std")]
@@ -641,7 +641,7 @@ impl SendXcm for DummyXcmSender {
 	type Ticket = ();
 	fn validate(
 		_: &mut Option<Location>,
-		_: &mut Option<xcm::v5::Xcm<()>>,
+		_: &mut Option<xcm::latest::Xcm<()>>,
 	) -> SendResult<Self::Ticket> {
 		Ok(((), Assets::new()))
 	}

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -94,7 +94,7 @@ use sp_staking::SessionIndex;
 #[cfg(any(feature = "std", test))]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use xcm::v4::{Assets, InteriorLocation, Location, SendError, SendResult, SendXcm, XcmHash};
+use xcm::v5::{Assets, InteriorLocation, Location, SendError, SendResult, SendXcm, XcmHash};
 
 pub use pallet_balances::Call as BalancesCall;
 #[cfg(feature = "std")]
@@ -641,7 +641,7 @@ impl SendXcm for DummyXcmSender {
 	type Ticket = ();
 	fn validate(
 		_: &mut Option<Location>,
-		_: &mut Option<xcm::v4::Xcm<()>>,
+		_: &mut Option<xcm::v5::Xcm<()>>,
 	) -> SendResult<Self::Ticket> {
 		Ok(((), Assets::new()))
 	}
@@ -659,7 +659,6 @@ impl coretime::Config for Runtime {
 	type BrokerId = BrokerId;
 	type WeightInfo = crate::coretime::TestWeightInfo;
 	type SendXcm = DummyXcmSender;
-	type MaxXcmTransactWeight = MaxXcmTransactWeight;
 	type BrokerPotLocation = BrokerPot;
 	type AssetTransactor = ();
 	type AccountToLocation = ();

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -585,7 +585,6 @@ impl parachains_paras::Config for Runtime {
 
 parameter_types! {
 	pub const BrokerId: u32 = 10u32;
-	pub MaxXcmTransactWeight: Weight = Weight::from_parts(10_000_000, 10_000);
 }
 
 pub struct BrokerPot;

--- a/polkadot/runtime/westend/src/impls.rs
+++ b/polkadot/runtime/westend/src/impls.rs
@@ -157,10 +157,7 @@ where
 					.into(),
 			},
 			// Poke the deposit to reserve the appropriate amount on the parachain.
-			Transact {
-				origin_kind: OriginKind::Superuser,
-				call: poke.encode().into(),
-			},
+			Transact { origin_kind: OriginKind::Superuser, call: poke.encode().into() },
 		]);
 
 		// send

--- a/polkadot/runtime/westend/src/impls.rs
+++ b/polkadot/runtime/westend/src/impls.rs
@@ -21,7 +21,7 @@ use core::marker::PhantomData;
 use frame_support::pallet_prelude::DispatchResult;
 use frame_system::RawOrigin;
 use polkadot_primitives::Balance;
-use polkadot_runtime_common::identity_migrator::{OnReapIdentity, WeightInfo};
+use polkadot_runtime_common::identity_migrator::OnReapIdentity;
 use westend_runtime_constants::currency::*;
 use xcm::{latest::prelude::*, VersionedLocation, VersionedXcm};
 use xcm_executor::traits::TransactAsset;
@@ -88,10 +88,7 @@ where
 	AccountId: Into<[u8; 32]> + Clone + Encode,
 {
 	fn on_reap_identity(who: &AccountId, fields: u32, subs: u32) -> DispatchResult {
-		use crate::{
-			impls::IdentityMigratorCalls::PokeDeposit,
-			weights::polkadot_runtime_common_identity_migrator::WeightInfo as MigratorWeights,
-		};
+		use crate::impls::IdentityMigratorCalls::PokeDeposit;
 
 		let total_to_send = Self::calculate_remote_deposit(fields, subs);
 
@@ -144,7 +141,6 @@ where
 				.into();
 
 		let poke = PeopleRuntimePallets::<AccountId>::IdentityMigrator(PokeDeposit(who.clone()));
-		let remote_weight_limit = MigratorWeights::<Runtime>::poke_deposit().saturating_mul(2);
 
 		// Actual program to execute on People Chain.
 		let program: Xcm<()> = Xcm(vec![
@@ -163,7 +159,6 @@ where
 			// Poke the deposit to reserve the appropriate amount on the parachain.
 			Transact {
 				origin_kind: OriginKind::Superuser,
-				require_weight_at_most: remote_weight_limit,
 				call: poke.encode().into(),
 			},
 		]);

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1315,7 +1315,6 @@ impl parachains_scheduler::Config for Runtime {
 parameter_types! {
 	pub const BrokerId: u32 = BROKER_ID;
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
-	pub MaxXcmTransactWeight: Weight = Weight::from_parts(200_000_000, 20_000);
 }
 
 pub struct BrokerPot;

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1339,7 +1339,6 @@ impl coretime::Config for Runtime {
 		xcm_config::ThisNetwork,
 		<Runtime as frame_system::Config>::AccountId,
 	>;
-	type MaxXcmTransactWeight = MaxXcmTransactWeight;
 }
 
 parameter_types! {

--- a/polkadot/runtime/westend/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/westend/src/weights/xcm/mod.rs
@@ -114,10 +114,7 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for WestendXcmWeight<RuntimeCall> {
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> Weight {
 		assets.weigh_assets(XcmBalancesWeight::<Runtime>::transfer_reserve_asset())
 	}
-	fn transact(
-		_origin_kind: &OriginKind,
-		_call: &DoubleEncoded<RuntimeCall>,
-	) -> Weight {
+	fn transact(_origin_kind: &OriginKind, _call: &DoubleEncoded<RuntimeCall>) -> Weight {
 		XcmGeneric::<Runtime>::transact()
 	}
 	fn hrmp_new_channel_open_request(

--- a/polkadot/runtime/westend/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/westend/src/weights/xcm/mod.rs
@@ -116,7 +116,6 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for WestendXcmWeight<RuntimeCall> {
 	}
 	fn transact(
 		_origin_kind: &OriginKind,
-		_require_weight_at_most: &Weight,
 		_call: &DoubleEncoded<RuntimeCall>,
 	) -> Weight {
 		XcmGeneric::<Runtime>::transact()

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -23,6 +23,7 @@ serde = { features = ["alloc", "derive", "rc"], workspace = true }
 schemars = { default-features = true, optional = true, workspace = true }
 xcm-procedural = { workspace = true, default-features = true }
 environmental = { workspace = true }
+frame-support = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true, default-features = true }
@@ -33,6 +34,7 @@ hex-literal = { workspace = true, default-features = true }
 default = ["std"]
 wasm-api = []
 std = [
+	"frame-support/std",
 	"bounded-collections/std",
 	"codec/std",
 	"environmental/std",

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -34,10 +34,10 @@ hex-literal = { workspace = true, default-features = true }
 default = ["std"]
 wasm-api = []
 std = [
-	"frame-support/std",
 	"bounded-collections/std",
 	"codec/std",
 	"environmental/std",
+	"frame-support/std",
 	"log/std",
 	"scale-info/std",
 	"serde/std",

--- a/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -149,7 +149,6 @@ benchmarks! {
 
 		let instruction = Instruction::Transact {
 			origin_kind: OriginKind::SovereignAccount,
-			require_weight_at_most: noop_call.get_dispatch_info().call_weight,
 			call: double_encoded_noop_call,
 		};
 		let xcm = Xcm(vec![instruction]);

--- a/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -19,7 +19,7 @@ use crate::{account_and_location, new_executor, EnsureDelivery, XcmCallOf};
 use alloc::{vec, vec::Vec};
 use codec::Encode;
 use frame_benchmarking::{benchmarks, BenchmarkError};
-use frame_support::{dispatch::GetDispatchInfo, traits::fungible::Inspect};
+use frame_support::traits::fungible::Inspect;
 use xcm::{
 	latest::{prelude::*, MaxDispatchErrorLen, MaybeErrorCode, Weight, MAX_ITEMS_IN_ASSETS},
 	DoubleEncoded,

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -2536,7 +2536,7 @@ impl<T: Config> Pallet<T> {
 	///
 	/// Returns execution result, events, and any forwarded XCMs to other locations.
 	/// Meant to be used in the `xcm_runtime_apis::dry_run::DryRunApi` runtime API.
-	pub fn dry_run_xcm<Runtime, Router, RuntimeCall, XcmConfig>(
+	pub fn dry_run_xcm<Runtime, Router, RuntimeCall: Decode + GetDispatchInfo, XcmConfig>(
 		origin_location: VersionedLocation,
 		xcm: VersionedXcm<RuntimeCall>,
 	) -> Result<XcmDryRunEffects<<Runtime as frame_system::Config>::RuntimeEvent>, XcmDryRunApiError>
@@ -3029,7 +3029,7 @@ impl<T: Config> xcm_executor::traits::AssetLock for Pallet<T> {
 }
 
 impl<T: Config> WrapVersion for Pallet<T> {
-	fn wrap_version<RuntimeCall>(
+	fn wrap_version<RuntimeCall: Decode + GetDispatchInfo>(
 		dest: &Location,
 		xcm: impl Into<VersionedXcm<RuntimeCall>>,
 	) -> Result<VersionedXcm<RuntimeCall>, ()> {

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -27,7 +27,6 @@ extern crate alloc;
 use codec::{Decode, DecodeLimit, Encode, Error as CodecError, Input, MaxEncodedLen};
 use derivative::Derivative;
 use scale_info::TypeInfo;
-use frame_support::dispatch::GetDispatchInfo;
 
 pub mod v3;
 pub mod v4;

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -26,6 +26,7 @@ extern crate alloc;
 
 use codec::{Decode, DecodeLimit, Encode, Error as CodecError, Input, MaxEncodedLen};
 use derivative::Derivative;
+use frame_support::dispatch::GetDispatchInfo;
 use scale_info::TypeInfo;
 
 pub mod v3;

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -27,6 +27,7 @@ extern crate alloc;
 use codec::{Decode, DecodeLimit, Encode, Error as CodecError, Input, MaxEncodedLen};
 use derivative::Derivative;
 use scale_info::TypeInfo;
+use frame_support::dispatch::GetDispatchInfo;
 
 pub mod v3;
 pub mod v4;
@@ -325,7 +326,7 @@ pub enum VersionedXcm<RuntimeCall> {
 	V5(v5::Xcm<RuntimeCall>),
 }
 
-impl<C> IntoVersion for VersionedXcm<C> {
+impl<C: Decode + GetDispatchInfo> IntoVersion for VersionedXcm<C> {
 	fn into_version(self, n: Version) -> Result<Self, ()> {
 		Ok(match n {
 			3 => Self::V3(self.try_into()?),
@@ -381,7 +382,7 @@ impl<RuntimeCall> From<v5::Xcm<RuntimeCall>> for VersionedXcm<RuntimeCall> {
 	}
 }
 
-impl<Call> TryFrom<VersionedXcm<Call>> for v3::Xcm<Call> {
+impl<Call: Decode + GetDispatchInfo> TryFrom<VersionedXcm<Call>> for v3::Xcm<Call> {
 	type Error = ();
 	fn try_from(x: VersionedXcm<Call>) -> Result<Self, ()> {
 		use VersionedXcm::*;
@@ -396,7 +397,7 @@ impl<Call> TryFrom<VersionedXcm<Call>> for v3::Xcm<Call> {
 	}
 }
 
-impl<Call> TryFrom<VersionedXcm<Call>> for v4::Xcm<Call> {
+impl<Call: Decode + GetDispatchInfo> TryFrom<VersionedXcm<Call>> for v4::Xcm<Call> {
 	type Error = ();
 	fn try_from(x: VersionedXcm<Call>) -> Result<Self, ()> {
 		use VersionedXcm::*;
@@ -408,7 +409,7 @@ impl<Call> TryFrom<VersionedXcm<Call>> for v4::Xcm<Call> {
 	}
 }
 
-impl<Call> TryFrom<VersionedXcm<Call>> for v5::Xcm<Call> {
+impl<Call: Decode + GetDispatchInfo> TryFrom<VersionedXcm<Call>> for v5::Xcm<Call> {
 	type Error = ();
 	fn try_from(x: VersionedXcm<Call>) -> Result<Self, ()> {
 		use VersionedXcm::*;
@@ -426,7 +427,7 @@ impl<Call> TryFrom<VersionedXcm<Call>> for v5::Xcm<Call> {
 /// Convert an `Xcm` datum into a `VersionedXcm`, based on a destination `Location` which will
 /// interpret it.
 pub trait WrapVersion {
-	fn wrap_version<RuntimeCall>(
+	fn wrap_version<RuntimeCall: Decode + GetDispatchInfo>(
 		dest: &latest::Location,
 		xcm: impl Into<VersionedXcm<RuntimeCall>>,
 	) -> Result<VersionedXcm<RuntimeCall>, ()>;
@@ -459,7 +460,7 @@ impl WrapVersion for () {
 /// wrapping it.
 pub struct AlwaysV3;
 impl WrapVersion for AlwaysV3 {
-	fn wrap_version<Call>(
+	fn wrap_version<Call: Decode + GetDispatchInfo>(
 		_: &latest::Location,
 		xcm: impl Into<VersionedXcm<Call>>,
 	) -> Result<VersionedXcm<Call>, ()> {
@@ -476,7 +477,7 @@ impl GetVersion for AlwaysV3 {
 /// wrapping it.
 pub struct AlwaysV4;
 impl WrapVersion for AlwaysV4 {
-	fn wrap_version<Call>(
+	fn wrap_version<Call: Decode + GetDispatchInfo>(
 		_: &latest::Location,
 		xcm: impl Into<VersionedXcm<Call>>,
 	) -> Result<VersionedXcm<Call>, ()> {
@@ -493,7 +494,7 @@ impl GetVersion for AlwaysV4 {
 /// wrapping it.
 pub struct AlwaysV5;
 impl WrapVersion for AlwaysV5 {
-	fn wrap_version<Call>(
+	fn wrap_version<Call: Decode + GetDispatchInfo>(
 		_: &latest::Location,
 		xcm: impl Into<VersionedXcm<Call>>,
 	) -> Result<VersionedXcm<Call>, ()> {

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -353,13 +353,12 @@ impl TryFrom<NewResponse> for Response {
 		Ok(match new {
 			Null => Self::Null,
 			Assets(assets) => Self::Assets(assets.try_into()?),
-			ExecutionResult(result) =>
-				Self::ExecutionResult(
-					result
-						.map(|(num, new_error)| (num, new_error.try_into()))
-						.map(|(num, result)| result.map(|inner| (num, inner)))
-						.transpose()?
-				),
+			ExecutionResult(result) => Self::ExecutionResult(
+				result
+					.map(|(num, new_error)| (num, new_error.try_into()))
+					.map(|(num, result)| result.map(|inner| (num, inner)))
+					.transpose()?,
+			),
 			Version(version) => Self::Version(version),
 			PalletsInfo(pallet_info) => {
 				let inner = pallet_info
@@ -1393,7 +1392,7 @@ impl<Call: Decode + GetDispatchInfo> TryFrom<NewInstruction<Call>> for Instructi
 				maybe_error
 					.map(|(num, new_error)| (num, new_error.try_into()))
 					.map(|(num, result)| result.map(|inner| (num, inner)))
-					.transpose()?
+					.transpose()?,
 			),
 			ExpectTransactStatus(maybe_error_code) => Self::ExpectTransactStatus(maybe_error_code),
 			QueryPallet { module_name, response_info } =>

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -1319,9 +1319,6 @@ impl<Call: Decode + GetDispatchInfo> TryFrom<NewInstruction<Call>> for Instructi
 			HrmpChannelClosing { initiator, sender, recipient } =>
 				Self::HrmpChannelClosing { initiator, sender, recipient },
 			Transact { origin_kind, mut call } => {
-				// TODO: This requires a FRAME dependency on the core XCM crate.
-				// I wouldn't want to have to do that, but it allows for better conversions
-				// from v5 to v4.
 				let require_weight_at_most = call.take_decoded()?.get_dispatch_info().call_weight;
 				Self::Transact { origin_kind, require_weight_at_most, call: call.into() }
 			},

--- a/polkadot/xcm/src/v5/mod.rs
+++ b/polkadot/xcm/src/v5/mod.rs
@@ -304,13 +304,12 @@ impl TryFrom<OldResponse> for Response {
 		Ok(match old {
 			Null => Self::Null,
 			Assets(assets) => Self::Assets(assets.try_into()?),
-			ExecutionResult(result) =>
-				Self::ExecutionResult(
-					result
-						.map(|(num, old_error)| (num, old_error.try_into()))
-						.map(|(num, result)| result.map(|inner| (num, inner)))
-						.transpose()?
-				),
+			ExecutionResult(result) => Self::ExecutionResult(
+				result
+					.map(|(num, old_error)| (num, old_error.try_into()))
+					.map(|(num, result)| result.map(|inner| (num, inner)))
+					.transpose()?,
+			),
 			Version(version) => Self::Version(version),
 			PalletsInfo(pallet_info) => {
 				let inner = pallet_info
@@ -1139,8 +1138,7 @@ impl<Call> Instruction<Call> {
 			HrmpChannelAccepted { recipient } => HrmpChannelAccepted { recipient },
 			HrmpChannelClosing { initiator, sender, recipient } =>
 				HrmpChannelClosing { initiator, sender, recipient },
-			Transact { origin_kind, call } =>
-				Transact { origin_kind, call: call.into() },
+			Transact { origin_kind, call } => Transact { origin_kind, call: call.into() },
 			ReportError(response_info) => ReportError(response_info),
 			DepositAsset { assets, beneficiary } => DepositAsset { assets, beneficiary },
 			DepositReserveAsset { assets, dest, xcm } => DepositReserveAsset { assets, dest, xcm },
@@ -1206,8 +1204,7 @@ impl<Call, W: XcmWeightInfo<Call>> GetWeight<W> for Instruction<Call> {
 			TransferAsset { assets, beneficiary } => W::transfer_asset(assets, beneficiary),
 			TransferReserveAsset { assets, dest, xcm } =>
 				W::transfer_reserve_asset(&assets, dest, xcm),
-			Transact { origin_kind, call } =>
-				W::transact(origin_kind, call),
+			Transact { origin_kind, call } => W::transact(origin_kind, call),
 			HrmpNewChannelOpenRequest { sender, max_message_size, max_capacity } =>
 				W::hrmp_new_channel_open_request(sender, max_message_size, max_capacity),
 			HrmpChannelAccepted { recipient } => W::hrmp_channel_accepted(recipient),

--- a/polkadot/xcm/src/v5/mod.rs
+++ b/polkadot/xcm/src/v5/mod.rs
@@ -494,8 +494,6 @@ pub enum Instruction<Call> {
 	/// The Transact Status Register is set according to the result of dispatching the call.
 	///
 	/// - `origin_kind`: The means of expressing the message origin as a dispatch origin.
-	/// - `require_weight_at_most`: The weight of `call`; this should be at least the chain's
-	///   calculated weight and will be used in the weight determination arithmetic.
 	/// - `call`: The encoded transaction to be applied.
 	///
 	/// Safety: No concerns.
@@ -503,7 +501,7 @@ pub enum Instruction<Call> {
 	/// Kind: *Command*.
 	///
 	/// Errors:
-	Transact { origin_kind: OriginKind, require_weight_at_most: Weight, call: DoubleEncoded<Call> },
+	Transact { origin_kind: OriginKind, call: DoubleEncoded<Call> },
 
 	/// A message to notify about a new incoming HRMP channel. This message is meant to be sent by
 	/// the relay-chain to a para.
@@ -1141,8 +1139,8 @@ impl<Call> Instruction<Call> {
 			HrmpChannelAccepted { recipient } => HrmpChannelAccepted { recipient },
 			HrmpChannelClosing { initiator, sender, recipient } =>
 				HrmpChannelClosing { initiator, sender, recipient },
-			Transact { origin_kind, require_weight_at_most, call } =>
-				Transact { origin_kind, require_weight_at_most, call: call.into() },
+			Transact { origin_kind, call } =>
+				Transact { origin_kind, call: call.into() },
 			ReportError(response_info) => ReportError(response_info),
 			DepositAsset { assets, beneficiary } => DepositAsset { assets, beneficiary },
 			DepositReserveAsset { assets, dest, xcm } => DepositReserveAsset { assets, dest, xcm },
@@ -1208,8 +1206,8 @@ impl<Call, W: XcmWeightInfo<Call>> GetWeight<W> for Instruction<Call> {
 			TransferAsset { assets, beneficiary } => W::transfer_asset(assets, beneficiary),
 			TransferReserveAsset { assets, dest, xcm } =>
 				W::transfer_reserve_asset(&assets, dest, xcm),
-			Transact { origin_kind, require_weight_at_most, call } =>
-				W::transact(origin_kind, require_weight_at_most, call),
+			Transact { origin_kind, call } =>
+				W::transact(origin_kind, call),
 			HrmpNewChannelOpenRequest { sender, max_message_size, max_capacity } =>
 				W::hrmp_new_channel_open_request(sender, max_message_size, max_capacity),
 			HrmpChannelAccepted { recipient } => W::hrmp_channel_accepted(recipient),
@@ -1323,8 +1321,8 @@ impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
 			HrmpChannelAccepted { recipient } => Self::HrmpChannelAccepted { recipient },
 			HrmpChannelClosing { initiator, sender, recipient } =>
 				Self::HrmpChannelClosing { initiator, sender, recipient },
-			Transact { origin_kind, require_weight_at_most, call } =>
-				Self::Transact { origin_kind, require_weight_at_most, call: call.into() },
+			Transact { origin_kind, require_weight_at_most: _, call } =>
+				Self::Transact { origin_kind, call: call.into() },
 			ReportError(response_info) => Self::ReportError(QueryResponseInfo {
 				query_id: response_info.query_id,
 				destination: response_info.destination.try_into().map_err(|_| ())?,

--- a/polkadot/xcm/src/v5/traits.rs
+++ b/polkadot/xcm/src/v5/traits.rs
@@ -427,7 +427,6 @@ pub type SendResult<T> = result::Result<(T, Assets), SendError>;
 /// let call: Vec<u8> = ().encode();
 /// let message = Xcm(vec![Instruction::Transact {
 ///     origin_kind: OriginKind::Superuser,
-///     require_weight_at_most: Weight::zero(),
 ///     call: call.into(),
 /// }]);
 /// let message_hash = message.using_encoded(sp_io::hashing::blake2_256);

--- a/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
+++ b/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
@@ -18,7 +18,10 @@
 
 use codec::{Decode, FullCodec, MaxEncodedLen};
 use core::{fmt::Debug, marker::PhantomData};
-use frame_support::{dispatch::GetDispatchInfo, traits::{ProcessMessage, ProcessMessageError}};
+use frame_support::{
+	dispatch::GetDispatchInfo,
+	traits::{ProcessMessage, ProcessMessageError},
+};
 use scale_info::TypeInfo;
 use sp_weights::{Weight, WeightMeter};
 use xcm::prelude::*;

--- a/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
+++ b/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
@@ -18,7 +18,7 @@
 
 use codec::{Decode, FullCodec, MaxEncodedLen};
 use core::{fmt::Debug, marker::PhantomData};
-use frame_support::traits::{ProcessMessage, ProcessMessageError};
+use frame_support::{dispatch::GetDispatchInfo, traits::{ProcessMessage, ProcessMessageError}};
 use scale_info::TypeInfo;
 use sp_weights::{Weight, WeightMeter};
 use xcm::prelude::*;

--- a/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
+++ b/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
@@ -18,7 +18,7 @@
 
 use codec::{Decode, FullCodec, MaxEncodedLen};
 use core::{fmt::Debug, marker::PhantomData};
-use frame_support::traits::{ProcessMessage, ProcessMessageError};
+use frame_support::{dispatch::GetDispatchInfo, traits::{ProcessMessage, ProcessMessageError}};
 use scale_info::TypeInfo;
 use sp_weights::{Weight, WeightMeter};
 use xcm::prelude::*;
@@ -32,7 +32,7 @@ pub struct ProcessXcmMessage<MessageOrigin, XcmExecutor, Call>(
 impl<
 		MessageOrigin: Into<Location> + FullCodec + MaxEncodedLen + Clone + Eq + PartialEq + TypeInfo + Debug,
 		XcmExecutor: ExecuteXcm<Call>,
-		Call,
+		Call: Decode + GetDispatchInfo,
 	> ProcessMessage for ProcessXcmMessage<MessageOrigin, XcmExecutor, Call>
 {
 	type Origin = MessageOrigin;

--- a/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
+++ b/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
@@ -18,7 +18,7 @@
 
 use codec::{Decode, FullCodec, MaxEncodedLen};
 use core::{fmt::Debug, marker::PhantomData};
-use frame_support::{dispatch::GetDispatchInfo, traits::{ProcessMessage, ProcessMessageError}};
+use frame_support::traits::{ProcessMessage, ProcessMessageError};
 use scale_info::TypeInfo;
 use sp_weights::{Weight, WeightMeter};
 use xcm::prelude::*;

--- a/polkadot/xcm/xcm-builder/src/tests/transacting.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/transacting.rs
@@ -53,10 +53,7 @@ fn transacting_should_respect_max_weight_requirement() {
 		weight_limit,
 		Weight::zero(),
 	);
-	assert_eq!(
-		r,
-		Outcome::Complete { used: Weight::from_parts(60, 60) }
-	);
+	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(60, 60) });
 }
 
 #[test]

--- a/polkadot/xcm/xcm-builder/src/tests/transacting.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/transacting.rs
@@ -22,7 +22,6 @@ fn transacting_should_work() {
 
 	let message = Xcm::<TestCall>(vec![Transact {
 		origin_kind: OriginKind::Native,
-		require_weight_at_most: Weight::from_parts(50, 50),
 		call: TestCall::Any(Weight::from_parts(50, 50), None).encode().into(),
 	}]);
 	let mut hash = fake_message_hash(&message);
@@ -43,7 +42,6 @@ fn transacting_should_respect_max_weight_requirement() {
 
 	let message = Xcm::<TestCall>(vec![Transact {
 		origin_kind: OriginKind::Native,
-		require_weight_at_most: Weight::from_parts(40, 40),
 		call: TestCall::Any(Weight::from_parts(50, 50), None).encode().into(),
 	}]);
 	let mut hash = fake_message_hash(&message);
@@ -57,7 +55,7 @@ fn transacting_should_respect_max_weight_requirement() {
 	);
 	assert_eq!(
 		r,
-		Outcome::Incomplete { used: Weight::from_parts(50, 50), error: XcmError::MaxWeightInvalid }
+		Outcome::Complete { used: Weight::from_parts(60, 60) }
 	);
 }
 
@@ -67,7 +65,6 @@ fn transacting_should_refund_weight() {
 
 	let message = Xcm::<TestCall>(vec![Transact {
 		origin_kind: OriginKind::Native,
-		require_weight_at_most: Weight::from_parts(50, 50),
 		call: TestCall::Any(Weight::from_parts(50, 50), Some(Weight::from_parts(30, 30)))
 			.encode()
 			.into(),
@@ -98,7 +95,6 @@ fn paid_transacting_should_refund_payment_for_unused_weight() {
 		BuyExecution { fees, weight_limit: Limited(Weight::from_parts(100, 100)) },
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			// call estimated at 50 but only takes 10.
 			call: TestCall::Any(Weight::from_parts(50, 50), Some(Weight::from_parts(10, 10)))
 				.encode()
@@ -130,7 +126,6 @@ fn report_successful_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::Any(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ReportTransactStatus(QueryResponseInfo {
@@ -166,7 +161,6 @@ fn report_failed_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::OnlyRoot(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ReportTransactStatus(QueryResponseInfo {
@@ -202,7 +196,6 @@ fn expect_successful_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::Any(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ExpectTransactStatus(MaybeErrorCode::Success),
@@ -221,7 +214,6 @@ fn expect_successful_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::OnlyRoot(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ExpectTransactStatus(MaybeErrorCode::Success),
@@ -248,7 +240,6 @@ fn expect_failed_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::OnlyRoot(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ExpectTransactStatus(vec![2].into()),
@@ -267,7 +258,6 @@ fn expect_failed_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::Any(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ExpectTransactStatus(vec![2].into()),
@@ -294,7 +284,6 @@ fn clear_transact_status_should_work() {
 	let message = Xcm::<TestCall>(vec![
 		Transact {
 			origin_kind: OriginKind::Native,
-			require_weight_at_most: Weight::from_parts(50, 50),
 			call: TestCall::OnlyRoot(Weight::from_parts(50, 50), None).encode().into(),
 		},
 		ClearTransactStatus,

--- a/polkadot/xcm/xcm-builder/src/weight.rs
+++ b/polkadot/xcm/xcm-builder/src/weight.rs
@@ -43,26 +43,26 @@ impl<T: Get<Weight>, C: Decode + GetDispatchInfo, M: Get<u32>> WeightBounds<C>
 		let mut instructions_left = M::get();
 		Self::weight_with_limit(message, &mut instructions_left)
 	}
-	fn instr_weight(instruction: &Instruction<C>) -> Result<Weight, ()> {
+	fn instr_weight(instruction: &mut Instruction<C>) -> Result<Weight, ()> {
 		Self::instr_weight_with_limit(instruction, &mut u32::max_value())
 	}
 }
 
 impl<T: Get<Weight>, C: Decode + GetDispatchInfo, M> FixedWeightBounds<T, C, M> {
-	fn weight_with_limit(message: &Xcm<C>, instrs_limit: &mut u32) -> Result<Weight, ()> {
+	fn weight_with_limit(message: &mut Xcm<C>, instrs_limit: &mut u32) -> Result<Weight, ()> {
 		let mut r: Weight = Weight::zero();
 		*instrs_limit = instrs_limit.checked_sub(message.0.len() as u32).ok_or(())?;
-		for m in message.0.iter() {
-			r = r.checked_add(&Self::instr_weight_with_limit(m, instrs_limit)?).ok_or(())?;
+		for instruction in message.0.iter_mut() {
+			r = r.checked_add(&Self::instr_weight_with_limit(instruction, instrs_limit)?).ok_or(())?;
 		}
 		Ok(r)
 	}
 	fn instr_weight_with_limit(
-		instruction: &Instruction<C>,
+		instruction: &mut Instruction<C>,
 		instrs_limit: &mut u32,
 	) -> Result<Weight, ()> {
 		let instr_weight = match instruction {
-			Transact { require_weight_at_most, .. } => *require_weight_at_most,
+			Transact { ref mut call, .. } => call.take_decoded()?.get_dispatch_info().call_weight,
 			SetErrorHandler(xcm) | SetAppendix(xcm) => Self::weight_with_limit(xcm, instrs_limit)?,
 			_ => Weight::zero(),
 		};
@@ -83,7 +83,7 @@ where
 		let mut instructions_left = M::get();
 		Self::weight_with_limit(message, &mut instructions_left)
 	}
-	fn instr_weight(instruction: &Instruction<C>) -> Result<Weight, ()> {
+	fn instr_weight(instruction: &mut Instruction<C>) -> Result<Weight, ()> {
 		Self::instr_weight_with_limit(instruction, &mut u32::max_value())
 	}
 }
@@ -95,20 +95,20 @@ where
 	M: Get<u32>,
 	Instruction<C>: xcm::latest::GetWeight<W>,
 {
-	fn weight_with_limit(message: &Xcm<C>, instrs_limit: &mut u32) -> Result<Weight, ()> {
+	fn weight_with_limit(message: &mut Xcm<C>, instrs_limit: &mut u32) -> Result<Weight, ()> {
 		let mut r: Weight = Weight::zero();
 		*instrs_limit = instrs_limit.checked_sub(message.0.len() as u32).ok_or(())?;
-		for m in message.0.iter() {
-			r = r.checked_add(&Self::instr_weight_with_limit(m, instrs_limit)?).ok_or(())?;
+		for instruction in message.0.iter_mut() {
+			r = r.checked_add(&Self::instr_weight_with_limit(instruction, instrs_limit)?).ok_or(())?;
 		}
 		Ok(r)
 	}
 	fn instr_weight_with_limit(
-		instruction: &Instruction<C>,
+		instruction: &mut Instruction<C>,
 		instrs_limit: &mut u32,
 	) -> Result<Weight, ()> {
 		let instr_weight = match instruction {
-			Transact { require_weight_at_most, .. } => *require_weight_at_most,
+			Transact { ref mut call, .. } => call.take_decoded()?.get_dispatch_info().call_weight,
 			SetErrorHandler(xcm) | SetAppendix(xcm) => Self::weight_with_limit(xcm, instrs_limit)?,
 			_ => Weight::zero(),
 		};

--- a/polkadot/xcm/xcm-builder/src/weight.rs
+++ b/polkadot/xcm/xcm-builder/src/weight.rs
@@ -53,7 +53,9 @@ impl<T: Get<Weight>, C: Decode + GetDispatchInfo, M> FixedWeightBounds<T, C, M> 
 		let mut r: Weight = Weight::zero();
 		*instrs_limit = instrs_limit.checked_sub(message.0.len() as u32).ok_or(())?;
 		for instruction in message.0.iter_mut() {
-			r = r.checked_add(&Self::instr_weight_with_limit(instruction, instrs_limit)?).ok_or(())?;
+			r = r
+				.checked_add(&Self::instr_weight_with_limit(instruction, instrs_limit)?)
+				.ok_or(())?;
 		}
 		Ok(r)
 	}
@@ -99,7 +101,9 @@ where
 		let mut r: Weight = Weight::zero();
 		*instrs_limit = instrs_limit.checked_sub(message.0.len() as u32).ok_or(())?;
 		for instruction in message.0.iter_mut() {
-			r = r.checked_add(&Self::instr_weight_with_limit(instruction, instrs_limit)?).ok_or(())?;
+			r = r
+				.checked_add(&Self::instr_weight_with_limit(instruction, instrs_limit)?)
+				.ok_or(())?;
 		}
 		Ok(r)
 	}

--- a/polkadot/xcm/xcm-builder/src/weight.rs
+++ b/polkadot/xcm/xcm-builder/src/weight.rs
@@ -62,7 +62,7 @@ impl<T: Get<Weight>, C: Decode + GetDispatchInfo, M> FixedWeightBounds<T, C, M> 
 		instrs_limit: &mut u32,
 	) -> Result<Weight, ()> {
 		let instr_weight = match instruction {
-			Transact { ref mut call, .. } => call.take_decoded()?.get_dispatch_info().call_weight,
+			Transact { ref mut call, .. } => call.ensure_decoded()?.get_dispatch_info().call_weight,
 			SetErrorHandler(xcm) | SetAppendix(xcm) => Self::weight_with_limit(xcm, instrs_limit)?,
 			_ => Weight::zero(),
 		};
@@ -108,7 +108,7 @@ where
 		instrs_limit: &mut u32,
 	) -> Result<Weight, ()> {
 		let instr_weight = match instruction {
-			Transact { ref mut call, .. } => call.take_decoded()?.get_dispatch_info().call_weight,
+			Transact { ref mut call, .. } => call.ensure_decoded()?.get_dispatch_info().call_weight,
 			SetErrorHandler(xcm) | SetAppendix(xcm) => Self::weight_with_limit(xcm, instrs_limit)?,
 			_ => Weight::zero(),
 		};

--- a/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -79,10 +79,7 @@ fn transact_recursion_limit_works() {
 		Xcm(vec![
 			WithdrawAsset((Here, 1_000).into()),
 			BuyExecution { fees: (Here, 1).into(), weight_limit: Unlimited },
-			Transact {
-				origin_kind: OriginKind::Native,
-				call: call.encode().into(),
-			},
+			Transact { origin_kind: OriginKind::Native, call: call.encode().into() },
 		])
 	};
 	let mut call: Option<polkadot_test_runtime::RuntimeCall> = None;

--- a/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -81,7 +81,6 @@ fn transact_recursion_limit_works() {
 			BuyExecution { fees: (Here, 1).into(), weight_limit: Unlimited },
 			Transact {
 				origin_kind: OriginKind::Native,
-				require_weight_at_most: call.get_dispatch_info().call_weight,
 				call: call.encode().into(),
 			},
 		])

--- a/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/integration-tests/src/lib.rs
@@ -17,7 +17,7 @@
 #![cfg(test)]
 
 use codec::Encode;
-use frame_support::{dispatch::GetDispatchInfo, weights::Weight};
+use frame_support::weights::Weight;
 use polkadot_test_client::{
 	BlockBuilderExt, ClientBlockImportExt, DefaultTestClientBuilderExt, InitPolkadotBlockBuilder,
 	TestClientBuilder, TestClientBuilderExt,

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -1007,9 +1007,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					};
 				let actual_weight = maybe_actual_weight.unwrap_or(weight);
 				let surplus = weight.saturating_sub(actual_weight);
-				// We assume that the `Config::Weigher` will count the `require_weight_at_most`
-				// for the estimate of how much weight this instruction will take. Now that we know
-				// that it's less, we credit it.
+				// If the actual weight of the call was less than the specified weight, we credit it.
 				//
 				// We make the adjustment for the total surplus, which is used eventually
 				// reported back to the caller and this ensures that they account for the total

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -926,7 +926,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					Ok(())
 				})
 			},
-			Transact { origin_kind, require_weight_at_most, mut call } => {
+			Transact { origin_kind, mut call } => {
 				// We assume that the Relay-chain is allowed to use transact on this parachain.
 				let origin = self.cloned_origin().ok_or_else(|| {
 					tracing::trace!(
@@ -983,18 +983,6 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				);
 
 				let weight = message_call.get_dispatch_info().call_weight;
-
-				if !weight.all_lte(require_weight_at_most) {
-					tracing::trace!(
-						target: "xcm::process_instruction::transact",
-						%weight,
-						%require_weight_at_most,
-						"Max weight bigger than require at most",
-					);
-
-					return Err(XcmError::MaxWeightInvalid)
-				}
-
 				let maybe_actual_weight =
 					match Config::CallDispatcher::dispatch(message_call, dispatch_origin) {
 						Ok(post_info) => {

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -773,7 +773,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			error_handler_weight = ?self.error_handler_weight,
 		);
 		let mut result = Ok(());
-		for (i, instr) in xcm.0.into_iter().enumerate() {
+		for (i, mut instr) in xcm.0.into_iter().enumerate() {
 			match &mut result {
 				r @ Ok(()) => {
 					// Initialize the recursion count only the first time we hit this code in our
@@ -809,7 +809,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					}
 				},
 				Err(ref mut error) =>
-					if let Ok(x) = Config::Weigher::instr_weight(&instr) {
+					if let Ok(x) = Config::Weigher::instr_weight(&mut instr) {
 						error.weight.saturating_accrue(x)
 					},
 			}

--- a/polkadot/xcm/xcm-executor/src/tests/mock.rs
+++ b/polkadot/xcm/xcm-executor/src/tests/mock.rs
@@ -86,7 +86,7 @@ impl<C> WeightBounds<C> for TestWeigher {
 		Ok(Weight::from_parts(2, 2))
 	}
 
-	fn instr_weight(_instruction: &Instruction<C>) -> Result<Weight, ()> {
+	fn instr_weight(_instruction: &mut Instruction<C>) -> Result<Weight, ()> {
 		Ok(Weight::from_parts(2, 2))
 	}
 }

--- a/polkadot/xcm/xcm-executor/src/traits/weight.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/weight.rs
@@ -26,7 +26,7 @@ pub trait WeightBounds<RuntimeCall> {
 
 	/// Return the maximum amount of weight that an attempted execution of this instruction could
 	/// consume.
-	fn instr_weight(instruction: &Instruction<RuntimeCall>) -> Result<Weight, ()>;
+	fn instr_weight(instruction: &mut Instruction<RuntimeCall>) -> Result<Weight, ()>;
 }
 
 /// Charge for weight in order to execute XCM.

--- a/polkadot/xcm/xcm-simulator/example/src/tests.rs
+++ b/polkadot/xcm/xcm-simulator/example/src/tests.rs
@@ -46,7 +46,6 @@ fn dmp() {
 			Parachain(1),
 			Xcm(vec![Transact {
 				origin_kind: OriginKind::SovereignAccount,
-				require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
 				call: remark.encode().into(),
 			}]),
 		));
@@ -74,7 +73,6 @@ fn ump() {
 			Parent,
 			Xcm(vec![Transact {
 				origin_kind: OriginKind::SovereignAccount,
-				require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
 				call: remark.encode().into(),
 			}]),
 		));
@@ -102,7 +100,6 @@ fn xcmp() {
 			(Parent, Parachain(2)),
 			Xcm(vec![Transact {
 				origin_kind: OriginKind::SovereignAccount,
-				require_weight_at_most: Weight::from_parts(INITIAL_BALANCE as u64, 1024 * 1024),
 				call: remark.encode().into(),
 			}]),
 		));
@@ -383,7 +380,6 @@ fn reserve_asset_class_create_and_reserve_transfer() {
 
 		let message = Xcm(vec![Transact {
 			origin_kind: OriginKind::Xcm,
-			require_weight_at_most: Weight::from_parts(1_000_000_000, 1024 * 1024),
 			call: parachain::RuntimeCall::from(
 				pallet_uniques::Call::<parachain::Runtime>::create {
 					collection: (Parent, 2u64).into(),

--- a/prdoc/pr_6228.prdoc
+++ b/prdoc/pr_6228.prdoc
@@ -1,0 +1,50 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Transact without having to specify weight
+
+doc:
+  - audience: [Runtime User, Runtime Dev]
+    description: |
+      In XCMv5, it's no longer required to pass in the expected weight when using
+      `Transact`.
+      This was made to remove a whole class of bugs where the weight specified
+      was not enough.
+
+crates:
+  - name: staging-xcm
+    bump: major
+  - name: staging-xcm-executor
+    bump: major
+  - name: snowbridge-router-primitives
+    bump: minor
+  - name: emulated-integration-tests-common
+    bump: minor
+  - name: cumulus-ping
+    bump: minor
+  - name: asset-hub-westend-runtime
+    bump: minor
+  - name: asset-hub-rococo-runtime
+    bump: minor
+  - name: parachains-runtimes-test-utils
+    bump: minor
+  - name: bridge-hub-westend-runtime
+    bump: minor
+  - name: bridge-hub-rococo-runtime
+    bump: minor
+  - name: coretime-rococo-runtime
+    bump: minor
+  - name: coretime-westend-runtime
+    bump: minor
+  - name: people-westend-runtime
+    bump: minor
+  - name: people-rococo-runtime
+    bump: minor
+  - name: rococo-runtime
+    bump: minor
+  - name: westend-runtime
+    bump: minor
+  - name: pallet-xcm-benchmarks
+    bump: minor
+  - name: xcm-simulator-example
+    bump: minor

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -131,6 +131,7 @@ use frame_support::{
 	dispatch::{
 		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchInfo,
 		DispatchResult, DispatchResultWithPostInfo, PerDispatchClass, PostDispatchInfo,
+		GetDispatchInfo,
 	},
 	ensure, impl_ensure_origin_with_arg_ignoring_arg,
 	migrations::MultiStepMigrator,
@@ -507,6 +508,7 @@ pub mod pallet {
 		type RuntimeCall: Parameter
 			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
 			+ Debug
+			+ GetDispatchInfo
 			+ From<Call<Self>>;
 
 		/// The aggregated `RuntimeTask` type.

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -130,8 +130,8 @@ use frame_support::traits::BuildGenesisConfig;
 use frame_support::{
 	dispatch::{
 		extract_actual_pays_fee, extract_actual_weight, DispatchClass, DispatchInfo,
-		DispatchResult, DispatchResultWithPostInfo, PerDispatchClass, PostDispatchInfo,
-		GetDispatchInfo,
+		DispatchResult, DispatchResultWithPostInfo, GetDispatchInfo, PerDispatchClass,
+		PostDispatchInfo,
 	},
 	ensure, impl_ensure_origin_with_arg_ignoring_arg,
 	migrations::MultiStepMigrator,


### PR DESCRIPTION
Addresses https://github.com/paritytech/polkadot-sdk/issues/4284

For V5, removed `required_weight_at_most` from `Transact`.
The weigher now has to decode the call inside of a transaction in order to know it's dispatch weight.
It's harder to make mistakes now, since the user no longer specifies a weight value which might be wrong.
