### PR TITLE
Implements a mechanism to lock/unlock the `SortedListProvider` and bags-list iter

### DIFF
--- a/substrate/frame/bags-list/src/list/mod.rs
+++ b/substrate/frame/bags-list/src/list/mod.rs
@@ -61,6 +61,12 @@ pub enum ListError {
 	NotInSameBag,
 	/// Given node id was not found.
 	NodeNotFound,
+	/// An action that affects ordering cannot complete since re-ordering is disabled.
+	ReorderingNotAllowed,
+	/// List lock is already set.
+	LockAlreadySet,
+	/// List lock is already released.
+	LockAlreadyUnset,
 }
 
 #[cfg(test)]

--- a/substrate/frame/election-provider-support/src/lib.rs
+++ b/substrate/frame/election-provider-support/src/lib.rs
@@ -548,6 +548,14 @@ pub trait SortedListProvider<AccountId> {
 	/// Returns `Ok(())` iff it successfully removes an item, an `Err(_)` otherwise.
 	fn on_remove(id: &AccountId) -> Result<(), Self::Error>;
 
+	/// Locks the explicit re-ordering of the provider list.
+	///
+	/// When locked, the list item's should not be re-ordered.
+	fn lock_ordering() -> Result<(), Self::Error>;
+
+	/// Unlocks the re-ordering of the provider list.
+	fn unlock_ordering() -> Result<(), Self::Error>;
+
 	/// Regenerate this list from scratch. Returns the count of items inserted.
 	///
 	/// This should typically only be used at a runtime upgrade.


### PR DESCRIPTION
Implements a mechanism to lock/unlock the `SortedListProvider` and bags-list iter. 

WIP and currently implementing **Option 1**.


**Goals**:
1. Add a new method to `trait SortedListProvider` to allow locking and unlocking the *ordering* of the list's elements.
2. Implement a mechanism to lock and unlock the ordering of the list iterator returned by `SortedListProvider::iter()` implementation of the bags-list.
3. When the lock is set, allow all the bags list mutations that do not change the order of the iterator.


### Option 1.
Return err `List::ReorderingNotAllowed` whenever a bags-list extrinsic or `SortedListProvider` method is called that *may* affect the iterator ordering while the lock is set, ie:
- `SortedListProvider::on_insert` (inserting ID in the list will change the iter)
- `SortedListProvider::on_update` (updating an ID score may cause a rebag)
- `SortedListProvider::on_remove` (removing an ID in the list will change the iter)
- `BagsList::call::rebag`
- `BagsList::call::put_in_front_of`
- `BagsList::call::put_in_front_of_other`

Even tough this approach is simple to implement and can be implemented all at the bags-list level, it may be too strict as some of the sorted list provider method calls may not affect the iter ordering or their implementation could be refactored to apply score mutations without changing the iter ordering e.g. `on_update` scores without rebag, `on_remove` do not remove the node from the list, etc.
