### PR TITLE
xcm: convert properly assets in xcmpayment apis

### DIFF
--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1885,7 +1885,8 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::TokenLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2445,7 +2445,8 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::TokenLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/prdoc/pr_7134.prdoc
+++ b/prdoc/pr_7134.prdoc
@@ -1,0 +1,11 @@
+title: 'xcm: convert properly assets in xcmpayment apis'
+doc:
+- audience: Runtime User
+  description: |-
+    Port #6459 changes to relays as well, which were probably forgotten in that PR.
+    Thanks!
+crates:
+- name: rococo-runtime
+  bump: patch
+- name: westend-runtime
+  bump: patch


### PR DESCRIPTION
Port #6459 changes to relays as well, which were probably forgotten in that PR.
Thanks!