### PR TITLE
xcm: Fixes for `UnpaidLocalExporter`

### DIFF
--- a/polkadot/xcm/xcm-builder/src/lib.rs
+++ b/polkadot/xcm/xcm-builder/src/lib.rs
@@ -132,6 +132,8 @@ pub use routing::{
 mod transactional;
 pub use transactional::FrameTransactionalProcessor;
 
+#[allow(deprecated)]
+pub use universal_exports::UnpaidLocalExporter;
 mod universal_exports;
 pub use universal_exports::{
 	ensure_is_remote, BridgeBlobDispatcher, BridgeMessage, DispatchBlob, DispatchBlobError,

--- a/polkadot/xcm/xcm-builder/src/lib.rs
+++ b/polkadot/xcm/xcm-builder/src/lib.rs
@@ -135,8 +135,8 @@ pub use transactional::FrameTransactionalProcessor;
 mod universal_exports;
 pub use universal_exports::{
 	ensure_is_remote, BridgeBlobDispatcher, BridgeMessage, DispatchBlob, DispatchBlobError,
-	ExporterFor, HaulBlob, HaulBlobError, HaulBlobExporter, NetworkExportTable,
-	NetworkExportTableItem, SovereignPaidRemoteExporter, UnpaidLocalExporter, UnpaidRemoteExporter,
+	ExporterFor, HaulBlob, HaulBlobError, HaulBlobExporter, LocalExporter, NetworkExportTable,
+	NetworkExportTableItem, SovereignPaidRemoteExporter, UnpaidRemoteExporter,
 };
 
 mod weight;

--- a/polkadot/xcm/xcm-builder/src/tests/bridging/local_para_para.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/bridging/local_para_para.rs
@@ -28,7 +28,7 @@ parameter_types! {
 type TheBridge =
 	TestBridge<BridgeBlobDispatcher<TestRemoteIncomingRouter, RemoteUniversalLocation, ()>>;
 type Router = TestTopic<
-	UnpaidLocalExporter<
+	LocalExporter<
 		HaulBlobExporter<TheBridge, RemoteNetwork, AlwaysLatest, Price>,
 		UniversalLocation,
 	>,

--- a/polkadot/xcm/xcm-builder/src/tests/bridging/local_relay_relay.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/bridging/local_relay_relay.rs
@@ -28,7 +28,7 @@ parameter_types! {
 type TheBridge =
 	TestBridge<BridgeBlobDispatcher<TestRemoteIncomingRouter, RemoteUniversalLocation, ()>>;
 type Router = TestTopic<
-	UnpaidLocalExporter<
+	LocalExporter<
 		HaulBlobExporter<TheBridge, RemoteNetwork, AlwaysLatest, Price>,
 		UniversalLocation,
 	>,

--- a/polkadot/xcm/xcm-builder/src/tests/bridging/mod.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/bridging/mod.rs
@@ -209,7 +209,7 @@ impl<Local: Get<Junctions>, Remote: Get<Junctions>, RemoteExporter: ExportXcm> S
 		let origin = Local::get().relative_to(&Remote::get());
 		AllowUnpaidFrom::set(vec![origin.clone()]);
 		set_exporter_override(price::<RemoteExporter>, deliver::<RemoteExporter>);
-		// The we execute it:
+		// Then we execute it:
 		let mut id = fake_id();
 		let outcome = XcmExecutor::<TestConfig>::prepare_and_execute(
 			origin,

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -58,11 +58,11 @@ pub fn ensure_is_remote(
 /// that the message sending cannot be abused in any way.
 ///
 /// This is only useful when the local chain has bridging capabilities.
-pub struct UnpaidLocalExporter<Exporter, UniversalLocation>(
+pub struct LocalExporter<Exporter, UniversalLocation>(
 	PhantomData<(Exporter, UniversalLocation)>,
 );
 impl<Exporter: ExportXcm, UniversalLocation: Get<InteriorLocation>> SendXcm
-	for UnpaidLocalExporter<Exporter, UniversalLocation>
+	for LocalExporter<Exporter, UniversalLocation>
 {
 	type Ticket = Exporter::Ticket;
 
@@ -703,9 +703,9 @@ mod tests {
 		let local_dest: Location = (Parent, Parachain(5678)).into();
 		assert!(ensure_is_remote(UniversalLocation::get(), local_dest.clone()).is_err());
 
-		// UnpaidLocalExporter
+		// LocalExporter
 		ensure_validate_does_not_consume_dest_or_msg::<
-			UnpaidLocalExporter<RoutableBridgeExporter, UniversalLocation>,
+			LocalExporter<RoutableBridgeExporter, UniversalLocation>,
 		>(local_dest.clone(), |result| assert_eq!(Err(NotApplicable), result));
 
 		// 2. check with not applicable from the inner router (using `NotApplicableBridgeSender`)
@@ -713,14 +713,14 @@ mod tests {
 			(Parent, Parent, DifferentRemote::get(), RemoteDestination::get()).into();
 		assert!(ensure_is_remote(UniversalLocation::get(), remote_dest.clone()).is_ok());
 
-		// UnpaidLocalExporter
+		// LocalExporter
 		ensure_validate_does_not_consume_dest_or_msg::<
-			UnpaidLocalExporter<NotApplicableBridgeExporter, UniversalLocation>,
+			LocalExporter<NotApplicableBridgeExporter, UniversalLocation>,
 		>(remote_dest.clone(), |result| assert_eq!(Err(NotApplicable), result));
 
 		// 3. Ok - deliver
 		// UnpaidRemoteExporter
-		assert_ok!(send_xcm::<UnpaidLocalExporter<RoutableBridgeExporter, UniversalLocation>>(
+		assert_ok!(send_xcm::<LocalExporter<RoutableBridgeExporter, UniversalLocation>>(
 			remote_dest,
 			Xcm::default()
 		));

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -66,7 +66,7 @@ pub struct UnpaidLocalExporter<Exporter, UniversalLocation>(
 	PhantomData<(Exporter, UniversalLocation)>,
 );
 impl<Exporter: ExportXcm, UniversalLocation: Get<InteriorLocation>> SendXcm
-for UnpaidLocalExporter<Exporter, UniversalLocation>
+	for UnpaidLocalExporter<Exporter, UniversalLocation>
 {
 	type Ticket = Exporter::Ticket;
 
@@ -88,12 +88,12 @@ for UnpaidLocalExporter<Exporter, UniversalLocation>
 			remote_location,
 			xcm.clone(),
 		)
-			.inspect_err(|err| {
-				if let NotApplicable = err {
-					// We need to make sure that msg is not consumed in case of `NotApplicable`.
-					*msg = Some(xcm);
-				}
-			})
+		.inspect_err(|err| {
+			if let NotApplicable = err {
+				// We need to make sure that msg is not consumed in case of `NotApplicable`.
+				*msg = Some(xcm);
+			}
+		})
 	}
 
 	fn deliver(ticket: Exporter::Ticket) -> Result<XcmHash, SendError> {
@@ -108,9 +108,7 @@ for UnpaidLocalExporter<Exporter, UniversalLocation>
 /// the message over a bridge.
 ///
 /// This is only useful when the local chain has bridging capabilities.
-pub struct LocalExporter<Exporter, UniversalLocation>(
-	PhantomData<(Exporter, UniversalLocation)>,
-);
+pub struct LocalExporter<Exporter, UniversalLocation>(PhantomData<(Exporter, UniversalLocation)>);
 impl<Exporter: ExportXcm, UniversalLocation: Get<InteriorLocation>> SendXcm
 	for LocalExporter<Exporter, UniversalLocation>
 {
@@ -127,7 +125,8 @@ impl<Exporter: ExportXcm, UniversalLocation: Get<InteriorLocation>> SendXcm
 		let (remote_network, remote_location) = devolved;
 		let xcm = msg.take().ok_or(MissingArgument)?;
 
-		let hash = (Some(Location::here()), &remote_location).using_encoded(sp_io::hashing::blake2_128);
+		let hash =
+			(Some(Location::here()), &remote_location).using_encoded(sp_io::hashing::blake2_128);
 		let channel = u32::decode(&mut hash.as_ref()).unwrap_or(0);
 
 		validate_export::<Exporter>(

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -77,9 +77,12 @@ impl<Exporter: ExportXcm, UniversalLocation: Get<InteriorLocation>> SendXcm
 		let (remote_network, remote_location) = devolved;
 		let xcm = msg.take().ok_or(MissingArgument)?;
 
+		let hash = (Some(Location::here()), &remote_location).using_encoded(sp_io::hashing::blake2_128);
+		let channel = u32::decode(&mut hash.as_ref()).unwrap_or(0);
+
 		validate_export::<Exporter>(
 			remote_network,
-			0,
+			channel,
 			universal_source,
 			remote_location,
 			xcm.clone(),

--- a/prdoc/pr_7126.prdoc
+++ b/prdoc/pr_7126.prdoc
@@ -2,13 +2,7 @@ title: 'xcm: Fixes for `UnpaidLocalExporter`'
 doc:
 - audience: Runtime Dev
   description: |-
-    ## Description
-
     This PR deprecates `UnpaidLocalExporter` in favor of the new `LocalExporter`. First, the name is misleading, as it can be used in both paid and unpaid scenarios. Second, it contains a hard-coded channel 0, whereas `LocalExporter` uses the same algorithm as `xcm-exporter`.
-
-    ## Future Improvements
-
-    Remove the `channel` argument and slightly modify the `ExportXcm::validate` signature as part of [this issue](https://github.com/orgs/paritytech/projects/145/views/8?pane=issue&itemId=84899273).
 crates:
 - name: staging-xcm-builder
   bump: patch

--- a/prdoc/pr_7126.prdoc
+++ b/prdoc/pr_7126.prdoc
@@ -1,0 +1,14 @@
+title: 'xcm: Fixes for `UnpaidLocalExporter`'
+doc:
+- audience: Runtime Dev
+  description: |-
+    ## Description
+
+    This PR deprecates `UnpaidLocalExporter` in favor of the new `LocalExporter`. First, the name is misleading, as it can be used in both paid and unpaid scenarios. Second, it contains a hard-coded channel 0, whereas `LocalExporter` uses the same algorithm as `xcm-exporter`.
+
+    ## Future Improvements
+
+    Remove the `channel` argument and slightly modify the `ExportXcm::validate` signature as part of [this issue](https://github.com/orgs/paritytech/projects/145/views/8?pane=issue&itemId=84899273).
+crates:
+- name: staging-xcm-builder
+  bump: patch

--- a/prdoc/pr_7126.prdoc
+++ b/prdoc/pr_7126.prdoc
@@ -1,8 +1,7 @@
 title: 'xcm: Fixes for `UnpaidLocalExporter`'
 doc:
 - audience: Runtime Dev
-  description: |-
-    This PR deprecates `UnpaidLocalExporter` in favor of the new `LocalExporter`. First, the name is misleading, as it can be used in both paid and unpaid scenarios. Second, it contains a hard-coded channel 0, whereas `LocalExporter` uses the same algorithm as `xcm-exporter`.
+  description: This PR deprecates `UnpaidLocalExporter` in favor of the new `LocalExporter`. First, the name is misleading, as it can be used in both paid and unpaid scenarios. Second, it contains a hard-coded channel 0, whereas `LocalExporter` uses the same algorithm as `xcm-exporter`.
 crates:
 - name: staging-xcm-builder
-  bump: patch
+  bump: minor


### PR DESCRIPTION
## Description

This PR deprecates `UnpaidLocalExporter` in favor of the new `LocalExporter`. First, the name is misleading, as it can be used in both paid and unpaid scenarios. Second, it contains a hard-coded channel 0, whereas `LocalExporter` uses the same algorithm as `xcm-exporter`.  

## Future Improvements  

Remove the `channel` argument and slightly modify the `ExportXcm::validate` signature as part of [this issue](https://github.com/orgs/paritytech/projects/145/views/8?pane=issue&itemId=84899273).  