### PR TITLE
fix(sync-templates): empty matrix strategy expansion

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -62,20 +62,20 @@ jobs:
         - name: Build runtime and generate chain spec
           run: |
             # Prepare directories
-            sudo mkdir -p ${{ matrix.template.runtime_path }}/target
-            sudo chmod -R 777 ${{ matrix.template.runtime_path }}/target
+            sudo mkdir -p ${{ matrix.runtime_path }}/target
+            sudo chmod -R 777 ${{ matrix.runtime_path }}/target
             
             # Build runtime
-            srtool build --package ${{ matrix.template.package_name }} --runtime-dir ${{ matrix.template.runtime_path }} --root
+            srtool build --package ${{ matrix.package_name }} --runtime-dir ${{ matrix.runtime_path }} --root
             
             # Generate chain spec
             # Note that para-id is set to 1000 for both minimal/parachain templates. 
             # `parachain-runtime` is hardcoded to use this parachain id. 
             # `minimal` template isn't using it, but when started with Omni Node, this para id is required (any number can do it, so setting it to 1000 for convenience).
             chain-spec-builder -c dev_chain_spec.json create \
-              --relay-chain "${{ matrix.template.relay_chain }}" \
+              --relay-chain "${{ matrix.relay_chain }}" \
               --para-id 1000 \
-              --runtime "${{ matrix.template.runtime_path }}/target/srtool/release/wbuild/${{ matrix.template.runtime_wasm_path }}" \
+              --runtime "${{ matrix.runtime_path }}/target/srtool/release/wbuild/${{ matrix.runtime_wasm_path }}" \
               named-preset development
 
         - name: Prepare upload directory


### PR DESCRIPTION
# Description

There is a small error (which slipped through reviews) in matrix strategy expansion which results in errors like this: https://github.com/paritytech/polkadot-sdk/actions/runs/13079943579/job/36501002368.

## Integration

N/A

## Review Notes

Need to fix this in master and then rerun it manually against `stable2412-1`.