### PR TITLE
[pallet-balances] Add SimpleStorageUpdate to migrate balances without any additional inactive tracks

### DIFF
--- a/substrate/frame/balances/src/migration.rs
+++ b/substrate/frame/balances/src/migration.rs
@@ -101,3 +101,24 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for ResetInactive<T, I> {
 		}
 	}
 }
+
+pub struct SimpleStorageUpdate<T, I = ()>(PhantomData<(T, I)>);
+impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for SimpleStorageUpdate<T, I> {
+	fn on_runtime_upgrade() -> Weight {
+		let current_storage_version = <Pallet<T>>::current_storage_version();
+		let on_chain_version = Pallet::<T, I>::on_chain_storage_version();
+
+		if onchain_storage_version == 0 && current_storage_version != 0 {
+			current_storage_version.put::<Pallet<T>>();
+
+			log::info!(target: LOG_TARGET, "Storage to version {current_storage_version}");
+			T::DbWeight::get().reads_writes(1, 1)
+		} else {
+			log::info!(
+				target: LOG_TARGET,
+				"Migration did not execute. This probably should be removed"
+			);
+			T::DbWeight::get().reads(1)
+		}
+	}
+}


### PR DESCRIPTION
During work on https://github.com/humanode-network/humanode/pull/940 in our humanode codebase to update substrate related dependencies to `polkadot-v0.9.43` we've faced some migration errors related to `pallet-balances` as the pallet's code has `StorageVersion = 1` but our mainnet balances `on_chain_version` is still equal to 0.


We've researched current existing migration options like `MigrateToTrackInactive`, `MigrateManyToTrackInactive` and  `ResetInactive`. So, there are no any options to do migration without including additional tracks of inactive funds. In our codebase we use own implementation to track inactive funds. As a result, it would great to have an option to do storage version update without doing additional inactive related stuff.

