### PR TITLE
fix chunk fetching network compatibility zombienet test

### DIFF
--- a/polkadot/zombienet_tests/functional/0014-chunk-fetching-network-compatibility.toml
+++ b/polkadot/zombienet_tests/functional/0014-chunk-fetching-network-compatibility.toml
@@ -42,7 +42,8 @@ chain = "glutton-westend-local-{{id}}"
 
     [parachains.collator]
     name = "collator"
-    image = "{{CUMULUS_IMAGE}}"
+    # Use an old image that does not send out v2 receipts, as the old validators will still check the collator signatures.
+    image = "docker.io/paritypr/polkadot-parachain-debug:master-bde0bbe5"
     args = ["-lparachain=debug"]
 
 {% endfor %}


### PR DESCRIPTION
Fix this zombienet test

It was failing because in https://github.com/paritytech/polkadot-sdk/pull/6452 I enabled the v2 receipts for testnet genesis,
so the collators started sending v2 receipts with zeroed collator signatures to old validators that were still checking those signatures (which lead to disputes, since new validators considered the candidates valid).

The fix is to also use an old image for collators, so that we don't create v2 receipts.

We cannot remove this test yet because collators also perform chunk recovery, so until all collators are upgraded, we need to maintain this compatibility with the old protocol version (which is also why systematic recovery was not yet enabled)