### PR TITLE
litep2p/kad: Switch to manual routing table mode

### DIFF
--- a/prdoc/pr_7796.prdoc
+++ b/prdoc/pr_7796.prdoc
@@ -1,0 +1,12 @@
+title: Switch to litep2p manual routing table mode
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      By default, litep2p will add to the routing table peers automatically.
+      In this PR, peers are added to the routing table only if they implement the substrate protocols.
+      For example, peers that implement the deprecated /kad/sup protocol will no longer be added to the routing table.
+
+crates:
+  - name: sc-network
+    bump: patch

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -34,7 +34,7 @@ use litep2p::{
 			kademlia::{
 				Config as KademliaConfig, ConfigBuilder as KademliaConfigBuilder, ContentProvider,
 				IncomingRecordValidationMode, KademliaEvent, KademliaHandle, PeerRecord, QueryId,
-				Quorum, Record, RecordKey,
+				Quorum, Record, RecordKey, RoutingTableUpdateMode,
 			},
 			ping::{Config as PingConfig, PingEvent},
 		},
@@ -284,6 +284,7 @@ impl Discovery {
 			KademliaConfigBuilder::new()
 				.with_known_peers(known_peers)
 				.with_protocol_names(protocol_names)
+				.with_routing_table_update_mode(RoutingTableUpdateMode::Manual)
 				.with_incoming_records_validation_mode(IncomingRecordValidationMode::Manual)
 				.build()
 		};


### PR DESCRIPTION
This PR changes the behavior of the kademlia implementation for litep2p.

By default, litep2p will add to the routing table peers automatically.
In this PR, peers are added to the routing table only if they implement the substrate protocols.
For example, peers that implement the deprecated `/kad/sup` protocol will no longer be added to the routing table.

This mirrors the libp2p behavior.

cc @paritytech/networking 