### PR TITLE
Update to frame-metadata 21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f840fb7195bcfc5e17ea40c26e5ce6d5b9ce5d584466e17703209657e459ae0"
 
 [[package]]
+name = "array-bytes"
+version = "9.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4449507daf4f07a8c8309e122d32a53d15c9f33e77eaf01c839fea42ccd4d673"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,7 +1779,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "binary-merkle-tree"
 version = "13.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "hash-db",
  "log",
  "parity-scale-codec",
@@ -4775,7 +4784,7 @@ dependencies = [
 name = "cumulus-relay-chain-minimal-node"
 version = "0.7.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
@@ -6370,7 +6379,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 name = "frame-benchmarking"
 version = "28.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "frame-support",
  "frame-support-procedural",
  "frame-system",
@@ -6400,7 +6409,7 @@ name = "frame-benchmarking-cli"
 version = "32.0.0"
 dependencies = [
  "Inflector",
- "array-bytes",
+ "array-bytes 6.2.2",
  "chrono",
  "clap",
  "comfy-table",
@@ -6549,7 +6558,7 @@ name = "frame-executive"
 version = "28.0.0"
 dependencies = [
  "aquamarine",
- "array-bytes",
+ "array-bytes 6.2.2",
  "frame-support",
  "frame-system",
  "frame-try-runtime",
@@ -6604,9 +6613,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
+checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -6618,10 +6627,10 @@ dependencies = [
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "const-hex",
  "docify",
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "frame-support",
  "frame-system",
  "log",
@@ -6682,12 +6691,12 @@ version = "28.0.0"
 dependencies = [
  "Inflector",
  "aquamarine",
- "array-bytes",
+ "array-bytes 6.2.2",
  "binary-merkle-tree",
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "frame-support-procedural",
  "frame-system",
  "impl-trait-for-tuples",
@@ -6775,7 +6784,7 @@ version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "frame-support",
  "frame-support-test-pallet",
  "frame-system",
@@ -8711,7 +8720,7 @@ checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
 name = "kitchensink-runtime"
 version = "3.0.0-dev"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "log",
  "node-primitives",
  "pallet-example-mbm",
@@ -9864,15 +9873,15 @@ dependencies = [
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9b7ac0ce054412d9a85ff39bac27aec27483b06cef8756b57d9c29d448d081"
+checksum = "b3e3e3f549d27d2dc054372f320ddf68045a833fab490563ff70d4cf1b9d91ea"
 dependencies = [
- "array-bytes",
+ "array-bytes 9.1.2",
  "blake3",
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "parity-scale-codec",
- "scale-decode 0.13.1",
+ "scale-decode 0.16.0",
  "scale-info",
 ]
 
@@ -10398,7 +10407,7 @@ checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 name = "node-bench"
 version = "0.9.0-dev"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-trait",
  "clap",
  "derive_more 0.99.17",
@@ -10919,7 +10928,7 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 name = "pallet-alliance"
 version = "27.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -11269,7 +11278,7 @@ dependencies = [
 name = "pallet-beefy-mmr"
 version = "28.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "binary-merkle-tree",
  "frame-benchmarking",
  "frame-support",
@@ -11521,7 +11530,7 @@ dependencies = [
 name = "pallet-contracts"
 version = "27.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "environmental",
  "frame-benchmarking",
@@ -11945,7 +11954,7 @@ dependencies = [
 name = "pallet-example-view-functions"
 version = "1.0.0"
 dependencies = [
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "frame-support",
  "frame-system",
  "log",
@@ -12598,7 +12607,7 @@ name = "pallet-revive"
 version = "0.1.0"
 dependencies = [
  "alloy-core",
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "derive_more 0.99.17",
  "environmental",
@@ -12812,7 +12821,7 @@ dependencies = [
 name = "pallet-sassafras"
 version = "0.3.5-dev"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -13137,7 +13146,7 @@ dependencies = [
 name = "pallet-transaction-storage"
 version = "27.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -14715,7 +14724,7 @@ name = "polkadot-node-core-pvf"
 version = "7.0.0"
 dependencies = [
  "always-assert",
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "criterion",
  "futures",
@@ -18560,7 +18569,7 @@ dependencies = [
 name = "sc-chain-spec"
 version = "28.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "clap",
  "docify",
  "memmap2 0.9.3",
@@ -18601,7 +18610,7 @@ dependencies = [
 name = "sc-cli"
 version = "0.36.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "chrono",
  "clap",
  "fdlimit",
@@ -18671,7 +18680,7 @@ dependencies = [
 name = "sc-client-db"
 version = "0.35.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "criterion",
  "hash-db",
  "kitchensink-runtime",
@@ -18832,7 +18841,7 @@ dependencies = [
 name = "sc-consensus-beefy"
 version = "13.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "async-trait",
  "futures",
@@ -18905,7 +18914,7 @@ name = "sc-consensus-grandpa"
 version = "0.19.0"
 dependencies = [
  "ahash 0.8.11",
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "async-trait",
  "dyn-clone",
@@ -19062,7 +19071,7 @@ dependencies = [
 name = "sc-executor"
 version = "0.32.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "criterion",
  "num_cpus",
@@ -19228,7 +19237,7 @@ dependencies = [
 name = "sc-keystore"
 version = "25.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "parking_lot 0.12.3",
  "serde_json",
  "sp-application-crypto 30.0.0",
@@ -19242,7 +19251,7 @@ dependencies = [
 name = "sc-mixnet"
 version = "0.4.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "arrayvec 0.7.4",
  "blake2 0.10.6",
  "bytes",
@@ -19269,7 +19278,7 @@ dependencies = [
 name = "sc-network"
 version = "0.34.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "async-channel 1.9.0",
  "async-trait",
@@ -19361,7 +19370,7 @@ dependencies = [
 name = "sc-network-light"
 version = "0.33.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "futures",
  "log",
@@ -19381,7 +19390,7 @@ dependencies = [
 name = "sc-network-statement"
 version = "0.16.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "futures",
  "log",
@@ -19400,7 +19409,7 @@ dependencies = [
 name = "sc-network-sync"
 version = "0.33.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
@@ -19471,7 +19480,7 @@ dependencies = [
 name = "sc-network-transactions"
 version = "0.33.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "futures",
  "log",
  "parity-scale-codec",
@@ -19637,7 +19646,7 @@ dependencies = [
 name = "sc-rpc-spec-v2"
 version = "0.34.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "async-trait",
  "futures",
@@ -19777,7 +19786,7 @@ dependencies = [
 name = "sc-service-test"
 version = "2.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "fdlimit",
  "futures",
@@ -20040,19 +20049,6 @@ dependencies = [
  "scale-info",
  "scale-type-resolver",
  "serde",
-]
-
-[[package]]
-name = "scale-decode"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
-dependencies = [
- "derive_more 0.99.17",
- "parity-scale-codec",
- "scale-bits 0.6.0",
- "scale-type-resolver",
- "smallvec",
 ]
 
 [[package]]
@@ -21231,7 +21227,7 @@ dependencies = [
 name = "snowbridge-merkle-tree"
 version = "0.2.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "hex",
  "hex-literal",
  "parity-scale-codec",
@@ -22064,7 +22060,7 @@ dependencies = [
 name = "sp-consensus-beefy"
 version = "13.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -22136,7 +22132,7 @@ name = "sp-core"
 version = "28.0.0"
 dependencies = [
  "ark-vrf",
- "array-bytes",
+ "array-bytes 6.2.2",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
@@ -22186,7 +22182,7 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2dac7e47c7ddbb61efe196d5cce99f6ea88926c961fa39909bfeae46fc5a7b"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
@@ -22233,7 +22229,7 @@ version = "33.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3368e32f6fda6e20b8af51f94308d033ab70a021e87f6abbd3fed5aca942b745"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
@@ -22280,7 +22276,7 @@ version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4532774405a712a366a98080cbb4daa28c38ddff0ec595902ad6ee6a78a809f8"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "bounded-collections",
@@ -22638,7 +22634,7 @@ dependencies = [
 name = "sp-metadata-ir"
 version = "0.6.0"
 dependencies = [
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -22668,7 +22664,7 @@ dependencies = [
 name = "sp-mmr-primitives"
 version = "26.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "log",
  "parity-scale-codec",
  "polkadot-ckb-merkle-mountain-range",
@@ -22984,7 +22980,7 @@ name = "sp-state-machine"
 version = "0.35.0"
 dependencies = [
  "arbitrary",
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_matches",
  "hash-db",
  "log",
@@ -23187,7 +23183,7 @@ name = "sp-trie"
 version = "29.0.0"
 dependencies = [
  "ahash 0.8.11",
- "array-bytes",
+ "array-bytes 6.2.2",
  "criterion",
  "hash-db",
  "memory-db",
@@ -23669,7 +23665,7 @@ dependencies = [
 name = "staging-node-cli"
 version = "3.0.0-dev"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "assert_cmd",
  "clap",
  "clap_complete",
@@ -23739,7 +23735,7 @@ version = "2.0.0"
 name = "staging-xcm"
 version = "7.0.1"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "bounded-collections",
  "derive-where",
  "environmental",
@@ -24155,7 +24151,7 @@ dependencies = [
 name = "substrate-test-client"
 version = "2.0.1"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "async-trait",
  "futures",
  "parity-scale-codec",
@@ -24179,7 +24175,7 @@ dependencies = [
 name = "substrate-test-runtime"
 version = "2.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "frame-executive",
  "frame-metadata-hash-extension",
  "frame-support",
@@ -24301,12 +24297,12 @@ dependencies = [
 name = "substrate-wasm-builder"
 version = "17.0.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata 20.0.0",
+ "frame-metadata 21.0.0",
  "jobserver",
  "merkleized-metadata",
  "parity-scale-codec",
@@ -26400,7 +26396,7 @@ name = "wasm-loader"
 version = "0.21.3"
 source = "git+https://github.com/chevdor/subwasm?rev=v0.21.3#aa8acb6fdfb34144ac51ab95618a9b37fa251295"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "log",
  "multibase 0.9.1",
  "multihash 0.19.1",
@@ -27491,7 +27487,7 @@ dependencies = [
 name = "xcm-emulator"
 version = "0.5.0"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.2",
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -789,7 +789,7 @@ frame-benchmarking-pallet-pov = { default-features = false, path = "substrate/fr
 frame-election-provider-solution-type = { path = "substrate/frame/election-provider-support/solution-type", default-features = false }
 frame-election-provider-support = { path = "substrate/frame/election-provider-support", default-features = false }
 frame-executive = { path = "substrate/frame/executive", default-features = false }
-frame-metadata = { version = "20.0.0", default-features = false }
+frame-metadata = { version = "21.0.0", default-features = false }
 frame-metadata-hash-extension = { path = "substrate/frame/metadata-hash-extension", default-features = false }
 frame-support = { path = "substrate/frame/support", default-features = false }
 frame-support-procedural = { path = "substrate/frame/support/procedural", default-features = false }
@@ -871,7 +871,7 @@ macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }
 memmap2 = { version = "0.9.3" }
 memory-db = { version = "0.32.0", default-features = false }
-merkleized-metadata = { version = "0.4.0" }
+merkleized-metadata = { version = "0.5.0" }
 merlin = { version = "3.0", default-features = false }
 messages-relay = { path = "bridges/relays/messages" }
 metered = { version = "0.6.1", default-features = false, package = "prioritized-metered-channel" }

--- a/prdoc/pr_8122.prdoc
+++ b/prdoc/pr_8122.prdoc
@@ -1,0 +1,14 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: Accommodate small changes to unstable V16 metadata format
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      The frame-metadata version is bumped, which leads to a few minor changes to our sp-metadata-ir crate
+      to accommodate small changes in the unstable V16 metadata format. 
+
+crates:
+  - name: sp-metadata-ir
+    bump: major

--- a/substrate/primitives/metadata-ir/src/unstable.rs
+++ b/substrate/primitives/metadata-ir/src/unstable.rs
@@ -18,7 +18,7 @@
 //! Convert the IR to V16 metadata.
 
 use crate::{
-	DeprecationInfoIR, DeprecationStatusIR, OuterEnumsIR, PalletAssociatedTypeMetadataIR,
+	DeprecationInfoIR, DeprecationStatusIR, PalletAssociatedTypeMetadataIR,
 	PalletCallMetadataIR, PalletConstantMetadataIR, PalletErrorMetadataIR, PalletEventMetadataIR,
 	PalletStorageMetadataIR, PalletViewFunctionMetadataIR, PalletViewFunctionParamMetadataIR,
 	StorageEntryMetadataIR,
@@ -26,17 +26,19 @@ use crate::{
 
 use super::types::{
 	ExtrinsicMetadataIR, MetadataIR, PalletMetadataIR, RuntimeApiMetadataIR,
-	RuntimeApiMethodMetadataIR, RuntimeApiMethodParamMetadataIR, TransactionExtensionMetadataIR,
+	RuntimeApiMethodMetadataIR, TransactionExtensionMetadataIR,
 };
 
 use frame_metadata::v16::{
-	CustomMetadata, DeprecationInfo, DeprecationStatus, ExtrinsicMetadata, OuterEnums,
+	CustomMetadata, DeprecationInfo, DeprecationStatus, ExtrinsicMetadata,
 	PalletAssociatedTypeMetadata, PalletCallMetadata, PalletConstantMetadata, PalletErrorMetadata,
 	PalletEventMetadata, PalletMetadata, PalletStorageMetadata, PalletViewFunctionMetadata,
-	PalletViewFunctionParamMetadata, RuntimeApiMetadata, RuntimeApiMethodMetadata,
-	RuntimeApiMethodParamMetadata, RuntimeMetadataV16, StorageEntryMetadata,
+	FunctionParamMetadata, RuntimeApiMetadata, RuntimeApiMethodMetadata, RuntimeMetadataV16, StorageEntryMetadata,
 	TransactionExtensionMetadata,
 };
+
+use scale_info::form::MetaForm;
+use codec::Compact;
 
 impl From<MetadataIR> for RuntimeMetadataV16 {
 	fn from(ir: MetadataIR) -> Self {
@@ -73,12 +75,6 @@ impl From<RuntimeApiMethodMetadataIR> for RuntimeApiMethodMetadata {
 			docs: ir.docs,
 			deprecation_info: ir.deprecation_info.into(),
 		}
-	}
-}
-
-impl From<RuntimeApiMethodParamMetadataIR> for RuntimeApiMethodParamMetadata {
-	fn from(ir: RuntimeApiMethodParamMetadataIR) -> Self {
-		RuntimeApiMethodParamMetadata { name: ir.name, ty: ir.ty }
 	}
 }
 
@@ -159,9 +155,9 @@ impl From<PalletViewFunctionMetadataIR> for PalletViewFunctionMetadata {
 	}
 }
 
-impl From<PalletViewFunctionParamMetadataIR> for PalletViewFunctionParamMetadata {
+impl From<PalletViewFunctionParamMetadataIR> for FunctionParamMetadata<MetaForm> {
 	fn from(ir: PalletViewFunctionParamMetadataIR) -> Self {
-		PalletViewFunctionParamMetadata { name: ir.name, ty: ir.ty }
+		FunctionParamMetadata { name: ir.name, ty: ir.ty }
 	}
 }
 
@@ -186,7 +182,7 @@ impl From<TransactionExtensionMetadataIR> for TransactionExtensionMetadata {
 impl From<ExtrinsicMetadataIR> for ExtrinsicMetadata {
 	fn from(ir: ExtrinsicMetadataIR) -> Self {
 		// Assume version 0 for all extensions.
-		let indexes = (0..ir.extensions.len()).map(|index| index as u32).collect();
+		let indexes = (0..ir.extensions.len()).map(|index| Compact(index as u32)).collect();
 		let transaction_extensions_by_version = [(0, indexes)].iter().cloned().collect();
 
 		ExtrinsicMetadata {
@@ -195,16 +191,6 @@ impl From<ExtrinsicMetadataIR> for ExtrinsicMetadata {
 			signature_ty: ir.signature_ty,
 			transaction_extensions_by_version,
 			transaction_extensions: ir.extensions.into_iter().map(Into::into).collect(),
-		}
-	}
-}
-
-impl From<OuterEnumsIR> for OuterEnums {
-	fn from(ir: OuterEnumsIR) -> Self {
-		OuterEnums {
-			call_enum_ty: ir.call_enum_ty,
-			event_enum_ty: ir.event_enum_ty,
-			error_enum_ty: ir.error_enum_ty,
 		}
 	}
 }

--- a/substrate/primitives/metadata-ir/src/unstable.rs
+++ b/substrate/primitives/metadata-ir/src/unstable.rs
@@ -18,8 +18,8 @@
 //! Convert the IR to V16 metadata.
 
 use crate::{
-	DeprecationInfoIR, DeprecationStatusIR, PalletAssociatedTypeMetadataIR,
-	PalletCallMetadataIR, PalletConstantMetadataIR, PalletErrorMetadataIR, PalletEventMetadataIR,
+	DeprecationInfoIR, DeprecationStatusIR, PalletAssociatedTypeMetadataIR, PalletCallMetadataIR,
+	PalletConstantMetadataIR, PalletErrorMetadataIR, PalletEventMetadataIR,
 	PalletStorageMetadataIR, PalletViewFunctionMetadataIR, PalletViewFunctionParamMetadataIR,
 	StorageEntryMetadataIR,
 };
@@ -30,15 +30,15 @@ use super::types::{
 };
 
 use frame_metadata::v16::{
-	CustomMetadata, DeprecationInfo, DeprecationStatus, ExtrinsicMetadata,
+	CustomMetadata, DeprecationInfo, DeprecationStatus, ExtrinsicMetadata, FunctionParamMetadata,
 	PalletAssociatedTypeMetadata, PalletCallMetadata, PalletConstantMetadata, PalletErrorMetadata,
 	PalletEventMetadata, PalletMetadata, PalletStorageMetadata, PalletViewFunctionMetadata,
-	FunctionParamMetadata, RuntimeApiMetadata, RuntimeApiMethodMetadata, RuntimeMetadataV16, StorageEntryMetadata,
+	RuntimeApiMetadata, RuntimeApiMethodMetadata, RuntimeMetadataV16, StorageEntryMetadata,
 	TransactionExtensionMetadata,
 };
 
-use scale_info::form::MetaForm;
 use codec::Compact;
+use scale_info::form::MetaForm;
 
 impl From<MetadataIR> for RuntimeMetadataV16 {
 	fn from(ir: MetadataIR) -> Self {


### PR DESCRIPTION
This PR will update polkadot-sdk to use frame-metadata 21.0.0, for the latest iteration of unstable V16 metadata. Hopefully this is the final change before we do a PR to stabilize v16 metadata at the end of April.

Also updates to `merkelized-metadata` 0.5.0 which supports this version.
