### PR TITLE
Mku txpool handling finality stalls

### DIFF
--- a/substrate/client/transaction-pool/src/common/tracing_log_xt.rs
+++ b/substrate/client/transaction-pool/src/common/tracing_log_xt.rs
@@ -21,34 +21,34 @@
 /// Logs every transaction from given `tx_collection` with given level.
 macro_rules! log_xt {
     (data: hash, target: $target:expr, $level:expr, $tx_collection:expr, $text_with_format:expr) => {
-        for tx in $tx_collection {
+        for tx_hash in $tx_collection {
             tracing::event!(
+                target: $target,
                 $level,
-                target = $target,
-                tx_hash = format!("{:?}", tx),
+                ?tx_hash,
                 $text_with_format,
             );
         }
     };
     (data: hash, target: $target:expr, $level:expr, $tx_collection:expr, $text_with_format:expr, $($arg:expr),*) => {
-        for tx in $tx_collection {
+        for tx_hash in $tx_collection {
             tracing::event!(
+                target: $target,
                 $level,
-                target = $target,
-                tx_hash = format!("{:?}", tx),
+                ?tx_hash,
                 $text_with_format,
                 $($arg),*
             );
         }
     };
     (data: tuple, target: $target:expr, $level:expr, $tx_collection:expr, $text_with_format:expr) => {
-        for tx in $tx_collection {
+        for (tx_hash, arg) in $tx_collection {
             tracing::event!(
+                target: $target,
                 $level,
-                target = $target,
-                tx_hash = format!("{:?}", tx.0),
+                ?tx_hash,
                 $text_with_format,
-                tx.1
+                arg
             );
         }
     };

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/dropped_watcher.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/dropped_watcher.rs
@@ -112,8 +112,8 @@ where
 	RemoveView(BlockHash<ChainApi>),
 	/// Removes referencing views for given extrinsic hashes.
 	///
-	/// Intended to ba called on finalization.
-	RemoveFinalizedTxs(Vec<ExtrinsicHash<ChainApi>>),
+	/// Intended to ba called when transactions were finalized or their finality timed out.
+	RemoveTransactions(Vec<ExtrinsicHash<ChainApi>>),
 }
 
 impl<ChainApi> Debug for Command<ChainApi>
@@ -124,7 +124,7 @@ where
 		match self {
 			Command::AddView(..) => write!(f, "AddView"),
 			Command::RemoveView(..) => write!(f, "RemoveView"),
-			Command::RemoveFinalizedTxs(..) => write!(f, "RemoveFinalizedTxs"),
+			Command::RemoveTransactions(..) => write!(f, "RemoveTransactions"),
 		}
 	}
 }
@@ -228,7 +228,7 @@ where
 					}
 				});
 			},
-			Command::RemoveFinalizedTxs(xts) => {
+			Command::RemoveTransactions(xts) => {
 				log_xt_trace!(
 					target: LOG_TARGET,
 					xts.clone(),
@@ -422,13 +422,13 @@ where
 	}
 
 	/// Removes status info for finalized transactions.
-	pub fn remove_finalized_txs(
+	pub fn remove_transactions(
 		&self,
 		xts: impl IntoIterator<Item = ExtrinsicHash<ChainApi>> + Clone,
 	) {
 		let _ = self
 			.controller
-			.unbounded_send(Command::RemoveFinalizedTxs(xts.into_iter().collect()))
+			.unbounded_send(Command::RemoveTransactions(xts.into_iter().collect()))
 			.map_err(|e| {
 				trace!(target: LOG_TARGET, "dropped_watcher: remove_finalized_txs send message failed: {e}");
 			});

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -1581,9 +1581,6 @@ where
 				// }
 			},
 			Ok(EnactmentAction::HandleEnactment(tree_route)) => {
-				if matches!(event, ChainEvent::Finalized { .. }) {
-					self.view_store.handle_pre_finalized(event.hash()).await;
-				};
 				self.handle_new_block(&tree_route).await;
 			},
 		};

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -1605,6 +1605,17 @@ where
 {
 	/// Executes the maintainance for the given chain event.
 	async fn maintain(&self, event: ChainEvent<Self::Block>) {
+		if std::path::Path::new("/tmp/skip-finalization").exists() {
+			let n = self
+				.api
+				.block_id_to_number(&BlockId::Hash(event.hash()))
+				.map_err(|e| format!("{}", e));
+			debug!("skipping: ChainEvent::Finalized {n:?}");
+			if matches!(event, ChainEvent::Finalized { .. }) {
+				return
+			}
+		}
+
 		let start = Instant::now();
 		debug!(
 			target: LOG_TARGET,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -179,7 +179,8 @@ where
 				target: LOG_TARGET,
 				xts.iter().map(|(_,xt)| self.pool.validated_pool().api().hash_and_length(xt).0),
 				"view::submit_many at:{}",
-				self.at.hash);
+				self.at.hash
+			);
 			self.pool.submit_at(&self.at, xts).await
 		} else {
 			self.pool.submit_at(&self.at, xts).await

--- a/substrate/client/transaction-pool/tests/fatp.rs
+++ b/substrate/client/transaction-pool/tests/fatp.rs
@@ -664,7 +664,6 @@ fn fatp_fork_no_xts_ready_switch_to_future() {
 
 	// wait 10 blocks for revalidation and 1 extra for applying revalidation results
 	let mut prev_header = forks[1][2].clone();
-	log::debug!("====> {:?}", prev_header);
 	for _ in 3..=12 {
 		let header = api.push_block_with_parent(prev_header.hash(), vec![], true);
 		let event = finalized_block_event(&pool, prev_header.hash(), header.hash());

--- a/substrate/client/transaction-pool/tests/fatp_finality_timeout.rs
+++ b/substrate/client/transaction-pool/tests/fatp_finality_timeout.rs
@@ -1,0 +1,187 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Tests for finality timeout handling for fork-aware transaction pool.
+
+pub mod fatp_common;
+
+use std::cmp::min;
+
+use fatp_common::{
+	finalized_block_event, invalid_hash, new_best_block_event, TestPoolBuilder, LOG_TARGET, SOURCE,
+};
+use futures::{executor::block_on, FutureExt};
+use sc_transaction_pool::ChainApi;
+use sc_transaction_pool_api::{MaintainedTransactionPool, TransactionPool, TransactionStatus};
+use substrate_test_runtime_client::Sr25519Keyring::*;
+use substrate_test_runtime_transaction_pool::uxt;
+
+#[test]
+fn fatp_finality_timeout_works() {
+	sp_tracing::try_init_simple();
+
+	const FINALITY_TIMEOUT_THRESHOLD: usize = 10;
+
+	let (pool, api, _) = TestPoolBuilder::new()
+		.with_finality_timeout_threshold(FINALITY_TIMEOUT_THRESHOLD)
+		.build();
+	api.set_nonce(api.genesis_hash(), Bob.into(), 300);
+	api.set_nonce(api.genesis_hash(), Charlie.into(), 400);
+	api.set_nonce(api.genesis_hash(), Dave.into(), 500);
+
+	let header01 = api.push_block(1, vec![], true);
+	block_on(pool.maintain(new_best_block_event(&pool, None, header01.hash())));
+
+	let xt0 = uxt(Alice, 200);
+	let xt1 = uxt(Bob, 300);
+	let xt2 = uxt(Charlie, 400);
+	let xt3 = uxt(Dave, 500);
+
+	let xt0_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt0.clone())).unwrap();
+	let xt1_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt1.clone())).unwrap();
+	let xt2_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt2.clone())).unwrap();
+	let xt3_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt3.clone())).unwrap();
+
+	assert_pool_status!(header01.hash(), &pool, 4, 0);
+	assert_ready_iterator!(header01.hash(), pool, [xt0, xt1, xt2, xt3]);
+
+	let header02a = api.push_block_with_parent(
+		header01.hash(),
+		vec![xt0.clone(), xt1.clone(), xt2.clone(), xt3.clone()],
+		true,
+	);
+	block_on(pool.maintain(new_best_block_event(&pool, Some(header01.hash()), header02a.hash())));
+	assert_pool_status!(header02a.hash(), &pool, 0, 0);
+
+	let header02b = api.push_block_with_parent(header01.hash(), vec![xt0, xt1, xt2, xt3], true);
+	block_on(pool.maintain(new_best_block_event(&pool, Some(header02a.hash()), header02b.hash())));
+	assert_pool_status!(header02b.hash(), &pool, 0, 0);
+
+	let mut prev_header = header02b.clone();
+	for n in 3..66 {
+		let header = api.push_block_with_parent(prev_header.hash(), vec![], true);
+		let event = new_best_block_event(&pool, Some(prev_header.hash()), header.hash());
+		block_on(pool.maintain(event));
+
+		prev_header = header;
+		if n < 3 + FINALITY_TIMEOUT_THRESHOLD {
+			assert_eq!(pool.active_views_count(), 2);
+		} else {
+			assert_eq!(pool.active_views_count(), 1);
+			assert_eq!(pool.inactive_views_count(), FINALITY_TIMEOUT_THRESHOLD);
+		}
+	}
+
+	for (i, watcher) in
+		vec![xt0_watcher, xt1_watcher, xt2_watcher, xt3_watcher].into_iter().enumerate()
+	{
+		assert_watcher_stream!(
+			watcher,
+			[
+				TransactionStatus::Ready,
+				TransactionStatus::InBlock((header02a.hash(), i)),
+				TransactionStatus::InBlock((header02b.hash(), i)),
+				TransactionStatus::FinalityTimeout(min(header02a.hash(), header02b.hash()))
+			]
+		);
+	}
+}
+
+#[test]
+fn fatp_finalized_still_works_after_finality_stall() {
+	sp_tracing::try_init_simple();
+
+	const FINALITY_TIMEOUT_THRESHOLD: usize = 10;
+
+	let (pool, api, _) = TestPoolBuilder::new()
+		.with_finality_timeout_threshold(FINALITY_TIMEOUT_THRESHOLD)
+		.build();
+	api.set_nonce(api.genesis_hash(), Bob.into(), 300);
+	api.set_nonce(api.genesis_hash(), Charlie.into(), 400);
+	api.set_nonce(api.genesis_hash(), Dave.into(), 500);
+
+	let header01 = api.push_block(1, vec![], true);
+	block_on(pool.maintain(new_best_block_event(&pool, None, header01.hash())));
+
+	let xt0 = uxt(Alice, 200);
+	let xt1 = uxt(Bob, 300);
+	let xt2 = uxt(Charlie, 400);
+	let xt3 = uxt(Dave, 500);
+
+	let xt0_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt0.clone())).unwrap();
+	let xt1_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt1.clone())).unwrap();
+	let xt2_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt2.clone())).unwrap();
+	let xt3_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt3.clone())).unwrap();
+
+	assert_pool_status!(header01.hash(), &pool, 4, 0);
+	assert_ready_iterator!(header01.hash(), pool, [xt0, xt1, xt2, xt3]);
+
+	let header02a = api.push_block_with_parent(
+		header01.hash(),
+		vec![xt0.clone(), xt1.clone(), xt2.clone()],
+		true,
+	);
+	block_on(pool.maintain(new_best_block_event(&pool, Some(header01.hash()), header02a.hash())));
+	assert_pool_status!(header02a.hash(), &pool, 1, 0);
+
+	let header02b = api.push_block_with_parent(header01.hash(), vec![xt0, xt1, xt2], true);
+	block_on(pool.maintain(new_best_block_event(&pool, Some(header02a.hash()), header02b.hash())));
+	assert_pool_status!(header02b.hash(), &pool, 1, 0);
+
+	let header03b = api.push_block_with_parent(header02b.hash(), vec![xt3], true);
+	block_on(pool.maintain(new_best_block_event(&pool, Some(header02b.hash()), header03b.hash())));
+	assert_pool_status!(header03b.hash(), &pool, 0, 0);
+
+	let mut prev_header = header03b.clone();
+	for n in 4..=3 + FINALITY_TIMEOUT_THRESHOLD {
+		let header = api.push_block_with_parent(prev_header.hash(), vec![], true);
+		let event = new_best_block_event(&pool, Some(prev_header.hash()), header.hash());
+		block_on(pool.maintain(event));
+
+		prev_header = header;
+		if n < 3 + FINALITY_TIMEOUT_THRESHOLD {
+			assert_eq!(pool.active_views_count(), 2);
+		} else {
+			assert_eq!(pool.active_views_count(), 1);
+			assert_eq!(pool.inactive_views_count(), FINALITY_TIMEOUT_THRESHOLD);
+		}
+	}
+
+	block_on(pool.maintain(finalized_block_event(&pool, api.genesis_hash(), header03b.hash())));
+
+	for (i, watcher) in vec![xt0_watcher, xt1_watcher, xt2_watcher].into_iter().enumerate() {
+		assert_watcher_stream!(
+			watcher,
+			[
+				TransactionStatus::Ready,
+				TransactionStatus::InBlock((header02a.hash(), i)),
+				TransactionStatus::InBlock((header02b.hash(), i)),
+				TransactionStatus::FinalityTimeout(min(header02a.hash(), header02b.hash()))
+			]
+		);
+	}
+
+	assert_watcher_stream!(
+		xt3_watcher,
+		[
+			TransactionStatus::Ready,
+			TransactionStatus::InBlock((header03b.hash(), 0)),
+			TransactionStatus::Finalized((header03b.hash(), 0))
+		]
+	);
+}


### PR DESCRIPTION
#### PR Description

This pull request introduces measures to handle finality stalls by :
- notifying outdated transactions with a [`FinalityTimeout`](https://github.com/paritytech/polkadot-sdk/blob/d821c84d61b8040d979178b2355be7dd1da83388/substrate/client/transaction-pool/api/src/lib.rs#L145-L147) event.
- removing outdated views from the `view_store`

An item is considered _outdated_ when the difference between its associated block and the current block exceeds a pre-defined threshold.

#### Note for Reviewers
The core logic is provided in the following small commits:
- `ViewStore`: new method [`finality_stall_view_cleanup`](https://github.com/paritytech/polkadot-sdk/blob/d821c84d61b8040d979178b2355be7dd1da83388/substrate/client/transaction-pool/src/fork_aware_txpool/view_store.rs#L869-L903) for removing stale views was added: 64267000db
- `ForkAwareTransactionPool`: core logic for tracking finality stalls added here: 7b37ea6f0b. Entry point in [`finality_stall_cleanup`](https://github.com/paritytech/polkadot-sdk/blob/d821c84d61b8040d979178b2355be7dd1da83388/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs#L1096-L1136)
- Some related renaming was made to better reflect purpose/shorten the names: 1a3a1284b4, a511601fe9. Also new method [`transactions_finality_timeout`](https://github.com/paritytech/polkadot-sdk/blob/a511601fe9f0febba43d223f12e23ee33e0606b1/substrate/client/transaction-pool/src/fork_aware_txpool/multi_view_listener.rs#L771-L790) for triggering external events was added for `MultiViewListener`.

I also sneaked in some minor improvements:
- fixed per-transaction logging: 1572f721e4
- `handle_pre_finalized` method was removed, it was some old leftover which is no longer needed: a6f84ad019,

closes: #5482 