### PR TITLE
`fatxpool`: event streams moved to view domain

### DIFF
--- a/substrate/client/transaction-pool/src/common/tests.rs
+++ b/substrate/client/transaction-pool/src/common/tests.rs
@@ -18,7 +18,7 @@
 
 //! Testing related primitives for internal usage in this crate.
 
-use crate::graph::{BlockHash, ChainApi, ExtrinsicFor, NumberFor, Pool, RawExtrinsicFor};
+use crate::graph::{BlockHash, ChainApi, ExtrinsicFor, NumberFor, RawExtrinsicFor};
 use codec::Encode;
 use parking_lot::Mutex;
 use sc_transaction_pool_api::error;
@@ -35,6 +35,8 @@ use substrate_test_runtime::{
 	substrate_test_pallet::pallet::Call as PalletCall, BalancesCall, Block, BlockNumber, Extrinsic,
 	ExtrinsicBuilder, Hashing, RuntimeCall, Transfer, TransferData, H256,
 };
+
+type Pool<Api> = crate::graph::Pool<Api, ()>;
 
 pub(crate) const INVALID_NONCE: u64 = 254;
 

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/dropped_watcher.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/dropped_watcher.rs
@@ -74,7 +74,8 @@ pub enum DroppedReason<Hash> {
 }
 
 /// Dropped-logic related event from the single view.
-pub type ViewStreamEvent<C> = crate::graph::TransactionStatusEvent<ExtrinsicHash<C>, BlockHash<C>>;
+pub type ViewStreamEvent<C> =
+	crate::fork_aware_txpool::view::TransactionStatusEvent<ExtrinsicHash<C>, BlockHash<C>>;
 
 /// Dropped-logic stream of events coming from the single view.
 type ViewStream<C> = Pin<Box<dyn futures::Stream<Item = ViewStreamEvent<C>> + Send>>;

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/mod.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/mod.rs
@@ -323,7 +323,7 @@
 //! [`MultiViewListener`]: crate::fork_aware_txpool::multi_view_listener::MultiViewListener
 //! [`Pool`]: crate::graph::Pool
 //! [`Watcher`]: crate::graph::watcher::Watcher
-//! [`AggregatedStream`]: crate::graph::AggregatedStream
+//! [`AggregatedStream`]: crate::fork_aware_txpool::view::AggregatedStream
 //! [`Options`]: crate::graph::Options
 //! [`vp::import_notification_stream`]: ../graph/validated_pool/struct.ValidatedPool.html#method.import_notification_stream
 //! [`vp::enforce_limits`]: ../graph/validated_pool/struct.ValidatedPool.html#method.enforce_limits

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/multi_view_listener.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/multi_view_listener.rs
@@ -22,8 +22,8 @@
 
 use crate::{
 	common::tracing_log_xt::log_xt_trace,
-	fork_aware_txpool::stream_map_util::next_event,
-	graph::{self, BlockHash, ExtrinsicHash, TransactionStatusEvent},
+	fork_aware_txpool::{stream_map_util::next_event, view::TransactionStatusEvent},
+	graph::{self, BlockHash, ExtrinsicHash},
 	LOG_TARGET,
 };
 use futures::{Future, FutureExt, Stream, StreamExt};

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/revalidation_worker.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/revalidation_worker.rs
@@ -205,13 +205,9 @@ mod tests {
 		let api = Arc::new(TestApi::default());
 		let block0 = api.expect_hash_and_number(0);
 
-		let view = Arc::new(View::new(
-			api.clone(),
-			block0,
-			Default::default(),
-			Default::default(),
-			false.into(),
-		));
+		let view = Arc::new(
+			View::new(api.clone(), block0, Default::default(), Default::default(), false.into()).0,
+		);
 		let queue = Arc::new(RevalidationQueue::new());
 
 		let uxt = uxt(Transfer {

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -27,13 +27,14 @@ use super::metrics::MetricsLink as PrometheusMetrics;
 use crate::{
 	common::tracing_log_xt::log_xt_trace,
 	graph::{
-		self, base_pool::TimedTransactionSource, ExtrinsicFor, ExtrinsicHash, IsValidator,
-		ValidatedPoolSubmitOutcome, ValidatedTransaction, ValidatedTransactionFor,
+		self, base_pool::TimedTransactionSource, BlockHash, ExtrinsicFor, ExtrinsicHash,
+		IsValidator, ValidatedPoolSubmitOutcome, ValidatedTransaction, ValidatedTransactionFor,
 	},
 	LOG_TARGET,
 };
 use parking_lot::Mutex;
-use sc_transaction_pool_api::{error::Error as TxPoolError, PoolStatus};
+use sc_transaction_pool_api::{error::Error as TxPoolError, PoolStatus, TransactionStatus};
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_blockchain::HashAndNumber;
 use sp_runtime::{
 	generic::BlockId, traits::Block as BlockT, transaction_validity::TransactionValidityError,
@@ -108,13 +109,139 @@ impl<ChainApi: graph::ChainApi> FinishRevalidationWorkerChannels<ChainApi> {
 	}
 }
 
+/// Single event used in aggregated stream. Tuple containing hash of transactions and its status.
+pub(super) type TransactionStatusEvent<H, BH> = (H, TransactionStatus<H, BH>);
+/// Warning threshold for (unbounded) channel used in aggregated view's streams.
+const VIEW_STREAM_WARN_THRESHOLD: usize = 100_000;
+
+/// Stream of events providing statuses of all the transactions within the pool.
+pub(super) type AggregatedStream<H, BH> = TracingUnboundedReceiver<TransactionStatusEvent<H, BH>>;
+
+/// Type alias for a stream of events intended to track dropped transactions.
+type DroppedMonitoringStream<H, BH> = TracingUnboundedReceiver<TransactionStatusEvent<H, BH>>;
+
+/// Notification handler for transactions updates triggered in `ValidatedPool`.
+///
+/// `ViewPoolObserver` handles transaction status changes notifications coming from an instance of
+/// validated pool associated with the `View` and forwards them through specified channels
+/// into the View's streams.
+pub(super) struct ViewPoolObserver<ChainApi: graph::ChainApi> {
+	/// The sink used to notify dropped by enforcing limits or by being usurped transactions.
+	///
+	/// Note: Ready and future statuses are alse communicated through this channel, enabling the
+	/// stream consumer to track views that reference the transaction.
+	dropped_stream_sink: TracingUnboundedSender<
+		TransactionStatusEvent<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	>,
+
+	/// The sink of the single, merged stream providing updates for all the transactions in the
+	/// associated pool.
+	///
+	/// Note: some of the events which are currently ignored on the other side of this channel
+	/// (external watcher) are not relayed.
+	aggregated_stream_sink: TracingUnboundedSender<
+		TransactionStatusEvent<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	>,
+}
+
+impl<C: graph::ChainApi> graph::EventHandler<C> for ViewPoolObserver<C> {
+	// note: skipped, notified by ForkAwareTxPool directly to multi view listener.
+	fn broadcasted(&self, _: ExtrinsicHash<C>, _: Vec<String>) {}
+	fn dropped(&self, _: ExtrinsicHash<C>) {}
+	fn invalid(&self, _: ExtrinsicHash<C>) {}
+	fn finalized(&self, _: ExtrinsicHash<C>, _: BlockHash<C>, _: usize) {}
+	fn retracted(&self, _: ExtrinsicHash<C>, _: BlockHash<C>) {
+		// note: [#5479], we do not send to aggregated stream.
+	}
+
+	fn ready(&self, tx: ExtrinsicHash<C>) {
+		let status = TransactionStatus::Ready;
+		self.send_to_dropped_stream_sink(tx, status.clone());
+		self.send_to_aggregated_stream_sink(tx, status);
+	}
+
+	fn future(&self, tx: ExtrinsicHash<C>) {
+		let status = TransactionStatus::Future;
+		self.send_to_dropped_stream_sink(tx, status.clone());
+		self.send_to_aggregated_stream_sink(tx, status);
+	}
+
+	fn limits_enforced(&self, tx: ExtrinsicHash<C>) {
+		let status = TransactionStatus::Dropped;
+		self.send_to_dropped_stream_sink(tx, status);
+	}
+
+	fn usurped(&self, tx: ExtrinsicHash<C>, by: ExtrinsicHash<C>) {
+		let status = TransactionStatus::Usurped(by.clone());
+		self.send_to_dropped_stream_sink(tx, status);
+	}
+
+	fn pruned(&self, tx: ExtrinsicHash<C>, block_hash: BlockHash<C>, tx_index: usize) {
+		let status = TransactionStatus::InBlock((block_hash, tx_index));
+		self.send_to_aggregated_stream_sink(tx, status);
+	}
+
+	fn finality_timeout(&self, tx: ExtrinsicHash<C>, hash: BlockHash<C>) {
+		let status = TransactionStatus::FinalityTimeout(hash);
+		//todo: do we need this? [related issue: #5482]
+		self.send_to_aggregated_stream_sink(tx, status);
+	}
+}
+
+impl<ChainApi: graph::ChainApi> ViewPoolObserver<ChainApi> {
+	/// Creates an instance of `ViewPoolObserver` together with associated view's streams.
+	///
+	/// This methods creates an event handler that shall be registered in the `ValidatedPool`
+	/// instance associated with the view. It also creates new view's streams:
+	/// - a single stream intended to watch dropped transactions only. The stream can be used to
+	///   subscribe to events related to dropping of all extrinsics in the pool.
+	/// - a single merged stream for all extrinsics in the associated pool. The stream can be used
+	/// to subscribe to life-cycle events of all extrinsics in the pool. For fork-aware
+	/// pool implementation this approach seems to be more efficient than using individual
+	/// streams for every transaction.
+	fn new() -> (
+		Self,
+		DroppedMonitoringStream<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+		AggregatedStream<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	) {
+		let (dropped_stream_sink, dropped_stream) =
+			tracing_unbounded("mpsc_txpool_watcher", VIEW_STREAM_WARN_THRESHOLD);
+		let (aggregated_stream_sink, aggregated_stream) =
+			tracing_unbounded("mpsc_txpool_aggregated_stream", VIEW_STREAM_WARN_THRESHOLD);
+
+		(Self { dropped_stream_sink, aggregated_stream_sink }, dropped_stream, aggregated_stream)
+	}
+
+	/// Sends given event to the `dropped_stream_sink`.
+	fn send_to_dropped_stream_sink(
+		&self,
+		tx: ExtrinsicHash<ChainApi>,
+		status: TransactionStatus<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	) {
+		if let Err(e) = self.dropped_stream_sink.unbounded_send((tx.clone(), status.clone())) {
+			trace!(target: LOG_TARGET, "[{:?}] dropped_sink: {:?} send message failed: {:?}", tx, status, e);
+		}
+	}
+
+	/// Sends given event to the `aggregated_stream_sink`.
+	fn send_to_aggregated_stream_sink(
+		&self,
+		tx: ExtrinsicHash<ChainApi>,
+		status: TransactionStatus<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	) {
+		if let Err(e) = self.aggregated_stream_sink.unbounded_send((tx.clone(), status.clone())) {
+			trace!(target: LOG_TARGET, "[{:?}] aggregated_stream {:?} send message failed: {:?}", tx, status, e);
+		}
+	}
+}
+
 /// Represents the state of transaction pool for given block.
 ///
 /// Refer to [*View*](../index.html#view) section for more details on the purpose and life cycle of
 /// the `View`.
 pub(super) struct View<ChainApi: graph::ChainApi> {
 	/// The internal pool keeping the set of ready and future transaction at the given block.
-	pub(super) pool: graph::Pool<ChainApi>,
+	pub(super) pool: graph::Pool<ChainApi, ViewPoolObserver<ChainApi>>,
 	/// The hash and number of the block with which this view is associated.
 	pub(super) at: HashAndNumber<ChainApi::Block>,
 	/// Endpoints of communication channel with background worker.
@@ -135,24 +262,50 @@ where
 		options: graph::Options,
 		metrics: PrometheusMetrics,
 		is_validator: IsValidator,
-	) -> Self {
+	) -> (
+		Self,
+		DroppedMonitoringStream<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+		AggregatedStream<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	) {
 		metrics.report(|metrics| metrics.non_cloned_views.inc());
-		Self {
-			pool: graph::Pool::new(options, is_validator, api),
-			at,
-			revalidation_worker_channels: Mutex::from(None),
-			metrics,
-		}
+		let (event_handler, dropped_stream, aggregated_stream) = ViewPoolObserver::new();
+		(
+			Self {
+				pool: graph::Pool::new_with_event_handler(
+					options,
+					is_validator,
+					api,
+					event_handler,
+				),
+				at,
+				revalidation_worker_channels: Mutex::from(None),
+				metrics,
+			},
+			dropped_stream,
+			aggregated_stream,
+		)
 	}
 
 	/// Creates a copy of the other view.
-	pub(super) fn new_from_other(&self, at: &HashAndNumber<ChainApi::Block>) -> Self {
-		View {
-			at: at.clone(),
-			pool: self.pool.deep_clone(),
-			revalidation_worker_channels: Mutex::from(None),
-			metrics: self.metrics.clone(),
-		}
+	pub(super) fn new_from_other(
+		&self,
+		at: &HashAndNumber<ChainApi::Block>,
+	) -> (
+		Self,
+		DroppedMonitoringStream<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+		AggregatedStream<ExtrinsicHash<ChainApi>, BlockHash<ChainApi>>,
+	) {
+		let (event_handler, dropped_stream, aggregated_stream) = ViewPoolObserver::new();
+		(
+			View {
+				at: at.clone(),
+				pool: self.pool.deep_clone_with_event_handler(event_handler),
+				revalidation_worker_channels: Mutex::from(None),
+				metrics: self.metrics.clone(),
+			},
+			dropped_stream,
+			aggregated_stream,
+		)
 	}
 
 	/// Imports single unvalidated extrinsic into the view.
@@ -498,7 +651,10 @@ where
 		listener_action: F,
 	) -> Vec<ExtrinsicHash<ChainApi>>
 	where
-		F: Fn(&mut crate::graph::Listener<ChainApi>, ExtrinsicHash<ChainApi>),
+		F: Fn(
+			&mut crate::graph::EventDispatcher<ChainApi, ViewPoolObserver<ChainApi>>,
+			ExtrinsicHash<ChainApi>,
+		),
 	{
 		self.pool.validated_pool().remove_subtree(tx_hash, listener_action)
 	}

--- a/substrate/client/transaction-pool/src/graph/listener.rs
+++ b/substrate/client/transaction-pool/src/graph/listener.rs
@@ -20,58 +20,91 @@ use std::{collections::HashMap, fmt::Debug, hash};
 
 use linked_hash_map::LinkedHashMap;
 use log::trace;
-use sc_transaction_pool_api::TransactionStatus;
-use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
-use serde::Serialize;
-use sp_runtime::traits;
 
 use super::{watcher, BlockHash, ChainApi, ExtrinsicHash};
 
 static LOG_TARGET: &str = "txpool::watcher";
 
-/// Single event used in aggregated stream. Tuple containing hash of transactions and its status.
-pub type TransactionStatusEvent<H, BH> = (H, TransactionStatus<H, BH>);
-/// Stream of events providing statuses of all the transactions within the pool.
-pub type AggregatedStream<H, BH> = TracingUnboundedReceiver<TransactionStatusEvent<H, BH>>;
+/// The `EventHandler` trait provides a mechanism for clients to respond to various
+/// transaction-related events. It offers a set of callback methods that are invoked by the
+/// transaction pool's event dispatcher to notify about changes in the status of transactions.
+///
+/// This trait can be implemented by any component that needs to respond to transaction lifecycle
+/// events, enabling custom logic and handling of these events.
+pub trait EventHandler<C: ChainApi> {
+	/// Called when a transaction is broadcasted.
+	fn broadcasted(&self, _hash: ExtrinsicHash<C>, _peers: Vec<String>) {}
 
-/// Warning threshold for (unbounded) channel used in aggregated stream.
-const AGGREGATED_STREAM_WARN_THRESHOLD: usize = 100_000;
+	/// Called when a transaction is ready for execution.
+	fn ready(&self, _tx: ExtrinsicHash<C>) {}
 
-/// Extrinsic pool default listener.
-pub struct Listener<H: hash::Hash + Eq, C: ChainApi> {
+	/// Called when a transaction is deemed to be executable in the future.
+	fn future(&self, _tx: ExtrinsicHash<C>) {}
+
+	/// Called when transaction pool limits result in a transaction being affected.
+	fn limits_enforced(&self, _tx: ExtrinsicHash<C>) {}
+
+	/// Called when a transaction is replaced by another.
+	fn usurped(&self, _tx: ExtrinsicHash<C>, _by: ExtrinsicHash<C>) {}
+
+	/// Called when a transaction is dropped from the pool.
+	fn dropped(&self, _tx: ExtrinsicHash<C>) {}
+
+	/// Called when a transaction is found to be invalid.
+	fn invalid(&self, _tx: ExtrinsicHash<C>) {}
+
+	/// Called when a transaction was pruned from the pool due to its presence in imported block.
+	fn pruned(&self, _tx: ExtrinsicHash<C>, _block_hash: BlockHash<C>, _tx_index: usize) {}
+
+	/// Called when a transaction is retracted from inclusion in a block.
+	fn retracted(&self, _tx: ExtrinsicHash<C>, _block_hash: BlockHash<C>) {}
+
+	/// Called when a transaction has not been finalized within a timeout period.
+	fn finality_timeout(&self, _tx: ExtrinsicHash<C>, _hash: BlockHash<C>) {}
+
+	/// Called when a transaction is finalized in a block.
+	fn finalized(&self, _tx: ExtrinsicHash<C>, _block_hash: BlockHash<C>, _tx_index: usize) {}
+}
+
+impl<C: ChainApi> EventHandler<C> for () {}
+
+/// The `EventDispatcher` struct is responsible for dispatching transaction-related events from the
+/// validated pool to interested observers and an optional event handler. It acts as the primary
+/// liaison between the transaction pool and clients that are monitoring transaction statuses.
+pub struct EventDispatcher<H: hash::Hash + Eq, C: ChainApi, L: EventHandler<C>> {
 	/// Map containing per-transaction sinks for emitting transaction status events.
 	watchers: HashMap<H, watcher::Sender<H, BlockHash<C>>>,
 	finality_watchers: LinkedHashMap<ExtrinsicHash<C>, Vec<H>>,
 
-	/// The sink used to notify dropped by enforcing limits or by being usurped transactions.
-	///
-	/// Note: Ready and future statuses are alse communicated through this channel, enabling the
-	/// stream consumer to track views that reference the transaction.
-	dropped_stream_sink: Option<TracingUnboundedSender<TransactionStatusEvent<H, BlockHash<C>>>>,
-
-	/// The sink of the single, merged stream providing updates for all the transactions in the
-	/// associated pool.
-	aggregated_stream_sink: Option<TracingUnboundedSender<TransactionStatusEvent<H, BlockHash<C>>>>,
+	/// Optional event handler (listener) that will be notified about all transactions status
+	/// changes from the pool.
+	event_handler: Option<L>,
 }
 
 /// Maximum number of blocks awaiting finality at any time.
 const MAX_FINALITY_WATCHERS: usize = 512;
 
-impl<H: hash::Hash + Eq + Debug, C: ChainApi> Default for Listener<H, C> {
+impl<H: hash::Hash + Eq + Debug, C: ChainApi, L: EventHandler<C>> Default
+	for EventDispatcher<H, C, L>
+{
 	fn default() -> Self {
 		Self {
 			watchers: Default::default(),
 			finality_watchers: Default::default(),
-			dropped_stream_sink: None,
-			aggregated_stream_sink: None,
+			event_handler: None,
 		}
 	}
 }
 
-impl<H: hash::Hash + traits::Member + Serialize + Clone, C: ChainApi> Listener<H, C> {
-	fn fire<F>(&mut self, hash: &H, fun: F)
+impl<C: ChainApi, L: EventHandler<C>> EventDispatcher<ExtrinsicHash<C>, C, L> {
+	/// Creates a new instance with provided event handler.
+	pub fn new_with_event_handler(event_handler: Option<L>) -> Self {
+		Self { event_handler, ..Default::default() }
+	}
+
+	fn fire<F>(&mut self, hash: &ExtrinsicHash<C>, fun: F)
 	where
-		F: FnOnce(&mut watcher::Sender<H, ExtrinsicHash<C>>),
+		F: FnOnce(&mut watcher::Sender<ExtrinsicHash<C>, ExtrinsicHash<C>>),
 	{
 		let clean = if let Some(h) = self.watchers.get_mut(hash) {
 			fun(h);
@@ -88,117 +121,73 @@ impl<H: hash::Hash + traits::Member + Serialize + Clone, C: ChainApi> Listener<H
 	/// Creates a new watcher for given verified extrinsic.
 	///
 	/// The watcher can be used to subscribe to life-cycle events of that extrinsic.
-	pub fn create_watcher(&mut self, hash: H) -> watcher::Watcher<H, ExtrinsicHash<C>> {
+	pub fn create_watcher(
+		&mut self,
+		hash: ExtrinsicHash<C>,
+	) -> watcher::Watcher<ExtrinsicHash<C>, ExtrinsicHash<C>> {
 		let sender = self.watchers.entry(hash.clone()).or_insert_with(watcher::Sender::default);
 		sender.new_watcher(hash)
 	}
 
-	/// Creates a new single stream intended to watch dropped transactions only.
-	///
-	/// The stream can be used to subscribe to events related to dropping of all extrinsics in the
-	/// pool.
-	pub fn create_dropped_by_limits_stream(&mut self) -> AggregatedStream<H, BlockHash<C>> {
-		let (sender, single_stream) =
-			tracing_unbounded("mpsc_txpool_watcher", AGGREGATED_STREAM_WARN_THRESHOLD);
-		self.dropped_stream_sink = Some(sender);
-		single_stream
-	}
-
-	/// Creates a new single merged stream for all extrinsics in the associated pool.
-	///
-	/// The stream can be used to subscribe to life-cycle events of all extrinsics in the pool. For
-	/// some implementations (e.g. fork-aware pool) this approach may be more efficient than using
-	/// individual streams for every transaction.
-	///
-	/// Note: some of the events which are currently ignored on the other side of this channel
-	/// (external watcher) are not sent.
-	pub fn create_aggregated_stream(&mut self) -> AggregatedStream<H, BlockHash<C>> {
-		let (sender, aggregated_stream) =
-			tracing_unbounded("mpsc_txpool_aggregated_stream", AGGREGATED_STREAM_WARN_THRESHOLD);
-		self.aggregated_stream_sink = Some(sender);
-		aggregated_stream
-	}
-
 	/// Notify the listeners about the extrinsic broadcast.
-	pub fn broadcasted(&mut self, hash: &H, peers: Vec<String>) {
+	pub fn broadcasted(&mut self, hash: &ExtrinsicHash<C>, peers: Vec<String>) {
 		trace!(target: LOG_TARGET, "[{:?}] Broadcasted", hash);
-		self.fire(hash, |watcher| watcher.broadcast(peers));
-	}
-
-	/// Sends given event to the `dropped_stream_sink`.
-	fn send_to_dropped_stream_sink(&mut self, tx: &H, status: TransactionStatus<H, BlockHash<C>>) {
-		if let Some(ref sink) = self.dropped_stream_sink {
-			if let Err(e) = sink.unbounded_send((tx.clone(), status.clone())) {
-				trace!(target: LOG_TARGET, "[{:?}] dropped_sink: {:?} send message failed: {:?}", tx, status, e);
-			}
-		}
-	}
-
-	/// Sends given event to the `aggregated_stream_sink`.
-	fn send_to_aggregated_stream_sink(
-		&mut self,
-		tx: &H,
-		status: TransactionStatus<H, BlockHash<C>>,
-	) {
-		if let Some(ref sink) = self.aggregated_stream_sink {
-			if let Err(e) = sink.unbounded_send((tx.clone(), status.clone())) {
-				trace!(target: LOG_TARGET, "[{:?}] aggregated_stream {:?} send message failed: {:?}", tx, status, e);
-			}
-		}
+		self.fire(hash, |watcher| watcher.broadcast(peers.clone()));
+		self.event_handler.as_ref().map(|l| l.broadcasted(*hash, peers));
 	}
 
 	/// New transaction was added to the ready pool or promoted from the future pool.
-	pub fn ready(&mut self, tx: &H, old: Option<&H>) {
-		trace!(target: LOG_TARGET, "[{:?}] Ready (replaced with {:?})", tx, old);
+	pub fn ready(&mut self, tx: &ExtrinsicHash<C>, old: Option<&ExtrinsicHash<C>>) {
+		trace!(target: LOG_TARGET, "[{:?}] Ready (replaced with {:?})", *tx, old);
 		self.fire(tx, |watcher| watcher.ready());
 		if let Some(old) = old {
 			self.fire(old, |watcher| watcher.usurped(tx.clone()));
 		}
 
-		self.send_to_dropped_stream_sink(tx, TransactionStatus::Ready);
-		self.send_to_aggregated_stream_sink(tx, TransactionStatus::Ready);
+		self.event_handler.as_ref().map(|l| l.ready(*tx));
 	}
 
 	/// New transaction was added to the future pool.
-	pub fn future(&mut self, tx: &H) {
+	pub fn future(&mut self, tx: &ExtrinsicHash<C>) {
 		trace!(target: LOG_TARGET, "[{:?}] Future", tx);
 		self.fire(tx, |watcher| watcher.future());
 
-		self.send_to_dropped_stream_sink(tx, TransactionStatus::Future);
-		self.send_to_aggregated_stream_sink(tx, TransactionStatus::Future);
+		self.event_handler.as_ref().map(|l| l.future(*tx));
 	}
 
 	/// Transaction was dropped from the pool because of enforcing the limit.
-	pub fn limits_enforced(&mut self, tx: &H) {
+	pub fn limits_enforced(&mut self, tx: &ExtrinsicHash<C>) {
 		trace!(target: LOG_TARGET, "[{:?}] Dropped (limits enforced)", tx);
 		self.fire(tx, |watcher| watcher.limit_enforced());
 
-		self.send_to_dropped_stream_sink(tx, TransactionStatus::Dropped);
+		self.event_handler.as_ref().map(|l| l.limits_enforced(*tx));
 	}
 
 	/// Transaction was replaced with other extrinsic.
-	pub fn usurped(&mut self, tx: &H, by: &H) {
+	pub fn usurped(&mut self, tx: &ExtrinsicHash<C>, by: &ExtrinsicHash<C>) {
 		trace!(target: LOG_TARGET, "[{:?}] Dropped (replaced with {:?})", tx, by);
 		self.fire(tx, |watcher| watcher.usurped(by.clone()));
 
-		self.send_to_dropped_stream_sink(tx, TransactionStatus::Usurped(by.clone()));
+		self.event_handler.as_ref().map(|l| l.usurped(*tx, *by));
 	}
 
 	/// Transaction was dropped from the pool because of the failure during the resubmission of
 	/// revalidate transactions or failure during pruning tags.
-	pub fn dropped(&mut self, tx: &H) {
+	pub fn dropped(&mut self, tx: &ExtrinsicHash<C>) {
 		trace!(target: LOG_TARGET, "[{:?}] Dropped", tx);
 		self.fire(tx, |watcher| watcher.dropped());
+		self.event_handler.as_ref().map(|l| l.dropped(*tx));
 	}
 
 	/// Transaction was removed as invalid.
-	pub fn invalid(&mut self, tx: &H) {
+	pub fn invalid(&mut self, tx: &ExtrinsicHash<C>) {
 		trace!(target: LOG_TARGET, "[{:?}] Extrinsic invalid", tx);
 		self.fire(tx, |watcher| watcher.invalid());
+		self.event_handler.as_ref().map(|l| l.invalid(*tx));
 	}
 
 	/// Transaction was pruned from the pool.
-	pub fn pruned(&mut self, block_hash: BlockHash<C>, tx: &H) {
+	pub fn pruned(&mut self, block_hash: BlockHash<C>, tx: &ExtrinsicHash<C>) {
 		trace!(target: LOG_TARGET, "[{:?}] Pruned at {:?}", tx, block_hash);
 		// Get the transactions included in the given block hash.
 		let txs = self.finality_watchers.entry(block_hash).or_insert(vec![]);
@@ -207,17 +196,13 @@ impl<H: hash::Hash + traits::Member + Serialize + Clone, C: ChainApi> Listener<H
 		let tx_index = txs.len() - 1;
 
 		self.fire(tx, |watcher| watcher.in_block(block_hash, tx_index));
-		self.send_to_aggregated_stream_sink(tx, TransactionStatus::InBlock((block_hash, tx_index)));
+		self.event_handler.as_ref().map(|l| l.pruned(*tx, block_hash, tx_index));
 
 		while self.finality_watchers.len() > MAX_FINALITY_WATCHERS {
 			if let Some((hash, txs)) = self.finality_watchers.pop_front() {
 				for tx in txs {
 					self.fire(&tx, |watcher| watcher.finality_timeout(hash));
-					//todo: do we need this? [related issue: #5482]
-					self.send_to_aggregated_stream_sink(
-						&tx,
-						TransactionStatus::FinalityTimeout(hash),
-					);
+					self.event_handler.as_ref().map(|l| l.finality_timeout(tx, block_hash));
 				}
 			}
 		}
@@ -228,7 +213,7 @@ impl<H: hash::Hash + traits::Member + Serialize + Clone, C: ChainApi> Listener<H
 		if let Some(hashes) = self.finality_watchers.remove(&block_hash) {
 			for hash in hashes {
 				self.fire(&hash, |watcher| watcher.retracted(block_hash));
-				// note: [#5479], we do not send to aggregated stream.
+				self.event_handler.as_ref().map(|l| l.retracted(hash, block_hash));
 			}
 		}
 	}
@@ -243,13 +228,14 @@ impl<H: hash::Hash + traits::Member + Serialize + Clone, C: ChainApi> Listener<H
 					hash,
 					block_hash,
 				);
-				self.fire(&hash, |watcher| watcher.finalized(block_hash, tx_index))
+				self.fire(&hash, |watcher| watcher.finalized(block_hash, tx_index));
+				self.event_handler.as_ref().map(|l| l.finalized(hash, block_hash, tx_index));
 			}
 		}
 	}
 
 	/// Provides hashes of all watched transactions.
-	pub fn watched_transactions(&self) -> impl Iterator<Item = &H> {
+	pub fn watched_transactions(&self) -> impl Iterator<Item = &ExtrinsicHash<C>> {
 		self.watchers.keys()
 	}
 }

--- a/substrate/client/transaction-pool/src/graph/mod.rs
+++ b/substrate/client/transaction-pool/src/graph/mod.rs
@@ -42,13 +42,12 @@ pub use self::pool::{
 	TransactionFor, ValidatedTransactionFor,
 };
 pub use validated_pool::{
-	BaseSubmitOutcome, IsValidator, Listener, ValidatedPoolSubmitOutcome, ValidatedTransaction,
+	BaseSubmitOutcome, EventDispatcher, IsValidator, ValidatedPoolSubmitOutcome,
+	ValidatedTransaction,
 };
 
 pub(crate) use self::pool::CheckBannedBeforeVerify;
-pub(crate) use listener::TransactionStatusEvent;
+pub(crate) use listener::EventHandler;
 
-#[cfg(doc)]
-pub(crate) use listener::AggregatedStream;
 #[cfg(doc)]
 pub(crate) use validated_pool::ValidatedPool;

--- a/substrate/client/transaction-pool/src/graph/pool.rs
+++ b/substrate/client/transaction-pool/src/graph/pool.rs
@@ -37,7 +37,7 @@ use std::{
 use super::{
 	base_pool as base,
 	validated_pool::{IsValidator, ValidatedPool, ValidatedTransaction},
-	ValidatedPoolSubmitOutcome,
+	EventHandler, ValidatedPoolSubmitOutcome,
 };
 
 /// Modification notification event stream type;
@@ -174,11 +174,11 @@ pub(crate) enum CheckBannedBeforeVerify {
 }
 
 /// Extrinsics pool that performs validation.
-pub struct Pool<B: ChainApi> {
-	validated_pool: Arc<ValidatedPool<B>>,
+pub struct Pool<B: ChainApi, L: EventHandler<B>> {
+	validated_pool: Arc<ValidatedPool<B, L>>,
 }
 
-impl<B: ChainApi> Pool<B> {
+impl<B: ChainApi, L: EventHandler<B>> Pool<B, L> {
 	/// Create a new transaction pool with statically sized rotator.
 	pub fn new_with_staticly_sized_rotator(
 		options: Options,
@@ -197,6 +197,23 @@ impl<B: ChainApi> Pool<B> {
 	/// Create a new transaction pool.
 	pub fn new(options: Options, is_validator: IsValidator, api: Arc<B>) -> Self {
 		Self { validated_pool: Arc::new(ValidatedPool::new(options, is_validator, api)) }
+	}
+
+	/// Create a new transaction pool.
+	pub fn new_with_event_handler(
+		options: Options,
+		is_validator: IsValidator,
+		api: Arc<B>,
+		event_handler: L,
+	) -> Self {
+		Self {
+			validated_pool: Arc::new(ValidatedPool::new_with_event_handler(
+				options,
+				is_validator,
+				api,
+				event_handler,
+			)),
+		}
 	}
 
 	/// Imports a bunch of unverified extrinsics to the pool
@@ -482,7 +499,7 @@ impl<B: ChainApi> Pool<B> {
 	}
 
 	/// Get a reference to the underlying validated pool.
-	pub fn validated_pool(&self) -> &ValidatedPool<B> {
+	pub fn validated_pool(&self) -> &ValidatedPool<B, L> {
 		&self.validated_pool
 	}
 
@@ -492,12 +509,13 @@ impl<B: ChainApi> Pool<B> {
 	}
 }
 
-impl<B: ChainApi> Pool<B> {
+impl<B: ChainApi, L: EventHandler<B>> Pool<B, L> {
 	/// Deep clones the pool.
 	///
 	/// Must be called on purpose: it duplicates all the internal structures.
-	pub fn deep_clone(&self) -> Self {
-		let other: ValidatedPool<B> = (*self.validated_pool).clone();
+	pub fn deep_clone_with_event_handler(&self, event_handler: L) -> Self {
+		let other: ValidatedPool<B, L> =
+			self.validated_pool().deep_clone_with_event_handler(event_handler);
 		Self { validated_pool: Arc::from(other) }
 	}
 }
@@ -519,6 +537,8 @@ mod tests {
 
 	const SOURCE: TimedTransactionSource =
 		TimedTransactionSource { source: TransactionSource::External, timestamp: None };
+
+	type Pool<Api> = super::Pool<Api, ()>;
 
 	#[test]
 	fn should_validate_and_import_transaction() {

--- a/substrate/client/transaction-pool/src/graph/validated_pool.rs
+++ b/substrate/client/transaction-pool/src/graph/validated_pool.rs
@@ -34,6 +34,7 @@ use std::time::Instant;
 
 use super::{
 	base_pool::{self as base, PruneStatus},
+	listener::EventHandler,
 	pool::{
 		BlockHash, ChainApi, EventStream, ExtrinsicFor, ExtrinsicHash, Options, TransactionFor,
 	},
@@ -90,8 +91,8 @@ impl<Hash, Ex, Error> ValidatedTransaction<Hash, Ex, Error> {
 pub type ValidatedTransactionFor<B> =
 	ValidatedTransaction<ExtrinsicHash<B>, ExtrinsicFor<B>, <B as ChainApi>::Error>;
 
-/// A type alias representing ValidatedPool listener for given ChainApi type.
-pub type Listener<B> = super::listener::Listener<ExtrinsicHash<B>, B>;
+/// A type alias representing ValidatedPool event dispatcher for given ChainApi type.
+pub type EventDispatcher<B, L> = super::listener::EventDispatcher<ExtrinsicHash<B>, B, L>;
 
 /// A closure that returns true if the local node is a validator that can author blocks.
 #[derive(Clone)]
@@ -154,23 +155,23 @@ impl<B: ChainApi, W> BaseSubmitOutcome<B, W> {
 }
 
 /// Pool that deals with validated transactions.
-pub struct ValidatedPool<B: ChainApi> {
+pub struct ValidatedPool<B: ChainApi, L: EventHandler<B>> {
 	api: Arc<B>,
 	is_validator: IsValidator,
 	options: Options,
-	listener: RwLock<Listener<B>>,
+	event_dispatcher: RwLock<EventDispatcher<B, L>>,
 	pub(crate) pool: RwLock<base::BasePool<ExtrinsicHash<B>, ExtrinsicFor<B>>>,
 	import_notification_sinks: Mutex<Vec<Sender<ExtrinsicHash<B>>>>,
 	rotator: PoolRotator<ExtrinsicHash<B>>,
 }
 
-impl<B: ChainApi> Clone for ValidatedPool<B> {
+impl<B: ChainApi, L: EventHandler<B>> Clone for ValidatedPool<B, L> {
 	fn clone(&self) -> Self {
 		Self {
 			api: self.api.clone(),
 			is_validator: self.is_validator.clone(),
 			options: self.options.clone(),
-			listener: Default::default(),
+			event_dispatcher: Default::default(),
 			pool: RwLock::from(self.pool.read().clone()),
 			import_notification_sinks: Default::default(),
 			rotator: self.rotator.clone(),
@@ -178,7 +179,16 @@ impl<B: ChainApi> Clone for ValidatedPool<B> {
 	}
 }
 
-impl<B: ChainApi> ValidatedPool<B> {
+impl<B: ChainApi, L: EventHandler<B>> ValidatedPool<B, L> {
+	pub fn deep_clone_with_event_handler(&self, event_handler: L) -> Self {
+		Self {
+			event_dispatcher: RwLock::new(EventDispatcher::new_with_event_handler(Some(
+				event_handler,
+			))),
+			..self.clone()
+		}
+	}
+
 	/// Create a new transaction pool with statically sized rotator.
 	pub fn new_with_staticly_sized_rotator(
 		options: Options,
@@ -186,7 +196,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 		api: Arc<B>,
 	) -> Self {
 		let ban_time = options.ban_time;
-		Self::new_with_rotator(options, is_validator, api, PoolRotator::new(ban_time))
+		Self::new_with_rotator(options, is_validator, api, PoolRotator::new(ban_time), None)
 	}
 
 	/// Create a new transaction pool.
@@ -198,6 +208,25 @@ impl<B: ChainApi> ValidatedPool<B> {
 			is_validator,
 			api,
 			PoolRotator::new_with_expected_size(ban_time, total_count),
+			None,
+		)
+	}
+
+	/// Create a new transaction pool with given event handler.
+	pub fn new_with_event_handler(
+		options: Options,
+		is_validator: IsValidator,
+		api: Arc<B>,
+		event_handler: L,
+	) -> Self {
+		let ban_time = options.ban_time;
+		let total_count = options.total_count();
+		Self::new_with_rotator(
+			options,
+			is_validator,
+			api,
+			PoolRotator::new_with_expected_size(ban_time, total_count),
+			Some(event_handler),
 		)
 	}
 
@@ -206,12 +235,13 @@ impl<B: ChainApi> ValidatedPool<B> {
 		is_validator: IsValidator,
 		api: Arc<B>,
 		rotator: PoolRotator<ExtrinsicHash<B>>,
+		event_handler: Option<L>,
 	) -> Self {
 		let base_pool = base::BasePool::new(options.reject_future_transactions);
 		Self {
 			is_validator,
 			options,
-			listener: Default::default(),
+			event_dispatcher: RwLock::new(EventDispatcher::new_with_event_handler(event_handler)),
 			api,
 			pool: RwLock::new(base_pool),
 			import_notification_sinks: Default::default(),
@@ -308,8 +338,8 @@ impl<B: ChainApi> ValidatedPool<B> {
 					});
 				}
 
-				let mut listener = self.listener.write();
-				fire_events(&mut *listener, &imported);
+				let mut event_dispatcher = self.event_dispatcher.write();
+				fire_events(&mut *event_dispatcher, &imported);
 				Ok(ValidatedPoolSubmitOutcome::new(*imported.hash(), Some(priority)))
 			},
 			ValidatedTransaction::Invalid(hash, err) => {
@@ -319,7 +349,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 			},
 			ValidatedTransaction::Unknown(hash, err) => {
 				log::trace!(target: LOG_TARGET, "[{:?}] ValidatedPool::submit_one unknown {:?}", hash, err);
-				self.listener.write().invalid(&hash);
+				self.event_dispatcher.write().invalid(&hash);
 				Err(err)
 			},
 		}
@@ -359,9 +389,9 @@ impl<B: ChainApi> ValidatedPool<B> {
 			}
 
 			// run notifications
-			let mut listener = self.listener.write();
+			let mut event_dispatcher = self.event_dispatcher.write();
 			for h in &removed {
-				listener.limits_enforced(h);
+				event_dispatcher.limits_enforced(h);
 			}
 
 			removed
@@ -397,12 +427,12 @@ impl<B: ChainApi> ValidatedPool<B> {
 		&self,
 		tx_hash: ExtrinsicHash<B>,
 	) -> Watcher<ExtrinsicHash<B>, ExtrinsicHash<B>> {
-		self.listener.write().create_watcher(tx_hash)
+		self.event_dispatcher.write().create_watcher(tx_hash)
 	}
 
 	/// Provides a list of hashes for all watched transactions in the pool.
 	pub fn watched_transactions(&self) -> Vec<ExtrinsicHash<B>> {
-		self.listener.read().watched_transactions().map(Clone::clone).collect()
+		self.event_dispatcher.read().watched_transactions().map(Clone::clone).collect()
 	}
 
 	/// Resubmits revalidated transactions back to the pool.
@@ -527,15 +557,15 @@ impl<B: ChainApi> ValidatedPool<B> {
 		};
 
 		// and now let's notify listeners about status changes
-		let mut listener = self.listener.write();
+		let mut event_dispatcher = self.event_dispatcher.write();
 		for (hash, final_status) in final_statuses {
 			let initial_status = initial_statuses.remove(&hash);
 			if initial_status.is_none() || Some(final_status) != initial_status {
 				match final_status {
-					Status::Future => listener.future(&hash),
-					Status::Ready => listener.ready(&hash, None),
-					Status::Dropped => listener.dropped(&hash),
-					Status::Failed => listener.invalid(&hash),
+					Status::Future => event_dispatcher.future(&hash),
+					Status::Ready => event_dispatcher.ready(&hash, None),
+					Status::Dropped => event_dispatcher.dropped(&hash),
+					Status::Failed => event_dispatcher.invalid(&hash),
 				}
 			}
 		}
@@ -568,12 +598,12 @@ impl<B: ChainApi> ValidatedPool<B> {
 		// Notify event listeners of all transactions
 		// that were promoted to `Ready` or were dropped.
 		{
-			let mut listener = self.listener.write();
+			let mut event_dispatcher = self.event_dispatcher.write();
 			for promoted in &status.promoted {
-				fire_events(&mut *listener, promoted);
+				fire_events(&mut *event_dispatcher, promoted);
 			}
 			for f in &status.failed {
-				listener.dropped(f);
+				event_dispatcher.dropped(f);
 			}
 		}
 
@@ -617,13 +647,13 @@ impl<B: ChainApi> ValidatedPool<B> {
 		at: &HashAndNumber<B::Block>,
 		hashes: impl Iterator<Item = ExtrinsicHash<B>>,
 	) {
-		let mut listener = self.listener.write();
+		let mut event_dispatcher = self.event_dispatcher.write();
 		let mut set = HashSet::with_capacity(hashes.size_hint().0);
 		for h in hashes {
 			// `hashes` has possibly duplicate hashes.
 			// we'd like to send out the `InBlock` notification only once.
 			if !set.contains(&h) {
-				listener.pruned(at.hash, &h);
+				event_dispatcher.pruned(at.hash, &h);
 				set.insert(h);
 			}
 		}
@@ -680,9 +710,9 @@ impl<B: ChainApi> ValidatedPool<B> {
 
 	/// Invoked when extrinsics are broadcasted.
 	pub fn on_broadcasted(&self, propagated: HashMap<ExtrinsicHash<B>, Vec<String>>) {
-		let mut listener = self.listener.write();
+		let mut event_dispatcher = self.event_dispatcher.write();
 		for (hash, peers) in propagated.into_iter() {
-			listener.broadcasted(&hash, peers);
+			event_dispatcher.broadcasted(&hash, peers);
 		}
 	}
 
@@ -708,9 +738,9 @@ impl<B: ChainApi> ValidatedPool<B> {
 		log::trace!(target: LOG_TARGET, "Removed invalid transactions: {:?}", invalid.len());
 		log_xt_trace!(target: LOG_TARGET, invalid.iter().map(|t| t.hash), "Removed invalid transaction");
 
-		let mut listener = self.listener.write();
+		let mut event_dispatcher = self.event_dispatcher.write();
 		for tx in &invalid {
-			listener.invalid(&tx.hash);
+			event_dispatcher.invalid(&tx.hash);
 		}
 
 		invalid
@@ -738,27 +768,13 @@ impl<B: ChainApi> ValidatedPool<B> {
 			"Attempting to notify watchers of finalization for {}",
 			block_hash,
 		);
-		self.listener.write().finalized(block_hash);
+		self.event_dispatcher.write().finalized(block_hash);
 		Ok(())
 	}
 
-	/// Notify the listener of retracted blocks
+	/// Notify the event_dispatcher of retracted blocks
 	pub fn on_block_retracted(&self, block_hash: BlockHash<B>) {
-		self.listener.write().retracted(block_hash)
-	}
-
-	/// Refer to [`Listener::create_dropped_by_limits_stream`] for details.
-	pub fn create_dropped_by_limits_stream(
-		&self,
-	) -> super::listener::AggregatedStream<ExtrinsicHash<B>, BlockHash<B>> {
-		self.listener.write().create_dropped_by_limits_stream()
-	}
-
-	/// Refer to [`Listener::create_aggregated_stream`]
-	pub fn create_aggregated_stream(
-		&self,
-	) -> super::listener::AggregatedStream<ExtrinsicHash<B>, BlockHash<B>> {
-		self.listener.write().create_aggregated_stream()
+		self.event_dispatcher.write().retracted(block_hash)
 	}
 
 	/// Resends ready and future events for all the ready and future transactions that are already
@@ -767,12 +783,12 @@ impl<B: ChainApi> ValidatedPool<B> {
 	/// Intended to be called after cloning the instance of `ValidatedPool`.
 	pub fn retrigger_notifications(&self) {
 		let pool = self.pool.read();
-		let mut listener = self.listener.write();
+		let mut event_dispatcher = self.event_dispatcher.write();
 		pool.ready().for_each(|r| {
-			listener.ready(&r.hash, None);
+			event_dispatcher.ready(&r.hash, None);
 		});
 		pool.futures().for_each(|f| {
-			listener.future(&f.hash);
+			event_dispatcher.future(&f.hash);
 		});
 	}
 
@@ -781,19 +797,19 @@ impl<B: ChainApi> ValidatedPool<B> {
 	/// This function traverses the dependency graph of transactions and removes the specified
 	/// transaction along with all its descendant transactions from the pool.
 	///
-	/// A `listener_action` callback function is invoked for every transaction that is removed,
-	/// providing a reference to the pool's listener and the hash of the removed transaction. This
-	/// allows to trigger the required events.
+	/// A `event_disaptcher_action` callback function is invoked for every transaction that is
+	/// removed, providing a reference to the pool's event dispatcher and the hash of the removed
+	/// transaction. This allows to trigger the required events.
 	///
 	/// Returns a vector containing the hashes of all removed transactions, including the root
 	/// transaction specified by `tx_hash`.
 	pub fn remove_subtree<F>(
 		&self,
 		tx_hash: ExtrinsicHash<B>,
-		listener_action: F,
+		event_dispatcher_action: F,
 	) -> Vec<ExtrinsicHash<B>>
 	where
-		F: Fn(&mut Listener<B>, ExtrinsicHash<B>),
+		F: Fn(&mut EventDispatcher<B, L>, ExtrinsicHash<B>),
 	{
 		self.pool
 			.write()
@@ -801,25 +817,28 @@ impl<B: ChainApi> ValidatedPool<B> {
 			.into_iter()
 			.map(|tx| {
 				let removed_tx_hash = tx.hash;
-				let mut listener = self.listener.write();
-				listener_action(&mut *listener, removed_tx_hash);
+				let mut event_dispatcher = self.event_dispatcher.write();
+				event_dispatcher_action(&mut *event_dispatcher, removed_tx_hash);
 				removed_tx_hash
 			})
 			.collect::<Vec<_>>()
 	}
 }
 
-fn fire_events<B, Ex>(listener: &mut Listener<B>, imported: &base::Imported<ExtrinsicHash<B>, Ex>)
-where
+fn fire_events<B, L, Ex>(
+	event_dispatcher: &mut EventDispatcher<B, L>,
+	imported: &base::Imported<ExtrinsicHash<B>, Ex>,
+) where
 	B: ChainApi,
+	L: EventHandler<B>,
 {
 	match *imported {
 		base::Imported::Ready { ref promoted, ref failed, ref removed, ref hash } => {
-			listener.ready(hash, None);
-			failed.iter().for_each(|f| listener.invalid(f));
-			removed.iter().for_each(|r| listener.usurped(&r.hash, hash));
-			promoted.iter().for_each(|p| listener.ready(p, None));
+			event_dispatcher.ready(hash, None);
+			failed.iter().for_each(|f| event_dispatcher.invalid(f));
+			removed.iter().for_each(|r| event_dispatcher.usurped(&r.hash, hash));
+			promoted.iter().for_each(|p| event_dispatcher.ready(p, None));
 		},
-		base::Imported::Future { ref hash } => listener.future(hash),
+		base::Imported::Future { ref hash } => event_dispatcher.future(hash),
 	}
 }

--- a/substrate/client/transaction-pool/src/single_state_txpool/revalidation.rs
+++ b/substrate/client/transaction-pool/src/single_state_txpool/revalidation.rs
@@ -24,7 +24,7 @@ use std::{
 	sync::Arc,
 };
 
-use crate::graph::{BlockHash, ChainApi, ExtrinsicHash, Pool, ValidatedTransaction};
+use crate::graph::{BlockHash, ChainApi, ExtrinsicHash, ValidatedTransaction};
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_runtime::{
 	generic::BlockId, traits::SaturatedConversion, transaction_validity::TransactionValidityError,
@@ -38,6 +38,8 @@ const BACKGROUND_REVALIDATION_INTERVAL: Duration = Duration::from_millis(200);
 const MIN_BACKGROUND_REVALIDATION_BATCH_SIZE: usize = 20;
 
 const LOG_TARGET: &str = "txpool::revalidation";
+
+type Pool<Api> = crate::graph::Pool<Api, ()>;
 
 /// Payload from queue to worker.
 struct WorkerPayload<Api: ChainApi> {

--- a/substrate/client/transaction-pool/src/single_state_txpool/single_state_txpool.rs
+++ b/substrate/client/transaction-pool/src/single_state_txpool/single_state_txpool.rs
@@ -29,7 +29,7 @@ use crate::{
 		error,
 		log_xt::log_xt_trace,
 	},
-	graph::{self, base_pool::TimedTransactionSource, ExtrinsicHash, IsValidator},
+	graph::{self, base_pool::TimedTransactionSource, EventHandler, ExtrinsicHash, IsValidator},
 	ReadyIteratorFor, LOG_TARGET,
 };
 use async_trait::async_trait;
@@ -61,7 +61,7 @@ where
 	Block: BlockT,
 	PoolApi: graph::ChainApi<Block = Block>,
 {
-	pool: Arc<graph::Pool<PoolApi>>,
+	pool: Arc<graph::Pool<PoolApi, ()>>,
 	api: Arc<PoolApi>,
 	revalidation_strategy: Arc<Mutex<RevalidationStrategy<NumberFor<Block>>>>,
 	revalidation_queue: Arc<revalidation::RevalidationQueue<PoolApi>>,
@@ -222,7 +222,7 @@ where
 	}
 
 	/// Gets shared reference to the underlying pool.
-	pub fn pool(&self) -> &Arc<graph::Pool<PoolApi>> {
+	pub fn pool(&self) -> &Arc<graph::Pool<PoolApi, ()>> {
 		&self.pool
 	}
 
@@ -579,10 +579,14 @@ impl<N: Clone + Copy + AtLeast32Bit> RevalidationStatus<N> {
 }
 
 /// Prune the known txs for the given block.
-pub async fn prune_known_txs_for_block<Block: BlockT, Api: graph::ChainApi<Block = Block>>(
+pub async fn prune_known_txs_for_block<
+	Block: BlockT,
+	Api: graph::ChainApi<Block = Block>,
+	L: EventHandler<Api>,
+>(
 	at: &HashAndNumber<Block>,
 	api: &Api,
-	pool: &graph::Pool<Api>,
+	pool: &graph::Pool<Api, L>,
 ) -> Vec<ExtrinsicHash<Api>> {
 	let extrinsics = api
 		.block_body(at.hash)

--- a/substrate/client/transaction-pool/tests/pool.rs
+++ b/substrate/client/transaction-pool/tests/pool.rs
@@ -45,6 +45,8 @@ use substrate_test_runtime_client::{
 };
 use substrate_test_runtime_transaction_pool::{uxt, TestApi};
 
+type Pool<Api> = sc_transaction_pool::Pool<Api, ()>;
+
 const LOG_TARGET: &str = "txpool";
 
 fn pool() -> (Pool<TestApi>, Arc<TestApi>) {


### PR DESCRIPTION
#### Overview

This pull request refactors the transaction pool `graph` module by renaming components for clarity and introducing the `EventHandler` trait to enhance flexibility in handling transaction lifecycle events. Changes include renaming `graph::Listener` to `graph::EventDispatcher`, updating generics, and moving certain functionalities to cleanup the codebase - mainly decouple graph from view-related specifics, and improve readability of the code.

#### Notes for Reviewers
All the changes looks dense at first, but in fact following was done:
- The `graph::Listener` was renamed to `graph::EventDispatcher`, to better reflect its role in dispatching transaction-related events from `ValidatedPool`. The `EventDispatcher` now utilizes the `L: EventHandler` generic type to handle transaction status events, allowing the removal of `View` related entities (e.g. streams) from the `ValidatedPool`.
- The new `EventHandler` trait was introduced to handle transaction lifecycle events, improving implementation flexibility and providing clearer role descriptions within the system.
- Fields, arguments, and variables previously named `listener` were renamed to `event_dispatcher` to align with their purpose and type naming.
- Dropped monitoring and aggregated events stream functionalities were moved from `ValidatedPool` to the `view` module, with `EventHandler` establishing the foundation for stream implementation.
- Updated various structs such as `Pool` and `ValidatedPool` to include a generic `L: EventHandler` across the codebase.
