### PR TITLE
Expose extension weights

### DIFF
--- a/prdoc/pr_7637.prdoc
+++ b/prdoc/pr_7637.prdoc
@@ -1,7 +1,7 @@
 title: 'Expose extension weights from frame-system'
 
 doc:
-  - audience: Node Dev
+  - audience: Runtime Dev
     description: This PR exposes the Extension weights from the `frame-system`
 
 crates:

--- a/prdoc/pr_7637.prdoc
+++ b/prdoc/pr_7637.prdoc
@@ -1,0 +1,9 @@
+title: 'Expose extension weights from frame-system'
+
+doc:
+  - audience: Node Dev
+    description: This PR exposes the Extension weights from the `frame-system`
+
+crates:
+  - name: frame-system
+    bump: minor

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -173,6 +173,7 @@ pub use extensions::{
 	check_non_zero_sender::CheckNonZeroSender, check_nonce::CheckNonce,
 	check_spec_version::CheckSpecVersion, check_tx_version::CheckTxVersion,
 	check_weight::CheckWeight, weight_reclaim::WeightReclaim, WeightInfo as ExtensionsWeightInfo,
+	weights::SubstrateWeight as SubstrateExtensionsWeight
 };
 // Backward compatible re-export.
 pub use extensions::check_mortality::CheckMortality as CheckEra;

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -172,8 +172,8 @@ pub use extensions::{
 	check_genesis::CheckGenesis, check_mortality::CheckMortality,
 	check_non_zero_sender::CheckNonZeroSender, check_nonce::CheckNonce,
 	check_spec_version::CheckSpecVersion, check_tx_version::CheckTxVersion,
-	check_weight::CheckWeight, weight_reclaim::WeightReclaim, WeightInfo as ExtensionsWeightInfo,
-	weights::SubstrateWeight as SubstrateExtensionsWeight
+	check_weight::CheckWeight, weight_reclaim::WeightReclaim,
+	weights::SubstrateWeight as SubstrateExtensionsWeight, WeightInfo as ExtensionsWeightInfo,
 };
 // Backward compatible re-export.
 pub use extensions::check_mortality::CheckMortality as CheckEra;


### PR DESCRIPTION
# Description
Seems like SubstrateWeights that used T::DBWeights was not public unlike the frame_system's Call weights. PR just made those weights public

## Integration
Instead of using `()` impl which used RockDB weights, ExtensionWeights can be used to to use the provided DBWeights to System config
