### PR TITLE
pallet-revive-fixtures: Try not to re-create fixture dir

### DIFF
--- a/substrate/frame/revive/fixtures/build.rs
+++ b/substrate/frame/revive/fixtures/build.rs
@@ -204,10 +204,14 @@ fn create_out_dir() -> Result<PathBuf> {
 	.join("pallet-revive-fixtures");
 
 	// clean up some leftover symlink from previous versions of this script
-	if out_dir.exists() && !out_dir.is_dir() {
+	let out_exists = out_dir.exists();
+	if out_exists && !out_dir.is_dir() {
 		fs::remove_file(&out_dir)?;
 	}
-	fs::create_dir_all(&out_dir).context("Failed to create output directory")?;
+
+	if !out_exists {
+		fs::create_dir(&out_dir).context("Failed to create output directory")?;
+	}
 
 	// write the location of the out dir so it can be found later
 	let mut file = fs::File::create(temp_dir.join("fixture_location.rs"))

--- a/substrate/frame/revive/fixtures/build.rs
+++ b/substrate/frame/revive/fixtures/build.rs
@@ -204,9 +204,10 @@ fn create_out_dir() -> Result<PathBuf> {
 	.join("pallet-revive-fixtures");
 
 	// clean up some leftover symlink from previous versions of this script
-	let out_exists = out_dir.exists();
+	let mut out_exists = out_dir.exists();
 	if out_exists && !out_dir.is_dir() {
 		fs::remove_file(&out_dir)?;
+		out_exists = false;
 	}
 
 	if !out_exists {


### PR DESCRIPTION
On some systems trying to re-create the output directory will lead to an error.

Fixes https://github.com/paritytech/subxt/issues/1876