### PR TITLE
[pallet-revive] add get_storage_var_key for variable-sized keys

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -2421,6 +2421,16 @@ impl_runtime_apis! {
 			)
 		}
 
+		fn get_storage_var_key(
+			address: H160,
+			key: Vec<u8>,
+		) -> pallet_revive::GetStorageResult {
+			Revive::get_storage_var_key(
+				address,
+				key
+			)
+		}
+
 		fn trace_block(
 			block: Block,
 			config: pallet_revive::evm::TracerConfig

--- a/prdoc/pr_8274.prdoc
+++ b/prdoc/pr_8274.prdoc
@@ -11,4 +11,4 @@ crates:
   - name: kitchensink-runtime
     bump: minor
   - name: pallet-revive
-    bump: minor
+    bump: major

--- a/prdoc/pr_8274.prdoc
+++ b/prdoc/pr_8274.prdoc
@@ -1,0 +1,14 @@
+title: '[pallet-revive] add get_storage_var_key for variable-sized keys'
+
+doc:
+  - audience: Runtime Dev
+    description: |-
+      This adds a new runtime ReviveApi call get_storage_var_key, which does the same as get_storage, but for variable-sized keys.
+
+crates:
+  - name: asset-hub-westend-runtime
+    bump: minor
+  - name: kitchensink-runtime
+    bump: minor
+  - name: pallet-revive
+    bump: minor

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3443,6 +3443,16 @@ impl_runtime_apis! {
 			)
 		}
 
+		fn get_storage_var_key(
+			address: H160,
+			key: Vec<u8>,
+		) -> pallet_revive::GetStorageResult {
+			Revive::get_storage_var_key(
+				address,
+				key
+			)
+		}
+
 		fn get_storage(
 			address: H160,
 			key: [u8; 32],

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1397,6 +1397,19 @@ where
 		Ok(maybe_value)
 	}
 
+	/// Query storage of a specified contract under a specified variable-sized key.
+	pub fn get_storage_var_key(address: H160, key: Vec<u8>) -> GetStorageResult {
+		let contract_info =
+			ContractInfoOf::<T>::get(&address).ok_or(ContractAccessError::DoesntExist)?;
+
+		let maybe_value = contract_info.read(
+			&Key::try_from_var(key)
+				.map_err(|_| ContractAccessError::KeyDecodingFailed)?
+				.into(),
+		);
+		Ok(maybe_value)
+	}
+
 	/// Uploads new code and returns the Wasm blob and deposit amount collected.
 	fn try_upload_code(
 		origin: T::AccountId,
@@ -1541,6 +1554,15 @@ sp_api::decl_runtime_apis! {
 			key: [u8; 32],
 		) -> GetStorageResult;
 
+		/// Query a given variable-sized storage key in a given contract.
+		///
+		/// Returns `Ok(Some(Vec<u8>))` if the storage value exists under the given key in the
+		/// specified account and `Ok(None)` if it doesn't. If the account specified by the address
+		/// doesn't exist, or doesn't have a contract then `Err` is returned.
+		fn get_storage_var_key(
+			address: H160,
+			key: Vec<u8>,
+		) -> GetStorageResult;
 
 		/// Traces the execution of an entire block and returns call traces.
 		///


### PR DESCRIPTION
# Description

Fixes #8253 

This adds a new runtime ReviveApi call `get_storage_var_key`, which does the same as `get_storage`, but for variable-sized keys, which are still being used by ink!v6 and use a different hashing function than the fixed-size 32-byte keys.

I've considered changing the API of `get_storage` to support both type of keys, but on the issue discussion it was said that it would be better to add a new runtime call.

## Integration

With the following runtime upgrade, all chains using revive should support it by default, as the low-level storage access already supports both types of keys. It was only the runtime call that was not exposing that properly.

The trait `pallet_revive::ReviveApi` has changed to include the new runtime call, to implement it just relay the call to `Revive::get_storage_var_key`.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
