### PR TITLE
Preserve Original Topic ID in forward_id_for for Consistent XCM Tracking

### DIFF
--- a/bridges/snowbridge/runtime/runtime-common/src/tests.rs
+++ b/bridges/snowbridge/runtime/runtime-common/src/tests.rs
@@ -99,7 +99,6 @@ fn handle_fee_success() {
 		origin: Some(Location::new(1, Parachain(1000))),
 		message_id: XcmHash::default(),
 		topic: None,
-		original_topic: None,
 	};
 	let reason = FeeReason::Export { network: EthereumNetwork::get(), destination: Here };
 	let result = XcmExportFeeToSibling::<
@@ -158,7 +157,6 @@ fn handle_fee_success_even_when_fee_insufficient() {
 		origin: Some(Location::new(1, Parachain(1000))),
 		message_id: XcmHash::default(),
 		topic: None,
-		original_topic: None,
 	};
 	let reason = FeeReason::Export { network: EthereumNetwork::get(), destination: Here };
 	let result = XcmExportFeeToSibling::<

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/hybrid_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/hybrid_transfers.rs
@@ -56,9 +56,7 @@ fn para_to_para_assethub_hop_assertions(t: ParaToParaThroughAHTest) {
 	);
 
 	let topic_ids = find_all_xcm_topic_ids!(AssetHubWestend);
-	for id in topic_ids.iter() {
-		TopicIdTracker::insert(*id);
-	}
+	TopicIdTracker::insert_many(topic_ids);
 	TopicIdTracker::assert_unique();
 }
 

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/hybrid_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/hybrid_transfers.rs
@@ -119,7 +119,7 @@ fn para_to_para_transfer_assets_through_ah(t: ParaToParaThroughAHTest) -> Dispat
 		t.args.weight_limit,
 	);
 
-	let msg_id_sent = find_xcm_sent_message_id!(PenpalA);
+	let msg_id_sent = find_xcm_sent_message_id!(PenpalA, RuntimeEvent::PolkadotXcm);
 	if let Some(msg_id) = msg_id_sent {
 		TopicIdTracker::insert(msg_id.into());
 		TopicIdTracker::assert_unique();

--- a/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/reserve_transfer.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/assets/asset-hub-westend/src/tests/reserve_transfer.rs
@@ -438,7 +438,7 @@ pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(t: Test<PenpalA, P
 		);
 	}
 
-	let msg_id_sent = find_xcm_sent_message_id!(PenpalA);
+	let msg_id_sent = find_xcm_sent_message_id!(PenpalA, RuntimeEvent::PolkadotXcm);
 	if let Some(msg_id) = msg_id_sent {
 		TopicIdTracker::insert(msg_id.into());
 		TopicIdTracker::assert_unique();

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/asset_transfers.rs
@@ -1439,39 +1439,32 @@ fn send_pens_and_wnds_from_penpal_westend_via_ahw_to_ahr() {
 	// reset topic tracker
 	TopicIdTracker::reset();
 
-	AssetHubRococo::execute_with(|| {
-		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
+	// transfer assets
+	do_send_pens_and_wnds_from_penpal_westend_via_ahw_to_asset_hub_rococo(
+		(wnd_at_westend_parachains.clone(), wnds_to_send),
+		(pens_location_on_penpal.try_into().unwrap(), pens_to_send),
+	);
 
-		let topic_ids = find_all_xcm_topic_ids!(AssetHubRococo);
-		println!("[Before Transfer Assets] AssetHubRococo->topic_ids: {:?}", topic_ids);
+	PenpalB::execute_with(|| {
+		type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
+
+		let topic_ids = find_all_xcm_topic_ids!(PenpalB);
+		println!("[After Transfer Assets] PenpalB->topic_ids: {:?}", topic_ids);
 	});
 
 	AssetHubWestend::execute_with(|| {
 		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
 		let topic_ids = find_all_xcm_topic_ids!(AssetHubWestend);
-		println!("[Before Transfer Assets] AssetHubWestend->topic_ids: {:?}", topic_ids);
+		println!("[After Transfer Assets] AssetHubWestend->topic_ids: {:?}", topic_ids);
 	});
 
 	BridgeHubWestend::execute_with(|| {
 		type RuntimeEvent = <BridgeHubWestend as Chain>::RuntimeEvent;
 
 		let topic_ids = find_all_xcm_topic_ids!(BridgeHubWestend);
-		println!("[Before Transfer Assets] BridgeHubWestend->topic_ids: {:?}", topic_ids);
+		println!("[After Transfer Assets] BridgeHubWestend->topic_ids: {:?}", topic_ids);
 	});
-
-	PenpalB::execute_with(|| {
-		type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(PenpalB);
-		println!("[Before Transfer Assets] PenpalB->topic_ids: {:?}", topic_ids);
-	});
-
-	// transfer assets
-	do_send_pens_and_wnds_from_penpal_westend_via_ahw_to_asset_hub_rococo(
-		(wnd_at_westend_parachains.clone(), wnds_to_send),
-		(pens_location_on_penpal.try_into().unwrap(), pens_to_send),
-	);
 
 	let wnd = Location::new(2, [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH))]);
 	AssetHubRococo::execute_with(|| {
@@ -1493,27 +1486,6 @@ fn send_pens_and_wnds_from_penpal_westend_via_ahw_to_ahr() {
 
 		let topic_ids = find_all_xcm_topic_ids!(AssetHubRococo);
 		println!("[After Transfer Assets] AssetHubRococo->topic_ids: {:?}", topic_ids);
-	});
-
-	AssetHubWestend::execute_with(|| {
-		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(AssetHubWestend);
-		println!("[After Transfer Assets] AssetHubWestend->topic_ids: {:?}", topic_ids);
-	});
-
-	BridgeHubWestend::execute_with(|| {
-		type RuntimeEvent = <BridgeHubWestend as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(BridgeHubWestend);
-		println!("[After Transfer Assets] BridgeHubWestend->topic_ids: {:?}", topic_ids);
-	});
-
-	PenpalB::execute_with(|| {
-		type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(PenpalB);
-		println!("[After Transfer Assets] PenpalB->topic_ids: {:?}", topic_ids);
 	});
 
 	// account balances after
@@ -1560,32 +1532,4 @@ fn send_pens_and_wnds_from_penpal_westend_via_ahw_to_ahr() {
 	assert_eq!(pens_in_reserve_on_ahw_after, pens_in_reserve_on_ahw_before + pens_to_send);
 	// Receiver's balance is increased by sent amount
 	assert_eq!(receiver_pens_after, receiver_pens_before + pens_to_send);
-
-	AssetHubRococo::execute_with(|| {
-		type RuntimeEvent = <AssetHubRococo as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(AssetHubRococo);
-		println!("[End of Test] AssetHubRococo->topic_ids: {:?}", topic_ids);
-	});
-
-	AssetHubWestend::execute_with(|| {
-		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(AssetHubWestend);
-		println!("[End of Test] AssetHubWestend->topic_ids: {:?}", topic_ids);
-	});
-
-	BridgeHubWestend::execute_with(|| {
-		type RuntimeEvent = <BridgeHubWestend as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(BridgeHubWestend);
-		println!("[End of Test] BridgeHubWestend->topic_ids: {:?}", topic_ids);
-	});
-
-	PenpalB::execute_with(|| {
-		type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
-
-		let topic_ids = find_all_xcm_topic_ids!(PenpalB);
-		println!("[End of Test] PenpalB->topic_ids: {:?}", topic_ids);
-	});
 }

--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -1380,14 +1380,12 @@ macro_rules! find_all_xcm_topic_ids {
 
 		for event in events.iter() {
 			match event {
-				RuntimeEvent::MessageQueue(
-					pallet_message_queue::Event::Processed { id, .. }
-				) => {
+				RuntimeEvent::MessageQueue(pallet_message_queue::Event::Processed {
+					id, ..
+				}) => {
 					topic_ids.push(*id);
 				},
-				RuntimeEvent::PolkadotXcm(
-					pallet_xcm::Event::Sent { message_id, .. }
-				) => {
+				RuntimeEvent::PolkadotXcm(pallet_xcm::Event::Sent { message_id, .. }) => {
 					topic_ids.push(H256::from(*message_id));
 				},
 				_ => continue,
@@ -1417,10 +1415,10 @@ macro_rules! find_mq_processed_id {
 
 #[macro_export]
 macro_rules! find_xcm_sent_message_id {
-	( $chain:ident ) => {{
+	( $chain:ident, $runtime_pallet:path ) => {{
 		let events = <$chain as $crate::Chain>::events();
 		events.iter().find_map(|event| {
-			if let RuntimeEvent::PolkadotXcm(pallet_xcm::Event::Sent { message_id, .. }) = event {
+			if let $runtime_pallet(pallet_xcm::Event::Sent { message_id, .. }) = event {
 				Some(*message_id)
 			} else {
 				None
@@ -1734,10 +1732,7 @@ pub mod helpers {
 		/// Asserts that the first tracked topic ID exists in the given list.
 		pub fn assert_first_id_in(topic_ids: &[H256]) {
 			let tracked_ids = Self::get();
-			assert!(
-				!tracked_ids.is_empty(),
-				"No topic IDs were tracked; expected at least one."
-			);
+			assert!(!tracked_ids.is_empty(), "No topic IDs were tracked; expected at least one.");
 
 			let tracked_id = &tracked_ids[0];
 			assert!(
@@ -1764,9 +1759,7 @@ pub mod helpers {
 
 		/// Retrieves all tracked topic IDs.
 		pub fn get() -> Vec<H256> {
-			TRACKED_TOPIC_IDS.with(|b| {
-				b.borrow().iter().cloned().collect()
-			})
+			TRACKED_TOPIC_IDS.with(|b| b.borrow().iter().cloned().collect())
 		}
 
 		/// Inserts a single topic ID into the tracker.

--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -1374,18 +1374,21 @@ macro_rules! assert_expected_events {
 #[macro_export]
 macro_rules! find_all_xcm_topic_ids {
 	( $chain:ident ) => {{
+		use sp_core::H256;
 		let events = <$chain as $crate::Chain>::events();
 		let mut topic_ids = Vec::new();
 
 		for event in events.iter() {
 			match event {
-				RuntimeEvent::MessageQueue(pallet_message_queue::Event::Processed {
-					id, ..
-				}) => {
+				RuntimeEvent::MessageQueue(
+					pallet_message_queue::Event::Processed { id, .. }
+				) => {
 					topic_ids.push(*id);
 				},
-				RuntimeEvent::PolkadotXcm(pallet_xcm::Event::Sent { message_id, .. }) => {
-					topic_ids.push(sp_core::H256::from(*message_id));
+				RuntimeEvent::PolkadotXcm(
+					pallet_xcm::Event::Sent { message_id, .. }
+				) => {
+					topic_ids.push(H256::from(*message_id));
 				},
 				_ => continue,
 			}

--- a/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm-benchmarks/src/generic/benchmarking.rs
@@ -368,7 +368,7 @@ mod benchmarks {
 		<T::XcmConfig as xcm_executor::Config>::AssetTrap::drop_assets(
 			&origin,
 			assets.clone().into(),
-			&XcmContext { origin: Some(origin.clone()), message_id: [0; 32], topic: None, original_topic: None },
+			&XcmContext { origin: Some(origin.clone()), message_id: [0; 32], topic: None },
 		);
 
 		// Assets should be in the trap now.
@@ -436,7 +436,7 @@ mod benchmarks {
 			&origin,
 			query_id,
 			max_response_weight,
-			&XcmContext { origin: Some(origin.clone()), message_id: [0; 32], topic: None, original_topic: None },
+			&XcmContext { origin: Some(origin.clone()), message_id: [0; 32], topic: None },
 		)
 		.map_err(|_| "Could not start subscription")?;
 		assert!(<T::XcmConfig as xcm_executor::Config>::SubscriptionService::is_subscribed(

--- a/polkadot/xcm/src/v5/mod.rs
+++ b/polkadot/xcm/src/v5/mod.rs
@@ -349,15 +349,13 @@ pub struct XcmContext {
 	pub message_id: XcmHash,
 	/// The current value of the Topic register of the `XCVM`.
 	pub topic: Option<[u8; 32]>,
-	/// Preserves the original topic for message traceability across network hops.
-	pub original_topic: Option<[u8; 32]>,
 }
 
 impl XcmContext {
 	/// Constructor which sets the message ID to the supplied parameter and leaves the origin and
 	/// topic unset.
 	pub fn with_message_id(message_id: XcmHash) -> XcmContext {
-		XcmContext { origin: None, message_id, topic: None, original_topic: None }
+		XcmContext { origin: None, message_id, topic: None }
 	}
 
 	/// Returns the topic if set, otherwise the original_topic if set, otherwise the message_id.

--- a/polkadot/xcm/xcm-builder/src/routing.rs
+++ b/polkadot/xcm/xcm-builder/src/routing.rs
@@ -45,14 +45,12 @@ impl<Inner: SendXcm> SendXcm for WithUniqueTopic<Inner> {
 	) -> SendResult<Self::Ticket> {
 		let mut message = message.take().ok_or(SendError::MissingArgument)?;
 		let unique_id = if let Some(SetTopic(id)) = message.last() {
-			let id_h256: sp_core::H256 = id.into();
-			tracing::trace!(target: "xcm::routing", topic_id=?id, ?id_h256, "Message already ends with `SetTopic`");
+			tracing::trace!(target: "xcm::routing", topic_id=?id, "Message already ends with `SetTopic`");
 			*id
 		} else {
 			let unique_id = unique(&message);
 			message.0.push(SetTopic(unique_id));
-			let id_h256: sp_core::H256 = unique_id.into();
-			tracing::trace!(target: "xcm::routing", topic_id=?unique_id, ?id_h256, "`SetTopic` appended to message");
+			tracing::trace!(target: "xcm::routing", topic_id=?unique_id, "`SetTopic` appended to message");
 			unique_id
 		};
 		let (ticket, assets) = Inner::validate(destination, &mut Some(message))?;

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -237,8 +237,7 @@ impl<T: Get<Vec<NetworkExportTableItem>>> ExporterFor for NetworkExportTable<T> 
 /// across chains. Returning the unchanged ID allows bridges and routers to recognise the
 /// same `SetTopic` identifier, avoiding confusion in message delivery and processing.
 pub fn forward_id_for(original_id: &XcmHash) -> XcmHash {
-	let id_h256: sp_core::H256 = original_id.into();
-	tracing::trace!(target: "xcm::exports", ?original_id, ?id_h256, "Extracted topic ID from `SetTopic` for XCM forwarding");
+	tracing::trace!(target: "xcm::exports", ?original_id, "Extracted topic ID from `SetTopic` for XCM forwarding");
 	*original_id
 }
 

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -233,12 +233,13 @@ impl<T: Get<Vec<NetworkExportTableItem>>> ExporterFor for NetworkExportTable<T> 
 	}
 }
 
+/// Preserves the original topic ID for XCM forwarding to ensure consistent message tracking
+/// across chains. Returning the unchanged ID allows bridges and routers to recognise the
+/// same `SetTopic` identifier, avoiding confusion in message delivery and processing.
 pub fn forward_id_for(original_id: &XcmHash) -> XcmHash {
-	let forward_id = (b"forward_id_for", original_id).using_encoded(sp_io::hashing::blake2_256);
-	let fid_h256: sp_core::H256 = forward_id.into();
-	let oid_h256: sp_core::H256 = original_id.into();
-	tracing::trace!(target: "xcm::exports", ?original_id, ?oid_h256, ?forward_id, ?fid_h256, "Topic ID mapped");
-	forward_id
+	let id_h256: sp_core::H256 = original_id.into();
+	tracing::trace!(target: "xcm::exports", ?original_id, ?id_h256, "Extracted topic ID from `SetTopic` for XCM forwarding");
+	*original_id
 }
 
 /// Implementation of `SendXcm` which wraps the message inside an `ExportMessage` instruction

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -813,16 +813,17 @@ impl<Config: config::Config> XcmExecutor<Config> {
 			tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "Message already ends with `SetTopic`");
 		} else if let Some(topic_id) = self.context.topic {
 			let id_h256: sp_core::H256 = topic_id.into();
-			tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` not required (context has topic)");
-		} else if self.context.origin.is_none() {
+			tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` not appended (context already has topic)");
+		} else {
 			let topic_id = self.context.message_id;
 			let id_h256: sp_core::H256 = topic_id.into();
-			msg.inner_mut().push(SetTopic(topic_id));
-			tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` appended to message (origin cleared)");
-		} else {
-			let message_id = self.context.message_id;
-			let id_h256: sp_core::H256 = message_id.into();
-			tracing::trace!(target: "xcm::send", ?message_id, ?id_h256, "`SetTopic` neither found nor appended at the end of message");
+
+			if self.context.origin.is_none() {
+				msg.inner_mut().push(SetTopic(topic_id));
+				tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` appended to message (origin cleared and no context topic)");
+			} else {
+				tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` neither found nor appended (origin not cleared)");
+			}
 		}
 	}
 

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -809,20 +809,16 @@ impl<Config: config::Config> XcmExecutor<Config> {
 	/// Preserves the original message ID as a topic if none exists and origin is cleared.
 	fn preserve_message_topic<T>(&self, msg: &mut Xcm<T>) {
 		if let Some(SetTopic(topic_id)) = msg.last() {
-			let id_h256: sp_core::H256 = topic_id.into();
-			tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "Message already ends with `SetTopic`");
+			tracing::trace!(target: "xcm::send", ?topic_id, "Message already ends with `SetTopic`");
 		} else if let Some(topic_id) = self.context.topic {
-			let id_h256: sp_core::H256 = topic_id.into();
-			tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` not appended (context already has topic)");
+			tracing::trace!(target: "xcm::send", ?topic_id, "`SetTopic` not appended (context already has topic)");
 		} else {
 			let topic_id = self.context.message_id;
-			let id_h256: sp_core::H256 = topic_id.into();
-
 			if self.context.origin.is_none() {
 				msg.inner_mut().push(SetTopic(topic_id));
-				tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` appended to message (origin cleared and no context topic)");
+				tracing::trace!(target: "xcm::send", ?topic_id, "`SetTopic` appended to message (origin cleared and no context topic)");
 			} else {
-				tracing::trace!(target: "xcm::send", ?topic_id, ?id_h256, "`SetTopic` neither found nor appended (origin not cleared)");
+				tracing::trace!(target: "xcm::send", ?topic_id, "`SetTopic` neither found nor appended (origin not cleared)");
 			}
 		}
 	}


### PR DESCRIPTION
This sub-PR to https://github.com/paritytech/polkadot-sdk/pull/7691 refines the `forward_id_for` function to explicitly preserve and return the original topic ID (`SetTopic`) during XCM forwarding. This change ensures message tracking remains consistent across chains by maintaining a stable identifier, which is crucial for bridges and routers to recognise forwarded messages as part of the same logical XCM flow.