### PR TITLE
expose current advertised xcm version

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -299,6 +299,7 @@ pub mod pallet {
 
 		/// The latest supported version that we advertise. Generally just set it to
 		/// `pallet_xcm::CurrentXcmVersion`.
+		#[pallet::constant]
 		type AdvertisedXcmVersion: Get<XcmVersion>;
 
 		/// The origin that is allowed to call privileged operations on the XCM pallet

--- a/prdoc/pr_8173.prdoc
+++ b/prdoc/pr_8173.prdoc
@@ -1,10 +1,7 @@
-title: expose current advertised xcm version
+title: Expose current advertised xcm version
 doc:
-- audience: Runtime Dev
-  description: Right now there is no "easy" way of knowing what is the currently supported
-    xcm version without looking at the code or the metadata. Since pallet-xcm already
-    has a constant to detect the latest advertised version, there is no reason (I
-    think) to not expose it as a constant
+- audience: Runtime User
+  description: Exposes `AdvertisedXcmVersion` via a metadata constant.
 crates:
 - name: pallet-xcm
   bump: patch

--- a/prdoc/pr_8173.prdoc
+++ b/prdoc/pr_8173.prdoc
@@ -1,0 +1,10 @@
+title: expose current advertised xcm version
+doc:
+- audience: Runtime Dev
+  description: Right now there is no "easy" way of knowing what is the currently supported
+    xcm version without looking at the code or the metadata. Since pallet-xcm already
+    has a constant to detect the latest advertised version, there is no reason (I
+    think) to not expose it as a constant
+crates:
+- name: pallet-xcm
+  bump: patch


### PR DESCRIPTION
Right now there is no "easy" way of knowing what is the currently supported xcm version without looking at the code or the metadata. Since pallet-xcm already has a constant to detect the latest advertised version, there is no reason (I think) to not expose it as a constant