### PR TITLE
[pallet-revive] implement the gas price API

### DIFF
--- a/substrate/frame/revive/fixtures/contracts/gas_price.rs
+++ b/substrate/frame/revive/fixtures/contracts/gas_price.rs
@@ -1,0 +1,34 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Returns the gas price back to the caller.
+
+#![no_std]
+#![no_main]
+
+extern crate common;
+use uapi::{HostFn, HostFnImpl as api, ReturnFlags};
+
+#[no_mangle]
+#[polkavm_derive::polkavm_export]
+pub extern "C" fn deploy() {}
+
+#[no_mangle]
+#[polkavm_derive::polkavm_export]
+pub extern "C" fn call() {
+	api::return_value(ReturnFlags::empty(), &api::gas_price().to_le_bytes());
+}

--- a/substrate/frame/revive/src/benchmarking/mod.rs
+++ b/substrate/frame/revive/src/benchmarking/mod.rs
@@ -23,6 +23,7 @@ mod call_builder;
 mod code;
 use self::{call_builder::CallSetup, code::WasmModule};
 use crate::{
+	evm::runtime::GAS_PRICE,
 	exec::{Key, MomentOf},
 	limits,
 	storage::WriteOutcome,
@@ -796,6 +797,17 @@ mod benchmarks {
 		}
 		assert_ok!(result);
 		assert_eq!(U256::from_little_endian(&memory[..]), U256::from(128));
+	}
+
+	#[benchmark(pov_mode = Measured)]
+	fn seal_gas_price() {
+		build_runtime!(runtime, memory: []);
+		let result;
+		#[block]
+		{
+			result = runtime.bench_gas_price(memory.as_mut_slice());
+		}
+		assert_eq!(result.unwrap(), u64::from(GAS_PRICE));
 	}
 
 	#[benchmark(pov_mode = Measured)]

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -29,7 +29,7 @@ use crate::{
 		ChainExtension, Environment, Ext, RegisteredChainExtension, Result as ExtensionResult,
 		RetVal, ReturnFlags,
 	},
-	evm::GenericTransaction,
+	evm::{runtime::GAS_PRICE, GenericTransaction},
 	exec::Key,
 	limits,
 	primitives::CodeUploadReturnValue,
@@ -4360,6 +4360,25 @@ fn create1_with_value_works() {
 		let account_id = <Test as Config>::AddressMapper::to_account_id(&address);
 		let usable_balance = <Test as Config>::Currency::usable_balance(&account_id);
 		assert_eq!(usable_balance, value);
+	});
+}
+
+
+#[test]
+fn gas_price_api_works() {
+	let (code, _) = compile_module("gas_price").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		// Create fixture: Constructor does nothing
+		let Contract { addr, .. } =
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
+
+		// Call the contract: It echoes back the value returned by the gas price API.
+		let received = builder::bare_call(addr).build_and_unwrap_result();
+		assert_eq!(received.flags, ReturnFlags::empty());
+		assert_eq!(u64::from_le_bytes(received.data[..].try_into().unwrap()), u64::from(GAS_PRICE));
 	});
 }
 

--- a/substrate/frame/revive/src/wasm/runtime.rs
+++ b/substrate/frame/revive/src/wasm/runtime.rs
@@ -19,6 +19,7 @@
 
 use crate::{
 	address::AddressMapper,
+	evm::runtime::GAS_PRICE,
 	exec::{ExecError, ExecResult, Ext, Key},
 	gas::{ChargedAmount, Token},
 	limits,
@@ -322,6 +323,8 @@ pub enum RuntimeCosts {
 	BlockNumber,
 	/// Weight of calling `seal_block_hash`.
 	BlockHash,
+	/// Weight of calling `seal_gas_price`.
+	GasPrice,
 	/// Weight of calling `seal_now`.
 	Now,
 	/// Weight of calling `seal_weight_to_fee`.
@@ -472,6 +475,7 @@ impl<T: Config> Token<T> for RuntimeCosts {
 			MinimumBalance => T::WeightInfo::seal_minimum_balance(),
 			BlockNumber => T::WeightInfo::seal_block_number(),
 			BlockHash => T::WeightInfo::seal_block_hash(),
+			GasPrice => T::WeightInfo::seal_gas_price(),
 			Now => T::WeightInfo::seal_now(),
 			WeightToFee => T::WeightInfo::seal_weight_to_fee(),
 			Terminate(locked_dependencies) => T::WeightInfo::seal_terminate(locked_dependencies),
@@ -1557,6 +1561,14 @@ pub mod env {
 			false,
 			already_charged,
 		)?)
+	}
+
+	#[stable]
+	/// Returns the simulated ethereum `GASPRICE` value.
+	/// See [`pallet_revive_uapi::HostFn::gas_price`].
+	fn gas_price(&mut self, memory: &mut M) -> Result<u64, TrapReason> {
+		self.charge_gas(RuntimeCosts::GasPrice)?;
+		Ok(GAS_PRICE.into())
 	}
 
 	/// Load the latest block timestamp into the supplied buffer

--- a/substrate/frame/revive/src/weights.rs
+++ b/substrate/frame/revive/src/weights.rs
@@ -84,6 +84,7 @@ pub trait WeightInfo {
 	fn seal_call_data_size() -> Weight;
 	fn seal_block_number() -> Weight;
 	fn seal_block_hash() -> Weight;
+	fn seal_gas_price() -> Weight;
 	fn seal_now() -> Weight;
 	fn seal_weight_to_fee() -> Weight;
 	fn seal_copy_to_contract(n: u32, ) -> Weight;
@@ -519,6 +520,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 3_690_000 picoseconds.
 		Weight::from_parts(3_791_000, 3495)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
+	fn seal_gas_price() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 261_000 picoseconds.
+		Weight::from_parts(307_000, 0)
 	}
 	fn seal_now() -> Weight {
 		// Proof Size summary in bytes:
@@ -1383,6 +1391,13 @@ impl WeightInfo for () {
 		// Minimum execution time: 3_690_000 picoseconds.
 		Weight::from_parts(3_791_000, 3495)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
+	}
+	fn seal_gas_price() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 261_000 picoseconds.
+		Weight::from_parts(307_000, 0)
 	}
 	fn seal_now() -> Weight {
 		// Proof Size summary in bytes:

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -87,6 +87,10 @@ pub trait HostFn: private::Sealed {
 	/// Returns the [EIP-155](https://eips.ethereum.org/EIPS/eip-155) chain ID.
 	fn chain_id(output: &mut [u8; 32]);
 
+	/// Returns the price per ref_time, akin to the EVM
+	/// [GASPRICE](https://www.evm.codes/?fork=cancun#3a) opcode.
+	fn gas_price() -> u64;
+
 	/// Stores the call data size as little endian U256 value into the supplied buffer.
 	///
 	/// # Parameters

--- a/substrate/frame/revive/uapi/src/host/riscv64.rs
+++ b/substrate/frame/revive/uapi/src/host/riscv64.rs
@@ -91,6 +91,7 @@ mod sys {
 			data_ptr: *const u8,
 			data_len: u32,
 		);
+		pub fn gas_price() -> u64;
 		pub fn call_data_size(out_ptr: *mut u8);
 		pub fn block_number(out_ptr: *mut u8);
 		pub fn block_hash(block_number_ptr: *const u8, out_ptr: *mut u8);
@@ -389,6 +390,10 @@ impl HostFn for HostFnImpl {
 	fn return_value(flags: ReturnFlags, return_value: &[u8]) -> ! {
 		unsafe { sys::seal_return(flags.bits(), return_value.as_ptr(), return_value.len() as u32) }
 		panic!("seal_return does not return");
+	}
+
+	fn gas_price() -> u64 {
+		unsafe { sys::gas_price() }
 	}
 
 	impl_wrapper_for! {


### PR DESCRIPTION
This PR implements the EVM gas price syscall API method. Currently this is a compile time constant in revive, but in the EVM it is an opcode. Thus we should provide an opcode for this in the pallet.