### PR TITLE
Bump parachains runtime api to 13

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/lib.rs
@@ -25,7 +25,7 @@ use emulated_integration_tests_common::{
 
 // Rococo declaration
 decl_test_relay_chains! {
-	#[api_version(12)]
+	#[api_version(13)]
 	pub struct Rococo {
 		genesis = genesis::genesis(),
 		on_init = (),

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/lib.rs
@@ -25,7 +25,7 @@ use emulated_integration_tests_common::{
 
 // Westend declaration
 decl_test_relay_chains! {
-	#[api_version(12)]
+	#[api_version(13)]
 	pub struct Westend {
 		genesis = genesis::genesis(),
 		on_init = (),

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -822,14 +822,14 @@ impl RuntimeApiRequest {
 	/// `candidates_pending_availability`
 	pub const CANDIDATES_PENDING_AVAILABILITY_RUNTIME_REQUIREMENT: u32 = 11;
 
-	/// `backing_constraints`
-	pub const CONSTRAINTS_RUNTIME_REQUIREMENT: u32 = 12;
-
-	/// `SchedulingLookahead`
-	pub const SCHEDULING_LOOKAHEAD_RUNTIME_REQUIREMENT: u32 = 12;
-
 	/// `ValidationCodeBombLimit`
 	pub const VALIDATION_CODE_BOMB_LIMIT_RUNTIME_REQUIREMENT: u32 = 12;
+
+	/// `backing_constraints`
+	pub const CONSTRAINTS_RUNTIME_REQUIREMENT: u32 = 13;
+
+	/// `SchedulingLookahead`
+	pub const SCHEDULING_LOOKAHEAD_RUNTIME_REQUIREMENT: u32 = 13;
 }
 
 /// A message to the Runtime API subsystem.

--- a/polkadot/primitives/src/runtime_api.rs
+++ b/polkadot/primitives/src/runtime_api.rs
@@ -299,19 +299,21 @@ sp_api::decl_runtime_apis! {
 		fn candidates_pending_availability(para_id: ppp::Id) -> Vec<CommittedCandidateReceipt<Hash>>;
 
 		/***** Added in v12 *****/
-		/// Returns the constraints on the actions that can be taken by a new parachain
-		/// block.
-		#[api_version(12)]
-		fn backing_constraints(para_id: ppp::Id) -> Option<Constraints>;
-
-		/***** Added in v12 *****/
-		/// Retrieve the scheduling lookahead
-		#[api_version(12)]
-		fn scheduling_lookahead() -> u32;
-
-		/***** Added in v12 *****/
 		/// Retrieve the maximum uncompressed code size.
 		#[api_version(12)]
 		fn validation_code_bomb_limit() -> u32;
+
+		/***** Added in v13 *****/
+		/// Returns the constraints on the actions that can be taken by a new parachain
+		/// block.
+		#[api_version(13)]
+		fn backing_constraints(para_id: ppp::Id) -> Option<Constraints>;
+
+		/***** Added in v13 *****/
+		/// Retrieve the scheduling lookahead
+		#[api_version(13)]
+		fn scheduling_lookahead() -> u32;
+
+
 	}
 }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1992,7 +1992,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(12)]
+	#[api_version(13)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -939,7 +939,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(12)]
+	#[api_version(13)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			runtime_impl::validators::<Runtime>()

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2076,7 +2076,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(12)]
+	#[api_version(13)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()

--- a/prdoc/pr_7981.prdoc
+++ b/prdoc/pr_7981.prdoc
@@ -1,14 +1,10 @@
-title: Bump parachains runtime api to 13
+title: Bump ParachainHost runtime API to 13
 doc:
-- audience: Runtime Dev
+- audience: [Runtime Dev, Node Dev]
   description: |-
-    We need to bump 2 runtime APIs to 13, because we are [backporting](https://github.com/paritytech/polkadot-sdk/pull/7824) validation code bomb API to 2412-4 patch which is supposed to be included in next fellowship release.
-
-    Details here: https://github.com/paritytech/polkadot-sdk/pull/7824#discussion_r2004824416
-
-    Should only be merged if https://github.com/paritytech/polkadot-sdk/pull/7824 is merged in 2412-4 patch.
-
-    Important note: on Westend, runtime needs to be upgraded first, then validators.
+    Bump `backing_constraints` and `scheduling_lookahead` API version to 13.
+    The `validation_code_bomb_limit` API remains at version 12.
+    Bump all ParachainHost runtime to version 13 in all test runtimes.
 crates:
 - name: polkadot-node-subsystem-types
   bump: minor

--- a/prdoc/pr_7981.prdoc
+++ b/prdoc/pr_7981.prdoc
@@ -1,0 +1,20 @@
+title: Bump parachains runtime api to 13
+doc:
+- audience: Runtime Dev
+  description: |-
+    We need to bump 2 runtime APIs to 13, because we are [backporting](https://github.com/paritytech/polkadot-sdk/pull/7824) validation code bomb API to 2412-4 patch which is supposed to be included in next fellowship release.
+
+    Details here: https://github.com/paritytech/polkadot-sdk/pull/7824#discussion_r2004824416
+
+    Should only be merged if https://github.com/paritytech/polkadot-sdk/pull/7824 is merged in 2412-4 patch.
+
+    Important note: on Westend, runtime needs to be upgraded first, then validators.
+crates:
+- name: polkadot-node-subsystem-types
+  bump: minor
+- name: polkadot-primitives
+  bump: minor
+- name: rococo-runtime
+  bump: minor
+- name: westend-runtime
+  bump: minor


### PR DESCRIPTION
We need to bump 2 runtime APIs to 13, because we are [backporting](https://github.com/paritytech/polkadot-sdk/pull/7824) validation code bomb API to 2412-4 patch which is supposed to be included in next fellowship release.

Details here: https://github.com/paritytech/polkadot-sdk/pull/7824#discussion_r2004824416

Should only be merged if https://github.com/paritytech/polkadot-sdk/pull/7824 is merged in 2412-4 patch.

Important note: on Westend, runtime needs to be upgraded first, then validators.
