### PR TITLE
Add migrations prelude to frame umbrella crate

### DIFF
--- a/substrate/frame/multisig/src/migrations.rs
+++ b/substrate/frame/multisig/src/migrations.rs
@@ -18,7 +18,7 @@
 // Migrations for Multisig Pallet
 
 use crate::*;
-use frame::prelude::*;
+use frame::migrations_prelude::*;
 
 pub mod v1 {
 	use super::*;
@@ -36,7 +36,7 @@ pub mod v1 {
 	pub struct MigrateToV1<T>(core::marker::PhantomData<T>);
 	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
 		#[cfg(feature = "try-runtime")]
-		fn pre_upgrade() -> Result<Vec<u8>, frame::try_runtime::TryRuntimeError> {
+		fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
 			log!(info, "Number of calls to refund and delete: {}", Calls::<T>::iter().count());
 
 			Ok(Vec::new())
@@ -69,7 +69,7 @@ pub mod v1 {
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(_state: Vec<u8>) -> Result<(), frame::try_runtime::TryRuntimeError> {
+		fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
 			ensure!(
 				Calls::<T>::iter().count() == 0,
 				"there are some dangling calls that need to be destroyed and refunded"

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -34,8 +34,8 @@
 //!
 //! This crate is organized into 3 stages:
 //!
-//! 1. preludes: `prelude`, `testing_prelude` and `runtime::prelude`, `benchmarking`,
-//!    `weights_prelude`, `try_runtime`.
+//! 1. preludes: `prelude`, `testing_prelude`, `runtime::prelude`, `benchmarking`,
+//!    `weights_prelude`, `migrations_prelude`, and `try_runtime`.
 //! 2. domain-specific modules: `traits`, `hashing`, `arithmetic` and `derive`.
 //! 3. Accessing frame/substrate dependencies directly: `deps`.
 //!
@@ -152,6 +152,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg(feature = "experimental")]
 
+extern crate alloc;
+
 #[doc(no_inline)]
 pub use frame_support::pallet;
 
@@ -207,7 +209,7 @@ pub mod prelude {
 		defensive, defensive_assert,
 		traits::{
 			Contains, EitherOf, EstimateNextSessionRotation, IsSubType, MapSuccess, NoOpPoll,
-			OnRuntimeUpgrade, OneSessionHandler, RankedMembers, RankedMembersSwapHandler,
+			OneSessionHandler, RankedMembers, RankedMembersSwapHandler,
 		},
 	};
 
@@ -334,6 +336,24 @@ pub mod testing_prelude {
 
 	/// Commonly used runtime traits for testing.
 	pub use sp_runtime::{traits::BadOrigin, StateVersion};
+
+	#[cfg(any(feature = "try-runtime", test))]
+	pub use sp_runtime::TryRuntimeError;
+}
+
+/// Prelude to be included in the `migration.rs` of each pallet.
+///
+/// ```
+/// pub use polkadot_sdk_frame::migrations_prelude::*;
+/// ```
+pub mod migrations_prelude {
+	pub use super::traits::UncheckedOnRuntimeUpgrade;
+	pub use frame_support::{migrations::*, storage_alias, traits::OnRuntimeUpgrade};
+
+	#[cfg(feature = "try-runtime")]
+	pub use alloc::vec::Vec;
+	#[cfg(feature = "try-runtime")]
+	pub use sp_runtime::TryRuntimeError;
 }
 
 /// All of the types and tools needed to build FRAME-based runtimes.


### PR DESCRIPTION
I noticed that we don't yet have a migrations prelude, which felt prudent; This PR adds that. In addition, it also shuffles the try_runtime prelude into both the testing and migrations prelude, as it seemed it would be unclear where to source the try_runtime types from with the redundancy introduced by the migrations prelude. Also small update to multisig pallet to use new prelude.

@re-gius 