### PR TITLE
Small nits for XCMv5

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
@@ -250,7 +250,11 @@ pub(crate) fn open_bridge_between_asset_hub_rococo_and_asset_hub_westend() {
 	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id(), ROC * 5);
 	AssetHubRococo::open_bridge(
 		AssetHubRococo::sibling_location_of(BridgeHubRococo::para_id()),
-		[GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(AssetHubWestend::para_id().into())].into(),
+		[
+			GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)),
+			Parachain(AssetHubWestend::para_id().into()),
+		]
+		.into(),
 		Some((
 			(roc_at_ah_rococo(), ROC * 1).into(),
 			BridgeHubRococo::sovereign_account_id_of(BridgeHubRococo::sibling_location_of(
@@ -263,7 +267,11 @@ pub(crate) fn open_bridge_between_asset_hub_rococo_and_asset_hub_westend() {
 	BridgeHubWestend::fund_para_sovereign(AssetHubWestend::para_id(), WND * 5);
 	AssetHubWestend::open_bridge(
 		AssetHubWestend::sibling_location_of(BridgeHubWestend::para_id()),
-		[GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(AssetHubRococo::para_id().into())].into(),
+		[
+			GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+			Parachain(AssetHubRococo::para_id().into()),
+		]
+		.into(),
 		Some((
 			(wnd_at_ah_westend(), WND * 1).into(),
 			BridgeHubWestend::sovereign_account_id_of(BridgeHubWestend::sibling_location_of(

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
@@ -711,7 +711,9 @@ fn send_pens_and_wnds_from_penpal_westend_via_ahw_to_ahr() {
 		pens_at_ahw
 			.interior()
 			.clone()
-			.pushed_front_with(Junction::GlobalConsensus(NetworkId::ByGenesis(WESTEND_GENESIS_HASH)))
+			.pushed_front_with(Junction::GlobalConsensus(NetworkId::ByGenesis(
+				WESTEND_GENESIS_HASH,
+			)))
 			.unwrap(),
 	);
 	let wnds_to_send = amount;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
@@ -260,7 +260,11 @@ pub(crate) fn open_bridge_between_asset_hub_rococo_and_asset_hub_westend() {
 	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id(), ROC * 5);
 	AssetHubRococo::open_bridge(
 		AssetHubRococo::sibling_location_of(BridgeHubRococo::para_id()),
-		[GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(AssetHubWestend::para_id().into())].into(),
+		[
+			GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)),
+			Parachain(AssetHubWestend::para_id().into()),
+		]
+		.into(),
 		Some((
 			(roc_at_ah_rococo(), ROC * 1).into(),
 			BridgeHubRococo::sovereign_account_id_of(BridgeHubRococo::sibling_location_of(
@@ -273,7 +277,11 @@ pub(crate) fn open_bridge_between_asset_hub_rococo_and_asset_hub_westend() {
 	BridgeHubWestend::fund_para_sovereign(AssetHubWestend::para_id(), WND * 5);
 	AssetHubWestend::open_bridge(
 		AssetHubWestend::sibling_location_of(BridgeHubWestend::para_id()),
-		[GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(AssetHubRococo::para_id().into())].into(),
+		[
+			GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+			Parachain(AssetHubRococo::para_id().into()),
+		]
+		.into(),
 		Some((
 			(wnd_at_ah_westend(), WND * 1).into(),
 			BridgeHubWestend::sovereign_account_id_of(BridgeHubWestend::sibling_location_of(

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
@@ -294,8 +294,10 @@ fn transfer_relay_token() {
 	BridgeHubWestend::fund_accounts(vec![(assethub_sovereign.clone(), INITIAL_FUND)]);
 
 	let asset_id: Location = Location { parents: 1, interior: [].into() };
-	let expected_asset_id: Location =
-		Location { parents: 1, interior: [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH))].into() };
+	let expected_asset_id: Location = Location {
+		parents: 1,
+		interior: [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH))].into(),
+	};
 
 	let expected_token_id = TokenIdOf::convert_location(&expected_asset_id).unwrap();
 
@@ -465,10 +467,15 @@ fn transfer_ah_token() {
 		],
 	);
 
-	let asset_id_after_reanchored =
-		Location::new(1, [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(AssetHubWestend::para_id().into())])
-			.appended_with(asset_id.clone().interior)
-			.unwrap();
+	let asset_id_after_reanchored = Location::new(
+		1,
+		[
+			GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)),
+			Parachain(AssetHubWestend::para_id().into()),
+		],
+	)
+	.appended_with(asset_id.clone().interior)
+	.unwrap();
 
 	let token_id = TokenIdOf::convert_location(&asset_id_after_reanchored).unwrap();
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_bulletin_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_bulletin_config.rs
@@ -246,12 +246,13 @@ where
 {
 	use pallet_xcm_bridge_hub::{Bridge, BridgeId, BridgeState};
 	use sp_runtime::traits::Zero;
-	use xcm::{VersionedInteriorLocation, latest::ROCOCO_GENESIS_HASH};
+	use xcm::{latest::ROCOCO_GENESIS_HASH, VersionedInteriorLocation};
 
 	// insert bridge metadata
 	let lane_id = with;
 	let sibling_parachain = Location::new(1, [Parachain(sibling_para_id)]);
-	let universal_source = [GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(sibling_para_id)].into();
+	let universal_source =
+		[GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(sibling_para_id)].into();
 	let universal_destination =
 		[GlobalConsensus(RococoBulletinGlobalConsensusNetwork::get()), Parachain(2075)].into();
 	let bridge_id = BridgeId::new(&universal_source, &universal_destination);

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
@@ -175,6 +175,7 @@ where
 {
 	use pallet_xcm_bridge_hub::{Bridge, BridgeId, BridgeState};
 	use sp_runtime::traits::Zero;
+	use xcm::latest::ROCOCO_GENESIS_HASH;
 	use xcm::VersionedInteriorLocation;
 
 	// insert bridge metadata

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_to_westend_config.rs
@@ -180,8 +180,10 @@ where
 	// insert bridge metadata
 	let lane_id = with;
 	let sibling_parachain = Location::new(1, [Parachain(sibling_para_id)]);
-	let universal_source = [GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(sibling_para_id)].into();
-	let universal_destination = [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(2075)].into();
+	let universal_source =
+		[GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(sibling_para_id)].into();
+	let universal_destination =
+		[GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(2075)].into();
 	let bridge_id = BridgeId::new(&universal_source, &universal_destination);
 
 	// insert only bridge metadata, because the benchmarks create lanes

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -82,7 +82,7 @@ pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 pub use sp_runtime::{MultiAddress, Perbill, Permill};
 
 #[cfg(feature = "runtime-benchmarks")]
-use xcm::latest::{ROCOCO_GENESIS_HASH, WESTEND_GENESIS_HASH};
+use xcm::latest::WESTEND_GENESIS_HASH;
 use xcm::VersionedLocation;
 use xcm_config::{TreasuryAccount, XcmOriginToTransactDispatchOrigin, XcmRouter};
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
@@ -204,6 +204,7 @@ where
 {
 	use pallet_xcm_bridge_hub::{Bridge, BridgeId, BridgeState};
 	use sp_runtime::traits::Zero;
+	use xcm::latest::WESTEND_GENESIS_HASH;
 	use xcm::VersionedInteriorLocation;
 
 	// insert bridge metadata

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
@@ -204,14 +204,15 @@ where
 {
 	use pallet_xcm_bridge_hub::{Bridge, BridgeId, BridgeState};
 	use sp_runtime::traits::Zero;
-	use xcm::latest::WESTEND_GENESIS_HASH;
-	use xcm::VersionedInteriorLocation;
+	use xcm::{latest::WESTEND_GENESIS_HASH, VersionedInteriorLocation};
 
 	// insert bridge metadata
 	let lane_id = with;
 	let sibling_parachain = Location::new(1, [Parachain(sibling_para_id)]);
-	let universal_source = [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(sibling_para_id)].into();
-	let universal_destination = [GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(2075)].into();
+	let universal_source =
+		[GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)), Parachain(sibling_para_id)].into();
+	let universal_destination =
+		[GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(2075)].into();
 	let bridge_id = BridgeId::new(&universal_source, &universal_destination);
 
 	// insert only bridge metadata, because the benchmarks create lanes

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -89,7 +89,7 @@ pub use sp_runtime::BuildStorage;
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 
 #[cfg(feature = "runtime-benchmarks")]
-use xcm::latest::{ROCOCO_GENESIS_HASH, WESTEND_GENESIS_HASH};
+use xcm::latest::ROCOCO_GENESIS_HASH;
 use xcm::prelude::*;
 
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};

--- a/cumulus/parachains/runtimes/bridge-hubs/common/src/message_queue.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/common/src/message_queue.rs
@@ -23,7 +23,7 @@ use frame_support::{
 use pallet_message_queue::OnQueueChanged;
 use scale_info::TypeInfo;
 use snowbridge_core::ChannelId;
-use xcm::v5::{Junction, Location};
+use xcm::latest::prelude::{Junction, Location};
 
 /// The aggregate origin of an inbound message.
 /// This is specialized for BridgeHub, as the snowbridge-outbound-queue-pallet is also using
@@ -53,7 +53,7 @@ impl From<AggregateMessageOrigin> for Location {
 			Here => Location::here(),
 			Parent => Location::parent(),
 			Sibling(id) => Location::new(1, Junction::Parachain(id.into())),
-			// NOTE: We don't need this conversion for Snowbridge. However we have to
+			// NOTE: We don't need this conversion for Snowbridge. However, we have to
 			// implement it anyway as xcm_builder::ProcessXcmMessage requires it.
 			Snowbridge(_) => Location::default(),
 		}

--- a/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/xcm_config.rs
@@ -51,12 +51,12 @@ use xcm_builder::{
 	AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom,
 	AsPrefixedGeneralIndex, ConvertedConcreteId, DescribeAllTerminal, DescribeFamily,
 	EnsureXcmOrigin, FixedWeightBounds, FrameTransactionalProcessor, FungibleAdapter,
-	FungiblesAdapter, HashedDescription, IsConcrete,
-	LocalMint, NativeAsset, NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
-	SendXcmFeeToAccount, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SignedToAccountId32, SingleAssetExchangeAdapter,
-	SovereignSignedViaLocation, StartsWith, TakeWeightCredit, TrailingSetTopicAsId,
-	UsingComponents, WithComputedOrigin, WithUniqueTopic, XcmFeeManagerFromComponents,
+	FungiblesAdapter, HashedDescription, IsConcrete, LocalMint, NativeAsset, NoChecking,
+	ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SendXcmFeeToAccount,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SingleAssetExchangeAdapter, SovereignSignedViaLocation, StartsWith,
+	TakeWeightCredit, TrailingSetTopicAsId, UsingComponents, WithComputedOrigin, WithUniqueTopic,
+	XcmFeeManagerFromComponents,
 };
 use xcm_executor::{traits::JustTry, XcmExecutor};
 

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -42,7 +42,9 @@ mod v_coretime {
 	use sp_arithmetic::traits::SaturatedConversion;
 	use sp_core::Get;
 	use sp_runtime::BoundedVec;
-	use xcm::prelude::{send_xcm, Instruction, Junction, Location, SendError, SendXcm, WeightLimit, Xcm};
+	use xcm::prelude::{
+		send_xcm, Instruction, Junction, Location, SendError, SendXcm, WeightLimit, Xcm,
+	};
 
 	/// Return information about a legacy lease of a parachain.
 	pub trait GetLegacyLease<N> {
@@ -198,9 +200,12 @@ mod v_coretime {
 			c.scheduler_params.num_cores = total_cores;
 		});
 
-		if let Err(err) =
-			migrate_send_assignments_to_coretime_chain::<T, XcmSender, LegacyLease, TIMESLICE_PERIOD>(
-			) {
+		if let Err(err) = migrate_send_assignments_to_coretime_chain::<
+			T,
+			XcmSender,
+			LegacyLease,
+			TIMESLICE_PERIOD,
+		>() {
 			log::error!("Sending legacy chain data to coretime chain failed: {:?}", err);
 		}
 

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -42,7 +42,7 @@ mod v_coretime {
 	use sp_arithmetic::traits::SaturatedConversion;
 	use sp_core::Get;
 	use sp_runtime::BoundedVec;
-	use xcm::prelude::{send_xcm, Instruction, Junction, Location, SendError, WeightLimit, Xcm};
+	use xcm::prelude::{send_xcm, Instruction, Junction, Location, SendError, SendXcm, WeightLimit, Xcm};
 
 	/// Return information about a legacy lease of a parachain.
 	pub trait GetLegacyLease<N> {
@@ -62,10 +62,10 @@ mod v_coretime {
 
 	impl<
 			T: Config,
-			SendXcm: xcm::latest::SendXcm,
+			XcmSender: SendXcm,
 			LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 			const TIMESLICE_PERIOD: u32,
-		> MigrateToCoretime<T, SendXcm, LegacyLease, TIMESLICE_PERIOD>
+		> MigrateToCoretime<T, XcmSender, LegacyLease, TIMESLICE_PERIOD>
 	{
 		fn already_migrated() -> bool {
 			// We are using the assigner coretime because the coretime pallet doesn't has any
@@ -95,10 +95,10 @@ mod v_coretime {
 
 	impl<
 			T: Config + crate::dmp::Config,
-			SendXcm: xcm::latest::SendXcm,
+			XcmSender: SendXcm,
 			LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 			const TIMESLICE_PERIOD: u32,
-		> OnRuntimeUpgrade for MigrateToCoretime<T, SendXcm, LegacyLease, TIMESLICE_PERIOD>
+		> OnRuntimeUpgrade for MigrateToCoretime<T, XcmSender, LegacyLease, TIMESLICE_PERIOD>
 	{
 		fn on_runtime_upgrade() -> Weight {
 			if Self::already_migrated() {
@@ -106,7 +106,7 @@ mod v_coretime {
 			}
 
 			log::info!("Migrating existing parachains to coretime.");
-			migrate_to_coretime::<T, SendXcm, LegacyLease, TIMESLICE_PERIOD>()
+			migrate_to_coretime::<T, XcmSender, LegacyLease, TIMESLICE_PERIOD>()
 		}
 
 		#[cfg(feature = "try-runtime")]
@@ -157,7 +157,7 @@ mod v_coretime {
 	// NOTE: Also migrates `num_cores` config value in configuration::ActiveConfig.
 	fn migrate_to_coretime<
 		T: Config,
-		SendXcm: xcm::latest::SendXcm,
+		XcmSender: SendXcm,
 		LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 		const TIMESLICE_PERIOD: u32,
 	>() -> Weight {
@@ -199,7 +199,7 @@ mod v_coretime {
 		});
 
 		if let Err(err) =
-			migrate_send_assignments_to_coretime_chain::<T, SendXcm, LegacyLease, TIMESLICE_PERIOD>(
+			migrate_send_assignments_to_coretime_chain::<T, XcmSender, LegacyLease, TIMESLICE_PERIOD>(
 			) {
 			log::error!("Sending legacy chain data to coretime chain failed: {:?}", err);
 		}
@@ -215,7 +215,7 @@ mod v_coretime {
 
 	fn migrate_send_assignments_to_coretime_chain<
 		T: Config,
-		SendXcm: xcm::latest::SendXcm,
+		XcmSender: SendXcm,
 		LegacyLease: GetLegacyLease<BlockNumberFor<T>>,
 		const TIMESLICE_PERIOD: u32,
 	>() -> result::Result<(), SendError> {
@@ -300,7 +300,7 @@ mod v_coretime {
 		};
 
 		for message in messages {
-			send_xcm::<SendXcm>(
+			send_xcm::<XcmSender>(
 				Location::new(0, Junction::Parachain(T::BrokerId::get())),
 				message,
 			)?;

--- a/polkadot/xcm/docs/src/cookbook/relay_token_transactor/parachain/xcm_config.rs
+++ b/polkadot/xcm/docs/src/cookbook/relay_token_transactor/parachain/xcm_config.rs
@@ -21,7 +21,7 @@ use frame::{
 	runtime::prelude::*,
 	traits::{Everything, Nothing},
 };
-use xcm::v5::prelude::*;
+use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin,
 	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete,

--- a/polkadot/xcm/docs/src/cookbook/relay_token_transactor/relay_chain/mod.rs
+++ b/polkadot/xcm/docs/src/cookbook/relay_token_transactor/relay_chain/mod.rs
@@ -23,7 +23,7 @@ use frame::{
 	traits::{IdentityLookup, ProcessMessage, ProcessMessageError},
 };
 use polkadot_runtime_parachains::inclusion::{AggregateMessageOrigin, UmpQueueId};
-use xcm::v5::prelude::*;
+use xcm::latest::prelude::*;
 
 mod xcm_config;
 pub use xcm_config::LocationToAccountId;

--- a/polkadot/xcm/docs/src/cookbook/relay_token_transactor/relay_chain/xcm_config.rs
+++ b/polkadot/xcm/docs/src/cookbook/relay_token_transactor/relay_chain/xcm_config.rs
@@ -21,7 +21,7 @@ use frame::{
 	runtime::prelude::*,
 	traits::{Everything, Nothing},
 };
-use xcm::v5::prelude::*;
+use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin,
 	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete,

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -57,7 +57,7 @@ pub use traits::{
 	SendError, SendResult, SendXcm, Weight, XcmHash,
 };
 // These parts of XCM v3 are unchanged in XCM v4, and are re-imported here.
-pub use super::v3::{MaybeErrorCode, OriginKind, WeightLimit};
+pub use super::v3::{MaxDispatchErrorLen, MaybeErrorCode, OriginKind, WeightLimit};
 
 /// This module's XCM version.
 pub const VERSION: super::Version = 4;
@@ -229,9 +229,6 @@ pub mod prelude {
 
 parameter_types! {
 	pub MaxPalletNameLen: u32 = 48;
-	/// Maximum size of the encoded error code coming from a `Dispatch` result, used for
-	/// `MaybeErrorCode`. This is not (yet) enforced, so it's just an indication of expectation.
-	pub MaxDispatchErrorLen: u32 = 128;
 	pub MaxPalletsInfo: u32 = 64;
 }
 

--- a/polkadot/xcm/src/v5/mod.rs
+++ b/polkadot/xcm/src/v5/mod.rs
@@ -52,7 +52,7 @@ pub use traits::{
 	SendError, SendResult, SendXcm, Weight, XcmHash,
 };
 // These parts of XCM v4 are unchanged in XCM v5, and are re-imported here.
-pub use super::v4::{MaybeErrorCode, OriginKind, WeightLimit};
+pub use super::v4::{MaxDispatchErrorLen, MaybeErrorCode, OriginKind, WeightLimit};
 
 pub const VERSION: super::Version = 5;
 
@@ -223,9 +223,6 @@ pub mod prelude {
 
 parameter_types! {
 	pub MaxPalletNameLen: u32 = 48;
-	/// Maximum size of the encoded error code coming from a `Dispatch` result, used for
-	/// `MaybeErrorCode`. This is not (yet) enforced, so it's just an indication of expectation.
-	pub MaxDispatchErrorLen: u32 = 128;
 	pub MaxPalletsInfo: u32 = 64;
 }
 


### PR DESCRIPTION
Small nits for XCMv5 found during review:

- `MaxDispatchErrorLen` cleanup
- Use `xcm::latest` instead of `xcm::v5`
- Use the same `SendXcm` import for coretime migration
