### PR TITLE
Balances: Allow Configurable Number of Genesis Accounts with Specified Balances for Benchmarking

### DIFF
--- a/substrate/frame/balances/Cargo.toml
+++ b/substrate/frame/balances/Cargo.toml
@@ -24,11 +24,11 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-runtime = { workspace = true }
 docify = { workspace = true }
+sp-core = { workspace = true, default-features = true }
 
 [dev-dependencies]
 pallet-transaction-payment = { workspace = true, default-features = true }
 frame-support = { features = ["experimental"], workspace = true, default-features = true }
-sp-core = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }
 paste = { workspace = true, default-features = true }
 

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -716,7 +716,12 @@ fn burn_must_work() {
 fn cannot_set_genesis_value_below_ed() {
 	EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = 11);
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let _ = crate::GenesisConfig::<Test> { balances: vec![(1, 10)] }
+	let _ = crate::GenesisConfig::<Test> { 
+		balances: vec![(1, 10)],
+		
+		#[cfg(feature = "runtime-benchmarks")]
+		dev_accounts: (1000000, 500, "//Sender/{}".to_string())
+	}
 		.assimilate_storage(&mut t)
 		.unwrap();
 }
@@ -725,7 +730,12 @@ fn cannot_set_genesis_value_below_ed() {
 #[should_panic = "duplicate balances in genesis."]
 fn cannot_set_genesis_value_twice() {
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	let _ = crate::GenesisConfig::<Test> { balances: vec![(1, 10), (2, 20), (1, 15)] }
+	let _ = crate::GenesisConfig::<Test> { 
+		balances: vec![(1, 10), (2, 20), (1, 15)],
+
+		#[cfg(feature = "runtime-benchmarks")]
+		dev_accounts: (1000000, 500, "//Sender/{}".to_string())
+	}
 		.assimilate_storage(&mut t)
 		.unwrap();
 }

--- a/substrate/frame/balances/src/tests/mod.rs
+++ b/substrate/frame/balances/src/tests/mod.rs
@@ -170,6 +170,8 @@ impl ExtBuilder {
 			} else {
 				vec![]
 			},
+			#[cfg(feature = "runtime-benchmarks")]
+			dev_accounts: (1000000, self.existential_deposit, "//Sender/{}".to_string())
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();


### PR DESCRIPTION

# Derived Dev Accounts

Resolves https://github.com/paritytech/polkadot-sdk/issues/6040