### PR TITLE
Fix typo in prdoc.md

### DIFF
--- a/docs/contributor/prdoc.md
+++ b/docs/contributor/prdoc.md
@@ -29,7 +29,7 @@ Options:
   about the meta-protocol, not the protocol itself.
   - `node_operator`: People who run the node. Think of validators, exchanges, indexer services, CI
     actions. Anything that modifies how the binary behaves (its arguments, default arguments, error
-    messags, etc) must be marked with this.
+    messages, etc) must be marked with this.
 - `bump:`: The default bump level for all crates. The PrDoc will likely need to be edited to reflect
   the actual changes after generation. More details in the section below.
   - `none`: There is no observable change. So to say: if someone were handed the old and the new


### PR DESCRIPTION
# Fix Typo in prdoc.md

## Description

This pull request corrects a typo in the `prdoc.md` file under the `docs/contributor` directory.

### Summary of Changes

#### **File:** `docs/contributor/prdoc.md`
- **Typo Fix:** Corrected the word "messags" to "messages."

### Why This Fix Is Important

- Ensures the documentation is clear and free of typographical errors.
- Improves the professionalism of the project's contributor documentation.

---

## Checklist

- [x] Verified the correction.
- [x] Ensured no other changes were made.
- [x] Followed the [contributing guidelines](https://github.com/paritytech/polkadot-sdk/blob/master/CONTRIBUTING.md).

---

### Notes for Reviewers

This change only corrects a small typo. Once reviewed, feel free to merge.

Thank you!
