### PR TITLE
network/litep2p: Update litep2p network backend to version 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10194,9 +10194,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7286b1971f85d1d60be40ef49e81c1f3b5a0d8b83cfa02ab53591cdacae22901"
+checksum = "5b67484b8ac41e1cfdf012f65fa81e88c2ef5f8a7d6dec0e2678c2d06dc04530"
 dependencies = [
  "async-trait",
  "bs58",
@@ -20402,7 +20402,7 @@ checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -20448,7 +20448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.87",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -848,7 +848,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.8.0", features = ["websocket"] }
+litep2p = { version = "0.8.1", features = ["websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }

--- a/prdoc/pr_6484.prdoc
+++ b/prdoc/pr_6484.prdoc
@@ -1,0 +1,10 @@
+title: Update litep2p network backend to version 0.8.1
+
+doc:
+  - audience: [ Node Dev, Node Operator ]
+    description: |
+      Release 0.8.1 of litep2p includes critical fixes to further enhance the stability and performance of the litep2p network backend.
+
+crates:
+  - name: sc-network
+    bump: patch

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -1074,7 +1074,13 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 							metrics.pending_connections_errors_total.with_label_values(&["transport-errors"]).inc();
 						}
 					}
-					_ => {}
+					None => {
+						log::error!(
+								target: LOG_TARGET,
+								"Litep2p backend terminated"
+						);
+						return
+					}
 				},
 			}
 		}


### PR DESCRIPTION
This PR updates the litep2p backend to version 0.8.1 from 0.8.0.
- Check the [litep2p updates forum post](https://forum.polkadot.network/t/litep2p-network-backend-updates/9973/3) for performance dashboards.
- Check [litep2p release notes](https://github.com/paritytech/litep2p/pull/288)

The v0.8.1 release includes key fixes that enhance the stability and performance of the litep2p library. The focus is on long-running stability and improvements to polling mechanisms.

### Long Running Stability Improvements

This issue caused long-running nodes to reject all incoming connections, impacting overall stability.

Addressed a bug in the connection limits functionality that incorrectly tracked connections due for rejection.

This issue caused an artificial increase in inbound peers, which were not being properly removed from the connection limit count.

This fix ensures more accurate tracking and management of peer connections [#286](https://github.com/paritytech/litep2p/pull/286).

### Polling implementation fixes

This release provides multiple fixes to the polling mechanism, improving how connections and events are processed:
 - Resolved an overflow issue in TransportContext’s polling index for streams, preventing potential crashes ([#283](https://github.com/paritytech/litep2p/pull/283)).
- Fixed a delay in the manager’s poll_next function that prevented immediate polling of newly added futures ([#287](https://github.com/paritytech/litep2p/pull/287)).
- Corrected an issue where the listener did not return Poll::Ready(None) when it was closed, ensuring proper signal handling ([#285](https://github.com/paritytech/litep2p/pull/285)).


### Fixed

- manager: Fix connection limits tracking of rejected connections  ([#286](https://github.com/paritytech/litep2p/pull/286))
- transport: Fix waking up on filtered events from `poll_next`  ([#287](https://github.com/paritytech/litep2p/pull/287))
- transports: Fix missing Poll::Ready(None) event from listener  ([#285](https://github.com/paritytech/litep2p/pull/285))
- manager: Avoid overflow on stream implementation for `TransportContext`  ([#283](https://github.com/paritytech/litep2p/pull/283))
- manager: Log when polling returns Ready(None)  ([#284](https://github.com/paritytech/litep2p/pull/284))


### Testing Done

Started kusama nodes running side by side with a higher number of inbound and outbound connections (500).
We previously tested with peers bounded at 50. This testing filtered out the fixes included in the latest release.

With this high connection testing setup, litep2p outperforms libp2p in almost every domain, from performance to the warnings / errors encountered while operating the nodes.

TLDR: this is the version we need to test on kusama validators next

- Litep2p

Repo            | Count      | Level      | Triage report
-|-|-|-
polkadot-sdk    | 409        | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Peer disconnected with inflight after backoffs. Banned, disconnecting.    )
litep2p         | 128        | warn       | Refusing to add known address that corresponds to a different peer ID
litep2p         | 54         | warn       | inbound identify substream opened for peer who doesn't exist
polkadot-sdk    | 7          | error      | 💔 Called `on_validated_block_announce` with a bad peer ID .*
polkadot-sdk    | 1          | warn       | ❌ Error while dialing .*: .*
polkadot-sdk    | 1          | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Invalid justification. Banned, disconnecting.    )

- Libp2p

Repo            | Count      | Level      | Triage report
-|-|-|-
polkadot-sdk    | 1023       | warn       | 💔 Ignored block \(#.* -- .*\) announcement from .* because all validation slots are occupied.
polkadot-sdk    | 472        | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Unsupported protocol. Banned, disconnecting.    )
polkadot-sdk    | 379        | error      | 💔 Called `on_validated_block_announce` with a bad peer ID .*
polkadot-sdk    | 163        | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Invalid justification. Banned, disconnecting.    )
polkadot-sdk    | 116        | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Peer disconnected with inflight after backoffs. Banned, disconnecting.    )
polkadot-sdk    | 83         | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Same block request multiple times. Banned, disconnecting.    )
polkadot-sdk    | 4          | warn       | Re-finalized block #.* \(.*\) in the canonical chain, current best finalized is #.*
polkadot-sdk    | 2          | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Genesis mismatch. Banned, disconnecting.    )
polkadot-sdk    | 2          | warn       | Report .*: .* to .*. Reason: .*. Banned, disconnecting. ( Not requested block data. Banned, disconnecting.    )
polkadot-sdk    | 2          | warn       | Can't listen on .* because: .*
polkadot-sdk    | 1          | warn       | ❌ Error while dialing .*: .*
