### PR TITLE
Snowbridge - Removes obsolete test in Outbound Queue v2

### DIFF
--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/mock.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/mock.rs
@@ -15,7 +15,7 @@ use scale_info::TypeInfo;
 use snowbridge_core::{
 	gwei, meth,
 	pricing::{PricingParameters, Rewards},
-	AgentId, AgentIdOf, ParaId,
+	ParaId,
 };
 use snowbridge_outbound_queue_primitives::{v2::*, Log, Proof, VerificationError, Verifier};
 use sp_core::{ConstU32, H160, H256};
@@ -24,8 +24,6 @@ use sp_runtime::{
 	AccountId32, BuildStorage, FixedU128,
 };
 use sp_std::marker::PhantomData;
-use xcm::prelude::Here;
-use xcm_executor::traits::ConvertLocation;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type AccountId = AccountId32;
@@ -172,32 +170,6 @@ pub fn run_to_end_of_next_block() {
 	MessageQueue::on_finalize(System::block_number());
 	OutboundQueue::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());
-}
-
-pub fn bridge_hub_root_origin() -> AgentId {
-	AgentIdOf::convert_location(&Here.into()).unwrap()
-}
-
-pub fn mock_governance_message<T>() -> Message
-where
-	T: Config,
-{
-	let _marker = PhantomData::<T>; // for clippy
-
-	Message {
-		origin: bridge_hub_root_origin(),
-		id: Default::default(),
-		fee: 0,
-		commands: BoundedVec::try_from(vec![Command::Upgrade {
-			impl_address: Default::default(),
-			impl_code_hash: Default::default(),
-			initializer: Initializer {
-				params: (0..512).map(|_| 1u8).collect::<Vec<u8>>(),
-				maximum_required_gas: 0,
-			},
-		}])
-		.unwrap(),
-	}
 }
 
 // Message should fail validation as it is too large


### PR DESCRIPTION
The test is only relevant for Snowbridge v1.

Resolves: [SNO-1432](https://linear.app/snowfork/issue/SNO-1432)