### PR TITLE
Fix reversed error message in DispatchInfo

### DIFF
--- a/prdoc/pr_7170.prdoc
+++ b/prdoc/pr_7170.prdoc
@@ -1,0 +1,8 @@
+title: Fix reversed error message in DispatchInfo
+doc:
+- audience: Runtime Dev
+  description: "Fix error message in `DispatchInfo` where post-dispatch and pre-dispatch\
+    \ weight was reversed.\r\n"
+crates:
+- name: frame-support
+  bump: patch

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -315,10 +315,8 @@ impl PostDispatchInfo {
 					"Post dispatch weight is greater than pre dispatch weight. \
 					Pre dispatch weight may underestimating the actual weight. \
 					Greater post dispatch weight components are ignored.
-					Pre dispatch weight: {:?},
-					Post dispatch weight: {:?}",
-					info_total_weight,
-					actual_weight,
+					Pre dispatch weight: {info_total_weight:?},
+					Post dispatch weight: {actual_weight:?}",
 				);
 			}
 			actual_weight.min(info.total_weight())

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -317,8 +317,8 @@ impl PostDispatchInfo {
 					Greater post dispatch weight components are ignored.
 					Pre dispatch weight: {:?},
 					Post dispatch weight: {:?}",
-					actual_weight,
 					info_total_weight,
+					actual_weight,
 				);
 			}
 			actual_weight.min(info.total_weight())


### PR DESCRIPTION
Fix error message in `DispatchInfo` where post-dispatch and pre-dispatch weight was reversed.
