### PR TITLE
Migrating pallet-xcm-benchmarks to V2

### DIFF
--- a/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -13,12 +13,13 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+#![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
 use crate::{account_and_location, new_executor, EnsureDelivery, XcmCallOf};
 use alloc::{vec, vec::Vec};
 use codec::Encode;
-use frame_benchmarking::{benchmarks, BenchmarkError};
+use frame_benchmarking::v2::*;
 use frame_support::traits::fungible::Inspect;
 use xcm::{
 	latest::{prelude::*, MaxDispatchErrorLen, MaybeErrorCode, Weight, MAX_ITEMS_IN_ASSETS},
@@ -29,16 +30,21 @@ use xcm_executor::{
 	ExecutorError, FeesMode,
 };
 
-benchmarks! {
-	report_holding {
+#[benchmarks]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn report_holding() -> Result<(), BenchmarkError> {
 		let (sender_account, sender_location) = account_and_location::<T>(1);
 		let destination = T::valid_destination().map_err(|_| BenchmarkError::Skip)?;
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&sender_location,
-			&destination,
-			FeeReason::Report,
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(
+				&sender_location,
+				&destination,
+				FeeReason::Report,
+			);
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
 		// generate holding and add possible required fees
@@ -65,20 +71,31 @@ benchmarks! {
 				max_weight: Weight::MAX,
 			},
 			// Worst case is looking through all holdings for every asset explicitly - respecting the limit `MAX_ITEMS_IN_ASSETS`.
-			assets: Definite(holding.into_inner().into_iter().take(MAX_ITEMS_IN_ASSETS).collect::<Vec<_>>().into()),
+			assets: Definite(
+				holding
+					.into_inner()
+					.into_iter()
+					.take(MAX_ITEMS_IN_ASSETS)
+					.collect::<Vec<_>>()
+					.into(),
+			),
 		};
 
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check we charged the delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
+
+		Ok(())
 	}
 
 	// This benchmark does not use any additional orders or instructions. This should be managed
 	// by the `deep` and `shallow` implementation.
-	buy_execution {
+	#[benchmark]
+	fn buy_execution() -> Result<(), BenchmarkError> {
 		let holding = T::worst_case_holding(0).into();
 
 		let mut executor = new_executor::<T>(Default::default());
@@ -92,13 +109,16 @@ benchmarks! {
 		};
 
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 
+		Ok(())
 	}
 
-	pay_fees {
+	#[benchmark]
+	fn pay_fees() -> Result<(), BenchmarkError> {
 		let holding = T::worst_case_holding(0).into();
 
 		let mut executor = new_executor::<T>(Default::default());
@@ -111,40 +131,53 @@ benchmarks! {
 		let instruction = Instruction::<XcmCallOf<T>>::PayFees { asset: fee_asset };
 
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {}
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		Ok(())
+	}
 
-	set_asset_claimer {
+	#[benchmark]
+	fn set_asset_claimer() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let (_, sender_location) = account_and_location::<T>(1);
 
-		let instruction = Instruction::SetAssetClaimer{ location:sender_location.clone() };
+		let instruction = Instruction::SetAssetClaimer { location: sender_location.clone() };
 
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.asset_claimer(), Some(sender_location.clone()));
+
+		Ok(())
 	}
 
-	query_response {
+	#[benchmark]
+	fn query_response() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let (query_id, response) = T::worst_case_response();
 		let max_weight = Weight::MAX;
 		let querier: Option<Location> = Some(Here.into());
 		let instruction = Instruction::QueryResponse { query_id, response, max_weight, querier };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// The assert above is enough to show this XCM succeeded
+
+		Ok(())
 	}
 
 	// We don't care about the call itself, since that is accounted for in the weight parameter
 	// and included in the final weight calculation. So this is just the overhead of submitting
 	// a noop call.
-	transact {
+	#[benchmark]
+	fn transact() -> Result<(), BenchmarkError> {
 		let (origin, noop_call) = T::transact_origin_and_runtime_call()?;
 		let mut executor = new_executor::<T>(origin);
 		let double_encoded_noop_call: DoubleEncoded<_> = noop_call.encode().into();
@@ -154,119 +187,145 @@ benchmarks! {
 			call: double_encoded_noop_call,
 		};
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// TODO Make the assertion configurable?
+
+		Ok(())
 	}
 
-	refund_surplus {
+	#[benchmark]
+	fn refund_surplus() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let holding_assets = T::worst_case_holding(1);
 		// We can already buy execution since we'll load the holding register manually
 		let asset_for_fees = T::fee_asset().unwrap();
-		let previous_xcm = Xcm(vec![BuyExecution { fees: asset_for_fees, weight_limit: Limited(Weight::from_parts(1337, 1337)) }]);
+		let previous_xcm = Xcm(vec![BuyExecution {
+			fees: asset_for_fees,
+			weight_limit: Limited(Weight::from_parts(1337, 1337)),
+		}]);
 		executor.set_holding(holding_assets.into());
 		executor.set_total_surplus(Weight::from_parts(1337, 1337));
 		executor.set_total_refunded(Weight::zero());
-		executor.bench_process(previous_xcm).expect("Holding has been loaded, so we can buy execution here");
+		executor
+			.bench_process(previous_xcm)
+			.expect("Holding has been loaded, so we can buy execution here");
 
 		let instruction = Instruction::<XcmCallOf<T>>::RefundSurplus;
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		let result = executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			let result = executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.total_surplus(), &Weight::from_parts(1337, 1337));
 		assert_eq!(executor.total_refunded(), &Weight::from_parts(1337, 1337));
+
+		Ok(())
 	}
 
-	set_error_handler {
+	#[benchmark]
+	fn set_error_handler() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let instruction = Instruction::<XcmCallOf<T>>::SetErrorHandler(Xcm(vec![]));
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.error_handler(), &Xcm(vec![]));
+
+		Ok(())
 	}
 
-	set_appendix {
+	#[benchmark]
+	fn set_appendix() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let appendix = Xcm(vec![]);
 		let instruction = Instruction::<XcmCallOf<T>>::SetAppendix(appendix);
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.appendix(), &Xcm(vec![]));
+		Ok(())
 	}
 
-	clear_error {
+	#[benchmark]
+	fn clear_error() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_error(Some((5u32, XcmError::Overflow)));
 		let instruction = Instruction::<XcmCallOf<T>>::ClearError;
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
-		assert!(executor.error().is_none())
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		assert!(executor.error().is_none());
+		Ok(())
 	}
 
-	descend_origin {
+	#[benchmark]
+	fn descend_origin() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let who = Junctions::from([OnlyChild, OnlyChild]);
 		let instruction = Instruction::DescendOrigin(who.clone());
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
-		assert_eq!(
-			executor.origin(),
-			&Some(Location {
-				parents: 0,
-				interior: who,
-			}),
-		);
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		assert_eq!(executor.origin(), &Some(Location { parents: 0, interior: who }),);
+
+		Ok(())
 	}
 
-	execute_with_origin {
+	#[benchmark]
+	fn execute_with_origin() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let who: Junctions = Junctions::from([AccountId32 { id: [0u8; 32], network: None }]);
-		let instruction = Instruction::ExecuteWithOrigin { descendant_origin: Some(who.clone()), xcm: Xcm(vec![]) };
+		let instruction = Instruction::ExecuteWithOrigin {
+			descendant_origin: Some(who.clone()),
+			xcm: Xcm(vec![]),
+		};
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
-		assert_eq!(
-			executor.origin(),
-			&Some(Location {
-				parents: 0,
-				interior: Here,
-			}),
-		);
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		assert_eq!(executor.origin(), &Some(Location { parents: 0, interior: Here }),);
+
+		Ok(())
 	}
 
-	clear_origin {
+	#[benchmark]
+	fn clear_origin() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let instruction = Instruction::ClearOrigin;
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.origin(), &None);
+		Ok(())
 	}
 
-	report_error {
+	#[benchmark]
+	fn report_error() -> Result<(), BenchmarkError> {
 		let (sender_account, sender_location) = account_and_location::<T>(1);
 		let query_id = Default::default();
 		let max_weight = Default::default();
 		let destination = T::valid_destination().map_err(|_| BenchmarkError::Skip)?;
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&sender_location,
-			&destination,
-			FeeReason::Report,
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(
+				&sender_location,
+				&destination,
+				FeeReason::Report,
+			);
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
 		let mut executor = new_executor::<T>(sender_location);
@@ -278,18 +337,21 @@ benchmarks! {
 		}
 		executor.set_error(Some((0u32, XcmError::Unimplemented)));
 
-		let instruction = Instruction::ReportError(QueryResponseInfo {
-			query_id, destination, max_weight
-		});
+		let instruction =
+			Instruction::ReportError(QueryResponseInfo { query_id, destination, max_weight });
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check we charged the delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
+
+		Ok(())
 	}
 
-	claim_asset {
+	#[benchmark]
+	fn claim_asset() -> Result<(), BenchmarkError> {
 		use xcm_executor::traits::DropAssets;
 
 		let (origin, ticket, assets) = T::claimable_asset()?;
@@ -298,11 +360,7 @@ benchmarks! {
 		<T::XcmConfig as xcm_executor::Config>::AssetTrap::drop_assets(
 			&origin,
 			assets.clone().into(),
-			&XcmContext {
-				origin: Some(origin.clone()),
-				message_id: [0; 32],
-				topic: None,
-			},
+			&XcmContext { origin: Some(origin.clone()), message_id: [0; 32], topic: None },
 		);
 
 		// Assets should be in the trap now.
@@ -310,28 +368,32 @@ benchmarks! {
 		let mut executor = new_executor::<T>(origin);
 		let instruction = Instruction::ClaimAsset { assets: assets.clone(), ticket };
 		let xcm = Xcm(vec![instruction]);
-	} :{
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert!(executor.holding().ensure_contains(&assets).is_ok());
+		Ok(())
 	}
 
-	trap {
+	#[benchmark]
+	fn trap() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let instruction = Instruction::Trap(10);
 		let xcm = Xcm(vec![instruction]);
 		// In order to access result in the verification below, it needs to be defined here.
 		let mut _result = Ok(());
-	} : {
-		_result = executor.bench_process(xcm);
-	} verify {
-		assert!(matches!(_result, Err(ExecutorError {
-			xcm_error: XcmError::Trap(10),
-			..
-		})));
+		#[block]
+		{
+			_result = executor.bench_process(xcm);
+		}
+		assert!(matches!(_result, Err(ExecutorError { xcm_error: XcmError::Trap(10), .. })));
+
+		Ok(())
 	}
 
-	subscribe_version {
+	#[benchmark]
+	fn subscribe_version() -> Result<(), BenchmarkError> {
 		use xcm_executor::traits::VersionChangeNotifier;
 		let origin = T::subscribe_origin()?;
 		let query_id = Default::default();
@@ -339,13 +401,18 @@ benchmarks! {
 		let mut executor = new_executor::<T>(origin.clone());
 		let instruction = Instruction::SubscribeVersion { query_id, max_response_weight };
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
-		assert!(<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(&origin));
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		assert!(<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(
+			&origin
+		));
+		Ok(())
 	}
 
-	unsubscribe_version {
+	#[benchmark]
+	fn unsubscribe_version() -> Result<(), BenchmarkError> {
 		use xcm_executor::traits::VersionChangeNotifier;
 		// First we need to subscribe to notifications.
 		let (origin, _) = T::transact_origin_and_runtime_call()?;
@@ -355,24 +422,28 @@ benchmarks! {
 			&origin,
 			query_id,
 			max_response_weight,
-			&XcmContext {
-				origin: Some(origin.clone()),
-				message_id: [0; 32],
-				topic: None,
-			},
-		).map_err(|_| "Could not start subscription")?;
-		assert!(<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(&origin));
+			&XcmContext { origin: Some(origin.clone()), message_id: [0; 32], topic: None },
+		)
+		.map_err(|_| "Could not start subscription")?;
+		assert!(<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(
+			&origin
+		));
 
 		let mut executor = new_executor::<T>(origin.clone());
 		let instruction = Instruction::UnsubscribeVersion;
 		let xcm = Xcm(vec![instruction]);
-	} : {
-		executor.bench_process(xcm)?;
-	} verify {
-		assert!(!<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(&origin));
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		assert!(!<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(
+			&origin
+		));
+		Ok(())
 	}
 
-	burn_asset {
+	#[benchmark]
+	fn burn_asset() -> Result<(), BenchmarkError> {
 		let holding = T::worst_case_holding(0);
 		let assets = holding.clone();
 
@@ -381,13 +452,16 @@ benchmarks! {
 
 		let instruction = Instruction::BurnAsset(assets.into());
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert!(executor.holding().is_empty());
+		Ok(())
 	}
 
-	expect_asset {
+	#[benchmark]
+	fn expect_asset() -> Result<(), BenchmarkError> {
 		let holding = T::worst_case_holding(0);
 		let assets = holding.clone();
 
@@ -396,71 +470,86 @@ benchmarks! {
 
 		let instruction = Instruction::ExpectAsset(assets.into());
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// `execute` completing successfully is as good as we can check.
+
+		Ok(())
 	}
 
-	expect_origin {
+	#[benchmark]
+	fn expect_origin() -> Result<(), BenchmarkError> {
 		let expected_origin = Parent.into();
 		let mut executor = new_executor::<T>(Default::default());
 
 		let instruction = Instruction::ExpectOrigin(Some(expected_origin));
 		let xcm = Xcm(vec![instruction]);
 		let mut _result = Ok(());
-	}: {
-		_result = executor.bench_process(xcm);
-	} verify {
-		assert!(matches!(_result, Err(ExecutorError {
-			xcm_error: XcmError::ExpectationFalse,
-			..
-		})));
+		#[block]
+		{
+			_result = executor.bench_process(xcm);
+		}
+		assert!(matches!(
+			_result,
+			Err(ExecutorError { xcm_error: XcmError::ExpectationFalse, .. })
+		));
+
+		Ok(())
 	}
 
-	expect_error {
+	#[benchmark]
+	fn expect_error() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_error(Some((3u32, XcmError::Overflow)));
 
 		let instruction = Instruction::ExpectError(None);
 		let xcm = Xcm(vec![instruction]);
 		let mut _result = Ok(());
-	}: {
-		_result = executor.bench_process(xcm);
-	} verify {
-		assert!(matches!(_result, Err(ExecutorError {
-			xcm_error: XcmError::ExpectationFalse,
-			..
-		})));
+		#[block]
+		{
+			_result = executor.bench_process(xcm);
+		}
+		assert!(matches!(
+			_result,
+			Err(ExecutorError { xcm_error: XcmError::ExpectationFalse, .. })
+		));
+
+		Ok(())
 	}
 
-	expect_transact_status {
+	#[benchmark]
+	fn expect_transact_status() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
-		let worst_error = || -> MaybeErrorCode {
-			vec![0; MaxDispatchErrorLen::get() as usize].into()
-		};
+		let worst_error =
+			|| -> MaybeErrorCode { vec![0; MaxDispatchErrorLen::get() as usize].into() };
 		executor.set_transact_status(worst_error());
 
 		let instruction = Instruction::ExpectTransactStatus(worst_error());
 		let xcm = Xcm(vec![instruction]);
 		let mut _result = Ok(());
-	}: {
-		_result = executor.bench_process(xcm);
-	} verify {
+		#[block]
+		{
+			_result = executor.bench_process(xcm);
+		}
 		assert!(matches!(_result, Ok(..)));
+		Ok(())
 	}
 
-	query_pallet {
+	#[benchmark]
+	fn query_pallet() -> Result<(), BenchmarkError> {
 		let (sender_account, sender_location) = account_and_location::<T>(1);
 		let query_id = Default::default();
 		let destination = T::valid_destination().map_err(|_| BenchmarkError::Skip)?;
 		let max_weight = Default::default();
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&sender_location,
-			&destination,
-			FeeReason::QueryPallet,
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(
+				&sender_location,
+				&destination,
+				FeeReason::QueryPallet,
+			);
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 		let mut executor = new_executor::<T>(sender_location);
 		if let Some(expected_fees_mode) = expected_fees_mode {
@@ -476,15 +565,19 @@ benchmarks! {
 			response_info: QueryResponseInfo { destination, query_id, max_weight },
 		};
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check we charged the delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
 		// TODO: Potentially add new trait to XcmSender to detect a queued outgoing message. #4426
+
+		Ok(())
 	}
 
-	expect_pallet {
+	#[benchmark]
+	fn expect_pallet() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		let valid_pallet = T::valid_pallet();
 		let instruction = Instruction::ExpectPallet {
@@ -495,23 +588,27 @@ benchmarks! {
 			min_crate_minor: valid_pallet.crate_version.minor.into(),
 		};
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// the execution succeeding is all we need to verify this xcm was successful
+		Ok(())
 	}
 
-	report_transact_status {
+	#[benchmark]
+	fn report_transact_status() -> Result<(), BenchmarkError> {
 		let (sender_account, sender_location) = account_and_location::<T>(1);
 		let query_id = Default::default();
 		let destination = T::valid_destination().map_err(|_| BenchmarkError::Skip)?;
 		let max_weight = Default::default();
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&sender_location,
-			&destination,
-			FeeReason::Report,
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(
+				&sender_location,
+				&destination,
+				FeeReason::Report,
+			);
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
 		let mut executor = new_executor::<T>(sender_location);
@@ -529,84 +626,102 @@ benchmarks! {
 			max_weight,
 		});
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check we charged the delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
 		// TODO: Potentially add new trait to XcmSender to detect a queued outgoing message. #4426
+		Ok(())
 	}
 
-	clear_transact_status {
+	#[benchmark]
+	fn clear_transact_status() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_transact_status(b"MyError".to_vec().into());
 
 		let instruction = Instruction::ClearTransactStatus;
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.transact_status(), &MaybeErrorCode::Success);
+		Ok(())
 	}
 
-	set_topic {
+	#[benchmark]
+	fn set_topic() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 
 		let instruction = Instruction::SetTopic([1; 32]);
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.topic(), &Some([1; 32]));
+		Ok(())
 	}
 
-	clear_topic {
+	#[benchmark]
+	fn clear_topic() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_topic(Some([2; 32]));
 
 		let instruction = Instruction::ClearTopic;
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.topic(), &None);
+		Ok(())
 	}
 
-	exchange_asset {
+	#[benchmark]
+	fn exchange_asset() -> Result<(), BenchmarkError> {
 		let (give, want) = T::worst_case_asset_exchange().map_err(|_| BenchmarkError::Skip)?;
 		let assets = give.clone();
 
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_holding(give.into());
-		let instruction = Instruction::ExchangeAsset {
-			give: assets.into(),
-			want: want.clone(),
-			maximal: true,
-		};
+		let instruction =
+			Instruction::ExchangeAsset { give: assets.into(), want: want.clone(), maximal: true };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.holding(), &want.into());
+		Ok(())
 	}
 
-	universal_origin {
+	#[benchmark]
+	fn universal_origin() -> Result<(), BenchmarkError> {
 		let (origin, alias) = T::universal_alias().map_err(|_| BenchmarkError::Skip)?;
 
 		let mut executor = new_executor::<T>(origin);
 
 		let instruction = Instruction::UniversalOrigin(alias);
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		use frame_support::traits::Get;
 		let universal_location = <T::XcmConfig as xcm_executor::Config>::UniversalLocation::get();
-		assert_eq!(executor.origin(), &Some(Junctions::from([alias]).relative_to(&universal_location)));
+		assert_eq!(
+			executor.origin(),
+			&Some(Junctions::from([alias]).relative_to(&universal_location))
+		);
+
+		Ok(())
 	}
 
-	export_message {
-		let x in 1 .. 1000;
+	#[benchmark]
+	fn export_message(x: Linear<1, 1000>) -> Result<(), BenchmarkError> {
 		// The `inner_xcm` influences `ExportMessage` total weight based on
 		// `inner_xcm.encoded_size()`, so for this benchmark use smallest encoded instruction
 		// to approximate weight per "unit" of encoded size; then actual weight can be estimated
@@ -616,11 +731,12 @@ benchmarks! {
 		// Get `origin`, `network` and `destination` from configured runtime.
 		let (origin, network, destination) = T::export_message_origin_and_destination()?;
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&origin,
-			&destination.clone().into(),
-			FeeReason::Export { network, destination: destination.clone() },
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(
+				&origin,
+				&destination.clone().into(),
+				FeeReason::Export { network, destination: destination.clone() },
+			);
 		let sender_account = T::AccountIdConverter::convert_location(&origin).unwrap();
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
@@ -631,37 +747,39 @@ benchmarks! {
 		if let Some(expected_assets_in_holding) = expected_assets_in_holding {
 			executor.set_holding(expected_assets_in_holding.into());
 		}
-		let xcm = Xcm(vec![ExportMessage {
-			network, destination: destination.clone(), xcm: inner_xcm,
-		}]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		let xcm =
+			Xcm(vec![ExportMessage { network, destination: destination.clone(), xcm: inner_xcm }]);
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check we charged the delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
 		// TODO: Potentially add new trait to XcmSender to detect a queued outgoing message. #4426
+		Ok(())
 	}
 
-	set_fees_mode {
+	#[benchmark]
+	fn set_fees_mode() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_fees_mode(FeesMode { jit_withdraw: false });
 
 		let instruction = Instruction::SetFeesMode { jit_withdraw: true };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.fees_mode(), &FeesMode { jit_withdraw: true });
+		Ok(())
 	}
 
-	lock_asset {
+	#[benchmark]
+	fn lock_asset() -> Result<(), BenchmarkError> {
 		let (unlocker, owner, asset) = T::unlockable_asset()?;
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&owner,
-			&unlocker,
-			FeeReason::LockAsset,
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(&owner, &unlocker, FeeReason::LockAsset);
 		let sender_account = T::AccountIdConverter::convert_location(&owner).unwrap();
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
@@ -681,15 +799,18 @@ benchmarks! {
 
 		let instruction = Instruction::LockAsset { asset, unlocker };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
 		// TODO: Potentially add new trait to XcmSender to detect a queued outgoing message. #4426
+		Ok(())
 	}
 
-	unlock_asset {
+	#[benchmark]
+	fn unlock_asset() -> Result<(), BenchmarkError> {
 		use xcm_executor::traits::{AssetLock, Enact};
 
 		let (unlocker, owner, asset) = T::unlockable_asset()?;
@@ -709,13 +830,15 @@ benchmarks! {
 		// ... then unlock them with the UnlockAsset instruction.
 		let instruction = Instruction::UnlockAsset { asset, target: owner };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
-
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		Ok(())
 	}
 
-	note_unlockable {
+	#[benchmark]
+	fn note_unlockable() -> Result<(), BenchmarkError> {
 		use xcm_executor::traits::{AssetLock, Enact};
 
 		let (unlocker, owner, asset) = T::unlockable_asset()?;
@@ -735,13 +858,15 @@ benchmarks! {
 		// ... then note them as unlockable with the NoteUnlockable instruction.
 		let instruction = Instruction::NoteUnlockable { asset, owner };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
-
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		Ok(())
 	}
 
-	request_unlock {
+	#[benchmark]
+	fn request_unlock() -> Result<(), BenchmarkError> {
 		use xcm_executor::traits::{AssetLock, Enact};
 
 		let (locker, owner, asset) = T::unlockable_asset()?;
@@ -756,11 +881,12 @@ benchmarks! {
 		.enact()
 		.map_err(|_| BenchmarkError::Skip)?;
 
-		let (expected_fees_mode, expected_assets_in_holding) = T::DeliveryHelper::ensure_successful_delivery(
-			&owner,
-			&locker,
-			FeeReason::RequestUnlock,
-		);
+		let (expected_fees_mode, expected_assets_in_holding) =
+			T::DeliveryHelper::ensure_successful_delivery(
+				&owner,
+				&locker,
+				FeeReason::RequestUnlock,
+			);
 		let sender_account = T::AccountIdConverter::convert_location(&owner).unwrap();
 		let sender_account_balance_before = T::TransactAsset::balance(&sender_account);
 
@@ -774,15 +900,18 @@ benchmarks! {
 		}
 		let instruction = Instruction::RequestUnlock { asset, locker };
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		// Check we charged the delivery fees
 		assert!(T::TransactAsset::balance(&sender_account) <= sender_account_balance_before);
 		// TODO: Potentially add new trait to XcmSender to detect a queued outgoing message. #4426
+		Ok(())
 	}
 
-	unpaid_execution {
+	#[benchmark]
+	fn unpaid_execution() -> Result<(), BenchmarkError> {
 		let mut executor = new_executor::<T>(Default::default());
 		executor.set_origin(Some(Here.into()));
 
@@ -792,21 +921,27 @@ benchmarks! {
 		};
 
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
+		Ok(())
 	}
 
-	alias_origin {
+	#[benchmark]
+	fn alias_origin() -> Result<(), BenchmarkError> {
 		let (origin, target) = T::alias_origin().map_err(|_| BenchmarkError::Skip)?;
 
 		let mut executor = new_executor::<T>(origin);
 
 		let instruction = Instruction::AliasOrigin(target.clone());
 		let xcm = Xcm(vec![instruction]);
-	}: {
-		executor.bench_process(xcm)?;
-	} verify {
+		#[block]
+		{
+			executor.bench_process(xcm)?;
+		}
 		assert_eq!(executor.origin(), &Some(target));
+		Ok(())
 	}
 
 	impl_benchmark_test_suite!(


### PR DESCRIPTION
# Description
Migrated pallet-xcm-benchmarks to benchmaking syntax V2
This is part of #6202 