### PR TITLE
pallet-membership: Do not verify the `MembershipChanged` in bechmarks

### DIFF
--- a/prdoc/pr_6439.prdoc
+++ b/prdoc/pr_6439.prdoc
@@ -2,7 +2,7 @@ title: 'pallet-membership: Do not verify the `MembershipChanged` in bechmarks'
 doc:
 - audience: Runtime Dev
   description: |-
-    There is no need to verify in the `pallet-membership` benchmak that the `MemembershipChanged` implementation works as the pallet thinks it should work. If you for example set it to `()`, `get_prime()` will always return `None`.
+    There is no need to verify in the `pallet-membership` benchmark that the `MemembershipChanged` implementation works as the pallet thinks it should work. If you for example set it to `()`, `get_prime()` will always return `None`.
 
     TLDR: Remove the checks of `MembershipChanged` in the benchmarks to support any kind of implementation.
 crates:

--- a/prdoc/pr_6439.prdoc
+++ b/prdoc/pr_6439.prdoc
@@ -1,0 +1,10 @@
+title: 'pallet-membership: Do not verify the `MembershipChanged`'
+doc:
+- audience: Runtime Dev
+  description: |-
+    There is no need to verify in the `pallet-membership` benchmak that the `MemembershipChanged` implementation works as the pallet thinks it should work. If you for example set it to `()`, `get_prime()` will always return `None`.
+
+    TLDR: Remove the checks of `MembershipChanged` in the benchmarks to support any kind of implementation.
+crates:
+- name: pallet-membership
+  bump: patch

--- a/prdoc/pr_6439.prdoc
+++ b/prdoc/pr_6439.prdoc
@@ -1,4 +1,4 @@
-title: 'pallet-membership: Do not verify the `MembershipChanged`'
+title: 'pallet-membership: Do not verify the `MembershipChanged` in bechmarks'
 doc:
 - audience: Runtime Dev
   description: |-

--- a/substrate/frame/membership/src/benchmarking.rs
+++ b/substrate/frame/membership/src/benchmarking.rs
@@ -99,7 +99,7 @@ benchmarks_instance_pallet! {
 		assert!(!Members::<T, I>::get().contains(&remove));
 		assert!(Members::<T, I>::get().contains(&add));
 		// prime is rejigged
-		assert!(Prime::<T, I>::get().is_some() && T::MembershipChanged::get_prime().is_some());
+		assert!(Prime::<T, I>::get().is_some());
 		#[cfg(test)] crate::mock::clean();
 	}
 
@@ -119,7 +119,7 @@ benchmarks_instance_pallet! {
 		new_members.sort();
 		assert_eq!(Members::<T, I>::get(), new_members);
 		// prime is rejigged
-		assert!(Prime::<T, I>::get().is_some() && T::MembershipChanged::get_prime().is_some());
+		assert!(Prime::<T, I>::get().is_some());
 		#[cfg(test)] crate::mock::clean();
 	}
 
@@ -157,7 +157,6 @@ benchmarks_instance_pallet! {
 		));
 	} verify {
 		assert!(Prime::<T, I>::get().is_some());
-		assert!(<T::MembershipChanged>::get_prime().is_some());
 		#[cfg(test)] crate::mock::clean();
 	}
 


### PR DESCRIPTION
There is no need to verify in the `pallet-membership` benchmark that the `MemembershipChanged` implementation works as the pallet thinks it should work. If you for example set it to `()`, `get_prime()` will always return `None`.

TLDR: Remove the checks of `MembershipChanged` in the benchmarks to support any kind of implementation.

