### PR TITLE
fix(sync-templates): keep parachain-template's workspace Cargo.toml

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -149,6 +149,10 @@ jobs:
         working-directory: polkadot-sdk/templates/${{ matrix.template }}/
       - name: Create a new workspace Cargo.toml
         run: |
+          # This replaces the existing Cargo.toml for parachain-template,
+          # corresponding to the `parachain-template-docs` crate, so no need
+          # to delete that `Cargo.toml` after copying the `polkadot-sdk/templates/parachain/*`
+          # to the `polkadot-sdk-parachain-template` repo.
           cat << EOF > Cargo.toml
           [workspace.package]
           license = "MIT-0"
@@ -199,8 +203,6 @@ jobs:
         working-directory: "${{ env.template-path }}"
       - name: Copy over the new changes
         run: |
-          # remove existing Cargo.toml of parachain-template (for the parachain-template-docs crate)
-          rm polkadot-sdk/templates/${{ matrix.template }}/Cargo.toml
           cp -r polkadot-sdk/templates/${{ matrix.template }}/* "${{ env.template-path }}/"
       - name: Remove unnecessary files from parachain template
         if: ${{ matrix.template == 'parachain' }}

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -199,12 +199,13 @@ jobs:
         working-directory: "${{ env.template-path }}"
       - name: Copy over the new changes
         run: |
+          # remove existing Cargo.toml of parachain-template (for the parachain-template-docs crate)
+          rm polkadot-sdk/templates/${{ matrix.template }}/Cargo.toml
           cp -r polkadot-sdk/templates/${{ matrix.template }}/* "${{ env.template-path }}/"
       - name: Remove unnecessary files from parachain template
         if: ${{ matrix.template == 'parachain' }}
         run: |
           rm -f "${{ env.template-path }}/README.docify.md"
-          rm -f "${{ env.template-path }}/Cargo.toml"
           rm -f "${{ env.template-path }}/src/lib.rs"
 
       - name: Run psvm on monorepo workspace dependencies


### PR DESCRIPTION
# Description

Another small fix for sync-templates. We're copying the `polkadot-sdk`'s `parachain-template` files (including the `parachain-template-docs`'s Cargo.toml) to the directory where we're creating the workspace with all `parachain-template` members crates, and workspace's toml. The error is that in this directory for the workspace we first create the workspace's Cargo.toml, and then copy the files of the `polkadot-sdk`'s `parachain-template`, including the `Cargo.toml` of the `parachain-template-docs` crate, which overwrites the workspace Cargo.toml. In the end we delete the `Cargo.toml` (which we assume it is of the `parachain-template-docs` crate), forgetting that previously there should've been a workspace Cargo.toml, which should still be kept and committed to the template's repository.

The error happens here: https://github.com/paritytech/polkadot-sdk/actions/runs/13111697690/job/36577834127

## Integration

N/A

## Review Notes

Once again, merging this into master requires re-running sync templates based on latest version on master. Hopefully this will be the last issue related to the workflow itself.