### PR TITLE
metadata/v15: Collect transaction extensions by versions into custom metadata

### DIFF
--- a/prdoc/pr_6755.prdoc
+++ b/prdoc/pr_6755.prdoc
@@ -1,0 +1,14 @@
+title: Collect transaction extensions by versions into custom metadata for v15
+
+doc:
+  - audience: [ Node Dev, Node Operator ]
+    description: |
+      This PR collects the transaction_extensions_by_version type information into the metadata V15 custom types.
+      This ensures the V15 contains enough information to work with multiple transaction extensions. The meaning of this field is identical to the one collected by the V16 unstable.
+      It includes indexes of extrinsics from the signed_extension field of the extrinsic metadata.
+
+crates:
+  - name: sp-metadata-ir
+    bump: patch
+  - name: frame-support-test
+    bump: none

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -1945,7 +1945,9 @@ fn metadata() {
 					ty: meta_type::<BTreeMap<u8, Vec<u32>>>(),
 					value: custom_value.encode(),
 				},
-			)],
+			)]
+			.into_iter()
+			.collect(),
 		},
 	)
 	.into();

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -1931,13 +1931,22 @@ fn metadata() {
 		error_enum_ty: meta_type::<RuntimeError>(),
 	};
 
+	let custom_value: BTreeMap<u8, Vec<u32>> = (0, vec![1]).into_iter().collect();
 	let expected_metadata: RuntimeMetadataPrefixed = RuntimeMetadataLastVersion::new(
 		pallets,
 		extrinsic,
 		meta_type::<Runtime>(),
 		vec![],
 		outer_enums,
-		CustomMetadata { map: Default::default() },
+		CustomMetadata {
+			map: [(
+				"transaction_extensions_by_version".into(),
+				CustomValueMetadata {
+					ty: meta_type::<BTreeMap<u8, Vec<u32>>>(),
+					value: custom_value.encode(),
+				},
+			)],
+		},
 	)
 	.into();
 	let expected_metadata = match expected_metadata.1 {

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -1931,7 +1931,7 @@ fn metadata() {
 		error_enum_ty: meta_type::<RuntimeError>(),
 	};
 
-	let custom_value: BTreeMap<u8, Vec<u32>> = (0, vec![0]).into_iter().collect();
+	let custom_value: BTreeMap<u8, Vec<u32>> = [(0, vec![0])].into_iter().collect();
 	let expected_metadata: RuntimeMetadataPrefixed = RuntimeMetadataLastVersion::new(
 		pallets,
 		extrinsic,

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -1471,7 +1471,7 @@ fn pallet_item_docs_in_metadata() {
 
 #[test]
 fn metadata() {
-	use codec::Decode;
+	use codec::{Decode, Encode};
 	use frame_metadata::{v15::*, *};
 
 	let readme = "Very important information :D\n";

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -1931,7 +1931,7 @@ fn metadata() {
 		error_enum_ty: meta_type::<RuntimeError>(),
 	};
 
-	let custom_value: BTreeMap<u8, Vec<u32>> = (0, vec![1]).into_iter().collect();
+	let custom_value: BTreeMap<u8, Vec<u32>> = (0, vec![0]).into_iter().collect();
 	let expected_metadata: RuntimeMetadataPrefixed = RuntimeMetadataLastVersion::new(
 		pallets,
 		extrinsic,

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -201,6 +201,15 @@ impl IntoPortable for ExtrinsicMetadataIR {
 	}
 }
 
+impl ExtrinsicMetadataIR {
+	/// Returns the transaction extensions by version.
+	pub fn transaction_extensions_by_version(&self) -> BTreeMap<u8, Vec<u32>> {
+		// Assume version 0 for all extensions.
+		let indexes = (0..self.extensions.len()).map(|index| index as u32).collect();
+		[(0, indexes)].iter().cloned().collect()
+	}
+}
+
 /// Metadata of a pallet's associated type.
 #[derive(Clone, PartialEq, Eq, Encode, Debug)]
 pub struct PalletAssociatedTypeMetadataIR<T: Form = MetaForm> {

--- a/substrate/primitives/metadata-ir/src/types.rs
+++ b/substrate/primitives/metadata-ir/src/types.rs
@@ -201,9 +201,12 @@ impl IntoPortable for ExtrinsicMetadataIR {
 	}
 }
 
+/// The type of the transaction extensions by version field.
+pub type TrasactionExtensionsByVersion = BTreeMap<u8, Vec<u32>>;
+
 impl ExtrinsicMetadataIR {
 	/// Returns the transaction extensions by version.
-	pub fn transaction_extensions_by_version(&self) -> BTreeMap<u8, Vec<u32>> {
+	pub fn transaction_extensions_by_version(&self) -> TrasactionExtensionsByVersion {
 		// Assume version 0 for all extensions.
 		let indexes = (0..self.extensions.len()).map(|index| index as u32).collect();
 		[(0, indexes)].iter().cloned().collect()

--- a/substrate/primitives/metadata-ir/src/unstable.rs
+++ b/substrate/primitives/metadata-ir/src/unstable.rs
@@ -162,9 +162,7 @@ impl From<TransactionExtensionMetadataIR> for TransactionExtensionMetadata {
 
 impl From<ExtrinsicMetadataIR> for ExtrinsicMetadata {
 	fn from(ir: ExtrinsicMetadataIR) -> Self {
-		// Assume version 0 for all extensions.
-		let indexes = (0..ir.extensions.len()).map(|index| index as u32).collect();
-		let transaction_extensions_by_version = [(0, indexes)].iter().cloned().collect();
+		let transaction_extensions_by_version = ir.transaction_extensions_by_version();
 
 		ExtrinsicMetadata {
 			versions: ir.versions,

--- a/substrate/primitives/metadata-ir/src/v15.rs
+++ b/substrate/primitives/metadata-ir/src/v15.rs
@@ -17,9 +17,7 @@
 
 //! Convert the IR to V15 metadata.
 
-use std::collections::BTreeMap;
-
-use crate::OuterEnumsIR;
+use crate::{OuterEnumsIR, TrasactionExtensionsByVersion};
 
 use super::types::{
 	ExtrinsicMetadataIR, MetadataIR, PalletMetadataIR, RuntimeApiMetadataIR,
@@ -49,7 +47,7 @@ impl From<MetadataIR> for RuntimeMetadataV15 {
 				map: [(
 					TRANSACTION_EXTENSIONS_BY_VERSION.into(),
 					CustomValueMetadata {
-						ty: meta_type::<BTreeMap<u8, Vec<u32>>>(),
+						ty: meta_type::<TrasactionExtensionsByVersion>(),
 						value: transaction_extensions_by_version.encode(),
 					},
 				)]


### PR DESCRIPTION
This PR collects the `transaction_extensions_by_version` type information into the metadata V15 custom types.

This ensures the V15 contains enough information to work with multiple transaction extensions. The meaning of this field is identical to the one collected by the V16 unstable. It includes indexes of extrinsics from the `signed_extension` field of the extrinsic metadata.

### Exposed Metadata


```

"custom": {
        "map": {
          "transaction_extensions_by_version": {
            "ty": 1074,
            "value": [
                  4, 0, 36, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0,
                  0, 7, 0, 0, 0, 8, 0, 0, 0,
              ]
          }
        }
      }

```

The decoded value is `Decoded: {0: [0, 1, 2, 3, 4, 5, 6, 7, 8]}`.

```rust
use codec::Decode;
use std::collections::BTreeMap;

fn main() {
    let value = vec![
        4, 0, 36, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0,
        0, 7, 0, 0, 0, 8, 0, 0, 0,
    ];
    let decoded: BTreeMap<u8, Vec<u32>> = Decode::decode(&mut &value[..]).unwrap();
    println!("Decoded: {decoded:?}");
}
```

cc @paritytech/subxt-team 