### PR TITLE
Add and test events in `pallet-conviction-voting`

### DIFF
--- a/prdoc/pr_6544.prdoc
+++ b/prdoc/pr_6544.prdoc
@@ -1,0 +1,14 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Add and test events to conviction voting pallet
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Add event for the unlocking of an expired conviction vote's funds, and test recently added
+      voting events.
+
+crates:
+  - name: pallet-conviction-voting
+    bump: major

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -171,10 +171,12 @@ pub mod pallet {
 		Delegated(T::AccountId, T::AccountId),
 		/// An \[account\] has cancelled a previous delegation operation.
 		Undelegated(T::AccountId),
-		/// An account that has voted
+		/// An account has voted
 		Voted { who: T::AccountId, vote: AccountVote<BalanceOf<T, I>> },
-		/// A vote that been removed
+		/// A vote has been removed
 		VoteRemoved { who: T::AccountId, vote: AccountVote<BalanceOf<T, I>> },
+		/// The lockup period of a conviction vote expired, and the funds have been unlocked.
+		VoteUnlocked { who: T::AccountId, class: ClassOf<T, I> }
 	}
 
 	#[pallet::error]
@@ -315,6 +317,7 @@ pub mod pallet {
 			ensure_signed(origin)?;
 			let target = T::Lookup::lookup(target)?;
 			Self::update_lock(&class, &target);
+			Self::deposit_event(Event::VoteUnlocked { who: target, class });
 			Ok(())
 		}
 

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -176,7 +176,7 @@ pub mod pallet {
 		/// A vote has been removed
 		VoteRemoved { who: T::AccountId, vote: AccountVote<BalanceOf<T, I>> },
 		/// The lockup period of a conviction vote expired, and the funds have been unlocked.
-		VoteUnlocked { who: T::AccountId, class: ClassOf<T, I> }
+		VoteUnlocked { who: T::AccountId, class: ClassOf<T, I> },
 	}
 
 	#[pallet::error]

--- a/substrate/frame/conviction-voting/src/tests.rs
+++ b/substrate/frame/conviction-voting/src/tests.rs
@@ -238,27 +238,52 @@ fn basic_stuff() {
 fn basic_voting_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(2, 5)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: aye(2, 5)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(10, 0, 2));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, nay(2, 5)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: nay(2, 5)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 10, 0));
 		assert_eq!(Balances::usable_balance(1), 8);
 
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(5, 1)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: aye(5, 1)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(5, 0, 5));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, nay(5, 1)));
 		assert_eq!(tally(3), Tally::from_parts(0, 5, 0));
 		assert_eq!(Balances::usable_balance(1), 5);
 
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(10, 0)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: aye(10, 0)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(1, 0, 10));
+
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, nay(10, 0)));
 		assert_eq!(tally(3), Tally::from_parts(0, 1, 0));
 		assert_eq!(Balances::usable_balance(1), 0);
 
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
+			who: 1,
+			vote: nay(10, 0)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 
 		assert_ok!(Voting::unlock(RuntimeOrigin::signed(1), class(3), 1));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteUnlocked {
+			who: 1,
+			class: class(3)
+		}));
 		assert_eq!(Balances::usable_balance(1), 10);
 	});
 }
@@ -267,15 +292,32 @@ fn basic_voting_works() {
 fn split_voting_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split(10, 0)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: split(10, 0)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(1, 0, 10));
+
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split(5, 5)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: split(5, 5)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 5));
 		assert_eq!(Balances::usable_balance(1), 0);
 
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
+			who: 1,
+			vote: split(5, 5)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 
 		assert_ok!(Voting::unlock(RuntimeOrigin::signed(1), class(3), 1));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteUnlocked {
+			who: 1,
+			class: class(3)
+		}));
 		assert_eq!(Balances::usable_balance(1), 10);
 	});
 }
@@ -284,25 +326,48 @@ fn split_voting_works() {
 fn abstain_voting_works() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split_abstain(0, 0, 10)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 1,
+			vote: split_abstain(0, 0, 10)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 10));
-		assert_ok!(Voting::vote(RuntimeOrigin::signed(2), 3, split_abstain(0, 0, 20)));
-		assert_eq!(tally(3), Tally::from_parts(0, 0, 30));
-		assert_ok!(Voting::vote(RuntimeOrigin::signed(2), 3, split_abstain(10, 0, 10)));
-		assert_eq!(tally(3), Tally::from_parts(1, 0, 30));
+
+		assert_ok!(Voting::vote(RuntimeOrigin::signed(6), 3, split_abstain(10, 0, 20)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 6,
+			vote: split_abstain(10, 0, 20)
+		}));
+		assert_eq!(tally(3), Tally::from_parts(1, 0, 40));
+
+		assert_ok!(Voting::vote(RuntimeOrigin::signed(6), 3, split_abstain(0, 0, 40)));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
+			who: 6,
+			vote: split_abstain(0, 0, 40)
+		}));
+
+ 		assert_eq!(tally(3), Tally::from_parts(0, 0, 50));
 		assert_eq!(Balances::usable_balance(1), 0);
-		assert_eq!(Balances::usable_balance(2), 0);
+		assert_eq!(Balances::usable_balance(6), 20);
 
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
-		assert_eq!(tally(3), Tally::from_parts(1, 0, 20));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
+			who: 1,
+			vote: split_abstain(0, 0, 10)
+		}));
+		assert_eq!(tally(3), Tally::from_parts(0, 0, 40));
 
-		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(2), None, 3));
+		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(6), Some(class(3)), 3));
+		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
+			who: 6,
+			vote: split_abstain(0, 0, 40)
+		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 
 		assert_ok!(Voting::unlock(RuntimeOrigin::signed(1), class(3), 1));
 		assert_eq!(Balances::usable_balance(1), 10);
 
-		assert_ok!(Voting::unlock(RuntimeOrigin::signed(2), class(3), 2));
-		assert_eq!(Balances::usable_balance(2), 20);
+		assert_ok!(Voting::unlock(RuntimeOrigin::signed(6), class(3), 6));
+		assert_eq!(Balances::usable_balance(6), 60);
 	});
 }
 

--- a/substrate/frame/conviction-voting/src/tests.rs
+++ b/substrate/frame/conviction-voting/src/tests.rs
@@ -240,13 +240,13 @@ fn basic_voting_works() {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(2, 5)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: aye(2, 5)
+			vote: aye(2, 5),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(10, 0, 2));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, nay(2, 5)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: nay(2, 5)
+			vote: nay(2, 5),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 10, 0));
 		assert_eq!(Balances::usable_balance(1), 8);
@@ -254,7 +254,7 @@ fn basic_voting_works() {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(5, 1)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: aye(5, 1)
+			vote: aye(5, 1),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(5, 0, 5));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, nay(5, 1)));
@@ -264,7 +264,7 @@ fn basic_voting_works() {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(10, 0)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: aye(10, 0)
+			vote: aye(10, 0),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(1, 0, 10));
 
@@ -275,14 +275,14 @@ fn basic_voting_works() {
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
 			who: 1,
-			vote: nay(10, 0)
+			vote: nay(10, 0),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 
 		assert_ok!(Voting::unlock(RuntimeOrigin::signed(1), class(3), 1));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteUnlocked {
 			who: 1,
-			class: class(3)
+			class: class(3),
 		}));
 		assert_eq!(Balances::usable_balance(1), 10);
 	});
@@ -294,14 +294,14 @@ fn split_voting_works() {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split(10, 0)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: split(10, 0)
+			vote: split(10, 0),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(1, 0, 10));
 
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split(5, 5)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: split(5, 5)
+			vote: split(5, 5),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 5));
 		assert_eq!(Balances::usable_balance(1), 0);
@@ -309,14 +309,14 @@ fn split_voting_works() {
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
 			who: 1,
-			vote: split(5, 5)
+			vote: split(5, 5),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 
 		assert_ok!(Voting::unlock(RuntimeOrigin::signed(1), class(3), 1));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteUnlocked {
 			who: 1,
-			class: class(3)
+			class: class(3),
 		}));
 		assert_eq!(Balances::usable_balance(1), 10);
 	});
@@ -328,38 +328,38 @@ fn abstain_voting_works() {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split_abstain(0, 0, 10)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
-			vote: split_abstain(0, 0, 10)
+			vote: split_abstain(0, 0, 10),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 10));
 
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(6), 3, split_abstain(10, 0, 20)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 6,
-			vote: split_abstain(10, 0, 20)
+			vote: split_abstain(10, 0, 20),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(1, 0, 40));
 
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(6), 3, split_abstain(0, 0, 40)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 6,
-			vote: split_abstain(0, 0, 40)
+			vote: split_abstain(0, 0, 40),
 		}));
 
- 		assert_eq!(tally(3), Tally::from_parts(0, 0, 50));
+		assert_eq!(tally(3), Tally::from_parts(0, 0, 50));
 		assert_eq!(Balances::usable_balance(1), 0);
 		assert_eq!(Balances::usable_balance(6), 20);
 
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(1), None, 3));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
 			who: 1,
-			vote: split_abstain(0, 0, 10)
+			vote: split_abstain(0, 0, 10),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 40));
 
 		assert_ok!(Voting::remove_vote(RuntimeOrigin::signed(6), Some(class(3)), 3));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::VoteRemoved {
 			who: 6,
-			vote: split_abstain(0, 0, 40)
+			vote: split_abstain(0, 0, 40),
 		}));
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 

--- a/substrate/frame/conviction-voting/src/types.rs
+++ b/substrate/frame/conviction-voting/src/types.rs
@@ -119,12 +119,7 @@ impl<
 		nays_with_conviction: Votes,
 		support: Votes,
 	) -> Self {
-		Self {
-			ayes: ayes_with_conviction,
-			nays: nays_with_conviction,
-			support,
-			dummy: PhantomData,
-		}
+		Self { ayes: ayes_with_conviction, nays: nays_with_conviction, support, dummy: PhantomData }
 	}
 
 	/// Add an account's vote into the tally.

--- a/substrate/frame/conviction-voting/src/types.rs
+++ b/substrate/frame/conviction-voting/src/types.rs
@@ -117,12 +117,12 @@ impl<
 	pub fn from_parts(
 		ayes_with_conviction: Votes,
 		nays_with_conviction: Votes,
-		ayes: Votes,
+		support: Votes,
 	) -> Self {
 		Self {
 			ayes: ayes_with_conviction,
 			nays: nays_with_conviction,
-			support: ayes,
+			support,
 			dummy: PhantomData,
 		}
 	}


### PR DESCRIPTION
# Description

https://github.com/paritytech/polkadot-sdk/pull/4613 introduced events for `pallet_conviction_voting::{vote, remove_vote, remove_other_vote}`.
However:
1. it did not include `unlock`
2. the pallet's unit tests were missing an update

## Integration

N/A

## Review Notes

This is as https://github.com/paritytech/polkadot-sdk/pull/6261 was, so it is a trivial change.