### PR TITLE
Stabilize `ensure_execute_processes_have_correct_num_threads` test

### DIFF
--- a/polkadot/node/core/pvf/tests/it/process.rs
+++ b/polkadot/node/core/pvf/tests/it/process.rs
@@ -77,7 +77,9 @@ fn find_process_by_sid_and_name(
 
 	let mut found = None;
 	for process in all_processes {
-		let stat = process.stat().expect("/proc existed above. Potential race occurred");
+		let Ok(stat) = process.stat() else {
+			continue;
+		};
 
 		if stat.session != sid || !process.exe().unwrap().to_str().unwrap().contains(exe_name) {
 			continue


### PR DESCRIPTION
Saw this test flake a few times, last time [here](https://github.com/paritytech/polkadot-sdk/actions/runs/12834432188/job/35791830215).

We first fetch all processes in the test, then query `/proc/<pid>/stat` for every one of them. When the file was not found, we would error. Now we tolerate not finding this file. Ran 200 times locally without error, before would fail a few times, probably depending on process fluctuation (which I expect to be high on CI runners). 