### PR TITLE
[Frame] Introduce VersionedCall to Handle Transaction Versioning in FRAME Pallets

### DIFF
--- a/substrate/frame/src/lib.rs
+++ b/substrate/frame/src/lib.rs
@@ -201,7 +201,7 @@ pub mod prelude {
 
 	/// Dispatch types from `frame-support`, other fundamental traits
 	#[doc(no_inline)]
-	pub use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
+	pub use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo, VersionedCall};
 	pub use frame_support::traits::{
 		Contains, EitherOf, EstimateNextSessionRotation, Everything, IsSubType, MapSuccess,
 		NoOpPoll, OnRuntimeUpgrade, OneSessionHandler, RankedMembers, RankedMembersSwapHandler,

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -687,6 +687,30 @@ impl<T> PaysFee<T> for (u64, Pays) {
 	}
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
+pub struct VersionedCall<Call> {
+    pub call: Call,
+    pub transaction_version: u32,
+}
+
+impl<Call> VersionedCall<Call> {
+	pub fn new(call: Call, transaction_version: u32) -> Self {
+		Self {
+			transaction_version,
+			call,
+		}
+	}
+    pub fn validate(&self, current_transaction_version: u32) -> Result<(), DispatchError> {
+        if self.transaction_version != current_transaction_version {
+            Err(DispatchError::Other("Transaction version mismatch"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+
+
 // END TODO
 
 #[cfg(test)]


### PR DESCRIPTION
Attempts to resolve #1138

# Description

I introduced a new VersionedCall type to handle transaction versioning in FRAME pallets. The VersionedCall type encapsulates a call along with its transaction version, ensuring that calls stored on-chain can be validated against the current runtime version. This prevents unexpected execution due to breaking changes in transaction semantics.
