### PR TITLE
`chain-spec-builder`: info about patch/full files added

### DIFF
--- a/prdoc/pr_6373.prdoc
+++ b/prdoc/pr_6373.prdoc
@@ -1,8 +1,8 @@
 title: '`chain-spec-builder`: info about patch/full files added'
 doc:
-- audience: Todo
+- audience: Runtime User
   description: There was no good example of what is patch and full genesis config
     file. Some explanation and example were to the `chain-spec-builder` doc.
 crates:
 - name: staging-chain-spec-builder
-  bump: major
+  bump: patch

--- a/prdoc/pr_6373.prdoc
+++ b/prdoc/pr_6373.prdoc
@@ -2,7 +2,7 @@ title: '`chain-spec-builder`: info about patch/full files added'
 doc:
 - audience: Runtime User
   description: There was no good example of what is patch and full genesis config
-    file. Some explanation and example were to the `chain-spec-builder` doc.
+    file. Some explanation and example were added to the `chain-spec-builder` doc.
 crates:
 - name: staging-chain-spec-builder
   bump: patch

--- a/prdoc/pr_6373.prdoc
+++ b/prdoc/pr_6373.prdoc
@@ -1,0 +1,8 @@
+title: '`chain-spec-builder`: info about patch/full files added'
+doc:
+- audience: Todo
+  description: There was no good example of what is patch and full genesis config
+    file. Some explanation and example were to the `chain-spec-builder` doc.
+crates:
+- name: staging-chain-spec-builder
+  bump: major

--- a/substrate/bin/utils/chain-spec-builder/README.docify.md
+++ b/substrate/bin/utils/chain-spec-builder/README.docify.md
@@ -73,6 +73,8 @@ storage (`-s`) version of chain spec:
 
 <!-- docify::embed!("tests/test.rs", cmd_create_with_patch_raw)-->
 
+Refer to [*patch file*](#patch-file) for some details on the patch file format.
+
 _Note:_ [`GenesisBuilder::get_preset`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.get_preset)
 and
 [`GenesisBuilder::build_state`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.build_state)
@@ -84,6 +86,8 @@ Build the chain spec using provided full genesis config json file. No defaults w
 
 <!-- docify::embed!("tests/test.rs", cmd_create_full_raw)-->
 
+Refer to [*full config file*](#full-genesis-config-files) for some details on the full file format.
+
 _Note_: [`GenesisBuilder::build_state`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.build_state)
 runtime function is called.
 
@@ -91,9 +95,49 @@ runtime function is called.
 
 <!-- docify::embed!("tests/test.rs", cmd_create_with_patch_plain)-->
 
+Refer to [*patch file*](#patch-file) for some details on the patch file format.
+
 ### Generate human readable chain spec using provided full genesis config
 
 <!-- docify::embed!("tests/test.rs", cmd_create_full_plain)-->
+
+Refer to [*full config file*](#full-genesis-config-file) for some details on the full file format.
+
+
+## Patch and full genesis config files
+This section provides details on the files that cane be used with `create patch` or `create full` subcommands.
+
+### Patch file
+The patch file for genesis config contains the key-value pairs valid for given runtime, that needs to be customized,
+	e.g:
+```
+{
+	"balances": {
+		"balances": [
+			[
+				"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+			    1000000000000000
+			],
+			[
+				"5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
+			     1000000000000000
+			],
+			[
+				"5CcjiSgG2KLuKAsqkE2Nak1S2FbAcMr5SxRASUuwR3zSNV2b",
+			    5000000000000000
+			]
+		]
+	},
+	"sudo": {
+		"key": "5Ff3iXP75ruzroPWRP2FYBHWnmGGBSb63857BgnzCoXNxfPo"
+	}
+}
+```
+The rest of genesis config keys will be initialized with default values.
+
+### Full genesis config file.
+The full genesis config file shall contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
+similar to patch format. Example is not provided here as it heavily depends on the runtime.
 
 ### Extra tools
 

--- a/substrate/bin/utils/chain-spec-builder/README.docify.md
+++ b/substrate/bin/utils/chain-spec-builder/README.docify.md
@@ -86,7 +86,7 @@ Build the chain spec using provided full genesis config json file. No defaults w
 
 <!-- docify::embed!("tests/test.rs", cmd_create_full_raw)-->
 
-Refer to [*full config file*](#full-genesis-config-files) for some details on the full file format.
+Refer to [*full config file*](#full-genesis-config-file) for some details on the full file format.
 
 _Note_: [`GenesisBuilder::build_state`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.build_state)
 runtime function is called.
@@ -105,7 +105,7 @@ Refer to [*full config file*](#full-genesis-config-file) for some details on the
 
 
 ## Patch and full genesis config files
-This section provides details on the files that cane be used with `create patch` or `create full` subcommands.
+This section provides details on the files that can be used with `create patch` or `create full` subcommands.
 
 ### Patch file
 The patch file for genesis config contains the key-value pairs valid for given runtime, that needs to be customized,
@@ -136,7 +136,7 @@ The patch file for genesis config contains the key-value pairs valid for given r
 The rest of genesis config keys will be initialized with default values.
 
 ### Full genesis config file.
-The full genesis config file shall contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
+The full genesis config file must contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
 similar to patch format. Example is not provided here as it heavily depends on the runtime.
 
 ### Extra tools

--- a/substrate/bin/utils/chain-spec-builder/README.docify.md
+++ b/substrate/bin/utils/chain-spec-builder/README.docify.md
@@ -135,9 +135,9 @@ The patch file for genesis config contains the key-value pairs valid for given r
 ```
 The rest of genesis config keys will be initialized with default values.
 
-### Full genesis config file.
-The full genesis config file must contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
-similar to patch format. Example is not provided here as it heavily depends on the runtime.
+### Full genesis config file
+The full genesis config file must contain values for *all* the keys present in the genesis config for given runtime. The
+format of the file is similar to patch format. Example is not provided here as it heavily depends on the runtime.
 
 ### Extra tools
 

--- a/substrate/bin/utils/chain-spec-builder/README.docify.md
+++ b/substrate/bin/utils/chain-spec-builder/README.docify.md
@@ -110,7 +110,7 @@ This section provides details on the files that can be used with `create patch` 
 ### Patch file
 The patch file for genesis config contains the key-value pairs valid for given runtime, that needs to be customized,
 	e.g:
-```
+```ignore
 {
 	"balances": {
 		"balances": [

--- a/substrate/bin/utils/chain-spec-builder/README.md
+++ b/substrate/bin/utils/chain-spec-builder/README.md
@@ -173,9 +173,9 @@ The patch file for genesis config contains the key-value pairs valid for given r
 ```
 The rest of genesis config keys will be initialized with default values.
 
-### Full genesis config file.
-The full genesis config file must contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
-similar to patch format. Example is not provided here as it heavily depends on the runtime.
+### Full genesis config file
+The full genesis config file must contain values for *all* the keys present in the genesis config for given runtime. The
+format of the file is similar to patch format. Example is not provided here as it heavily depends on the runtime.
 
 ### Extra tools
 

--- a/substrate/bin/utils/chain-spec-builder/README.md
+++ b/substrate/bin/utils/chain-spec-builder/README.md
@@ -116,7 +116,7 @@ bash!(
 )
 ```
 
-Refer to [*full config file*](#full-genesis-config-files) for some details on the full file format.
+Refer to [*full config file*](#full-genesis-config-file) for some details on the full file format.
 
 _Note_: [`GenesisBuilder::build_state`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.build_state)
 runtime function is called.
@@ -143,7 +143,7 @@ Refer to [*full config file*](#full-genesis-config-file) for some details on the
 
 
 ## Patch and full genesis config files
-This section provides details on the files that cane be used with `create patch` or `create full` subcommands.
+This section provides details on the files that can be used with `create patch` or `create full` subcommands.
 
 ### Patch file
 The patch file for genesis config contains the key-value pairs valid for given runtime, that needs to be customized,
@@ -174,7 +174,7 @@ The patch file for genesis config contains the key-value pairs valid for given r
 The rest of genesis config keys will be initialized with default values.
 
 ### Full genesis config file.
-The full genesis config file shall contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
+The full genesis config file must contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
 similar to patch format. Example is not provided here as it heavily depends on the runtime.
 
 ### Extra tools

--- a/substrate/bin/utils/chain-spec-builder/README.md
+++ b/substrate/bin/utils/chain-spec-builder/README.md
@@ -148,7 +148,7 @@ This section provides details on the files that can be used with `create patch` 
 ### Patch file
 The patch file for genesis config contains the key-value pairs valid for given runtime, that needs to be customized,
 	e.g:
-```
+```ignore
 {
 	"balances": {
 		"balances": [

--- a/substrate/bin/utils/chain-spec-builder/README.md
+++ b/substrate/bin/utils/chain-spec-builder/README.md
@@ -99,6 +99,8 @@ bash!(
 )
 ```
 
+Refer to [*patch file*](#patch-file) for some details on the patch file format.
+
 _Note:_ [`GenesisBuilder::get_preset`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.get_preset)
 and
 [`GenesisBuilder::build_state`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.build_state)
@@ -114,6 +116,8 @@ bash!(
 )
 ```
 
+Refer to [*full config file*](#full-genesis-config-files) for some details on the full file format.
+
 _Note_: [`GenesisBuilder::build_state`](https://docs.rs/sp-genesis-builder/latest/sp_genesis_builder/trait.GenesisBuilder.html#method.build_state)
 runtime function is called.
 
@@ -125,6 +129,8 @@ bash!(
 )
 ```
 
+Refer to [*patch file*](#patch-file) for some details on the patch file format.
+
 ### Generate human readable chain spec using provided full genesis config
 
 ```rust,ignore
@@ -132,6 +138,44 @@ bash!(
 	chain-spec-builder -c "/dev/stdout" create -r $runtime_path full "tests/input/full.json"
 )
 ```
+
+Refer to [*full config file*](#full-genesis-config-file) for some details on the full file format.
+
+
+## Patch and full genesis config files
+This section provides details on the files that cane be used with `create patch` or `create full` subcommands.
+
+### Patch file
+The patch file for genesis config contains the key-value pairs valid for given runtime, that needs to be customized,
+	e.g:
+```
+{
+	"balances": {
+		"balances": [
+			[
+				"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+			    1000000000000000
+			],
+			[
+				"5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
+			     1000000000000000
+			],
+			[
+				"5CcjiSgG2KLuKAsqkE2Nak1S2FbAcMr5SxRASUuwR3zSNV2b",
+			    5000000000000000
+			]
+		]
+	},
+	"sudo": {
+		"key": "5Ff3iXP75ruzroPWRP2FYBHWnmGGBSb63857BgnzCoXNxfPo"
+	}
+}
+```
+The rest of genesis config keys will be initialized with default values.
+
+### Full genesis config file.
+The full genesis config file shall contain values for *all* the keys present in the genesis config for given runtime. The format of the file is
+similar to patch format. Example is not provided here as it heavily depends on the runtime.
 
 ### Extra tools
 


### PR DESCRIPTION
There was no good example of what is patch and full genesis config file. Some explanation and example were added to the `chain-spec-builder` doc.