### PR TITLE
Migrate `pallet-dev-mode` & `pallet-example-kitchensink` to umbrella crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13282,15 +13282,11 @@ dependencies = [
 name = "pallet-dev-mode"
 version = "10.0.0"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
  "log",
  "pallet-balances 28.0.0",
  "parity-scale-codec",
+ "polkadot-sdk-frame 0.1.0",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -13495,16 +13491,12 @@ dependencies = [
 name = "pallet-example-kitchensink"
 version = "4.0.0-dev"
 dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
  "log",
  "pallet-balances 28.0.0",
  "parity-scale-codec",
+ "polkadot-sdk-frame 0.1.0",
  "scale-info",
  "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
 ]
 
 [[package]]

--- a/substrate/frame/examples/dev-mode/Cargo.toml
+++ b/substrate/frame/examples/dev-mode/Cargo.toml
@@ -19,31 +19,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"] }
 pallet-balances = { workspace = true }
-sp-io = { workspace = true }
-sp-runtime = { workspace = true }
-
-[dev-dependencies]
-sp-core = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
-	"frame-support/std",
-	"frame-system/std",
+	"frame/std",
 	"log/std",
 	"pallet-balances/std",
 	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
+	"frame/try-runtime",
 	"pallet-balances/try-runtime",
-	"sp-runtime/try-runtime",
 ]

--- a/substrate/frame/examples/dev-mode/src/lib.rs
+++ b/substrate/frame/examples/dev-mode/src/lib.rs
@@ -31,8 +31,7 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
-use frame_support::dispatch::DispatchResult;
-use frame_system::ensure_signed;
+use frame::prelude::*;
 
 // Re-export pallet items so that they can be accessed from the crate namespace.
 pub use pallet::*;
@@ -44,11 +43,9 @@ mod tests;
 type BalanceOf<T> = <T as pallet_balances::Config>::Balance;
 
 /// Enable `dev_mode` for this pallet.
-#[frame_support::pallet(dev_mode)]
+#[frame::pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::*;
 
 	#[pallet::config]
 	pub trait Config: pallet_balances::Config + frame_system::Config {

--- a/substrate/frame/examples/dev-mode/src/tests.rs
+++ b/substrate/frame/examples/dev-mode/src/tests.rs
@@ -18,19 +18,14 @@
 //! Tests for pallet-dev-mode.
 
 use crate::*;
-use frame_support::{assert_ok, derive_impl};
-use sp_core::H256;
-use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
-	BuildStorage,
-};
+use frame::testing_prelude::*;
 // Reexport crate as its pallet name for construct_runtime.
 use crate as pallet_dev_mode;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // For testing the pallet, we construct a mock runtime.
-frame_support::construct_runtime!(
+construct_runtime!(
 	pub enum Test
 	{
 		System: frame_system,

--- a/substrate/frame/examples/kitchensink/Cargo.toml
+++ b/substrate/frame/examples/kitchensink/Cargo.toml
@@ -20,13 +20,7 @@ codec = { workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 
-frame-support = { features = ["experimental"], workspace = true }
-frame-system = { workspace = true }
-
-sp-io = { workspace = true }
-sp-runtime = { workspace = true }
-
-frame-benchmarking = { optional = true, workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"] }
 
 pallet-balances = { workspace = true }
 
@@ -37,26 +31,16 @@ sp-core = { workspace = true }
 default = ["std"]
 std = [
 	"codec/std",
-	"frame-benchmarking?/std",
-	"frame-support/std",
-	"frame-system/std",
+	"frame/std",
 	"log/std",
 	"pallet-balances/std",
 	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
+	"frame/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
+	"frame/try-runtime",
 	"pallet-balances/try-runtime",
-	"sp-runtime/try-runtime",
 ]

--- a/substrate/frame/examples/kitchensink/src/benchmarking.rs
+++ b/substrate/frame/examples/kitchensink/src/benchmarking.rs
@@ -24,8 +24,7 @@ use super::*;
 #[allow(unused)]
 use crate::Pallet as Kitchensink;
 
-use frame_benchmarking::v2::*;
-use frame_system::RawOrigin;
+use frame::benchmarking::prelude::*;
 
 // To actually run this benchmark on pallet-example-kitchensink, we need to put this pallet into the
 //   runtime and compile it with `runtime-benchmarks` feature. The detail procedures are

--- a/substrate/frame/examples/kitchensink/src/lib.rs
+++ b/substrate/frame/examples/kitchensink/src/lib.rs
@@ -37,18 +37,17 @@ mod tests;
 mod benchmarking;
 
 #[cfg(feature = "try-runtime")]
-use sp_runtime::TryRuntimeError;
+use frame::try_runtime::TryRuntimeError;
 
 pub mod weights;
 pub use weights::*;
 
 extern crate alloc;
+pub use frame::prelude::*;
 
-#[frame_support::pallet]
+#[frame::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::*;
 
 	/// The config trait of the pallet. You can basically do anything with the config trait that you
 	/// can do with a normal rust trait: import items consisting of types, constants and functions.
@@ -76,7 +75,7 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		/// This is a normal Rust type, nothing specific to FRAME here.
-		type Currency: frame_support::traits::fungible::Inspect<Self::AccountId>;
+		type Currency: frame::traits::fungible::Inspect<Self::AccountId>;
 
 		/// Similarly, let the runtime decide this.
 		fn some_function() -> u32;
@@ -104,7 +103,7 @@ pub mod pallet {
 		}
 	}
 
-	const STORAGE_VERSION: frame_support::traits::StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: frame::traits::StorageVersion = StorageVersion::new(1);
 
 	/// The pallet struct. There's nothing special to FRAME about this; it can implement functions
 	/// in an impl blocks, traits and so on.

--- a/substrate/frame/examples/kitchensink/src/tests.rs
+++ b/substrate/frame/examples/kitchensink/src/tests.rs
@@ -18,15 +18,14 @@
 //! Tests for pallet-example-kitchensink.
 
 use crate::*;
-use frame_support::{assert_ok, derive_impl, parameter_types, traits::VariantCountOf};
-use sp_runtime::BuildStorage;
+use frame::testing_prelude::*;
 // Reexport crate as its pallet name for construct_runtime.
 use crate as pallet_example_kitchensink;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // For testing the pallet, we construct a mock runtime.
-frame_support::construct_runtime!(
+construct_runtime!(
 	pub enum Test
 	{
 		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
@@ -48,7 +47,7 @@ impl pallet_balances::Config for Test {
 	type AccountStore = System;
 	type WeightInfo = ();
 	type FreezeIdentifier = RuntimeFreezeReason;
-	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
+	type MaxFreezes = frame::traits::VariantCountOf<RuntimeFreezeReason>;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 }
@@ -73,7 +72,7 @@ impl Config for Test {
 
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
-pub fn new_test_ext() -> sp_io::TestExternalities {
+pub fn new_test_ext() -> TestExternalities {
 	let t = RuntimeGenesisConfig {
 		// We use default for brevity, but you can configure as desired if needed.
 		system: Default::default(),

--- a/substrate/frame/examples/kitchensink/src/weights.rs
+++ b/substrate/frame/examples/kitchensink/src/weights.rs
@@ -45,7 +45,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame::weights_prelude::*;
 use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_template.


### PR DESCRIPTION
part of https://github.com/paritytech/polkadot-sdk/issues/6504