### PR TITLE
Removed `pallet:getter` from Snowbridge pallets

### DIFF
--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -238,30 +238,6 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		/// Latest imported checkpoint root
-		pub fn initial_checkpoint_root() -> H256 {
-			InitialCheckpointRoot::<T>::get()
-		}
-
-		/// Latest imported finalized block root
-		pub fn latest_finalized_block_root() -> H256 {
-			LatestFinalizedBlockRoot::<T>::get()
-		}
-
-		/// Beacon state by finalized block root
-		pub fn finalized_beacon_state(block_root: &H256) -> Option<CompactBeaconState> {
-			FinalizedBeaconState::<T>::get(block_root)
-		}
-
-		pub fn validators_root() -> H256 {
-			ValidatorsRoot::<T>::get()
-		}
-
-		/// The current operating mode of the pallet.
-		pub fn operating_mode() -> BasicOperatingMode {
-			OperatingMode::<T>::get()
-		}
-
 		/// Forces a finalized beacon header checkpoint update. The current sync committee,
 		/// with a header attesting to the current sync committee, should be provided.
 		/// An `block_roots` proof should also be provided. This is used for ancestry proofs
@@ -652,19 +628,19 @@ pub mod pallet {
 		/// Returns the fork version based on the current epoch.
 		pub(super) fn select_fork_version(fork_versions: &ForkVersions, epoch: u64) -> ForkVersion {
 			if epoch >= fork_versions.electra.epoch {
-				return fork_versions.electra.version;
+				return fork_versions.electra.version
 			}
 			if epoch >= fork_versions.deneb.epoch {
-				return fork_versions.deneb.version;
+				return fork_versions.deneb.version
 			}
 			if epoch >= fork_versions.capella.epoch {
-				return fork_versions.capella.version;
+				return fork_versions.capella.version
 			}
 			if epoch >= fork_versions.bellatrix.epoch {
-				return fork_versions.bellatrix.version;
+				return fork_versions.bellatrix.version
 			}
 			if epoch >= fork_versions.altair.epoch {
-				return fork_versions.altair.version;
+				return fork_versions.altair.version
 			}
 			fork_versions.genesis.version
 		}

--- a/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
+++ b/bridges/snowbridge/pallets/ethereum-client/src/lib.rs
@@ -152,17 +152,14 @@ pub mod pallet {
 
 	/// Latest imported checkpoint root
 	#[pallet::storage]
-	#[pallet::getter(fn initial_checkpoint_root)]
 	pub type InitialCheckpointRoot<T: Config> = StorageValue<_, H256, ValueQuery>;
 
 	/// Latest imported finalized block root
 	#[pallet::storage]
-	#[pallet::getter(fn latest_finalized_block_root)]
 	pub type LatestFinalizedBlockRoot<T: Config> = StorageValue<_, H256, ValueQuery>;
 
 	/// Beacon state by finalized block root
 	#[pallet::storage]
-	#[pallet::getter(fn finalized_beacon_state)]
 	pub type FinalizedBeaconState<T: Config> =
 		StorageMap<_, Identity, H256, CompactBeaconState, OptionQuery>;
 
@@ -176,7 +173,6 @@ pub mod pallet {
 		StorageMap<_, Identity, u32, H256, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn validators_root)]
 	pub type ValidatorsRoot<T: Config> = StorageValue<_, H256, ValueQuery>;
 
 	/// Sync committee for current period
@@ -193,7 +189,6 @@ pub mod pallet {
 
 	/// The current operating mode of the pallet.
 	#[pallet::storage]
-	#[pallet::getter(fn operating_mode)]
 	pub type OperatingMode<T: Config> = StorageValue<_, BasicOperatingMode, ValueQuery>;
 
 	#[pallet::call]
@@ -243,6 +238,30 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Latest imported checkpoint root
+		pub fn initial_checkpoint_root() -> H256 {
+			InitialCheckpointRoot::<T>::get()
+		}
+
+		/// Latest imported finalized block root
+		pub fn latest_finalized_block_root() -> H256 {
+			LatestFinalizedBlockRoot::<T>::get()
+		}
+
+		/// Beacon state by finalized block root
+		pub fn finalized_beacon_state(block_root: &H256) -> Option<CompactBeaconState> {
+			FinalizedBeaconState::<T>::get(block_root)
+		}
+
+		pub fn validators_root() -> H256 {
+			ValidatorsRoot::<T>::get()
+		}
+
+		/// The current operating mode of the pallet.
+		pub fn operating_mode() -> BasicOperatingMode {
+			OperatingMode::<T>::get()
+		}
+
 		/// Forces a finalized beacon header checkpoint update. The current sync committee,
 		/// with a header attesting to the current sync committee, should be provided.
 		/// An `block_roots` proof should also be provided. This is used for ancestry proofs
@@ -633,19 +652,19 @@ pub mod pallet {
 		/// Returns the fork version based on the current epoch.
 		pub(super) fn select_fork_version(fork_versions: &ForkVersions, epoch: u64) -> ForkVersion {
 			if epoch >= fork_versions.electra.epoch {
-				return fork_versions.electra.version
+				return fork_versions.electra.version;
 			}
 			if epoch >= fork_versions.deneb.epoch {
-				return fork_versions.deneb.version
+				return fork_versions.deneb.version;
 			}
 			if epoch >= fork_versions.capella.epoch {
-				return fork_versions.capella.version
+				return fork_versions.capella.version;
 			}
 			if epoch >= fork_versions.bellatrix.epoch {
-				return fork_versions.bellatrix.version
+				return fork_versions.bellatrix.version;
 			}
 			if epoch >= fork_versions.altair.epoch {
-				return fork_versions.altair.version
+				return fork_versions.altair.version;
 			}
 			fork_versions.genesis.version
 		}

--- a/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
@@ -252,7 +252,7 @@ pub mod pallet {
 			// Verify message nonce
 			<Nonce<T>>::try_mutate(envelope.channel_id, |nonce| -> DispatchResult {
 				if *nonce == u64::MAX {
-					return Err(Error::<T>::MaxNonceReached.into());
+					return Err(Error::<T>::MaxNonceReached.into())
 				}
 				if envelope.nonce != nonce.saturating_add(1) {
 					Err(Error::<T>::InvalidNonce.into())
@@ -321,11 +321,6 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		/// The current operating mode of the pallet.
-		pub fn operating_mode() -> BasicOperatingMode {
-			OperatingMode::<T>::get()
-		}
-
 		pub fn do_convert(
 			message_id: H256,
 			message: VersionedMessage,

--- a/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue/src/lib.rs
@@ -223,7 +223,6 @@ pub mod pallet {
 
 	/// The current operating mode of the pallet.
 	#[pallet::storage]
-	#[pallet::getter(fn operating_mode)]
 	pub type OperatingMode<T: Config> = StorageValue<_, BasicOperatingMode, ValueQuery>;
 
 	#[pallet::call]
@@ -253,7 +252,7 @@ pub mod pallet {
 			// Verify message nonce
 			<Nonce<T>>::try_mutate(envelope.channel_id, |nonce| -> DispatchResult {
 				if *nonce == u64::MAX {
-					return Err(Error::<T>::MaxNonceReached.into())
+					return Err(Error::<T>::MaxNonceReached.into());
 				}
 				if envelope.nonce != nonce.saturating_add(1) {
 					Err(Error::<T>::InvalidNonce.into())
@@ -322,6 +321,11 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// The current operating mode of the pallet.
+		pub fn operating_mode() -> BasicOperatingMode {
+			OperatingMode::<T>::get()
+		}
+
 		pub fn do_convert(
 			message_id: H256,
 			message: VersionedMessage,

--- a/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
@@ -277,21 +277,11 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		/// Hashes of the ABI-encoded messages in the `Messages` storage value.
-		pub fn message_leaves() -> Vec<H256> {
-			MessageLeaves::<T>::get()
-		}
-
-		/// The current operating mode of the pallet.
-		pub fn operating_mode() -> BasicOperatingMode {
-			OperatingMode::<T>::get()
-		}
-
 		/// Generate a messages commitment and insert it into the header digest
 		pub(crate) fn commit() {
 			let count = MessageLeaves::<T>::decode_len().unwrap_or_default() as u64;
 			if count == 0 {
-				return;
+				return
 			}
 
 			// Create merkle root of messages

--- a/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
@@ -277,7 +277,7 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		/// Hashes of the ABI-encoded messages in the [`Messages`] storage value.
+		/// Hashes of the ABI-encoded messages in the `Messages` storage value.
 		pub fn message_leaves() -> Vec<H256> {
 			MessageLeaves::<T>::get()
 		}

--- a/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
+++ b/bridges/snowbridge/pallets/outbound-queue/src/lib.rs
@@ -227,7 +227,6 @@ pub mod pallet {
 	/// `on_initialize`, so should never go into block PoV.
 	#[pallet::storage]
 	#[pallet::unbounded]
-	#[pallet::getter(fn message_leaves)]
 	pub(super) type MessageLeaves<T: Config> = StorageValue<_, Vec<H256>, ValueQuery>;
 
 	/// The current nonce for each message origin
@@ -236,7 +235,6 @@ pub mod pallet {
 
 	/// The current operating mode of the pallet.
 	#[pallet::storage]
-	#[pallet::getter(fn operating_mode)]
 	pub type OperatingMode<T: Config> = StorageValue<_, BasicOperatingMode, ValueQuery>;
 
 	#[pallet::hooks]
@@ -279,11 +277,21 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Hashes of the ABI-encoded messages in the [`Messages`] storage value.
+		pub fn message_leaves() -> Vec<H256> {
+			MessageLeaves::<T>::get()
+		}
+
+		/// The current operating mode of the pallet.
+		pub fn operating_mode() -> BasicOperatingMode {
+			OperatingMode::<T>::get()
+		}
+
 		/// Generate a messages commitment and insert it into the header digest
 		pub(crate) fn commit() {
 			let count = MessageLeaves::<T>::decode_len().unwrap_or_default() as u64;
 			if count == 0 {
-				return
+				return;
 			}
 
 			// Create merkle root of messages

--- a/bridges/snowbridge/pallets/system/src/lib.rs
+++ b/bridges/snowbridge/pallets/system/src/lib.rs
@@ -253,16 +253,13 @@ pub mod pallet {
 
 	/// The set of registered agents
 	#[pallet::storage]
-	#[pallet::getter(fn agents)]
 	pub type Agents<T: Config> = StorageMap<_, Twox64Concat, AgentId, (), OptionQuery>;
 
 	/// The set of registered channels
 	#[pallet::storage]
-	#[pallet::getter(fn channels)]
 	pub type Channels<T: Config> = StorageMap<_, Twox64Concat, ChannelId, Channel, OptionQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn parameters)]
 	pub type PricingParameters<T: Config> =
 		StorageValue<_, PricingParametersOf<T>, ValueQuery, T::DefaultPricingParameters>;
 
@@ -638,6 +635,20 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// The set of registered agents
+		pub fn agents(agent_id: &AgentId) -> Option<()> {
+			Agents::<T>::get(agent_id)
+		}
+
+		/// The set of registered channels
+		pub fn channels(channel_id: &ChannelId) -> Option<Channel> {
+			Channels::<T>::get(channel_id)
+		}
+
+		pub fn parameters() -> PricingParametersOf<T> {
+			PricingParameters::<T>::get()
+		}
+
 		/// Send `command` to the Gateway on the Channel identified by `channel_id`
 		fn send(channel_id: ChannelId, command: Command, pays_fee: PaysFee<T>) -> DispatchResult {
 			let message = Message { id: None, channel_id, command };

--- a/bridges/snowbridge/pallets/system/src/lib.rs
+++ b/bridges/snowbridge/pallets/system/src/lib.rs
@@ -635,20 +635,6 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		/// The set of registered agents
-		pub fn agents(agent_id: &AgentId) -> Option<()> {
-			Agents::<T>::get(agent_id)
-		}
-
-		/// The set of registered channels
-		pub fn channels(channel_id: &ChannelId) -> Option<Channel> {
-			Channels::<T>::get(channel_id)
-		}
-
-		pub fn parameters() -> PricingParametersOf<T> {
-			PricingParameters::<T>::get()
-		}
-
 		/// Send `command` to the Gateway on the Channel identified by `channel_id`
 		fn send(channel_id: ChannelId, command: Command, pays_fee: PaysFee<T>) -> DispatchResult {
 			let message = Message { id: None, channel_id, command };

--- a/prdoc/pr_7914.prdoc
+++ b/prdoc/pr_7914.prdoc
@@ -1,0 +1,16 @@
+title: Removed pallet::getter from Snowbridge pallets
+doc:
+  - audience: Runtime Dev
+    description: |
+        This pr removes all pallet::getter occurrences from Snowbridge pallets, replacing them with explicit implementations.
+
+crates:
+  - name: snowbridge-pallet-ethereum-client
+    bump: patch
+  - name: snowbridge-pallet-inbound-queue
+    bump: patch
+  - name: snowbridge-pallet-outbound-queue
+    bump: patch
+  - name: snowbridge-pallet-system 
+    bump: patch
+

--- a/prdoc/pr_7914.prdoc
+++ b/prdoc/pr_7914.prdoc
@@ -2,7 +2,7 @@ title: Removed pallet::getter from Snowbridge pallets
 doc:
   - audience: Runtime Dev
     description: |
-        This pr removes all pallet::getter occurrences from Snowbridge pallets, replacing them with explicit implementations.
+        This pr removes all pallet::getter occurrences from Snowbridge pallets.
 
 crates:
   - name: snowbridge-pallet-ethereum-client


### PR DESCRIPTION
# Description

Part of #3326 

As per title, the `pallet:getter` usage has been removed from:
- `snowbridge-pallet-ethereum-client`
- `snowbridge-pallet-inbound-queue`
- `snowbridge-pallet-outbound-queue`
- `snowbridge-pallet-system`

Getters have been implemented manually for all storage items where an auto-generated one has been removed.

polkadot address: 12poSUQPtcF1HUPQGY3zZu2P8emuW9YnsPduA4XG3oCEfJVp

