### PR TITLE
fix(substrate/client): cast `MAJOR_SYNC_BLOCKS` to usize

### DIFF
--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -827,7 +827,7 @@ where
 			// more than `MAJOR_SYNC_BLOCKS` behind the best block or as importing
 			// if the same can be said about queued blocks.
 			let best_block = self.client.info().best_number;
-			if target > best_block && target - best_block > MAJOR_SYNC_BLOCKS {
+			if target > best_block && target - best_block > MAJOR_SYNC_BLOCKS.into() {
 				// If target is not queued, we're downloading, otherwise importing.
 				if target > self.best_queued_number {
 					SyncState::Downloading { target }

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -93,7 +93,7 @@ const STATE_SYNC_FINALITY_THRESHOLD: u32 = 8;
 /// chain as (or at least closer to) the peer so we want to delay
 /// the ancestor search to not waste time doing that when we are
 /// so far behind.
-const MAJOR_SYNC_BLOCKS: usize = 5;
+const MAJOR_SYNC_BLOCKS: u8 = 5;
 
 mod rep {
 	use sc_network::ReputationChange as Rep;
@@ -1023,7 +1023,7 @@ where
 				// If there are more than `MAJOR_SYNC_BLOCKS` in the import queue then we have
 				// enough to do in the import queue that it's not worth kicking off
 				// an ancestor search, which is what we do in the next match case below.
-				if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS {
+				if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS as usize {
 					debug!(
 						target: LOG_TARGET,
 						"New peer {} with unknown best hash {} ({}), assuming common block.",
@@ -1839,7 +1839,7 @@ where
 					MAX_BLOCKS_TO_LOOK_BACKWARDS.into() &&
 					best_queued < peer.best_number &&
 					peer.common_number < last_finalized &&
-					queue_blocks.len() <= MAJOR_SYNC_BLOCKS
+					queue_blocks.len() <= MAJOR_SYNC_BLOCKS as usize
 				{
 					trace!(
 						target: LOG_TARGET,

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -93,7 +93,7 @@ const STATE_SYNC_FINALITY_THRESHOLD: u32 = 8;
 /// chain as (or at least closer to) the peer so we want to delay
 /// the ancestor search to not waste time doing that when we are
 /// so far behind.
-const MAJOR_SYNC_BLOCKS: u8 = 5;
+const MAJOR_SYNC_BLOCKS: usize = 5;
 
 mod rep {
 	use sc_network::ReputationChange as Rep;
@@ -827,7 +827,7 @@ where
 			// more than `MAJOR_SYNC_BLOCKS` behind the best block or as importing
 			// if the same can be said about queued blocks.
 			let best_block = self.client.info().best_number;
-			if target > best_block && target - best_block > MAJOR_SYNC_BLOCKS.into() {
+			if target > best_block && target - best_block > MAJOR_SYNC_BLOCKS {
 				// If target is not queued, we're downloading, otherwise importing.
 				if target > self.best_queued_number {
 					SyncState::Downloading { target }
@@ -1023,7 +1023,7 @@ where
 				// If there are more than `MAJOR_SYNC_BLOCKS` in the import queue then we have
 				// enough to do in the import queue that it's not worth kicking off
 				// an ancestor search, which is what we do in the next match case below.
-				if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS.into() {
+				if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS {
 					debug!(
 						target: LOG_TARGET,
 						"New peer {} with unknown best hash {} ({}), assuming common block.",
@@ -1839,7 +1839,7 @@ where
 					MAX_BLOCKS_TO_LOOK_BACKWARDS.into() &&
 					best_queued < peer.best_number &&
 					peer.common_number < last_finalized &&
-					queue_blocks.len() <= MAJOR_SYNC_BLOCKS.into()
+					queue_blocks.len() <= MAJOR_SYNC_BLOCKS
 				{
 					trace!(
 						target: LOG_TARGET,


### PR DESCRIPTION
Rustc started complaining from some versions onward when calling `into` on `MAJOR_SYNC_BLOCKS`.

Not sure what's the version from which it fails, but it does. I'm on 1.85.1, it did fail on 1.82 as well.
