### PR TITLE
backport/2412: Update litep2p to v0.8.3 (#6742)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9414,9 +9414,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569e7dbec8a0d4b08d30f4942cd579cfe8db5d3f83f8604abe61697c38d17e73"
+checksum = "14e490b5a6d486711fd0284bd30e607a287343f2935a59a9192bd7109e85f443"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -848,7 +848,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.8.2", features = ["websocket"] }
+litep2p = { version = "0.8.3", features = ["websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }

--- a/prdoc/pr_6742.prdoc
+++ b/prdoc/pr_6742.prdoc
@@ -1,0 +1,11 @@
+title: Update litep2p backend to v0.8.3
+doc:
+- audience: Node Dev
+  description: |-
+    This release includes two fixes for small memory leaks on edge-cases in the notification and request-response protocols.
+    While at it, have downgraded a log message from litep2p.
+
+crates:
+- name: sc-network
+  bump: patch
+

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -753,7 +753,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 							}
 
 							if self.litep2p.add_known_address(peer.into(), iter::once(address.clone())) == 0usize {
-								log::warn!(
+								log::debug!(
 									target: LOG_TARGET,
 									"couldn't add known address ({address}) for {peer:?}, unsupported transport"
 								);


### PR DESCRIPTION
Backport for: https://github.com/paritytech/polkadot-sdk/pull/6742

cc @paritytech/sdk-node 