### PR TITLE
sync best justification

### DIFF
--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -28,10 +28,12 @@ log = { workspace = true, default-features = true }
 parity-db = { workspace = true }
 parking_lot = { workspace = true, default-features = true }
 sc-client-api = { workspace = true, default-features = true }
+sc-consensus-grandpa = { workspace = true }
 sc-state-db = { workspace = true, default-features = true }
 schnellru = { workspace = true }
 sp-arithmetic = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }
+sp-consensus-grandpa = { workspace = true }
 sp-core = { workspace = true, default-features = true }
 sp-database = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }


### PR DESCRIPTION
# Description
`/sync/2` protocol allows fetching headers, bodies, justifications.

Call stack for getting justification from `/sync/2`:
- [`BlockRequestHandler::get_block_response`]()
- [`BlockchainDb::justifications`](https://github.com/paritytech/polkadot-sdk/blob/ca7817922148c1e6f6856138998f7135f42f3f4f/substrate/client/db/src/lib.rs#L728-L734)
- [`BlockchainDb::justifications_uncached`](https://github.com/paritytech/polkadot-sdk/blob/ca7817922148c1e6f6856138998f7135f42f3f4f/substrate/client/db/src/lib.rs#L588-L594)
  Reads key `(BlockNumber, BlockHash)` from column family `JUSTIFICATION = "col6"`.

It was observed, that `/sync/2` doesn't return best justification, but `/sync/warp` does.
`JUSTIFICATION` stores mandatory justifications, and no more than 1 justification for each 512 blocks.
Best justification is stored in `AUX`.

Call stack for getting justification from `/sync/warp`:
- [`WarpSyncProof::generate`](https://github.com/paritytech/polkadot-sdk/blob/ca7817922148c1e6f6856138998f7135f42f3f4f/substrate/client/consensus/grandpa/src/warp_proof.rs#L160)
- [`best_justification`](https://github.com/paritytech/polkadot-sdk/blob/ca7817922148c1e6f6856138998f7135f42f3f4f/substrate/client/consensus/grandpa/src/aux_schema.rs#L464-L471)
  Reads key `"grandpa_best_justification"` from column family `AUX = "col8"`.

Added `best_justification` call to `BlockchainDb::justifications_uncached` to return best justification.

## Integration
No interface was changed.
Users of `sc-client-db` crate don't need additional changes.

## Review Notes
