### PR TITLE
[WIP] Ensure ED is respected over total balance when depositing new funds to an account.

### DIFF
--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -213,7 +213,11 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 		} else {
 			old_balance.checked_add(&amount).ok_or(ArithmeticError::Overflow)?
 		};
-		if new_balance < Self::minimum_balance() {
+
+		// look at total balance to ensure ED is respected.
+		let new_total_balance = amount.saturating_add(Self::total_balance(who));
+
+		if new_total_balance < Self::minimum_balance() {
 			// Attempt to increase from 0 to below minimum -> stays at zero.
 			if let BestEffort = precision {
 				Ok(Default::default())


### PR DESCRIPTION
## Change
When new funds are minted into an account (e.g., for staking rewards), check the account’s total balance rather than just the free balance to ensure it never falls between 0 and the Existential Deposit (ED).

## Context
Currently, users can stake with all their funds on staking (including ED). `pallet-staking` uses locks (similar to freezes) and locked balance are part of free balance so this is not an issue as any staked balance is still part of the free balance.

Staking should though switch to use `fungible::hold` (See https://github.com/paritytech/polkadot-sdk/issues/226 and https://github.com/paritytech/polkadot-sdk/pull/5501), and held balance is taken away from free balance. 

The accounts that are staking all their funds, once we migrate them to hold, will have no free balance. Any staking rewards that are paid out to them, if less than the minimum balance, won't be able to be minted as free balance without this change.

## Alternative solution
- Ensure all stakers maintain at least ED in their stash accounts. 
- At migration, stakers who do not have enough free balance left after hold, will be force withdrawn upto ED to maintain this free balance. This would imply the total stake of the system would reduce by 23k DOT in the worst case where all stakers are fully staked.
-  Pools would need to maintain ED in their pool accounts as well. Since there are only around 250 pools, treasury could probably fund this, but in future, should come from pool operator and refunded to them when pool is destroyed.

