### PR TITLE
Increase the number of pvf execute workers

### DIFF
--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -944,14 +944,9 @@ pub fn new_full<
 				secure_validator_mode,
 				prep_worker_path,
 				exec_worker_path,
-				pvf_execute_workers_max_num: execute_workers_max_num.unwrap_or_else(
-					|| match config.chain_spec.identify_chain() {
-						// The intention is to use this logic for gradual increasing from 2 to 4
-						// of this configuration chain by chain until it reaches production chain.
-						Chain::Polkadot => 2,
-						Chain::Rococo | Chain::Westend  | Chain::Kusama | Chain::Unknown => 4,
-					},
-				),
+				// Default execution workers is 4 because we have 8 cores on the reference hardware,
+				// and this accounts for 50% of that cpu capacity.
+				pvf_execute_workers_max_num: execute_workers_max_num.unwrap_or(4),
 				pvf_prepare_workers_soft_max_num: prepare_workers_soft_max_num.unwrap_or(1),
 				pvf_prepare_workers_hard_max_num: prepare_workers_hard_max_num.unwrap_or(2),
 			})

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -944,14 +944,9 @@ pub fn new_full<
 				secure_validator_mode,
 				prep_worker_path,
 				exec_worker_path,
-				pvf_execute_workers_max_num: execute_workers_max_num.unwrap_or_else(
-					|| match config.chain_spec.identify_chain() {
-						// The intention is to use this logic for gradual increasing from 2 to 4
-						// of this configuration chain by chain until it reaches production chain.
-						Chain::Polkadot | Chain::Kusama => 2,
-						Chain::Rococo | Chain::Westend | Chain::Unknown => 4,
-					},
-				),
+				// Default execution workers is 4 because we have 8 cores on the reference hardware,
+				// and this accounts for 50% of that cpu capacity.
+				pvf_execute_workers_max_num: execute_workers_max_num.unwrap_or(4),
 				pvf_prepare_workers_soft_max_num: prepare_workers_soft_max_num.unwrap_or(1),
 				pvf_prepare_workers_hard_max_num: prepare_workers_hard_max_num.unwrap_or(2),
 			})

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -944,9 +944,14 @@ pub fn new_full<
 				secure_validator_mode,
 				prep_worker_path,
 				exec_worker_path,
-				// Default execution workers is 4 because we have 8 cores on the reference hardware,
-				// and this accounts for 50% of that cpu capacity.
-				pvf_execute_workers_max_num: execute_workers_max_num.unwrap_or(4),
+				pvf_execute_workers_max_num: execute_workers_max_num.unwrap_or_else(
+					|| match config.chain_spec.identify_chain() {
+						// The intention is to use this logic for gradual increasing from 2 to 4
+						// of this configuration chain by chain until it reaches production chain.
+						Chain::Polkadot => 2,
+						Chain::Rococo | Chain::Westend  | Chain::Kusama | Chain::Unknown => 4,
+					},
+				),
 				pvf_prepare_workers_soft_max_num: prepare_workers_soft_max_num.unwrap_or(1),
 				pvf_prepare_workers_hard_max_num: prepare_workers_hard_max_num.unwrap_or(2),
 			})

--- a/prdoc/pr_7116.prdoc
+++ b/prdoc/pr_7116.prdoc
@@ -1,0 +1,8 @@
+title: Migrate pallet-fast-unstake and pallet-babe benchmark to v2
+doc:
+- audience: Node Dev
+  description: |-
+    Increase the number of pvf execution workers from 2 to 4.
+crates:
+- name: polkadot-service
+  bump: patch

--- a/prdoc/pr_7116.prdoc
+++ b/prdoc/pr_7116.prdoc
@@ -1,4 +1,4 @@
-title: Migrate pallet-fast-unstake and pallet-babe benchmark to v2
+title: Increase the number of pvf execution workers from 2 to 4
 doc:
 - audience: Node Dev
   description: |-


### PR DESCRIPTION
Reference hardware requirements have been bumped to at least 8 cores so we can no allocate 50% of that capacity to PVF execution.