### PR TITLE
Deprecate ParaBackingState API

### DIFF
--- a/cumulus/client/relay-chain-minimal-node/src/blockchain_rpc_client.rs
+++ b/cumulus/client/relay-chain-minimal-node/src/blockchain_rpc_client.rs
@@ -26,7 +26,7 @@ use futures::{Stream, StreamExt};
 use polkadot_core_primitives::{Block, BlockNumber, Hash, Header};
 use polkadot_overseer::{ChainApiBackend, RuntimeApiSubsystemClient};
 use polkadot_primitives::{
-	async_backing::AsyncBackingParams, slashing, vstaging::async_backing::BackingState,
+	async_backing::AsyncBackingParams, slashing, vstaging::async_backing::{BackingState, Constraints},
 	ApprovalVotingParams, CoreIndex, NodeFeatures,
 };
 use sc_authority_discovery::{AuthorityDiscovery, Error as AuthorityDiscoveryError};
@@ -453,6 +453,14 @@ impl RuntimeApiSubsystemClient for BlockChainRpcClient {
 			.rpc_client
 			.parachain_host_candidates_pending_availability(at, para_id)
 			.await?)
+	}
+
+	async fn constraints(
+		&self,
+		at: Hash,
+		para_id: ParaId,
+	) -> Result<Option<Constraints>, ApiError> {
+		Ok(self.rpc_client.parachain_host_constraints(at, para_id).await?)
 	}
 }
 

--- a/cumulus/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -35,7 +35,7 @@ use cumulus_primitives_core::{
 		async_backing::AsyncBackingParams,
 		slashing,
 		vstaging::{
-			async_backing::BackingState, CandidateEvent,
+			async_backing::{BackingState, Constraints}, CandidateEvent,
 			CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
 			ScrapedOnChainVotes,
 		},
@@ -718,6 +718,15 @@ impl RelayChainRpcClient {
 			Some((para_id, occupied_core_assumption)),
 		)
 		.await
+	}
+
+	pub async fn parachain_host_constraints(
+		&self,
+		at: RelayHash,
+		para_id: ParaId,
+	) -> Result<Option<Constraints>, RelayChainError> {
+		self.call_remote_runtime_function("ParachainHost_constraints", at, Some(para_id))
+			.await
 	}
 
 	fn send_register_message_to_worker(

--- a/polkadot/node/core/prospective-parachains/src/fragment_chain/mod.rs
+++ b/polkadot/node/core/prospective-parachains/src/fragment_chain/mod.rs
@@ -132,7 +132,8 @@ use std::{
 use super::LOG_TARGET;
 use polkadot_node_subsystem::messages::Ancestors;
 use polkadot_node_subsystem_util::inclusion_emulator::{
-	self, validate_commitments, ConstraintModifications, Constraints, Fragment, HypotheticalOrConcreteCandidate, ProspectiveCandidate, RelayChainBlockInfo
+	self, validate_commitments, ConstraintModifications, Constraints, Fragment,
+	HypotheticalOrConcreteCandidate, ProspectiveCandidate, RelayChainBlockInfo,
 };
 use polkadot_primitives::{
 	vstaging::CommittedCandidateReceiptV2 as CommittedCandidateReceipt, BlockNumber,
@@ -1076,7 +1077,6 @@ impl FragmentChain {
 				(true, self.scope.base_constraints.clone(), None)
 			};
 
-
 		// Check for cycles or invalid tree transitions.
 		if let Some(ref output_head_hash) = candidate.output_head_data_hash() {
 			self.check_cycles_or_invalid_tree(output_head_hash)?;
@@ -1095,8 +1095,9 @@ impl FragmentChain {
 					&self.scope.base_constraints,
 					&relay_parent,
 					commitments,
-					&validation_code_hash)
-					.map_err(Error::CheckAgainstConstraints)
+					&validation_code_hash,
+				)
+				.map_err(Error::CheckAgainstConstraints)
 			}
 			Fragment::check_against_constraints(
 				&relay_parent,

--- a/polkadot/node/core/prospective-parachains/src/fragment_chain/tests.rs
+++ b/polkadot/node/core/prospective-parachains/src/fragment_chain/tests.rs
@@ -34,6 +34,7 @@ fn make_constraints(
 		min_relay_parent_number,
 		max_pov_size: 1_000_000,
 		max_code_size: 1_000_000,
+		max_head_data_size: 20480,
 		ump_remaining: 10,
 		ump_remaining_bytes: 1_000,
 		max_ump_num_per_candidate: 10,

--- a/polkadot/node/core/runtime-api/src/cache.rs
+++ b/polkadot/node/core/runtime-api/src/cache.rs
@@ -20,10 +20,10 @@ use schnellru::{ByLength, LruMap};
 use sp_consensus_babe::Epoch;
 
 use polkadot_primitives::{
-	async_backing, slashing, vstaging,
+	async_backing, slashing,
 	vstaging::{
-		CandidateEvent, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
-		ScrapedOnChainVotes,
+		self, async_backing::Constraints, CandidateEvent,
+		CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState, ScrapedOnChainVotes,
 	},
 	ApprovalVotingParams, AuthorityDiscoveryId, BlockNumber, CandidateCommitments, CandidateHash,
 	CoreIndex, DisputeState, ExecutorParams, GroupRotationInfo, Hash, Id as ParaId,
@@ -75,6 +75,7 @@ pub(crate) struct RequestResultCache {
 	node_features: LruMap<SessionIndex, NodeFeatures>,
 	approval_voting_params: LruMap<SessionIndex, ApprovalVotingParams>,
 	claim_queue: LruMap<Hash, BTreeMap<CoreIndex, VecDeque<ParaId>>>,
+	constraints: LruMap<(Hash, ParaId), Option<Constraints>>,
 }
 
 impl Default for RequestResultCache {
@@ -112,6 +113,7 @@ impl Default for RequestResultCache {
 			async_backing_params: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			node_features: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			claim_queue: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
+			constraints: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 		}
 	}
 }
@@ -559,6 +561,14 @@ impl RequestResultCache {
 	) {
 		self.claim_queue.insert(relay_parent, value);
 	}
+
+	pub(crate) fn constraints(&mut self, key: (Hash, ParaId)) -> Option<&Option<Constraints>> {
+		self.constraints.get(&key).map(|v| &*v)
+	}
+
+	pub(crate) fn cache_constraints(&mut self, key: (Hash, ParaId), value: Option<Constraints>) {
+		self.constraints.insert(key, value);
+	}
 }
 
 pub(crate) enum RequestResult {
@@ -610,4 +620,5 @@ pub(crate) enum RequestResult {
 	NodeFeatures(SessionIndex, NodeFeatures),
 	ClaimQueue(Hash, BTreeMap<CoreIndex, VecDeque<ParaId>>),
 	CandidatesPendingAvailability(Hash, ParaId, Vec<CommittedCandidateReceipt>),
+	Constraints(Hash, ParaId, Option<Constraints>),
 }

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -183,6 +183,8 @@ where
 			ClaimQueue(relay_parent, sender) => {
 				self.requests_cache.cache_claim_queue(relay_parent, sender);
 			},
+			Constraints(relay_parent, para_id, constraints) =>
+				self.requests_cache.cache_constraints((relay_parent, para_id), constraints),
 		}
 	}
 
@@ -340,6 +342,8 @@ where
 			},
 			Request::ClaimQueue(sender) =>
 				query!(claim_queue(), sender).map(|sender| Request::ClaimQueue(sender)),
+			Request::Constraints(para, sender) =>
+				query!(constraints(para), sender).map(|sender| Request::Constraints(para, sender)),
 		}
 	}
 
@@ -652,5 +656,13 @@ where
 			ver = Request::CLAIM_QUEUE_RUNTIME_REQUIREMENT,
 			sender
 		),
+		Request::Constraints(para, sender) => {
+			query!(
+				Constraints,
+				constraints(para),
+				ver = Request::CONSTRAINTS_RUNTIME_REQUIREMENT,
+				sender
+			)
+		},
 	}
 }

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -42,11 +42,7 @@ use polkadot_node_primitives::{
 	ValidationResult,
 };
 use polkadot_primitives::{
-	async_backing, slashing, vstaging,
-	vstaging::{
-		BackedCandidate, CandidateReceiptV2 as CandidateReceipt,
-		CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
-	},
+	async_backing, slashing, vstaging::{self, async_backing::Constraints, BackedCandidate, CandidateReceiptV2 as CandidateReceipt, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState},
 	ApprovalVotingParams, AuthorityDiscoveryId, BlockNumber, CandidateCommitments, CandidateHash,
 	CandidateIndex, CoreIndex, DisputeState, ExecutorParams, GroupIndex, GroupRotationInfo, Hash,
 	HeadData, Header as BlockHeader, Id as ParaId, InboundDownwardMessage, InboundHrmpMessage,
@@ -772,6 +768,9 @@ pub enum RuntimeApiRequest {
 	/// Get the candidates pending availability for a particular parachain
 	/// `V11`
 	CandidatesPendingAvailability(ParaId, RuntimeApiSender<Vec<CommittedCandidateReceipt>>),
+	/// Get the constraints for a particular parachain.
+	/// `V12`
+	Constraints(ParaId, RuntimeApiSender<Option<Constraints>>),
 }
 
 impl RuntimeApiRequest {
@@ -812,6 +811,9 @@ impl RuntimeApiRequest {
 
 	/// `candidates_pending_availability`
 	pub const CANDIDATES_PENDING_AVAILABILITY_RUNTIME_REQUIREMENT: u32 = 11;
+
+	/// `constraints`
+	pub const CONSTRAINTS_RUNTIME_REQUIREMENT: u32 = 12;
 }
 
 /// A message to the Runtime API subsystem.

--- a/polkadot/node/subsystem-types/src/runtime_client.rs
+++ b/polkadot/node/subsystem-types/src/runtime_client.rs
@@ -18,11 +18,7 @@ use async_trait::async_trait;
 use polkadot_primitives::{
 	async_backing,
 	runtime_api::ParachainHost,
-	slashing, vstaging,
-	vstaging::{
-		CandidateEvent, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
-		ScrapedOnChainVotes,
-	},
+	slashing, vstaging::{self, async_backing::Constraints, CandidateEvent, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState, ScrapedOnChainVotes},
 	ApprovalVotingParams, Block, BlockNumber, CandidateCommitments, CandidateHash, CoreIndex,
 	DisputeState, ExecutorParams, GroupRotationInfo, Hash, Header, Id, InboundDownwardMessage,
 	InboundHrmpMessage, NodeFeatures, OccupiedCoreAssumption, PersistedValidationData,
@@ -347,6 +343,15 @@ pub trait RuntimeApiSubsystemClient {
 		at: Hash,
 		para_id: Id,
 	) -> Result<Vec<CommittedCandidateReceipt<Hash>>, ApiError>;
+
+	// == v12 ==
+	/// Get the constraints on the actions that can be taken by a new parachain
+	/// block.
+	async fn constraints(
+		&self,
+		at: Hash,
+		para_id: Id,
+	) -> Result<Option<Constraints>, ApiError>;
 }
 
 /// Default implementation of [`RuntimeApiSubsystemClient`] using the client.
@@ -623,6 +628,10 @@ where
 
 	async fn claim_queue(&self, at: Hash) -> Result<BTreeMap<CoreIndex, VecDeque<Id>>, ApiError> {
 		self.client.runtime_api().claim_queue(at)
+	}
+
+	async fn constraints(&self, at: Hash, para_id: Id) -> Result<Option<Constraints>, ApiError> {
+		self.client.runtime_api().constraints(at, para_id)
 	}
 }
 

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -43,7 +43,7 @@ use futures::channel::{mpsc, oneshot};
 use polkadot_primitives::{
 	slashing,
 	vstaging::{
-		async_backing::BackingState, CandidateEvent,
+		async_backing::{Constraints, BackingState}, CandidateEvent,
 		CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState, ScrapedOnChainVotes,
 	},
 	AsyncBackingParams, AuthorityDiscoveryId, CandidateHash, CoreIndex, EncodeAs, ExecutorParams,
@@ -313,6 +313,8 @@ specialize_requests! {
 	fn request_async_backing_params() -> AsyncBackingParams; AsyncBackingParams;
 	fn request_claim_queue() -> BTreeMap<CoreIndex, VecDeque<ParaId>>; ClaimQueue;
 	fn request_para_backing_state(para_id: ParaId) -> Option<BackingState>; ParaBackingState;
+	fn request_constraints(para_id: ParaId) -> Option<Constraints>; Constraints;
+
 }
 
 /// Requests executor parameters from the runtime effective at given relay-parent. First obtains

--- a/polkadot/primitives/src/runtime_api.rs
+++ b/polkadot/primitives/src/runtime_api.rs
@@ -117,7 +117,7 @@ use crate::{
 	slashing,
 	vstaging::{
 		self, CandidateEvent, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
-		ScrapedOnChainVotes,
+		ScrapedOnChainVotes, async_backing::Constraints,
 	},
 	ApprovalVotingParams, AsyncBackingParams, BlockNumber, CandidateCommitments, CandidateHash,
 	CoreIndex, DisputeState, ExecutorParams, GroupRotationInfo, Hash, NodeFeatures,
@@ -297,5 +297,11 @@ sp_api::decl_runtime_apis! {
 		/// Elastic scaling support
 		#[api_version(11)]
 		fn candidates_pending_availability(para_id: ppp::Id) -> Vec<CommittedCandidateReceipt<Hash>>;
+
+		/***** Added in v12 *****/
+		/// Returns the constraints on the actions that can be taken by a new parachain
+		/// block.
+		#[api_version(12)]
+		fn constraints(para_id: ppp::Id) -> Option<Constraints>;
 	}
 }

--- a/polkadot/primitives/src/vstaging/async_backing.rs
+++ b/polkadot/primitives/src/vstaging/async_backing.rs
@@ -50,12 +50,50 @@ impl<H: Copy> From<CandidatePendingAvailability<H>>
 	}
 }
 
+/// Constraints on the actions that can be taken by a new parachain
+/// block. These limitations are implicitly associated with some particular
+/// parachain, which should be apparent from usage.
+#[derive(RuntimeDebug, Clone, PartialEq, Encode, Decode, TypeInfo)]
+pub struct Constraints<N = BlockNumber> {
+	/// The minimum relay-parent number accepted under these constraints.
+	pub min_relay_parent_number: N,
+	/// The maximum Proof-of-Validity size allowed, in bytes.
+	pub max_pov_size: u32,
+	/// The maximum new validation code size allowed, in bytes.
+	pub max_code_size: u32,
+	/// The maximum head-data size, in bytes.
+	pub max_head_data_size: u32,
+	/// The amount of UMP messages remaining.
+	pub ump_remaining: u32,
+	/// The amount of UMP bytes remaining.
+	pub ump_remaining_bytes: u32,
+	/// The maximum number of UMP messages allowed per candidate.
+	pub max_ump_num_per_candidate: u32,
+	/// Remaining DMP queue. Only includes sent-at block numbers.
+	pub dmp_remaining_messages: Vec<N>,
+	/// The limitations of all registered inbound HRMP channels.
+	pub hrmp_inbound: InboundHrmpLimitations<N>,
+	/// The limitations of all registered outbound HRMP channels.
+	pub hrmp_channels_out: Vec<(Id, OutboundHrmpChannelLimitations)>,
+	/// The maximum number of HRMP messages allowed per candidate.
+	pub max_hrmp_num_per_candidate: u32,
+	/// The required parent head-data of the parachain.
+	pub required_parent: HeadData,
+	/// The expected validation-code-hash of this parachain.
+	pub validation_code_hash: ValidationCodeHash,
+	/// The code upgrade restriction signal as-of this parachain.
+	pub upgrade_restriction: Option<UpgradeRestriction>,
+	/// The future validation code hash, if any, and at what relay-parent
+	/// number the upgrade would be minimally applied.
+	pub future_validation_code: Option<(N, ValidationCodeHash)>,
+}
+
 /// The per-parachain state of the backing system, including
 /// state-machine constraints and candidates pending availability.
 #[derive(RuntimeDebug, Clone, PartialEq, Encode, Decode, TypeInfo)]
 pub struct BackingState<H = Hash, N = BlockNumber> {
 	/// The state-machine constraints of the parachain.
-	pub constraints: Constraints<N>,
+	pub constraints: crate::async_backing::Constraints<N>,
 	/// The candidates pending availability. These should be ordered, i.e. they should form
 	/// a sub-chain, where the first candidate builds on top of the required parent of the
 	/// constraints and each subsequent builds on top of the previous head-data.

--- a/polkadot/primitives/src/vstaging/mod.rs
+++ b/polkadot/primitives/src/vstaging/mod.rs
@@ -19,10 +19,10 @@ use crate::{ValidatorIndex, ValidityAttestation};
 
 // Put any primitives used by staging APIs functions here
 use super::{
-	async_backing::Constraints, BlakeTwo256, BlockNumber, CandidateCommitments,
+	async_backing::{InboundHrmpLimitations, OutboundHrmpChannelLimitations}, BlakeTwo256, BlockNumber, CandidateCommitments,
 	CandidateDescriptor, CandidateHash, CollatorId, CollatorSignature, CoreIndex, GroupIndex, Hash,
 	HashT, HeadData, Header, Id, Id as ParaId, MultiDisputeStatementSet, ScheduledCore,
-	UncheckedSignedAvailabilityBitfields, ValidationCodeHash,
+	UncheckedSignedAvailabilityBitfields, ValidationCodeHash, UpgradeRestriction
 };
 use alloc::{
 	collections::{BTreeMap, BTreeSet, VecDeque},

--- a/polkadot/roadmap/implementers-guide/src/node/backing/prospective-parachains.md
+++ b/polkadot/roadmap/implementers-guide/src/node/backing/prospective-parachains.md
@@ -126,6 +126,9 @@ prospective validation data. This is unlikely to change.
 - `RuntimeApiRequest::ParaBackingState`
   - Gets the backing state of the given para (the constraints of the para and
     candidates pending availability).
+- `RuntimeApiRequest::Constraints`
+  - Gets the constraints on the actions that can be taken by a new parachain
+    block.
 - `RuntimeApiRequest::AvailabilityCores`
   - Gets information on all availability cores.
 - `ChainApiMessage::Ancestors`

--- a/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -15,3 +15,93 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Put implementations of functions from staging APIs here.
+
+use crate::{
+	configuration, dmp, hrmp, inclusion, initializer, paras,
+	shared,
+};
+use frame_support::traits::{GetStorageVersion, StorageVersion};
+use frame_system::pallet_prelude::*;
+use polkadot_primitives::{
+	async_backing::{
+		InboundHrmpLimitations, OutboundHrmpChannelLimitations,
+	},
+	vstaging::{
+		async_backing::Constraints,
+	},
+	Id as ParaId,
+};
+
+/// Implementation for `constraints` function from the runtime API
+pub fn constraints<T: initializer::Config>(para_id: ParaId) -> Option<Constraints<BlockNumberFor<T>>> {
+	let config = configuration::ActiveConfig::<T>::get();
+	// Async backing is only expected to be enabled with a tracker capacity of 1.
+	// Subsequent configuration update gets applied on new session, which always
+	// clears the buffer.
+	//
+	// Thus, minimum relay parent is ensured to have asynchronous backing enabled.
+	let now = frame_system::Pallet::<T>::block_number();
+
+	// Use the right storage depending on version to ensure #64 doesn't cause issues with this
+	// migration.
+	let min_relay_parent_number = if shared::Pallet::<T>::on_chain_storage_version() ==
+		StorageVersion::new(0)
+	{
+		shared::migration::v0::AllowedRelayParents::<T>::get().hypothetical_earliest_block_number(
+			now,
+			config.async_backing_params.allowed_ancestry_len,
+		)
+	} else {
+		shared::AllowedRelayParents::<T>::get().hypothetical_earliest_block_number(
+			now,
+			config.async_backing_params.allowed_ancestry_len,
+		)
+	};
+
+	let required_parent = paras::Heads::<T>::get(para_id)?;
+	let validation_code_hash = paras::CurrentCodeHash::<T>::get(para_id)?;
+
+	let upgrade_restriction = paras::UpgradeRestrictionSignal::<T>::get(para_id);
+	let future_validation_code =
+		paras::FutureCodeUpgrades::<T>::get(para_id).and_then(|block_num| {
+			// Only read the storage if there's a pending upgrade.
+			Some(block_num).zip(paras::FutureCodeHash::<T>::get(para_id))
+		});
+
+	let (ump_msg_count, ump_total_bytes) =
+		inclusion::Pallet::<T>::relay_dispatch_queue_size(para_id);
+	let ump_remaining = config.max_upward_queue_count - ump_msg_count;
+	let ump_remaining_bytes = config.max_upward_queue_size - ump_total_bytes;
+
+	let dmp_remaining_messages = dmp::Pallet::<T>::dmq_contents(para_id)
+		.into_iter()
+		.map(|msg| msg.sent_at)
+		.collect();
+
+	let valid_watermarks = hrmp::Pallet::<T>::valid_watermarks(para_id);
+	let hrmp_inbound = InboundHrmpLimitations { valid_watermarks };
+	let hrmp_channels_out = hrmp::Pallet::<T>::outbound_remaining_capacity(para_id)
+		.into_iter()
+		.map(|(para, (messages_remaining, bytes_remaining))| {
+			(para, OutboundHrmpChannelLimitations { messages_remaining, bytes_remaining })
+		})
+		.collect();
+
+	Some(Constraints {
+		min_relay_parent_number,
+		max_pov_size: config.max_pov_size,
+		max_code_size: config.max_code_size,
+		max_head_data_size: config.max_head_data_size,
+		ump_remaining,
+		ump_remaining_bytes,
+		max_ump_num_per_candidate: config.max_upward_message_num_per_candidate,
+		dmp_remaining_messages,
+		hrmp_inbound,
+		hrmp_channels_out,
+		max_hrmp_num_per_candidate: config.hrmp_max_message_num_per_candidate,
+		required_parent,
+		validation_code_hash,
+		upgrade_restriction,
+		future_validation_code,
+	})
+}

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -39,7 +39,7 @@ use polkadot_primitives::{
 	slashing,
 	vstaging::{
 		CandidateEvent, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
-		ScrapedOnChainVotes,
+		ScrapedOnChainVotes, async_backing::Constraints,
 	},
 	AccountId, AccountIndex, ApprovalVotingParams, Balance, BlockNumber, CandidateHash, CoreIndex,
 	DisputeState, ExecutorParams, GroupRotationInfo, Hash, Id as ParaId, InboundDownwardMessage,
@@ -68,6 +68,7 @@ use polkadot_runtime_parachains::{
 	origin as parachains_origin, paras as parachains_paras,
 	paras_inherent as parachains_paras_inherent,
 	runtime_api_impl::v11 as parachains_runtime_api_impl,
+	runtime_api_impl::vstaging as parachains_runtime_vstaging_api_impl,
 	scheduler as parachains_scheduler, session_info as parachains_session_info,
 	shared as parachains_shared,
 };
@@ -1969,7 +1970,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(11)]
+	#[api_version(12)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -2132,6 +2133,10 @@ sp_api::impl_runtime_apis! {
 
 		fn candidates_pending_availability(para_id: ParaId) -> Vec<CommittedCandidateReceipt<Hash>> {
 			parachains_runtime_api_impl::candidates_pending_availability::<Runtime>(para_id)
+		}
+
+		fn constraints(para_id: ParaId) -> Option<Constraints> {
+			parachains_runtime_vstaging_api_impl::constraints::<Runtime>(para_id)
 		}
 	}
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -53,7 +53,7 @@ use polkadot_primitives::{
 	slashing,
 	vstaging::{
 		CandidateEvent, CommittedCandidateReceiptV2 as CommittedCandidateReceipt, CoreState,
-		ScrapedOnChainVotes,
+		ScrapedOnChainVotes, async_backing::Constraints,
 	},
 	AccountId, AccountIndex, ApprovalVotingParams, Balance, BlockNumber, CandidateHash, CoreIndex,
 	DisputeState, ExecutorParams, GroupRotationInfo, Hash, Id as ParaId, InboundDownwardMessage,
@@ -85,6 +85,7 @@ use polkadot_runtime_parachains::{
 	origin as parachains_origin, paras as parachains_paras,
 	paras_inherent as parachains_paras_inherent, reward_points as parachains_reward_points,
 	runtime_api_impl::v11 as parachains_runtime_api_impl,
+	runtime_api_impl::vstaging as parachains_runtime_vstaging_api_impl,
 	scheduler as parachains_scheduler, session_info as parachains_session_info,
 	shared as parachains_shared,
 };
@@ -1995,7 +1996,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(11)]
+	#[api_version(12)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -2158,6 +2159,10 @@ sp_api::impl_runtime_apis! {
 
 		fn candidates_pending_availability(para_id: ParaId) -> Vec<CommittedCandidateReceipt<Hash>> {
 			parachains_runtime_api_impl::candidates_pending_availability::<Runtime>(para_id)
+		}
+
+		fn constraints(para_id: ParaId) -> Option<Constraints> {
+			parachains_runtime_vstaging_api_impl::constraints::<Runtime>(para_id)
 		}
 	}
 


### PR DESCRIPTION
Currently the `para_backing_state` API is used only by the prospective parachains subsystems and returns 2 things: the constraints for parachain blocks and the candidates pending availability. 

This PR deprecates `para_backing_state` and introduces a new `constraints` API that can be used together with `candidate_pending_availability` to get the same information provided by `para_backing_state`.

TODO:
- [ ] PRDoc