### PR TITLE
Add freebsd sysinfo for telemetry

### DIFF
--- a/substrate/client/sysinfo/src/lib.rs
+++ b/substrate/client/sysinfo/src/lib.rs
@@ -25,6 +25,8 @@ use std::time::Duration;
 mod sysinfo;
 #[cfg(target_os = "linux")]
 mod sysinfo_linux;
+#[cfg(target_os = "freebsd")]
+mod sysinfo_freebsd;
 
 pub use sysinfo::{
 	benchmark_cpu, benchmark_cpu_parallelism, benchmark_disk_random_writes,

--- a/substrate/client/sysinfo/src/sysinfo.rs
+++ b/substrate/client/sysinfo/src/sysinfo.rs
@@ -317,6 +317,9 @@ pub fn gather_sysinfo() -> SysInfo {
 	#[cfg(target_os = "linux")]
 	crate::sysinfo_linux::gather_linux_sysinfo(&mut sysinfo);
 
+	#[cfg(target_os = "freebsd")]
+	crate::sysinfo_freebsd::gather_freebsd_sysinfo(&mut sysinfo);
+
 	sysinfo
 }
 

--- a/substrate/client/sysinfo/src/sysinfo_freebsd.rs
+++ b/substrate/client/sysinfo/src/sysinfo_freebsd.rs
@@ -1,0 +1,49 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use sc_telemetry::SysInfo;
+use std::process::Command;
+use std::str;
+
+fn sysctl_output(name: &str) -> Option<String> {
+    let output = Command::new("sysctl").arg("-n").arg(name).output().ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Some(stdout)
+}
+
+pub fn gather_freebsd_sysinfo(sysinfo: &mut SysInfo) {
+    if let Some(cpu_model) = sysctl_output("hw.model") {
+        sysinfo.cpu = Some(cpu_model);
+    }
+
+    if let Some(cores) = sysctl_output("hw.ncpu") {
+        sysinfo.core_count = cores.parse().ok();
+    }
+
+    if let Some(memory) = sysctl_output("hw.physmem") {
+        sysinfo.memory = memory.parse().ok();
+    }
+
+    if let Some(virtualization) = sysctl_output("kern.vm_guest") {
+        sysinfo.is_virtual_machine = Some(virtualization != "none");
+    }
+
+    if let Some(freebsd_version) = sysctl_output("kern.osrelease") {
+        sysinfo.linux_distro = Some(freebsd_version);
+    }
+}


### PR DESCRIPTION

✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏 Please make sure it follows the contribution guidelines outlined in [this
document](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md) and fill out the
sections below. Once you're ready to submit your PR for review, please delete this section and leave only the text under
the "Description" heading.

# Description

Gathering hardware information on FreeBSD

## Integration

N/A (I think)

## Review Notes

Please note FreeBSD does not use the linux kernel, nor is it's kernel versioned differently as in linux distros.

# Checklist

* [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!

✄ -----------------------------------------------------------------------------
