### PR TITLE
Glue in the staking clients pallets + improve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11034,8 +11034,10 @@ dependencies = [
  "pallet-staking-rc-client",
  "pallet-timestamp",
  "parity-scale-codec",
+ "polkadot-runtime-parachains",
  "polkadot-sdk-frame",
  "scale-info",
+ "sp-tracing 16.0.0",
  "staging-xcm",
 ]
 
@@ -15642,7 +15644,6 @@ dependencies = [
  "pallet-message-queue",
  "pallet-mmr",
  "pallet-session",
- "pallet-staking",
  "pallet-timestamp",
  "parity-scale-codec",
  "polkadot-core-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11037,8 +11037,9 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-sdk-frame",
  "scale-info",
+ "sp-session",
+ "sp-staking",
  "sp-tracing 16.0.0",
- "staging-xcm",
 ]
 
 [[package]]
@@ -13133,7 +13134,6 @@ dependencies = [
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
  "sp-staking",
- "staging-xcm",
 ]
 
 [[package]]
@@ -13149,7 +13149,6 @@ dependencies = [
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
  "sp-staking",
- "staging-xcm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -420,6 +420,7 @@ members = [
 	"substrate/frame/society",
 	"substrate/frame/staking",
 	"substrate/frame/staking/ah-client",
+	"substrate/frame/staking/ahm-test",
 	"substrate/frame/staking/rc-client",
 	"substrate/frame/staking/ahm-test",
 	"substrate/frame/staking/reward-curve",

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -1019,10 +1019,12 @@ impl<T: Config> Pallet<T> {
 
 	pub(crate) fn phase_transition(to: Phase<T>) {
 		let from = Self::current_phase();
-		log!(debug, "transitioning phase from {:?} to {:?}", from, to);
 		use sp_std::mem::discriminant;
 		if discriminant(&from) != discriminant(&to) {
+			log!(debug, "transitioning phase from {:?} to {:?}", from, to);
 			Self::deposit_event(Event::PhaseTransitioned { from, to });
+		} else {
+			log!(trace, "transitioning phase from {:?} to {:?}", from, to);
 		}
 		<CurrentPhase<T>>::put(to);
 	}

--- a/substrate/frame/election-provider-support/src/lib.rs
+++ b/substrate/frame/election-provider-support/src/lib.rs
@@ -488,16 +488,27 @@ pub trait ElectionProvider {
 	}
 
 	/// Return the duration of your election.
+	///
+	/// This excludes the duration of the export. For that, use [`duration_with_export`].
 	fn duration() -> Self::BlockNumber;
+
+	/// Return the duration of your election, including the export.
+	fn duration_with_export() -> Self::BlockNumber
+	where
+		Self::BlockNumber: From<PageIndex> + core::ops::Add<Output = Self::BlockNumber>,
+	{
+		let export: Self::BlockNumber = Self::Pages::get().into();
+		Self::duration() + export
+	}
 
 	/// Signal that the election should start
 	fn start() -> Result<(), Self::Error>;
 
 	/// Indicate whether this election provider is currently ongoing an asynchronous election.
 	///
-	/// `Err(())` should signal that we are not doing anything, and `elect` should def. not be called.
-	/// `Ok(false)` means we are doing something, but work is still ongoing. `elect` should not be called.
-	/// `Ok(true)` means we are done and ready for a call to `elect`.
+	/// `Err(())` should signal that we are not doing anything, and `elect` should def. not be
+	/// called. `Ok(false)` means we are doing something, but work is still ongoing. `elect` should
+	/// not be called. `Ok(true)` means we are done and ready for a call to `elect`.
 	fn status() -> Result<bool, ()>;
 }
 

--- a/substrate/frame/staking/ah-client/Cargo.toml
+++ b/substrate/frame/staking/ah-client/Cargo.toml
@@ -22,7 +22,6 @@ scale-info = { workspace = true, features = ["derive"] }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-staking = { workspace = true }
-xcm = { workspace = true }
 
 [features]
 default = ["std"]
@@ -41,7 +40,6 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"xcm/std",
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
@@ -52,7 +50,6 @@ runtime-benchmarks = [
 	"polkadot-runtime-parachains/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
-	"xcm/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/substrate/frame/staking/ah-client/src/lib.rs
+++ b/substrate/frame/staking/ah-client/src/lib.rs
@@ -95,11 +95,9 @@ pub trait SendToAssetHub {
 pub mod pallet {
 	use crate::*;
 	use alloc::vec;
-	use core::result;
 	use frame_support::traits::UnixTime;
 	use frame_system::pallet_prelude::*;
 	use pallet_session::historical;
-	use polkadot_runtime_parachains::origin::{ensure_parachain, Origin};
 	use sp_runtime::{traits::Saturating, Perbill};
 	use sp_staking::{
 		offence::{OffenceSeverity, OnOffenceHandler},

--- a/substrate/frame/staking/ah-client/src/lib.rs
+++ b/substrate/frame/staking/ah-client/src/lib.rs
@@ -251,8 +251,6 @@ pub mod pallet {
 				(T::UnixTime::now().as_millis().saturated_into::<u64>(), 0)
 			});
 
-			// TODO: we need to know here if the ending of this session, which causes the start of a
-			// new session, is when a new validator set is being activated.
 			let session_report = pallet_staking_rc_client::SessionReport {
 				end_index: session_index,
 				validator_points,
@@ -269,8 +267,6 @@ pub mod pallet {
 
 	impl<T: Config> pallet_authorship::EventHandler<T::AccountId, BlockNumberFor<T>> for Pallet<T> {
 		fn note_author(author: T::AccountId) {
-			// TODO: points from para-validation should also be collected somewhere, and added to
-			// the same storage item.
 			ValidatorPoints::<T>::mutate(author, |points| {
 				points.saturating_accrue(T::PointsPerBlock::get());
 			});

--- a/substrate/frame/staking/ah-client/src/lib.rs
+++ b/substrate/frame/staking/ah-client/src/lib.rs
@@ -194,6 +194,8 @@ pub mod pallet {
 		}
 
 		fn end_session(session_index: u32) {
+			log::debug!(target: LOG_TARGET, "Ending session {}", session_index);
+
 			let authors = BlockAuthors::<T>::iter().collect::<Vec<_>>();
 			// The maximum number of block authors is `num_cores * max_validators_per_core` (both
 			// are parameters from [`SchedulerParams`]).

--- a/substrate/frame/staking/ah-client/src/lib.rs
+++ b/substrate/frame/staking/ah-client/src/lib.rs
@@ -43,9 +43,12 @@
 //!
 //! * Implement `SessionManager` (and historical variant thereof).
 //! * Implement `OnOffenceHandler`.
-//! * Implement
+//! * Implement reward related APIs.
 //! * If further communication is needed to the session pallet, either a custom trait (`trait
 //!   SessionInterface`) or tightly coupling the session-pallet should work.
+//!
+//! TODO:
+//! * Governance functions to force set validators.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/substrate/frame/staking/ahm-test/Cargo.toml
+++ b/substrate/frame/staking/ahm-test/Cargo.toml
@@ -21,6 +21,9 @@ log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true, default-features = true }
 frame = { package = "polkadot-sdk-frame", workspace = true, default-features = true }
 frame-support = { workspace = true, default-features = true }
+sp-session = { workspace = true, default-features = true }
+sp-staking = { workspace = true, default-features = true }
+sp-tracing = { workspace = true, default-features = true }
 
 # pallets we need in both
 pallet-balances = { workspace = true, default-features = true }
@@ -29,15 +32,12 @@ pallet-balances = { workspace = true, default-features = true }
 pallet-staking ={ workspace = true, default-features = true }
 pallet-staking-rc-client ={ workspace = true, default-features = true }
 pallet-election-provider-multi-block = { workspace = true, default-features = true }
-pallet-timestamp = { workspace = true, default-features = true }
 frame-election-provider-support = { workspace = true, default-features = true }
-xcm ={ workspace = true, default-features = true }
-sp-tracing = { workspace = true, default-features = true }
-# we skip nompools, fast-unstake, and other misc staking pallets as they are not important in this case.
 
 # pallets we need in the RC
 pallet-session = { workspace = true, default-features = true }
 pallet-staking-ah-client = { workspace = true, default-features = true }
+pallet-timestamp = { workspace = true, default-features = true }
 polkadot-runtime-parachains = { workspace = true, default-features = true }
 
 [features]

--- a/substrate/frame/staking/ahm-test/Cargo.toml
+++ b/substrate/frame/staking/ahm-test/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "pallet-ahm-test"
+version = "1.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "e2e unit tests for staking in AHM"
+publish = false
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dev-dependencies]
+codec = { features = ["derive"], workspace = true, default-features = true }
+log = { workspace = true }
+scale-info = { features = ["derive"], workspace = true, default-features = true }
+frame = { package = "polkadot-sdk-frame", workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+
+# pallets we need in both
+pallet-balances = { workspace = true, default-features = true }
+
+# pallets that we need in AH
+pallet-staking ={ workspace = true, default-features = true }
+pallet-staking-rc-client ={ workspace = true, default-features = true }
+pallet-election-provider-multi-block = { workspace = true, default-features = true }
+pallet-timestamp = { workspace = true, default-features = true }
+frame-election-provider-support = { workspace = true, default-features = true }
+xcm ={ workspace = true, default-features = true }
+sp-tracing = { workspace = true, default-features = true }
+# we skip nompools, fast-unstake, and other misc staking pallets as they are not important in this case.
+
+# pallets we need in the RC
+pallet-session = { workspace = true, default-features = true }
+pallet-staking-ah-client = { workspace = true, default-features = true }
+polkadot-runtime-parachains = { workspace = true, default-features = true }
+
+[features]
+std = []
+try-runtime = [
+	"pallet-balances/try-runtime",
+
+	"pallet-staking/try-runtime",
+	"pallet-staking-rc-client/try-runtime",
+
+	"pallet-session/try-runtime",
+	"pallet-staking-ah-client/try-runtime",
+]

--- a/substrate/frame/staking/ahm-test/src/ah/mock.rs
+++ b/substrate/frame/staking/ahm-test/src/ah/mock.rs
@@ -1,0 +1,342 @@
+use std::ops::Mul;
+
+use crate::shared::acc;
+use frame::{testing_prelude::*, traits::Extrinsic as _};
+use frame_election_provider_support::SequentialPhragmen;
+use frame_support::sp_runtime::testing::TestXt;
+use pallet_election_provider_multi_block as multi_block;
+
+construct_runtime! {
+	pub enum Runtime {
+		System: frame_system,
+		Balances: pallet_balances,
+		Timestamp: pallet_timestamp,
+
+		Staking: pallet_staking,
+		RcClient: pallet_staking_rc_client,
+
+		MultiBlock: multi_block,
+		MultiBlockVerifier: multi_block::verifier,
+		MultiBlockSigned: multi_block::signed,
+		MultiBlockUnsigned: multi_block::unsigned,
+	}
+}
+
+pub fn roll_next() {
+	let now = System::block_number();
+	let next = now + 1;
+
+	System::set_block_number(next);
+
+	Staking::on_initialize(next);
+	RcClient::on_initialize(next);
+	MultiBlock::on_initialize(next);
+	MultiBlockVerifier::on_initialize(next);
+	MultiBlockSigned::on_initialize(next);
+	MultiBlockUnsigned::on_initialize(next);
+
+	// we assume this block is empty, no operations happen.
+
+	// staking is the only pallet that has on-finalize.
+	Staking::on_finalize(now);
+}
+
+pub type AccountId = <Runtime as frame_system::Config>::AccountId;
+pub type Balance = <Runtime as pallet_balances::Config>::Balance;
+pub type Hash = <Runtime as frame_system::Config>::Hash;
+pub type BlockNumber = BlockNumberFor<Runtime>;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Runtime {
+	type Block = MockBlock<Self>;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type AccountId = frame::runtime::types_common::AccountId;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Runtime {
+	type AccountStore = System;
+}
+
+frame_election_provider_support::generate_solution_type!(
+	pub struct TestNposSolution::<
+		VoterIndex = u16,
+		TargetIndex = u16,
+		Accuracy = PerU16,
+		MaxVoters = ConstU32::<1000>
+	>(16)
+);
+
+type Extrinsic = TestXt<RuntimeCall, ()>;
+impl<LocalCall> frame_system::offchain::CreateTransactionBase<LocalCall> for Runtime
+where
+	RuntimeCall: From<LocalCall>,
+{
+	type RuntimeCall = RuntimeCall;
+	type Extrinsic = Extrinsic;
+}
+
+impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Runtime
+where
+	RuntimeCall: From<LocalCall>,
+{
+	fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
+		Extrinsic::new_bare(call)
+	}
+}
+
+type MaxVotesPerVoter = pallet_staking::MaxNominationsOf<Runtime>;
+parameter_types! {
+	pub static MaxValidators: u32 = 32;
+	pub static MaxBackersPerWinner: u32 = 16;
+	pub static MaxExposurePageSize: u32 = 8;
+	pub static MaxBackersPerWinnerFinal: u32 = 16;
+	pub static MaxWinnersPerPage: u32 = 16;
+	pub static MaxLength: u32 = 4 * 1024 * 1024;
+	pub static Pages: u32 = 3;
+	pub static TargetSnapshotPerBlock: u32 = 4;
+	pub static VoterSnapshotPerBlock: u32 = 4;
+
+	pub static SignedPhase: BlockNumber = 4;
+	pub static UnsignedPhase: BlockNumber = 4;
+	pub static SignedValidationPhase: BlockNumber = (2 * Pages::get() as BlockNumber);
+}
+
+impl multi_block::unsigned::miner::MinerConfig for Runtime {
+	type AccountId = AccountId;
+	type Hash = Hash;
+	type MaxBackersPerWinner = MaxBackersPerWinner;
+	type MaxWinnersPerPage = MaxWinnersPerPage;
+	type MaxBackersPerWinnerFinal = MaxBackersPerWinnerFinal;
+	type MaxVotesPerVoter = MaxVotesPerVoter;
+	type Solution = TestNposSolution;
+	type MaxLength = MaxLength;
+	type Pages = Pages;
+	type Solver = SequentialPhragmen<AccountId, Perbill>;
+	type TargetSnapshotPerBlock = TargetSnapshotPerBlock;
+	type VoterSnapshotPerBlock = VoterSnapshotPerBlock;
+}
+
+impl multi_block::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+
+	type AdminOrigin = EnsureRoot<AccountId>;
+	type DataProvider = Staking;
+	type Fallback = multi_block::Continue<Self>;
+	type MinerConfig = Self;
+
+	type Pages = Pages;
+	type SignedPhase = SignedPhase;
+	type UnsignedPhase = UnsignedPhase;
+	type SignedValidationPhase = SignedValidationPhase;
+	type TargetSnapshotPerBlock = TargetSnapshotPerBlock;
+	type VoterSnapshotPerBlock = VoterSnapshotPerBlock;
+	type Verifier = MultiBlockVerifier;
+	type WeightInfo = multi_block::weights::AllZeroWeights;
+}
+
+impl multi_block::verifier::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+
+	type MaxBackersPerWinner = MaxBackersPerWinner;
+	type MaxBackersPerWinnerFinal = MaxBackersPerWinnerFinal;
+	type MaxWinnersPerPage = MaxWinnersPerPage;
+
+	type SolutionDataProvider = MultiBlockSigned;
+	type SolutionImprovementThreshold = ();
+	type WeightInfo = multi_block::weights::AllZeroWeights;
+}
+
+impl multi_block::unsigned::Config for Runtime {
+	type WeightInfo = multi_block::weights::AllZeroWeights;
+	type MinerTxPriority = ConstU64<{ u64::MAX }>;
+	type OffchainRepeat = ();
+	type OffchainSolver = SequentialPhragmen<AccountId, Perbill>;
+}
+
+parameter_types! {
+	pub static DepositBase: Balance = 1;
+	pub static DepositPerPage: Balance = 1;
+	pub static EstimateCallFee: Balance = 1;
+	pub static MaxSubmissions: u32 = 2;
+	pub static RewardBase: Balance = 5;
+}
+
+impl multi_block::signed::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
+
+	type Currency = Balances;
+
+	type BailoutGraceRatio = ();
+	type DepositBase = DepositBase;
+	type DepositPerPage = DepositPerPage;
+	type EstimateCallFee = EstimateCallFee;
+	type MaxSubmissions = MaxSubmissions;
+	type RewardBase = RewardBase;
+	type WeightInfo = multi_block::weights::AllZeroWeights;
+}
+
+parameter_types! {
+	pub static BondingDuration: u32 = 3;
+	pub static SlashDeferredDuration: u32 = 2;
+	pub static SessionsPerEra: u32 = 3;
+}
+
+impl pallet_staking::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = RuntimeHoldReason;
+
+	type AdminOrigin = EnsureRoot<AccountId>;
+	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
+	type BondingDuration = BondingDuration;
+	type SessionsPerEra = SessionsPerEra;
+
+	type Currency = Balances;
+	type OldCurrency = Balances;
+	type CurrencyBalance = Balance;
+	type CurrencyToVote = ();
+
+	type ElectionProvider = MultiBlock;
+	type GenesisElectionProvider = Self::ElectionProvider;
+
+	type EraPayout = ();
+	type EventListeners = ();
+	type Reward = ();
+	type RewardRemainder = ();
+	type Slash = ();
+	type SlashDeferDuration = SlashDeferredDuration;
+	type UnixTime = Timestamp;
+
+	type HistoryDepth = ConstU32<7>;
+	type MaxControllersInDeprecationBatch = ();
+
+	type MaxDisabledValidators = MaxValidators;
+	type MaxValidatorSet = MaxValidators;
+	type MaxExposurePageSize = MaxExposurePageSize;
+	type MaxInvulnerables = MaxValidators;
+	type MaxUnlockingChunks = ConstU32<16>;
+	type NominationsQuota = pallet_staking::FixedNominationsQuota<16>;
+
+	type VoterList = pallet_staking::UseNominatorsAndValidatorsMap<Self>;
+	type TargetList = pallet_staking::UseValidatorsMap<Self>;
+
+	// TODO
+	type NextNewSession = ();
+	// TODO
+	type SessionInterface = ();
+
+	type WeightInfo = ();
+}
+
+impl pallet_staking_rc_client::Config for Runtime {
+	type AdminOrigin = EnsureRoot<AccountId>;
+	type StakingApi = Staking;
+	type ValidatorId = AccountId;
+	type SendXcm = AhMockXCM;
+}
+
+parameter_types! {
+	pub static XcmQueue: Vec<xcm::v5::Xcm<()>> = Default::default();
+}
+
+pub struct AhMockXCM;
+impl xcm::v5::SendXcm for AhMockXCM {
+	type Ticket = xcm::v5::Xcm<()>;
+
+	fn deliver(
+		ticket: Self::Ticket,
+	) -> std::result::Result<xcm::prelude::XcmHash, xcm::prelude::SendError> {
+		let mut queue = XcmQueue::get();
+		queue.push(ticket.clone());
+		XcmQueue::set(queue);
+		Ok(ticket.using_encoded(frame::hashing::blake2_256))
+	}
+
+	fn validate(
+		destination: &mut Option<xcm::prelude::Location>,
+		message: &mut Option<xcm::prelude::Xcm<()>>,
+	) -> xcm::prelude::SendResult<Self::Ticket> {
+		let message = message.take().unwrap();
+
+		// TODO: check destination to be RC.
+		let destination = destination.take().unwrap();
+		let assets = Default::default();
+
+		Ok((message, assets))
+	}
+}
+
+impl pallet_timestamp::Config for Runtime {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = ConstU64<3>;
+	type WeightInfo = ();
+}
+
+parameter_types! {}
+
+const INITIAL_BALANCE: Balance = 1000;
+const INITIAL_STAKE: Balance = 100;
+
+pub struct ExtBuilder {}
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self {}
+	}
+}
+
+impl ExtBuilder {
+	pub fn build(self) -> TestState {
+		let _ = sp_tracing::try_init_simple();
+		let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+
+		let validators = vec![1, 2, 3, 4, 5, 6, 7, 8]
+			.into_iter()
+			.map(|x| (acc(x), acc(x), INITIAL_STAKE, pallet_staking::StakerStatus::Validator));
+
+		let nominators = vec![
+			(100, vec![1, 2]),
+			(101, vec![2, 5]),
+			(102, vec![1, 1]),
+			(103, vec![3, 3]),
+			(104, vec![1, 5]),
+			(105, vec![5, 4]),
+			(106, vec![6, 2]),
+			(107, vec![1, 6]),
+			(108, vec![2, 7]),
+			(109, vec![4, 8]),
+			(110, vec![5, 2]),
+			(111, vec![6, 6]),
+			(112, vec![8, 1]),
+		]
+		.into_iter()
+		.map(|(x, y)| {
+			let y = y.into_iter().map(|x| acc(x)).collect::<Vec<_>>();
+			(acc(x), acc(x), INITIAL_STAKE, pallet_staking::StakerStatus::Nominator(y))
+		});
+
+		let stakers = validators.chain(nominators).collect::<Vec<_>>();
+		let balances = stakers
+			.clone()
+			.into_iter()
+			.map(|(x, _, _, _)| (x, INITIAL_BALANCE))
+			.collect::<Vec<_>>();
+
+		pallet_balances::GenesisConfig::<Runtime> { balances, ..Default::default() }
+			.assimilate_storage(&mut t)
+			.unwrap();
+		pallet_staking::GenesisConfig::<Runtime> {
+			stakers,
+			validator_count: 4,
+			minimum_validator_count: 2,
+			..Default::default()
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		t.into()
+	}
+}

--- a/substrate/frame/staking/ahm-test/src/ah/mod.rs
+++ b/substrate/frame/staking/ahm-test/src/ah/mod.rs
@@ -1,0 +1,5 @@
+pub mod test;
+pub mod mock;
+
+// re-export for easier use in dual runtime tests.
+pub use mock::*;

--- a/substrate/frame/staking/ahm-test/src/ah/test.rs
+++ b/substrate/frame/staking/ahm-test/src/ah/test.rs
@@ -1,0 +1,6 @@
+use crate::ah::mock::*;
+
+// Tests that are specific to ah.
+
+#[test]
+fn foo() {}

--- a/substrate/frame/staking/ahm-test/src/lib.rs
+++ b/substrate/frame/staking/ahm-test/src/lib.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+pub mod ah;
+#[cfg(test)]
+pub mod rc;
+#[cfg(test)]
+pub mod shared;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame::deps::frame_system;
+	use xcm::v5::*;
+	use codec::Decode;
+	// shared tests.
+
+	#[test]
+	fn rc_session_change_reported_to_ah() {
+		let mut rc = rc::ExtBuilder::default().build();
+		let mut ah = ah::ExtBuilder::default().build();
+
+		// ah-client reports session change to ah
+		rc.execute_with(|| {
+			// when
+			assert!(frame_system::Pallet::<rc::Runtime>::block_number() == 0);
+			assert!(rc::XcmQueue::get().is_empty());
+
+			// given
+			rc::roll_until_matches(|| pallet_session::CurrentIndex::<rc::Runtime>::get() == 1);
+
+			// then
+			assert_eq!(frame_system::Pallet::<rc::Runtime>::block_number(), 10);
+			// end session 0, start session 1.
+			assert_eq!(rc::XcmQueue::get().len(), 2);
+		});
+
+		// enacted the queued XCM message on ah.
+		ah.execute_with(|| {
+			rc::XcmQueue::get().into_iter().for_each(|instructions| {
+				instructions.into_iter().for_each(|instruction| {
+					if let Instruction::Transact { origin_kind, fallback_max_weight, call } =
+						instruction
+					{
+						let () = call;
+						// This should be decode-able as a AH call.
+						let call = ah::RuntimeCall::decode_all(&mut &call[..]).unwrap();
+					} else {
+						// nada.
+					}
+				})
+			})
+		})
+
+		// rc-client reports session change to staking
+		// staking progresses era accordingly
+		// staking calls `ElectionProvider::start` accordingly.
+	}
+
+	#[test]
+	fn election_result_on_ah_reported_to_rc() {
+		// when election result is complete
+		// staking stores all exposures
+		// validators reported to rc
+		// validators enacted for next session
+	}
+
+	#[test]
+	fn rc_continues_with_same_validators_if_ah_is_late() {
+		// A test where ah is late to give us election result.
+	}
+
+	#[test]
+	fn authoring_points_reported_to_ah_per_session() {}
+
+	#[test]
+	fn rc_is_late_to_report_session_change() {}
+}

--- a/substrate/frame/staking/ahm-test/src/rc/mock.rs
+++ b/substrate/frame/staking/ahm-test/src/rc/mock.rs
@@ -1,0 +1,186 @@
+use frame::testing_prelude::*;
+use frame::deps::sp_runtime::testing::UintAuthorityId;
+use pallet_staking::NullIdentity;
+
+construct_runtime! {
+	pub enum Runtime {
+		System: frame_system,
+		Balances: pallet_balances,
+		ParasOrigin: polkadot_runtime_parachains::origin,
+
+		Session: pallet_session,
+		SessionHistorical: pallet_session::historical,
+		StakingAhClient: pallet_staking_ah_client,
+	}
+}
+
+pub fn roll_next() {
+	let now = System::block_number();
+	let next = now + 1;
+
+	System::set_block_number(next);
+
+	Session::on_initialize(next);
+	StakingAhClient::on_initialize(next);
+}
+
+pub fn roll_until_matches(criteria: impl Fn() -> bool) {
+	while !criteria() {
+		roll_next();
+	}
+}
+
+pub type AccountId = <Runtime as frame_system::Config>::AccountId;
+pub type Balance = <Runtime as pallet_balances::Config>::Balance;
+pub type Hash = <Runtime as frame_system::Config>::Hash;
+pub type BlockNumber = BlockNumberFor<Runtime>;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Runtime {
+	type Block = MockBlock<Self>;
+	type AccountData = pallet_balances::AccountData<u64>;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type AccountId = frame::runtime::types_common::AccountId;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Runtime {
+	type AccountStore = System;
+}
+
+pub struct ValidatorIdOf;
+impl Convert<AccountId, Option<AccountId>> for ValidatorIdOf {
+	fn convert(a: AccountId) -> Option<AccountId> {
+		Some(a)
+	}
+}
+
+pub struct OtherSessionHandler;
+impl OneSessionHandler<AccountId> for OtherSessionHandler {
+	type Key = UintAuthorityId;
+
+	fn on_genesis_session<'a, I: 'a>(_: I)
+	where
+		I: Iterator<Item = (&'a AccountId, Self::Key)>,
+		AccountId: 'a,
+	{
+	}
+
+	fn on_new_session<'a, I: 'a>(_: bool, _: I, _: I)
+	where
+		I: Iterator<Item = (&'a AccountId, Self::Key)>,
+		AccountId: 'a,
+	{
+	}
+
+	fn on_disabled(_validator_index: u32) {}
+}
+
+impl BoundToRuntimeAppPublic for OtherSessionHandler {
+	type Public = UintAuthorityId;
+}
+
+frame::deps::sp_runtime::impl_opaque_keys! {
+	pub struct SessionKeys {
+		pub other: OtherSessionHandler,
+	}
+}
+
+parameter_types! {
+	pub static Period: BlockNumber = 10;
+	pub static Offset: BlockNumber = 0;
+}
+
+// TODO: tsvetimor/ankan to check this
+pub struct FullIdentificationOf;
+impl Convert<AccountId, Option<()>> for FullIdentificationOf {
+	fn convert(_: AccountId) -> Option<()> {
+		Some(Default::default())
+	}
+}
+
+impl pallet_session::historical::Config for Runtime {
+	type FullIdentification = ();
+	type FullIdentificationOf = FullIdentificationOf;
+}
+
+impl pallet_session::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+
+	type ValidatorIdOf = ValidatorIdOf;
+	type ValidatorId = AccountId;
+
+	type DisablingStrategy = ();
+
+	type Keys = SessionKeys;
+	type SessionHandler = <SessionKeys as frame::traits::OpaqueKeys>::KeyTypeIdProviders;
+
+	type NextSessionRotation = Self::ShouldEndSession;
+	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+
+	// Should be AH-client
+	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Self, StakingAhClient>;
+
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub static AssetHubId: u32 = 42;
+}
+
+parameter_types! {
+	pub static XcmQueue: Vec<xcm::v5::Xcm<()>> = Default::default();
+}
+
+pub struct RcMockXCM;
+impl xcm::v5::SendXcm for RcMockXCM {
+	type Ticket = xcm::v5::Xcm<RuntimeCall>;
+
+	fn deliver(
+		ticket: Self::Ticket,
+	) -> std::result::Result<xcm::prelude::XcmHash, xcm::prelude::SendError> {
+		let mut queue = XcmQueue::get();
+		queue.push(ticket.clone());
+		XcmQueue::set(queue);
+		Ok(ticket.using_encoded(frame::hashing::blake2_256))
+	}
+
+	fn validate(
+		destination: &mut Option<xcm::prelude::Location>,
+		message: &mut Option<Self::Ticket>,
+	) -> xcm::prelude::SendResult<Self::Ticket> {
+		let message = message.take().unwrap();
+
+		// TODO: check destination to be RC.
+		let destination = destination.take().unwrap();
+		let assets = Default::default();
+
+		Ok((message, assets))
+	}
+}
+
+// needed because of the `RuntimeOrigin` of `pallet_staking_ah_client`
+impl polkadot_runtime_parachains::origin::Config for Runtime {}
+
+impl pallet_staking_ah_client::Config for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type AssetHubId = AssetHubId;
+	type CurrencyBalance = Balance;
+	type SendXcm = RcMockXCM;
+}
+
+pub struct ExtBuilder;
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self
+	}
+}
+
+impl ExtBuilder {
+	pub fn build(self) -> TestState {
+		let _ = sp_tracing::try_init_simple();
+		let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+		t.into()
+	}
+}

--- a/substrate/frame/staking/ahm-test/src/rc/mod.rs
+++ b/substrate/frame/staking/ahm-test/src/rc/mod.rs
@@ -1,0 +1,5 @@
+pub mod test;
+pub mod mock;
+
+// re-export for easier use in dual runtime tests.
+pub use mock::*;

--- a/substrate/frame/staking/ahm-test/src/rc/test.rs
+++ b/substrate/frame/staking/ahm-test/src/rc/test.rs
@@ -1,0 +1,3 @@
+use crate::rc::mock::*;
+
+// Tests that are specific to RC.

--- a/substrate/frame/staking/ahm-test/src/rc/test.rs
+++ b/substrate/frame/staking/ahm-test/src/rc/test.rs
@@ -1,3 +1,113 @@
 use crate::rc::mock::*;
+use pallet_staking_rc_client::{self as rc_client, SessionReport};
 
 // Tests that are specific to RC.
+#[test]
+fn send_session_report_no_election_comes_in() {
+	ExtBuilder::default().local_queue().build().execute_with(|| {
+		roll_until_matches(|| pallet_session::CurrentIndex::<Runtime>::get() == 10, false);
+		assert_eq!(
+			LocalQueue::get().unwrap(),
+			vec![
+				(
+					30,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 0,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					60,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 1,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					90,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 2,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					120,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 3,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					150,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 4,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					180,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 5,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					210,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 6,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					240,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 7,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					270,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 8,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				),
+				(
+					300,
+					OutgoingMessages::SessionReport(SessionReport {
+						end_index: 9,
+						validator_points: vec![],
+						activation_timestamp: None,
+						leftover: false
+					})
+				)
+			]
+		);
+	})
+}
+
+#[test]
+fn upon_receiving_election_queue_and_activate_next_session() {
+
+}
+
+#[test]
+fn sends_offence_report() {}

--- a/substrate/frame/staking/ahm-test/src/shared.rs
+++ b/substrate/frame/staking/ahm-test/src/shared.rs
@@ -1,8 +1,38 @@
-use std::cell::RefCell;
-use std::rc::Rc;
 use frame::testing_prelude::*;
+use std::{
+	cell::{RefCell, UnsafeCell},
+	rc::Rc,
+};
 
 thread_local! {
-	pub static RC_STATE: Rc<RefCell<TestState>> = Rc::new(RefCell::new(Default::default()));
-	pub static AH_STATE: Rc<RefCell<TestState>> = Rc::new(RefCell::new(Default::default()));
+	pub static RC_STATE: UnsafeCell<TestState> = UnsafeCell::new(Default::default());
+	pub static AH_STATE: UnsafeCell<TestState> = UnsafeCell::new(Default::default());
+}
+
+pub fn put_ah_state(ah: TestState) {
+	AH_STATE.with(|state| unsafe {
+		let ptr = state.get();
+		*ptr = ah;
+	})
+}
+
+pub fn in_ah(f: impl Fn() -> ()) {
+	AH_STATE.with(|state| unsafe {
+		let ptr = state.get();
+		(*ptr).execute_with(f)
+	})
+}
+
+pub fn put_rc_state(rc: TestState) {
+	RC_STATE.with(|state| unsafe {
+		let ptr = state.get();
+		*ptr = rc;
+	})
+}
+
+pub fn in_rc(f: impl Fn() -> ()) {
+	RC_STATE.with(|state| unsafe {
+		let ptr = state.get();
+		(*ptr).execute_with(f)
+	})
 }

--- a/substrate/frame/staking/ahm-test/src/shared.rs
+++ b/substrate/frame/staking/ahm-test/src/shared.rs
@@ -1,0 +1,8 @@
+use crate::ah::mock::AccountId;
+use codec::Decode;
+use frame::traits::TrailingZeroInput;
+
+/// Convert a number to a 32 byte account id.
+pub fn acc(who: u32) -> AccountId {
+	<AccountId as Decode>::decode(&mut TrailingZeroInput::new(who.to_le_bytes().as_ref())).unwrap()
+}

--- a/substrate/frame/staking/ahm-test/src/shared.rs
+++ b/substrate/frame/staking/ahm-test/src/shared.rs
@@ -1,8 +1,8 @@
-use crate::ah::mock::AccountId;
-use codec::Decode;
-use frame::traits::TrailingZeroInput;
+use std::cell::RefCell;
+use std::rc::Rc;
+use frame::testing_prelude::*;
 
-/// Convert a number to a 32 byte account id.
-pub fn acc(who: u32) -> AccountId {
-	<AccountId as Decode>::decode(&mut TrailingZeroInput::new(who.to_le_bytes().as_ref())).unwrap()
+thread_local! {
+	pub static RC_STATE: Rc<RefCell<TestState>> = Rc::new(RefCell::new(Default::default()));
+	pub static AH_STATE: Rc<RefCell<TestState>> = Rc::new(RefCell::new(Default::default()));
 }

--- a/substrate/frame/staking/ahm-test/src/shared.rs
+++ b/substrate/frame/staking/ahm-test/src/shared.rs
@@ -1,8 +1,5 @@
 use frame::testing_prelude::*;
-use std::{
-	cell::{RefCell, UnsafeCell},
-	rc::Rc,
-};
+use std::cell::UnsafeCell;
 
 thread_local! {
 	pub static RC_STATE: UnsafeCell<TestState> = UnsafeCell::new(Default::default());

--- a/substrate/frame/staking/rc-client/Cargo.toml
+++ b/substrate/frame/staking/rc-client/Cargo.toml
@@ -17,7 +17,6 @@ scale-info = { workspace = true, features = ["derive"] }
 sp-core = { workspace = true }
 sp-runtime = { features = ["serde"], workspace = true }
 sp-staking = { features = ["serde"], workspace = true }
-xcm = { workspace = true }
 
 [features]
 default = ["std"]
@@ -30,14 +29,12 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-staking/std",
-	"xcm/std",
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
-	"xcm/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/substrate/frame/staking/rc-client/src/lib.rs
+++ b/substrate/frame/staking/rc-client/src/lib.rs
@@ -35,6 +35,22 @@ use xcm::prelude::*;
 
 const LOG_TARGET: &str = "runtime::staking::rc-client";
 
+/// An interface for our communication with AssetHub.
+///
+/// This trait should only encapsulate our _outgoing_ communication with AH. Any incoming
+/// communication comes it directly via our calls.
+///
+/// In a real runtime, this is implemented via XCM calls, much like how the coretime pallet works. In a test runtime, it can be wired to direct function call.
+pub trait AssetHubInterface {
+	/// A new session has started in the relay chain, report it to AH.
+	///
+	/// Start of session `x` always implies the end of session `x-1`, and planning of session `x+1`.
+	fn on_relay_chain_session_start(start_index: SessionIndex);
+
+	/// A new offence has happened on the relay chain, report it to AH.
+	fn on_new_offences(session: SessionIndex, offences: Vec<Offence>);
+}
+
 // Provides to the pallet a validator set produced by an election or other similar mechanism.
 pub trait ElectionResultHandler<ValidatorId> {
 	fn handle_election_result(result: Vec<ValidatorId>);

--- a/substrate/frame/staking/rc-client/src/lib.rs
+++ b/substrate/frame/staking/rc-client/src/lib.rs
@@ -15,111 +15,268 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This pallet is intended to be used on AssetHub. It provides extrinsics used by
-//! `pallet-staking-ah-client` and serves as an interface between the relay chain and the staking
-//! pallet on AssetHub.
+//! The client for the relay chain, intended to be used in AssetHub.
+//!
+//! The counter-part for this pallet is `pallet-staking-ah-client` on the relay chain.
+//!
+//! This documentation is divided into the following sections:
+//!
+//! 1. Incoming messages: the messages that we receive from the relay chian.
+//! 2. Outgoing messages: the messaged that we sent to the relay chain.
+//! 3. Local interfaces: the interfaces that we expose to other pallets in the runtime.
+//!
+//! ## Incoming Messages
+//!
+//! All incoming messages are handled via `Call`. They are all gated to be dispatched only by the
+//! relay chain origin, as per [`Config::RelayChainOrigin`].
+//!
+//! After queuing, they are passed to pallet-staking via [`AHStakingInterface`].
+//!
+//! The calls are:
+//!
+//! * [`Call::relay_session_report`]: A report from the relay chain, indicating the end of a
+//!   session. We allow ourselves to know an implementation detail:
+//!
+//! **The ending of session `x` always implies start of session `x+1` and planning of session
+//! `x+2`.** This allows us to have just one message per session.
+//!
+//! * [`Call::relay_new_offence`]: A report of one or more offences on the relay chain.
+//!
+//! ## Outgoing Messages
+//!
+//! The outgoing messages are expressed in [`SendToRelayChain`].
+//!
+//! ## Local Interfaces
+//!
+//! Within this pallet, we need to talk to the staking pallet in AH. This is done via
+//! [`AHStakingInterface`] trait.
+//!
+//! The staking pallet in AH has no communication with session pallet whatsoever, therefore its
+//! implementation of `SessionManager`, and it associated type `SessionInterface` no longer exists.
+//! Moreover, pallet-staking no longer has a notion of timestamp locally, and only relies in the
+//! timestamp passed in in the `SessionReport`.
+//!
+//! ## Session Change
+//!
+//! Further details of how the session change works follows. These details are important to how
+//! `pallet-staking` should rotate sessions/eras going forward.
+//!
+//! ### Synchronous Model
+//!
+//! Let's first consider the old school model, when staking and session lived in the same runtime.
+//! Assume 3 sessions is one era.
+//!
+//! The session pallet issues the following events:
+//!
+//! end_session / start_session / new_session
+//!
+//! * end 0, start 1, plan 2
+//! * end 1, start 2, plan 3 (new validator set returned)
+//! * end 2, start 3 (new validator set activated), plan 4
+//! * end 3, start 4, plan 5
+//! * end 4, start 5, plan 6 (ah-client to already return validator set)
+//! and so on.
+//!
+//! Staking should then do the following:
+//!
+//! * once a request to plan session 3 comes in, it must return a validator set. This is queued
+//!   internally in the session pallet, and is enacted later.
+//! * at the same time, staking increases its notion of `current_era` to 1. Yet, `active_era` is
+//!   still 0. This is because the validator elected for era 1 are not yet active in the session
+//!   pallet.
+//! * once a request to start session 3 comes in, staking will rotate its `active_era` to also be 1.
+//!
+//! ### Asynchronous Model
+//!
+//! Now, if staking lives in AH and the session pallet lives in the relay chain, how will this look
+//! like?
+//!
+//! Staking knows that by the time the relay-chain session index `3` (and later on `6` and so on) is
+//! _planned_, it must have already returned a validator set via XCM.
+//!
+//! conceptually, staking must:
+//!
+//! - listen to the [`SessionReport`]s coming in, and start a new staking election such that we can
+//!   be sure it is delivered to the RC well before the the message for planning session 3 received.
+//! - Staking should know that, regardless of the timing, these validators correspond to session 3,
+//!   and an upcoming era.
+//! - Staking will keep these pending validators internally within its state.
+//! - Once the message to start session 3 is received, staking will act upon it locally.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
+use alloc::vec::Vec;
+use frame_support::pallet_prelude::*;
+use sp_runtime::Perbill;
+use sp_staking::SessionIndex;
 
 /// Export everything needed for the pallet to be used in the runtime.
 pub use pallet::*;
 
-use alloc::vec::Vec;
-use frame_support::pallet_prelude::*;
-use sp_core::crypto::AccountId32;
-use sp_runtime::Perbill;
-use sp_staking::SessionIndex;
-use xcm::prelude::*;
-
 const LOG_TARGET: &str = "runtime::staking::rc-client";
 
-/// An interface for our communication with AssetHub.
+// syntactic sugar for logging.
+#[macro_export]
+macro_rules! log {
+	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
+		log::$level!(
+			target: crate::LOG_TARGET,
+			concat!("[{:?}] ⬇️ ", $patter), <frame_system::Pallet<T>>::block_number() $(, $values)*
+		)
+	};
+}
+
+/// The communication trait of `pallet-staking-rc-client` -> `relay-chain`.
 ///
-/// This trait should only encapsulate our _outgoing_ communication with AH. Any incoming
+/// This trait should only encapsulate our _outgoing_ communication to the RC. Any incoming
 /// communication comes it directly via our calls.
 ///
-/// In a real runtime, this is implemented via XCM calls, much like how the coretime pallet works. In a test runtime, it can be wired to direct function call.
-pub trait AssetHubInterface {
-	/// A new session has started in the relay chain, report it to AH.
+/// In a real runtime, this is implemented via XCM calls, much like how the coretime pallet works.
+/// In a test runtime, it can be wired to direct function call.
+pub trait SendToRelayChain {
+	/// The validator account ids.
+	type AccountId;
+
+	/// Send a new validator set report to relay chain.
+	fn validator_set(report: ValidatorSetReport<Self::AccountId>);
+}
+
+#[derive(Encode, Decode, DecodeWithMemTracking, Debug, Clone, PartialEq, TypeInfo)]
+/// A report about a new validator set. This is sent from AH -> RC.
+pub struct ValidatorSetReport<AccountId> {
+	/// The new validator set.
+	pub new_validator_set: Vec<AccountId>,
+	/// The id of this validator set.
 	///
-	/// Start of session `x` always implies the end of session `x-1`, and planning of session `x+1`.
-	fn on_relay_chain_session_start(start_index: SessionIndex);
-
-	/// A new offence has happened on the relay chain, report it to AH.
-	fn on_new_offences(session: SessionIndex, offences: Vec<Offence>);
+	/// Is an always incrementing identifier for this validator set, the activation of which can be
+	/// later pointed to in a `SessionReport`.
+	pub id: u32,
+	/// Signal the relay chain that it can prune up to this session, ans enough eras have passed.
+	pub prune_up_to: SessionIndex,
+	/// Same semantics as [`SessionReport::leftover`].
+	pub leftover: bool,
 }
 
-// Provides to the pallet a validator set produced by an election or other similar mechanism.
-pub trait ElectionResultHandler<ValidatorId> {
-	fn handle_election_result(result: Vec<ValidatorId>);
-}
+impl<AccountId> ValidatorSetReport<AccountId> {
+	/// A new instance of self that is terminal. This is useful when we want to send everything in
+	/// one go.
+	pub fn new_terminal(
+		new_validator_set: Vec<AccountId>,
+		id: u32,
+		prune_up_to: SessionIndex,
+	) -> Self {
+		Self { new_validator_set, id, prune_up_to, leftover: false }
+	}
 
-// API provided by the staking pallet.
-pub trait StakingApi {
-	/// New session with index `start_index` has started on the relay chain.
-	fn on_relay_chain_session_start(start_index: SessionIndex);
-	/// A session with index `end_index` has ended on the relay chain. The block authors and their
-	/// corresponding session points are reported.
-	fn on_relay_chain_session_end(end_index: SessionIndex, block_authors: Vec<(AccountId32, u32)>);
-	/// Report one or more offences on the relay chain.
-	fn on_new_offences(slash_session: SessionIndex, offences: Vec<Offence>) -> Weight;
-	/// Report validator rewards.
-	fn reward_by_ids(validators_points: Vec<(AccountId32, u32)>);
-}
-
-// TODO: update the comment
-/// Means for interacting with a specialized version of the `session` trait.
-///
-/// This is needed because `Staking` sets the `ValidatorIdOf` of the `pallet_session::Config`
-pub trait SessionInterface<AccountId> {
-	/// Get the validators from session.
-	fn validators() -> Vec<AccountId>;
-}
-
-impl<AccountId> SessionInterface<AccountId> for () {
-	fn validators() -> Vec<AccountId> {
-		Vec::new()
+	/// Merge oneself with another instance.
+	pub fn merge(mut self, other: Self) -> Result<Self, ()> {
+		if self.id != other.id || self.prune_up_to != other.prune_up_to {
+			// Must be some bug -- don't merge.
+			return Err(());
+		}
+		self.new_validator_set.extend(other.new_validator_set);
+		self.leftover = other.leftover;
+		Ok(self)
 	}
 }
 
-/// `pallet-staking-ah-client` pallet index on Relay chain. Used to construct remote calls.
-///
-/// The codec index must correspond to the index of `pallet-staking-ah-client` in the
-/// `construct_runtime` of the Relay chain.
-#[derive(Encode, Decode)]
-enum RelayChainRuntimePallets {
-	#[codec(index = 50)]
-	AhClient(SessionCalls),
+#[derive(
+	Encode, Decode, DecodeWithMemTracking, Debug, Clone, PartialEq, TypeInfo, MaxEncodedLen,
+)]
+/// The information that is sent from RC -> AH on session end.
+pub struct SessionReport<AccountId> {
+	/// The session that is ending.
+	///
+	/// This always implies start of `end_index + 1`, and planning of `end_index + 2`.
+	pub end_index: SessionIndex,
+	/// All of the points that validators have accumulated.
+	///
+	/// This can be either from block authoring, or from parachain consensus, or anything else.
+	pub validator_points: Vec<(AccountId, u32)>,
+	/// If none, it means no new validator set was activated as a part of this session.
+	///
+	/// If `Some((timestamp, id))`, it means that the new validator set was activated at the given
+	/// timestamp, and the id of the validator set is `id`.
+	pub activation_timestamp: Option<(u64, u32)>,
+	/// If this session report is self-contained, then it is false.
+	///
+	/// If this session report has some leftover, it should not be acted upon until a subsequent
+	/// message with `leftover = true` comes in. The client pallets should handle this queuing.
+	///
+	/// This is in place to future proof us against possibly needing to send multiple rounds of
+	/// messages to convey all of the `validator_points`.
+	///
+	/// Upon processing, this should always be true, and it should be ignored.
+	pub leftover: bool,
 }
 
-/// Call encoding for the calls needed from the pallet.
-#[derive(Encode, Decode)]
-enum SessionCalls {
-	#[codec(index = 0)]
-	NewValidatorSet(Vec<AccountId32>),
+impl<AccountId> SessionReport<AccountId> {
+	/// A new instance of self that is terminal. This is useful when we want to send everything in
+	/// one go.
+	pub fn new_terminal(
+		end_index: SessionIndex,
+		validator_points: Vec<(AccountId, u32)>,
+		activation_timestamp: Option<(u64, u32)>,
+	) -> Self {
+		Self { end_index, validator_points, activation_timestamp, leftover: false }
+	}
+
+	/// Merge oneself with another instance.
+	pub fn merge(mut self, other: Self) -> Result<Self, ()> {
+		if self.end_index != other.end_index ||
+			self.activation_timestamp != other.activation_timestamp
+		{
+			// Must be some bug -- don't merge.
+			return Err(());
+		}
+		self.validator_points.extend(other.validator_points);
+		self.leftover = other.leftover;
+		Ok(self)
+	}
+}
+
+/// Our communication trait of `pallet-staking-rc-client` -> `pallet-staking`.
+///
+/// This is merely a shorthand to avoid tightly-coupling the staking pallet to this pallet. It
+/// limits what we can say to `pallet-staking` to only these functions.
+pub trait AHStakingInterface {
+	/// The validator account id type.
+	type AccountId;
+
+	/// New session report from the relay chain.
+	fn on_relay_session_report(report: SessionReport<Self::AccountId>);
+
+	/// Report one or more offences on the relay chain.
+	///
+	/// This returns its consumed weight because its complexity is hard to measure.
+	fn on_new_offences(
+		slash_session: SessionIndex,
+		offences: Vec<Offence<Self::AccountId>>,
+	) -> Weight;
+}
+
+/// The communication trait of `pallet-staking` -> `pallet-staking-rc-client`.
+pub trait RcClientInterface {
+	/// The validator account ids.
+	type AccountId;
+
+	/// Report a new validator set.
+	fn validator_set(new_validator_set: Vec<Self::AccountId>, id: u32, prune_up_tp: u32);
 }
 
 // An offence on the relay chain. Based on [`sp_staking::offence::OffenceDetails`].
 #[derive(Encode, Decode, DecodeWithMemTracking, Debug, Clone, PartialEq, TypeInfo)]
-pub struct Offence {
-	pub offender: AccountId32,
-	pub reporters: Vec<AccountId32>,
+pub struct Offence<AccountId> {
+	/// The offender.
+	pub offender: AccountId,
+	/// Those who have reported this offence.
+	pub reporters: Vec<AccountId>,
+	/// The amount that they should be slashed.
 	pub slash_fraction: Perbill,
 }
 
-impl Offence {
-	pub fn new(
-		offender: AccountId32,
-		reporters: Vec<AccountId32>,
-		slash_fraction: Perbill,
-	) -> Self {
-		Self { offender, reporters, slash_fraction }
-	}
-}
-
-#[frame_support::pallet(dev_mode)]
+#[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use alloc::vec;
@@ -128,41 +285,37 @@ pub mod pallet {
 	/// The in-code storage version.
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
+	/// An incomplete incoming session report that we have not acted upon yet.
+	#[pallet::storage]
+	#[pallet::unbounded] // TODO: use a max validator set size bound
+	pub type IncompleteSessionReport<T: Config> =
+		StorageValue<_, SessionReport<T::AccountId>, OptionQuery>;
+
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
-		type AdminOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-		/// A stable ID for a validator.
-		type ValidatorId: Member
-			+ Parameter
-			+ MaybeSerializeDeserialize
-			+ MaxEncodedLen
-			+ TryFrom<Self::AccountId>;
+		/// An origin type that allows us to be sure a call is being dispatched by the relay chain.
+		///
+		/// It be can be configured to something like `Root` or relay chain or similar.
+		type RelayChainOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
-		/// Handler for staking calls
-		type StakingApi: StakingApi;
-		/// The XCM sender.
-		type SendXcm: SendXcm;
+		/// Our communication handle to the local staking pallet.
+		type AHStakingInterface: AHStakingInterface<AccountId = Self::AccountId>;
+
+		/// Our communication handle to the relay chain.
+		type SendToRelayChain: SendToRelayChain<AccountId = Self::AccountId>;
 	}
 
-	impl<T: Config, ValidatorId: Into<AccountId32>> ElectionResultHandler<ValidatorId> for Pallet<T> {
-		fn handle_election_result(result: Vec<ValidatorId>) {
-			let new_validator_set = result.into_iter().map(Into::into).collect::<Vec<_>>();
+	impl<T: Config> RcClientInterface for Pallet<T> {
+		type AccountId = T::AccountId;
 
-			let message = Xcm(vec![
-				Instruction::UnpaidExecution {
-					weight_limit: WeightLimit::Unlimited,
-					check_origin: None,
-				},
-				mk_relay_chain_call(SessionCalls::NewValidatorSet(new_validator_set)),
-			]);
-
-			if let Err(err) = send_xcm::<T::SendXcm>(Location::new(1, Here), message) {
-				log::error!(target: LOG_TARGET, "Sending `NewValidatorSet` to relay chain failed: {:?}", err);
-			}
+		fn validator_set(new_validator_set: Vec<Self::AccountId>, id: u32, prune_up_tp: u32) {
+			// TODO: possibly chunk this up if needed, else send it one one go for now.
+			let report = ValidatorSetReport::new_terminal(new_validator_set, id, prune_up_tp);
+			T::SendToRelayChain::validator_set(report);
 		}
 	}
 
@@ -170,67 +323,43 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Called to indicate the start of a new session on the relay chain.
 		#[pallet::call_index(0)]
-		// #[pallet::weight(T::WeightInfo::relay_chain_session_start())] // TODO
-		pub fn relay_chain_session_start(
+		#[pallet::weight(0)]
+		pub fn relay_session_report(
 			origin: OriginFor<T>,
-			start_index: SessionIndex,
+			report: SessionReport<T::AccountId>,
 		) -> DispatchResult {
-			T::AdminOrigin::ensure_origin_or_root(origin)?;
-			T::StakingApi::on_relay_chain_session_start(start_index);
-			Ok(())
-		}
+			log!(info, "Received session report: {:?}", report);
+			T::RelayChainOrigin::ensure_origin_or_root(origin)?;
 
-		/// Called to indicate the end of a session on the relay chain. Accepts the session id and
-		/// the block authors with their corresponding session points for the finished session.
-		#[pallet::call_index(1)]
-		// #[pallet::weight(T::WeightInfo::relay_chain_session_end())] // TODO
-		pub fn relay_chain_session_end(
-			origin: OriginFor<T>,
-			end_index: SessionIndex,
-			block_authors: Vec<(AccountId32, u32)>,
-		) -> DispatchResult {
-			T::AdminOrigin::ensure_origin_or_root(origin)?;
-			T::StakingApi::on_relay_chain_session_end(end_index, block_authors);
+			// If we have anything previously buffered, then merge it.
+			let new_session_report = match IncompleteSessionReport::<T>::take() {
+				Some(old) =>
+					old.merge(report.clone()).map_err(|_| "CouldNotMerge")?,
+				None => report,
+			};
+
+			if new_session_report.leftover {
+				// this is still not final -- buffer it.
+				IncompleteSessionReport::<T>::put(new_session_report);
+			} else {
+				// this is final, report it.
+				T::AHStakingInterface::on_relay_session_report(new_session_report);
+			}
+
 			Ok(())
 		}
 
 		/// Called to report one or more new offenses on the relay chain.
 		#[pallet::call_index(2)]
-		// #[pallet::weight(T::WeightInfo::new_relay_chain_offence())] // TODO
-		pub fn new_relay_chain_offence(
+		#[pallet::weight(0)]
+		pub fn relay_new_offence(
 			origin: OriginFor<T>,
 			slash_session: SessionIndex,
-			offences: Vec<Offence>,
+			offences: Vec<Offence<T::AccountId>>,
 		) -> DispatchResult {
-			T::AdminOrigin::ensure_origin_or_root(origin)?;
-			T::StakingApi::on_new_offences(slash_session, offences);
+			T::RelayChainOrigin::ensure_origin_or_root(origin)?;
+			let weight = T::AHStakingInterface::on_new_offences(slash_session, offences);
 			Ok(())
-		}
-
-		#[pallet::call_index(3)]
-		// #[pallet::weight(T::WeightInfo::end_session())] // TODO
-		pub fn parachain_session_points(
-			origin: OriginFor<T>,
-			session_points: Vec<(AccountId32, u32)>,
-		) -> DispatchResult {
-			T::AdminOrigin::ensure_origin_or_root(origin)?;
-			T::StakingApi::reward_by_ids(session_points);
-			Ok(())
-		}
-	}
-
-	impl<T: Config> SessionInterface<T::AccountId> for Pallet<T> {
-		fn validators() -> Vec<T::AccountId> {
-			// TODO: cache the last applied validator set and return it here
-			vec![]
-		}
-	}
-
-	fn mk_relay_chain_call(call: SessionCalls) -> Instruction<()> {
-		Instruction::Transact {
-			origin_kind: OriginKind::Superuser,
-			fallback_max_weight: None,
-			call: RelayChainRuntimePallets::AhClient(call).encode().into(),
 		}
 	}
 }

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -473,7 +473,7 @@ pub type NegativeImbalanceOf<T> =
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 
 /// Information regarding the active era (era in used in session).
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen, PartialEq, Eq, Clone)]
 pub struct ActiveEraInfo {
 	/// Index of era.
 	pub index: EraIndex,

--- a/substrate/frame/staking/src/mock.rs
+++ b/substrate/frame/staking/src/mock.rs
@@ -139,6 +139,7 @@ sp_runtime::impl_opaque_keys! {
 		pub other: OtherSessionHandler,
 	}
 }
+
 impl pallet_session::Config for Test {
 	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Test, Staking>;
 	type Keys = SessionKeys;

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -17,6 +17,14 @@
 
 //! Implementations for the Staking FRAME Pallet.
 
+use crate::{
+	asset, election_size_tracker::StaticTracker, log, slashing, weights::WeightInfo, ActiveEraInfo,
+	BalanceOf, BoundedExposuresOf, EraInfo, EraPayout, Exposure, Forcing, IndividualExposure,
+	LedgerIntegrityState, MaxNominationsOf, MaxWinnersOf, MaxWinnersPerPageOf, Nominations,
+	NominationsQuota, PositiveImbalanceOf, RewardDestination, SnapshotStatus, StakingLedger,
+	ValidatorPrefs, STAKING_ID,
+};
+use alloc::{boxed::Box, vec, vec::Vec};
 use frame_election_provider_support::{
 	bounds::CountBound, data_provider, BoundedSupportsOf, DataProviderBounds, ElectionDataProvider,
 	ElectionProvider, PageIndex, ScoreProvider, SortedListProvider, VoteWeight, VoterOf,
@@ -27,7 +35,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{
 		Defensive, DefensiveSaturating, EstimateNextNewSession, Get, Imbalance,
-		InspectLockableCurrency, Len, LockableCurrency, OnUnbalanced, TryCollect, UnixTime,
+		InspectLockableCurrency, Len, LockableCurrency, OnUnbalanced, TryCollect,
 	},
 	weights::Weight,
 };
@@ -43,15 +51,6 @@ use sp_staking::{
 	StakingAccount::{self, Controller, Stash},
 	StakingInterface,
 };
-
-use crate::{
-	asset, election_size_tracker::StaticTracker, log, slashing, weights::WeightInfo, ActiveEraInfo,
-	BalanceOf, BoundedExposuresOf, EraInfo, EraPayout, Exposure, Forcing, IndividualExposure,
-	LedgerIntegrityState, MaxNominationsOf, MaxWinnersOf, MaxWinnersPerPageOf, Nominations,
-	NominationsQuota, PositiveImbalanceOf, RewardDestination, SnapshotStatus, StakingLedger,
-	ValidatorPrefs, STAKING_ID,
-};
-use alloc::{boxed::Box, vec, vec::Vec};
 
 use super::pallet::*;
 
@@ -450,169 +449,6 @@ impl<T: Config> Pallet<T> {
 		maybe_imbalance.map(|imbalance| (imbalance, dest))
 	}
 
-	/// Plan a new session potentially trigger a new era.
-	///
-	/// Subsequent function calls in the happy path are as follows:
-	/// 1. `try_plan_new_era`
-	/// 2. `plan_new_era`
-	fn new_session(
-		session_index: SessionIndex,
-		is_genesis: bool,
-	) -> Option<BoundedVec<T::AccountId, MaxWinnersOf<T>>> {
-		if let Some(current_era) = CurrentEra::<T>::get() {
-			// Initial era has been set.
-			let current_era_start_session_index = ErasStartSessionIndex::<T>::get(current_era)
-				.unwrap_or_else(|| {
-					frame_support::print("Error: start_session_index must be set for current_era");
-					0
-				});
-
-			let era_length = session_index.saturating_sub(current_era_start_session_index); // Must never happen.
-
-			match ForceEra::<T>::get() {
-				// Will be set to `NotForcing` again if a new era has been triggered.
-				Forcing::ForceNew => (),
-				// Short circuit to `try_plan_new_era`.
-				Forcing::ForceAlways => (),
-				// Only go to `try_plan_new_era` if deadline reached.
-				Forcing::NotForcing if era_length >= T::SessionsPerEra::get() => (),
-				_ => {
-					// Either `Forcing::ForceNone`,
-					// or `Forcing::NotForcing if era_length >= T::SessionsPerEra::get()`.
-					return None
-				},
-			}
-
-			// New era.
-			let maybe_new_era_validators = Self::try_plan_new_era(session_index, is_genesis);
-			if maybe_new_era_validators.is_some() &&
-				matches!(ForceEra::<T>::get(), Forcing::ForceNew)
-			{
-				Self::set_force_era(Forcing::NotForcing);
-			}
-
-			maybe_new_era_validators
-		} else {
-			// Set initial era.
-			log!(debug, "Starting the first era.");
-			Self::try_plan_new_era(session_index, is_genesis)
-		}
-	}
-
-	/// Start a session potentially starting an era.
-	fn start_session(start_session: SessionIndex) {
-		let next_active_era = ActiveEra::<T>::get().map(|e| e.index + 1).unwrap_or(0);
-		// This is only `Some` when current era has already progressed to the next era, while the
-		// active era is one behind (i.e. in the *last session of the active era*, or *first session
-		// of the new current era*, depending on how you look at it).
-		if let Some(next_active_era_start_session_index) =
-			ErasStartSessionIndex::<T>::get(next_active_era)
-		{
-			if next_active_era_start_session_index == start_session {
-				Self::start_era(start_session);
-			} else if next_active_era_start_session_index < start_session {
-				// This arm should never happen, but better handle it than to stall the staking
-				// pallet.
-				frame_support::print("Warning: A session appears to have been skipped.");
-				Self::start_era(start_session);
-			}
-
-			// trigger election in the last session of the era
-			if start_session + 1 == next_active_era_start_session_index {
-				// TODO: trigger election
-				// Self::trigger_election();
-			}
-		}
-	}
-
-	/// End a session potentially ending an era.
-	fn end_session(session_index: SessionIndex) {
-		if let Some(active_era) = ActiveEra::<T>::get() {
-			if let Some(next_active_era_start_session_index) =
-				ErasStartSessionIndex::<T>::get(active_era.index + 1)
-			{
-				if next_active_era_start_session_index == session_index + 1 {
-					Self::end_era(active_era, session_index);
-				}
-			}
-		}
-	}
-
-	/// Start a new era. It does:
-	/// * Increment `active_era.index`,
-	/// * reset `active_era.start`,
-	/// * update `BondedEras` and apply slashes.
-	fn start_era(start_session: SessionIndex) {
-		let active_era = ActiveEra::<T>::mutate(|active_era| {
-			let new_index = active_era.as_ref().map(|info| info.index + 1).unwrap_or(0);
-			log!(debug, "starting active era {:?}", new_index);
-			*active_era = Some(ActiveEraInfo {
-				index: new_index,
-				// Set new active era start in next `on_finalize`. To guarantee usage of `Time`
-				start: None,
-			});
-			new_index
-		});
-
-		let bonding_duration = T::BondingDuration::get();
-
-		BondedEras::<T>::mutate(|bonded| {
-			bonded.push((active_era, start_session));
-
-			if active_era > bonding_duration {
-				let first_kept = active_era.defensive_saturating_sub(bonding_duration);
-
-				// Prune out everything that's from before the first-kept index.
-				let n_to_prune =
-					bonded.iter().take_while(|&&(era_idx, _)| era_idx < first_kept).count();
-
-				// Kill slashing metadata.
-				for (pruned_era, _) in bonded.drain(..n_to_prune) {
-					slashing::clear_era_metadata::<T>(pruned_era);
-				}
-
-				// TODO: should be handled in ah_client (see the comment there)
-				// if let Some(&(_, first_session)) = bonded.first() {
-				// 	T::SessionInterface::prune_historical_up_to(first_session);
-				// }
-			}
-		});
-	}
-
-	/// Compute payout for era.
-	fn end_era(active_era: ActiveEraInfo, _session_index: SessionIndex) {
-		// Note: active_era_start can be None if end era is called during genesis config.
-		if let Some(active_era_start) = active_era.start {
-			let now_as_millis_u64 = T::UnixTime::now().as_millis().saturated_into::<u64>();
-
-			let era_duration = (now_as_millis_u64.defensive_saturating_sub(active_era_start))
-				.saturated_into::<u64>();
-			let staked = ErasTotalStake::<T>::get(&active_era.index);
-			let issuance = asset::total_issuance::<T>();
-
-			let (validator_payout, remainder) =
-				T::EraPayout::era_payout(staked, issuance, era_duration);
-
-			let total_payout = validator_payout.saturating_add(remainder);
-			let max_staked_rewards =
-				MaxStakedRewards::<T>::get().unwrap_or(Percent::from_percent(100));
-
-			// apply cap to validators payout and add difference to remainder.
-			let validator_payout = validator_payout.min(max_staked_rewards * total_payout);
-			let remainder = total_payout.saturating_sub(validator_payout);
-
-			Self::deposit_event(Event::<T>::EraPaid {
-				era_index: active_era.index,
-				validator_payout,
-				remainder,
-			});
-
-			// Set ending era reward.
-			<ErasValidatorReward<T>>::insert(&active_era.index, validator_payout);
-			T::RewardRemainder::on_unbalanced(asset::issue::<T>(remainder));
-		}
-	}
-
 	/// Helper function provided to other pallets that want to rely on pallet-stkaing for
 	/// testing/benchmarking, and wish to populate `ElectableStashes`, such that a next call (post
 	/// genesis) to `try_plan_new_era` works.
@@ -626,119 +462,6 @@ impl<T: Config> Pallet<T> {
 		})?;
 		Self::do_elect_paged_inner(supports).map_err(|_| "do_elect_paged_inner")?;
 		Ok(())
-	}
-
-	/// Potentially plan a new era.
-	///
-	/// The election results are either fetched directly from an election provider if it is the
-	/// "genesis" election or from a cached set of winners.
-	///
-	/// In case election result has more than [`MinimumValidatorCount`] validator trigger a new era.
-	///
-	/// In case a new era is planned, the new validator set is returned.
-	pub(crate) fn try_plan_new_era(
-		start_session_index: SessionIndex,
-		is_genesis: bool,
-	) -> Option<BoundedVec<T::AccountId, MaxWinnersOf<T>>> {
-		// TODO: weights of this call path are rather crude, improve.
-		let validators: BoundedVec<T::AccountId, MaxWinnersOf<T>> = if is_genesis {
-			// genesis election only uses one election result page.
-			let result = <T::GenesisElectionProvider>::elect(Zero::zero()).map_err(|e| {
-				log!(warn, "genesis election provider failed due to {:?}", e);
-				Self::deposit_event(Event::StakingElectionFailed);
-			});
-
-			let exposures = Self::collect_exposures(result.ok().unwrap_or_default());
-
-			let validators = exposures
-				.iter()
-				.map(|(validator, _)| validator)
-				.cloned()
-				.try_collect()
-				.unwrap_or_default();
-
-			// set stakers info for genesis era (0).
-			let _ = Self::store_stakers_info(exposures, Zero::zero());
-
-			// consume full block weight to be safe.
-			Self::register_weight(sp_runtime::traits::Bounded::max_value());
-			validators
-		} else {
-			// note: exposures have already been processed and stored for each of the election
-			// solution page at the time of `elect_paged(page_index)`.
-			Self::register_weight(T::DbWeight::get().reads(1));
-			ElectableStashes::<T>::take()
-				.into_inner()
-				.into_iter()
-				.collect::<Vec<_>>()
-				.try_into()
-				.expect("same bounds, will fit; qed.")
-		};
-
-		log!(
-			info,
-			"try_plan_new_era: (is_genesis?: {:?}) electable validators count for session starting {:?}, era {:?}: {:?}",
-			is_genesis,
-			start_session_index,
-			CurrentEra::<T>::get().unwrap_or_default() + 1,
-			validators.len()
-		);
-
-		if (validators.len() as u32) < MinimumValidatorCount::<T>::get().max(1) {
-			// Session will panic if we ever return an empty validator set, thus max(1) ^^.
-			match CurrentEra::<T>::get() {
-				Some(current_era) if current_era > 0 => log!(
-					warn,
-					"chain does not have enough staking candidates to operate for era {:?} ({} \
-					elected, minimum is {})",
-					CurrentEra::<T>::get().unwrap_or(0),
-					validators.len(),
-					MinimumValidatorCount::<T>::get(),
-				),
-				None => {
-					// The initial era is allowed to have no exposures.
-					// In this case the SessionManager is expected to choose a sensible validator
-					// set.
-					// TODO: this should be simplified #8911
-					CurrentEra::<T>::put(0);
-					ErasStartSessionIndex::<T>::insert(&0, &start_session_index);
-				},
-				_ => {},
-			}
-			// election failed, clear election prep metadata.
-			Self::deposit_event(Event::StakingElectionFailed);
-			Self::clear_election_metadata();
-
-			None
-		} else {
-			Self::deposit_event(Event::StakersElected);
-			Self::clear_election_metadata();
-			Self::plan_new_era(start_session_index);
-
-			Some(validators)
-		}
-	}
-
-	/// Plan a new era.
-	///
-	/// * Bump the current era storage (which holds the latest planned era).
-	/// * Store start session index for the new planned era.
-	/// * Clean old era information.
-	///
-	/// The new validator set for this era is stored under `ElectableStashes`.
-	pub fn plan_new_era(start_session_index: SessionIndex) {
-		// Increment or set current era.
-		let new_planned_era = CurrentEra::<T>::mutate(|s| {
-			*s = Some(s.map(|s| s + 1).unwrap_or(0));
-			s.unwrap()
-		});
-		ErasStartSessionIndex::<T>::insert(&new_planned_era, &start_session_index);
-
-		// Clean old era information.
-		if let Some(old_era) = new_planned_era.checked_sub(T::HistoryDepth::get() + 1) {
-			log!(trace, "Removing era information for {:?}", old_era);
-			Self::clear_era_information(old_era);
-		}
 	}
 
 	/// Paginated elect.
@@ -1636,15 +1359,244 @@ impl<T: Config> ElectionDataProvider for Pallet<T> {
 
 use pallet_staking_rc_client::{self as rc_client};
 
+impl<T: Config> Pallet<T> {
+	/// Plan a new session potentially trigger a new era.
+	///
+	/// Subsequent function calls in the happy path are as follows:
+	/// 1. `try_plan_new_era`
+	/// 2. `plan_new_era`
+	fn new_session(
+		session_index: SessionIndex,
+		is_genesis: bool,
+	) -> Option<BoundedVec<T::AccountId, MaxWinnersOf<T>>> {
+		if let Some(current_era) = CurrentEra::<T>::get() {
+			// Initial era has been set.
+			let current_era_start_session_index = ErasStartSessionIndex::<T>::get(current_era)
+				.unwrap_or_else(|| {
+					frame_support::print("Error: start_session_index must be set for current_era");
+					0
+				});
+
+			let era_length = session_index.saturating_sub(current_era_start_session_index); // Must never happen.
+
+			match ForceEra::<T>::get() {
+				// Will be set to `NotForcing` again if a new era has been triggered.
+				Forcing::ForceNew => (),
+				// Short circuit to `try_plan_new_era`.
+				Forcing::ForceAlways => (),
+				// Only go to `try_plan_new_era` if deadline reached.
+				Forcing::NotForcing if era_length >= T::SessionsPerEra::get() => (),
+				_ => {
+					// Either `Forcing::ForceNone`,
+					// or `Forcing::NotForcing if era_length >= T::SessionsPerEra::get()`.
+					return None
+				},
+			}
+
+			// New era.
+			let maybe_new_era_validators = Self::try_plan_new_era(session_index, is_genesis);
+			if maybe_new_era_validators.is_some() &&
+				matches!(ForceEra::<T>::get(), Forcing::ForceNew)
+			{
+				Self::set_force_era(Forcing::NotForcing);
+			}
+
+			maybe_new_era_validators
+		} else {
+			// Set initial era.
+			log!(debug, "Starting the first era.");
+			Self::try_plan_new_era(session_index, is_genesis)
+		}
+	}
+
+	/// Start a new era. It does:
+	/// * Increment `active_era.index`,
+	/// * reset `active_era.start`,
+	/// * update `BondedEras` and apply slashes.
+	fn start_era(start_session: SessionIndex, start_timestamp: u64) {
+		let active_era = ActiveEra::<T>::mutate(|active_era| {
+			let new_index = active_era.as_ref().map(|info| info.index + 1).unwrap_or(0);
+			log!(
+				debug,
+				"starting active era {:?} with RC-provided timestamp {:?}",
+				new_index,
+				start_timestamp
+			);
+			*active_era = Some(ActiveEraInfo { index: new_index, start: Some(start_timestamp) });
+			new_index
+		});
+
+		let bonding_duration = T::BondingDuration::get();
+
+		BondedEras::<T>::mutate(|bonded| {
+			bonded.push((active_era, start_session));
+
+			if active_era > bonding_duration {
+				let first_kept = active_era.defensive_saturating_sub(bonding_duration);
+
+				// Prune out everything that's from before the first-kept index.
+				let n_to_prune =
+					bonded.iter().take_while(|&&(era_idx, _)| era_idx < first_kept).count();
+
+				// Kill slashing metadata.
+				for (pruned_era, _) in bonded.drain(..n_to_prune) {
+					slashing::clear_era_metadata::<T>(pruned_era);
+				}
+			}
+		});
+	}
+
+	/// Compute payout for era.
+	fn compute_era_payout(active_era: ActiveEraInfo, era_duration: u64) {
+		let staked = ErasTotalStake::<T>::get(&active_era.index);
+		let issuance = asset::total_issuance::<T>();
+
+		let (validator_payout, remainder) =
+			T::EraPayout::era_payout(staked, issuance, era_duration);
+
+		let total_payout = validator_payout.saturating_add(remainder);
+		let max_staked_rewards = MaxStakedRewards::<T>::get().unwrap_or(Percent::from_percent(100));
+
+		// apply cap to validators payout and add difference to remainder.
+		let validator_payout = validator_payout.min(max_staked_rewards * total_payout);
+		let remainder = total_payout.saturating_sub(validator_payout);
+
+		Self::deposit_event(Event::<T>::EraPaid {
+			era_index: active_era.index,
+			validator_payout,
+			remainder,
+		});
+
+		// Set ending era reward.
+		<ErasValidatorReward<T>>::insert(&active_era.index, validator_payout);
+		T::RewardRemainder::on_unbalanced(asset::issue::<T>(remainder));
+	}
+
+	/// Potentially plan a new era.
+	///
+	/// The election results are either fetched directly from an election provider if it is the
+	/// "genesis" election or from a cached set of winners.
+	///
+	/// In case election result has more than [`MinimumValidatorCount`] validator trigger a new era.
+	///
+	/// In case a new era is planned, the new validator set is returned.
+	pub(crate) fn try_plan_new_era(
+		start_session_index: SessionIndex,
+		is_genesis: bool,
+	) -> Option<BoundedVec<T::AccountId, MaxWinnersOf<T>>> {
+		// TODO: weights of this call path are rather crude, improve.
+		let validators: BoundedVec<T::AccountId, MaxWinnersOf<T>> = if is_genesis {
+			// genesis election only uses one election result page.
+			let result = <T::GenesisElectionProvider>::elect(Zero::zero()).map_err(|e| {
+				log!(warn, "genesis election provider failed due to {:?}", e);
+				Self::deposit_event(Event::StakingElectionFailed);
+			});
+
+			let exposures = Self::collect_exposures(result.ok().unwrap_or_default());
+
+			let validators = exposures
+				.iter()
+				.map(|(validator, _)| validator)
+				.cloned()
+				.try_collect()
+				.unwrap_or_default();
+
+			// set stakers info for genesis era (0).
+			let _ = Self::store_stakers_info(exposures, Zero::zero());
+
+			// consume full block weight to be safe.
+			Self::register_weight(sp_runtime::traits::Bounded::max_value());
+			validators
+		} else {
+			// note: exposures have already been processed and stored for each of the election
+			// solution page at the time of `elect_paged(page_index)`.
+			Self::register_weight(T::DbWeight::get().reads(1));
+			ElectableStashes::<T>::take()
+				.into_inner()
+				.into_iter()
+				.collect::<Vec<_>>()
+				.try_into()
+				.expect("same bounds, will fit; qed.")
+		};
+
+		log!(
+			info,
+			"try_plan_new_era: (is_genesis?: {:?}) electable validators count for session starting {:?}, era {:?}: {:?}",
+			is_genesis,
+			start_session_index,
+			CurrentEra::<T>::get().unwrap_or_default() + 1,
+			validators.len()
+		);
+
+		if (validators.len() as u32) < MinimumValidatorCount::<T>::get().max(1) {
+			// Session will panic if we ever return an empty validator set, thus max(1) ^^.
+			match CurrentEra::<T>::get() {
+				Some(current_era) if current_era > 0 => log!(
+					warn,
+					"chain does not have enough staking candidates to operate for era {:?} ({} \
+					elected, minimum is {})",
+					CurrentEra::<T>::get().unwrap_or(0),
+					validators.len(),
+					MinimumValidatorCount::<T>::get(),
+				),
+				None => {
+					// The initial era is allowed to have no exposures.
+					// In this case the SessionManager is expected to choose a sensible validator
+					// set.
+					// TODO: this should be simplified #8911
+					CurrentEra::<T>::put(0);
+					ErasStartSessionIndex::<T>::insert(&0, &start_session_index);
+				},
+				_ => {},
+			}
+			// election failed, clear election prep metadata.
+			Self::deposit_event(Event::StakingElectionFailed);
+			Self::clear_election_metadata();
+
+			None
+		} else {
+			Self::deposit_event(Event::StakersElected);
+			Self::clear_election_metadata();
+			Self::plan_new_era(start_session_index);
+
+			Some(validators)
+		}
+	}
+
+	/// Plan a new era.
+	///
+	/// * Bump the current era storage (which holds the latest planned era).
+	/// * Store start session index for the new planned era.
+	/// * Clean old era information.
+	///
+	/// The new validator set for this era is stored under `ElectableStashes`.
+	pub fn plan_new_era(start_session_index: SessionIndex) {
+		// Increment or set current era.
+		let new_planned_era = CurrentEra::<T>::mutate(|s| {
+			*s = Some(s.map(|s| s + 1).unwrap_or(0));
+			s.unwrap()
+		});
+		ErasStartSessionIndex::<T>::insert(&new_planned_era, &start_session_index);
+
+		// Clean old era information.
+		if let Some(old_era) = new_planned_era.checked_sub(T::HistoryDepth::get() + 1) {
+			log!(trace, "Removing era information for {:?}", old_era);
+			Self::clear_era_information(old_era);
+		}
+	}
+}
+
 impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 	type AccountId = T::AccountId;
 
 	fn on_relay_session_report(report: rc_client::SessionReport<Self::AccountId>) {
-		let rc_client::SessionReport { end_index, activation_timestamp, validator_points, leftover } = report;
+		let rc_client::SessionReport {
+			end_index,
+			activation_timestamp,
+			validator_points,
+			leftover,
+		} = report;
 		debug_assert!(!leftover);
-
-		// TODO: pass the timestamp to end_session to be used for era calculation, and remove the
-		// local timestamp.
 
 		// TODO: handle reward points here -- no longer need of knowing that each
 		// block author will be equal to 20 points. The input is the sum of all points.
@@ -1659,17 +1611,32 @@ impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 			planning
 		);
 
+		// first, handle planning a new session/era
 		CurrentPlannedSession::<T>::put(planning);
 		Self::new_session(planning, false);
-		Self::end_session(end_index);
-		Self::start_session(starting);
 
-		// all all is said and done, possibly start the election.
 		let current_era = CurrentEra::<T>::get().unwrap_or_default();
 		let start_index = ErasStartSessionIndex::<T>::get(current_era).unwrap_or_default();
+
 		if T::maybe_start_election(planning, start_index) {
 			log!(info, "sending election start signal");
 			T::ElectionProvider::start();
+		}
+
+		// then, handle starting/ending a session/era
+		if let Some((this_era_start, _id)) = activation_timestamp {
+			/// If ^^^^^^ is None, it means we should not alter the era. If Some(_), we should, and
+			/// the inner value is the duration of the era. At genesis, this is always `None`
+			/// because we may not have an initial timestamp for the era.
+			if let Some(current_active_era) = ActiveEra::<T>::get() {
+				let previous_era_start =
+					current_active_era.start.defensive_unwrap_or(this_era_start);
+				let era_duration = this_era_start.saturating_sub(previous_era_start);
+				Self::compute_era_payout(current_active_era, era_duration);
+				Self::start_era(starting, this_era_start);
+			} else {
+				todo!("genesis era only, do something reasonable")
+			}
 		}
 	}
 

--- a/substrate/frame/staking/src/pallet/impls.rs
+++ b/substrate/frame/staking/src/pallet/impls.rs
@@ -41,7 +41,7 @@ use frame_support::{
 };
 use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
 use sp_runtime::{
-	traits::{Bounded, CheckedAdd, Convert, SaturatedConversion, Saturating, StaticLookup, Zero},
+	traits::{Bounded, CheckedAdd, Convert, Saturating, StaticLookup, Zero},
 	ArithmeticError, DispatchResult, Perbill, Percent,
 };
 use sp_staking::{

--- a/substrate/frame/staking/src/pallet/mod.rs
+++ b/substrate/frame/staking/src/pallet/mod.rs
@@ -95,7 +95,7 @@ pub mod pallet {
 	}
 
 	#[pallet::config(with_default)]
-	pub trait Config: frame_system::Config<AccountId = AccountId32> {
+	pub trait Config: frame_system::Config<AccountId = AccountId32> { // TODO: remove this.
 		/// The old trait for staking balance. Deprecated and only used for migrating old ledgers.
 		#[pallet::no_default]
 		type OldCurrency: InspectLockableCurrency<


### PR DESCRIPTION
This is a PR that glues everything in https://github.com/paritytech/polkadot-sdk/pull/7658 together.

Next Steps after merge: 

- [ ] improve era rotation logic in Staking. We likely can get rid of `CurrentEra`.
- [ ] improve election start logic in staking. We should do a more clearer bookkeeping of where we are, and when we are done.
- [ ] report historical session pruning back to RC and act upon it
- [ ] test and complete the buffering
- [ ] finish and test parachain reward collection
- [ ] ...