### PR TITLE
Use type alias for transactions

### DIFF
--- a/substrate/client/network/transactions/src/lib.rs
+++ b/substrate/client/network/transactions/src/lib.rs
@@ -480,7 +480,7 @@ where
 				continue
 			}
 
-			let (hashes, to_send): (Vec<_>, Vec<_>) = transactions
+			let (hashes, to_send): (Vec<_>, Transactions<_>) = transactions
 				.iter()
 				.filter(|(hash, _)| peer.known_transactions.insert(hash.clone()))
 				.cloned()


### PR DESCRIPTION
Very tiny change that helps with debugging of transactions propagation by referring to the same type alias not only at receiving side, but also on the sending size for symmetry