### PR TITLE
sc-tracing-proc-macro: missing bump due to incomplete prdoc

### DIFF
--- a/prdoc/stable2503/pr_7464.prdoc
+++ b/prdoc/stable2503/pr_7464.prdoc
@@ -7,3 +7,5 @@ doc:
 crates:
 - name: parachain-template-node
   bump: minor
+- name: sc-tracing-proc-macro
+  bump: minor


### PR DESCRIPTION
# Description

We made changes to `sc-tracing-proc-macro` in #7464 which weren't carried to the prdoc, so once stable2503 got released there wasn't a bump for `sc-tracing-proc-macro`, and now it is needed for updating `parachain-template` repo to 2503. It seems that the prdoc check did not catch the missing required bump (it might be because the change was in a `proc-macro` crate).

## Integration

N/A

## Review Notes

Planning to update stable2503 prdocs retroactively (so the change itself doesn't count for next patch release), and we should request either way a force bump for the following crates:

1. `sc-tracing-proc-macro`
2. `sc-tracing` (depends on 1.)
3. `polkadot-sdk` (depends on 1. & 2.)