### PR TITLE
added reserve asset transfer script

### DIFF
--- a/cumulus/parachains/integration-tests/chopsticks/configs/westend-penpal-override.yaml
+++ b/cumulus/parachains/integration-tests/chopsticks/configs/westend-penpal-override.yaml
@@ -1,0 +1,35 @@
+endpoint: wss://westend-penpal-rpc.polkadot.io 
+mock-signature-host: true
+#block: ${env.WESTEND_BRIDGE_HUB_BLOCK_NUMBER}
+db: ./db.sqlite
+runtime-log-level: 5
+wasm-override: wasms/penpal_runtime.compact.compressed.wasm
+
+import-storage:
+  PolkadotXcm:
+    SafeXcmVersion: 5
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+        - providers: 1
+          data:
+            free: 1000000000000000
+      -
+        -
+          - 5Eg2fntQqFi3EvFWAf71G66Ecjjah26bmFzoANAeHFgj9Lia
+        - providers: 1
+          data:
+            free: 1000000000000000
+      -
+        -
+          - 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty # Bob
+        - providers: 1
+          data:
+            free: 1000000000000000
+  Assets:
+    Account:
+      - [[1984, 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY], { balance: 1000000000 }]
+      - [[1984, 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty], { balance: 1000000000 }] # Bob
+    Asset: [[[1984], { supply: 1000000000 }]]

--- a/cumulus/parachains/integration-tests/chopsticks/tests/v5-tests/index.ts
+++ b/cumulus/parachains/integration-tests/chopsticks/tests/v5-tests/index.ts
@@ -387,3 +387,100 @@ test("Initiate Teleport with remote fees", async () => {
 	const r = await ahToWnd.signAndSubmit(aliceSigner);
 	expect(r).toBeTruthy();
 })
+
+test("Withdraw USDT from Alice to Bob", async () => {
+
+	const msg = Enum('V5', [
+		XcmV4Instruction.WithdrawAsset([
+			{
+				id: {
+					parents: 1,
+					interior: XcmV3Junctions.Here(),
+				},
+				fun: XcmV3MultiassetFungibility.Fungible(3_000_000_000_000n),
+			},
+		]),
+		Enum('PayFees', {
+			asset: {
+				id: {
+					parents: 1,
+					interior: XcmV3Junctions.Here(),
+				},
+				fun: XcmV3MultiassetFungibility.Fungible(1_000_000_000_000n),
+			}
+		}),
+		XcmV4Instruction.TransferReserveAsset({
+			assets: [
+				{
+					id: {
+						parents: 0,
+						interior: XcmV3Junctions.X2([
+							XcmV3Junction.PalletInstance(50),
+							XcmV3Junction.GeneralIndex(1984n)]),
+					},
+					fun: XcmV3MultiassetFungibility.Fungible(100_000_000n),
+				},
+				{
+					id: {
+						parents: 1,
+						interior: XcmV3Junctions.Here(),
+					},
+					fun: XcmV3MultiassetFungibility.Fungible(2_000_000_000_000n),
+				},
+			],
+			dest: {
+				parents: 1,
+				interior: XcmV3Junctions.X1(
+					XcmV3Junction.Parachain(2042),
+				),
+			},
+			xcm: [
+				Enum('PayFees', {
+					asset: {
+						id: {
+							parents: 1,
+							interior: XcmV3Junctions.Here(),
+						},
+						fun: XcmV3MultiassetFungibility.Fungible(1_000_000_000_000n),
+					}
+				}),
+				XcmV4Instruction.DepositAsset({
+					assets: XcmV3MultiassetMultiAssetFilter.Wild({
+						type: 'All',
+						value: undefined,
+					}),
+					// granular version
+					// assets: XcmV4AssetAssetFilter.Definite([{
+					// 	id: {
+					// 		parents: 1,
+					// 		// interior: XcmV3Junctions.Here(),
+					// 		interior: XcmV3Junctions.X3([
+					// 			XcmV3Junction.Parachain(1000),
+					// 			XcmV3Junction.PalletInstance(50),
+					// 			XcmV3Junction.GeneralIndex(1984n)]),
+					// 	},
+					// 	// fun: XcmV3MultiassetFungibility.Fungible(1_000_000_000_000n),
+					// 	fun: XcmV3MultiassetFungibility.Fungible(100_000_000n),
+					// }]),
+					beneficiary: {
+						parents: 0,
+						interior: XcmV3Junctions.X1(XcmV3Junction.AccountId32({
+							network: undefined,
+							id: Binary.fromBytes(hdkdKeyPairAlice.publicKey),
+						})),
+					},
+				}),
+			],
+		}),
+	]);
+
+
+	const ahToWnd = AHApi.tx.PolkadotXcm.execute({
+			message: msg,
+			// max_weight: { ref_time: weight.value.ref_time, proof_size: weight.value.proof_size },
+			max_weight: { ref_time: 81834380000n, proof_size: 823193n },
+		},
+	);
+	const r = await ahToWnd.signAndSubmit(aliceSigner);
+	expect(r).toBeTruthy();
+})

--- a/cumulus/parachains/integration-tests/chopsticks/tests/v5-tests/index.ts
+++ b/cumulus/parachains/integration-tests/chopsticks/tests/v5-tests/index.ts
@@ -477,7 +477,6 @@ test("Withdraw USDT from Alice to Bob", async () => {
 
 	const ahToWnd = AHApi.tx.PolkadotXcm.execute({
 			message: msg,
-			// max_weight: { ref_time: weight.value.ref_time, proof_size: weight.value.proof_size },
 			max_weight: { ref_time: 81834380000n, proof_size: 823193n },
 		},
 	);


### PR DESCRIPTION
Added reserve asset transfer script. 

To run chopsticks use:
bunx @acala-network/chopsticks@latest xcm -r configs/westend-override.yaml -p configs/westend-asset-hub-override.yaml -p configs/westend-penpal-override.yaml 
