### PR TITLE
Let cmd bot to trigger ci on commit

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -292,9 +292,17 @@ jobs:
       image: ${{ needs.set-image.outputs.IMAGE }}
     timeout-minutes: 1440 # 24 hours per runtime
     steps:
+      - name: Generate token
+        uses: actions/create-github-app-token@v1
+        id: generate_token
+        with:
+          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           repository: ${{ needs.get-pr-branch.outputs.repo }}
           ref: ${{ needs.get-pr-branch.outputs.pr-branch }}
 
@@ -392,18 +400,12 @@ jobs:
           name: command-output
           path: /tmp/cmd/command_output.log
 
-      - name: Generate token
-        uses: actions/create-github-app-token@v1
-        id: generate_token
-        with:
-          app-id: ${{ secrets.CMD_BOT_APP_ID }}
-          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
-
       - name: Commit changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            git config --local user.email "action@github.com"
-            git config --local user.name "cmd-bot"
+            git config --global user.name command-bot
+            git config --global user.email "<>"
+            git config --global pull.rebase false
 
             # Push the results to the target branch
             git remote add \

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.CMD_BOT_APP_ID }}
-          private_key: ${{ secrets.CMD_BOT_APP_KEY }}
+          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
 
       - name: Check if user is a member of the organization
         id: is-member
@@ -392,19 +392,39 @@ jobs:
           name: command-output
           path: /tmp/cmd/command_output.log
 
+      - name: Generate token
+        uses: actions/create-github-app-token@v1
+        id: generate_token
+        with:
+          app-id: ${{ secrets.CMD_BOT_APP_ID }}
+          private-key: ${{ secrets.CMD_BOT_APP_KEY }}
+
       - name: Commit changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
+            git config --local user.name "cmd-bot"
+
+            # Push the results to the target branch
+            git remote add \
+              github \
+              "https://token:${{ steps.generate_token.outputs.token }}@github.com/${{ github.event.repository.owner.login }}/${{ github.event.repository.name }}.git" || :
+
+            push_changes() {
+              git push github "HEAD:${{ needs.get-pr-branch.outputs.pr-branch }}"
+            }
 
             git add .
             git restore --staged Cargo.lock # ignore changes in Cargo.lock
             git commit -m "Update from ${{ github.actor }} running command '${{ steps.get-pr-comment.outputs.group2 }}'" || true
             
-            git pull --rebase origin ${{ needs.get-pr-branch.outputs.pr-branch }}
-            
-            git push origin ${{ needs.get-pr-branch.outputs.pr-branch }}
+            # Attempt to push changes
+            if ! push_changes; then
+              echo "Push failed, trying to rebase..."
+              git pull --rebase github "${{ needs.get-pr-branch.outputs.pr-branch }}"
+              # After successful rebase, try pushing again
+              push_changes
+            fi
           else
             echo "Nothing to commit";
           fi


### PR DESCRIPTION
Improvements:
- switch to github native token creation action
- refresh branch in CI from HEAD, to prevent failure
- add APP token when pushing, to allow CI to be retriggering by bot