### PR TITLE
add the ability to declare multiple impl blocks

### DIFF
--- a/substrate/frame/support/test/tests/runtime_metadata.rs
+++ b/substrate/frame/support/test/tests/runtime_metadata.rs
@@ -102,7 +102,12 @@ mod apis {
 
 			fn wild_card(_: u32) {}
 		}
+		pub use ext::*;
+	}
 
+	#[sp_api::impl_runtime_apis_ext]
+	mod ext {
+		use super::*;
 		impl sp_api::Core<Block> for Runtime {
 			fn version() -> sp_version::RuntimeVersion {
 				unimplemented!()
@@ -110,7 +115,9 @@ mod apis {
 			fn execute_block(_: Block) {
 				unimplemented!()
 			}
-			fn initialize_block(_: &<Block as BlockT>::Header) -> sp_runtime::ExtrinsicInclusionMode {
+			fn initialize_block(
+				_: &<Block as BlockT>::Header,
+			) -> sp_runtime::ExtrinsicInclusionMode {
 				unimplemented!()
 			}
 		}

--- a/substrate/primitives/api/proc-macro/src/lib.rs
+++ b/substrate/primitives/api/proc-macro/src/lib.rs
@@ -42,3 +42,8 @@ pub fn mock_impl_runtime_apis(input: TokenStream) -> TokenStream {
 pub fn decl_runtime_apis(input: TokenStream) -> TokenStream {
 	decl_runtime_apis::decl_runtime_apis_impl(input)
 }
+
+#[proc_macro_attribute]
+pub fn impl_runtime_apis_ext(_attrs: TokenStream, tokens: TokenStream) -> TokenStream {
+	impl_runtime_apis::impl_runtime_apis_impl_ext(tokens)
+}

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -523,6 +523,9 @@ pub use sp_api_proc_macro::impl_runtime_apis;
 /// ```
 pub use sp_api_proc_macro::mock_impl_runtime_apis;
 
+/// Ass
+pub use sp_api_proc_macro::impl_runtime_apis_ext;
+
 /// A type that records all accessed trie nodes and generates a proof out of it.
 #[cfg(feature = "std")]
 pub type ProofRecorder<B> = sp_trie::recorder::Recorder<HashingFor<B>>;
@@ -848,3 +851,4 @@ decl_runtime_apis! {
 sp_core::generate_feature_enabled_macro!(std_enabled, feature = "std", $);
 sp_core::generate_feature_enabled_macro!(std_disabled, not(feature = "std"), $);
 sp_core::generate_feature_enabled_macro!(frame_metadata_enabled, feature = "frame-metadata", $);
+pub trait RuntimeBase {}


### PR DESCRIPTION
# Description

Adds the ability to split single `impl_runtime_apis` into multiple modules through `sp_api::impl_runtime_apis_ext`.

Example block would look like: 
```rust
impl_runtime_apis! {
    impl trait Example<Block> for Runtime {
             fn example() {}
    }
    // `use` makes metadata from and runtime_versions visible to the main impl block.
    use other::*;
}

#[sp_api::impl_runtime_apis_ext]
mod other {
        use super::*; 
     	impl super::Example2<Block> for Runtime {
		fn same_name() -> String {
			"example".to_string()
		}
	}
}
```

also see: https://github.com/paritytech/polkadot-sdk/issues/3067


## Review Notes
 
The main difference between `impl_runtime_apis` and `impl_runtime_apis_ext` is the fact that the latter doesn't generate base runtime structures and doesn't track the imports to aggregate them inside the `metadata` and `runtime_api_versions`. 

TODOs: 
- `RUNTIME_API_VERSION` 
    was a `const` before, i've moved it to a standalone function inside the main impl block.
    The question is should it be tied to the runtime via trait e.g `RuntimeApiVersion` and if yes where should it go?(sp_api or sp_version)
    I've tried to figure out a way to use a `const` but given that all of the `const` declarations contain data inside a `std::borrow::Cow` and and there's no way to get value out in const expression i've failed to do so, if someone has any idea how to get around this i would really appreciate some input.
    ```rust
    		pub fn runtime_api_versions() -> #c::ApisVec {
			let api = #c::vec::Vec::from([RUNTIME_API_VERSIONS.into_owned(), #(#modules::RUNTIME_API_VERSIONS.into_owned()),*]).concat();
			api.into()
		}
    ```	

# Checklist

* [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
