### PR TITLE
Update dispatchables doc link in pallet-revive's README

### DIFF
--- a/substrate/frame/revive/README.md
+++ b/substrate/frame/revive/README.md
@@ -41,7 +41,7 @@ to handle that failure, either proceeding or reverting A's changes.
 ### Dispatchable functions
 
 Those are documented in the [reference
-documentation](https://paritytech.github.io/substrate/master/pallet_revive/index.html#dispatchable-functions).
+documentation](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/index.html).
 
 ## Usage
 


### PR DESCRIPTION
Pallet-revive's README has an outdated link for dispatchables documentation in its README. It was giving 404. Put the up-to-date one.
