### PR TITLE
Improve documentation around development environment configuration

### DIFF
--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -169,20 +169,20 @@
 //!         "--target-dir=target/rust-analyzer"
 //!       },
 //!     },
-//!     check = {
-//!       overrideCommand = {
-//!         "cargo",
-//!         "remote",
-//!         "--build-env",
-//!         "SKIP_WASM_BUILD=1",
-//!         "--",
-//!         "check",
-//!         "--workspace",
-//!         "--message-format=json",
-//!         "--all-targets",
-//!         "--all-features",
-//!         "--target-dir=target/rust-analyzer"
-//!       },
+//!   },
+//!   check = {
+//!     overrideCommand = {
+//!       "cargo",
+//!       "remote",
+//!       "--build-env",
+//!       "SKIP_WASM_BUILD=1",
+//!       "--",
+//!       "check",
+//!       "--workspace",
+//!       "--message-format=json",
+//!       "--all-targets",
+//!       "--all-features",
+//!       "--target-dir=target/rust-analyzer"
 //!     },
 //!   },
 //! },

--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -10,7 +10,7 @@
 //! [Rust Analyzer](https://rust-analyzer.github.io/) is the defacto [LSP](https://langserver.org/) for Rust. Its default
 //! settings are fine for smaller projects, but not well optimised for polkadot-sdk.
 //!
-//! Below is a suggested configuration for VSCode:
+//! Below is a suggested configuration for VSCode or any VSCode-based editor like Cursor:
 //!
 //! ```json
 //! {
@@ -118,7 +118,8 @@
 //! freeing up local resources for other tasks like `rust-analyzer`.
 //!
 //! When using `cargo-remote`, you can configure your editor to perform the the typical
-//! "check-on-save" remotely as well. The configuration for VSCode is as follows:
+//! "check-on-save" remotely as well. The configuration for VSCode (or any VSCode-based editor like
+//! Cursor) is as follows:
 //!
 //! ```json
 //! {

--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -85,6 +85,61 @@
 //! },
 //! ```
 //!
+//! Alternatively for neovim, if you are using [Rustaceanvim](https://github.com/mrcjkb/rustaceanvim) - as
+//! installed currently by default in LazyVim via [:LazyExtras](https://www.lazyvim.org/extras/lang/rust),
+//! you can achieve the same configuring `rustaceanvim` as follows:
+//! ```lua
+//! return {
+//!  {
+//!    "mrcjkb/rustaceanvim",
+//!    lazy = false,
+//!    opts = {
+//!      server = {
+//!        default_settings = {
+//!           ["rust-analyzer"] = {
+//!            rust = {
+//!              -- Use a separate target dir for Rust Analyzer. Helpful if you want to use Rust
+//!              --  Analyzer and cargo on the command line at the same time.
+//!              analyzerTargetDir = "target/nvim-rust-analyzer",
+//!            },
+//!            server = {
+//!              -- Improve stability
+//!              extraEnv = {
+//!                ["CHALK_OVERFLOW_DEPTH"] = "100000000",
+//!                ["CHALK_SOLVER_MAX_SIZE"] = "100000000",
+//!              },
+//!            },
+//!            cargo = {
+//!              -- Check feature-gated code
+//!              features = "all",
+//!              extraEnv = {
+//!                -- Skip building WASM, there is never need for it here
+//!                ["SKIP_WASM_BUILD"] = "1",
+//!              },
+//!            },
+//!            procMacro = {
+//!              -- Don't expand some problematic proc_macros
+//!              ignored = {
+//!                ["async-trait"] = { "async_trait" },
+//!                ["napi-derive"] = { "napi" },
+//!                ["async-recursion"] = { "async_recursion" },
+//!                ["async-std"] = { "async_std" },
+//!              },
+//!            },
+//!            rustfmt = {
+//!              -- Use nightly formatting.
+//!              -- See the polkadot-sdk CI job that checks formatting for the current version used in
+//!              -- polkadot-sdk.
+//!              extraArgs = { "+nightly-2024-04-10" },
+//!            },
+//!          },
+//!        },
+//!      },
+//!    },
+//!  },
+//! }
+//! ```
+//!
 //! Similarly for Zed, a suggested configuration in `~/.config/zed/settings.json` is as follows:
 //! ```json
 //! "lsp": {
@@ -229,6 +284,54 @@
 //!   },
 //! },
 //! ```
+//! Alternatively in neovim, you can achieve the same configuring `rustaceanvim` as follows:
+//! ```lua
+//! return {
+//!   {
+//!     "mrcjkb/rustaceanvim",
+//!     opts = {
+//!       server = {
+//!         default_settings = {
+//!           ["rust-analyzer"] = {
+//!             cargo = {
+//!               buildScripts = {
+//!                 overrideCommand = {
+//!                   "cargo",
+//!                   "remote",
+//!                   "--build-env",
+//!                   "SKIP_WASM_BUILD=1",
+//!                   "--",
+//!                   "check",
+//!                   "--message-format=json",
+//!                   "--all-targets",
+//!                   "--all-features",
+//!                   "--target-dir=target/rust-analyzer",
+//!                 },
+//!               },
+//!             },
+//!             check = {
+//!               overrideCommand = {
+//!                 "cargo",
+//!                 "remote",
+//!                 "--build-env",
+//!                 "SKIP_WASM_BUILD=1",
+//!                 "--",
+//!                 "check", -- or clippy, but will be slower
+//!                 "--workspace",
+//!                 "--message-format=json",
+//!                 "--all-targets",
+//!                 "--all-features",
+//!                 "--target-dir=target/nvim-rust-analyzer",
+//!               },
+//!             },
+//!           },
+//!         },
+//!       },
+//!     },
+//!   },
+//! }
+//! ```
+//!
 //! For Zed please add the  following in your `~/.config/zed/settings.json`:
 //! ```json
 //! "lsp": {

--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -85,6 +85,47 @@
 //! },
 //! ```
 //!
+//! Similarly for Zed, a suggested configuration in `~/.config/zed/settings.json` is as follows:
+//! ```json
+//! "lsp": {
+//!   "rust-analyzer": {
+//!     "initialization_options": {
+//!       "rust": {
+//!         // Use a separate target dir for Rust Analyzer. Helpful if you want to use Rust
+//!         // Analyzer and cargo on the command line at the same time.
+//!         "analyzerTargetDir": "target/zed-rust-analyzer"
+//!       },
+//!       // Improve stability
+//!       "server": {
+//!         "extraEnv": {
+//!           "CHALK_OVERFLOW_DEPTH": "100000000",
+//!           "CHALK_SOLVER_MAX_SIZE": "10000000"
+//!         }
+//!       },
+//!       // Check feature-gated code
+//!       "cargo": {
+//!         "features": "all",
+//!         "extraEnv": {
+//!           "SKIP_WASM_BUILD": "1"
+//!         },
+//!       },
+//!       // Don't expand some problematic proc_macros
+//!       "procMacro": {
+//!         "ignored": {
+//!           "async-trait": ["async_trait"],
+//!           "napi-derive": ["napi"],
+//!           "async-recursion": ["async_recursion"],
+//!           "async-std": ["async_std"]
+//!         }
+//!       },
+//!       // Use nightly formatting.
+//!       // See the polkadot-sdk CI job that checks formatting for the current version used in
+//!       // polkadot-sdk.
+//!       "rustfmt.extraArgs": ["+nightly-2024-04-10"],
+//!     }
+//!   }
+//! },
+//! ```
 //! For the full set of configuration options see <https://rust-analyzer.github.io/manual.html#configuration>.
 //!
 //! ## Cargo Usage
@@ -186,5 +227,45 @@
 //!       "--target-dir=target/rust-analyzer"
 //!     },
 //!   },
+//! },
+//! ```
+//! For Zed please add the  following in your `~/.config/zed/settings.json`:
+//! ```json
+//! "lsp": {
+//!   "rust-analyzer": {
+//!     "initialization_options": {
+//!       "cargo": {
+//!         "buildScripts": {
+//!           "overrideCommand": [
+//!             "cargo",
+//!             "remote",
+//!             "--build-env",
+//!             "SKIP_WASM_BUILD=1",
+//!             "--",
+//!             "check",
+//!             "--message-format=json",
+//!             "--all-targets",
+//!             "--all-features",
+//!             "--target-dir=target/rust-analyzer"
+//!           ]
+//!         }
+//!       },
+//!       "check": {
+//!         "overrideCommand": [
+//!           "cargo",
+//!           "remote",
+//!           "--build-env",
+//!           "SKIP_WASM_BUILD=1",
+//!           "--",
+//!           "check",
+//!           "--workspace",
+//!           "--message-format=json",
+//!           "--all-targets",
+//!           "--all-features",
+//!           "--target-dir=target/rust-analyzer"
+//!         ]
+//!       }
+//!     }
+//!   }
 //! },
 //! ```

--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -85,53 +85,17 @@
 //! },
 //! ```
 //!
-//! Alternatively for neovim, if you are using [Rustaceanvim](https://github.com/mrcjkb/rustaceanvim) - as
-//! installed currently by default in LazyVim via [:LazyExtras](https://www.lazyvim.org/extras/lang/rust),
-//! you can achieve the same configuring `rustaceanvim` as follows:
+//! Alternatively for neovim, if you are using [Rustaceanvim](https://github.com/mrcjkb/rustaceanvim),
+//! you can achieve the same configuring `rust-analyzer` via `rustaceanvim` as follows:
 //! ```lua
 //! return {
 //!  {
 //!    "mrcjkb/rustaceanvim",
-//!    lazy = false,
 //!    opts = {
 //!      server = {
 //!        default_settings = {
 //!           ["rust-analyzer"] = {
-//!            rust = {
-//!              -- Use a separate target dir for Rust Analyzer. Helpful if you want to use Rust
-//!              --  Analyzer and cargo on the command line at the same time.
-//!              analyzerTargetDir = "target/nvim-rust-analyzer",
-//!            },
-//!            server = {
-//!              -- Improve stability
-//!              extraEnv = {
-//!                ["CHALK_OVERFLOW_DEPTH"] = "100000000",
-//!                ["CHALK_SOLVER_MAX_SIZE"] = "100000000",
-//!              },
-//!            },
-//!            cargo = {
-//!              -- Check feature-gated code
-//!              features = "all",
-//!              extraEnv = {
-//!                -- Skip building WASM, there is never need for it here
-//!                ["SKIP_WASM_BUILD"] = "1",
-//!              },
-//!            },
-//!            procMacro = {
-//!              -- Don't expand some problematic proc_macros
-//!              ignored = {
-//!                ["async-trait"] = { "async_trait" },
-//!                ["napi-derive"] = { "napi" },
-//!                ["async-recursion"] = { "async_recursion" },
-//!                ["async-std"] = { "async_std" },
-//!              },
-//!            },
-//!            rustfmt = {
-//!              -- Use nightly formatting.
-//!              -- See the polkadot-sdk CI job that checks formatting for the current version used in
-//!              -- polkadot-sdk.
-//!              extraArgs = { "+nightly-2024-04-10" },
-//!            },
+//!            // put the same config as for nvim-lspconfig here
 //!          },
 //!        },
 //!      },
@@ -140,47 +104,20 @@
 //! }
 //! ```
 //!
-//! Similarly for Zed, a suggested configuration in `~/.config/zed/settings.json` is as follows:
+//! Similarly for Zed, you can replicate the same VSCode configuration  in
+//! `~/.config/zed/settings.json` as follows:
 //! ```json
 //! "lsp": {
 //!   "rust-analyzer": {
 //!     "initialization_options": {
-//!       "rust": {
-//!         // Use a separate target dir for Rust Analyzer. Helpful if you want to use Rust
-//!         // Analyzer and cargo on the command line at the same time.
-//!         "analyzerTargetDir": "target/zed-rust-analyzer"
-//!       },
-//!       // Improve stability
-//!       "server": {
-//!         "extraEnv": {
-//!           "CHALK_OVERFLOW_DEPTH": "100000000",
-//!           "CHALK_SOLVER_MAX_SIZE": "10000000"
-//!         }
-//!       },
-//!       // Check feature-gated code
-//!       "cargo": {
-//!         "features": "all",
-//!         "extraEnv": {
-//!           "SKIP_WASM_BUILD": "1"
-//!         },
-//!       },
-//!       // Don't expand some problematic proc_macros
-//!       "procMacro": {
-//!         "ignored": {
-//!           "async-trait": ["async_trait"],
-//!           "napi-derive": ["napi"],
-//!           "async-recursion": ["async_recursion"],
-//!           "async-std": ["async_std"]
-//!         }
-//!       },
-//!       // Use nightly formatting.
-//!       // See the polkadot-sdk CI job that checks formatting for the current version used in
-//!       // polkadot-sdk.
-//!       "rustfmt.extraArgs": ["+nightly-2024-04-10"],
+//!       // same config as for VSCode for rust, cargo, procMacros, ...
 //!     }
 //!   }
 //! },
 //! ```
+//!
+//! In general, refer to your favorite editor / IDE's documentation to properly configure
+//! `rust-analyzer` as language server.
 //! For the full set of configuration options see <https://rust-analyzer.github.io/manual.html#configuration>.
 //!
 //! ## Cargo Usage
@@ -282,93 +219,5 @@
 //!       "--target-dir=target/rust-analyzer"
 //!     },
 //!   },
-//! },
-//! ```
-//! Alternatively in neovim, you can achieve the same configuring `rustaceanvim` as follows:
-//! ```lua
-//! return {
-//!   {
-//!     "mrcjkb/rustaceanvim",
-//!     opts = {
-//!       server = {
-//!         default_settings = {
-//!           ["rust-analyzer"] = {
-//!             cargo = {
-//!               buildScripts = {
-//!                 overrideCommand = {
-//!                   "cargo",
-//!                   "remote",
-//!                   "--build-env",
-//!                   "SKIP_WASM_BUILD=1",
-//!                   "--",
-//!                   "check",
-//!                   "--message-format=json",
-//!                   "--all-targets",
-//!                   "--all-features",
-//!                   "--target-dir=target/rust-analyzer",
-//!                 },
-//!               },
-//!             },
-//!             check = {
-//!               overrideCommand = {
-//!                 "cargo",
-//!                 "remote",
-//!                 "--build-env",
-//!                 "SKIP_WASM_BUILD=1",
-//!                 "--",
-//!                 "check", -- or clippy, but will be slower
-//!                 "--workspace",
-//!                 "--message-format=json",
-//!                 "--all-targets",
-//!                 "--all-features",
-//!                 "--target-dir=target/nvim-rust-analyzer",
-//!               },
-//!             },
-//!           },
-//!         },
-//!       },
-//!     },
-//!   },
-//! }
-//! ```
-//!
-//! For Zed please add the  following in your `~/.config/zed/settings.json`:
-//! ```json
-//! "lsp": {
-//!   "rust-analyzer": {
-//!     "initialization_options": {
-//!       "cargo": {
-//!         "buildScripts": {
-//!           "overrideCommand": [
-//!             "cargo",
-//!             "remote",
-//!             "--build-env",
-//!             "SKIP_WASM_BUILD=1",
-//!             "--",
-//!             "check",
-//!             "--message-format=json",
-//!             "--all-targets",
-//!             "--all-features",
-//!             "--target-dir=target/rust-analyzer"
-//!           ]
-//!         }
-//!       },
-//!       "check": {
-//!         "overrideCommand": [
-//!           "cargo",
-//!           "remote",
-//!           "--build-env",
-//!           "SKIP_WASM_BUILD=1",
-//!           "--",
-//!           "check",
-//!           "--workspace",
-//!           "--message-format=json",
-//!           "--all-targets",
-//!           "--all-features",
-//!           "--target-dir=target/rust-analyzer"
-//!         ]
-//!       }
-//!     }
-//!   }
 //! },
 //! ```


### PR DESCRIPTION
Update the development environment configuration:
- fixing the configuration for `neovim` around `cargo-remote`, where `check` override was incorrectly set under `cargo`
- adding a note about  `neovim`/ `rustaceanvim` vs `rust-analyzer`
- adding a  basoc configuration for `Zed`
- adding a note for `Cursor`  
