### PR TITLE
Pure state sync refactoring (part-1)

### DIFF
--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -37,7 +37,9 @@ pub use sp_trie::MerkleValue;
 
 use crate::{blockchain::Backend as BlockchainBackend, UsageInfo};
 
-pub use sp_state_machine::{Backend as StateBackend, BackendTransaction, KeyValueStates};
+pub use sp_state_machine::{
+	Backend as StateBackend, BackendTransaction, KeyValueStates, KeyValueStorageLevel,
+};
 
 /// Extracts the state backend type for the given backend.
 pub type StateBackendFor<B, Block> = <B as Backend<Block>>::State;

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -211,14 +211,14 @@ where
 				for StateEntry { key, value } in state.entries {
 					// Skip all child key root (will be recalculated on import).
 					if is_top && well_known_keys::is_child_storage_key(key.as_slice()) {
-						child_roots.push((value, key));
+						child_roots.push((key, value));
 					} else {
 						self.imported_bytes += key.len() as u64;
 						entry.0.push((key, value))
 					}
 				}
-				for (root, storage_key) in child_roots {
-					self.state.entry(root).or_default().1.push(storage_key);
+				for key_value in child_roots {
+					self.insert_child_trie_roots(key_value);
 				}
 			}
 		}

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use log::debug;
-use sc_client_api::{CompactProof, KeyValueStates, ProofProvider};
+use sc_client_api::{CompactProof, KeyValueStates, KeyValueStorageLevel, ProofProvider};
 use sc_consensus::ImportedState;
 use smallvec::SmallVec;
 use sp_core::storage::well_known_keys;
@@ -138,31 +138,40 @@ where
 		self.state.entry(key_value.1).or_default().1.push(key_value.0);
 	}
 
+	fn process_state_key_values(
+		&mut self,
+		state_root: Vec<u8>,
+		key_values: impl IntoIterator<Item = (Vec<u8>, Vec<u8>)>,
+	) {
+		let is_top = state_root.is_empty();
+
+		let (child_key_values, top_key_values): (Vec<_>, Vec<_>) =
+			key_values.into_iter().partition(|key_value| {
+				is_top && well_known_keys::is_child_storage_key(key_value.0.as_slice())
+			});
+
+		for key_value in child_key_values {
+			self.insert_child_trie_roots(key_value);
+		}
+
+		let entry = self.state.entry(state_root).or_default();
+
+		if entry.0.len() > 0 && entry.1.len() > 1 {
+			// Already imported child_trie with same root.
+			// Warning this will not work with parallel download.
+		} else {
+			for (key, _value) in &top_key_values {
+				self.imported_bytes += key.len() as u64;
+			}
+
+			entry.0.extend(top_key_values);
+		}
+	}
+
 	fn process_state_verified(&mut self, values: KeyValueStates) {
 		for values in values.0 {
-			let is_top = values.state_root.is_empty();
-
-			let (child_key_values, top_key_values): (Vec<_>, Vec<_>) =
-				values.key_values.into_iter().partition(|key_value| {
-					is_top && well_known_keys::is_child_storage_key(key_value.0.as_slice())
-				});
-
-			for key_value in child_key_values {
-				self.insert_child_trie_roots(key_value);
-			}
-
-			let entry = self.state.entry(values.state_root).or_default();
-
-			if entry.0.len() > 0 && entry.1.len() > 1 {
-				// Already imported child_trie with same root.
-				// Warning this will not work with parallel download.
-			} else {
-				for (key, _value) in &top_key_values {
-					self.imported_bytes += key.len() as u64;
-				}
-
-				entry.0.extend(top_key_values);
-			}
+			let KeyValueStorageLevel { state_root, parent_storage_keys: _, key_values } = values;
+			self.process_state_key_values(state_root, key_values);
 		}
 	}
 

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -205,15 +205,20 @@ where
 				// Already imported child trie with same root.
 			} else {
 				let mut child_roots = Vec::new();
+				let mut top_key_values = Vec::new();
+
 				for StateEntry { key, value } in state.entries {
 					// Skip all child key root (will be recalculated on import).
 					if is_top && well_known_keys::is_child_storage_key(key.as_slice()) {
 						child_roots.push((key, value));
 					} else {
 						self.imported_bytes += key.len() as u64;
-						entry.0.push((key, value))
+						top_key_values.push((key, value));
 					}
 				}
+
+				entry.0.extend(top_key_values);
+
 				for key_value in child_roots {
 					self.insert_child_trie_roots(key_value);
 				}

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -133,6 +133,11 @@ where
 		}
 	}
 
+	// key_value = (storage_key, child_root)
+	fn insert_child_trie_roots(&mut self, key_value: (Vec<u8>, Vec<u8>)) {
+		self.state.entry(key_value.1).or_default().1.push(key_value.0);
+	}
+
 	fn process_state_verified(&mut self, values: KeyValueStates) {
 		for values in values.0 {
 			let key_values = if values.state_root.is_empty() {
@@ -142,11 +147,7 @@ where
 					.into_iter()
 					.filter(|key_value| {
 						if well_known_keys::is_child_storage_key(key_value.0.as_slice()) {
-							self.state
-								.entry(key_value.1.clone())
-								.or_default()
-								.1
-								.push(key_value.0.clone());
+							self.insert_child_trie_roots(key_value.clone());
 							false
 						} else {
 							true

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -151,9 +151,8 @@ where
 			// Already imported child_trie with same root.
 			// Warning this will not work with parallel download.
 		} else {
-			for (key, _value) in &top_key_values {
-				self.imported_bytes += key.len() as u64;
-			}
+			self.imported_bytes +=
+				top_key_values.iter().map(|(key, _value)| key.len()).sum::<usize>() as u64;
 
 			entry.0.extend(top_key_values);
 

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -156,17 +156,12 @@ where
 			if entry.0.len() > 0 && entry.1.len() > 1 {
 				// Already imported child_trie with same root.
 				// Warning this will not work with parallel download.
-			} else if entry.0.is_empty() {
-				for (key, _value) in top_key_values.iter() {
+			} else {
+				for (key, _value) in &top_key_values {
 					self.imported_bytes += key.len() as u64;
 				}
 
-				entry.0 = top_key_values;
-			} else {
-				for (key, value) in top_key_values {
-					self.imported_bytes += key.len() as u64;
-					entry.0.push((key, value))
-				}
+				entry.0.extend(top_key_values);
 			}
 		}
 	}

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -150,10 +150,6 @@ where
 				is_top && well_known_keys::is_child_storage_key(key_value.0.as_slice())
 			});
 
-		for key_value in child_key_values {
-			self.insert_child_trie_roots(key_value);
-		}
-
 		let entry = self.state.entry(state_root).or_default();
 
 		if entry.0.len() > 0 && entry.1.len() > 1 {
@@ -165,6 +161,10 @@ where
 			}
 
 			entry.0.extend(top_key_values);
+
+			for key_value in child_key_values {
+				self.insert_child_trie_roots(key_value);
+			}
 		}
 	}
 

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -133,11 +133,6 @@ where
 		}
 	}
 
-	// key_value = (storage_key, child_root)
-	fn insert_child_trie_roots(&mut self, key_value: (Vec<u8>, Vec<u8>)) {
-		self.state.entry(key_value.1).or_default().1.push(key_value.0);
-	}
-
 	fn process_state_key_values(
 		&mut self,
 		state_root: Vec<u8>,
@@ -163,7 +158,7 @@ where
 			entry.0.extend(top_key_values);
 
 			for key_value in child_key_values {
-				self.insert_child_trie_roots(key_value);
+				self.state.entry(key_value.1).or_default().1.push(key_value.0);
 			}
 		}
 	}


### PR DESCRIPTION
This pure refactoring of state sync is preparing for https://github.com/paritytech/polkadot-sdk/issues/4. As the rough plan in https://github.com/paritytech/polkadot-sdk/issues/4#issuecomment-2439588876, there will be two PRs for the state sync refactoring. 

This first PR focuses on isolating the function `process_state_key_values()` as the central point for storing received state data in memory. This function will later be adapted to forward the state data directly to the DB layer for persistent sync. A follow-up PR will handle the encapsulation of `StateSyncMetadata` to support this persistent storage.

Although there are many commits in this PR, each commit is small and intentionally incremental to facilitate a smoother review, please review them commit by commit. Each commit should represent an equivalent rewrite of the existing logic, with one exception https://github.com/paritytech/polkadot-sdk/commit/bb447b2daa01fecf3bf0ca20c451ac6147f3f8c7, which has a slight deviation from the original but is correct IMHO. Please give this commit special attention during the review.