### PR TITLE
Remove stale extenstion version from `UncheckedExtrinsic` v4 structure

### DIFF
--- a/substrate/bin/node/testing/src/bench.rs
+++ b/substrate/bin/node/testing/src/bench.rs
@@ -590,7 +590,6 @@ impl BenchKeyring {
 					preamble: Preamble::Signed(
 						sp_runtime::MultiAddress::Id(signed),
 						signature,
-						0,
 						tx_ext,
 					),
 					function: payload.0,

--- a/substrate/bin/node/testing/src/keyring.rs
+++ b/substrate/bin/node/testing/src/keyring.rs
@@ -123,7 +123,6 @@ pub fn sign(
 				preamble: sp_runtime::generic::Preamble::Signed(
 					sp_runtime::MultiAddress::Id(signed),
 					signature,
-					0,
 					tx_ext,
 				),
 				function: payload.0,

--- a/substrate/frame/examples/offchain-worker/src/tests.rs
+++ b/substrate/frame/examples/offchain-worker/src/tests.rs
@@ -240,7 +240,7 @@ fn should_submit_signed_transaction_on_chain() {
 		let tx = pool_state.write().transactions.pop().unwrap();
 		assert!(pool_state.read().transactions.is_empty());
 		let tx = Extrinsic::decode(&mut &*tx).unwrap();
-		assert!(matches!(tx.preamble, sp_runtime::generic::Preamble::Signed(0, (), 0, (),)));
+		assert!(matches!(tx.preamble, sp_runtime::generic::Preamble::Signed(0, (), (),)));
 		assert_eq!(tx.function, RuntimeCall::Example(crate::Call::submit_price { price: 15523 }));
 	});
 }

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -83,7 +83,7 @@ pub enum Preamble<Address, Signature, Extension> {
 	Bare(ExtrinsicVersion),
 	/// An old-school transaction extrinsic which includes a signature of some hard-coded crypto.
 	/// Available only on extrinsic version 4.
-	Signed(Address, Signature, ExtensionVersion, Extension),
+	Signed(Address, Signature, Extension),
 	/// A new-school transaction extrinsic which does not include a signature by default. The
 	/// origin authorization, through signatures or other means, is performed by the transaction
 	/// extension in this extrinsic. Available starting with extrinsic version 5.
@@ -117,7 +117,7 @@ where
 				let address = Address::decode(input)?;
 				let signature = Signature::decode(input)?;
 				let ext = Extension::decode(input)?;
-				Self::Signed(address, signature, 0, ext)
+				Self::Signed(address, signature, ext)
 			},
 			(EXTRINSIC_FORMAT_VERSION, GENERAL_EXTRINSIC) => {
 				let ext_version = ExtensionVersion::decode(input)?;
@@ -140,7 +140,7 @@ where
 	fn size_hint(&self) -> usize {
 		match &self {
 			Preamble::Bare(_) => EXTRINSIC_FORMAT_VERSION.size_hint(),
-			Preamble::Signed(address, signature, _, ext) => LEGACY_EXTRINSIC_FORMAT_VERSION
+			Preamble::Signed(address, signature, ext) => LEGACY_EXTRINSIC_FORMAT_VERSION
 				.size_hint()
 				.saturating_add(address.size_hint())
 				.saturating_add(signature.size_hint())
@@ -157,7 +157,7 @@ where
 			Preamble::Bare(extrinsic_version) => {
 				(extrinsic_version | BARE_EXTRINSIC).encode_to(dest);
 			},
-			Preamble::Signed(address, signature, _, ext) => {
+			Preamble::Signed(address, signature, ext) => {
 				(LEGACY_EXTRINSIC_FORMAT_VERSION | SIGNED_EXTRINSIC).encode_to(dest);
 				address.encode_to(dest);
 				signature.encode_to(dest);
@@ -176,7 +176,7 @@ impl<Address, Signature, Extension> Preamble<Address, Signature, Extension> {
 	/// Returns `Some` if this is a signed extrinsic, together with the relevant inner fields.
 	pub fn to_signed(self) -> Option<(Address, Signature, Extension)> {
 		match self {
-			Self::Signed(a, s, _, e) => Some((a, s, e)),
+			Self::Signed(a, s, e) => Some((a, s, e)),
 			_ => None,
 		}
 	}
@@ -190,8 +190,7 @@ where
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Bare(_) => write!(f, "Bare"),
-			Self::Signed(address, _, ext_version, tx_ext) =>
-				write!(f, "Signed({:?}, {:?}, {:?})", address, ext_version, tx_ext),
+			Self::Signed(address, _, tx_ext) => write!(f, "Signed({:?}, {:?})", address, tx_ext),
 			Self::General(ext_version, tx_ext) =>
 				write!(f, "General({:?}, {:?})", ext_version, tx_ext),
 		}
@@ -305,7 +304,7 @@ impl<Address, Call, Signature, Extension> UncheckedExtrinsic<Address, Call, Sign
 		signature: Signature,
 		tx_ext: Extension,
 	) -> Self {
-		Self { preamble: Preamble::Signed(signed, signature, 0, tx_ext), function }
+		Self { preamble: Preamble::Signed(signed, signature, tx_ext), function }
 	}
 
 	/// New instance of an new-school unsigned transaction.
@@ -345,7 +344,7 @@ where
 
 	fn check(self, lookup: &Lookup) -> Result<Self::Checked, TransactionValidityError> {
 		Ok(match self.preamble {
-			Preamble::Signed(signed, signature, _, tx_ext) => {
+			Preamble::Signed(signed, signature, tx_ext) => {
 				let signed = lookup.lookup(signed)?;
 				// The `Implicit` is "implicitly" included in the payload.
 				let raw_payload = SignedPayload::new(self.function, tx_ext)?;
@@ -370,7 +369,7 @@ where
 		lookup: &Lookup,
 	) -> Result<Self::Checked, TransactionValidityError> {
 		Ok(match self.preamble {
-			Preamble::Signed(signed, _, _, extra) => {
+			Preamble::Signed(signed, _, extra) => {
 				let signed = lookup.lookup(signed)?;
 				CheckedExtrinsic {
 					format: ExtrinsicFormat::Signed(signed, extra),
@@ -403,8 +402,7 @@ impl<Address, Call: Dispatchable, Signature, Extension: TransactionExtension<Cal
 	pub fn extension_weight(&self) -> Weight {
 		match &self.preamble {
 			Preamble::Bare(_) => Weight::zero(),
-			Preamble::Signed(_, _, _, ext) | Preamble::General(_, ext) =>
-				ext.weight(&self.function),
+			Preamble::Signed(_, _, ext) | Preamble::General(_, ext) => ext.weight(&self.function),
 		}
 	}
 }
@@ -915,7 +913,7 @@ mod tests {
 		assert_eq!(decoded_old_ux.function, call);
 		assert_eq!(
 			decoded_old_ux.preamble,
-			Preamble::Signed(signed, legacy_signature.clone(), 0, extension.clone())
+			Preamble::Signed(signed, legacy_signature.clone(), extension.clone())
 		);
 
 		let new_ux =
@@ -952,7 +950,7 @@ mod tests {
 		assert_eq!(decoded_old_ux.function, call);
 		assert_eq!(
 			decoded_old_ux.preamble,
-			Preamble::Signed(signed, signature.clone(), 0, extension.clone())
+			Preamble::Signed(signed, signature.clone(), extension.clone())
 		);
 
 		let new_ux = Ex::new_signed(call.clone(), signed, signature.clone(), extension.clone());

--- a/substrate/test-utils/runtime/src/extrinsic.rs
+++ b/substrate/test-utils/runtime/src/extrinsic.rs
@@ -69,7 +69,7 @@ impl TryFrom<&Extrinsic> for TransferData {
 		match uxt {
 			Extrinsic {
 				function: RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest, value }),
-				preamble: Preamble::Signed(from, _, _, ((CheckNonce(nonce), ..), ..)),
+				preamble: Preamble::Signed(from, _, ((CheckNonce(nonce), ..), ..)),
 			} => Ok(TransferData { from: *from, to: *dest, amount: *value, nonce: *nonce }),
 			Extrinsic {
 				function: RuntimeCall::SubstrateTest(PalletCall::bench_call { transfer }),


### PR DESCRIPTION
Follow up to #3685 

The main PR introduced bare support for the new extension version byte. However, the extension version byte is not used for the old signed extrinsic type in version 4. This PR removes the byte from that structure, previously unused and defaulted to `0`.

In this same PR, new weights will be generated for the modules affected by the main PR.