### PR TITLE
Removed `pallet::getter` from `pallet-election-provider-multi-block`

### DIFF
--- a/prdoc/pr_7932.prdoc
+++ b/prdoc/pr_7932.prdoc
@@ -1,0 +1,9 @@
+title: Removed pallet::getter from pallet-election-provider-multi-block
+doc:
+  - audience: Runtime Dev
+    description: |
+      This pr removes all pallet::getter occurrences from pallet-election-provider-multi-block, replacing them with explicit implementations.
+
+crates:
+  - name: pallet-election-provider-multi-block
+    bump: patch

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -697,12 +697,10 @@ pub mod pallet {
 	///
 	/// This is merely incremented once per every time that an upstream `elect` is called.
 	#[pallet::storage]
-	#[pallet::getter(fn round)]
 	pub type Round<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	/// Current phase.
 	#[pallet::storage]
-	#[pallet::getter(fn current_phase)]
 	pub type CurrentPhase<T: Config> = StorageValue<_, Phase<BlockNumberFor<T>>, ValueQuery>;
 
 	/// Wrapper struct for working with snapshots.
@@ -1009,6 +1007,16 @@ pub mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+	/// Internal counter for the number of rounds.
+	pub fn round() -> u32 {
+		Round::<T>::get()
+	}
+
+	/// Current phase.
+	pub fn current_phase() -> Phase<BlockNumberFor<T>> {
+		CurrentPhase::<T>::get()
+	}
+
 	/// Returns the most significant page of the snapshot.
 	///
 	/// Based on the contract of `ElectionDataProvider`, this is the first page that is filled.

--- a/substrate/frame/election-provider-multi-block/src/verifier/impls.rs
+++ b/substrate/frame/election-provider-multi-block/src/verifier/impls.rs
@@ -513,12 +513,10 @@ pub(crate) mod pallet {
 
 	/// The minimum score that each solution must attain in order to be considered feasible.
 	#[pallet::storage]
-	#[pallet::getter(fn minimum_score)]
 	pub(crate) type MinimumScore<T: Config> = StorageValue<_, ElectionScore>;
 
 	/// Storage item for [`Status`].
 	#[pallet::storage]
-	#[pallet::getter(fn status_storage)]
 	pub(crate) type StatusStorage<T: Config> = StorageValue<_, Status, ValueQuery>;
 
 	#[pallet::pallet]
@@ -552,6 +550,16 @@ pub(crate) mod pallet {
 }
 
 impl<T: Config> Pallet<T> {
+	/// The minimum score that each solution must attain in order to be considered feasible.
+	pub fn minimum_score() -> Option<ElectionScore> {
+		MinimumScore::<T>::get()
+	}
+
+	/// Storage item for `Status`.
+	pub fn status_storage() -> Status {
+		StatusStorage::<T>::get()
+	}
+
 	fn do_on_initialize() -> Weight {
 		if let Status::Ongoing(current_page) = Self::status_storage() {
 			let maybe_page_solution =


### PR DESCRIPTION
# Description

Part of #3326 

As per title, the `pallet:getter` usage has been removed from `pallet-election-provider-multi-block`.
Getters have been implemented manually for all storage items where an auto-generated one has been removed.

polkadot address: 12poSUQPtcF1HUPQGY3zZu2P8emuW9YnsPduA4XG3oCEfJVp
