### PR TITLE
Add stable2412 to target_branches for command-backport.yml

### DIFF
--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -40,7 +40,7 @@ jobs:
         uses: korthout/backport-action@v3
         id: backport
         with:
-          target_branches: stable2407 stable2409
+          target_branches: stable2407 stable2409 stable2412
           merge_commits: skip
           github_token: ${{ steps.generate_token.outputs.token }}
           pull_description: |


### PR DESCRIPTION
The backport bot opens PR for `A4-needs-backport` only for stable2407 stable2409, but we have already stable2412.

The question is, when should we append a new `stable*` branch here? Should it be done when a new `stable*` branch is created? Can we automate this process somehow?