### PR TITLE
Migration of polkadot-runtime-common paras_registrar benchmarking to v2.

### DIFF
--- a/polkadot/runtime/common/src/paras_registrar/mod.rs
+++ b/polkadot/runtime/common/src/paras_registrar/mod.rs
@@ -318,7 +318,7 @@ pub mod pallet {
 			// early, since swapping the same id would otherwise be a noop.
 			if id == other {
 				PendingSwap::<T>::remove(id);
-				return Ok(())
+				return Ok(());
 			}
 
 			// Sanity check that `id` is even a para.
@@ -330,23 +330,23 @@ pub mod pallet {
 					paras::Pallet::<T>::lifecycle(other).ok_or(Error::<T>::NotRegistered)?;
 				// identify which is a lease holding parachain and which is a parathread (on-demand
 				// parachain)
-				if id_lifecycle == ParaLifecycle::Parachain &&
-					other_lifecycle == ParaLifecycle::Parathread
+				if id_lifecycle == ParaLifecycle::Parachain
+					&& other_lifecycle == ParaLifecycle::Parathread
 				{
 					Self::do_thread_and_chain_swap(id, other);
-				} else if id_lifecycle == ParaLifecycle::Parathread &&
-					other_lifecycle == ParaLifecycle::Parachain
+				} else if id_lifecycle == ParaLifecycle::Parathread
+					&& other_lifecycle == ParaLifecycle::Parachain
 				{
 					Self::do_thread_and_chain_swap(other, id);
-				} else if id_lifecycle == ParaLifecycle::Parachain &&
-					other_lifecycle == ParaLifecycle::Parachain
+				} else if id_lifecycle == ParaLifecycle::Parachain
+					&& other_lifecycle == ParaLifecycle::Parachain
 				{
 					// If both chains are currently parachains, there is nothing funny we
 					// need to do for their lifecycle management, just swap the underlying
 					// data.
 					T::OnSwap::on_swap(id, other);
 				} else {
-					return Err(Error::<T>::CannotSwap.into())
+					return Err(Error::<T>::CannotSwap.into());
 				}
 				Self::deposit_event(Event::<T>::Swapped { para_id: id, other_id: other });
 				PendingSwap::<T>::remove(other);
@@ -1532,7 +1532,7 @@ mod benchmarking {
 	use polkadot_runtime_parachains::{paras, shared, Origin as ParaOrigin};
 	use sp_runtime::traits::Bounded;
 
-	use frame_benchmarking::{account, benchmarks, whitelisted_caller};
+	use frame_benchmarking::v2::*;
 
 	fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 		let events = frame_system::Pallet::<T>::events();
@@ -1559,7 +1559,7 @@ mod benchmarking {
 			frame_system::Origin::<T>::Root.into(),
 			validation_code,
 		));
-		return para
+		return para;
 	}
 
 	fn para_origin(id: u32) -> ParaOrigin {
@@ -1572,66 +1572,105 @@ mod benchmarking {
 		paras::Pallet::<T>::test_on_new_session();
 	}
 
-	benchmarks! {
-		where_clause { where ParaOrigin: Into<<T as frame_system::Config>::RuntimeOrigin> }
+	#[benchmarks(
+		where ParaOrigin: Into<<T as frame_system::Config>::RuntimeOrigin>,
+	)]
+	mod benchmarks {
+		use super::*;
 
-		reserve {
+		#[benchmark]
+		fn reserve() -> Result<(), BenchmarkError> {
 			let caller: T::AccountId = whitelisted_caller();
 			T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
-		}: _(RawOrigin::Signed(caller.clone()))
-		verify {
-			assert_last_event::<T>(Event::<T>::Reserved { para_id: LOWEST_PUBLIC_ID, who: caller }.into());
+
+			#[extrinsic_call]
+			_(RawOrigin::Signed(caller.clone()));
+
+			assert_last_event::<T>(
+				Event::<T>::Reserved { para_id: LOWEST_PUBLIC_ID, who: caller }.into(),
+			);
 			assert!(Paras::<T>::get(LOWEST_PUBLIC_ID).is_some());
 			assert_eq!(paras::Pallet::<T>::lifecycle(LOWEST_PUBLIC_ID), None);
+
+			Ok(())
 		}
 
-		register {
+		#[benchmark]
+		fn register() -> Result<(), BenchmarkError> {
 			let para = LOWEST_PUBLIC_ID;
 			let genesis_head = Registrar::<T>::worst_head_data();
 			let validation_code = Registrar::<T>::worst_validation_code();
 			let caller: T::AccountId = whitelisted_caller();
 			T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 			assert_ok!(Registrar::<T>::reserve(RawOrigin::Signed(caller.clone()).into()));
-		}: _(RawOrigin::Signed(caller.clone()), para, genesis_head, validation_code.clone())
-		verify {
-			assert_last_event::<T>(Event::<T>::Registered{ para_id: para, manager: caller }.into());
+
+			#[extrinsic_call]
+			_(RawOrigin::Signed(caller.clone()), para, genesis_head, validation_code.clone());
+
+			assert_last_event::<T>(
+				Event::<T>::Registered { para_id: para, manager: caller }.into(),
+			);
 			assert_eq!(paras::Pallet::<T>::lifecycle(para), Some(ParaLifecycle::Onboarding));
-			assert_ok!(polkadot_runtime_parachains::paras::Pallet::<T>::add_trusted_validation_code(
-				frame_system::Origin::<T>::Root.into(),
-				validation_code,
-			));
+			assert_ok!(
+				polkadot_runtime_parachains::paras::Pallet::<T>::add_trusted_validation_code(
+					frame_system::Origin::<T>::Root.into(),
+					validation_code,
+				)
+			);
 			next_scheduled_session::<T>();
 			assert_eq!(paras::Pallet::<T>::lifecycle(para), Some(ParaLifecycle::Parathread));
+
+			Ok(())
 		}
 
-		force_register {
+		#[benchmark]
+		fn force_register() -> Result<(), BenchmarkError> {
 			let manager: T::AccountId = account("manager", 0, 0);
 			let deposit = 0u32.into();
 			let para = ParaId::from(69);
 			let genesis_head = Registrar::<T>::worst_head_data();
 			let validation_code = Registrar::<T>::worst_validation_code();
-		}: _(RawOrigin::Root, manager.clone(), deposit, para, genesis_head, validation_code.clone())
-		verify {
+
+			#[extrinsic_call]
+			_(
+				RawOrigin::Root,
+				manager.clone(),
+				deposit,
+				para,
+				genesis_head,
+				validation_code.clone(),
+			);
+
 			assert_last_event::<T>(Event::<T>::Registered { para_id: para, manager }.into());
 			assert_eq!(paras::Pallet::<T>::lifecycle(para), Some(ParaLifecycle::Onboarding));
-			assert_ok!(polkadot_runtime_parachains::paras::Pallet::<T>::add_trusted_validation_code(
-				frame_system::Origin::<T>::Root.into(),
-				validation_code,
-			));
+			assert_ok!(
+				polkadot_runtime_parachains::paras::Pallet::<T>::add_trusted_validation_code(
+					frame_system::Origin::<T>::Root.into(),
+					validation_code,
+				)
+			);
 			next_scheduled_session::<T>();
 			assert_eq!(paras::Pallet::<T>::lifecycle(para), Some(ParaLifecycle::Parathread));
+
+			Ok(())
 		}
 
-		deregister {
+		#[benchmark]
+		fn deregister() -> Result<(), BenchmarkError> {
 			let para = register_para::<T>(LOWEST_PUBLIC_ID.into());
 			next_scheduled_session::<T>();
 			let caller: T::AccountId = whitelisted_caller();
-		}: _(RawOrigin::Signed(caller), para)
-		verify {
+
+			#[extrinsic_call]
+			_(RawOrigin::Signed(caller), para);
+
 			assert_last_event::<T>(Event::<T>::Deregistered { para_id: para }.into());
+
+			Ok(())
 		}
 
-		swap {
+		#[benchmark]
+		fn swap() -> Result<(), BenchmarkError> {
 			// On demand parachain
 			let parathread = register_para::<T>(LOWEST_PUBLIC_ID.into());
 			let parachain = register_para::<T>((LOWEST_PUBLIC_ID + 1).into());
@@ -1650,25 +1689,41 @@ mod benchmarking {
 
 			let caller: T::AccountId = whitelisted_caller();
 			Registrar::<T>::swap(parachain_origin.into(), parachain, parathread)?;
-		}: _(RawOrigin::Signed(caller.clone()), parathread, parachain)
-		verify {
+
+			#[extrinsic_call]
+			_(RawOrigin::Signed(caller.clone()), parathread, parachain);
+
 			next_scheduled_session::<T>();
 			// Swapped!
 			assert_eq!(paras::Pallet::<T>::lifecycle(parachain), Some(ParaLifecycle::Parathread));
 			assert_eq!(paras::Pallet::<T>::lifecycle(parathread), Some(ParaLifecycle::Parachain));
+
+			Ok(())
 		}
 
-		schedule_code_upgrade {
-			let b in MIN_CODE_SIZE .. MAX_CODE_SIZE;
+		#[benchmark]
+		fn schedule_code_upgrade(
+			b: Linear<MIN_CODE_SIZE, MAX_CODE_SIZE>,
+		) -> Result<(), BenchmarkError> {
 			let new_code = ValidationCode(vec![0; b as usize]);
 			let para_id = ParaId::from(1000);
-		}: _(RawOrigin::Root, para_id, new_code)
 
-		set_current_head {
-			let b in 1 .. MAX_HEAD_DATA_SIZE;
+			#[extrinsic_call]
+			_(RawOrigin::Root, para_id, new_code);
+
+			Ok(())
+		}
+
+		#[benchmark]
+		fn set_current_head(b: Linear<1, MAX_HEAD_DATA_SIZE>) -> Result<(), BenchmarkError> {
 			let new_head = HeadData(vec![0; b as usize]);
 			let para_id = ParaId::from(1000);
-		}: _(RawOrigin::Root, para_id, new_head)
+
+			#[extrinsic_call]
+			_(RawOrigin::Root, para_id, new_head);
+
+			Ok(())
+		}
 
 		impl_benchmark_test_suite!(
 			Registrar,


### PR DESCRIPTION
#Description
Migrated polkadot-runtime-common paras_registrar benchmarking to the new benchmarking syntax v2.
This is part of #6202 