### PR TITLE
Backport: make macro expansion not rely on sp-std in scope.

### DIFF
--- a/bridges/primitives/runtime/src/chain.rs
+++ b/bridges/primitives/runtime/src/chain.rs
@@ -351,7 +351,7 @@ macro_rules! decl_bridge_finality_runtime_apis {
 						$(
 							/// Returns the justifications accepted in the current block.
 							fn [<synced_headers_ $consensus:lower _info>](
-							) -> sp_std::vec::Vec<$justification_type>;
+							) -> $crate::private::Vec<$justification_type>;
 						)?
 					}
 				}
@@ -409,7 +409,7 @@ macro_rules! decl_bridge_messages_runtime_apis {
 							lane: $lane_id_type,
 							begin: bp_messages::MessageNonce,
 							end: bp_messages::MessageNonce,
-						) -> sp_std::vec::Vec<bp_messages::OutboundMessageDetails>;
+						) -> $crate::private::Vec<bp_messages::OutboundMessageDetails>;
 					}
 
 					/// Inbound message lane API for messages sent by this chain.
@@ -423,8 +423,8 @@ macro_rules! decl_bridge_messages_runtime_apis {
 						/// Return details of given inbound messages.
 						fn message_details(
 							lane: $lane_id_type,
-							messages: sp_std::vec::Vec<(bp_messages::MessagePayload, bp_messages::OutboundMessageDetails)>,
-						) -> sp_std::vec::Vec<bp_messages::InboundMessageDetails>;
+							messages: $crate::private::Vec<(bp_messages::MessagePayload, bp_messages::OutboundMessageDetails)>,
+						) -> $crate::private::Vec<bp_messages::InboundMessageDetails>;
 					}
 				}
 			}

--- a/bridges/primitives/runtime/src/lib.rs
+++ b/bridges/primitives/runtime/src/lib.rs
@@ -52,6 +52,8 @@ pub use storage_proof::{
 };
 pub use storage_types::BoundedStorageValue;
 
+extern crate alloc;
+
 pub mod extensions;
 pub mod messages;
 
@@ -61,6 +63,13 @@ mod storage_types;
 
 // Re-export macro to avoid include paste dependency everywhere
 pub use sp_runtime::paste;
+
+// Re-export for usage in macro.
+#[doc(hidden)]
+pub mod private {
+	#[doc(hidden)]
+	pub use alloc::vec::Vec;
+}
 
 /// Use this when something must be shared among all instances.
 pub const NO_INSTANCE_ID: ChainId = [0, 0, 0, 0];


### PR DESCRIPTION
make macro in bp-runtime no longer require sp-std in scope.