### PR TITLE
Remove warning log from frame-omni-bencher CLI

### DIFF
--- a/prdoc/pr_7020.prdoc
+++ b/prdoc/pr_7020.prdoc
@@ -1,0 +1,18 @@
+title: Remove warning log from frame-omni-bencher CLI
+doc:
+- audience: Node Operator
+  description: |-
+    # Description
+
+    This PR removes the outdated warning message from the `frame-omni-bencher` CLI that states the tool is "not yet battle tested". Fixes #7019
+
+    ## Integration
+
+    No integration steps are required.
+
+    ## Review Notes
+
+    The functionality of the tool remains unchanged. Removes the warning message from the CLI output.
+crates:
+- name: frame-omni-bencher
+  bump: patch

--- a/substrate/utils/frame/omni-bencher/src/main.rs
+++ b/substrate/utils/frame/omni-bencher/src/main.rs
@@ -24,8 +24,6 @@ use tracing_subscriber::EnvFilter;
 fn main() -> Result<()> {
 	setup_logger();
 
-	log::warn!("The FRAME omni-bencher is not yet battle tested - double check the results.",);
-
 	command::Command::parse().run()
 }
 


### PR DESCRIPTION
# Description

This PR removes the outdated warning message from the `frame-omni-bencher` CLI that states the tool is "not yet battle tested". Fixes #7019 

## Integration

No integration steps are required.

## Review Notes

The functionality of the tool remains unchanged. Removes the warning message from the CLI output.