### PR TITLE
Migrate pallet-balances to umbrella style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12362,17 +12362,11 @@ name = "pallet-balances"
 version = "28.0.0"
 dependencies = [
  "docify",
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "log",
  "pallet-transaction-payment 28.0.0",
  "parity-scale-codec",
  "paste",
+ "polkadot-sdk-frame 0.1.0",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
 ]
 
 [[package]]

--- a/cumulus/bin/pov-validator/Cargo.toml
+++ b/cumulus/bin/pov-validator/Cargo.toml
@@ -19,8 +19,8 @@ sc-executor.workspace = true
 sp-core.workspace = true
 sp-io.workspace = true
 sp-maybe-compressed-blob.workspace = true
-tracing-subscriber.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/substrate/frame/balances/Cargo.toml
+++ b/substrate/frame/balances/Cargo.toml
@@ -18,46 +18,28 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
 docify = { workspace = true }
-frame-benchmarking = { optional = true, workspace = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-log = { workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"] }
 scale-info = { features = ["derive"], workspace = true }
-sp-runtime = { workspace = true }
 
 [dev-dependencies]
-frame-support = { features = ["experimental"], workspace = true, default-features = true }
 pallet-transaction-payment = { workspace = true, default-features = true }
 paste = { workspace = true, default-features = true }
-sp-core = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
-	"frame-benchmarking?/std",
-	"frame-support/std",
-	"frame-system/std",
-	"log/std",
-	"pallet-transaction-payment/std",
+	"frame/std",
 	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
-	"sp-runtime/std",
 ]
-# Enable support for setting the existential deposit to zero.
-insecure_zero_ed = []
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
+	"frame/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
+	"frame/try-runtime",
 	"pallet-transaction-payment/try-runtime",
-	"sp-runtime/try-runtime",
 ]
+
+# Enable support for setting the existential deposit to zero.
+insecure_zero_ed = []

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -19,7 +19,7 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use super::{*, Pallet as Balances};
+use super::{Pallet as Balances, *};
 use frame::benchmarking::prelude::*;
 
 const SEED: u32 = 0;

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -19,13 +19,8 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use super::*;
-use crate::Pallet as Balances;
-
-use frame_benchmarking::v2::*;
-use frame_system::RawOrigin;
-use sp_runtime::traits::Bounded;
-use types::ExtraFlags;
+use super::{*, Pallet as Balances};
+use frame::benchmarking::prelude::*;
 
 const SEED: u32 = 0;
 // existential deposit multiplier

--- a/substrate/frame/balances/src/impl_fungible.rs
+++ b/substrate/frame/balances/src/impl_fungible.rs
@@ -16,12 +16,13 @@
 // limitations under the License.
 
 //! Implementation of `fungible` traits for Balances pallet.
+
 use super::*;
-use frame_support::traits::{
+use frame::traits::{
 	tokens::{
-		Fortitude,
-		Preservation::{self, Preserve, Protect},
-		Provenance::{self, Minted},
+		DepositConsequence, Preservation,
+		Provenance::{self, *},
+		WithdrawConsequence,
 	},
 	AccountTouch,
 };

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -307,7 +307,7 @@ pub mod pallet {
 	}
 
 	/// The in-code storage version.
-	const STORAGE_VERSION: frame::traits::StorageVersion = frame::traits::StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -154,6 +154,8 @@ mod impl_fungible;
 mod tests;
 mod types;
 
+#[cfg(feature = "try-runtime")]
+use frame::try_runtime::prelude::*;
 pub use impl_currency::{NegativeImbalance, PositiveImbalance};
 pub use pallet::*;
 pub use types::{
@@ -547,7 +549,7 @@ pub mod pallet {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), TryRuntimeError> {
 			Holds::<T, I>::iter_keys().try_for_each(|k| {
 				if Holds::<T, I>::decode_len(k).unwrap_or(0) >
 					T::RuntimeHoldReason::VARIANT_COUNT as usize

--- a/substrate/frame/balances/src/migration.rs
+++ b/substrate/frame/balances/src/migration.rs
@@ -15,11 +15,6 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use frame_support::{
-	pallet_prelude::*,
-	traits::{OnRuntimeUpgrade, PalletInfoAccess},
-	weights::Weight,
-};
 
 fn migrate_v0_to_v1<T: Config<I>, I: 'static>(accounts: &[T::AccountId]) -> Weight {
 	let on_chain_version = Pallet::<T, I>::on_chain_storage_version();
@@ -32,7 +27,7 @@ fn migrate_v0_to_v1<T: Config<I>, I: 'static>(accounts: &[T::AccountId]) -> Weig
 		Pallet::<T, I>::deactivate(total);
 
 		// Remove the old `StorageVersion` type.
-		frame_support::storage::unhashed::kill(&frame_support::storage::storage_prefix(
+		storage::unhashed::kill(&storage::storage_prefix(
 			Pallet::<T, I>::name().as_bytes(),
 			"StorageVersion".as_bytes(),
 		));
@@ -80,7 +75,7 @@ impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for ResetInactive<T, I> {
 
 		if on_chain_version == 1 {
 			// Remove the old `StorageVersion` type.
-			frame_support::storage::unhashed::kill(&frame_support::storage::storage_prefix(
+			storage::unhashed::kill(&storage::storage_prefix(
 				Pallet::<T, I>::name().as_bytes(),
 				"StorageVersion".as_bytes(),
 			));

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -18,25 +18,17 @@
 //! Tests regarding the functionality of the `Currency` trait set implementations.
 
 use super::*;
-use crate::{Event, NegativeImbalance};
-use frame_support::{
-	traits::{
-		BalanceStatus::{Free, Reserved},
-		Currency,
-		ExistenceRequirement::{self, AllowDeath, KeepAlive},
-		Hooks, InspectLockableCurrency, LockIdentifier, LockableCurrency, NamedReservableCurrency,
-		ReservableCurrency, WithdrawReasons,
-	},
-	StorageNoopGuard,
+use frame::traits::{
+	BalanceStatus::*, Imbalance, InspectLockableCurrency, LockIdentifier, LockableCurrency,
+	NamedReservableCurrency, WithdrawReasons,
 };
-use frame_system::Event as SysEvent;
-use sp_runtime::traits::DispatchTransaction;
-
-const ID_1: LockIdentifier = *b"1       ";
-const ID_2: LockIdentifier = *b"2       ";
+use ExistenceRequirement::*;
 
 pub const CALL: &<Test as frame_system::Config>::RuntimeCall =
 	&RuntimeCall::Balances(crate::Call::transfer_allow_death { dest: 0, value: 0 });
+
+const ID_1: LockIdentifier = *b"1       ";
+const ID_2: LockIdentifier = *b"2       ";
 
 #[test]
 fn ed_should_work() {
@@ -895,7 +887,7 @@ fn emit_events_with_existential_deposit() {
 		assert_eq!(
 			events(),
 			[
-				RuntimeEvent::System(system::Event::NewAccount { account: 1 }),
+				RuntimeEvent::System(frame_system::Event::NewAccount { account: 1 }),
 				RuntimeEvent::Balances(crate::Event::Endowed { account: 1, free_balance: 100 }),
 				RuntimeEvent::Balances(crate::Event::Issued { amount: 100 }),
 				RuntimeEvent::Balances(crate::Event::BalanceSet { who: 1, free: 100 }),
@@ -908,7 +900,7 @@ fn emit_events_with_existential_deposit() {
 		assert_eq!(
 			events(),
 			[
-				RuntimeEvent::System(system::Event::KilledAccount { account: 1 }),
+				RuntimeEvent::System(frame_system::Event::KilledAccount { account: 1 }),
 				RuntimeEvent::Balances(crate::Event::DustLost { account: 1, amount: 99 }),
 				RuntimeEvent::Balances(crate::Event::Slashed { who: 1, amount: 1 }),
 				RuntimeEvent::Balances(crate::Event::Rescinded { amount: 1 }),
@@ -926,7 +918,7 @@ fn emit_events_with_no_existential_deposit_suicide() {
 			events(),
 			[
 				RuntimeEvent::Balances(crate::Event::BalanceSet { who: 1, free: 100 }),
-				RuntimeEvent::System(system::Event::NewAccount { account: 1 }),
+				RuntimeEvent::System(frame_system::Event::NewAccount { account: 1 }),
 				RuntimeEvent::Balances(crate::Event::Endowed { account: 1, free_balance: 100 }),
 				RuntimeEvent::Balances(crate::Event::Issued { amount: 100 }),
 			]
@@ -938,7 +930,7 @@ fn emit_events_with_no_existential_deposit_suicide() {
 		assert_eq!(
 			events(),
 			[
-				RuntimeEvent::System(system::Event::KilledAccount { account: 1 }),
+				RuntimeEvent::System(frame_system::Event::KilledAccount { account: 1 }),
 				RuntimeEvent::Balances(crate::Event::Slashed { who: 1, amount: 100 }),
 				RuntimeEvent::Balances(crate::Event::Rescinded { amount: 100 }),
 			]
@@ -1409,7 +1401,7 @@ fn self_transfer_noop() {
 			events(),
 			[
 				Event::Deposit { who: 1, amount: 100 }.into(),
-				SysEvent::NewAccount { account: 1 }.into(),
+				frame_system::Event::NewAccount { account: 1 }.into(),
 				Event::Endowed { account: 1, free_balance: 100 }.into(),
 				Event::Issued { amount: 100 }.into(),
 			]

--- a/substrate/frame/balances/src/tests/dispatchable_tests.rs
+++ b/substrate/frame/balances/src/tests/dispatchable_tests.rs
@@ -17,13 +17,11 @@
 
 //! Tests regarding the functionality of the dispatchables/extrinsics.
 
-use super::*;
-use crate::{
+use super::{
 	AdjustmentDirection::{Decrease as Dec, Increase as Inc},
-	Event,
+	*,
 };
-use frame_support::traits::{fungible::Unbalanced, tokens::Preservation::Expendable};
-use fungible::{hold::Mutate as HoldMutate, Inspect, Mutate};
+use frame::traits::fungible::{Mutate, MutateHold};
 
 /// Alice account ID for more readable tests.
 const ALICE: u64 = 1;
@@ -75,7 +73,7 @@ fn balance_transfer_works() {
 fn force_transfer_works() {
 	ExtBuilder::default().build_and_execute_with(|| {
 		let _ = Balances::mint_into(&1, 111);
-		assert_noop!(Balances::force_transfer(Some(2).into(), 1, 2, 69), BadOrigin,);
+		assert_noop!(Balances::force_transfer(Some(2).into(), 1, 2, 69), BadOrigin);
 		assert_ok!(Balances::force_transfer(RawOrigin::Root.into(), 1, 2, 69));
 		assert_eq!(Balances::total_balance(&1), 42);
 		assert_eq!(Balances::total_balance(&2), 69);
@@ -222,7 +220,7 @@ fn upgrade_accounts_should_work() {
 			assert_eq!(System::providers(&7), 1);
 			assert_eq!(System::consumers(&7), 1);
 
-			<Balances as frame_support::traits::ReservableCurrency<_>>::unreserve(&7, 5);
+			<Balances as ReservableCurrency<_>>::unreserve(&7, 5);
 			assert_ok!(<Balances as fungible::Mutate<_>>::transfer(&7, &1, 10, Expendable));
 			assert_eq!(Balances::total_balance(&7), 0);
 			assert_eq!(System::providers(&7), 0);
@@ -320,8 +318,8 @@ fn force_adjust_total_issuance_rejects_more_than_inactive() {
 		assert_eq!(Balances::active_issuance(), 48);
 
 		// Works with up to 48:
-		assert_ok!(Balances::force_adjust_total_issuance(RawOrigin::Root.into(), Dec, 40),);
-		assert_ok!(Balances::force_adjust_total_issuance(RawOrigin::Root.into(), Dec, 8),);
+		assert_ok!(Balances::force_adjust_total_issuance(RawOrigin::Root.into(), Dec, 40));
+		assert_ok!(Balances::force_adjust_total_issuance(RawOrigin::Root.into(), Dec, 8));
 		assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), 16);
 		assert_eq!(Balances::active_issuance(), 0);
 		// Errors with more than 48:
@@ -330,7 +328,7 @@ fn force_adjust_total_issuance_rejects_more_than_inactive() {
 			Error::<Test>::IssuanceDeactivated,
 		);
 		// Increasing again increases the inactive issuance:
-		assert_ok!(Balances::force_adjust_total_issuance(RawOrigin::Root.into(), Inc, 10),);
+		assert_ok!(Balances::force_adjust_total_issuance(RawOrigin::Root.into(), Inc, 10));
 		assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), 26);
 		assert_eq!(Balances::active_issuance(), 10);
 	});

--- a/substrate/frame/balances/src/tests/fungible_conformance_tests.rs
+++ b/substrate/frame/balances/src/tests/fungible_conformance_tests.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use super::*;
-use frame_support::traits::fungible::{conformance_tests, Inspect, Mutate};
+use frame::traits::fungible::{conformance_tests, Mutate};
 use paste::paste;
 
 macro_rules! generate_tests {

--- a/substrate/frame/balances/src/tests/fungible_tests.rs
+++ b/substrate/frame/balances/src/tests/fungible_tests.rs
@@ -18,20 +18,15 @@
 //! Tests regarding the functionality of the `fungible` trait set implementations.
 
 use super::*;
-use frame_support::traits::{
-	tokens::{
-		Fortitude::{Force, Polite},
-		Precision::{BestEffort, Exact},
-		Preservation::{Expendable, Preserve, Protect},
-		Restriction::Free,
+use frame::traits::{
+	fungible::{
+		FreezeConsideration, HoldConsideration, Inspect, InspectFreeze, InspectHold,
+		LoneFreezeConsideration, LoneHoldConsideration, Mutate, MutateFreeze, MutateHold,
+		Unbalanced,
 	},
+	tokens::{Precision::*, Restriction::*},
 	Consideration, Footprint, LinearStoragePrice, MaybeConsideration,
 };
-use fungible::{
-	FreezeConsideration, HoldConsideration, Inspect, InspectFreeze, InspectHold,
-	LoneFreezeConsideration, LoneHoldConsideration, Mutate, MutateFreeze, MutateHold, Unbalanced,
-};
-use sp_core::ConstU64;
 
 #[test]
 fn inspect_trait_reducible_balance_basic_works() {
@@ -274,8 +269,8 @@ fn frozen_hold_balance_best_effort_transfer_works() {
 				Free,
 				Polite
 			));
-			assert_eq!(Balances::total_balance(&1), 5);
-			assert_eq!(Balances::total_balance(&2), 25);
+			assert_eq!(<Balances as Inspect<_>>::total_balance(&1), 5);
+			assert_eq!(<Balances as Inspect<_>>::total_balance(&2), 25);
 		});
 }
 

--- a/substrate/frame/balances/src/tests/general_tests.rs
+++ b/substrate/frame/balances/src/tests/general_tests.rs
@@ -17,19 +17,9 @@
 
 #![cfg(test)]
 
-use crate::{
-	system::AccountInfo,
-	tests::{ensure_ti_valid, Balances, ExtBuilder, System, Test, TestId, UseSystem},
-	AccountData, ExtraFlags, TotalIssuance,
-};
-use frame_support::{
-	assert_noop, assert_ok, hypothetically,
-	traits::{
-		fungible::{Mutate, MutateHold},
-		tokens::Precision,
-	},
-};
-use sp_runtime::DispatchError;
+use super::*;
+use frame::traits::fungible::{Mutate, MutateHold};
+use frame_system::AccountInfo;
 
 /// There are some accounts that have one consumer ref too few. These accounts are at risk of losing
 /// their held (reserved) balance. They do not just lose it - it is also not accounted for in the

--- a/substrate/frame/balances/src/tests/reentrancy_tests.rs
+++ b/substrate/frame/balances/src/tests/reentrancy_tests.rs
@@ -18,12 +18,7 @@
 //! Tests regarding the reentrancy functionality.
 
 use super::*;
-use frame_support::traits::tokens::{
-	Fortitude::Force,
-	Precision::BestEffort,
-	Preservation::{Expendable, Protect},
-};
-use fungible::Balanced;
+use frame::traits::{fungible::Balanced, tokens::Precision::*, Imbalance};
 
 #[test]
 fn transfer_dust_removal_tst1_should_work() {
@@ -165,14 +160,14 @@ fn emit_events_with_no_existential_deposit_suicide_with_dust() {
 		assert_eq!(
 			events(),
 			[
-				RuntimeEvent::System(system::Event::NewAccount { account: 1 }),
+				RuntimeEvent::System(frame_system::Event::NewAccount { account: 1 }),
 				RuntimeEvent::Balances(crate::Event::Endowed { account: 1, free_balance: 100 }),
 				RuntimeEvent::Balances(crate::Event::Issued { amount: 100 }),
 				RuntimeEvent::Balances(crate::Event::BalanceSet { who: 1, free: 100 }),
 			]
 		);
 
-		let res = Balances::withdraw(&1, 98, BestEffort, Protect, Force);
+		let res = <Balances as Balanced<_>>::withdraw(&1, 98, BestEffort, Protect, Force);
 		assert_eq!(res.unwrap().peek(), 98);
 
 		// no events
@@ -181,13 +176,13 @@ fn emit_events_with_no_existential_deposit_suicide_with_dust() {
 			[RuntimeEvent::Balances(crate::Event::Withdraw { who: 1, amount: 98 })]
 		);
 
-		let res = Balances::withdraw(&1, 1, BestEffort, Expendable, Force);
+		let res = <Balances as Balanced<_>>::withdraw(&1, 1, BestEffort, Expendable, Force);
 		assert_eq!(res.unwrap().peek(), 1);
 
 		assert_eq!(
 			events(),
 			[
-				RuntimeEvent::System(system::Event::KilledAccount { account: 1 }),
+				RuntimeEvent::System(frame_system::Event::KilledAccount { account: 1 }),
 				RuntimeEvent::Balances(crate::Event::DustLost { account: 1, amount: 1 }),
 				RuntimeEvent::Balances(crate::Event::Withdraw { who: 1, amount: 1 })
 			]

--- a/substrate/frame/balances/src/types.rs
+++ b/substrate/frame/balances/src/types.rs
@@ -17,12 +17,9 @@
 
 //! Types used in the pallet.
 
-use crate::{Config, CreditOf, Event, Pallet};
-use codec::{Decode, Encode, MaxEncodedLen};
+use super::*;
 use core::ops::BitOr;
-use frame_support::traits::{Imbalance, LockIdentifier, OnUnbalanced, WithdrawReasons};
-use scale_info::TypeInfo;
-use sp_runtime::{RuntimeDebug, Saturating};
+use frame::traits::{WithdrawReasons, LockIdentifier, Imbalance};
 
 /// Simplified reasons for withdrawing balance.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]

--- a/substrate/frame/balances/src/types.rs
+++ b/substrate/frame/balances/src/types.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 use core::ops::BitOr;
-use frame::traits::{WithdrawReasons, LockIdentifier, Imbalance};
+use frame::traits::{Imbalance, LockIdentifier, WithdrawReasons};
 
 /// Simplified reasons for withdrawing balance.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]

--- a/substrate/frame/balances/src/weights.rs
+++ b/substrate/frame/balances/src/weights.rs
@@ -46,8 +46,8 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use core::marker::PhantomData;
+use frame::weights_prelude::*;
 
 /// Weight functions needed for `pallet_balances`.
 pub trait WeightInfo {

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -210,7 +210,8 @@ pub mod prelude {
 	#[doc(no_inline)]
 	pub use frame_support::{
 		traits::{
-			Contains, Defensive, ExistenceRequirement, IsSubType, OnRuntimeUpgrade, VariantCountOf,
+			Contains, Defensive, ExistenceRequirement, IsSubType, OnRuntimeUpgrade, StorageVersion,
+			VariantCountOf,
 		},
 		BoundedSlice, BoundedVec, PalletId, WeakBoundedVec,
 	};

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -202,11 +202,11 @@ pub mod prelude {
 	#[doc(no_inline)]
 	pub use frame_support::pallet_prelude::*;
 
-	/// Dispatch types from `frame-support`, other fundamental traits
+	/// Dispatch types from `frame-support`.
 	#[doc(no_inline)]
 	pub use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
 
-	/// Frequently used general items in FRAME.
+	/// Frequently used fundamental/general items in FRAME.
 	#[doc(no_inline)]
 	pub use frame_support::{
 		traits::{

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -400,7 +400,7 @@ pub mod runtime {
 		/// Primary types used to parameterize `EnsureOrigin` and `EnsureRootWithArg`.
 		pub use frame_system::{
 			EnsureNever, EnsureNone, EnsureRoot, EnsureRootWithSuccess, EnsureSigned,
-			EnsureSignedBy, RawOrigin,
+			EnsureSignedBy,
 		};
 
 		/// Types to define your runtime version.
@@ -416,6 +416,7 @@ pub mod runtime {
 		pub use sp_api::impl_runtime_apis;
 
 		// Types often used in the runtime APIs.
+		pub use frame_system::RawOrigin;
 		pub use sp_core::OpaqueMetadata;
 		pub use sp_genesis_builder::{
 			PresetId, Result as GenesisBuilderResult, DEV_RUNTIME_PRESET,

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -258,7 +258,9 @@ pub mod prelude {
 
 #[cfg(any(feature = "try-runtime", test))]
 pub mod try_runtime {
-	pub use sp_runtime::TryRuntimeError;
+	pub mod prelude {
+		pub use sp_runtime::TryRuntimeError;
+	}
 }
 
 /// Prelude to be included in the `benchmarking.rs` of a pallet.


### PR DESCRIPTION
- Use procedural macro version `construct_runtime` in mock.
- Part of #6504.

---

Polkadot address: 156HGo9setPcU2qhFMVWLkcmtCEGySLwNqa3DaEiYSWtte4Y