### PR TITLE
CI: Only format umbrella crate during umbrella check

### DIFF
--- a/.github/workflows/checks-quick.yml
+++ b/.github/workflows/checks-quick.yml
@@ -138,7 +138,7 @@ jobs:
           # Fixes "detected dubious ownership" error in the ci
           git config --global --add safe.directory '*'
           python3 scripts/generate-umbrella.py --sdk . --version 0.1.0
-          cargo +nightly fmt --all
+          cargo +nightly fmt -p polkadot-sdk
 
           if [ -n "$(git status --porcelain)" ]; then
             cat <<EOF


### PR DESCRIPTION
The umbrella crate quick-check was always failing whenever there was something misformated in the whole codebase.
This leads to an error that indicates that a new crate was added, even when it was not.

After this PR we only apply `cargo fmt` to the newly generated umbrella crate `polkadot-sdk`. This results in this check being independent from the fmt job which should check the entire codebase.