### PR TITLE
pallet-revive: Trade code size for call stack depth

### DIFF
--- a/prdoc/pr_6264.prdoc
+++ b/prdoc/pr_6264.prdoc
@@ -1,0 +1,12 @@
+title: 'pallet-revive: Trade code size for call stack depth'
+doc:
+- audience: Runtime Dev
+  description: This will reduce the call stack depth in order to raise the allowed
+    code size. Should allow around 100KB of instructions. This is necessary to stay
+    within the memory envelope. More code size is more appropriate for testing right
+    now. We will re-evaluate parameters once we have 64bit support.
+crates:
+- name: pallet-revive-fixtures
+  bump: major
+- name: pallet-revive
+  bump: major

--- a/substrate/frame/revive/fixtures/contracts/oom_rw_trailing.rs
+++ b/substrate/frame/revive/fixtures/contracts/oom_rw_trailing.rs
@@ -26,7 +26,7 @@ extern crate common;
 
 use uapi::{HostFn, HostFnImpl as api, ReturnFlags};
 
-static mut BUFFER: [u8; 1025 * 1024] = [0; 1025 * 1024];
+static mut BUFFER: [u8; 2 * 1025 * 1024] = [0; 2 * 1025 * 1024];
 
 #[no_mangle]
 #[polkavm_derive::polkavm_export]

--- a/substrate/frame/revive/src/limits.rs
+++ b/substrate/frame/revive/src/limits.rs
@@ -36,7 +36,7 @@
 ///
 /// A 0 means that no callings of other contracts are possible. In other words only the origin
 /// called "root contract" is allowed to execute then.
-pub const CALL_STACK_DEPTH: u32 = 10;
+pub const CALL_STACK_DEPTH: u32 = 5;
 
 /// The maximum number of topics a call to [`crate::SyscallDoc::deposit_event`] can emit.
 ///
@@ -97,7 +97,7 @@ pub mod code {
 	/// for more code or more data. However, since code will decompress
 	/// into a bigger representation on compilation it will only increase
 	/// the allowed code size by [`BYTE_PER_INSTRUCTION`].
-	pub const STATIC_MEMORY_BYTES: u32 = 1024 * 1024;
+	pub const STATIC_MEMORY_BYTES: u32 = 2 * 1024 * 1024;
 
 	/// How much memory each instruction will take in-memory after compilation.
 	///


### PR DESCRIPTION
This will reduce the call stack depth in order to raise the allowed code size. Should allow around 100KB of instructions. This is necessary to stay within the memory envelope. More code size is more appropriate for testing right now. We will re-evaluate parameters once we have 64bit support.