### PR TITLE
Apply a few minor fixes found while addressing the fellows PR for weights.

### DIFF
--- a/bridges/bin/runtime-common/src/integrity.rs
+++ b/bridges/bin/runtime-common/src/integrity.rs
@@ -21,11 +21,11 @@
 
 use bp_header_chain::ChainWithGrandpa;
 use bp_messages::{ChainWithMessages, InboundLaneData, MessageNonce};
-use bp_runtime::Chain;
+use bp_runtime::{AccountIdOf, Chain};
 use codec::Encode;
 use frame_support::{storage::generator::StorageValue, traits::Get, weights::Weight};
 use frame_system::limits;
-use pallet_bridge_messages::WeightInfoExt as _;
+use pallet_bridge_messages::{ThisChainOf, WeightInfoExt as _};
 
 // Re-export to avoid include all dependencies everywhere.
 #[doc(hidden)]
@@ -364,8 +364,11 @@ pub fn check_message_lane_weights<
 	);
 
 	// check that weights allow us to receive delivery confirmations
-	let max_incoming_inbound_lane_data_proof_size =
-		InboundLaneData::<()>::encoded_size_hint_u32(this_chain_max_unrewarded_relayers as _);
+	let max_incoming_inbound_lane_data_proof_size = InboundLaneData::<
+		AccountIdOf<ThisChainOf<T, MessagesPalletInstance>>,
+	>::encoded_size_hint_u32(
+		this_chain_max_unrewarded_relayers as _
+	);
 	pallet_bridge_messages::ensure_able_to_receive_confirmation::<Weights<T, MessagesPalletInstance>>(
 		C::max_extrinsic_size(),
 		C::max_extrinsic_weight(),

--- a/bridges/modules/messages/src/lib.rs
+++ b/bridges/modules/messages/src/lib.rs
@@ -230,8 +230,8 @@ pub mod pallet {
 			// why do we need to know the weight of this (`receive_messages_proof`) call? Because
 			// we may want to return some funds for not-dispatching (or partially dispatching) some
 			// messages to the call origin (relayer). And this is done by returning actual weight
-			// from the call. But we only know dispatch weight of every messages. So to refund
-			// relayer because we have not dispatched Message, we need to:
+			// from the call. But we only know dispatch weight of every message. So to refund
+			// relayer because we have not dispatched message, we need to:
 			//
 			// ActualWeight = DeclaredWeight - Message.DispatchWeight
 			//

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1822,7 +1822,7 @@ mod benches {
 		[polkadot_runtime_parachains::initializer, Initializer]
 		[polkadot_runtime_parachains::paras_inherent, ParaInherent]
 		[polkadot_runtime_parachains::paras, Paras]
-		[polkadot_runtime_parachains::assigner_on_demand, OnDemandAssignmentProvider]
+		[polkadot_runtime_parachains::on_demand, OnDemandAssignmentProvider]
 		// Substrate
 		[pallet_balances, Balances]
 		[pallet_balances, NisCounterpartBalances]


### PR DESCRIPTION
This PR addresses a few minor issues found while working on the polkadot-fellows PR [https://github.com/polkadot-fellows/runtimes/pull/522](https://github.com/polkadot-fellows/runtimes/pull/522):  
- Incorrect generic type for `InboundLaneData` in `check_message_lane_weights`.  
- Renaming leftovers: `assigner_on_demand` -> `on_demand`.  