### PR TITLE
Snowbridge: Ringfence Polkadot Tokens by Agent

### DIFF
--- a/bridges/snowbridge/pallets/system/src/weights.rs
+++ b/bridges/snowbridge/pallets/system/src/weights.rs
@@ -43,6 +43,7 @@ pub trait WeightInfo {
 	fn set_token_transfer_fees() -> Weight;
 	fn set_pricing_parameters() -> Weight;
 	fn register_token() -> Weight;
+	fn force_register_token() -> Weight;
 }
 
 // For backwards compatibility and tests.
@@ -249,6 +250,16 @@ impl WeightInfo for () {
 	}
 
 	fn register_token() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `256`
+		//  Estimated: `6044`
+		// Minimum execution time: 45_000_000 picoseconds.
+		Weight::from_parts(45_000_000, 6044)
+			.saturating_add(RocksDbWeight::get().reads(5_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+
+	fn force_register_token() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `256`
 		//  Estimated: `6044`

--- a/bridges/snowbridge/primitives/core/src/outbound.rs
+++ b/bridges/snowbridge/primitives/core/src/outbound.rs
@@ -152,6 +152,8 @@ mod v1 {
 		},
 		/// Register foreign token from Polkadot
 		RegisterForeignToken {
+			/// ID of the agent
+			agent_id: H256,
 			/// ID for the token
 			token_id: H256,
 			/// Name of the token
@@ -163,6 +165,8 @@ mod v1 {
 		},
 		/// Mint foreign token from Polkadot
 		MintForeignToken {
+			/// ID of the agent
+			agent_id: H256,
 			/// ID for the token
 			token_id: H256,
 			/// The recipient of the newly minted tokens
@@ -252,15 +256,17 @@ mod v1 {
 						Token::Address(*recipient),
 						Token::Uint(U256::from(*amount)),
 					])]),
-				Command::RegisterForeignToken { token_id, name, symbol, decimals } =>
+				Command::RegisterForeignToken { agent_id, token_id, name, symbol, decimals } =>
 					ethabi::encode(&[Token::Tuple(vec![
+						Token::FixedBytes(agent_id.as_bytes().to_owned()),
 						Token::FixedBytes(token_id.as_bytes().to_owned()),
 						Token::String(name.to_owned()),
 						Token::String(symbol.to_owned()),
 						Token::Uint(U256::from(*decimals)),
 					])]),
-				Command::MintForeignToken { token_id, recipient, amount } =>
+				Command::MintForeignToken { agent_id, token_id, recipient, amount } =>
 					ethabi::encode(&[Token::Tuple(vec![
+						Token::FixedBytes(agent_id.as_bytes().to_owned()),
 						Token::FixedBytes(token_id.as_bytes().to_owned()),
 						Token::Address(*recipient),
 						Token::Uint(U256::from(*amount)),

--- a/bridges/snowbridge/primitives/router/src/inbound/mod.rs
+++ b/bridges/snowbridge/primitives/router/src/inbound/mod.rs
@@ -168,7 +168,8 @@ impl<
 		ConvertAssetId,
 		EthereumUniversalLocation,
 		GlobalAssetHubLocation,
-	> where
+	>
+where
 	CreateAssetCall: Get<CallIndex>,
 	CreateAssetDeposit: Get<u128>,
 	InboundQueuePalletInstance: Get<u8>,
@@ -226,7 +227,8 @@ impl<
 		ConvertAssetId,
 		EthereumUniversalLocation,
 		GlobalAssetHubLocation,
-	> where
+	>
+where
 	CreateAssetCall: Get<CallIndex>,
 	CreateAssetDeposit: Get<u128>,
 	InboundQueuePalletInstance: Get<u8>,

--- a/bridges/snowbridge/primitives/router/src/outbound/mod.rs
+++ b/bridges/snowbridge/primitives/router/src/outbound/mod.rs
@@ -44,7 +44,8 @@ impl<UniversalLocation, EthereumNetwork, OutboundQueue, AgentHashedDescription, 
 		OutboundQueue,
 		AgentHashedDescription,
 		ConvertAssetId,
-	> where
+	>
+where
 	UniversalLocation: Get<InteriorLocation>,
 	EthereumNetwork: Get<NetworkId>,
 	OutboundQueue: SendMessage<Balance = u128>,
@@ -401,6 +402,9 @@ where
 		// Check if there is a SetTopic and skip over it if found.
 		let topic_id = match_expression!(self.next()?, SetTopic(id), id).ok_or(SetTopicExpected)?;
 
-		Ok((Command::MintForeignToken { token_id, recipient, amount }, *topic_id))
+		Ok((
+			Command::MintForeignToken { agent_id: self.agent_id, token_id, recipient, amount },
+			*topic_id,
+		))
 	}
 }

--- a/bridges/snowbridge/runtime/runtime-common/src/lib.rs
+++ b/bridges/snowbridge/runtime/runtime-common/src/lib.rs
@@ -50,7 +50,8 @@ impl<Balance, AccountId, FeeAssetLocation, EthereumNetwork, AssetTransactor, Fee
 		EthereumNetwork,
 		AssetTransactor,
 		FeeProvider,
-	> where
+	>
+where
 	Balance: BaseArithmetic + Unsigned + Copy + From<u128> + Into<u128> + Debug,
 	AccountId: Clone + FullCodec,
 	FeeAssetLocation: Get<Location>,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/snowbridge_pallet_system.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/snowbridge_pallet_system.rs
@@ -263,4 +263,14 @@ impl<T: frame_system::Config> snowbridge_pallet_system::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
+
+	fn force_register_token() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `256`
+		//  Estimated: `6044`
+		// Minimum execution time: 45_000_000 picoseconds.
+		Weight::from_parts(45_000_000, 6044)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/snowbridge_pallet_system.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/snowbridge_pallet_system.rs
@@ -263,4 +263,14 @@ impl<T: frame_system::Config> snowbridge_pallet_system::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
+
+	fn force_register_token() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `256`
+		//  Estimated: `6044`
+		// Minimum execution time: 45_000_000 picoseconds.
+		Weight::from_parts(45_000_000, 6044)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
 }


### PR DESCRIPTION
# Description

Changes `register_token` to accept an XCM origin, this origin has a corresponding agent on the Ethereum side of the bridge that will become the owner of the token.

Related Solidity changes: https://github.com/Snowfork/snowbridge/pull/1350