### PR TITLE
Improve debugging by using `#[track_caller]` in system `assert_last_event` and `assert_has_event`

### DIFF
--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2045,7 +2045,7 @@ impl<T: Config> Pallet<T> {
 		};
 
 		let last_event =
-			Self::events().last().expect(&format!("{warn}events expected")).event.clone();
+			Self::events().last().expect(&alloc::format!("{warn}events expected")).event.clone();
 		assert_eq!(
 			last_event, event,
 			"{warn}expected event {event:?} is not equal to the last event {last_event:?}",

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2019,8 +2019,8 @@ impl<T: Config> Pallet<T> {
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	#[track_caller]
 	pub fn assert_has_event(event: T::RuntimeEvent) {
-		let additional_note = if Self::block_number().is_zero() {
-			"\nWARNING: block number is zero, and events are not registered at block number zero."
+		let warn = if Self::block_number().is_zero() {
+			"WARNING: block number is zero, and events are not registered at block number zero.\n"
 		} else {
 			""
 		};
@@ -2028,7 +2028,7 @@ impl<T: Config> Pallet<T> {
 		let events = Self::events();
 		assert!(
 			events.iter().any(|record| record.event == event),
-			"expected event {event:?} not found in events {events:?}{additional_note}",
+			"{warn}expected event {event:?} not found in events {events:?}",
 		);
 	}
 
@@ -2038,20 +2038,17 @@ impl<T: Config> Pallet<T> {
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	#[track_caller]
 	pub fn assert_last_event(event: T::RuntimeEvent) {
-		let additional_note = if Self::block_number().is_zero() {
-			"\nWARNING: block number is zero, and events are not registered at block number zero."
+		let warn = if Self::block_number().is_zero() {
+			"WARNING: block number is zero, and events are not registered at block number zero.\n"
 		} else {
 			""
 		};
 
-		let last_event = Self::events()
-			.last()
-			.expect(&*format!("events expected{additional_note}"))
-			.event
-			.clone();
+		let last_event =
+			Self::events().last().expect(&*format!("{warn}events expected")).event.clone();
 		assert_eq!(
 			last_event, event,
-			"expected event {event:?} is not equal to the last event {last_event:?}{additional_note}",
+			"{warn}expected event {event:?} is not equal to the last event {last_event:?}",
 		);
 	}
 

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2044,8 +2044,11 @@ impl<T: Config> Pallet<T> {
 			""
 		};
 
-		let last_event =
-			Self::events().last().expect(&alloc::format!("{warn}events expected")).event.clone();
+		let last_event = Self::events()
+			.last()
+			.expect(&alloc::format!("{warn}events expected"))
+			.event
+			.clone();
 		assert_eq!(
 			last_event, event,
 			"{warn}expected event {event:?} is not equal to the last event {last_event:?}",

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2019,10 +2019,16 @@ impl<T: Config> Pallet<T> {
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	#[track_caller]
 	pub fn assert_has_event(event: T::RuntimeEvent) {
+		let additional_note = if Self::block_number().is_zero() {
+			"\nWARNING: block number is zero, and events are not registered at block number zero."
+		} else {
+			""
+		};
+
 		let events = Self::events();
 		assert!(
 			events.iter().any(|record| record.event == event),
-			"expected event {event:?} not found in events {events:?}",
+			"expected event {event:?} not found in events {events:?}{additional_note}",
 		);
 	}
 
@@ -2032,10 +2038,20 @@ impl<T: Config> Pallet<T> {
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	#[track_caller]
 	pub fn assert_last_event(event: T::RuntimeEvent) {
-		let last_event = Self::events().last().expect("events expected").event.clone();
+		let additional_note = if Self::block_number().is_zero() {
+			"\nWARNING: block number is zero, and events are not registered at block number zero."
+		} else {
+			""
+		};
+
+		let last_event = Self::events()
+			.last()
+			.expect(&*format!("events expected{additional_note}"))
+			.event
+			.clone();
 		assert_eq!(
 			last_event, event,
-			"expected event {event:?} is not equal to the last event {last_event:?}",
+			"expected event {event:?} is not equal to the last event {last_event:?}{additional_note}",
 		);
 	}
 

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2045,7 +2045,7 @@ impl<T: Config> Pallet<T> {
 		};
 
 		let last_event =
-			Self::events().last().expect(&*format!("{warn}events expected")).event.clone();
+			Self::events().last().expect(&format!("{warn}events expected")).event.clone();
 		assert_eq!(
 			last_event, event,
 			"{warn}expected event {event:?} is not equal to the last event {last_event:?}",

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2017,6 +2017,7 @@ impl<T: Config> Pallet<T> {
 	///
 	/// NOTE: Events not registered at the genesis block and quietly omitted.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	#[track_caller]
 	pub fn assert_has_event(event: T::RuntimeEvent) {
 		let events = Self::events();
 		assert!(
@@ -2029,6 +2030,7 @@ impl<T: Config> Pallet<T> {
 	///
 	/// NOTE: Events not registered at the genesis block and quietly omitted.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	#[track_caller]
 	pub fn assert_last_event(event: T::RuntimeEvent) {
 		let last_event = Self::events().last().expect("events expected").event.clone();
 		assert_eq!(


### PR DESCRIPTION
Without track caller the error message of the assert points to the `assert_last_event` function, which is not useful.
```
thread 'tests::set_metadata_works' panicked at /home/gui/Developpement/polkadot-sdk/substrate/frame/system/src/lib.rs:2034:9:
assertion `left == right` failed: expected event RuntimeEvent::Referenda(Event::MetadataSet { index: 0, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa }) is not equal to the last event RuntimeEvent::Referenda(Event::MetadataSet { index: 1, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa })
  left: RuntimeEvent::Referenda(Event::MetadataSet { index: 1, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa })
 right: RuntimeEvent::Referenda(Event::MetadataSet { index: 0, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa })
```

With the track caller the error message points to the caller, showing the source of the error:
```
thread 'tests::set_metadata_works' panicked at substrate/frame/referenda/src/tests.rs:639:9:
assertion `left == right` failed: expected event RuntimeEvent::Referenda(Event::MetadataSet { index: 0, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa }) is not equal to the last event RuntimeEvent::Referenda(Event::MetadataSet { index: 1, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa })
  left: RuntimeEvent::Referenda(Event::MetadataSet { index: 1, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa })
 right: RuntimeEvent::Referenda(Event::MetadataSet { index: 0, hash: 0xbb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa })
```

I also improved the error message to include a warning when checking events on block number zero.