### PR TITLE
Collation fairness in backing subsystem

### DIFF
--- a/polkadot/node/core/backing/src/error.rs
+++ b/polkadot/node/core/backing/src/error.rs
@@ -117,6 +117,15 @@ pub enum Error {
 
 	#[error("Falied to send `CanClaim` response")]
 	SendCanClaim,
+
+	#[error("ChainApiSubsystem channel closed before receipt")]
+	BlockHeader(#[source] oneshot::Canceled),
+
+	#[error("Can't get block header from ChainApiSubsystem")]
+	ChainApi(#[source] polkadot_node_subsystem::ChainApiError),
+
+	#[error("Block header not found for relay parent {0:?}")]
+	MissingBlockHeader(polkadot_primitives::Hash),
 }
 
 /// Utility for eating top level errors and log them.

--- a/polkadot/node/core/backing/src/error.rs
+++ b/polkadot/node/core/backing/src/error.rs
@@ -111,6 +111,9 @@ pub enum Error {
 
 	#[error("No free slot in claim queue for candidate")]
 	NoFreeSlotInClaimQueue,
+
+	#[error("Failed to send claimed slots")]
+	SendClaimedSlots,
 }
 
 /// Utility for eating top level errors and log them.

--- a/polkadot/node/core/backing/src/error.rs
+++ b/polkadot/node/core/backing/src/error.rs
@@ -108,6 +108,9 @@ pub enum Error {
 
 	#[error("Runtime API returned None for executor params")]
 	MissingExecutorParams,
+
+	#[error("No free slot in claim queue for candidate")]
+	NoFreeSlotInClaimQueue,
 }
 
 /// Utility for eating top level errors and log them.

--- a/polkadot/node/core/backing/src/error.rs
+++ b/polkadot/node/core/backing/src/error.rs
@@ -114,6 +114,9 @@ pub enum Error {
 
 	#[error("Failed to send claimed slots")]
 	SendClaimedSlots,
+
+	#[error("Falied to send `CanClaim` response")]
+	SendCanClaim,
 }
 
 /// Utility for eating top level errors and log them.

--- a/polkadot/node/core/backing/src/lib.rs
+++ b/polkadot/node/core/backing/src/lib.rs
@@ -982,7 +982,7 @@ async fn handle_communication<Context>(
 				state.claim_queue_state.release_claims_for_candidate(&candidate_hash);
 			},
 		CandidateBackingMessage::ClaimedSlots(relay_parent, tx) => {
-			let res = state.claim_queue_state.get_claimed_slots_at(&relay_parent);
+			let res = state.claim_queue_state.get_pending_slots_at(&relay_parent);
 			tx.send(res).map_err(|_| Error::SendClaimedSlots)?
 		},
 		CandidateBackingMessage::CanClaim(relay_parent, para_id, tx) => {

--- a/polkadot/node/core/backing/src/lib.rs
+++ b/polkadot/node/core/backing/src/lib.rs
@@ -985,6 +985,10 @@ async fn handle_communication<Context>(
 			let res = state.claim_queue_state.get_claimed_slots_at(&relay_parent);
 			tx.send(res).map_err(|_| Error::SendClaimedSlots)?
 		},
+		CandidateBackingMessage::CanClaim(relay_parent, para_id, tx) => {
+			let res = state.claim_queue_state.has_free_slot_for_para_id(&relay_parent, &para_id);
+			tx.send(res).map_err(|_| Error::SendCanClaim)?
+		},
 	}
 
 	Ok(())

--- a/polkadot/node/core/backing/src/lib.rs
+++ b/polkadot/node/core/backing/src/lib.rs
@@ -1468,7 +1468,7 @@ async fn handle_can_second_request<Context>(
 		let candidate_relay_parent = hypothetical_candidate.relay_parent();
 		let candidate_para_id = hypothetical_candidate.candidate_para();
 
-		let cq = if let Some(core_index) = state
+		let cq_state = if let Some(core_index) = state
 			.per_relay_parent
 			.get(&relay_parent)
 			.and_then(|rp_state| rp_state.assigned_core)
@@ -1481,7 +1481,8 @@ async fn handle_can_second_request<Context>(
 		};
 
 		let result =
-			seconding_sanity_check(ctx, &state.implicit_view, hypothetical_candidate, cq).await;
+			seconding_sanity_check(ctx, &state.implicit_view, hypothetical_candidate, cq_state)
+				.await;
 
 		match result {
 			SecondingAllowed::No => false,
@@ -1491,7 +1492,7 @@ async fn handle_can_second_request<Context>(
 				// only make claims at the leaves at which we can second the candidate. Calling
 				// `claim_pending_slot` here might make unnecessary claims.
 				for leaf in leaves.iter() {
-					let res = cq.claim_pending_slot_at_leaf(
+					let res = cq_state.claim_pending_slot_at_leaf(
 						&leaf,
 						&candidate_hash,
 						&candidate_relay_parent,

--- a/polkadot/node/core/backing/src/lib.rs
+++ b/polkadot/node/core/backing/src/lib.rs
@@ -1351,10 +1351,22 @@ async fn seconding_sanity_check<Context>(
 	let candidate_hash = hypothetical_candidate.candidate_hash();
 
 	for head in implicit_view.leaves() {
+		gum::trace!(
+			target: LOG_TARGET,
+			?candidate_hash,
+			leaf_hash = ?head,
+			"Checking leaf for seconding",
+		);
 		// Check that the candidate relay parent is allowed for para, skip the leaf otherwise.
 		let allowed_parents_for_para =
 			implicit_view.known_allowed_relay_parents_under(head, Some(candidate_para));
 		if !allowed_parents_for_para.unwrap_or_default().contains(&candidate_relay_parent) {
+			gum::trace!(
+				target: LOG_TARGET,
+				?candidate_hash,
+				leaf_hash = ?head,
+				"seconding_sanity_check: skipping leaf because relay parent is not allowed for para",
+			);
 			continue
 		}
 
@@ -1365,6 +1377,13 @@ async fn seconding_sanity_check<Context>(
 			&candidate_para,
 			&candidate_hash,
 		) {
+			gum::trace!(
+				target: LOG_TARGET,
+				?candidate_hash,
+				leaf_hash = ?head,
+				"seconding_sanity_check: skipping leaf because there is no free claim queue slot for the candidate",
+			);
+
 			continue
 		}
 

--- a/polkadot/node/core/backing/src/lib.rs
+++ b/polkadot/node/core/backing/src/lib.rs
@@ -1266,6 +1266,8 @@ async fn seconding_sanity_check<Context>(
 	let candidate_relay_parent = hypothetical_candidate.relay_parent();
 	let candidate_hash = hypothetical_candidate.candidate_hash();
 
+	// TODO: throttle here
+
 	for head in implicit_view.leaves() {
 		// Check that the candidate relay parent is allowed for para, skip the
 		// leaf otherwise.
@@ -1602,6 +1604,7 @@ async fn import_statement<Context>(
 	// our active leaves.
 	if let StatementWithPVD::Seconded(candidate, pvd) = statement.payload() {
 		if !per_candidate.contains_key(&candidate_hash) {
+			// TODO: throttle here
 			let (tx, rx) = oneshot::channel();
 			ctx.send_message(ProspectiveParachainsMessage::IntroduceSecondedCandidate(
 				IntroduceSecondedCandidateRequest {

--- a/polkadot/node/network/collator-protocol/src/validator_side/collation.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/collation.rs
@@ -289,7 +289,7 @@ impl Collations {
 	/// fulfilled.
 	pub(super) fn pick_a_collation_to_fetch(
 		&mut self,
-		unfulfilled_claim_queue_entries: VecDeque<ParaId>,
+		unfulfilled_claim_queue_entries: &VecDeque<ParaId>,
 	) -> Option<(PendingCollation, CollatorId)> {
 		gum::trace!(
 			target: LOG_TARGET,

--- a/polkadot/node/network/collator-protocol/src/validator_side/collation.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/collation.rs
@@ -242,7 +242,7 @@ pub struct Collations {
 }
 
 impl Collations {
-	pub(super) fn new(group_assignments: &Vec<ParaId>) -> Self {
+	pub(super) fn new(group_assignments: &VecDeque<ParaId>) -> Self {
 		let mut candidates_state = BTreeMap::<ParaId, CandidatesStatePerPara>::new();
 
 		for para_id in group_assignments {
@@ -289,7 +289,7 @@ impl Collations {
 	/// fulfilled.
 	pub(super) fn pick_a_collation_to_fetch(
 		&mut self,
-		unfulfilled_claim_queue_entries: Vec<ParaId>,
+		unfulfilled_claim_queue_entries: VecDeque<ParaId>,
 	) -> Option<(PendingCollation, CollatorId)> {
 		gum::trace!(
 			target: LOG_TARGET,

--- a/polkadot/node/network/collator-protocol/src/validator_side/collation.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/collation.rs
@@ -198,7 +198,7 @@ pub enum CollationStatus {
 	/// We are waiting for a collation to be advertised to us.
 	Waiting,
 	/// We are currently fetching a collation for the specified `ParaId`.
-	Fetching(ParaId),
+	Fetching,
 	/// We are waiting that a collation is being validated.
 	WaitingOnValidation,
 }
@@ -310,13 +310,6 @@ impl Collations {
 		}
 
 		None
-	}
-
-	pub(super) fn seconded_for_para(&self, para_id: &ParaId) -> usize {
-		self.candidates_state
-			.get(&para_id)
-			.map(|state| state.seconded_per_para)
-			.unwrap_or_default()
 	}
 }
 

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -48,6 +48,7 @@ use polkadot_node_subsystem::{
 };
 use polkadot_node_subsystem_util::{
 	backing_implicit_view::View as ImplicitView,
+	claim_queue_state::ClaimQueueState,
 	reputation::{ReputationAggregator, REPUTATION_CHANGE_INTERVAL},
 	request_async_backing_params, request_claim_queue, request_session_index_for_child,
 	runtime::{recv_runtime, request_node_features},
@@ -63,11 +64,8 @@ use crate::error::{Error, FetchError, Result, SecondingError};
 
 use self::collation::BlockedCollationId;
 
-use self::claim_queue_state::ClaimQueueState;
-
 use super::{modify_reputation, tick_stream, LOG_TARGET};
 
-mod claim_queue_state;
 mod collation;
 mod metrics;
 

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1522,7 +1522,7 @@ async fn process_msg<Context>(
 				)
 				.await;
 
-				// If async backing is enabled, make an attempt to fetch next collation.
+				// try to fetch next collation.
 				let maybe_candidate_hash =
 					prospective_candidate.as_ref().map(ProspectiveCandidate::candidate_hash);
 				dequeue_next_collation_and_fetch(

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -339,7 +339,7 @@ impl PeerData {
 #[derive(Debug)]
 struct GroupAssignments {
 	/// Current assignments.
-	current: Vec<ParaId>,
+	current: VecDeque<ParaId>,
 }
 
 struct PerRelayParent {
@@ -526,7 +526,7 @@ where
 		}
 	}
 
-	let assignment = GroupAssignments { current: assigned_paras.into_iter().collect() };
+	let assignment = GroupAssignments { current: assigned_paras };
 	let collations = Collations::new(&assignment.current);
 
 	Ok(Some(PerRelayParent {
@@ -2135,7 +2135,7 @@ async fn handle_collation_fetch_response(
 // Returns the claim queue without fetched or pending advertisement. The resulting `Vec` keeps the
 // order in the claim queue so the earlier an element is located in the `Vec` the higher its
 // priority is.
-fn unfulfilled_claim_queue_entries(relay_parent: &Hash, state: &State) -> Result<Vec<ParaId>> {
+fn unfulfilled_claim_queue_entries(relay_parent: &Hash, state: &State) -> Result<VecDeque<ParaId>> {
 	let relay_parent_state = state
 		.per_relay_parent
 		.get(relay_parent)

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -112,6 +112,8 @@ pub enum CandidateBackingMessage {
 	DropClaims(HashSet<CandidateHash>),
 	/// Returns `ParaId`s with claimed slots that are not yet seconded.
 	ClaimedSlots(Hash, oneshot::Sender<VecDeque<ParaId>>),
+	/// Returns true if there is unclaimed slot for the given para id at the specified relay parent
+	CanClaim(Hash, ParaId, oneshot::Sender<bool>),
 }
 
 /// Blanket error for validation failing for internal reasons.

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -110,7 +110,7 @@ pub enum CandidateBackingMessage {
 	Statement(Hash, SignedFullStatementWithPVD),
 	/// Drops all claims for a candidate hash
 	DropClaims(HashSet<CandidateHash>),
-	/// Returns all claimed slots
+	/// Returns `ParaId`s with claimed slots that are not yet seconded.
 	ClaimedSlots(Hash, oneshot::Sender<VecDeque<ParaId>>),
 }
 

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -110,6 +110,8 @@ pub enum CandidateBackingMessage {
 	Statement(Hash, SignedFullStatementWithPVD),
 	/// Drops all claims for a candidate hash
 	DropClaims(HashSet<CandidateHash>),
+	/// Returns all claimed slots
+	ClaimedSlots(Hash, oneshot::Sender<VecDeque<ParaId>>),
 }
 
 /// Blanket error for validation failing for internal reasons.

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -97,10 +97,8 @@ pub enum CandidateBackingMessage {
 	/// The rule is to only fetch collations that can either be directly chained to any
 	/// FragmentChain in the view or there is at least one FragmentChain where this candidate is a
 	/// potentially unconnected candidate (we predict that it may become connected to a
-	/// FragmentChain in the future).
-	///
-	/// Always responds with `false` if async backing is disabled for candidate's relay
-	/// parent.
+	/// FragmentChain in the future). If the result is positive a claim for the candidate is made.
+	/// This claim needs to be dropped explicitly in a event of a failure.
 	CanSecond(CanSecondRequest, oneshot::Sender<bool>),
 	/// Note that the Candidate Backing subsystem should second the given candidate in the context
 	/// of the given relay-parent (ref. by hash). This candidate must be validated.
@@ -110,6 +108,8 @@ pub enum CandidateBackingMessage {
 	/// Disputes Subsystem, though that escalation is deferred until the approval voting stage to
 	/// guarantee availability. Agreements are simply tallied until a quorum is reached.
 	Statement(Hash, SignedFullStatementWithPVD),
+	/// Drops all claims for a candidate hash
+	DropClaims(HashSet<CandidateHash>),
 }
 
 /// Blanket error for validation failing for internal reasons.

--- a/polkadot/node/subsystem-util/src/claim_queue_state.rs
+++ b/polkadot/node/subsystem-util/src/claim_queue_state.rs
@@ -511,6 +511,13 @@ impl PerLeafClaimQueueState {
 		if let Some(mut path) = maybe_path {
 			path.add_leaf(leaf, claim_queue);
 			self.leaves.insert(*leaf, path);
+			gum::trace!(
+				target: LOG_TARGET,
+				?leaf,
+				?parent,
+				?claim_queue,
+				"add_leaf: adding to existing path"
+			);
 			return
 		}
 
@@ -519,6 +526,13 @@ impl PerLeafClaimQueueState {
 			if let Some(mut new_fork) = fork_from_state(state, parent) {
 				new_fork.add_leaf(leaf, claim_queue);
 				self.leaves.insert(*leaf, new_fork);
+				gum::trace!(
+					target: LOG_TARGET,
+					?leaf,
+					?parent,
+					?claim_queue,
+					"add_leaf: adding fork from a previous -non-leaf block"
+				);
 				return
 			}
 		}
@@ -527,6 +541,13 @@ impl PerLeafClaimQueueState {
 		let mut new_fork = ClaimQueueState::new();
 		new_fork.add_leaf(leaf, claim_queue);
 		self.leaves.insert(*leaf, new_fork);
+		gum::trace!(
+			target: LOG_TARGET,
+			?leaf,
+			?parent,
+			?claim_queue,
+			"add_leaf: adding new fork"
+		);
 	}
 
 	/// Removes a set of pruned blocks from all paths. If a path becomes empty it is removed from

--- a/polkadot/node/subsystem-util/src/claim_queue_state.rs
+++ b/polkadot/node/subsystem-util/src/claim_queue_state.rs
@@ -263,6 +263,7 @@ impl ClaimQueueState {
 			target: LOG_TARGET,
 			?para_id,
 			?relay_parent,
+			?candidate_hash,
 			"second_at"
 		);
 
@@ -535,6 +536,8 @@ impl PerLeafClaimQueueState {
 	/// Adds new leaf to the state. If the parent of the leaf is already in the state `leaf` is
 	/// added to the corresponding path. Otherwise a new path is created.
 	pub fn add_leaf(&mut self, leaf: &Hash, claim_queue: &VecDeque<ParaId>, parent: &Hash) {
+		debug_assert!(leaf != parent, "Leaf and parent can't be equal");
+
 		let maybe_path = self.leaves.remove(parent);
 
 		// The new leaf builds on top of previous leaf
@@ -649,10 +652,19 @@ impl PerLeafClaimQueueState {
 		para_id: &ParaId,
 	) -> bool {
 		let mut result = false;
-		for (_, state) in &mut self.leaves {
+		for (leaf, state) in &mut self.leaves {
 			if state.claim_seconded_at(relay_parent, para_id, *candidate_hash) {
 				result = true;
 			}
+			gum::trace!(
+				target: LOG_TARGET,
+				?leaf,
+				?para_id,
+				?relay_parent,
+				?candidate_hash,
+				result,
+				"claim_seconded_slot"
+			);
 		}
 		result
 	}

--- a/polkadot/node/subsystem-util/src/claim_queue_state.rs
+++ b/polkadot/node/subsystem-util/src/claim_queue_state.rs
@@ -488,6 +488,7 @@ fn fork_from_state(
 }
 
 /// Keeps a per leaf state of the claim queue for multiple forks.
+#[derive(Default)]
 pub struct PerLeafClaimQueueState {
 	/// The state of the claim queue per leaf
 	leaves: HashMap<Hash, ClaimQueueState>,

--- a/polkadot/node/subsystem-util/src/claim_queue_state.rs
+++ b/polkadot/node/subsystem-util/src/claim_queue_state.rs
@@ -607,8 +607,7 @@ impl PerLeafClaimQueueState {
 		para_id: &ParaId,
 	) -> bool {
 		if let Some(leaf_state) = self.leaves.get_mut(leaf) {
-			leaf_state.claim_pending_at(relay_parent, para_id, *candidate_hash);
-			return true
+			return leaf_state.claim_pending_at(relay_parent, para_id, *candidate_hash);
 		}
 		return false
 	}

--- a/polkadot/node/subsystem-util/src/claim_queue_state.rs
+++ b/polkadot/node/subsystem-util/src/claim_queue_state.rs
@@ -599,6 +599,8 @@ impl PerLeafClaimQueueState {
 	}
 
 	/// Claims a slot in pending state for a candidate at a concrete leaf.
+	/// NOTE: This functions performs a claim only at the specified leaf. The caller needs to ensure
+	/// that this is correct.
 	pub fn claim_pending_slot_at_leaf(
 		&mut self,
 		leaf: &Hash,

--- a/polkadot/node/subsystem-util/src/claim_queue_state.rs
+++ b/polkadot/node/subsystem-util/src/claim_queue_state.rs
@@ -505,6 +505,17 @@ impl PerLeafClaimQueueState {
 		})
 	}
 
+	/// Returns `true` if there is a free claim for `para_id` at `relay_parent` in at least one
+	/// leaf.
+	pub fn has_free_slot_for_para_id(&mut self, relay_parent: &Hash, para_id: &ParaId) -> bool {
+		for (_, state) in &mut self.state {
+			if state.can_claim_at(relay_parent, para_id, None) {
+				return true
+			}
+		}
+		false
+	}
+
 	/// Releases a claim for a candidate.
 	pub fn release_claims_for_candidate(&mut self, candidate_hash: &Hash) -> bool {
 		let mut result = false;

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -78,6 +78,10 @@ pub mod availability_chunks;
 /// leaves and the minimum allowed relay-parents that parachain candidates can have
 /// and be backed in those leaves' children.
 pub mod backing_implicit_view;
+
+/// Utility for tracking claims from the claim queue.
+pub mod claim_queue_state;
+
 /// Database trait for subsystem.
 pub mod database;
 /// An emulator for node-side code to predict the results of on-chain parachain inclusion


### PR DESCRIPTION
https://github.com/paritytech/polkadot-sdk/pull/4880 implements collation fairness in the collator protocol subsystem but it has got some drawbacks:

1. It doesn't take into account group rotations. The new backing group has no way to know if claims within its view has been claimed by the previous backing group.
2. It doesn't take into account statements from other validators on the same backing group. If multiple collators are generating candidates via different validators the latter don't know about each other fetches. As a result they might fetch more advertisements than necessary.

To overcome these problems a solution was proposed in https://github.com/paritytech/polkadot-sdk/issues/5079#issuecomment-2368091701. In nutshell the idea is to move collations tracking in the backing subsystem since it has got a better view on what candidates are being fetched and seconded. How this solves the problems outline above? One of backing subsystem's goals is to keep track of all candidates that are getting backed no matter if they originate from validator's own backing group (if any or not). This fact naturally solves both problems. First we track candidates from group rotations since we have got a single view of the claim queue. Second we receive statements from all backing groups and we can keep the local claim queue state relatively up to date.

## Implementation notes
The PR touches collation-protocol/validator side, backing subsystem and `ClaimQueueState` (introduced with https://github.com/paritytech/polkadot-sdk/pull/4880).

## `ClaimQueueState`
`ClaimQueueState` was created on the fly in https://github.com/paritytech/polkadot-sdk/pull/4880. This means that each time we wanted to know the state of the claim queue we built `ClaimQueueState` instance. In this PR we want to keep a single view of the claim queue for each leaf and each core and continuously update it by adding new leaves and candidates and dropping old ones. For this reason `ClaimQueueState` is extended to keep track of the candidate hash occupying each a slot. This is needed because we want to be able to drop claims for failed fetches, invaid candidates, etc. So `claimed` is no longer a `bool` but an enum:
```rust
enum ClaimState {
	/// Unclaimed
	Free,
	/// The candidate is pending fetching or validation.
	Pending(CandidateHash),
	/// The candidate is seconded.
	Seconded(CandidateHash),
}
```
Note that the ordering here is not perfect. Let's say there are candidates A1->A2->A3 for a parachain built on top of each other. If we see them in the order A2, A3, A1 we will insert them in the claim queue in the same (wrong) order. This is fine because (a) we need the candidate hash only to be able to release claims and (b) the exact order of candidates is known by the prospective parachains subsystem.

The second change in this module is related to leaves. The claim queue has got different state for each fork and we need to be able to track this. For this reason `PerLeafClaimQueueState` which wraps a `HashMap` of `ClaimQueueState` for each leaf. The non-trivial logic here is adding a new leaf (`add_leaf`). We need to handle three different cases:
1. The new leaf builds on top of old leaf. Or in other words we are just extending a fork with a new element.
2. The new leaf is a for from a non-leaf block in another fork. In this case we are creating a new fork.
3. The new leaf is a completely new and separate fork.

:exclamation:  All these cases are covered with unit tests but I'd appreciate an extra attention from the reviewers. :exclamation:

## backing subsystem
Backing subsystem has got an instance of `PerLeafClaimQueueState` for each core and updates it by keeping track of new candidates. We have got three different set of candidates:
1. Candidates which the local validator fetches from a collator.
2. Seconded candidates from our backing group which we receive from statement distribution.
3. Backed candidates from other backing groups.

Each group is handled differently:
1. When we receive an advertisement which we want to fetch first we reserve a claim in the claim queue (handled by collator protocol). When we receive the candidate we validate it. On fetch or validation failure we need to drop the claim.
2. We import the candidate if we have got a free slot in the claim queue and validate it. We drop the claim if validation fails.
3. If there is a spot in the claim queue we claim and import it. Once claimed these slots are not supposed to be released.

To achieve all these three new messages are introduced:
- `CanClaim` returns `true` if a claim can be made for a specific para id. This message is needed to handle collator protocol v1 advertisements which don't contain candidate hash. More on this in the next section.
- `PendingSlots` - returns all pending claims from the claim queue.
- `DropClaims` - drops claims for one or more candidates. 

All these messages are used by the collator protocol and their application will be explained there.

In nutshell the following changes are made in backing:
1. Instantiate `PerLeafClaimQueueState` and keep it up to date. This includes adding new leaves, removing stale leaves, making claims for candidate and releasing claims for bad candidates. These should be easy to spot in the PR.
2. Handle the new messages mentioned in the previous paragraph. 

## collator protocol
Most controversial changes are in this subsystem. Since backing subsystem keeps track of the claim queue state the collator protocol no longer builds `ClaimQueueState` 'on the fly'. The price to pay is additional messages exchanged with backing.
Generally speaking the collator protocol follows these steps:
1. An advertisement is received. 
    If it is over protocol version 2+ `CanSecond` message is sent to the backing subsystem. The latter gets the leaves where the candidate can be seconded and makes a claim for each leaf. If a claim can't be made - the leaf is dropped.
  If it is over protocol version 1 we can't claim a slot in the claim queue since we don't know the candidate hash. I opted not to support generic claims since they complicate the implementation and hopefully we will deprecate v1 at some point. So what we do is send `CanClaim` to backing subsystem and get a confirmation that at this point there is a free spot for the candidate in the claim queue. There is a potential race here because the spot is not claimed and can be occupied by another candidate while we do the fetch. I think this risk is acceptable. Worst case we might have a few extra candidates.
2. If we get a confirmation from backing that we can fetch the candidate the actual fetch is initiated. If it is successful the collator protocol sends `Seconded` to backing and the claim is marked as `Seconded`. If the fetch is unsuccessful we use `DropClaims` to notify backing that the claim should be released.
3. We might have more than one candidate to fetch. If so - we need to make a decision based on the claim queue. The problem is we no longer have the claim queue state locally so we need to get it with yet another message. `PendingSlots` returns all claims in pending state (these are all pending fetches). We see if we have got a pending candidate for this para id and fetch it. The claims in the result are ordered by priority.

- [ ] While writing this I just realised we can optimise it for some cases. If there is only one pending candidate in the queue we don't care about the claim queue state. Note that if we receive an advertisement and there is no pending fetch we immediately initiate fetching without adding the candidate in the queue. So in the happy case we don't send `PendingSlots`.

The collator protocol also keeps track of candidates which are blocked by backing (`CanSecond` has returned `BlockedByBacking` error for them). These candidates has got pending claims and if their relay parent goes out of view they are dropped.

:exclamation: Note for the reviewer: This might be abused by making a lot of unbackable advertisements which fill in the claim queue. The alternative is to release claims for these candidates and making a new claim when they are unblocked. This will introduce additional complexity but might be worth doing. I'd love to get some feedback on this. :exclamation: 

### TODOs
The testing for this PR is still work in progress, but the functionally I consider it done.

- [ ] Handle the TODOs in the code
- [ ] Add support for forks in backing tests so that all current tests are green.
- [ ] Add fairness tests in backing.
- [ ] Fix collator tests and add cases for the new flows.