### PR TITLE
Omni Node: Enable OCW http

### DIFF
--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -318,7 +318,7 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 						)),
 						network_provider: Arc::new(network.clone()),
 						is_validator: parachain_config.role.is_authority(),
-						enable_http_requests: false,
+						enable_http_requests: true,
 						custom_extensions: move |_| vec![],
 					})?;
 				task_manager.spawn_handle().spawn(

--- a/prdoc/pr_8208.prdoc
+++ b/prdoc/pr_8208.prdoc
@@ -1,0 +1,11 @@
+title: 'Omni Node: Enable OCW http'
+doc:
+- audience: Node Operator
+  description: |-
+    This enables the HTTP support for the OCW.
+
+
+    Closes: https://github.com/paritytech/polkadot-sdk/issues/8203
+crates:
+- name: polkadot-omni-node-lib
+  bump: patch


### PR DESCRIPTION
This enables the HTTP support for the OCW.


Closes: https://github.com/paritytech/polkadot-sdk/issues/8203