### PR TITLE
Snowbridge V1: deprecate fee handler

### DIFF
--- a/bridges/snowbridge/primitives/outbound-queue/src/v1/converter/mod.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v1/converter/mod.rs
@@ -126,15 +126,12 @@ where
 		let outbound_message = Message { id: Some(message_id.into()), channel_id, command };
 
 		// validate the message
-		let (ticket, fee) = OutboundQueue::validate(&outbound_message).map_err(|err| {
+		let (ticket, _) = OutboundQueue::validate(&outbound_message).map_err(|err| {
 			log::error!(target: "xcm::ethereum_blob_exporter", "OutboundQueue validation of message failed. {err:?}");
 			SendError::Unroutable
 		})?;
 
-		// convert fee to Asset
-		let fee = Asset::from((Location::parent(), fee.total())).into();
-
-		Ok(((ticket.encode(), message_id), fee))
+		Ok(((ticket.encode(), message_id), Assets::default()))
 	}
 
 	fn deliver(blob: (Vec<u8>, XcmHash)) -> Result<XcmHash, SendError> {

--- a/bridges/snowbridge/runtime/runtime-common/src/v1/fee_handler.rs
+++ b/bridges/snowbridge/runtime/runtime-common/src/v1/fee_handler.rs
@@ -18,6 +18,7 @@ pub const LOG_TARGET: &str = "xcm::export-fee-to-sibling";
 /// to Snowbridge and splits off the remote fee and deposits it to the origin
 /// parachain sovereign account. The local fee is then returned back to be handled by
 /// the next fee handler in the chain. Most likely the treasury account.
+#[allow(deprecated)]
 pub struct XcmExportFeeToSibling<
 	Balance,
 	AccountId,
@@ -36,6 +37,7 @@ pub struct XcmExportFeeToSibling<
 	)>,
 );
 
+#[allow(deprecated)]
 impl<Balance, AccountId, FeeAssetLocation, EthereumNetwork, AssetTransactor, FeeProvider> HandleFee
 	for XcmExportFeeToSibling<
 		Balance,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-rococo/src/tests/snowbridge.rs
@@ -35,8 +35,6 @@ use testnet_parachains_constants::rococo::snowbridge::EthereumNetwork;
 
 const INITIAL_FUND: u128 = 5_000_000_000 * ROCOCO_ED;
 pub const CHAIN_ID: u64 = 11155111;
-const TREASURY_ACCOUNT: [u8; 32] =
-	hex!("6d6f646c70792f74727372790000000000000000000000000000000000000000");
 pub const WETH: [u8; 20] = hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
 const ETHEREUM_DESTINATION_ADDRESS: [u8; 20] = hex!("44a57ee2f2FCcb85FDa2B0B18EBD0D8D2333700e");
 const INSUFFICIENT_XCM_FEE: u128 = 1000;
@@ -507,25 +505,6 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 				RuntimeEvent::EthereumOutboundQueue(snowbridge_pallet_outbound_queue::Event::MessageQueued {..}) => {},
 			]
 		);
-		let events = BridgeHubRococo::events();
-		// Check that the local fee was credited to the Snowbridge sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _amount })
-					if *who == TREASURY_ACCOUNT.into()
-			)),
-			"Snowbridge sovereign takes local fee."
-		);
-		// Check that the remote fee was credited to the AssetHub sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _amount })
-					if *who == assethub_sovereign
-			)),
-			"AssetHub sovereign takes remote fee."
-		);
 	});
 }
 
@@ -661,26 +640,6 @@ fn send_eth_asset_from_asset_hub_to_ethereum_and_back() {
 				RuntimeEvent::EthereumOutboundQueue(snowbridge_pallet_outbound_queue::Event::MessageAccepted {..}) => {},
 				RuntimeEvent::EthereumOutboundQueue(snowbridge_pallet_outbound_queue::Event::MessageQueued {..}) => {},
 			]
-		);
-
-		let events = BridgeHubRococo::events();
-		// Check that the local fee was credited to the Snowbridge sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _amount })
-					if *who == TREASURY_ACCOUNT.into()
-			)),
-			"Snowbridge sovereign takes local fee."
-		);
-		// Check that the remote fee was credited to the AssetHub sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _amount })
-					if *who == assethub_sovereign
-			)),
-			"AssetHub sovereign takes remote fee."
 		);
 	});
 }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge.rs
@@ -56,9 +56,6 @@ const ETHEREUM_DESTINATION_ADDRESS: [u8; 20] = hex!("44a57ee2f2FCcb85FDa2B0B18EB
 const XCM_FEE: u128 = 100_000_000_000;
 const INSUFFICIENT_XCM_FEE: u128 = 1000;
 const TOKEN_AMOUNT: u128 = 100_000_000_000;
-const TREASURY_ACCOUNT: [u8; 32] =
-	hex!("6d6f646c70792f74727372790000000000000000000000000000000000000000");
-
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
 pub enum ControlCall {
 	#[codec(index = 3)]
@@ -465,26 +462,6 @@ fn send_eth_asset_from_asset_hub_to_ethereum_and_back() {
 				RuntimeEvent::EthereumOutboundQueue(snowbridge_pallet_outbound_queue::Event::MessageQueued {..}) => {},
 			]
 		);
-
-		let events = BridgeHubWestend::events();
-		// Check that the local fee was credited to the Snowbridge sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _ })
-					if *who == TREASURY_ACCOUNT.into()
-			)),
-			"Snowbridge sovereign takes local fee."
-		);
-		// Check that the remote fee was credited to the AssetHub sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _ })
-					if *who == assethub_sovereign
-			)),
-			"AssetHub sovereign takes remote fee."
-		);
 	});
 }
 
@@ -830,32 +807,12 @@ fn send_weth_asset_from_asset_hub_to_ethereum() {
 	});
 
 	BridgeHubWestend::execute_with(|| {
-		use bridge_hub_westend_runtime::xcm_config::TreasuryAccount;
 		type RuntimeEvent = <BridgeHubWestend as Chain>::RuntimeEvent;
 		// Check that the transfer token back to Ethereum message was queue in the Ethereum
 		// Outbound Queue
 		assert_expected_events!(
 			BridgeHubWestend,
 			vec![RuntimeEvent::EthereumOutboundQueue(snowbridge_pallet_outbound_queue::Event::MessageQueued{ .. }) => {},]
-		);
-		let events = BridgeHubWestend::events();
-		// Check that the local fee was credited to the Snowbridge sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _amount })
-					if *who == TreasuryAccount::get().into()
-			)),
-			"Snowbridge sovereign takes local fee."
-		);
-		// Check that the remote fee was credited to the AssetHub sovereign account
-		assert!(
-			events.iter().any(|event| matches!(
-				event,
-				RuntimeEvent::Balances(pallet_balances::Event::Minted { who, amount: _amount })
-					if *who == assethub_sovereign
-			)),
-			"AssetHub sovereign takes remote fee."
 		);
 	});
 }

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/xcm_config.rs
@@ -41,7 +41,6 @@ use parachains_common::{
 };
 use polkadot_parachain_primitives::primitives::Sibling;
 use polkadot_runtime_common::xcm_sender::ExponentialPrice;
-use snowbridge_runtime_common::XcmExportFeeToSibling;
 use sp_runtime::traits::AccountIdConversion;
 use testnet_parachains_constants::rococo::snowbridge::EthereumNetwork;
 use xcm::latest::{prelude::*, ROCOCO_GENESIS_HASH};
@@ -222,17 +221,7 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type FeeManager = XcmFeeManagerFromComponentsBridgeHub<
 		WaivedLocations,
-		(
-			XcmExportFeeToSibling<
-				bp_rococo::Balance,
-				AccountId,
-				TokenLocation,
-				EthereumNetwork,
-				Self::AssetTransactor,
-				crate::EthereumOutboundQueue,
-			>,
-			SendXcmFeeToAccount<Self::AssetTransactor, TreasuryAccount>,
-		),
+		(SendXcmFeeToAccount<Self::AssetTransactor, TreasuryAccount>,),
 	>;
 	type MessageExporter = (
 		XcmOverBridgeHubWestend,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/xcm_config.rs
@@ -40,7 +40,6 @@ use parachains_common::{
 };
 use polkadot_parachain_primitives::primitives::Sibling;
 use polkadot_runtime_common::xcm_sender::ExponentialPrice;
-use snowbridge_runtime_common::XcmExportFeeToSibling;
 use sp_runtime::traits::AccountIdConversion;
 use sp_std::marker::PhantomData;
 use testnet_parachains_constants::westend::snowbridge::EthereumNetwork;
@@ -232,17 +231,7 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type FeeManager = XcmFeeManagerFromComponentsBridgeHub<
 		WaivedLocations,
-		(
-			XcmExportFeeToSibling<
-				bp_westend::Balance,
-				AccountId,
-				WestendLocation,
-				EthereumNetwork,
-				Self::AssetTransactor,
-				crate::EthereumOutboundQueue,
-			>,
-			SendXcmFeeToAccount<Self::AssetTransactor, TreasuryAccount>,
-		),
+		(SendXcmFeeToAccount<Self::AssetTransactor, TreasuryAccount>,),
 	>;
 	type MessageExporter = (
 		XcmOverBridgeHubRococo,


### PR DESCRIPTION
### Context

To simplifies the fee flow in V1 to mimic that of V2 and removes deprecated codes.

It also makes setting [BridgeHubEthereumBaseFee](https://github.com/paritytech/polkadot-sdk/blob/6ce6110199a429ce449841fe7222a5ba96eafb5c/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs#L684) on AH easier - we can set it to a very low value (to encourage end users to use the bridge) without worrying about matching the execution cost on Ethereum.
