### PR TITLE
Typo fix candidate-pending-availability.md

### DIFF
--- a/polkadot/roadmap/implementers-guide/src/runtime-api/candidate-pending-availability.md
+++ b/polkadot/roadmap/implementers-guide/src/runtime-api/candidate-pending-availability.md
@@ -4,7 +4,7 @@ Get the receipt of a candidate pending availability. This returns `Some` for any
 `availability_cores` and `None` otherwise.
 
 ```rust
-// Deprectated.
+// Deprecated.
 fn candidate_pending_availability(at: Block, ParaId) -> Option<CommittedCandidateReceipt>;
 // Use this one
 fn candidates_pending_availability(at: Block, ParaId) -> Vec<CommittedCandidateReceipt>;


### PR DESCRIPTION
# Pull Request Form

## Title of the Pull Request
Typo fix in `candidate-pending-availability.md`

---

## Description
This pull request fixes a minor typo in the `candidate-pending-availability.md` file located in `roadmap/implementers-guide/src/runtime-api/`:
- Corrected "Deprectated" to "Deprecated."
