### PR TITLE
pallet-revive: Adjust error handling of sub calls

### DIFF
--- a/substrate/frame/revive/fixtures/contracts/caller_contract.rs
+++ b/substrate/frame/revive/fixtures/contracts/caller_contract.rs
@@ -65,7 +65,7 @@ pub extern "C" fn call() {
 		None,
 		Some(&salt),
 	);
-	assert!(matches!(res, Err(ReturnErrorCode::CalleeTrapped)));
+	assert!(matches!(res, Err(ReturnErrorCode::OutOfResources)));
 
 	// Fail to deploy the contract due to insufficient proof_size weight.
 	let res = api::instantiate(
@@ -79,7 +79,7 @@ pub extern "C" fn call() {
 		None,
 		Some(&salt),
 	);
-	assert!(matches!(res, Err(ReturnErrorCode::CalleeTrapped)));
+	assert!(matches!(res, Err(ReturnErrorCode::OutOfResources)));
 
 	// Deploy the contract successfully.
 	let mut callee = [0u8; 20];
@@ -121,7 +121,7 @@ pub extern "C" fn call() {
 		&input,
 		None,
 	);
-	assert!(matches!(res, Err(ReturnErrorCode::CalleeTrapped)));
+	assert!(matches!(res, Err(ReturnErrorCode::OutOfResources)));
 
 	// Fail to call the contract due to insufficient proof_size weight.
 	let res = api::call(
@@ -134,7 +134,7 @@ pub extern "C" fn call() {
 		&input,
 		None,
 	);
-	assert!(matches!(res, Err(ReturnErrorCode::CalleeTrapped)));
+	assert!(matches!(res, Err(ReturnErrorCode::OutOfResources)));
 
 	// Call the contract successfully.
 	let mut output = [0u8; 4];

--- a/substrate/frame/revive/fixtures/contracts/create_storage_and_call.rs
+++ b/substrate/frame/revive/fixtures/contracts/create_storage_and_call.rs
@@ -40,7 +40,7 @@ pub extern "C" fn call() {
 	api::set_storage(StorageFlags::empty(), buffer, &[1u8; 4]);
 
 	// Call the callee
-	api::call(
+	let ret = api::call(
 		uapi::CallFlags::empty(),
 		callee,
 		0u64, // How much ref_time weight to devote for the execution. 0 = all.
@@ -49,8 +49,10 @@ pub extern "C" fn call() {
 		&[0u8; 32], // Value transferred to the contract.
 		input,
 		None,
-	)
-	.unwrap();
+	);
+	if let Err(code) = ret {
+		api::return_value(uapi::ReturnFlags::REVERT, &(code as u32).to_le_bytes());
+	};
 
 	// create 8 byte of storage after calling
 	// item of 12 bytes because we override 4 bytes

--- a/substrate/frame/revive/fixtures/contracts/create_storage_and_instantiate.rs
+++ b/substrate/frame/revive/fixtures/contracts/create_storage_and_instantiate.rs
@@ -39,7 +39,7 @@ pub extern "C" fn call() {
 	let salt = [0u8; 32];
 	let mut address = [0u8; 20];
 
-	api::instantiate(
+	let ret = api::instantiate(
 		code_hash,
 		0u64, // How much ref_time weight to devote for the execution. 0 = all.
 		0u64, // How much proof_size weight to devote for the execution. 0 = all.
@@ -49,8 +49,10 @@ pub extern "C" fn call() {
 		Some(&mut address),
 		None,
 		Some(&salt),
-	)
-	.unwrap();
+	);
+	if let Err(code) = ret {
+		api::return_value(uapi::ReturnFlags::REVERT, &(code as u32).to_le_bytes());
+	};
 
 	// Return the deployed contract address.
 	api::return_value(uapi::ReturnFlags::empty(), &address);

--- a/substrate/frame/revive/fixtures/contracts/delegate_call_deposit_limit.rs
+++ b/substrate/frame/revive/fixtures/contracts/delegate_call_deposit_limit.rs
@@ -34,7 +34,11 @@ pub extern "C" fn call() {
 	);
 
 	let input = [0u8; 0];
-	api::delegate_call(uapi::CallFlags::empty(), address, 0, 0, Some(&u256_bytes(deposit_limit)), &input, None).unwrap();
+	let ret = api::delegate_call(uapi::CallFlags::empty(), address, 0, 0, Some(&u256_bytes(deposit_limit)), &input, None);
+
+	if let Err(code) = ret {
+		api::return_value(uapi::ReturnFlags::REVERT, &(code as u32).to_le_bytes());
+	};
 
 	let mut key = [0u8; 32];
 	key[0] = 1u8;

--- a/substrate/frame/revive/fixtures/contracts/set_code_hash.rs
+++ b/substrate/frame/revive/fixtures/contracts/set_code_hash.rs
@@ -29,7 +29,7 @@ pub extern "C" fn deploy() {}
 #[polkavm_derive::polkavm_export]
 pub extern "C" fn call() {
 	input!(addr: &[u8; 32],);
-	api::set_code_hash(addr).unwrap();
+	api::set_code_hash(addr);
 
 	// we return 1 after setting new code_hash
 	// next `call` will NOT return this value, because contract code has been changed

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -38,8 +38,8 @@ use crate::{
 	wasm::Memory,
 	weights::WeightInfo,
 	AccountId32Mapper, BalanceOf, Code, CodeInfoOf, CollectEvents, Config, ContractInfo,
-	ContractInfoOf, DebugInfo, DeletionQueueCounter, Error, HoldReason, Origin, Pallet,
-	PristineCode, H160,
+	ContractInfoOf, DebugInfo, DeletionQueueCounter, DepositLimit, Error, HoldReason, Origin,
+	Pallet, PristineCode, H160,
 };
 
 use crate::test_utils::builder::Contract;
@@ -1211,14 +1211,11 @@ fn delegate_call_with_deposit_limit() {
 
 		// Delegate call will write 1 storage and deposit of 2 (1 item) + 32 (bytes) is required.
 		// Fails, not enough deposit
-		assert_err!(
-			builder::bare_call(caller_addr)
-				.value(1337)
-				.data((callee_addr, 33u64).encode())
-				.build()
-				.result,
-			Error::<Test>::StorageDepositLimitExhausted,
-		);
+		let ret = builder::bare_call(caller_addr)
+			.value(1337)
+			.data((callee_addr, 33u64).encode())
+			.build_and_unwrap_result();
+		assert_return_code!(ret, RuntimeReturnCode::OutOfResources);
 
 		assert_ok!(builder::call(caller_addr)
 			.value(1337)
@@ -3463,13 +3460,11 @@ fn deposit_limit_in_nested_calls() {
 		// nested call. This should fail as callee adds up 2 bytes to the storage, meaning
 		// that the nested call should have a deposit limit of at least 2 Balance. The
 		// sub-call should be rolled back, which is covered by the next test case.
-		assert_err_ignore_postinfo!(
-			builder::call(addr_caller)
-				.storage_deposit_limit(16)
-				.data((102u32, &addr_callee, U256::from(1u64)).encode())
-				.build(),
-			<Error<Test>>::StorageDepositLimitExhausted,
-		);
+		let ret = builder::bare_call(addr_caller)
+			.storage_deposit_limit(DepositLimit::Balance(16))
+			.data((102u32, &addr_callee, U256::from(1u64)).encode())
+			.build_and_unwrap_result();
+		assert_return_code!(ret, RuntimeReturnCode::OutOfResources);
 
 		// Refund in the callee contract but not enough to cover the 14 Balance required by the
 		// caller. Note that if previous sub-call wouldn't roll back, this call would pass
@@ -3485,13 +3480,11 @@ fn deposit_limit_in_nested_calls() {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 511);
 
 		// Require more than the sender's balance.
-		// We don't set a special limit for the nested call.
-		assert_err_ignore_postinfo!(
-			builder::call(addr_caller)
-				.data((512u32, &addr_callee, U256::from(1u64)).encode())
-				.build(),
-			<Error<Test>>::StorageDepositLimitExhausted,
-		);
+		// Limit the sub call to little balance so it should fail in there
+		let ret = builder::bare_call(addr_caller)
+			.data((512u32, &addr_callee, U256::from(1u64)).encode())
+			.build_and_unwrap_result();
+		assert_return_code!(ret, RuntimeReturnCode::OutOfResources);
 
 		// Same as above but allow for the additional deposit of 1 Balance in parent.
 		// We set the special deposit limit of 1 Balance for the nested call, which isn't
@@ -3563,14 +3556,12 @@ fn deposit_limit_in_nested_instantiate() {
 		// Now we set enough limit in parent call, but an insufficient limit for child
 		// instantiate. This should fail during the charging for the instantiation in
 		// `RawMeter::charge_instantiate()`
-		assert_err_ignore_postinfo!(
-			builder::call(addr_caller)
-				.origin(RuntimeOrigin::signed(BOB))
-				.storage_deposit_limit(callee_info_len + 2 + ED + 2)
-				.data((0u32, &code_hash_callee, U256::from(callee_info_len + 2 + ED + 1)).encode())
-				.build(),
-			<Error<Test>>::StorageDepositLimitExhausted,
-		);
+		let ret = builder::bare_call(addr_caller)
+			.origin(RuntimeOrigin::signed(BOB))
+			.storage_deposit_limit(DepositLimit::Balance(callee_info_len + 2 + ED + 2))
+			.data((0u32, &code_hash_callee, U256::from(callee_info_len + 2 + ED + 1)).encode())
+			.build_and_unwrap_result();
+		assert_return_code!(ret, RuntimeReturnCode::OutOfResources);
 		// The charges made on the instantiation should be rolled back.
 		assert_eq!(<Test as Config>::Currency::free_balance(&BOB), 1_000_000);
 
@@ -3578,14 +3569,12 @@ fn deposit_limit_in_nested_instantiate() {
 		// item of 1 byte to be covered by the limit, which implies 3 more Balance.
 		// Now we set enough limit for the parent call, but insufficient limit for child
 		// instantiate. This should fail right after the constructor execution.
-		assert_err_ignore_postinfo!(
-			builder::call(addr_caller)
-				.origin(RuntimeOrigin::signed(BOB))
-				.storage_deposit_limit(callee_info_len + 2 + ED + 3) // enough parent limit
-				.data((1u32, &code_hash_callee, U256::from(callee_info_len + 2 + ED + 2)).encode())
-				.build(),
-			<Error<Test>>::StorageDepositLimitExhausted,
-		);
+		let ret = builder::bare_call(addr_caller)
+			.origin(RuntimeOrigin::signed(BOB))
+			.storage_deposit_limit(DepositLimit::Balance(callee_info_len + 2 + ED + 3)) // enough parent limit
+			.data((1u32, &code_hash_callee, U256::from(callee_info_len + 2 + ED + 2)).encode())
+			.build_and_unwrap_result();
+		assert_return_code!(ret, RuntimeReturnCode::OutOfResources);
 		// The charges made on the instantiation should be rolled back.
 		assert_eq!(<Test as Config>::Currency::free_balance(&BOB), 1_000_000);
 

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -1678,8 +1678,8 @@ fn instantiate_return_code() {
 
 		// Contract has enough balance but the passed code hash is invalid
 		<Test as Config>::Currency::set_balance(&contract.account_id, min_balance + 10_000);
-		let result = builder::bare_call(contract.addr).data(vec![0; 33]).build_and_unwrap_result();
-		assert_return_code!(result, RuntimeReturnCode::CodeNotFound);
+		let result = builder::bare_call(contract.addr).data(vec![0; 33]).build();
+		assert_err!(result.result, <Error<Test>>::CodeNotFound);
 
 		// Contract has enough balance but callee reverts because "1" is passed.
 		let result = builder::bare_call(contract.addr)
@@ -3890,7 +3890,7 @@ fn locking_delegate_dependency_works() {
 		assert_ok!(Contracts::remove_code(RuntimeOrigin::signed(ALICE_FALLBACK), callee_hashes[0]));
 
 		// Calling should fail since the delegated contract is not on chain anymore.
-		assert_err!(call(&addr_caller, &noop_input).result, Error::<Test>::ContractTrapped);
+		assert_err!(call(&addr_caller, &noop_input).result, Error::<Test>::CodeNotFound);
 
 		// Add the dependency back.
 		Contracts::upload_code(

--- a/substrate/frame/revive/src/wasm/runtime.rs
+++ b/substrate/frame/revive/src/wasm/runtime.rs
@@ -754,12 +754,15 @@ impl<'a, E: Ext, M: ?Sized + Memory<E::T>> Runtime<'a, E, M> {
 		use ReturnErrorCode::*;
 
 		let transfer_failed = Error::<E::T>::TransferFailed.into();
+		let out_of_gas = Error::<E::T>::OutOfGas.into();
 
 		match (from.error, from.origin) {
 			// on ethereum a failing transfer does not trap the caller
 			(err, _) if err == transfer_failed => Ok(TransferFailed),
+			// seperate error if the sub contract ran out of resources
+			(err, Callee) if err == out_of_gas => Ok(OutOfResources),
 			// any error within the sub context will not trap the caller
-			(_, Callee) => Ok(ReturnErrorCode::CalleeTrapped),
+			(_, Callee) => Ok(CalleeTrapped),
 			// any other error is within the caller and should trap it
 			(err, _) => Err(err),
 		}

--- a/substrate/frame/revive/src/wasm/runtime.rs
+++ b/substrate/frame/revive/src/wasm/runtime.rs
@@ -755,15 +755,13 @@ impl<'a, E: Ext, M: ?Sized + Memory<E::T>> Runtime<'a, E, M> {
 
 		let transfer_failed = Error::<E::T>::TransferFailed.into();
 		let out_of_gas = Error::<E::T>::OutOfGas.into();
+		let out_of_deposit = Error::<E::T>::StorageDepositLimitExhausted.into();
 
+		// errors in the callee do not trap the caller
 		match (from.error, from.origin) {
-			// on ethereum a failing transfer does not trap the caller
 			(err, _) if err == transfer_failed => Ok(TransferFailed),
-			// seperate error if the sub contract ran out of resources
-			(err, Callee) if err == out_of_gas => Ok(OutOfResources),
-			// any error within the sub context will not trap the caller
+			(err, Callee) if err == out_of_gas || err == out_of_deposit => Ok(OutOfResources),
 			(_, Callee) => Ok(CalleeTrapped),
-			// any other error is within the caller and should trap it
 			(err, _) => Err(err),
 		}
 	}

--- a/substrate/frame/revive/src/wasm/runtime.rs
+++ b/substrate/frame/revive/src/wasm/runtime.rs
@@ -751,12 +751,10 @@ impl<'a, E: Ext, M: ?Sized + Memory<E::T>> Runtime<'a, E, M> {
 
 		let transfer_failed = Error::<E::T>::TransferFailed.into();
 		let no_code = Error::<E::T>::CodeNotFound.into();
-		let not_found = Error::<E::T>::ContractNotFound.into();
 
 		match from {
 			x if x == transfer_failed => Ok(TransferFailed),
 			x if x == no_code => Ok(CodeNotFound),
-			x if x == not_found => Ok(NotCallable),
 			err => Err(err),
 		}
 	}

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -566,10 +566,10 @@ pub trait HostFn: private::Sealed {
 	/// - `code_hash`: The hash of the new code. Should be decodable as an `T::Hash`. Traps
 	///   otherwise.
 	///
-	/// # Errors
+	/// # Panics
 	///
-	/// - [CodeNotFound][`crate::ReturnErrorCode::CodeNotFound]
-	fn set_code_hash(code_hash: &[u8; 32]) -> Result;
+	/// Panics if there is no code on-chain with the specified hash.
+	fn set_code_hash(code_hash: &[u8; 32]);
 
 	/// Set the value at the given key in the contract storage.
 	///

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -138,7 +138,6 @@ pub trait HostFn: private::Sealed {
 	/// - [CalleeReverted][`crate::ReturnErrorCode::CalleeReverted]: Output buffer is returned.
 	/// - [CalleeTrapped][`crate::ReturnErrorCode::CalleeTrapped]
 	/// - [TransferFailed][`crate::ReturnErrorCode::TransferFailed]
-	/// - [NotCallable][`crate::ReturnErrorCode::NotCallable]
 	fn call(
 		flags: CallFlags,
 		callee: &[u8; 20],

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -138,6 +138,7 @@ pub trait HostFn: private::Sealed {
 	/// - [CalleeReverted][`crate::ReturnErrorCode::CalleeReverted]: Output buffer is returned.
 	/// - [CalleeTrapped][`crate::ReturnErrorCode::CalleeTrapped]
 	/// - [TransferFailed][`crate::ReturnErrorCode::TransferFailed]
+	/// - [OutOfResources][`crate::ReturnErrorCode::OutOfResources]
 	fn call(
 		flags: CallFlags,
 		callee: &[u8; 20],
@@ -340,7 +341,7 @@ pub trait HostFn: private::Sealed {
 	///
 	/// - [CalleeReverted][`crate::ReturnErrorCode::CalleeReverted]: Output buffer is returned.
 	/// - [CalleeTrapped][`crate::ReturnErrorCode::CalleeTrapped]
-	/// - [CodeNotFound][`crate::ReturnErrorCode::CodeNotFound]
+	/// - [OutOfResources][`crate::ReturnErrorCode::OutOfResources]
 	fn delegate_call(
 		flags: CallFlags,
 		address: &[u8; 20],
@@ -467,7 +468,7 @@ pub trait HostFn: private::Sealed {
 	/// - [CalleeReverted][`crate::ReturnErrorCode::CalleeReverted]: Output buffer is returned.
 	/// - [CalleeTrapped][`crate::ReturnErrorCode::CalleeTrapped]
 	/// - [TransferFailed][`crate::ReturnErrorCode::TransferFailed]
-	/// - [CodeNotFound][`crate::ReturnErrorCode::CodeNotFound]
+	/// - [OutOfResources][`crate::ReturnErrorCode::OutOfResources]
 	fn instantiate(
 		code_hash: &[u8; 32],
 		ref_time_limit: u64,

--- a/substrate/frame/revive/uapi/src/host/riscv64.rs
+++ b/substrate/frame/revive/uapi/src/host/riscv64.rs
@@ -115,7 +115,7 @@ mod sys {
 			message_len: u32,
 			message_ptr: *const u8,
 		) -> ReturnCode;
-		pub fn set_code_hash(code_hash_ptr: *const u8) -> ReturnCode;
+		pub fn set_code_hash(code_hash_ptr: *const u8);
 		pub fn ecdsa_to_eth_address(key_ptr: *const u8, out_ptr: *mut u8) -> ReturnCode;
 		pub fn instantiation_nonce() -> u64;
 		pub fn lock_delegate_dependency(code_hash_ptr: *const u8);
@@ -531,9 +531,8 @@ impl HostFn for HostFnImpl {
 		ret_val.into_bool()
 	}
 
-	fn set_code_hash(code_hash: &[u8; 32]) -> Result {
-		let ret_val = unsafe { sys::set_code_hash(code_hash.as_ptr()) };
-		ret_val.into()
+	fn set_code_hash(code_hash: &[u8; 32]) {
+		unsafe { sys::set_code_hash(code_hash.as_ptr()) }
 	}
 
 	fn code_hash(address: &[u8; 20], output: &mut [u8; 32]) {

--- a/substrate/frame/revive/uapi/src/lib.rs
+++ b/substrate/frame/revive/uapi/src/lib.rs
@@ -87,21 +87,19 @@ define_error_codes! {
 	TransferFailed = 4,
 	/// No code could be found at the supplied code hash.
 	CodeNotFound = 5,
-	/// The account that was called is no contract.
-	NotCallable = 6,
 	/// The call to `debug_message` had no effect because debug message
 	/// recording was disabled.
-	LoggingDisabled = 7,
+	LoggingDisabled = 6,
 	/// The call dispatched by `call_runtime` was executed but returned an error.
-	CallRuntimeFailed = 8,
+	CallRuntimeFailed = 7,
 	/// ECDSA public key recovery failed. Most probably wrong recovery id or signature.
-	EcdsaRecoveryFailed = 9,
+	EcdsaRecoveryFailed = 8,
 	/// sr25519 signature verification failed.
-	Sr25519VerifyFailed = 10,
+	Sr25519VerifyFailed = 9,
 	/// The `xcm_execute` call failed.
-	XcmExecutionFailed = 11,
+	XcmExecutionFailed = 10,
 	/// The `xcm_send` call failed.
-	XcmSendFailed = 12,
+	XcmSendFailed = 11,
 }
 
 /// The raw return code returned by the host side.

--- a/substrate/frame/revive/uapi/src/lib.rs
+++ b/substrate/frame/revive/uapi/src/lib.rs
@@ -85,21 +85,19 @@ define_error_codes! {
 	/// Transfer failed for other not further specified reason. Most probably
 	/// reserved or locked balance of the sender that was preventing the transfer.
 	TransferFailed = 4,
-	/// No code could be found at the supplied code hash.
-	CodeNotFound = 5,
 	/// The call to `debug_message` had no effect because debug message
 	/// recording was disabled.
-	LoggingDisabled = 6,
+	LoggingDisabled = 5,
 	/// The call dispatched by `call_runtime` was executed but returned an error.
-	CallRuntimeFailed = 7,
+	CallRuntimeFailed = 6,
 	/// ECDSA public key recovery failed. Most probably wrong recovery id or signature.
-	EcdsaRecoveryFailed = 8,
+	EcdsaRecoveryFailed = 7,
 	/// sr25519 signature verification failed.
-	Sr25519VerifyFailed = 9,
+	Sr25519VerifyFailed = 8,
 	/// The `xcm_execute` call failed.
-	XcmExecutionFailed = 10,
+	XcmExecutionFailed = 9,
 	/// The `xcm_send` call failed.
-	XcmSendFailed = 11,
+	XcmSendFailed = 10,
 }
 
 /// The raw return code returned by the host side.

--- a/substrate/frame/revive/uapi/src/lib.rs
+++ b/substrate/frame/revive/uapi/src/lib.rs
@@ -98,6 +98,8 @@ define_error_codes! {
 	XcmExecutionFailed = 9,
 	/// The `xcm_send` call failed.
 	XcmSendFailed = 10,
+	/// The subcall ran out of weight or storage deposit.
+	OutOfResources = 11,
 }
 
 /// The raw return code returned by the host side.


### PR DESCRIPTION
We were trapping the host context in case a sub call was exhausting the storage deposit limit set for this sub call. This prevents the caller from handling this error. In this PR we added a new error code that is returned when either gas or storage deposit limit is exhausted by the sub call.

We also remove the longer used `NotCallable` error. No longer used because this is no longer an error: It will just be a balance transfer.

We also make `set_code_hash` infallible to be consistent with other host functions which just trap on any error condition.