### PR TITLE
XCM v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6347,6 +6347,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6429,6 +6441,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.87",
@@ -27863,6 +27895,7 @@ dependencies = [
  "array-bytes",
  "bounded-collections",
  "derivative",
+ "educe",
  "environmental",
  "frame-support 28.0.0",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -754,6 +754,7 @@ emulated-integration-tests-common = { path = "cumulus/parachains/integration-tes
 enumflags2 = { version = "0.7.7" }
 enumn = { version = "0.1.13" }
 env_logger = { version = "0.11.2" }
+educe = { version = "0.6.0", default-features = false, features = ["Debug", "Clone", "PartialEq", "Eq", "PartialOrd", "Ord", "Default"] }
 environmental = { version = "1.1.4", default-features = false }
 equivocation-detector = { path = "bridges/relays/equivocation" }
 ethabi = { version = "2.0.0", default-features = false, package = "ethabi-decode" }

--- a/polkadot/xcm/Cargo.toml
+++ b/polkadot/xcm/Cargo.toml
@@ -16,6 +16,7 @@ array-bytes = { workspace = true, default-features = true }
 bounded-collections = { features = ["serde"], workspace = true }
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
 derivative = { features = ["use_core"], workspace = true }
+educe = { workspace = true }
 environmental = { workspace = true }
 frame-support = { workspace = true }
 hex-literal = { workspace = true, default-features = true }

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -32,6 +32,7 @@ use scale_info::TypeInfo;
 pub mod v3;
 pub mod v4;
 pub mod v5;
+pub mod v6;
 
 pub mod lts {
 	pub use super::v4::*;

--- a/polkadot/xcm/src/v6/instruction.rs
+++ b/polkadot/xcm/src/v6/instruction.rs
@@ -1,0 +1,59 @@
+#[macro_export]
+macro_rules! impl_xcm_instruction {
+    (
+		$( #[$doc:meta] )*
+		$vis:vis enum $name:ident<$generic:ident> {
+			$(
+				$( #[$instr_doc:meta] )*
+				$instr:ident $(< $instr_generic:ident >)?,
+			)+
+		}
+    ) => {
+        $( #[$doc] )*
+        $vis enum $name<$generic> {
+            $(
+                // $( #[$instr_doc] )*
+                $instr($instr $(< $instr_generic >)?),
+            )+
+        }
+
+		impl <$generic> $name<$generic> {
+			pub fn into<C>(self) -> $name<C> {
+				$name::from(self)
+			}
+
+			pub fn from<C>(value: $name<C>) -> Self {
+				match value {
+					$(
+						$name::$instr(x) => $name::$instr(x.into()),
+					)+
+				}
+			}
+		}
+
+		$(
+			impl<$generic> From<$instr $(< $instr_generic >)?> for $name<$generic> {
+				fn from(x: $instr $(< $instr_generic >)?) -> Self {
+					Self::$instr(x)
+				}
+			}
+
+			impl<$generic> TryFrom<$name<$generic>> for $instr $(< $instr_generic >)? {
+				type Error = ();
+				fn try_from(x: $name<$generic>) -> Result<Self, ()> {
+					match x {
+						$name::$instr(x) => Ok(x),
+						_ => Err(()),
+					}
+				}
+			}
+
+			// TODO: make it $crate::IntoInstruction
+			impl<$generic> IntoInstruction<$generic> for $instr $(< $instr_generic >)? {
+				fn into_instruction(self) -> $name<$generic> {
+					$name::$instr(self)
+				}
+			}
+		)+
+    };
+}

--- a/polkadot/xcm/src/v6/instructions/mod.rs
+++ b/polkadot/xcm/src/v6/instructions/mod.rs
@@ -1,0 +1,995 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Instructions for XCM v5.
+
+use bounded_collections::BoundedVec;
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+use educe::Educe;
+
+use crate::DoubleEncoded;
+use crate::v5::{
+	Asset, AssetFilter, AssetTransferFilter, Assets, Error, Hint, HintNumVariants,
+	InteriorLocation, Junction, Location, MaybeErrorCode, NetworkId, OriginKind, QueryId,
+	QueryResponseInfo, Response, Weight, WeightLimit, Xcm,
+};
+
+// TODO: group instructions by type
+
+/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place them into the Holding
+/// Register.
+///
+/// - `assets`: The asset(s) to be withdrawn into holding.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct WithdrawAsset(pub Assets);
+
+/// Asset(s) (`assets`) have been received into the ownership of this system on the `origin`
+/// system and equivalent derivatives should be placed into the Holding Register.
+///
+/// - `assets`: The asset(s) that are minted into holding.
+///
+/// Safety: `origin` must be trusted to have received and be storing `assets` such that they
+/// may later be withdrawn should this system send a corresponding message.
+///
+/// Kind: *Trusted Indication*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ReserveAssetDeposited(pub Assets);
+
+/// Asset(s) (`assets`) have been destroyed on the `origin` system and equivalent assets should
+/// be created and placed into the Holding Register.
+///
+/// - `assets`: The asset(s) that are minted into the Holding Register.
+///
+/// Safety: `origin` must be trusted to have irrevocably destroyed the corresponding `assets`
+/// prior as a consequence of sending this message.
+///
+/// Kind: *Trusted Indication*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ReceiveTeleportedAsset(pub Assets);
+
+/// Respond with information that the local system is expecting.
+///
+/// - `query_id`: The identifier of the query that resulted in this message being sent.
+/// - `response`: The message content.
+/// - `max_weight`: The maximum weight that handling this response should take.
+/// - `querier`: The location responsible for the initiation of the response, if there is one.
+///   In general this will tend to be the same location as the receiver of this message. NOTE:
+///   As usual, this is interpreted from the perspective of the receiving consensus system.
+///
+/// Safety: Since this is information only, there are no immediate concerns. However, it should
+/// be remembered that even if the Origin behaves reasonably, it can always be asked to make
+/// a response to a third-party chain who may or may not be expecting the response. Therefore
+/// the `querier` should be checked to match the expected value.
+///
+/// Kind: *Information*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct QueryResponse {
+	#[codec(compact)]
+	pub query_id: u64,
+	pub response: Response,
+	pub max_weight: Weight,
+	pub querier: Option<Location>,
+}
+
+/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place equivalent assets
+/// under the ownership of `beneficiary`.
+///
+/// - `assets`: The asset(s) to be withdrawn.
+/// - `beneficiary`: The new owner for the assets.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct TransferAsset {
+	pub assets: Assets,
+	pub beneficiary: Location,
+}
+
+/// Withdraw asset(s) (`assets`) from the ownership of `origin` and place equivalent assets
+/// under the ownership of `dest` within this consensus system (i.e. its sovereign account).
+///
+/// Send an onward XCM message to `dest` of `ReserveAssetDeposited` with the given
+/// `xcm`.
+///
+/// - `assets`: The asset(s) to be withdrawn.
+/// - `dest`: The location whose sovereign account will own the assets and thus the effective
+///   beneficiary for the assets and the notification target for the reserve asset deposit
+///   message.
+/// - `xcm`: The instructions that should follow the `ReserveAssetDeposited` instruction, which
+///   is sent onwards to `dest`.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct TransferReserveAsset {
+	pub assets: Assets,
+	pub dest: Location,
+	pub xcm: Xcm<()>,
+}
+
+/// Apply the encoded transaction `call`, whose dispatch-origin should be `origin` as expressed
+/// by the kind of origin `origin_kind`.
+///
+/// The Transact Status Register is set according to the result of dispatching the call.
+///
+/// - `origin_kind`: The means of expressing the message origin as a dispatch origin.
+/// - `call`: The encoded transaction to be applied.
+/// - `fallback_max_weight`: Used for compatibility with previous versions. Corresponds to the
+///   `require_weight_at_most` parameter in previous versions. If you don't care about
+///   compatibility you can just put `None`. WARNING: If you do, your XCM might not work with
+///   older versions. Make sure to dry-run and validate.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+#[scale_info(skip_type_params(Call))]
+pub struct Transact<Call> {
+	pub origin_kind: OriginKind,
+	pub fallback_max_weight: Option<Weight>,
+	pub call: DoubleEncoded<Call>,
+}
+
+impl<Call> Transact<Call> {
+	pub fn into<C>(self) -> Transact<C> {
+		Transact::from(self)
+	}
+
+	pub fn from<C>(xcm: Transact<C>) -> Self {
+		Self {
+			origin_kind: xcm.origin_kind,
+			fallback_max_weight: xcm.fallback_max_weight,
+			call: xcm.call.into(),
+		}
+	}
+}
+
+/// A message to notify about a new incoming HRMP channel. This message is meant to be sent by
+/// the relay-chain to a para.
+///
+/// - `sender`: The sender in the to-be opened channel. Also, the initiator of the channel
+///   opening.
+/// - `max_message_size`: The maximum size of a message proposed by the sender.
+/// - `max_capacity`: The maximum number of messages that can be queued in the channel.
+///
+/// Safety: The message should originate directly from the relay-chain.
+///
+/// Kind: *System Notification*
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct HrmpNewChannelOpenRequest {
+	#[codec(compact)]
+	pub sender: u32,
+	#[codec(compact)]
+	pub max_message_size: u32,
+	#[codec(compact)]
+	pub max_capacity: u32,
+}
+
+/// A message to notify about that a previously sent open channel request has been accepted by
+/// the recipient. That means that the channel will be opened during the next relay-chain
+/// session change. This message is meant to be sent by the relay-chain to a para.
+///
+/// Safety: The message should originate directly from the relay-chain.
+///
+/// Kind: *System Notification*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct HrmpChannelAccepted {
+	// NOTE: We keep this as a structured item to a) keep it consistent with the other Hrmp
+	// items; and b) because the field's meaning is not obvious/mentioned from the item name.
+	#[codec(compact)]
+	pub recipient: u32,
+}
+
+/// A message to notify that the other party in an open channel decided to close it. In
+/// particular, `initiator` is going to close the channel opened from `sender` to the
+/// `recipient`. The close will be enacted at the next relay-chain session change. This message
+/// is meant to be sent by the relay-chain to a para.
+///
+/// Safety: The message should originate directly from the relay-chain.
+///
+/// Kind: *System Notification*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct HrmpChannelClosing {
+	#[codec(compact)]
+	pub initiator: u32,
+	#[codec(compact)]
+	pub sender: u32,
+	#[codec(compact)]
+	pub recipient: u32,
+}
+
+/// Clear the origin.
+///
+/// This may be used by the XCM author to ensure that later instructions cannot command the
+/// authority of the origin (e.g. if they are being relayed from an untrusted source, as often
+/// the case with `ReserveAssetDeposited`).
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ClearOrigin;
+
+/// Mutate the origin to some interior location.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct DescendOrigin(pub InteriorLocation);
+
+/// Immediately report the contents of the Error Register to the given destination via XCM.
+///
+/// A `QueryResponse` message of type `ExecutionOutcome` is sent to the described destination.
+///
+/// - `response_info`: Information for making the response.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ReportError(pub QueryResponseInfo);
+
+/// Remove the asset(s) (`assets`) from the Holding Register and place equivalent assets under
+/// the ownership of `beneficiary` within this consensus system.
+///
+/// - `assets`: The asset(s) to remove from holding.
+/// - `beneficiary`: The new owner for the assets.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct DepositAsset {
+	pub assets: AssetFilter,
+	pub beneficiary: Location,
+}
+
+/// Remove the asset(s) (`assets`) from the Holding Register and place equivalent assets under
+/// the ownership of `dest` within this consensus system (i.e. deposit them into its sovereign
+/// account).
+///
+/// Send an onward XCM message to `dest` of `ReserveAssetDeposited` with the given `effects`.
+///
+/// - `assets`: The asset(s) to remove from holding.
+/// - `dest`: The location whose sovereign account will own the assets and thus the effective
+///   beneficiary for the assets and the notification target for the reserve asset deposit
+///   message.
+/// - `xcm`: The orders that should follow the `ReserveAssetDeposited` instruction which is
+///   sent onwards to `dest`.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct DepositReserveAsset {
+	pub assets: AssetFilter,
+	pub dest: Location,
+	pub xcm: Xcm<()>,
+}
+
+/// Remove the asset(s) (`want`) from the Holding Register and replace them with alternative
+/// assets.
+///
+/// The minimum amount of assets to be received into the Holding Register for the order not to
+/// fail may be stated.
+///
+/// - `give`: The maximum amount of assets to remove from holding.
+/// - `want`: The minimum amount of assets which `give` should be exchanged for.
+/// - `maximal`: If `true`, then prefer to give as much as possible up to the limit of `give`
+///   and receive accordingly more. If `false`, then prefer to give as little as possible in
+///   order to receive as little as possible while receiving at least `want`.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExchangeAsset {
+	pub give: AssetFilter,
+	pub want: Assets,
+	pub maximal: bool,
+}
+
+/// Remove the asset(s) (`assets`) from holding and send a `WithdrawAsset` XCM message to a
+/// reserve location.
+///
+/// - `assets`: The asset(s) to remove from holding.
+/// - `reserve`: A valid location that acts as a reserve for all asset(s) in `assets`. The
+///   sovereign account of this consensus system *on the reserve location* will have
+///   appropriate assets withdrawn and `effects` will be executed on them. There will typically
+///   be only one valid location on any given asset/chain combination.
+/// - `xcm`: The instructions to execute on the assets once withdrawn *on the reserve
+///   location*.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct InitiateReserveWithdraw {
+	pub assets: AssetFilter,
+	pub reserve: Location,
+	pub xcm: Xcm<()>,
+}
+
+/// Remove the asset(s) (`assets`) from holding and send a `ReceiveTeleportedAsset` XCM message
+/// to a `dest` location.
+///
+/// - `assets`: The asset(s) to remove from holding.
+/// - `dest`: A valid location that respects teleports coming from this location.
+/// - `xcm`: The instructions to execute on the assets once arrived *on the destination
+///   location*.
+///
+/// NOTE: The `dest` location *MUST* respect this origin as a valid teleportation origin for
+/// all `assets`. If it does not, then the assets may be lost.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct InitiateTeleport {
+	pub assets: AssetFilter,
+	pub dest: Location,
+	pub xcm: Xcm<()>,
+}
+
+/// Report to a given destination the contents of the Holding Register.
+///
+/// A `QueryResponse` message of type `Assets` is sent to the described destination.
+///
+/// - `response_info`: Information for making the response.
+/// - `assets`: A filter for the assets that should be reported back. The assets reported back
+///   will be, asset-wise, *the lesser of this value and the holding register*. No wildcards
+///   will be used when reporting assets back.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ReportHolding {
+	pub response_info: QueryResponseInfo,
+	pub assets: AssetFilter,
+}
+
+/// Pay for the execution of some XCM `xcm` and `orders` with up to `weight`
+/// picoseconds of execution time, paying for this with up to `fees` from the Holding Register.
+///
+/// - `fees`: The asset(s) to remove from the Holding Register to pay for fees.
+/// - `weight_limit`: The maximum amount of weight to purchase; this must be at least the
+///   expected maximum weight of the total XCM to be executed for the
+///   `AllowTopLevelPaidExecutionFrom` barrier to allow the XCM be executed.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct BuyExecution {
+	pub fees: Asset,
+	pub weight_limit: WeightLimit,
+}
+
+/// Refund any surplus weight previously bought with `BuyExecution`.
+///
+/// Kind: *Command*
+///
+/// Errors: None.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct RefundSurplus;
+
+/// Set the Error Handler Register. This is code that should be called in the case of an error
+/// happening.
+///
+/// An error occurring within execution of this code will _NOT_ result in the error register
+/// being set, nor will an error handler be called due to it. The error handler and appendix
+/// may each still be set.
+///
+/// The apparent weight of this instruction is inclusive of the inner `Xcm`; the executing
+/// weight however includes only the difference between the previous handler and the new
+/// handler, which can reasonably be negative, which would result in a surplus.
+///
+/// Kind: *Command*
+///
+/// Errors: None.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+#[scale_info(skip_type_params(Call))]
+pub struct SetErrorHandler<Call>(pub Xcm<Call>);
+
+impl<Call> SetErrorHandler<Call> {
+	pub fn into<C>(self) -> SetErrorHandler<C> {
+		SetErrorHandler::from(self)
+	}
+
+	pub fn from<C>(xcm: SetErrorHandler<C>) -> Self {
+		Self(xcm.0.into())
+	}
+}
+
+/// Set the Appendix Register. This is code that should be called after code execution
+/// (including the error handler if any) is finished. This will be called regardless of whether
+/// an error occurred.
+///
+/// Any error occurring due to execution of this code will result in the error register being
+/// set, and the error handler (if set) firing.
+///
+/// The apparent weight of this instruction is inclusive of the inner `Xcm`; the executing
+/// weight however includes only the difference between the previous appendix and the new
+/// appendix, which can reasonably be negative, which would result in a surplus.
+///
+/// Kind: *Command*
+///
+/// Errors: None.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+#[scale_info(skip_type_params(Call))]
+pub struct SetAppendix<Call>(pub Xcm<Call>);
+
+impl<Call> SetAppendix<Call> {
+	pub fn into<C>(self) -> SetAppendix<C> {
+		SetAppendix::from(self)
+	}
+
+	pub fn from<C>(xcm: SetAppendix<C>) -> Self {
+		Self(xcm.0.into())
+	}
+}
+
+/// Clear the Error Register.
+///
+/// Kind: *Command*
+///
+/// Errors: None.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ClearError;
+
+/// Create some assets which are being held on behalf of the origin.
+///
+/// - `assets`: The assets which are to be claimed. This must match exactly with the assets
+///   claimable by the origin of the ticket.
+/// - `ticket`: The ticket of the asset; this is an abstract identifier to help locate the
+///   asset.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ClaimAsset {
+	pub assets: Assets,
+	pub ticket: Location,
+}
+
+/// Always throws an error of type `Trap`.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `Trap`: All circumstances, whose inner value is the same as this item's inner value.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct Trap(#[codec(compact)] pub u64);
+
+/// Ask the destination system to respond with the most recent version of XCM that they
+/// support in a `QueryResponse` instruction. Any changes to this should also elicit similar
+/// responses when they happen.
+///
+/// - `query_id`: An identifier that will be replicated into the returned XCM message.
+/// - `max_response_weight`: The maximum amount of weight that the `QueryResponse` item which
+///   is sent as a reply may take to execute. NOTE: If this is unexpectedly large then the
+///   response may not execute at all.
+///
+/// Kind: *Command*
+///
+/// Errors: *Fallible*
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct SubscribeVersion {
+	#[codec(compact)]
+	pub query_id: QueryId,
+	pub max_response_weight: Weight,
+}
+
+/// Cancel the effect of a previous `SubscribeVersion` instruction.
+///
+/// Kind: *Command*
+///
+/// Errors: *Fallible*
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct UnsubscribeVersion;
+
+/// Reduce Holding by up to the given assets.
+///
+/// Holding is reduced by as much as possible up to the assets in the parameter. It is not an
+/// error if the Holding does not contain the assets (to make this an error, use `ExpectAsset`
+/// prior).
+///
+/// Kind: *Command*
+///
+/// Errors: *Infallible*
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct BurnAsset(pub Assets);
+
+/// Throw an error if Holding does not contain at least the given assets.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `ExpectationFalse`: If Holding Register does not contain the assets in the parameter.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExpectAsset(pub Assets);
+
+/// Ensure that the Origin Register equals some given value and throw an error if not.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `ExpectationFalse`: If Origin Register is not equal to the parameter.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExpectOrigin(pub Option<Location>);
+
+/// Ensure that the Error Register equals some given value and throw an error if not.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `ExpectationFalse`: If the value of the Error Register is not equal to the parameter.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExpectError(pub Option<(u32, Error)>);
+
+/// Ensure that the Transact Status Register equals some given value and throw an error if
+/// not.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `ExpectationFalse`: If the value of the Transact Status Register is not equal to the
+///   parameter.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExpectTransactStatus(pub MaybeErrorCode);
+
+/// Query the existence of a particular pallet type.
+///
+/// - `module_name`: The module name of the pallet to query.
+/// - `response_info`: Information for making the response.
+///
+/// Sends a `QueryResponse` to Origin whose data field `PalletsInfo` containing the information
+/// of all pallets on the local chain whose name is equal to `name`. This is empty in the case
+/// that the local chain is not based on Substrate Frame.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+///
+/// Errors: *Fallible*.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct QueryPallet {
+	pub module_name: Vec<u8>,
+	pub response_info: QueryResponseInfo,
+}
+
+/// Ensure that a particular pallet with a particular version exists.
+///
+/// - `index: Compact`: The index which identifies the pallet. An error if no pallet exists at
+///   this index.
+/// - `name: Vec<u8>`: Name which must be equal to the name of the pallet.
+/// - `module_name: Vec<u8>`: Module name which must be equal to the name of the module in
+///   which the pallet exists.
+/// - `crate_major: Compact`: Version number which must be equal to the major version of the
+///   crate which implements the pallet.
+/// - `min_crate_minor: Compact`: Version number which must be at most the minor version of the
+///   crate which implements the pallet.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `ExpectationFalse`: In case any of the expectations are broken.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExpectPallet {
+	#[codec(compact)]
+	pub index: u32,
+	pub name: Vec<u8>,
+	pub module_name: Vec<u8>,
+	#[codec(compact)]
+	pub crate_major: u32,
+	#[codec(compact)]
+	pub min_crate_minor: u32,
+}
+
+/// Send a `QueryResponse` message containing the value of the Transact Status Register to some
+/// destination.
+///
+/// - `query_response_info`: The information needed for constructing and sending the
+///   `QueryResponse` message.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+///
+/// Errors: *Fallible*.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ReportTransactStatus(pub QueryResponseInfo);
+
+/// Set the Transact Status Register to its default, cleared, value.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+///
+/// Errors: *Infallible*.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ClearTransactStatus;
+
+/// Set the Origin Register to be some child of the Universal Ancestor.
+///
+/// Safety: Should only be usable if the Origin is trusted to represent the Universal Ancestor
+/// child in general. In general, no Origin should be able to represent the Universal Ancestor
+/// child which is the root of the local consensus system since it would by extension
+/// allow it to act as any location within the local consensus.
+///
+/// The `Junction` parameter should generally be a `GlobalConsensus` variant since it is only
+/// these which are children of the Universal Ancestor.
+///
+/// Kind: *Command*
+///
+/// Errors: *Fallible*.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct UniversalOrigin(pub Junction);
+
+/// Send a message on to Non-Local Consensus system.
+///
+/// This will tend to utilize some extra-consensus mechanism, the obvious one being a bridge.
+/// A fee may be charged; this may be determined based on the contents of `xcm`. It will be
+/// taken from the Holding register.
+///
+/// - `network`: The remote consensus system to which the message should be exported.
+/// - `destination`: The location relative to the remote consensus system to which the message
+///   should be sent on arrival.
+/// - `xcm`: The message to be exported.
+///
+/// As an example, to export a message for execution on Statemine (parachain #1000 in the
+/// Kusama network), you would call with `network: NetworkId::Kusama` and
+/// `destination: [Parachain(1000)].into()`. Alternatively, to export a message for execution
+/// on Polkadot, you would call with `network: NetworkId:: Polkadot` and `destination: Here`.
+///
+/// Kind: *Command*
+///
+/// Errors: *Fallible*.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ExportMessage {
+	pub network: NetworkId,
+	pub destination: InteriorLocation,
+	pub xcm: Xcm<()>,
+}
+
+/// Lock the locally held asset and prevent further transfer or withdrawal.
+///
+/// This restriction may be removed by the `UnlockAsset` instruction being called with an
+/// Origin of `unlocker` and a `target` equal to the current `Origin`.
+///
+/// If the locking is successful, then a `NoteUnlockable` instruction is sent to `unlocker`.
+///
+/// - `asset`: The asset(s) which should be locked.
+/// - `unlocker`: The value which the Origin must be for a corresponding `UnlockAsset`
+///   instruction to work.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct LockAsset {
+	pub asset: Asset,
+	pub unlocker: Location,
+}
+
+/// Remove the lock over `asset` on this chain and (if nothing else is preventing it) allow the
+/// asset to be transferred.
+///
+/// - `asset`: The asset to be unlocked.
+/// - `target`: The owner of the asset on the local chain.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct UnlockAsset {
+	pub asset: Asset,
+	pub target: Location,
+}
+
+/// Asset (`asset`) has been locked on the `origin` system and may not be transferred. It may
+/// only be unlocked with the receipt of the `UnlockAsset` instruction from this chain.
+///
+/// - `asset`: The asset(s) which are now unlockable from this origin.
+/// - `owner`: The owner of the asset on the chain in which it was locked. This may be a
+///   location specific to the origin network.
+///
+/// Safety: `origin` must be trusted to have locked the corresponding `asset`
+/// prior as a consequence of sending this message.
+///
+/// Kind: *Trusted Indication*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct NoteUnlockable {
+	pub asset: Asset,
+	pub owner: Location,
+}
+
+/// Send an `UnlockAsset` instruction to the `locker` for the given `asset`.
+///
+/// This may fail if the local system is making use of the fact that the asset is locked or,
+/// of course, if there is no record that the asset actually is locked.
+///
+/// - `asset`: The asset(s) to be unlocked.
+/// - `locker`: The location from which a previous `NoteUnlockable` was sent and to which an
+///   `UnlockAsset` should be sent.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct RequestUnlock {
+	pub asset: Asset,
+	pub locker: Location,
+}
+
+/// Sets the Fees Mode Register.
+///
+/// - `jit_withdraw`: The fees mode item; if set to `true` then fees for any instructions are
+///   withdrawn as needed using the same mechanism as `WithdrawAssets`.
+///
+/// Kind: *Command*.
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct SetFeesMode {
+	pub jit_withdraw: bool,
+}
+
+/// Set the Topic Register.
+///
+/// The 32-byte array identifier in the parameter is not guaranteed to be
+/// unique; if such a property is desired, it is up to the code author to
+/// enforce uniqueness.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+///
+/// Errors:
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct SetTopic(pub [u8; 32]);
+
+/// Clear the Topic Register.
+///
+/// Kind: *Command*
+///
+/// Errors: None.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct ClearTopic;
+
+/// Alter the current Origin to another given origin.
+///
+/// Kind: *Command*
+///
+/// Errors: If the existing state would not allow such a change.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct AliasOrigin(pub Location);
+
+/// A directive to indicate that the origin expects free execution of the message.
+///
+/// At execution time, this instruction just does a check on the Origin register.
+/// However, at the barrier stage messages starting with this instruction can be disregarded if
+/// the origin is not acceptable for free execution or the `weight_limit` is `Limited` and
+/// insufficient.
+///
+/// Kind: *Indication*
+///
+/// Errors: If the given origin is `Some` and not equal to the current Origin register.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct UnpaidExecution {
+	pub weight_limit: WeightLimit,
+	pub check_origin: Option<Location>,
+}
+
+/// Pay Fees.
+///
+/// Successor to `BuyExecution`.
+/// Defined in fellowship RFC 105.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct PayFees {
+	pub asset: Asset,
+}
+
+/// Initiates cross-chain transfer as follows:
+///
+/// Assets in the holding register are matched using the given list of `AssetTransferFilter`s,
+/// they are then transferred based on their specified transfer type:
+///
+/// - teleport: burn local assets and append a `ReceiveTeleportedAsset` XCM instruction to the
+///   XCM program to be sent onward to the `destination` location,
+///
+/// - reserve deposit: place assets under the ownership of `destination` within this consensus
+///   system (i.e. its sovereign account), and append a `ReserveAssetDeposited` XCM instruction
+///   to the XCM program to be sent onward to the `destination` location,
+///
+/// - reserve withdraw: burn local assets and append a `WithdrawAsset` XCM instruction to the
+///   XCM program to be sent onward to the `destination` location,
+///
+/// The onward XCM is then appended a `ClearOrigin` to allow safe execution of any following
+/// custom XCM instructions provided in `remote_xcm`.
+///
+/// The onward XCM also contains either a `PayFees` or `UnpaidExecution` instruction based
+/// on the presence of the `remote_fees` parameter (see below).
+///
+/// If an XCM program requires going through multiple hops, it can compose this instruction to
+/// be used at every chain along the path, describing that specific leg of the flow.
+///
+/// Parameters:
+/// - `destination`: The location of the program next hop.
+/// - `remote_fees`: If set to `Some(asset_xfer_filter)`, the single asset matching
+///   `asset_xfer_filter` in the holding register will be transferred first in the remote XCM
+///   program, followed by a `PayFees(fee)`, then rest of transfers follow. This guarantees
+///   `remote_xcm` will successfully pass a `AllowTopLevelPaidExecutionFrom` barrier. If set to
+///   `None`, a `UnpaidExecution` instruction is appended instead. Please note that these
+///   assets are **reserved** for fees, they are sent to the fees register rather than holding.
+///   Best practice is to only add here enough to cover fees, and transfer the rest through the
+///   `assets` parameter.
+/// - `preserve_origin`: Specifies whether the original origin should be preserved or cleared,
+///   using the instructions `AliasOrigin` or `ClearOrigin` respectively.
+/// - `assets`: List of asset filters matched against existing assets in holding. These are
+///   transferred over to `destination` using the specified transfer type, and deposited to
+///   holding on `destination`.
+/// - `remote_xcm`: Custom instructions that will be executed on the `destination` chain. Note
+///   that these instructions will be executed after a `ClearOrigin` so their origin will be
+///   `None`.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct InitiateTransfer {
+	pub destination: Location,
+	pub remote_fees: Option<AssetTransferFilter>,
+	pub preserve_origin: bool,
+	pub assets: Vec<AssetTransferFilter>,
+	pub remote_xcm: Xcm<()>,
+}
+
+/// Executes inner `xcm` with origin set to the provided `descendant_origin`. Once the inner
+/// `xcm` is executed, the original origin (the one active for this instruction) is restored.
+///
+/// Parameters:
+/// - `descendant_origin`: The origin that will be used during the execution of the inner
+///   `xcm`. If set to `None`, the inner `xcm` is executed with no origin. If set to `Some(o)`,
+///   the inner `xcm` is executed as if there was a `DescendOrigin(o)` executed before it, and
+///   runs the inner xcm with origin: `original_origin.append_with(o)`.
+/// - `xcm`: Inner instructions that will be executed with the origin modified according to
+///   `descendant_origin`.
+///
+/// Safety: No concerns.
+///
+/// Kind: *Command*
+///
+/// Errors:
+/// - `BadOrigin`
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+#[scale_info(skip_type_params(Call))]
+pub struct ExecuteWithOrigin<Call> { // TODO: make this generic over Xcm so it is using the current version
+	pub descendant_origin: Option<InteriorLocation>,
+	pub xcm: Xcm<Call>,
+}
+
+impl<Call> ExecuteWithOrigin<Call> {
+	pub fn into<C>(self) -> ExecuteWithOrigin<C> {
+		ExecuteWithOrigin::from(self)
+	}
+
+	pub fn from<C>(xcm: ExecuteWithOrigin<C>) -> Self {
+		Self {
+			descendant_origin: xcm.descendant_origin,
+			xcm: xcm.xcm.into(),
+		}
+	}
+}
+
+/// Set hints for XCM execution.
+///
+/// These hints change the behaviour of the XCM program they are present in.
+///
+/// Parameters:
+///
+/// - `hints`: A bounded vector of `ExecutionHint`, specifying the different hints that will
+/// be activated.
+#[derive(Educe, Encode, Decode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+pub struct SetHints {
+	pub hints: BoundedVec<Hint, HintNumVariants>,
+}

--- a/polkadot/xcm/src/v6/mod.rs
+++ b/polkadot/xcm/src/v6/mod.rs
@@ -1,0 +1,528 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Version 6 of the Cross-Consensus Message format data structures.
+
+pub use super::v3::GetWeight;
+use super::v5::{Instruction as OldInstruction, Xcm as OldXcm, MAX_INSTRUCTIONS_TO_DECODE};
+use crate::v5::Weight;
+use alloc::{vec, vec::Vec};
+use codec::{
+	self, decode_vec_with_len, Compact, Decode, Encode, Error as CodecError, Input as CodecInput,
+};
+use core::result;
+use educe::Educe;
+use scale_info::TypeInfo;
+
+pub mod instruction;
+pub mod instructions;
+
+use crate::impl_xcm_instruction;
+pub use instructions::*;
+
+pub const VERSION: super::Version = 6;
+
+#[derive(Educe, Default, Encode, TypeInfo)]
+#[educe(Clone, Eq, PartialEq, Debug)]
+#[codec(encode_bound())]
+#[codec(decode_bound())]
+#[scale_info(bounds(), skip_type_params(Call))]
+pub struct Xcm<Call>(pub Vec<Instruction<Call>>);
+
+environmental::environmental!(instructions_count: u8);
+
+impl<Call> Decode for Xcm<Call> {
+	fn decode<I: CodecInput>(input: &mut I) -> core::result::Result<Self, CodecError> {
+		instructions_count::using_once(&mut 0, || {
+			let number_of_instructions: u32 = <Compact<u32>>::decode(input)?.into();
+			instructions_count::with(|count| {
+				*count = count.saturating_add(number_of_instructions as u8);
+				if *count > MAX_INSTRUCTIONS_TO_DECODE {
+					return Err(CodecError::from("Max instructions exceeded"));
+				}
+				Ok(())
+			})
+			.expect("Called in `using` context and thus can not return `None`; qed")?;
+			let decoded_instructions = decode_vec_with_len(input, number_of_instructions as usize)?;
+			Ok(Self(decoded_instructions))
+		})
+	}
+}
+
+impl<Call> Xcm<Call> {
+	/// Create an empty instance.
+	pub fn new() -> Self {
+		Self(vec![])
+	}
+
+	/// Return `true` if no instructions are held in `self`.
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
+
+	/// Return the number of instructions held in `self`.
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
+
+	/// Return a reference to the inner value.
+	pub fn inner(&self) -> &[Instruction<Call>] {
+		&self.0
+	}
+
+	/// Return a mutable reference to the inner value.
+	pub fn inner_mut(&mut self) -> &mut Vec<Instruction<Call>> {
+		&mut self.0
+	}
+
+	/// Consume and return the inner value.
+	pub fn into_inner(self) -> Vec<Instruction<Call>> {
+		self.0
+	}
+
+	/// Return an iterator over references to the items.
+	pub fn iter(&self) -> impl Iterator<Item = &Instruction<Call>> {
+		self.0.iter()
+	}
+
+	/// Return an iterator over mutable references to the items.
+	pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Instruction<Call>> {
+		self.0.iter_mut()
+	}
+
+	/// Consume and return an iterator over the items.
+	pub fn into_iter(self) -> impl Iterator<Item = Instruction<Call>> {
+		self.0.into_iter()
+	}
+
+	/// Consume and either return `self` if it contains some instructions, or if it's empty, then
+	/// instead return the result of `f`.
+	pub fn or_else(self, f: impl FnOnce() -> Self) -> Self {
+		if self.0.is_empty() {
+			f()
+		} else {
+			self
+		}
+	}
+
+	/// Return the first instruction, if any.
+	pub fn first(&self) -> Option<&Instruction<Call>> {
+		self.0.first()
+	}
+
+	/// Return the last instruction, if any.
+	pub fn last(&self) -> Option<&Instruction<Call>> {
+		self.0.last()
+	}
+
+	/// Return the only instruction, contained in `Self`, iff only one exists (`None` otherwise).
+	pub fn only(&self) -> Option<&Instruction<Call>> {
+		if self.0.len() == 1 {
+			self.0.first()
+		} else {
+			None
+		}
+	}
+
+	/// Return the only instruction, contained in `Self`, iff only one exists (returns `self`
+	/// otherwise).
+	pub fn into_only(mut self) -> core::result::Result<Instruction<Call>, Self> {
+		if self.0.len() == 1 {
+			self.0.pop().ok_or(self)
+		} else {
+			Err(self)
+		}
+	}
+}
+
+impl<Call> From<Vec<Instruction<Call>>> for Xcm<Call> {
+	fn from(c: Vec<Instruction<Call>>) -> Self {
+		Self(c)
+	}
+}
+
+impl<Call> From<Xcm<Call>> for Vec<Instruction<Call>> {
+	fn from(c: Xcm<Call>) -> Self {
+		c.0
+	}
+}
+
+/// A prelude for importing all types typically used when interacting with XCM messages.
+pub mod prelude {
+	mod contents {
+		pub use super::super::VERSION as XCM_VERSION;
+		pub use crate::v5::prelude::{
+			send_xcm, validate_send, Ancestor, AncestorThen, Asset,
+			AssetFilter::{self, *},
+			AssetId,
+			AssetInstance::{self, *},
+			Assets, BodyId, BodyPart, ExecuteXcm,
+			Fungibility::{self, *},
+			Hint::{self, *},
+			HintNumVariants,
+			Instruction::*,
+			InteriorLocation,
+			Junction::{self, *},
+			Junctions::{self, Here},
+			Location, MaybeErrorCode,
+			NetworkId::{self, *},
+			OriginKind, Outcome, PalletInfo, Parent, ParentThen, PreparedMessage, QueryId,
+			QueryResponseInfo, Reanchorable, Response, SendError, SendResult, SendXcm, Weight,
+			WeightLimit::{self, *},
+			WildAsset::{self, *},
+			WildFungibility::{self, Fungible as WildFungible, NonFungible as WildNonFungible},
+			XcmContext, XcmError, XcmHash, XcmResult, XcmWeightInfo,
+		};
+	}
+	pub use super::{Instruction, Xcm};
+	pub use contents::*;
+	pub mod opaque {
+		pub use super::{
+			super::opaque::{Instruction, Xcm},
+			contents::*,
+		};
+	}
+}
+
+pub trait IntoInstruction<Call> {
+	fn into_instruction(self) -> Instruction<Call>;
+}
+
+impl_xcm_instruction! {
+	/// Cross-Consensus Message: A message from one consensus system to another.
+	///
+	/// Consensus systems that may send and receive messages include blockchains and smart contracts.
+	///
+	/// All messages are delivered from a known *origin*, expressed as a `Location`.
+	///
+	/// This is the inner XCM format and is version-sensitive. Messages are typically passed using the
+	/// outer XCM format, known as `VersionedXcm`.
+	#[derive(
+		Educe,
+		Encode,
+		Decode,
+		TypeInfo,
+		xcm_procedural::XcmWeightInfoTrait,
+		xcm_procedural::Builder,
+	)]
+	#[educe(Clone, Eq, PartialEq, Debug)]
+	#[codec(encode_bound())]
+	#[codec(decode_bound())]
+	#[scale_info(bounds(), skip_type_params(Call))]
+
+	pub enum Instruction<Call> {
+		#[builder(loads_holding)] // TODO: move builder attribute to the instruction struct
+		WithdrawAsset,
+		#[builder(loads_holding)]
+		ReserveAssetDeposited,
+		#[builder(loads_holding)]
+		ReceiveTeleportedAsset,
+		QueryResponse,
+		TransferAsset,
+		TransferReserveAsset,
+		Transact<Call>,
+		HrmpNewChannelOpenRequest,
+		HrmpChannelAccepted,
+		HrmpChannelClosing,
+		ClearOrigin,
+		DescendOrigin,
+		ReportError,
+		DepositAsset,
+		DepositReserveAsset,
+		ExchangeAsset,
+		InitiateReserveWithdraw,
+		InitiateTeleport,
+		ReportHolding,
+		#[builder(pays_fees)]
+		BuyExecution,
+		RefundSurplus,
+		SetErrorHandler<Call>,
+		SetAppendix<Call>,
+		ClearError,
+		#[builder(loads_holding)]
+		ClaimAsset,
+		Trap,
+		SubscribeVersion,
+		UnsubscribeVersion,
+		BurnAsset,
+		ExpectAsset,
+		ExpectOrigin,
+		ExpectError,
+		ExpectTransactStatus,
+		QueryPallet,
+		ExpectPallet,
+		ReportTransactStatus,
+		ClearTransactStatus,
+		UniversalOrigin,
+		ExportMessage,
+		LockAsset,
+		UnlockAsset,
+		NoteUnlockable,
+		RequestUnlock,
+		SetFeesMode,
+		SetTopic,
+		ClearTopic,
+		AliasOrigin,
+		UnpaidExecution,
+		#[builder(pays_fees)]
+		PayFees,
+		InitiateTransfer,
+		ExecuteWithOrigin<Call>,
+		SetHints,
+	}
+}
+
+impl<Call> Xcm<Call> {
+	pub fn into<C>(self) -> Xcm<C> {
+		Xcm::from(self)
+	}
+	pub fn from<C>(xcm: Xcm<C>) -> Self {
+		Self(xcm.0.into_iter().map(Instruction::<Call>::from).collect())
+	}
+}
+
+// // TODO: Automate Generation
+// impl<Call, W: XcmWeightInfo<Call>> GetWeight<W> for Instruction<Call> {
+// 	fn weight(&self) -> Weight {
+// 		use Instruction::*;
+// 		match self {
+// 			WithdrawAsset(assets) => W::withdraw_asset(assets),
+// 			ReserveAssetDeposited(assets) => W::reserve_asset_deposited(assets),
+// 			ReceiveTeleportedAsset(assets) => W::receive_teleported_asset(assets),
+// 			QueryResponse { query_id, response, max_weight, querier } =>
+// 				W::query_response(query_id, response, max_weight, querier),
+// 			TransferAsset { assets, beneficiary } => W::transfer_asset(assets, beneficiary),
+// 			TransferReserveAsset { assets, dest, xcm } =>
+// 				W::transfer_reserve_asset(&assets, dest, xcm),
+// 			Transact { origin_kind, fallback_max_weight, call } =>
+// 				W::transact(origin_kind, fallback_max_weight, call),
+// 			HrmpNewChannelOpenRequest { sender, max_message_size, max_capacity } =>
+// 				W::hrmp_new_channel_open_request(sender, max_message_size, max_capacity),
+// 			HrmpChannelAccepted { recipient } => W::hrmp_channel_accepted(recipient),
+// 			HrmpChannelClosing { initiator, sender, recipient } =>
+// 				W::hrmp_channel_closing(initiator, sender, recipient),
+// 			ClearOrigin => W::clear_origin(),
+// 			DescendOrigin(who) => W::descend_origin(who),
+// 			ReportError(response_info) => W::report_error(&response_info),
+// 			DepositAsset { assets, beneficiary } => W::deposit_asset(assets, beneficiary),
+// 			DepositReserveAsset { assets, dest, xcm } =>
+// 				W::deposit_reserve_asset(assets, dest, xcm),
+// 			ExchangeAsset { give, want, maximal } => W::exchange_asset(give, want, maximal),
+// 			InitiateReserveWithdraw { assets, reserve, xcm } =>
+// 				W::initiate_reserve_withdraw(assets, reserve, xcm),
+// 			InitiateTeleport { assets, dest, xcm } => W::initiate_teleport(assets, dest, xcm),
+// 			ReportHolding { response_info, assets } => W::report_holding(&response_info, &assets),
+// 			BuyExecution { fees, weight_limit } => W::buy_execution(fees, weight_limit),
+// 			RefundSurplus => W::refund_surplus(),
+// 			SetErrorHandler(xcm) => W::set_error_handler(xcm),
+// 			SetAppendix(xcm) => W::set_appendix(xcm),
+// 			ClearError => W::clear_error(),
+// 			SetHints { hints } => W::set_hints(hints),
+// 			ClaimAsset { assets, ticket } => W::claim_asset(assets, ticket),
+// 			Trap(code) => W::trap(code),
+// 			SubscribeVersion { query_id, max_response_weight } =>
+// 				W::subscribe_version(query_id, max_response_weight),
+// 			UnsubscribeVersion => W::unsubscribe_version(),
+// 			BurnAsset(assets) => W::burn_asset(assets),
+// 			ExpectAsset(assets) => W::expect_asset(assets),
+// 			ExpectOrigin(origin) => W::expect_origin(origin),
+// 			ExpectError(error) => W::expect_error(error),
+// 			ExpectTransactStatus(transact_status) => W::expect_transact_status(transact_status),
+// 			QueryPallet { module_name, response_info } =>
+// 				W::query_pallet(module_name, response_info),
+// 			ExpectPallet { index, name, module_name, crate_major, min_crate_minor } =>
+// 				W::expect_pallet(index, name, module_name, crate_major, min_crate_minor),
+// 			ReportTransactStatus(response_info) => W::report_transact_status(response_info),
+// 			ClearTransactStatus => W::clear_transact_status(),
+// 			UniversalOrigin(j) => W::universal_origin(j),
+// 			ExportMessage { network, destination, xcm } =>
+// 				W::export_message(network, destination, xcm),
+// 			LockAsset { asset, unlocker } => W::lock_asset(asset, unlocker),
+// 			UnlockAsset { asset, target } => W::unlock_asset(asset, target),
+// 			NoteUnlockable { asset, owner } => W::note_unlockable(asset, owner),
+// 			RequestUnlock { asset, locker } => W::request_unlock(asset, locker),
+// 			SetFeesMode { jit_withdraw } => W::set_fees_mode(jit_withdraw),
+// 			SetTopic(topic) => W::set_topic(topic),
+// 			ClearTopic => W::clear_topic(),
+// 			AliasOrigin(location) => W::alias_origin(location),
+// 			UnpaidExecution { weight_limit, check_origin } =>
+// 				W::unpaid_execution(weight_limit, check_origin),
+// 			PayFees { asset } => W::pay_fees(asset),
+// 			InitiateTransfer { destination, remote_fees, preserve_origin, assets, remote_xcm } =>
+// 				W::initiate_transfer(destination, remote_fees, preserve_origin, assets, remote_xcm),
+// 			ExecuteWithOrigin { descendant_origin, xcm } =>
+// 				W::execute_with_origin(descendant_origin, xcm),
+// 		}
+// 	}
+// }
+
+pub mod opaque {
+	/// The basic concrete type of `Xcm`, which doesn't make any assumptions about the
+	/// format of a call other than it is pre-encoded.
+	pub type Xcm = super::Xcm<()>;
+
+	/// The basic concrete type of `Instruction`, which doesn't make any assumptions about the
+	/// format of a call other than it is pre-encoded.
+	pub type Instruction = super::Instruction<()>;
+}
+
+// Convert from a v5 XCM to a v6 XCM
+impl<Call> TryFrom<OldXcm<Call>> for Xcm<Call> {
+	type Error = ();
+	fn try_from(old_xcm: OldXcm<Call>) -> result::Result<Self, Self::Error> {
+		Ok(Xcm(old_xcm.0.into_iter().map(TryInto::try_into).collect::<result::Result<_, _>>()?))
+	}
+}
+
+// Convert from a v5 instruction to a v6 instruction
+impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
+	type Error = ();
+	fn try_from(old_instruction: OldInstruction<Call>) -> result::Result<Self, Self::Error> {
+		Ok(match old_instruction {
+			OldInstruction::WithdrawAsset(assets) => WithdrawAsset(assets).into_instruction(),
+			OldInstruction::ReserveAssetDeposited(assets) => {
+				ReserveAssetDeposited(assets).into_instruction()
+			},
+			OldInstruction::ReceiveTeleportedAsset(assets) => {
+				ReceiveTeleportedAsset(assets).into_instruction()
+			},
+			OldInstruction::QueryResponse { query_id, response, max_weight, querier } => {
+				QueryResponse { query_id, response, max_weight, querier }.into_instruction()
+			},
+			OldInstruction::TransferAsset { assets, beneficiary } => {
+				TransferAsset { assets, beneficiary }.into_instruction()
+			},
+			OldInstruction::TransferReserveAsset { assets, dest, xcm } => {
+				TransferReserveAsset { assets, dest, xcm }.into_instruction()
+			},
+			OldInstruction::Transact { origin_kind, fallback_max_weight, call } => {
+				Transact { origin_kind, fallback_max_weight, call }.into_instruction()
+			},
+			OldInstruction::HrmpNewChannelOpenRequest {
+				sender,
+				max_message_size,
+				max_capacity,
+			} => HrmpNewChannelOpenRequest { sender, max_message_size, max_capacity }
+				.into_instruction(),
+			OldInstruction::HrmpChannelAccepted { recipient } => {
+				HrmpChannelAccepted { recipient }.into_instruction()
+			},
+			OldInstruction::HrmpChannelClosing { initiator, sender, recipient } => {
+				HrmpChannelClosing { initiator, sender, recipient }.into_instruction()
+			},
+			OldInstruction::ClearOrigin => ClearOrigin.into_instruction(),
+			OldInstruction::DescendOrigin(junctions) => DescendOrigin(junctions).into_instruction(),
+			OldInstruction::ReportError(query_response_info) => {
+				ReportError(query_response_info).into_instruction()
+			},
+			OldInstruction::DepositAsset { assets, beneficiary } => {
+				DepositAsset { assets, beneficiary }.into_instruction()
+			},
+			OldInstruction::DepositReserveAsset { assets, dest, xcm } => {
+				DepositReserveAsset { assets, dest, xcm }.into_instruction()
+			},
+			OldInstruction::ExchangeAsset { give, want, maximal } => {
+				ExchangeAsset { give, want, maximal }.into_instruction()
+			},
+			OldInstruction::InitiateReserveWithdraw { assets, reserve, xcm } => {
+				InitiateReserveWithdraw { assets, reserve, xcm }.into_instruction()
+			},
+			OldInstruction::InitiateTeleport { assets, dest, xcm } => {
+				InitiateTeleport { assets, dest, xcm }.into_instruction()
+			},
+			OldInstruction::ReportHolding { response_info, assets } => {
+				ReportHolding { response_info, assets }.into_instruction()
+			},
+			OldInstruction::BuyExecution { fees, weight_limit } => {
+				BuyExecution { fees, weight_limit }.into_instruction()
+			},
+			OldInstruction::RefundSurplus => RefundSurplus.into_instruction(),
+			OldInstruction::SetErrorHandler(xcm) => SetErrorHandler(xcm).into_instruction(),
+			OldInstruction::SetAppendix(xcm) => SetAppendix(xcm).into_instruction(),
+			OldInstruction::ClearError => ClearError.into_instruction(),
+			OldInstruction::ClaimAsset { assets, ticket } => {
+				ClaimAsset { assets, ticket }.into_instruction()
+			},
+			OldInstruction::Trap(_) => Trap(0).into_instruction(),
+			OldInstruction::SubscribeVersion { query_id, max_response_weight } => {
+				SubscribeVersion { query_id, max_response_weight }.into_instruction()
+			},
+			OldInstruction::UnsubscribeVersion => UnsubscribeVersion.into_instruction(),
+			OldInstruction::BurnAsset(assets) => BurnAsset(assets).into_instruction(),
+			OldInstruction::ExpectAsset(assets) => ExpectAsset(assets).into_instruction(),
+			OldInstruction::ExpectOrigin(location) => ExpectOrigin(location).into_instruction(),
+			OldInstruction::ExpectError(_) => ExpectError(None).into_instruction(),
+			OldInstruction::ExpectTransactStatus(maybe_error_code) => {
+				ExpectTransactStatus(maybe_error_code).into_instruction()
+			},
+			OldInstruction::QueryPallet { module_name, response_info } => {
+				QueryPallet { module_name, response_info }.into_instruction()
+			},
+			OldInstruction::ExpectPallet {
+				index,
+				name,
+				module_name,
+				crate_major,
+				min_crate_minor,
+			} => ExpectPallet { index, name, module_name, crate_major, min_crate_minor }
+				.into_instruction(),
+			OldInstruction::ReportTransactStatus(query_response_info) => {
+				ReportTransactStatus(query_response_info).into_instruction()
+			},
+			OldInstruction::ClearTransactStatus => ClearTransactStatus.into_instruction(),
+			OldInstruction::UniversalOrigin(junction) => {
+				UniversalOrigin(junction).into_instruction()
+			},
+			OldInstruction::ExportMessage { network, destination, xcm } => {
+				ExportMessage { network, destination, xcm }.into_instruction()
+			},
+			OldInstruction::LockAsset { asset, unlocker } => {
+				LockAsset { asset, unlocker }.into_instruction()
+			},
+			OldInstruction::UnlockAsset { asset, target } => {
+				UnlockAsset { asset, target }.into_instruction()
+			},
+			OldInstruction::NoteUnlockable { asset, owner } => {
+				NoteUnlockable { asset, owner }.into_instruction()
+			},
+			OldInstruction::RequestUnlock { asset, locker } => {
+				RequestUnlock { asset, locker }.into_instruction()
+			},
+			OldInstruction::SetFeesMode { jit_withdraw } => {
+				SetFeesMode { jit_withdraw }.into_instruction()
+			},
+			OldInstruction::SetTopic(topic) => SetTopic(topic).into_instruction(),
+			OldInstruction::ClearTopic => ClearTopic.into_instruction(),
+			OldInstruction::AliasOrigin(location) => AliasOrigin(location).into_instruction(),
+			OldInstruction::UnpaidExecution { weight_limit, check_origin } => {
+				UnpaidExecution { weight_limit, check_origin }.into_instruction()
+			},
+			OldInstruction::PayFees { asset } => PayFees { asset }.into_instruction(),
+			OldInstruction::InitiateTransfer {
+				destination,
+				remote_fees,
+				preserve_origin,
+				assets,
+				remote_xcm,
+			} => InitiateTransfer { destination, remote_fees, preserve_origin, assets, remote_xcm }
+				.into_instruction(),
+			OldInstruction::ExecuteWithOrigin { descendant_origin, xcm } => {
+				ExecuteWithOrigin { descendant_origin, xcm }.into_instruction()
+			},
+			OldInstruction::SetHints { hints } => SetHints { hints }.into_instruction(),
+		})
+	}
+}


### PR DESCRIPTION
#closes 7095

Setup XCM v6 but with a more extensible approach. This should be 100% ABI with XCM v5 currently but need tests to assert that.

This is only a (not so) quick draft and looking for initial feedbacks.

Ideally, in future XCM versions, we only need to implement the new instructions without the need to duplicate all the existing ones.