### PR TITLE
workflows: add debug input for sync templates act

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -119,6 +119,7 @@ jobs:
           toml set templates/${{ matrix.template }}/Cargo.toml 'workspace.package.edition' "$(toml get --raw Cargo.toml 'workspace.package.edition')" > Cargo.temp
           mv Cargo.temp ./templates/${{ matrix.template }}/Cargo.toml
         working-directory: polkadot-sdk
+
       - name: Print the result Cargo.tomls for debugging
         if: ${{ github.event.inputs.debug }}
         run: find . -type f -name 'Cargo.toml' -exec cat {} \;
@@ -145,6 +146,12 @@ jobs:
             toml get ../polkadot-sdk/Cargo.toml 'workspace.dependencies' --output-toml | grep "^${missing_dep} = " >> Cargo.toml
           done;
         working-directory: "${{ env.template-path }}"
+
+      - name: Print the result Cargo.tomls for debugging after copying required workspace dependencies
+        if: ${{ github.event.inputs.debug }}
+        run: find . -type f -name 'Cargo.toml' -exec cat {} \;
+        working-directory: polkadot-sdk/templates/${{ matrix.template }}/
+
 
       # 3. Verify the build. Push the changes or create a PR.
 

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -90,7 +90,7 @@ jobs:
           EOF
 
           [ ${{ matrix.template }} != "solochain" ] && echo "# Leave out the node compilation from regular template usage." \
-            && echo "\"default-members\" = [\"pallets/template\", \"runtime\"]" >> Cargo.toml
+            && echo "default-members = [\"pallets/template\", \"runtime\"]" >> Cargo.toml
           [ ${{ matrix.template }} == "solochain" ] && echo "# The node isn't yet replaceable by Omni Node."
           cat << EOF >> Cargo.toml
           members = [

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -21,6 +21,10 @@ on:
       stable_release_branch:
         description: 'Stable release branch, e.g. stable2407'
         required: true
+      debug:
+        description: Enable runner debug logging
+        required: false
+        default: false
 
 jobs:
   sync-templates:
@@ -116,7 +120,7 @@ jobs:
           mv Cargo.temp ./templates/${{ matrix.template }}/Cargo.toml
         working-directory: polkadot-sdk
       - name: Print the result Cargo.tomls for debugging
-        if: runner.debug == '1'
+        if: ${{ github.event.inputs.debug }}
         run: find . -type f -name 'Cargo.toml' -exec cat {} \;
         working-directory: polkadot-sdk/templates/${{ matrix.template }}/
 


### PR DESCRIPTION
# Description

Introduce a workflow `debug` input for `misc-sync-templates.yml` and use it instead of the `runner.debug` context variable, which is set to '1' when `ACTIONS_RUNNER_DEBUG` env/secret is set (https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging#enabling-runner-diagnostic-logging).  This is useful for controlling when to show debug prints.

## Integration

N/A

## Review Notes

Using `runner.debug` requires setting the `ACTIONS_RUNNER_DEBUG` env variable, but setting it to false/true is doable through an input, or by importing a variable from the github env file (which requires a code change). This input alone can replace the entire `runner.debug` + `ACTIONS_RUNNER_DEBUG` setup, which simplifies debug printing, but it doesn't look as standard as `runner.debug`. I don't think it is a big deal overall, for this action alone, but happy to account for other opinions.

Note: setting the `ACTIONS_RUNNER_DEBUG` whenever we want in a separate branch wouldn't be useful because we can not run the `misc-sync-templates.yml` action from other branch than `master` (due to branch protection rules), so we need to expose this input to be controllable from `master`.