### PR TITLE
Rename PanicInfo to PanicHookInfo

### DIFF
--- a/prdoc/pr_6865.prdoc
+++ b/prdoc/pr_6865.prdoc
@@ -1,0 +1,9 @@
+title: Rename PanicInfo to PanicHookInfo
+doc:
+- audience: Node Dev
+  description: Starting with Rust 1.82 `PanicInfo` is deprecated and will throw warnings
+    when used. The new type is available since Rust 1.81 and should be available on
+    our CI.
+crates:
+- name: sp-panic-handler
+  bump: patch

--- a/substrate/primitives/panic-handler/src/lib.rs
+++ b/substrate/primitives/panic-handler/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 	cell::Cell,
 	io::{self, Write},
 	marker::PhantomData,
-	panic::{self, PanicInfo},
+	panic::{self, PanicHookInfo},
 	sync::LazyLock,
 	thread,
 };
@@ -149,7 +149,7 @@ fn strip_control_codes(input: &str) -> std::borrow::Cow<str> {
 }
 
 /// Function being called when a panic happens.
-fn panic_hook(info: &PanicInfo, report_url: &str, version: &str) {
+fn panic_hook(info: &PanicHookInfo, report_url: &str, version: &str) {
 	let location = info.location();
 	let file = location.as_ref().map(|l| l.file()).unwrap_or("<unknown>");
 	let line = location.as_ref().map(|l| l.line()).unwrap_or(0);


### PR DESCRIPTION
Starting with Rust 1.82 `PanicInfo` is deprecated and will throw warnings when used. The new type is available since Rust 1.81 and should be available on our CI.