### PR TITLE
Deprecate `para_id` Field from Chain Specification

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1623,6 +1623,12 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl cumulus_primitives_core::GetParachainInfo<Block> for Runtime {
+		fn id() -> ParaId {
+			ParachainInfo::parachain_id()
+		}
+	}
+
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
 		fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {

--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -402,4 +402,11 @@ sp_api::decl_runtime_apis! {
 		/// Retrieve core selector and claim queue offset for the next block.
 		fn core_selector() -> (CoreSelector, ClaimQueueOffset);
 	}
+
+	/// Runtime api used to access general info about a parachain runtime.
+	pub trait GetParachainInfo {
+
+		/// Retrieve the parachain id used for runtime.
+		fn id() -> ParaId;
+	}
 }


### PR DESCRIPTION
- Resolving #7384 and related Issues:
- #75
- #2116