### PR TITLE
feat(xcm): add ExecuteWithOrigin instruction

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/mod.rs
@@ -257,4 +257,7 @@ impl<Call> XcmWeightInfo<Call> for AssetHubRococoXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -366,4 +366,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 757_000 picoseconds.
 		Weight::from_parts(800_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/mod.rs
@@ -257,4 +257,7 @@ impl<Call> XcmWeightInfo<Call> for AssetHubWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -366,4 +366,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -259,4 +259,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 	fn set_asset_claimer(_location: &Location) -> Weight {
 		XcmGeneric::<Runtime>::set_asset_claimer()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -380,4 +380,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/mod.rs
@@ -260,4 +260,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -380,4 +380,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/mod.rs
@@ -257,4 +257,7 @@ impl<Call> XcmWeightInfo<Call> for CoretimeRococoXcmWeight<Call> {
 	fn set_asset_claimer(_location: &Location) -> Weight {
 		XcmGeneric::<Runtime>::set_asset_claimer()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -338,4 +338,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/mod.rs
@@ -257,4 +257,7 @@ impl<Call> XcmWeightInfo<Call> for CoretimeWestendXcmWeight<Call> {
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -338,4 +338,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/mod.rs
@@ -256,4 +256,7 @@ impl<Call> XcmWeightInfo<Call> for PeopleRococoXcmWeight<Call> {
 	fn set_asset_claimer(_location: &Location) -> Weight {
 		XcmGeneric::<Runtime>::set_asset_claimer()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -338,4 +338,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/mod.rs
@@ -256,4 +256,7 @@ impl<Call> XcmWeightInfo<Call> for PeopleWestendXcmWeight<Call> {
 	fn set_asset_claimer(_location: &Location) -> Weight {
 		XcmGeneric::<Runtime>::set_asset_claimer()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -338,4 +338,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 707_000 picoseconds.
 		Weight::from_parts(749_000, 0)
 	}
+	pub fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/polkadot/runtime/rococo/src/weights/pallet_xcm_benchmarks_generic.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_xcm_benchmarks_generic.rs
@@ -344,4 +344,11 @@ impl<T: frame_system::Config> pallet_xcm_benchmarks::generic::WeightInfo for Wei
 		Weight::from_parts(1_354_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 	}
+	fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/polkadot/runtime/rococo/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/rococo/src/weights/xcm/mod.rs
@@ -292,6 +292,9 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for RococoXcmWeight<RuntimeCall> {
 	fn set_asset_claimer(_location: &Location) -> Weight {
 		XcmGeneric::<Runtime>::set_asset_claimer()
 	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<Call>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
+	}
 }
 
 #[test]

--- a/polkadot/runtime/westend/src/weights/xcm/mod.rs
+++ b/polkadot/runtime/westend/src/weights/xcm/mod.rs
@@ -18,6 +18,7 @@ mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
 use crate::Runtime;
+use crate::xcm_config::Weigher;
 use alloc::vec::Vec;
 use frame_support::weights::Weight;
 use xcm::{
@@ -296,6 +297,9 @@ impl<RuntimeCall> XcmWeightInfo<RuntimeCall> for WestendXcmWeight<RuntimeCall> {
 	}
 	fn unpaid_execution(_: &WeightLimit, _: &Option<Location>) -> Weight {
 		XcmGeneric::<Runtime>::unpaid_execution()
+	}
+	fn execute_with_origin(_: &Option<InteriorLocation>, _: &Xcm<RuntimeCall>) -> Weight {
+		XcmGeneric::<Runtime>::execute_with_origin()
 	}
 }
 

--- a/polkadot/runtime/westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/polkadot/runtime/westend/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -329,4 +329,11 @@ impl<T: frame_system::Config> WeightInfo<T> {
 		// Minimum execution time: 713_000 picoseconds.
 		Weight::from_parts(776_000, 0)
 	}
+	pub(crate) fn execute_with_origin() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 713_000 picoseconds.
+		Weight::from_parts(776_000, 0)
+	}
 }

--- a/polkadot/runtime/westend/src/xcm_config.rs
+++ b/polkadot/runtime/westend/src/xcm_config.rs
@@ -183,6 +183,12 @@ pub type Barrier = TrailingSetTopicAsId<(
 /// We only waive fees for system functions, which these locations represent.
 pub type WaivedLocations = (SystemParachains, Equals<RootLocation>, LocalPlurality);
 
+pub type Weigher = WeightInfoBounds<
+	crate::weights::xcm::WestendXcmWeight<RuntimeCall>,
+	RuntimeCall,
+	MaxInstructions,
+>;
+
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
@@ -193,11 +199,7 @@ impl xcm_executor::Config for XcmConfig {
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
-	type Weigher = WeightInfoBounds<
-		crate::weights::xcm::WestendXcmWeight<RuntimeCall>,
-		RuntimeCall,
-		MaxInstructions,
-	>;
+	type Weigher = Weigher;
 	type Trader =
 		UsingComponents<WeightToFee, TokenLocation, AccountId, Balances, ToAuthor<Runtime>>;
 	type ResponseHandler = XcmPallet;

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -1422,8 +1422,8 @@ impl<Call> TryFrom<NewInstruction<Call>> for Instruction<Call> {
 				weight_limit,
 				check_origin: check_origin.map(|origin| origin.try_into()).transpose()?,
 			},
-			InitiateTransfer { .. } | PayFees { .. } | SetAssetClaimer { .. } => {
-				log::debug!(target: "xcm::v5tov4", "`{new_instruction:?}` not supported by v4");
+			InitiateTransfer { .. } | PayFees { .. } | SetAssetClaimer { .. } | ExecuteWithOrigin { .. } => {
+				log::debug!(target: "xcm::versions::v5tov4", "`{new_instruction:?}` not supported by v4");
 				return Err(());
 			},
 		})

--- a/polkadot/xcm/xcm-builder/src/weight.rs
+++ b/polkadot/xcm/xcm-builder/src/weight.rs
@@ -63,7 +63,7 @@ impl<T: Get<Weight>, C: Decode + GetDispatchInfo, M> FixedWeightBounds<T, C, M> 
 	) -> Result<Weight, ()> {
 		let instr_weight = match instruction {
 			Transact { require_weight_at_most, .. } => *require_weight_at_most,
-			SetErrorHandler(xcm) | SetAppendix(xcm) => Self::weight_with_limit(xcm, instrs_limit)?,
+			SetErrorHandler(xcm) | SetAppendix(xcm) | ExecuteWithOrigin { xcm, .. } => Self::weight_with_limit(xcm, instrs_limit)?,
 			_ => Weight::zero(),
 		};
 		T::get().checked_add(&instr_weight).ok_or(())

--- a/polkadot/xcm/xcm-executor/src/tests/execute_with_origin.rs
+++ b/polkadot/xcm/xcm-executor/src/tests/execute_with_origin.rs
@@ -1,0 +1,181 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Unit tests for the `ExecuteWithOrigin` instruction.
+//!
+//! See the [XCM RFC](https://github.com/polkadot-fellows/xcm-format/pull/38)
+//! and the [specification](https://github.com/polkadot-fellows/xcm-format/tree/8cef08e375c6f6d3966909ccf773ed46ac703917) for more information.
+//!
+//! The XCM RFCs were moved to the fellowship RFCs but this one was approved and merged before that.
+
+use xcm::prelude::*;
+
+use crate::ExecutorError;
+use super::mock::*;
+
+// The sender and recipient we use across these tests.
+const SENDER_1: [u8; 32] = [0; 32];
+const SENDER_2: [u8; 32] = [1; 32];
+const RECIPIENT: [u8; 32] = [2; 32];
+
+// ===== Happy path =====
+
+// In this test, root descends into one account to pay fees, pops that origin
+// and descends into a second account to withdraw funds.
+// These assets can now be used to perform actions as root.
+#[test]
+fn root_can_descend_into_more_than_one_account() {
+	// Make sure the sender has enough funds to withdraw.
+	add_asset(SENDER_1, (Here, 10u128));
+	add_asset(SENDER_2, (Here, 100u128));
+
+	// Build xcm.
+	let xcm = Xcm::<TestCall>::builder_unsafe()
+		.execute_with_origin(
+		    Some(SENDER_1.into()),
+		    Xcm::<TestCall>::builder_unsafe()
+		        .withdraw_asset((Here, 10u128))
+		        .pay_fees((Here, 10u128))
+		        .build()
+		)
+		.execute_with_origin(
+			Some(SENDER_2.into()),
+			Xcm::<TestCall>::builder_unsafe()
+				.withdraw_asset((Here, 100u128))
+				.build()
+		)
+		.expect_origin(Some(Here.into()))
+		.deposit_asset(All, RECIPIENT)
+		.build();
+
+	let (mut vm, weight) = instantiate_executor(Here, xcm.clone());
+
+	// Program runs successfully.
+	assert!(vm.bench_process(xcm).is_ok());
+	assert!(vm.bench_post_process(weight).ensure_complete().is_ok());
+
+	// RECIPIENT gets the funds.
+	assert_eq!(asset_list(RECIPIENT), [(Here, 100u128).into()]);
+}
+
+// ExecuteWithOrigin works for clearing the origin as well.
+#[test]
+fn works_for_clearing_origin() {
+	// Make sure the sender has enough funds to withdraw.
+	add_asset(SENDER_1, (Here, 100u128));
+
+	// Build xcm.
+	let xcm = Xcm::<TestCall>::builder_unsafe()
+		// Root code.
+		.expect_origin(Some(Here.into()))
+		.execute_with_origin(
+		    None,
+		    // User code, we run it with no origin.
+		    Xcm::<TestCall>::builder_unsafe()
+		    	.expect_origin(None)
+		        .build()
+		)
+		// We go back to root code.
+		.build();
+
+	let (mut vm, weight) = instantiate_executor(Here, xcm.clone());
+
+	// Program runs successfully.
+	assert!(vm.bench_process(xcm).is_ok());
+	assert!(vm.bench_post_process(weight).ensure_complete().is_ok());
+}
+
+// Setting the error handler or appendix inside of `ExecuteWithOrigin`
+// will work as expected.
+#[test]
+fn set_error_handler_and_appendix_work() {
+	add_asset(SENDER_1, (Here, 110u128));
+
+	let xcm = Xcm::<TestCall>::builder_unsafe()
+		.execute_with_origin(
+		    Some(SENDER_1.into()),
+		    Xcm::<TestCall>::builder_unsafe()
+		        .withdraw_asset((Here, 110u128))
+		        .pay_fees((Here, 10u128))
+		        .set_error_handler(Xcm::<TestCall>::builder_unsafe()
+		        	.deposit_asset(vec![(Here, 10u128).into()], SENDER_2)
+		        	.build()
+		        )
+		        .set_appendix(Xcm::<TestCall>::builder_unsafe()
+		        	.deposit_asset(All, RECIPIENT)
+		        	.build()
+		        )
+		        .build()
+		)
+		.build();
+
+	let (mut vm, weight) = instantiate_executor(Here, xcm.clone());
+
+	// Program runs successfully.
+	assert!(vm.bench_process(xcm).is_ok());
+
+	assert_eq!(vm.error_handler(), &Xcm::<TestCall>(vec![
+		DepositAsset {
+			assets: vec![Asset { id: AssetId(Location::new(0, [])), fun: Fungible(10) }].into(),
+			beneficiary: Location::new(0, [AccountId32 { id: SENDER_2, network: None }]),
+		},
+	]));
+	assert_eq!(vm.appendix(), &Xcm::<TestCall>(vec![
+		DepositAsset {
+			assets: All.into(),
+			beneficiary: Location::new(0, [AccountId32 { id: RECIPIENT, network: None }]),
+		},
+	]));
+
+	assert!(vm.bench_post_process(weight).ensure_complete().is_ok());
+}
+
+// ===== Unhappy path =====
+
+// Processing still can't be called recursively more than the limit.
+#[test]
+fn recursion_exceeds_limit() {
+	// Make sure the sender has enough funds to withdraw.
+	add_asset(SENDER_1, (Here, 10u128));
+	add_asset(SENDER_2, (Here, 100u128));
+
+	let mut xcm = Xcm::<TestCall>::builder_unsafe()
+		.execute_with_origin(
+			None,
+			Xcm::<TestCall>::builder_unsafe()
+				.clear_origin()
+				.build()
+		)
+		.build();
+
+	// 10 is the RECURSION_LIMIT.
+	for _ in 0..10 {
+		let clone_of_xcm = xcm.clone();
+		if let ExecuteWithOrigin { xcm: ref mut inner, .. } = xcm.inner_mut()[0] {
+			*inner = clone_of_xcm;
+		}
+	}
+
+	let (mut vm, weight) = instantiate_executor(Here, xcm.clone());
+
+	// Program errors with `ExceedsStackLimit`.
+	assert_eq!(vm.bench_process(xcm), Err(ExecutorError {
+		index: 0,
+		xcm_error: XcmError::ExceedsStackLimit,
+		weight: Weight::zero(),
+	}));
+	assert!(vm.bench_post_process(weight).ensure_complete().is_ok());
+}

--- a/polkadot/xcm/xcm-executor/src/tests/mod.rs
+++ b/polkadot/xcm/xcm-executor/src/tests/mod.rs
@@ -23,3 +23,4 @@
 mod mock;
 mod pay_fees;
 mod set_asset_claimer;
+mod execute_with_origin;


### PR DESCRIPTION
Added `ExecuteWithOrigin` instruction according to the old XCM RFC 38: https://github.com/polkadot-fellows/xcm-format/pull/38.

This instruction allows you to descend or clear while going back again.

## TODO
- [x] Implementation
- [x] Unit tests
- [ ] Modify `WithComputedOrigin` barrier
- [ ] Integration tests
- [ ] Benchmarks
