### PR TITLE
optional rocksdb for frame-benchmarking-cli

### DIFF
--- a/cumulus/bin/pov-validator/Cargo.toml
+++ b/cumulus/bin/pov-validator/Cargo.toml
@@ -19,8 +19,8 @@ sc-executor.workspace = true
 sp-core.workspace = true
 sp-io.workspace = true
 sp-maybe-compressed-blob.workspace = true
-tracing-subscriber.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/cumulus/bin/pov-validator/Cargo.toml
+++ b/cumulus/bin/pov-validator/Cargo.toml
@@ -19,8 +19,8 @@ sc-executor.workspace = true
 sp-core.workspace = true
 sp-io.workspace = true
 sp-maybe-compressed-blob.workspace = true
-tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/cumulus/client/cli/Cargo.toml
+++ b/cumulus/client/cli/Cargo.toml
@@ -18,9 +18,9 @@ url = { workspace = true }
 
 # Substrate
 sc-chain-spec = { workspace = true, default-features = true }
-sc-cli = { workspace = true, default-features = true }
+sc-cli = { workspace = true, default-features = false }
 sc-client-api = { workspace = true, default-features = true }
-sc-service = { workspace = true, default-features = true }
+sc-service = { workspace = true, default-features = false }
 sp-blockchain = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }

--- a/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
@@ -17,7 +17,7 @@ futures = { workspace = true }
 futures-timer = { workspace = true }
 
 # Substrate
-sc-cli = { workspace = true, default-features = true }
+sc-cli = { workspace = true, default-features = false }
 sc-client-api = { workspace = true, default-features = true }
 sc-sysinfo = { workspace = true, default-features = true }
 sc-telemetry = { workspace = true, default-features = true }

--- a/cumulus/polkadot-omni-node/lib/Cargo.toml
+++ b/cumulus/polkadot-omni-node/lib/Cargo.toml
@@ -43,7 +43,7 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true, default-feature
 prometheus-endpoint = { workspace = true, default-features = true }
 sc-basic-authorship = { workspace = true, default-features = true }
 sc-chain-spec = { workspace = true, default-features = true }
-sc-cli = { workspace = true, default-features = true }
+sc-cli = { workspace = true, default-features = false }
 sc-client-api = { workspace = true, default-features = true }
 sc-client-db = { workspace = true, default-features = true }
 sc-consensus = { workspace = true, default-features = true }
@@ -53,7 +53,7 @@ sc-network = { workspace = true, default-features = true }
 sc-offchain = { workspace = true, default-features = true }
 sc-rpc = { workspace = true, default-features = true }
 sc-runtime-utilities = { workspace = true, default-features = true }
-sc-service = { workspace = true, default-features = true }
+sc-service = { workspace = true, default-features = false }
 sc-sysinfo = { workspace = true, default-features = true }
 sc-telemetry = { workspace = true, default-features = true }
 sc-tracing = { workspace = true, default-features = true }

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -18,13 +18,13 @@ gum = { workspace = true, default-features = true }
 
 metered = { features = ["futures_channel"], workspace = true }
 # Both `sc-service` and `sc-cli` are required by runtime metrics `logger_hook()`.
-sc-cli = { workspace = true , default-features = false}
-sc-service = { workspace = true, default-features = false }
 bs58 = { features = ["alloc"], workspace = true, default-features = true }
 codec = { workspace = true, default-features = true }
 log = { workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }
 prometheus-endpoint = { workspace = true, default-features = true }
+sc-cli = { workspace = true, default-features = false }
+sc-service = { workspace = true, default-features = false }
 sc-tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -18,9 +18,8 @@ gum = { workspace = true, default-features = true }
 
 metered = { features = ["futures_channel"], workspace = true }
 # Both `sc-service` and `sc-cli` are required by runtime metrics `logger_hook()`.
-sc-cli = { workspace = true }
-sc-service = { workspace = true, default-features = true }
-
+sc-cli = { workspace = true , default-features = false}
+sc-service = { workspace = true, default-features = false }
 bs58 = { features = ["alloc"], workspace = true, default-features = true }
 codec = { workspace = true, default-features = true }
 log = { workspace = true, default-features = true }

--- a/prdoc/pr_7649.prdoc
+++ b/prdoc/pr_7649.prdoc
@@ -7,14 +7,14 @@ doc:
 
 crates:
   - name: cumulus-client-cli
-    bump: minor
+    bump: patch
   - name: sc-cli
-    bump: minor
+    bump: patch
   - name: polkadot-node-metrics
-    bump: minor
+    bump: patch
   - name: frame-benchmarking-cli
-    bump: minor
+    bump: patch
   - name: cumulus-relay-chain-inprocess-interface
-    bump: minor
+    bump: patch
   - name: polkadot-omni-node-lib
-    bump: minor
+    bump: patch

--- a/prdoc/pr_7649.prdoc
+++ b/prdoc/pr_7649.prdoc
@@ -1,0 +1,20 @@
+title: 'frame-benchmarking-cli should not build RocksDB by default'
+
+doc:
+  - audience: Node Dev
+    description: |- 
+      This PR ensures `frame-benchmarking-cli` does not build RocksDB by default and also ensures rocksDB is not built when `default-features=false`.
+
+crates:
+  - name: cumulus-client-cli
+    bump: minor
+  - name: sc-cli
+    bump: minor
+  - name: polkadot-node-metrics
+    bump: minor
+  - name: frame-benchmarking-cli
+    bump: minor
+  - name: cumulus-relay-chain-inprocess-interface
+    bump: minor
+  - name: polkadot-omni-node-lib
+    bump: minor

--- a/substrate/client/cli/Cargo.toml
+++ b/substrate/client/cli/Cargo.toml
@@ -35,11 +35,11 @@ thiserror = { workspace = true }
 # personal fork here as workaround for: https://github.com/rust-bitcoin/rust-bip39/pull/64
 bip39 = { package = "parity-bip39", version = "2.0.1", features = ["rand"] }
 sc-client-api = { workspace = true, default-features = true }
-sc-client-db = { workspace = true }
+sc-client-db = { workspace = true, default-features = false }
 sc-keystore = { workspace = true, default-features = true }
 sc-mixnet = { workspace = true, default-features = true }
 sc-network = { workspace = true, default-features = true }
-sc-service = { workspace = true }
+sc-service = { workspace = true, default-features = false }
 sc-telemetry = { workspace = true, default-features = true }
 sc-tracing = { workspace = true, default-features = true }
 sc-transaction-pool = { workspace = true, default-features = true }

--- a/substrate/test-utils/cli/Cargo.toml
+++ b/substrate/test-utils/cli/Cargo.toml
@@ -22,8 +22,8 @@ nix = { features = ["signal"], workspace = true }
 node-cli = { workspace = true }
 node-primitives = { workspace = true, default-features = true }
 regex = { workspace = true }
-sc-cli = { workspace = true, default-features = true }
-sc-service = { workspace = true, default-features = true }
+sc-cli = { workspace = true, default-features = false }
+sc-service = { workspace = true, default-features = false }
 sp-rpc = { workspace = true, default-features = true }
 substrate-rpc-client = { workspace = true, default-features = true }
 tokio = { features = ["full"], workspace = true, default-features = true }

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -23,10 +23,10 @@ futures = { workspace = true }
 sc-client-api = { workspace = true, default-features = true }
 sc-client-db = { features = [
 	"test-helpers",
-], workspace = true }
+], workspace = true, default-features = false }
 sc-consensus = { workspace = true, default-features = true }
 sc-executor = { workspace = true, default-features = true }
-sc-service = { workspace = true }
+sc-service = { workspace = true, default-features = false }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }

--- a/substrate/utils/frame/benchmarking-cli/Cargo.toml
+++ b/substrate/utils/frame/benchmarking-cli/Cargo.toml
@@ -39,13 +39,13 @@ rand = { features = ["small_rng"], workspace = true, default-features = true }
 rand_pcg = { workspace = true }
 sc-block-builder = { workspace = true, default-features = true }
 sc-chain-spec = { workspace = true }
-sc-cli = { workspace = true }
+sc-cli = { workspace = true, default-features = false }
 sc-client-api = { workspace = true, default-features = true }
-sc-client-db = { workspace = true }
+sc-client-db = { workspace = true, default-features = false }
 sc-executor = { workspace = true, default-features = true }
 sc-executor-common = { workspace = true }
 sc-runtime-utilities = { workspace = true, default-features = true }
-sc-service = { workspace = true }
+sc-service = { workspace = true, default-features = false }
 sc-sysinfo = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
@@ -79,7 +79,7 @@ substrate-test-runtime = { workspace = true, default-features = true }
 westend-runtime = { workspace = true, default-features = true }
 
 [features]
-default = ["rocksdb"]
+default = []
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",


### PR DESCRIPTION
`sc-cli` brings rocksdb dependency into frame-benchmarking-cli when used with `default-features = false`. 
This PR makes rocksdb deps optional that sc-cli brings in some of the crates. I think I covered all the crates that depend on sc-cli but please let me know if I missed any.

Fixes: https://github.com/paritytech/polkadot-sdk/issues/3793