### PR TITLE
Bump a timeout in zombienet coretime smoke test

### DIFF
--- a/polkadot/zombienet_tests/smoke/0004-coretime-smoke-test.zndsl
+++ b/polkadot/zombienet_tests/smoke/0004-coretime-smoke-test.zndsl
@@ -9,7 +9,7 @@ coretime-collator: is up
 alice: js-script ./0004-configure-relay.js with "" return is 0 within 600 secs
 
 # Coretime chain should be producing blocks when the extrinsic is sent
-alice: parachain 1005 block height is at least 10 within 120 seconds
+alice: parachain 1005 block height is at least 10 within 180 seconds
 
 # configure broker chain
 coretime-collator: js-script ./0004-configure-broker.js with "" return is 0 within 600 secs


### PR DESCRIPTION
polkadot/zombienet_tests/smoke/0004-coretime-smoke-test.zndsl still timeouts on CI from time to time. Bumping the timeout a bit more.