### PR TITLE
Add pool accounts `view_function`

### DIFF
--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -1740,6 +1740,16 @@ pub mod pallet {
 	pub type ClaimPermissions<T: Config> =
 		StorageMap<_, Twox64Concat, T::AccountId, ClaimPermission, ValueQuery>;
 
+	#[pallet::view_functions]
+	impl<T: Config> Pallet<T> {
+		/// Provide bonded account and reward account for nomination pool.
+		pub fn pool_accountss(pool_id: PoolId) -> (T::AccountId, T::AccountId) {
+			let bonded_account = Self::generate_bonded_account(pool_id);
+			let reward_account = Self::generate_reward_account(pool_id);
+			(bonded_account, reward_account)
+		}
+	}
+
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub min_join_bond: BalanceOf<T>,
@@ -4070,15 +4080,5 @@ impl<T: Config> sp_staking::OnStakingUpdate<T::AccountId, BalanceOf<T>> for Pall
 				tvl.saturating_reduce(amount);
 			});
 		}
-	}
-}
-
-#[pallet::view_functions]
-impl<T: Config> Pallet<T> {
-	/// Provide bonded account and reward account for nomination pool.
-	pub fn pool_accounts(pool_id: PoolId) -> (T::AccountId, T::AccountId) {
-		let bonded_account = Self::generate_bonded_account(pool_id);
-		let reward_account = Self::generate_reward_account(pool_id);
-		(bonded_account, reward_account)
 	}
 }

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -4075,7 +4075,7 @@ impl<T: Config> sp_staking::OnStakingUpdate<T::AccountId, BalanceOf<T>> for Pall
 
 #[pallet::view_functions]
 impl<T: Config> Pallet<T> {
-	/// Query value no args.
+	/// Provide bonded account and reward account for nomination pool.
 	pub fn pool_accounts(pool_id: PoolId) -> (T::AccountId, T::AccountId) {
 		let bonded_account = Self::generate_bonded_account(pool_id);
 		let reward_account = Self::generate_reward_account(pool_id);

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -4072,3 +4072,13 @@ impl<T: Config> sp_staking::OnStakingUpdate<T::AccountId, BalanceOf<T>> for Pall
 		}
 	}
 }
+
+#[pallet::view_functions]
+impl<T: Config> Pallet<T> {
+	/// Query value no args.
+	pub fn pool_accounts(pool_id: PoolId) -> (T::AccountId, T::AccountId) {
+		let bonded_account = Self::generate_bonded_account(pool_id);
+		let reward_account = Self::generate_reward_account(pool_id);
+		(bonded_account, reward_account)
+	}
+}


### PR DESCRIPTION
Draft PR that would solve #6358 with pallet view functions building on top of #4722. 

Providing bonded and reward account for nomination pool through a pallet view function.