### PR TITLE
PVF: use landlock V4 for extra networking sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9744,9 +9744,9 @@ dependencies = [
 
 [[package]]
 name = "landlock"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1530c5b973eeed4ac216af7e24baf5737645a6272e361f1fb95710678b67d9cc"
+checksum = "18738c5d4c7fae6727a96adb94722ef7ce82f3eafea0a11777e258a93816537e"
 dependencies = [
  "enumflags2",
  "libc",

--- a/polkadot/node/core/pvf/common/Cargo.toml
+++ b/polkadot/node/core/pvf/common/Cargo.toml
@@ -35,7 +35,7 @@ sp-io = { workspace = true, default-features = true }
 sp-tracing = { workspace = true, default-features = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = "0.3.0"
+landlock = "0.4.0"
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 seccompiler = "0.4.0"

--- a/polkadot/node/core/pvf/common/src/lib.rs
+++ b/polkadot/node/core/pvf/common/src/lib.rs
@@ -52,8 +52,10 @@ pub struct SecurityStatus {
 	/// Whether Secure Validator Mode is enabled. This mode enforces that all required security
 	/// features are present. All features are enabled on a best-effort basis regardless.
 	pub secure_validator_mode: bool,
-	/// Whether the landlock features we use are fully available on this system.
-	pub can_enable_landlock: bool,
+	/// Whether the landlock FS features we use are fully available on this system.
+	pub can_enable_landlock_fs: bool,
+	/// Whether the landlock network features we use are fully available on this system.
+	pub can_enable_landlock_net: bool,
 	/// Whether the seccomp features we use are fully available on this system.
 	pub can_enable_seccomp: bool,
 	/// Whether we are able to unshare the user namespace and change the filesystem root.

--- a/polkadot/node/core/pvf/common/src/worker/mod.rs
+++ b/polkadot/node/core/pvf/common/src/worker/mod.rs
@@ -82,9 +82,26 @@ macro_rules! decl_worker_main {
 					return
 				},
 
-				"--check-can-enable-landlock" => {
+				"--check-can-enable-landlock-fs" => {
 					#[cfg(target_os = "linux")]
-					let status = if let Err(err) = security::landlock::check_can_fully_enable() {
+					let status = if let Err(err) = security::landlock::check_can_fully_enable(
+						security::landlock::LANDLOCK_ABI_FS,
+					) {
+						// Write the error to stderr, log it on the host-side.
+						eprintln!("{}", err);
+						-1
+					} else {
+						0
+					};
+					#[cfg(not(target_os = "linux"))]
+					let status = -1;
+					std::process::exit(status)
+				},
+				"--check-can-enable-landlock-net" => {
+					#[cfg(target_os = "linux")]
+					let status = if let Err(err) = security::landlock::check_can_fully_enable(
+						security::landlock::LANDLOCK_ABI_NET,
+					) {
 						// Write the error to stderr, log it on the host-side.
 						eprintln!("{}", err);
 						-1
@@ -342,7 +359,7 @@ pub fn run_worker<F>(
 				"Node and worker version mismatch, node needs restarting, forcing shutdown",
 			);
 			kill_parent_node_in_emergency();
-			worker_shutdown(worker_info, "Version mismatch");
+			worker_shutdown(&worker_info, "Version mismatch");
 		}
 	}
 
@@ -354,7 +371,7 @@ pub fn run_worker<F>(
 			gum::trace!(target: LOG_TARGET, ?worker_info, "content of worker dir: {:?}", entries),
 		Err(err) => {
 			let err = format!("Could not read worker dir: {}", err.to_string());
-			worker_shutdown_error(worker_info, &err);
+			worker_shutdown_error(&worker_info, &err);
 		},
 	}
 
@@ -366,107 +383,131 @@ pub fn run_worker<F>(
 	}();
 	let mut stream = match stream {
 		Ok(ok) => ok,
-		Err(err) => worker_shutdown_error(worker_info, &err.to_string()),
+		Err(err) => worker_shutdown_error(&worker_info, &err.to_string()),
 	};
 
 	let WorkerHandshake { security_status } = match recv_worker_handshake(&mut stream) {
 		Ok(ok) => ok,
-		Err(err) => worker_shutdown_error(worker_info, &err.to_string()),
+		Err(err) => worker_shutdown_error(&worker_info, &err.to_string()),
 	};
 
-	// Enable some security features.
-	{
-		gum::trace!(target: LOG_TARGET, ?security_status, "Enabling security features");
-
-		// First, make sure env vars were cleared, to match the environment we perform the checks
-		// within. (In theory, running checks with different env vars could result in different
-		// outcomes of the checks.)
-		if !security::check_env_vars_were_cleared(&worker_info) {
-			let err = "not all env vars were cleared when spawning the process";
-			gum::error!(
-				target: LOG_TARGET,
-				?worker_info,
-				"{}",
-				err
-			);
-			if security_status.secure_validator_mode {
-				worker_shutdown(worker_info, err);
-			}
-		}
-
-		// Call based on whether we can change root. Error out if it should work but fails.
-		//
-		// NOTE: This should not be called in a multi-threaded context (i.e. inside the tokio
-		// runtime). `unshare(2)`:
-		//
-		//       > CLONE_NEWUSER requires that the calling process is not threaded.
-		#[cfg(target_os = "linux")]
-		if security_status.can_unshare_user_namespace_and_change_root {
-			if let Err(err) = security::change_root::enable_for_worker(&worker_info) {
-				// The filesystem may be in an inconsistent state, always bail out.
-				let err = format!("Could not change root to be the worker cache path: {}", err);
-				worker_shutdown_error(worker_info, &err);
-			}
-			worker_info.worker_dir_path = std::path::Path::new("/").to_owned();
-		}
-
-		#[cfg(target_os = "linux")]
-		if security_status.can_enable_landlock {
-			if let Err(err) = security::landlock::enable_for_worker(&worker_info) {
-				// We previously were able to enable, so this should never happen. Shutdown if
-				// running in secure mode.
-				let err = format!("could not fully enable landlock: {:?}", err);
-				gum::error!(
-					target: LOG_TARGET,
-					?worker_info,
-					"{}. This should not happen, please report an issue",
-					err
-				);
-				if security_status.secure_validator_mode {
-					worker_shutdown(worker_info, &err);
-				}
-			}
-		}
-
-		// TODO: We can enable the seccomp networking blacklist on aarch64 as well, but we need a CI
-		//       job to catch regressions. See issue ci_cd/issues/609.
-		#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-		if security_status.can_enable_seccomp {
-			if let Err(err) = security::seccomp::enable_for_worker(&worker_info) {
-				// We previously were able to enable, so this should never happen. Shutdown if
-				// running in secure mode.
-				let err = format!("could not fully enable seccomp: {:?}", err);
-				gum::error!(
-					target: LOG_TARGET,
-					?worker_info,
-					"{}. This should not happen, please report an issue",
-					err
-				);
-				if security_status.secure_validator_mode {
-					worker_shutdown(worker_info, &err);
-				}
-			}
-		}
-	}
+	sandbox_worker(&mut worker_info, &security_status);
 
 	// Run the main worker loop.
 	let err = event_loop(stream, &worker_info, security_status)
 		// It's never `Ok` because it's `Ok(Never)`.
 		.unwrap_err();
 
-	worker_shutdown(worker_info, &err.to_string());
+	worker_shutdown(&worker_info, &err.to_string());
 }
 
 /// Provide a consistent message on unexpected worker shutdown.
-fn worker_shutdown(worker_info: WorkerInfo, err: &str) -> ! {
+fn worker_shutdown(worker_info: &WorkerInfo, err: &str) -> ! {
 	gum::warn!(target: LOG_TARGET, ?worker_info, "quitting pvf worker ({}): {}", worker_info.kind, err);
 	std::process::exit(1);
 }
 
 /// Provide a consistent error on unexpected worker shutdown.
-fn worker_shutdown_error(worker_info: WorkerInfo, err: &str) -> ! {
+fn worker_shutdown_error(worker_info: &WorkerInfo, err: &str) -> ! {
 	gum::error!(target: LOG_TARGET, ?worker_info, "quitting pvf worker ({}): {}", worker_info.kind, err);
 	std::process::exit(1);
+}
+
+/// Enable some security features.
+fn sandbox_worker(worker_info: &mut WorkerInfo, security_status: &SecurityStatus) {
+	gum::trace!(target: LOG_TARGET, ?security_status, "Enabling security features");
+
+	// First, make sure env vars were cleared, to match the environment we perform the checks
+	// within. (In theory, running checks with different env vars could result in different
+	// outcomes of the checks.)
+	if !security::check_env_vars_were_cleared(worker_info) {
+		let err = "not all env vars were cleared when spawning the process";
+		gum::error!(
+			target: LOG_TARGET,
+			?worker_info,
+			"{}",
+			err
+		);
+		if security_status.secure_validator_mode {
+			worker_shutdown(worker_info, err);
+		}
+	}
+
+	// Call based on whether we can change root. Error out if it should work but fails.
+	//
+	// NOTE: This should not be called in a multi-threaded context (i.e. inside the tokio
+	// runtime). `unshare(2)`:
+	//
+	//       > CLONE_NEWUSER requires that the calling process is not threaded.
+	#[cfg(target_os = "linux")]
+	if security_status.can_unshare_user_namespace_and_change_root {
+		if let Err(err) = security::change_root::enable_for_worker(worker_info) {
+			// The filesystem may be in an inconsistent state, always bail out.
+			let err = format!("Could not change root to be the worker cache path: {}", err);
+			worker_shutdown_error(worker_info, &err);
+		}
+		worker_info.worker_dir_path = std::path::Path::new("/").to_owned();
+	}
+
+	#[cfg(target_os = "linux")]
+	if security_status.can_enable_landlock_fs {
+		if let Err(err) =
+			security::landlock::enable_for_worker(worker_info, security::landlock::LANDLOCK_ABI_FS)
+		{
+			// We previously were able to enable, so this should never happen. Shutdown if
+			// running in secure mode.
+			let err = format!("could not fully enable landlock: {:?}", err);
+			gum::error!(
+				target: LOG_TARGET,
+				?worker_info,
+				"{}. This should not happen, please report an issue",
+				err
+			);
+			if security_status.secure_validator_mode {
+				worker_shutdown(worker_info, &err);
+			}
+		}
+	}
+
+	#[cfg(target_os = "linux")]
+	if security_status.can_enable_landlock_net {
+		if let Err(err) =
+			security::landlock::enable_for_worker(worker_info, security::landlock::LANDLOCK_ABI_NET)
+		{
+			// We previously were able to enable, so this should never happen. Shutdown if
+			// running in secure mode.
+			let err = format!("could not fully enable landlock: {:?}", err);
+			gum::error!(
+				target: LOG_TARGET,
+				?worker_info,
+				"{}. This should not happen, please report an issue",
+				err
+			);
+			if security_status.secure_validator_mode {
+				worker_shutdown(worker_info, &err);
+			}
+		}
+	}
+
+	// TODO: We can enable the seccomp networking blacklist on aarch64 as well, but we need a CI
+	//       job to catch regressions. See issue ci_cd/issues/609.
+	#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+	if security_status.can_enable_seccomp {
+		if let Err(err) = security::seccomp::enable_for_worker(worker_info) {
+			// We previously were able to enable, so this should never happen. Shutdown if
+			// running in secure mode.
+			let err = format!("could not fully enable seccomp: {:?}", err);
+			gum::error!(
+				target: LOG_TARGET,
+				?worker_info,
+				"{}. This should not happen, please report an issue",
+				err
+			);
+			if security_status.secure_validator_mode {
+				worker_shutdown(worker_info, &err);
+			}
+		}
+	}
 }
 
 /// Loop that runs in the CPU time monitor thread on prepare and execute jobs. Continuously wakes up
@@ -707,7 +748,7 @@ pub mod thread {
 		F: FnOnce() -> R,
 		F: panic::UnwindSafe,
 	{
-		let result = panic::catch_unwind(|| f());
+		let result = panic::catch_unwind(f);
 		cond_notify_all(cond, outcome);
 		match result {
 			Ok(inner) => return inner,

--- a/polkadot/node/core/pvf/prepare-worker/src/lib.rs
+++ b/polkadot/node/core/pvf/prepare-worker/src/lib.rs
@@ -517,11 +517,11 @@ fn handle_child_process(
 		"prepare worker",
 		move || {
 			#[allow(unused_mut)]
-			let mut result = prepare_artifact(pvf).map(|o| (o,));
+			let mut result = prepare_artifact(pvf).map(|o| (o, ()));
 
 			// Get the `ru_maxrss` stat. If supported, call getrusage for the thread.
 			#[cfg(target_os = "linux")]
-			let mut result = result.map(|outcome| (outcome.0, get_max_rss_thread()));
+			let mut result = result.map(|(outcome, _)| (outcome, get_max_rss_thread()));
 
 			// If we are pre-checking, check for runtime construction errors.
 			//
@@ -575,7 +575,7 @@ fn handle_child_process(
 						if #[cfg(target_os = "linux")] {
 							let (PrepareOutcome { compiled_artifact, observed_wasm_code_len }, max_rss) = ok;
 						} else {
-							let (PrepareOutcome { compiled_artifact, observed_wasm_code_len },) = ok;
+							let (PrepareOutcome { compiled_artifact, observed_wasm_code_len }, _) = ok;
 						}
 					}
 

--- a/polkadot/node/core/pvf/src/security.rs
+++ b/polkadot/node/core/pvf/src/security.rs
@@ -32,8 +32,9 @@ use std::{fmt, path::Path};
 pub async fn check_security_status(config: &Config) -> Result<SecurityStatus, String> {
 	let Config { prepare_worker_program_path, secure_validator_mode, cache_path, .. } = config;
 
-	let (landlock, seccomp, change_root, secure_clone) = join!(
-		check_landlock(prepare_worker_program_path),
+	let (landlock_fs, landlock_net, seccomp, change_root, secure_clone) = join!(
+		check_landlock_fs(prepare_worker_program_path),
+		check_landlock_net(prepare_worker_program_path),
 		check_seccomp(prepare_worker_program_path),
 		check_can_unshare_user_namespace_and_change_root(prepare_worker_program_path, cache_path),
 		check_can_do_secure_clone(prepare_worker_program_path),
@@ -41,7 +42,8 @@ pub async fn check_security_status(config: &Config) -> Result<SecurityStatus, St
 
 	let full_security_status = FullSecurityStatus::new(
 		*secure_validator_mode,
-		landlock,
+		landlock_fs,
+		landlock_net,
 		seccomp,
 		change_root,
 		secure_clone,
@@ -76,7 +78,8 @@ struct FullSecurityStatus {
 impl FullSecurityStatus {
 	fn new(
 		secure_validator_mode: bool,
-		landlock: SecureModeResult,
+		landlock_fs: SecureModeResult,
+		landlock_net: SecureModeResult,
 		seccomp: SecureModeResult,
 		change_root: SecureModeResult,
 		secure_clone: SecureModeResult,
@@ -84,12 +87,13 @@ impl FullSecurityStatus {
 		Self {
 			partial: SecurityStatus {
 				secure_validator_mode,
-				can_enable_landlock: landlock.is_ok(),
+				can_enable_landlock_fs: landlock_fs.is_ok(),
+				can_enable_landlock_net: landlock_net.is_ok(),
 				can_enable_seccomp: seccomp.is_ok(),
 				can_unshare_user_namespace_and_change_root: change_root.is_ok(),
 				can_do_secure_clone: secure_clone.is_ok(),
 			},
-			errs: [landlock, seccomp, change_root, secure_clone]
+			errs: [landlock_fs, landlock_net, seccomp, change_root, secure_clone]
 				.into_iter()
 				.filter_map(|result| result.err())
 				.collect(),
@@ -128,7 +132,8 @@ type SecureModeResult = std::result::Result<(), SecureModeError>;
 /// Errors related to enabling Secure Validator Mode.
 #[derive(Debug)]
 enum SecureModeError {
-	CannotEnableLandlock { err: String, abi: u8 },
+	CannotEnableLandlockFs { err: String, abi: u8 },
+	CannotEnableLandlockNet { err: String, abi: u8 },
 	CannotEnableSeccomp(String),
 	CannotUnshareUserNamespaceAndChangeRoot(String),
 	CannotDoSecureClone(String),
@@ -141,13 +146,16 @@ impl SecureModeError {
 		match self {
 			// Landlock is present on relatively recent Linuxes. This is optional if the unshare
 			// capability is present, providing FS sandboxing a different way.
-			CannotEnableLandlock { .. } =>
+			CannotEnableLandlockFs { .. } =>
 				security_status.can_unshare_user_namespace_and_change_root,
+			// Landlock is present on relatively recent Linuxes. This is optional if the seccomp
+			// capability is present, providing network sandboxing a different way.
+			CannotEnableLandlockNet { .. } => security_status.can_enable_seccomp,
 			// seccomp should be present on all modern Linuxes unless it's been disabled.
-			CannotEnableSeccomp(_) => false,
+			CannotEnableSeccomp(_) => security_status.can_enable_landlock_net,
 			// Should always be present on modern Linuxes. If not, Landlock also provides FS
 			// sandboxing, so don't enforce this.
-			CannotUnshareUserNamespaceAndChangeRoot(_) => security_status.can_enable_landlock,
+			CannotUnshareUserNamespaceAndChangeRoot(_) => security_status.can_enable_landlock_fs,
 			// We have not determined the kernel requirements for this capability, and it's also not
 			// necessary for FS or networking restrictions.
 			CannotDoSecureClone(_) => true,
@@ -159,7 +167,8 @@ impl fmt::Display for SecureModeError {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		use SecureModeError::*;
 		match self {
-			CannotEnableLandlock{err, abi} => write!(f, "Cannot enable landlock (ABI {abi}), a Linux 5.13+ kernel security feature: {err}"),
+			CannotEnableLandlockFs{err, abi} => write!(f, "Cannot enable landlock (ABI {abi}), a Linux 5.13+ kernel security feature: {err}"),
+			CannotEnableLandlockNet{err, abi} => write!(f, "Cannot enable landlock (ABI {abi}), a Linux 6.7+ kernel security feature: {err}"),
 			CannotEnableSeccomp(err) => write!(f, "Cannot enable seccomp, a Linux-specific kernel security feature: {err}"),
 			CannotUnshareUserNamespaceAndChangeRoot(err) => write!(f, "Cannot unshare user namespace and change root, which are Linux-specific kernel security features: {err}"),
 			CannotDoSecureClone(err) => write!(f, "Cannot call clone with all sandboxing flags, a Linux-specific kernel security features: {err}"),
@@ -191,10 +200,6 @@ fn print_secure_mode_error_or_warning(security_status: &FullSecurityStatus) {
 }
 
 /// Check if we can change root to a new, sandboxed root and return an error if not.
-///
-/// We do this check by spawning a new process and trying to sandbox it. To get as close as possible
-/// to running the check in a worker, we try it... in a worker. The expected return status is 0 on
-/// success and -1 on failure.
 async fn check_can_unshare_user_namespace_and_change_root(
 	prepare_worker_program_path: &Path,
 	cache_path: &Path,
@@ -217,28 +222,31 @@ async fn check_can_unshare_user_namespace_and_change_root(
 	.map_err(|err| SecureModeError::CannotUnshareUserNamespaceAndChangeRoot(err))
 }
 
-/// Check if landlock is supported and return an error if not.
-///
-/// We do this check by spawning a new process and trying to sandbox it. To get as close as possible
-/// to running the check in a worker, we try it... in a worker. The expected return status is 0 on
-/// success and -1 on failure.
-async fn check_landlock(prepare_worker_program_path: &Path) -> SecureModeResult {
-	let abi = polkadot_node_core_pvf_common::worker::security::landlock::LANDLOCK_ABI as u8;
+/// Check if landlock's FS restrictions are supported and return an error if not.
+async fn check_landlock_fs(prepare_worker_program_path: &Path) -> SecureModeResult {
+	let abi = polkadot_node_core_pvf_common::worker::security::landlock::LANDLOCK_ABI_FS as u8;
 	spawn_process_for_security_check(
 		prepare_worker_program_path,
-		"--check-can-enable-landlock",
+		"--check-can-enable-landlock-fs",
 		std::iter::empty::<&str>(),
 	)
 	.await
-	.map_err(|err| SecureModeError::CannotEnableLandlock { err, abi })
+	.map_err(|err| SecureModeError::CannotEnableLandlockFs { err, abi })
+}
+
+/// Check if landlock's network restrictions are supported and return an error if not.
+async fn check_landlock_net(prepare_worker_program_path: &Path) -> SecureModeResult {
+	let abi = polkadot_node_core_pvf_common::worker::security::landlock::LANDLOCK_ABI_NET as u8;
+	spawn_process_for_security_check(
+		prepare_worker_program_path,
+		"--check-can-enable-landlock-net",
+		std::iter::empty::<&str>(),
+	)
+	.await
+	.map_err(|err| SecureModeError::CannotEnableLandlockNet { err, abi })
 }
 
 /// Check if seccomp is supported and return an error if not.
-///
-/// We do this check by spawning a new process and trying to sandbox it. To get as close as possible
-/// to running the check in a worker, we try it... in a worker. The expected return status is 0 on
-/// success and -1 on failure.
-
 #[cfg(target_arch = "x86_64")]
 async fn check_seccomp(prepare_worker_program_path: &Path) -> SecureModeResult {
 	spawn_process_for_security_check(
@@ -258,10 +266,6 @@ async fn check_seccomp(_: &Path) -> SecureModeResult {
 }
 
 /// Check if we can call `clone` with all sandboxing flags, and return an error if not.
-///
-/// We do this check by spawning a new process and trying to sandbox it. To get as close as possible
-/// to running the check in a worker, we try it... in a worker. The expected return status is 0 on
-/// success and -1 on failure.
 async fn check_can_do_secure_clone(prepare_worker_program_path: &Path) -> SecureModeResult {
 	spawn_process_for_security_check(
 		prepare_worker_program_path,
@@ -272,6 +276,9 @@ async fn check_can_do_secure_clone(prepare_worker_program_path: &Path) -> Secure
 	.map_err(|err| SecureModeError::CannotDoSecureClone(err))
 }
 
+/// We do this check by spawning a new process and trying to sandbox it. To get as close as possible
+/// to running the check in a worker, we try it... in a worker. The expected return status is 0 on
+/// success and -1 on failure.
 async fn spawn_process_for_security_check<I, S>(
 	prepare_worker_program_path: &Path,
 	check_arg: &'static str,
@@ -312,33 +319,55 @@ mod tests {
 
 	#[test]
 	fn test_secure_mode_error_optionality() {
-		let err = SecureModeError::CannotEnableLandlock { err: String::new(), abi: 3 };
+		let err = SecureModeError::CannotEnableLandlockFs { err: String::new(), abi: 3 };
 		assert!(err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: false,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
 			can_enable_seccomp: false,
 			can_unshare_user_namespace_and_change_root: true,
 			can_do_secure_clone: true,
 		}));
 		assert!(!err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: false,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
 			can_enable_seccomp: true,
 			can_unshare_user_namespace_and_change_root: false,
+			can_do_secure_clone: false,
+		}));
+
+		let err = SecureModeError::CannotEnableLandlockNet { err: String::new(), abi: 3 };
+		assert!(err.is_allowed_in_secure_mode(&SecurityStatus {
+			secure_validator_mode: true,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
+			can_enable_seccomp: true,
+			can_unshare_user_namespace_and_change_root: false,
+			can_do_secure_clone: true,
+		}));
+		assert!(!err.is_allowed_in_secure_mode(&SecurityStatus {
+			secure_validator_mode: true,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
+			can_enable_seccomp: false,
+			can_unshare_user_namespace_and_change_root: true,
 			can_do_secure_clone: false,
 		}));
 
 		let err = SecureModeError::CannotEnableSeccomp(String::new());
 		assert!(!err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: false,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
 			can_enable_seccomp: false,
 			can_unshare_user_namespace_and_change_root: true,
 			can_do_secure_clone: true,
 		}));
 		assert!(!err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: false,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
 			can_enable_seccomp: true,
 			can_unshare_user_namespace_and_change_root: false,
 			can_do_secure_clone: false,
@@ -347,14 +376,16 @@ mod tests {
 		let err = SecureModeError::CannotUnshareUserNamespaceAndChangeRoot(String::new());
 		assert!(err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: true,
+			can_enable_landlock_fs: true,
+			can_enable_landlock_net: true,
 			can_enable_seccomp: false,
 			can_unshare_user_namespace_and_change_root: false,
 			can_do_secure_clone: false,
 		}));
 		assert!(!err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: false,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
 			can_enable_seccomp: true,
 			can_unshare_user_namespace_and_change_root: false,
 			can_do_secure_clone: false,
@@ -363,14 +394,16 @@ mod tests {
 		let err = SecureModeError::CannotDoSecureClone(String::new());
 		assert!(err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: true,
-			can_enable_landlock: true,
+			can_enable_landlock_fs: true,
+			can_enable_landlock_net: true,
 			can_enable_seccomp: true,
 			can_unshare_user_namespace_and_change_root: true,
 			can_do_secure_clone: true,
 		}));
 		assert!(err.is_allowed_in_secure_mode(&SecurityStatus {
 			secure_validator_mode: false,
-			can_enable_landlock: false,
+			can_enable_landlock_fs: false,
+			can_enable_landlock_net: false,
 			can_enable_seccomp: false,
 			can_unshare_user_namespace_and_change_root: false,
 			can_do_secure_clone: false,


### PR DESCRIPTION
Adds an additional security feature based on Landlock networking restrictions. In Secure Validator Mode, this feature should be optional if the seccomp feature is available. Likewise the seccomp feature becomes optional if the new feature is available.

I have not been able to test this because `cargo test` made my VPS explode.

Closes https://github.com/paritytech/polkadot-sdk/issues/7162