### PR TITLE
Add `TransactionSource` as argument in `TransactionExtension::validate`

### DIFF
--- a/bridges/bin/runtime-common/src/extensions.rs
+++ b/bridges/bin/runtime-common/src/extensions.rs
@@ -299,6 +299,7 @@ macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
 				_len: usize,
 				_self_implicit: Self::Implicit,
 				_inherited_implication: &impl codec::Encode,
+				_source: sp_runtime::transaction_validity::TransactionSource,
 			) -> Result<
 				(
 					sp_runtime::transaction_validity::ValidTransaction,
@@ -393,6 +394,7 @@ mod tests {
 		transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
 		DispatchError,
 	};
+	use sp_runtime::transaction_validity::TransactionSource::External;
 
 	parameter_types! {
 		pub MsgProofsRewardsAccount: RewardsAccountParams<TestLaneIdType> = RewardsAccountParams::new(
@@ -610,7 +612,8 @@ mod tests {
 					42u64.into(),
 					&MockCall { data: 1 },
 					&(),
-					0
+					0,
+					External,
 				),
 				InvalidTransaction::Custom(1)
 			);
@@ -629,7 +632,8 @@ mod tests {
 					42u64.into(),
 					&MockCall { data: 2 },
 					&(),
-					0
+					0,
+					External,
 				),
 				InvalidTransaction::Custom(2)
 			);
@@ -645,7 +649,7 @@ mod tests {
 
 			assert_eq!(
 				BridgeRejectObsoleteHeadersAndMessages
-					.validate_only(42u64.into(), &MockCall { data: 3 }, &(), 0)
+					.validate_only(42u64.into(), &MockCall { data: 3 }, &(), 0, External)
 					.unwrap()
 					.0,
 				ValidTransaction { priority: 3, ..Default::default() },

--- a/bridges/modules/relayers/src/extension/mod.rs
+++ b/bridges/modules/relayers/src/extension/mod.rs
@@ -33,6 +33,7 @@ use bp_runtime::{Chain, RangeInclusiveExt, StaticStrProvider};
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, PostDispatchInfo},
+	pallet_prelude::TransactionSource,
 	weights::Weight,
 	CloneNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
@@ -304,6 +305,7 @@ where
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, R::RuntimeCall> {
 		// Prepare relevant data for `prepare`
 		let parsed_call = match C::parse_and_check_for_obsolete_call(call)? {
@@ -466,6 +468,7 @@ mod tests {
 		transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
 		DispatchError,
 	};
+	use sp_runtime::transaction_validity::TransactionSource::External;
 
 	parameter_types! {
 		TestParachain: u32 = BridgedUnderlyingParachain::PARACHAIN_ID;
@@ -1076,6 +1079,7 @@ mod tests {
 				&call,
 				&DispatchInfo::default(),
 				0,
+				External,
 			)
 			.map(|t| t.0)
 	}
@@ -1088,6 +1092,7 @@ mod tests {
 				&call,
 				&DispatchInfo::default(),
 				0,
+				External,
 			)
 			.map(|t| t.0)
 	}
@@ -1100,6 +1105,7 @@ mod tests {
 				&call,
 				&DispatchInfo::default(),
 				0,
+				External,
 			)
 			.map(|t| t.0)
 	}

--- a/substrate/frame/examples/authorization-tx-extension/src/extensions.rs
+++ b/substrate/frame/examples/authorization-tx-extension/src/extensions.rs
@@ -18,7 +18,7 @@
 use core::{fmt, marker::PhantomData};
 
 use codec::{Decode, Encode};
-use frame_support::{traits::OriginTrait, Parameter};
+use frame_support::{pallet_prelude::TransactionSource, traits::OriginTrait, Parameter};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
@@ -94,6 +94,7 @@ where
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		inherited_implication: &impl codec::Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
 		// If the extension is inactive, just move on in the pipeline.
 		let Some(auth) = &self.inner else {

--- a/substrate/frame/examples/basic/src/lib.rs
+++ b/substrate/frame/examples/basic/src/lib.rs
@@ -61,6 +61,7 @@ use codec::{Decode, Encode};
 use core::marker::PhantomData;
 use frame_support::{
 	dispatch::{ClassifyDispatch, DispatchClass, DispatchResult, Pays, PaysFee, WeighData},
+	pallet_prelude::TransactionSource,
 	traits::IsSubType,
 	weights::Weight,
 };
@@ -508,6 +509,7 @@ where
 		len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, <T as frame_system::Config>::RuntimeCall> {
 		// if the transaction is too big, just drop it.
 		if len > 200 {

--- a/substrate/frame/examples/basic/src/tests.rs
+++ b/substrate/frame/examples/basic/src/tests.rs
@@ -28,6 +28,7 @@ use sp_core::H256;
 // or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 use sp_runtime::{
 	traits::{BlakeTwo256, DispatchTransaction, IdentityLookup},
+	transaction_validity::TransactionSource::External,
 	BuildStorage,
 };
 // Reexport crate as its pallet name for construct_runtime.
@@ -146,7 +147,7 @@ fn signed_ext_watch_dummy_works() {
 
 		assert_eq!(
 			WatchDummy::<Test>(PhantomData)
-				.validate_only(Some(1).into(), &call, &info, 150)
+				.validate_only(Some(1).into(), &call, &info, 150, External)
 				.unwrap()
 				.0
 				.priority,
@@ -154,7 +155,7 @@ fn signed_ext_watch_dummy_works() {
 		);
 		assert_eq!(
 			WatchDummy::<Test>(PhantomData)
-				.validate_only(Some(1).into(), &call, &info, 250)
+				.validate_only(Some(1).into(), &call, &info, 250, External)
 				.unwrap_err(),
 			InvalidTransaction::ExhaustsResources.into(),
 		);

--- a/substrate/frame/examples/kitchensink/src/benchmarking.rs
+++ b/substrate/frame/examples/kitchensink/src/benchmarking.rs
@@ -26,6 +26,7 @@ use crate::Pallet as Kitchensink;
 
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
+use frame_support::pallet_prelude::TransactionSource;
 
 // To actually run this benchmark on pallet-example-kitchensink, we need to put this pallet into the
 //   runtime and compile it with `runtime-benchmarks` feature. The detail procedures are

--- a/substrate/frame/sudo/src/extension.rs
+++ b/substrate/frame/sudo/src/extension.rs
@@ -18,7 +18,7 @@
 use crate::{Config, Key};
 use codec::{Decode, Encode};
 use core::{fmt, marker::PhantomData};
-use frame_support::{dispatch::DispatchInfo, ensure};
+use frame_support::{dispatch::DispatchInfo, ensure, pallet_prelude::TransactionSource};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
@@ -94,6 +94,7 @@ where
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> Result<
 		(
 			ValidTransaction,

--- a/substrate/frame/system/benchmarking/src/inner.rs
+++ b/substrate/frame/system/benchmarking/src/inner.rs
@@ -49,6 +49,8 @@ pub trait Config: frame_system::Config {
 
 #[benchmarks]
 mod benchmarks {
+	use frame_support::pallet_prelude::TransactionSource;
+
 	use super::*;
 
 	#[benchmark]

--- a/substrate/frame/system/src/extensions/check_mortality.rs
+++ b/substrate/frame/system/src/extensions/check_mortality.rs
@@ -17,6 +17,7 @@
 
 use crate::{pallet_prelude::BlockNumberFor, BlockHash, Config, Pallet};
 use codec::{Decode, Encode};
+use frame_support::pallet_prelude::TransactionSource;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	generic::Era,
@@ -91,6 +92,7 @@ impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckMort
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
 		let current_u64 = <Pallet<T>>::block_number().saturated_into::<u64>();
 		let valid_till = self.0.death(current_u64);
@@ -116,6 +118,7 @@ mod tests {
 	};
 	use sp_core::H256;
 	use sp_runtime::traits::DispatchTransaction;
+	use sp_runtime::transaction_validity::TransactionSource::External;
 
 	#[test]
 	fn signed_ext_check_era_should_work() {
@@ -151,7 +154,7 @@ mod tests {
 			<BlockHash<Test>>::insert(16, H256::repeat_byte(1));
 
 			assert_eq!(
-				ext.validate_only(Some(1).into(), CALL, &normal, len).unwrap().0.longevity,
+				ext.validate_only(Some(1).into(), CALL, &normal, len, External).unwrap().0.longevity,
 				15
 			);
 		})

--- a/substrate/frame/system/src/extensions/check_non_zero_sender.rs
+++ b/substrate/frame/system/src/extensions/check_non_zero_sender.rs
@@ -18,7 +18,7 @@
 use crate::Config;
 use codec::{Decode, Encode};
 use core::marker::PhantomData;
-use frame_support::{traits::OriginTrait, DefaultNoBound};
+use frame_support::{pallet_prelude::TransactionSource, traits::OriginTrait, DefaultNoBound};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	impl_tx_ext_default,
@@ -68,6 +68,7 @@ impl<T: Config + Send + Sync> TransactionExtension<T::RuntimeCall> for CheckNonZ
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> sp_runtime::traits::ValidateResult<Self::Val, T::RuntimeCall> {
 		if let Some(who) = origin.as_signer() {
 			if who.using_encoded(|d| d.iter().all(|x| *x == 0)) {
@@ -88,6 +89,7 @@ mod tests {
 		traits::{AsTransactionAuthorizedOrigin, DispatchTransaction},
 		transaction_validity::TransactionValidityError,
 	};
+	use sp_runtime::transaction_validity::TransactionSource::External;
 
 	#[test]
 	fn zero_account_ban_works() {
@@ -96,7 +98,7 @@ mod tests {
 			let len = 0_usize;
 			assert_eq!(
 				CheckNonZeroSender::<Test>::new()
-					.validate_only(Some(0).into(), CALL, &info, len)
+					.validate_only(Some(0).into(), CALL, &info, len, External)
 					.unwrap_err(),
 				TransactionValidityError::from(InvalidTransaction::BadSigner)
 			);
@@ -104,7 +106,8 @@ mod tests {
 				Some(1).into(),
 				CALL,
 				&info,
-				len
+				len,
+				External,
 			));
 		})
 	}
@@ -115,7 +118,7 @@ mod tests {
 			let info = DispatchInfo::default();
 			let len = 0_usize;
 			let (_, _, origin) = CheckNonZeroSender::<Test>::new()
-				.validate(None.into(), CALL, &info, len, (), CALL)
+				.validate(None.into(), CALL, &info, len, (), CALL, External)
 				.unwrap();
 			assert!(!origin.is_transaction_authorized());
 		})

--- a/substrate/frame/system/src/extensions/check_weight.rs
+++ b/substrate/frame/system/src/extensions/check_weight.rs
@@ -19,6 +19,7 @@ use crate::{limits::BlockWeights, Config, Pallet, LOG_TARGET};
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, PostDispatchInfo},
+	pallet_prelude::TransactionSource,
 	traits::Get,
 };
 use scale_info::TypeInfo;
@@ -254,6 +255,7 @@ where
 		len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
 		let (validity, next_len) = Self::do_validate(info, len)?;
 		Ok((validity, next_len, origin))

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -47,6 +47,7 @@ extern crate alloc;
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, DispatchResult, PostDispatchInfo},
+	pallet_prelude::TransactionSource,
 	traits::IsType,
 	DefaultNoBound,
 };
@@ -308,6 +309,7 @@ where
 		len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
 		let Some(who) = origin.as_system_origin_signer() else {
 			return Ok((ValidTransaction::default(), Val::NoCharge, origin))

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
@@ -38,7 +38,7 @@
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, DispatchResult, PostDispatchInfo},
-	pallet_prelude::Weight,
+	pallet_prelude::{TransactionSource, Weight},
 	traits::{
 		tokens::{
 			fungibles::{Balanced, Credit, Inspect},
@@ -324,6 +324,7 @@ where
 		len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> Result<
 		(ValidTransaction, Self::Val, <T::RuntimeCall as Dispatchable>::RuntimeOrigin),
 		TransactionValidityError,

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/lib.rs
@@ -39,6 +39,7 @@
 use codec::{Decode, Encode};
 use frame_support::{
 	dispatch::{CheckIfFeeless, DispatchResult},
+	pallet_prelude::TransactionSource,
 	traits::{IsType, OriginTrait},
 	weights::Weight,
 };
@@ -147,12 +148,20 @@ where
 		len: usize,
 		self_implicit: S::Implicit,
 		inherited_implication: &impl Encode,
+		source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
 		if call.is_feeless(&origin) {
 			Ok((Default::default(), Skip(origin.caller().clone()), origin))
 		} else {
-			let (x, y, z) =
-				self.0.validate(origin, call, info, len, self_implicit, inherited_implication)?;
+			let (x, y, z) = self.0.validate(
+				origin,
+				call,
+				info,
+				len,
+				self_implicit,
+				inherited_implication,
+				source,
+			)?;
 			Ok((x, Apply(y), z))
 		}
 	}

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/mock.rs
@@ -60,6 +60,7 @@ impl TransactionExtension<RuntimeCall> for DummyExtension {
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, RuntimeCall> {
 		ValidateCount::mutate(|c| *c += 1);
 		Ok((ValidTransaction::default(), (), origin))

--- a/substrate/frame/transaction-payment/skip-feeless-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/skip-feeless-payment/src/tests.rs
@@ -18,6 +18,7 @@ use crate::mock::{
 	pallet_dummy::Call, DummyExtension, PrepareCount, Runtime, RuntimeCall, ValidateCount,
 };
 use frame_support::dispatch::DispatchInfo;
+use sp_runtime::transaction_validity::TransactionSource;
 use sp_runtime::traits::DispatchTransaction;
 
 #[test]
@@ -41,14 +42,14 @@ fn validate_works() {
 
 	let call = RuntimeCall::DummyPallet(Call::<Runtime>::aux { data: 1 });
 	SkipCheckIfFeeless::<Runtime, DummyExtension>::from(DummyExtension)
-		.validate_only(Some(0).into(), &call, &DispatchInfo::default(), 0)
+		.validate_only(Some(0).into(), &call, &DispatchInfo::default(), 0, TransactionSource::External)
 		.unwrap();
 	assert_eq!(ValidateCount::get(), 1);
 	assert_eq!(PrepareCount::get(), 0);
 
 	let call = RuntimeCall::DummyPallet(Call::<Runtime>::aux { data: 0 });
 	SkipCheckIfFeeless::<Runtime, DummyExtension>::from(DummyExtension)
-		.validate_only(Some(0).into(), &call, &DispatchInfo::default(), 0)
+		.validate_only(Some(0).into(), &call, &DispatchInfo::default(), 0, TransactionSource::External)
 		.unwrap();
 	assert_eq!(ValidateCount::get(), 1);
 	assert_eq!(PrepareCount::get(), 0);

--- a/substrate/frame/transaction-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/src/lib.rs
@@ -54,6 +54,7 @@ use frame_support::{
 	dispatch::{
 		DispatchClass, DispatchInfo, DispatchResult, GetDispatchInfo, Pays, PostDispatchInfo,
 	},
+	pallet_prelude::TransactionSource,
 	traits::{Defensive, EstimateCallFee, Get},
 	weights::{Weight, WeightToFee},
 	RuntimeDebugNoBound,
@@ -916,6 +917,7 @@ where
 		len: usize,
 		_: (),
 		_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> Result<
 		(ValidTransaction, Self::Val, <T::RuntimeCall as Dispatchable>::RuntimeOrigin),
 		TransactionValidityError,

--- a/substrate/frame/transaction-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/src/tests.rs
@@ -24,6 +24,7 @@ use sp_runtime::{
 	generic::UncheckedExtrinsic,
 	traits::{DispatchTransaction, One},
 	transaction_validity::InvalidTransaction,
+	transaction_validity::TransactionSource::External,
 	BuildStorage,
 };
 
@@ -235,7 +236,7 @@ fn transaction_extension_allows_free_transactions() {
 				class: DispatchClass::Operational,
 				pays_fee: Pays::No,
 			};
-			assert_ok!(Ext::from(0).validate_only(Some(1).into(), CALL, &op_tx, len));
+			assert_ok!(Ext::from(0).validate_only(Some(1).into(), CALL, &op_tx, len, External));
 
 			// like a InsecureFreeNormal
 			let free_tx = DispatchInfo {
@@ -245,7 +246,7 @@ fn transaction_extension_allows_free_transactions() {
 				pays_fee: Pays::Yes,
 			};
 			assert_eq!(
-				Ext::from(0).validate_only(Some(1).into(), CALL, &free_tx, len).unwrap_err(),
+				Ext::from(0).validate_only(Some(1).into(), CALL, &free_tx, len, External).unwrap_err(),
 				TransactionValidityError::Invalid(InvalidTransaction::Payment),
 			);
 		});
@@ -659,11 +660,11 @@ fn should_alter_operational_priority() {
 		};
 
 		let ext = Ext::from(tip);
-		let priority = ext.validate_only(Some(2).into(), CALL, &normal, len).unwrap().0.priority;
+		let priority = ext.validate_only(Some(2).into(), CALL, &normal, len, External).unwrap().0.priority;
 		assert_eq!(priority, 60);
 
 		let ext = Ext::from(2 * tip);
-		let priority = ext.validate_only(Some(2).into(), CALL, &normal, len).unwrap().0.priority;
+		let priority = ext.validate_only(Some(2).into(), CALL, &normal, len, External).unwrap().0.priority;
 		assert_eq!(priority, 110);
 	});
 
@@ -676,11 +677,11 @@ fn should_alter_operational_priority() {
 		};
 
 		let ext = Ext::from(tip);
-		let priority = ext.validate_only(Some(2).into(), CALL, &op, len).unwrap().0.priority;
+		let priority = ext.validate_only(Some(2).into(), CALL, &op, len, External).unwrap().0.priority;
 		assert_eq!(priority, 5810);
 
 		let ext = Ext::from(2 * tip);
-		let priority = ext.validate_only(Some(2).into(), CALL, &op, len).unwrap().0.priority;
+		let priority = ext.validate_only(Some(2).into(), CALL, &op, len, External).unwrap().0.priority;
 		assert_eq!(priority, 6110);
 	});
 }
@@ -698,7 +699,7 @@ fn no_tip_has_some_priority() {
 			pays_fee: Pays::Yes,
 		};
 		let ext = Ext::from(tip);
-		let priority = ext.validate_only(Some(2).into(), CALL, &normal, len).unwrap().0.priority;
+		let priority = ext.validate_only(Some(2).into(), CALL, &normal, len, External).unwrap().0.priority;
 		assert_eq!(priority, 10);
 	});
 
@@ -710,7 +711,7 @@ fn no_tip_has_some_priority() {
 			pays_fee: Pays::Yes,
 		};
 		let ext = Ext::from(tip);
-		let priority = ext.validate_only(Some(2).into(), CALL, &op, len).unwrap().0.priority;
+		let priority = ext.validate_only(Some(2).into(), CALL, &op, len, External).unwrap().0.priority;
 		assert_eq!(priority, 5510);
 	});
 }
@@ -729,7 +730,7 @@ fn higher_tip_have_higher_priority() {
 				pays_fee: Pays::Yes,
 			};
 			let ext = Ext::from(tip);
-			pri1 = ext.validate_only(Some(2).into(), CALL, &normal, len).unwrap().0.priority;
+			pri1 = ext.validate_only(Some(2).into(), CALL, &normal, len, External).unwrap().0.priority;
 		});
 
 		ExtBuilder::default().balance_factor(100).build().execute_with(|| {
@@ -740,7 +741,7 @@ fn higher_tip_have_higher_priority() {
 				pays_fee: Pays::Yes,
 			};
 			let ext = Ext::from(tip);
-			pri2 = ext.validate_only(Some(2).into(), CALL, &op, len).unwrap().0.priority;
+			pri2 = ext.validate_only(Some(2).into(), CALL, &op, len, External).unwrap().0.priority;
 		});
 
 		(pri1, pri2)

--- a/substrate/frame/verify-signature/src/benchmarking.rs
+++ b/substrate/frame/verify-signature/src/benchmarking.rs
@@ -27,7 +27,10 @@ use super::*;
 use crate::{extension::VerifySignature, Config, Pallet as VerifySignaturePallet};
 use alloc::vec;
 use frame_benchmarking::{v2::*, BenchmarkError};
-use frame_support::dispatch::{DispatchInfo, GetDispatchInfo};
+use frame_support::{
+	dispatch::{DispatchInfo, GetDispatchInfo},
+	pallet_prelude::TransactionSource,
+};
 use frame_system::{Call as SystemCall, RawOrigin};
 use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{AsTransactionAuthorizedOrigin, Dispatchable, TransactionExtension};
@@ -55,7 +58,17 @@ mod benchmarks {
 
 		#[block]
 		{
-			assert!(ext.validate(RawOrigin::None.into(), &call, &info, 0, (), &call).is_ok());
+			assert!(ext
+				.validate(
+					RawOrigin::None.into(),
+					&call,
+					&info,
+					0,
+					(),
+					&call,
+					TransactionSource::External
+				)
+				.is_ok());
 		}
 
 		Ok(())

--- a/substrate/frame/verify-signature/src/extension.rs
+++ b/substrate/frame/verify-signature/src/extension.rs
@@ -20,7 +20,7 @@
 
 use crate::{Config, WeightInfo};
 use codec::{Decode, Encode};
-use frame_support::traits::OriginTrait;
+use frame_support::{pallet_prelude::TransactionSource, traits::OriginTrait};
 use scale_info::TypeInfo;
 use sp_io::hashing::blake2_256;
 use sp_runtime::{
@@ -113,6 +113,7 @@ where
 		_len: usize,
 		_: (),
 		inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> Result<
 		(ValidTransaction, Self::Val, <T::RuntimeCall as Dispatchable>::RuntimeOrigin),
 		TransactionValidityError,

--- a/substrate/frame/verify-signature/src/tests.rs
+++ b/substrate/frame/verify-signature/src/tests.rs
@@ -25,7 +25,7 @@ use extension::VerifySignature;
 use frame_support::{
 	derive_impl,
 	dispatch::GetDispatchInfo,
-	pallet_prelude::{InvalidTransaction, TransactionValidityError},
+	pallet_prelude::{InvalidTransaction, TransactionValidityError, TransactionSource},
 	traits::OriginTrait,
 };
 use frame_system::Call as SystemCall;
@@ -84,7 +84,7 @@ fn verification_works() {
 	let info = call.get_dispatch_info();
 
 	let (_, _, origin) = VerifySignature::<Test>::new_with_signature(sig, who)
-		.validate_only(None.into(), &call, &info, 0)
+		.validate_only(None.into(), &call, &info, 0, TransactionSource::External)
 		.unwrap();
 	assert_eq!(origin.as_signer().unwrap(), &who)
 }
@@ -98,7 +98,7 @@ fn bad_signature() {
 
 	assert_eq!(
 		VerifySignature::<Test>::new_with_signature(sig, who)
-			.validate_only(None.into(), &call, &info, 0)
+			.validate_only(None.into(), &call, &info, 0, TransactionSource::External)
 			.unwrap_err(),
 		TransactionValidityError::Invalid(InvalidTransaction::BadProof)
 	);
@@ -113,7 +113,7 @@ fn bad_starting_origin() {
 
 	assert_eq!(
 		VerifySignature::<Test>::new_with_signature(sig, who)
-			.validate_only(Some(42).into(), &call, &info, 0)
+			.validate_only(Some(42).into(), &call, &info, 0, TransactionSource::External)
 			.unwrap_err(),
 		TransactionValidityError::Invalid(InvalidTransaction::BadSigner)
 	);
@@ -126,7 +126,7 @@ fn disabled_extension_works() {
 	let info = call.get_dispatch_info();
 
 	let (_, _, origin) = VerifySignature::<Test>::new_disabled()
-		.validate_only(Some(who).into(), &call, &info, 0)
+		.validate_only(Some(who).into(), &call, &info, 0, TransactionSource::External)
 		.unwrap();
 	assert_eq!(origin.as_signer().unwrap(), &who)
 }

--- a/substrate/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -85,10 +85,11 @@ where
 			},
 			ExtrinsicFormat::Signed(ref signer, ref extension) => {
 				let origin = Some(signer.clone()).into();
-				extension.validate_only(origin, &self.function, info, len).map(|x| x.0)
+				extension.validate_only(origin, &self.function, info, len, source).map(|x| x.0)
 			},
-			ExtrinsicFormat::General(ref extension) =>
-				extension.validate_only(None.into(), &self.function, info, len).map(|x| x.0),
+			ExtrinsicFormat::General(ref extension) => extension
+				.validate_only(None.into(), &self.function, info, len, source)
+				.map(|x| x.0),
 		}
 	}
 
@@ -111,10 +112,18 @@ where
 				Extension::bare_post_dispatch(info, &mut post_info, len, &pd_res)?;
 				Ok(res)
 			},
-			ExtrinsicFormat::Signed(signer, extension) =>
-				extension.dispatch_transaction(Some(signer).into(), self.function, info, len),
-			ExtrinsicFormat::General(extension) =>
-				extension.dispatch_transaction(None.into(), self.function, info, len),
+			ExtrinsicFormat::Signed(signer, extension) => extension.dispatch_transaction(
+				Some(signer).into(),
+				self.function,
+				info,
+				len,
+			),
+			ExtrinsicFormat::General(extension) => extension.dispatch_transaction(
+				None.into(),
+				self.function,
+				info,
+				len,
+			),
 		}
 	}
 }

--- a/substrate/primitives/runtime/src/traits/transaction_extension/as_transaction_extension.rs
+++ b/substrate/primitives/runtime/src/traits/transaction_extension/as_transaction_extension.rs
@@ -25,7 +25,7 @@ use sp_core::RuntimeDebug;
 
 use crate::{
 	traits::{AsSystemOriginSigner, SignedExtension, ValidateResult},
-	transaction_validity::InvalidTransaction,
+	transaction_validity::{InvalidTransaction, TransactionSource},
 };
 
 use super::*;
@@ -74,6 +74,7 @@ where
 		len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, SE::Call> {
 		let who = origin.as_system_origin_signer().ok_or(InvalidTransaction::BadSigner)?;
 		let r = self.0.validate(who, call, info, len)?;

--- a/substrate/primitives/runtime/src/traits/transaction_extension/dispatch_transaction.rs
+++ b/substrate/primitives/runtime/src/traits/transaction_extension/dispatch_transaction.rs
@@ -17,7 +17,10 @@
 
 //! The [DispatchTransaction] trait.
 
-use crate::{traits::AsTransactionAuthorizedOrigin, transaction_validity::InvalidTransaction};
+use crate::{
+	traits::AsTransactionAuthorizedOrigin,
+	transaction_validity::{InvalidTransaction, TransactionSource},
+};
 
 use super::*;
 
@@ -45,6 +48,7 @@ pub trait DispatchTransaction<Call: Dispatchable> {
 		call: &Call,
 		info: &Self::Info,
 		len: usize,
+		source: TransactionSource,
 	) -> Result<(ValidTransaction, Self::Val, Self::Origin), TransactionValidityError>;
 	/// Validate and prepare a transaction, ready for dispatch.
 	fn validate_and_prepare(
@@ -93,8 +97,9 @@ where
 		call: &Call,
 		info: &DispatchInfoOf<Call>,
 		len: usize,
+		source: TransactionSource,
 	) -> Result<(ValidTransaction, T::Val, Self::Origin), TransactionValidityError> {
-		match self.validate(origin, call, info, len, self.implicit()?, call) {
+		match self.validate(origin, call, info, len, self.implicit()?, call, source) {
 			// After validation, some origin must have been authorized.
 			Ok((_, _, origin)) if !origin.is_transaction_authorized() =>
 				Err(InvalidTransaction::UnknownOrigin.into()),
@@ -108,7 +113,7 @@ where
 		info: &DispatchInfoOf<Call>,
 		len: usize,
 	) -> Result<(T::Pre, Self::Origin), TransactionValidityError> {
-		let (_, val, origin) = self.validate_only(origin, call, info, len)?;
+		let (_, val, origin) = self.validate_only(origin, call, info, len, TransactionSource::InBlock)?;
 		let pre = self.prepare(val, &origin, &call, info, len)?;
 		Ok((pre, origin))
 	}
@@ -140,7 +145,8 @@ where
 			Self::Origin,
 		) -> crate::DispatchResultWithInfo<<Call as Dispatchable>::PostInfo>,
 	) -> Self::Result {
-		let (pre, origin) = self.validate_and_prepare(origin, &call, info, len)?;
+		let (pre, origin) =
+			self.validate_and_prepare(origin, &call, info, len)?;
 		let mut res = substitute(origin);
 		let pd_res = res.map(|_| ()).map_err(|e| e.error);
 		let post_info = match &mut res {

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -292,6 +292,7 @@ impl sp_runtime::traits::TransactionExtension<RuntimeCall> for CheckSubstrateCal
 		_len: usize,
 		_self_implicit: Self::Implicit,
 		_inherited_implication: &impl Encode,
+		_source: TransactionSource,
 	) -> Result<
 		(ValidTransaction, Self::Val, <RuntimeCall as Dispatchable>::RuntimeOrigin),
 		TransactionValidityError,
@@ -1054,6 +1055,7 @@ mod tests {
 	use sp_runtime::{
 		traits::{DispatchTransaction, Hash as _},
 		transaction_validity::{InvalidTransaction, ValidTransaction},
+		transaction_validity::TransactionSource::External,
 	};
 	use substrate_test_runtime_client::{
 		prelude::*, runtime::TestAPI, DefaultTestClientBuilderExt, TestClientBuilder,
@@ -1211,6 +1213,7 @@ mod tests {
 						&ExtrinsicBuilder::new_call_with_priority(16).build().function,
 						&info,
 						len,
+						External,
 					)
 					.unwrap()
 					.0
@@ -1225,6 +1228,7 @@ mod tests {
 						&ExtrinsicBuilder::new_call_do_not_propagate().build().function,
 						&info,
 						len,
+						External,
 					)
 					.unwrap()
 					.0


### PR DESCRIPTION
### Meta 

This PR is part of 4 PR:
* 1 - this one: add `TransactionSource` as argument in `TransactionExtension::validate`
* 2 - implement a new attribute in pallet macro: `#[pallet::authorize(...)]` that allows to define a special function to validate the call.
* 3 - use `#[pallet::authorize(...)]` to migrate unsigned in system
* 4 - use `#[pallet::authorize(...)]` to migrate all unsigned in polkadot-sdk

### Description

One goal of transaction extension is to get rid or unsigned transactions.

But unsigned transaction validation has access to the `TransactionSource`.

The source is used for unsigned transactions that the node trust and don't want to pay upfront.

Instead of using transaction source we could do: the transaction is valid if it is signed by the block author, conceptually it should work, but it doesn't look so easy.