### PR TITLE
Update to Rust stable 1.84.1

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,1 +1,1 @@
-IMAGE="docker.io/paritytech/ci-unified:bullseye-1.81.0-2024-11-19-v202411281558"
+IMAGE="docker.io/paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ workflow:
 
 variables:
   # CI_IMAGE: !reference [ .ci-unified, variables, CI_IMAGE ]
-  CI_IMAGE: "docker.io/paritytech/ci-unified:bullseye-1.81.0-2024-11-19-v202411281558"
+  CI_IMAGE: "docker.io/paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220"
   # BUILDAH_IMAGE is defined in group variables
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
   RELENG_SCRIPTS_BRANCH: "master"
@@ -125,18 +125,18 @@ default:
     - cat .forklift/config-gitlab.toml > .forklift/config.toml
     - >
       if [ "$FORKLIFT_BYPASS" != "true" ]; then
-        echo "FORKLIFT_BYPASS not set"; 
+        echo "FORKLIFT_BYPASS not set";
         if command -v forklift >/dev/null 2>&1; then
-          echo "forklift already exists"; 
+          echo "forklift already exists";
           forklift version
         else
           echo "forklift does not exist, downloading";
-          curl --header "PRIVATE-TOKEN: $FL_CI_GROUP_TOKEN" -o forklift  -L "${CI_API_V4_URL}/projects/676/packages/generic/forklift/${FL_FORKLIFT_VERSION}/forklift_${FL_FORKLIFT_VERSION}_linux_amd64"; 
+          curl --header "PRIVATE-TOKEN: $FL_CI_GROUP_TOKEN" -o forklift  -L "${CI_API_V4_URL}/projects/676/packages/generic/forklift/${FL_FORKLIFT_VERSION}/forklift_${FL_FORKLIFT_VERSION}_linux_amd64";
           chmod +x forklift;
           export PATH=$PATH:$(pwd);
           echo ${FL_FORKLIFT_VERSION};
         fi
-        echo "Creating alias cargo='forklift cargo'"; 
+        echo "Creating alias cargo='forklift cargo'";
         shopt -s expand_aliases;
         alias cargo="forklift cargo";
       fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,15 +1748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
 dependencies = [
@@ -29642,6 +29633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
+name = "target-triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+
+[[package]]
 name = "tempfile"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30489,18 +30486,18 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "trybuild"
-version = "1.0.89"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9d3ba662913483d6722303f619e75ea10b7855b0f8e0d72799cf8621bb488f"
+checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
 dependencies = [
- "basic-toml",
  "dissimilar",
  "glob",
- "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
+ "target-triple",
  "termcolor",
+ "toml 0.8.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1369,7 +1369,7 @@ trie-bench = { version = "0.39.0" }
 trie-db = { version = "0.29.1", default-features = false }
 trie-root = { version = "0.18.0", default-features = false }
 trie-standardmap = { version = "0.16.0" }
-trybuild = { version = "1.0.89" }
+trybuild = { version = "1.0.103" }
 tt-call = { version = "1.0.8" }
 tuplex = { version = "0.1", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }

--- a/bridges/modules/grandpa/src/lib.rs
+++ b/bridges/modules/grandpa/src/lib.rs
@@ -789,12 +789,9 @@ where
 	pub fn synced_headers_grandpa_info() -> Vec<StoredHeaderGrandpaInfo<BridgedHeader<T, I>>> {
 		frame_system::Pallet::<T>::read_events_no_consensus()
 			.filter_map(|event| {
-				if let Event::<T, I>::UpdatedBestFinalizedHeader { grandpa_info, .. } =
-					event.event.try_into().ok()?
-				{
-					return Some(grandpa_info)
-				}
-				None
+				let Event::<T, I>::UpdatedBestFinalizedHeader { grandpa_info, .. } =
+					event.event.try_into().ok()?;
+				Some(grandpa_info)
 			})
 			.collect()
 	}

--- a/bridges/primitives/test-utils/src/lib.rs
+++ b/bridges/primitives/test-utils/src/lib.rs
@@ -110,7 +110,7 @@ pub fn make_justification_for_header<H: HeaderT>(
 	);
 
 	// Roughly, how many vote ancestries do we want per fork
-	let target_depth = (ancestors + forks - 1) / forks;
+	let target_depth = ancestors.div_ceil(forks);
 
 	let mut unsigned_precommits = vec![];
 	for i in 0..forks {

--- a/bridges/relays/lib-substrate-relay/src/messages/mod.rs
+++ b/bridges/relays/lib-substrate-relay/src/messages/mod.rs
@@ -820,6 +820,7 @@ mod tests {
 	}
 
 	// mock runtime with `pallet_bridge_messages`
+	#[allow(unexpected_cfgs)]
 	mod mock {
 		use super::super::*;
 		use bp_messages::{target_chain::ForbidInboundMessages, HashedLaneId};

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1687,6 +1687,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1883,6 +1883,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -1086,6 +1086,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -976,6 +976,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -1088,6 +1088,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -785,6 +785,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -953,6 +953,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -945,6 +945,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -459,6 +459,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -901,6 +901,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -899,6 +899,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -1140,6 +1140,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -206,6 +206,7 @@ macro_rules! impl_node_runtime_apis {
 					unimplemented!()
 				}
 
+				#[allow(non_local_definitions)]
 				fn dispatch_benchmark(
 					_: frame_benchmarking::BenchmarkConfig
 				) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, String> {

--- a/docs/contributor/container.md
+++ b/docs/contributor/container.md
@@ -24,7 +24,7 @@ The command below allows building a Linux binary without having to even install 
 docker run --rm -it \
     -w /polkadot-sdk \
     -v $(pwd):/polkadot-sdk \
-    docker.io/paritytech/ci-unified:bullseye-1.81.0-2024-11-19-v202411281558 \
+    docker.io/paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220 \
     cargo build --release --locked -p polkadot-parachain-bin --bin polkadot-parachain
 sudo chown -R $(id -u):$(id -g) target/
 ```

--- a/docs/sdk/src/lib.rs
+++ b/docs/sdk/src/lib.rs
@@ -23,6 +23,8 @@
 #![doc = simple_mermaid::mermaid!("../../mermaid/IA.mmd")]
 #![warn(rustdoc::broken_intra_doc_links)]
 #![warn(rustdoc::private_intra_doc_links)]
+// Frame macros reference features which this crate does not have
+#![allow(unexpected_cfgs)]
 #![doc(html_favicon_url = "https://polkadot.com/favicon.ico")]
 #![doc(
 	html_logo_url = "https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/docs/images/Polkadot_Logo_Horizontal_Pink_White.png"

--- a/polkadot/node/network/statement-distribution/src/v2/tests/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/tests/mod.rs
@@ -776,6 +776,7 @@ async fn answer_expected_hypothetical_membership_request(
 	)
 }
 
+/// Assert that the correct peer is reported.
 #[macro_export]
 macro_rules! assert_peer_reported {
 	($virtual_overseer:expr, $peer_id:expr, $rep_change:expr $(,)*) => {

--- a/polkadot/node/overseer/src/lib.rs
+++ b/polkadot/node/overseer/src/lib.rs
@@ -60,7 +60,8 @@
 // unused dependencies can not work for test and examples at the same time
 // yielding false positives
 #![warn(missing_docs)]
-#![allow(dead_code)] // TODO https://github.com/paritytech/polkadot-sdk/issues/5793
+// TODO https://github.com/paritytech/polkadot-sdk/issues/5793
+#![allow(dead_code, irrefutable_let_patterns)]
 
 use std::{
 	collections::{hash_map, HashMap},

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -120,6 +120,7 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-election-provider-support/runtime-benchmarks",
+	"frame-support-test/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"libsecp256k1/hmac",

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -120,6 +120,7 @@ std = [
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
+	"frame-support-test/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-babe/runtime-benchmarks",

--- a/polkadot/runtime/parachains/src/coretime/migration.rs
+++ b/polkadot/runtime/parachains/src/coretime/migration.rs
@@ -250,7 +250,7 @@ mod v_coretime {
 					return None
 				},
 			};
-			let time_slice = (valid_until + TIMESLICE_PERIOD - 1) / TIMESLICE_PERIOD;
+			let time_slice = valid_until.div_ceil(TIMESLICE_PERIOD);
 			log::trace!(target: "coretime-migration", "Sending of lease holding para {:?}, valid_until: {:?}, time_slice: {:?}", p, valid_until, time_slice);
 			Some(mk_coretime_call::<T>(crate::coretime::CoretimeCalls::SetLease(p.into(), time_slice)))
 		});

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2467,6 +2467,7 @@ sp_api::impl_runtime_apis! {
 			return (list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig,
 		) -> Result<

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2648,6 +2648,7 @@ sp_api::impl_runtime_apis! {
 			return (list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig,
 		) -> Result<

--- a/polkadot/xcm/docs/src/lib.rs
+++ b/polkadot/xcm/docs/src/lib.rs
@@ -50,6 +50,8 @@
 //!
 //! ## Docs structure
 #![doc = simple_mermaid::mermaid!("../mermaid/structure.mmd")]
+// Frame macros reference features which this crate does not have
+#![allow(unexpected_cfgs)]
 
 /// Fundamentals of the XCM language. The virtual machine, instructions, locations and assets.
 pub mod fundamentals;

--- a/polkadot/xcm/xcm-simulator/example/src/lib.rs
+++ b/polkadot/xcm/xcm-simulator/example/src/lib.rs
@@ -14,7 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod parachain;
+
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod relay_chain;
 
 #[cfg(test)]

--- a/polkadot/xcm/xcm-simulator/fuzzer/src/fuzz.rs
+++ b/polkadot/xcm/xcm-simulator/fuzzer/src/fuzz.rs
@@ -14,7 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod parachain;
+
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod relay_chain;
 
 use codec::DecodeLimit;

--- a/prdoc/pr_7625.prdoc
+++ b/prdoc/pr_7625.prdoc
@@ -1,0 +1,118 @@
+title: Update to Rust stable 1.84.1
+doc:
+- audience: Runtime Dev
+  description: |-
+    Ref https://github.com/paritytech/ci_cd/issues/1107
+
+    We mainly need that so that we can finally compile the `pallet_revive` fixtures on stable. I did my best to keep the commits focused on one thing to make review easier.
+
+    All the changes are needed because rustc introduced more warnings or is more strict about existing ones. Most of the stuff could just be fixed and the commits should be pretty self explanatory. However, there are a few this that are notable:
+
+    ## `non_local_definitions `
+
+    A lot of runtimes to write `impl` blocks inside functions. This makes sense to reduce the amount of conditional compilation. I guess I could have moved them into a module instead. But I think allowing it here makes sense to avoid the code churn.
+
+    ## `unexpected_cfgs`
+
+    The FRAME macros emit code that references various features like `std`, `runtime-benchmarks` or `try-runtime`. If a create that uses those macros does not have those features we get this warning. Those were mostly when defining a `mock` runtime. I opted for silencing the warning in this case rather than adding not needed features.
+
+    For the benchmarking ui tests I opted for adding the `runtime-benchmark` feature to the `Cargo.toml`.
+
+    ## Failing UI test
+
+    I am bumping the `trybuild` version and regenerating the ui tests. The old version seems to be incompatible. This requires us to pass `deny_warnings` in `CARGO_ENCODED_RUSTFLAGS` as `RUSTFLAGS` is ignored in the new version.
+
+    ## Removing toolchain file from the pallet revive fixtures
+
+    This is no longer needed since the latest stable will compile them fine using the `RUSTC_BOOTSTRAP=1`.
+crates:
+- name: asset-hub-rococo-runtime
+  bump: patch
+- name: asset-hub-westend-runtime
+  bump: patch
+- name: bridge-hub-rococo-runtime
+  bump: patch
+- name: bridge-hub-westend-runtime
+  bump: patch
+- name: collectives-westend-runtime
+  bump: patch
+- name: contracts-rococo-runtime
+  bump: patch
+- name: coretime-rococo-runtime
+  bump: patch
+- name: coretime-westend-runtime
+  bump: patch
+- name: glutton-westend-runtime
+  bump: patch
+- name: people-rococo-runtime
+  bump: patch
+- name: people-westend-runtime
+  bump: patch
+- name: penpal-runtime
+  bump: patch
+- name: polkadot-omni-node-lib
+  bump: patch
+- name: rococo-runtime
+  bump: patch
+- name: westend-runtime
+  bump: patch
+- name: pallet-babe
+  bump: patch
+- name: frame-benchmarking
+  bump: patch
+- name: sp-core
+  bump: patch
+- name: sp-runtime
+  bump: patch
+- name: pallet-bridge-grandpa
+  bump: patch
+- name: frame-support
+  bump: patch
+- name: sc-network-types
+  bump: patch
+- name: pallet-migrations
+  bump: patch
+- name: pallet-parameters
+  bump: patch
+- name: bp-test-utils
+  bump: patch
+- name: polkadot-runtime-parachains
+  bump: patch
+- name: sc-allocator
+  bump: patch
+- name: pallet-transaction-storage
+  bump: patch
+- name: pallet-utility
+  bump: patch
+- name: sp-transaction-storage-proof
+  bump: patch
+- name: sp-trie
+  bump: patch
+- name: pallet-revive-fixtures
+  bump: patch
+- name: polkadot-statement-distribution
+  bump: patch
+- name: mmr-gadget
+  bump: patch
+- name: sc-rpc-spec-v2
+  bump: patch
+- name: sp-state-machine
+  bump: patch
+- name: xcm-simulator-example
+  bump: patch
+- name: pallet-node-authorization
+  bump: patch
+- name: pallet-scored-pool
+  bump: patch
+- name: pallet-statement
+  bump: patch
+- name: polkadot-overseer
+  bump: patch
+- name: polkadot-runtime-common
+  bump: patch
+- name: pallet-lottery
+  bump: patch
+- name: pallet-society
+  bump: patch
+- name: sp-runtime-interface
+  bump: patch

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -4058,6 +4058,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/substrate/client/allocator/src/freeing_bump.rs
+++ b/substrate/client/allocator/src/freeing_bump.rs
@@ -350,7 +350,7 @@ pub struct AllocationStats {
 ///
 /// Returns `None` if the number of pages to not fit into `u32`.
 fn pages_from_size(size: u64) -> Option<u32> {
-	u32::try_from((size + PAGE_SIZE as u64 - 1) / PAGE_SIZE as u64).ok()
+	u32::try_from(size.div_ceil(PAGE_SIZE as u64)).ok()
 }
 
 /// An implementation of freeing bump allocator.
@@ -378,7 +378,7 @@ impl FreeingBumpHeapAllocator {
 	///
 	/// - `heap_base` - the offset from the beginning of the linear memory where the heap starts.
 	pub fn new(heap_base: u32) -> Self {
-		let aligned_heap_base = (heap_base + ALIGNMENT - 1) / ALIGNMENT * ALIGNMENT;
+		let aligned_heap_base = heap_base.div_ceil(ALIGNMENT) * ALIGNMENT;
 
 		FreeingBumpHeapAllocator {
 			original_heap_base: aligned_heap_base,

--- a/substrate/client/merkle-mountain-range/src/test_utils.rs
+++ b/substrate/client/merkle-mountain-range/src/test_utils.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Test utilities.
+
 use crate::MmrGadget;
 use parking_lot::Mutex;
 use sc_block_builder::BlockBuilderBuilder;
@@ -67,9 +69,12 @@ pub(crate) struct MmrBlock {
 	pub(crate) leaf_data: Vec<u8>,
 }
 
+/// Which kind of key type to use.
 #[derive(Clone, Copy)]
 pub enum OffchainKeyType {
+	/// Temporary key.
 	Temp,
+	/// Cononical key.
 	Canon,
 }
 

--- a/substrate/client/network/types/src/kad.rs
+++ b/substrate/client/network/types/src/kad.rs
@@ -101,7 +101,7 @@ impl Record {
 
 	/// Checks whether the record is expired w.r.t. the given `Instant`.
 	pub fn is_expired(&self, now: Instant) -> bool {
-		self.expires.map_or(false, |t| now >= t)
+		self.expires.is_some_and(|t| now >= t)
 	}
 }
 

--- a/substrate/client/network/types/src/multiaddr/protocol.rs
+++ b/substrate/client/network/types/src/multiaddr/protocol.rs
@@ -66,14 +66,14 @@ pub enum Protocol<'a> {
 	Wss(Cow<'a, str>),
 }
 
-impl<'a> Display for Protocol<'a> {
+impl Display for Protocol<'_> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let protocol = LiteP2pProtocol::from(self.clone());
 		Display::fmt(&protocol, f)
 	}
 }
 
-impl<'a> From<IpAddr> for Protocol<'a> {
+impl From<IpAddr> for Protocol<'_> {
 	#[inline]
 	fn from(addr: IpAddr) -> Self {
 		match addr {
@@ -83,14 +83,14 @@ impl<'a> From<IpAddr> for Protocol<'a> {
 	}
 }
 
-impl<'a> From<Ipv4Addr> for Protocol<'a> {
+impl From<Ipv4Addr> for Protocol<'_> {
 	#[inline]
 	fn from(addr: Ipv4Addr) -> Self {
 		Protocol::Ip4(addr)
 	}
 }
 
-impl<'a> From<Ipv6Addr> for Protocol<'a> {
+impl From<Ipv6Addr> for Protocol<'_> {
 	#[inline]
 	fn from(addr: Ipv6Addr) -> Self {
 		Protocol::Ip6(addr)

--- a/substrate/client/rpc-spec-v2/src/chain_head/test_utils.rs
+++ b/substrate/client/rpc-spec-v2/src/chain_head/test_utils.rs
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Test utilities.
+
 use parking_lot::Mutex;
 use sc_client_api::{
 	execution_extensions::ExecutionExtensions, BlockBackend, BlockImportNotification,
@@ -36,6 +38,7 @@ use sp_version::RuntimeVersion;
 use std::sync::Arc;
 use substrate_test_runtime::{Block, Hash, Header, H256};
 
+/// A mock client used for testing.
 pub struct ChainHeadMockClient<Client> {
 	client: Arc<Client>,
 	import_sinks: Mutex<Vec<TracingUnboundedSender<BlockImportNotification<Block>>>>,
@@ -44,6 +47,7 @@ pub struct ChainHeadMockClient<Client> {
 }
 
 impl<Client> ChainHeadMockClient<Client> {
+	/// Create a new mock client.
 	pub fn new(client: Arc<Client>) -> Self {
 		ChainHeadMockClient {
 			client,
@@ -53,6 +57,7 @@ impl<Client> ChainHeadMockClient<Client> {
 		}
 	}
 
+	/// Trigger the import stram from a header.
 	pub async fn trigger_import_stream(&self, header: Header) {
 		// Ensure the client called the `import_notification_stream`.
 		while self.import_sinks.lock().is_empty() {
@@ -69,6 +74,7 @@ impl<Client> ChainHeadMockClient<Client> {
 		}
 	}
 
+	/// Trigger the import stram from a header and a list of stale heads.
 	pub async fn trigger_finality_stream(&self, header: Header, stale_heads: Vec<Hash>) {
 		// Ensure the client called the `finality_notification_stream`.
 		while self.finality_sinks.lock().is_empty() {

--- a/substrate/frame/babe/src/tests.rs
+++ b/substrate/frame/babe/src/tests.rs
@@ -35,6 +35,12 @@ const EMPTY_RANDOMNESS: [u8; RANDOMNESS_LENGTH] = [
 	161, 164, 127, 217, 153, 138, 37, 48, 192, 248, 0,
 ];
 
+impl crate::migrations::BabePalletPrefix for Test {
+	fn pallet_prefix() -> &'static str {
+		"Babe"
+	}
+}
+
 #[test]
 fn empty_randomness_is_correct() {
 	let s = compute_randomness([0; RANDOMNESS_LENGTH], 0, std::iter::empty(), None);
@@ -942,12 +948,6 @@ fn valid_equivocation_reports_dont_pay_fees() {
 #[test]
 fn add_epoch_configurations_migration_works() {
 	use frame_support::storage::migration::{get_storage_value, put_storage_value};
-
-	impl crate::migrations::BabePalletPrefix for Test {
-		fn pallet_prefix() -> &'static str {
-			"Babe"
-		}
-	}
 
 	new_test_ext(1).execute_with(|| {
 		let next_config_descriptor =

--- a/substrate/frame/benchmarking/src/tests_instance.rs
+++ b/substrate/frame/benchmarking/src/tests_instance.rs
@@ -86,6 +86,11 @@ frame_support::construct_runtime!(
 	}
 );
 
+crate::define_benchmarks!(
+	[pallet_test, TestPallet]
+	[pallet_test, TestPallet2]
+);
+
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Test {
 	type BaseCallFilter = frame_support::traits::Everything;
@@ -186,11 +191,6 @@ mod benchmarks {
 #[test]
 fn ensure_correct_instance_is_selected() {
 	use crate::utils::Benchmarking;
-
-	crate::define_benchmarks!(
-		[pallet_test, TestPallet]
-		[pallet_test, TestPallet2]
-	);
 
 	let whitelist = vec![];
 

--- a/substrate/frame/contracts/fixtures/contracts/crypto_hashes.rs
+++ b/substrate/frame/contracts/fixtures/contracts/crypto_hashes.rs
@@ -48,7 +48,6 @@ pub extern "C" fn deploy() {}
 /// |     2 |    BLAKE2 |       256 |
 /// |     3 |    BLAKE2 |       128 |
 /// ---------------------------------
-
 #[no_mangle]
 #[polkavm_derive::polkavm_export]
 pub extern "C" fn call() {

--- a/substrate/frame/election-provider-multi-phase/test-staking-e2e/src/lib.rs
+++ b/substrate/frame/election-provider-multi-phase/test-staking-e2e/src/lib.rs
@@ -16,6 +16,9 @@
 // limitations under the License.
 
 #![cfg(test)]
+
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod mock;
 
 pub(crate) const LOG_TARGET: &str = "tests::e2e-epm";

--- a/substrate/frame/lottery/Cargo.toml
+++ b/substrate/frame/lottery/Cargo.toml
@@ -46,6 +46,7 @@ std = [
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
+	"frame-support-test/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",

--- a/substrate/frame/migrations/src/lib.rs
+++ b/substrate/frame/migrations/src/lib.rs
@@ -784,7 +784,7 @@ impl<T: Config> Pallet<T> {
 				Self::deposit_event(Event::MigrationAdvanced { index: cursor.index, took });
 				cursor.inner_cursor = Some(bound_next_cursor);
 
-				if max_steps.map_or(false, |max| took > max.into()) {
+				if max_steps.is_some_and(|max| took > max.into()) {
 					Self::deposit_event(Event::MigrationFailed { index: cursor.index, took });
 					Self::upgrade_failed(Some(cursor.index));
 					None

--- a/substrate/frame/node-authorization/src/lib.rs
+++ b/substrate/frame/node-authorization/src/lib.rs
@@ -38,6 +38,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(test)]
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod mock;
 #[cfg(test)]
 mod tests;

--- a/substrate/frame/nomination-pools/test-delegate-stake/src/lib.rs
+++ b/substrate/frame/nomination-pools/test-delegate-stake/src/lib.rs
@@ -17,6 +17,8 @@
 
 #![cfg(test)]
 
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod mock;
 
 use frame_support::{

--- a/substrate/frame/parameters/src/tests/mock.rs
+++ b/substrate/frame/parameters/src/tests/mock.rs
@@ -107,7 +107,7 @@ mod custom_origin {
 		) -> Result<Self::Success, RuntimeOrigin> {
 			// Account 123 is allowed to set parameters in benchmarking only:
 			#[cfg(feature = "runtime-benchmarks")]
-			if ensure_signed(origin.clone()).map_or(false, |acc| acc == 123) {
+			if ensure_signed(origin.clone()).is_ok_and(|acc| acc == 123) {
 				return Ok(());
 			}
 

--- a/substrate/frame/revive/fixtures/Cargo.toml
+++ b/substrate/frame/revive/fixtures/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Fixtures for testing and benchmarking"
 homepage.workspace = true
 repository.workspace = true
+rust-version = "1.84"
 
 [package.metadata.polkadot-sdk]
 exclude-from-umbrella = true

--- a/substrate/frame/revive/fixtures/build.rs
+++ b/substrate/frame/revive/fixtures/build.rs
@@ -109,11 +109,6 @@ fn create_cargo_toml<'a>(
 	let cargo_toml = toml::to_string_pretty(&cargo_toml)?;
 	fs::write(output_dir.join("Cargo.toml"), cargo_toml.clone())
 		.with_context(|| format!("Failed to write {cargo_toml:?}"))?;
-	fs::copy(
-		fixtures_dir.join("build/_rust-toolchain.toml"),
-		output_dir.join("rust-toolchain.toml"),
-	)
-	.context("Failed to write toolchain file")?;
 	Ok(())
 }
 

--- a/substrate/frame/revive/fixtures/build/_rust-toolchain.toml
+++ b/substrate/frame/revive/fixtures/build/_rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly-2024-11-19"
-components = ["rust-src"]
-profile = "minimal"

--- a/substrate/frame/scored-pool/src/lib.rs
+++ b/substrate/frame/scored-pool/src/lib.rs
@@ -93,6 +93,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(test)]
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod mock;
 
 #[cfg(test)]

--- a/substrate/frame/society/Cargo.toml
+++ b/substrate/frame/society/Cargo.toml
@@ -55,6 +55,7 @@ std = [
 runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-benchmarking/runtime-benchmarks",
+	"frame-support-test/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",

--- a/substrate/frame/statement/src/lib.rs
+++ b/substrate/frame/statement/src/lib.rs
@@ -45,6 +45,8 @@ use sp_statement_store::{
 };
 
 #[cfg(test)]
+// We do not declare all features used by `construct_runtime`
+#[allow(unexpected_cfgs)]
 mod mock;
 #[cfg(test)]
 mod tests;

--- a/substrate/frame/support/src/traits/hooks.rs
+++ b/substrate/frame/support/src/traits/hooks.rs
@@ -628,6 +628,8 @@ pub trait OnTimestampSet<Moment> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::parameter_types;
+	use alloc::vec::Vec;
 	use sp_io::TestExternalities;
 
 	#[cfg(feature = "try-runtime")]
@@ -712,7 +714,9 @@ mod tests {
 
 	#[test]
 	fn on_idle_round_robin_works() {
-		static mut ON_IDLE_INVOCATION_ORDER: alloc::vec::Vec<&str> = alloc::vec::Vec::new();
+		parameter_types! {
+			static OnIdleInvocationOrder: Vec<&'static str> = Vec::new();
+		}
 
 		struct Test1;
 		struct Test2;
@@ -720,49 +724,41 @@ mod tests {
 		type TestTuple = (Test1, Test2, Test3);
 		impl OnIdle<u32> for Test1 {
 			fn on_idle(_n: u32, _weight: Weight) -> Weight {
-				unsafe {
-					ON_IDLE_INVOCATION_ORDER.push("Test1");
-				}
+				OnIdleInvocationOrder::mutate(|o| o.push("Test1"));
 				Weight::zero()
 			}
 		}
 		impl OnIdle<u32> for Test2 {
 			fn on_idle(_n: u32, _weight: Weight) -> Weight {
-				unsafe {
-					ON_IDLE_INVOCATION_ORDER.push("Test2");
-				}
+				OnIdleInvocationOrder::mutate(|o| o.push("Test2"));
 				Weight::zero()
 			}
 		}
 		impl OnIdle<u32> for Test3 {
 			fn on_idle(_n: u32, _weight: Weight) -> Weight {
-				unsafe {
-					ON_IDLE_INVOCATION_ORDER.push("Test3");
-				}
+				OnIdleInvocationOrder::mutate(|o| o.push("Test3"));
 				Weight::zero()
 			}
 		}
 
-		unsafe {
-			TestTuple::on_idle(0, Weight::zero());
-			assert_eq!(ON_IDLE_INVOCATION_ORDER, ["Test1", "Test2", "Test3"].to_vec());
-			ON_IDLE_INVOCATION_ORDER.clear();
+		TestTuple::on_idle(0, Weight::zero());
+		assert_eq!(OnIdleInvocationOrder::get(), ["Test1", "Test2", "Test3"].to_vec());
+		OnIdleInvocationOrder::mutate(|o| o.clear());
 
-			TestTuple::on_idle(1, Weight::zero());
-			assert_eq!(ON_IDLE_INVOCATION_ORDER, ["Test2", "Test3", "Test1"].to_vec());
-			ON_IDLE_INVOCATION_ORDER.clear();
+		TestTuple::on_idle(1, Weight::zero());
+		assert_eq!(OnIdleInvocationOrder::get(), ["Test2", "Test3", "Test1"].to_vec());
+		OnIdleInvocationOrder::mutate(|o| o.clear());
 
-			TestTuple::on_idle(2, Weight::zero());
-			assert_eq!(ON_IDLE_INVOCATION_ORDER, ["Test3", "Test1", "Test2"].to_vec());
-			ON_IDLE_INVOCATION_ORDER.clear();
+		TestTuple::on_idle(2, Weight::zero());
+		assert_eq!(OnIdleInvocationOrder::get(), ["Test3", "Test1", "Test2"].to_vec());
+		OnIdleInvocationOrder::mutate(|o| o.clear());
 
-			TestTuple::on_idle(3, Weight::zero());
-			assert_eq!(ON_IDLE_INVOCATION_ORDER, ["Test1", "Test2", "Test3"].to_vec());
-			ON_IDLE_INVOCATION_ORDER.clear();
+		TestTuple::on_idle(3, Weight::zero());
+		assert_eq!(OnIdleInvocationOrder::get(), ["Test1", "Test2", "Test3"].to_vec());
+		OnIdleInvocationOrder::mutate(|o| o.clear());
 
-			TestTuple::on_idle(4, Weight::zero());
-			assert_eq!(ON_IDLE_INVOCATION_ORDER, ["Test2", "Test3", "Test1"].to_vec());
-			ON_IDLE_INVOCATION_ORDER.clear();
-		}
+		TestTuple::on_idle(4, Weight::zero());
+		assert_eq!(OnIdleInvocationOrder::get(), ["Test2", "Test3", "Test1"].to_vec());
+		OnIdleInvocationOrder::mutate(|o| o.clear());
 	}
 }

--- a/substrate/frame/support/test/Cargo.toml
+++ b/substrate/frame/support/test/Cargo.toml
@@ -60,6 +60,12 @@ std = [
 	"test-pallet/std",
 ]
 experimental = ["frame-support/experimental", "frame-system/experimental"]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+]
 try-runtime = [
 	"frame-executive/try-runtime",
 	"frame-support/try-runtime",

--- a/substrate/frame/support/test/tests/benchmark_ui.rs
+++ b/substrate/frame/support/test/tests/benchmark_ui.rs
@@ -28,7 +28,7 @@ fn benchmark_ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Deny all warnings since we emit warnings as part of a Pallet's UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/benchmark_ui/*.rs");

--- a/substrate/frame/support/test/tests/benchmark_ui/invalid_origin.stderr
+++ b/substrate/frame/support/test/tests/benchmark_ui/invalid_origin.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<T as frame_support_test::Config>::RuntimeOrigin:
   --> tests/benchmark_ui/invalid_origin.rs:23:1
    |
 23 | #[benchmarks]
-   | ^^^^^^^^^^^^^ the trait `From<{integer}>` is not implemented for `<T as frame_support_test::Config>::RuntimeOrigin`, which is required by `{integer}: Into<_>`
+   | ^^^^^^^^^^^^^ the trait `From<{integer}>` is not implemented for `<T as frame_support_test::Config>::RuntimeOrigin`
    |
    = note: required for `{integer}` to implement `Into<<T as frame_support_test::Config>::RuntimeOrigin>`
    = note: this error originates in the attribute macro `benchmarks` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/benchmark_ui/pass/valid_const_expr.rs
+++ b/substrate/frame/support/test/tests/benchmark_ui/pass/valid_const_expr.rs
@@ -25,6 +25,7 @@ mod benches {
 
 	const MY_CONST: u32 = 100;
 
+	#[allow(dead_code)]
 	const fn my_fn() -> u32 {
 		200
 	}

--- a/substrate/frame/support/test/tests/construct_runtime_ui.rs
+++ b/substrate/frame/support/test/tests/construct_runtime_ui.rs
@@ -28,7 +28,7 @@ fn ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Deny all warnings since we emit warnings as part of a Runtime's UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/construct_runtime_ui/*.rs");

--- a/substrate/frame/support/test/tests/construct_runtime_ui/deprecated_where_block.stderr
+++ b/substrate/frame/support/test/tests/construct_runtime_ui/deprecated_where_block.stderr
@@ -86,7 +86,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `Pallet<Runtime>: Callable<Runtime>`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `Callable<T>` is implemented for `Pallet<T>`
    = note: required for `Pallet<Runtime>` to implement `Callable<Runtime>`
@@ -237,7 +237,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `&frame_system::Event<Runtime>: std::fmt::Debug`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `std::fmt::Debug` is implemented for `frame_system::Event<T>`
    = note: required for `frame_system::Event<Runtime>` to implement `std::fmt::Debug`
@@ -256,7 +256,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `&frame_system::Error<Runtime>: std::fmt::Debug`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `std::fmt::Debug` is implemented for `frame_system::Error<T>`
    = note: required for `frame_system::Error<Runtime>` to implement `std::fmt::Debug`
@@ -295,7 +295,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `RawOrigin<_>: Into<_>`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = note: required for `RawOrigin<_>` to implement `Into<RuntimeOrigin>`
    = note: this error originates in the macro `frame_support::construct_runtime` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -344,7 +344,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `Pallet<Runtime>: PalletInfoAccess`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `PalletInfoAccess` is implemented for `Pallet<T>`
    = note: required for `Pallet<Runtime>` to implement `PalletInfoAccess`
@@ -360,7 +360,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `Pallet<Runtime>: Callable<Runtime>`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `Callable<T>` is implemented for `Pallet<T>`
    = note: required for `Pallet<Runtime>` to implement `Callable<Runtime>`
@@ -376,7 +376,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `Pallet<Runtime>: Callable<Runtime>`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `Callable<T>` is implemented for `Pallet<T>`
    = note: required for `Pallet<Runtime>` to implement `Callable<Runtime>`
@@ -466,7 +466,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `Pallet<Runtime>: Callable<Runtime>`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `Callable<T>` is implemented for `Pallet<T>`
    = note: required for `Pallet<Runtime>` to implement `Callable<Runtime>`
@@ -569,7 +569,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
   --> tests/construct_runtime_ui/deprecated_where_block.rs:26:3
    |
 26 |         System: frame_system::{Pallet, Call, Storage, Config<T>, Event<T>},
-   |         ^^^^^^ the trait `Config` is not implemented for `Runtime`, which is required by `Pallet<Runtime>: ViewFunctionIdPrefix`
+   |         ^^^^^^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `ViewFunctionIdPrefix` is implemented for `Pallet<T>`
    = note: required for `Pallet<Runtime>` to implement `ViewFunctionIdPrefix`
@@ -784,7 +784,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `GenesisConfig<Runtime>: Serialize`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the trait `Serialize` is implemented for `GenesisConfig<T>`
    = note: required for `GenesisConfig<Runtime>` to implement `Serialize`
@@ -846,10 +846,13 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `GenesisConfig<Runtime>: std::default::Default`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
-   = help: the trait `std::default::Default` is implemented for `GenesisConfig<T>`
-   = note: required for `GenesisConfig<Runtime>` to implement `std::default::Default`
+note: required by a bound in `GenesisConfig`
+  --> $WORKSPACE/substrate/frame/system/src/lib.rs
+   |
+   |     pub struct GenesisConfig<T: Config> {
+   |                                 ^^^^^^ required by this bound in `GenesisConfig`
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Runtime: Config` is not satisfied
@@ -862,7 +865,7 @@ error[E0277]: the trait bound `Runtime: Config` is not satisfied
 ...  |
 27 | |     }
 28 | | }
-   | |_^ the trait `Config` is not implemented for `Runtime`, which is required by `(Pallet<Runtime>,): OnGenesis`
+   | |_^ the trait `Config` is not implemented for `Runtime`
    |
    = help: the following other types implement trait `OnGenesis`:
              ()

--- a/substrate/frame/support/test/tests/derive_impl_ui.rs
+++ b/substrate/frame/support/test/tests/derive_impl_ui.rs
@@ -30,7 +30,7 @@ fn derive_impl_ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Deny all warnings since we emit warnings as part of a Pallet's UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/derive_impl_ui/*.rs");

--- a/substrate/frame/support/test/tests/derive_no_bound_ui.rs
+++ b/substrate/frame/support/test/tests/derive_no_bound_ui.rs
@@ -27,6 +27,9 @@ fn derive_no_bound_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
+	// Deny all warnings since we emit warnings as part of a Pallet's UI.
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
+
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/derive_no_bound_ui/*.rs");
 }

--- a/substrate/frame/support/test/tests/pallet_ui.rs
+++ b/substrate/frame/support/test/tests/pallet_ui.rs
@@ -28,7 +28,7 @@ fn pallet_ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Deny all warnings since we emit warnings as part of a Pallet's UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/pallet_ui/*.rs");

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -18,7 +18,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
 38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`, which is required by `&<T as pallet::Config>::Bar: std::fmt::Debug`
+   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`
 

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -18,7 +18,7 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
 38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`, which is required by `&<T as pallet::Config>::Bar: std::fmt::Debug`
+   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`
 
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: Encode` is not satisf
    | ------------------------ required by a bound introduced by this call
 ...
 38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
-   |                                          ^^^^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`, which is required by `<T as pallet::Config>::Bar: Encode`
+   |                                          ^^^^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
    |
    = note: required for `<T as pallet::Config>::Bar` to implement `Encode`
 
@@ -49,7 +49,7 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: Decode` is not satisf
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:38:42
    |
 38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
-   |                                                ^^^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`, which is required by `<T as pallet::Config>::Bar: Decode`
+   |                                                ^^^^^^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
    |
    = note: required for `<T as pallet::Config>::Bar` to implement `Decode`
 

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -18,7 +18,7 @@ error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
 40 |         pub fn foo(origin: OriginFor<T>, _bar: Bar) -> DispatchResultWithPostInfo {
    |                                          ^^^^ `Bar` cannot be formatted using `{:?}`
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `Bar`, which is required by `&Bar: std::fmt::Debug`
+   = help: the trait `std::fmt::Debug` is not implemented for `Bar`
    = note: add `#[derive(Debug)]` to `Bar` or manually `impl std::fmt::Debug for Bar`
    = note: required for `&Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&Bar` to `&dyn std::fmt::Debug`

--- a/substrate/frame/support/test/tests/pallet_ui/call_missing_index.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_missing_index.stderr
@@ -46,3 +46,24 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_1::_w`:
    |
 36 |         #[pallet::weight(0)]
    |                          ^
+
+error: associated function `error_metadata` is never used
+  --> tests/pallet_ui/call_missing_index.rs:26:12
+   |
+26 |     #[pallet::pallet]
+   |               ^^^^^^ associated function in this implementation
+   |
+   = note: `-D dead-code` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(dead_code)]`
+
+error: associated functions `new_call_variant_foo` and `new_call_variant_bar` are never used
+  --> tests/pallet_ui/call_missing_index.rs:32:10
+   |
+29 |     #[pallet::call]
+   |               ---- associated functions in this implementation
+...
+32 |         pub fn foo(_: OriginFor<T>) -> DispatchResult {
+   |                ^^^
+...
+37 |         pub fn bar(_: OriginFor<T>) -> DispatchResult {
+   |                ^^^

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_const_warning.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_const_warning.stderr
@@ -11,3 +11,21 @@ error: use of deprecated constant `pallet::warnings::ConstantWeight_0::_w`:
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`
+
+error: associated function `error_metadata` is never used
+  --> tests/pallet_ui/call_weight_const_warning.rs:26:12
+   |
+26 |     #[pallet::pallet]
+   |               ^^^^^^ associated function in this implementation
+   |
+   = note: `-D dead-code` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(dead_code)]`
+
+error: associated function `new_call_variant_foo` is never used
+  --> tests/pallet_ui/call_weight_const_warning.rs:33:10
+   |
+29 |     #[pallet::call]
+   |               ---- associated function in this implementation
+...
+33 |         pub fn foo(_: OriginFor<T>) -> DispatchResult { Ok(()) }
+   |                ^^^

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_unchecked_warning.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_unchecked_warning.stderr
@@ -11,3 +11,21 @@ error: use of deprecated constant `pallet::warnings::UncheckedWeightWitness_0::_
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`
+
+error: associated function `error_metadata` is never used
+  --> tests/pallet_ui/call_weight_unchecked_warning.rs:26:12
+   |
+26 |     #[pallet::pallet]
+   |               ^^^^^^ associated function in this implementation
+   |
+   = note: `-D dead-code` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(dead_code)]`
+
+error: associated function `new_call_variant_foo` is never used
+  --> tests/pallet_ui/call_weight_unchecked_warning.rs:33:10
+   |
+29 |     #[pallet::call]
+   |               ---- associated function in this implementation
+...
+33 |         pub fn foo(_: OriginFor<T>, _unused: u64) -> DispatchResult { Ok(()) }
+   |                ^^^

--- a/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `Vec<u8>: MaxEncodedLen` is not satisfied
 ...  |
 35 | |     #[pallet::storage]
 36 | |     type MyStorage<T: Config> = StorageValue<_, Vec<u8>>;
-   | |__________________^ the trait `MaxEncodedLen` is not implemented for `Vec<u8>`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageMyStorage<T>, Vec<u8>>: StorageInfoTrait`
+   | |__________________^ the trait `MaxEncodedLen` is not implemented for `Vec<u8>`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
              ()

--- a/substrate/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
@@ -16,6 +16,6 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
 41 |         B { b: T::Bar },
    |             ^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
-   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`, which is required by `&<T as pallet::Config>::Bar: std::fmt::Debug`
+   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`

--- a/substrate/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
@@ -18,4 +18,6 @@ error[E0277]: the trait bound `pallet::Pallet<T>: Hooks<<<<T as frame_system::Co
   --> tests/pallet_ui/hooks_invalid_item.rs:28:12
    |
 28 |     #[pallet::hooks]
-   |               ^^^^^ the trait `Hooks<<<<T as frame_system::Config>::Block as frame_support::sp_runtime::traits::Block>::Header as frame_support::sp_runtime::traits::Header>::Number>` is not implemented for `pallet::Pallet<T>`
+   |               ^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Hooks<<<<T as frame_system::Config>::Block as frame_support::sp_runtime::traits::Block>::Header as frame_support::sp_runtime::traits::Header>::Number>` is not implemented for `pallet::Pallet<T>`

--- a/substrate/frame/support/test/tests/pallet_ui/pass/config_multiple_attr.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/config_multiple_attr.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::*;
 
 	#[pallet::config(with_default, without_automatic_metadata)]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/config_without_metadata.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/config_without_metadata.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::*;
 
 	#[pallet::config(without_automatic_metadata)]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/default_config.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/default_config.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::*;
 
 	#[pallet::config(with_default)]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/error_nested_types.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/error_nested_types.rs
@@ -20,7 +20,7 @@ use frame_support::PalletError;
 
 #[frame_support::pallet]
 #[allow(unused_imports)]
-mod pallet {
+pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
 

--- a/substrate/frame/support/test/tests/pallet_ui/pass/event_type_bound_system_config_assoc_type.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/event_type_bound_system_config_assoc_type.rs
@@ -17,7 +17,7 @@
 
 #[frame_support::pallet]
 #[allow(unused_imports)]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::{Hooks, IsType};
 	use frame_system::pallet_prelude::BlockNumberFor;
 

--- a/substrate/frame/support/test/tests/pallet_ui/pass/feeless_call.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/feeless_call.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet(dev_mode)]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::DispatchResult;
 	use frame_system::pallet_prelude::OriginFor;
 

--- a/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight.rs
@@ -23,7 +23,7 @@ pub trait WeightInfo {
 }
 
 #[frame_support::pallet]
-mod parentheses {
+pub mod parentheses {
 	use super::*;
 
 	#[pallet::config]
@@ -44,7 +44,7 @@ mod parentheses {
 }
 
 #[frame_support::pallet]
-mod assign {
+pub mod assign {
 	use super::*;
 
 	#[pallet::config]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight2.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight2.rs
@@ -29,7 +29,7 @@ impl WeightInfo for () {
 }
 
 #[frame_support::pallet]
-mod parentheses {
+pub mod parentheses {
 	use super::*;
 
 	#[pallet::config]
@@ -50,7 +50,7 @@ mod parentheses {
 }
 
 #[frame_support::pallet]
-mod assign {
+pub mod assign {
 	use super::*;
 
 	#[pallet::config]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight3.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight3.rs
@@ -19,16 +19,16 @@ use frame_support::pallet_prelude::*;
 use frame_system::pallet_prelude::*;
 
 // If, for whatever reason, you don't to not use a `WeightInfo` trait - it will still work.
-struct Impl;
+pub struct Impl;
 
 impl Impl {
-	fn foo() -> Weight {
+	pub fn foo() -> Weight {
 		Weight::zero()
 	}
 }
 
 #[frame_support::pallet]
-mod parentheses {
+pub mod parentheses {
 	use super::*;
 
 	#[pallet::config]
@@ -48,7 +48,7 @@ mod parentheses {
 }
 
 #[frame_support::pallet]
-mod assign {
+pub mod assign {
 	use super::*;
 
 	#[pallet::config]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight_dev_mode.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/inherited_call_weight_dev_mode.rs
@@ -23,7 +23,7 @@ pub trait WeightInfo {
 }
 
 #[frame_support::pallet(dev_mode)]
-mod pallet {
+pub mod pallet {
 	use super::*;
 
 	#[pallet::config]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/simple_storage.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/simple_storage.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::*;
 
 	#[pallet::config(with_default)]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/task_valid.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/task_valid.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet(dev_mode)]
-mod pallet {
+pub mod pallet {
 	use frame_support::{ensure, pallet_prelude::DispatchResult};
 
 	#[pallet::config]
@@ -40,7 +40,7 @@ mod pallet {
 }
 
 #[frame_support::pallet(dev_mode)]
-mod pallet_with_instance {
+pub mod pallet_with_instance {
 	use frame_support::pallet_prelude::{ValueQuery, StorageValue};
 
 	#[pallet::config]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/trait_constant_valid_bounds.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/trait_constant_valid_bounds.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::BlockNumberFor;
 

--- a/substrate/frame/support/test/tests/pallet_ui/pass/view_function_valid.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/view_function_valid.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	use frame_support::pallet_prelude::*;
 
 	#[pallet::config(with_default)]

--- a/substrate/frame/support/test/tests/pallet_ui/pass/where_clause_missing_hooks.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/where_clause_missing_hooks.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[frame_support::pallet]
-mod pallet {
+pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config
 	where
@@ -34,7 +34,7 @@ mod pallet {
 	where
 		<T as frame_system::Config>::Nonce: From<u128>,
 	{
-		fn foo(x: u128) {
+		pub fn foo(x: u128) {
 			let _index = <T as frame_system::Config>::Nonce::from(x);
 		}
 	}

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: PartialStorageInfoTrait`
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `EncodeLike` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: PartialStorageInfoTrait`
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
@@ -58,7 +58,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: PartialStorageInfoTrait`
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -81,7 +81,7 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `TypeInfo` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `TypeInfo` is not implemented for `Bar`
    |
    = help: the following other types implement trait `TypeInfo`:
              &T
@@ -102,7 +102,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
@@ -119,7 +119,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `EncodeLike` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
@@ -141,7 +141,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -164,7 +164,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: TryDecodeEntireStorage`
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
@@ -181,7 +181,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `EncodeLike` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: TryDecodeEntireStorage`
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
@@ -203,7 +203,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: TryDecodeEntireStorage`
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: PartialStorageInfoTrait`
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `EncodeLike` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: PartialStorageInfoTrait`
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
@@ -58,7 +58,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: PartialStorageInfoTrait`
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -81,7 +81,7 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `TypeInfo` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `TypeInfo` is not implemented for `Bar`
    |
    = help: the following other types implement trait `TypeInfo`:
              &T
@@ -102,7 +102,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
@@ -119,7 +119,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `EncodeLike` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
@@ -141,7 +141,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageEntryMetadataBuilder`
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -164,7 +164,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: TryDecodeEntireStorage`
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
@@ -181,7 +181,7 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `EncodeLike` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: TryDecodeEntireStorage`
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
@@ -203,7 +203,7 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: TryDecodeEntireStorage`
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>: StorageInfoTrait`
+   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
              ()

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -9,7 +9,7 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
 ...  |
 41 | |     #[pallet::storage]
 42 | |     type Foo<T> = StorageNMap<_, Key<Twox64Concat, Bar>, u32>;
-   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`, which is required by `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, NMapKey<frame_support::Twox64Concat, Bar>, u32>: StorageInfoTrait`
+   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
    = help: the following other types implement trait `MaxEncodedLen`:
              ()
@@ -22,4 +22,5 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
            and $N others
    = note: required for `NMapKey<frame_support::Twox64Concat, Bar>` to implement `KeyGeneratorMaxEncodedLen`
-   = note: required for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, NMapKey<frame_support::Twox64Concat, Bar>, u32>` to implement `StorageInfoTrait`
+   = note: required for `StorageNMap<_GeneratedPrefixForStorageFoo<T>, Key<..., ...>, ...>` to implement `StorageInfoTrait`
+   = note: consider using `--verbose` to print the full type name to the console

--- a/substrate/frame/support/test/tests/runtime_ui.rs
+++ b/substrate/frame/support/test/tests/runtime_ui.rs
@@ -28,7 +28,7 @@ fn ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Deny all warnings since we emit warnings as part of a Runtime's UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/runtime_ui/*.rs");

--- a/substrate/frame/support/test/tests/split_ui.rs
+++ b/substrate/frame/support/test/tests/split_ui.rs
@@ -28,7 +28,7 @@ fn split_ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Deny all warnings since we emit warnings as part of a Pallet's UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/split_ui/*.rs");

--- a/substrate/frame/support/test/tests/storage_alias_ui.rs
+++ b/substrate/frame/support/test/tests/storage_alias_ui.rs
@@ -27,6 +27,9 @@ fn storage_alias_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
+	// Deny all warnings since we emit warnings as part of a Runtime's UI.
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
+
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/storage_alias_ui/*.rs");
 }

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -85,7 +85,7 @@ pub struct TransactionInfo {
 }
 
 fn num_chunks(bytes: u32) -> u32 {
-	((bytes as u64 + CHUNK_SIZE as u64 - 1) / CHUNK_SIZE as u64) as u32
+	(bytes as u64).div_ceil(CHUNK_SIZE as u64) as u32
 }
 
 #[frame_support::pallet]

--- a/substrate/frame/utility/src/lib.rs
+++ b/substrate/frame/utility/src/lib.rs
@@ -141,9 +141,9 @@ pub mod pallet {
 		/// The limit on the number of batched calls.
 		fn batched_calls_limit() -> u32 {
 			let allocator_limit = sp_core::MAX_POSSIBLE_ALLOCATION;
-			let call_size = ((core::mem::size_of::<<T as Config>::RuntimeCall>() as u32 +
-				CALL_ALIGN - 1) /
-				CALL_ALIGN) * CALL_ALIGN;
+			let call_size = (core::mem::size_of::<<T as Config>::RuntimeCall>() as u32)
+				.div_ceil(CALL_ALIGN) *
+				CALL_ALIGN;
 			// The margin to take into account vec doubling capacity.
 			let margin_factor = 3;
 

--- a/substrate/primitives/api/test/tests/trybuild.rs
+++ b/substrate/primitives/api/test/tests/trybuild.rs
@@ -28,7 +28,7 @@ fn ui() {
 	std::env::set_var("SKIP_WASM_BUILD", "1");
 
 	// Warnings are part of our UI.
-	std::env::set_var("RUSTFLAGS", "--deny warnings");
+	std::env::set_var("CARGO_ENCODED_RUSTFLAGS", "--deny=warnings");
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/ui/*.rs");

--- a/substrate/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
+++ b/substrate/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
@@ -54,10 +54,6 @@ note: associated function defined here
    |
 27 |         fn test(data: u64);
    |            ^^^^
-help: consider removing the borrow
-   |
-33 |         fn test(data: &u64) {
-   |
 
 error: unused variable: `data`
   --> tests/ui/type_reference_in_impl_runtime_apis_call.rs:33:11

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -481,16 +481,17 @@ macro_rules! generate_feature_enabled_macro {
 mod tests {
 	use super::*;
 
+	generate_feature_enabled_macro!(if_test, test, $);
+	generate_feature_enabled_macro!(if_not_test, not(test), $);
+
 	#[test]
 	#[should_panic]
 	fn generate_feature_enabled_macro_panics() {
-		generate_feature_enabled_macro!(if_test, test, $);
 		if_test!(panic!("This should panic"));
 	}
 
 	#[test]
 	fn generate_feature_enabled_macro_works() {
-		generate_feature_enabled_macro!(if_not_test, not(test), $);
 		if_not_test!(panic!("This should not panic"));
 	}
 }

--- a/substrate/primitives/runtime-interface/test-wasm/src/lib.rs
+++ b/substrate/primitives/runtime-interface/test-wasm/src/lib.rs
@@ -83,7 +83,7 @@ pub trait TestApi {
 	/// Copy `hello` into the given mutable reference
 	fn return_value_into_mutable_reference(&self, data: &mut [u8]) {
 		let res = "hello";
-		data[..res.as_bytes().len()].copy_from_slice(res.as_bytes());
+		data[..res.len()].copy_from_slice(res.as_bytes());
 	}
 
 	/// Returns the input data wrapped in an `Option` as result.

--- a/substrate/primitives/runtime-interface/tests/ui/no_feature_gated_method.stderr
+++ b/substrate/primitives/runtime-interface/tests/ui/no_feature_gated_method.stderr
@@ -26,7 +26,7 @@ note: the item is gated here
    | ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `runtime_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: unexpected `cfg` condition value: `bar-feature`
+warning: unexpected `cfg` condition value: `bar-feature`
   --> tests/ui/no_feature_gated_method.rs:24:8
    |
 24 |     #[cfg(feature = "bar-feature")]
@@ -35,10 +35,9 @@ error: unexpected `cfg` condition value: `bar-feature`
    = note: expected values for `feature` are: `default`, `disable_target_static_assertions`, and `std`
    = help: consider adding `bar-feature` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
-   = note: `-D unexpected-cfgs` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(unexpected_cfgs)]`
+   = note: `#[warn(unexpected_cfgs)]` on by default
 
-error: unexpected `cfg` condition value: `bar-feature`
+warning: unexpected `cfg` condition value: `bar-feature`
   --> tests/ui/no_feature_gated_method.rs:27:12
    |
 27 |     #[cfg(not(feature = "bar-feature"))]

--- a/substrate/primitives/runtime/src/lib.rs
+++ b/substrate/primitives/runtime/src/lib.rs
@@ -1237,16 +1237,17 @@ mod tests {
 mod sp_core_tests {
 	use super::*;
 
+	sp_core::generate_feature_enabled_macro!(if_test, test, $);
+	sp_core::generate_feature_enabled_macro!(if_not_test, not(test), $);
+
 	#[test]
 	#[should_panic]
 	fn generate_feature_enabled_macro_panics() {
-		sp_core::generate_feature_enabled_macro!(if_test, test, $);
 		if_test!(panic!("This should panic"));
 	}
 
 	#[test]
 	fn generate_feature_enabled_macro_works() {
-		sp_core::generate_feature_enabled_macro!(if_not_test, not(test), $);
 		if_not_test!(panic!("This should not panic"));
 	}
 }

--- a/substrate/primitives/state-machine/src/ext.rs
+++ b/substrate/primitives/state-machine/src/ext.rs
@@ -139,6 +139,7 @@ where
 	H::Out: Ord + 'static,
 	B: 'a + Backend<H>,
 {
+	/// Return all storage pairs from the backend and overlay combined.
 	pub fn storage_pairs(&mut self) -> Vec<(StorageKey, StorageValue)> {
 		use std::collections::HashMap;
 

--- a/substrate/primitives/transaction-storage-proof/src/lib.rs
+++ b/substrate/primitives/transaction-storage-proof/src/lib.rs
@@ -189,10 +189,8 @@ pub mod registration {
 		let mut target_chunk_key = Default::default();
 		let mut chunk_proof = Default::default();
 
-		let total_chunks: u64 = transactions
-			.iter()
-			.map(|t| ((t.len() + CHUNK_SIZE - 1) / CHUNK_SIZE) as u64)
-			.sum();
+		let total_chunks: u64 =
+			transactions.iter().map(|t| t.len().div_ceil(CHUNK_SIZE) as u64).sum();
 		let mut buf = [0u8; 8];
 		buf.copy_from_slice(&random_hash[0..8]);
 		let random_u64 = u64::from_be_bytes(buf);

--- a/substrate/primitives/trie/src/node_codec.rs
+++ b/substrate/primitives/trie/src/node_codec.rs
@@ -118,10 +118,7 @@ where
 				if padding && nibble_ops::pad_left(data[input.offset]) != 0 {
 					return Err(Error::BadFormat)
 				}
-				let partial = input.take(
-					(nibble_count + (nibble_ops::NIBBLE_PER_BYTE - 1)) /
-						nibble_ops::NIBBLE_PER_BYTE,
-				)?;
+				let partial = input.take(nibble_count.div_ceil(nibble_ops::NIBBLE_PER_BYTE))?;
 				let partial_padding = nibble_ops::number_padding(nibble_count);
 				let bitmap_range = input.take(BITMAP_LENGTH)?;
 				let bitmap = Bitmap::decode(&data[bitmap_range])?;
@@ -166,10 +163,7 @@ where
 				if padding && nibble_ops::pad_left(data[input.offset]) != 0 {
 					return Err(Error::BadFormat)
 				}
-				let partial = input.take(
-					(nibble_count + (nibble_ops::NIBBLE_PER_BYTE - 1)) /
-						nibble_ops::NIBBLE_PER_BYTE,
-				)?;
+				let partial = input.take(nibble_count.div_ceil(nibble_ops::NIBBLE_PER_BYTE))?;
 				let partial_padding = nibble_ops::number_padding(nibble_count);
 				let value = if contains_hash {
 					ValuePlan::Node(input.take(H::LENGTH)?)

--- a/templates/parachain/runtime/src/apis.rs
+++ b/templates/parachain/runtime/src/apis.rs
@@ -265,6 +265,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/templates/solochain/runtime/src/apis.rs
+++ b/templates/solochain/runtime/src/apis.rs
@@ -241,6 +241,7 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {


### PR DESCRIPTION
Ref https://github.com/paritytech/ci_cd/issues/1107

We mainly need that so that we can finally compile the `pallet_revive` fixtures on stable. I did my best to keep the commits focused on one thing to make review easier.

All the changes are needed because rustc introduced more warnings or is more strict about existing ones. Most of the stuff could just be fixed and the commits should be pretty self explanatory. However, there are a few this that are notable:

## `non_local_definitions `

A lot of runtimes to write `impl` blocks inside functions. This makes sense to reduce the amount of conditional compilation. I guess I could have moved them into a module instead. But I think allowing it here makes sense to avoid the code churn.

## `unexpected_cfgs`

The FRAME macros emit code that references various features like `std`, `runtime-benchmarks` or `try-runtime`. If a create that uses those macros does not have those features we get this warning. Those were mostly when defining a `mock` runtime. I opted for silencing the warning in this case rather than adding not needed features.

For the benchmarking ui tests I opted for adding the `runtime-benchmark` feature to the `Cargo.toml`.

## Failing UI test

I am bumping the `trybuild` version and regenerating the ui tests. The old version seems to be incompatible. This requires us to pass `deny_warnings` in `CARGO_ENCODED_RUSTFLAGS` as `RUSTFLAGS` is ignored in the new version.

## Removing toolchain file from the pallet revive fixtures

This is no longer needed since the latest stable will compile them fine using the `RUSTC_BOOTSTRAP=1`.