### PR TITLE
Initiate reserve withdraw test scenario

### DIFF
--- a/cumulus/parachains/integration-tests/chopsticks/tests/v5-tests/README.md
+++ b/cumulus/parachains/integration-tests/chopsticks/tests/v5-tests/README.md
@@ -5,7 +5,8 @@ To install dependencies:
 ```bash
 bun add polkadot-api
 # now you need to switch to another terminal window where you executed bunx command, make sure that chains are running and copy Asset Hub's port in the command below (usually the port is 8001).
-bun papi add wnd_ah -w ws://localhost:8001
+bun papi add wnd_ah -w ws://localhost:8000
+bun papi add wnd_penpal -w ws://localhost:8001
 bun add @polkadot-labs/hdkd
 ```
 


### PR DESCRIPTION
Added initiate reserve withdraw test scenario. 
Added penpal client to test set-up and updated Readme.

In order to verify USDT transfer from Asset Hub to Penpal (ReserveAssetTransfer): 
- go to Penpal's chain state (https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A8001#/chainstate) 
- select foreignAssets pallet and then select asset map
- within asset map specify relative path to USDT on Asset Hub (i.e. parents: 1, Parachain(1000), PalletInstance(50), GeneralIndex(1984) and hit "+" button 
- within the response make sure that there is one account (`accounts: 1`) holding this foreign asset

In order to verify USDT transfer from Penpal to AssetHub (InitiateReserveWithdraw): 
- go to Asset Hub's chain state (https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A8000#/chainstate) 
- select asset pallet and account map 
- below select Bob's account from the list (we use Bob for this test scenario but you can also check if Alice's balance was decreased)
- and set id (u32) to 1984 (or USDT)
- then hit "+" button and make sure that Bob's balance is correct