### PR TITLE
Snowbridge V2: Add missing `set_operating_mode` call in outbound-queue pallet

### DIFF
--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/send_message_impl.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/send_message_impl.rs
@@ -33,8 +33,10 @@ where
 	}
 
 	fn deliver(ticket: Self::Ticket) -> Result<H256, SendError> {
-		let origin = AggregateMessageOrigin::SnowbridgeV2(ticket.origin);
+		// Ensure the pallet is in normal operations.
+		ensure!(!Self::operating_mode().is_halted(), SendError::Halted);
 
+		let origin = AggregateMessageOrigin::SnowbridgeV2(ticket.origin);
 		let message =
 			BoundedVec::try_from(ticket.encode()).map_err(|_| SendError::MessageTooLarge)?;
 


### PR DESCRIPTION

## Description 

This PR adds the `set_operating_mode` extrinsic to `snowbridge-pallet-outbound-queue-v2`, alongside its corresponding weight hint and test.

## Motivation

The `set_operating_mode` call allows us to control the queuing (and thus processing) of messages inside this pallet in a specific chain, which in my opinion is a nice feature to count with.

## Note

This extrinsic is present in the previous versions (V1) of the outbound and inbound queue pallets, as well as in the new V2 of the inbound queue pallet.

Was the fact of not including the extrinsic in the `outbound-queue-v2` intentional for any reason? In that case, let me know and I'll close this PR (cc @claravanstaden @vgeddes @yrong).