### PR TITLE
backport/stable2412: Update litep2p to version 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7360,9 +7360,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -9420,9 +9420,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e490b5a6d486711fd0284bd30e607a287343f2935a59a9192bd7109e85f443"
+checksum = "2b0fef34af8847e816003bf7fdeac5ea50b9a7a88441ac927a6166b5e812ab79"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -848,7 +848,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.8.3", features = ["websocket"] }
+litep2p = { version = "0.8.4", features = ["websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }

--- a/prdoc/pr_6860.prdoc
+++ b/prdoc/pr_6860.prdoc
@@ -1,0 +1,10 @@
+title: Update litep2p network backend to v0.8.4
+
+doc:
+  - audience: [ Node Dev, Node Operator ]
+    description: |
+      This PR updates the Litep2p network backend to version 0.8.4
+
+crates: 
+  - name: sc-network
+    bump: patch


### PR DESCRIPTION
Backport of:
- https://github.com/paritytech/polkadot-sdk/pull/6860

cc @paritytech/networking 