### PR TITLE
Improve `set_validation_data` error message.

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -309,8 +309,12 @@ pub mod pallet {
 			<UpgradeRestrictionSignal<T>>::kill();
 			let relay_upgrade_go_ahead = <UpgradeGoAhead<T>>::take();
 
-			let vfp = <ValidationData<T>>::get()
-				.expect("set_validation_data inherent needs to be present in every block!");
+			let vfp = <ValidationData<T>>::get().expect(
+				r"Missing required set_validation_data inherent. This inherent must be
+				present in every block. This error typically occurs when the set_validation_data
+				execution failed and was rejected by the block builder. Check earlier log entries
+				for the specific cause of the failure.",
+			);
 
 			LastRelayChainBlockNumber::<T>::put(vfp.relay_parent_number);
 

--- a/prdoc/pr_7359.prdoc
+++ b/prdoc/pr_7359.prdoc
@@ -1,0 +1,8 @@
+title: Improve `set_validation_data` error message.
+doc:
+- audience: Runtime Dev
+  description: The old error message was often confusing, because the real reason
+    for the error will be printed during inherent execution.
+crates:
+- name: cumulus-pallet-parachain-system
+  bump: patch

--- a/prdoc/pr_7359.prdoc
+++ b/prdoc/pr_7359.prdoc
@@ -1,8 +1,7 @@
 title: Improve `set_validation_data` error message.
 doc:
 - audience: Runtime Dev
-  description: The old error message was often confusing, because the real reason
-    for the error will be printed during inherent execution.
+  description: Adds a more elaborate error message to the error that appears when `set_validation_data` is missing in a parachain block.
 crates:
 - name: cumulus-pallet-parachain-system
   bump: patch


### PR DESCRIPTION
The old error message was often confusing, because the real reason for the error will be printed during inherent execution.