### PR TITLE
Fix `check-publish-compile` job

### DIFF
--- a/prdoc/pr_6689.prdoc
+++ b/prdoc/pr_6689.prdoc
@@ -3,7 +3,7 @@ doc:
 - audience: Runtime Dev
   description: |-
     Update the current approach to attach the `ref_time`, `pov` and `deposit` parameters to an Ethereum transaction.
-Previously, these three parameters were passed along with the signed payload, and the fees resulting from gas × gas_price were checked to ensure they matched the actual fees paid by the user for the extrinsic
+    Previously, these three parameters were passed along with the signed payload, and the fees resulting from gas × gas_price were checked to ensure they matched the actual fees paid by the user for the extrinsic
 
     This approach unfortunately can be attacked. A malicious actor could force such a transaction to fail by injecting low values for some of these extra parameters as they are not part of the signed payload.
 


### PR DESCRIPTION
One more red job turned green. Did not investigate how misformated prdoc 6689 made it in, but this fixes the check-publish-compile job on CI.

Failure example: https://github.com/paritytech/polkadot-sdk/actions/runs/12925909945/job/36047953474