### PR TITLE
[stable2412] Fix feature bandersnatch-experimental

### DIFF
--- a/.github/scripts/check-workspace.py
+++ b/.github/scripts/check-workspace.py
@@ -144,7 +144,9 @@ def check_links(all_crates):
 						return
 
 		def check_crate(deps):
-			to_checks = ['dependencies', 'dev-dependencies', 'build-dependencies']
+			# We dont check dev-dependencies and build-dependencies for the stable2412 release since
+			# that would introduce a cycle.
+			to_checks = ['dependencies']
 
 			for to_check in to_checks:
 				if to_check in deps:

--- a/.github/scripts/check-workspace.py
+++ b/.github/scripts/check-workspace.py
@@ -145,7 +145,7 @@ def check_links(all_crates):
 
 		def check_crate(deps):
 			# We dont check dev-dependencies and build-dependencies for the stable2412 release since
-			# that would introduce a cycle.
+			# that they are using `path = ` instead of `workspace = true`.
 			to_checks = ['dependencies']
 
 			for to_check in to_checks:

--- a/.github/workflows/checks-quick.yml
+++ b/.github/workflows/checks-quick.yml
@@ -93,6 +93,8 @@ jobs:
           "substrate/frame/contracts/fixtures/contracts/common"
           "substrate/frame/revive/fixtures/build"
           "substrate/frame/revive/fixtures/contracts/common"
+          "substrate/frame/sassafras"
+          "substrate/primitives/consensus/sassafras"
       - name: deny git deps
         run: python3 .github/scripts/deny-git-deps.py .
   check-markdown:

--- a/substrate/client/keystore/src/local.rs
+++ b/substrate/client/keystore/src/local.rs
@@ -32,10 +32,6 @@ use std::{
 	sync::Arc,
 };
 
-sp_keystore::bandersnatch_experimental_enabled! {
-use sp_core::bandersnatch;
-}
-
 sp_keystore::bls_experimental_enabled! {
 use sp_core::{bls381, ecdsa_bls381, KeccakHasher};
 }
@@ -271,65 +267,6 @@ impl Keystore for LocalKeystore {
 			.key_pair_by_type::<ecdsa::Pair>(public, key_type)?
 			.map(|pair| pair.sign_prehashed(msg));
 		Ok(sig)
-	}
-
-	sp_keystore::bandersnatch_experimental_enabled! {
-		fn bandersnatch_public_keys(&self, key_type: KeyTypeId) -> Vec<bandersnatch::Public> {
-			self.public_keys::<bandersnatch::Pair>(key_type)
-		}
-
-		/// Generate a new pair compatible with the 'bandersnatch' signature scheme.
-		///
-		/// If `[seed]` is `Some` then the key will be ephemeral and stored in memory.
-		fn bandersnatch_generate_new(
-			&self,
-			key_type: KeyTypeId,
-			seed: Option<&str>,
-		) -> std::result::Result<bandersnatch::Public, TraitError> {
-			self.generate_new::<bandersnatch::Pair>(key_type, seed)
-		}
-
-		fn bandersnatch_sign(
-			&self,
-			key_type: KeyTypeId,
-			public: &bandersnatch::Public,
-			msg: &[u8],
-		) -> std::result::Result<Option<bandersnatch::Signature>, TraitError> {
-			self.sign::<bandersnatch::Pair>(key_type, public, msg)
-		}
-
-		fn bandersnatch_vrf_sign(
-			&self,
-			key_type: KeyTypeId,
-			public: &bandersnatch::Public,
-			data: &bandersnatch::vrf::VrfSignData,
-		) -> std::result::Result<Option<bandersnatch::vrf::VrfSignature>, TraitError> {
-			self.vrf_sign::<bandersnatch::Pair>(key_type, public, data)
-		}
-
-		fn bandersnatch_vrf_pre_output(
-			&self,
-			key_type: KeyTypeId,
-			public: &bandersnatch::Public,
-			input: &bandersnatch::vrf::VrfInput,
-		) -> std::result::Result<Option<bandersnatch::vrf::VrfPreOutput>, TraitError> {
-			self.vrf_pre_output::<bandersnatch::Pair>(key_type, public, input)
-		}
-
-		fn bandersnatch_ring_vrf_sign(
-			&self,
-			key_type: KeyTypeId,
-			public: &bandersnatch::Public,
-			data: &bandersnatch::vrf::VrfSignData,
-			prover: &bandersnatch::ring_vrf::RingProver,
-		) -> std::result::Result<Option<bandersnatch::ring_vrf::RingVrfSignature>, TraitError> {
-			let sig = self
-				.0
-				.read()
-				.key_pair_by_type::<bandersnatch::Pair>(public, key_type)?
-				.map(|pair| pair.ring_vrf_sign(data, prover));
-			Ok(sig)
-		}
 	}
 
 	sp_keystore::bls_experimental_enabled! {

--- a/substrate/client/statement-store/README.md
+++ b/substrate/client/statement-store/README.md
@@ -3,7 +3,6 @@ Substrate statement store implementation.
 License: GPL-3.0-or-later WITH Classpath-exception-2.0
 
 
-
 ## Release
 
 Polkadot SDK Stable 2412

--- a/substrate/primitives/application-crypto/check-features-variants.sh
+++ b/substrate/primitives/application-crypto/check-features-variants.sh
@@ -7,6 +7,5 @@ cargo check --release --target=$T --no-default-features
 cargo check --release --target=$T --no-default-features  --features="full_crypto"
 cargo check --release --target=$T --no-default-features  --features="serde"
 cargo check --release --target=$T --no-default-features  --features="serde,full_crypto"
-cargo check --release --target=$T --no-default-features  --features="bandersnatch-experimental"
 cargo check --release --target=$T --no-default-features  --features="bls-experimental"
 cargo check --release --target=$T --no-default-features  --features="bls-experimental,full_crypto"

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -44,8 +44,6 @@ pub use scale_info;
 #[cfg(feature = "serde")]
 pub use serde;
 
-#[cfg(feature = "bandersnatch-experimental")]
-pub mod bandersnatch;
 #[cfg(feature = "bls-experimental")]
 pub mod bls381;
 pub mod ecdsa;

--- a/substrate/primitives/consensus/sassafras/Cargo.toml
+++ b/substrate/primitives/consensus/sassafras/Cargo.toml
@@ -22,9 +22,9 @@ codec = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["derive"], optional = true, workspace = true }
 sp-api.workspace = true
-sp-application-crypto = { features = ["bandersnatch-experimental"], workspace = true }
+sp-application-crypto = { workspace = true }
 sp-consensus-slots.workspace = true
-sp-core = { features = ["bandersnatch-experimental"], workspace = true }
+sp-core = { workspace = true }
 sp-runtime.workspace = true
 
 [features]

--- a/substrate/primitives/core/check-features-variants.sh
+++ b/substrate/primitives/core/check-features-variants.sh
@@ -5,8 +5,6 @@ T=wasm32-unknown-unknown
 
 cargo check --target=$T --release --no-default-features  --features="bls-experimental"
 cargo check --target=$T --release --no-default-features  --features="full_crypto,bls-experimental"
-cargo check --target=$T --release --no-default-features  --features="bandersnatch-experimental"
-cargo check --target=$T --release --no-default-features  --features="full_crypto,serde,bandersnatch-experimental"
 cargo check --target=$T --release --no-default-features  --features="full_crypto,serde"
 cargo check --target=$T --release --no-default-features  --features="full_crypto"
 cargo check --target=$T --release --no-default-features  --features="serde"

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -70,8 +70,6 @@ pub mod testing;
 pub mod traits;
 pub mod uint;
 
-#[cfg(feature = "bandersnatch-experimental")]
-pub mod bandersnatch;
 #[cfg(feature = "bls-experimental")]
 pub mod bls;
 pub mod crypto_bytes;

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -94,8 +94,6 @@ use sp_core::{
 #[cfg(feature = "std")]
 use sp_keystore::KeystoreExt;
 
-#[cfg(feature = "bandersnatch-experimental")]
-use sp_core::bandersnatch;
 use sp_core::{
 	crypto::KeyTypeId,
 	ecdsa, ed25519,
@@ -1236,25 +1234,6 @@ pub trait Crypto {
 			.expect("No `keystore` associated for the current context!")
 			.ecdsa_bls381_generate_new(id, seed)
 			.expect("`ecdsa_bls381_generate` failed")
-	}
-
-	/// Generate a `bandersnatch` key pair for the given key type using an optional
-	/// `seed` and store it in the keystore.
-	///
-	/// The `seed` needs to be a valid utf8.
-	///
-	/// Returns the public key.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_generate(
-		&mut self,
-		id: KeyTypeId,
-		seed: Option<Vec<u8>>,
-	) -> bandersnatch::Public {
-		let seed = seed.as_ref().map(|s| std::str::from_utf8(s).expect("Seed is valid utf8!"));
-		self.extension::<KeystoreExt>()
-			.expect("No `keystore` associated for the current context!")
-			.bandersnatch_generate_new(id, seed)
-			.expect("`bandernatch_generate` failed")
 	}
 }
 

--- a/substrate/primitives/keyring/check-features-variants.sh
+++ b/substrate/primitives/keyring/check-features-variants.sh
@@ -4,5 +4,4 @@ export RUSTFLAGS="-Cdebug-assertions=y -Dwarnings"
 T=wasm32-unknown-unknown
 
 cargo check --release
-cargo check --release --features="bandersnatch-experimental" 
 cargo check --release --target=$T --no-default-features

--- a/substrate/primitives/keyring/src/lib.rs
+++ b/substrate/primitives/keyring/src/lib.rs
@@ -28,16 +28,10 @@ pub mod sr25519;
 /// Test account crypto for ed25519.
 pub mod ed25519;
 
-/// Test account crypto for bandersnatch.
-#[cfg(feature = "bandersnatch-experimental")]
-pub mod bandersnatch;
-
 /// Convenience export: Sr25519's Keyring is exposed as `AccountKeyring`, since it tends to be
 /// used for accounts (although it may also be used by authorities).
 pub use sr25519::Keyring as AccountKeyring;
 
-#[cfg(feature = "bandersnatch-experimental")]
-pub use bandersnatch::Keyring as BandersnatchKeyring;
 pub use ed25519::Keyring as Ed25519Keyring;
 pub use sr25519::Keyring as Sr25519Keyring;
 

--- a/substrate/primitives/keystore/src/lib.rs
+++ b/substrate/primitives/keystore/src/lib.rs
@@ -24,8 +24,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 pub mod testing;
 
-#[cfg(feature = "bandersnatch-experimental")]
-use sp_core::bandersnatch;
 #[cfg(feature = "bls-experimental")]
 use sp_core::{bls381, ecdsa_bls381};
 use sp_core::{
@@ -191,91 +189,6 @@ pub trait Keystore: Send + Sync {
 		msg: &[u8; 32],
 	) -> Result<Option<ecdsa::Signature>, Error>;
 
-	/// Returns all the bandersnatch public keys for the given key type.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_public_keys(&self, key_type: KeyTypeId) -> Vec<bandersnatch::Public>;
-
-	/// Generate a new bandersnatch key pair for the given key type and an optional seed.
-	///
-	/// Returns an `bandersnatch::Public` key of the generated key pair or an `Err` if
-	/// something failed during key generation.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_generate_new(
-		&self,
-		key_type: KeyTypeId,
-		seed: Option<&str>,
-	) -> Result<bandersnatch::Public, Error>;
-
-	/// Generate an bandersnatch signature for a given message.
-	///
-	/// Receives [`KeyTypeId`] and an [`bandersnatch::Public`] key to be able to map
-	/// them to a private key that exists in the keystore.
-	///
-	/// Returns an [`bandersnatch::Signature`] or `None` in case the given `key_type`
-	/// and `public` combination doesn't exist in the keystore.
-	/// An `Err` will be returned if generating the signature itself failed.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_sign(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		msg: &[u8],
-	) -> Result<Option<bandersnatch::Signature>, Error>;
-
-	/// Generate a bandersnatch VRF signature for the given data.
-	///
-	/// Receives [`KeyTypeId`] and an [`bandersnatch::Public`] key to be able to map
-	/// them to a private key that exists in the keystore.
-	///
-	/// Returns `None` if the given `key_type` and `public` combination doesn't
-	/// exist in the keystore or an `Err` when something failed.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_vrf_sign(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		input: &bandersnatch::vrf::VrfSignData,
-	) -> Result<Option<bandersnatch::vrf::VrfSignature>, Error>;
-
-	/// Generate a bandersnatch VRF pre-output for a given input data.
-	///
-	/// Receives [`KeyTypeId`] and an [`bandersnatch::Public`] key to be able to map
-	/// them to a private key that exists in the keystore.
-	///
-	/// Returns `None` if the given `key_type` and `public` combination doesn't
-	/// exist in the keystore or an `Err` when something failed.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_vrf_pre_output(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		input: &bandersnatch::vrf::VrfInput,
-	) -> Result<Option<bandersnatch::vrf::VrfPreOutput>, Error>;
-
-	/// Generate a bandersnatch ring-VRF signature for the given data.
-	///
-	/// Receives [`KeyTypeId`] and an [`bandersnatch::Public`] key to be able to map
-	/// them to a private key that exists in the keystore.
-	///
-	/// Also takes a [`bandersnatch::ring_vrf::RingProver`] instance obtained from
-	/// a valid [`bandersnatch::ring_vrf::RingContext`].
-	///
-	/// The ring signature is verifiable if the public key corresponding to the
-	/// signing [`bandersnatch::Pair`] is part of the ring from which the
-	/// [`bandersnatch::ring_vrf::RingProver`] has been constructed.
-	/// If not, the produced signature is just useless.
-	///
-	/// Returns `None` if the given `key_type` and `public` combination doesn't
-	/// exist in the keystore or an `Err` when something failed.
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_ring_vrf_sign(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		input: &bandersnatch::vrf::VrfSignData,
-		prover: &bandersnatch::ring_vrf::RingProver,
-	) -> Result<Option<bandersnatch::ring_vrf::RingVrfSignature>, Error>;
-
 	/// Returns all bls12-381 public keys for the given key type.
 	#[cfg(feature = "bls-experimental")]
 	fn bls381_public_keys(&self, id: KeyTypeId) -> Vec<bls381::Public>;
@@ -412,24 +325,6 @@ pub trait Keystore: Send + Sync {
 
 				self.ecdsa_sign(id, &public, msg)?.map(|s| s.encode())
 			},
-			#[cfg(feature = "bandersnatch-experimental")]
-			bandersnatch::CRYPTO_ID => {
-				let public = bandersnatch::Public::from_slice(public)
-					.map_err(|_| Error::ValidationError("Invalid public key format".into()))?;
-				self.bandersnatch_sign(id, &public, msg)?.map(|s| s.encode())
-			},
-			#[cfg(feature = "bls-experimental")]
-			bls381::CRYPTO_ID => {
-				let public = bls381::Public::from_slice(public)
-					.map_err(|_| Error::ValidationError("Invalid public key format".into()))?;
-				self.bls381_sign(id, &public, msg)?.map(|s| s.encode())
-			},
-			#[cfg(feature = "bls-experimental")]
-			ecdsa_bls381::CRYPTO_ID => {
-				let public = ecdsa_bls381::Public::from_slice(public)
-					.map_err(|_| Error::ValidationError("Invalid public key format".into()))?;
-				self.ecdsa_bls381_sign(id, &public, msg)?.map(|s| s.encode())
-			},
 			_ => return Err(Error::KeyNotSupported(id)),
 		};
 		Ok(signature)
@@ -527,61 +422,6 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 		(**self).ecdsa_sign_prehashed(key_type, public, msg)
 	}
 
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_public_keys(&self, key_type: KeyTypeId) -> Vec<bandersnatch::Public> {
-		(**self).bandersnatch_public_keys(key_type)
-	}
-
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_generate_new(
-		&self,
-		key_type: KeyTypeId,
-		seed: Option<&str>,
-	) -> Result<bandersnatch::Public, Error> {
-		(**self).bandersnatch_generate_new(key_type, seed)
-	}
-
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_sign(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		msg: &[u8],
-	) -> Result<Option<bandersnatch::Signature>, Error> {
-		(**self).bandersnatch_sign(key_type, public, msg)
-	}
-
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_vrf_sign(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		input: &bandersnatch::vrf::VrfSignData,
-	) -> Result<Option<bandersnatch::vrf::VrfSignature>, Error> {
-		(**self).bandersnatch_vrf_sign(key_type, public, input)
-	}
-
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_vrf_pre_output(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		input: &bandersnatch::vrf::VrfInput,
-	) -> Result<Option<bandersnatch::vrf::VrfPreOutput>, Error> {
-		(**self).bandersnatch_vrf_pre_output(key_type, public, input)
-	}
-
-	#[cfg(feature = "bandersnatch-experimental")]
-	fn bandersnatch_ring_vrf_sign(
-		&self,
-		key_type: KeyTypeId,
-		public: &bandersnatch::Public,
-		input: &bandersnatch::vrf::VrfSignData,
-		prover: &bandersnatch::ring_vrf::RingProver,
-	) -> Result<Option<bandersnatch::ring_vrf::RingVrfSignature>, Error> {
-		(**self).bandersnatch_ring_vrf_sign(key_type, public, input, prover)
-	}
-
 	#[cfg(feature = "bls-experimental")]
 	fn bls381_public_keys(&self, id: KeyTypeId) -> Vec<bls381::Public> {
 		(**self).bls381_public_keys(id)
@@ -674,12 +514,6 @@ impl KeystoreExt {
 		Self(Arc::new(keystore))
 	}
 }
-
-sp_core::generate_feature_enabled_macro!(
-	bandersnatch_experimental_enabled,
-	feature = "bandersnatch-experimental",
-	$
-);
 
 sp_core::generate_feature_enabled_macro!(
 	bls_experimental_enabled,


### PR DESCRIPTION
Fix the CI issue on the stable2412 branch by deleting the `bandersnatch-experimental` dependant code. Also fix some other CI checks.

The Bandersnatch VRFs crate is not on crates-io, hence why it is not included in the release https://github.com/paritytech/polkadot-sdk/blob/a843d15eb44275685d5e0fdd3372f4ee3da4d016/substrate/primitives/core/Cargo.toml#L73

The only upstream crate that depends on this is `sp-consensus-sassafras`, but we dont release that. So hopefully CI goes green.