### PR TITLE
network/libp2p-backend: Suppress warning adding already reserved node as reserved

### DIFF
--- a/prdoc/pr_6703.prdoc
+++ b/prdoc/pr_6703.prdoc
@@ -1,0 +1,7 @@
+title: 'network/libp2p-backend: Suppress warning adding already reserved node as reserved'
+doc:
+- audience: Node Dev
+  description: Fixes https://github.com/paritytech/polkadot-sdk/issues/6598.
+crates:
+- name: sc-network
+  bump: patch

--- a/substrate/client/network/src/protocol_controller.rs
+++ b/substrate/client/network/src/protocol_controller.rs
@@ -464,7 +464,7 @@ impl ProtocolController {
 	/// maintain connections with such peers.
 	fn on_add_reserved_peer(&mut self, peer_id: PeerId) {
 		if self.reserved_nodes.contains_key(&peer_id) {
-			warn!(
+			debug!(
 				target: LOG_TARGET,
 				"Trying to add an already reserved node {peer_id} as reserved on {:?}.",
 				self.set_id,


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/6598.