### PR TITLE
[Release|CI/CD] Fix GH_TOKEN owner

### DIFF
--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -42,7 +42,7 @@ jobs:
         with:
             app-id: ${{ vars.RELEASE_AUTOMATION_APP_ID }}
             private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
-            owner: paritytech-release
+            owner: paritytech
 
       - name: Checkout sources
         uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7

--- a/.github/workflows/release-branchoff-stable.yml
+++ b/.github/workflows/release-branchoff-stable.yml
@@ -58,7 +58,7 @@ jobs:
         with:
             app-id: ${{ vars.RELEASE_AUTOMATION_APP_ID }}
             private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
-            owner: paritytech-release
+            owner: paritytech
 
       - name: Checkout sources
         uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7


### PR DESCRIPTION
A quick fix to the step that generates temporary token used in the pipeline