### PR TITLE
Fix XCM decoding inconsistencies

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -1631,7 +1631,7 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 		let messages: Vec<VersionedXcm<()>> = PendingUpwardMessages::<T>::get()
 			.iter()
 			.map(|encoded_message| {
-				VersionedXcm::<()>::decode_with_depth_limit(
+				VersionedXcm::<()>::decode_all_with_depth_limit(
 					MAX_XCM_DECODE_DEPTH,
 					&mut &encoded_message[..],
 				)

--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -107,12 +107,12 @@ mod benchmarks {
 		let data = VersionedXcm::<T>::from(xcm).encode();
 		assert!(data.len() < max_downward_message_size, "Page size is too small");
 		// Verify that decoding works with the exact recursion limit:
-		VersionedXcm::<T::RuntimeCall>::decode_with_depth_limit(
+		VersionedXcm::<T::RuntimeCall>::decode_all_with_depth_limit(
 			MAX_XCM_DECODE_DEPTH,
 			&mut &data[..],
 		)
 		.unwrap();
-		VersionedXcm::<T::RuntimeCall>::decode_with_depth_limit(
+		VersionedXcm::<T::RuntimeCall>::decode_all_with_depth_limit(
 			MAX_XCM_DECODE_DEPTH - 1,
 			&mut &data[..],
 		)

--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -22,11 +22,11 @@ use codec::DecodeAll;
 use frame_benchmarking::v2::*;
 use frame_support::traits::Hooks;
 use frame_system::RawOrigin;
+use xcm::MAX_INSTRUCTIONS_TO_DECODE;
 
 #[benchmarks]
 mod benchmarks {
 	use super::*;
-	use xcm::MAX_INSTRUCTIONS_TO_DECODE;
 
 	/// Modify any of the `QueueConfig` fields with a new `u32` value.
 	///

--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -26,6 +26,7 @@ use frame_system::RawOrigin;
 #[benchmarks]
 mod benchmarks {
 	use super::*;
+	use xcm::MAX_INSTRUCTIONS_TO_DECODE;
 
 	/// Modify any of the `QueueConfig` fields with a new `u32` value.
 	///

--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -22,7 +22,6 @@ use codec::DecodeAll;
 use frame_benchmarking::v2::*;
 use frame_support::traits::Hooks;
 use frame_system::RawOrigin;
-use xcm::v3::MAX_INSTRUCTIONS_TO_DECODE;
 
 #[benchmarks]
 mod benchmarks {

--- a/cumulus/pallets/xcmp-queue/src/benchmarking.rs
+++ b/cumulus/pallets/xcmp-queue/src/benchmarking.rs
@@ -22,10 +22,12 @@ use codec::DecodeAll;
 use frame_benchmarking::v2::*;
 use frame_support::traits::Hooks;
 use frame_system::RawOrigin;
+use xcm::MAX_INSTRUCTIONS_TO_DECODE;
 
 #[benchmarks]
 mod benchmarks {
 	use super::*;
+	use xcm::MAX_XCM_DECODE_DEPTH;
 
 	/// Modify any of the `QueueConfig` fields with a new `u32` value.
 	///
@@ -105,17 +107,6 @@ mod benchmarks {
 
 		let data = VersionedXcm::<T>::from(xcm).encode();
 		assert!(data.len() < max_downward_message_size, "Page size is too small");
-		// Verify that decoding works with the exact recursion limit:
-		VersionedXcm::<T::RuntimeCall>::decode_with_depth_limit(
-			MAX_XCM_DECODE_DEPTH,
-			&mut &data[..],
-		)
-		.unwrap();
-		VersionedXcm::<T::RuntimeCall>::decode_with_depth_limit(
-			MAX_XCM_DECODE_DEPTH - 1,
-			&mut &data[..],
-		)
-		.unwrap_err();
 
 		#[block]
 		{

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -972,7 +972,7 @@ impl<T: Config> SendXcm for Pallet<T> {
 				let versioned_xcm = T::VersionWrapper::wrap_version(&d, xcm)
 					.map_err(|()| SendError::DestinationUnsupported)?;
 				versioned_xcm
-					.validate_xcm_decoding()
+					.check_is_decodable()
 					.map_err(|()| SendError::ExceedsMaxMessageSize)?;
 
 				Ok(((id, versioned_xcm), price))

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -72,10 +72,7 @@ use polkadot_runtime_parachains::FeeTracker;
 use scale_info::TypeInfo;
 use sp_core::MAX_POSSIBLE_ALLOCATION;
 use sp_runtime::{FixedU128, RuntimeDebug, Saturating, WeakBoundedVec};
-use xcm::{
-	latest::prelude::*, VersionedLocation, VersionedXcm, WrapVersion, MAX_INSTRUCTIONS_TO_DECODE,
-	MAX_XCM_DECODE_DEPTH,
-};
+use xcm::{latest::prelude::*, VersionedLocation, VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH};
 use xcm_builder::InspectMessageQueues;
 use xcm_executor::traits::ConvertOrigin;
 

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -54,7 +54,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use bounded_collections::BoundedBTreeSet;
-use codec::{Decode, DecodeLimit, Encode, MaxEncodedLen};
+use codec::{Decode, Encode, MaxEncodedLen};
 use cumulus_primitives_core::{
 	relay_chain::BlockNumber as RelayBlockNumber, ChannelStatus, GetChannelInfo, MessageSendError,
 	ParaId, XcmpMessageFormat, XcmpMessageHandler, XcmpMessageSource,
@@ -72,10 +72,7 @@ use polkadot_runtime_parachains::FeeTracker;
 use scale_info::TypeInfo;
 use sp_core::MAX_POSSIBLE_ALLOCATION;
 use sp_runtime::{FixedU128, RuntimeDebug, Saturating, WeakBoundedVec};
-use xcm::{
-	latest::prelude::*, VersionedLocation, VersionedXcm, WrapVersion, MAX_INSTRUCTIONS_TO_DECODE,
-	MAX_XCM_DECODE_DEPTH,
-};
+use xcm::{latest::prelude::*, VersionedLocation, VersionedXcm, WrapVersion};
 use xcm_builder::InspectMessageQueues;
 use xcm_executor::traits::ConvertOrigin;
 
@@ -679,8 +676,7 @@ impl<T: Config> Pallet<T> {
 			return Err(())
 		}
 
-		let xcm = VersionedXcm::<()>::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, data)
-			.map_err(|_| ())?;
+		let xcm = VersionedXcm::<()>::decode(data).map_err(|_| ())?;
 		xcm.encode().try_into().map_err(|_| ())
 	}
 
@@ -1030,11 +1026,7 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 				}
 				let mut decoded_messages = Vec::new();
 				while !data.is_empty() {
-					let decoded_message = VersionedXcm::<()>::decode_with_depth_limit(
-						MAX_XCM_DECODE_DEPTH,
-						&mut data,
-					)
-					.unwrap();
+					let decoded_message = VersionedXcm::<()>::decode(&mut data).unwrap();
 					decoded_messages.push(decoded_message);
 				}
 

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -72,7 +72,10 @@ use polkadot_runtime_parachains::FeeTracker;
 use scale_info::TypeInfo;
 use sp_core::MAX_POSSIBLE_ALLOCATION;
 use sp_runtime::{FixedU128, RuntimeDebug, Saturating, WeakBoundedVec};
-use xcm::{latest::prelude::*, VersionedLocation, VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH};
+use xcm::{
+	latest::prelude::*, VersionedLocation, VersionedXcm, WrapVersion, MAX_INSTRUCTIONS_TO_DECODE,
+	MAX_XCM_DECODE_DEPTH,
+};
 use xcm_builder::InspectMessageQueues;
 use xcm_executor::traits::ConvertOrigin;
 

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -531,11 +531,7 @@ impl<T: Config> Pallet<T> {
 					recipient,
 					channel_details.last_index - 1,
 					|page| {
-						if XcmpMessageFormat::decode_with_depth_limit(
-							MAX_XCM_DECODE_DEPTH,
-							&mut &page[..],
-						) != Ok(format)
-						{
+						if XcmpMessageFormat::decode(&mut &page[..]) != Ok(format) {
 							defensive!("Bad format in outbound queue; dropping message");
 							return Err(())
 						}
@@ -1028,9 +1024,7 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 		OutboundXcmpMessages::<T>::iter()
 			.map(|(para_id, _, messages)| {
 				let mut data = &messages[..];
-				let decoded_format =
-					XcmpMessageFormat::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut data)
-						.unwrap();
+				let decoded_format = XcmpMessageFormat::decode(&mut data).unwrap();
 				if decoded_format != XcmpMessageFormat::ConcatenatedVersionedXcm {
 					panic!("Unexpected format.")
 				}

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -972,7 +972,7 @@ impl<T: Config> SendXcm for Pallet<T> {
 				let versioned_xcm = T::VersionWrapper::wrap_version(&d, xcm)
 					.map_err(|()| SendError::DestinationUnsupported)?;
 				versioned_xcm
-					.validate_xcm_nesting()
+					.validate_xcm_decoding()
 					.map_err(|()| SendError::ExceedsMaxMessageSize)?;
 
 				Ok(((id, versioned_xcm), price))

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -28,6 +28,7 @@ use frame_support::{
 use mock::{new_test_ext, ParachainSystem, RuntimeOrigin as Origin, Test, XcmpQueue};
 use sp_runtime::traits::{BadOrigin, Zero};
 use std::iter::{once, repeat};
+use xcm::MAX_XCM_DECODE_DEPTH;
 use xcm_builder::InspectMessageQueues;
 
 #[test]

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -28,7 +28,7 @@ use frame_support::{
 use mock::{new_test_ext, ParachainSystem, RuntimeOrigin as Origin, Test, XcmpQueue};
 use sp_runtime::traits::{BadOrigin, Zero};
 use std::iter::{once, repeat};
-use xcm::MAX_XCM_DECODE_DEPTH;
+use xcm::{MAX_INSTRUCTIONS_TO_DECODE, MAX_XCM_DECODE_DEPTH};
 use xcm_builder::InspectMessageQueues;
 
 #[test]
@@ -902,7 +902,7 @@ fn page_not_modified_when_fragment_does_not_fit() {
 		ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(sibling);
 
 		let destination: Location = (Parent, Parachain(sibling.into())).into();
-		let message = Xcm(vec![ClearOrigin; 600]);
+		let message = Xcm(vec![ClearOrigin; MAX_INSTRUCTIONS_TO_DECODE as usize]);
 
 		loop {
 			let old_page_zero = OutboundXcmpMessages::<Test>::get(sibling, 0);

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -15,7 +15,7 @@
 
 use core::marker::PhantomData;
 
-use codec::Decode;
+use codec::{Decode, DecodeLimit};
 use cumulus_primitives_core::{
 	relay_chain::Slot, AbridgedHrmpChannel, ParaId, PersistedValidationData,
 };
@@ -41,7 +41,7 @@ use sp_runtime::{
 use xcm::{
 	latest::{Asset, Location, XcmContext, XcmHash},
 	prelude::*,
-	VersionedXcm,
+	VersionedXcm, MAX_XCM_DECODE_DEPTH,
 };
 use xcm_executor::{traits::TransactAsset, AssetsInHolding};
 
@@ -734,9 +734,12 @@ impl<HrmpChannelSource: cumulus_primitives_core::XcmpMessageSource, AllPalletsWi
 				let mut xcm_message_data = &xcm_message_data[..];
 				// decode
 				let _ = XcmpMessageFormat::decode(&mut xcm_message_data).expect("valid format");
-				VersionedXcm::<()>::decode(&mut xcm_message_data)
-					.map(|x| Some(x))
-					.expect("result with xcm")
+				VersionedXcm::<()>::decode_with_depth_limit(
+					MAX_XCM_DECODE_DEPTH,
+					&mut xcm_message_data,
+				)
+				.map(|x| Some(x))
+				.expect("result with xcm")
 			},
 			_ => return None,
 		}

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -733,11 +733,7 @@ impl<HrmpChannelSource: cumulus_primitives_core::XcmpMessageSource, AllPalletsWi
 			[(para_id, ref mut xcm_message_data)] if para_id.eq(&sent_to_para_id.into()) => {
 				let mut xcm_message_data = &xcm_message_data[..];
 				// decode
-				let _ = XcmpMessageFormat::decode_with_depth_limit(
-					MAX_XCM_DECODE_DEPTH,
-					&mut xcm_message_data,
-				)
-				.expect("valid format");
+				let _ = XcmpMessageFormat::decode(&mut xcm_message_data).expect("valid format");
 				VersionedXcm::<()>::decode_with_depth_limit(
 					MAX_XCM_DECODE_DEPTH,
 					&mut xcm_message_data,

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -15,7 +15,7 @@
 
 use core::marker::PhantomData;
 
-use codec::{Decode, DecodeLimit};
+use codec::Decode;
 use cumulus_primitives_core::{
 	relay_chain::Slot, AbridgedHrmpChannel, ParaId, PersistedValidationData,
 };
@@ -41,7 +41,7 @@ use sp_runtime::{
 use xcm::{
 	latest::{Asset, Location, XcmContext, XcmHash},
 	prelude::*,
-	VersionedXcm, MAX_XCM_DECODE_DEPTH,
+	VersionedXcm,
 };
 use xcm_executor::{traits::TransactAsset, AssetsInHolding};
 
@@ -734,12 +734,9 @@ impl<HrmpChannelSource: cumulus_primitives_core::XcmpMessageSource, AllPalletsWi
 				let mut xcm_message_data = &xcm_message_data[..];
 				// decode
 				let _ = XcmpMessageFormat::decode(&mut xcm_message_data).expect("valid format");
-				VersionedXcm::<()>::decode_with_depth_limit(
-					MAX_XCM_DECODE_DEPTH,
-					&mut xcm_message_data,
-				)
-				.map(|x| Some(x))
-				.expect("result with xcm")
+				VersionedXcm::<()>::decode(&mut xcm_message_data)
+					.map(|x| Some(x))
+					.expect("result with xcm")
 			},
 			_ => return None,
 		}

--- a/cumulus/primitives/utility/src/lib.rs
+++ b/cumulus/primitives/utility/src/lib.rs
@@ -73,7 +73,7 @@ where
 			let versioned_xcm =
 				W::wrap_version(&d, xcm).map_err(|()| SendError::DestinationUnsupported)?;
 			versioned_xcm
-				.validate_xcm_decoding()
+				.check_is_decodable()
 				.map_err(|()| SendError::ExceedsMaxMessageSize)?;
 			let data = versioned_xcm.encode();
 

--- a/cumulus/primitives/utility/src/lib.rs
+++ b/cumulus/primitives/utility/src/lib.rs
@@ -845,7 +845,7 @@ impl<
 		dest: &Location,
 		fee_reason: xcm_executor::traits::FeeReason,
 	) -> (Option<xcm_executor::FeesMode>, Option<Assets>) {
-		use xcm::latest::{MAX_INSTRUCTIONS_TO_DECODE, MAX_ITEMS_IN_ASSETS};
+		use xcm::{latest::MAX_ITEMS_IN_ASSETS, MAX_INSTRUCTIONS_TO_DECODE};
 		use xcm_executor::{traits::FeeManager, FeesMode};
 
 		// check if the destination is relay/parent

--- a/cumulus/primitives/utility/src/lib.rs
+++ b/cumulus/primitives/utility/src/lib.rs
@@ -73,7 +73,7 @@ where
 			let versioned_xcm =
 				W::wrap_version(&d, xcm).map_err(|()| SendError::DestinationUnsupported)?;
 			versioned_xcm
-				.validate_xcm_nesting()
+				.validate_xcm_decoding()
 				.map_err(|()| SendError::ExceedsMaxMessageSize)?;
 			let data = versioned_xcm.encode();
 

--- a/polkadot/runtime/common/src/xcm_sender.rs
+++ b/polkadot/runtime/common/src/xcm_sender.rs
@@ -122,7 +122,7 @@ where
 		let para = id.into();
 		let price = P::price_for_delivery(para, &xcm);
 		let versioned_xcm = W::wrap_version(&d, xcm).map_err(|()| DestinationUnsupported)?;
-		versioned_xcm.validate_xcm_decoding().map_err(|()| ExceedsMaxMessageSize)?;
+		versioned_xcm.check_is_decodable().map_err(|()| ExceedsMaxMessageSize)?;
 		let blob = versioned_xcm.encode();
 		dmp::Pallet::<T>::can_queue_downward_message(&config, &para, &blob)
 			.map_err(Into::<SendError>::into)?;

--- a/polkadot/runtime/common/src/xcm_sender.rs
+++ b/polkadot/runtime/common/src/xcm_sender.rs
@@ -17,7 +17,7 @@
 //! XCM sender for relay chain.
 
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
+use codec::{DecodeLimit, Encode};
 use core::marker::PhantomData;
 use frame_support::traits::Get;
 use frame_system::pallet_prelude::BlockNumberFor;
@@ -27,7 +27,7 @@ use polkadot_runtime_parachains::{
 	dmp, FeeTracker,
 };
 use sp_runtime::FixedPointNumber;
-use xcm::prelude::*;
+use xcm::{prelude::*, MAX_XCM_DECODE_DEPTH};
 use xcm_builder::InspectMessageQueues;
 use SendError::*;
 
@@ -159,7 +159,7 @@ impl<T: dmp::Config, W, P> InspectMessageQueues for ChildParachainRouter<T, W, P
 				let decoded_messages: Vec<VersionedXcm<()>> = messages
 					.iter()
 					.map(|downward_message| {
-						let message = VersionedXcm::<()>::decode(&mut &downward_message.msg[..]).unwrap();
+						let message = VersionedXcm::<()>::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut &downward_message.msg[..]).unwrap();
 						log::trace!(target: "xcm::DownwardMessageQueues::get_messages", "Message: {:?}, sent at: {:?}", message, downward_message.sent_at);
 						message
 					})

--- a/polkadot/runtime/common/src/xcm_sender.rs
+++ b/polkadot/runtime/common/src/xcm_sender.rs
@@ -159,12 +159,22 @@ impl<T: dmp::Config, W, P> InspectMessageQueues for ChildParachainRouter<T, W, P
 				let decoded_messages: Vec<VersionedXcm<()>> = messages
 					.iter()
 					.map(|downward_message| {
-						let message = VersionedXcm::<()>::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut &downward_message.msg[..]).unwrap();
-						log::trace!(target: "xcm::DownwardMessageQueues::get_messages", "Message: {:?}, sent at: {:?}", message, downward_message.sent_at);
+						let message = VersionedXcm::<()>::decode_all_with_depth_limit(
+							MAX_XCM_DECODE_DEPTH,
+							&mut &downward_message.msg[..],
+						)
+						.unwrap();
+						log::trace!(
+							target: "xcm::DownwardMessageQueues::get_messages",
+							"Message: {:?}, sent at: {:?}", message, downward_message.sent_at
+						);
 						message
 					})
 					.collect();
-				(VersionedLocation::from(Location::from(Parachain(para_id.into()))), decoded_messages)
+				(
+					VersionedLocation::from(Location::from(Parachain(para_id.into()))),
+					decoded_messages,
+				)
 			})
 			.collect()
 	}

--- a/polkadot/runtime/common/src/xcm_sender.rs
+++ b/polkadot/runtime/common/src/xcm_sender.rs
@@ -122,7 +122,7 @@ where
 		let para = id.into();
 		let price = P::price_for_delivery(para, &xcm);
 		let versioned_xcm = W::wrap_version(&d, xcm).map_err(|()| DestinationUnsupported)?;
-		versioned_xcm.validate_xcm_nesting().map_err(|()| ExceedsMaxMessageSize)?;
+		versioned_xcm.validate_xcm_decoding().map_err(|()| ExceedsMaxMessageSize)?;
 		let blob = versioned_xcm.encode();
 		dmp::Pallet::<T>::can_queue_downward_message(&config, &para, &blob)
 			.map_err(Into::<SendError>::into)?;

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -371,12 +371,11 @@ impl<C> IdentifyVersion for VersionedXcm<C> {
 }
 
 impl<C> VersionedXcm<C> {
-	/// Checks that the XCM is decodable. Consequently, it checks all decode implementations and
-	/// limits, such as `MAX_XCM_DECODE_DEPTH`, `MAX_ITEMS_IN_ASSETS` or
-	/// `MAX_INSTRUCTIONS_TO_DECODE`.
+	/// Checks if the XCM is decodable. Consequently, it checks all decoding constraints,
+	/// such as `MAX_XCM_DECODE_DEPTH`, `MAX_ITEMS_IN_ASSETS` or `MAX_INSTRUCTIONS_TO_DECODE`.
 	///
 	/// Note that this uses the limit of the sender - not the receiver. It is a best effort.
-	pub fn validate_xcm_decoding(&self) -> Result<(), ()> {
+	pub fn check_is_decodable(&self) -> Result<(), ()> {
 		self.using_encoded(|mut enc| Self::decode_all(&mut enc).map(|_| ()))
 			.map_err(|e| {
 				log::error!(target: "xcm::validate_xcm_decoding", "Decode error: {e:?} for xcm: {self:?}!");
@@ -638,7 +637,7 @@ fn size_limits() {
 }
 
 #[test]
-fn validate_xcm_decoding_works() {
+fn check_is_decodable_works() {
 	use crate::{
 		latest::{
 			prelude::{GeneralIndex, ReserveAssetDeposited, SetAppendix},
@@ -670,46 +669,46 @@ fn validate_xcm_decoding_works() {
 		ReserveAssetDeposited(assets(1));
 		(MAX_INSTRUCTIONS_TO_DECODE - 1) as usize
 	]))
-	.validate_xcm_decoding()
+	.check_is_decodable()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![
 		ReserveAssetDeposited(assets(1));
 		MAX_INSTRUCTIONS_TO_DECODE as usize
 	]))
-	.validate_xcm_decoding()
+	.check_is_decodable()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![
 		ReserveAssetDeposited(assets(1));
 		(MAX_INSTRUCTIONS_TO_DECODE + 1) as usize
 	]))
-	.validate_xcm_decoding()
+	.check_is_decodable()
 	.is_err());
 
 	// `MAX_XCM_DECODE_DEPTH` check
 	assert!(VersionedXcm::<()>::from(with_instr(MAX_XCM_DECODE_DEPTH - 1))
-		.validate_xcm_decoding()
+		.check_is_decodable()
 		.is_ok());
 	assert!(VersionedXcm::<()>::from(with_instr(MAX_XCM_DECODE_DEPTH))
-		.validate_xcm_decoding()
+		.check_is_decodable()
 		.is_ok());
 	assert!(VersionedXcm::<()>::from(with_instr(MAX_XCM_DECODE_DEPTH + 1))
-		.validate_xcm_decoding()
+		.check_is_decodable()
 		.is_err());
 
 	// `MAX_ITEMS_IN_ASSETS` check
 	assert!(VersionedXcm::<()>::from(Xcm(vec![ReserveAssetDeposited(assets(
 		MAX_ITEMS_IN_ASSETS
 	))]))
-	.validate_xcm_decoding()
+	.check_is_decodable()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![ReserveAssetDeposited(assets(
 		MAX_ITEMS_IN_ASSETS - 1
 	))]))
-	.validate_xcm_decoding()
+	.check_is_decodable()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![ReserveAssetDeposited(assets(
 		MAX_ITEMS_IN_ASSETS + 1
 	))]))
-	.validate_xcm_decoding()
+	.check_is_decodable()
 	.is_err());
 }

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -25,8 +25,7 @@
 extern crate alloc;
 
 use codec::{
-	Decode, DecodeAll, DecodeLimit, DecodeWithMemTracking, Encode, Error as CodecError, Input,
-	MaxEncodedLen,
+	Decode, DecodeLimit, DecodeWithMemTracking, Encode, Error as CodecError, Input, MaxEncodedLen,
 };
 use derive_where::derive_where;
 use frame_support::dispatch::GetDispatchInfo;
@@ -376,7 +375,7 @@ impl<C> VersionedXcm<C> {
 	///
 	/// Note that this uses the limit of the sender - not the receiver. It is a best effort.
 	pub fn check_is_decodable(&self) -> Result<(), ()> {
-		self.using_encoded(|mut enc| Self::decode_all(&mut enc).map(|_| ()))
+		self.using_encoded(|mut enc| Self::decode_all_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut enc).map(|_| ()))
 			.map_err(|e| {
 				log::error!(target: "xcm::check_is_decodable", "Decode error: {e:?} for xcm: {self:?}!");
 				()

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -313,7 +313,7 @@ versioned_type! {
 }
 
 /// A single XCM message, together with its version code.
-#[derive(Encode, DecodeWithMemTracking, TypeInfo)]
+#[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo)]
 #[derive_where(Clone, Eq, PartialEq, Debug)]
 #[codec(encode_bound())]
 #[codec(decode_bound())]
@@ -326,26 +326,6 @@ pub enum VersionedXcm<RuntimeCall> {
 	V4(v4::Xcm<RuntimeCall>),
 	#[codec(index = 5)]
 	V5(v5::Xcm<RuntimeCall>),
-}
-
-impl<RuntimeCall> Decode for VersionedXcm<RuntimeCall> {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, CodecError> {
-		fn decode_variant<T: Decode, I: Input>(input: &mut I) -> Result<T, CodecError> {
-			T::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, input)
-		}
-
-		Ok(
-			match input.read_byte().map_err(|e| {
-				e.chain("Could not decode `VersionedXcm`, failed to read variant byte")
-			})? as u32
-			{
-				v3::VERSION => Self::V3(decode_variant(input)?),
-				v4::VERSION => Self::V4(decode_variant(input)?),
-				v5::VERSION => Self::V5(decode_variant(input)?),
-				_ => return Err("Could not decode `VersionedXcm`, variant doesn't exist".into()),
-			},
-		)
-	}
 }
 
 impl<C: Decode + GetDispatchInfo> IntoVersion for VersionedXcm<C> {

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -378,7 +378,7 @@ impl<C> VersionedXcm<C> {
 	pub fn check_is_decodable(&self) -> Result<(), ()> {
 		self.using_encoded(|mut enc| Self::decode_all(&mut enc).map(|_| ()))
 			.map_err(|e| {
-				log::error!(target: "xcm::validate_xcm_decoding", "Decode error: {e:?} for xcm: {self:?}!");
+				log::error!(target: "xcm::check_is_decodable", "Decode error: {e:?} for xcm: {self:?}!");
 				()
 			})
 	}

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -355,11 +355,13 @@ impl<C> VersionedXcm<C> {
 	///
 	/// Note that this uses the limit of the sender - not the receiver. It is a best effort.
 	pub fn check_is_decodable(&self) -> Result<(), ()> {
-		self.using_encoded(|mut enc| Self::decode_all_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut enc).map(|_| ()))
-			.map_err(|e| {
-				log::error!(target: "xcm::check_is_decodable", "Decode error: {e:?} for xcm: {self:?}!");
-				()
-			})
+		self.using_encoded(|mut enc| {
+			Self::decode_all_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut enc).map(|_| ())
+		})
+		.map_err(|e| {
+			log::error!(target: "xcm::check_is_decodable", "Decode error: {e:?} for xcm: {self:?}!");
+			()
+		})
 	}
 }
 

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -46,11 +46,17 @@ pub mod latest {
 mod double_encoded;
 pub use double_encoded::DoubleEncoded;
 
+mod utils;
+
 #[cfg(test)]
 mod tests;
 
 /// Maximum nesting level for XCM decoding.
 pub const MAX_XCM_DECODE_DEPTH: u32 = 8;
+/// The maximal number of instructions in an XCM before decoding fails.
+///
+/// This is a deliberate limit - not a technical one.
+pub const MAX_INSTRUCTIONS_TO_DECODE: u8 = 100;
 
 /// A version of XCM.
 pub type Version = u32;
@@ -614,9 +620,12 @@ fn size_limits() {
 
 #[test]
 fn validate_xcm_nesting_works() {
-	use crate::latest::{
-		prelude::{GeneralIndex, ReserveAssetDeposited, SetAppendix},
-		Assets, Xcm, MAX_INSTRUCTIONS_TO_DECODE, MAX_ITEMS_IN_ASSETS,
+	use crate::{
+		latest::{
+			prelude::{GeneralIndex, ReserveAssetDeposited, SetAppendix},
+			Assets, Xcm, MAX_ITEMS_IN_ASSETS,
+		},
+		MAX_INSTRUCTIONS_TO_DECODE,
 	};
 
 	// closure generates assets of `count`

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -338,10 +338,11 @@ impl<RuntimeCall> Decode for VersionedXcm<RuntimeCall> {
 		Ok(
 			match input.read_byte().map_err(|e| {
 				e.chain("Could not decode `VersionedXcm`, failed to read variant byte")
-			})? {
-				3 => Self::V3(decode_variant(input)?),
-				4 => Self::V4(decode_variant(input)?),
-				5 => Self::V5(decode_variant(input)?),
+			})? as u32
+			{
+				v3::VERSION => Self::V3(decode_variant(input)?),
+				v4::VERSION => Self::V4(decode_variant(input)?),
+				v5::VERSION => Self::V5(decode_variant(input)?),
 				_ => return Err("Could not decode `VersionedXcm`, variant doesn't exist".into()),
 			},
 		)

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -376,10 +376,10 @@ impl<C> VersionedXcm<C> {
 	/// `MAX_INSTRUCTIONS_TO_DECODE`.
 	///
 	/// Note that this uses the limit of the sender - not the receiver. It is a best effort.
-	pub fn validate_xcm_nesting(&self) -> Result<(), ()> {
+	pub fn validate_xcm_decoding(&self) -> Result<(), ()> {
 		self.using_encoded(|mut enc| Self::decode_all(&mut enc).map(|_| ()))
 			.map_err(|e| {
-				log::error!(target: "xcm::validate_xcm_nesting", "Decode error: {e:?} for xcm: {self:?}!");
+				log::error!(target: "xcm::validate_xcm_decoding", "Decode error: {e:?} for xcm: {self:?}!");
 				()
 			})
 	}
@@ -638,7 +638,7 @@ fn size_limits() {
 }
 
 #[test]
-fn validate_xcm_nesting_works() {
+fn validate_xcm_decoding_works() {
 	use crate::{
 		latest::{
 			prelude::{GeneralIndex, ReserveAssetDeposited, SetAppendix},
@@ -670,46 +670,46 @@ fn validate_xcm_nesting_works() {
 		ReserveAssetDeposited(assets(1));
 		(MAX_INSTRUCTIONS_TO_DECODE - 1) as usize
 	]))
-	.validate_xcm_nesting()
+	.validate_xcm_decoding()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![
 		ReserveAssetDeposited(assets(1));
 		MAX_INSTRUCTIONS_TO_DECODE as usize
 	]))
-	.validate_xcm_nesting()
+	.validate_xcm_decoding()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![
 		ReserveAssetDeposited(assets(1));
 		(MAX_INSTRUCTIONS_TO_DECODE + 1) as usize
 	]))
-	.validate_xcm_nesting()
+	.validate_xcm_decoding()
 	.is_err());
 
 	// `MAX_XCM_DECODE_DEPTH` check
 	assert!(VersionedXcm::<()>::from(with_instr(MAX_XCM_DECODE_DEPTH - 1))
-		.validate_xcm_nesting()
+		.validate_xcm_decoding()
 		.is_ok());
 	assert!(VersionedXcm::<()>::from(with_instr(MAX_XCM_DECODE_DEPTH))
-		.validate_xcm_nesting()
+		.validate_xcm_decoding()
 		.is_ok());
 	assert!(VersionedXcm::<()>::from(with_instr(MAX_XCM_DECODE_DEPTH + 1))
-		.validate_xcm_nesting()
+		.validate_xcm_decoding()
 		.is_err());
 
 	// `MAX_ITEMS_IN_ASSETS` check
 	assert!(VersionedXcm::<()>::from(Xcm(vec![ReserveAssetDeposited(assets(
 		MAX_ITEMS_IN_ASSETS
 	))]))
-	.validate_xcm_nesting()
+	.validate_xcm_decoding()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![ReserveAssetDeposited(assets(
 		MAX_ITEMS_IN_ASSETS - 1
 	))]))
-	.validate_xcm_nesting()
+	.validate_xcm_decoding()
 	.is_ok());
 	assert!(VersionedXcm::<()>::from(Xcm(vec![ReserveAssetDeposited(assets(
 		MAX_ITEMS_IN_ASSETS + 1
 	))]))
-	.validate_xcm_nesting()
+	.validate_xcm_decoding()
 	.is_err());
 }

--- a/polkadot/xcm/src/lib.rs
+++ b/polkadot/xcm/src/lib.rs
@@ -25,7 +25,8 @@
 extern crate alloc;
 
 use codec::{
-	Decode, DecodeLimit, DecodeWithMemTracking, Encode, Error as CodecError, Input, MaxEncodedLen,
+	Decode, DecodeAll, DecodeLimit, DecodeWithMemTracking, Encode, Error as CodecError, Input,
+	MaxEncodedLen,
 };
 use derive_where::derive_where;
 use frame_support::dispatch::GetDispatchInfo;
@@ -369,19 +370,17 @@ impl<C> IdentifyVersion for VersionedXcm<C> {
 }
 
 impl<C> VersionedXcm<C> {
-	/// Checks that the XCM is decodable with `MAX_XCM_DECODE_DEPTH`. Consequently, it also checks
-	/// all decode implementations and limits, such as MAX_ITEMS_IN_ASSETS or
-	/// MAX_INSTRUCTIONS_TO_DECODE.
+	/// Checks that the XCM is decodable. Consequently, it checks all decode implementations and
+	/// limits, such as `MAX_XCM_DECODE_DEPTH`, `MAX_ITEMS_IN_ASSETS` or
+	/// `MAX_INSTRUCTIONS_TO_DECODE`.
 	///
 	/// Note that this uses the limit of the sender - not the receiver. It is a best effort.
 	pub fn validate_xcm_nesting(&self) -> Result<(), ()> {
-		self.using_encoded(|mut enc| {
-			Self::decode_all_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut enc).map(|_| ())
-		})
-		.map_err(|e| {
-			log::error!(target: "xcm::validate_xcm_nesting", "Decode error: {e:?} for xcm: {self:?}!");
-			()
-		})
+		self.using_encoded(|mut enc| Self::decode_all(&mut enc).map(|_| ()))
+			.map_err(|e| {
+				log::error!(target: "xcm::validate_xcm_nesting", "Decode error: {e:?} for xcm: {self:?}!");
+				()
+			})
 	}
 }
 

--- a/polkadot/xcm/src/utils.rs
+++ b/polkadot/xcm/src/utils.rs
@@ -20,9 +20,8 @@ use crate::MAX_INSTRUCTIONS_TO_DECODE;
 
 use alloc::vec::Vec;
 use codec::{decode_vec_with_len, Compact, Decode};
-use sp_runtime::SaturatedConversion;
 
-environmental::environmental!(instructions_count: u8);
+environmental::environmental!(instructions_count: u32);
 
 /// Decode a `vec` of XCM instructions.
 ///
@@ -34,8 +33,8 @@ pub fn decode_xcm_instructions<I: codec::Input, T: Decode>(
 	instructions_count::using_once(&mut 0, || {
 		let vec_len: u32 = <Compact<u32>>::decode(input)?.into();
 		instructions_count::with(|count| {
-			*count = count.saturating_add(vec_len.saturated_into());
-			if *count > MAX_INSTRUCTIONS_TO_DECODE {
+			*count = count.saturating_add(vec_len);
+			if *count > MAX_INSTRUCTIONS_TO_DECODE as u32 {
 				return Err(codec::Error::from("Max instructions exceeded"))
 			}
 			Ok(())

--- a/polkadot/xcm/src/utils.rs
+++ b/polkadot/xcm/src/utils.rs
@@ -20,8 +20,9 @@ use crate::MAX_INSTRUCTIONS_TO_DECODE;
 
 use alloc::vec::Vec;
 use codec::{decode_vec_with_len, Compact, Decode};
+use sp_runtime::SaturatedConversion;
 
-environmental::environmental!(instructions_count: u32);
+environmental::environmental!(instructions_count: u8);
 
 /// Decode a `vec` of XCM instructions.
 ///
@@ -33,8 +34,8 @@ pub fn decode_xcm_instructions<I: codec::Input, T: Decode>(
 	instructions_count::using_once(&mut 0, || {
 		let vec_len: u32 = <Compact<u32>>::decode(input)?.into();
 		instructions_count::with(|count| {
-			*count = count.saturating_add(vec_len);
-			if *count > MAX_INSTRUCTIONS_TO_DECODE as u32 {
+			*count = count.saturating_add(vec_len as u8);
+			if *count > MAX_INSTRUCTIONS_TO_DECODE {
 				return Err(codec::Error::from("Max instructions exceeded"))
 			}
 			Ok(())

--- a/polkadot/xcm/src/utils.rs
+++ b/polkadot/xcm/src/utils.rs
@@ -20,7 +20,6 @@ use crate::MAX_INSTRUCTIONS_TO_DECODE;
 
 use alloc::vec::Vec;
 use codec::{decode_vec_with_len, Compact, Decode};
-use sp_runtime::SaturatedConversion;
 
 environmental::environmental!(instructions_count: u8);
 

--- a/polkadot/xcm/src/utils.rs
+++ b/polkadot/xcm/src/utils.rs
@@ -1,0 +1,43 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! XCM utils for internal use.
+
+use crate::MAX_INSTRUCTIONS_TO_DECODE;
+
+use alloc::vec::Vec;
+use codec::{decode_vec_with_len, Compact, Decode};
+use sp_runtime::SaturatedConversion;
+
+environmental::environmental!(instructions_count: u8);
+
+pub fn decode_xcm_instructions<I: codec::Input, T: Decode>(
+	input: &mut I,
+) -> Result<Vec<T>, codec::Error> {
+	instructions_count::using_once(&mut 0, || {
+		let number_of_instructions: u32 = <Compact<u32>>::decode(input)?.into();
+		instructions_count::with(|count| {
+			*count = count.saturating_add(number_of_instructions.saturated_into());
+			if *count > MAX_INSTRUCTIONS_TO_DECODE {
+				return Err(codec::Error::from("Max instructions exceeded"))
+			}
+			Ok(())
+		})
+		.expect("Called in `using` context and thus can not return `None`; qed")?;
+		let decoded_instructions = decode_vec_with_len(input, number_of_instructions as usize)?;
+		Ok(decoded_instructions)
+	})
+}

--- a/polkadot/xcm/src/v3/mod.rs
+++ b/polkadot/xcm/src/v3/mod.rs
@@ -20,12 +20,12 @@ use super::v4::{
 	Instruction as NewInstruction, PalletInfo as NewPalletInfo,
 	QueryResponseInfo as NewQueryResponseInfo, Response as NewResponse, Xcm as NewXcm,
 };
-use crate::DoubleEncoded;
+use crate::{utils::decode_xcm_instructions, DoubleEncoded};
 use alloc::{vec, vec::Vec};
 use bounded_collections::{parameter_types, BoundedVec};
 use codec::{
-	self, decode_vec_with_len, Compact, Decode, DecodeWithMemTracking, Encode, Error as CodecError,
-	Input as CodecInput, MaxEncodedLen,
+	self, Decode, DecodeWithMemTracking, Encode, Error as CodecError, Input as CodecInput,
+	MaxEncodedLen,
 };
 use core::{fmt::Debug, result};
 use derive_where::derive_where;
@@ -65,28 +65,9 @@ pub type QueryId = u64;
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Xcm<Call>(pub Vec<Instruction<Call>>);
 
-/// The maximal number of instructions in an XCM before decoding fails.
-///
-/// This is a deliberate limit - not a technical one.
-pub const MAX_INSTRUCTIONS_TO_DECODE: u8 = 100;
-
-environmental::environmental!(instructions_count: u8);
-
 impl<Call> Decode for Xcm<Call> {
 	fn decode<I: CodecInput>(input: &mut I) -> core::result::Result<Self, CodecError> {
-		instructions_count::using_once(&mut 0, || {
-			let number_of_instructions: u32 = <Compact<u32>>::decode(input)?.into();
-			instructions_count::with(|count| {
-				*count = count.saturating_add(number_of_instructions as u8);
-				if *count > MAX_INSTRUCTIONS_TO_DECODE {
-					return Err(CodecError::from("Max instructions exceeded"))
-				}
-				Ok(())
-			})
-			.unwrap_or(Ok(()))?;
-			let decoded_instructions = decode_vec_with_len(input, number_of_instructions as usize)?;
-			Ok(Self(decoded_instructions))
-		})
+		Ok(Xcm(decode_xcm_instructions(input)?))
 	}
 }
 
@@ -1460,6 +1441,7 @@ impl<Call> TryFrom<NewInstruction<Call>> for Instruction<Call> {
 #[cfg(test)]
 mod tests {
 	use super::{prelude::*, *};
+	use crate::MAX_INSTRUCTIONS_TO_DECODE;
 
 	#[test]
 	fn decoding_respects_limit() {

--- a/polkadot/xcm/src/v4/mod.rs
+++ b/polkadot/xcm/src/v4/mod.rs
@@ -27,12 +27,12 @@ use super::{
 		QueryResponseInfo as NewQueryResponseInfo, Response as NewResponse, Xcm as NewXcm,
 	},
 };
-use crate::DoubleEncoded;
+use crate::{utils::decode_xcm_instructions, DoubleEncoded};
 use alloc::{vec, vec::Vec};
 use bounded_collections::{parameter_types, BoundedVec};
 use codec::{
-	self, decode_vec_with_len, Compact, Decode, DecodeWithMemTracking, Encode, Error as CodecError,
-	Input as CodecInput, MaxEncodedLen,
+	self, Decode, DecodeWithMemTracking, Encode, Error as CodecError, Input as CodecInput,
+	MaxEncodedLen,
 };
 use core::{fmt::Debug, result};
 use derive_where::derive_where;
@@ -72,25 +72,9 @@ pub type QueryId = u64;
 #[scale_info(bounds(), skip_type_params(Call))]
 pub struct Xcm<Call>(pub Vec<Instruction<Call>>);
 
-pub const MAX_INSTRUCTIONS_TO_DECODE: u8 = 100;
-
-environmental::environmental!(instructions_count: u8);
-
 impl<Call> Decode for Xcm<Call> {
 	fn decode<I: CodecInput>(input: &mut I) -> core::result::Result<Self, CodecError> {
-		instructions_count::using_once(&mut 0, || {
-			let number_of_instructions: u32 = <Compact<u32>>::decode(input)?.into();
-			instructions_count::with(|count| {
-				*count = count.saturating_add(number_of_instructions as u8);
-				if *count > MAX_INSTRUCTIONS_TO_DECODE {
-					return Err(CodecError::from("Max instructions exceeded"))
-				}
-				Ok(())
-			})
-			.expect("Called in `using` context and thus can not return `None`; qed")?;
-			let decoded_instructions = decode_vec_with_len(input, number_of_instructions as usize)?;
-			Ok(Self(decoded_instructions))
-		})
+		Ok(Xcm(decode_xcm_instructions(input)?))
 	}
 }
 
@@ -1610,9 +1594,12 @@ impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
 #[cfg(test)]
 mod tests {
 	use super::{prelude::*, *};
-	use crate::v3::{
-		Junctions::Here as OldHere, MultiAssetFilter as OldMultiAssetFilter,
-		WildMultiAsset as OldWildMultiAsset,
+	use crate::{
+		v3::{
+			Junctions::Here as OldHere, MultiAssetFilter as OldMultiAssetFilter,
+			WildMultiAsset as OldWildMultiAsset,
+		},
+		MAX_INSTRUCTIONS_TO_DECODE,
 	};
 
 	#[test]

--- a/polkadot/xcm/src/v5/mod.rs
+++ b/polkadot/xcm/src/v5/mod.rs
@@ -21,12 +21,12 @@ use super::v4::{
 	Instruction as OldInstruction, PalletInfo as OldPalletInfo,
 	QueryResponseInfo as OldQueryResponseInfo, Response as OldResponse, Xcm as OldXcm,
 };
-use crate::DoubleEncoded;
+use crate::{utils::decode_xcm_instructions, DoubleEncoded};
 use alloc::{vec, vec::Vec};
 use bounded_collections::{parameter_types, BoundedVec};
 use codec::{
-	self, decode_vec_with_len, Compact, Decode, DecodeWithMemTracking, Encode, Error as CodecError,
-	Input as CodecInput, MaxEncodedLen,
+	self, Decode, DecodeWithMemTracking, Encode, Error as CodecError, Input as CodecInput,
+	MaxEncodedLen,
 };
 use core::{fmt::Debug, result};
 use derive_where::derive_where;
@@ -66,25 +66,9 @@ pub type QueryId = u64;
 #[scale_info(bounds(), skip_type_params(Call))]
 pub struct Xcm<Call>(pub Vec<Instruction<Call>>);
 
-pub const MAX_INSTRUCTIONS_TO_DECODE: u8 = 100;
-
-environmental::environmental!(instructions_count: u8);
-
 impl<Call> Decode for Xcm<Call> {
 	fn decode<I: CodecInput>(input: &mut I) -> core::result::Result<Self, CodecError> {
-		instructions_count::using_once(&mut 0, || {
-			let number_of_instructions: u32 = <Compact<u32>>::decode(input)?.into();
-			instructions_count::with(|count| {
-				*count = count.saturating_add(number_of_instructions as u8);
-				if *count > MAX_INSTRUCTIONS_TO_DECODE {
-					return Err(CodecError::from("Max instructions exceeded"))
-				}
-				Ok(())
-			})
-			.expect("Called in `using` context and thus can not return `None`; qed")?;
-			let decoded_instructions = decode_vec_with_len(input, number_of_instructions as usize)?;
-			Ok(Self(decoded_instructions))
-		})
+		Ok(Xcm(decode_xcm_instructions(input)?))
 	}
 }
 
@@ -1510,8 +1494,11 @@ impl<Call> TryFrom<OldInstruction<Call>> for Instruction<Call> {
 #[cfg(test)]
 mod tests {
 	use super::{prelude::*, *};
-	use crate::v4::{
-		AssetFilter as OldAssetFilter, Junctions::Here as OldHere, WildAsset as OldWildAsset,
+	use crate::{
+		v4::{
+			AssetFilter as OldAssetFilter, Junctions::Here as OldHere, WildAsset as OldWildAsset,
+		},
+		MAX_INSTRUCTIONS_TO_DECODE,
 	};
 
 	#[test]

--- a/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
+++ b/polkadot/xcm/xcm-builder/src/process_xcm_message.rs
@@ -47,17 +47,19 @@ impl<
 		meter: &mut WeightMeter,
 		id: &mut XcmHash,
 	) -> Result<bool, ProcessMessageError> {
-		let versioned_message =
-			VersionedXcm::<Call>::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut &message[..])
-				.map_err(|e| {
-					tracing::trace!(
-						target: LOG_TARGET,
-						?e,
-						"`VersionedXcm` failed to decode",
-					);
+		let versioned_message = VersionedXcm::<Call>::decode_all_with_depth_limit(
+			MAX_XCM_DECODE_DEPTH,
+			&mut &message[..],
+		)
+		.map_err(|e| {
+			tracing::trace!(
+				target: LOG_TARGET,
+				?e,
+				"`VersionedXcm` failed to decode",
+			);
 
-					ProcessMessageError::Corrupt
-				})?;
+			ProcessMessageError::Corrupt
+		})?;
 		let message = Xcm::<Call>::try_from(versioned_message).map_err(|_| {
 			tracing::trace!(
 				target: LOG_TARGET,

--- a/polkadot/xcm/xcm-builder/src/routing.rs
+++ b/polkadot/xcm/xcm-builder/src/routing.rs
@@ -209,7 +209,7 @@ impl<Inner: SendXcm> SendXcm for EnsureDecodableXcm<Inner> {
 	) -> SendResult<Self::Ticket> {
 		if let Some(msg) = message {
 			let versioned_xcm = VersionedXcm::<()>::from(msg.clone());
-			if versioned_xcm.validate_xcm_decoding().is_err() {
+			if versioned_xcm.check_is_decodable().is_err() {
 				tracing::debug!(
 					target: "xcm::validate_xcm_nesting",
 					?versioned_xcm,

--- a/polkadot/xcm/xcm-builder/src/routing.rs
+++ b/polkadot/xcm/xcm-builder/src/routing.rs
@@ -209,7 +209,7 @@ impl<Inner: SendXcm> SendXcm for EnsureDecodableXcm<Inner> {
 	) -> SendResult<Self::Ticket> {
 		if let Some(msg) = message {
 			let versioned_xcm = VersionedXcm::<()>::from(msg.clone());
-			if versioned_xcm.validate_xcm_nesting().is_err() {
+			if versioned_xcm.validate_xcm_decoding().is_err() {
 				tracing::debug!(
 					target: "xcm::validate_xcm_nesting",
 					?versioned_xcm,

--- a/polkadot/xcm/xcm-simulator/fuzzer/src/fuzz.rs
+++ b/polkadot/xcm/xcm-simulator/fuzzer/src/fuzz.rs
@@ -103,7 +103,7 @@ impl<'a> Arbitrary<'a> for XcmMessage {
 		let destination: u32 = u.arbitrary()?;
 		let mut encoded_message: &[u8] = u.arbitrary()?;
 		if let Ok(message) =
-			DecodeLimit::decode_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut encoded_message)
+			DecodeLimit::decode_all_with_depth_limit(MAX_XCM_DECODE_DEPTH, &mut encoded_message)
 		{
 			return Ok(XcmMessage { source, destination, message });
 		}

--- a/prdoc/pr_7856.prdoc
+++ b/prdoc/pr_7856.prdoc
@@ -12,12 +12,14 @@ doc:
 
 crates:
   - name: staging-xcm
-    bump: minor
+    bump: major
   - name: staging-xcm-builder
-    bump: minor
+    bump: patch
   - name: cumulus-pallet-xcmp-queue
-    bump: minor
+    bump: patch
   - name: cumulus-primitives-utility
-    bump: minor
+    bump: patch
   - name: parachains-runtimes-test-utils
-    bump: minor
+    bump: patch
+  - name: polkadot-runtime-common
+    bump: patch

--- a/prdoc/pr_7856.prdoc
+++ b/prdoc/pr_7856.prdoc
@@ -6,8 +6,8 @@ title: Fix XCM decoding inconsistencies
 doc:
   - audience: Runtime Dev
     description: |
-      This PR adjusts the XCM decoding logic in order to use `decode_with_depth_limit()` consistently for `VersionedXcm`
-      and to deduplicate the logic used for decoding `v3::Xcm`, `v4::Xcm` and `v5::Xcm`.
+      This PR adjusts the XCM decoding logic in order to deduplicate the logic used for decoding `v3::Xcm`, `v4::Xcm`
+      and `v5::Xcm` and also to use `decode_with_depth_limit()` in some more places.
       Also `VersionedXcm::validate_xcm_nesting()` is renamed to `VersionedXcm::check_is_decodable()`.
 
 crates:
@@ -16,6 +16,8 @@ crates:
   - name: staging-xcm-builder
     bump: patch
   - name: cumulus-pallet-xcmp-queue
+    bump: patch
+  - name: cumulus-pallet-parachain-system
     bump: patch
   - name: cumulus-primitives-utility
     bump: patch

--- a/prdoc/pr_7856.prdoc
+++ b/prdoc/pr_7856.prdoc
@@ -1,0 +1,23 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Fix XCM decoding inconsistencies
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      This PR adjusts the XCM decoding logic in order to use `decode_with_depth_limit()` consistently for `VersionedXcm`
+      and to deduplicate the logic used for decoding `v3::Xcm`, `v4::Xcm` and `v5::Xcm`.
+      Also `VersionedXcm::validate_xcm_nesting()` is renamed to `VersionedXcm::validate_xcm_decoding()`.
+
+crates:
+  - name: staging-xcm
+    bump: minor
+  - name: staging-xcm-builder
+    bump: minor
+  - name: cumulus-pallet-xcmp-queue
+    bump: minor
+  - name: cumulus-primitives-utility
+    bump: minor
+  - name: parachains-runtimes-test-utils
+    bump: minor

--- a/prdoc/pr_7856.prdoc
+++ b/prdoc/pr_7856.prdoc
@@ -8,7 +8,7 @@ doc:
     description: |
       This PR adjusts the XCM decoding logic in order to use `decode_with_depth_limit()` consistently for `VersionedXcm`
       and to deduplicate the logic used for decoding `v3::Xcm`, `v4::Xcm` and `v5::Xcm`.
-      Also `VersionedXcm::validate_xcm_nesting()` is renamed to `VersionedXcm::validate_xcm_decoding()`.
+      Also `VersionedXcm::validate_xcm_nesting()` is renamed to `VersionedXcm::check_is_decodable()`.
 
 crates:
   - name: staging-xcm


### PR DESCRIPTION
This PR includes:

- deduplicating some XCM decoding logic
- making use of `decode_with_depth_limit` consistently for `VersionedXcm`
- some cleanup 