### PR TITLE
Update the pushgateway url for zombienet

### DIFF
--- a/.github/zombienet-env
+++ b/.github/zombienet-env
@@ -1,6 +1,6 @@
 ZOMBIENET_IMAGE=docker.io/paritytech/zombienet:v1.3.126
 ZOMBIENET_RUNNER=zombienet-arc-runner
-PUSHGATEWAY_URL=http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics
+PUSHGATEWAY_URL=http://prometheus-pushgateway.monitoring.svc.cluster.local:9091/metrics/job/zombie-metrics
 DEBUG=zombie,zombie::network-node,zombie::kube::client::logs
 ZOMBIE_PROVIDER=k8s
 RUST_LOG=info,zombienet_orchestrator=debug


### PR DESCRIPTION
Updated the new pushgateway url for zombienet due to the restructuring of the zombienet infra

https://github.com/paritytech/devops/issues/3857