### PR TITLE
hotfix sync backing zombienet test

### DIFF
--- a/polkadot/zombienet-sdk-tests/tests/functional/sync_backing.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/sync_backing.rs
@@ -7,7 +7,6 @@ use anyhow::anyhow;
 
 use cumulus_zombienet_sdk_helpers::{assert_finality_lag, assert_finalized_para_throughput};
 use polkadot_primitives::Id as ParaId;
-use serde_json::json;
 use subxt::{OnlineClient, PolkadotConfig};
 use zombienet_sdk::NetworkConfigBuilder;
 
@@ -26,15 +25,6 @@ async fn sync_backing_test() -> Result<(), anyhow::Error> {
 				.with_default_command("polkadot")
 				.with_default_image(images.polkadot.as_str())
 				.with_default_args(vec![("-lparachain=debug").into()])
-				.with_genesis_overrides(json!({
-					"configuration": {
-						"config": {
-							"scheduler_params": {
-								"group_rotation_frequency": 4,
-							},
-						}
-					}
-				}))
 				.with_node(|node| node.with_name("validator-0"));
 
 			(1..5).fold(r, |acc, i| acc.with_node(|node| node.with_name(&format!("validator-{i}"))))


### PR DESCRIPTION
Proper fix is described in https://github.com/paritytech/polkadot-sdk/issues/8131, but do this to quickly fix this test