### PR TITLE
Use rpc_port in bridge tests

### DIFF
--- a/.gitlab/pipeline/zombienet.yml
+++ b/.gitlab/pipeline/zombienet.yml
@@ -1,7 +1,7 @@
 .zombienet-refs:
   extends: .build-refs
   variables:
-    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.119"
+    ZOMBIENET_IMAGE: "docker.io/paritytech/zombienet:v1.3.120"
     PUSHGATEWAY_URL: "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics"
     DEBUG: "zombie,zombie::network-node,zombie::kube::client::logs"
     ZOMBIE_PROVIDER: "k8s"

--- a/bridges/testing/environments/rococo-westend/bridge_hub_rococo_local_network.toml
+++ b/bridges/testing/environments/rococo-westend/bridge_hub_rococo_local_network.toml
@@ -9,22 +9,19 @@ chain = "rococo-local"
 	[[relaychain.nodes]]
 	name = "alice-rococo-validator"
 	validator = true
-	rpc_port = 9932
-	ws_port = 9942
+	rpc_port = 9942
 	balance = 2000000000000
 
 	[[relaychain.nodes]]
 	name = "bob-rococo-validator"
 	validator = true
-	rpc_port = 9933
-	ws_port = 9943
+	rpc_port = 9943
 	balance = 2000000000000
 
 	[[relaychain.nodes]]
 	name = "charlie-rococo-validator"
 	validator = true
-	rpc_port = 9934
-	ws_port = 9944
+	rpc_port = 9944
 	balance = 2000000000000
 
 [[parachains]]
@@ -37,8 +34,7 @@ cumulus_based = true
 	name = "bridge-hub-rococo-collator1"
 	validator = true
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
-	rpc_port = 8933
-	ws_port = 8943
+	rpc_port = 8943
 	args = [
 		"-lparachain=debug,runtime::bridge=trace,xcm=trace,txpool=trace"
 	]
@@ -48,8 +44,7 @@ cumulus_based = true
 	name = "bridge-hub-rococo-collator2"
 	validator = true
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
-	rpc_port = 8934
-	ws_port = 8944
+	rpc_port = 8944
 	args = [
 		"-lparachain=debug,runtime::bridge=trace,xcm=trace,txpool=trace"
 	]
@@ -61,8 +56,7 @@ cumulus_based = true
 
 	[[parachains.collators]]
 	name = "asset-hub-rococo-collator1"
-	rpc_port = 9911
-	ws_port = 9910
+	rpc_port = 9910
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
 	args = [
 		"-lparachain=debug,xcm=trace,runtime::bridge=trace,txpool=trace"

--- a/bridges/testing/environments/rococo-westend/bridge_hub_westend_local_network.toml
+++ b/bridges/testing/environments/rococo-westend/bridge_hub_westend_local_network.toml
@@ -9,22 +9,19 @@ chain = "westend-local"
 	[[relaychain.nodes]]
 	name = "alice-westend-validator"
 	validator = true
-	rpc_port = 9935
-	ws_port = 9945
+	rpc_port = 9945
 	balance = 2000000000000
 
 	[[relaychain.nodes]]
 	name = "bob-westend-validator"
 	validator = true
-	rpc_port = 9936
-	ws_port = 9946
+	rpc_port = 9946
 	balance = 2000000000000
 
 	[[relaychain.nodes]]
 	name = "charlie-westend-validator"
 	validator = true
-	rpc_port = 9937
-	ws_port = 9947
+	rpc_port = 9947
 	balance = 2000000000000
 
 [[parachains]]
@@ -37,8 +34,7 @@ cumulus_based = true
 	name = "bridge-hub-westend-collator1"
 	validator = true
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
-	rpc_port = 8935
-	ws_port = 8945
+	rpc_port = 8945
 	args = [
 		"-lparachain=debug,runtime::bridge=trace,xcm=trace,txpool=trace"
 	]
@@ -48,8 +44,7 @@ cumulus_based = true
 	name = "bridge-hub-westend-collator2"
 	validator = true
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
-	rpc_port = 8936
-	ws_port = 8946
+	rpc_port = 8946
 	args = [
 		"-lparachain=debug,runtime::bridge=trace,xcm=trace,txpool=trace"
 	]
@@ -61,8 +56,7 @@ cumulus_based = true
 
 	[[parachains.collators]]
 	name = "asset-hub-westend-collator1"
-	rpc_port = 9011
-	ws_port = 9010
+	rpc_port = 9010
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
 	args = [
 		"-lparachain=debug,xcm=trace,runtime::bridge=trace,txpool=trace"


### PR DESCRIPTION
Use `rpc_port` instead of `ws_port` in bridge tests since `ws_port` is deprecated.