### PR TITLE
Clarify Benchmarking CLI install instructions

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/README.md
+++ b/substrate/utils/frame/benchmarking-cli/README.md
@@ -49,7 +49,7 @@ It currently only supports pallet benchmarking, since the other commands still r
 
 ## Installation
 
-Installing from local source repository:
+Installing from local source repository (you must have the Polkadot SDK folder open for this to work):
 
 ```sh
 cargo install --locked --path substrate/utils/frame/omni-bencher --profile=production


### PR DESCRIPTION
I was trying to install it while working on my file and it obviously wasn't working so then I installed it from crates.io without the production profile, and then none of the benchmarking would work.
