### PR TITLE
client/rpc: Add new RPC for current transaction pool status

### DIFF
--- a/bridges/relays/client-substrate/src/client/rpc_api.rs
+++ b/bridges/relays/client-substrate/src/client/rpc_api.rs
@@ -79,6 +79,9 @@ pub(crate) trait SubstrateAuthor<C> {
 	/// Return vector of pending extrinsics from the transaction pool.
 	#[method(name = "pendingExtrinsics")]
 	async fn pending_extrinsics(&self) -> RpcResult<Vec<Bytes>>;
+	/// Return current status of the transaction pool.
+	#[method(name = "poolStatus")]
+	aysnc fn pool_status(&self) -> RpcResult<sc_rpc_api::author::PoolStatus>;
 	/// Submit and watch for extrinsic state.
 	#[subscription(name = "submitAndWatchExtrinsic", unsubscribe = "unwatchExtrinsic", item = TransactionStatusOf<C>)]
 	async fn submit_and_watch_extrinsic(&self, extrinsic: Bytes);

--- a/bridges/relays/client-substrate/src/client/traits.rs
+++ b/bridges/relays/client-substrate/src/client/traits.rs
@@ -33,6 +33,7 @@ use sp_runtime::{traits::Header as _, transaction_validity::TransactionValidity}
 use sp_trie::StorageProof;
 use sp_version::RuntimeVersion;
 use std::fmt::Debug;
+use sc_transaction_pool_api::PoolStatus;
 
 /// Relay uses the `Client` to communicate with the node, connected to Substrate
 /// chain `C`.
@@ -157,6 +158,10 @@ pub trait Client<C: Chain>: 'static + Send + Sync + Clone + Debug {
 
 	/// Returns pending extrinsics from transaction pool.
 	async fn pending_extrinsics(&self) -> Result<Vec<Bytes>>;
+
+	/// Returns current status of the transaction pool.	
+	async fn pool_status(&self) -> Result<PoolStatus>;
+
 	/// Submit unsigned extrinsic for inclusion in a block.
 	///
 	/// Note: The given transaction needs to be SCALE encoded beforehand.

--- a/substrate/client/rpc-api/src/author/mod.rs
+++ b/substrate/client/rpc-api/src/author/mod.rs
@@ -23,7 +23,7 @@ pub mod hash;
 
 use error::Error;
 use jsonrpsee::proc_macros::rpc;
-use sc_transaction_pool_api::TransactionStatus;
+use sc_transaction_pool_api::{TransactionStatus, PoolStatus};
 use sp_core::Bytes;
 
 /// Substrate authoring RPC API
@@ -58,6 +58,10 @@ pub trait AuthorApi<Hash, BlockHash> {
 	/// Returns all pending extrinsics, potentially grouped by sender.
 	#[method(name = "author_pendingExtrinsics")]
 	fn pending_extrinsics(&self) -> Result<Vec<Bytes>, Error>;
+
+	/// Returns the current status of the transaction pool.
+	#[method(name = "author_poolStatus")]
+	fn pool_status(&self) -> Result<PoolStatus, Error>;
 
 	/// Remove given extrinsic from the pool and temporarily ban it to prevent reimporting.
 	#[method(name = "author_removeExtrinsic", with_extensions)]

--- a/substrate/client/rpc/src/author/mod.rs
+++ b/substrate/client/rpc/src/author/mod.rs
@@ -33,7 +33,7 @@ use jsonrpsee::{core::async_trait, types::ErrorObject, Extensions, PendingSubscr
 use sc_rpc_api::check_if_safe;
 use sc_transaction_pool_api::{
 	error::IntoPoolError, BlockHash, InPoolTransaction, TransactionFor, TransactionPool,
-	TransactionSource, TxHash,
+	TransactionSource, TxHash, PoolStatus
 };
 use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
@@ -69,6 +69,8 @@ impl<P, Client> Author<P, Client> {
 		Author { client, pool, keystore, executor }
 	}
 }
+
+
 
 /// Currently we treat all RPC transactions as externals.
 ///
@@ -153,6 +155,10 @@ where
 
 	fn pending_extrinsics(&self) -> Result<Vec<Bytes>> {
 		Ok(self.pool.ready().map(|tx| tx.data().encode().into()).collect())
+	}
+
+	fn pool_status(&self) -> Result<PoolStatus> {
+		Ok(self.pool.status().into())
 	}
 
 	fn remove_extrinsic(

--- a/substrate/client/rpc/src/author/tests.rs
+++ b/substrate/client/rpc/src/author/tests.rs
@@ -183,6 +183,24 @@ async fn author_should_return_pending_extrinsics() {
 }
 
 #[tokio::test]
+async fn author_should_return_pool_status() {
+	let api = TestSetup::into_rpc();
+
+	let xt_bytes: Bytes = uxt(Sr25519Keyring::Alice, 0).encode().into();
+	api.call::<_, H256>("author_submitExtrinsic", [to_hex(&xt_bytes, true)])
+		.await
+		.unwrap();
+
+	let pool_status: sc_transaction_pool_api::PoolStatus =
+		api.call("author_poolStatus", ((),)).await.unwrap();
+
+	assert_eq!(pool_status.ready, 1);
+	assert_eq!(pool_status.ready_bytes, 136);
+	assert_eq!(pool_status.future, 0);
+	assert_eq!(pool_status.future_bytes, 0);
+}
+
+#[tokio::test]
 async fn author_should_remove_extrinsics() {
 	const METHOD: &'static str = "author_removeExtrinsic";
 	let setup = TestSetup::default();

--- a/substrate/client/transaction-pool/api/src/lib.rs
+++ b/substrate/client/transaction-pool/api/src/lib.rs
@@ -36,7 +36,7 @@ pub use sp_runtime::transaction_validity::{
 };
 
 /// Transaction pool status.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]	
 pub struct PoolStatus {
 	/// Number of transactions in the ready queue.
 	pub ready: usize,


### PR DESCRIPTION
# Description

This PR adds a new RPC which shows the current status of the substrate transaction pool.

During one of the implementation of a queue which submits batch transaction in thousands, I did not find a way of getting the status of the pool. We set the pool limit in transactions and its size with `--pool-limit` & `--pool-kbytes` respectively. 
I wanted a way to find if the transaction pool is nearing its limit or not before any new bulk transactions are sent to the pool so the transaction do not get bounced, which is my current case. 

I have used `author_pendingExtrinsics` RPC but it does not give the bytes occupied in the pool. Since bytes occupied is also another crucial factor along with count for the limit to be enforced whether the pool is full or not.
Another downside of using this RPC is that that response is too big adding unnecessary load to the nodes and to parse the data as well. 

Since we are already using `status()` method at various places of `TransactionPool` trait. Send the data as a RPC too, benefitting with low response size.

In future I wish to add the current limits on count and size to this response as well. For now I will assume that `transaction-pool` will be full when `ready.count + future.count(10% of ready.count) > pool_limit` or `ready.total_bytes + future.total_bytes(10 > pool_limit_bytes`. 

<!-- 
*A concise description of what your PR is doing, and what potential issue it is solving. Use [Github semantic
linking](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
to link the PR to an issue that must be closed once this is merged.*
-->

## Review Notes

Utilise the `status()` method of `TransactionPool` trait to expose that data as part of a new RPC call named `poolStatus` as part of `author`.
I have added tests to demonstrate the same. 

# Checklist

* [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)