### PR TITLE
Bump signature v2.1.0 to v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24329,9 +24329,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6279,9 +6279,9 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",


### PR DESCRIPTION
non-functional signature 2.1 -> 2.2 change detailed here: https://github.com/RustCrypto/traits/blob/master/signature/CHANGELOG.md

and the ecdsa version bump is just loosening the requirement on signature:
https://github.com/RustCrypto/signatures/blob/master/ecdsa/CHANGELOG.md

(We could just bump `ecdsa` crate so it can resolve and work with signature 2.2 without being forced to, but the signature 2.2 change looks like a low risk change we should pick up.)

Not sure if it's PRdoc-worthy?