### PR TITLE
[pallet-revive] revive json-rpc small adjustments

### DIFF
--- a/prdoc/pr_6309.prdoc
+++ b/prdoc/pr_6309.prdoc
@@ -4,7 +4,7 @@ doc:
   description: |-
     Small adjustments to eth-rpc
     - bump cache size
-    - use essential-tasks to spawn the json-rpc block subsrciption tasks
+    - use essential-tasks to spawn the json-rpc block subscription tasks
 crates:
 - name: sc-service
   bump: patch

--- a/prdoc/pr_6309.prdoc
+++ b/prdoc/pr_6309.prdoc
@@ -1,0 +1,12 @@
+title: '[pallet-revive] revive json-rpc small adjustments'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Small adjustments to eth-rpc
+    - bump cache size
+    - use essential-tasks to spawn the json-rpc block subsrciption tasks
+crates:
+- name: sc-service
+  bump: patch
+- name: pallet-revive-eth-rpc
+  bump: patch

--- a/substrate/client/service/src/lib.rs
+++ b/substrate/client/service/src/lib.rs
@@ -98,7 +98,9 @@ pub use sc_transaction_pool::TransactionPoolOptions;
 pub use sc_transaction_pool_api::{error::IntoPoolError, InPoolTransaction, TransactionPool};
 #[doc(hidden)]
 pub use std::{ops::Deref, result::Result, sync::Arc};
-pub use task_manager::{SpawnTaskHandle, Task, TaskManager, TaskRegistry, DEFAULT_GROUP_NAME};
+pub use task_manager::{
+	SpawnEssentialTaskHandle, SpawnTaskHandle, Task, TaskManager, TaskRegistry, DEFAULT_GROUP_NAME,
+};
 use tokio::runtime::Handle;
 
 const DEFAULT_PROTOCOL_ID: &str = "sup";

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -35,7 +35,6 @@ use pallet_revive::{
 	},
 	EthContractResult,
 };
-use sc_service::SpawnTaskHandle;
 use sp_runtime::traits::{BlakeTwo256, Hash};
 use sp_weights::Weight;
 use std::{
@@ -165,7 +164,7 @@ impl From<ClientError> for ErrorObjectOwned {
 
 /// The number of recent blocks maintained by the cache.
 /// For each block in the cache, we also store the EVM transaction receipts.
-pub const CACHE_SIZE: usize = 10;
+pub const CACHE_SIZE: usize = 256;
 
 impl<const N: usize> BlockCache<N> {
 	fn latest_block(&self) -> Option<&Arc<SubstrateBlock>> {
@@ -344,7 +343,10 @@ async fn extract_block_timestamp(block: &SubstrateBlock) -> Option<u64> {
 impl Client {
 	/// Create a new client instance.
 	/// The client will subscribe to new blocks and maintain a cache of [`CACHE_SIZE`] blocks.
-	pub async fn from_url(url: &str, spawn_handle: &SpawnTaskHandle) -> Result<Self, ClientError> {
+	pub async fn from_url(
+		url: &str,
+		spawn_handle: &sc_service::SpawnEssentialTaskHandle,
+	) -> Result<Self, ClientError> {
 		log::info!(target: LOG_TARGET, "Connecting to node at: {url} ...");
 		let inner: Arc<ClientInner> = Arc::new(ClientInner::from_url(url).await?);
 		log::info!(target: LOG_TARGET, "Connected to node at: {url}");


### PR DESCRIPTION
Small adjustments to eth-rpc 
- bump cache size
- use essential-tasks to spawn the json-rpc block subsrciption tasks