### PR TITLE
XCM: fix for Transact v5->v4 decoding

### DIFF
--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -1315,7 +1315,8 @@ impl<Call: Decode + GetDispatchInfo> TryFrom<NewInstruction<Call>> for Instructi
 			HrmpChannelClosing { initiator, sender, recipient } =>
 				Self::HrmpChannelClosing { initiator, sender, recipient },
 			Transact { origin_kind, mut call } => {
-				let require_weight_at_most = call.take_decoded()
+				let require_weight_at_most = call
+					.take_decoded()
 					.map(|c| c.get_dispatch_info().call_weight)
 					.unwrap_or(Weight::MAX);
 				Self::Transact { origin_kind, require_weight_at_most, call: call.into() }

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -1315,7 +1315,9 @@ impl<Call: Decode + GetDispatchInfo> TryFrom<NewInstruction<Call>> for Instructi
 			HrmpChannelClosing { initiator, sender, recipient } =>
 				Self::HrmpChannelClosing { initiator, sender, recipient },
 			Transact { origin_kind, mut call } => {
-				let require_weight_at_most = call.take_decoded()?.get_dispatch_info().call_weight;
+				let require_weight_at_most = call.take_decoded()
+					.map(|c| c.get_dispatch_info().call_weight)
+					.unwrap_or(Weight::MAX);
 				Self::Transact { origin_kind, require_weight_at_most, call: call.into() }
 			},
 			ReportError(response_info) => Self::ReportError(QueryResponseInfo {


### PR DESCRIPTION
Closes: https://github.com/paritytech/polkadot-sdk/issues/6585
Relates to: https://github.com/paritytech/polkadot-sdk/pull/6228