### PR TITLE
chain-spec-guide-runtime: path to wasm blob fixed

### DIFF
--- a/docs/sdk/src/reference_docs/chain_spec_runtime/tests/chain_spec_builder_tests.rs
+++ b/docs/sdk/src/reference_docs/chain_spec_runtime/tests/chain_spec_builder_tests.rs
@@ -1,8 +1,10 @@
 use serde_json::{json, Value};
 use std::{process::Command, str};
 
-const WASM_FILE_PATH: &str =
-	"../../../../../target/release/wbuild/chain-spec-guide-runtime/chain_spec_guide_runtime.wasm";
+fn wasm_file_path() -> &'static str {
+	chain_spec_guide_runtime::runtime::WASM_BINARY_PATH
+		.expect("chain_spec_guide_runtime wasm should exists. qed")
+}
 
 const CHAIN_SPEC_BUILDER_PATH: &str = "../../../../../target/release/chain-spec-builder";
 
@@ -26,7 +28,7 @@ fn list_presets() {
 	let output = Command::new(get_chain_spec_builder_path())
 		.arg("list-presets")
 		.arg("-r")
-		.arg(WASM_FILE_PATH)
+		.arg(wasm_file_path())
 		.output()
 		.expect("Failed to execute command");
 
@@ -50,7 +52,7 @@ fn get_preset() {
 	let output = Command::new(get_chain_spec_builder_path())
 		.arg("display-preset")
 		.arg("-r")
-		.arg(WASM_FILE_PATH)
+		.arg(wasm_file_path())
 		.arg("-p")
 		.arg("preset_2")
 		.output()
@@ -83,7 +85,7 @@ fn generate_chain_spec() {
 		.arg("/dev/stdout")
 		.arg("create")
 		.arg("-r")
-		.arg(WASM_FILE_PATH)
+		.arg(wasm_file_path())
 		.arg("named-preset")
 		.arg("preset_2")
 		.output()
@@ -140,7 +142,7 @@ fn generate_para_chain_spec() {
 		.arg("-p")
 		.arg("1000")
 		.arg("-r")
-		.arg(WASM_FILE_PATH)
+		.arg(wasm_file_path())
 		.arg("named-preset")
 		.arg("preset_2")
 		.output()


### PR DESCRIPTION
In `chain-spec-guide-runtime` crate's tests, there was assumption that release version of wasm blob exists. This PR uses `chain_spec_guide_runtime::runtime::WASM_BINARY_PATH` const to use correct path to runtime blob.