### PR TITLE
Make pallet-transaction-payment-benchmark work with ed 0

### DIFF
--- a/prdoc/pr_7820.prdoc
+++ b/prdoc/pr_7820.prdoc
@@ -1,0 +1,8 @@
+title: 'Make pallet-transaction-payment-benchmark work with ed 0'
+doc:
+- audience: Runtime Dev
+  description: |
+    Make it possible to use the transaction-payment work with existential deposit 0
+crates:
+- name: pallet-transaction-payment
+  bump: minor

--- a/substrate/frame/transaction-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/src/benchmarking.rs
@@ -45,20 +45,17 @@ mod benchmarks {
 	#[benchmark]
 	fn charge_transaction_payment() {
 		let caller: T::AccountId = account("caller", 0, 0);
-		let existential_deposit = <T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance();
-	
-		let (amount_to_endow, tip) =  if existential_deposit.is_zero() {
+		let existential_deposit =
+			<T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance();
+
+		let (amount_to_endow, tip) = if existential_deposit.is_zero() {
 			let min_tip: <<T as pallet::Config>::OnChargeTransaction as payment::OnChargeTransaction<T>>::Balance = 1_000_000_000u32.into();
 			(min_tip * 1000u32.into(), min_tip)
-		}
-		else {
+		} else {
 			(existential_deposit * 1000u32.into(), existential_deposit)
 		};
 
-		<T::OnChargeTransaction as OnChargeTransaction<T>>::endow_account(
-			&caller,
-			amount_to_endow,
-		);
+		<T::OnChargeTransaction as OnChargeTransaction<T>>::endow_account(&caller, amount_to_endow);
 
 		let ext: ChargeTransactionPayment<T> = ChargeTransactionPayment::from(tip);
 		let inner = frame_system::Call::remark { remark: alloc::vec![] };

--- a/substrate/frame/transaction-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/src/benchmarking.rs
@@ -46,18 +46,20 @@ mod benchmarks {
 	fn charge_transaction_payment() {
 		let caller: T::AccountId = account("caller", 0, 0);
 		let existential_deposit = <T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance();
+	
 		let (amount_to_endow, tip) =  if existential_deposit.is_zero() {
-			let unit = 1_000_000_000_000;
-			(unit * 1000u32.into(), unit)
+			let min_tip: <<T as pallet::Config>::OnChargeTransaction as payment::OnChargeTransaction<T>>::Balance = 1_000_000_000u32.into();
+			(min_tip * 1000u32.into(), min_tip)
 		}
 		else {
 			(existential_deposit * 1000u32.into(), existential_deposit)
-		}
+		};
 
 		<T::OnChargeTransaction as OnChargeTransaction<T>>::endow_account(
 			&caller,
 			amount_to_endow,
 		);
+
 		let ext: ChargeTransactionPayment<T> = ChargeTransactionPayment::from(tip);
 		let inner = frame_system::Call::remark { remark: alloc::vec![] };
 		let call = T::RuntimeCall::from(inner);

--- a/substrate/frame/transaction-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/src/benchmarking.rs
@@ -45,11 +45,19 @@ mod benchmarks {
 	#[benchmark]
 	fn charge_transaction_payment() {
 		let caller: T::AccountId = account("caller", 0, 0);
+		let existential_deposit = <T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance();
+		let (amount_to_endow, tip) =  if existential_deposit.is_zero() {
+			let unit = 1_000_000_000_000;
+			(unit * 1000u32.into(), unit)
+		}
+		else {
+			(existential_deposit * 1000u32.into(), existential_deposit)
+		}
+
 		<T::OnChargeTransaction as OnChargeTransaction<T>>::endow_account(
 			&caller,
-			<T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance() * 1000u32.into(),
+			amount_to_endow,
 		);
-		let tip = <T::OnChargeTransaction as OnChargeTransaction<T>>::minimum_balance();
 		let ext: ChargeTransactionPayment<T> = ChargeTransactionPayment::from(tip);
 		let inner = frame_system::Call::remark { remark: alloc::vec![] };
 		let call = T::RuntimeCall::from(inner);


### PR DESCRIPTION

# Description

Chains like moonbeam work with an ED deposit of 0 (insecure-ed-0) which is unsable with the current pallet-transaction-payment benchmark. This PR adds an if-else case in case the existential deposit found is 0.