### PR TITLE
Add asset-hub-next as a trusted teleporter

### DIFF
--- a/polkadot/runtime/westend/constants/src/lib.rs
+++ b/polkadot/runtime/westend/constants/src/lib.rs
@@ -113,6 +113,8 @@ pub mod system_parachain {
 	pub const PEOPLE_ID: u32 = 1004;
 	/// Brokerage parachain ID.
 	pub const BROKER_ID: u32 = 1005;
+	/// AH-next - temporary AH clone.
+	pub const ASSET_HUB_NEXT_ID: u32 = 1100;
 
 	/// All system parachains of Westend.
 	pub type SystemParachains = IsChildSystemParachain<Id>;

--- a/polkadot/runtime/westend/src/xcm_config.rs
+++ b/polkadot/runtime/westend/src/xcm_config.rs
@@ -111,6 +111,7 @@ pub type XcmRouter = WithUniqueTopic<
 
 parameter_types! {
 	pub AssetHub: Location = Parachain(ASSET_HUB_ID).into_location();
+	pub AssetHubNext: Location = Parachain(ASSET_HUB_NEXT_ID).into_location();
 	pub Collectives: Location = Parachain(COLLECTIVES_ID).into_location();
 	pub BridgeHub: Location = Parachain(BRIDGE_HUB_ID).into_location();
 	pub Encointer: Location = Parachain(ENCOINTER_ID).into_location();
@@ -118,6 +119,7 @@ parameter_types! {
 	pub Broker: Location = Parachain(BROKER_ID).into_location();
 	pub Wnd: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(TokenLocation::get()) });
 	pub WndForAssetHub: (AssetFilter, Location) = (Wnd::get(), AssetHub::get());
+	pub WndForAssetHubNext: (AssetFilter, Location) = (Wnd::get(), AssetHubNext::get());
 	pub WndForCollectives: (AssetFilter, Location) = (Wnd::get(), Collectives::get());
 	pub WndForBridgeHub: (AssetFilter, Location) = (Wnd::get(), BridgeHub::get());
 	pub WndForEncointer: (AssetFilter, Location) = (Wnd::get(), Encointer::get());
@@ -129,6 +131,7 @@ parameter_types! {
 
 pub type TrustedTeleporters = (
 	xcm_builder::Case<WndForAssetHub>,
+	xcm_builder::Case<WndForAssetHubNext>,
 	xcm_builder::Case<WndForCollectives>,
 	xcm_builder::Case<WndForBridgeHub>,
 	xcm_builder::Case<WndForEncointer>,

--- a/prdoc/pr_7787.prdoc
+++ b/prdoc/pr_7787.prdoc
@@ -1,0 +1,11 @@
+title: Add asset-hub-next as a trusted teleporter
+doc:
+- audience: Runtime Dev
+  description: |-
+    Asset Hub Next has been deployed on Westend as parachain 1100, but it's not yet a trusted teleporter.
+    This minimal PR adds it in stable2412 so that it can be deployed right away without waiting for the rest of the release to be finalised and deployed.
+crates:
+- name: westend-runtime-constants
+  bump: patch
+- name: westend-runtime
+  bump: patch


### PR DESCRIPTION
Asset Hub Next has been deployed on Westend as parachain 1100, but it's not yet a trusted teleporter.
This minimal PR adds it in stable2412 so that it can be deployed right away without waiting for the rest of the release to be finalised and deployed.