### PR TITLE
Multiple instances for pallet-bridge-relayers fix

### DIFF
--- a/bridges/modules/relayers/src/extension/mod.rs
+++ b/bridges/modules/relayers/src/extension/mod.rs
@@ -129,7 +129,7 @@ pub struct BridgeRelayersTransactionExtension<Runtime, Config, LaneId>(
 impl<R, C, LaneId> BridgeRelayersTransactionExtension<R, C, LaneId>
 where
 	Self: 'static + Send + Sync,
-	R: RelayersConfig<LaneId = LaneId>
+	R: RelayersConfig<C::BridgeRelayersPalletInstance, LaneId = LaneId>
 		+ BridgeMessagesConfig<C::BridgeMessagesPalletInstance, LaneId = LaneId>
 		+ TransactionPaymentConfig,
 	C: ExtensionConfig<Runtime = R, LaneId = LaneId>,
@@ -250,7 +250,7 @@ where
 		// let's also replace the weight of slashing relayer with the weight of rewarding relayer
 		if call_info.is_receive_messages_proof_call() {
 			post_info_weight = post_info_weight.saturating_sub(
-				<R as RelayersConfig>::WeightInfo::extra_weight_of_successful_receive_messages_proof_call(),
+				<R as RelayersConfig<C::BridgeRelayersPalletInstance>>::WeightInfo::extra_weight_of_successful_receive_messages_proof_call(),
 			);
 		}
 
@@ -278,7 +278,7 @@ impl<R, C, LaneId> TransactionExtension<R::RuntimeCall>
 	for BridgeRelayersTransactionExtension<R, C, LaneId>
 where
 	Self: 'static + Send + Sync,
-	R: RelayersConfig<LaneId = LaneId>
+	R: RelayersConfig<C::BridgeRelayersPalletInstance, LaneId = LaneId>
 		+ BridgeMessagesConfig<C::BridgeMessagesPalletInstance, LaneId = LaneId>
 		+ TransactionPaymentConfig,
 	C: ExtensionConfig<Runtime = R, LaneId = LaneId>,
@@ -326,7 +326,7 @@ where
 		};
 
 		// we only boost priority if relayer has staked required balance
-		if !RelayersPallet::<R>::is_registration_active(&data.relayer) {
+		if !RelayersPallet::<R, C::BridgeRelayersPalletInstance>::is_registration_active(&data.relayer) {
 			return Ok((Default::default(), Some(data), origin))
 		}
 
@@ -382,7 +382,7 @@ where
 		match call_result {
 			RelayerAccountAction::None => (),
 			RelayerAccountAction::Reward(relayer, reward_account, reward) => {
-				RelayersPallet::<R>::register_relayer_reward(reward_account, &relayer, reward);
+				RelayersPallet::<R, C::BridgeRelayersPalletInstance>::register_relayer_reward(reward_account, &relayer, reward);
 
 				log::trace!(
 					target: LOG_TARGET,
@@ -394,7 +394,7 @@ where
 				);
 			},
 			RelayerAccountAction::Slash(relayer, slash_account) =>
-				RelayersPallet::<R>::slash_and_deregister(
+				RelayersPallet::<R, C::BridgeRelayersPalletInstance>::slash_and_deregister(
 					&relayer,
 					ExplicitOrAccountParams::Params(slash_account),
 				),

--- a/bridges/modules/relayers/src/extension/mod.rs
+++ b/bridges/modules/relayers/src/extension/mod.rs
@@ -326,7 +326,9 @@ where
 		};
 
 		// we only boost priority if relayer has staked required balance
-		if !RelayersPallet::<R, C::BridgeRelayersPalletInstance>::is_registration_active(&data.relayer) {
+		if !RelayersPallet::<R, C::BridgeRelayersPalletInstance>::is_registration_active(
+			&data.relayer,
+		) {
 			return Ok((Default::default(), Some(data), origin))
 		}
 
@@ -382,7 +384,11 @@ where
 		match call_result {
 			RelayerAccountAction::None => (),
 			RelayerAccountAction::Reward(relayer, reward_account, reward) => {
-				RelayersPallet::<R, C::BridgeRelayersPalletInstance>::register_relayer_reward(reward_account, &relayer, reward);
+				RelayersPallet::<R, C::BridgeRelayersPalletInstance>::register_relayer_reward(
+					reward_account,
+					&relayer,
+					reward,
+				);
 
 				log::trace!(
 					target: LOG_TARGET,


### PR DESCRIPTION
Previously, we added multi-instance pallet support for `pallet-bridge-relayers`, but missed fixing it in this one place.