### PR TITLE
polkadot-service: Fix flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15992,7 +15992,6 @@ dependencies = [
  "sc-transaction-pool-api",
  "serde",
  "serde_json",
- "serial_test",
  "sp-api 26.0.0",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -20639,31 +20638,6 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot 0.12.3",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1210,7 +1210,6 @@ serde-big-array = { version = "0.3.2" }
 serde_derive = { version = "1.0.117" }
 serde_json = { version = "1.0.132", default-features = false }
 serde_yaml = { version = "0.9" }
-serial_test = { version = "2.0.0" }
 sha1 = { version = "0.10.6" }
 sha2 = { version = "0.10.7", default-features = false }
 sha3 = { version = "0.10.0", default-features = false }

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -140,7 +140,6 @@ polkadot-node-subsystem-test-helpers = { workspace = true }
 polkadot-primitives-test-helpers = { workspace = true }
 sp-tracing = { workspace = true }
 assert_matches = { workspace = true }
-serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [features]


### PR DESCRIPTION
The tests used the same paths. When run on CI, each test is run in its own process and thus, this "serial_test" crate wasn't used. The tests are now using their own thread local tempdir, which ensures that the tests are working when running in parallel in the same program or when being run individually.


