### PR TITLE
[pallet-revive] block.timestamps should return seconds

### DIFF
--- a/prdoc/pr_7784.prdoc
+++ b/prdoc/pr_7784.prdoc
@@ -6,6 +6,6 @@ doc:
     see https://docs.soliditylang.org/en/latest/units-and-global-variables.html#block-and-transaction-properties
 crates:
 - name: pallet-revive
-  bump: minor
+  bump: patch
 - name: pallet-revive-uapi
-  bump: minor
+  bump: patch

--- a/prdoc/pr_7784.prdoc
+++ b/prdoc/pr_7784.prdoc
@@ -1,0 +1,11 @@
+title: '[pallet-revive] block.timestamps should return seconds'
+doc:
+- audience: Runtime Dev
+  description: |-
+    In solidity `block.timestamp` should be expressed in seconds
+    see https://docs.soliditylang.org/en/latest/units-and-global-variables.html#block-and-transaction-properties
+crates:
+- name: pallet-revive
+  bump: minor
+- name: pallet-revive-uapi
+  bump: minor

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -357,7 +357,7 @@ pub trait Ext: sealing::Sealed {
 	/// Returns the value transferred along with this call.
 	fn value_transferred(&self) -> U256;
 
-	/// Returns the timestamp of the current block
+	/// Returns the timestamp of the current block in seconds.
 	fn now(&self) -> U256;
 
 	/// Returns the minimum balance that is required for creating an account.

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1796,7 +1796,7 @@ where
 	}
 
 	fn now(&self) -> U256 {
-		self.timestamp.into()
+		(self.timestamp / 1000u32.into()).into()
 	}
 
 	fn minimum_balance(&self) -> U256 {

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -325,7 +325,7 @@ pub trait HostFn: private::Sealed {
 		salt: Option<&[u8; 32]>,
 	) -> Result;
 
-	/// Load the latest block timestamp into the supplied buffer
+	/// Load the latest block timestamp in seconds into the supplied buffer
 	///
 	/// # Parameters
 	///


### PR DESCRIPTION
In solidity `block.timestamp` should be expressed in seconds
see https://docs.soliditylang.org/en/latest/units-and-global-variables.html#block-and-transaction-properties