### PR TITLE
Bridges: emulated tests small nits/improvements

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/common/src/macros.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/macros.rs
@@ -644,9 +644,8 @@ macro_rules! test_dry_run_transfer_across_pk_bridge {
 			let transfer_amount = 10_000_000_000_000u128;
 			let initial_balance = transfer_amount * 10;
 
-			// Bridge setup.
+			// AssetHub setup.
 			$sender_asset_hub::force_xcm_version($destination, XCM_VERSION);
-			open_bridge_between_asset_hub_rococo_and_asset_hub_westend();
 
 			<$sender_asset_hub as TestExt>::execute_with(|| {
 				type Runtime = <$sender_asset_hub as Chain>::Runtime;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/asset_transfers.rs
@@ -25,9 +25,6 @@ fn send_assets_over_bridge<F: FnOnce()>(send_fn: F) {
 	AssetHubRococo::force_xcm_version(asset_hub_westend_location(), XCM_VERSION);
 	BridgeHubRococo::force_xcm_version(bridge_hub_westend_location(), XCM_VERSION);
 
-	// open bridge
-	open_bridge_between_asset_hub_rococo_and_asset_hub_westend();
-
 	// send message over bridge
 	send_fn();
 

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/mod.rs
@@ -51,9 +51,6 @@ pub(crate) fn bridged_roc_at_ah_westend() -> Location {
 }
 
 // WND and wWND
-pub(crate) fn wnd_at_ah_westend() -> Location {
-	Parent.into()
-}
 pub(crate) fn bridged_wnd_at_ah_rococo() -> Location {
 	Location::new(2, [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH))])
 }
@@ -239,44 +236,4 @@ pub(crate) fn assert_bridge_hub_westend_message_received() {
 			]
 		);
 	})
-}
-
-pub(crate) fn open_bridge_between_asset_hub_rococo_and_asset_hub_westend() {
-	use testnet_parachains_constants::{
-		rococo::currency::UNITS as ROC, westend::currency::UNITS as WND,
-	};
-
-	// open AHR -> AHW
-	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id(), ROC * 5);
-	AssetHubRococo::open_bridge(
-		AssetHubRococo::sibling_location_of(BridgeHubRococo::para_id()),
-		[
-			GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)),
-			Parachain(AssetHubWestend::para_id().into()),
-		]
-		.into(),
-		Some((
-			(roc_at_ah_rococo(), ROC * 1).into(),
-			BridgeHubRococo::sovereign_account_id_of(BridgeHubRococo::sibling_location_of(
-				AssetHubRococo::para_id(),
-			)),
-		)),
-	);
-
-	// open AHW -> AHR
-	BridgeHubWestend::fund_para_sovereign(AssetHubWestend::para_id(), WND * 5);
-	AssetHubWestend::open_bridge(
-		AssetHubWestend::sibling_location_of(BridgeHubWestend::para_id()),
-		[
-			GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
-			Parachain(AssetHubRococo::para_id().into()),
-		]
-		.into(),
-		Some((
-			(wnd_at_ah_westend(), WND * 1).into(),
-			BridgeHubWestend::sovereign_account_id_of(BridgeHubWestend::sibling_location_of(
-				AssetHubWestend::para_id(),
-			)),
-		)),
-	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/send_xcm.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/send_xcm.rs
@@ -74,9 +74,6 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	// fund sender
 	AssetHubRococo::fund_accounts(vec![(AssetHubRococoSender::get().into(), amount * 10)]);
 
-	// open bridge
-	open_bridge_between_asset_hub_rococo_and_asset_hub_westend();
-
 	// Initially set only default version on all runtimes
 	let newer_xcm_version = xcm::prelude::XCM_VERSION;
 	let older_xcm_version = newer_xcm_version - 1;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
@@ -26,9 +26,6 @@ fn send_assets_over_bridge<F: FnOnce()>(send_fn: F) {
 	AssetHubWestend::force_xcm_version(asset_hub_rococo_location(), XCM_VERSION);
 	BridgeHubWestend::force_xcm_version(bridge_hub_rococo_location(), XCM_VERSION);
 
-	// open bridge
-	open_bridge_between_asset_hub_rococo_and_asset_hub_westend();
-
 	// send message over bridge
 	send_fn();
 

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
@@ -52,9 +52,6 @@ pub(crate) fn bridged_wnd_at_ah_rococo() -> Location {
 }
 
 // ROC and wROC
-pub(crate) fn roc_at_ah_rococo() -> Location {
-	Parent.into()
-}
 pub(crate) fn bridged_roc_at_ah_westend() -> Location {
 	Location::new(2, [GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH))])
 }
@@ -249,44 +246,4 @@ pub(crate) fn assert_bridge_hub_rococo_message_received() {
 			]
 		);
 	})
-}
-
-pub(crate) fn open_bridge_between_asset_hub_rococo_and_asset_hub_westend() {
-	use testnet_parachains_constants::{
-		rococo::currency::UNITS as ROC, westend::currency::UNITS as WND,
-	};
-
-	// open AHR -> AHW
-	BridgeHubRococo::fund_para_sovereign(AssetHubRococo::para_id(), ROC * 5);
-	AssetHubRococo::open_bridge(
-		AssetHubRococo::sibling_location_of(BridgeHubRococo::para_id()),
-		[
-			GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH)),
-			Parachain(AssetHubWestend::para_id().into()),
-		]
-		.into(),
-		Some((
-			(roc_at_ah_rococo(), ROC * 1).into(),
-			BridgeHubRococo::sovereign_account_id_of(BridgeHubRococo::sibling_location_of(
-				AssetHubRococo::para_id(),
-			)),
-		)),
-	);
-
-	// open AHW -> AHR
-	BridgeHubWestend::fund_para_sovereign(AssetHubWestend::para_id(), WND * 5);
-	AssetHubWestend::open_bridge(
-		AssetHubWestend::sibling_location_of(BridgeHubWestend::para_id()),
-		[
-			GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
-			Parachain(AssetHubRococo::para_id().into()),
-		]
-		.into(),
-		Some((
-			(wnd_at_ah_westend(), WND * 1).into(),
-			BridgeHubWestend::sovereign_account_id_of(BridgeHubWestend::sibling_location_of(
-				AssetHubWestend::para_id(),
-			)),
-		)),
-	);
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/send_xcm.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/send_xcm.rs
@@ -74,9 +74,6 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	// fund sender
 	AssetHubWestend::fund_accounts(vec![(AssetHubWestendSender::get().into(), amount * 10)]);
 
-	// open bridge
-	open_bridge_between_asset_hub_rococo_and_asset_hub_westend();
-
 	// Initially set only default version on all runtimes
 	let newer_xcm_version = xcm::prelude::XCM_VERSION;
 	let older_xcm_version = newer_xcm_version - 1;


### PR DESCRIPTION
This PR includes minor fixes identified during work on the larger PR: [https://github.com/paritytech/polkadot-sdk/issues/6906](https://github.com/paritytech/polkadot-sdk/issues/6906).  

Specifically, this PR removes the use of `open_bridge_between_asset_hub_rococo_and_asset_hub_westend`, which is no longer relevant for BridgeHubs, as bridges are now created with genesis settings. This function was used in the generic `test_dry_run_transfer_across_pk_bridge` macro, which could cause compilation issues when used in other contexts (e.g. fellows repo).