### PR TITLE
collator-protocol-revamp: temporary memory db impl for reputations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14290,6 +14290,7 @@ dependencies = [
  "sp-runtime 31.0.1",
  "sp-tracing 16.0.0",
  "thiserror 1.0.65",
+ "tokio",
  "tokio-util",
  "tracing-gum",
 ]

--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -42,6 +42,7 @@ sc-keystore = { workspace = true, default-features = true }
 sc-network = { workspace = true, default-features = true }
 sp-core = { features = ["std"], workspace = true, default-features = true }
 sp-keyring = { workspace = true, default-features = true }
+tokio = { features = ["macros"], workspace = true, default-features = true }
 
 polkadot-node-subsystem-test-helpers = { workspace = true }
 polkadot-primitives-test-helpers = { workspace = true }

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/common.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/common.rs
@@ -37,6 +37,10 @@ pub const VALID_INCLUDED_CANDIDATE_BUMP: u16 = 10;
 /// authored by the peer)
 pub const INACTIVITY_DECAY: u16 = 1;
 
+/// Maximum number of stored peer scores for a paraid. Should be greater than
+/// `CONNECTED_PEERS_PARA_LIMIT`.
+pub const MAX_STORED_SCORES_PER_PARA: u8 = 150;
+
 /// Reputation score type.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Default)]
 pub struct Score(u16);

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/backend.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/backend.rs
@@ -24,7 +24,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 #[async_trait]
 pub trait Backend {
 	/// Instantiate a new backend.
-	async fn new() -> Self;
+	async fn new(stored_limit_per_para: u8) -> Self;
 	/// Return the latest known leaf for which the backend processed bumps.
 	async fn latest_block_number(&self) -> Option<BlockNumber>;
 	/// Get the peer's stored reputation for this paraid, if any.
@@ -35,7 +35,10 @@ pub trait Backend {
 	async fn prune_paras(&mut self, registered_paras: BTreeSet<ParaId>);
 	/// Process the reputation bumps, returning all the reputation changes that were done in
 	/// consequence. This is needed because a reputation bump for a para also means a reputation
-	/// decay for the other collators of that para (if the `decay_value` param is present).
+	/// decay for the other collators of that para (if the `decay_value` param is present) and
+	/// because if the number of stored reputations go over the `stored_limit_per_para`, we'll 100%
+	/// slash the least recently bumped peers. `leaf_number` needs to be at least equal to the
+	/// `latest_block_number`
 	async fn process_bumps(
 		&mut self,
 		leaf_number: BlockNumber,

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
@@ -15,41 +15,732 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::validator_side_experimental::{
-	common::Score,
-	peer_manager::{backend::Backend, ReputationUpdate},
+	common::{Score, INACTIVITY_DECAY},
+	peer_manager::{backend::Backend, ReputationUpdate, ReputationUpdateKind},
 };
 use async_trait::async_trait;
 use polkadot_node_network_protocol::PeerId;
 use polkadot_primitives::{BlockNumber, Hash, Id as ParaId};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+	collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap},
+	time::{SystemTime, UNIX_EPOCH},
+};
 
-pub struct Db;
+/// This is an in-memory temporary implementation for the DB, to be used only for prototyping and
+/// testing purposes.
+pub struct Db {
+	db: BTreeMap<ParaId, HashMap<PeerId, ScoreEntry>>,
+	highest_block: Option<BlockNumber>,
+	stored_limit_per_para: u8,
+}
 
-// Dummy implementation for now
+type Timestamp = u128;
+
+#[derive(Clone, Debug)]
+struct ScoreEntry {
+	score: Score,
+	last_bumped: Timestamp,
+}
+
 #[async_trait]
 impl Backend for Db {
-	async fn new() -> Self {
-		Db
+	async fn new(stored_limit_per_para: u8) -> Self {
+		Self { db: BTreeMap::new(), highest_block: None, stored_limit_per_para }
 	}
 
 	async fn latest_block_number(&self) -> Option<BlockNumber> {
-		None
+		self.highest_block
 	}
 
-	async fn query(&self, _peer_id: &PeerId, _para_id: &ParaId) -> Option<Score> {
-		None
+	async fn query(&self, peer_id: &PeerId, para_id: &ParaId) -> Option<Score> {
+		self.db.get(para_id).and_then(|per_para| per_para.get(peer_id).map(|e| e.score))
 	}
 
-	async fn slash(&mut self, _peer_id: &PeerId, _para_id: &ParaId, _value: Score) {}
+	async fn slash(&mut self, peer_id: &PeerId, para_id: &ParaId, value: Score) {
+		if let btree_map::Entry::Occupied(mut per_para_entry) = self.db.entry(*para_id) {
+			if let hash_map::Entry::Occupied(mut e) = per_para_entry.get_mut().entry(*peer_id) {
+				let score = e.get_mut().score;
+				// Remove the entry if it goes to zero.
+				if score <= value {
+					e.remove();
+				} else {
+					e.get_mut().score.saturating_sub(value.into());
+				}
+			}
 
-	async fn prune_paras(&mut self, _registered_paras: BTreeSet<ParaId>) {}
+			// If the per_para length went to 0, remove it completely
+			if per_para_entry.get().is_empty() {
+				per_para_entry.remove();
+			}
+		}
+	}
+
+	async fn prune_paras(&mut self, registered_paras: BTreeSet<ParaId>) {
+		self.db.retain(|para, _| registered_paras.contains(&para));
+	}
 
 	async fn process_bumps(
 		&mut self,
-		_leaf_number: BlockNumber,
-		_bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
-		_decay_value: Option<Score>,
+		leaf_number: BlockNumber,
+		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
+		decay_value: Option<Score>,
 	) -> Vec<ReputationUpdate> {
-		vec![]
+		if self.highest_block.unwrap_or(0) > leaf_number {
+			return vec![]
+		}
+
+		self.highest_block = Some(leaf_number);
+		self.bump_reputations(bumps, decay_value)
+	}
+}
+
+impl Db {
+	fn bump_reputations(
+		&mut self,
+		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
+		maybe_decay_value: Option<Score>,
+	) -> Vec<ReputationUpdate> {
+		let mut reported_updates = vec![];
+		let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+
+		for (para, bumps_per_para) in bumps {
+			reported_updates.reserve(bumps_per_para.len());
+
+			for (peer_id, bump) in bumps_per_para.iter() {
+				if u16::from(*bump) == 0 {
+					continue
+				}
+
+				self.db
+					.entry(para)
+					.or_default()
+					.entry(*peer_id)
+					.and_modify(|e| {
+						e.score.saturating_add(u16::from(*bump));
+						e.last_bumped = now;
+					})
+					.or_insert(ScoreEntry { score: *bump, last_bumped: now });
+
+				reported_updates.push(ReputationUpdate {
+					peer_id: *peer_id,
+					para_id: para,
+					value: *bump,
+					kind: ReputationUpdateKind::Bump,
+				});
+			}
+
+			if let btree_map::Entry::Occupied(mut per_para_entry) = self.db.entry(para) {
+				if let Some(decay_value) = maybe_decay_value {
+					let peers_to_slash = per_para_entry
+						.get()
+						.keys()
+						.filter(|peer_id| !bumps_per_para.contains_key(peer_id))
+						.copied()
+						.collect::<Vec<PeerId>>();
+
+					for peer_id in peers_to_slash {
+						if let hash_map::Entry::Occupied(mut e) =
+							per_para_entry.get_mut().entry(peer_id)
+						{
+							// Remove the entry if it goes to zero.
+							if e.get_mut().score <= decay_value {
+								let score = e.remove().score;
+								reported_updates.push(ReputationUpdate {
+									peer_id,
+									para_id: para,
+									value: score,
+									kind: ReputationUpdateKind::Slash,
+								});
+							} else {
+								e.get_mut().score.saturating_sub(decay_value.into());
+								reported_updates.push(ReputationUpdate {
+									peer_id,
+									para_id: para,
+									value: decay_value,
+									kind: ReputationUpdateKind::Slash,
+								});
+							}
+						}
+					}
+				}
+
+				let per_para_limit = self.stored_limit_per_para as usize;
+				if per_para_entry.get().is_empty() {
+					// If the per_para length went to 0, remove it completely
+					per_para_entry.remove();
+				} else if per_para_entry.get().len() > per_para_limit {
+					// We have exceeded the maximum capacity, in which case we need to prune
+					// the least recently bumped values
+					let diff = per_para_entry.get().len() - per_para_limit;
+					Self::prune_for_para(&para, &mut per_para_entry, diff, &mut reported_updates);
+				}
+			}
+		}
+
+		reported_updates
+	}
+
+	fn prune_for_para(
+		para_id: &ParaId,
+		per_para: &mut btree_map::OccupiedEntry<ParaId, HashMap<PeerId, ScoreEntry>>,
+		diff: usize,
+		reported_updates: &mut Vec<ReputationUpdate>,
+	) {
+		for _ in 0..diff {
+			let (peer_id_to_remove, score) = per_para
+				.get()
+				.iter()
+				.min_by_key(|(_peer, entry)| entry.last_bumped)
+				.map(|(peer, entry)| (*peer, entry.score))
+				.expect("We know there are enough reps over the limit");
+
+			per_para.get_mut().remove(&peer_id_to_remove);
+
+			reported_updates.push(ReputationUpdate {
+				peer_id: peer_id_to_remove,
+				para_id: *para_id,
+				value: score,
+				kind: ReputationUpdateKind::Slash,
+			});
+		}
+	}
+
+	#[cfg(test)]
+	fn len(&self) -> usize {
+		self.db.len()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use super::*;
+
+	#[tokio::test]
+	// Test different types of reputation updates and their effects.
+	async fn test_reputation_updates() {
+		let mut db = Db::new(10).await;
+		assert_eq!(db.latest_block_number().await, None);
+		assert_eq!(db.len(), 0);
+
+		// Test empty update with no decay.
+		assert!(db.process_bumps(10, Default::default(), None).await.is_empty());
+		assert_eq!(db.latest_block_number().await, Some(10));
+		assert_eq!(db.len(), 0);
+
+		// Test a query on a non-existant entry.
+		assert_eq!(db.query(&PeerId::random(), &ParaId::from(1000)).await, None);
+
+		// Test empty update with decay.
+		assert!(db
+			.process_bumps(11, Default::default(), Some(Score::new(1).unwrap()))
+			.await
+			.is_empty());
+		assert_eq!(db.latest_block_number().await, Some(11));
+		assert_eq!(db.len(), 0);
+
+		// Test empty update with a leaf number smaller than the latest one.
+		assert!(db
+			.process_bumps(5, Default::default(), Some(Score::new(1).unwrap()))
+			.await
+			.is_empty());
+		assert_eq!(db.latest_block_number().await, Some(11));
+		assert_eq!(db.len(), 0);
+
+		// Test an update with zeroed score.
+		assert!(db
+			.process_bumps(
+				12,
+				[(
+					ParaId::from(100),
+					[(PeerId::random(), Score::new(0).unwrap())].into_iter().collect()
+				)]
+				.into_iter()
+				.collect(),
+				Some(Score::new(1).unwrap())
+			)
+			.await
+			.is_empty());
+		assert_eq!(db.latest_block_number().await, Some(12));
+		assert_eq!(db.len(), 0);
+
+		// Test a non-zero update on an empty DB.
+		let first_peer_id = PeerId::random();
+		let first_para_id = ParaId::from(100);
+		assert_eq!(
+			db.process_bumps(
+				// Reuse the same 12 block height, it should be taken into consideration.
+				12,
+				[(first_para_id, [(first_peer_id, Score::new(10).unwrap())].into_iter().collect())]
+					.into_iter()
+					.collect(),
+				Some(Score::new(1).unwrap())
+			)
+			.await,
+			vec![ReputationUpdate {
+				peer_id: first_peer_id,
+				para_id: first_para_id,
+				kind: ReputationUpdateKind::Bump,
+				value: Score::new(10).unwrap()
+			}]
+		);
+		assert_eq!(db.latest_block_number().await, Some(12));
+		assert_eq!(db.len(), 1);
+		assert_eq!(
+			db.query(&first_peer_id, &first_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+		// Query a non-existant peer_id for this para.
+		assert_eq!(db.query(&PeerId::random(), &first_para_id).await, None);
+		// Query this peer's rep for a different para.
+		assert_eq!(db.query(&first_peer_id, &ParaId::from(200)).await, None);
+
+		// Test a subsequent update with a lower block height. Will be ignored.
+		assert!(db
+			.process_bumps(
+				10,
+				[(first_para_id, [(first_peer_id, Score::new(10).unwrap())].into_iter().collect())]
+					.into_iter()
+					.collect(),
+				Some(Score::new(1).unwrap())
+			)
+			.await
+			.is_empty());
+		assert_eq!(db.latest_block_number().await, Some(12));
+		assert_eq!(db.len(), 1);
+		assert_eq!(
+			db.query(&first_peer_id, &first_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+
+		let second_para_id = ParaId::from(200);
+		let second_peer_id = PeerId::random();
+		// Test a subsequent update with no decay.
+		assert_eq!(
+			db.process_bumps(
+				13,
+				[
+					(
+						first_para_id,
+						[(second_peer_id, Score::new(10).unwrap())].into_iter().collect()
+					),
+					(
+						second_para_id,
+						[(first_peer_id, Score::new(5).unwrap())].into_iter().collect()
+					)
+				]
+				.into_iter()
+				.collect(),
+				None
+			)
+			.await,
+			vec![
+				ReputationUpdate {
+					peer_id: second_peer_id,
+					para_id: first_para_id,
+					kind: ReputationUpdateKind::Bump,
+					value: Score::new(10).unwrap()
+				},
+				ReputationUpdate {
+					peer_id: first_peer_id,
+					para_id: second_para_id,
+					kind: ReputationUpdateKind::Bump,
+					value: Score::new(5).unwrap()
+				}
+			]
+		);
+		assert_eq!(db.len(), 2);
+		assert_eq!(db.latest_block_number().await, Some(13));
+		assert_eq!(
+			db.query(&first_peer_id, &first_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+		assert_eq!(
+			db.query(&second_peer_id, &first_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+		assert_eq!(
+			db.query(&first_peer_id, &second_para_id).await.unwrap(),
+			Score::new(5).unwrap()
+		);
+
+		// Empty update with decay has no effect.
+		assert!(db
+			.process_bumps(14, Default::default(), Some(Score::new(1).unwrap()))
+			.await
+			.is_empty());
+		assert_eq!(db.latest_block_number().await, Some(14));
+		assert_eq!(db.len(), 2);
+		assert_eq!(
+			db.query(&first_peer_id, &first_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+		assert_eq!(
+			db.query(&second_peer_id, &first_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+		assert_eq!(
+			db.query(&first_peer_id, &second_para_id).await.unwrap(),
+			Score::new(5).unwrap()
+		);
+
+		// Test a subsequent update with decay.
+		assert_eq!(
+			db.process_bumps(
+				14,
+				[
+					(
+						first_para_id,
+						[(first_peer_id, Score::new(10).unwrap())].into_iter().collect()
+					),
+					(
+						second_para_id,
+						[(second_peer_id, Score::new(10).unwrap())].into_iter().collect()
+					),
+				]
+				.into_iter()
+				.collect(),
+				Some(Score::new(1).unwrap())
+			)
+			.await,
+			vec![
+				ReputationUpdate {
+					peer_id: first_peer_id,
+					para_id: first_para_id,
+					kind: ReputationUpdateKind::Bump,
+					value: Score::new(10).unwrap()
+				},
+				ReputationUpdate {
+					peer_id: second_peer_id,
+					para_id: first_para_id,
+					kind: ReputationUpdateKind::Slash,
+					value: Score::new(1).unwrap()
+				},
+				ReputationUpdate {
+					peer_id: second_peer_id,
+					para_id: second_para_id,
+					kind: ReputationUpdateKind::Bump,
+					value: Score::new(10).unwrap()
+				},
+				ReputationUpdate {
+					peer_id: first_peer_id,
+					para_id: second_para_id,
+					kind: ReputationUpdateKind::Slash,
+					value: Score::new(1).unwrap()
+				},
+			]
+		);
+		assert_eq!(db.latest_block_number().await, Some(14));
+		assert_eq!(db.len(), 2);
+		assert_eq!(
+			db.query(&first_peer_id, &first_para_id).await.unwrap(),
+			Score::new(20).unwrap()
+		);
+		assert_eq!(
+			db.query(&second_peer_id, &first_para_id).await.unwrap(),
+			Score::new(9).unwrap()
+		);
+		assert_eq!(
+			db.query(&first_peer_id, &second_para_id).await.unwrap(),
+			Score::new(4).unwrap()
+		);
+		assert_eq!(
+			db.query(&second_peer_id, &second_para_id).await.unwrap(),
+			Score::new(10).unwrap()
+		);
+
+		// Test a decay that makes the reputation go to 0 (The peer's entry will be removed)
+		assert_eq!(
+			db.process_bumps(
+				15,
+				[(
+					second_para_id,
+					[(second_peer_id, Score::new(10).unwrap())].into_iter().collect()
+				),]
+				.into_iter()
+				.collect(),
+				Some(Score::new(5).unwrap())
+			)
+			.await,
+			vec![
+				ReputationUpdate {
+					peer_id: second_peer_id,
+					para_id: second_para_id,
+					kind: ReputationUpdateKind::Bump,
+					value: Score::new(10).unwrap()
+				},
+				ReputationUpdate {
+					peer_id: first_peer_id,
+					para_id: second_para_id,
+					kind: ReputationUpdateKind::Slash,
+					value: Score::new(4).unwrap()
+				}
+			]
+		);
+		assert_eq!(db.latest_block_number().await, Some(15));
+		assert_eq!(db.len(), 2);
+		assert_eq!(
+			db.query(&first_peer_id, &first_para_id).await.unwrap(),
+			Score::new(20).unwrap()
+		);
+		assert_eq!(
+			db.query(&second_peer_id, &first_para_id).await.unwrap(),
+			Score::new(9).unwrap()
+		);
+		assert_eq!(db.query(&first_peer_id, &second_para_id).await, None);
+		assert_eq!(
+			db.query(&second_peer_id, &second_para_id).await.unwrap(),
+			Score::new(20).unwrap()
+		);
+
+		// Test an update which ends up pruning least recently used entries. The per-para limit is
+		// 10.
+		let mut db = Db::new(10).await;
+		let peer_ids = (0..10).map(|_| PeerId::random()).collect::<Vec<_>>();
+
+		// Add an equal reputation for all peers.
+		assert_eq!(
+			db.process_bumps(
+				1,
+				[(
+					first_para_id,
+					peer_ids.iter().map(|peer_id| (*peer_id, Score::new(10).unwrap())).collect()
+				)]
+				.into_iter()
+				.collect(),
+				None,
+			)
+			.await
+			.len(),
+			10
+		);
+		assert_eq!(db.len(), 1);
+
+		for peer_id in peer_ids.iter() {
+			assert_eq!(db.query(peer_id, &first_para_id).await.unwrap(), Score::new(10).unwrap());
+		}
+
+		// Now sleep for one second and then bump the reputations of all peers except for the one
+		// with 4th index. We need to sleep so that the update time of the 4th peer is older than
+		// the rest.
+		tokio::time::sleep(Duration::from_millis(100)).await;
+		assert_eq!(
+			db.process_bumps(
+				2,
+				[(
+					first_para_id,
+					peer_ids
+						.iter()
+						.enumerate()
+						.filter_map(
+							|(i, peer_id)| (i != 4).then_some((*peer_id, Score::new(10).unwrap()))
+						)
+						.collect()
+				)]
+				.into_iter()
+				.collect(),
+				Some(Score::new(5).unwrap()),
+			)
+			.await
+			.len(),
+			10
+		);
+
+		for (i, peer_id) in peer_ids.iter().enumerate() {
+			if i == 4 {
+				assert_eq!(
+					db.query(peer_id, &first_para_id).await.unwrap(),
+					Score::new(5).unwrap()
+				);
+			} else {
+				assert_eq!(
+					db.query(peer_id, &first_para_id).await.unwrap(),
+					Score::new(20).unwrap()
+				);
+			}
+		}
+
+		// Now add a 11th peer. It should evict the 4th peer.
+		let new_peer = PeerId::random();
+		tokio::time::sleep(Duration::from_millis(100)).await;
+		assert_eq!(
+			db.process_bumps(
+				3,
+				[(first_para_id, [(new_peer, Score::new(10).unwrap())].into_iter().collect())]
+					.into_iter()
+					.collect(),
+				Some(Score::new(5).unwrap()),
+			)
+			.await
+			.len(),
+			11
+		);
+		for (i, peer_id) in peer_ids.iter().enumerate() {
+			if i == 4 {
+				assert_eq!(db.query(peer_id, &first_para_id).await, None);
+			} else {
+				assert_eq!(
+					db.query(peer_id, &first_para_id).await.unwrap(),
+					Score::new(15).unwrap()
+				);
+			}
+		}
+		assert_eq!(db.query(&new_peer, &first_para_id).await.unwrap(), Score::new(10).unwrap());
+
+		// Now try adding yet another peer. The decay would naturally evict the new peer so no need
+		// to evict the least recently bumped.
+		let yet_another_peer = PeerId::random();
+		assert_eq!(
+			db.process_bumps(
+				4,
+				[(
+					first_para_id,
+					[(yet_another_peer, Score::new(10).unwrap())].into_iter().collect()
+				)]
+				.into_iter()
+				.collect(),
+				Some(Score::new(10).unwrap()),
+			)
+			.await
+			.len(),
+			11
+		);
+		for (i, peer_id) in peer_ids.iter().enumerate() {
+			if i == 4 {
+				assert_eq!(db.query(peer_id, &first_para_id).await, None);
+			} else {
+				assert_eq!(
+					db.query(peer_id, &first_para_id).await.unwrap(),
+					Score::new(5).unwrap()
+				);
+			}
+		}
+		assert_eq!(db.query(&new_peer, &first_para_id).await, None);
+		assert_eq!(
+			db.query(&yet_another_peer, &first_para_id).await,
+			Some(Score::new(10).unwrap())
+		);
+	}
+
+	#[tokio::test]
+	// Test reputation slashes.
+	async fn test_slash() {
+		let mut db = Db::new(10).await;
+
+		// Test slash on empty DB
+		let peer_id = PeerId::random();
+		db.slash(&peer_id, &ParaId::from(100), Score::new(50).unwrap()).await;
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await, None);
+
+		// Test slash on non-existent para
+		let another_peer_id = PeerId::random();
+		assert_eq!(
+			db.process_bumps(
+				1,
+				[
+					(ParaId::from(100), [(peer_id, Score::new(10).unwrap())].into_iter().collect()),
+					(
+						ParaId::from(200),
+						[(another_peer_id, Score::new(12).unwrap())].into_iter().collect()
+					),
+					(ParaId::from(300), [(peer_id, Score::new(15).unwrap())].into_iter().collect())
+				]
+				.into_iter()
+				.collect(),
+				Some(Score::new(10).unwrap()),
+			)
+			.await
+			.len(),
+			3
+		);
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await.unwrap(), Score::new(10).unwrap());
+		assert_eq!(
+			db.query(&another_peer_id, &ParaId::from(200)).await.unwrap(),
+			Score::new(12).unwrap()
+		);
+		assert_eq!(db.query(&peer_id, &ParaId::from(300)).await.unwrap(), Score::new(15).unwrap());
+
+		db.slash(&peer_id, &ParaId::from(200), Score::new(4).unwrap()).await;
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await.unwrap(), Score::new(10).unwrap());
+		assert_eq!(
+			db.query(&another_peer_id, &ParaId::from(200)).await.unwrap(),
+			Score::new(12).unwrap()
+		);
+		assert_eq!(db.query(&peer_id, &ParaId::from(300)).await.unwrap(), Score::new(15).unwrap());
+
+		// Test regular slash
+		db.slash(&peer_id, &ParaId::from(100), Score::new(4).unwrap()).await;
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await.unwrap(), Score::new(6).unwrap());
+
+		// Test slash which removes the entry altogether
+		db.slash(&peer_id, &ParaId::from(100), Score::new(8).unwrap()).await;
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await, None);
+		assert_eq!(db.len(), 2);
+	}
+
+	#[tokio::test]
+	// Test para pruning.
+	async fn test_prune_paras() {
+		let mut db = Db::new(10).await;
+
+		db.prune_paras(BTreeSet::new()).await;
+		assert_eq!(db.len(), 0);
+
+		db.prune_paras([ParaId::from(100), ParaId::from(200)].into_iter().collect())
+			.await;
+		assert_eq!(db.len(), 0);
+
+		let peer_id = PeerId::random();
+		let another_peer_id = PeerId::random();
+
+		assert_eq!(
+			db.process_bumps(
+				1,
+				[
+					(ParaId::from(100), [(peer_id, Score::new(10).unwrap())].into_iter().collect()),
+					(
+						ParaId::from(200),
+						[(another_peer_id, Score::new(12).unwrap())].into_iter().collect()
+					),
+					(ParaId::from(300), [(peer_id, Score::new(15).unwrap())].into_iter().collect())
+				]
+				.into_iter()
+				.collect(),
+				Some(Score::new(10).unwrap()),
+			)
+			.await
+			.len(),
+			3
+		);
+		assert_eq!(db.len(), 3);
+
+		// Registered paras include the existing ones. Does nothing
+		db.prune_paras(
+			[ParaId::from(100), ParaId::from(200), ParaId::from(300), ParaId::from(400)]
+				.into_iter()
+				.collect(),
+		)
+		.await;
+		assert_eq!(db.len(), 3);
+
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await.unwrap(), Score::new(10).unwrap());
+		assert_eq!(
+			db.query(&another_peer_id, &ParaId::from(200)).await.unwrap(),
+			Score::new(12).unwrap()
+		);
+		assert_eq!(db.query(&peer_id, &ParaId::from(300)).await.unwrap(), Score::new(15).unwrap());
+
+		// Prunes multiple paras.
+		db.prune_paras([ParaId::from(300)].into_iter().collect()).await;
+		assert_eq!(db.len(), 1);
+		assert_eq!(db.query(&peer_id, &ParaId::from(100)).await, None);
+		assert_eq!(db.query(&another_peer_id, &ParaId::from(200)).await, None);
+		assert_eq!(db.query(&peer_id, &ParaId::from(300)).await.unwrap(), Score::new(15).unwrap());
+
+		// Prunes all paras.
+		db.prune_paras(BTreeSet::new()).await;
+		assert_eq!(db.len(), 0);
+		assert_eq!(db.query(&peer_id, &ParaId::from(300)).await, None);
 	}
 }

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/mod.rs
@@ -24,7 +24,8 @@ use crate::{
 	validator_side_experimental::{
 		common::{
 			PeerInfo, PeerState, Score, CONNECTED_PEERS_LIMIT, CONNECTED_PEERS_PARA_LIMIT,
-			INACTIVITY_DECAY, MAX_STARTUP_ANCESTRY_LOOKBACK, VALID_INCLUDED_CANDIDATE_BUMP,
+			INACTIVITY_DECAY, MAX_STARTUP_ANCESTRY_LOOKBACK, MAX_STORED_SCORES_PER_PARA,
+			VALID_INCLUDED_CANDIDATE_BUMP,
 		},
 		error::{Error, Result},
 	},
@@ -48,6 +49,7 @@ use polkadot_primitives::{
 	vstaging::CandidateEvent, BlockNumber, CandidateHash, Hash, Id as ParaId,
 };
 
+#[derive(Debug, PartialEq, Clone)]
 pub struct ReputationUpdate {
 	pub peer_id: PeerId,
 	pub para_id: ParaId,
@@ -55,6 +57,7 @@ pub struct ReputationUpdate {
 	pub kind: ReputationUpdateKind,
 }
 
+#[derive(Debug, PartialEq, Clone)]
 pub enum ReputationUpdateKind {
 	Bump,
 	Slash,
@@ -101,7 +104,7 @@ impl<B: Backend> PeerManager<B> {
 		scheduled_paras: BTreeSet<ParaId>,
 	) -> Result<Self> {
 		// Open the Db.
-		let db = B::new().await;
+		let db = B::new(MAX_STORED_SCORES_PER_PARA).await;
 		let latest_block_number = db.latest_block_number().await;
 
 		let mut instance = Self {


### PR DESCRIPTION
Stacked on top of: https://github.com/paritytech/polkadot-sdk/pull/8191

Implements an in-memory reputation "DB" for testing purposes.
This way, we can test the entire implementation while the DB is still being developed (enables parallelization of development tasks) and have some unit tests that validate it works as expected.

The entire new subsystem is feature-gated, so not included in the release binaries.

Proper DB impl tracked by https://github.com/paritytech/polkadot-sdk/issues/7751