### PR TITLE
Increased dots to move from 25 to 1000

### DIFF
--- a/polkadot/node/doppelganger/consensus/src/lib.rs
+++ b/polkadot/node/doppelganger/consensus/src/lib.rs
@@ -131,7 +131,7 @@ where
 
 						if state.parent_storage_keys.len() == 0 && state.state_root.len() == 0 {
 							// AHM
-							const AMOUNT_OF_DOTS_TO_MOVE: u128 = 250000000000_u128;
+							const AMOUNT_OF_DOTS_TO_MOVE: u128 = 10000000000000_u128;
 							let account_to_subtract_k: Vec<u8> = hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da91cdb29d91f7665b36dc5ec5903de32467628a5be63c4d3c8dbb96c2904b1a9682e02831a1af836c7efc808020b92fa63").into();
 							let account_alice_k: Vec<u8> = hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").into();
 							{


### PR DESCRIPTION
force_schedule_code_upgrade call takes 201 dots to execute.  re-starting zombie-bite takes around 25 mins. 
Increasing the balance so that I can experiment with calls without restarting zombie-bite