### PR TITLE
Add `offchain_localStorageClear` RPC method

### DIFF
--- a/substrate/client/offchain/src/api.rs
+++ b/substrate/client/offchain/src/api.rs
@@ -375,7 +375,7 @@ mod tests {
 	}
 
 	#[test]
-	fn should_set_and_get_local_storage() {
+	fn should_set_get_and_clear_local_storage() {
 		// given
 		let kind = StorageKind::PERSISTENT;
 		let mut api = offchain_db();
@@ -387,6 +387,12 @@ mod tests {
 
 		// then
 		assert_eq!(api.local_storage_get(kind, key), Some(b"value".to_vec()));
+
+		// when
+		api.local_storage_clear(kind, key);
+
+		// then
+		assert_eq!(api.local_storage_get(kind, key), None);
 	}
 
 	#[test]

--- a/substrate/client/rpc-api/src/offchain/mod.rs
+++ b/substrate/client/rpc-api/src/offchain/mod.rs
@@ -31,6 +31,10 @@ pub trait OffchainApi {
 	#[method(name = "offchain_localStorageSet", with_extensions)]
 	fn set_local_storage(&self, kind: StorageKind, key: Bytes, value: Bytes) -> Result<(), Error>;
 
+	/// Clear offchain local storage under given key and prefix.
+	#[method(name = "offchain_localStorageClear", with_extensions)]
+	fn clear_local_storage(&self, kind: StorageKind, key: Bytes) -> Result<(), Error>;
+
 	/// Get offchain local storage under given key and prefix.
 	#[method(name = "offchain_localStorageGet", with_extensions)]
 	fn get_local_storage(&self, kind: StorageKind, key: Bytes) -> Result<Option<Bytes>, Error>;

--- a/substrate/client/rpc/src/offchain/mod.rs
+++ b/substrate/client/rpc/src/offchain/mod.rs
@@ -66,6 +66,23 @@ impl<T: OffchainStorage + 'static> OffchainApiServer for Offchain<T> {
 		Ok(())
 	}
 
+	fn clear_local_storage(
+		&self,
+		ext: &Extensions,
+		kind: StorageKind,
+		key: Bytes,
+	) -> Result<(), Error> {
+		check_if_safe(ext)?;
+
+		let prefix = match kind {
+			StorageKind::PERSISTENT => sp_offchain::STORAGE_PREFIX,
+			StorageKind::LOCAL => return Err(Error::UnavailableStorageKind),
+		};
+		self.storage.write().remove(prefix, &key);
+
+		Ok(())
+	}
+
 	fn get_local_storage(
 		&self,
 		ext: &Extensions,

--- a/substrate/client/rpc/src/offchain/tests.rs
+++ b/substrate/client/rpc/src/offchain/tests.rs
@@ -38,6 +38,14 @@ fn local_storage_should_work() {
 		offchain.get_local_storage(&ext, StorageKind::PERSISTENT, key),
 		Ok(Some(ref v)) if *v == value
 	);
+	assert_matches!(
+		offchain.clear_local_storage(&ext, StorageKind::PERSISTENT, key),
+		Ok(())
+	);
+	assert_matches!(
+		offchain.get_local_storage(&ext, StorageKind::PERSISTENT, key),
+		Ok(None)
+	);
 }
 
 #[test]
@@ -51,6 +59,12 @@ fn offchain_calls_considered_unsafe() {
 
 	assert_matches!(
 		offchain.set_local_storage(&ext, StorageKind::PERSISTENT, key.clone(), value.clone()),
+		Err(Error::UnsafeRpcCalled(e)) => {
+			assert_eq!(e.to_string(), "RPC call is unsafe to be called externally")
+		}
+	);
+	assert_matches!(
+		offchain.clear_local_storage(&ext, StorageKind::PERSISTENT, key),
 		Err(Error::UnsafeRpcCalled(e)) => {
 			assert_eq!(e.to_string(), "RPC call is unsafe to be called externally")
 		}


### PR DESCRIPTION
# Description

Closes https://github.com/paritytech/polkadot-sdk/issues/7265.

## Integration

Requires changes in `https://github.com/polkadot-js/api/packages/{rpc-augment,types-support-types}` to be visible in Polkadot\Substrate Portal and in other libraries where we should explicitly state RPC methods.