### PR TITLE
HashAndNumber: Ord, Eq, PartialOrd, PartialEq implemented

### DIFF
--- a/prdoc/pr_7612.prdoc
+++ b/prdoc/pr_7612.prdoc
@@ -1,0 +1,9 @@
+title: 'HashAndNumber: Ord, Eq, PartialOrd, PartialEq implemented'
+doc:
+- audience: Node Dev
+  description: This PR adds implementation of `Ord, Eq, PartialOrd, PartialEq`  traits
+    for [`HashAndNumber` ](https://github.com/paritytech/polkadot-sdk/blob/6e645915639ee0bf682de06a0306a4baf712c1d2/substrate/primitives/blockchain/src/header_metadata.rs#L149-L154)
+    struct.
+crates:
+- name: sp-blockchain
+  bump: minor

--- a/prdoc/pr_7612.prdoc
+++ b/prdoc/pr_7612.prdoc
@@ -2,8 +2,7 @@ title: 'HashAndNumber: Ord, Eq, PartialOrd, PartialEq implemented'
 doc:
 - audience: Node Dev
   description: This PR adds implementation of `Ord, Eq, PartialOrd, PartialEq`  traits
-    for [`HashAndNumber` ](https://github.com/paritytech/polkadot-sdk/blob/6e645915639ee0bf682de06a0306a4baf712c1d2/substrate/primitives/blockchain/src/header_metadata.rs#L149-L154)
-    struct.
+    for `HashAndNumber` struct.
 crates:
 - name: sp-blockchain
   bump: minor

--- a/substrate/primitives/blockchain/src/header_metadata.rs
+++ b/substrate/primitives/blockchain/src/header_metadata.rs
@@ -153,6 +153,29 @@ pub struct HashAndNumber<Block: BlockT> {
 	pub hash: Block::Hash,
 }
 
+impl<Block: BlockT> Eq for HashAndNumber<Block> {}
+
+impl<Block: BlockT> PartialEq for HashAndNumber<Block> {
+	fn eq(&self, other: &Self) -> bool {
+		self.number.eq(&other.number) && self.hash.eq(&other.hash)
+	}
+}
+
+impl<Block: BlockT> Ord for HashAndNumber<Block> {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		match self.number.cmp(&other.number) {
+			std::cmp::Ordering::Equal => self.hash.cmp(&other.hash),
+			result => result,
+		}
+	}
+}
+
+impl<Block: BlockT> PartialOrd for HashAndNumber<Block> {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(&other))
+	}
+}
+
 /// A tree-route from one block to another in the chain.
 ///
 /// All blocks prior to the pivot in the vector is the reverse-order unique ancestry


### PR DESCRIPTION
This PR adds implementation of `Ord, Eq, PartialOrd, PartialEq`  traits for [`HashAndNumber` ](https://github.com/paritytech/polkadot-sdk/blob/6e645915639ee0bf682de06a0306a4baf712c1d2/substrate/primitives/blockchain/src/header_metadata.rs#L149-L154) struct.