### PR TITLE
[xcm-builder][origin_conversion] LocationAsSuperuser converter introduced

### DIFF
--- a/polkadot/xcm/xcm-builder/src/lib.rs
+++ b/polkadot/xcm/xcm-builder/src/lib.rs
@@ -115,9 +115,9 @@ pub use origin_aliases::*;
 mod origin_conversion;
 pub use origin_conversion::{
 	BackingToPlurality, ChildParachainAsNative, ChildSystemParachainAsSuperuser, EnsureXcmOrigin,
-	OriginToPluralityVoice, ParentAsSuperuser, RelayChainAsNative, SiblingParachainAsNative,
-	SiblingSystemParachainAsSuperuser, SignedAccountId32AsNative, SignedAccountKey20AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation,
+	LocationAsSuperuser, OriginToPluralityVoice, ParentAsSuperuser, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingSystemParachainAsSuperuser, SignedAccountId32AsNative,
+	SignedAccountKey20AsNative, SignedToAccountId32, SovereignSignedViaLocation,
 };
 
 mod pay;

--- a/polkadot/xcm/xcm-builder/src/origin_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/origin_conversion.rs
@@ -333,15 +333,13 @@ impl<RuntimeOrigin: Clone, EnsureBodyOrigin: EnsureOrigin<RuntimeOrigin>, Body: 
 	}
 }
 
-/// Implements `ConvertOrigin` to convert specific `Location`s into `RuntimeOrigin::root()`.
-///
-/// This is typically used when configuring `pallet-xcm` to allow a remote `Location`
-/// to act as the `Root` origin on the local chain.
+/// Converter that allows specific `Location`s to act as a superuser (`RuntimeOrigin::root()`)
+/// if it matches the predefined `WhitelistedSuperuserLocations` filter and `OriginKind::Superuser`.
 pub struct LocationAsSuperuser<WhitelistedSuperuserLocations, RuntimeOrigin>(
-	PhantomData<(SuperuserLocation, RuntimeOrigin)>,
+	PhantomData<(WhitelistedSuperuserLocations, RuntimeOrigin)>,
 );
-impl<SuperuserLocation: Contains<Location>, RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>
-	for LocationAsSuperuser<SuperuserLocation, RuntimeOrigin>
+impl<WhitelistedSuperuserLocations: Contains<Location>, RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>
+	for LocationAsSuperuser<WhitelistedSuperuserLocations, RuntimeOrigin>
 {
 	fn convert_origin(
 		origin: impl Into<Location>,
@@ -354,7 +352,7 @@ impl<SuperuserLocation: Contains<Location>, RuntimeOrigin: OriginTrait> ConvertO
 			"LocationAsSuperuser",
 		);
 		match (kind, &origin) {
-			(OriginKind::Superuser, loc) if SuperuserLocation::contains(loc) =>
+			(OriginKind::Superuser, loc) if WhitelistedSuperuserLocations::contains(loc) =>
 				Ok(RuntimeOrigin::root()),
 			_ => Err(origin),
 		}

--- a/polkadot/xcm/xcm-builder/src/origin_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/origin_conversion.rs
@@ -333,7 +333,7 @@ impl<RuntimeOrigin: Clone, EnsureBodyOrigin: EnsureOrigin<RuntimeOrigin>, Body: 
 	}
 }
 
-/// Implements `ConvertOrigin` to convert a `Location` into `RuntimeOrigin::root()`.
+/// Implements `ConvertOrigin` to convert specific `Location`s into `RuntimeOrigin::root()`.
 ///
 /// This is typically used when configuring `pallet-xcm` to allow a remote `Location`
 /// to act as the `Root` origin on the local chain.

--- a/polkadot/xcm/xcm-builder/src/origin_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/origin_conversion.rs
@@ -338,7 +338,8 @@ impl<RuntimeOrigin: Clone, EnsureBodyOrigin: EnsureOrigin<RuntimeOrigin>, Body: 
 pub struct LocationAsSuperuser<WhitelistedSuperuserLocations, RuntimeOrigin>(
 	PhantomData<(WhitelistedSuperuserLocations, RuntimeOrigin)>,
 );
-impl<WhitelistedSuperuserLocations: Contains<Location>, RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>
+impl<WhitelistedSuperuserLocations: Contains<Location>, RuntimeOrigin: OriginTrait>
+	ConvertOrigin<RuntimeOrigin>
 	for LocationAsSuperuser<WhitelistedSuperuserLocations, RuntimeOrigin>
 {
 	fn convert_origin(

--- a/polkadot/xcm/xcm-builder/src/origin_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/origin_conversion.rs
@@ -17,7 +17,7 @@
 //! Various implementations for `ConvertOrigin`.
 
 use core::marker::PhantomData;
-use frame_support::traits::{EnsureOrigin, Get, GetBacking, OriginTrait};
+use frame_support::traits::{Contains, EnsureOrigin, Get, GetBacking, OriginTrait};
 use frame_system::RawOrigin as SystemRawOrigin;
 use polkadot_parachain_primitives::primitives::IsSystem;
 use sp_runtime::traits::TryConvert;
@@ -330,5 +330,125 @@ impl<RuntimeOrigin: Clone, EnsureBodyOrigin: EnsureOrigin<RuntimeOrigin>, Body: 
 			Ok(_) => Ok(Junction::Plurality { id: Body::get(), part: BodyPart::Voice }.into()),
 			Err(o) => Err(o),
 		}
+	}
+}
+
+/// Implements `ConvertOrigin` to convert a `Location` into `RuntimeOrigin::root()`.
+///
+/// This is typically used when configuring `pallet-xcm` to allow a remote `Location`
+/// to act as the `Root` origin on the local chain.
+pub struct LocationAsSuperuser<SuperuserLocation, RuntimeOrigin>(
+	PhantomData<(SuperuserLocation, RuntimeOrigin)>,
+);
+impl<SuperuserLocation: Contains<Location>, RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>
+	for LocationAsSuperuser<SuperuserLocation, RuntimeOrigin>
+{
+	fn convert_origin(
+		origin: impl Into<Location>,
+		kind: OriginKind,
+	) -> Result<RuntimeOrigin, Location> {
+		let origin = origin.into();
+		tracing::trace!(
+			target: "xcm::origin_conversion",
+			?origin, ?kind,
+			"LocationAsSuperuser",
+		);
+		match (kind, &origin) {
+			(OriginKind::Superuser, loc) if SuperuserLocation::contains(loc) =>
+				Ok(RuntimeOrigin::root()),
+			_ => Err(origin),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame_support::{construct_runtime, derive_impl, parameter_types, traits::Equals};
+	use xcm::latest::{Junction::*, OriginKind};
+
+	type Block = frame_system::mocking::MockBlock<Test>;
+
+	construct_runtime!(
+		pub enum Test
+		{
+			System: frame_system,
+		}
+	);
+
+	#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+	impl frame_system::Config for Test {
+		type Block = Block;
+	}
+
+	parameter_types! {
+		pub SuperuserLocation: Location = Location::new(0, Parachain(1));
+	}
+
+	#[test]
+	fn superuser_location_works() {
+		let test_conversion = |loc, kind| {
+			LocationAsSuperuser::<Equals<SuperuserLocation>, RuntimeOrigin>::convert_origin(
+				loc, kind,
+			)
+		};
+
+		// Location that was set as SuperUserLocation should result in success conversion to Root
+		assert!(matches!(test_conversion(SuperuserLocation::get(), OriginKind::Superuser), Ok(..)));
+		// Same Location as SuperUserLocation::get()
+		assert!(matches!(
+			test_conversion(Location::new(0, Parachain(1)), OriginKind::Superuser),
+			Ok(..)
+		));
+
+		// Same Location but different origin kind
+		assert!(matches!(test_conversion(SuperuserLocation::get(), OriginKind::Native), Err(..)));
+		assert!(matches!(
+			test_conversion(SuperuserLocation::get(), OriginKind::SovereignAccount),
+			Err(..)
+		));
+		assert!(matches!(test_conversion(SuperuserLocation::get(), OriginKind::Xcm), Err(..)));
+
+		// No other location should result in successful conversion to Root
+		// thus expecting Err in all cases below
+		//
+		// Non-matching parachain number
+		assert!(matches!(
+			test_conversion(Location::new(0, Parachain(2)), OriginKind::Superuser),
+			Err(..)
+		));
+		// Non-matching parents count
+		assert!(matches!(
+			test_conversion(Location::new(1, Parachain(1)), OriginKind::Superuser),
+			Err(..)
+		));
+		// Child location of SuperUserLocation
+		assert!(matches!(
+			test_conversion(
+				Location::new(1, [Parachain(1), GeneralIndex(0)]),
+				OriginKind::Superuser
+			),
+			Err(..)
+		));
+		// Here
+		assert!(matches!(test_conversion(Location::new(0, Here), OriginKind::Superuser), Err(..)));
+		// Parent
+		assert!(matches!(test_conversion(Location::new(1, Here), OriginKind::Superuser), Err(..)));
+		// Some random account
+		assert!(matches!(
+			test_conversion(
+				Location::new(0, AccountId32 { network: None, id: [0u8; 32] }),
+				OriginKind::Superuser
+			),
+			Err(..)
+		));
+		// Child location of SuperUserLocation
+		assert!(matches!(
+			test_conversion(
+				Location::new(0, [Parachain(1), AccountId32 { network: None, id: [1u8; 32] }]),
+				OriginKind::Superuser
+			),
+			Err(..)
+		));
 	}
 }

--- a/polkadot/xcm/xcm-builder/src/origin_conversion.rs
+++ b/polkadot/xcm/xcm-builder/src/origin_conversion.rs
@@ -337,7 +337,7 @@ impl<RuntimeOrigin: Clone, EnsureBodyOrigin: EnsureOrigin<RuntimeOrigin>, Body: 
 ///
 /// This is typically used when configuring `pallet-xcm` to allow a remote `Location`
 /// to act as the `Root` origin on the local chain.
-pub struct LocationAsSuperuser<SuperuserLocation, RuntimeOrigin>(
+pub struct LocationAsSuperuser<WhitelistedSuperuserLocations, RuntimeOrigin>(
 	PhantomData<(SuperuserLocation, RuntimeOrigin)>,
 );
 impl<SuperuserLocation: Contains<Location>, RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>

--- a/prdoc/pr_8210.prdoc
+++ b/prdoc/pr_8210.prdoc
@@ -2,14 +2,7 @@ title: '[xcm-builder][origin_conversion] LocationAsSuperuser converter introduce
 doc:
 - audience: Runtime Dev
   description: |-
-    Relates to: https://github.com/polkadot-fellows/runtimes/issues/651
-    Already used by: https://github.com/polkadot-fellows/runtimes/pull/626
-
-    # Description
-
-    This PR introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow specific `Location`s defined through XCM configuration to act as Root on the local chain.
-
-    Implementation is generic over `Location` but was created for purposes of allowing AssetHub system chain (by other system chains and relay chains) to execute Root level extrinsics like `authorize_upgrade` on them.
+    Introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow specific `Location`s defined through XCM configuration to act as Root on the local chain. Implementation is generic over `Location` but was created for purposes of allowing AssetHub system chain (by other system chains and relay chains) to execute Root level extrinsics like `authorize_upgrade` on them.
 crates:
 - name: staging-xcm-builder
   bump: patch

--- a/prdoc/pr_8210.prdoc
+++ b/prdoc/pr_8210.prdoc
@@ -1,0 +1,19 @@
+title: '[xcm-builder][origin_conversion] LocationAsSuperuser converter introduced'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Relates to: https://github.com/polkadot-fellows/runtimes/issues/651
+    Already used by: https://github.com/polkadot-fellows/runtimes/pull/626
+
+    # Description
+
+    This PR introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow some `Location` chosen by the XCM configuration to act as Root on the local chain.
+
+    Implementation is generic over `Location` but was created for purposes of allowing AssetHub system chain (by other system chains and relay chains) to execute Root level extrinsics like `authorize_upgrade` on them.
+
+    ## TODO
+    * [ ] backport to stable2412
+    * [ ] backport to stable2503
+crates:
+- name: staging-xcm-builder
+  bump: patch

--- a/prdoc/pr_8210.prdoc
+++ b/prdoc/pr_8210.prdoc
@@ -7,13 +7,9 @@ doc:
 
     # Description
 
-    This PR introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow some `Location` chosen by the XCM configuration to act as Root on the local chain.
+    This PR introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow specific `Location`s defined through XCM configuration to act as Root on the local chain.
 
     Implementation is generic over `Location` but was created for purposes of allowing AssetHub system chain (by other system chains and relay chains) to execute Root level extrinsics like `authorize_upgrade` on them.
-
-    ## TODO
-    * [ ] backport to stable2412
-    * [ ] backport to stable2503
 crates:
 - name: staging-xcm-builder
   bump: patch

--- a/prdoc/pr_8210.prdoc
+++ b/prdoc/pr_8210.prdoc
@@ -5,4 +5,4 @@ doc:
     Introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow specific `Location`s defined through XCM configuration to act as Root on the local chain. Implementation is generic over `Location` but was created for purposes of allowing AssetHub system chain (by other system chains and relay chains) to execute Root level extrinsics like `authorize_upgrade` on them.
 crates:
 - name: staging-xcm-builder
-  bump: patch
+  bump: minor


### PR DESCRIPTION
Relates to: https://github.com/polkadot-fellows/runtimes/issues/651
Already used by: https://github.com/polkadot-fellows/runtimes/pull/626

# Description

This PR introduces a `LocationAsSuperuser` struct that implements `ConvertOrigin` to allow some `Location` chosen by the XCM configuration to act as Root on the local chain.

Implementation is generic over `Location` but was created for purposes of allowing AssetHub system chain (by other system chains and relay chains) to execute Root level extrinsics like `authorize_upgrade` on them.

## TODO
* [ ] backport to stable2412
* [ ] backport to stable2503


