### PR TITLE
Fix `frame-benchmarking-cli` not buildable without rocksdb

### DIFF
--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -18,7 +18,7 @@ gum = { workspace = true, default-features = true }
 
 metered = { features = ["futures_channel"], workspace = true }
 # Both `sc-service` and `sc-cli` are required by runtime metrics `logger_hook()`.
-sc-cli = { workspace = true, default-features = true }
+sc-cli = { workspace = true }
 sc-service = { workspace = true, default-features = true }
 
 bs58 = { features = ["alloc"], workspace = true, default-features = true }

--- a/prdoc/pr_7263.prdoc
+++ b/prdoc/pr_7263.prdoc
@@ -1,0 +1,28 @@
+title: Fix `frame-benchmarking-cli` not buildable without rocksdb
+doc:
+- audience: Runtime Dev
+  description: |-
+    ## Description
+
+    The `frame-benchmarking-cli`  crate has not been buildable without the `rocksdb` feature since version 1.17.0.
+
+    **Error:**
+    ```rust
+    self.database()?.unwrap_or(Database::RocksDb),
+                                 ^^^^^^^ variant or associated item not found in `Database`
+    ```
+
+    This issue is also related to the `rocksdb` feature bleeding (#3793), where the `rocksdb` feature was always activated even when compiling this crate with `--no-default-features`.
+
+    **Fix:**
+    - Resolved the error by choosing `paritydb` as the default database when compiled without the `rocksdb` feature.
+    - Fixed the issue where the `sc-cli` crate's `rocksdb` feature was always active, even compiling `frame-benchmarking-cli` with `--no-default-features`.
+
+    ## Review Notes
+
+    Fix the crate to be built without rocksdb, not intended to solve #3793.
+crates:
+- name: polkadot-node-metrics
+  bump: patch
+- name: frame-benchmarking-cli
+  bump: patch

--- a/substrate/utils/frame/benchmarking-cli/src/overhead/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/overhead/command.rs
@@ -482,7 +482,7 @@ impl OverheadCmd {
 		let database_source = self.database_config(
 			&base_path.path().to_path_buf(),
 			self.database_cache_size()?.unwrap_or(1024),
-			self.database()?.unwrap_or(Database::RocksDb),
+			self.database()?.unwrap_or(Database::Auto),
 		)?;
 
 		let backend = new_db_backend(DatabaseSettings {


### PR DESCRIPTION
## Description

The `frame-benchmarking-cli`  crate has not been buildable without the `rocksdb` feature since version 1.17.0.  

**Error:**  
```rust
self.database()?.unwrap_or(Database::RocksDb),
                             ^^^^^^^ variant or associated item not found in `Database`
```

This issue is also related to the `rocksdb` feature bleeding (#3793), where the `rocksdb` feature was always activated even when compiling this crate with `--no-default-features`.  

**Fix:**  
- Resolved the error by choosing `paritydb` as the default database when compiled without the `rocksdb` feature.  
- Fixed the issue where the `sc-cli` crate's `rocksdb` feature was always active, even compiling `frame-benchmarking-cli` with `--no-default-features`.  

## Review Notes

Fix the crate to be built without rocksdb, not intended to solve #3793.
