### PR TITLE
enable approval-voting-parallel on polkadot

### DIFF
--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -148,8 +148,8 @@ pub struct RunCmd {
 
 	/// Enable approval-voting message processing in parallel.
 	///
-	///**Dangerous!** This is an experimental feature and should not be used in production, unless
-	/// explicitly advised to.
+	/// This is a flag used for gradually enabling approval-voting-parallel in production, 
+	/// should not be used unless explicitly advised to. It will be removed in the future.
 	#[arg(long, default_value = "true", action=ArgAction::Set)]
 	pub enable_approval_voting_parallel: bool,
 }

--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -18,7 +18,7 @@
 
 pub use polkadot_node_primitives::NODE_VERSION;
 
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use std::path::PathBuf;
 
 #[allow(missing_docs)]
@@ -150,7 +150,7 @@ pub struct RunCmd {
 	///
 	///**Dangerous!** This is an experimental feature and should not be used in production, unless
 	/// explicitly advised to.
-	#[arg(long)]
+	#[arg(long, default_value = "true", action=ArgAction::Set)]
 	pub enable_approval_voting_parallel: bool,
 }
 

--- a/polkadot/cli/src/cli.rs
+++ b/polkadot/cli/src/cli.rs
@@ -148,7 +148,7 @@ pub struct RunCmd {
 
 	/// Enable approval-voting message processing in parallel.
 	///
-	/// This is a flag used for gradually enabling approval-voting-parallel in production, 
+	/// This is a flag used for gradually enabling approval-voting-parallel in production,
 	/// should not be used unless explicitly advised to. It will be removed in the future.
 	#[arg(long, default_value = "true", action=ArgAction::Set)]
 	pub enable_approval_voting_parallel: bool,

--- a/polkadot/node/service/src/lib.rs
+++ b/polkadot/node/service/src/lib.rs
@@ -759,13 +759,6 @@ pub fn new_full<
 		Some(backoff)
 	};
 
-	// Running approval voting in parallel is enabled by default on all networks except Polkadot
-	// unless explicitly enabled by the commandline option.
-	// This is meant to be temporary until we have enough confidence in the new system to enable it
-	// by default on all networks.
-	let enable_approval_voting_parallel =
-		!config.chain_spec.is_polkadot() || enable_approval_voting_parallel;
-
 	let disable_grandpa = config.disable_grandpa;
 	let name = config.network.node_name.clone();
 

--- a/prdoc/pr_7504.prdoc
+++ b/prdoc/pr_7504.prdoc
@@ -7,3 +7,5 @@ doc:
 crates:
   - name: polkadot-service
     bump: patch
+  - name: polkadot-cli
+    bump: patch

--- a/prdoc/pr_7504.prdoc
+++ b/prdoc/pr_7504.prdoc
@@ -1,0 +1,9 @@
+title: Enable approval-voting-parallel by default on polkadot
+
+doc:
+  - audience: Node Dev
+    description: |
+        Enable approval-voting-parallel by default on polkadot
+crates:
+  - name: polkadot-service
+    bump: patch


### PR DESCRIPTION
approval-voting-parallel has been running on all network types except polkadot since release `1.17.0`, so it has around 2 months of baking and running without any reported issues, so let's enable it on polkadot as well.

After running in polkadot for awhile the flag will be entirely removed.