### PR TITLE
req-resp/litep2p: Reject inbound requests from banned peers

### DIFF
--- a/prdoc/pr_7158.prdoc
+++ b/prdoc/pr_7158.prdoc
@@ -1,0 +1,12 @@
+title: Reject litep2p inbound requests from banned peers
+
+doc:
+  - audience: Node Dev
+    description: |
+      This PR rejects inbound requests from banned peers (reputation is below the banned threshold).
+      This mirrors the request-response implementation from the libp2p side.
+      While at it, have registered a new inbound failure metric to have visibility into this.
+
+crates:
+- name: sc-network
+  bump: patch

--- a/substrate/client/network/src/litep2p/shim/request_response/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/request_response/mod.rs
@@ -284,6 +284,19 @@ impl RequestResponseProtocol {
 			return;
 		};
 
+		let peer_id = peer.into();
+		if self.peerstore_handle.is_banned(&peer_id) {
+			log::trace!(
+				target: LOG_TARGET,
+				"{}: rejecting inbound request from banned {peer:?} ({request_id:?})",
+				self.protocol,
+			);
+
+			self.handle.reject_request(request_id);
+			self.metrics.register_inbound_request_failure("banned-peer");
+			return;
+		}
+
 		log::trace!(
 			target: LOG_TARGET,
 			"{}: request received from {peer:?} ({fallback:?} {request_id:?}), request size {:?}",

--- a/substrate/client/network/src/litep2p/shim/request_response/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/request_response/mod.rs
@@ -284,8 +284,7 @@ impl RequestResponseProtocol {
 			return;
 		};
 
-		let peer_id = peer.into();
-		if self.peerstore_handle.is_banned(&peer_id) {
+		if self.peerstore_handle.is_banned(&peer.into()) {
 			log::trace!(
 				target: LOG_TARGET,
 				"{}: rejecting inbound request from banned {peer:?} ({request_id:?})",

--- a/substrate/client/network/src/litep2p/shim/request_response/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/request_response/mod.rs
@@ -273,6 +273,13 @@ impl RequestResponseProtocol {
 		request_id: RequestId,
 		request: Vec<u8>,
 	) {
+		log::trace!(
+			target: LOG_TARGET,
+			"{}: request received from {peer:?} ({fallback:?} {request_id:?}), request size {:?}",
+			self.protocol,
+			request.len(),
+		);
+
 		let Some(inbound_queue) = &self.inbound_queue else {
 			log::trace!(
 				target: LOG_TARGET,
@@ -296,12 +303,6 @@ impl RequestResponseProtocol {
 			return;
 		}
 
-		log::trace!(
-			target: LOG_TARGET,
-			"{}: request received from {peer:?} ({fallback:?} {request_id:?}), request size {:?}",
-			self.protocol,
-			request.len(),
-		);
 		let (tx, rx) = oneshot::channel();
 
 		match inbound_queue.try_send(IncomingRequest {


### PR DESCRIPTION
This PR rejects inbound requests from banned peers (reputation is below the banned threshold).

This mirrors the request-response implementation from the libp2p side.
I won't expect this to get triggered too often, but we'll monitor this metric.  

While at it, have registered a new inbound failure metric to have visibility into this.

Discovered during the investigation of: https://github.com/paritytech/polkadot-sdk/issues/7076#issuecomment-2589613046

cc @paritytech/networking 