### PR TITLE
Migrate `pallet-timestamp` to umbrella crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15449,17 +15449,10 @@ name = "pallet-timestamp"
 version = "27.0.0"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
  "log",
  "parity-scale-codec",
+ "polkadot-sdk-frame 0.1.0",
  "scale-info",
- "sp-core 28.0.0",
- "sp-inherents 26.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-storage 19.0.0",
  "sp-timestamp 26.0.0",
 ]
 

--- a/substrate/frame/timestamp/Cargo.toml
+++ b/substrate/frame/timestamp/Cargo.toml
@@ -20,46 +20,27 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
-frame-benchmarking = { optional = true, workspace = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-sp-inherents = { workspace = true }
-sp-io = { optional = true, workspace = true }
-sp-runtime = { workspace = true }
-sp-storage = { workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"] }
 sp-timestamp = { workspace = true }
 
 docify = { workspace = true }
 
-[dev-dependencies]
-sp-core = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
+# [dev-dependencies]
+# sp-core = { workspace = true, default-features = true }
+# sp-io = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
-	"frame-benchmarking?/std",
-	"frame-support/std",
-	"frame-system/std",
+	"frame/std",
 	"log/std",
 	"scale-info/std",
-	"sp-core/std",
-	"sp-inherents/std",
-	"sp-io?/std",
-	"sp-runtime/std",
-	"sp-storage/std",
 	"sp-timestamp/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
-	"sp-io",
-	"sp-runtime/runtime-benchmarks",
+	"frame/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
-	"sp-runtime/try-runtime",
+	"frame/try-runtime",
 ]

--- a/substrate/frame/timestamp/src/benchmarking.rs
+++ b/substrate/frame/timestamp/src/benchmarking.rs
@@ -18,12 +18,13 @@
 //! Timestamp pallet benchmarking.
 
 #![cfg(feature = "runtime-benchmarks")]
-
+/*
 use frame_benchmarking::{benchmarking::add_to_whitelist, v2::*};
 use frame_support::traits::OnFinalize;
 use frame_system::RawOrigin;
 use sp_storage::TrackedStorageKey;
-
+*/
+use frame::{benchmarking::prelude::*, traits::TrackedStorageKey};
 use crate::*;
 
 const MAX_TIME: u32 = 100;

--- a/substrate/frame/timestamp/src/lib.rs
+++ b/substrate/frame/timestamp/src/lib.rs
@@ -52,12 +52,11 @@
 //!
 //! ```
 //! use pallet_timestamp::{self as timestamp};
+//! use frame::prelude::*;
 //!
-//! #[frame_support::pallet]
+//! #[frame::pallet]
 //! pub mod pallet {
 //! 	use super::*;
-//! 	use frame_support::pallet_prelude::*;
-//! 	use frame_system::pallet_prelude::*;
 //!
 //! 	#[pallet::pallet]
 //! 	pub struct Pallet<T>(_);
@@ -134,18 +133,24 @@ mod tests;
 pub mod weights;
 
 use core::{cmp, result};
+/*
 use frame_support::traits::{OnTimestampSet, Time, UnixTime};
 use sp_runtime::traits::{AtLeast32Bit, SaturatedConversion, Scale, Zero};
+*/
+use frame::{prelude::*, runtime::prelude::derive_impl, arithmetic::AtLeast32Bit, traits::{Scale, OnTimestampSet, Time, UnixTime}};
 use sp_timestamp::{InherentError, InherentType, INHERENT_IDENTIFIER};
 pub use weights::WeightInfo;
 
 pub use pallet::*;
 
-#[frame_support::pallet]
+// #[frame_support::pallet]
+#[frame::pallet]
 pub mod pallet {
 	use super::*;
+	/*
 	use frame_support::{derive_impl, pallet_prelude::*};
 	use frame_system::pallet_prelude::*;
+	*/
 
 	/// Default preludes for [`Config`].
 	pub mod config_preludes {
@@ -157,7 +162,8 @@ pub mod pallet {
 		#[derive_impl(frame_system::config_preludes::TestDefaultConfig, no_aggregated_types)]
 		impl frame_system::DefaultConfig for TestDefaultConfig {}
 
-		#[frame_support::register_default_impl(TestDefaultConfig)]
+		// #[frame_support::register_default_impl(TestDefaultConfig)]
+		#[frame::prelude::register_default_impl(TestDefaultConfig)]
 		impl DefaultConfig for TestDefaultConfig {
 			type Moment = u64;
 			type OnTimestampSet = ();
@@ -354,7 +360,7 @@ impl<T: Config> Time for Pallet<T> {
 	/// A type that represents a unit of time.
 	type Moment = T::Moment;
 
-	fn now() -> Self::Moment {
+	fn now() -> <pallet::Pallet<T> as Time>::Moment {
 		Now::<T>::get()
 	}
 }

--- a/substrate/frame/timestamp/src/mock.rs
+++ b/substrate/frame/timestamp/src/mock.rs
@@ -19,15 +19,16 @@
 
 use super::*;
 use crate as pallet_timestamp;
-
+/*
 use frame_support::{derive_impl, parameter_types, traits::ConstU64};
 use sp_io::TestExternalities;
 use sp_runtime::BuildStorage;
-
+*/
+use frame::{prelude::*, runtime::{testing_prelude::BuildStorage, prelude::*}, testing_prelude::TestExternalities};
 type Block = frame_system::mocking::MockBlock<Test>;
 type Moment = u64;
 
-frame_support::construct_runtime!(
+construct_runtime!(
 	pub enum Test
 	{
 		System: frame_system,

--- a/substrate/frame/timestamp/src/tests.rs
+++ b/substrate/frame/timestamp/src/tests.rs
@@ -18,7 +18,9 @@
 //! Tests for the Timestamp module.
 
 use crate::mock::*;
-use frame_support::assert_ok;
+//use frame_support::assert_ok;
+
+use frame::testing_prelude::*;
 
 #[test]
 fn timestamp_works() {

--- a/substrate/frame/timestamp/src/weights.rs
+++ b/substrate/frame/timestamp/src/weights.rs
@@ -46,7 +46,8 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+// use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame::weights_prelude::*;
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_timestamp`.


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot-sdk/issues/6504