### PR TITLE
Able to chill inactive validator

### DIFF
--- a/polkadot/runtime/westend/src/weights/pallet_staking.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_staking.rs
@@ -826,4 +826,8 @@ impl<T: frame_system::Config> pallet_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
+	// TODO: benchmark.
+	fn chill_inactive_validator(l: u32, ) -> Weight {
+		0.into()
+	}
 }

--- a/substrate/frame/staking/src/benchmarking.rs
+++ b/substrate/frame/staking/src/benchmarking.rs
@@ -1141,13 +1141,8 @@ mod benchmarks {
 	fn chill_inactive_validator(
 		l: Linear<2, { ChillInactiveValidatorThreshold::<T>::get() }>,
 	) -> Result<(), BenchmarkError> {
-		let (stash, _) = create_validator_with_nominators::<T>(
-			0,
-			0,
-			false,
-			true,
-			RewardDestination::Staked,
-		)?;
+		let (stash, _) =
+			create_validator_with_nominators::<T>(0, 0, false, true, RewardDestination::Staked)?;
 		assert!(T::VoterList::contains(&stash));
 
 		Staking::<T>::set_staking_configs(

--- a/substrate/frame/staking/src/benchmarking.rs
+++ b/substrate/frame/staking/src/benchmarking.rs
@@ -336,7 +336,7 @@ mod benchmarks {
 
 		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
 
-		// setup a worst case list scenario. Note that we don't care about the setup of the
+		// Setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
@@ -461,7 +461,7 @@ mod benchmarks {
 
 		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
 
-		// setup a worst case list scenario. Note we don't care about the destination position,
+		// Setup a worst case list scenario. Note we don't care about the destination position,
 		// because we are just doing an insert into the origin position.
 		ListScenario::<T>::new(origin_weight, true)?;
 		let (stash, controller) = create_stash_controller_with_balance::<T>(
@@ -494,7 +494,7 @@ mod benchmarks {
 
 		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
 
-		// setup a worst case list scenario. Note that we don't care about the setup of the
+		// Setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
@@ -655,7 +655,7 @@ mod benchmarks {
 
 		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
 
-		// setup a worst case list scenario. Note that we don't care about the setup of the
+		// Setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
@@ -749,7 +749,7 @@ mod benchmarks {
 			// we use 100 to play friendly with the list threshold values in the mock
 			.max(100u32.into());
 
-		// setup a worst case list scenario.
+		// Setup a worst case list scenario.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let dest_weight = scenario.dest_weight;
 
@@ -793,7 +793,7 @@ mod benchmarks {
 
 		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
 
-		// setup a worst case list scenario. Note that we don't care about the setup of the
+		// Setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let controller = scenario.origin_controller1.clone();
@@ -1006,6 +1006,7 @@ mod benchmarks {
 			ConfigOp::Set(u32::MAX),
 			ConfigOp::Set(u32::MAX),
 			ConfigOp::Set(Percent::max_value()),
+			ConfigOp::Set(T::HistoryDepth::get()),
 			ConfigOp::Set(Perbill::max_value()),
 			ConfigOp::Set(Percent::max_value()),
 		);
@@ -1015,6 +1016,7 @@ mod benchmarks {
 		assert_eq!(MaxNominatorsCount::<T>::get(), Some(u32::MAX));
 		assert_eq!(MaxValidatorsCount::<T>::get(), Some(u32::MAX));
 		assert_eq!(ChillThreshold::<T>::get(), Some(Percent::from_percent(100)));
+		assert_eq!(ChillInactiveValidatorThreshold::<T>::get(), T::HistoryDepth::get());
 		assert_eq!(MinCommission::<T>::get(), Perbill::from_percent(100));
 		assert_eq!(MaxStakedRewards::<T>::get(), Some(Percent::from_percent(100)));
 	}
@@ -1024,6 +1026,7 @@ mod benchmarks {
 		#[extrinsic_call]
 		set_staking_configs(
 			RawOrigin::Root,
+			ConfigOp::Remove,
 			ConfigOp::Remove,
 			ConfigOp::Remove,
 			ConfigOp::Remove,
@@ -1049,7 +1052,7 @@ mod benchmarks {
 
 		let origin_weight = MinNominatorBond::<T>::get().max(asset::existential_deposit::<T>());
 
-		// setup a worst case list scenario. Note that we don't care about the setup of the
+		// Setup a worst case list scenario. Note that we don't care about the setup of the
 		// destination position because we are doing a removal from the list but no insert.
 		let scenario = ListScenario::<T>::new(origin_weight, true)?;
 		let stash = scenario.origin_stash1;
@@ -1062,6 +1065,7 @@ mod benchmarks {
 			ConfigOp::Set(0),
 			ConfigOp::Set(0),
 			ConfigOp::Set(Percent::from_percent(0)),
+			ConfigOp::Set(2),
 			ConfigOp::Set(Zero::zero()),
 			ConfigOp::Noop,
 		)?;
@@ -1129,6 +1133,56 @@ mod benchmarks {
 		_(RawOrigin::Root, stash.clone(), None, None, None);
 
 		assert_eq!(Staking::<T>::inspect_bond_state(&stash), Ok(LedgerIntegrityState::Ok));
+
+		Ok(())
+	}
+
+	#[benchmark]
+	fn chill_inactive_validator(
+		l: Linear<2, { ChillInactiveValidatorThreshold::<T>::get() }>,
+	) -> Result<(), BenchmarkError> {
+		let (stash, _) = create_validator_with_nominators::<T>(
+			0,
+			0,
+			false,
+			true,
+			RewardDestination::Staked,
+		)?;
+		assert!(T::VoterList::contains(&stash));
+
+		Staking::<T>::set_staking_configs(
+			RawOrigin::Root.into(),
+			ConfigOp::Set(BalanceOf::<T>::max_value()),
+			ConfigOp::Set(BalanceOf::<T>::max_value()),
+			ConfigOp::Set(0),
+			ConfigOp::Set(0),
+			ConfigOp::Set(Percent::from_percent(0)),
+			ConfigOp::Set(l),
+			ConfigOp::Set(Zero::zero()),
+			ConfigOp::Noop,
+		)?;
+
+		let caller = whitelisted_caller();
+		// Set the validator has been inactive for `l` eras.
+		let proof = (0..l)
+			.map(|era| {
+				ErasRewardPoints::<T>::insert(
+					era,
+					EraRewardPoints {
+						total: 0,
+						individual: BTreeMap::from_iter([(stash.clone(), 0)]),
+					},
+				);
+
+				era
+			})
+			.collect::<Vec<_>>();
+		let proof = BoundedVec::truncate_from(proof);
+
+		#[extrinsic_call]
+		_(RawOrigin::Signed(caller), stash.clone(), proof);
+
+		assert!(!T::VoterList::contains(&stash));
 
 		Ok(())
 	}

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -2372,7 +2372,7 @@ pub mod pallet {
 					if consecutive_inactives >= threshold {
 						Self::chill_stash(&stash);
 
-						return Ok(());
+						return Ok(Pays::No.into());
 					}
 				} else {
 					consecutive_inactives = 0;

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -2336,7 +2336,6 @@ pub mod pallet {
 			proof: BoundedVec<EraIndex, T::HistoryDepth>,
 		) -> DispatchResult {
 			ensure_signed(origin)?;
-
 			ensure!(Validators::<T>::contains_key(&stash), Error::<T>::NotValidator);
 
 			let threshold = ChillInactiveValidatorThreshold::<T>::get();

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -1936,6 +1936,8 @@ pub mod pallet {
 		///   set to `None`, no limit is enforced.
 		/// * `chill_threshold`: The ratio of `max_nominator_count` or `max_validator_count` which
 		///   should be filled in order for the `chill_other` transaction to work.
+		/// * `chill_inactive_validator_threshold`: The number of consecutive eras a validator can
+		///   remain inactive before being subject to chilling by anyone.
 		/// * `min_commission`: The minimum amount of commission that each validators must maintain.
 		///   This is checked only upon calling `validate`. Existing validators are not affected.
 		///

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -2341,6 +2341,8 @@ pub mod pallet {
 			ensure!(Validators::<T>::contains_key(&stash), Error::<T>::NotValidator);
 
 			let threshold = ChillInactiveValidatorThreshold::<T>::get();
+			
+			if threshold.is_zero() { return Ok(()); }
 
 			ensure!(proof.len() as EraIndex >= threshold, Error::<T>::InvalidProof);
 

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -2354,18 +2354,14 @@ pub mod pallet {
 			let mut consecutive_inactives = 0;
 
 			for era in proof {
-				// Check if the ear exists.
+				// Check if the era exists.
 				if !ErasRewardPoints::<T>::contains_key(era) {
-					consecutive_inactives = 0;
-
-					continue;
+					break;
 				}
 
 				// Check if the stash was a validator of the era.
 				let Some(&points) = ErasRewardPoints::<T>::get(era).individual.get(&stash) else {
-					consecutive_inactives = 0;
-
-					continue;
+					break;
 				};
 
 				if points == 0 {
@@ -2377,7 +2373,7 @@ pub mod pallet {
 						return Ok(Pays::No.into());
 					}
 				} else {
-					consecutive_inactives = 0;
+					break;
 				}
 			}
 

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -2341,8 +2341,11 @@ pub mod pallet {
 			ensure!(Validators::<T>::contains_key(&stash), Error::<T>::NotValidator);
 
 			let threshold = ChillInactiveValidatorThreshold::<T>::get();
-			
-			if threshold.is_zero() { return Ok(()); }
+
+			// Impossible case, but we still check.
+			if threshold.is_zero() {
+				return Ok(());
+			}
 
 			ensure!(proof.len() as EraIndex >= threshold, Error::<T>::InvalidProof);
 

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -5929,17 +5929,6 @@ fn chill_inactive_validator_works() {
 			);
 		});
 
-		// Consecutive part cannot fit the threshold will be rejected.
-		{
-			let proof =
-				BoundedVec::truncate_from((0..10).chain(11..history_depth + 1).collect::<Vec<_>>());
-			assert_eq!(proof.len() as EraIndex, history_depth);
-			assert_noop!(
-				Staking::chill_inactive_validator(RuntimeOrigin::signed(0), 11, proof),
-				Error::<Test>::InvalidProof,
-			);
-		}
-
 		// Unsorted proof will be rejected.
 		//
 		// After sorting, the proof will be valid.

--- a/substrate/frame/staking/src/tests.rs
+++ b/substrate/frame/staking/src/tests.rs
@@ -5860,7 +5860,7 @@ fn chill_inactive_validator_works() {
 			Error::<Test>::InvalidProof,
 		);
 
-		// `11` wasn't a validator of the some of the eras, the proof will be rejected.
+		// `11` wasn't a validator of some of the eras, the proof will be rejected.
 		(0..history_depth).for_each(|era| {
 			if era % 2 == 0 {
 				ErasRewardPoints::<Test>::insert(era, EraRewardPoints::default())

--- a/substrate/frame/staking/src/weights.rs
+++ b/substrate/frame/staking/src/weights.rs
@@ -83,6 +83,7 @@ pub trait WeightInfo {
 	fn force_apply_min_commission() -> Weight;
 	fn set_min_commission() -> Weight;
 	fn restore_ledger() -> Weight;
+	fn chill_inactive_validator(l: u32, ) -> Weight;
 }
 
 /// Weights for `pallet_staking` using the Substrate node and recommended hardware.
@@ -834,6 +835,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	/// TODO: benchmark.
+	fn chill_inactive_validator(l: u32, ) -> Weight {
+		0.into()
+	}
 }
 
 // For backwards compatibility and tests.
@@ -1583,5 +1588,9 @@ impl WeightInfo for () {
 		Weight::from_parts(45_611_000, 4764)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
+	/// TODO: benchmark.
+	fn chill_inactive_validator(l: u32, ) -> Weight {
+		0.into()
 	}
 }


### PR DESCRIPTION
Add a new extrinsic `chill_inactive_validator` and a new storage config `ChillInactiveValidatorThreshold`:
- Anyone can call this function.
- The validator's stash account should be provided.
- The proof should be a list of consecutive sorted era indexes where the validator has
  not produced any blocks.
- This will only be successful if the validator has not produced any blocks in `ChillInactiveValidatorThreshold` consecutive eras.
- If the `ChillInactiveValidatorThreshold` is not set, it will fallback to `Config::HistoryDepth`. It's almost the same as current on-chain logic. The inactive validator is almost impossible to be chilled by others, unless it missed `84` eras.

Closes #5674.

---

Polkadot address: 156HGo9setPcU2qhFMVWLkcmtCEGySLwNqa3DaEiYSWtte4Y