### PR TITLE
[Tx ext stage 2: 3/4]  use `#[pallet::authorize(...)]` to migrate unsigned in system: tasks + apply_authorized_call

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/frame_system.rs
@@ -179,4 +179,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/frame_system.rs
@@ -178,4 +178,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/frame_system.rs
@@ -178,4 +178,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/frame_system.rs
@@ -179,4 +179,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/frame_system.rs
@@ -178,4 +178,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/weights/frame_system.rs
@@ -187,4 +187,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/weights/frame_system.rs
@@ -187,4 +187,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-rococo/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/weights/frame_system.rs
@@ -157,4 +157,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/cumulus/parachains/runtimes/people/people-westend/src/weights/frame_system.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/weights/frame_system.rs
@@ -157,4 +157,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/polkadot/runtime/rococo/src/weights/frame_system.rs
+++ b/polkadot/runtime/rococo/src/weights/frame_system.rs
@@ -171,4 +171,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/polkadot/runtime/westend/src/weights/frame_system.rs
+++ b/polkadot/runtime/westend/src/weights/frame_system.rs
@@ -171,4 +171,7 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		Weight::zero()
+	}
 }

--- a/substrate/frame/examples/tasks/src/lib.rs
+++ b/substrate/frame/examples/tasks/src/lib.rs
@@ -19,7 +19,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::dispatch::DispatchResult;
-use frame_system::offchain::CreateInherent;
+use frame_system::offchain::CreateAuthorizedTransaction;
 #[cfg(feature = "experimental")]
 use frame_system::offchain::SubmitTransaction;
 // Re-export pallet items so that they can be accessed from the crate namespace.
@@ -77,7 +77,7 @@ pub mod pallet {
 				let call = frame_system::Call::<T>::do_task { task: runtime_task.into() };
 
 				// Submit the task as an unsigned transaction
-				let xt = <T as CreateInherent<frame_system::Call<T>>>::create_inherent(call.into());
+				let xt = <T as CreateAuthorizedTransaction<frame_system::Call<T>>>::create_authorized_transaction(call.into());
 				let res = SubmitTransaction::<T, frame_system::Call<T>>::submit_transaction(xt);
 				match res {
 					Ok(_) => log::info!(target: LOG_TARGET, "Submitted the task."),
@@ -91,7 +91,9 @@ pub mod pallet {
 	}
 
 	#[pallet::config]
-	pub trait Config: CreateInherent<frame_system::Call<Self>> + frame_system::Config {
+	pub trait Config:
+		CreateAuthorizedTransaction<frame_system::Call<Self>> + frame_system::Config
+	{
 		type RuntimeTask: frame_support::traits::Task
 			+ IsType<<Self as frame_system::Config>::RuntimeTask>
 			+ From<Task<Self>>;

--- a/substrate/frame/examples/tasks/src/mock.rs
+++ b/substrate/frame/examples/tasks/src/mock.rs
@@ -20,20 +20,27 @@
 
 use crate::{self as pallet_example_tasks};
 use frame_support::derive_impl;
-use sp_runtime::testing::TestXt;
+use sp_runtime::testing::UintAuthorityId;
 
 pub type AccountId = u32;
 pub type Balance = u32;
 
-type Block = frame_system::mocking::MockBlock<Runtime>;
+pub type TransactionExtension = (frame_system::AuthorizeCall<Runtime>,);
+pub type Header = sp_runtime::generic::Header<u64, sp_runtime::traits::BlakeTwo256>;
+pub type Block = sp_runtime::generic::Block<Header, Extrinsic>;
+pub type Extrinsic = sp_runtime::generic::UncheckedExtrinsic<
+	u64,
+	RuntimeCall,
+	UintAuthorityId,
+	TransactionExtension,
+>;
+
 frame_support::construct_runtime!(
 	pub enum Runtime {
 		System: frame_system,
 		TasksExample: pallet_example_tasks,
 	}
 );
-
-pub type Extrinsic = TestXt<RuntimeCall, ()>;
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
@@ -48,12 +55,23 @@ where
 	type Extrinsic = Extrinsic;
 }
 
-impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Runtime
+impl<LocalCall> frame_system::offchain::CreateTransaction<LocalCall> for Runtime
 where
 	RuntimeCall: From<LocalCall>,
 {
-	fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
-		Extrinsic::new_bare(call)
+	type Extension = TransactionExtension;
+
+	fn create_transaction(call: RuntimeCall, extension: Self::Extension) -> Self::Extrinsic {
+		Extrinsic::new_transaction(call, extension)
+	}
+}
+
+impl<LocalCall> frame_system::offchain::CreateAuthorizedTransaction<LocalCall> for Runtime
+where
+	RuntimeCall: From<LocalCall>,
+{
+	fn create_extension() -> Self::Extension {
+		(frame_system::AuthorizeCall::<Runtime>::new(),)
 	}
 }
 

--- a/substrate/frame/examples/tasks/src/tests.rs
+++ b/substrate/frame/examples/tasks/src/tests.rs
@@ -19,15 +19,23 @@
 #![cfg(test)]
 
 use crate::{mock::*, Numbers};
-#[cfg(feature = "experimental")]
-use codec::Decode;
 use frame_support::traits::Task;
+use sp_runtime::BuildStorage;
+#[cfg(feature = "experimental")]
+use codec::{Decode, Encode};
+#[cfg(feature = "experimental")]
+use frame_support::{
+	assert_noop, assert_ok, dispatch::GetDispatchInfo,
+	storage::{with_transaction_unchecked, TransactionOutcome},
+};
 #[cfg(feature = "experimental")]
 use sp_core::offchain::{testing, OffchainWorkerExt, TransactionPoolExt};
-use sp_runtime::BuildStorage;
-
 #[cfg(feature = "experimental")]
-use frame_support::{assert_noop, assert_ok};
+use sp_runtime::{
+	traits::{Applyable, Checkable},
+	transaction_validity::TransactionSource,
+};
+
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
@@ -157,7 +165,52 @@ fn task_with_offchain_worker() {
 		let tx = pool_state.write().transactions.pop().unwrap();
 		assert!(pool_state.read().transactions.is_empty());
 		let tx = Extrinsic::decode(&mut &*tx).unwrap();
-		use sp_runtime::traits::ExtrinsicLike;
-		assert!(tx.is_bare());
+		assert!(matches!(tx.preamble, sp_runtime::generic::Preamble::General(..)));
+
+		let info = tx.get_dispatch_info();
+		let len = tx.using_encoded(|e| e.len());
+
+		let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
+			.expect("Transaction is general so signature is good");
+
+		with_transaction_unchecked(|| {
+			checked
+				.validate::<Runtime>(TransactionSource::External, &info, len)
+				.expect("call valid");
+			TransactionOutcome::Rollback(())
+		});
+
+		checked
+			.apply::<Runtime>(&info, len)
+			.expect("Transaction is valid")
+			.expect("Transaction is successful");
+	});
+}
+
+#[cfg(feature = "experimental")]
+#[test]
+fn task_with_bare_also_work() {
+	new_test_ext().execute_with(|| {
+		Numbers::<Runtime>::insert(0, 1);
+		let task = <Runtime as frame_system::Config>::RuntimeTask::iter()
+			.next()
+			.expect("There is one task");
+		let call = frame_system::Call::<Runtime>::do_task { task };
+		let tx = Extrinsic::new_bare(call.into());
+
+		let info = tx.get_dispatch_info();
+		let len = tx.using_encoded(|e| e.len());
+
+		let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
+			.expect("Transaction is general so signature is good");
+
+		checked
+			.validate::<Runtime>(TransactionSource::External, &info, len)
+			.expect("call valid");
+
+		checked
+			.apply::<Runtime>(&info, len)
+			.expect("Transaction is valid")
+			.expect("Transaction is successful");
 	});
 }

--- a/substrate/frame/system/benchmarking/src/inner.rs
+++ b/substrate/frame/system/benchmarking/src/inner.rs
@@ -228,5 +228,25 @@ mod benchmarks {
 		Ok(())
 	}
 
+	#[benchmark]
+	fn authorize_apply_authorized_upgrade() -> Result<(), BenchmarkError> {
+		let runtime_blob = T::prepare_set_code_data();
+		T::setup_set_code_requirements(&runtime_blob)?;
+		let hash = T::Hashing::hash(&runtime_blob);
+		// Will be heavier when it needs to do verification (i.e. don't use `...without_checks`).
+		System::<T>::authorize_upgrade(RawOrigin::Root.into(), hash)?;
+
+		let call = Call::<T>::apply_authorized_upgrade { code: runtime_blob };
+
+		#[block]
+		{
+			use frame_support::pallet_prelude::Authorize;
+			call.authorize(TransactionSource::External)
+				.ok_or("Call must give some authorization")??;
+		}
+
+		Ok(())
+	}
+
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -19,12 +19,14 @@ use crate::*;
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::{Pays, PostDispatchInfo, WithPostDispatchInfo},
-	traits::{OnRuntimeUpgrade, WhitelistedStorageKeys},
+	traits::{OnRuntimeUpgrade, UnfilteredDispatchable, WhitelistedStorageKeys},
 };
 use mock::{RuntimeOrigin, *};
 use sp_core::{hexdisplay::HexDisplay, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, Header},
+	transaction_validity::TransactionValidityError,
+	transaction_validity::TransactionSource,
 	DispatchError, DispatchErrorWithPostInfo,
 };
 use std::collections::BTreeSet;
@@ -890,5 +892,50 @@ fn test_default_account_nonce() {
 
 		Account::<Test>::remove(&1);
 		assert_eq!(System::account_nonce(&1), 5u64.into());
+	});
+}
+
+#[test]
+fn set_code_via_authorization_and_general_transaction() {
+	let executor = substrate_test_runtime_client::WasmExecutor::default();
+	let mut ext = new_test_ext();
+	ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(executor));
+	ext.execute_with(|| {
+		System::set_block_number(1);
+		assert!(System::authorized_upgrade().is_none());
+
+		let runtime = substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec();
+		let hash = <mock::Test as pallet::Config>::Hashing::hash(&runtime);
+
+		let apply_call = Call::<Test>::apply_authorized_upgrade { code: runtime };
+
+		// Can't apply before authorization
+		assert_noop!(
+			apply_call.authorize(TransactionSource::External).unwrap(),
+			TransactionValidityError::Invalid(InvalidTransaction::Call.into()),
+		);
+
+		// Can authorize
+		assert_ok!(System::authorize_upgrade(RawOrigin::Root.into(), hash));
+		System::assert_has_event(
+			SysEvent::UpgradeAuthorized { code_hash: hash, check_version: true }.into(),
+		);
+		assert!(System::authorized_upgrade().is_some());
+
+		// Can't be sneaky
+		let mut bad_runtime = substrate_test_runtime_client::runtime::wasm_binary_unwrap().to_vec();
+		bad_runtime.extend(b"sneaky");
+		assert_noop!(
+			Call::<Test>::apply_authorized_upgrade { code: bad_runtime }
+				.authorize(TransactionSource::External)
+				.unwrap(),
+			TransactionValidityError::Invalid(InvalidTransaction::Call.into()),
+		);
+
+		// Can apply correct runtime
+		assert_ok!(apply_call.authorize(TransactionSource::External).unwrap());
+		assert_ok!(apply_call.dispatch_bypass_filter(RawOrigin::Authorized.into()));
+		System::assert_has_event(SysEvent::CodeUpdated.into());
+		assert!(System::authorized_upgrade().is_none());
 	});
 }

--- a/substrate/frame/system/src/weights.rs
+++ b/substrate/frame/system/src/weights.rs
@@ -60,6 +60,7 @@ pub trait WeightInfo {
 	fn kill_prefix(p: u32, ) -> Weight;
 	fn authorize_upgrade() -> Weight;
 	fn apply_authorized_upgrade() -> Weight;
+	fn validate_apply_authorized_upgrade() -> Weight;
 }
 
 /// Weights for `frame_system` using the Substrate node and recommended hardware.
@@ -181,6 +182,10 @@ impl<T: crate::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		// TODO TODO:
+		Weight::zero()
+	}
 }
 
 // For backwards compatibility and tests.
@@ -300,5 +305,9 @@ impl WeightInfo for () {
 		Weight::from_parts(87_636_595_000, 67035)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	fn validate_apply_authorized_upgrade() -> Weight {
+		// TODO TODO:
+		Weight::default()
 	}
 }


### PR DESCRIPTION
### Meta 

This PR is part of 4 PR:
* 1 - this one: add `TransactionSource` as argument in `TransactionExtension::validate`
* 2 - implement a new attribute in pallet macro: `#[pallet::authorize(...)]` that allows to define a special function to validate the call.
* 3 - use `#[pallet::authorize(...)]` to migrate unsigned in system
* 4 - use `#[pallet::authorize(...)]` to migrate all unsigned in polkadot-sdk
