### PR TITLE
Enable query creation and response retrieval in `pallet_revive`

### DIFF
--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -729,6 +729,7 @@ pub mod pallet_test_notifier {
 				.map_err(|_| Error::<T>::BadAccountFormat)?;
 			let qid = <pallet_xcm::Pallet<T> as XcmQueryHandler>::new_query(
 				Junction::AccountId32 { network: None, id },
+				None,
 				100u32.into(),
 				Here,
 			);

--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -393,6 +393,7 @@ pub mod pallet {
 			let responder = <T as Config>::ExecuteXcmOrigin::ensure_origin(origin)?;
 			let query_id = <Self as QueryHandler>::new_query(
 				responder,
+				None,
 				timeout,
 				Location::try_from(match_querier)
 					.map_err(|_| Into::<DispatchError>::into(Error::<T>::BadVersion))?,
@@ -1475,10 +1476,11 @@ impl<T: Config> QueryHandler for Pallet<T> {
 	/// Attempt to create a new query ID and register it as a query that is yet to respond.
 	fn new_query(
 		responder: impl Into<Location>,
+		maybe_notify: Option<(u8, u8)>,
 		timeout: BlockNumberFor<T>,
 		match_querier: impl Into<Location>,
 	) -> QueryId {
-		Self::do_new_query(responder, None, timeout, match_querier)
+		Self::do_new_query(responder, maybe_notify, timeout, match_querier)
 	}
 
 	/// To check the status of the query, use `fn query()` passing the resultant `QueryId`
@@ -1492,7 +1494,7 @@ impl<T: Config> QueryHandler for Pallet<T> {
 		let destination = Self::UniversalLocation::get()
 			.invert_target(&responder)
 			.map_err(|()| XcmError::LocationNotInvertible)?;
-		let query_id = Self::new_query(responder, timeout, Here);
+		let query_id = Self::new_query(responder, None, timeout, Here);
 		let response_info = QueryResponseInfo { destination, query_id, max_weight: Weight::zero() };
 		let report_error = Xcm(vec![ReportError(response_info)]);
 		message.0.insert(0, SetAppendix(report_error));

--- a/polkadot/xcm/pallet-xcm/src/mock.rs
+++ b/polkadot/xcm/pallet-xcm/src/mock.rs
@@ -95,6 +95,7 @@ pub mod pallet_test_notifier {
 				.map_err(|_| Error::<T>::BadAccountFormat)?;
 			let qid = <crate::Pallet<T> as QueryHandler>::new_query(
 				Junction::AccountId32 { network: None, id },
+				None,
 				100u32.into(),
 				querier,
 			);

--- a/polkadot/xcm/xcm-builder/src/pay.rs
+++ b/polkadot/xcm/xcm-builder/src/pay.rs
@@ -106,7 +106,7 @@ impl<
 		let beneficiary = BeneficiaryRefToLocation::try_convert(&who)
 			.map_err(|_| xcm::latest::Error::InvalidLocation)?;
 
-		let query_id = Querier::new_query(asset_location.clone(), Timeout::get(), Interior::get());
+		let query_id = Querier::new_query(asset_location.clone(), None, Timeout::get(), Interior::get());
 
 		let message = Xcm(vec![
 			DescendOrigin(Interior::get()),

--- a/polkadot/xcm/xcm-builder/src/pay.rs
+++ b/polkadot/xcm/xcm-builder/src/pay.rs
@@ -106,7 +106,8 @@ impl<
 		let beneficiary = BeneficiaryRefToLocation::try_convert(&who)
 			.map_err(|_| xcm::latest::Error::InvalidLocation)?;
 
-		let query_id = Querier::new_query(asset_location.clone(), None, Timeout::get(), Interior::get());
+		let query_id =
+			Querier::new_query(asset_location.clone(), None, Timeout::get(), Interior::get());
 
 		let message = Xcm(vec![
 			DescendOrigin(Interior::get()),

--- a/polkadot/xcm/xcm-builder/src/tests/mock.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/mock.rs
@@ -426,6 +426,7 @@ impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 
 	fn new_query(
 		responder: impl Into<Location>,
+		_maybe_notify: Option<(u8, u8)>,
 		_timeout: Self::BlockNumber,
 		_match_querier: impl Into<Location>,
 	) -> QueryId {
@@ -443,7 +444,7 @@ impl<T: Config, BlockNumber: sp_runtime::traits::Zero + Encode> QueryHandler
 		let destination = Self::UniversalLocation::get()
 			.invert_target(&responder)
 			.map_err(|()| XcmError::LocationNotInvertible)?;
-		let query_id = Self::new_query(responder, timeout, Here);
+		let query_id = Self::new_query(responder, None, timeout, Here);
 		let response_info = QueryResponseInfo { destination, query_id, max_weight: Weight::zero() };
 		let report_error = Xcm(vec![ReportError(response_info)]);
 		message.0.insert(0, SetAppendix(report_error));

--- a/polkadot/xcm/xcm-executor/src/traits/on_response.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/on_response.rs
@@ -118,6 +118,7 @@ pub trait QueryHandler {
 	/// Attempt to create a new query ID and register it as a query that is yet to respond.
 	fn new_query(
 		responder: impl Into<Location>,
+		maybe_notify: Option<(u8, u8)>,
 		timeout: Self::BlockNumber,
 		match_querier: impl Into<Location>,
 	) -> QueryId;
@@ -162,6 +163,7 @@ impl QueryHandler for () {
 	}
 	fn new_query(
 		_responder: impl Into<Location>,
+		_maybe_notify: Option<(u8, u8)>,
 		_timeout: Self::BlockNumber,
 		_match_querier: impl Into<Location>,
 	) -> QueryId {

--- a/polkadot/xcm/xcm-executor/src/traits/on_response.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/on_response.rs
@@ -19,6 +19,7 @@ use codec::{Decode, Encode};
 use core::{fmt::Debug, result};
 use frame_support::{pallet_prelude::Get, parameter_types};
 use sp_arithmetic::traits::Zero;
+use sp_core::U256;
 use xcm::latest::{
 	Error as XcmError, InteriorLocation, Location, QueryId, Response, Result as XcmResult, Weight,
 	XcmContext,
@@ -111,7 +112,7 @@ pub enum QueryResponseStatus<BlockNumber> {
 
 /// Provides methods to expect responses from XCMs and query their status.
 pub trait QueryHandler {
-	type BlockNumber: Zero + Encode;
+	type BlockNumber: Zero + Encode + TryFrom<U256>;
 	type Error;
 	type UniversalLocation: Get<InteriorLocation>;
 

--- a/substrate/frame/revive/src/wasm/runtime.rs
+++ b/substrate/frame/revive/src/wasm/runtime.rs
@@ -595,9 +595,8 @@ impl<'a, E: Ext, M: PolkaVmInstance<E::T>> Runtime<'a, E, M> {
 				log::error!(target: LOG_TARGET, "polkavm execution error: {error}");
 				Some(Err(Error::<E::T>::ExecutionFailed.into()))
 			},
-			Ok(Finished) => {
-				Some(Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: Vec::new() }))
-			},
+			Ok(Finished) => 
+				Some(Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: Vec::new() })),
 			Ok(Trap) => Some(Err(Error::<E::T>::ContractTrapped.into())),
 			Ok(Segfault(_)) => Some(Err(Error::<E::T>::ExecutionFailed.into())),
 			Ok(NotEnoughGas) => Some(Err(Error::<E::T>::OutOfGas.into())),
@@ -611,7 +610,7 @@ impl<'a, E: Ext, M: PolkaVmInstance<E::T>> Runtime<'a, E, M> {
 					return Some(Ok(ExecReturnValue {
 						flags: ReturnFlags::empty(),
 						data: Vec::new(),
-					}));
+					}))
 				}
 				let Some(syscall_symbol) = module.imports().get(idx) else {
 					return Some(Err(<Error<E::T>>::InvalidSyscall.into()));
@@ -622,12 +621,11 @@ impl<'a, E: Ext, M: PolkaVmInstance<E::T>> Runtime<'a, E, M> {
 						instance.write_output(return_value);
 						None
 					},
-					Err(TrapReason::Return(ReturnData { flags, data })) => {
+					Err(TrapReason::Return(ReturnData { flags, data })) =>
 						match ReturnFlags::from_bits(flags) {
 							None => Some(Err(Error::<E::T>::InvalidCallFlags.into())),
 							Some(flags) => Some(Ok(ExecReturnValue { flags, data })),
-						}
-					},
+						},
 					Err(TrapReason::Termination) => Some(Ok(Default::default())),
 					Err(TrapReason::SupervisorError(error)) => Some(Err(error.into())),
 				}
@@ -1809,9 +1807,8 @@ pub mod env {
 			Environment::new(self, memory, id, input_ptr, input_len, output_ptr, output_len_ptr);
 		let ret = match chain_extension.call(env)? {
 			RetVal::Converging(val) => Ok(val),
-			RetVal::Diverging { flags, data } => {
-				Err(TrapReason::Return(ReturnData { flags: flags.bits(), data }))
-			},
+			RetVal::Diverging { flags, data } =>
+				Err(TrapReason::Return(ReturnData { flags: flags.bits(), data })),
 		};
 		self.chain_extension = Some(chain_extension);
 		ret

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -735,6 +735,17 @@ pub trait HostFn: private::Sealed {
 	/// execution fails, `ReturnErrorCode::XcmSendFailed` is returned.
 	#[unstable_hostfn]
 	fn xcm_send(dest: &[u8], msg: &[u8], output: &mut [u8; 32]) -> Result;
+
+	/// Create a new query
+	/// 
+	/// # Parameters
+	/// 
+	/// - `responder`:  
+	/// - `maybe_notify`:  
+	/// - `timeout`:  
+	/// 
+	#[unstable_hostfn]
+	fn new_query(responder: &[u8], maybe_notify: &[u8], timeout: &[u8], output: &mut [u8; 32]) -> Result;
 }
 
 mod private {

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -736,16 +736,17 @@ pub trait HostFn: private::Sealed {
 	#[unstable_hostfn]
 	fn xcm_send(dest: &[u8], msg: &[u8], output: &mut [u8; 32]) -> Result;
 
-	/// Create a new query
+	/// Create a new query that's been stored on the `Queries` map in `pallet_revive`
 	/// 
 	/// # Parameters
 	/// 
-	/// - `responder`:  
-	/// - `maybe_notify`:  
-	/// - `timeout`:  
+	/// - `responder`: The Location of the responder.
+	/// - `maybe_notify`: The callback to be called when the query is responded to (Optional).
+	/// - `timeout`: The timeout for the query to be responded to.
+	/// - `output`: The output buffer to write the query id.  
 	/// 
 	#[unstable_hostfn]
-	fn new_query(responder: &[u8], maybe_notify: &[u8], timeout: &[u8], output: &mut [u8; 32]) -> Result;
+	fn new_query(responder: &[u8], maybe_notify: &[u8], timeout: &[u8; 32], output: &mut [u8; 32]);
 }
 
 mod private {

--- a/substrate/frame/revive/uapi/src/host.rs
+++ b/substrate/frame/revive/uapi/src/host.rs
@@ -737,14 +737,13 @@ pub trait HostFn: private::Sealed {
 	fn xcm_send(dest: &[u8], msg: &[u8], output: &mut [u8; 32]) -> Result;
 
 	/// Create a new query that's been stored on the `Queries` map in `pallet_revive`
-	/// 
+	///
 	/// # Parameters
-	/// 
+	///
 	/// - `responder`: The Location of the responder.
 	/// - `maybe_notify`: The callback to be called when the query is responded to (Optional).
 	/// - `timeout`: The timeout for the query to be responded to.
-	/// - `output`: The output buffer to write the query id.  
-	/// 
+	/// - `output`: The output buffer to write the query id.
 	#[unstable_hostfn]
 	fn new_query(responder: &[u8], maybe_notify: &[u8], timeout: &[u8; 32], output: &mut [u8; 32]);
 }

--- a/substrate/frame/revive/uapi/src/host/riscv64.rs
+++ b/substrate/frame/revive/uapi/src/host/riscv64.rs
@@ -150,6 +150,14 @@ mod sys {
 			msg_len: u32,
 			out_ptr: *mut u8,
 		) -> ReturnCode;
+		pub fn new_query(
+			responder_ptr: *const u8,
+			responder_len: *const u8,
+			maybe_notify_ptr: *const u8,
+			maybe_notify_len: u32,
+			timeout_ptr: *const u8,
+			out_ptr: *mut u8,
+		) -> ReturnCode;
 		pub fn return_data_size() -> u64;
 		pub fn return_data_copy(out_ptr: *mut u8, out_len_ptr: *mut u32, offset: u32);
 	}
@@ -605,6 +613,21 @@ impl HostFn for HostFnImpl {
 				dest.len() as _,
 				msg.as_ptr(),
 				msg.len() as _,
+				output.as_mut_ptr(),
+			)
+		};
+		ret_code.into()
+	}
+
+	#[unstable_hostfn]
+	fn new_query(responder: &[u8], maybe_notify: &[u8], timeout: &[u8], output: &mut [u8; 32]) -> Result {
+		let ret_code = unsafe {
+			sys::new_query(
+				responder.as_ptr(),
+				responder.len() as _,
+				maybe_notify.as_ptr(),
+				maybe_notify.len() as _,
+				timeout.as_ptr(),
 				output.as_mut_ptr(),
 			)
 		};

--- a/substrate/frame/revive/uapi/src/host/riscv64.rs
+++ b/substrate/frame/revive/uapi/src/host/riscv64.rs
@@ -620,7 +620,12 @@ impl HostFn for HostFnImpl {
 	}
 
 	#[unstable_hostfn]
-	fn new_query(responder: &[u8], maybe_notify: &[u8], timeout: &[u8], output: &mut [u8; 32]) -> Result {
+	fn new_query(
+		responder: &[u8],
+		maybe_notify: &[u8],
+		timeout: &[u8],
+		output: &mut [u8; 32],
+	) -> Result {
 		let ret_code = unsafe {
 			sys::new_query(
 				responder.as_ptr(),


### PR DESCRIPTION
> Partially addresses #7735 and #7881 

## Description

This PR introduces a mechanism for creating queries and handling responses to retrieve the result of a remote execution (on a remote chain) within the context of `pallet_revive`. This is particularly relevant for smart contracts on Asset Hub.

In the future, this can be integrated with PVQ, enabling users to also query data from external consensus systems (e.g. call view functions in external smart contracts) and receive the result back as a response.

I've implemented a draft of `new_query` in `pallet_revive`, allowing developers to store new queries in the `Queries` storage map within `pallet-xcm`. I also modified `new_query` in `pallet-xcm` to account for callbacks and updated `on_response` to ensure that callbacks are not executed if the timeout has passed.

Still a work in progress.

## Checklist

* [ ] Ensure gas is charged for executing `new_query`
* [ ] Change `maybe_notify` in `pallet-xcm` so it also stores the call data (currently it stores only the pallet and call indexes)
* [ ] Implement `take_response`

