### PR TITLE
Snowbridge V2: Add `OnNewCommitment` hook to outbound-queue pallet

### DIFF
--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/lib.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/lib.rs
@@ -91,7 +91,7 @@ use sp_runtime::{
 	DigestItem,
 };
 use sp_std::prelude::*;
-pub use types::{PendingOrder, ProcessMessageOriginOf};
+pub use types::{PendingOrder, ProcessMessageOriginOf, OnNewCommitment};
 pub use weights::WeightInfo;
 use xcm::latest::{Location, NetworkId};
 type DeliveryReceiptOf<T> = DeliveryReceipt<<T as frame_system::Config>::AccountId>;
@@ -127,6 +127,9 @@ pub mod pallet {
 		/// Max number of messages processed per block
 		#[pallet::constant]
 		type MaxMessagesPerBlock: Get<u32>;
+
+		/// Hook that is called whenever there is a new commitment.
+		type OnNewCommitment: OnNewCommitment;
 
 		/// Convert a weight value into a deductible fee based.
 		type WeightToFee: WeightToFee<Balance = Self::Balance>;
@@ -283,6 +286,8 @@ pub mod pallet {
 
 			// Insert merkle root into the header digest
 			<frame_system::Pallet<T>>::deposit_log(digest_item);
+
+			T::OnNewCommitment::on_new_commitment(root);
 
 			Self::deposit_event(Event::MessagesCommitted { root, count });
 		}

--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/mock.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/mock.rs
@@ -145,6 +145,7 @@ impl crate::Config for Test {
 	type EthereumNetwork = EthereumNetwork;
 	type RewardKind = BridgeReward;
 	type DefaultRewardKind = DefaultMyRewardKind;
+	type OnNewCommitment = ();
 }
 
 fn setup() {

--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/types.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/types.rs
@@ -5,6 +5,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::ProcessMessage;
 use scale_info::TypeInfo;
 pub use snowbridge_merkle_tree::MerkleProof;
+use sp_core::H256;
 use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
 
@@ -20,4 +21,13 @@ pub struct PendingOrder<BlockNumber> {
 	/// The fee in Ether provided by the user to incentivize message delivery
 	#[codec(compact)]
 	pub fee: u128,
+}
+
+/// Hook that will be called when a new message commitment is constructed.
+pub trait OnNewCommitment {
+	fn on_new_commitment(commitment: H256);
+}
+
+impl OnNewCommitment for () {
+	fn on_new_commitment(_commitment: H256) {}
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -197,6 +197,7 @@ impl snowbridge_pallet_outbound_queue_v2::Config for Runtime {
 
 	type DefaultRewardKind = SnowbridgeReward;
 	type RewardPayment = BridgeRelayers;
+	type OnNewCommitment = ();
 }
 
 #[cfg(any(feature = "std", feature = "fast-runtime", feature = "runtime-benchmarks", test))]


### PR DESCRIPTION

### Description

This PR adds a simple hook to `snowbridge-pallet-outbound-queue-v2` which allows to perform actions whenever there is a new commitment in this pallet.

TODO: 

- [ ] add pr doc
