### PR TITLE
net/transactions: Optimize the protocol to enhance transaction throughput

### DIFF
--- a/substrate/client/network/transactions/src/lib.rs
+++ b/substrate/client/network/transactions/src/lib.rs
@@ -220,19 +220,18 @@ pub struct TransactionsHandlerController<H: ExHashT> {
 }
 
 impl<H: ExHashT> TransactionsHandlerController<H> {
-	/// You may call this when new transactions are imported by the transaction pool.
+	/// Available transactions from the transaction pool will be propagated to peers.
 	///
-	/// All transactions will be fetched from the `TransactionPool` that was passed at
-	/// initialization as part of the configuration and propagated to peers.
-	pub fn propagate_transactions(&self) {
+	/// This operation also happens periodically and is controlled by the `PROPAGATE_TIMEOUT`.
+	pub fn propagate_pool_transactions(&self) {
 		let _ = self.to_handler.unbounded_send(ToHandler::PropagateTransactions);
 	}
 
-	/// You must call when new a transaction is imported by the transaction pool.
+	/// The provided transactions are propagated to peers.
 	///
-	/// This transaction will be fetched from the `TransactionPool` that was passed at
-	/// initialization as part of the configuration and propagated to peers.
-	pub fn propagate_transaction(&self, hash: H) {
+	/// The transactions are provided by the transaction pool import notification stream
+	/// (ie `import_notification_stream`).
+	pub fn propagate_imported_transactions(&self, hash: H) {
 		let _ = self.to_handler.unbounded_send(ToHandler::PropagateTransaction(hash));
 	}
 }

--- a/substrate/client/network/transactions/src/lib.rs
+++ b/substrate/client/network/transactions/src/lib.rs
@@ -314,7 +314,11 @@ where
 				}
 				message = self.from_controller.select_next_some() => {
 					match message {
-						ToHandler::PropagateImportedTransaction(hashes) => self.propagate_imported_transactions(hashes),
+						ToHandler::PropagateImportedTransaction(hashes) => {
+							trace!(target: "sync", "Propagating transaction from controller num={}", hashes.len());
+
+							self.propagate_imported_transactions(hashes);
+						}
 						ToHandler::PropagatePoolTransactions => self.propagate_transactions(),
 					}
 				},

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -600,7 +600,7 @@ pub async fn propagate_transaction_notifications<Block, ExPool>(
 					hashes.push(hash);
 				}
 
-				tx_handler_controller.propagate_imported_transactions(hash);
+				tx_handler_controller.propagate_imported_transactions(hashes);
 
 				tx_imported = true;
 			},

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -593,7 +593,14 @@ pub async fn propagate_transaction_notifications<Block, ExPool>(
 			notification = notifications.next() => {
 				let Some(hash) = notification else { return };
 
-				tx_handler_controller.propagate_transaction(hash);
+				let mut hashes = Vec::with_capacity(8);
+				hashes.push(hash);
+				// Drain the notifications that are readily available on `notifications`.
+				while let Some(hash) = notifications.next().now_or_never().flatten() {
+					hashes.push(hash);
+				}
+
+				tx_handler_controller.propagate_imported_transactions(hash);
 
 				tx_imported = true;
 			},


### PR DESCRIPTION
This PR modifies the transaction protocol in the following ways:
- (1) transaction controller provides a batch of transactions readily available form the import substreams
   - This eliminates inefficiencies of handling transaction messages from the controller, instead all available transactions are handled immediately
   
- (2) transaction notification is modified to include more than 1 transaction
  - [RFC #56](https://github.com/polkadot-fellows/RFCs/blob/main/text/0056-one-transaction-per-notification.md) states that the notification of the transaction protocol must always contain a vector of a single transaction
  - Sending one single transaction at a time leads to inefficiencies when handling a large number of transactions
  - Instead, we send all available transactions in one notification. This might cause issues with the lightclients, but otherwise should be compatible with all other types of nodes.


### Considerations
Since lightclients might be affected by this change, we must introduce a new RFC, effectively creating a new `transactions/v2` protocol. High overview:
- Instead of scale-encoding a vector of transactions which might not get decoded properly by smoldot we must change the encoding.


The following is the most compact representation of the transactions, the code will become similar to:

```rust
for tx in transactions {
   encoded = tx.encode(); // this is scale(transcation1)
   notification_bytes +=  (encoded.len().to_leb128(), encoded);
}
```

Binary representation over the wire:
```bash
concat(
    leb128(size(scale(transaction1))), scale(transaction1),
    leb128(size(scale(transaction2))), scale(transaction2),
    leb128(size(scale(transaction3))), scale(transaction3),
)
```


### Before

```
# This is the normal behavior before this PR
sync: Sending bytes=142 tx=1 to 12D3KooWRkZhiRhsqmrQ28rt73K7V3aCBpqKrLGSXmZ99PTcTZby
...
~17219 lines later
...
sync: Sending bytes=142 tx=1 to 12D3KooWRkZhiRhsqmrQ28rt73K7V3aCBpqKrLGSXmZ99PTcTZby
```

### After

We see under high-stress scenarios notifications of ~2.3 MiB instead of sending 17k notifications of 142 bytes.

The high-stress tx pool tests decreased their time from `206.42s` to `77.47s`.

```
# This is the behavior after the optimizations
sync: Sending bytes=36380 tx=257 to 12D3KooWRkZhiRhsqmrQ28rt73K7V3aCBpqKrLGSXmZ99PTcTZby
sync: Sending bytes=2440940 tx=17219 to 12D3KooWRkZhiRhsqmrQ28rt73K7V3aCBpqKrLGSXmZ99PTcTZby
sync: Sending bytes=2465976 tx=17396 to 12D3KooWRkZhiRhsqmrQ28rt73K7V3aCBpqKrLGSXmZ99PTcTZby
sync: Sending bytes=1389821 tx=9803 to 12D3KooWRkZhiRhsqmrQ28rt73K7V3aCBpqKrLGSXmZ99PTcTZby
```
  
cc @michalkucharczyk 