### PR TITLE
`DeprecationInfo` Remove `deprecated` attribute from generated code.

### DIFF
--- a/substrate/frame/support/procedural/src/deprecation.rs
+++ b/substrate/frame/support/procedural/src/deprecation.rs
@@ -36,6 +36,11 @@ fn deprecation_msg_formatter(msg: &str) -> String {
 	)
 }
 
+/// removes deprecation attribute if its present.
+pub fn remove_deprecation_attribute(attrs: &mut Vec<syn::Attribute>) {
+	attrs.retain(|attr| !attr.path().is_ident("deprecated"))
+}
+
 fn parse_deprecated_meta(crate_: &TokenStream, attr: &syn::Attribute) -> Result<TokenStream> {
 	match &attr.meta {
 		Meta::List(meta_list) => {

--- a/substrate/frame/support/procedural/src/pallet/expand/call.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/call.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use crate::{
+	deprecation::remove_deprecation_attribute,
 	pallet::{
 		expand::warnings::{weight_constant_warning, weight_witness_warning},
 		parse::{call::CallWeightDef, helper::CallReturnType},
@@ -209,6 +210,8 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 				let return_type =
 					&call.methods.get(i).expect("def should be consistent with item").return_type;
 
+				remove_deprecation_attribute(&mut method.attrs);
+
 				let (ok_type, err_type) = match return_type {
 					CallReturnType::DispatchResult => (
 						quote::quote!(()),
@@ -270,6 +273,11 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 	) {
 		Ok(deprecation) => deprecation,
 		Err(e) => return e.into_compile_error(),
+	};
+
+	match def.call.as_mut() {
+		Some(call) => remove_deprecation_attribute(&mut call.attrs),
+		None => (),
 	};
 
 	quote::quote_spanned!(span =>

--- a/substrate/frame/support/procedural/src/pallet/expand/config.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/config.rs
@@ -15,7 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::pallet::Def;
+use crate::{
+	deprecation::remove_deprecation_attribute,
+	pallet::{parse::helper::MutItemAttrs, Def},
+};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse_quote, Item};
@@ -47,6 +50,10 @@ Consequently, a runtime that wants to include this pallet must implement this tr
 			]
 		),
 	);
+	config_item.attrs.retain(|attr| !attr.path().is_ident("deprecated"));
+	for item in config_item.items.iter_mut() {
+		item.mut_item_attrs().map(remove_deprecation_attribute);
+	}
 
 	// we only emit `DefaultConfig` if there are trait items, so an empty `DefaultConfig` is
 	// impossible consequently.

--- a/substrate/frame/support/procedural/src/pallet/expand/error.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/error.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use crate::{
+	deprecation::remove_deprecation_attribute,
 	pallet::{
 		parse::error::{VariantDef, VariantField},
 		Def,
@@ -99,7 +100,6 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 			unreachable!("Checked by error parser")
 		}
 	};
-
 	error_item.variants.insert(0, phantom_variant);
 
 	let capture_docs = if cfg!(feature = "no-metadata-docs") { "never" } else { "always" };
@@ -116,6 +116,12 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 		Ok(deprecation) => deprecation,
 		Err(e) => return e.into_compile_error(),
 	};
+
+	error_item
+		.variants
+		.iter_mut()
+		.for_each(|variant| remove_deprecation_attribute(&mut variant.attrs));
+	remove_deprecation_attribute(&mut error_item.attrs);
 
 	// derive TypeInfo for error metadata
 	error_item.attrs.push(syn::parse_quote! {

--- a/substrate/frame/support/procedural/src/pallet/expand/mod.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/mod.rs
@@ -37,8 +37,10 @@ mod type_value;
 mod validate_unsigned;
 mod warnings;
 
-use crate::pallet::Def;
+use crate::{deprecation::remove_deprecation_attribute, pallet::Def};
 use quote::ToTokens;
+
+use super::parse::helper::MutItemAttrs;
 
 /// Merge where clause together, `where` token span is taken from the first not none one.
 pub fn merge_where_clauses(clauses: &[&Option<syn::WhereClause>]) -> Option<syn::WhereClause> {
@@ -121,12 +123,13 @@ storage item. Otherwise, all storage items are listed among [*Type Definitions*]
 		#composites
 	);
 
-	def.item
-		.content
-		.as_mut()
-		.expect("This is checked by parsing")
-		.1
-		.push(syn::Item::Verbatim(new_items));
+	let item = &mut def.item.content.as_mut().expect("This is checked by parsing").1;
+	item.push(syn::Item::Verbatim(new_items));
+	for i in item {
+		if let Some(attrs) = i.mut_item_attrs() {
+			remove_deprecation_attribute(attrs);
+		}
+	}
 
 	def.item.into_token_stream()
 }

--- a/substrate/frame/support/procedural/src/pallet/expand/storage.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/storage.rs
@@ -17,6 +17,7 @@
 
 use crate::{
 	counter_prefix,
+	deprecation::remove_deprecation_attribute,
 	pallet::{
 		parse::{
 			helper::two128_str,
@@ -425,6 +426,7 @@ pub fn expand_storages(def: &mut Def) -> proc_macro2::TokenStream {
 			Ok(deprecation) => deprecation,
 			Err(e) => return e.into_compile_error(),
 		};
+
 		entries_builder.push(quote::quote_spanned!(storage.attr_span =>
 			#(#cfg_attrs)*
 			(|entries: &mut #frame_support::__private::Vec<_>| {
@@ -439,6 +441,9 @@ pub fn expand_storages(def: &mut Def) -> proc_macro2::TokenStream {
 				}
 			})
 		))
+	}
+	for storage in &mut def.storages.iter_mut() {
+		remove_deprecation_attribute(&mut storage.attrs);
 	}
 
 	let getters = def.storages.iter().map(|storage| {

--- a/substrate/frame/support/procedural/src/runtime/expand/mod.rs
+++ b/substrate/frame/support/procedural/src/runtime/expand/mod.rs
@@ -237,7 +237,7 @@ fn construct_runtime_final_expansion(
 		&unchecked_extrinsic,
 		&system_pallet.path,
 	);
-	let outer_config = expand::expand_outer_config(&name, &pallets, &scrate);
+	let outer_config: TokenStream2 = expand::expand_outer_config(&name, &pallets, &scrate);
 	let inherent =
 		expand::expand_outer_inherent(&name, &block, &unchecked_extrinsic, &pallets, &scrate);
 	let validate_unsigned = expand::expand_outer_validate_unsigned(&name, &pallets, &scrate);

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -14,7 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![allow(useless_deprecated, deprecated, clippy::deprecated_semver)]
+#![allow(useless_deprecated, clippy::deprecated_semver)]
 
 use std::collections::BTreeMap;
 
@@ -121,6 +121,7 @@ impl SomeAssociation2 for u64 {
 // Comments should not be included in the pallet documentation
 #[pallet_doc("../example-pallet-doc.md")]
 #[doc = include_str!("../example-readme.md")]
+#[deprecated = "example"]
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
@@ -138,6 +139,7 @@ pub mod pallet {
 	{
 		/// Some comment
 		/// Some comment
+		#[deprecated = "test 2"]
 		#[pallet::constant]
 		type MyGetParam: Get<u32>;
 
@@ -178,6 +180,7 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
+	#[deprecated = "example"]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
@@ -2552,6 +2555,15 @@ fn pallet_metadata() {
 				codec::Compact(0),
 				DeprecationStatusIR::Deprecated { note: "test", since: None }
 			)])),
+			meta.deprecation_info
+		)
+	}
+	{
+		// Example pallet constant is deprecated
+		let meta = &example.constants[0];
+		dbg!(meta);
+		assert_eq!(
+			DeprecationStatusIR::Deprecated { note: "test 2", since: None },
 			meta.deprecation_info
 		)
 	}

--- a/substrate/primitives/api/proc-macro/src/common.rs
+++ b/substrate/primitives/api/proc-macro/src/common.rs
@@ -33,6 +33,16 @@ pub const CHANGED_IN_ATTRIBUTE: &str = "changed_in";
 ///
 /// Is used when a trait method was renamed.
 pub const RENAMED_ATTRIBUTE: &str = "renamed";
+/// The `deprecated` attribute.
+///
+/// Is used when a trait or it's method was deprecated.
+pub const DEPRECATED_ATTRIBUTE: &str = "deprecated";
+
 /// All attributes that we support in the declaration of a runtime api trait.
-pub const SUPPORTED_ATTRIBUTE_NAMES: &[&str] =
-	&[CORE_TRAIT_ATTRIBUTE, API_VERSION_ATTRIBUTE, CHANGED_IN_ATTRIBUTE, RENAMED_ATTRIBUTE];
+pub const SUPPORTED_ATTRIBUTE_NAMES: &[&str] = &[
+	CORE_TRAIT_ATTRIBUTE,
+	API_VERSION_ATTRIBUTE,
+	CHANGED_IN_ATTRIBUTE,
+	RENAMED_ATTRIBUTE,
+	DEPRECATED_ATTRIBUTE,
+];

--- a/substrate/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -201,58 +201,61 @@ fn generate_runtime_decls(decls: &[ItemTrait]) -> Result<TokenStream> {
 
 		// Process the items in the declaration. The filter_map function below does a lot of stuff
 		// because the method attributes are stripped at this point
-		decl.items.iter_mut().for_each(|i| match i {
-			TraitItem::Fn(ref mut method) => {
-				let method_attrs = remove_supported_attributes(&mut method.attrs);
-				let mut method_version = trait_api_version;
-				// validate the api version for the method (if any) and generate default
-				// implementation for versioned methods
-				if let Some(version_attribute) = method_attrs.get(API_VERSION_ATTRIBUTE) {
-					method_version = match parse_runtime_api_version(version_attribute) {
-						Ok(method_api_ver) if method_api_ver < trait_api_version => {
-							let method_ver = method_api_ver.to_string();
-							let trait_ver = trait_api_version.to_string();
-							let mut err1 = Error::new(
-								version_attribute.span(),
-								format!(
+		decl.items.iter_mut().for_each(|i| {
+			match i {
+				TraitItem::Fn(ref mut method) => {
+					let method_attrs = remove_supported_attributes(&mut method.attrs);
+					let mut method_version = trait_api_version;
+					// validate the api version for the method (if any) and generate default
+					// implementation for versioned methods
+					if let Some(version_attribute) = method_attrs.get(API_VERSION_ATTRIBUTE) {
+						method_version = match parse_runtime_api_version(version_attribute) {
+							Ok(method_api_ver) if method_api_ver < trait_api_version => {
+								let method_ver = method_api_ver.to_string();
+								let trait_ver = trait_api_version.to_string();
+								let mut err1 = Error::new(
+									version_attribute.span(),
+									format!(
 										"Method version `{}` is older than (or equal to) trait version `{}`.\
 										 Methods can't define versions older than the trait version.",
 										method_ver,
 										trait_ver,
 									),
-							);
+								);
 
-							let err2 = match found_attributes.get(&API_VERSION_ATTRIBUTE) {
-								Some(attr) => Error::new(attr.span(), "Trait version is set here."),
-								None => Error::new(
-									decl_span,
-									"Trait version is not set so it is implicitly equal to 1.",
-								),
-							};
-							err1.combine(err2);
-							result.push(err1.to_compile_error());
+								let err2 = match found_attributes.get(&API_VERSION_ATTRIBUTE) {
+									Some(attr) =>
+										Error::new(attr.span(), "Trait version is set here."),
+									None => Error::new(
+										decl_span,
+										"Trait version is not set so it is implicitly equal to 1.",
+									),
+								};
+								err1.combine(err2);
+								result.push(err1.to_compile_error());
 
-							trait_api_version
-						},
-						Ok(method_api_ver) => method_api_ver,
-						Err(e) => {
-							result.push(e.to_compile_error());
-							trait_api_version
-						},
-					};
-				}
+								trait_api_version
+							},
+							Ok(method_api_ver) => method_api_ver,
+							Err(e) => {
+								result.push(e.to_compile_error());
+								trait_api_version
+							},
+						};
+					}
 
-				// Any method with the `changed_in` attribute isn't required for the runtime
-				// anymore.
-				if !method_attrs.contains_key(CHANGED_IN_ATTRIBUTE) {
-					// Make sure we replace all the wild card parameter names.
-					replace_wild_card_parameter_names(&mut method.sig);
+					// Any method with the `changed_in` attribute isn't required for the runtime
+					// anymore.
+					if !method_attrs.contains_key(CHANGED_IN_ATTRIBUTE) {
+						// Make sure we replace all the wild card parameter names.
+						replace_wild_card_parameter_names(&mut method.sig);
 
-					// partition methods by api version
-					methods_by_version.entry(method_version).or_default().push(method.clone());
-				}
-			},
-			_ => (),
+						// partition methods by api version
+						methods_by_version.entry(method_version).or_default().push(method.clone());
+					}
+				},
+				_ => (),
+			}
 		});
 
 		let versioned_api_traits = generate_versioned_api_traits(decl.clone(), methods_by_version);


### PR DESCRIPTION
# Description

Removed `#[deprecated]` attribute from the generated code, so that code is not littered with useless warnings but `DeprecationInfo` is still propagated in `MetadataIr`

see an example of warnings being too noisy: #6169

## Review Notes

The change itself is just adding attribute removal code after specific steps during macro expansion.
