### PR TITLE
`basic-authorship`: debug level is now less spammy

### DIFF
--- a/prdoc/pr_6768.prdoc
+++ b/prdoc/pr_6768.prdoc
@@ -1,0 +1,14 @@
+title: '`basic-authorship`: debug level is now less spammy'
+doc:
+- audience: Node Dev
+  description: |-
+    The `debug` level in `sc-basic-authorship`  is now less spammy. Previously it was outputing logs per individual transactions. It made quite hard to follow the logs (and also generates unneeded traffic in grafana).
+
+    Now debug level only show some internal details, without spamming output with per-transaction logs. They were moved to `trace` level.
+
+    I also added the `EndProposingReason` to the summary INFO message. This allows us to know what was the block limit (which is very useful for debugging).
+crates:
+- name: sc-basic-authorship
+  bump: major
+- name: sc-proposer-metrics
+  bump: major

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -483,7 +483,7 @@ where
 			match sc_block_builder::BlockBuilder::push(block_builder, pending_tx_data) {
 				Ok(()) => {
 					transaction_pushed = true;
-					debug!(target: LOG_TARGET, "[{:?}] Pushed to the block.", pending_tx_hash);
+					trace!(target: LOG_TARGET, "[{:?}] Pushed to the block.", pending_tx_hash);
 				},
 				Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() => {
 					pending_iterator.report_invalid(&pending_tx);
@@ -565,20 +565,22 @@ where
 
 		if log::log_enabled!(log::Level::Info) {
 			info!(
-				"🎁 Prepared block for proposing at {} ({} ms) [hash: {:?}; parent_hash: {}; extrinsics_count: {}",
+				"🎁 Prepared block for proposing at {} ({} ms) hash: {:?}; parent_hash: {}; end: {:?}; extrinsics_count: {};",
 				block.header().number(),
 				block_took.as_millis(),
 				<Block as BlockT>::Hash::from(block.header().hash()),
 				block.header().parent_hash(),
+				end_reason,
 				extrinsics.len()
 			)
-		} else if log::log_enabled!(log::Level::Debug) {
-			debug!(
-				"🎁 Prepared block for proposing at {} ({} ms) [hash: {:?}; parent_hash: {}; {extrinsics_summary}",
+		} else if log::log_enabled!(log::Level::Trace) {
+			trace!(
+				"🎁 Prepared block for proposing at {} ({} ms) hash: {:?}; parent_hash: {}; end: {:?}; {extrinsics_summary}",
 				block.header().number(),
 				block_took.as_millis(),
 				<Block as BlockT>::Hash::from(block.header().hash()),
 				block.header().parent_hash(),
+				end_reason
 			);
 		}
 

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -565,7 +565,7 @@ where
 
 		if log::log_enabled!(log::Level::Info) {
 			info!(
-				"🎁 Prepared block for proposing at {} ({} ms) hash: {:?}; parent_hash: {}; end: {:?}; extrinsics_count: {};",
+				"🎁 Prepared block for proposing at {} ({} ms) hash: {:?}; parent_hash: {}; end: {:?}; extrinsics_count: {}",
 				block.header().number(),
 				block_took.as_millis(),
 				<Block as BlockT>::Hash::from(block.header().hash()),

--- a/substrate/client/proposer-metrics/src/lib.rs
+++ b/substrate/client/proposer-metrics/src/lib.rs
@@ -44,7 +44,7 @@ impl MetricsLink {
 }
 
 /// The reason why proposing a block ended.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum EndProposingReason {
 	NoMoreTransactions,
 	HitDeadline,


### PR DESCRIPTION
The `debug` level in `sc-basic-authorship`  is now less spammy. Previously it was outputing logs per individual transactions. It was quite hard to follow the logs (and also generates unneeded traffic in grafana).

Now `debug` level only show some internal details, without spamming output with per-transaction logs. They were moved to `trace` level.

I also added the `EndProposingReason` to the summary INFO message. This allows us to know what was the block limit (which is very useful for debugging).

Example:
```
🎁 Prepared block for proposing at 64 (1186 ms) hash: 0x4b5386c13c507d0dbab319ac054cc1bcfa08311e184452221ad07f12ecc6091c; parent_hash: 0x157c…ca5e; end: HitBlockWeightLimit; extrinsics_count: 7032; 
```