### PR TITLE
rpc server: fix subscription id_provider being reset to default one.

### DIFF
--- a/prdoc/pr_6588.prdoc
+++ b/prdoc/pr_6588.prdoc
@@ -1,7 +1,7 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: Fix id_provider being reset to default one.
+title: "rpc server: fix subscription id_provider being reset to default one"
 
 doc:
   - audience: Node Dev

--- a/prdoc/pr_6588.prdoc
+++ b/prdoc/pr_6588.prdoc
@@ -11,4 +11,4 @@ doc:
 
 crates:
   - name: sc-rpc-server
-    bump: minor
+    bump: patch

--- a/prdoc/pr_6588.prdoc
+++ b/prdoc/pr_6588.prdoc
@@ -1,7 +1,7 @@
 # Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
 # See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
 
-title: Fix benchmark failures when using insecure_zero_ed flag
+title: Fix id_provider being reset to default one.
 
 doc:
   - audience: Node Dev
@@ -11,4 +11,4 @@ doc:
 
 crates:
   - name: sc-rpc-server
-  bump: minor
+    bump: minor

--- a/prdoc/pr_6588.prdoc
+++ b/prdoc/pr_6588.prdoc
@@ -1,0 +1,14 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fix benchmark failures when using insecure_zero_ed flag
+
+doc:
+  - audience: Node Dev
+    description: |
+      The modification ensures that the id_provider variable is cloned instead of taken, which can help prevent issues related id provider being reset to the default.
+
+
+crates:
+    - name: sc-rpc-server
+    bump: minor

--- a/prdoc/pr_6588.prdoc
+++ b/prdoc/pr_6588.prdoc
@@ -10,5 +10,5 @@ doc:
 
 
 crates:
-    - name: sc-rpc-server
-    bump: minor
+  - name: sc-rpc-server
+  bump: minor

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -200,7 +200,7 @@ where
 					.custom_tokio_runtime(cfg.tokio_handle.clone())
 					.set_id_provider(RandomStringIdProvider::new(16));
 
-				if let Some(provider) = id_provider2.take() {
+				if let Some(provider) = id_provider2.clone() {
 					builder = builder.set_id_provider(provider);
 				} else {
 					builder = builder.set_id_provider(RandomStringIdProvider::new(16));

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -197,7 +197,7 @@ where
 					.set_http_middleware(http_middleware)
 					.set_message_buffer_capacity(max_buffer_capacity_per_connection)
 					.set_batch_request_config(batch_config)
-					.custom_tokio_runtime(cfg.tokio_handle.clone())
+					.custom_tokio_runtime(cfg.tokio_handle.clone());
 
 				if let Some(provider) = id_provider2.clone() {
 					builder = builder.set_id_provider(provider);

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -198,7 +198,6 @@ where
 					.set_message_buffer_capacity(max_buffer_capacity_per_connection)
 					.set_batch_request_config(batch_config)
 					.custom_tokio_runtime(cfg.tokio_handle.clone())
-					.set_id_provider(RandomStringIdProvider::new(16));
 
 				if let Some(provider) = id_provider2.clone() {
 					builder = builder.set_id_provider(provider);

--- a/substrate/client/rpc-servers/src/lib.rs
+++ b/substrate/client/rpc-servers/src/lib.rs
@@ -144,7 +144,7 @@ where
 		local_addrs.push(local_addr);
 		let cfg = cfg.clone();
 
-		let mut id_provider2 = id_provider.clone();
+		let id_provider2 = id_provider.clone();
 
 		tokio_handle.spawn(async move {
 			loop {


### PR DESCRIPTION
# Description

The PR ensures that the id_provider variable is cloned instead of taken, which can help prevent issues related id provider being reset to the default.

In [a test in moonbeam](https://github.com/moonbeam-foundation/moonbeam/blob/c6d07d703dfcdd94cc311fa83b553071b7d433ff/test/suites/dev/moonbase/test-subscription/test-subscription.ts#L20-L31) we found that the id_provider is being reset somehow and changed to the default one. Changing .take() to .clone() would fix the issue.


# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
