### PR TITLE
License scanner node.js upgrade

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
       - uses: actions/setup-node@v4.1.0
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://npm.pkg.github.com"
           scope: "@paritytech"
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
       - uses: actions/setup-node@v4.1.0
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://npm.pkg.github.com"
           scope: "@paritytech"
 


### PR DESCRIPTION
Following https://github.com/paritytech/license-scanner/issues/61, this
updates node.js for license-scanner. The scanner itself is not pinned,
so it should already be using the newly published version.
