### PR TITLE
templates/parachain: add polkadot wiki reference in README

### DIFF
--- a/templates/parachain/README.md
+++ b/templates/parachain/README.md
@@ -27,6 +27,7 @@
   - [Connect with the Polkadot-JS Apps Front-End](#connect-with-the-polkadot-js-apps-front-end)
   - [Takeaways](#takeaways)
 
+- [Deploying a Parachain](#deploying-a-parachain)
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 
@@ -196,6 +197,10 @@ Development parachains:
 - 🧹 Do not persist the state.
 - 💰 Are preconfigured with a genesis state that includes several prefunded development accounts.
 - 🧑‍⚖️ Development accounts are used as validators, collators, and `sudo` accounts.
+
+## Deploying a Parachain
+
+A deployment guide can be found on [`Polkadot Wiki`](https://wiki.polkadot.network/docs/build-guides-template-basic).
 
 ## Contributing
 


### PR DESCRIPTION
# Description

Adds a reference at the end towards a guide for deploying a parachain. The guide is on Polkadot Wiki, and now it refers to `polkadot-parachain`. Pending on some wiki updates tracked under: https://github.com/w3f/polkadot-wiki/issues/5928.

## Integration

N/A, just better linking of resources starting from the templates for everyone.

## Review Notes

The Polkadot Wiki guide refers to `polkadot-parachain` binary for template deployment, while the parachain template README refers to `polkadot-omni-node` for regular development.

Omni node docs present a unified user journey based on `polkadot-omni-node`: https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/omni_node/index.html#omnitools-user-journey. No mention of `polkadot-parachain`, or existing docs to clarify its scope. At the same time there is no need to do it, since `polkadot-parachain` is more like an example of `polkadot-omni-node-lib` usage, while `polkadot-omni-node-bin` will be the go to node that should be able to wrap around most of the runtimes (and if not, extended to do so for the reasonable use cases).