### PR TITLE
Update prometheus binding failure logging format

### DIFF
--- a/prdoc/pr_6979.prdoc
+++ b/prdoc/pr_6979.prdoc
@@ -1,0 +1,8 @@
+title: Update prometheus binding failure logging format
+doc:
+- audience: Node Dev
+  description: |-
+    Using `{:#?}` for the error details is a bit annoying, this change makes a more consistent formatting style for error messages.
+crates:
+- name: substrate-prometheus-endpoint
+  bump: patch

--- a/substrate/utils/prometheus/src/lib.rs
+++ b/substrate/utils/prometheus/src/lib.rs
@@ -87,7 +87,7 @@ async fn request_metrics(
 /// to serve metrics.
 pub async fn init_prometheus(prometheus_addr: SocketAddr, registry: Registry) -> Result<(), Error> {
 	let listener = tokio::net::TcpListener::bind(&prometheus_addr).await.map_err(|e| {
-		log::error!(target: "prometheus", "Error binding to '{:?}': {:?}", prometheus_addr, e);
+		log::error!(target: "prometheus", "Error binding to '{prometheus_addr:?}': {e:?}");
 		Error::PortInUse(prometheus_addr)
 	})?;
 

--- a/substrate/utils/prometheus/src/lib.rs
+++ b/substrate/utils/prometheus/src/lib.rs
@@ -87,7 +87,7 @@ async fn request_metrics(
 /// to serve metrics.
 pub async fn init_prometheus(prometheus_addr: SocketAddr, registry: Registry) -> Result<(), Error> {
 	let listener = tokio::net::TcpListener::bind(&prometheus_addr).await.map_err(|e| {
-		log::error!(target: "prometheus", "Error binding to '{:#?}': {:#?}", prometheus_addr, e);
+		log::error!(target: "prometheus", "Error binding to '{:?}': {:?}", prometheus_addr, e);
 		Error::PortInUse(prometheus_addr)
 	})?;
 


### PR DESCRIPTION
Using `{:#?}` for the error details is a bit annoying, this change makes a more consistent formatting style for error messages.

