### PR TITLE
feat:  add keys retrieving storage for multi `SteppedMigrations`

### DIFF
--- a/substrate/frame/support/src/migrations.rs
+++ b/substrate/frame/support/src/migrations.rs
@@ -504,6 +504,11 @@ pub trait SteppedMigration {
 		None
 	}
 
+	/// Returns an iterator over storage prefixes that the migration will modify.
+	fn migrating_prefixes() -> impl IntoIterator<Item = Vec<u8>> {
+        core::iter::empty()
+    }
+
 	/// Try to migrate as much as possible with the given weight.
 	///
 	/// **ANY STORAGE CHANGES MUST BE ROLLED-BACK BY THE CALLER UPON ERROR.** This is necessary


### PR DESCRIPTION
Part 1 of https://github.com/paritytech/polkadot-sdk/issues/6128. 

Changes : 
-  [x] add `SteppedMigration::migrating_prefixes` for the default impl to return empty iterator
-  [x] add `nth_migrating_prefixes` 


Still to do : 
 - [ ] Complete MockedMigrations:SteppedMigrations with `nth_migrating_prefixes`/ `mock_migrating_prefixes`
 - [ ]  fix test tuple_migrations_work, or combine it with a new test 
 - [ ] add test for nth_migrating_prefixes

