### PR TITLE
[WIP]: Update Scheduler to Support Relay Chain Block Number Provider #3970

### DIFF
--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -604,11 +604,13 @@ parameter_types! {
 #[cfg(not(feature = "runtime-benchmarks"))]
 parameter_types! {
 	pub const MaxScheduledPerBlock: u32 = 50;
+	pub const MaxScheduledBlocks: u32 = 50;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
 parameter_types! {
 	pub const MaxScheduledPerBlock: u32 = 200;
+	pub const MaxScheduledBlocks: u32 = 200;
 }
 
 impl pallet_scheduler::Config for Runtime {
@@ -622,6 +624,8 @@ impl pallet_scheduler::Config for Runtime {
 	type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
 	type OriginPrivilegeCmp = EqualOrGreatestRootCmp;
 	type Preimages = Preimage;
+	type BlockNumberProvider = frame_system::Pallet<Runtime>;
+	type MaxScheduledBlocks = MaxScheduledBlocks;
 }
 
 parameter_types! {

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -231,6 +231,7 @@ parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
 		BlockWeights::get().max_block;
 	pub const MaxScheduledPerBlock: u32 = 50;
+	pub const MaxScheduledBlocks: u32 = 50;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
 
@@ -331,6 +332,8 @@ impl pallet_scheduler::Config for Runtime {
 	type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
 	type OriginPrivilegeCmp = OriginPrivilegeCmp;
 	type Preimages = Preimage;
+	type BlockNumberProvider = frame_system::Pallet<Runtime>;
+	type MaxScheduledBlocks = MaxScheduledBlocks;
 }
 
 parameter_types! {

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -231,6 +231,7 @@ parameter_types! {
 	pub MaximumSchedulerWeight: frame_support::weights::Weight = Perbill::from_percent(80) *
 		BlockWeights::get().max_block;
 	pub const MaxScheduledPerBlock: u32 = 50;
+	pub const MaxScheduledBlocks: u32 = 50;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
 
@@ -247,6 +248,8 @@ impl pallet_scheduler::Config for Runtime {
 	type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
 	type OriginPrivilegeCmp = frame_support::traits::EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type BlockNumberProvider = frame_system::Pallet<Runtime>;
+	type MaxScheduledBlocks = MaxScheduledBlocks;
 }
 
 parameter_types! {

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -462,6 +462,11 @@ impl pallet_scheduler::Config for Runtime {
 	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type BlockNumberProvider = frame_system::Pallet<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type MaxScheduledBlocks = ConstU32<512>;
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	type MaxScheduledBlocks = ConstU32<50>;
 }
 
 impl pallet_glutton::Config for Runtime {

--- a/substrate/frame/democracy/src/tests.rs
+++ b/substrate/frame/democracy/src/tests.rs
@@ -106,6 +106,8 @@ impl pallet_scheduler::Config for Test {
 	type WeightInfo = ();
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = ();
+	type BlockNumberProvider = frame_system::Pallet<Test>;
+	type MaxScheduledBlocks = ConstU32<100>;
 }
 
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]

--- a/substrate/frame/referenda/src/mock.rs
+++ b/substrate/frame/referenda/src/mock.rs
@@ -81,6 +81,8 @@ impl pallet_scheduler::Config for Test {
 	type WeightInfo = ();
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type BlockNumberProvider = frame_system::Pallet<Test>;
+	type MaxScheduledBlocks = ConstU32<100>;
 }
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {

--- a/substrate/frame/scheduler/src/lib.rs
+++ b/substrate/frame/scheduler/src/lib.rs
@@ -107,7 +107,7 @@ use frame_system::{
 use scale_info::TypeInfo;
 use sp_io::hashing::blake2_256;
 use sp_runtime::{
-	traits::{BadOrigin, Dispatchable, One, Saturating, Zero},
+	traits::{BadOrigin, BlockNumberProvider, Dispatchable, One, Saturating, Zero},
 	BoundedVec, DispatchError, RuntimeDebug,
 };
 
@@ -292,6 +292,9 @@ pub mod pallet {
 
 		/// The preimage provider with which we look up call hashes to get the call.
 		type Preimages: QueryPreimage<H = Self::Hashing> + StorePreimage;
+
+		/// Provider for the block number. Normally this is the `frame_system` pallet.
+		type BlockNumberProvider: BlockNumberProvider<BlockNumber = BlockNumberFor<Self>>;
 	}
 
 	#[pallet::storage]
@@ -889,7 +892,7 @@ impl<T: Config> Pallet<T> {
 	fn resolve_time(
 		when: DispatchTime<BlockNumberFor<T>>,
 	) -> Result<BlockNumberFor<T>, DispatchError> {
-		let now = frame_system::Pallet::<T>::block_number();
+		let now = T::BlockNumberProvider::current_block_number();
 
 		let when = match when {
 			DispatchTime::At(x) => x,

--- a/substrate/frame/scheduler/src/mock.rs
+++ b/substrate/frame/scheduler/src/mock.rs
@@ -228,6 +228,7 @@ impl Config for Test {
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
 	type BlockNumberProvider = frame_system::Pallet<Self>;
+	type MaxScheduledBlocks = ConstU32<20>;
 }
 
 pub type LoggerCall = logger::Call<Test>;

--- a/substrate/frame/scheduler/src/mock.rs
+++ b/substrate/frame/scheduler/src/mock.rs
@@ -227,6 +227,7 @@ impl Config for Test {
 	type WeightInfo = TestWeightInfo;
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = Preimage;
+	type BlockNumberProvider = frame_system::Pallet<Self>;
 }
 
 pub type LoggerCall = logger::Call<Test>;
@@ -242,6 +243,12 @@ pub fn run_to_block(n: u64) {
 		System::set_block_number(System::block_number() + 1);
 		Scheduler::on_initialize(System::block_number());
 	}
+}
+
+pub fn go_to_block(n: u64) {
+	System::set_block_number(n);
+	Scheduler::on_initialize(n);
+	Scheduler::on_finalize(n);
 }
 
 pub fn root() -> OriginCaller {

--- a/substrate/frame/scheduler/src/tests.rs
+++ b/substrate/frame/scheduler/src/tests.rs
@@ -1683,10 +1683,7 @@ fn on_initialize_weight_is_correct() {
 		// Will contain none
 		System::set_block_number(4);
 		let actual_weight = Scheduler::on_initialize(4);
-		assert_eq!(
-			actual_weight,
-			TestWeightInfo::service_agendas_base() + TestWeightInfo::service_agenda_base(0)
-		);
+		assert_eq!(actual_weight, TestWeightInfo::service_agendas_base());
 	});
 }
 


### PR DESCRIPTION
Step in https://github.com/paritytech/polkadot-sdk/issues/6297

This PR adds a Queue to the scheduler pallet that helps in tracking the block numbers with valid agenda. This helps in scheduling the tasks even if the pallet is deployed on a parachain that does not produce blocks on a regular cadence.

Todo
- [ ] Migration
- [ ] Update Benchmarks