### PR TITLE
Remove leftover references of Wococo

### DIFF
--- a/bridges/primitives/messages/src/lane.rs
+++ b/bridges/primitives/messages/src/lane.rs
@@ -108,8 +108,8 @@ impl TypeId for LegacyLaneId {
 /// concatenation (separated by some binary data). I.e.:
 ///
 /// ```nocompile
-/// let endpoint1 = X2(GlobalConsensus(NetworkId::Rococo), Parachain(42));
-/// let endpoint2 = X2(GlobalConsensus(NetworkId::Wococo), Parachain(777));
+/// let endpoint1 = X2(GlobalConsensus(NetworkId::Polkadot), Parachain(42));
+/// let endpoint2 = X2(GlobalConsensus(NetworkId::Kusama), Parachain(777));
 ///
 /// let final_lane_key = if endpoint1 < endpoint2 {
 ///     (endpoint1, VALUES_SEPARATOR, endpoint2)

--- a/cumulus/parachains/runtimes/assets/common/src/matching.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/matching.rs
@@ -149,7 +149,7 @@ mod tests {
 
 	parameter_types! {
 		pub UniversalLocation: InteriorLocation = [GlobalConsensus(Rococo), Parachain(1000)].into();
-		pub ExpectedNetworkId: NetworkId = Wococo;
+		pub ExpectedNetworkId: NetworkId = Westend;
 	}
 
 	#[test]
@@ -158,13 +158,13 @@ mod tests {
 		let asset: Location = (
 			Parent,
 			Parent,
-			GlobalConsensus(Wococo),
+			GlobalConsensus(Westend),
 			Parachain(1000),
 			PalletInstance(1),
 			GeneralIndex(1),
 		)
 			.into();
-		let origin: Location = (Parent, Parent, GlobalConsensus(Wococo), Parachain(1000)).into();
+		let origin: Location = (Parent, Parent, GlobalConsensus(Westend), Parachain(1000)).into();
 		assert!(FromNetwork::<UniversalLocation, ExpectedNetworkId>::contains(&asset, &origin));
 
 		// asset and origin from local consensus fails
@@ -195,14 +195,14 @@ mod tests {
 			GeneralIndex(1),
 		)
 			.into();
-		let origin: Location = (Parent, Parent, GlobalConsensus(Wococo), Parachain(1000)).into();
+		let origin: Location = (Parent, Parent, GlobalConsensus(Westend), Parachain(1000)).into();
 		assert!(!FromNetwork::<UniversalLocation, ExpectedNetworkId>::contains(&asset, &origin));
 
 		// origin from different consensus fails
 		let asset: Location = (
 			Parent,
 			Parent,
-			GlobalConsensus(Wococo),
+			GlobalConsensus(Westend),
 			Parachain(1000),
 			PalletInstance(1),
 			GeneralIndex(1),

--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -79,7 +79,7 @@ pub struct RunCmd {
 
 	/// Disable the BEEFY gadget.
 	///
-	/// Currently enabled by default on 'Rococo', 'Wococo' and 'Versi'.
+	/// Currently enabled by default.
 	#[arg(long)]
 	pub no_beefy: bool,
 


### PR DESCRIPTION
Remove references of now defunct Wococo network.

The XCM `NetworkId::Wococo` will also be removed with [XCMv5 PR](https://github.com/paritytech/polkadot-sdk/pull/4826)