### PR TITLE
Fix semver job by updating cargo toolchain

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -2,7 +2,7 @@ name: Check semver
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
 
 concurrency:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TOOLCHAIN: nightly-2024-06-01
+  TOOLCHAIN: stable
 
 jobs:
   preflight:
@@ -18,7 +18,7 @@ jobs:
   check-semver:
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    needs: [preflight]
+    needs: [ preflight ]
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
     steps:


### PR DESCRIPTION
Changes here  https://github.com/paritytech/polkadot-sdk/pull/6254 broke the semver job: https://github.com/paritytech/polkadot-sdk/actions/runs/11590030127/job/32266861391?pr=5891

Because it is using an old nightly without `PanicHookInfo`. Attempting to fix this by changing to stable. We can also use newer nightly, but reasons for nightly are unclear to me currently.