### PR TITLE
Relay chain client pallet for AH Staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12770,6 +12770,8 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-authorship",
+ "pallet-session",
+ "pallet-staking",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 31.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12774,9 +12774,34 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
+ "sp-io 30.0.0",
  "sp-runtime 31.0.1",
  "sp-staking",
  "sp-std 14.0.0",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "pallet-staking-rc-client-tests"
+version = "0.0.1"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-rc-client",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking",
+ "sp-std 14.0.0",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12764,6 +12764,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking-rc-client"
+version = "0.0.1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 31.0.1",
+ "sp-staking",
+ "sp-std 14.0.0",
+]
+
+[[package]]
 name = "pallet-staking-reward-curve"
 version = "11.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -413,6 +413,7 @@ members = [
 	"substrate/frame/society",
 	"substrate/frame/staking",
   "substrate/frame/staking/rc-client",
+  "substrate/frame/staking/rc-client/integration-tests",
 	"substrate/frame/staking/reward-curve",
 	"substrate/frame/staking/reward-fn",
 	"substrate/frame/staking/runtime-api",
@@ -980,6 +981,7 @@ pallet-skip-feeless-payment = { path = "substrate/frame/transaction-payment/skip
 pallet-society = { path = "substrate/frame/society", default-features = false }
 pallet-staking = { path = "substrate/frame/staking", default-features = false }
 pallet-staking-rc-client = { path = "substrate/frame/staking/rc-client", default-features = false }
+pallet-staking-rc-client-tests = { path = "substrate/frame/staking/rc-client/integration-tests", default-features = false }
 pallet-staking-reward-curve = { path = "substrate/frame/staking/reward-curve", default-features = false }
 pallet-staking-reward-fn = { path = "substrate/frame/staking/reward-fn", default-features = false }
 pallet-staking-runtime-api = { path = "substrate/frame/staking/runtime-api", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,6 +412,7 @@ members = [
 	"substrate/frame/session/benchmarking",
 	"substrate/frame/society",
 	"substrate/frame/staking",
+  "substrate/frame/staking/rc-client",
 	"substrate/frame/staking/reward-curve",
 	"substrate/frame/staking/reward-fn",
 	"substrate/frame/staking/runtime-api",
@@ -978,6 +979,7 @@ pallet-session-benchmarking = { path = "substrate/frame/session/benchmarking", d
 pallet-skip-feeless-payment = { path = "substrate/frame/transaction-payment/skip-feeless-payment", default-features = false }
 pallet-society = { path = "substrate/frame/society", default-features = false }
 pallet-staking = { path = "substrate/frame/staking", default-features = false }
+pallet-staking-rc-client = { path = "substrate/frame/staking/rc-client", default-features = false }
 pallet-staking-reward-curve = { path = "substrate/frame/staking/reward-curve", default-features = false }
 pallet-staking-reward-fn = { path = "substrate/frame/staking/reward-fn", default-features = false }
 pallet-staking-runtime-api = { path = "substrate/frame/staking/runtime-api", default-features = false }

--- a/substrate/frame/staking/rc-client/Cargo.toml
+++ b/substrate/frame/staking/rc-client/Cargo.toml
@@ -24,6 +24,9 @@ sp-staking = { default-features = true, workspace = true }
 frame-support = { default-features = true, workspace = true }
 frame-system = { default-features = true, workspace = true }
 pallet-authorship = { workspace = true }
+pallet-session = { workspace = true }
+pallet-staking = { workspace = true }
+
 
 [features]
 default = ["std"]
@@ -36,4 +39,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-authorship/std",
+	"pallet-session/std",
+	"pallet-staking/std",
 ]

--- a/substrate/frame/staking/rc-client/Cargo.toml
+++ b/substrate/frame/staking/rc-client/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "pallet-staking-rc-client"
+version = "0.0.1"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "FRAME pallet staking relay chain client"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+
+sp-runtime = { default-features = true, workspace = true }
+sp-std = { default-features = true, workspace = true }
+sp-staking = { default-features = true, workspace = true }
+frame-support = { default-features = true, workspace = true }
+frame-system = { default-features = true, workspace = true }
+pallet-authorship = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"sp-staking/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-authorship/std",
+]

--- a/substrate/frame/staking/rc-client/integration-tests/Cargo.toml
+++ b/substrate/frame/staking/rc-client/integration-tests/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
-name = "pallet-staking-rc-client"
+name = "pallet-staking-rc-client-tests"
 version = "0.0.1"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
 homepage.workspace = true
 repository.workspace = true
-description = "FRAME pallet staking relay chain client"
+description = "FRAME integration tests for pallet staking relay chain client"
+publish = false
 
 [lints]
 workspace = true
@@ -20,16 +21,20 @@ scale-info = { features = ["derive"], workspace = true }
 
 sp-runtime = { default-features = true, workspace = true }
 sp-std = { default-features = true, workspace = true }
+sp-io = { default-features = true, workspace = true }
+sp-core = { default-features = true, workspace = true }
+sp-tracing = { default-features = true, workspace = true }
 sp-staking = { default-features = true, workspace = true }
 frame-support = { default-features = true, workspace = true }
 frame-system = { default-features = true, workspace = true }
-pallet-authorship = { workspace = true }
 pallet-session = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-authorship = { workspace = true }
 pallet-staking = { workspace = true }
+pallet-staking-rc-client = { workspace = true }
+frame-election-provider-support = { workspace = true }
 
-[dev-dependencies]
-sp-tracing = { workspace = true }
-sp-io = { workspace = true }
 
 [features]
 default = ["std"]
@@ -38,10 +43,16 @@ std = [
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-io/std",
+	"sp-core/std",
 	"sp-staking/std",
 	"frame-support/std",
 	"frame-system/std",
-	"pallet-authorship/std",
+	"pallet-balances/std",
+	"pallet-timestamp/std",
 	"pallet-session/std",
+	"pallet-authorship/std",
 	"pallet-staking/std",
+	"pallet-staking-rc-client/std",
+	"frame-election-provider-support/std",
 ]

--- a/substrate/frame/staking/rc-client/integration-tests/src/lib.rs
+++ b/substrate/frame/staking/rc-client/integration-tests/src/lib.rs
@@ -15,24 +15,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Staking Relay chain client tests
+
+mod mock;
+
 use crate::mock::*;
 
-use frame_support::assert_ok;
-use sp_runtime::testing::UintAuthorityId;
-
 #[test]
-fn set_session_keys_works() {
+fn test_setup_works() {
 	ExtBuilder::default().build_and_execute(|| {
-		assert!(Outbound::get().is_empty());
-
-		let keys: <Test as crate::Config>::SessionKeys = UintAuthorityId(1).into();
-
-		assert_ok!(Client::set_validator_keys(
-			RuntimeOrigin::signed(1),
-			keys.clone(),
-			vec![0, 0, 0]
-		));
-
-		assert_eq!(Outbound::get(), vec![MockMessages::SetSessionKeys((1, keys, vec![0, 0, 0]))]);
+		assert!(true);
 	})
 }

--- a/substrate/frame/staking/rc-client/integration-tests/src/mock.rs
+++ b/substrate/frame/staking/rc-client/integration-tests/src/mock.rs
@@ -1,0 +1,278 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use frame_support::{derive_impl, parameter_types, traits::FindAuthor};
+use pallet_session::{SessionHandler, SessionManager, ShouldEndSession};
+use pallet_staking::{SessionInterface, UseNominatorsAndValidatorsMap, UseValidatorsMap};
+use pallet_staking_rc_client::{AsyncBroker, AsyncOffenceBroker, AsyncSessionBroker};
+use sp_core::{crypto::KeyTypeId, ConstU64};
+use sp_runtime::{impl_opaque_keys, testing::UintAuthorityId};
+use sp_staking::SessionIndex;
+
+type Block = frame_system::mocking::MockBlock<Runtime>;
+type BlockNumber = u64;
+type AccountId = u64;
+type Balance = u128;
+
+pub const KEY_TYPE_IDS: KeyTypeId = KeyTypeId(*b"para");
+
+/// Author of block is always 11
+pub struct Author11;
+impl FindAuthor<AccountId> for Author11 {
+	fn find_author<'a, I>(_digests: I) -> Option<AccountId>
+	where
+		I: 'a + IntoIterator<Item = (frame_support::ConsensusEngineId, &'a [u8])>,
+	{
+		Some(11)
+	}
+}
+
+frame_support::construct_runtime!(
+	pub enum Runtime {
+		// pallets that will be part of both relay-chain and parachain runtimes. Using the same in
+		// the tests for simplicity.
+		System: frame_system,
+		Balances: pallet_balances,
+
+		// relay-chain pallets.
+		RCSession: pallet_session,
+		RCHistorical: pallet_session::historical,
+		RCAuthorship: pallet_authorship,
+
+		// pallets in a different consensus system than relay-chain. The Client pallet is used as a
+		// broker for the staking to communcate (one way, async) with the staking pallet.
+		Staking: pallet_staking,
+		Timestamp: pallet_timestamp,
+		Client: pallet_staking_rc_client,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Block = Block;
+	type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+parameter_types! {
+	pub static ExistentialDeposit: Balance = 1;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Runtime {
+	type MaxLocks = frame_support::traits::ConstU32<1024>;
+	type Balance = Balance;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+}
+
+impl pallet_timestamp::Config for Runtime {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = ConstU64<5>;
+	type WeightInfo = ();
+}
+
+impl_opaque_keys! {
+	pub struct SessionKeys {
+		pub dummy: UintAuthorityId,
+	}
+}
+
+impl pallet_session::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type ValidatorId = AccountId;
+	type ValidatorIdOf = TransparentAccountConvertion;
+	type ShouldEndSession = TestShouldEndSession;
+	type NextSessionRotation = ();
+	// implemented by the relay-chain side staking client pallet.
+	type SessionManager = TestSessionManager;
+	// implemented by the relay-chain side staking client pallet.
+	type SessionHandler = TestSessionHandler;
+	type Keys = SessionKeys;
+	type WeightInfo = ();
+}
+
+impl pallet_session::historical::Config for Runtime {
+	type FullIdentification = pallet_staking::Exposure<AccountId, Balance>;
+	type FullIdentificationOf = pallet_staking::ExposureOf<Runtime>;
+}
+impl pallet_authorship::Config for Runtime {
+	type FindAuthor = Author11;
+	// implemented by the relay-chain side staking client pallet.
+	type EventHandler = Staking;
+}
+
+pub struct TransparentAccountConvertion;
+impl sp_runtime::traits::Convert<AccountId, Option<AccountId>> for TransparentAccountConvertion {
+	fn convert(a: AccountId) -> Option<AccountId> {
+		Some(a)
+	}
+}
+
+pub struct TestShouldEndSession;
+impl ShouldEndSession<BlockNumber> for TestShouldEndSession {
+	fn should_end_session(_now: BlockNumber) -> bool {
+		todo!()
+	}
+}
+
+pub struct TestSessionManager;
+impl SessionManager<AccountId> for TestSessionManager {
+	fn new_session(_new_index: SessionIndex) -> Option<Vec<AccountId>> {
+		todo!()
+	}
+	fn end_session(_end_index: SessionIndex) {
+		todo!()
+	}
+	fn start_session(_start_index: SessionIndex) {
+		todo!()
+	}
+	fn new_session_genesis(_new_index: SessionIndex) -> Option<Vec<AccountId>> {
+		todo!()
+	}
+}
+
+pub struct TestSessionHandler;
+impl SessionHandler<AccountId> for TestSessionHandler {
+	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[KEY_TYPE_IDS];
+
+	fn on_disabled(_validator_index: u32) {
+		todo!()
+	}
+	fn on_new_session<Ks: sp_runtime::traits::OpaqueKeys>(
+		_changed: bool,
+		_validators: &[(AccountId, Ks)],
+		_queued_validators: &[(AccountId, Ks)],
+	) {
+		todo!()
+	}
+	fn on_genesis_session<Ks: sp_runtime::traits::OpaqueKeys>(_validators: &[(AccountId, Ks)]) {
+		todo!()
+	}
+	fn on_before_session_ending() {
+		todo!()
+	}
+}
+
+parameter_types! {
+	pub static MaxWinners: u32 = 10;
+}
+
+#[derive_impl(pallet_staking::config_preludes::TestDefaultConfig)]
+impl pallet_staking::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type UnixTime = Timestamp;
+	type ElectionProvider =
+		frame_election_provider_support::NoElection<(AccountId, BlockNumber, Staking, MaxWinners)>;
+	type GenesisElectionProvider = Self::ElectionProvider;
+	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
+	type EraPayout = ();
+	type VoterList = UseNominatorsAndValidatorsMap<Self>;
+	type TargetList = UseValidatorsMap<Self>;
+
+	// session interfaces are implemented by the rc-client pallet.
+
+	// session related types must live in the parachain (ie, rc-client acts as broker).
+	type NextNewSession = Client;
+	type SessionInterface = Client;
+}
+
+parameter_types! {
+	pub static MaxOffenders: u32 = 10;
+}
+
+impl pallet_staking_rc_client::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type ValidatorId = AccountId;
+	type FullValidatorId = pallet_staking::Exposure<Self::AccountId, Balance>;
+	type Staking = Staking;
+	type MaxOffenders = MaxOffenders;
+	type MaxValidatorSet = MaxWinners;
+	type SessionKeys = SessionKeys;
+	type RelayChainClient = Broker;
+}
+
+/// Type that implements the XCM communication between the rc-client and the relay chain.
+pub struct Broker;
+impl AsyncBroker for Broker {}
+
+impl AsyncSessionBroker for Broker {
+	type AccountId = AccountId;
+	type SessionKeys = SessionKeys;
+	type SessionKeysProof = pallet_staking_rc_client::SessionKeysProof;
+	type MaxValidatorSet = MaxWinners;
+	type Error = &'static str;
+
+	fn set_session_keys(
+		_who: Self::AccountId,
+		_session_keys: Self::SessionKeys,
+		_proof: Self::SessionKeysProof,
+	) -> Result<(), Self::Error> {
+		todo!()
+	}
+
+	fn purge_session_keys(_who: Self::AccountId) -> Result<(), Self::Error> {
+		todo!()
+	}
+
+	fn new_validator_set(
+		_session_index: SessionIndex,
+		_validator_set: sp_runtime::BoundedVec<Self::AccountId, Self::MaxValidatorSet>,
+	) -> Result<(), Self::Error> {
+		todo!()
+	}
+}
+
+impl SessionInterface<AccountId> for Broker {
+	fn validators() -> Vec<AccountId> {
+		todo!()
+	}
+	fn disable_validator(_validator_index: u32) -> bool {
+		todo!()
+	}
+	fn prune_historical_up_to(_up_to: SessionIndex) {
+		todo!()
+	}
+}
+
+impl AsyncOffenceBroker for Broker {}
+
+#[derive(Default)]
+pub struct ExtBuilder {}
+
+impl ExtBuilder {
+	pub fn build(self) -> sp_io::TestExternalities {
+		use sp_runtime::BuildStorage;
+
+		sp_tracing::try_init_simple();
+
+		let mut storage =
+			frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+
+		// set pallet's genesis state
+		sp_io::TestExternalities::from(storage)
+	}
+
+	pub fn build_and_execute(self, test: impl FnOnce() -> ()) {
+		sp_tracing::try_init_simple();
+
+		let mut ext = self.build();
+		ext.execute_with(test);
+	}
+}

--- a/substrate/frame/staking/rc-client/src/lib.rs
+++ b/substrate/frame/staking/rc-client/src/lib.rs
@@ -1,0 +1,350 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Staking Relay chain client
+//!
+//! The Staking Relay chain client is used as a interface between the Staking pallet and an external
+//! consensus system (e.g. Polkadot's Relay chain).
+//!
+//! ## Overview
+//!
+//! The Staking Relay chain client (`rc-client` pallet) implements an abstraction for the i/o
+//! of the staking pallet. This abstraction is especially helpfull when the staking pallet
+//! and the its "consumers" live in different consensus systems. Most notably, this pallet handles
+//! the following i/o tasks:
+//!
+//! - Communicates a new set of validators to a party an external consensus system;
+//! - Communicates setting and purging validator keys to an external consensus system;
+//! - Receives and pre-processes offence reports from a trusteed external consensus system;
+//! - Receives and pre-processes block authoring reports;
+//!
+//! This pallet also exposes an extrinsic for signed origins to report staking offences which are
+//! communicated to both the staking pallet and an external consensus system.
+//!
+//!	In sum, this pallet works as an adapter pallet that can be used for the staking pallet to
+//!	communicate with external consensus systems.
+//!
+//! ## Inbound
+//!
+//! All the inbound request should be performed through extrinsics. External consensus systems may
+//! call the inbound extrinsics through XCM transact.
+//!
+//! ### Block authoring
+//!
+//! This pallet exposes an extrinsict, [`Call::author`], that processes block authoring events.
+//! Block authoring information can only be submitted by the runtime's root origin. Successfull
+//! calls will be redirected to staking through the [`pallet_authorship::EventHandler`]) interface.
+//!
+//! ### Offence reports
+//!
+//! This pallet exposes an extrinsict, [`Call::report_offence`], that processes priviledged offence
+//! reports. These reports can only be submitted by the runtime's root origin. Successfull calls
+//! will be redirected to staking through the [`sp_staking::offence::OnOffenceHandler`]) interface.
+//!
+//! ## Outbound
+//!
+//!	### Validator keys
+//!
+//!	This pallet implements a set of extrinsics that handles session key management requests for
+//! staking validators. Note, however, that this pallet is not the source of truth for session
+//! keys. It only exposes interfaces for accounts to request session key initialization and
+//! termination, performs pre-checks and propagates that information to another pallet or consensus
+//! system through the [`crate::Config::SessionKeysHandler`].
+//!
+//!	Callers can request to 1) set validator keys and 2) purge validator keys. These actions *may
+//! not be atomic*, i.e., the action and correspoding data may need to be propagated to an external
+//! consensus system and take several blocks to be enacted.
+//
+//!	The session key management actions exposed by this pallet are:
+//!
+//! 1. **Set session keys**: Extrinsic [`Call::set_session_keys`] alows an account to set its
+//!    session key prior to becoming a validator.
+//! 2. **Purge session keys**: Extrinsic [`Call::purge_session_keys`] removes any session key(s) of
+//!    the caller.
+//!
+//! ### New set of validator IDs
+//!
+//! This pallet exposes a configuration type that implements the [`traits::ValidatorSetHandler`],
+//! which defines what to do when pallet staking has a new validator set ready. Note, however, that
+//! this pallet is not the source of truth for validator sets.
+//!
+//! ### Signed offence reports
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+/// Re-exports this crate's trait implementations.
+pub use impls::*;
+/// Re-exports this crate's traits.
+pub use traits::*;
+
+use frame_support::{dispatch::Parameter, weights::Weight};
+use frame_system::pallet_prelude::*;
+use sp_runtime::{
+	traits::{Member, OpaqueKeys},
+	Perbill,
+};
+
+use pallet_authorship::EventHandler as AuthorshipEventHandler;
+use sp_staking::{
+	offence::{OffenceDetails, OnOffenceHandler},
+	SessionIndex,
+};
+
+/// The type of session key proof expected by this pallet.
+pub(crate) type SessionKeyProof = Vec<u8>;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: IsType<<Self as frame_system::Config>::RuntimeEvent> + From<Event<Self>>;
+
+		/// The staking interface.
+		type Staking: AuthorshipEventHandler<Self::AccountId, BlockNumberFor<Self>>
+			+ OnOffenceHandler<Self::AccountId, Self::AccountId, Weight>;
+
+		/// The max offenders a report supports.
+		type MaxOffenders: Get<u32>;
+
+		/// The session keys.
+		type SessionKeys: OpaqueKeys + Member + Parameter + MaybeSerializeDeserialize;
+
+		/// The session keys handler that requests from this pallet.
+		type SessionKeysHandler: SessionKeysHandler<
+			AccountId = Self::AccountId,
+			Keys = Self::SessionKeys,
+			Proof = SessionKeyProof,
+		>;
+
+		/// The max mumber of validators a [`Self::ValidatorSetHandler`] can operate.
+		type MaxValidators: Get<u32>;
+
+		/// An handler for when a new validator set must be enacted.
+		type ValidatorSetHandler: ValidatorSetHandler<
+			AccountId = Self::AccountId,
+			MaxValidators = Self::MaxValidators,
+		>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	pub enum Event<T: Config> {}
+
+	#[pallet::error]
+	#[derive(PartialEq)]
+	pub enum Error<T> {
+		/// Session key set request was unsuccessful.
+		SetKeys,
+		/// Session key purge request was unsuccessful.
+		PurgeKeys,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Sets the session key(s) of the function caller to `keys`.
+		#[pallet::call_index(0)]
+		pub fn set_validator_keys(
+			origin: OriginFor<T>,
+			session_keys: T::SessionKeys,
+			proof: Vec<u8>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			// TODO(gpestana): any pre-checks?
+
+			<T::SessionKeysHandler as SessionKeysHandler>::set_keys(who, session_keys, proof)
+				.map_err(|_| Error::<T>::SetKeys)?;
+
+			todo!()
+		}
+
+		/// Removes any session key(s) of the function caller.
+		#[pallet::call_index(1)]
+		pub fn purge_validator_keys(origin: OriginFor<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			// TODO(gpestana): any pre-checks?
+
+			<T::SessionKeysHandler as SessionKeysHandler>::purge_keys(who)
+				.map_err(|_| Error::<T>::PurgeKeys)?;
+
+			Ok(())
+		}
+
+		/// Receives block authoring information and redirects it to staking.
+		///
+		/// Only `RuntimeOrigin::Root` is authorized to call this extrinsic.
+		#[pallet::call_index(2)]
+		pub fn author(origin: OriginFor<T>, author: T::AccountId) -> DispatchResult {
+			let _ = ensure_root(origin);
+
+			// TODO: (perhaps?) instead of calling directly staking, batch authoring points instead
+			// and use `on_initialize` or some other mechanism to notify staking of a set of
+			// authoring notes.
+
+			<T::Staking as AuthorshipEventHandler<_, _>>::note_author(author);
+
+			Ok(())
+		}
+
+		/// Receives offence reports and redirects them to staking.
+		///
+		/// Only `RuntimeOrigin::Root` is authorized to call this extrinsic.
+		#[pallet::call_index(3)]
+		pub fn report_offence(
+			origin: OriginFor<T>,
+			offenders: BoundedVec<OffenceDetails<T::AccountId, T::AccountId>, T::MaxOffenders>,
+			slash_fraction: BoundedVec<Perbill, T::MaxOffenders>,
+			session: SessionIndex,
+		) -> DispatchResult {
+			let _ = ensure_root(origin);
+
+			let _weight = <T::Staking as OnOffenceHandler<_, _, _>>::on_offence(
+				&offenders,
+				&slash_fraction,
+				session,
+			);
+
+			Ok(())
+		}
+	}
+}
+
+pub mod traits {
+	use super::*;
+
+	/// Something that handles the management of session keys.
+	///
+	/// It allows to define the behaviour when new session keys are set and purged.
+	pub trait SessionKeysHandler {
+		/// The account ID type.
+		type AccountId;
+		/// The keys type that is supported by the manager.
+		type Keys;
+		/// The proof type for [`Self::Keys`].
+		type Proof;
+		/// The error type.
+		type Error;
+
+		fn set_keys(
+			who: Self::AccountId,
+			session_keys: Self::Keys,
+			proof: Self::Proof,
+		) -> Result<(), Self::Error>;
+
+		fn purge_keys(who: Self::AccountId) -> Result<(), Self::Error>;
+	}
+
+	/// Something that handles a new validator set.
+	pub trait ValidatorSetHandler {
+		/// The account ID type.
+		type AccountId;
+		/// The max number of validators the provider can return.
+		type MaxValidators;
+		/// The error type.
+		type Error;
+
+		/// A new validator set is ready.
+		fn new_validator_set(
+			session_index: SessionIndex,
+			validator_set: sp_runtime::BoundedVec<Self::AccountId, Self::MaxValidators>,
+		) -> Result<(), Self::Error>;
+	}
+}
+
+pub mod impls {
+	use std::marker::PhantomData;
+
+	use super::{
+		pallet::{Config, Error as PalletError},
+		*,
+	};
+
+	/// Propagates session key management actions and data through XCM.
+	pub struct SessionKeysHandlerXCM<T: Config>(PhantomData<T>);
+
+	impl<T: Config> SessionKeysHandler for SessionKeysHandlerXCM<T> {
+		type AccountId = T::AccountId;
+		type Keys = T::SessionKeys;
+		type Proof = SessionKeyProof;
+		type Error = PalletError<T>;
+
+		fn set_keys(
+			_who: Self::AccountId,
+			_session_keys: Self::Keys,
+			_proof: Self::Proof,
+		) -> Result<(), Self::Error> {
+			todo!()
+		}
+
+		fn purge_keys(_who: Self::AccountId) -> Result<(), Self::Error> {
+			todo!()
+		}
+	}
+
+	/// Propagates a new set of validators through XCM.
+	pub struct ValidatorSetHandlerXCM<T: Config>(PhantomData<T>);
+
+	impl<T: Config> ValidatorSetHandler for ValidatorSetHandlerXCM<T> {
+		type AccountId = T::AccountId;
+		type MaxValidators = T::MaxValidators;
+		type Error = PalletError<T>;
+
+		fn new_validator_set(
+			_session: SessionIndex,
+			_validator_set: sp_runtime::BoundedVec<Self::AccountId, Self::MaxValidators>,
+		) -> Result<(), Self::Error> {
+			// TODO: consider doing batching, buffering, etc.
+
+			/*
+			// TODO: preparing and sending the XCM messages should probably be part of the
+			// parachain's runtime config, not here.
+
+			let new_validator_set_call = RelayRuntimePallets::StakingClient(validator_set, session_index);
+			let call_weight: Weight = Default::default();
+
+			let message = Xcm(
+				Vec![Instruction::UnpaidExecution {
+					weight_limit: WeightLimit::Unlimited,
+					check_origin: None,
+				},
+					origin_kind: OriginKind::Native,
+					require_weight_at_most: call_weight,
+					call: new_validator_set_call,
+				]
+			);
+
+			match PolkadotXcm::send_xcm(Here, Location::parent(), message.clone()) {
+				Ok(_) => (),
+				Err(_) => (),
+			};
+			*/
+
+			Ok(())
+		}
+	}
+}

--- a/substrate/frame/staking/rc-client/src/mock.rs
+++ b/substrate/frame/staking/rc-client/src/mock.rs
@@ -1,0 +1,91 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{self as pallet_rc_client, *};
+
+use frame_support::{derive_impl, parameter_types};
+use sp_runtime::{impl_opaque_keys, testing::UintAuthorityId, Perbill};
+use sp_staking::{offence::OnOffenceHandler, SessionIndex};
+
+use std::collections::BTreeMap;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+type AccountId = u64;
+type AuthorshipPoints = u32;
+type Weight = sp_runtime::Weight;
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		RCClient: pallet_rc_client,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Block = Block;
+}
+
+impl_opaque_keys! {
+	pub struct MockSessionKeys {
+		pub dummy: UintAuthorityId,
+	}
+}
+
+parameter_types! {
+	pub static MaxOffenders: u32 = 5;
+	pub static MaxValidators: u32 = 10;
+}
+
+impl crate::pallet::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Staking = MockStaking;
+	type MaxOffenders = MaxOffenders;
+	type MaxValidators = MaxValidators;
+	type SessionKeys = MockSessionKeys;
+	type SessionKeysHandler = impls::SessionKeysHandlerXCM<Self>;
+	type ValidatorSetHandler = impls::ValidatorSetHandlerXCM<Self>;
+}
+
+parameter_types! {
+	pub static AuthoringState: Vec<(AccountId, SessionIndex, AuthorshipPoints)> = vec![];
+	pub static OffencesState: BTreeMap<SessionIndex, (AccountId, AccountId, Perbill)> = BTreeMap::new();
+}
+
+pub struct MockStaking;
+
+impl<BlockNumber> AuthorshipEventHandler<AccountId, BlockNumber> for MockStaking {
+	fn note_author(author: AccountId) {
+		// one point per authoring.
+		AuthoringState::mutate(|s| {
+			let session = 0; // TODO
+			s.push((author, session, 1))
+		});
+	}
+}
+
+impl OnOffenceHandler<AccountId, AccountId, Weight> for MockStaking {
+	fn on_offence(
+		_offenders: &[sp_staking::offence::OffenceDetails<AccountId, AccountId>],
+		_slash_fraction: &[Perbill],
+		_session: SessionIndex,
+	) -> Weight {
+		todo!()
+	}
+}

--- a/substrate/frame/staking/rc-client/src/tests.rs
+++ b/substrate/frame/staking/rc-client/src/tests.rs
@@ -1,0 +1,21 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::mock::*;
+
+#[cfg(test)]
+mod tests {}


### PR DESCRIPTION
This PR introduces a new pallet (`pallet-staking-rc-client`) which abstracts the interfaces that staking needs to interact with but, in the context of AHM, will be in a different consensus system (i.e. in the relay chain). This new pallet acts as a session and on-offence handler broker and sits in "between" the staking pallet in AH and the relay chain, while being part of the AH runtime.

The main design goal of  this pallet is twofold:
1. Implement a façade of the `trait SessionManager` and other interfaces in Asset Hub in a way that is transparent to the pallet staking. The current staking logic should have no changes (minimal at most) and it doesn't really care whether the session manager implementors and others are part of the AH runtime or in an external consensus system.
2. Handle the async message flow from `staking > relay chain` and abstract it as much as possible, implementing caching and  other strategies to mimmic as much as possible a sync flow between staking and the relay chain.

This PR also adds an integration test module where the behaviour between staking and the relay-chain pallets, brokered by `pallet-staking-rc-client`, can be tested as close as possible to the real case scenario of multi-chain communication.  
 
Closes https://github.com/paritytech/polkadot-sdk/issues/6166