### PR TITLE
Add sorted voter list preserve mechanism to multi-block staking pallet

### DIFF
--- a/prdoc/pr_6520.prdoc
+++ b/prdoc/pr_6520.prdoc
@@ -1,0 +1,10 @@
+title: Implements a mechanism to perserve the bags-list ID order
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Refactors the bags list pallet to support a mode which perserves the order of the elements in the list.
+
+crates:
+ - name: pallet-bags-list
+   bump: major

--- a/substrate/frame/bags-list/src/list/mod.rs
+++ b/substrate/frame/bags-list/src/list/mod.rs
@@ -840,7 +840,7 @@ impl<T: Config<I>, I: 'static> Node<T, I> {
 		crate::ListNodes::<T, I>::insert(self.id.clone(), self);
 	}
 
-	/// Update neighboring nodes to point to reach other.
+	/// Update neighboring nodes to point to each other.
 	///
 	/// Only updates storage for adjacent nodes, but not `self`; so the user may need to call
 	/// `self.put`.

--- a/substrate/frame/bags-list/src/mock.rs
+++ b/substrate/frame/bags-list/src/mock.rs
@@ -56,6 +56,7 @@ impl frame_system::Config for Runtime {
 
 parameter_types! {
 	pub static BagThresholds: &'static [VoteWeight] = &[10, 20, 30, 40, 50, 60, 1_000, 2_000, 10_000];
+	pub static PreserveOrder: bool = false;
 }
 
 impl bags_list::Config for Runtime {
@@ -64,6 +65,7 @@ impl bags_list::Config for Runtime {
 	type BagThresholds = BagThresholds;
 	type ScoreProvider = StakingMock;
 	type Score = VoteWeight;
+	type PreserveOrder = PreserveOrder;
 }
 
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/substrate/frame/nomination-pools/test-delegate-stake/src/mock.rs
+++ b/substrate/frame/nomination-pools/test-delegate-stake/src/mock.rs
@@ -117,6 +117,7 @@ impl pallet_bags_list::Config<VoterBagsListInstance> for Runtime {
 	type BagThresholds = BagThresholds;
 	type ScoreProvider = Staking;
 	type Score = VoteWeight;
+	type PreserveOrder = Staking;
 }
 
 pub struct BalanceToU256;

--- a/substrate/frame/nomination-pools/test-transfer-stake/src/mock.rs
+++ b/substrate/frame/nomination-pools/test-transfer-stake/src/mock.rs
@@ -109,6 +109,7 @@ impl pallet_bags_list::Config<VoterBagsListInstance> for Runtime {
 	type BagThresholds = BagThresholds;
 	type ScoreProvider = Staking;
 	type Score = VoteWeight;
+	type PreserveOrder = Staking;
 }
 
 pub struct BalanceToU256;

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -220,6 +220,7 @@ impl pallet_bags_list::Config<VoterBagsListInstance> for Test {
 	type ScoreProvider = Staking;
 	type BagThresholds = BagThresholds;
 	type Score = VoteWeight;
+	type PreserveOrder = Staking;
 }
 
 // multi-page types and controller.

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -1727,6 +1727,18 @@ where
 	}
 }
 
+/// Implements the lock to be used by the the sorted list providers implemented by the bags list
+/// pallet.
+///
+/// When it returns `true`, the bags list ID ordering should be disabled.
+impl<T: Config> Get<bool> for Pallet<T> {
+	fn get() -> bool {
+		// sorted list provider order perservation not enabled yet, see
+		// <https://github.com/paritytech/polkadot-sdk/pull/6034>.
+		false
+	}
+}
+
 impl<T: Config> ScoreProvider<T::AccountId> for Pallet<T> {
 	type Score = VoteWeight;
 
@@ -1808,6 +1820,7 @@ impl<T: Config> SortedListProvider<T::AccountId> for UseValidatorsMap<T> {
 		// nothing to do upon regenerate.
 		0
 	}
+
 	#[cfg(feature = "try-runtime")]
 	fn try_state() -> Result<(), TryRuntimeError> {
 		Ok(())


### PR DESCRIPTION
Do not merge yet.

This PR has https://github.com/paritytech/polkadot-sdk/pull/6520 merged in and shows how to integrate the sorted list preserve logic in staking's multi-page snapshot creation.

- [ ] merge https://github.com/paritytech/polkadot-sdk/pull/6520 into `master`
- [ ] merge `master` into `gpestana/epm-mb`
- [ ] squash + merge this PR into the `gpestana/epm-mb` branch