### PR TITLE
revive: Fix compilation of `uapi` crate when `unstable-hostfn` is not set

### DIFF
--- a/.github/workflows/build-misc.yml
+++ b/.github/workflows/build-misc.yml
@@ -46,6 +46,34 @@ jobs:
           app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
           app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
 
+  # As part of our test fixtures we build the revive-uapi crate always with the `unstable-hostfn` feature.
+  # To make sure that it won't break for users downstream which are not setting this feature
+  # It doesn't need to produce working code so we just use a similar enough RISC-V target
+  check-revive-stable-uapi-polkavm:
+    timeout-minutes: 30
+    needs: [preflight]
+    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Rust
+        run: |
+          rustup show
+          rustup +nightly show
+
+      - name: Build
+        id: required
+        run: forklift cargo +nightly check -p pallet-revive-uapi --no-default-features --target riscv64imac-unknown-none-elf -Zbuild-std=core
+      - name: Stop all workflows if failed
+        if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/workflow-stopper
+        with:
+          app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
+          app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
+
   build-subkey:
     timeout-minutes: 20
     needs: [preflight]

--- a/prdoc/pr_7318.prdoc
+++ b/prdoc/pr_7318.prdoc
@@ -1,0 +1,8 @@
+title: 'revive: Fix compilation of `uapi` crate when `unstable-hostfn` is not set'
+doc:
+- audience: Runtime Dev
+  description: This regression was introduced with some of the recent PRs. Regression
+    fixed and test added.
+crates:
+- name: pallet-revive-uapi
+  bump: minor

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -144,18 +144,6 @@ pub trait HostFn: private::Sealed {
 	/// - `output`: A reference to the output data buffer to write the origin's address.
 	fn origin(output: &mut [u8; 20]);
 
-	/// Retrieve the account id for a specified address.
-	///
-	/// # Parameters
-	///
-	/// - `addr`: A `H160` address.
-	/// - `output`: A reference to the output data buffer to write the account id.
-	///
-	/// # Note
-	///
-	/// If no mapping exists for `addr`, the fallback account id will be returned.
-	fn to_account_id(addr: &[u8; 20], output: &mut [u8]);
-
 	/// Retrieve the code hash for a specified contract address.
 	///
 	/// # Parameters
@@ -415,8 +403,20 @@ pub trait HostFn: private::Sealed {
 	/// # Parameters
 	///
 	/// - `output`: A reference to the output data buffer to write the block number.
-	#[unstable_hostfn]
 	fn block_number(output: &mut [u8; 32]);
+
+	/// Retrieve the account id for a specified address.
+	///
+	/// # Parameters
+	///
+	/// - `addr`: A `H160` address.
+	/// - `output`: A reference to the output data buffer to write the account id.
+	///
+	/// # Note
+	///
+	/// If no mapping exists for `addr`, the fallback account id will be returned.
+	#[unstable_hostfn]
+	fn to_account_id(addr: &[u8; 20], output: &mut [u8]);
 
 	/// Stores the block hash of the given block number into the supplied buffer.
 	///


### PR DESCRIPTION
This regression was introduced with some of the recent PRs. Regression fixed and test added.