### PR TITLE
migrate pallet-mixnet to umbrella crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14029,7 +14029,6 @@ dependencies = [
 name = "pallet-mixnet"
 version = "0.4.0"
 dependencies = [
- "frame-benchmarking 28.0.0",
  "log",
  "parity-scale-codec",
  "polkadot-sdk-frame 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14030,17 +14030,13 @@ name = "pallet-mixnet"
 version = "0.4.0"
 dependencies = [
  "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
  "log",
  "parity-scale-codec",
+ "polkadot-sdk-frame 0.1.0",
  "scale-info",
  "serde",
  "sp-application-crypto 30.0.0",
- "sp-arithmetic 23.0.0",
- "sp-io 30.0.0",
  "sp-mixnet 0.4.0",
- "sp-runtime 31.0.1",
 ]
 
 [[package]]

--- a/prdoc/pr_6986.prdoc
+++ b/prdoc/pr_6986.prdoc
@@ -11,6 +11,8 @@ doc:
 
 crates:
   - name: pallet-mixnet
-    bump: none
+    bump: minor
   - name: polkadot-sdk-frame
+    bump: none
+  - name: polkadot-sdk
     bump: none

--- a/prdoc/pr_6986.prdoc
+++ b/prdoc/pr_6986.prdoc
@@ -13,6 +13,6 @@ crates:
   - name: pallet-mixnet
     bump: minor
   - name: polkadot-sdk-frame
-    bump: none
+    bump: minor
   - name: polkadot-sdk
     bump: none

--- a/prdoc/pr_6986.prdoc
+++ b/prdoc/pr_6986.prdoc
@@ -1,0 +1,16 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: '[pallet-mixnet] Migrate to using frame umbrella crate'
+
+doc:
+  - audience: Runtime Dev
+    description: This PR migrates the pallet-mixnet to use the frame umbrella crate. This
+      is part of the ongoing effort to migrate all pallets to use the frame umbrella crate.
+      The effort is tracked [here](https://github.com/paritytech/polkadot-sdk/issues/6504).
+
+crates:
+  - name: pallet-mixnet
+    bump: none
+  - name: polkadot-sdk-frame
+    bump: none

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -36,9 +36,6 @@ std = [
 	"sp-application-crypto/std",
 	"sp-mixnet/std",
 ]
-runtime-benchmarks = [
-	"frame/runtime-benchmarks",
-]
 try-runtime = [
 	"frame/try-runtime",
 ]

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -35,6 +35,9 @@ std = [
 	"sp-application-crypto/std",
 	"sp-mixnet/std",
 ]
+runtime-benchmarks = [
+	"frame/runtime-benchmarks",
+]
 try-runtime = [
 	"frame/try-runtime",
 ]

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -17,13 +17,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
-scale-info = { features = ["derive"], workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"] }
 frame-benchmarking = { optional = true, workspace = true }
 log = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["derive"], workspace = true }
 sp-application-crypto = { workspace = true }
 sp-mixnet = { workspace = true }
-frame = { workspace = true, features = ["experimental", "runtime"] }
 
 [features]
 default = ["std"]

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -18,7 +18,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
 frame = { workspace = true, features = ["experimental", "runtime"] }
-frame-benchmarking = { optional = true, workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["derive"], workspace = true }

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -35,9 +35,6 @@ std = [
 	"sp-application-crypto/std",
 	"sp-mixnet/std",
 ]
-runtime-benchmarks = [
-	"frame/runtime-benchmarks",
-]
 try-runtime = [
 	"frame/try-runtime",
 ]

--- a/substrate/frame/mixnet/Cargo.toml
+++ b/substrate/frame/mixnet/Cargo.toml
@@ -17,42 +17,28 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
-frame-benchmarking = { optional = true, workspace = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
+frame-benchmarking = { optional = true, workspace = true }
+log = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 sp-application-crypto = { workspace = true }
-sp-arithmetic = { workspace = true }
-sp-io = { workspace = true }
 sp-mixnet = { workspace = true }
-sp-runtime = { workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"] }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
-	"frame-benchmarking?/std",
-	"frame-support/std",
-	"frame-system/std",
+	"frame/std",
 	"log/std",
 	"scale-info/std",
 	"serde/std",
 	"sp-application-crypto/std",
-	"sp-arithmetic/std",
-	"sp-io/std",
 	"sp-mixnet/std",
-	"sp-runtime/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
+	"frame/runtime-benchmarks",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
-	"sp-runtime/try-runtime",
+	"frame/try-runtime",
 ]

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -28,7 +28,6 @@ pub use pallet::*;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use serde::{Deserialize, Serialize};
-
 use frame::{
 	deps::{
 		sp_io::{self, MultiRemovalResults},

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -27,7 +27,6 @@ pub use pallet::*;
 
 use alloc::vec::Vec;
 use core::cmp::Ordering;
-
 use serde::{Deserialize, Serialize};
 
 use frame::{

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -23,29 +23,25 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-use codec::{Decode, Encode, MaxEncodedLen};
-use core::cmp::Ordering;
-use frame_support::{
-	traits::{EstimateNextSessionRotation, Get, OneSessionHandler},
-	BoundedVec,
-};
-use frame_system::{
-	offchain::{CreateInherent, SubmitTransaction},
-	pallet_prelude::BlockNumberFor,
-};
 pub use pallet::*;
-use scale_info::TypeInfo;
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
 use serde::{Deserialize, Serialize};
+
+use frame::{
+    deps::{
+        sp_io::{self, MultiRemovalResults},
+        sp_runtime,
+    },
+    prelude::*,
+};
 use sp_application_crypto::RuntimeAppPublic;
-use sp_arithmetic::traits::{CheckedSub, Saturating, UniqueSaturatedInto, Zero};
-use sp_io::MultiRemovalResults;
 use sp_mixnet::types::{
 	AuthorityId, AuthoritySignature, KxPublic, Mixnode, MixnodesErr, PeerId, SessionIndex,
 	SessionPhase, SessionStatus, KX_PUBLIC_SIZE,
 };
-use sp_runtime::RuntimeDebug;
-
 const LOG_TARGET: &str = "runtime::mixnet";
 
 /// Index of an authority in the authority list for a session.
@@ -168,12 +164,9 @@ fn twox<BlockNumber: UniqueSaturatedInto<u64>>(
 // The pallet
 ////////////////////////////////////////////////////////////////////////////////
 
-#[frame_support::pallet(dev_mode)]
+#[frame::pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::*;
-
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
@@ -254,7 +247,7 @@ pub mod pallet {
 		StorageDoubleMap<_, Identity, SessionIndex, Identity, AuthorityIndex, BoundedMixnodeFor<T>>;
 
 	#[pallet::genesis_config]
-	#[derive(frame_support::DefaultNoBound)]
+	#[derive(frame::prelude::DefaultNoBound)]
 	pub struct GenesisConfig<T: Config> {
 		/// The mixnode set for the very first session.
 		pub mixnodes: BoundedVec<BoundedMixnodeFor<T>, T::MaxAuthorities>,
@@ -308,7 +301,7 @@ pub mod pallet {
 
 		fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
 			let Self::Call::register { registration, signature } = call else {
-				return InvalidTransaction::Call.into()
+				return InvalidTransaction::Call.into();
 			};
 
 			// Check session index matches
@@ -320,16 +313,16 @@ pub mod pallet {
 
 			// Check authority index is valid
 			if registration.authority_index >= T::MaxAuthorities::get() {
-				return InvalidTransaction::BadProof.into()
+				return InvalidTransaction::BadProof.into();
 			}
 			let Some(authority_id) = NextAuthorityIds::<T>::get(registration.authority_index)
 			else {
-				return InvalidTransaction::BadProof.into()
+				return InvalidTransaction::BadProof.into();
 			};
 
 			// Check the authority hasn't registered a mixnode yet
 			if Self::already_registered(registration.session_index, registration.authority_index) {
-				return InvalidTransaction::Stale.into()
+				return InvalidTransaction::Stale.into();
 			}
 
 			// Check signature. Note that we don't use regular signed transactions for registration
@@ -339,7 +332,7 @@ pub mod pallet {
 				authority_id.verify(&encoded_registration, signature)
 			});
 			if !signature_ok {
-				return InvalidTransaction::BadProof.into()
+				return InvalidTransaction::BadProof.into();
 			}
 
 			ValidTransaction::with_tag_prefix("MixnetRegistration")
@@ -368,12 +361,12 @@ impl<T: Config> Pallet<T> {
 			.saturating_sub(CurrentSessionStartBlock::<T>::get());
 		let Some(block_in_phase) = block_in_phase.checked_sub(&T::NumCoverToCurrentBlocks::get())
 		else {
-			return SessionPhase::CoverToCurrent
+			return SessionPhase::CoverToCurrent;
 		};
 		let Some(block_in_phase) =
 			block_in_phase.checked_sub(&T::NumRequestsToCurrentBlocks::get())
 		else {
-			return SessionPhase::RequestsToCurrent
+			return SessionPhase::RequestsToCurrent;
 		};
 		if block_in_phase < T::NumCoverToPrevBlocks::get() {
 			SessionPhase::CoverToPrev
@@ -411,7 +404,7 @@ impl<T: Config> Pallet<T> {
 			return Err(MixnodesErr::InsufficientRegistrations {
 				num: 0,
 				min: T::MinMixnodes::get(),
-			})
+			});
 		};
 		Self::mixnodes(prev_session_index)
 	}
@@ -430,7 +423,7 @@ impl<T: Config> Pallet<T> {
 		// registering
 		let block_in_session = block_number.saturating_sub(CurrentSessionStartBlock::<T>::get());
 		if block_in_session < T::NumRegisterStartSlackBlocks::get() {
-			return false
+			return false;
 		}
 
 		let (Some(end_block), _weight) =
@@ -438,7 +431,7 @@ impl<T: Config> Pallet<T> {
 		else {
 			// Things aren't going to work terribly well in this case as all the authorities will
 			// just pile in after the slack period...
-			return true
+			return true;
 		};
 
 		let remaining_blocks = end_block
@@ -447,7 +440,7 @@ impl<T: Config> Pallet<T> {
 		if remaining_blocks.is_zero() {
 			// Into the slack time at the end of the session. Not necessarily too late;
 			// registrations are accepted right up until the session ends.
-			return true
+			return true;
 		}
 
 		// Want uniform distribution over the remaining blocks, so pick this block with probability
@@ -496,7 +489,7 @@ impl<T: Config> Pallet<T> {
 				"Session {session_index} registration attempted, \
 				but current session is {current_session_index}",
 			);
-			return false
+			return false;
 		}
 
 		let block_number = frame_system::Pallet::<T>::block_number();
@@ -505,7 +498,7 @@ impl<T: Config> Pallet<T> {
 				target: LOG_TARGET,
 				"Waiting for the session to progress further before registering",
 			);
-			return false
+			return false;
 		}
 
 		let Some((authority_index, authority_id)) = Self::next_local_authority() else {
@@ -513,7 +506,7 @@ impl<T: Config> Pallet<T> {
 				target: LOG_TARGET,
 				"Not an authority in the next session; cannot register a mixnode",
 			);
-			return false
+			return false;
 		};
 
 		if Self::already_registered(session_index, authority_index) {
@@ -521,14 +514,14 @@ impl<T: Config> Pallet<T> {
 				target: LOG_TARGET,
 				"Already registered a mixnode for the next session",
 			);
-			return false
+			return false;
 		}
 
 		let registration =
 			Registration { block_number, session_index, authority_index, mixnode: mixnode.into() };
 		let Some(signature) = authority_id.sign(&registration.encode()) else {
 			log::debug!(target: LOG_TARGET, "Failed to sign registration");
-			return false
+			return false;
 		};
 		let call = Call::register { registration, signature };
 		let xt = T::create_inherent(call.into());

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -27,7 +27,6 @@ pub use pallet::*;
 
 use alloc::vec::Vec;
 use core::cmp::Ordering;
-use serde::{Deserialize, Serialize};
 use frame::{
 	deps::{
 		sp_io::{self, MultiRemovalResults},
@@ -35,6 +34,7 @@ use frame::{
 	},
 	prelude::*,
 };
+use serde::{Deserialize, Serialize};
 use sp_application_crypto::RuntimeAppPublic;
 use sp_mixnet::types::{
 	AuthorityId, AuthoritySignature, KxPublic, Mixnode, MixnodesErr, PeerId, SessionIndex,

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -40,6 +40,7 @@ use sp_mixnet::types::{
 	AuthorityId, AuthoritySignature, KxPublic, Mixnode, MixnodesErr, PeerId, SessionIndex,
 	SessionPhase, SessionStatus, KX_PUBLIC_SIZE,
 };
+
 const LOG_TARGET: &str = "runtime::mixnet";
 
 /// Index of an authority in the authority list for a session.

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -31,11 +31,11 @@ use core::cmp::Ordering;
 use serde::{Deserialize, Serialize};
 
 use frame::{
-    deps::{
-        sp_io::{self, MultiRemovalResults},
-        sp_runtime,
-    },
-    prelude::*,
+	deps::{
+		sp_io::{self, MultiRemovalResults},
+		sp_runtime,
+	},
+	prelude::*,
 };
 use sp_application_crypto::RuntimeAppPublic;
 use sp_mixnet::types::{

--- a/substrate/frame/mixnet/src/lib.rs
+++ b/substrate/frame/mixnet/src/lib.rs
@@ -247,7 +247,7 @@ pub mod pallet {
 		StorageDoubleMap<_, Identity, SessionIndex, Identity, AuthorityIndex, BoundedMixnodeFor<T>>;
 
 	#[pallet::genesis_config]
-	#[derive(frame::prelude::DefaultNoBound)]
+	#[derive(DefaultNoBound)]
 	pub struct GenesisConfig<T: Config> {
 		/// The mixnode set for the very first session.
 		pub mixnodes: BoundedVec<BoundedMixnodeFor<T>, T::MaxAuthorities>,

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -203,11 +203,17 @@ pub mod prelude {
 	/// Dispatch types from `frame-support`, other fundamental traits
 	#[doc(no_inline)]
 	pub use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
-	pub use frame_support::traits::{Contains, IsSubType, OnRuntimeUpgrade};
+	pub use frame_support::traits::{
+		Contains, EstimateNextSessionRotation, IsSubType, OnRuntimeUpgrade, OneSessionHandler,
+	};
 
 	/// Pallet prelude of `frame-system`.
 	#[doc(no_inline)]
 	pub use frame_system::pallet_prelude::*;
+
+	/// Transaction related helpers to submit transactions.
+	#[doc(no_inline)]
+	pub use frame_system::offchain::*;
 
 	/// All FRAME-relevant derive macros.
 	#[doc(no_inline)]
@@ -216,6 +222,9 @@ pub mod prelude {
 	/// All hashing related things
 	pub use super::hashing::*;
 
+	/// All arithmetic types and traits used for safe math.
+	pub use super::arithmetic::*;
+
 	/// Runtime traits
 	#[doc(no_inline)]
 	pub use sp_runtime::traits::{
@@ -223,9 +232,9 @@ pub mod prelude {
 		Saturating, StaticLookup, TrailingZeroInput,
 	};
 
-	/// Other error/result types for runtime
+	/// Other runtime types and traits
 	#[doc(no_inline)]
-	pub use sp_runtime::{DispatchErrorWithPostInfo, DispatchResultWithInfo, TokenError};
+	pub use sp_runtime::{DispatchErrorWithPostInfo, DispatchResultWithInfo, TokenError, BoundToRuntimeAppPublic};
 }
 
 #[cfg(any(feature = "try-runtime", test))]
@@ -509,6 +518,8 @@ pub mod traits {
 }
 
 /// The arithmetic types used for safe math.
+///
+/// This is already part of the [`prelude`].
 pub mod arithmetic {
 	pub use sp_arithmetic::{traits::*, *};
 }

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -234,7 +234,9 @@ pub mod prelude {
 
 	/// Other runtime types and traits
 	#[doc(no_inline)]
-	pub use sp_runtime::{DispatchErrorWithPostInfo, DispatchResultWithInfo, TokenError, BoundToRuntimeAppPublic};
+	pub use sp_runtime::{
+		BoundToRuntimeAppPublic, DispatchErrorWithPostInfo, DispatchResultWithInfo, TokenError,
+	};
 }
 
 #[cfg(any(feature = "try-runtime", test))]

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -290,7 +290,6 @@ runtime-benchmarks = [
 	"pallet-membership?/runtime-benchmarks",
 	"pallet-message-queue?/runtime-benchmarks",
 	"pallet-migrations?/runtime-benchmarks",
-	"pallet-mixnet?/runtime-benchmarks",
 	"pallet-mmr?/runtime-benchmarks",
 	"pallet-multisig?/runtime-benchmarks",
 	"pallet-nft-fractionalization?/runtime-benchmarks",

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -290,6 +290,7 @@ runtime-benchmarks = [
 	"pallet-membership?/runtime-benchmarks",
 	"pallet-message-queue?/runtime-benchmarks",
 	"pallet-migrations?/runtime-benchmarks",
+	"pallet-mixnet?/runtime-benchmarks",
 	"pallet-mmr?/runtime-benchmarks",
 	"pallet-multisig?/runtime-benchmarks",
 	"pallet-nft-fractionalization?/runtime-benchmarks",


### PR DESCRIPTION
# Description

Migrate pallet-mixnet to use umbrella crate whilst adding a few types and traits in the frame prelude that are used by other pallets as well.

## Review Notes

* This PR migrates `pallet-mixnet` to use the umbrella crate. 
* Note that some imports like `use sp_application_crypto::RuntimeAppPublic;` and imports from `sp_mixnet::types::` have not been migrated to the umbrella crate as they are not used in any / many other places and are relevant only to the `pallet-mixnet`.
* Transaction related helpers to submit transactions from `frame-system` have been added to the main `prelude` as they have usage across various pallets.
```Rust
	pub use frame_system::offchain::*;
```
* Exporting `arithmetic` module in the main `prelude` since this is used a lot throughout various pallets.
* Nightly formatting has been applied using `cargo fmt`
* Benchmarking dependencies have been removed from`palet-mixnet` as there is no benchmarking.rs present for `pallet-mixnet`. For the same reason, `"pallet-mixnet?/runtime-benchmarks"` has been removed from `umbrella/Cargo.toml`.
