### PR TITLE
litep2p: Update litep2p to v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9400,9 +9400,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ab2528b02b6dbbc3e6ec4b55ccde885647c622a315b7da45081ed2dfe4b813"
+checksum = "7286b1971f85d1d60be40ef49e81c1f3b5a0d8b83cfa02ab53591cdacae22901"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -848,7 +848,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.7.0", features = ["websocket"] }
+litep2p = { version = "0.8.0", features = ["websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }

--- a/prdoc/pr_6353.prdoc
+++ b/prdoc/pr_6353.prdoc
@@ -1,0 +1,12 @@
+title: Update litep2p network backend to version 0.8.0
+
+doc:
+  - audience: [ Node Dev, Node Operator ]
+    description: |
+      This release adds support for content provider advertisement and discovery to Kademlia protocol implementation (see libp2p
+      [spec](https://github.com/libp2p/specs/blob/master/kad-dht/README.md#content-provider-advertisement-and-discovery)).
+      Additionally, the release includes several improvements and memory leak fixes to enhance the stability and performance of the litep2p library.
+
+crates:
+  - name: sc-network
+    bump: patch

--- a/prdoc/pr_6353.prdoc
+++ b/prdoc/pr_6353.prdoc
@@ -3,9 +3,7 @@ title: Update litep2p network backend to version 0.8.0
 doc:
   - audience: [ Node Dev, Node Operator ]
     description: |
-      This release adds support for content provider advertisement and discovery to Kademlia protocol implementation (see libp2p
-      [spec](https://github.com/libp2p/specs/blob/master/kad-dht/README.md#content-provider-advertisement-and-discovery)).
-      Additionally, the release includes several improvements and memory leak fixes to enhance the stability and performance of the litep2p library.
+      Release 0.8.0 of litep2p includes several improvements and memory leak fixes enhancing the stability and performance of the litep2p network backend.
 
 crates:
   - name: sc-network

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -576,6 +576,9 @@ impl Stream for Discovery {
 
 				return Poll::Ready(Some(DiscoveryEvent::IncomingRecord { record }))
 			},
+			// Content provider events are ignored for now.
+			Poll::Ready(Some(KademliaEvent::GetProvidersSuccess { .. })) |
+			Poll::Ready(Some(KademliaEvent::IncomingProvider { .. })) => {},
 		}
 
 		match Pin::new(&mut this.identify_event_stream).poll_next(cx) {

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -553,7 +553,7 @@ impl Stream for Discovery {
 
 				return Poll::Ready(Some(DiscoveryEvent::GetRecordSuccess { query_id, records }));
 			},
-			Poll::Ready(Some(KademliaEvent::PutRecordSucess { query_id, key: _ })) =>
+			Poll::Ready(Some(KademliaEvent::PutRecordSuccess { query_id, key: _ })) =>
 				return Poll::Ready(Some(DiscoveryEvent::PutRecordSuccess { query_id })),
 			Poll::Ready(Some(KademliaEvent::QueryFailed { query_id })) => {
 				match this.find_node_query_id == Some(query_id) {


### PR DESCRIPTION
This PR updates litep2p to the latest release.

- `KademliaEvent::PutRecordSucess` is renamed to fix word typo
- `KademliaEvent::GetProvidersSuccess` and `KademliaEvent::IncomingProvider` are needed for bootnodes on DHT work and will be utilized later


### Added

- kad: Providers part 8: unit, e2e, and `libp2p` conformance tests  ([#258](https://github.com/paritytech/litep2p/pull/258))
- kad: Providers part 7: better types and public API, public addresses & known providers  ([#246](https://github.com/paritytech/litep2p/pull/246))
- kad: Providers part 6: stop providing  ([#245](https://github.com/paritytech/litep2p/pull/245))
- kad: Providers part 5: `GET_PROVIDERS` query  ([#236](https://github.com/paritytech/litep2p/pull/236))
- kad: Providers part 4: refresh local providers  ([#235](https://github.com/paritytech/litep2p/pull/235))
- kad: Providers part 3: publish provider records (start providing)  ([#234](https://github.com/paritytech/litep2p/pull/234))

### Changed

- transport_service: Improve connection stability by downgrading connections on substream inactivity  ([#260](https://github.com/paritytech/litep2p/pull/260))
- transport: Abort canceled dial attempts for TCP, WebSocket and Quic  ([#255](https://github.com/paritytech/litep2p/pull/255))
- kad/executor: Add timeout for writting frames  ([#277](https://github.com/paritytech/litep2p/pull/277))
- kad: Avoid cloning the `KademliaMessage` and use reference for `RoutingTable::closest`  ([#233](https://github.com/paritytech/litep2p/pull/233))
- peer_state: Robust state machine transitions  ([#251](https://github.com/paritytech/litep2p/pull/251))
- address_store: Improve address tracking and add eviction algorithm  ([#250](https://github.com/paritytech/litep2p/pull/250))
- kad: Remove unused serde cfg  ([#262](https://github.com/paritytech/litep2p/pull/262))
- req-resp: Refactor to move functionality to dedicated methods  ([#244](https://github.com/paritytech/litep2p/pull/244))
- transport_service: Improve logs and move code from tokio::select macro  ([#254](https://github.com/paritytech/litep2p/pull/254))

### Fixed

- tcp/websocket/quic: Fix cancel memory leak  ([#272](https://github.com/paritytech/litep2p/pull/272))
- transport: Fix pending dials memory leak  ([#271](https://github.com/paritytech/litep2p/pull/271))
- ping: Fix memory leak of unremoved `pending_opens`  ([#274](https://github.com/paritytech/litep2p/pull/274))
- identify: Fix memory leak of unused `pending_opens`  ([#273](https://github.com/paritytech/litep2p/pull/273))
- kad: Fix not retrieving local records  ([#221](https://github.com/paritytech/litep2p/pull/221))

See release changelog for more details: https://github.com/paritytech/litep2p/releases/tag/v0.8.0

cc @paritytech/networking 