### PR TITLE
litep2p: Sufix litep2p to the identify agent version for visibility

### DIFF
--- a/prdoc/pr_7133.prdoc
+++ b/prdoc/pr_7133.prdoc
@@ -1,0 +1,15 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Sufix litep2p to the identify agent version for visibility
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      This PR adds the `(litep2p)` suffix to the agent version (user agent) of the identify protocol.
+      The change is needed to gain visibility into network backends and determine exactly the number of validators that are running litep2p.
+      Using tools like subp2p-explorer, we can determine if the validators are running litep2p nodes.
+
+crates:
+- name: sc-network
+  bump: patch

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -254,7 +254,7 @@ impl Discovery {
 		_peerstore_handle: Arc<dyn PeerStoreProvider>,
 	) -> (Self, PingConfig, IdentifyConfig, KademliaConfig, Option<MdnsConfig>) {
 		let (ping_config, ping_event_stream) = PingConfig::default();
-		let user_agent = format!("{} ({})", config.client_version, config.node_name);
+		let user_agent = format!("{} ({}) (litep2p)", config.client_version, config.node_name);
 
 		let (identify_config, identify_event_stream) =
 			IdentifyConfig::new("/substrate/1.0".to_string(), Some(user_agent));


### PR DESCRIPTION
This PR adds the `(litep2p)` suffix to the agent version (user agent) of the identify protocol.

The change is needed to gain visibility into network backends and determine exactly the number of validators that are running litep2p.
Using tools like subp2p-explorer, we can determine if the validators are running litep2p nodes.

This reflects on the identify protocol:

```
info=Identify {
  protocol_version: Some("/substrate/1.0"),
  agent_version: Some("polkadot-parachain/v1.17.0-967989c5d94 (kusama-node-name-01) (litep2p)")
  ...
}
```

cc @paritytech/networking 