### PR TITLE
cumulus-client: use only valid syntax in Cargo.toml

### DIFF
--- a/cumulus/client/relay-chain-rpc-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-rpc-interface/Cargo.toml
@@ -48,8 +48,8 @@ rand = { workspace = true, default-features = true }
 schnellru = { workspace = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
-smoldot = { default_features = false, features = ["std"], workspace = true }
-smoldot-light = { default_features = false, features = ["std"], workspace = true }
+smoldot = { default-features = false, features = ["std"], workspace = true }
+smoldot-light = { default-features = false, features = ["std"], workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, default-features = true }
 url = { workspace = true }


### PR DESCRIPTION
# Description

This PR ensure that only valid syntax is uses inside the `Cargo.toml`. 

## Integration

Not sure if worth backporting. Came across this when trying to package `try-runtime-cli`.

## Review Notes

It should be obvious that this is not valid syntax. I am not able to add labels and doubt this requires a prdoc.
