### PR TITLE
authority-discovery: Ignore multi-addresses without IP from DHT records

### DIFF
--- a/substrate/client/authority-discovery/src/worker.rs
+++ b/substrate/client/authority-discovery/src/worker.rs
@@ -850,7 +850,9 @@ where
 		// Ignore [`Multiaddr`]s without [`PeerId`] or with own addresses.
 		let addresses: Vec<Multiaddr> = addresses
 			.into_iter()
-			.filter(|a| get_peer_id(&a).filter(|p| *p != local_peer_id).is_some())
+			.filter(|a| {
+				!address_is_empty(a) && get_peer_id(&a).filter(|p| *p != local_peer_id).is_some()
+			})
 			.collect();
 
 		let remote_peer_id = single(addresses.iter().map(|a| get_peer_id(&a)))
@@ -1030,6 +1032,15 @@ impl AddressType {
 			Some(address)
 		}
 	}
+}
+
+/// Checks if an authority-discovery address is empty.
+///
+/// An empty address is an address without protocols, or an address with only the `/p2p/..`
+/// protocol.
+fn address_is_empty(address: &Multiaddr) -> bool {
+	address.is_empty() ||
+		address.iter().all(|protocol| matches!(protocol, multiaddr::Protocol::P2p(_)))
 }
 
 /// NetworkProvider provides [`Worker`] with all necessary hooks into the

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -748,6 +748,14 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 						NetworkServiceCommand::AddKnownAddress { peer, address } => {
 							let mut address: Multiaddr = address.into();
 
+							if address.is_empty() {
+								log::debug!(
+									target: LOG_TARGET,
+									"Ignoring empty address for {peer:?}",
+								);
+								continue
+							}
+
 							if !address.iter().any(|protocol| std::matches!(protocol, Protocol::P2p(_))) {
 								address.push(Protocol::P2p(litep2p::PeerId::from(peer).into()));
 							}

--- a/substrate/client/network/src/peer_info.rs
+++ b/substrate/client/network/src/peer_info.rs
@@ -31,6 +31,7 @@ use libp2p::{
 		Info as IdentifyInfo,
 	},
 	identity::PublicKey,
+	multiaddr::Protocol,
 	ping::{Behaviour as Ping, Config as PingConfig, Event as PingEvent},
 	swarm::{
 		behaviour::{
@@ -66,6 +67,9 @@ pub struct PeerInfoBehaviour {
 	ping: Ping,
 	/// Periodically identifies the remote and responds to incoming requests.
 	identify: Identify,
+	/// Identity of our local node.
+	local_peer_id: PeerId,
+
 	/// Information that we know about all nodes.
 	nodes_info: FnvHashMap<PeerId, NodeInfo>,
 	/// Interval at which we perform garbage collection in `nodes_info`.
@@ -123,6 +127,7 @@ impl PeerInfoBehaviour {
 		local_public_key: PublicKey,
 		external_addresses: Arc<Mutex<HashSet<Multiaddr>>>,
 	) -> Self {
+		let local_peer_id = local_public_key.to_peer_id();
 		let identify = {
 			let cfg = IdentifyConfig::new("/substrate/1.0".to_string(), local_public_key)
 				.with_agent_version(user_agent)
@@ -134,6 +139,7 @@ impl PeerInfoBehaviour {
 		Self {
 			ping: Ping::new(PingConfig::new()),
 			identify,
+			local_peer_id,
 			nodes_info: FnvHashMap::default(),
 			garbage_collect: Box::pin(interval(GARBAGE_COLLECT_INTERVAL)),
 			external_addresses: ExternalAddresses { addresses: external_addresses },
@@ -177,6 +183,53 @@ impl PeerInfoBehaviour {
 			error!(target: "sub-libp2p",
 				"Received pong from node we're not connected to {:?}", peer_id);
 		}
+	}
+
+	/// Verify the external address discovered by the identify protocol.
+	///
+	/// This ensures that:
+	/// - the address is not empty
+	/// - the address contains a valid IP address
+	/// - the address is for the local peer ID
+	fn verify_external_address(&mut self, address: &Multiaddr) -> bool {
+		if address.is_empty() {
+			log::warn!(
+				target: "sub-libp2p",
+				"🔍 Discovered empty address",
+			);
+			return false;
+		};
+
+		// Expect the address to contain a valid IP address.
+		if std::matches!(
+			address.iter().next(),
+			Some(
+				Protocol::Dns(_) |
+					Protocol::Dns4(_) |
+					Protocol::Dns6(_) |
+					Protocol::Ip6(_) |
+					Protocol::Ip4(_),
+			)
+		) {
+			log::warn!(
+				target: "sub-libp2p",
+				"🔍 Discovered external address does not contain a valid IP address: {address}",
+			);
+			return false;
+		};
+
+		if let Some(Protocol::P2p(peer_id)) = address.iter().last() {
+			// Invalid address if the reported peer ID is not the local peer ID.
+			if peer_id != self.local_peer_id {
+				log::warn!(
+					target: "sub-libp2p",
+					"🔍 Discovered external address that is not us: {address}",
+				);
+				return false
+			}
+		}
+
+		true
 	}
 }
 
@@ -401,17 +454,20 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 				self.external_addresses.remove(e.addr);
 			},
 			FromSwarm::NewExternalAddrCandidate(e @ NewExternalAddrCandidate { addr }) => {
-				self.ping.on_swarm_event(FromSwarm::NewExternalAddrCandidate(e));
-				self.identify.on_swarm_event(FromSwarm::NewExternalAddrCandidate(e));
+				// Verify the external address is valid.
+				if self.verify_external_address(addr) {
+					self.ping.on_swarm_event(FromSwarm::NewExternalAddrCandidate(e));
+					self.identify.on_swarm_event(FromSwarm::NewExternalAddrCandidate(e));
 
-				// Manually confirm all external address candidates.
-				// TODO: consider adding [AutoNAT protocol](https://docs.rs/libp2p/0.52.3/libp2p/autonat/index.html)
-				// (must go through the polkadot protocol spec) or implemeting heuristics for
-				// approving external address candidates. This can be done, for example, by
-				// approving only addresses reported by multiple peers.
-				// See also https://github.com/libp2p/rust-libp2p/pull/4721 introduced
-				// in libp2p v0.53 for heuristics approach.
-				self.pending_actions.push_back(ToSwarm::ExternalAddrConfirmed(addr.clone()));
+					// Manually confirm all external address candidates.
+					// TODO: consider adding [AutoNAT protocol](https://docs.rs/libp2p/0.52.3/libp2p/autonat/index.html)
+					// (must go through the polkadot protocol spec) or implemeting heuristics for
+					// approving external address candidates. This can be done, for example, by
+					// approving only addresses reported by multiple peers.
+					// See also https://github.com/libp2p/rust-libp2p/pull/4721 introduced
+					// in libp2p v0.53 for heuristics approach.
+					self.pending_actions.push_back(ToSwarm::ExternalAddrConfirmed(addr.clone()));
+				}
 			},
 			FromSwarm::ExternalAddrConfirmed(e @ ExternalAddrConfirmed { addr }) => {
 				self.ping.on_swarm_event(FromSwarm::ExternalAddrConfirmed(e));

--- a/substrate/client/network/types/src/multiaddr.rs
+++ b/substrate/client/network/types/src/multiaddr.rs
@@ -42,6 +42,11 @@ pub struct Multiaddr {
 }
 
 impl Multiaddr {
+	/// Returns `true` if this multiaddress is empty.
+	pub fn is_empty(&self) -> bool {
+		self.multiaddr.is_empty()
+	}
+
 	/// Create a new, empty multiaddress.
 	pub fn empty() -> Self {
 		Self { multiaddr: LiteP2pMultiaddr::empty() }


### PR DESCRIPTION
Kusama has several authority-discovery records published without a proper mutlti-address format.

```bash
authority="CzHcp6nEsT4NJuAbf4yCS2J8KKYpvuAe63bkWrPWhjaaT6w" 
..
addresses={.., /p2p/12D3KooWFegWJubWCeJCbWpDEAwukQmXKaWTyRgRRZ8NNdzmuxSr, ..}
```
In the previous example, an multiaddress of form `/p2p/12D3KooWFegWJubWCeJCbWpDEAwukQmXKaWTyRgRRZ8NNdzmuxSr` cannot establish a connection to the authority.

This PR changes the following:
- publishing DHT records no longer includes multi addresses that are empty or just contain `/p2p/[peer]` format
- received DHT records are filtered in a similar manner 
- litep2p and libp2p backends verify discovered external addresses before pushing them to other subcomponents


### Next Steps
- [ ] versi-net burnin with detailed logs
- [ ] kusama nodes (litep2p + libp2p) to ensure the warnings are not excessive

Closes: https://github.com/paritytech/polkadot-sdk/issues/6518

cc @paritytech/networking 