### PR TITLE
[pallet-revive] tracing should wrap around call stack execution

### DIFF
--- a/prdoc/pr_7676.prdoc
+++ b/prdoc/pr_7676.prdoc
@@ -1,0 +1,7 @@
+title: '[pallet-revive] tracing should wrap around call stack execution'
+doc:
+- audience: Runtime Dev
+  description: Fix tracing should wrap around the entire call stack execution
+crates:
+- name: pallet-revive
+  bump: minor


### PR DESCRIPTION
Fix tracing should wrap around the entire call stack execution