### PR TITLE
Fix flaky `build-runtimes-polkavm` CI job

### DIFF
--- a/.github/workflows/build-misc.yml
+++ b/.github/workflows/build-misc.yml
@@ -20,7 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable-preflight.yml
 
   build-runtimes-polkavm:
-    timeout-minutes: 20
+    timeout-minutes: 60
     needs: [preflight]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     container:

--- a/.github/workflows/build-misc.yml
+++ b/.github/workflows/build-misc.yml
@@ -38,11 +38,7 @@ jobs:
         env:
           SUBSTRATE_RUNTIME_TARGET: riscv
         id: required
-        run: |
-          forklift cargo check -p minimal-template-runtime
-          forklift cargo check -p westend-runtime
-          forklift cargo check -p rococo-runtime
-          forklift cargo check -p polkadot-test-runtime
+        run: forklift cargo check -p minimal-template-runtime -p westend-runtime -p rococo-runtime -p polkadot-test-runtime
       - name: Stop all workflows if failed
         if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/workflow-stopper


### PR DESCRIPTION
The timeout was too low which made the job not finish in time sometimes:

Hence:
- Bumping the timeout to 60 minutes which is in line with other jobs which are building substantial parts of the repo.
- Roll all the runtime builds into a single cargo invocation so that it aborts after the first failure. It also allows for more parallel compiling.