### PR TITLE
FungibleAdapter: change active_issuance on teleport

### DIFF
--- a/polkadot/xcm/xcm-builder/src/fungible_adapter.rs
+++ b/polkadot/xcm/xcm-builder/src/fungible_adapter.rs
@@ -96,11 +96,13 @@ impl<
 
 	fn accrue_checked(checking_account: AccountId, amount: Fungible::Balance) {
 		let ok = Fungible::mint_into(&checking_account, amount).is_ok();
+		<Fungible as fungible::Unbalanced<_>>::deactivate(amount);
 		debug_assert!(ok, "`can_accrue_checked` must have returned `true` immediately prior; qed");
 	}
 
 	fn reduce_checked(checking_account: AccountId, amount: Fungible::Balance) {
 		let ok = Fungible::burn_from(&checking_account, amount, Expendable, Exact, Polite).is_ok();
+		<Fungible as fungible::Unbalanced<_>>::reactivate(amount);
 		debug_assert!(ok, "`can_reduce_checked` must have returned `true` immediately prior; qed");
 	}
 }


### PR DESCRIPTION
The `FungibleAdapter` was missing deactivating balance when it was teleported away and reactivating it when it was teleported back into.

Fixes https://github.com/paritytech/polkadot-sdk/issues/8055.
