### PR TITLE
Bump VALIDATION_CODE_BOMB_LIMIT

### DIFF
--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -33,7 +33,7 @@ use polkadot_primitives::{
 	vstaging::CommittedCandidateReceiptV2 as CommittedCandidateReceipt, BlakeTwo256, BlockNumber,
 	CandidateCommitments, CandidateHash, ChunkIndex, CollatorPair, CompactStatement, CoreIndex,
 	EncodeAs, Hash, HashT, HeadData, Id as ParaId, PersistedValidationData, SessionIndex, Signed,
-	UncheckedSigned, ValidationCode, ValidationCodeHash, MAX_CODE_SIZE, MAX_POV_SIZE,
+	UncheckedSigned, ValidationCode, ValidationCodeHash, MAX_POV_SIZE,
 };
 pub use sp_consensus_babe::{
 	AllowedSlots as BabeAllowedSlots, BabeEpochConfiguration, Epoch as BabeEpoch,

--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -69,7 +69,7 @@ const MERKLE_NODE_MAX_SIZE: usize = 512 + 100;
 const MERKLE_PROOF_MAX_DEPTH: usize = 8;
 
 /// The bomb limit for decompressing code blobs.
-pub const VALIDATION_CODE_BOMB_LIMIT: usize = (MAX_CODE_SIZE * 4u32) as usize;
+pub const VALIDATION_CODE_BOMB_LIMIT: usize = 32 * 1024 * 1024;
 
 /// The bomb limit for decompressing PoV blobs.
 pub const POV_BOMB_LIMIT: usize = (MAX_POV_SIZE * 4u32) as usize;

--- a/prdoc/pr_7710.prdoc
+++ b/prdoc/pr_7710.prdoc
@@ -1,0 +1,12 @@
+title: Bump VALIDATION_CODE_BOMB_LIMIT
+doc:
+- audience: Node Dev
+  description: |-
+    It used to be 16MiB some [time ago](https://github.com/paritytech/polkadot-sdk/commit/6b1baba49072aa99763b53b4ed1c2347e9b74339#diff-f0f67ea8902415829518ebc28ae8f60bdb286ebce3c4d141d31392983fa98ef7L52). Bumping to 32MiB sounds sensible to me, as we've seen some recent runtimes expanding close to the previous 16MiB.
+
+    This is just a short term fix for https://github.com/paritytech/polkadot-sdk/issues/7664 - needs to be backported and deployed ASAP.
+
+    While this unblocks assethub, I will create another PR to promote it into a HostConfiguration parameter and associated runtime api.
+crates:
+- name: polkadot-node-primitives
+  bump: minor


### PR DESCRIPTION
It used to be 16MiB some [time ago](https://github.com/paritytech/polkadot-sdk/commit/6b1baba49072aa99763b53b4ed1c2347e9b74339#diff-f0f67ea8902415829518ebc28ae8f60bdb286ebce3c4d141d31392983fa98ef7L52). Bumping to 32MiB sounds sensible to me, as we've seen some recent runtimes expanding close to the previous 16MiB.

This is just a short term fix for https://github.com/paritytech/polkadot-sdk/issues/7664 - needs to be backported and deployed ASAP. 

While this unblocks assethub, I will create another PR to promote it into a HostConfiguration parameter and associated runtime api.