### PR TITLE
Migrate pallet-nomination-pools-benchmarking and pallet-nomination-pools-fuzzer to use umbrella crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14360,10 +14360,7 @@ dependencies = [
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
 dependencies = [
- "frame-benchmarking 28.0.0",
  "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
  "pallet-bags-list 27.0.0",
  "pallet-balances 28.0.0",
  "pallet-delegated-staking 1.0.0",
@@ -14372,12 +14369,9 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp 27.0.0",
  "parity-scale-codec",
+ "polkadot-sdk-frame 0.1.0",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
  "sp-runtime-interface 24.0.0",
- "sp-staking 26.0.0",
 ]
 
 [[package]]
@@ -14405,14 +14399,11 @@ dependencies = [
 name = "pallet-nomination-pools-fuzzer"
 version = "2.0.0"
 dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
  "honggfuzz",
  "log",
  "pallet-nomination-pools 25.0.0",
+ "polkadot-sdk-frame 0.1.0",
  "rand",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
  "sp-tracing 16.0.0",
 ]
 

--- a/substrate/frame/nomination-pools/benchmarking/Cargo.toml
+++ b/substrate/frame/nomination-pools/benchmarking/Cargo.toml
@@ -21,36 +21,28 @@ codec = { features = ["derive"], workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 
 # FRAME
-frame-benchmarking = { workspace = true }
 frame-election-provider-support = { workspace = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
+frame = { workspace = true, features = ["experimental", "runtime"]}
 pallet-bags-list = { workspace = true }
 pallet-delegated-staking = { workspace = true }
 pallet-nomination-pools = { workspace = true }
 pallet-staking = { workspace = true }
 
 # Substrate Primitives
-sp-runtime = { workspace = true }
 sp-runtime-interface = { workspace = true }
-sp-staking = { workspace = true }
 
 [dev-dependencies]
 pallet-balances = { workspace = true }
 pallet-staking-reward-curve = { workspace = true, default-features = true }
 pallet-timestamp = { workspace = true, default-features = true }
-sp-core = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]
 
 std = [
 	"codec/std",
-	"frame-benchmarking/std",
+	"frame/std",
 	"frame-election-provider-support/std",
-	"frame-support/std",
-	"frame-system/std",
 	"pallet-bags-list/std",
 	"pallet-balances/std",
 	"pallet-delegated-staking/std",
@@ -58,24 +50,15 @@ std = [
 	"pallet-staking/std",
 	"pallet-timestamp/std",
 	"scale-info/std",
-	"sp-core/std",
-	"sp-io/std",
 	"sp-runtime-interface/std",
-	"sp-runtime/std",
-	"sp-staking/std",
 ]
 
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
 	"frame-election-provider-support/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
 	"pallet-bags-list/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-delegated-staking/runtime-benchmarks",
 	"pallet-nomination-pools/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	"sp-staking/runtime-benchmarks",
 ]

--- a/substrate/frame/nomination-pools/benchmarking/src/inner.rs
+++ b/substrate/frame/nomination-pools/benchmarking/src/inner.rs
@@ -18,16 +18,9 @@
 //! Benchmarks for the nomination pools coupled with the staking and bags list pallets.
 
 use alloc::{vec, vec::Vec};
-use frame_benchmarking::v2::*;
+use frame::benchmarking::prelude::*;
 use frame_election_provider_support::SortedListProvider;
-use frame_support::{
-	assert_ok, ensure,
-	traits::{
-		fungible::{Inspect, Mutate, Unbalanced},
-		tokens::Preservation,
-		Get, Imbalance,
-	},
-};
+
 use frame_system::RawOrigin as RuntimeOrigin;
 use pallet_nomination_pools::{
 	adapter::{Member, Pool, StakeStrategy, StakeStrategyType},
@@ -37,11 +30,8 @@ use pallet_nomination_pools::{
 	Pallet as Pools, PoolId, PoolMembers, PoolRoles, PoolState, RewardPools, SubPoolsStorage,
 };
 use pallet_staking::MaxNominationsOf;
-use sp_runtime::{
-	traits::{Bounded, StaticLookup, Zero},
-	Perbill,
-};
-use sp_staking::{EraIndex, StakingUnchecked};
+
+use frame::deps::sp_staking::{EraIndex, StakingUnchecked};
 // `frame_benchmarking::benchmarks!` macro needs this
 use pallet_nomination_pools::Call;
 

--- a/substrate/frame/nomination-pools/fuzzer/Cargo.toml
+++ b/substrate/frame/nomination-pools/fuzzer/Cargo.toml
@@ -18,14 +18,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 honggfuzz = { workspace = true }
-
+frame = { workspace = true, features = ["experimental", "runtime"]}
 pallet-nomination-pools = { features = ["fuzzing"], workspace = true, default-features = true }
 
-frame-support = { workspace = true, default-features = true }
-frame-system = { workspace = true, default-features = true }
 
-sp-io = { workspace = true, default-features = true }
-sp-runtime = { workspace = true, default-features = true }
 sp-tracing = { workspace = true, default-features = true }
 
 log = { workspace = true, default-features = true }

--- a/substrate/frame/nomination-pools/fuzzer/src/call.rs
+++ b/substrate/frame/nomination-pools/fuzzer/src/call.rs
@@ -23,10 +23,7 @@
 //! Once a panic is found, it can be debugged with
 //! `cargo hfuzz run-debug per_thing_rational hfuzz_workspace/call/*.fuzz`.
 
-use frame_support::{
-	assert_ok,
-	traits::{Currency, GetCallName, UnfilteredDispatchable},
-};
+
 use honggfuzz::fuzz;
 use pallet_nomination_pools::{
 	log,
@@ -37,7 +34,7 @@ use pallet_nomination_pools::{
 	MaxPools, MinCreateBond, MinJoinBond, PoolId,
 };
 use rand::{seq::SliceRandom, Rng};
-use sp_runtime::{assert_eq_error_rate, Perbill, Perquintill};
+use frame::testing_prelude::*;
 
 const ERA: BlockNumber = 1000;
 const MAX_ED_MULTIPLE: Balance = 10_000;

--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -204,10 +204,13 @@ pub mod prelude {
 	#[doc(no_inline)]
 	pub use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
 	pub use frame_support::{
-		defensive, defensive_assert,
+		defensive, defensive_assert, ensure,
 		traits::{
-			Contains, EitherOf, EstimateNextSessionRotation, IsSubType, MapSuccess, NoOpPoll,
-			OnRuntimeUpgrade, OneSessionHandler, RankedMembers, RankedMembersSwapHandler,
+			fungible::{Inspect, Mutate, Unbalanced},
+			tokens::Preservation,
+			Contains, Currency, EitherOf, EstimateNextSessionRotation, Get, GetCallName, Imbalance,
+			IsSubType, MapSuccess, NoOpPoll, OnRuntimeUpgrade, OneSessionHandler, RankedMembers,
+			RankedMembersSwapHandler, UnfilteredDispatchable,
 		},
 	};
 
@@ -231,9 +234,13 @@ pub mod prelude {
 
 	/// Runtime traits
 	#[doc(no_inline)]
-	pub use sp_runtime::traits::{
-		BlockNumberProvider, Bounded, Convert, DispatchInfoOf, Dispatchable, ReduceBy,
-		ReplaceWithDefault, SaturatedConversion, Saturating, StaticLookup, TrailingZeroInput,
+	pub use sp_runtime::{
+		traits::{
+			BlockNumberProvider, Bounded, Convert, DispatchInfoOf, Dispatchable, IdentityLookup,
+			ReduceBy, ReplaceWithDefault, SaturatedConversion, Saturating, StaticLookup,
+			TrailingZeroInput, Zero,
+		},
+		BuildStorage, FixedU128, Perbill, Perquintill,
 	};
 	/// Other error/result types for runtime
 	#[doc(no_inline)]


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot-sdk/issues/6504

Polkadot Address: 121HJWZtD13GJQPD82oEj3gSeHqsRYm1mFgRALu4L96kfPD1