### PR TITLE
backport/2412: Increase litep2p keep-alive to 10 seconds to mirror libp2p

### DIFF
--- a/prdoc/pr_7488.prdoc
+++ b/prdoc/pr_7488.prdoc
@@ -1,0 +1,10 @@
+title: Increase litep2p keep-alive to 10 seconds to mirror libp2p
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      Increase litep2p keep-alive to 10 seconds to mirror libp2p behavior.
+
+crates:
+  - name: sc-network
+    bump: patch

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -100,6 +100,9 @@ mod peerstore;
 mod service;
 mod shim;
 
+/// Timeout for connection waiting new substreams.
+const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Litep2p bandwidth sink.
 struct Litep2pBandwidthSink {
 	sink: litep2p::BandwidthSink,
@@ -558,6 +561,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 			.with_connection_limits(ConnectionLimitsConfig::default().max_incoming_connections(
 				Some(crate::MAX_CONNECTIONS_ESTABLISHED_INCOMING as usize),
 			))
+			// This has the same effect as `libp2p::Swarm::with_idle_connection_timeout` which is
+			// set to 10 seconds as well.
+			.with_keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
 			.with_executor(executor);
 
 		if let Some(config) = maybe_mdns_config {


### PR DESCRIPTION
This PR backports:
- https://github.com/paritytech/polkadot-sdk/pull/7488

cc @EgorPopelyaev 