### PR TITLE
omni-node: Tolerate failing metadata check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18152,7 +18152,6 @@ dependencies = [
  "sp-crypto-hashing 0.1.0",
  "sp-genesis-builder 0.8.0",
  "sp-inherents 26.0.0",
- "sp-io 30.0.0",
  "sp-keystore 0.34.0",
  "sp-runtime 31.0.1",
  "sp-session 27.0.0",

--- a/cumulus/polkadot-omni-node/lib/Cargo.toml
+++ b/cumulus/polkadot-omni-node/lib/Cargo.toml
@@ -69,7 +69,6 @@ sp-inherents = { workspace = true, default-features = true }
 sp-api = { workspace = true, default-features = true }
 sp-consensus = { workspace = true, default-features = true }
 sp-consensus-aura = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
 sc-consensus-manual-seal = { workspace = true, default-features = true }
 sc-sysinfo = { workspace = true, default-features = true }
 prometheus-endpoint = { workspace = true, default-features = true }

--- a/cumulus/polkadot-omni-node/lib/src/common/runtime.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/runtime.rs
@@ -103,7 +103,11 @@ pub struct DefaultRuntimeResolver;
 
 impl RuntimeResolver for DefaultRuntimeResolver {
 	fn runtime(&self, chain_spec: &dyn ChainSpec) -> sc_cli::Result<Runtime> {
-		let metadata_inspector = MetadataInspector::new(chain_spec)?;
+		let Ok(metadata_inspector) = MetadataInspector::new(chain_spec) else {
+			log::info!("Unable to check metadata. Skipping metadata checks. Metadata checks are supported for metadata versions v14 and higher.");
+			return Ok(Runtime::Omni(BlockNumber::U32, Consensus::Aura(AuraConsensusId::Sr25519)))
+		};
+
 		let block_number = match metadata_inspector.block_number() {
 			Some(inner) => inner,
 			None => {

--- a/prdoc/pr_6923.prdoc
+++ b/prdoc/pr_6923.prdoc
@@ -1,0 +1,12 @@
+title: 'omni-node: Tolerate failing metadata check'
+doc:
+- audience: Node Operator
+  description: |-
+    #6450 introduced metadata checks. Supported are metadata v14 and higher.
+
+    However, of course old chain-specs have a genesis code blob that might be on older version. This needs to be tolerated. We should just skip the checks in that case.
+
+    Fixes #6921
+crates:
+- name: polkadot-omni-node-lib
+  bump: patch


### PR DESCRIPTION
#6450 introduced metadata checks. Supported are metadata v14 and higher.

However, of course old chain-specs have a genesis code blob that might be on older version. This needs to be tolerated. We should just skip the checks in that case.

Fixes #6921 