### PR TITLE
Add support for feature `pallet_balances/insecure_zero_ed` in benchmarks and testing

### DIFF
--- a/prdoc/pr_7379.prdoc
+++ b/prdoc/pr_7379.prdoc
@@ -1,0 +1,13 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "Add support for feature pallet_balances/insecure_zero_ed in benchmarks and testing"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Currently benchmarks and tests on pallet_balances would fail when the feature insecure_zero_ed is enabled. This PR allows to run such benchmark and tests keeping into account the fact that accounts would not be deleted when their balance goes below a threshold.
+
+crates:
+  - name: pallet-balances
+    bump: patch

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -65,11 +65,11 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount);
 
-		#[cfg(not(feature = "insecure_zero_ed"))]
-		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
-
-		#[cfg(feature = "insecure_zero_ed")]
-		assert_eq!(Balances::<T, I>::free_balance(&caller), balance - transfer_amount);
+		if cfg!(feature = "insecure_zero_ed") {
+			assert_eq!(Balances::<T, I>::free_balance(&caller), balance - transfer_amount);
+		} else {
+			assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+		}
 
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
@@ -178,11 +178,11 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Root, source_lookup, recipient_lookup, transfer_amount);
 
-		#[cfg(not(feature = "insecure_zero_ed"))]
-		assert_eq!(Balances::<T, I>::free_balance(&source), Zero::zero());
-
-		#[cfg(feature = "insecure_zero_ed")]
-		assert_eq!(Balances::<T, I>::free_balance(&source), balance - transfer_amount);
+		if cfg!(feature = "insecure_zero_ed") {
+			assert_eq!(Balances::<T, I>::free_balance(&source), balance - transfer_amount);
+		} else {
+			assert_eq!(Balances::<T, I>::free_balance(&source), Zero::zero());
+		}
 
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
@@ -218,11 +218,11 @@ mod benchmarks {
 		#[extrinsic_call]
 		transfer_allow_death(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount);
 
-		#[cfg(not(feature = "insecure_zero_ed"))]
-		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
-
-		#[cfg(feature = "insecure_zero_ed")]
-		assert_eq!(Balances::<T, I>::free_balance(&caller), balance - transfer_amount);
+		if cfg!(feature = "insecure_zero_ed") {
+			assert_eq!(Balances::<T, I>::free_balance(&caller), balance - transfer_amount);
+		} else {
+			assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+		}
 
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -68,6 +68,9 @@ mod benchmarks {
 		#[cfg(not(feature = "insecure_zero_ed"))]
 		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
 
+		#[cfg(feature = "insecure_zero_ed")]
+		assert_eq!(Balances::<T, I>::free_balance(&caller), balance - transfer_amount);
+
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
 
@@ -178,6 +181,9 @@ mod benchmarks {
 		#[cfg(not(feature = "insecure_zero_ed"))]
 		assert_eq!(Balances::<T, I>::free_balance(&source), Zero::zero());
 
+		#[cfg(feature = "insecure_zero_ed")]
+		assert_eq!(Balances::<T, I>::free_balance(&source), balance - transfer_amount);
+
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
 
@@ -214,6 +220,9 @@ mod benchmarks {
 
 		#[cfg(not(feature = "insecure_zero_ed"))]
 		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+
+		#[cfg(feature = "insecure_zero_ed")]
+		assert_eq!(Balances::<T, I>::free_balance(&caller), balance - transfer_amount);
 
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -323,7 +323,7 @@ mod benchmarks {
 	/// Benchmark `burn` extrinsic with the worst possible condition - burn kills the account.
 	#[benchmark]
 	fn burn_allow_death() {
-		let existential_deposit = T::ExistentialDeposit::get();
+		let existential_deposit: T::Balance = minimum_balance::<T, I>();
 		let caller = whitelisted_caller();
 
 		// Give some multiple of the existential deposit
@@ -342,7 +342,7 @@ mod benchmarks {
 	// Benchmark `burn` extrinsic with the case where account is kept alive.
 	#[benchmark]
 	fn burn_keep_alive() {
-		let existential_deposit = T::ExistentialDeposit::get();
+		let existential_deposit: T::Balance = minimum_balance::<T, I>();
 		let caller = whitelisted_caller();
 
 		// Give some multiple of the existential deposit

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -65,7 +65,9 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount);
 
+		#[cfg(not(feature = "insecure_zero_ed"))]
 		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
 
@@ -173,7 +175,9 @@ mod benchmarks {
 		#[extrinsic_call]
 		_(RawOrigin::Root, source_lookup, recipient_lookup, transfer_amount);
 
+		#[cfg(not(feature = "insecure_zero_ed"))]
 		assert_eq!(Balances::<T, I>::free_balance(&source), Zero::zero());
+
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
 
@@ -208,7 +212,9 @@ mod benchmarks {
 		#[extrinsic_call]
 		transfer_allow_death(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount);
 
+		#[cfg(not(feature = "insecure_zero_ed"))]
 		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+
 		assert_eq!(Balances::<T, I>::free_balance(&recipient), transfer_amount);
 	}
 

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -336,7 +336,11 @@ mod benchmarks {
 		#[extrinsic_call]
 		burn(RawOrigin::Signed(caller.clone()), burn_amount, false);
 
-		assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+		if cfg!(feature = "insecure_zero_ed") {
+			assert_eq!(Balances::<T, I>::free_balance(&caller), balance - burn_amount);
+		} else {
+			assert_eq!(Balances::<T, I>::free_balance(&caller), Zero::zero());
+		}
 	}
 
 	// Benchmark `burn` extrinsic with the case where account is kept alive.

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -1136,6 +1136,7 @@ fn operations_on_dead_account_should_not_change_state() {
 
 #[test]
 #[should_panic = "The existential deposit must be greater than zero!"]
+#[cfg(not(feature = "insecure_zero_ed"))]
 fn zero_ed_is_prohibited() {
 	// These functions all use `mutate_account` which may introduce a storage change when
 	// the account never existed to begin with, and shouldn't exist in the end.

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -24,7 +24,7 @@ use frame_support::{
 		BalanceStatus::{Free, Reserved},
 		Currency,
 		ExistenceRequirement::{self, AllowDeath, KeepAlive},
-		Hooks, InspectLockableCurrency, LockIdentifier, LockableCurrency, NamedReservableCurrency,
+		InspectLockableCurrency, LockIdentifier, LockableCurrency, NamedReservableCurrency,
 		ReservableCurrency, WithdrawReasons,
 	},
 	StorageNoopGuard,
@@ -1138,6 +1138,7 @@ fn operations_on_dead_account_should_not_change_state() {
 #[should_panic = "The existential deposit must be greater than zero!"]
 #[cfg(not(feature = "insecure_zero_ed"))]
 fn zero_ed_is_prohibited() {
+	use frame_support::traits::Hooks;
 	// These functions all use `mutate_account` which may introduce a storage change when
 	// the account never existed to begin with, and shouldn't exist in the end.
 	ExtBuilder::default().existential_deposit(0).build_and_execute_with(|| {


### PR DESCRIPTION
# Description

Currently benchmarks and tests on pallet_balances would fail when the feature insecure_zero_ed is enabled. This PR allows to run such benchmark and tests keeping into account the fact that accounts would not be deleted when their balance goes below a threshold.

## Integration

*In depth notes about how this PR should be integrated by downstream projects. This part is mandatory, and should be
reviewed by reviewers, if the PR does NOT have the `R0-Silent` label. In case of a `R0-Silent`, it can be ignored.*

## Review Notes

*In depth notes about the **implementation** details of your PR. This should be the main guide for reviewers to
understand your approach and effectively review it. If too long, use
[`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)*.

*Imagine that someone who is depending on the old code wants to integrate your new code and the only information that
they get is this section. It helps to include example usage and default value here, with a `diff` code-block to show
possibly integration.*

*Include your leftover TODOs, if any, here.*

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [x] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!

✄ -----------------------------------------------------------------------------
