### PR TITLE
Add deposit for setting session keys

### DIFF
--- a/substrate/frame/session/README.md
+++ b/substrate/frame/session/README.md
@@ -23,10 +23,12 @@ same as the account ID. For staking systems using a stash/controller model, the 
 ID of the controller.
 - **Session key configuration process:** Session keys are set using `set_keys` for use not in the next session, but the
 session after next. They are stored in `NextKeys`, a mapping between the caller's `ValidatorId` and the session keys
-provided. `set_keys` allows users to set their session key prior to being selected as validator. It is a public call
-since it uses `ensure_signed`, which checks that the origin is a signed account. As such, the account ID of the origin
-stored in `NextKeys` may not necessarily be associated with a block author or a validator. The session keys of accounts
-are removed once their account balance is zero.
+provided. `set_keys` allows users to set their session key prior to being selected as validator. When setting keys, a deposit 
+is required and reserved from the account. The account must have sufficient funds available for this deposit, or the 
+operation will fail. This deposit is returned when the keys are purged. `set_keys` is a public call since it uses 
+`ensure_signed`, which checks that the origin is a signed account. As such, the account ID of the origin stored in 
+`NextKeys` may not necessarily be associated with a block author or a validator. The session keys of accounts are removed 
+once their account balance is zero.
 - **Session length:** This pallet does not assume anything about the length of each session. Rather, it relies on an
 implementation of `ShouldEndSession` to dictate a new session's start. This pallet provides the `PeriodicSessions`
 struct for simple periodic sessions.

--- a/substrate/frame/session/src/lib.rs
+++ b/substrate/frame/session/src/lib.rs
@@ -442,8 +442,11 @@ pub mod pallet {
 		
 		/// The amount to be reserved when setting keys.
 		#[pallet::constant]
-		type KeyDeposit: Get<<Self::Currency as Currency<Self::AccountId>>::Balance>;
+		type KeyDeposit: Get<BalanceOf<Self>>;
 	}
+
+	// Add a type alias for the balance
+	type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]


### PR DESCRIPTION
# Description
Implement reserved balance tracking for test accounts in the session pallet. 
Update KeyDeposit type to use BalanceOf. Add tests for setting and purging keys to verify fund reservation and unreservation.
Update inner_set_keys to accept old keys as an argument to reduce redundant storage reads and improve efficiency in the session pallet.