### PR TITLE
first pass at removing bool and added module

### DIFF
--- a/polkadot/node/subsystem-bench/src/cli/prometheus.rs
+++ b/polkadot/node/subsystem-bench/src/cli/prometheus.rs
@@ -1,0 +1,52 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use color_eyre::eyre;
+
+static PROMETHEUS_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Show if the app is running under Prometheus monitoring
+pub(crate) fn is_prometheus_running() -> bool {
+    PROMETHEUS_RUNNING.load(Ordering::SeqCst)
+}
+
+/// Relaunch the app in Prometheus monitoring mode
+pub(crate) fn relaunch_in_prometheus_mode() -> eyre::Result<()> {
+    if is_prometheus_running() {
+        println!("Prometheus mode is already active.");
+        return Ok(());
+    }
+
+    // Mark Prometheus as running
+    PROMETHEUS_RUNNING.store(true, Ordering::SeqCst);
+
+    // Start Prometheus monitoring on a predefined address
+    let registry = prometheus::Registry::new();
+    tokio::spawn(async move {
+        if let Err(e) = prometheus_endpoint::init_prometheus(
+            std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 9999),
+            registry,
+        )
+        .await
+        {
+            eprintln!("Failed to initialize Prometheus endpoint: {:?}", e);
+        }
+    });
+
+    println!("App relaunched in Prometheus monitoring mode.");
+    Ok(())
+}

--- a/polkadot/node/subsystem-bench/src/lib/approval/mod.rs
+++ b/polkadot/node/subsystem-bench/src/lib/approval/mod.rs
@@ -915,13 +915,11 @@ fn build_overseer(
 pub fn prepare_test(
 	config: TestConfiguration,
 	options: ApprovalsOptions,
-	with_prometheus_endpoint: bool,
 ) -> (TestEnvironment, ApprovalTestState) {
 	prepare_test_inner(
 		config,
 		TestEnvironmentDependencies::default(),
 		options,
-		with_prometheus_endpoint,
 	)
 }
 
@@ -930,7 +928,6 @@ fn prepare_test_inner(
 	config: TestConfiguration,
 	dependencies: TestEnvironmentDependencies,
 	options: ApprovalsOptions,
-	with_prometheus_endpoint: bool,
 ) -> (TestEnvironment, ApprovalTestState) {
 	gum::info!("Prepare test state");
 	let state = ApprovalTestState::new(&config, options, &dependencies);
@@ -959,7 +956,6 @@ fn prepare_test_inner(
 			overseer,
 			overseer_handle,
 			state.test_authorities.clone(),
-			with_prometheus_endpoint,
 		),
 		state,
 	)

--- a/polkadot/node/subsystem-bench/src/lib/availability/mod.rs
+++ b/polkadot/node/subsystem-bench/src/lib/availability/mod.rs
@@ -149,7 +149,6 @@ fn build_overseer_for_availability_write(
 pub fn prepare_test(
 	state: &TestState,
 	mode: TestDataAvailability,
-	with_prometheus_endpoint: bool,
 ) -> (TestEnvironment, Vec<ProtocolConfig>) {
 	let dependencies = TestEnvironmentDependencies::default();
 
@@ -295,7 +294,6 @@ pub fn prepare_test(
 			overseer,
 			overseer_handle,
 			state.test_authorities.clone(),
-			with_prometheus_endpoint,
 		),
 		req_cfgs,
 	)

--- a/polkadot/node/subsystem-bench/src/lib/statement/mod.rs
+++ b/polkadot/node/subsystem-bench/src/lib/statement/mod.rs
@@ -154,7 +154,6 @@ fn build_overseer(
 
 pub fn prepare_test(
 	state: &TestState,
-	with_prometheus_endpoint: bool,
 ) -> (TestEnvironment, Vec<ProtocolConfig>) {
 	let dependencies = TestEnvironmentDependencies::default();
 	let (network, network_interface, network_receiver) = new_network(
@@ -174,7 +173,6 @@ pub fn prepare_test(
 			overseer,
 			overseer_handle,
 			state.test_authorities.clone(),
-			with_prometheus_endpoint,
 		),
 		cfg,
 	)


### PR DESCRIPTION
# Description
Extract the prometheus endpoint launching outside the test, as we already do with valgrind and pyroscope.
This is a PR for #3600 