### PR TITLE
backport/stable2412: chainHead: Always report discarded items for storage operations

### DIFF
--- a/prdoc/pr_6760.prdoc
+++ b/prdoc/pr_6760.prdoc
@@ -1,0 +1,9 @@
+title: 'chainHead: Always report discarded items for storage operations'
+doc:
+- audience: [Node Dev, Node Operator]
+  description: |-
+    This PR ensures that substrate always reports discarded items as zero.
+    This is needed to align with the rpc-v2 spec
+crates:
+- name: sc-rpc-spec-v2
+  bump: patch

--- a/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs
@@ -318,7 +318,7 @@ where
 				}),
 			};
 
-			let (rp, rp_fut) = method_started_response(operation_id);
+			let (rp, rp_fut) = method_started_response(operation_id, None);
 			let fut = async move {
 				// Wait for the server to send out the response and if it produces an error no event
 				// should be generated.
@@ -432,7 +432,8 @@ where
 
 		let mut storage_client = ChainHeadStorage::<Client, Block, BE>::new(self.client.clone());
 
-		let (rp, rp_fut) = method_started_response(block_guard.operation().operation_id());
+		// Storage items are never discarded.
+		let (rp, rp_fut) = method_started_response(block_guard.operation().operation_id(), Some(0));
 
 		let fut = async move {
 			// Wait for the server to send out the response and if it produces an error no event
@@ -507,7 +508,7 @@ where
 		let operation_id = block_guard.operation().operation_id();
 		let client = self.client.clone();
 
-		let (rp, rp_fut) = method_started_response(operation_id.clone());
+		let (rp, rp_fut) = method_started_response(operation_id.clone(), None);
 		let fut = async move {
 			// Wait for the server to send out the response and if it produces an error no event
 			// should be generated.
@@ -630,8 +631,9 @@ where
 
 fn method_started_response(
 	operation_id: String,
+	discarded_items: Option<usize>,
 ) -> (ResponsePayload<'static, MethodResponse>, MethodResponseFuture) {
-	let rp = MethodResponse::Started(MethodResponseStarted { operation_id, discarded_items: None });
+	let rp = MethodResponse::Started(MethodResponseStarted { operation_id, discarded_items });
 	ResponsePayload::success(rp).notify_on_completion()
 }
 

--- a/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/tests.rs
@@ -2871,7 +2871,7 @@ async fn ensure_operation_limits_works() {
 	let operation_id = match response {
 		MethodResponse::Started(started) => {
 			// Check discarded items.
-			assert!(started.discarded_items.is_none());
+			assert_eq!(started.discarded_items, Some(0));
 			started.operation_id
 		},
 		MethodResponse::LimitReached => panic!("Expected started response"),
@@ -3228,7 +3228,10 @@ async fn storage_closest_merkle_value() {
 			.await
 			.unwrap();
 		let operation_id = match response {
-			MethodResponse::Started(started) => started.operation_id,
+			MethodResponse::Started(started) => {
+				assert_eq!(started.discarded_items, Some(0));
+				started.operation_id
+			},
 			MethodResponse::LimitReached => panic!("Expected started response"),
 		};
 


### PR DESCRIPTION
Backport PR for:
- https://github.com/paritytech/polkadot-sdk/pull/6760

cc @paritytech/subxt-team 
