### PR TITLE
Backport 7074 to stable2412

### DIFF
--- a/.github/workflows/release-reusable-rc-buid.yml
+++ b/.github/workflows/release-reusable-rc-buid.yml
@@ -149,7 +149,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      SKIP_WASM_BUILD: 1
     steps:
       - name: Checkout sources
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/prdoc/pr_7074.prdoc
+++ b/prdoc/pr_7074.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Unset SKIP_WASM_BUILD=1 for aarch64 binaries release 
+
+doc:
+  - audience: [ Node Dev, Runtime Dev]
+    description:
+      Fix the release pipeline environment by unsetting SKIP_WASM_BUILD=1
+      so that aarch64 binaries are built so that they contain runtimes
+      accordingly.
+
+crates: [ ]


### PR DESCRIPTION
# Description

Unsets SKIP_WASM_BUILD which was introduced by mistake for aarch64 binaries release: #7074.

## Integration

Aarch64 binaries can be consumed as the x86_64 ones.

## Review Notes

Details on #7074 .