### PR TITLE
New getting started script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,22 @@ forks](https://img.shields.io/github/forks/paritytech/polkadot-sdk)
 
 </div>
 
-## ⚡ Quickstart
-If you want to get an example node running quickly you can execute the following getting started script:
+## 🚀 Getting Started
 
-```
+We provide two ways to get started with the Polkadot SDK:
+
+### Quick Setup (Environment Only)
+To set up your development environment with the basic dependencies:
+
+```bash
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/scripts/getting-started.sh | bash
+```
+
+### Interactive Setup (Recommended)
+To set up your environment AND choose from our pre-configured templates (minimal node, parachain, or solochain):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/scripts/getting-started-full.sh | bash
 ```
 
 ## 📚 Documentation

--- a/scripts/getting-started-full.sh
+++ b/scripts/getting-started-full.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env sh
+
+set -e
+
+prompt() {
+    while true; do
+        printf "$1 [y/N]\n"
+        read yn
+        case $yn in
+            [Yy]* ) return 0;;  # Yes, return 0 (true)
+            [Nn]* ) return 1;;  # No, return 1 (false)
+            "" ) return 1;;     # Default to no if user just presses Enter
+            * ) printf "Please answer yes or no.\n";;
+        esac
+    done
+}
+
+prompt_default_yes() {
+    while true; do
+        printf "$1 [Y/n]\n"
+        read yn
+        case $yn in
+            [Yy]* ) return 0;;  # Yes, return 0 (true)
+            [Nn]* ) return 1;;  # No, return 1 (false)
+            "" ) return 0;;     # Default to yes if user just presses Enter
+            * ) printf "Please answer yes or no.\n";;
+        esac
+    done
+}
+
+clone_and_enter_template() {
+    template="$1" # minimal, solochain, or parachain
+    if [ -d "${template}-template" ]; then
+        printf "\n✅︎ ${template}-template directory already exists. -> Entering.\n"
+    else
+        printf "\n↓ Let's grab the ${template} template from github.\n"
+        git clone --quiet https://github.com/paritytech/polkadot-sdk-${template}-template.git ${template}-template
+    fi
+    cd ${template}-template
+}
+
+cat <<EOF
+
+ Welcome to the
+
+     , __       _   _                          ____  ____  _  __
+    /|/  \     | | | |           |            / ___||  _ \| |/ /
+     |___/ __  | | | |   __,   __|   __ _|_   \___ \| | | | ' / 
+     |    /  \_|/  |/_) /  |  /  |  /  \_|     ___) | |_| | . \ 
+     |    \__/ |__/| \_/\_/|_/\_/|_/\__/ |_/  |____/|____/|_|\_\ 
+                                                                    quickstart!
+
+⚡ We will help setting up the environment for you to experiment with.
+EOF
+
+# Determine OS
+os_name=$(uname -s)
+if [ "$os_name" = "Darwin" ]; then
+    printf "🍎 Detected macOS. Installing dependencies via Homebrew.\n"
+
+    # Check if brew is installed
+    if command -v brew >/dev/null 2>&1; then
+        printf "\n✅︎🍺 Homebrew already installed.\n"
+    else
+        if prompt_default_yes "\n🍺 Homebrew is not installed. Install it?\n"; then
+            printf "🍺 Installing Homebrew.\n"
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+        else
+            printf "❌ Cannot continue without homebrew. Aborting.\n"
+            exit 1
+        fi
+    fi
+
+    brew update
+    if command -v git >/dev/null 2>&1; then
+        printf "\n✅︎🍺 git already installed.\n"
+    else
+        if prompt_default_yes "\n🍺 git seems to be missing but we will need it; install git?\n"; then
+            brew install git
+        else
+            printf "❌ Cannot continue without git. Aborting.\n"
+            exit 1
+        fi
+    fi
+
+    if prompt "\n🍺 Install cmake, openssl and protobuf?"; then
+        brew install cmake openssl protobuf
+    else
+        printf "🍺 Assuming cmake, openssl and protobuf are present.\n"
+    fi
+elif [ "$os_name" = "Linux" ]; then
+    # find the distro name in the release files
+    distro=$( cat /etc/*-release | tr '[:upper:]' '[:lower:]' | grep -Poi '(debian|ubuntu|arch|fedora|opensuse)' | uniq | head -n 1 )
+
+    if [ "$distro" = "ubuntu" ]; then
+        printf "\n🐧 Detected Ubuntu. Using apt to install dependencies.\n"
+        sudo apt -qq update
+        sudo apt -qq install --assume-yes git clang curl libssl-dev protobuf-compiler make
+    elif [ "$distro" = "debian" ]; then
+        printf "\n🐧 Detected Debian. Using apt to install dependencies.\n"
+        sudo apt -qq update
+        sudo apt -qq install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
+    elif [ "$distro" = "arch" ]; then
+        printf "\n🐧 Detected Arch Linux. Using pacman to install dependencies.\n"
+        pacman -Syu --needed --noconfirm curl git clang make protobuf
+    elif [ "$distro" = "fedora" ]; then
+        printf "\n🐧 Detected Fedora. Using dnf to install dependencies.\n"
+        sudo dnf update --assumeyes
+        sudo dnf install --assumeyes clang curl git openssl-devel make protobuf-compiler perl
+    elif [ "$distro" = "opensuse" ]; then
+        printf "\n🐧 Detected openSUSE. Using zypper to install dependencies.\n"
+        sudo zypper install --no-confirm clang gcc gcc-c++ curl git openssl-devel llvm-devel libudev-devel make awk protobuf-devel
+    else
+        if prompt "\n🐧 Unknown Linux distribution. Unable to install dependencies. Continue anyway?\n"; then
+            printf "\n🐧 Proceeding with unknown linux distribution...\n"
+        else
+            exit 1
+        fi
+    fi
+else
+    printf "❌ Unknown operating system. Aborting.\n"
+    exit 1
+fi
+
+# Check if rust is installed
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+if command -v rustc >/dev/null 2>&1; then
+    printf "\n✅︎🦀 Rust already installed.\n"
+else
+    if prompt_default_yes "\n🦀 Rust is not installed. Install it?"; then
+        printf "🦀 Installing via rustup.\n"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+        . "$HOME/.cargo/env"
+    else
+        printf "Aborting.\n"
+        exit 1
+    fi
+fi
+
+# Ensure that we have wasm support
+if prompt_default_yes "\n🦀 Setup the Rust environment (e.g. WASM support)?"; then
+    printf "🦀 Setting up Rust environment.\n"
+    rustup default stable
+    rustup update
+    rustup target add wasm32-unknown-unknown
+    rustup component add rust-src
+fi
+
+# Always prompt for template selection in the full version
+while true; do
+    printf "\nWhich template would you like to start with?\n"
+    printf "1) minimal template\n"
+    printf "2) parachain template\n"
+    printf "3) solochain template\n"
+    printf "q) exit without template\n"
+    read -p "#? " template
+    case $template in
+        [1]* ) clone_and_enter_template minimal; break;;
+        [2]* ) clone_and_enter_template parachain; break;;
+        [3]* ) clone_and_enter_template solochain; break;;
+        [qQ]* ) printf "Exiting without template.\n"; exit 0;;
+        * ) printf "Selection not recognized.\n";;
+    esac
+done
+
+if ! prompt_default_yes "\n⚙️ Let's compile the node? It might take a while."; then
+    printf "⚡ Script finished, you can continue in the ${template}-template directory.\n"
+    exit 0
+fi
+
+cargo build --release
+
+if prompt_default_yes "\n🚀 Everything ready to go, let's run the node?\n"; then
+    cargo run --release -- --dev
+fi


### PR DESCRIPTION
I'm proposing improvements to the `scripts/getting-started.sh` script. When you run it on a new machine, this is the log:

```
spongebob@karim-test:~$ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/scripts/getting-started.sh | bash

 Welcome to the

     , __       _   _                          ____  ____  _  __
    /|/  \     | | | |           |            / ___||  _ \| |/ /
     |___/ __  | | | |   __,   __|   __ _|_   \___ \| | | | ' / 
     |    /  \_|/  |/_) /  |  /  |  /  \_|     ___) | |_| | . \ 
     |    \__/ |__/| \_/\_/|_/\_/|_/\__/ |_/  |____/|____/|_|\_\ 
                                                                    quickstart!

⚡ We will help setting up the environment for you to experiment with.

🐧 Detected Debian. Using apt to install dependencies.
5 packages can be upgraded. Run 'apt list --upgradable' to see them.
git is already the newest version (1:2.39.5-0+deb12u1).
clang is already the newest version (1:14.0-55.7~deb12u1).
curl is already the newest version (7.88.1-10+deb12u8).
libssl-dev is already the newest version (3.0.15-1~deb12u1).
llvm is already the newest version (1:14.0-55.7~deb12u1).
libudev-dev is already the newest version (252.33-1~deb12u1).
make is already the newest version (4.3-4.1).
protobuf-compiler is already the newest version (3.21.12-3).
0 upgraded, 0 newly installed, 0 to remove and 5 not upgraded.

🦀 Rust is not installed. Install it? [Y/n]
🦀 Installing via rustup.
info: downloading installer

Welcome to Rust!

This will download and install the official compiler for the Rust
programming language, and its package manager, Cargo.

Rustup metadata and toolchains will be installed into the Rustup
home directory, located at:

  /home/spongebob/.rustup

This can be modified with the RUSTUP_HOME environment variable.

The Cargo home directory is located at:

  /home/spongebob/.cargo

This can be modified with the CARGO_HOME environment variable.

The cargo, rustc, rustup and other commands will be added to
Cargo's bin directory, located at:

  /home/spongebob/.cargo/bin

This path will then be added to your PATH environment variable by
modifying the profile files located at:

  /home/spongebob/.profile
  /home/spongebob/.bashrc

You can uninstall at any time with rustup self uninstall and
these changes will be reverted.

Current installation options:


   default host triple: x86_64-unknown-linux-gnu
     default toolchain: stable (default)
               profile: default
  modify PATH variable: yes

1) Proceed with standard installation (default - just press enter)
2) Customize installation
3) Cancel installation
>1

info: profile set to 'default'
info: default host triple is x86_64-unknown-linux-gnu
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2025-01-09, rust version 1.84.0 (9fc6b4312 2025-01-07)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
 16.5 MiB /  16.5 MiB (100 %)   7.2 MiB/s in  1s ETA:  0s
info: installing component 'rust-std'
 29.0 MiB /  29.0 MiB (100 %)  16.4 MiB/s in  1s ETA:  0s
info: installing component 'rustc'
 70.6 MiB /  70.6 MiB (100 %)  17.2 MiB/s in  4s ETA:  0s
info: installing component 'rustfmt'
info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu installed - rustc 1.84.0 (9fc6b4312 2025-01-07)


Rust is installed now. Great!

To get started you may need to restart your current shell.
This would reload your PATH environment variable to include
Cargo's bin directory ($HOME/.cargo/bin).

To configure your current shell, you need to source
the corresponding env file under $HOME/.cargo.

This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish

🦀 Setup the Rust environment (e.g. WASM support)? [Y/n]
🦀 Setting up Rust environment.
info: using existing install for 'stable-x86_64-unknown-linux-gnu'
info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.84.0 (9fc6b4312 2025-01-07)

info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: checking for self-update

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.84.0 (9fc6b4312 2025-01-07)

info: cleaning up downloads & tmp directories
info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
info: installing component 'rust-std' for 'wasm32-unknown-unknown'
 19.3 MiB /  19.3 MiB (100 %)  16.9 MiB/s in  1s ETA:  0s
info: downloading component 'rust-src'
info: installing component 'rust-src'

Would you like to start with one of the templates? [y/N]
⚡ All done, the environment is ready for hacking.
spongebob@karim-test:~$ 

```

The template step is automatically skipped, without the option to choose a template. To address this, I've created a new script `getting-started-full.sh` that provides a more interactive experience:

- The original `getting-started.sh` remains unchanged, maintaining backward compatibility and avoiding complexity by adding flags or environment variables, so no breaking changes here
- The new `getting-started-full.sh` always prompts for template selection and other configuration options
- Users can choose which script to use based on their needs:
  - Quick setup: `curl ... | bash` with the original script
  - Interactive setup: Download and run `getting-started-full.sh` or similarly `curl ... | bash`

This approach keeps things simple, but allows users to choose the level of customization they need. Ideally, the new script will be the default and the original one will be deprecated.

---

Here is the diff between both files : 

```diff
spongebob@bikinibottom:~/repos/polkadot-sdk$ diff scripts/getting-started.sh scripts/getting-started-full.sh 
149,153c149
< if ! prompt "\nWould you like to start with one of the templates?"; then
<     printf "⚡ All done, the environment is ready for hacking.\n"
<     exit 0
< fi
< 
---
> # Always prompt for template selection in the full version
159c155
<     printf "q) cancel\n"
---
>     printf "q) exit without template\n"
165c161
<         [qQ]* ) printf "Canceling, not using a template.\n"; exit 0;;
---
>         [qQ]* ) printf "Exiting without template.\n"; exit 0;;
```