### PR TITLE
allow use reserved balances for staking

### DIFF
--- a/prdoc/pr_7047.prdoc
+++ b/prdoc/pr_7047.prdoc
@@ -1,0 +1,13 @@
+title: Allow use reserved balances for staking
+doc:
+- audience:
+  - Runtime Dev
+  - Runtime User
+  description: |-
+    Allow reserved balances to be used for staking.
+
+    Previously there is an inconsistency that reserved balances cannot be used for staking, but can be transferred out if staked balances is greater than reserved amount. Effectively allow reserved balances to be used for staking.
+
+crates:
+- name: pallet-staking
+  bump: minor

--- a/substrate/frame/staking/src/asset.rs
+++ b/substrate/frame/staking/src/asset.rs
@@ -41,7 +41,7 @@ pub fn total_balance<T: Config>(who: &T::AccountId) -> BalanceOf<T> {
 ///
 /// This includes balance free to stake along with any balance that is already staked.
 pub fn stakeable_balance<T: Config>(who: &T::AccountId) -> BalanceOf<T> {
-	T::Currency::free_balance(who)
+	T::Currency::total_balance(who)
 }
 
 /// Balance of `who` that is currently at stake.

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -8718,6 +8718,33 @@ fn do_not_reenable_higher_offenders_mock() {
 		});
 }
 
+#[test]
+fn can_stake_reserve_balances() {
+	use frame_support::traits::{
+		fungible::Inspect,
+		tokens::{Fortitude, Preservation},
+	};
+
+	ExtBuilder::default().build_and_execute(|| {
+		// account 1 have 10 tokens
+
+		// reserve 5
+		let _ = Balances::reserve(&1, 5);
+
+		// check transferable balance = 10 - 5 - ED = 4
+		assert_eq!(Balances::reducible_balance(&1, Preservation::Expendable, Fortitude::Polite), 4);
+
+		// stake all tokens
+		assert_ok!(Staking::bond(RuntimeOrigin::signed(1), 10, RewardDestination::Staked));
+
+		// all 10 is staked
+		assert_eq!(Staking::ledger(1.into()).unwrap().active, 10);
+
+		// check transferable balance
+		assert_eq!(Balances::reducible_balance(&1, Preservation::Expendable, Fortitude::Polite), 0);
+	});
+}
+
 #[cfg(all(feature = "try-runtime", test))]
 mod migration_tests {
 	use super::*;


### PR DESCRIPTION
Closes #6984

Allow reserved balances to be used for staking.

Previously there is an inconsistency that reserved balances cannot be used for staking, but can be transferred out if staked balances is greater than reserved amount. Effectively allow reserved balances to be used for staking. 