### PR TITLE
pallet-revive: Add env var to allow skipping of validation for testing

### DIFF
--- a/prdoc/pr_7562.prdoc
+++ b/prdoc/pr_7562.prdoc
@@ -1,0 +1,10 @@
+title: 'pallet-revive: Add env var to allow skipping of validation for testing'
+doc:
+- audience: Runtime Dev
+  description: |-
+    When trying to reproduce bugs we sometimes need to deploy code that wouldn't pass validation. This PR adds a new environment variable `REVIVE_SKIP_VALIDATION` that when set will skip all validation except the contract blob size limit.
+
+    Please note that this only applies to when the pallet is compiled for `std` and hence will never be part of on-chain.
+crates:
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/src/limits.rs
+++ b/substrate/frame/revive/src/limits.rs
@@ -119,6 +119,12 @@ pub mod code {
 
 		let blob: CodeVec = blob.try_into().map_err(|_| <Error<T>>::BlobTooLarge)?;
 
+		#[cfg(feature = "std")]
+		if std::env::var_os("REVIVE_SKIP_VALIDATION").is_some() {
+			log::warn!(target: LOG_TARGET, "Skipping validation because env var REVIVE_SKIP_VALIDATION is set");
+			return Ok(blob)
+		}
+
 		let program = polkavm::ProgramBlob::parse(blob.as_slice().into()).map_err(|err| {
 			log::debug!(target: LOG_TARGET, "failed to parse polkavm blob: {err:?}");
 			Error::<T>::CodeRejected

--- a/substrate/frame/revive/src/wasm/mod.rs
+++ b/substrate/frame/revive/src/wasm/mod.rs
@@ -312,6 +312,7 @@ impl<T: Config> WasmBlob<T> {
 		config.set_cache_enabled(false);
 		#[cfg(feature = "std")]
 		if std::env::var_os("REVIVE_USE_COMPILER").is_some() {
+			log::warn!(target: LOG_TARGET, "Using PolkaVM compiler backend because env var REVIVE_USE_COMPILER is set");
 			config.set_backend(Some(polkavm::BackendKind::Compiler));
 		}
 		let engine = polkavm::Engine::new(&config).expect(


### PR DESCRIPTION
When trying to reproduce bugs we sometimes need to deploy code that wouldn't pass validation. This PR adds a new environment variable `REVIVE_SKIP_VALIDATION` that when set will skip all validation except the contract blob size limit.

Please note that this only applies to when the pallet is compiled for `std` and hence will never be part of on-chain. 