### PR TITLE
`UncheckedExtrinsic`: lazily decode the call

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1472,13 +1472,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1412,7 +1412,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1774,7 +1774,7 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1880,13 +1880,13 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -786,7 +786,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -829,13 +829,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -737,7 +737,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -780,13 +780,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -948,13 +948,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -905,7 +905,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -815,13 +815,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -766,7 +766,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -767,7 +767,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -816,13 +816,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -398,7 +398,7 @@ impl_runtime_apis! {
 		}
 
 		fn check_inherents(block: Block, data: sp_inherents::InherentData) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -720,7 +720,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -763,13 +763,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -722,7 +722,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -765,13 +765,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -992,7 +992,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -1035,13 +1035,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -807,13 +807,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -754,7 +754,7 @@ impl_runtime_apis! {
 		}
 
 		fn check_inherents(block: Block, data: sp_inherents::InherentData) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
@@ -601,13 +601,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
@@ -548,7 +548,7 @@ impl_runtime_apis! {
 		}
 
 		fn check_inherents(block: Block, data: sp_inherents::InherentData) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/cumulus/primitives/core/src/parachain_block_data.rs
+++ b/cumulus/primitives/core/src/parachain_block_data.rs
@@ -214,8 +214,8 @@ mod tests {
 		let v0 = ParachainBlockDataV0::<TestBlock> {
 			header: Header::new_from_number(10),
 			extrinsics: vec![
-				TestExtrinsic::new_bare(MockCallU64(10)),
-				TestExtrinsic::new_bare(MockCallU64(100)),
+				TestExtrinsic::new_bare(MockCallU64(10)).with_encoded_call(),
+				TestExtrinsic::new_bare(MockCallU64(100)).with_encoded_call(),
 			],
 			storage_proof: CompactProof { encoded_nodes: vec![vec![10u8; 200], vec![20u8; 30]] },
 		};
@@ -244,8 +244,8 @@ mod tests {
 			blocks: vec![TestBlock::new(
 				Header::new_from_number(10),
 				vec![
-					TestExtrinsic::new_bare(MockCallU64(10)),
-					TestExtrinsic::new_bare(MockCallU64(100)),
+					TestExtrinsic::new_bare(MockCallU64(10)).with_encoded_call(),
+					TestExtrinsic::new_bare(MockCallU64(100)).with_encoded_call(),
 				],
 			)],
 			proof: CompactProof { encoded_nodes: vec![vec![10u8; 200], vec![20u8; 30]] },

--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -565,7 +565,7 @@ impl_runtime_apis! {
 		}
 
 		fn check_inherents(block: Block, data: sp_inherents::InherentData) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/docs/sdk/packages/guides/first-runtime/src/lib.rs
+++ b/docs/sdk/packages/guides/first-runtime/src/lib.rs
@@ -271,10 +271,10 @@ impl_runtime_apis! {
 		interface::Balance,
 	> for Runtime {
 		fn query_info(uxt: ExtrinsicFor<Runtime>, len: u32) -> RuntimeDispatchInfo<interface::Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: ExtrinsicFor<Runtime>, len: u32) -> FeeDetails<interface::Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> interface::Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/docs/sdk/packages/guides/first-runtime/src/lib.rs
+++ b/docs/sdk/packages/guides/first-runtime/src/lib.rs
@@ -214,7 +214,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: InherentData,
 		) -> CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/docs/sdk/src/reference_docs/extrinsic_encoding.rs
+++ b/docs/sdk/src/reference_docs/extrinsic_encoding.rs
@@ -230,13 +230,13 @@
 
 #[docify::export]
 pub mod call_data {
-	use codec::{Decode, Encode};
+	use codec::{Decode, DecodeWithMemTracking, Encode};
 	use sp_runtime::{traits::Dispatchable, DispatchResultWithInfo};
 
 	// The outer enum composes calls within
 	// different pallets together. We have two
 	// pallets, "PalletA" and "PalletB".
-	#[derive(Encode, Decode, Clone)]
+	#[derive(Encode, Decode, DecodeWithMemTracking, Clone)]
 	pub enum Call {
 		#[codec(index = 0)]
 		PalletA(PalletACall),
@@ -247,13 +247,13 @@ pub mod call_data {
 	// An inner enum represents the calls within
 	// a specific pallet. "PalletA" has one call,
 	// "Foo".
-	#[derive(Encode, Decode, Clone)]
+	#[derive(Encode, Decode, DecodeWithMemTracking, Clone)]
 	pub enum PalletACall {
 		#[codec(index = 0)]
 		Foo(String),
 	}
 
-	#[derive(Encode, Decode, Clone)]
+	#[derive(Encode, Decode, DecodeWithMemTracking, Clone)]
 	pub enum PalletBCall {
 		#[codec(index = 0)]
 		Bar(String),

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2433,10 +2433,10 @@ sp_api::impl_runtime_apis! {
 		Balance,
 	> for Runtime {
 		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1994,7 +1994,7 @@ sp_api::impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -939,7 +939,7 @@ sp_api::impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -1323,10 +1323,10 @@ sp_api::impl_runtime_apis! {
 		Balance,
 	> for Runtime {
 		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2665,10 +2665,10 @@ sp_api::impl_runtime_apis! {
 		Balance,
 	> for Runtime {
 		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2217,7 +2217,7 @@ sp_api::impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/substrate/bin/node/cli/tests/fees.rs
+++ b/substrate/bin/node/cli/tests/fees.rs
@@ -30,7 +30,10 @@ use kitchensink_runtime::{
 use node_primitives::Balance;
 use node_testing::keyring::*;
 use polkadot_sdk::*;
-use sp_runtime::{traits::One, Perbill};
+use sp_runtime::{
+	traits::{LazyExtrinsic, One},
+	Perbill,
+};
 
 pub mod common;
 use self::common::{sign, *};
@@ -148,7 +151,7 @@ fn transaction_fee_is_correct() {
 	t.insert(<frame_system::BlockHash<Runtime>>::hashed_key_for(0), vec![0u8; 32]);
 
 	let tip = 1_000_000;
-	let xt = sign(CheckedExtrinsic {
+	let mut xt = sign(CheckedExtrinsic {
 		format: sp_runtime::generic::ExtrinsicFormat::Signed(alice(), tx_ext(0, tip)),
 		function: RuntimeCall::Balances(default_transfer_call()),
 	});
@@ -176,7 +179,7 @@ fn transaction_fee_is_correct() {
 		balance_alice -= length_fee;
 
 		let mut info = default_transfer_call().get_dispatch_info();
-		info.extension_weight = xt.0.extension_weight();
+		info.extension_weight = xt.expect_as_ref().extension_weight();
 		let weight = info.total_weight();
 		let weight_fee = IdentityFee::<Balance>::weight_to_fee(&weight);
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3109,7 +3109,7 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 		}
 
 		fn check_inherents(block: Block, data: InherentData) -> CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3382,10 +3382,10 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 		Balance,
 	> for Runtime {
 		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -3794,17 +3794,19 @@ pub(crate) mod tests {
 				assert_eq!(None, bc.body(blocks[1]).unwrap());
 				assert_eq!(None, bc.body(blocks[2]).unwrap());
 				assert_eq!(
-					Some(vec![UncheckedXt::new_transaction(3.into(), ())]),
+					Some(vec![UncheckedXt::new_transaction(3.into(), ()).with_encoded_call()]),
 					bc.body(blocks[3]).unwrap()
 				);
 				assert_eq!(
-					Some(vec![UncheckedXt::new_transaction(4.into(), ())]),
+					Some(vec![UncheckedXt::new_transaction(4.into(), ()).with_encoded_call()]),
 					bc.body(blocks[4]).unwrap()
 				);
 			} else {
 				for i in 0..5 {
 					assert_eq!(
-						Some(vec![UncheckedXt::new_transaction((i as u64).into(), ())]),
+						Some(vec![
+							UncheckedXt::new_transaction((i as u64).into(), ()).with_encoded_call()
+						]),
 						bc.body(blocks[i]).unwrap()
 					);
 				}
@@ -3869,7 +3871,7 @@ pub(crate) mod tests {
 
 			let bc = backend.blockchain();
 			assert_eq!(
-				Some(vec![UncheckedXt::new_transaction(2.into(), ())]),
+				Some(vec![UncheckedXt::new_transaction(2.into(), ()).with_encoded_call()]),
 				bc.body(fork_hash_root).unwrap()
 			);
 
@@ -3886,17 +3888,19 @@ pub(crate) mod tests {
 				assert_eq!(None, bc.body(blocks[2]).unwrap());
 
 				assert_eq!(
-					Some(vec![UncheckedXt::new_transaction(3.into(), ())]),
+					Some(vec![UncheckedXt::new_transaction(3.into(), ()).with_encoded_call()]),
 					bc.body(blocks[3]).unwrap()
 				);
 				assert_eq!(
-					Some(vec![UncheckedXt::new_transaction(4.into(), ())]),
+					Some(vec![UncheckedXt::new_transaction(4.into(), ()).with_encoded_call()]),
 					bc.body(blocks[4]).unwrap()
 				);
 			} else {
 				for i in 0..5 {
 					assert_eq!(
-						Some(vec![UncheckedXt::new_transaction((i as u64).into(), ())]),
+						Some(vec![
+							UncheckedXt::new_transaction((i as u64).into(), ()).with_encoded_call()
+						]),
 						bc.body(blocks[i]).unwrap()
 					);
 				}
@@ -3904,7 +3908,7 @@ pub(crate) mod tests {
 
 			if matches!(pruning, BlocksPruning::KeepAll) {
 				assert_eq!(
-					Some(vec![UncheckedXt::new_transaction(2.into(), ())]),
+					Some(vec![UncheckedXt::new_transaction(2.into(), ()).with_encoded_call()]),
 					bc.body(fork_hash_root).unwrap()
 				);
 			} else {
@@ -3965,19 +3969,19 @@ pub(crate) mod tests {
 		assert_eq!(None, bc.body(block_1b).unwrap());
 		assert_eq!(None, bc.body(block_2b).unwrap());
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(0x00.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(0x00.into(), ()).with_encoded_call()]),
 			bc.body(block_0).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(0x1a.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(0x1a.into(), ()).with_encoded_call()]),
 			bc.body(block_1a).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(0x2a.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(0x2a.into(), ()).with_encoded_call()]),
 			bc.body(block_2a).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(0x3a.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(0x3a.into(), ()).with_encoded_call()]),
 			bc.body(block_3a).unwrap()
 		);
 	}
@@ -4646,7 +4650,7 @@ pub(crate) mod tests {
 		// Check that we can properly access values when there is reference count
 		// but no value.
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(1.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(1.into(), ()).with_encoded_call()]),
 			bc.body(blocks[1]).unwrap()
 		);
 
@@ -4666,12 +4670,12 @@ pub(crate) mod tests {
 		// Block 0, 1, 2, 3 are pinned, so all values should be cached.
 		// Block 4 is inside the pruning window, its value is in db.
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(0.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(0.into(), ()).with_encoded_call()]),
 			bc.body(blocks[0]).unwrap()
 		);
 
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(1.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(1.into(), ()).with_encoded_call()]),
 			bc.body(blocks[1]).unwrap()
 		);
 		assert_eq!(
@@ -4680,7 +4684,7 @@ pub(crate) mod tests {
 		);
 
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(2.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(2.into(), ()).with_encoded_call()]),
 			bc.body(blocks[2]).unwrap()
 		);
 		assert_eq!(
@@ -4689,7 +4693,7 @@ pub(crate) mod tests {
 		);
 
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(3.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(3.into(), ()).with_encoded_call()]),
 			bc.body(blocks[3]).unwrap()
 		);
 		assert_eq!(
@@ -4698,7 +4702,7 @@ pub(crate) mod tests {
 		);
 
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(4.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(4.into(), ()).with_encoded_call()]),
 			bc.body(blocks[4]).unwrap()
 		);
 		assert_eq!(
@@ -4732,7 +4736,7 @@ pub(crate) mod tests {
 
 		// Block 4 is inside the pruning window and still kept
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(4.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(4.into(), ()).with_encoded_call()]),
 			bc.body(blocks[4]).unwrap()
 		);
 		assert_eq!(
@@ -4767,7 +4771,7 @@ pub(crate) mod tests {
 		assert!(bc.body(blocks[3]).unwrap().is_none());
 
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(4.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(4.into(), ()).with_encoded_call()]),
 			bc.body(blocks[4]).unwrap()
 		);
 		assert_eq!(
@@ -4775,7 +4779,7 @@ pub(crate) mod tests {
 			bc.justifications(blocks[4]).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(5.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(5.into(), ()).with_encoded_call()]),
 			bc.body(blocks[5]).unwrap()
 		);
 		assert!(bc.header(blocks[5]).ok().flatten().is_some());
@@ -4810,7 +4814,7 @@ pub(crate) mod tests {
 		backend.commit_operation(op).unwrap();
 
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(5.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(5.into(), ()).with_encoded_call()]),
 			bc.body(blocks[5]).unwrap()
 		);
 		assert!(bc.header(blocks[5]).ok().flatten().is_some());
@@ -4891,31 +4895,31 @@ pub(crate) mod tests {
 
 		let bc = backend.blockchain();
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(0.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(0.into(), ()).with_encoded_call()]),
 			bc.body(blocks[0]).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(1.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(1.into(), ()).with_encoded_call()]),
 			bc.body(blocks[1]).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(2.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(2.into(), ()).with_encoded_call()]),
 			bc.body(blocks[2]).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(3.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(3.into(), ()).with_encoded_call()]),
 			bc.body(blocks[3]).unwrap()
 		);
 		assert_eq!(
-			Some(vec![UncheckedXt::new_transaction(4.into(), ())]),
+			Some(vec![UncheckedXt::new_transaction(4.into(), ()).with_encoded_call()]),
 			bc.body(blocks[4]).unwrap()
 		);
 		// Check the fork hashes.
 		assert_eq!(None, bc.body(fork_hash_root).unwrap());
 		assert_eq!(
 			Some(vec![
-				UncheckedXt::new_transaction(3.into(), ()),
-				UncheckedXt::new_transaction(11.into(), ())
+				UncheckedXt::new_transaction(3.into(), ()).with_encoded_call(),
+				UncheckedXt::new_transaction(11.into(), ()).with_encoded_call()
 			]),
 			bc.body(fork_hash_3).unwrap()
 		);

--- a/substrate/client/offchain/src/lib.rs
+++ b/substrate/client/offchain/src/lib.rs
@@ -473,7 +473,7 @@ mod tests {
 		// then
 		assert_eq!(pool.status().ready, 1);
 		assert!(matches!(
-			pool.ready().next().unwrap().data().function,
+			pool.ready().next().unwrap().data().call.try_decode().unwrap(),
 			RuntimeCall::SubstrateTest(PalletCall::storage_change { .. })
 		));
 	}

--- a/substrate/frame/election-provider-multi-block/src/mock/mod.rs
+++ b/substrate/frame/election-provider-multi-block/src/mock/mod.rs
@@ -733,7 +733,8 @@ pub fn roll_to_with_ocw(n: BlockNumber, maybe_pool: Option<Arc<RwLock<PoolState>
 				.into_iter()
 				.map(|uxt| <Extrinsic as codec::Decode>::decode(&mut &*uxt).unwrap())
 				.for_each(|xt| {
-					xt.function.dispatch(frame_system::RawOrigin::None.into()).unwrap();
+					let call = xt.call.try_decode().unwrap();
+					call.dispatch(frame_system::RawOrigin::None.into()).unwrap();
 				});
 			pool.try_write().unwrap().transactions.clear();
 		}

--- a/substrate/frame/examples/authorization-tx-extension/src/tests.rs
+++ b/substrate/frame/examples/authorization-tx-extension/src/tests.rs
@@ -33,7 +33,7 @@ use pallet_verify_signature::VerifySignature;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::{
 	generic::ExtensionVersion,
-	traits::{Applyable, Checkable, IdentityLookup, TransactionExtension},
+	traits::{Applyable, Checkable, IdentityLookup, LazyExtrinsic, TransactionExtension},
 	MultiSignature, MultiSigner,
 };
 
@@ -73,9 +73,9 @@ fn create_asset_works() {
 			frame_system::CheckEra::<Runtime>::from(sp_runtime::generic::Era::immortal()),
 		);
 		// Create the transaction and we're ready for dispatch.
-		let uxt = UncheckedExtrinsic::new_transaction(create_asset_call, tx_ext);
+		let mut uxt = UncheckedExtrinsic::new_transaction(create_asset_call, tx_ext);
 		// Check Extrinsic validity and apply it.
-		let uxt_info = uxt.get_dispatch_info();
+		let uxt_info = uxt.expect_as_ref().get_dispatch_info();
 		let uxt_len = uxt.using_encoded(|e| e.len());
 		// Manually pay for Alice's nonce.
 		frame_system::Account::<Runtime>::mutate(&alice_account, |info| {
@@ -164,9 +164,9 @@ fn create_coowned_asset_works() {
 			frame_system::CheckEra::<Runtime>::from(sp_runtime::generic::Era::immortal()),
 		);
 		// Create the transaction and we're ready for dispatch.
-		let uxt = UncheckedExtrinsic::new_transaction(create_asset_call, tx_ext);
+		let mut uxt = UncheckedExtrinsic::new_transaction(create_asset_call, tx_ext);
 		// Check Extrinsic validity and apply it.
-		let uxt_info = uxt.get_dispatch_info();
+		let uxt_info = uxt.expect_as_ref().get_dispatch_info();
 		let uxt_len = uxt.using_encoded(|e| e.len());
 		// Manually pay for Charlie's nonce.
 		frame_system::Account::<Runtime>::mutate(&charlie_account, |info| {
@@ -255,9 +255,9 @@ fn inner_authorization_works() {
 			frame_system::CheckEra::<Runtime>::from(sp_runtime::generic::Era::immortal()),
 		);
 		// Create the transaction and we're ready for dispatch.
-		let uxt = UncheckedExtrinsic::new_transaction(create_asset_call, tx_ext);
+		let mut uxt = UncheckedExtrinsic::new_transaction(create_asset_call, tx_ext);
 		// Check Extrinsic validity and apply it.
-		let uxt_info = uxt.get_dispatch_info();
+		let uxt_info = uxt.expect_as_ref().get_dispatch_info();
 		let uxt_len = uxt.using_encoded(|e| e.len());
 		// Manually pay for Charlie's nonce.
 		frame_system::Account::<Runtime>::mutate(charlie_account, |info| {

--- a/substrate/frame/executive/src/tests.rs
+++ b/substrate/frame/executive/src/tests.rs
@@ -1553,16 +1553,19 @@ fn post_inherent_called_after_all_optional_inherents() {
 
 #[test]
 fn is_inherent_works() {
-	let ext = UncheckedXt::new_bare(RuntimeCall::Custom2(custom2::Call::inherent {}));
-	assert!(Runtime::is_inherent(&ext));
-	let ext = UncheckedXt::new_bare(RuntimeCall::Custom2(custom2::Call::optional_inherent {}));
-	assert!(Runtime::is_inherent(&ext));
+	let mut ext = UncheckedXt::new_bare(RuntimeCall::Custom2(custom2::Call::inherent {}));
+	assert!(Runtime::is_inherent(&ext.expect_as_ref()));
+	let mut ext = UncheckedXt::new_bare(RuntimeCall::Custom2(custom2::Call::optional_inherent {}));
+	assert!(Runtime::is_inherent(&ext.expect_as_ref()));
 
-	let ext = UncheckedXt::new_signed(call_transfer(33, 0), 1, 1.into(), tx_ext(0, 0));
-	assert!(!Runtime::is_inherent(&ext));
+	let mut ext = UncheckedXt::new_signed(call_transfer(33, 0), 1, 1.into(), tx_ext(0, 0));
+	assert!(!Runtime::is_inherent(&ext.expect_as_ref()));
 
-	let ext = UncheckedXt::new_bare(RuntimeCall::Custom2(custom2::Call::allowed_unsigned {}));
-	assert!(!Runtime::is_inherent(&ext), "Unsigned ext are not automatically inherents");
+	let mut ext = UncheckedXt::new_bare(RuntimeCall::Custom2(custom2::Call::allowed_unsigned {}));
+	assert!(
+		!Runtime::is_inherent(&ext.expect_as_ref()),
+		"Unsigned ext are not automatically inherents"
+	);
 }
 
 #[test]

--- a/substrate/frame/meta-tx/src/tests.rs
+++ b/substrate/frame/meta-tx/src/tests.rs
@@ -22,7 +22,7 @@ use sp_io::hashing::blake2_256;
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::{
 	generic::Era,
-	traits::{Applyable, Checkable, Hash, IdentityLookup},
+	traits::{Applyable, Checkable, Hash, IdentityLookup, LazyExtrinsic},
 	DispatchErrorWithPostInfo, MultiSignature,
 };
 
@@ -74,9 +74,9 @@ fn force_set_balance(account: AccountId) -> Balance {
 	balance
 }
 
-fn apply_extrinsic(uxt: UncheckedExtrinsic) -> DispatchResultWithPostInfo {
-	let uxt_info = uxt.get_dispatch_info();
+fn apply_extrinsic(mut uxt: UncheckedExtrinsic) -> DispatchResultWithPostInfo {
 	let uxt_len = uxt.using_encoded(|e| e.len());
+	let uxt_info = uxt.expect_as_ref().get_dispatch_info();
 	let xt = <UncheckedExtrinsic as Checkable<IdentityLookup<AccountId>>>::check(
 		uxt,
 		&Default::default(),

--- a/substrate/frame/origin-restriction/src/mock.rs
+++ b/substrate/frame/origin-restriction/src/mock.rs
@@ -29,7 +29,7 @@ use pallet_transaction_payment::ConstFeeMultiplier;
 use sp_core::{ConstU64, H256};
 use sp_runtime::{
 	testing::UintAuthorityId,
-	traits::{Applyable, BlakeTwo256, Checkable, ConstUint, IdentityLookup},
+	traits::{Applyable, BlakeTwo256, Checkable, ConstUint, IdentityLookup, LazyExtrinsic},
 	transaction_validity::{InvalidTransaction, TransactionSource},
 	BuildStorage, DispatchError, FixedU128, TransactionOutcome,
 };
@@ -321,8 +321,8 @@ pub fn exec_signed_tx_disabled(
 }
 
 /// Execute a transaction with the given origin, call and transaction extension.
-pub fn exec_tx(tx: UncheckedExtrinsic) -> Result<(), TransactionExecutionError> {
-	let info = tx.get_dispatch_info();
+pub fn exec_tx(mut tx: UncheckedExtrinsic) -> Result<(), TransactionExecutionError> {
+	let info = tx.expect_as_ref().get_dispatch_info();
 	let len = tx.encoded_size();
 
 	let checked = Checkable::check(tx, &frame_system::ChainContext::<Test>::default())?;

--- a/substrate/frame/people/src/mock.rs
+++ b/substrate/frame/people/src/mock.rs
@@ -28,7 +28,7 @@ use frame_system::{offchain::CreateTransactionBase, ChainContext};
 use sp_core::{ConstU16, ConstU32, ConstU64, H256};
 use sp_runtime::{
 	testing::UintAuthorityId,
-	traits::{Applyable, BlakeTwo256, Checkable, IdentityLookup},
+	traits::{Applyable, BlakeTwo256, Checkable, IdentityLookup, LazyExtrinsic},
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError},
 	BuildStorage, DispatchError, Weight,
 };
@@ -323,12 +323,12 @@ pub fn exec_tx(
 	tx_ext: TransactionExtension,
 	call: impl Into<RuntimeCall>,
 ) -> Result<(), TransactionExecutionError> {
-	let tx = match who {
+	let mut tx = match who {
 		Some(who) => UncheckedExtrinsic::new_signed(call.into(), who, UintAuthorityId(who), tx_ext),
 		None => UncheckedExtrinsic::new_transaction(call.into(), tx_ext),
 	};
 
-	let info = tx.get_dispatch_info();
+	let info = tx.expect_as_ref().get_dispatch_info();
 	let len = tx.encoded_size();
 
 	// Check and validate the extrinsic.

--- a/substrate/frame/revive/dev-node/runtime/src/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/src/lib.rs
@@ -424,10 +424,10 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 		Balance,
 	> for Runtime {
 		fn query_info(uxt: ExtrinsicFor<Runtime>, len: u32) -> RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: ExtrinsicFor<Runtime>, len: u32) -> FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/substrate/frame/revive/dev-node/runtime/src/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/src/lib.rs
@@ -381,7 +381,7 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 			block: Block,
 			data: InherentData,
 		) -> CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -140,9 +140,14 @@ where
 {
 	type Checked = CheckedExtrinsic<AccountIdOf<E::Config>, CallOf<E::Config>, E::Extension>;
 
-	fn check(self, lookup: &Lookup) -> Result<Self::Checked, TransactionValidityError> {
+	fn check(mut self, lookup: &Lookup) -> Result<Self::Checked, TransactionValidityError> {
 		if !self.0.is_signed() {
-			if let Some(crate::Call::eth_transact { payload }) = self.0.function.is_sub_type() {
+			let call = self
+				.0
+				.call
+				.try_get_or_decode()
+				.map_err(|_| InvalidTransaction::UnableToDecodeCall)?;
+			if let Some(crate::Call::eth_transact { payload }) = call.is_sub_type() {
 				let checked = E::try_into_checked_extrinsic(payload.to_vec(), self.encoded_size())?;
 				return Ok(checked)
 			};

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -35,8 +35,8 @@ use sp_core::{Get, H256, U256};
 use sp_runtime::{
 	generic::{self, CheckedExtrinsic, ExtrinsicFormat},
 	traits::{
-		Checkable, Dispatchable, ExtrinsicCall, ExtrinsicLike, ExtrinsicMetadata, LazyExtrinsic,
-		TransactionExtension,
+		BaseExtrinsicCall, Checkable, Dispatchable, ExtrinsicLike, ExtrinsicMetadata,
+		LazyExtrinsic, TransactionExtension,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic, RuntimeDebug,
@@ -106,12 +106,10 @@ impl<Address, Signature, E: EthExtra> ExtrinsicMetadata
 	type TransactionExtensions = E::Extension;
 }
 
-impl<Address, Signature, E: EthExtra> ExtrinsicCall for UncheckedExtrinsic<Address, Signature, E> {
+impl<Address, Signature, E: EthExtra> BaseExtrinsicCall
+	for UncheckedExtrinsic<Address, Signature, E>
+{
 	type Call = CallOf<E::Config>;
-
-	fn call(&self) -> &Self::Call {
-		self.0.call()
-	}
 }
 
 impl<LookupSource, Signature, E, Lookup> Checkable<Lookup>

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1545,13 +1545,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1439,7 +1439,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -2498,10 +2498,10 @@ sp_api::impl_runtime_apis! {
 		Balance,
 	> for Runtime {
 		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -2050,7 +2050,7 @@ sp_api::impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/inherent.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/inherent.rs
@@ -56,7 +56,14 @@ pub fn expand_outer_inherent(
 		trait InherentDataExt {
 			fn create_extrinsics(&self) ->
 				#scrate::__private::Vec<<#block as #scrate::sp_runtime::traits::Block>::Extrinsic>;
+
 			fn check_extrinsics(&self, block: &#block) -> #scrate::inherent::CheckInherentsResult;
+
+			fn check_extrinsics_from_runtime_api(&self, block: #block) ->
+				#scrate::inherent::CheckInherentsResult
+			{
+				self.check_extrinsics(&block)
+			}
 		}
 
 		impl InherentDataExt for #scrate::inherent::InherentData {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/metadata.rs
@@ -99,7 +99,7 @@ pub fn expand_runtime_metadata(
 						<#extrinsic as #scrate::traits::SignedTransactionBuilder>::Address
 					>();
 				let call_ty = #scrate::__private::scale_info::meta_type::<
-						<#extrinsic as #scrate::sp_runtime::traits::ExtrinsicCall>::Call
+						<#extrinsic as #scrate::sp_runtime::traits::BaseExtrinsicCall>::Call
 					>();
 				let signature_ty = #scrate::__private::scale_info::meta_type::<
 						<#extrinsic as #scrate::traits::SignedTransactionBuilder>::Signature

--- a/substrate/frame/support/src/inherent.rs
+++ b/substrate/frame/support/src/inherent.rs
@@ -19,6 +19,11 @@ pub use sp_inherents::{
 	CheckInherentsResult, InherentData, InherentIdentifier, IsFatalError, MakeFatalError,
 };
 
+#[derive(Debug)]
+pub enum CheckExtrinsicsError {
+	UnableToDecodeCall,
+}
+
 /// A pallet that provides or verifies an inherent extrinsic will implement this trait.
 ///
 /// The pallet may provide an inherent, verify an inherent, or both provide and verify.

--- a/substrate/frame/support/src/traits/misc.rs
+++ b/substrate/frame/support/src/traits/misc.rs
@@ -931,7 +931,7 @@ impl<Address, Call, Signature, Extra> InherentBuilder
 	for sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: TypeInfo,
-	Call: Clone + DecodeWithMemTracking + TypeInfo,
+	Call: DecodeWithMemTracking + TypeInfo,
 	Signature: TypeInfo,
 	Extra: TypeInfo,
 {
@@ -960,7 +960,7 @@ impl<Address, Call, Signature, Extension> SignedTransactionBuilder
 	for sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: TypeInfo,
-	Call: Clone + DecodeWithMemTracking + TypeInfo,
+	Call: DecodeWithMemTracking + TypeInfo,
 	Signature: TypeInfo,
 	Extension: TypeInfo,
 {

--- a/substrate/frame/support/src/traits/misc.rs
+++ b/substrate/frame/support/src/traits/misc.rs
@@ -35,7 +35,7 @@ pub use sp_runtime::traits::{
 	ConstU32, ConstU64, ConstU8, ConstUint, Get, GetDefault, TryCollect, TypedGet,
 };
 use sp_runtime::{
-	traits::{Block as BlockT, ExtrinsicCall},
+	traits::{BaseExtrinsicCall, Block as BlockT, LazyExtrinsic},
 	DispatchError,
 };
 
@@ -916,13 +916,13 @@ pub trait GetBacking {
 }
 
 /// A trait to check if an extrinsic is an inherent.
-pub trait IsInherent<Extrinsic> {
+pub trait IsInherent<Extrinsic: for<'a> LazyExtrinsic<'a>> {
 	/// Whether this extrinsic is an inherent.
-	fn is_inherent(ext: &Extrinsic) -> bool;
+	fn is_inherent(ext: &<Extrinsic as LazyExtrinsic<'_>>::ExtrinsicRef) -> bool;
 }
 
 /// Interface for types capable of constructing an inherent extrinsic.
-pub trait InherentBuilder: ExtrinsicCall {
+pub trait InherentBuilder: BaseExtrinsicCall {
 	/// Create a new inherent from a given call.
 	fn new_inherent(call: Self::Call) -> Self;
 }
@@ -941,7 +941,7 @@ where
 }
 
 /// Interface for types capable of constructing a signed transaction.
-pub trait SignedTransactionBuilder: ExtrinsicCall {
+pub trait SignedTransactionBuilder: BaseExtrinsicCall {
 	type Address;
 	type Signature;
 	type Extension;

--- a/substrate/frame/support/src/traits/misc.rs
+++ b/substrate/frame/support/src/traits/misc.rs
@@ -19,7 +19,10 @@
 
 use crate::dispatch::{DispatchResult, Parameter};
 use alloc::{vec, vec::Vec};
-use codec::{CompactLen, Decode, DecodeLimit, Encode, EncodeLike, Input, MaxEncodedLen};
+use codec::{
+	CompactLen, Decode, DecodeLimit, DecodeWithMemTracking, Encode, EncodeLike, Input,
+	MaxEncodedLen,
+};
 use impl_trait_for_tuples::impl_for_tuples;
 use scale_info::{build::Fields, meta_type, Path, Type, TypeInfo, TypeParameter};
 use sp_arithmetic::traits::{CheckedAdd, CheckedMul, CheckedSub, One, Saturating};
@@ -928,7 +931,7 @@ impl<Address, Call, Signature, Extra> InherentBuilder
 	for sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, Extra>
 where
 	Address: TypeInfo,
-	Call: TypeInfo,
+	Call: Clone + DecodeWithMemTracking + TypeInfo,
 	Signature: TypeInfo,
 	Extra: TypeInfo,
 {
@@ -957,7 +960,7 @@ impl<Address, Call, Signature, Extension> SignedTransactionBuilder
 	for sp_runtime::generic::UncheckedExtrinsic<Address, Call, Signature, Extension>
 where
 	Address: TypeInfo,
-	Call: TypeInfo,
+	Call: Clone + DecodeWithMemTracking + TypeInfo,
 	Signature: TypeInfo,
 	Extension: TypeInfo,
 {

--- a/substrate/frame/support/test/tests/authorize.rs
+++ b/substrate/frame/support/test/tests/authorize.rs
@@ -23,7 +23,7 @@ use frame_support::{
 };
 use sp_runtime::{
 	testing::UintAuthorityId,
-	traits::{Applyable, Checkable},
+	traits::{Applyable, Checkable, LazyExtrinsic},
 	transaction_validity::{
 		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction,
 	},
@@ -407,9 +407,9 @@ fn valid_call_weight_test() {
 		new_test_ext().execute_with(|| {
 			let tx_ext = frame_system::AuthorizeCall::<Runtime>::new();
 
-			let tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
+			let mut tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
 
-			let info = tx.get_dispatch_info();
+			let info = tx.expect_as_ref().get_dispatch_info();
 			let len = tx.using_encoded(|e| e.len());
 
 			let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
@@ -493,9 +493,9 @@ fn call_validity() {
 		new_test_ext().execute_with(|| {
 			let tx_ext = frame_system::AuthorizeCall::<Runtime>::new();
 
-			let tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
+			let mut tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
 
-			let info = tx.get_dispatch_info();
+			let info = tx.expect_as_ref().get_dispatch_info();
 			let len = tx.using_encoded(|e| e.len());
 
 			let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
@@ -513,9 +513,9 @@ fn signed_is_valid_but_dispatch_error() {
 		let call = RuntimeCall::Pallet1(pallet1::Call::call1 {});
 		let tx_ext = frame_system::AuthorizeCall::<Runtime>::new();
 
-		let tx = UncheckedExtrinsic::new_signed(call, 1u64, 1.into(), tx_ext);
+		let mut tx = UncheckedExtrinsic::new_signed(call, 1u64, 1.into(), tx_ext);
 
-		let info = tx.get_dispatch_info();
+		let info = tx.expect_as_ref().get_dispatch_info();
 		let len = tx.using_encoded(|e| e.len());
 
 		let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
@@ -550,9 +550,9 @@ fn call_without_authorization() {
 		// tests for transaction extension implementation
 		let tx_ext = frame_system::AuthorizeCall::<Runtime>::new();
 
-		let tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
+		let mut tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
 
-		let info = tx.get_dispatch_info();
+		let info = tx.expect_as_ref().get_dispatch_info();
 		let len = tx.using_encoded(|e| e.len());
 
 		let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())

--- a/substrate/frame/support/test/tests/pallet.rs
+++ b/substrate/frame/support/test/tests/pallet.rs
@@ -997,7 +997,7 @@ fn inherent_expand() {
 		vec![UncheckedExtrinsic::new_bare(RuntimeCall::Example(pallet::Call::foo_no_post_info {}))];
 	assert_eq!(expected, inherents);
 
-	let block = Block::new(
+	let mut block = Block::new(
 		Header::new(
 			1,
 			BlakeTwo256::hash(b"test"),
@@ -1014,9 +1014,9 @@ fn inherent_expand() {
 		],
 	);
 
-	assert!(InherentData::new().check_extrinsics(&block).ok());
+	assert!(InherentData::new().check_extrinsics(&mut block).unwrap().ok());
 
-	let block = Block::new(
+	let mut block = Block::new(
 		Header::new(
 			1,
 			BlakeTwo256::hash(b"test"),
@@ -1033,9 +1033,9 @@ fn inherent_expand() {
 		],
 	);
 
-	assert!(InherentData::new().check_extrinsics(&block).fatal_error());
+	assert!(InherentData::new().check_extrinsics(&mut block).unwrap().fatal_error());
 
-	let block = Block::new(
+	let mut block = Block::new(
 		Header::new(
 			1,
 			BlakeTwo256::hash(b"test"),
@@ -1050,9 +1050,9 @@ fn inherent_expand() {
 
 	let mut inherent = InherentData::new();
 	inherent.put_data(*b"required", &true).unwrap();
-	assert!(inherent.check_extrinsics(&block).fatal_error());
+	assert!(inherent.check_extrinsics(&mut block).unwrap().fatal_error());
 
-	let block = Block::new(
+	let mut block = Block::new(
 		Header::new(
 			1,
 			BlakeTwo256::hash(b"test"),
@@ -1070,7 +1070,7 @@ fn inherent_expand() {
 
 	let mut inherent = InherentData::new();
 	inherent.put_data(*b"required", &true).unwrap();
-	assert!(inherent.check_extrinsics(&block).fatal_error());
+	assert!(inherent.check_extrinsics(&mut block).unwrap().fatal_error());
 }
 
 #[test]

--- a/substrate/frame/system/src/extensions/authorize_call.rs
+++ b/substrate/frame/system/src/extensions/authorize_call.rs
@@ -122,7 +122,9 @@ mod tests {
 	};
 	use sp_runtime::{
 		testing::UintAuthorityId,
-		traits::{Applyable, Checkable, TransactionExtension as _, TxBaseImplication},
+		traits::{
+			Applyable, Checkable, LazyExtrinsic, TransactionExtension as _, TxBaseImplication,
+		},
 		transaction_validity::{
 			InvalidTransaction, TransactionSource::External, TransactionValidityError,
 		},
@@ -225,9 +227,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let tx_ext = (frame_system::AuthorizeCall::<Runtime>::new(),);
 
-			let tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
+			let mut tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
 
-			let info = tx.get_dispatch_info();
+			let info = tx.expect_as_ref().get_dispatch_info();
 			let len = tx.using_encoded(|e| e.len());
 
 			let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
@@ -258,9 +260,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let tx_ext = (frame_system::AuthorizeCall::<Runtime>::new(),);
 
-			let tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
+			let mut tx = UncheckedExtrinsic::new_transaction(call, tx_ext);
 
-			let info = tx.get_dispatch_info();
+			let info = tx.expect_as_ref().get_dispatch_info();
 			let len = tx.using_encoded(|e| e.len());
 
 			let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())
@@ -287,9 +289,9 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let tx_ext = (frame_system::AuthorizeCall::<Runtime>::new(),);
 
-			let tx = UncheckedExtrinsic::new_signed(call, 42, 42.into(), tx_ext);
+			let mut tx = UncheckedExtrinsic::new_signed(call, 42, 42.into(), tx_ext);
 
-			let info = tx.get_dispatch_info();
+			let info = tx.expect_as_ref().get_dispatch_info();
 			let len = tx.using_encoded(|e| e.len());
 
 			let checked = Checkable::check(tx, &frame_system::ChainContext::<Runtime>::default())

--- a/substrate/frame/transaction-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/src/lib.rs
@@ -534,13 +534,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Query the data that we know about the fee of a given `call` from a runtime API.
-	pub fn query_info_from_runtime_api<
-		Extrinsic: sp_runtime::traits::ExtrinsicLike + GetDispatchInfo,
-	>(
-		unchecked_extrinsic: Extrinsic,
+	pub fn query_info_from_runtime_api<Extrinsic>(
+		mut unchecked_extrinsic: Extrinsic,
 		len: u32,
 	) -> RuntimeDispatchInfo<BalanceOf<T>>
 	where
+		Extrinsic: for<'a> sp_runtime::traits::LazyExtrinsic<'a>,
+		for<'a> <Extrinsic as sp_runtime::traits::LazyExtrinsic<'a>>::ExtrinsicRef:
+			sp_runtime::traits::ExtrinsicLike + GetDispatchInfo,
 		T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
 	{
 		Self::query_info(unchecked_extrinsic.expect_as_ref(), len)
@@ -567,13 +568,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Query the detailed fee of a given `call` from a runtime API.
-	pub fn query_fee_details_from_runtime_api<
-		Extrinsic: sp_runtime::traits::ExtrinsicLike + GetDispatchInfo,
-	>(
-		unchecked_extrinsic: Extrinsic,
+	pub fn query_fee_details_from_runtime_api<Extrinsic>(
+		mut unchecked_extrinsic: Extrinsic,
 		len: u32,
 	) -> FeeDetails<BalanceOf<T>>
 	where
+		Extrinsic: for<'a> sp_runtime::traits::LazyExtrinsic<'a>,
+		for<'a> <Extrinsic as sp_runtime::traits::LazyExtrinsic<'a>>::ExtrinsicRef:
+			sp_runtime::traits::ExtrinsicLike + GetDispatchInfo,
 		T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
 	{
 		Self::query_fee_details(unchecked_extrinsic.expect_as_ref(), len)

--- a/substrate/frame/transaction-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/src/lib.rs
@@ -533,6 +533,19 @@ impl<T: Config> Pallet<T> {
 		RuntimeDispatchInfo { weight: dispatch_info.total_weight(), class, partial_fee }
 	}
 
+	/// Query the data that we know about the fee of a given `call` from a runtime API.
+	pub fn query_info_from_runtime_api<
+		Extrinsic: sp_runtime::traits::ExtrinsicLike + GetDispatchInfo,
+	>(
+		unchecked_extrinsic: Extrinsic,
+		len: u32,
+	) -> RuntimeDispatchInfo<BalanceOf<T>>
+	where
+		T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
+	{
+		Self::query_info(unchecked_extrinsic.expect_as_ref(), len)
+	}
+
 	/// Query the detailed fee of a given `call`.
 	pub fn query_fee_details<Extrinsic: sp_runtime::traits::ExtrinsicLike + GetDispatchInfo>(
 		unchecked_extrinsic: Extrinsic,
@@ -551,6 +564,19 @@ impl<T: Config> Pallet<T> {
 		} else {
 			Self::compute_fee_details(len, &dispatch_info, tip)
 		}
+	}
+
+	/// Query the detailed fee of a given `call` from a runtime API.
+	pub fn query_fee_details_from_runtime_api<
+		Extrinsic: sp_runtime::traits::ExtrinsicLike + GetDispatchInfo,
+	>(
+		unchecked_extrinsic: Extrinsic,
+		len: u32,
+	) -> FeeDetails<BalanceOf<T>>
+	where
+		T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
+	{
+		Self::query_fee_details(unchecked_extrinsic.expect_as_ref(), len)
 	}
 
 	/// Query information of a dispatch class, weight, and fee of a given encoded `Call`.

--- a/substrate/frame/transaction-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/src/tests.rs
@@ -18,6 +18,8 @@
 use super::*;
 use crate as pallet_transaction_payment;
 
+use sp_runtime::traits::LazyExtrinsic;
+
 use codec::Encode;
 
 use sp_runtime::{
@@ -282,13 +284,13 @@ fn query_info_and_fee_details_works() {
 	let call = RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 2, value: 69 });
 	let origin = 111111;
 	let extra = ();
-	let xt = UncheckedExtrinsic::new_signed(call.clone(), origin, (), extra);
-	let info = xt.get_dispatch_info();
+	let mut xt = UncheckedExtrinsic::new_signed(call.clone(), origin, (), extra);
+	let info = xt.expect_as_ref().get_dispatch_info();
 	let ext = xt.encode();
 	let len = ext.len() as u32;
 
-	let unsigned_xt = UncheckedExtrinsic::<u64, _, (), ()>::new_bare(call);
-	let unsigned_xt_info = unsigned_xt.get_dispatch_info();
+	let mut unsigned_xt = UncheckedExtrinsic::<u64, _, (), ()>::new_bare(call);
+	let unsigned_xt_info = unsigned_xt.expect_as_ref().get_dispatch_info();
 
 	ExtBuilder::default()
 		.base_weight(Weight::from_parts(5, 0))

--- a/substrate/frame/transaction-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/src/tests.rs
@@ -299,7 +299,7 @@ fn query_info_and_fee_details_works() {
 			NextFeeMultiplier::<Runtime>::put(Multiplier::saturating_from_rational(3, 2));
 
 			assert_eq!(
-				TransactionPayment::query_info(xt.clone(), len),
+				TransactionPayment::query_info_from_runtime_api(xt.clone(), len),
 				RuntimeDispatchInfo {
 					weight: info.total_weight(),
 					class: info.class,
@@ -310,7 +310,7 @@ fn query_info_and_fee_details_works() {
 			);
 
 			assert_eq!(
-				TransactionPayment::query_info(unsigned_xt.clone(), len),
+				TransactionPayment::query_info_from_runtime_api(unsigned_xt.clone(), len),
 				RuntimeDispatchInfo {
 					weight: unsigned_xt_info.call_weight,
 					class: unsigned_xt_info.class,
@@ -319,7 +319,7 @@ fn query_info_and_fee_details_works() {
 			);
 
 			assert_eq!(
-				TransactionPayment::query_fee_details(xt, len),
+				TransactionPayment::query_fee_details_from_runtime_api(xt, len),
 				FeeDetails {
 					inclusion_fee: Some(InclusionFee {
 						base_fee: 5 * 2,
@@ -334,7 +334,7 @@ fn query_info_and_fee_details_works() {
 			);
 
 			assert_eq!(
-				TransactionPayment::query_fee_details(unsigned_xt, len),
+				TransactionPayment::query_fee_details_from_runtime_api(unsigned_xt, len),
 				FeeDetails { inclusion_fee: None, tip: 0 },
 			);
 		});

--- a/substrate/primitives/runtime/src/generic/block.rs
+++ b/substrate/primitives/runtime/src/generic/block.rs
@@ -110,9 +110,15 @@ where
 	fn header(&self) -> &Self::Header {
 		&self.header
 	}
+
 	fn extrinsics(&self) -> &[Self::Extrinsic] {
 		&self.extrinsics[..]
 	}
+
+	fn extrinsics_mut(&mut self) -> &mut [Self::Extrinsic] {
+		&mut self.extrinsics[..]
+	}
+
 	fn deconstruct(self) -> (Self::Header, Vec<Self::Extrinsic>) {
 		(self.header, self.extrinsics)
 	}

--- a/substrate/primitives/runtime/src/generic/mod.rs
+++ b/substrate/primitives/runtime/src/generic/mod.rs
@@ -34,7 +34,8 @@ pub use self::{
 	era::{Era, Phase},
 	header::Header,
 	unchecked_extrinsic::{
-		ExtensionVersion, Preamble, SignedPayload, UncheckedExtrinsic, EXTRINSIC_FORMAT_VERSION,
+		ExtensionVersion, Preamble, SignedPayload, UncheckedExtrinsic, UncheckedExtrinsicRef,
+		EXTRINSIC_FORMAT_VERSION,
 	},
 };
 pub use unchecked_extrinsic::UncheckedSignaturePayload;

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -20,9 +20,9 @@
 use crate::{
 	generic::{CheckedExtrinsic, ExtrinsicFormat},
 	traits::{
-		self, transaction_extension::TransactionExtension, Checkable, Dispatchable, ExtrinsicCall,
-		ExtrinsicLike, ExtrinsicMetadata, IdentifyAccount, LazyExtrinsic, MaybeDisplay, Member,
-		SignaturePayload,
+		self, transaction_extension::TransactionExtension, BaseExtrinsicCall, Checkable,
+		Dispatchable, ExtrinsicCall, ExtrinsicLike, ExtrinsicMetadata, IdentifyAccount,
+		LazyExtrinsic, MaybeDisplay, Member, SignaturePayload,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError},
 	OpaqueExtrinsic,
@@ -419,14 +419,10 @@ impl<Address, Call, Signature, Extension> ExtrinsicLike
 	}
 }
 
-impl<Address, Call, Signature, Extra> ExtrinsicCall
+impl<Address, Call, Signature, Extra> BaseExtrinsicCall
 	for UncheckedExtrinsic<Address, Call, Signature, Extra>
 {
 	type Call = Call;
-
-	fn call(&self) -> &Call {
-		&self.function
-	}
 }
 
 // TODO: Migrate existing extension pipelines to support current `Signed` transactions as `General`
@@ -636,6 +632,24 @@ impl<'a, Address, Call, Signature, Extension> ExtrinsicLike
 
 	fn is_bare(&self) -> bool {
 		matches!(self.preamble, Preamble::Bare(_))
+	}
+}
+
+impl<'a, Address, Call, Signature, Extra> BaseExtrinsicCall
+	for UncheckedExtrinsicRef<'a, Address, Call, Signature, Extra>
+{
+	type Call = Call;
+}
+
+impl<'a, Address, Call, Signature, Extra> ExtrinsicCall<'a>
+	for UncheckedExtrinsicRef<'a, Address, Call, Signature, Extra>
+{
+	fn call(&self) -> &Call {
+		self.call
+	}
+
+	fn into_call_ref(self) -> &'a Self::Call {
+		self.call
 	}
 }
 

--- a/substrate/primitives/runtime/src/testing.rs
+++ b/substrate/primitives/runtime/src/testing.rs
@@ -255,12 +255,19 @@ impl<
 	fn header(&self) -> &Self::Header {
 		&self.header
 	}
+
 	fn extrinsics(&self) -> &[Self::Extrinsic] {
 		&self.extrinsics[..]
 	}
+
+	fn extrinsics_mut(&mut self) -> &mut [Self::Extrinsic] {
+		&mut self.extrinsics[..]
+	}
+
 	fn deconstruct(self) -> (Self::Header, Vec<Self::Extrinsic>) {
 		(self.header, self.extrinsics)
 	}
+
 	fn new(header: Self::Header, extrinsics: Vec<Self::Extrinsic>) -> Self {
 		Block { header, extrinsics }
 	}

--- a/substrate/primitives/runtime/src/traits/mod.rs
+++ b/substrate/primitives/runtime/src/traits/mod.rs
@@ -1411,6 +1411,22 @@ pub trait ExtrinsicCall: ExtrinsicLike {
 	fn call(&self) -> &Self::Call;
 }
 
+/// An extrinsic where the call will be lazily decoded.
+pub trait LazyExtrinsic<'a>: ExtrinsicLike {
+	/// A structure representing an extrinsic, but with all the fields referencing decoded values.
+	type ExtrinsicRef: ExtrinsicLike;
+
+	/// Tries to return an `ExtrinsicRef`.
+	fn try_as_ref(&'a mut self) -> Result<Self::ExtrinsicRef, codec::Error>;
+
+	/// Tries to return an `ExtrinsicRef`
+	///
+	/// In case of an error, it panics.
+	fn expect_as_ref(&'a mut self) -> Self::ExtrinsicRef {
+		self.try_as_ref().expect("Error while lazy decoding extrinsic")
+	}
+}
+
 /// Something that acts like a [`SignaturePayload`](Extrinsic::SignaturePayload) of an
 /// [`Extrinsic`].
 pub trait SignaturePayload {

--- a/substrate/primitives/runtime/src/transaction_validity.rs
+++ b/substrate/primitives/runtime/src/transaction_validity.rs
@@ -87,6 +87,8 @@ pub enum InvalidTransaction {
 	IndeterminateImplicit,
 	/// The transaction extension did not authorize any origin.
 	UnknownOrigin,
+	/// The call of the transaction could not be decoded correctly.
+	UnableToDecodeCall,
 }
 
 impl InvalidTransaction {
@@ -122,6 +124,8 @@ impl From<InvalidTransaction> for &'static str {
 				"The implicit data was unable to be calculated",
 			InvalidTransaction::UnknownOrigin =>
 				"The transaction extension did not authorize any origin",
+			InvalidTransaction::UnableToDecodeCall =>
+				"The transaction call could not be decoded correctly",
 		}
 	}
 }

--- a/substrate/test-utils/runtime/src/extrinsic.rs
+++ b/substrate/test-utils/runtime/src/extrinsic.rs
@@ -70,10 +70,12 @@ impl TryFrom<&Extrinsic> for TransferData {
 			Extrinsic {
 				function: RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest, value }),
 				preamble: Preamble::Signed(from, _, ((CheckNonce(nonce), ..), ..)),
+				..
 			} => Ok(TransferData { from: *from, to: *dest, amount: *value, nonce: *nonce }),
 			Extrinsic {
 				function: RuntimeCall::SubstrateTest(PalletCall::bench_call { transfer }),
 				preamble: Preamble::Bare(_),
+				..
 			} => Ok(transfer.clone()),
 			_ => Err(()),
 		}

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -1152,7 +1152,7 @@ mod tests {
 	use sp_consensus::BlockOrigin;
 	use sp_core::{storage::well_known_keys::HEAP_PAGES, traits::CallContext};
 	use sp_runtime::{
-		traits::{DispatchTransaction, Hash as _},
+		traits::{DispatchTransaction, Hash as _, LazyExtrinsic},
 		transaction_validity::{InvalidTransaction, TransactionSource::External, ValidTransaction},
 	};
 	use substrate_test_runtime_client::{
@@ -1316,7 +1316,7 @@ mod tests {
 				CheckSubstrateCall {}
 					.validate_only(
 						Some(x).into(),
-						&ExtrinsicBuilder::new_call_with_priority(16).build().function,
+						&ExtrinsicBuilder::new_call_with_priority(16).build().expect_as_ref().call,
 						&info,
 						len,
 						External,
@@ -1332,7 +1332,7 @@ mod tests {
 				CheckSubstrateCall {}
 					.validate_only(
 						Some(x).into(),
-						&ExtrinsicBuilder::new_call_do_not_propagate().build().function,
+						&ExtrinsicBuilder::new_call_do_not_propagate().build().expect_as_ref().call,
 						&info,
 						len,
 						External,

--- a/templates/minimal/runtime/src/lib.rs
+++ b/templates/minimal/runtime/src/lib.rs
@@ -261,7 +261,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: InherentData,
 		) -> CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/templates/minimal/runtime/src/lib.rs
+++ b/templates/minimal/runtime/src/lib.rs
@@ -304,10 +304,10 @@ impl_runtime_apis! {
 		interface::Balance,
 	> for Runtime {
 		fn query_info(uxt: ExtrinsicFor<Runtime>, len: u32) -> RuntimeDispatchInfo<interface::Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(uxt: ExtrinsicFor<Runtime>, len: u32) -> FeeDetails<interface::Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> interface::Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/templates/parachain/runtime/src/apis.rs
+++ b/templates/parachain/runtime/src/apis.rs
@@ -187,13 +187,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/templates/parachain/runtime/src/apis.rs
+++ b/templates/parachain/runtime/src/apis.rs
@@ -144,7 +144,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 

--- a/templates/solochain/runtime/src/apis.rs
+++ b/templates/solochain/runtime/src/apis.rs
@@ -181,13 +181,13 @@ impl_runtime_apis! {
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-			TransactionPayment::query_info(uxt, len)
+			TransactionPayment::query_info_from_runtime_api(uxt, len)
 		}
 		fn query_fee_details(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
 		) -> pallet_transaction_payment::FeeDetails<Balance> {
-			TransactionPayment::query_fee_details(uxt, len)
+			TransactionPayment::query_fee_details_from_runtime_api(uxt, len)
 		}
 		fn query_weight_to_fee(weight: Weight) -> Balance {
 			TransactionPayment::weight_to_fee(weight)

--- a/templates/solochain/runtime/src/apis.rs
+++ b/templates/solochain/runtime/src/apis.rs
@@ -98,7 +98,7 @@ impl_runtime_apis! {
 			block: Block,
 			data: sp_inherents::InherentData,
 		) -> sp_inherents::CheckInherentsResult {
-			data.check_extrinsics(&block)
+			data.check_extrinsics_from_runtime_api(block)
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/4255

This PR changes some core logic in order to lazily decode the `RuntimeCall` inside an `UncheckedExtrinsic`

This is a significant rework of https://github.com/paritytech/polkadot-sdk/pull/4296. The main problem with #4296 was that it was always decoding a call at least twice. This PR comes with a different approach, that avoids the need to decode twice.