### PR TITLE
chore: Update litep2p to v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10216,9 +10216,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b67484b8ac41e1cfdf012f65fa81e88c2ef5f8a7d6dec0e2678c2d06dc04530"
+checksum = "569e7dbec8a0d4b08d30f4942cd579cfe8db5d3f83f8604abe61697c38d17e73"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -848,7 +848,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.8.1", features = ["websocket"] }
+litep2p = { version = "0.8.2", features = ["websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }

--- a/prdoc/pr_6677.prdoc
+++ b/prdoc/pr_6677.prdoc
@@ -6,44 +6,6 @@ doc:
 
     While at it, have stopped the oncall pain of alerts around `incoming_connections_total`. We can rethink the metric expose of litep2p in Q1.
 
-
-
-
-
-    ## [0.8.2] - 2024-11-27
-
-    This release ensures that the provided peer identity is verified at the crypto/noise protocol level, enhancing security and preventing potential misuses.
-    The release also includes a fix that caused `TransportService` component to panic on debug builds.
-
-    ### Fixed
-
-    - req-resp: Fix panic on connection closed for substream open failure  ([#291](https://github.com/paritytech/litep2p/pull/291))
-    - crypto/noise: Verify crypto/noise signature payload  ([#278](https://github.com/paritytech/litep2p/pull/278))
-
-    ### Changed
-
-    - transport_service/logs: Provide less details for trace logs  ([#292](https://github.com/paritytech/litep2p/pull/292))
-
-
-    ## Testing Done
-
-    This has been extensively tested in Kusama on all validators, that are now running litep2p.
-
-    Deployed PR: https://github.com/paritytech/polkadot-sdk/pull/6638
-
-    ### Litep2p Dashboards
-    ![Screenshot 2024-11-26 at 19 19 41](https://github.com/user-attachments/assets/e00b2b2b-7e64-4d96-ab26-165e2b8d0dc9)
-
-
-    ### Libp2p vs Litep2p CPU usage
-
-    After deploying litep2p we have reduced CPU usage from around 300-400% to 200%, this is a significant boost in performance, freeing resources for other subcomponents to function more optimally.
-
-    ![image(1)](https://github.com/user-attachments/assets/fa793df5-4d58-4601-963d-246e56dd2a26)
-
-
-
-    cc @paritytech/sdk-node
 crates:
 - name: sc-network
   bump: patch

--- a/prdoc/pr_6677.prdoc
+++ b/prdoc/pr_6677.prdoc
@@ -1,0 +1,11 @@
+title: Update litep2p network backend to v0.8.2
+doc:
+  - audience: [ Node Dev, Node Operator ]
+  description: |
+    This release ensures that the provided peer identity is verified at the crypto/noise protocol level, enhancing security and preventing potential misuses.
+    The release also includes a fix that caused `TransportService` component to panic on debug builds.
+
+crates:
+  - name: sc-network
+    bump: patch
+

--- a/prdoc/pr_6677.prdoc
+++ b/prdoc/pr_6677.prdoc
@@ -8,4 +8,4 @@ doc:
 
 crates:
 - name: sc-network
-  bump: patch
+  bump: minor

--- a/prdoc/pr_6677.prdoc
+++ b/prdoc/pr_6677.prdoc
@@ -1,11 +1,49 @@
-title: Update litep2p network backend to v0.8.2
+title: 'chore: Update litep2p to v0.8.2'
 doc:
-  - audience: [ Node Dev, Node Operator ]
-  description: |
+- audience: Node Dev
+  description: |-
+    This includes a critical fix for debug release versions of litep2p (which are running in Kusama as validators).
+
+    While at it, have stopped the oncall pain of alerts around `incoming_connections_total`. We can rethink the metric expose of litep2p in Q1.
+
+
+
+
+
+    ## [0.8.2] - 2024-11-27
+
     This release ensures that the provided peer identity is verified at the crypto/noise protocol level, enhancing security and preventing potential misuses.
     The release also includes a fix that caused `TransportService` component to panic on debug builds.
 
-crates:
-  - name: sc-network
-    bump: patch
+    ### Fixed
 
+    - req-resp: Fix panic on connection closed for substream open failure  ([#291](https://github.com/paritytech/litep2p/pull/291))
+    - crypto/noise: Verify crypto/noise signature payload  ([#278](https://github.com/paritytech/litep2p/pull/278))
+
+    ### Changed
+
+    - transport_service/logs: Provide less details for trace logs  ([#292](https://github.com/paritytech/litep2p/pull/292))
+
+
+    ## Testing Done
+
+    This has been extensively tested in Kusama on all validators, that are now running litep2p.
+
+    Deployed PR: https://github.com/paritytech/polkadot-sdk/pull/6638
+
+    ### Litep2p Dashboards
+    ![Screenshot 2024-11-26 at 19 19 41](https://github.com/user-attachments/assets/e00b2b2b-7e64-4d96-ab26-165e2b8d0dc9)
+
+
+    ### Libp2p vs Litep2p CPU usage
+
+    After deploying litep2p we have reduced CPU usage from around 300-400% to 200%, this is a significant boost in performance, freeing resources for other subcomponents to function more optimally.
+
+    ![image(1)](https://github.com/user-attachments/assets/fa793df5-4d58-4601-963d-246e56dd2a26)
+
+
+
+    cc @paritytech/sdk-node
+crates:
+- name: sc-network
+  bump: patch

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -1058,6 +1058,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 									NegotiationError::ParseError(_) => "parse-error",
 									NegotiationError::IoError(_) => "io-error",
 									NegotiationError::WebSocket(_) => "webscoket-error",
+									NegotiationError::BadSignature => "bad-signature",
 								}
 							};
 

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -986,7 +986,15 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 
 						let direction = match endpoint {
 							Endpoint::Dialer { .. } => "out",
-							Endpoint::Listener { .. } => "in",
+							Endpoint::Listener { .. } => {
+								// Increment incoming connections counter.
+								//
+								// Note: For litep2p these are represented by established negotiated connections,
+								// while for libp2p (legacy) these represent not-yet-negotiated connections.
+								metrics.incoming_connections_total.inc();
+
+								"in"
+							},
 						};
 						metrics.connections_opened_total.with_label_values(&[direction]).inc();
 


### PR DESCRIPTION
This includes a critical fix for debug release versions of litep2p (which are running in Kusama as validators).

While at it, have stopped the oncall pain of alerts around `incoming_connections_total`. We can rethink the metric expose of litep2p in Q1. 





## [0.8.2] - 2024-11-27

This release ensures that the provided peer identity is verified at the crypto/noise protocol level, enhancing security and preventing potential misuses.
The release also includes a fix that caused `TransportService` component to panic on debug builds.

### Fixed

- req-resp: Fix panic on connection closed for substream open failure  ([#291](https://github.com/paritytech/litep2p/pull/291))
- crypto/noise: Verify crypto/noise signature payload  ([#278](https://github.com/paritytech/litep2p/pull/278))

### Changed

- transport_service/logs: Provide less details for trace logs  ([#292](https://github.com/paritytech/litep2p/pull/292))


## Testing Done

This has been extensively tested in Kusama on all validators, that are now running litep2p.

Deployed PR: https://github.com/paritytech/polkadot-sdk/pull/6638

### Litep2p Dashboards
![Screenshot 2024-11-26 at 19 19 41](https://github.com/user-attachments/assets/e00b2b2b-7e64-4d96-ab26-165e2b8d0dc9)


### Libp2p vs Litep2p CPU usage

After deploying litep2p we have reduced CPU usage from around 300-400% to 200%, this is a significant boost in performance, freeing resources for other subcomponents to function more optimally. 

![image(1)](https://github.com/user-attachments/assets/fa793df5-4d58-4601-963d-246e56dd2a26)



cc @paritytech/sdk-node 