### PR TITLE
Update Pallet Referenda to support  Block Number Provider

### DIFF
--- a/substrate/frame/referenda/src/benchmarking.rs
+++ b/substrate/frame/referenda/src/benchmarking.rs
@@ -33,6 +33,10 @@ use sp_runtime::traits::Bounded as ArithBounded;
 
 const SEED: u32 = 0;
 
+fn set_block_number<T: Config<I>, I: 'static>(n: BlockNumberFor<T>) {
+	<T as Config<I>>::BlockNumberProvider::set_block_number(n);
+}
+
 fn assert_last_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
@@ -151,25 +155,25 @@ fn make_failing<T: Config<I>, I: 'static>(index: ReferendumIndex) {
 fn skip_prepare_period<T: Config<I>, I: 'static>(index: ReferendumIndex) {
 	let status = Referenda::<T, I>::ensure_ongoing(index).unwrap();
 	let prepare_period_over = status.submitted + info::<T, I>(index).prepare_period;
-	frame_system::Pallet::<T>::set_block_number(prepare_period_over);
+	set_block_number::<T, I>(prepare_period_over);
 }
 
 fn skip_decision_period<T: Config<I>, I: 'static>(index: ReferendumIndex) {
 	let status = Referenda::<T, I>::ensure_ongoing(index).unwrap();
 	let decision_period_over = status.deciding.unwrap().since + info::<T, I>(index).decision_period;
-	frame_system::Pallet::<T>::set_block_number(decision_period_over);
+	set_block_number::<T, I>(decision_period_over);
 }
 
 fn skip_confirm_period<T: Config<I>, I: 'static>(index: ReferendumIndex) {
 	let status = Referenda::<T, I>::ensure_ongoing(index).unwrap();
 	let confirm_period_over = status.deciding.unwrap().confirming.unwrap();
-	frame_system::Pallet::<T>::set_block_number(confirm_period_over);
+	set_block_number::<T, I>(confirm_period_over);
 }
 
 fn skip_timeout_period<T: Config<I>, I: 'static>(index: ReferendumIndex) {
 	let status = Referenda::<T, I>::ensure_ongoing(index).unwrap();
 	let timeout_period_over = status.submitted + T::UndecidingTimeout::get();
-	frame_system::Pallet::<T>::set_block_number(timeout_period_over);
+	set_block_number::<T, I>(timeout_period_over);
 }
 
 fn alarm_time<T: Config<I>, I: 'static>(

--- a/substrate/frame/referenda/src/mock.rs
+++ b/substrate/frame/referenda/src/mock.rs
@@ -206,6 +206,7 @@ impl Config for Test {
 	type AlarmInterval = AlarmInterval;
 	type Tracks = TestTracksInfo;
 	type Preimages = Preimage;
+	type BlockNumberProvider = System;
 }
 pub struct ExtBuilder {}
 


### PR DESCRIPTION
This PR introduces BlockNumberProvider config for the referenda pallet.
closes part of https://github.com/paritytech/polkadot-sdk/issues/6297