### PR TITLE
Allow ranked collective members below mininum required rank to vote but with zero weight

### DIFF
--- a/substrate/frame/ranked-collective/src/lib.rs
+++ b/substrate/frame/ranked-collective/src/lib.rs
@@ -96,14 +96,17 @@ pub type Votes = u32;
 #[codec(mel_bound())]
 pub struct Tally<T, I, M: GetMaxVoters> {
 	bare_ayes: MemberIndex,
+	out_of_rank_ayes: MemberIndex,
+	out_of_rank_nays: MemberIndex,
 	ayes: Votes,
 	nays: Votes,
 	dummy: PhantomData<(T, I, M)>,
+
 }
 
 impl<T: Config<I>, I: 'static, M: GetMaxVoters> Tally<T, I, M> {
-	pub fn from_parts(bare_ayes: MemberIndex, ayes: Votes, nays: Votes) -> Self {
-		Tally { bare_ayes, ayes, nays, dummy: PhantomData }
+	pub fn from_parts(bare_ayes: MemberIndex, out_of_rank_ayes: MemberIndex, out_of_rank_nays: MemberIndex, ayes: Votes, nays: Votes) -> Self {
+		Tally { bare_ayes, out_of_rank_ayes, out_of_rank_nays, ayes, nays, dummy: PhantomData }
 	}
 }
 
@@ -123,7 +126,7 @@ impl<T: Config<I>, I: 'static, M: GetMaxVoters<Class = ClassOf<T, I>>>
 	VoteTally<Votes, ClassOf<T, I>> for Tally<T, I, M>
 {
 	fn new(_: ClassOf<T, I>) -> Self {
-		Self { bare_ayes: 0, ayes: 0, nays: 0, dummy: PhantomData }
+		Self { bare_ayes: 0, out_of_rank_ayes: 0, out_of_rank_nays: 0, ayes: 0, nays: 0, dummy: PhantomData }
 	}
 	fn ayes(&self, _: ClassOf<T, I>) -> Votes {
 		self.bare_ayes
@@ -192,16 +195,18 @@ impl MemberRecord {
 #[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum VoteRecord {
 	/// Vote was an aye with given vote weight.
-	Aye(Votes),
+	Aye(Option<Votes>),
 	/// Vote was a nay with given vote weight.
-	Nay(Votes),
+	Nay(Option<Votes>),
 }
 
-impl From<(bool, Votes)> for VoteRecord {
-	fn from((aye, votes): (bool, Votes)) -> Self {
-		match aye {
-			true => VoteRecord::Aye(votes),
-			false => VoteRecord::Nay(votes),
+impl From<(bool, Option<Votes>)> for VoteRecord {
+	fn from((aye, votes): (bool, Option<Votes>)) -> Self {
+		match (aye, votes) {
+			(true, Some(votes)) => VoteRecord::Aye(Some(votes)),
+			(true, None) => VoteRecord::Aye(None),
+			(false, Some(votes)) => VoteRecord::Nay(Some(votes)),
+			(false, None) => VoteRecord::Nay(None),
 		}
 	}
 }
@@ -514,8 +519,6 @@ pub mod pallet {
 		NoneRemaining,
 		/// Unexpected error in state.
 		Corruption,
-		/// The member's rank is too low to vote.
-		RankTooLow,
 		/// The information provided is incorrect.
 		InvalidWitness,
 		/// The origin is not sufficiently privileged to do the operation.
@@ -630,23 +633,46 @@ pub mod pallet {
 							Err(Error::<T, I>::NotPolling)?,
 						PollStatus::Ongoing(ref mut tally, class) => {
 							match Voting::<T, I>::get(&poll, &who) {
-								Some(Aye(votes)) => {
-									tally.bare_ayes.saturating_dec();
-									tally.ayes.saturating_reduce(votes);
+								Some(Aye(Some(votes))) => {
+										tally.bare_ayes.saturating_dec();
+										tally.ayes.saturating_reduce(votes);
+									}
+								Some(Aye(None)) => {
+									tally.out_of_rank_ayes.saturating_dec();
 								},
-								Some(Nay(votes)) => tally.nays.saturating_reduce(votes),
+								Some(Nay(Some(votes))) => {
+										tally.nays.saturating_reduce(votes)
+									},
+								Some(Nay(None)) => {
+									tally.out_of_rank_nays.saturating_dec();
+								},
 								None => pays = Pays::No,
 							}
 							let min_rank = T::MinRankOfClass::convert(class);
-							let votes = Self::rank_to_votes(record.rank, min_rank)?;
+							let votes = Self::rank_to_votes(record.rank, min_rank);
 							let vote = VoteRecord::from((aye, votes));
-							match aye {
-								true => {
-									tally.bare_ayes.saturating_inc();
-									tally.ayes.saturating_accrue(votes);
+							match votes {
+								None => {
+									match aye {
+										true => {
+											tally.out_of_rank_ayes.saturating_inc();
+										},
+										false => {
+											tally.out_of_rank_nays.saturating_inc();
+										},
+									}
 								},
-								false => tally.nays.saturating_accrue(votes),
+								Some(votes) => {
+									match aye {
+										true => {
+											tally.bare_ayes.saturating_inc();
+											tally.ayes.saturating_accrue(votes);
+										},
+										false => tally.nays.saturating_accrue(votes),
+									}
+								},
 							}
+							
 							Voting::<T, I>::insert(&poll, &who, &vote);
 							Ok((tally.clone(), vote))
 						},
@@ -741,9 +767,9 @@ pub mod pallet {
 			Members::<T, I>::get(who).ok_or(Error::<T, I>::NotMember.into())
 		}
 
-		fn rank_to_votes(rank: Rank, min: Rank) -> Result<Votes, DispatchError> {
-			let excess = rank.checked_sub(min).ok_or(Error::<T, I>::RankTooLow)?;
-			Ok(T::VoteWeight::convert(excess))
+		fn rank_to_votes(rank: Rank, min: Rank) -> Option<Votes> {
+			let excess = rank.checked_sub(min)?;
+			Some(T::VoteWeight::convert(excess))
 		}
 
 		fn remove_from_rank(who: &T::AccountId, rank: Rank) -> DispatchResult {


### PR DESCRIPTION
This PR adjusts the `ranked_collective` pallet to allow ranked collective members below the minimum required rank to vote. But this vote doesn't affect the outcome of a poll because it carries zero weight (0 voting power).

Currently, a vote by members below the minimum rank results in a `RankTooLow` error. This PR removes this error and allows such members to vote successfully. This means `Tally.bare_ayes` increases by one for such members, but no changes are made to `Ayes`/`Nays`

This PR also extends `Tally` to include both `out_of_rank_ayes` and `out_of_rank_nays` for tracking votes of members below the minimum rank

This PR is a replacement for [PR 3461](https://github.com/paritytech/polkadot-sdk/pull/3461), which I had to abandon because a little security mishap required me to re-write history and force-push.

Implements the feature discussed in #3210.
