### PR TITLE
Pallet `assets-vesting`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12143,6 +12143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-assets-vesting"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "pallet-assets 29.1.0",
+ "parity-scale-codec",
+ "polkadot-sdk-frame 0.1.0",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-atomic-swap"
 version = "28.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12148,6 +12148,8 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pallet-assets 29.1.0",
+ "pallet-assets-freezer 0.1.0",
+ "pallet-balances 28.0.0",
  "parity-scale-codec",
  "polkadot-sdk-frame 0.1.0",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,7 @@ members = [
 	"substrate/frame/asset-rewards",
 	"substrate/frame/assets",
 	"substrate/frame/assets-freezer",
+	"substrate/frame/assets-vesting",
 	"substrate/frame/atomic-swap",
 	"substrate/frame/aura",
 	"substrate/frame/authority-discovery",
@@ -899,6 +900,7 @@ pallet-asset-rewards = { path = "substrate/frame/asset-rewards", default-feature
 pallet-asset-tx-payment = { path = "substrate/frame/transaction-payment/asset-tx-payment", default-features = false }
 pallet-assets = { path = "substrate/frame/assets", default-features = false }
 pallet-assets-freezer = { path = "substrate/frame/assets-freezer", default-features = false }
+pallet-assets-vesting = { path = "substrate/frame/assets-vesting", default-features = false }
 pallet-atomic-swap = { default-features = false, path = "substrate/frame/atomic-swap" }
 pallet-aura = { path = "substrate/frame/aura", default-features = false }
 pallet-authority-discovery = { path = "substrate/frame/authority-discovery", default-features = false }

--- a/substrate/frame/assets-vesting/Cargo.toml
+++ b/substrate/frame/assets-vesting/Cargo.toml
@@ -22,6 +22,8 @@ scale-info = { features = ["derive"], workspace = true }
 
 [dev-dependencies]
 pallet-assets = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-assets-freezer = { workspace = true }
 
 [features]
 default = ["std"]
@@ -29,14 +31,20 @@ std = [
     "codec/std",
     "frame/std",
     "log/std",
+    "pallet-assets-freezer/std",
     "pallet-assets/std",
+    "pallet-balances/std",
     "scale-info/std",
 ]
 runtime-benchmarks = [
     "frame/runtime-benchmarks",
+    "pallet-assets-freezer/runtime-benchmarks",
     "pallet-assets/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
 ]
 try-runtime = [
     "frame/try-runtime",
+    "pallet-assets-freezer/try-runtime",
     "pallet-assets/try-runtime",
+    "pallet-balances/try-runtime",
 ]

--- a/substrate/frame/assets-vesting/Cargo.toml
+++ b/substrate/frame/assets-vesting/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "pallet-assets-vesting"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license = "MIT-0"
+homepage.workspace = true
+repository.workspace = true
+description = "FRAME pallet for manage vesting on Assets"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { workspace = true }
+frame = { workspace = true, features = ["runtime"] }
+log = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+
+[dev-dependencies]
+pallet-assets = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "frame/std",
+    "log/std",
+    "pallet-assets/std",
+    "scale-info/std",
+]
+runtime-benchmarks = [
+    "frame/runtime-benchmarks",
+    "pallet-assets/runtime-benchmarks",
+]
+try-runtime = [
+    "frame/try-runtime",
+    "pallet-assets/try-runtime",
+]

--- a/substrate/frame/assets-vesting/src/lib.rs
+++ b/substrate/frame/assets-vesting/src/lib.rs
@@ -1,0 +1,728 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Assets Vesting Pallet
+//!
+//! - [`Config`]
+//! - [`Call`]
+//!
+//! ## Overview
+//!
+//! A simple pallet providing a means of placing a linear curve on an assets account's frozen
+//! balance. This pallet ensures that there is a frozen amount in place preventing the balance to
+//! drop below the *unvested* amount.
+//!
+//! As the vested amount increases over time, the unvested amount reduces. However, freezes remain
+//! in place and an explicit action is needed on behalf of the user to ensure that the frozen
+//! amount is equivalent to the amount remaining to be vested. This is done through a dispatchable
+//! function, either `vest` (in typical case where the sender is calling on their own behalf) or
+//! `vest_other` in case the sender is calling on another account's behalf.
+//!
+//! ## Interface
+//!
+//! This pallet implements the `VestingSchedule` trait.
+//!
+//! ### Dispatchable Functions
+//!
+//! - `vest` - Update the lock, reducing it in line with the amount "vested" so far.
+//! - `vest_other` - Update the lock of another account, reducing it in line with the amount
+//!   "vested" so far.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+#[cfg(test)]
+mod mocks;
+#[cfg(test)]
+mod tests;
+
+mod types;
+mod weights;
+
+use frame::{
+	prelude::*,
+	traits::{
+		fungibles::{Inspect, Mutate, MutateFreeze, VestedTransfer, VestingSchedule},
+		tokens::Preservation,
+	},
+};
+pub use pallet::*;
+pub use types::*;
+pub use weights::*;
+
+#[frame::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config<I: 'static = ()>: frame_system::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event<Self, I>>
+			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// An Origin that can control the `force` calls.
+		type ForceOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// Type represents interactions between assets
+		type Assets: Inspect<AccountIdOf<Self>> + Mutate<AccountIdOf<Self>>;
+
+		/// Type allows handling fungibles' freezes.
+		type Freezer: Inspect<AccountIdOf<Self>, AssetId = AssetIdOf<Self, I>, Balance = BalanceOf<Self, I>>
+			+ MutateFreeze<
+				AccountIdOf<Self>,
+				Id = Self::RuntimeFreezeReason,
+				AssetId = AssetIdOf<Self, I>,
+				Balance = BalanceOf<Self, I>,
+			>;
+
+		/// Convert the block number into a balance.
+		type BlockNumberToBalance: Convert<BlockNumberFor<Self>, BalanceOf<Self, I>>;
+
+		/// The overarching freeze reason.
+		type RuntimeFreezeReason: From<FreezeReason>;
+
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+
+		/// The minimum amount transferred to call `vested_transfer`.
+		#[pallet::constant]
+		type MinVestedTransfer: Get<BalanceOf<Self, I>>;
+
+		/// Provider for the block number.
+		type BlockNumberProvider: BlockNumberProvider<BlockNumber = BlockNumberFor<Self>>;
+
+		/// Maximum number of vesting schedules an account may have at a given moment.
+		const MAX_VESTING_SCHEDULES: u32;
+	}
+
+	#[pallet::extra_constants]
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		#[pallet::constant_name(MaxVestingSchedules)]
+		fn max_vesting_schedules() -> u32 {
+			T::MAX_VESTING_SCHEDULES
+		}
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T, I = ()>(_);
+
+	/// Information regarding the vesting of a given account.
+	#[pallet::storage]
+	pub type Vesting<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		AssetIdOf<T, I>,
+		Blake2_128Concat,
+		T::AccountId,
+		BoundedVec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>, MaxVestingSchedulesGet<T, I>>,
+	>;
+
+	#[pallet::hooks]
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+		fn integrity_test() {
+			assert!(T::MAX_VESTING_SCHEDULES > 0, "`MaxVestingSchedules` must ge greater than 0");
+		}
+	}
+
+	/// A reason for the pallet assets vesting placing a freeze on funds.
+	#[pallet::composite_enum]
+	pub enum FreezeReason {
+		// An account is vesting some funds.
+		Vesting,
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config<I>, I: 'static = ()> {
+		/// The amount vested has been updated. This could indicate a change in funds available.
+		/// The balance given is the amount which is left unvested (and thus frozen).
+		VestingUpdated { asset: AssetIdOf<T, I>, account: T::AccountId, unvested: BalanceOf<T, I> },
+		/// An \[asset account\] has become fully vested.
+		VestingCompleted { asset: AssetIdOf<T, I>, account: T::AccountId },
+	}
+
+	/// Error for the vesting pallet.
+	#[pallet::error]
+	pub enum Error<T, I = ()> {
+		/// The account given is not vesting.
+		NotVesting,
+		/// The account already has `MaxVestingSchedules` count of schedules and thus
+		/// cannot add another one. Consider merging existing schedules in order to add another.
+		AtMaxVestingSchedules,
+		/// Amount being transferred is too low to create a vesting schedule.
+		AmountLow,
+		/// An index was out of bounds of the vesting schedules.
+		ScheduleIndexOutOfBounds,
+		/// Failed to create a new schedule because some parameter was invalid.
+		InvalidScheduleParams,
+	}
+
+	#[pallet::call]
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		/// Unlock any vested funds of the sender account.
+		///
+		/// The dispatch origin for this call must be _Signed_ and the sender must have funds still
+		/// frozen under this pallet.
+		///
+		/// - `asset`: Id of the asset class of the asset account for which the vesting applies.
+		///
+		/// Emits either `VestingCompleted` or `VestingUpdated`.
+		///
+		/// ## Complexity
+		/// - `O(1)`.
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::WeightInfo::vest_locked(1, T::MAX_VESTING_SCHEDULES)
+				.max(T::WeightInfo::vest_unlocked(1, T::MAX_VESTING_SCHEDULES))
+		)]
+		pub fn vest(origin: OriginFor<T>, asset: AssetIdOf<T, I>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			Self::do_vest(asset, who)
+		}
+
+		/// Unlock any vested funds of a `target` account.
+		///
+		/// The dispatch origin for this call must be _Signed_.
+		///
+		/// - `asset`: Id of the asset class of the asset account for which the vesting applies.
+		/// - `target`: The account whose vested funds should be unlocked. Must have funds still
+		/// frozen under this pallet.
+		///
+		/// Emits either `VestingCompleted` or `VestingUpdated`.
+		///
+		/// ## Complexity
+		/// - `O(1)`.
+		#[pallet::call_index(1)]
+		#[pallet::weight(T::WeightInfo::vest_other_locked(1, T::MAX_VESTING_SCHEDULES)
+				.max(T::WeightInfo::vest_other_unlocked(1, T::MAX_VESTING_SCHEDULES))
+			)]
+		pub fn vest_other(
+			origin: OriginFor<T>,
+			asset: AssetIdOf<T, I>,
+			target: AccountIdLookupOf<T>,
+		) -> DispatchResult {
+			ensure_signed(origin)?;
+			let who = T::Lookup::lookup(target)?;
+			Self::do_vest(asset, who)
+		}
+
+		/// Create a vested transfer.
+		///
+		/// The dispatch origin for this call must be _Signed_.
+		///
+		/// - `asset`: Id of the asset class of the asset account for which the vesting applies.
+		/// - `target`: The account receiving the vested funds.
+		/// - `schedule`: The vesting schedule attached to the transfer.
+		///
+		/// Emits `VestingCreated`.
+		///
+		/// NOTE: This will unlock all schedules through the current block.
+		///
+		/// ## Complexity
+		/// - `O(1)`.
+		#[pallet::call_index(2)]
+		#[pallet::weight(T::WeightInfo::vested_transfer(1, T::MAX_VESTING_SCHEDULES))]
+		pub fn vested_transfer(
+			origin: OriginFor<T>,
+			asset: AssetIdOf<T, I>,
+			target: AccountIdLookupOf<T>,
+			schedule: VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>,
+		) -> DispatchResult {
+			let transactor = ensure_signed(origin)?;
+			let target = T::Lookup::lookup(target)?;
+			Self::do_vested_transfer(asset, &transactor, &target, schedule)
+		}
+
+		/// Force a vested transfer.
+		///
+		/// The dispatch origin for this call must be `ForceOrigin`.
+		///
+		/// - `asset`: Id of the asset class of the asset account for which the vesting applies.
+		/// - `source`: The account whose funds should be transferred.
+		/// - `target`: The account that should be transferred the vested funds.
+		/// - `schedule`: The vesting schedule attached to the transfer.
+		///
+		/// Emits `VestingCreated`.
+		///
+		/// NOTE: This will unlock all schedules through the current block.
+		///
+		/// ## Complexity
+		/// - `O(1)`.
+		#[pallet::call_index(3)]
+		#[pallet::weight(T::WeightInfo::force_vested_transfer(1, T::MAX_VESTING_SCHEDULES))]
+		pub fn force_vested_transfer(
+			origin: OriginFor<T>,
+			asset: AssetIdOf<T, I>,
+			source: AccountIdLookupOf<T>,
+			target: AccountIdLookupOf<T>,
+			schedule: VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			let target = T::Lookup::lookup(target)?;
+			let source = T::Lookup::lookup(source)?;
+			Self::do_vested_transfer(asset, &source, &target, schedule)
+		}
+
+		/// Merge two vesting schedules together, creating a new vesting schedule that unlocks over
+		/// the highest possible start and end blocks. If both schedules have already started the
+		/// current block will be used as the schedule start; with the caveat that if one schedule
+		/// is finished by the current block, the other will be treated as the new merged schedule,
+		/// unmodified.
+		///
+		/// NOTE: If `schedule1_index == schedule2_index` this is a no-op.
+		/// NOTE: This will unlock all schedules through the current block prior to merging.
+		/// NOTE: If both schedules have ended by the current block, no new schedule will be created
+		/// and both will be removed.
+		///
+		/// Merged schedule attributes:
+		/// - `starting_block`: `MAX(schedule1.starting_block, scheduled2.starting_block,
+		///   current_block)`.
+		/// - `ending_block`: `MAX(schedule1.ending_block, schedule2.ending_block)`.
+		/// - `locked`: `schedule1.locked_at(current_block) + schedule2.locked_at(current_block)`.
+		/// The dispatch origin for this call must be _Signed_.
+		///
+		/// - `asset`: Id of the asset class of the asset account for which the vesting applies.
+		/// - `schedule1_index`: index of the first schedule to merge.
+		/// - `schedule2_index`: index of the second schedule to merge.
+		#[pallet::call_index(4)]
+		#[pallet::weight(
+				T::WeightInfo::not_unlocking_merge_schedules(1, T::MAX_VESTING_SCHEDULES)
+					.max(T::WeightInfo::unlocking_merge_schedules(1, T::MAX_VESTING_SCHEDULES))
+			)]
+		pub fn merge_schedules(
+			origin: OriginFor<T>,
+			asset: AssetIdOf<T, I>,
+			schedule1_index: u32,
+			schedule2_index: u32,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			if schedule1_index == schedule2_index {
+				return Ok(())
+			};
+			let schedule1_index = schedule1_index as usize;
+			let schedule2_index = schedule2_index as usize;
+
+			let schedules = Vesting::<T, I>::get(&asset, &who).ok_or(Error::<T, I>::NotVesting)?;
+			let merge_action =
+				VestingAction::Merge { index1: schedule1_index, index2: schedule2_index };
+
+			let (schedules, locked_now) = Self::exec_action(schedules.to_vec(), merge_action)?;
+
+			Self::write_vesting(asset.clone(), &who, schedules)?;
+			Self::write_lock(asset, &who, locked_now)?;
+
+			Ok(())
+		}
+
+		/// Force remove a vesting schedule
+		///
+		/// The dispatch origin for this call must be of `ForceOrigin`.
+		///
+		/// - `asset`: Id of the asset class of the asset account for which the vesting applies.
+		/// - `target`: An account that has a vesting schedule
+		/// - `schedule_index`: The vesting schedule index that should be removed
+		#[pallet::call_index(5)]
+		#[pallet::weight(T::WeightInfo::force_remove_vesting_schedule(
+			1,
+			T::MAX_VESTING_SCHEDULES
+		))]
+		pub fn force_remove_vesting_schedule(
+			origin: OriginFor<T>,
+			asset: AssetIdOf<T, I>,
+			target: <T::Lookup as StaticLookup>::Source,
+			schedule_index: u32,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			let who = T::Lookup::lookup(target)?;
+
+			let schedules_count =
+				Vesting::<T, I>::decode_len(asset.clone(), &who).unwrap_or_default();
+			ensure!(schedule_index < schedules_count as u32, Error::<T, I>::InvalidScheduleParams);
+
+			Self::remove_vesting_schedule(asset, &who, schedule_index)?;
+
+			Ok(Some(T::WeightInfo::force_remove_vesting_schedule(
+				T::MAX_VESTING_SCHEDULES,
+				schedules_count as u32,
+			))
+			.into())
+		}
+	}
+}
+
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Public function for accessing vesting storage
+	pub fn vesting(
+		asset: AssetIdOf<T, I>,
+		account: T::AccountId,
+	) -> Option<
+		BoundedVec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>, MaxVestingSchedulesGet<T, I>>,
+	> {
+		Vesting::<T, I>::get(asset, account)
+	}
+
+	// Create a new `VestingInfo`, based off of two other `VestingInfo`s.
+	// NOTE: We assume both schedules have had funds unlocked up through the current block.
+	fn merge_vesting_info(
+		now: BlockNumberFor<T>,
+		schedule1: VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>,
+		schedule2: VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>,
+	) -> Option<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>> {
+		let schedule1_ending_block = schedule1.ending_block_as_balance::<T::BlockNumberToBalance>();
+		let schedule2_ending_block = schedule2.ending_block_as_balance::<T::BlockNumberToBalance>();
+		let now_as_balance = T::BlockNumberToBalance::convert(now);
+
+		// Check if one or both schedules have ended.
+		match (schedule1_ending_block <= now_as_balance, schedule2_ending_block <= now_as_balance) {
+			// If both schedules have ended, we don't merge and exit early.
+			(true, true) => return None,
+			// If one schedule has ended, we treat the one that has not ended as the new
+			// merged schedule.
+			(true, false) => return Some(schedule2),
+			(false, true) => return Some(schedule1),
+			// If neither schedule has ended don't exit early.
+			_ => {},
+		}
+
+		let frozen = schedule1
+			.locked_at::<T::BlockNumberToBalance>(now)
+			.saturating_add(schedule2.locked_at::<T::BlockNumberToBalance>(now));
+		// This shouldn't happen because we know at least one ending block is greater than now,
+		// thus at least a schedule a some locked balance.
+		debug_assert!(
+			!frozen.is_zero(),
+			"merge_vesting_info validation checks failed to catch a locked of 0"
+		);
+
+		let ending_block = schedule1_ending_block.max(schedule2_ending_block);
+		let starting_block = now.max(schedule1.starting_block()).max(schedule2.starting_block());
+
+		let per_block = {
+			let duration = ending_block
+				.saturating_sub(T::BlockNumberToBalance::convert(starting_block))
+				.max(One::one());
+			(frozen / duration).max(One::one())
+		};
+
+		let schedule = VestingInfo::new(frozen, per_block, starting_block);
+		debug_assert!(schedule.is_valid(), "merge_vesting_info schedule validation check failed");
+
+		Some(schedule)
+	}
+
+	// Execute a vested transfer from `source` to `target` with the given `schedule`.
+	fn do_vested_transfer(
+		asset: AssetIdOf<T, I>,
+		source: &T::AccountId,
+		target: &T::AccountId,
+		schedule: VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>,
+	) -> DispatchResult {
+		// Validate user inputs.
+		ensure!(schedule.locked() >= T::MinVestedTransfer::get(), Error::<T, I>::AmountLow);
+		if !schedule.is_valid() {
+			return Err(Error::<T, I>::InvalidScheduleParams.into())
+		};
+
+		// Check we can add to this account prior to any storage writes.
+		Self::can_add_vesting_schedule(
+			asset.clone(),
+			target,
+			schedule.locked(),
+			schedule.per_block(),
+			schedule.starting_block(),
+		)?;
+
+		T::Assets::transfer(
+			asset.clone(),
+			source,
+			target,
+			schedule.locked(),
+			Preservation::Preserve,
+		)?;
+
+		// We can't let this fail because the currency transfer has already happened.
+		// Must be successful as it has been checked before.
+		// Better to return error on failure anyway.
+		let res = Self::add_vesting_schedule(
+			asset,
+			target,
+			schedule.locked(),
+			schedule.per_block(),
+			schedule.starting_block(),
+		);
+		debug_assert!(res.is_ok(), "Failed to add a schedule when we had to succeed.");
+
+		Ok(())
+	}
+
+	/// Iterate through the schedules to track the current locked amount and
+	/// filter out completed and specified schedules.
+	///
+	/// Returns a tuple that consists of:
+	/// - Vec of vesting schedules, where completed schedules and those specified
+	/// 	by filter are removed. (Note the vec is not checked for respecting
+	/// 	bounded length.)
+	/// - The amount locked at the current block number based on the given schedules.
+	///
+	/// NOTE: the amount locked does not include any schedules that are filtered out via `action`.
+	fn report_schedule_updates(
+		schedules: Vec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>>,
+		action: VestingAction,
+	) -> (Vec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>>, BalanceOf<T, I>) {
+		let now = T::BlockNumberProvider::current_block_number();
+
+		let mut total_locked_now: BalanceOf<T, I> = Zero::zero();
+		let filtered_schedules = action
+			.pick_schedules::<T, I>(schedules)
+			.filter(|schedule| {
+				let locked_now = schedule.locked_at::<T::BlockNumberToBalance>(now);
+				let keep = !locked_now.is_zero();
+				if keep {
+					total_locked_now = total_locked_now.saturating_add(locked_now);
+				}
+				keep
+			})
+			.collect::<Vec<_>>();
+
+		(filtered_schedules, total_locked_now)
+	}
+
+	/// Write an accounts updated vesting lock to storage.
+	fn write_lock(
+		asset: AssetIdOf<T, I>,
+		who: &T::AccountId,
+		total_locked_now: BalanceOf<T, I>,
+	) -> DispatchResult {
+		T::Freezer::set_freeze(
+			asset.clone(),
+			&FreezeReason::Vesting.into(),
+			&who,
+			total_locked_now,
+		)?;
+
+		if total_locked_now.is_zero() {
+			Self::deposit_event(Event::<T, I>::VestingCompleted { asset, account: who.clone() });
+		} else {
+			Self::deposit_event(Event::<T, I>::VestingUpdated {
+				asset,
+				account: who.clone(),
+				unvested: total_locked_now,
+			});
+		}
+
+		Ok(())
+	}
+
+	/// Write an accounts updated vesting schedules to storage.
+	fn write_vesting(
+		asset: AssetIdOf<T, I>,
+		who: &T::AccountId,
+		schedules: Vec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>>,
+	) -> Result<(), DispatchError> {
+		let schedules: BoundedVec<
+			VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>,
+			MaxVestingSchedulesGet<T, I>,
+		> = schedules.try_into().map_err(|_| Error::<T, I>::AtMaxVestingSchedules)?;
+
+		if schedules.len() == 0 {
+			Vesting::<T, I>::remove(asset, &who);
+		} else {
+			Vesting::<T, I>::insert(asset, who, schedules)
+		}
+
+		Ok(())
+	}
+
+	/// Unlock any vested funds of `who`.
+	fn do_vest(asset: AssetIdOf<T, I>, who: T::AccountId) -> DispatchResult {
+		let schedules = Vesting::<T, I>::get(&asset, &who).ok_or(Error::<T, I>::NotVesting)?;
+
+		let (schedules, locked_now) =
+			Self::exec_action(schedules.to_vec(), VestingAction::Passive)?;
+
+		Self::write_vesting(asset.clone(), &who, schedules)?;
+		Self::write_lock(asset, &who, locked_now)?;
+
+		Ok(())
+	}
+
+	/// Execute a `VestingAction` against the given `schedules`. Returns the updated schedules
+	/// and locked amount.
+	fn exec_action(
+		schedules: Vec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>>,
+		action: VestingAction,
+	) -> Result<
+		(Vec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>>, BalanceOf<T, I>),
+		DispatchError,
+	> {
+		let (schedules, locked_now) = match action {
+			VestingAction::Merge { index1: idx1, index2: idx2 } => {
+				// The schedule index is based off of the schedule ordering prior to filtering out
+				// any schedules that may be ending at this block.
+				let schedule1 =
+					*schedules.get(idx1).ok_or(Error::<T, I>::ScheduleIndexOutOfBounds)?;
+				let schedule2 =
+					*schedules.get(idx2).ok_or(Error::<T, I>::ScheduleIndexOutOfBounds)?;
+
+				// The length of `schedules` decreases by 2 here since we filter out 2 schedules.
+				// Thus we know below that we can push the new merged schedule without error
+				// (assuming initial state was valid).
+				let (mut schedules, mut locked_now) =
+					Self::report_schedule_updates(schedules.to_vec(), action);
+
+				let now = T::BlockNumberProvider::current_block_number();
+				if let Some(new_schedule) = Self::merge_vesting_info(now, schedule1, schedule2) {
+					// Merging created a new schedule so we:
+					// 1) need to add it to the accounts vesting schedule collection,
+					schedules.push(new_schedule);
+					// (we use `locked_at` in case this is a schedule that started in the past)
+					let new_schedule_locked =
+						new_schedule.locked_at::<T::BlockNumberToBalance>(now);
+					// and 2) update the locked amount to reflect the schedule we just added.
+					locked_now = locked_now.saturating_add(new_schedule_locked);
+				} // In the None case there was no new schedule to account for.
+
+				(schedules, locked_now)
+			},
+			_ => Self::report_schedule_updates(schedules.to_vec(), action),
+		};
+
+		debug_assert!(
+			locked_now > Zero::zero() && schedules.len() > 0 ||
+				locked_now == Zero::zero() && schedules.len() == 0
+		);
+
+		Ok((schedules, locked_now))
+	}
+}
+
+impl<T: Config<I>, I: 'static> VestingSchedule<T::AccountId> for Pallet<T, I>
+where
+	BalanceOf<T, I>: MaybeSerializeDeserialize + Debug,
+{
+	type Moment = BlockNumberFor<T>;
+	type AssetId = AssetIdOf<T, I>;
+	type Balance = BalanceOf<T, I>;
+
+	fn vesting_balance(asset: AssetIdOf<T, I>, who: &T::AccountId) -> Option<BalanceOf<T, I>> {
+		Vesting::<T, I>::get(&asset, who).map(|v| {
+			let now = T::BlockNumberProvider::current_block_number();
+			let total_locked_now = v.iter().fold(Zero::zero(), |total, schedule| {
+				schedule.locked_at::<T::BlockNumberToBalance>(now).saturating_add(total)
+			});
+			total_locked_now
+		})
+	}
+
+	fn add_vesting_schedule(
+		asset: AssetIdOf<T, I>,
+		who: &T::AccountId,
+		locked: BalanceOf<T, I>,
+		per_block: BalanceOf<T, I>,
+		starting_block: BlockNumberFor<T>,
+	) -> DispatchResult {
+		if locked.is_zero() {
+			return Ok(())
+		}
+
+		let vesting_schedule = VestingInfo::new(locked, per_block, starting_block);
+		// Check for `per_block` or `locked` of 0.
+		if !vesting_schedule.is_valid() {
+			return Err(Error::<T, I>::InvalidScheduleParams.into())
+		};
+
+		let mut schedules = Vesting::<T, I>::get(&asset, who).unwrap_or_default();
+
+		// NOTE: we must push the new schedule so that `exec_action`
+		// will give the correct new locked amount.
+		ensure!(schedules.try_push(vesting_schedule).is_ok(), Error::<T, I>::AtMaxVestingSchedules);
+
+		let (schedules, locked_now) =
+			Self::exec_action(schedules.to_vec(), VestingAction::Passive)?;
+
+		Self::write_vesting(asset.clone(), who, schedules)?;
+		Self::write_lock(asset, who, locked_now)?;
+
+		Ok(())
+	}
+
+	fn can_add_vesting_schedule(
+		asset: AssetIdOf<T, I>,
+		who: &T::AccountId,
+		locked: BalanceOf<T, I>,
+		per_block: BalanceOf<T, I>,
+		starting_block: BlockNumberFor<T>,
+	) -> DispatchResult {
+		// Check for `per_block` or `locked` of 0.
+		if !VestingInfo::new(locked, per_block, starting_block).is_valid() {
+			return Err(Error::<T, I>::InvalidScheduleParams.into())
+		}
+
+		ensure!(
+			(Vesting::<T, I>::decode_len(asset, who).unwrap_or_default() as u32) <
+				T::MAX_VESTING_SCHEDULES,
+			Error::<T, I>::AtMaxVestingSchedules
+		);
+
+		Ok(())
+	}
+
+	fn remove_vesting_schedule(
+		asset: AssetIdOf<T, I>,
+		who: &T::AccountId,
+		schedule_index: u32,
+	) -> DispatchResult {
+		let schedules = Vesting::<T, I>::get(&asset, who).ok_or(Error::<T, I>::NotVesting)?;
+		let remove_action = VestingAction::Remove { index: schedule_index as usize };
+
+		let (schedules, locked_now) = Self::exec_action(schedules.to_vec(), remove_action)?;
+
+		Self::write_vesting(asset.clone(), who, schedules)?;
+		Self::write_lock(asset, who, locked_now)?;
+		Ok(())
+	}
+}
+
+impl<T: Config<I>, I: 'static> VestedTransfer<T::AccountId> for Pallet<T, I>
+where
+	BalanceOf<T, I>: MaybeSerializeDeserialize + Debug,
+{
+	type Moment = BlockNumberFor<T>;
+	type AssetId = AssetIdOf<T, I>;
+	type Balance = BalanceOf<T, I>;
+
+	fn vested_transfer(
+		asset: AssetIdOf<T, I>,
+		source: &T::AccountId,
+		target: &T::AccountId,
+		locked: BalanceOf<T, I>,
+		per_block: BalanceOf<T, I>,
+		starting_block: BlockNumberFor<T>,
+	) -> DispatchResult {
+		use storage::{with_transaction, TransactionOutcome};
+		let schedule = VestingInfo::new(locked, per_block, starting_block);
+		with_transaction(|| -> TransactionOutcome<DispatchResult> {
+			let result = Self::do_vested_transfer(asset, source, target, schedule);
+
+			match &result {
+				Ok(()) => TransactionOutcome::Commit(result),
+				_ => TransactionOutcome::Rollback(result),
+			}
+		})
+	}
+}

--- a/substrate/frame/assets-vesting/src/mock.rs
+++ b/substrate/frame/assets-vesting/src/mock.rs
@@ -1,0 +1,211 @@
+use crate as pallet_assets_vesting;
+pub use frame::{
+	deps::{codec::Encode, sp_runtime::traits::Identity},
+	testing_prelude::{Get, *},
+};
+use std::collections::HashSet;
+
+#[frame_construct_runtime]
+mod runtime {
+	// The main runtime
+	#[runtime::runtime]
+	// Runtime Types to be generated
+	#[runtime::derive(
+		RuntimeCall,
+		RuntimeEvent,
+		RuntimeError,
+		RuntimeOrigin,
+		RuntimeFreezeReason,
+		RuntimeHoldReason,
+		RuntimeSlashReason,
+		RuntimeLockId,
+		RuntimeTask,
+		RuntimeViewFunction
+	)]
+	pub struct Test;
+
+	#[runtime::pallet_index(0)]
+	pub type System = frame_system;
+	#[runtime::pallet_index(1)]
+	pub type Balances = pallet_balances;
+	#[runtime::pallet_index(2)]
+	pub type Assets = pallet_assets;
+	#[runtime::pallet_index(3)]
+	pub type AssetsFreezer = pallet_assets_freezer;
+	#[runtime::pallet_index(4)]
+	pub type AssetsVesting = pallet_assets_vesting;
+}
+
+type Block = MockBlock<Test>;
+pub type BlockNumber = BlockNumberFor<Test>;
+pub type AccountId = <Test as frame_system::Config>::AccountId;
+type ExistentialDeposit = <Test as pallet_balances::Config>::ExistentialDeposit;
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+pub type AssetId = <Test as pallet_assets::Config>::AssetId;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+	type AccountData = pallet_balances::AccountData<u64>;
+	type Block = Block;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+	type AccountStore = System;
+	type MaxFreezes = ConstU32<2>;
+}
+
+#[derive_impl(pallet_assets::config_preludes::TestDefaultConfig)]
+impl pallet_assets::Config for Test {
+	type Currency = Balances;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type CreateOrigin = EnsureSigned<AccountId>;
+	type Freezer = AssetsFreezer;
+}
+
+impl pallet_assets_freezer::Config for Test {
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type RuntimeEvent = RuntimeEvent;
+}
+
+parameter_types! {
+	pub const MinVestedTransfer: u64 = 256 * 2;
+}
+
+impl pallet_assets_vesting::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type Assets = Assets;
+	type Freezer = AssetsFreezer;
+	type BlockNumberToBalance = Identity;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type WeightInfo = ();
+	type MinVestedTransfer = MinVestedTransfer;
+	type BlockNumberProvider = System;
+	const MAX_VESTING_SCHEDULES: u32 = 3;
+}
+
+// Test Externalities
+
+#[derive(Clone)]
+pub(crate) struct AssetsGenesis {
+	id: AssetId,
+	minimum_balance: Balance,
+	owner: AccountId,
+	accounts: Vec<(AccountId, Balance)>,
+}
+
+pub struct ExtBuilder {
+	assets: Option<Vec<AssetsGenesis>>,
+	vesting_genesis_config: Option<Vec<(AssetId, AccountId, BlockNumber, BlockNumber, Balance)>>,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self { assets: None, vesting_genesis_config: None }
+	}
+}
+
+impl ExtBuilder {
+	pub fn with_min_balance(self, id: AssetId, minimum_balance: Balance) -> Self {
+		self.with_asset(
+			id,
+			0,
+			minimum_balance,
+			vec![(1, 10), (2, 20), (3, 30), (4, 40), (12, 10), (13, 9999)]
+				.iter()
+				.map(|(who, amount)| (*who, *amount * minimum_balance))
+				.collect(),
+		)
+		.with_vesting_genesis_config((id, 1, 0, 10, 5 * minimum_balance))
+		.with_vesting_genesis_config((id, 2, 10, 20, 0))
+		.with_vesting_genesis_config((id, 12, 10, 20, 5 * minimum_balance))
+	}
+
+	pub fn with_asset(
+		mut self,
+		id: AssetId,
+		owner: AccountId,
+		minimum_balance: Balance,
+		accounts: Vec<(AccountId, Balance)>,
+	) -> Self {
+		let mut assets = self.assets.unwrap_or(vec![]);
+		assets.push(AssetsGenesis { id, owner, minimum_balance, accounts });
+		self.assets = Some(assets);
+		self
+	}
+
+	pub fn with_vesting_genesis_config(
+		mut self,
+		config: (AssetId, AccountId, BlockNumber, BlockNumber, Balance),
+	) -> Self {
+		let mut vesting_genesis_config = self.vesting_genesis_config.unwrap_or(vec![]);
+		vesting_genesis_config.push(config);
+		self.vesting_genesis_config = Some(vesting_genesis_config);
+		self
+	}
+
+	pub fn build(self) -> TestExternalities {
+		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+
+		let assets = self.assets.unwrap_or(vec![AssetsGenesis {
+			id: 1,
+			minimum_balance: 1,
+			owner: 0,
+			accounts: vec![(1, 10), (2, 20), (3, 30), (4, 40), (12, 10), (13, 9999)],
+		}]);
+
+		// Configure genesis for `Balances`
+		let balances: HashSet<(AccountId, Balance)> = assets
+			.clone()
+			.into_iter()
+			.flat_map(|AssetsGenesis { accounts, .. }| {
+				accounts
+					.iter()
+					.map(|(who, _)| (*who, <ExistentialDeposit as Get<Balance>>::get()))
+					.collect::<Vec<_>>()
+			})
+			.collect();
+		pallet_balances::GenesisConfig::<Test> {
+			balances: balances.into_iter().collect(),
+			dev_accounts: None,
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		// Configure genesis for `Assets`
+		let mut assets_genesis = pallet_assets::GenesisConfig::<Test> {
+			assets: vec![],
+			accounts: vec![],
+			metadata: vec![],
+			next_asset_id: None,
+		};
+		for AssetsGenesis { id, owner, minimum_balance, accounts } in assets.clone() {
+			assets_genesis.assets.push((id, owner, true, minimum_balance));
+			assets_genesis
+				.accounts
+				.append(&mut accounts.into_iter().map(|(who, amount)| (id, who, amount)).collect());
+		}
+		assets_genesis.assimilate_storage(&mut t).unwrap();
+
+		// Configure genesis for `AssetsVesting`
+		pallet_assets_vesting::GenesisConfig::<Test> {
+			vesting: self
+				.vesting_genesis_config
+				.unwrap_or(vec![
+					(assets[0].id, 1, 0, 10, 5 * assets[0].minimum_balance),
+					(assets[0].id, 2, 10, 20, 0),
+					(assets[0].id, 12, 10, 20, 5 * assets[0].minimum_balance),
+				])
+				.into_iter()
+				.map(|(id, who, begin, length, liquid)| (id.encode(), who, begin, length, liquid))
+				.collect(),
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		let mut ext = TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}

--- a/substrate/frame/assets-vesting/src/tests.rs
+++ b/substrate/frame/assets-vesting/src/tests.rs
@@ -1,0 +1,306 @@
+use super::{mock::*, AccountIdOf, AssetIdOf, Error, Vesting as VestingStorage, VestingInfo};
+use codec::EncodeLike;
+use frame::traits::fungibles::VestingSchedule;
+
+const ASSET_ID: AssetId = 1;
+const MINIMUM_BALANCE: Balance = 256;
+
+/// Calls vest, and asserts that there is no entry for `account`
+/// in the `Vesting` storage item.
+fn vest_and_assert_no_vesting<T, I: 'static>(asset: AssetId, account: AccountId)
+where
+	AssetId: EncodeLike<AssetIdOf<T, I>>,
+	AccountId: EncodeLike<AccountIdOf<T>>,
+	T: crate::Config<I> + pallet_assets::Config<I>,
+{
+	// Its ok for this to fail because the user may already have no schedules.
+	let _result = AssetsVesting::vest(Some(account).into(), asset.clone());
+	assert!(!<VestingStorage<T, I>>::contains_key(asset, account));
+}
+
+#[test]
+fn check_vesting_status() {
+	ExtBuilder::default()
+		.with_min_balance(ASSET_ID, MINIMUM_BALANCE)
+		.build()
+		.execute_with(|| {
+			let user_1 = 1;
+			let user_2 = 2;
+			let user_12 = 12;
+
+			let user1_account_balance = Assets::balance(ASSET_ID, &user_1);
+			let user2_account_balance = Assets::balance(ASSET_ID, &user_2);
+			let user12_account_balance = Assets::balance(ASSET_ID, &user_12);
+
+			assert_eq!(user1_account_balance, MINIMUM_BALANCE * 10); // Account 1 has balance
+			assert_eq!(user2_account_balance, MINIMUM_BALANCE * 20); // Account 2 has balance
+			assert_eq!(user12_account_balance, MINIMUM_BALANCE * 10); // Account 12 has balance
+
+			let user1_vesting_schedule = VestingInfo::new(
+				MINIMUM_BALANCE * 5,
+				128, // Vesting over 10 blocks
+				0,
+			);
+			let user2_vesting_schedule = VestingInfo::new(
+				MINIMUM_BALANCE * 20,
+				MINIMUM_BALANCE, // Vesting over 20 blocks
+				10,
+			);
+			let user12_vesting_schedule = VestingInfo::new(
+				MINIMUM_BALANCE * 5,
+				64, // Vesting over 20 blocks
+				10,
+			);
+
+			assert_eq!(
+				VestingStorage::<Test>::get(ASSET_ID, &user_1).unwrap(),
+				vec![user1_vesting_schedule]
+			); // Account 1 has a vesting schedule
+			assert_eq!(
+				VestingStorage::<Test>::get(ASSET_ID, &user_2).unwrap(),
+				vec![user2_vesting_schedule]
+			); // Account 2 has a vesting schedule
+			assert_eq!(
+				VestingStorage::<Test>::get(ASSET_ID, &user_12).unwrap(),
+				vec![user12_vesting_schedule]
+			); // Account 12 has a vesting schedule
+
+			// Account 1 has only 128 units vested from their illiquid MINIMUM_BALANCE * 5 units at
+			// block 1
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &user_1), Some(128 * 9));
+			// Account 2 has their full balance locked
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &user_2),
+				Some(user2_account_balance)
+			);
+			// Account 12 has only their illiquid funds locked
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &user_12),
+				Some(user12_account_balance - MINIMUM_BALANCE * 5)
+			);
+
+			System::set_block_number(10);
+			assert_eq!(System::block_number(), 10);
+
+			// Account 1 has fully vested by block 10
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(0));
+			// Account 2 has started vesting by block 10
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &2), Some(user2_account_balance));
+			// Account 12 has started vesting by block 10
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &12),
+				Some(user12_account_balance - MINIMUM_BALANCE * 5)
+			);
+
+			System::set_block_number(30);
+			assert_eq!(System::block_number(), 30);
+
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(0)); // Account 1 is still fully vested, and not negative
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &2), Some(0)); // Account 2 has fully vested by block 30
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &12), Some(0)); // Account 2 has fully vested by block 30
+
+			// Once we unlock the funds, they are removed from storage.
+			vest_and_assert_no_vesting::<Test, ()>(ASSET_ID, 1);
+			vest_and_assert_no_vesting::<Test, ()>(ASSET_ID, 2);
+			vest_and_assert_no_vesting::<Test, ()>(ASSET_ID, 12);
+		});
+}
+
+#[test]
+fn check_vesting_status_for_multi_schedule_account() {
+	ExtBuilder::default()
+		.with_min_balance(ASSET_ID, MINIMUM_BALANCE)
+		.build()
+		.execute_with(|| {
+			assert_eq!(System::block_number(), 1);
+			let sched0 = VestingInfo::new(
+				MINIMUM_BALANCE * 20,
+				MINIMUM_BALANCE, // Vesting over 20 blocks
+				10,
+			);
+			// Account 2 already has a vesting schedule.
+			assert_eq!(VestingStorage::<Test>::get(ASSET_ID, &2).unwrap(), vec![sched0]);
+
+			// Account 2's free balance is from sched0.
+			let account_balance = Assets::balance(ASSET_ID, &2);
+			assert_eq!(account_balance, MINIMUM_BALANCE * (20));
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &2), Some(account_balance));
+
+			// Add a 2nd schedule that is already unlocking by block #1.
+			let sched1 = VestingInfo::new(
+				MINIMUM_BALANCE * 10,
+				MINIMUM_BALANCE, // Vesting over 10 blocks
+				0,
+			);
+			assert_ok!(AssetsVesting::vested_transfer(Some(4).into(), ASSET_ID, 2, sched1));
+			// Free balance is equal to the two existing schedules total amount.
+			let account_balance = Assets::balance(ASSET_ID, &2);
+			assert_eq!(account_balance, MINIMUM_BALANCE * (10 + 20));
+			// The most recently added schedule exists.
+			assert_eq!(VestingStorage::<Test>::get(ASSET_ID, &2).unwrap(), vec![sched0, sched1]);
+			// sched1 has free funds at block #1, but nothing else.
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &2),
+				Some(account_balance - sched1.per_block())
+			);
+
+			// Add a 3rd schedule.
+			let sched2 = VestingInfo::new(
+				MINIMUM_BALANCE * 30,
+				MINIMUM_BALANCE, // Vesting over 30 blocks
+				5,
+			);
+			assert_ok!(AssetsVesting::vested_transfer(Some(4).into(), ASSET_ID, 2, sched2));
+
+			System::set_block_number(9);
+			// Free balance is equal to the 3 existing schedules total amount.
+			let account_balance = Assets::balance(ASSET_ID, &2);
+			assert_eq!(account_balance, MINIMUM_BALANCE * (10 + 20 + 30));
+			// sched1 and sched2 are freeing funds at block #9.
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &2),
+				Some(account_balance - sched1.per_block() * 9 - sched2.per_block() * 4)
+			);
+
+			System::set_block_number(20);
+			// At block #20 sched1 is fully unlocked while sched2 and sched0 are partially unlocked.
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &2),
+				Some(
+					account_balance -
+						sched1.locked() - sched2.per_block() * 15 -
+						sched0.per_block() * 10
+				)
+			);
+
+			System::set_block_number(30);
+			// At block #30 sched0 and sched1 are fully unlocked while sched2 is partially unlocked.
+			assert_eq!(
+				AssetsVesting::vesting_balance(ASSET_ID, &2),
+				Some(account_balance - sched1.locked() - sched2.per_block() * 25 - sched0.locked())
+			);
+
+			// At block #35 sched2 fully unlocks and thus all schedules funds are unlocked.
+			System::set_block_number(35);
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &2), Some(0));
+			// Since we have not called any extrinsics that would unlock funds the schedules
+			// are still in storage,
+			assert_eq!(
+				VestingStorage::<Test>::get(ASSET_ID, &2).unwrap(),
+				vec![sched0, sched1, sched2]
+			);
+			// but once we unlock the funds, they are removed from storage.
+			vest_and_assert_no_vesting::<Test, ()>(ASSET_ID, 2);
+		});
+}
+
+#[test]
+fn unvested_balance_should_not_transfer() {
+	ExtBuilder::default().with_min_balance(ASSET_ID, 10).build().execute_with(|| {
+		let user1_account_balance = Assets::balance(ASSET_ID, &1);
+		assert_eq!(user1_account_balance, 100); // Account 1 has account balance
+										  // Account 1 has only 5 units vested at block 1 (plus 50 unvested)
+		assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(45));
+		// Account 1 cannot send more than vested amount...
+		// TODO: this error should change to `TokenError::Frozen` once #4530 is merged
+		assert_noop!(
+			Assets::transfer(Some(1).into(), ASSET_ID, 2, 56),
+			pallet_assets::Error::<Test>::BalanceLow
+		);
+	});
+}
+
+#[test]
+fn vested_balance_should_transfer() {
+	ExtBuilder::default().with_min_balance(ASSET_ID, 10).build().execute_with(|| {
+		let user1_account_balance = Assets::balance(ASSET_ID, &1);
+		assert_eq!(user1_account_balance, 100); // Account 1 has account balance
+										  // Account 1 has only 5 units vested at block 1 (plus 50 unvested)
+		assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(45));
+		assert_ok!(AssetsVesting::vest(Some(1).into(), ASSET_ID));
+		// TODO: this value should be changed to 55 once #4530 is merged
+		assert_ok!(Assets::transfer(Some(1).into(), ASSET_ID, 2, 45));
+	});
+}
+
+#[test]
+fn vested_balance_should_transfer_with_multi_sched() {
+	ExtBuilder::default()
+		.with_min_balance(ASSET_ID, MINIMUM_BALANCE)
+		.build()
+		.execute_with(|| {
+			let sched0 = VestingInfo::new(5 * MINIMUM_BALANCE, 128, 0);
+			assert_ok!(AssetsVesting::vested_transfer(Some(13).into(), ASSET_ID, 1, sched0));
+			// Total 10*ED locked for all the schedules.
+			assert_eq!(VestingStorage::<Test>::get(ASSET_ID, &1).unwrap(), vec![sched0, sched0]);
+
+			let user1_account_balance = Assets::balance(ASSET_ID, &1);
+			assert_eq!(user1_account_balance, 3840); // Account 1 has account balance
+
+			// Account 1 has only 256 units unlocking at block 1 (plus 1280 already fee).
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(2304));
+			assert_ok!(AssetsVesting::vest(Some(1).into(), ASSET_ID));
+			// TODO: this value should be changed to 1536 once #4530 is merged
+			assert_ok!(Assets::transfer(Some(1).into(), ASSET_ID, 2, 1280));
+		});
+}
+
+#[test]
+fn non_vested_cannot_vest() {
+	ExtBuilder::default()
+		.with_min_balance(ASSET_ID, MINIMUM_BALANCE)
+		.build()
+		.execute_with(|| {
+			assert!(!<VestingStorage<Test>>::contains_key(ASSET_ID, 4));
+			assert_noop!(AssetsVesting::vest(Some(4).into(), ASSET_ID), Error::<Test>::NotVesting);
+		});
+}
+
+#[test]
+fn vested_balance_should_transfer_using_vest_other() {
+	ExtBuilder::default().with_min_balance(ASSET_ID, 10).build().execute_with(|| {
+		let user1_account_balance = Assets::balance(ASSET_ID, &1);
+		assert_eq!(user1_account_balance, 100); // Account 1 has account balance
+										  // Account 1 has only 5 units vested at block 1 (plus 50 unvested)
+		assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(45));
+		assert_ok!(AssetsVesting::vest_other(Some(2).into(), ASSET_ID, 1));
+		// TODO: this value should be changed to 55 once #4530 is merged
+		assert_ok!(Assets::transfer(Some(1).into(), ASSET_ID, 2, 45));
+	});
+}
+
+#[test]
+fn vested_balance_should_transfer_using_vest_other_with_multi_sched() {
+	ExtBuilder::default()
+		.with_min_balance(ASSET_ID, MINIMUM_BALANCE)
+		.build()
+		.execute_with(|| {
+			let sched0 = VestingInfo::new(5 * MINIMUM_BALANCE, 128, 0);
+			assert_ok!(AssetsVesting::vested_transfer(Some(13).into(), ASSET_ID, 1, sched0));
+			// Total of 10*ED of locked for all the schedules.
+			assert_eq!(VestingStorage::<Test>::get(ASSET_ID, &1).unwrap(), vec![sched0, sched0]);
+
+			let user1_account_balance = Assets::balance(ASSET_ID, &1);
+			assert_eq!(user1_account_balance, 3840); // Account 1 has account balance
+
+			// Account 1 has only 256 units unlocking at block 1 (plus 1280 already free).
+			assert_eq!(AssetsVesting::vesting_balance(ASSET_ID, &1), Some(2304));
+			assert_ok!(AssetsVesting::vest_other(Some(2).into(), ASSET_ID, 1));
+			// TODO: this value should be changed to 1536 once #4530 is merged
+			assert_ok!(Assets::transfer(Some(1).into(), ASSET_ID, 2, 1280));
+		});
+}
+
+#[test]
+fn non_vested_cannot_vest_other() {
+	ExtBuilder::default()
+		.with_min_balance(ASSET_ID, MINIMUM_BALANCE)
+		.build()
+		.execute_with(|| {
+			assert!(!<VestingStorage<Test>>::contains_key(ASSET_ID, 4));
+			assert_noop!(
+				AssetsVesting::vest_other(Some(3).into(), ASSET_ID, 4),
+				Error::<Test>::NotVesting
+			);
+		});
+}

--- a/substrate/frame/assets-vesting/src/types.rs
+++ b/substrate/frame/assets-vesting/src/types.rs
@@ -89,11 +89,11 @@ where
 {
 	/// Instantiate a new `VestingInfo`.
 	pub fn new(
-		locked: Balance,
+		frozen: Balance,
 		per_block: Balance,
 		starting_block: BlockNumber,
 	) -> VestingInfo<Balance, BlockNumber> {
-		VestingInfo { frozen: locked, per_block, starting_block }
+		VestingInfo { frozen, per_block, starting_block }
 	}
 
 	/// Validate parameters for `VestingInfo`. Note that this does not check

--- a/substrate/frame/assets-vesting/src/types.rs
+++ b/substrate/frame/assets-vesting/src/types.rs
@@ -1,0 +1,166 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module to manage types related to vesting.
+
+use super::*;
+
+pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+pub(crate) type AssetIdOf<T, I = ()> =
+	<<T as Config<I>>::Assets as Inspect<AccountIdOf<T>>>::AssetId;
+pub(crate) type BalanceOf<T, I = ()> =
+	<<T as Config<I>>::Assets as Inspect<AccountIdOf<T>>>::Balance;
+pub(crate) type AccountIdLookupOf<T> =
+	<<T as frame_system::Config>::Lookup as StaticLookup>::Source;
+
+/// Actions to take against a user's `Vesting` storage entry.
+#[derive(Clone, Copy)]
+pub(crate) enum VestingAction {
+	/// Do not actively remove any schedules.
+	Passive,
+	/// Remove the schedule specified by the index.
+	Remove { index: usize },
+	/// Remove the two schedules, specified by index, so they can be merged.
+	Merge { index1: usize, index2: usize },
+}
+
+impl VestingAction {
+	/// Whether or not the filter says the schedule index should be removed.
+	pub(crate) fn should_remove(&self, index: usize) -> bool {
+		match self {
+			Self::Passive => false,
+			Self::Remove { index: index1 } => *index1 == index,
+			Self::Merge { index1, index2 } => *index1 == index || *index2 == index,
+		}
+	}
+
+	/// Pick the schedules that this action dictates should continue vesting undisturbed.
+	pub(crate) fn pick_schedules<T: Config<I>, I: 'static>(
+		&self,
+		schedules: Vec<VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>>,
+	) -> impl Iterator<Item = VestingInfo<BalanceOf<T, I>, BlockNumberFor<T>>> + '_ {
+		schedules.into_iter().enumerate().filter_map(move |(index, schedule)| {
+			if self.should_remove(index) {
+				None
+			} else {
+				Some(schedule)
+			}
+		})
+	}
+}
+
+// Wrapper for `T::MAX_VESTING_SCHEDULES` to satisfy `trait Get`.
+pub struct MaxVestingSchedulesGet<T, I = ()>(PhantomData<(T, I)>);
+impl<T: Config<I>, I: 'static> Get<u32> for MaxVestingSchedulesGet<T, I> {
+	fn get() -> u32 {
+		T::MAX_VESTING_SCHEDULES
+	}
+}
+
+/// Struct to encode the vesting schedule of an individual account.
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
+pub struct VestingInfo<Balance, BlockNumber> {
+	/// Locked amount at genesis.
+	frozen: Balance,
+	/// Amount that gets unlocked every block after `starting_block`.
+	per_block: Balance,
+	/// Starting block for unlocking(vesting).
+	starting_block: BlockNumber,
+}
+
+impl<Balance, BlockNumber> VestingInfo<Balance, BlockNumber>
+where
+	Balance: AtLeast32BitUnsigned + Copy,
+	BlockNumber: AtLeast32BitUnsigned + Copy + Bounded,
+{
+	/// Instantiate a new `VestingInfo`.
+	pub fn new(
+		locked: Balance,
+		per_block: Balance,
+		starting_block: BlockNumber,
+	) -> VestingInfo<Balance, BlockNumber> {
+		VestingInfo { frozen: locked, per_block, starting_block }
+	}
+
+	/// Validate parameters for `VestingInfo`. Note that this does not check
+	/// against `MinVestedTransfer`.
+	pub fn is_valid(&self) -> bool {
+		!self.frozen.is_zero() && !self.raw_per_block().is_zero()
+	}
+
+	/// Locked amount at schedule creation.
+	pub fn locked(&self) -> Balance {
+		self.frozen
+	}
+
+	/// Amount that gets thawed every block after `starting_block`. Corrects for `per_block` of 0.
+	/// We don't let `per_block` be less than 1, or else the vesting will never end.
+	/// This should be used whenever accessing `per_block` unless explicitly checking for 0 values.
+	pub fn per_block(&self) -> Balance {
+		self.per_block.max(One::one())
+	}
+
+	/// Get the unmodified `per_block`. Generally should not be used, but is useful for
+	/// validating `per_block`.
+	pub(crate) fn raw_per_block(&self) -> Balance {
+		self.per_block
+	}
+
+	/// Starting block for thawing(vesting).
+	pub fn starting_block(&self) -> BlockNumber {
+		self.starting_block
+	}
+
+	/// Amount frozen at block `n`.
+	pub fn locked_at<BlockNumberToBalance: Convert<BlockNumber, Balance>>(
+		&self,
+		n: BlockNumber,
+	) -> Balance {
+		// Number of blocks that count toward vesting;
+		// saturating to 0 when n < starting_block.
+		let vested_block_count = n.saturating_sub(self.starting_block);
+		let vested_block_count = BlockNumberToBalance::convert(vested_block_count);
+		// Return amount that is still frozen in vesting.
+		vested_block_count
+			.checked_mul(&self.per_block()) // `per_block` accessor guarantees at least 1.
+			.map(|to_unlock| self.frozen.saturating_sub(to_unlock))
+			.unwrap_or(Zero::zero())
+	}
+
+	/// Block number at which the schedule ends (as type `Balance`).
+	pub fn ending_block_as_balance<BlockNumberToBalance: Convert<BlockNumber, Balance>>(
+		&self,
+	) -> Balance {
+		let starting_block = BlockNumberToBalance::convert(self.starting_block);
+		let duration = if self.per_block() >= self.frozen {
+			// If `per_block` is bigger than `frozen`, the schedule will end
+			// the block after starting.
+			One::one()
+		} else {
+			self.frozen / self.per_block() +
+				if (self.frozen % self.per_block()).is_zero() {
+					Zero::zero()
+				} else {
+					// `per_block` does not perfectly divide `frozen`, so we need an extra block to
+					// thaw some amount less than `per_block`.
+					One::one()
+				}
+		};
+
+		starting_block.saturating_add(duration)
+	}
+}

--- a/substrate/frame/assets-vesting/src/weights.rs
+++ b/substrate/frame/assets-vesting/src/weights.rs
@@ -1,0 +1,448 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Weights for `pallet_vesting`
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+#![allow(missing_docs)]
+
+use frame::traits::Get;
+use core::marker::PhantomData;
+use frame::deps::frame_system;
+use frame::weights_prelude::{RocksDbWeight, Weight};
+
+/// Weight functions needed for `pallet_vesting`.
+pub trait WeightInfo {
+	fn vest_locked(l: u32, s: u32, ) -> Weight;
+	fn vest_unlocked(l: u32, s: u32, ) -> Weight;
+	fn vest_other_locked(l: u32, s: u32, ) -> Weight;
+	fn vest_other_unlocked(l: u32, s: u32, ) -> Weight;
+	fn vested_transfer(l: u32, s: u32, ) -> Weight;
+	fn force_vested_transfer(l: u32, s: u32, ) -> Weight;
+	fn not_unlocking_merge_schedules(l: u32, s: u32, ) -> Weight;
+	fn unlocking_merge_schedules(l: u32, s: u32, ) -> Weight;
+	fn force_remove_vesting_schedule(l: u32, s: u32, ) -> Weight;
+}
+
+/// Weights for `pallet_vesting` using the Substrate node and recommended hardware.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_locked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 39_505_000 picoseconds.
+		Weight::from_parts(39_835_306, 4764)
+			// Standard Error: 1_394
+			.saturating_add(Weight::from_parts(21_450, 0).saturating_mul(l.into()))
+			// Standard Error: 2_481
+			.saturating_add(Weight::from_parts(70_901, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_unlocked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 40_781_000 picoseconds.
+		Weight::from_parts(40_777_528, 4764)
+			// Standard Error: 1_209
+			.saturating_add(Weight::from_parts(35_116, 0).saturating_mul(l.into()))
+			// Standard Error: 2_151
+			.saturating_add(Weight::from_parts(83_093, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_other_locked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `517 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 41_590_000 picoseconds.
+		Weight::from_parts(40_756_231, 4764)
+			// Standard Error: 1_420
+			.saturating_add(Weight::from_parts(45_223, 0).saturating_mul(l.into()))
+			// Standard Error: 2_527
+			.saturating_add(Weight::from_parts(102_603, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_other_unlocked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `517 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 43_490_000 picoseconds.
+		Weight::from_parts(43_900_384, 4764)
+			// Standard Error: 1_670
+			.saturating_add(Weight::from_parts(31_084, 0).saturating_mul(l.into()))
+			// Standard Error: 2_971
+			.saturating_add(Weight::from_parts(66_673, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[0, 27]`.
+	fn vested_transfer(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `588 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 76_194_000 picoseconds.
+		Weight::from_parts(77_923_603, 4764)
+			// Standard Error: 2_141
+			.saturating_add(Weight::from_parts(50_161, 0).saturating_mul(l.into()))
+			// Standard Error: 3_810
+			.saturating_add(Weight::from_parts(97_415, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:2 w:2)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[0, 27]`.
+	fn force_vested_transfer(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `691 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `6196`
+		// Minimum execution time: 78_333_000 picoseconds.
+		Weight::from_parts(80_199_350, 6196)
+			// Standard Error: 1_903
+			.saturating_add(Weight::from_parts(46_798, 0).saturating_mul(l.into()))
+			// Standard Error: 3_385
+			.saturating_add(Weight::from_parts(106_311, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(5_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[2, 28]`.
+	fn not_unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 40_102_000 picoseconds.
+		Weight::from_parts(39_552_301, 4764)
+			// Standard Error: 1_309
+			.saturating_add(Weight::from_parts(37_184, 0).saturating_mul(l.into()))
+			// Standard Error: 2_418
+			.saturating_add(Weight::from_parts(91_621, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[2, 28]`.
+	fn unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 42_287_000 picoseconds.
+		Weight::from_parts(41_937_484, 4764)
+			// Standard Error: 1_306
+			.saturating_add(Weight::from_parts(39_880, 0).saturating_mul(l.into()))
+			// Standard Error: 2_412
+			.saturating_add(Weight::from_parts(85_247, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[2, 28]`.
+	fn force_remove_vesting_schedule(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `588 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 46_462_000 picoseconds.
+		Weight::from_parts(46_571_504, 4764)
+			// Standard Error: 1_298
+			.saturating_add(Weight::from_parts(42_091, 0).saturating_mul(l.into()))
+			// Standard Error: 2_397
+			.saturating_add(Weight::from_parts(77_382, 0).saturating_mul(s.into()))
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+}
+
+// For backwards compatibility and tests.
+impl WeightInfo for () {
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_locked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 39_505_000 picoseconds.
+		Weight::from_parts(39_835_306, 4764)
+			// Standard Error: 1_394
+			.saturating_add(Weight::from_parts(21_450, 0).saturating_mul(l.into()))
+			// Standard Error: 2_481
+			.saturating_add(Weight::from_parts(70_901, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_unlocked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 40_781_000 picoseconds.
+		Weight::from_parts(40_777_528, 4764)
+			// Standard Error: 1_209
+			.saturating_add(Weight::from_parts(35_116, 0).saturating_mul(l.into()))
+			// Standard Error: 2_151
+			.saturating_add(Weight::from_parts(83_093, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_other_locked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `517 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 41_590_000 picoseconds.
+		Weight::from_parts(40_756_231, 4764)
+			// Standard Error: 1_420
+			.saturating_add(Weight::from_parts(45_223, 0).saturating_mul(l.into()))
+			// Standard Error: 2_527
+			.saturating_add(Weight::from_parts(102_603, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[1, 28]`.
+	fn vest_other_unlocked(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `517 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 43_490_000 picoseconds.
+		Weight::from_parts(43_900_384, 4764)
+			// Standard Error: 1_670
+			.saturating_add(Weight::from_parts(31_084, 0).saturating_mul(l.into()))
+			// Standard Error: 2_971
+			.saturating_add(Weight::from_parts(66_673, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[0, 27]`.
+	fn vested_transfer(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `588 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 76_194_000 picoseconds.
+		Weight::from_parts(77_923_603, 4764)
+			// Standard Error: 2_141
+			.saturating_add(Weight::from_parts(50_161, 0).saturating_mul(l.into()))
+			// Standard Error: 3_810
+			.saturating_add(Weight::from_parts(97_415, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:2 w:2)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[0, 27]`.
+	fn force_vested_transfer(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `691 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `6196`
+		// Minimum execution time: 78_333_000 picoseconds.
+		Weight::from_parts(80_199_350, 6196)
+			// Standard Error: 1_903
+			.saturating_add(Weight::from_parts(46_798, 0).saturating_mul(l.into()))
+			// Standard Error: 3_385
+			.saturating_add(Weight::from_parts(106_311, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(5_u64))
+			.saturating_add(RocksDbWeight::get().writes(4_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[2, 28]`.
+	fn not_unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 40_102_000 picoseconds.
+		Weight::from_parts(39_552_301, 4764)
+			// Standard Error: 1_309
+			.saturating_add(Weight::from_parts(37_184, 0).saturating_mul(l.into()))
+			// Standard Error: 2_418
+			.saturating_add(Weight::from_parts(91_621, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[2, 28]`.
+	fn unlocking_merge_schedules(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `414 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 42_287_000 picoseconds.
+		Weight::from_parts(41_937_484, 4764)
+			// Standard Error: 1_306
+			.saturating_add(Weight::from_parts(39_880, 0).saturating_mul(l.into()))
+			// Standard Error: 2_412
+			.saturating_add(Weight::from_parts(85_247, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Vesting::Vesting` (r:1 w:1)
+	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// The range of component `l` is `[0, 49]`.
+	/// The range of component `s` is `[2, 28]`.
+	fn force_remove_vesting_schedule(l: u32, s: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `588 + l * (25 ±0) + s * (36 ±0)`
+		//  Estimated: `4764`
+		// Minimum execution time: 46_462_000 picoseconds.
+		Weight::from_parts(46_571_504, 4764)
+			// Standard Error: 1_298
+			.saturating_add(Weight::from_parts(42_091, 0).saturating_mul(l.into()))
+			// Standard Error: 2_397
+			.saturating_add(Weight::from_parts(77_382, 0).saturating_mul(s.into()))
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+}

--- a/substrate/frame/support/src/traits/tokens/fungible/mod.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/mod.rs
@@ -159,6 +159,7 @@ pub(crate) mod imbalance;
 mod item_of;
 mod regular;
 mod union_of;
+mod vesting;
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::marker::PhantomData;
@@ -185,6 +186,7 @@ use sp_arithmetic::traits::Zero;
 use sp_core::Get;
 use sp_runtime::{traits::Convert, DispatchError};
 pub use union_of::{NativeFromLeft, NativeOrWithId, UnionOf};
+pub use vesting::{VestedTransfer, VestingSchedule};
 
 #[cfg(feature = "experimental")]
 use crate::traits::MaybeConsideration;

--- a/substrate/frame/support/src/traits/tokens/fungible/vesting.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/vesting.rs
@@ -1,0 +1,116 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `VestingSchedule` and `VestedTransfer` traits for working with vesting schedules.
+//!
+//! See the [`crate::traits::fungible`] doc for more information about fungible traits.
+
+use crate::dispatch::DispatchResult;
+
+/// A vesting schedule over a fungible type. This allows a particular currency to have vesting
+/// limits applied to it.
+pub trait VestingSchedule<AccountId> {
+	/// The quantity used to denote time; usually just a `BlockNumber`.
+	type Moment;
+
+	/// The balance type that this schedule applies to.
+	type Balance;
+
+	/// Get the amount that is currently being vested and cannot be transferred out of this account.
+	/// Returns `None` if the account has no vesting schedule.
+	fn vesting_balance(who: &AccountId) -> Option<Self::Balance>;
+
+	/// Adds a vesting schedule to a given account.
+	///
+	/// If the account has `MaxVestingSchedules`, an Error is returned and nothing
+	/// is updated.
+	///
+	/// Is a no-op if the amount to be vested is zero.
+	///
+	/// NOTE: This doesn't alter the free balance of the account.
+	fn add_vesting_schedule(
+		who: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	) -> DispatchResult;
+
+	/// Checks if `add_vesting_schedule` would work against `who`.
+	fn can_add_vesting_schedule(
+		who: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	) -> DispatchResult;
+
+	/// Remove a vesting schedule for a given account.
+	///
+	/// NOTE: This doesn't alter the free balance of the account.
+	fn remove_vesting_schedule(who: &AccountId, schedule_index: u32) -> DispatchResult;
+}
+
+/// A vested transfer over a token. This allows a transferred amount to vest over time.
+pub trait VestedTransfer<AccountId> {
+	/// The quantity used to denote time; usually just a `BlockNumber`.
+	type Moment;
+
+	/// The balance type that this schedule applies to.
+	type Balance;
+
+	/// Execute a vested transfer from `source` to `target` with the given schedule:
+	/// 	- `frozen`: The amount of tokens to be transferred and for the vesting schedule to apply
+	///    to.
+	/// 	- `per_block`: The amount to be unlocked each block. (linear vesting)
+	/// 	- `starting_block`: The block where the vesting should start. This block can be in the past
+	///    or future, and should adjust when the balance become available to the user.
+	///
+	/// Example: Assume we are on block 100. If `frozen` amount is 100, and `per_block` is 1:
+	/// 	- If `starting_block` is 0, then the whole 100 tokens will be available right away as the
+	///    vesting schedule started in the past and has fully completed.
+	/// 	- If `starting_block` is 50, then 50 tokens are made available right away, and 50 more
+	///    tokens will unlock one token at a time until block 150.
+	/// 	- If `starting_block` is 100, then each block, 1 tokens will be unlocked until the whole
+	///    balance is unlocked at block 200.
+	/// 	- If `starting_block` is 200, then the 100 token balance will be completely locked until
+	///    block 200, and then start to unlock one token at a time until block 300.
+	fn vested_transfer(
+		source: &AccountId,
+		target: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	) -> DispatchResult;
+}
+
+// A no-op implementation of `VestedTransfer` for pallets that require this trait, but users may
+// not want to implement this functionality
+pub struct NoVestedTransfers<B>(core::marker::PhantomData<B>);
+
+impl<AccountId, Balance> VestedTransfer<AccountId> for NoVestedTransfers<Balance> {
+	type Moment = ();
+	type Balance = Balance;
+
+	fn vested_transfer(
+		_source: &AccountId,
+		_target: &AccountId,
+		_locked: Self::Balance,
+		_per_block: Self::Balance,
+		_starting_block: Self::Moment,
+	) -> DispatchResult {
+		Err(sp_runtime::DispatchError::Unavailable.into())
+	}
+}

--- a/substrate/frame/support/src/traits/tokens/fungibles/mod.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/mod.rs
@@ -36,6 +36,7 @@ pub mod metadata;
 mod regular;
 pub mod roles;
 mod union_of;
+mod vesting;
 
 pub use enumerable::Inspect as InspectEnumerable;
 pub use freeze::{Inspect as InspectFreeze, Mutate as MutateFreeze};
@@ -49,3 +50,4 @@ pub use regular::{
 	Balanced, DecreaseIssuance, Dust, IncreaseIssuance, Inspect, Mutate, Unbalanced,
 };
 pub use union_of::UnionOf;
+pub use vesting::{VestedTransfer, VestingSchedule};

--- a/substrate/frame/support/src/traits/tokens/fungibles/vesting.rs
+++ b/substrate/frame/support/src/traits/tokens/fungibles/vesting.rs
@@ -1,0 +1,131 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `VestingSchedule` and `VestedTransfer` traits for working with vesting schedules.
+//!
+//! See the [`crate::traits::fungibles`] doc for more information about fungibles traits.
+
+use crate::{dispatch::DispatchResult, traits::tokens::misc::AssetId};
+
+/// A vesting schedule over a fungible asset class. This allows a particular currency to have
+/// vesting limits applied to it.
+pub trait VestingSchedule<AccountId> {
+	/// The quantity used to denote time; usually just a `BlockNumber`.
+	type Moment;
+
+	/// Means of identifying one asset class from another.
+	type AssetId: AssetId;
+
+	/// The balance type that this schedule applies to.
+	type Balance;
+
+	/// Get the amount that is currently being vested and cannot be transferred out of this asset
+	/// account. Returns `None` if the asset account has no vesting schedule.
+	fn vesting_balance(asset: Self::AssetId, who: &AccountId) -> Option<Self::Balance>;
+
+	/// Adds a vesting schedule to a given asset account.
+	///
+	/// If the account has `MaxVestingSchedules`, an Error is returned and nothing
+	/// is updated.
+	///
+	/// Is a no-op if the amount to be vested is zero.
+	///
+	/// NOTE: This doesn't alter the free balance of the asset account.
+	fn add_vesting_schedule(
+		asset: Self::AssetId,
+		who: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	) -> DispatchResult;
+
+	/// Checks if `add_vesting_schedule` would work against `who`.
+	fn can_add_vesting_schedule(
+		asset: Self::AssetId,
+		who: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	) -> DispatchResult;
+
+	/// Remove a vesting schedule for a given asset account.
+	///
+	/// NOTE: This doesn't alter the free balance of the asset account.
+	fn remove_vesting_schedule(
+		asset: Self::AssetId,
+		who: &AccountId,
+		schedule_index: u32,
+	) -> DispatchResult;
+}
+
+/// A vested transfer over an asset. This allows a transferred amount to vest over time.
+pub trait VestedTransfer<AccountId> {
+	/// The quantity used to denote time; usually just a `BlockNumber`.
+	type Moment;
+
+	/// Means of identifying one asset class from another.
+	type AssetId: AssetId;
+
+	/// The balance type that this schedule applies to.
+	type Balance;
+
+	/// Execute a vested transfer from `source` to `target` with the given schedule:
+	/// 	- `frozen`: The amount of assets to be transferred and for the vesting schedule to apply
+	///    to.
+	/// 	- `per_block`: The amount to be unlocked each block. (linear vesting)
+	/// 	- `starting_block`: The block where the vesting should start. This block can be in the past
+	///    or future, and should adjust when the balance become available to the user.
+	///
+	/// Example: Assume we are on block 100. If `frozen` amount is 100, and `per_block` is 1:
+	/// 	- If `starting_block` is 0, then the whole 100 tokens will be available right away as the
+	///    vesting schedule started in the past and has fully completed.
+	/// 	- If `starting_block` is 50, then 50 tokens are made available right away, and 50 more
+	///    tokens will unlock one token at a time until block 150.
+	/// 	- If `starting_block` is 100, then each block, 1 tokens will be unlocked until the whole
+	///    balance is unlocked at block 200.
+	/// 	- If `starting_block` is 200, then the 100 token balance will be completely locked until
+	///    block 200, and then start to unlock one token at a time until block 300.
+	fn vested_transfer(
+		asset: Self::AssetId,
+		source: &AccountId,
+		target: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	) -> DispatchResult;
+}
+
+// A no-op implementation of `VestedTransfer` for pallets that require this trait, but users may
+// not want to implement this functionality
+pub struct NoVestedTransfers<A, B>(core::marker::PhantomData<(A, B)>);
+
+impl<AccountId, Id: AssetId, Balance> VestedTransfer<AccountId> for NoVestedTransfers<Id, Balance> {
+	type Moment = ();
+	type AssetId = Id;
+	type Balance = Balance;
+
+	fn vested_transfer(
+		_asset: Self::AssetId,
+		_source: &AccountId,
+		_target: &AccountId,
+		_locked: Self::Balance,
+		_per_block: Self::Balance,
+		_starting_block: Self::Moment,
+	) -> DispatchResult {
+		Err(sp_runtime::DispatchError::Unavailable.into())
+	}
+}


### PR DESCRIPTION
Fixes #4090.

# Description

The `pallet-assets-vesting` is a pallet that supports handling vesting of an instances of `pallet-assets` through freezing `fungibles`.

The behaviour is analog to what already exists with `pallet-vesting`, with small differences (like adding an `asset` parameter where the `AssetId` goes on every call). Also, `WithdrawalReasons` are no longer used, since they're related to `Currency`.

## Integration

This pallet can be integrated into any runtime that already has an instance of `pallet-assets` and `pallet-assets-freezer`. 

The instance must be the same as the one that pallets mentioned above use.

```rs
type AssetsInstance = pallet_assets::Instance1;

#[derive_impl(pallet_assets::config_preludes::ParachainDefaultConfig)]
impl pallet_assets::Config<AssetsInstance> for Test {
	type Currency = Balances;
	type ForceOrigin = EnsureRoot<AccountId>;
	type CreateOrigin = EnsureSigned<AccountId>;
	type Freezer = AssetsFreezer;
}

impl pallet_assets_freezer::Config<AssetsInstance> for Runtime {
	type RuntimeFreezeReason = RuntimeFreezeReason;
	type RuntimeEvent = RuntimeEvent;
}

impl pallet_assets_vesting::Config<AssetsInstance> for Test {
	type RuntimeEvent = RuntimeEvent;
	type ForceOrigin = EnsureRoot<AccountId>;
	type Assets = Assets;
	type Freezer = AssetsFreezer;
	type BlockNumberToBalance = Identity;
	type RuntimeFreezeReason = RuntimeFreezeReason;
	type WeightInfo = ();
	type MinVestedTransfer = MinVestedTransfer;
	type BlockNumberProvider = System;
	const MAX_VESTING_SCHEDULES: u32 = 3;
}
```

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
