### PR TITLE
Enforce Consistent `SetTopic` Appending in Outbound XCM

### DIFF
--- a/polkadot/xcm/xcm-builder/src/routing.rs
+++ b/polkadot/xcm/xcm-builder/src/routing.rs
@@ -45,14 +45,10 @@ impl<Inner: SendXcm> SendXcm for WithUniqueTopic<Inner> {
 	) -> SendResult<Self::Ticket> {
 		let mut message = message.take().ok_or(SendError::MissingArgument)?;
 		let unique_id = if let Some(SetTopic(id)) = message.last() {
-			let id_h256: sp_core::H256 = id.into();
-			tracing::trace!(target: "xcm::routing", topic_id=?id, ?id_h256, "Message already ends with `SetTopic`");
 			*id
 		} else {
 			let unique_id = unique(&message);
 			message.0.push(SetTopic(unique_id));
-			let id_h256: sp_core::H256 = unique_id.into();
-			tracing::trace!(target: "xcm::routing", topic_id=?unique_id, ?id_h256, "`SetTopic` appended to message");
 			unique_id
 		};
 		let (ticket, assets) = Inner::validate(destination, &mut Some(message))?;

--- a/polkadot/xcm/xcm-builder/src/routing.rs
+++ b/polkadot/xcm/xcm-builder/src/routing.rs
@@ -45,12 +45,14 @@ impl<Inner: SendXcm> SendXcm for WithUniqueTopic<Inner> {
 	) -> SendResult<Self::Ticket> {
 		let mut message = message.take().ok_or(SendError::MissingArgument)?;
 		let unique_id = if let Some(SetTopic(id)) = message.last() {
-			tracing::trace!(target: "xcm::routing", topic_id=?id, "Message already ends with `SetTopic`");
+			let id_h256: sp_core::H256 = id.into();
+			tracing::trace!(target: "xcm::routing", topic_id=?id, ?id_h256, "Message already ends with `SetTopic`");
 			*id
 		} else {
 			let unique_id = unique(&message);
 			message.0.push(SetTopic(unique_id));
-			tracing::trace!(target: "xcm::routing", topic_id=?unique_id, "`SetTopic` appended to message");
+			let id_h256: sp_core::H256 = unique_id.into();
+			tracing::trace!(target: "xcm::routing", topic_id=?unique_id, ?id_h256, "`SetTopic` appended to message");
 			unique_id
 		};
 		let (ticket, assets) = Inner::validate(destination, &mut Some(message))?;

--- a/polkadot/xcm/xcm-builder/src/tests/assets.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/assets.rs
@@ -187,14 +187,18 @@ fn reserve_transfer_should_work() {
 	);
 	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(10, 10) });
 
-	let expected_msg = Xcm::<()>(vec![
+	let mut expected_msg = Xcm::<()>(vec![
 		ReserveAssetDeposited((Parent, 100u128).into()),
 		ClearOrigin,
 		DepositAsset { assets: AllCounted(1).into(), beneficiary: three },
 	]);
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		expected_msg.0.push(SetTopic(*topic_id));
+	}
 	let expected_hash = fake_message_hash(&expected_msg);
 	assert_eq!(asset_list(Parachain(2)), vec![(Here, 100).into()]);
-	assert_eq!(sent_xcm(), vec![(Parachain(2).into(), expected_msg, expected_hash)]);
+	assert_eq!(xcm_sent, vec![(Parachain(2).into(), expected_msg, expected_hash)]);
 }
 
 #[test]

--- a/polkadot/xcm/xcm-builder/src/tests/querying.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/querying.rs
@@ -39,14 +39,18 @@ fn pallet_query_should_work() {
 	);
 	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(10, 10) });
 
-	let expected_msg = Xcm::<()>(vec![QueryResponse {
+	let mut expected_msg = Xcm::<()>(vec![QueryResponse {
 		query_id: 1,
 		max_weight: Weight::from_parts(50, 50),
 		response: Response::PalletsInfo(Default::default()),
 		querier: Some(Here.into()),
 	}]);
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		expected_msg.0.push(SetTopic(*topic_id));
+	}
 	let expected_hash = fake_message_hash(&expected_msg);
-	assert_eq!(sent_xcm(), vec![(Parachain(1).into(), expected_msg, expected_hash)]);
+	assert_eq!(xcm_sent, vec![(Parachain(1).into(), expected_msg, expected_hash)]);
 }
 
 #[test]
@@ -72,7 +76,7 @@ fn pallet_query_with_results_should_work() {
 	);
 	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(10, 10) });
 
-	let expected_msg = Xcm::<()>(vec![QueryResponse {
+	let mut expected_msg = Xcm::<()>(vec![QueryResponse {
 		query_id: 1,
 		max_weight: Weight::from_parts(50, 50),
 		response: Response::PalletsInfo(
@@ -90,8 +94,12 @@ fn pallet_query_with_results_should_work() {
 		),
 		querier: Some(Here.into()),
 	}]);
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		expected_msg.0.push(SetTopic(*topic_id));
+	}
 	let expected_hash = fake_message_hash(&expected_msg);
-	assert_eq!(sent_xcm(), vec![(Parachain(1).into(), expected_msg, expected_hash)]);
+	assert_eq!(xcm_sent, vec![(Parachain(1).into(), expected_msg, expected_hash)]);
 }
 
 #[test]

--- a/polkadot/xcm/xcm-builder/src/tests/transacting.rs
+++ b/polkadot/xcm/xcm-builder/src/tests/transacting.rs
@@ -146,14 +146,18 @@ fn report_successful_transact_status_should_work() {
 		Weight::zero(),
 	);
 	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(70, 70) });
-	let expected_msg = Xcm(vec![QueryResponse {
+	let mut expected_msg = Xcm(vec![QueryResponse {
 		response: Response::DispatchResult(MaybeErrorCode::Success),
 		query_id: 42,
 		max_weight: Weight::from_parts(5000, 5000),
 		querier: Some(Here.into()),
 	}]);
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		expected_msg.0.push(SetTopic(*topic_id));
+	}
 	let expected_hash = fake_message_hash(&expected_msg);
-	assert_eq!(sent_xcm(), vec![(Parent.into(), expected_msg, expected_hash)]);
+	assert_eq!(xcm_sent, vec![(Parent.into(), expected_msg, expected_hash)]);
 }
 
 #[test]
@@ -182,14 +186,18 @@ fn report_failed_transact_status_should_work() {
 		Weight::zero(),
 	);
 	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(70, 70) });
-	let expected_msg = Xcm(vec![QueryResponse {
+	let mut expected_msg = Xcm(vec![QueryResponse {
 		response: Response::DispatchResult(vec![2].into()),
 		query_id: 42,
 		max_weight: Weight::from_parts(5000, 5000),
 		querier: Some(Here.into()),
 	}]);
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		expected_msg.0.push(SetTopic(*topic_id));
+	}
 	let expected_hash = fake_message_hash(&expected_msg);
-	assert_eq!(sent_xcm(), vec![(Parent.into(), expected_msg, expected_hash)]);
+	assert_eq!(xcm_sent, vec![(Parent.into(), expected_msg, expected_hash)]);
 }
 
 #[test]
@@ -311,12 +319,16 @@ fn clear_transact_status_should_work() {
 		Weight::zero(),
 	);
 	assert_eq!(r, Outcome::Complete { used: Weight::from_parts(80, 80) });
-	let expected_msg = Xcm(vec![QueryResponse {
+	let mut expected_msg = Xcm(vec![QueryResponse {
 		response: Response::DispatchResult(MaybeErrorCode::Success),
 		query_id: 42,
 		max_weight: Weight::from_parts(5000, 5000),
 		querier: Some(Here.into()),
 	}]);
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		expected_msg.0.push(SetTopic(*topic_id));
+	}
 	let expected_hash = fake_message_hash(&expected_msg);
-	assert_eq!(sent_xcm(), vec![(Parent.into(), expected_msg, expected_hash)]);
+	assert_eq!(xcm_sent, vec![(Parent.into(), expected_msg, expected_hash)]);
 }

--- a/polkadot/xcm/xcm-builder/src/universal_exports.rs
+++ b/polkadot/xcm/xcm-builder/src/universal_exports.rs
@@ -283,7 +283,7 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorLocat
 		// `xcm` should already end with `SetTopic` - if it does, then extract and derive into
 		// an onward topic ID.
 		let maybe_forward_id = match xcm.last() {
-			Some(SetTopic(t)) => Some(t),
+			Some(SetTopic(t)) => Some(*t),
 			_ => None,
 		};
 
@@ -364,7 +364,7 @@ impl<Bridges: ExporterFor, Router: SendXcm, UniversalLocation: Get<InteriorLocat
 		// `xcm` should already end with `SetTopic` - if it does, then extract and derive into
 		// an onward topic ID.
 		let maybe_forward_id = match xcm.last() {
-			Some(SetTopic(t)) => Some(t),
+			Some(SetTopic(t)) => Some(*t),
 			_ => None,
 		};
 

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -263,7 +263,7 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 
 		if let Some(SetTopic(topic_id)) = message.last() {
 			let id_h256: sp_core::H256 = topic_id.into();
-				tracing::debug!(
+			tracing::debug!(
 				target: "xcm::execute",
 				?topic_id,
 				?id_h256,

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -464,6 +464,12 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		let topic_id = self.context.topic;
 		let message_id: sp_core::H256 = self.context.message_id.into();
 		tracing::debug!(target: "xcm::send", ?topic_id, ?message_id);
+		let mut msg = msg;
+		if !matches!(msg.last(), Some(SetTopic(_))) {
+			let topic_id = self.context.topic_or_message_id();
+			msg.0.push(SetTopic(topic_id.into()));
+			tracing::debug!(target: "xcm::send", ?topic_id, "Appended `SetTopic` from `context.topic_or_message_id()`");
+		}
 		tracing::trace!(
 			target: "xcm::send",
 			?msg,

--- a/polkadot/xcm/xcm-executor/src/lib.rs
+++ b/polkadot/xcm/xcm-executor/src/lib.rs
@@ -243,11 +243,13 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 		weight_credit: Weight,
 	) -> Outcome {
 		let origin = origin.into();
+		let id_h256: sp_core::H256 = id.into();
 		tracing::trace!(
 			target: "xcm::execute",
 			?origin,
 			?message,
 			?id,
+			?id_h256,
 			?weight_credit,
 			"Executing message",
 		);
@@ -257,6 +259,16 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 		// so as to not degrade regular performance.
 		if Config::XcmRecorder::should_record() {
 			Config::XcmRecorder::record(message.clone().into());
+		}
+
+		if let Some(SetTopic(topic_id)) = message.last() {
+			let id_h256: sp_core::H256 = topic_id.into();
+				tracing::debug!(
+				target: "xcm::execute",
+				?topic_id,
+				?id_h256,
+				"Before `Barrier::should_execute`",
+			);
 		}
 
 		if let Err(e) = Config::Barrier::should_execute(
@@ -278,6 +290,16 @@ impl<Config: config::Config> ExecuteXcm<Config::RuntimeCall> for XcmExecutor<Con
 				used: xcm_weight,         // Weight consumed before the error
 				error: XcmError::Barrier, // The error that occurred
 			};
+		}
+
+		if let Some(SetTopic(topic_id)) = message.last() {
+			let id_h256: sp_core::H256 = topic_id.into();
+			tracing::debug!(
+				target: "xcm::execute",
+				?topic_id,
+				?id_h256,
+				"After `Barrier::should_execute`",
+			);
 		}
 
 		*id = properties.message_id.unwrap_or(*id);
@@ -380,6 +402,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 	/// This includes refunding surplus weight, trapping extra holding funds, and returning any
 	/// errors during execution.
 	pub fn post_process(mut self, xcm_weight: Weight) -> Outcome {
+		let topic_id = self.context.topic;
+		let message_id: sp_core::H256 = self.context.message_id.into();
+		tracing::debug!(target: "xcm::post_process", ?topic_id, ?message_id);
 		// We silently drop any error from our attempt to refund the surplus as it's a charitable
 		// thing so best-effort is all we will do.
 		let _ = self.refund_surplus();
@@ -436,6 +461,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		msg: Xcm<()>,
 		reason: FeeReason,
 	) -> Result<XcmHash, XcmError> {
+		let topic_id = self.context.topic;
+		let message_id: sp_core::H256 = self.context.message_id.into();
+		tracing::debug!(target: "xcm::send", ?topic_id, ?message_id);
 		tracing::trace!(
 			target: "xcm::send",
 			?msg,
@@ -445,8 +473,12 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		);
 		let (ticket, fee) = validate_send::<Config::XcmSender>(dest.clone(), msg)?;
 		self.take_fee(fee, reason)?;
+		tracing::debug!(target: "xcm::send", before_send_topic=?self.context.topic, before_send_message_id=?message_id);
 		match Config::XcmSender::deliver(ticket) {
 			Ok(message_id) => {
+				let topic_id: sp_core::H256 = message_id.into();
+				let msg_id_h256: sp_core::H256 = self.context.message_id.into();
+				tracing::debug!(target: "xcm::send", ?topic_id, after_send_topic=?self.context.topic, after_send_message_id=?msg_id_h256);
 				Config::XcmEventEmitter::emit_sent_event(
 					self.original_origin.clone(),
 					dest,
@@ -880,6 +912,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		&mut self,
 		instr: Instruction<Config::RuntimeCall>,
 	) -> Result<(), XcmError> {
+		let topic_id = self.context.topic;
+		let message_id: sp_core::H256 = self.context.message_id.into();
+		tracing::debug!(target: "xcm::process_instruction", ?topic_id, ?message_id);
 		tracing::trace!(
 			target: "xcm::process_instruction",
 			instruction = ?instr,
@@ -1330,6 +1365,7 @@ impl<Config: config::Config> XcmExecutor<Config> {
 					// append custom instructions
 					message.extend(remote_xcm.0.into_iter());
 					// send the onward XCM
+					tracing::debug!(target: "xcm::initiate_transfer", topic_before_send=?self.context.topic, message_id=?self.context.message_id);
 					self.send(destination, Xcm(message), FeeReason::InitiateTransfer)?;
 					Ok(())
 				});
@@ -1596,6 +1632,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				result
 			},
 			LockAsset { asset, unlocker } => {
+				let topic_id = self.context.topic;
+				let message_id: sp_core::H256 = self.context.message_id.into();
+				tracing::debug!(target: "xcm::xcm_executor::process_instruction", ?topic_id, ?message_id);
 				let old_holding = self.holding.clone();
 				let result = Config::TransactionalProcessor::process(|| {
 					let origin = self.cloned_origin().ok_or(XcmError::BadOrigin)?;
@@ -1680,10 +1719,13 @@ impl<Config: config::Config> XcmExecutor<Config> {
 				Ok(())
 			},
 			SetTopic(topic) => {
+				let id_h256: sp_core::H256 = topic.into();
+				tracing::debug!(target: "xcm::process_instruction", old_topic=?self.context.topic, new_topic=?id_h256);
 				self.context.topic = Some(topic);
 				Ok(())
 			},
 			ClearTopic => {
+				tracing::debug!(target: "xcm::process_instruction", cleared_topic=?self.context.topic);
 				self.context.topic = None;
 				Ok(())
 			},
@@ -1790,6 +1832,9 @@ impl<Config: config::Config> XcmExecutor<Config> {
 		reason: FeeReason,
 		xcm: &Xcm<()>,
 	) -> Result<Option<AssetsInHolding>, XcmError> {
+		let topic_id = self.context.topic;
+		let message_id: sp_core::H256 = self.context.message_id.into();
+		tracing::debug!(target: "xcm::take_delivery_fee_from_assets", ?topic_id, ?message_id);
 		let to_weigh = assets.clone();
 		let to_weigh_reanchored = Self::reanchored(to_weigh, &destination, None);
 		let remote_instruction = match reason {

--- a/polkadot/xcm/xcm-executor/src/tests/initiate_transfer.rs
+++ b/polkadot/xcm/xcm-executor/src/tests/initiate_transfer.rs
@@ -58,7 +58,7 @@ fn clears_origin() {
 
 	let (dest, sent_message) = sent_xcm().pop().unwrap();
 	assert_eq!(dest, Parent.into());
-	assert_eq!(sent_message.len(), 5);
+	assert_eq!(sent_message.len(), 6);
 	let mut instr = sent_message.inner().iter();
 	assert!(matches!(instr.next().unwrap(), ReserveAssetDeposited(..)));
 	assert!(matches!(instr.next().unwrap(), PayFees { .. }));
@@ -95,7 +95,7 @@ fn preserves_origin() {
 
 	let (dest, sent_message) = sent_xcm().pop().unwrap();
 	assert_eq!(dest, Parent.into());
-	assert_eq!(sent_message.len(), 5);
+	assert_eq!(sent_message.len(), 6);
 	let mut instr = sent_message.inner().iter();
 	assert!(matches!(instr.next().unwrap(), ReserveAssetDeposited(..)));
 	assert!(matches!(instr.next().unwrap(), PayFees { .. }));
@@ -136,7 +136,7 @@ fn unpaid_execution_goes_after_origin_alteration() {
 
 	let (destination, sent_message) = sent_xcm().pop().unwrap();
 	assert_eq!(destination, Parent.into());
-	assert_eq!(sent_message.len(), 5);
+	assert_eq!(sent_message.len(), 6);
 	let mut instructions = sent_message.inner().iter();
 	assert!(matches!(instructions.next().unwrap(), ReserveAssetDeposited(..)));
 	assert!(matches!(
@@ -177,7 +177,7 @@ fn no_alias_origin_if_root() {
 
 	let (destination, sent_message) = sent_xcm().pop().unwrap();
 	assert_eq!(destination, Parent.into());
-	assert_eq!(sent_message.len(), 4);
+	assert_eq!(sent_message.len(), 5);
 	let mut instructions = sent_message.inner().iter();
 	assert!(matches!(instructions.next().unwrap(), ReserveAssetDeposited(..)));
 	assert!(matches!(instructions.next().unwrap(), UnpaidExecution { .. }));
@@ -213,7 +213,7 @@ fn unpaid_transact() {
 
 	let (destination, sent_message) = sent_xcm().pop().unwrap();
 	assert_eq!(destination, to_another_system_para);
-	assert_eq!(sent_message.len(), 2);
+	assert_eq!(sent_message.len(), 3);
 	let mut instructions = sent_message.inner().iter();
 	assert!(matches!(instructions.next().unwrap(), UnpaidExecution { .. }));
 	assert!(matches!(instructions.next().unwrap(), Transact { .. }));

--- a/polkadot/xcm/xcm-executor/src/tests/pay_fees.rs
+++ b/polkadot/xcm/xcm-executor/src/tests/pay_fees.rs
@@ -103,7 +103,7 @@ fn works_for_delivery_fees() {
 
 	let querier: Location =
 		(Parachain(1000), AccountId32 { id: SENDER.into(), network: None }).into();
-	let sent_message = Xcm(vec![QueryResponse {
+	let mut sent_message = Xcm(vec![QueryResponse {
 		query_id: 0,
 		response: Response::ExecutionResult(None),
 		max_weight: Weight::zero(),
@@ -111,8 +111,12 @@ fn works_for_delivery_fees() {
 	}]);
 
 	// The messages were "sent" successfully.
+	let xcm_sent = sent_xcm();
+	if let Some(SetTopic(topic_id)) = xcm_sent[0].1.last() {
+		sent_message.0.push(SetTopic(*topic_id));
+	}
 	assert_eq!(
-		sent_xcm(),
+		xcm_sent,
 		vec![
 			(Parent.into(), sent_message.clone()),
 			(Parent.into(), sent_message.clone()),

--- a/prdoc/pr_7691.prdoc
+++ b/prdoc/pr_7691.prdoc
@@ -1,8 +1,8 @@
-title: Ensure SetTopic is Always Applied in XCM Execution
+title: Ensure Consistent Topic IDs for Traceable Cross-Chain XCM
 doc:
 - audience: Runtime Dev
   description: |-
-    This PR ensures every XCM processed in `xcm::execute` applies the `SetTopic` instruction to improve traceability.
+    This PR ensures every XCM processed with the same topic ID across multiple chains to improve traceability.
 crates:
 - name: staging-xcm-builder
   bump: patch

--- a/prdoc/pr_7691.prdoc
+++ b/prdoc/pr_7691.prdoc
@@ -10,3 +10,7 @@ crates:
   bump: patch
 - name: xcm-emulator
   bump: minor
+- name: asset-hub-westend-integration-tests
+  bump: none
+- name: bridge-hub-westend-integration-tests
+  bump: none


### PR DESCRIPTION
This sub-PR to #7691 focuses on ensuring that a `SetTopic` instruction is consistently added to all outbound XCM messages that don't already have one. The `topic_or_message_id()` function is employed to achieve this, using the message ID as a fallback for reliable traceability.