### PR TITLE
[CI/CD] Fix polkadot, polkadot-parachain and general bin docker images

### DIFF
--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -46,7 +46,7 @@ on:
         required: true
 
       stable_tag:
-        description: Tag matching the actual stable release version in the format polkadpt-stableYYMM(-rcX) or plkadot-stableYYMM-X(-rcX) for patch releases
+        description: Tag matching the actual stable release version in the format polkadot-stableYYMM(-rcX) or polkadot-stableYYMM-X(-rcX) for patch releases
         required: true
 
 permissions:

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -311,9 +311,9 @@ jobs:
           # TODO: The owner should be used below but buildx does not resolve the VARs
           # TODO: It would be good to get rid of this GHA that we don't really need.
           tags: |
-            egorpop/polkadot:${{ steps.fetch-data.outputs.stable }}
-            egorpop/polkadot:latest
-            egorpop/polkadot:${{ needs.fetch-latest-debian-package-version.outputs.polkadot_container_tag }}
+            parity/polkadot:${{ steps.fetch-data.outputs.stable }}
+            parity/polkadot:latest
+            parity/polkadot:${{ needs.fetch-latest-debian-package-version.outputs.polkadot_container_tag }}
           build-args: |
             VCS_REF=${{ github.ref }}
             POLKADOT_VERSION=${{ needs.fetch-latest-debian-package-version.outputs.polkadot_apt_version }}

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -311,9 +311,9 @@ jobs:
           # TODO: The owner should be used below but buildx does not resolve the VARs
           # TODO: It would be good to get rid of this GHA that we don't really need.
           tags: |
-            parity/polkadot:${{ steps.fetch-data.outputs.stable }}
-            parity/polkadot:latest
-            parity/polkadot:${{ needs.fetch-latest-debian-package-version.outputs.polkadot_container_tag }}
+            egorpop/polkadot:${{ steps.fetch-data.outputs.stable }}
+            egorpop/polkadot:latest
+            egorpop/polkadot:${{ needs.fetch-latest-debian-package-version.outputs.polkadot_container_tag }}
           build-args: |
             VCS_REF=${{ github.ref }}
             POLKADOT_VERSION=${{ needs.fetch-latest-debian-package-version.outputs.polkadot_apt_version }}

--- a/.github/workflows/release-reusable-rc-buid.yml
+++ b/.github/workflows/release-reusable-rc-buid.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
       release_tag:
-        description: Tag matching the actual release candidate with the format polkadpt-stableYYMM(-rcX) or plkadot-stableYYMM-X(-rcX)
+        description: Tag matching the actual release candidate with the format polkadot-stableYYMM(-rcX) or polkadot-stableYYMM-X(-rcX)
         required: true
         type: string
 

--- a/docker/dockerfiles/binary_injected.Dockerfile
+++ b/docker/dockerfiles/binary_injected.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/parity/base-bin
+FROM docker.io/paritytech/base-bin
 
 # This file allows building a Generic container image
 # based on one or multiple pre-built Linux binaries.

--- a/docker/dockerfiles/polkadot-parachain/polkadot-parachain_injected.Dockerfile
+++ b/docker/dockerfiles/polkadot-parachain/polkadot-parachain_injected.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/parity/base-bin
+FROM docker.io/paritytech/base-bin
 
 # metadata
 ARG VCS_REF

--- a/docker/dockerfiles/polkadot/polkadot_builder.Dockerfile
+++ b/docker/dockerfiles/polkadot/polkadot_builder.Dockerfile
@@ -7,7 +7,7 @@ COPY . /polkadot
 RUN cargo build --locked --release
 
 # This is the 2nd stage: a very small image where we copy the Polkadot binary."
-FROM docker.io/parity/base-bin:latest
+FROM docker.io/paritytech/base-bin:latest
 
 LABEL description="Multistage Docker image for Polkadot: a platform for web3" \
 	io.parity.image.type="builder" \

--- a/docker/dockerfiles/polkadot/polkadot_injected.Dockerfile
+++ b/docker/dockerfiles/polkadot/polkadot_injected.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/parity/base-bin
+FROM docker.io/paritytech/base-bin
 
 # metadata
 ARG VCS_REF

--- a/docker/dockerfiles/polkadot/polkadot_injected_debian.Dockerfile
+++ b/docker/dockerfiles/polkadot/polkadot_injected_debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/parity/base-bin
+FROM docker.io/paritytech/base-bin
 
 # metadata
 ARG VCS_REF

--- a/docker/dockerfiles/polkadot/polkadot_injected_debian.Dockerfile
+++ b/docker/dockerfiles/polkadot/polkadot_injected_debian.Dockerfile
@@ -4,8 +4,6 @@ FROM docker.io/paritytech/base-bin
 ARG VCS_REF
 ARG BUILD_DATE
 ARG POLKADOT_VERSION
-ARG POLKADOT_GPGKEY=9D4B2B6EB8F97156D19669A9FF0812D491B96798
-ARG GPG_KEYSERVER="keyserver.ubuntu.com"
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -162,7 +162,7 @@ to the release branch
 6. Trigger [Release - Promote RC to final candidate on S3](/.github/workflows/release-31_promote-rc-to-final.yml)
 to have it as a final rc on the S3
 7. Publish deb package for the `polkadot` binary using
-[Release - Publish polkadot deb package](/.github/workflows/release-40_publish-deb-package.yml)
+[Release - Publish Polkadot deb package](/.github/workflows/release-40_publish-deb-package.yml)
 8. Adjust the release draft and publish release on the GitHub.
 9. Publish docker images using [Release - Publish Docker Image](/.github/workflows/release-50_publish-docker.yml)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -161,8 +161,8 @@ to the release branch
 5. Repeat steps 1-3 to prepare the rc
 6. Trigger [Release - Promote RC to final candidate on S3](/.github/workflows/release-31_promote-rc-to-final.yml)
 to have it as a final rc on the S3
-7. Publish deb package for the `polakdot` binary using
-[Release - Publish polakdot deb package](/.github/workflows/release-40_publish-deb-package.yml)
+7. Publish deb package for the `polkadot` binary using
+[Release - Publish polkadot deb package](/.github/workflows/release-40_publish-deb-package.yml)
 8. Adjust the release draft and publish release on the GitHub.
 9. Publish docker images using [Release - Publish Docker Image](/.github/workflows/release-50_publish-docker.yml)
 


### PR DESCRIPTION
This PR replaces `parity/base-bin ` with the `paritytech/base-bin` image in the docker files for `polkadot`, `polkadot-parachain` and general one. And fixes few typos in the CI flows

Closes: https://github.com/paritytech/release-engineering/issues/256