### PR TITLE
Fix defensive! macro to be used in umbrella crates

### DIFF
--- a/prdoc/pr_7069.prdoc
+++ b/prdoc/pr_7069.prdoc
@@ -1,0 +1,10 @@
+title: Fix defensive! macro to be used in umbrella crates
+doc:
+- audience: Runtime Dev
+  description: |-
+    PR for #7054
+
+    Replaced frame_support with $crate from @gui1117 's suggestion to fix the dependency issue
+crates:
+- name: frame-support
+  bump: patch

--- a/substrate/frame/support/src/traits/misc.rs
+++ b/substrate/frame/support/src/traits/misc.rs
@@ -66,7 +66,7 @@ impl<T: VariantCount> Get<u32> for VariantCountOf<T> {
 #[macro_export]
 macro_rules! defensive {
 	() => {
-		frame_support::__private::log::error!(
+		$crate::__private::log::error!(
 			target: "runtime::defensive",
 			"{}",
 			$crate::traits::DEFENSIVE_OP_PUBLIC_ERROR
@@ -74,7 +74,7 @@ macro_rules! defensive {
 		debug_assert!(false, "{}", $crate::traits::DEFENSIVE_OP_INTERNAL_ERROR);
 	};
 	($error:expr $(,)?) => {
-		frame_support::__private::log::error!(
+		$crate::__private::log::error!(
 			target: "runtime::defensive",
 			"{}: {:?}",
 			$crate::traits::DEFENSIVE_OP_PUBLIC_ERROR,
@@ -83,7 +83,7 @@ macro_rules! defensive {
 		debug_assert!(false, "{}: {:?}", $crate::traits::DEFENSIVE_OP_INTERNAL_ERROR, $error);
 	};
 	($error:expr, $proof:expr $(,)?) => {
-		frame_support::__private::log::error!(
+		$crate::__private::log::error!(
 			target: "runtime::defensive",
 			"{}: {:?}: {:?}",
 			$crate::traits::DEFENSIVE_OP_PUBLIC_ERROR,


### PR DESCRIPTION
PR for #7054 

Replaced frame_support with $crate from @gui1117 's suggestion to fix the dependency issue