### PR TITLE
Fix `Collectives` location for AHW-next configuration

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-next-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-next-westend/src/xcm_config.rs
@@ -556,7 +556,7 @@ pub type XcmRouter = WithUniqueTopic<(
 )>;
 
 parameter_types! {
-	pub Collectives: Location = Parachain(COLLECTIVES_ID).into_location();
+	pub Collectives: Location = Location::new(1, [Parachain(COLLECTIVES_ID)]);
 }
 
 impl pallet_xcm::Config for Runtime {


### PR DESCRIPTION
`<Junctions>.into_location()` generates `Location { parents: 0, interior: <Junctions> }` - `parents` defaults to `0`

