### PR TITLE
[pallet-revive] rpc server add docker file

### DIFF
--- a/prdoc/pr_6278.prdoc
+++ b/prdoc/pr_6278.prdoc
@@ -1,0 +1,14 @@
+title: '[pallet-revive] rpc server add docker file'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Add a docker for pallet-revive eth-rpc
+
+     Tested with
+    ```
+    sudo docker build . -t eth-rpc -f substrate/frame/revive/rpc/Dockerfile
+    sudo docker run --network="host" -e RUST_LOG="info,eth-rpc=debug" eth-rpc
+    ```
+crates:
+- name: pallet-revive-eth-rpc
+  bump: minor

--- a/substrate/frame/revive/rpc/.dockerignore
+++ b/substrate/frame/revive/rpc/.dockerignore
@@ -1,0 +1,7 @@
+doc
+**target*
+.idea/
+Dockerfile
+.dockerignore
+.local
+.env*

--- a/substrate/frame/revive/rpc/Dockerfile
+++ b/substrate/frame/revive/rpc/Dockerfile
@@ -9,7 +9,7 @@ COPY . /polkadot
 RUN cargo build --locked --profile production -p pallet-revive-eth-rpc --bin eth-rpc
 
 FROM docker.io/parity/base-bin:latest
-COPY --from=builder /polkadot/target/release/eth-rpc /usr/local/bin
+COPY --from=builder /polkadot/target/production/eth-rpc /usr/local/bin
 
 USER root
 RUN useradd -m -u 1001 -U -s /bin/sh -d /polkadot polkadot && \

--- a/substrate/frame/revive/rpc/Dockerfile
+++ b/substrate/frame/revive/rpc/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust AS builder
+
+RUN apt-get update && \
+		DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		protobuf-compiler
+
+WORKDIR /polkadot
+COPY . /polkadot
+RUN cargo build --locked --release -p pallet-revive-eth-rpc --bin eth-rpc
+
+FROM docker.io/parity/base-bin:latest
+COPY --from=builder /polkadot/target/release/eth-rpc /usr/local/bin
+
+USER root
+RUN useradd -m -u 1001 -U -s /bin/sh -d /polkadot polkadot && \
+# unclutter and minimize the attack surface
+	rm -rf /usr/bin /usr/sbin && \
+# check if executable works in this container
+	/usr/local/bin/eth-rpc --help
+
+USER polkadot
+EXPOSE 8545
+ENTRYPOINT ["/usr/local/bin/eth-rpc"]

--- a/substrate/frame/revive/rpc/Dockerfile
+++ b/substrate/frame/revive/rpc/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 
 WORKDIR /polkadot
 COPY . /polkadot
-RUN cargo build --locked --release -p pallet-revive-eth-rpc --bin eth-rpc
+RUN cargo build --locked --profile production -p pallet-revive-eth-rpc --bin eth-rpc
 
 FROM docker.io/parity/base-bin:latest
 COPY --from=builder /polkadot/target/release/eth-rpc /usr/local/bin


### PR DESCRIPTION
Add a docker for pallet-revive eth-rpc

 Tested with 
```
sudo docker build . -t eth-rpc -f substrate/frame/revive/rpc/Dockerfile
sudo docker run --network="host" -e RUST_LOG="info,eth-rpc=debug" eth-rpc
```