### PR TITLE
[Pallet-grandpa] Update schedule_change to increment CurrentSetId #7363

### DIFF
--- a/substrate/frame/grandpa/src/lib.rs
+++ b/substrate/frame/grandpa/src/lib.rs
@@ -541,6 +541,11 @@ impl<T: Config> Pallet<T> {
 				forced,
 			});
 
+			CurrentSetId:<T>::mutate(|s| {
+				*s += 1;
+				*s
+			});
+
 			Ok(())
 		} else {
 			Err(Error::<T>::ChangePending.into())
@@ -647,6 +652,12 @@ where
 			// of the current set.
 			CurrentSetId::<T>::get()
 		};
+
+		if changed || Stalled::<T>::exists() {
+			let current_set_id = CurrentSetId::<T>::mutate(|s| {
+				*s += 1;
+				*s
+			});
 
 		// update the mapping to note that the current set corresponds to the
 		// latest equivalent session (i.e. now).

--- a/substrate/frame/grandpa/src/lib.rs
+++ b/substrate/frame/grandpa/src/lib.rs
@@ -541,7 +541,7 @@ impl<T: Config> Pallet<T> {
 				forced,
 			});
 
-			CurrentSetId:<T>::mutate(|s| {
+			CurrentSetId::<T>::mutate(|s| {
 				*s += 1;
 				*s
 			});
@@ -663,6 +663,8 @@ where
 		// latest equivalent session (i.e. now).
 		let session_index = pallet_session::Pallet::<T>::current_index();
 		SetIdSession::<T>::insert(current_set_id, &session_index);
+
+		}
 	}
 
 	fn on_disabled(i: u32) {


### PR DESCRIPTION


# Description

Attempts to resolve #7363

By updating schedule_change to increment CurrentSetId, you ensure that the runtime reflects the correct authority set when changes are scheduled.
This adjustment aligns the Grandpa module's internal tracking (CurrentSetId) with the expected behavior during authority set changes.


