### PR TITLE
Update merkleized-metadata to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10722,9 +10722,9 @@ dependencies = [
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f6d92804ed0100803d51fa9b21fd9432b5d122ba4c713dc26fe6d2f619cf6"
+checksum = "38c592efaf1b3250df14c8f3c2d952233f0302bb81d3586db2f303666c1cd607"
 dependencies = [
  "array-bytes",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -854,7 +854,7 @@ macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }
 memmap2 = { version = "0.9.3" }
 memory-db = { version = "0.32.0", default-features = false }
-merkleized-metadata = { version = "0.1.2" }
+merkleized-metadata = { version = "0.2.0" }
 merlin = { version = "3.0", default-features = false }
 messages-relay = { path = "bridges/relays/messages" }
 metered = { version = "0.6.1", default-features = false, package = "prioritized-metered-channel" }

--- a/prdoc/pr_6863.prdoc
+++ b/prdoc/pr_6863.prdoc
@@ -3,4 +3,6 @@ doc:
 - audience: Node Dev
   description: |-
     0.1.2 was yanked as it was breaking semver.
-crates: []
+crates: 
+  - name: substrate-wasm-builder
+    bump: patch

--- a/prdoc/pr_6863.prdoc
+++ b/prdoc/pr_6863.prdoc
@@ -1,0 +1,6 @@
+title: Update merkleized-metadata to 0.2.0
+doc:
+- audience: Node Dev
+  description: |-
+    0.1.2 was yanked as it was breaking semver.
+crates: []

--- a/prdoc/pr_6863.prdoc
+++ b/prdoc/pr_6863.prdoc
@@ -6,3 +6,4 @@ doc:
 crates: 
   - name: substrate-wasm-builder
     bump: patch
+    validate: false


### PR DESCRIPTION
0.1.2 was yanked as it was breaking semver.

