### PR TITLE
Added Asset issuance config

### DIFF
--- a/cumulus/parachains/integration-tests/chopsticks/configs/westend-asset-hub-override.yaml
+++ b/cumulus/parachains/integration-tests/chopsticks/configs/westend-asset-hub-override.yaml
@@ -26,3 +26,7 @@ import-storage:
         - providers: 1
           data:
             free: 1000000000000000
+  Assets:
+    Account:
+      - [[1984, 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY], { balance: 1000000000 }]
+    Asset: [[[1984], { supply: 1000000000 }]]


### PR DESCRIPTION
Asset issuance config for test-tether. On Westend total issuance of this token is equal to 0 (when in doubt check https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fasset-hub-westend-rpc.dwellir.com#/assets for Asset Hub). Even if you set yourself balance of 1 billion test-tether tokens, the execution will fail during withdrawal thus issuance config is needed. 