### PR TITLE
[pallet-revive] rpc add --earliest-receipt-block

### DIFF
--- a/prdoc/pr_7589.prdoc
+++ b/prdoc/pr_7589.prdoc
@@ -1,0 +1,8 @@
+title: '[pallet-revive] rpc add --earliest-receipt-block'
+doc:
+- audience: Runtime Dev
+  description: "Add a cli option to skip searching receipts for blocks older than\
+    \ the specified limit\r\n"
+crates:
+- name: pallet-revive-eth-rpc
+  bump: minor

--- a/substrate/frame/revive/rpc/src/receipt_extractor.rs
+++ b/substrate/frame/revive/rpc/src/receipt_extractor.rs
@@ -14,9 +14,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 use crate::{
-	client::SubstrateBlock,
+	client::{SubstrateBlock, SubstrateBlockNumber},
 	subxt_client::{
 		revive::{calls::types::EthTransact, events::ContractEmitted},
 		system::events::ExtrinsicSuccess,
@@ -37,16 +36,22 @@ use sp_core::keccak_256;
 pub struct ReceiptExtractor {
 	/// The native to eth decimal ratio, used to calculated gas from native fees.
 	native_to_eth_ratio: u32,
+
+	/// Earliest block number to consider when searching for transaction receipts.
+	earliest_receipt_block: Option<SubstrateBlockNumber>,
 }
 
 impl ReceiptExtractor {
 	/// Create a new `ReceiptExtractor` with the given native to eth ratio.
-	pub fn new(native_to_eth_ratio: u32) -> Self {
-		Self { native_to_eth_ratio }
+	pub fn new(
+		native_to_eth_ratio: u32,
+		earliest_receipt_block: Option<SubstrateBlockNumber>,
+	) -> Self {
+		Self { native_to_eth_ratio, earliest_receipt_block }
 	}
 
 	/// Extract a [`TransactionSigned`] and a [`ReceiptInfo`] and  from an extrinsic.
-	pub async fn extract_from_extrinsic(
+	async fn extract_from_extrinsic(
 		&self,
 		block: &SubstrateBlock,
 		ext: subxt::blocks::ExtrinsicDetails<SrcChainConfig, subxt::OnlineClient<SrcChainConfig>>,
@@ -139,6 +144,13 @@ impl ReceiptExtractor {
 		&self,
 		block: &SubstrateBlock,
 	) -> Result<Vec<(TransactionSigned, ReceiptInfo)>, ClientError> {
+		if let Some(earliest_receipt_block) = self.earliest_receipt_block {
+			if block.number() < earliest_receipt_block {
+				log::debug!(target: LOG_TARGET, "Block number {block_number} is less than earliest receipt block {earliest_receipt_block}. Skipping.", block_number = block.number(), earliest_receipt_block = earliest_receipt_block);
+				return Ok(vec![]);
+			}
+		}
+
 		// Filter extrinsics from pallet_revive
 		let extrinsics = block.extrinsics().await.inspect_err(|err| {
 			log::debug!(target: LOG_TARGET, "Error fetching for #{:?} extrinsics: {err:?}", block.number());

--- a/substrate/frame/revive/rpc/src/receipt_extractor.rs
+++ b/substrate/frame/revive/rpc/src/receipt_extractor.rs
@@ -146,7 +146,7 @@ impl ReceiptExtractor {
 	) -> Result<Vec<(TransactionSigned, ReceiptInfo)>, ClientError> {
 		if let Some(earliest_receipt_block) = self.earliest_receipt_block {
 			if block.number() < earliest_receipt_block {
-				log::debug!(target: LOG_TARGET, "Block number {block_number} is less than earliest receipt block {earliest_receipt_block}. Skipping.", block_number = block.number(), earliest_receipt_block = earliest_receipt_block);
+				log::trace!(target: LOG_TARGET, "Block number {block_number} is less than earliest receipt block {earliest_receipt_block}. Skipping.", block_number = block.number(), earliest_receipt_block = earliest_receipt_block);
 				return Ok(vec![]);
 			}
 		}

--- a/substrate/frame/revive/rpc/src/receipt_provider/db.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider/db.rs
@@ -410,7 +410,7 @@ mod tests {
 		DBReceiptProvider {
 			pool,
 			block_provider: Arc::new(MockBlockInfoProvider {}),
-			receipt_extractor: ReceiptExtractor::new(1_000_000),
+			receipt_extractor: ReceiptExtractor::new(1_000_000, None),
 			prune_old_blocks: true,
 		}
 	}


### PR DESCRIPTION
Add a cli option to skip searching receipts for blocks older than the specified limit
