### PR TITLE
Warn about cargo remote not copying hidden file by default

### DIFF
--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -109,6 +109,10 @@
 //!
 //! ### Cargo Remote
 //!
+//! Warning: cargo remote by default doesn't transfer hidden files to the remote machine. But hidden
+//! files can be useful, e.g. for sqlx usage. On the other hand using `--transfer-hidden` flag will
+//! transfer `.git` which is big.
+//!
 //! If you have a powerful remote server available, you may consider using
 //! [cargo-remote](https://github.com/sgeisler/cargo-remote) to execute cargo commands on it,
 //! freeing up local resources for other tasks like `rust-analyzer`.


### PR DESCRIPTION
add a warning about hidden file not transfered.

cargo remote is not really configurable so I just use my own fork for now: https://github.com/sgeisler/cargo-remote/pull/25