### PR TITLE
migrate pallet-fast-unstake to bench v2 syntax

### DIFF
--- a/substrate/frame/fast-unstake/src/benchmarking.rs
+++ b/substrate/frame/fast-unstake/src/benchmarking.rs
@@ -21,7 +21,7 @@
 
 use crate::{types::*, Pallet as FastUnstake, *};
 use alloc::{vec, vec::Vec};
-use frame_benchmarking::v1::{benchmarks, whitelist_account, BenchmarkError};
+use frame_benchmarking::v2::*;
 use frame_support::{
 	assert_ok,
 	traits::{Currency, EnsureOrigin, Get, Hooks},
@@ -92,10 +92,13 @@ fn on_idle_full_block<T: Config>() {
 	FastUnstake::<T>::on_idle(Zero::zero(), remaining_weight);
 }
 
-benchmarks! {
-	// on_idle, we don't check anyone, but fully unbond them.
-	on_idle_unstake {
-		let b in 1 .. T::BatchSize::get();
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn on_idle_unstake(b: Linear<1, { T::BatchSize::get() }>) {
+		// on_idle. we don't check anyone, but fully unbond them.
 
 		ErasToCheckPerBlock::<T>::put(1);
 		for who in create_unexposed_batch::<T>(b).into_iter() {
@@ -116,21 +119,22 @@ benchmarks! {
 				..
 			}) if checked.len() == 1 && stashes.len() as u32 == b
 		));
-	}
-	: {
-		on_idle_full_block::<T>();
-	}
-	verify {
-		assert!(matches!(
+
+		#[block]
+		{
+			on_idle_full_block::<T>();
+		}
+
+		assert_eq!(
 			fast_unstake_events::<T>().last(),
-			Some(Event::BatchFinished { size: b })
-		));
+			Some(&Event::BatchFinished { size: b })
+		);
 	}
 
-	// on_idle, when we check some number of eras and the queue is already set.
-	on_idle_check {
-		let v in 1 .. 256;
-		let b in 1 .. T::BatchSize::get();
+	#[benchmark]
+	fn on_idle_check(v: Linear<1, 256>, b: Linear<1, { T::BatchSize::get() }>) {
+		// on_idle, when we check some number of eras and the queue is already set.
+
 		let u = T::MaxErasToCheckPerBlock::get().min(T::Staking::bonding_duration());
 
 		ErasToCheckPerBlock::<T>::put(u);
@@ -150,11 +154,12 @@ benchmarks! {
 		assert_eq!(Head::<T>::get(), None);
 
 		Head::<T>::put(UnstakeRequest { stashes: stashes.clone().try_into().unwrap(), checked: Default::default() });
-	}
-	: {
-		on_idle_full_block::<T>();
-	}
-	verify {
+
+		#[block]
+		{
+			on_idle_full_block::<T>();
+		}
+
 		let checked = (1..=u).rev().collect::<Vec<EraIndex>>();
 		let request = Head::<T>::get().unwrap();
 		assert_eq!(checked, request.checked.into_inner());
@@ -165,19 +170,22 @@ benchmarks! {
 		assert!(stashes.iter().all(|(s, _)| request.stashes.iter().any(|(ss, _)| ss == s)));
 	}
 
-	register_fast_unstake {
+	#[benchmark]
+	fn register_fast_unstake() {
 		ErasToCheckPerBlock::<T>::put(1);
 		let who = create_unexposed_batch::<T>(1).get(0).cloned().unwrap();
 		whitelist_account!(who);
 		assert_eq!(Queue::<T>::count(), 0);
 
-	}
-	:_(RawOrigin::Signed(who.clone()))
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(who.clone()));
+
 		assert_eq!(Queue::<T>::count(), 1);
 	}
 
-	deregister {
+	#[benchmark]
+	fn deregister() {
 		ErasToCheckPerBlock::<T>::put(1);
 		let who = create_unexposed_batch::<T>(1).get(0).cloned().unwrap();
 		assert_ok!(FastUnstake::<T>::register_fast_unstake(
@@ -185,18 +193,23 @@ benchmarks! {
 		));
 		assert_eq!(Queue::<T>::count(), 1);
 		whitelist_account!(who);
-	}
-	:_(RawOrigin::Signed(who.clone()))
-	verify {
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(who.clone()));
+
 		assert_eq!(Queue::<T>::count(), 0);
 	}
 
-	control {
+	#[benchmark]
+	fn control() -> Result<(), BenchmarkError> {
 		let origin = <T as Config>::ControlOrigin::try_successful_origin()
 			.map_err(|_| BenchmarkError::Weightless)?;
-	}
-	: _<T::RuntimeOrigin>(origin, T::MaxErasToCheckPerBlock::get())
-	verify {}
 
-	impl_benchmark_test_suite!(Pallet, crate::mock::ExtBuilder::default().build(), crate::mock::Runtime)
+		#[extrinsic_call]
+		_(origin as T::RuntimeOrigin, T::MaxErasToCheckPerBlock::get());
+
+		Ok(())
+	}
+
+	impl_benchmark_test_suite!(Pallet, crate::mock::ExtBuilder::default().build(), crate::mock::Runtime);
 }


### PR DESCRIPTION
Migrates the pallet-fast-unstake to the benchmark v2 syntax.

Part of:
* https://github.com/paritytech/polkadot-sdk/issues/6202