### PR TITLE
Snowbridge - fix the mismatched index

### DIFF
--- a/bridges/snowbridge/primitives/outbound-queue/src/v1/message.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v1/message.rs
@@ -136,12 +136,12 @@ impl Command {
 		match self {
 			Command::AgentExecute { .. } => 0,
 			Command::Upgrade { .. } => 1,
-			Command::SetOperatingMode { .. } => 2,
-			Command::SetTokenTransferFees { .. } => 3,
-			Command::SetPricingParameters { .. } => 4,
-			Command::UnlockNativeToken { .. } => 5,
-			Command::RegisterForeignToken { .. } => 6,
-			Command::MintForeignToken { .. } => 7,
+			Command::SetOperatingMode { .. } => 5,
+			Command::SetTokenTransferFees { .. } => 7,
+			Command::SetPricingParameters { .. } => 8,
+			Command::UnlockNativeToken { .. } => 9,
+			Command::RegisterForeignToken { .. } => 10,
+			Command::MintForeignToken { .. } => 11,
 		}
 	}
 


### PR DESCRIPTION
A bug introduced in #7402, the command IDs need to match on the contract side https://github.com/Snowfork/snowbridge/blob/b2eb7a4e0e8f9ef6182ff378733453a9513cb76b/contracts/src/Types.sol#L78