### PR TITLE
Statement-store: new RPC: `account_channel_priority` to get the priority of the statement in the channel for the account

### DIFF
--- a/substrate/client/rpc-api/src/statement/mod.rs
+++ b/substrate/client/rpc-api/src/statement/mod.rs
@@ -57,4 +57,13 @@ pub trait StatementApi {
 	/// Remove a statement from the store.
 	#[method(name = "statement_remove")]
 	fn remove(&self, statement_hash: [u8; 32]) -> RpcResult<()>;
+
+	/// Return the priority of the statement in given channel for the given account, or `None` if
+	/// the statement doesn't have a priority or if there is no statement.
+	#[method(name = "statement_accountChannelPriority")]
+	fn account_channel_priority(
+		&self,
+		account: [u8; 32],
+		channel: [u8; 32],
+	) -> RpcResult<Option<u32>>;
 }

--- a/substrate/client/rpc-api/src/statement/mod.rs
+++ b/substrate/client/rpc-api/src/statement/mod.rs
@@ -59,7 +59,7 @@ pub trait StatementApi {
 	fn remove(&self, statement_hash: [u8; 32]) -> RpcResult<()>;
 
 	/// Return the priority of the statement in given channel for the given account, or `None` if
-	/// the statement doesn't have a priority or if there is no statement.
+	/// there is no statement.
 	#[method(name = "statement_accountChannelPriority")]
 	fn account_channel_priority(
 		&self,

--- a/substrate/client/rpc/src/statement/mod.rs
+++ b/substrate/client/rpc/src/statement/mod.rs
@@ -103,4 +103,14 @@ impl StatementApiServer for StatementStore {
 	fn remove(&self, hash: [u8; 32]) -> RpcResult<()> {
 		Ok(self.store.remove(&hash).map_err(|e| Error::StatementStore(e.to_string()))?)
 	}
+
+	fn account_channel_priority(
+		&self,
+		account: [u8; 32],
+		channel: [u8; 32],
+	) -> RpcResult<Option<u32>> {
+		Ok(self.store
+			.account_channel_priority(&account, &channel)
+			.map_err(|e| Error::StatementStore(e.to_string()))?)
+	}
 }

--- a/substrate/client/rpc/src/statement/mod.rs
+++ b/substrate/client/rpc/src/statement/mod.rs
@@ -109,7 +109,8 @@ impl StatementApiServer for StatementStore {
 		account: [u8; 32],
 		channel: [u8; 32],
 	) -> RpcResult<Option<u32>> {
-		Ok(self.store
+		Ok(self
+			.store
 			.account_channel_priority(&account, &channel)
 			.map_err(|e| Error::StatementStore(e.to_string()))?)
 	}

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -925,6 +925,20 @@ impl StatementStore for Store {
 		}
 		Ok(())
 	}
+
+	fn account_channel_priority(
+		&self,
+		account_id: &AccountId,
+		channel: &Channel,
+	) -> Result<Option<u32>> {
+		let index = self.index.read();
+
+		Ok(
+			index.accounts.get(account_id)
+				.and_then(|a| a.channels.get(channel))
+				.map(|c| c.priority.0)
+		)
+	}
 }
 
 #[cfg(test)]

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -933,11 +933,11 @@ impl StatementStore for Store {
 	) -> Result<Option<u32>> {
 		let index = self.index.read();
 
-		Ok(
-			index.accounts.get(account_id)
-				.and_then(|a| a.channels.get(channel))
-				.map(|c| c.priority.0)
-		)
+		Ok(index
+			.accounts
+			.get(account_id)
+			.and_then(|a| a.channels.get(channel))
+			.map(|c| c.priority.0))
 	}
 }
 

--- a/substrate/primitives/statement-store/src/store_api.rs
+++ b/substrate/primitives/statement-store/src/store_api.rs
@@ -89,7 +89,7 @@ pub trait StatementStore: Send + Sync {
 	fn remove(&self, hash: &Hash) -> Result<()>;
 
 	/// Return the priority of the statement in given channel for the given account, or `None` if
-	/// the statement doesn't have a priority or if there is no statement.
+	/// there is no statement.
 	fn account_channel_priority(
 		&self,
 		account: &AccountId,

--- a/substrate/primitives/statement-store/src/store_api.rs
+++ b/substrate/primitives/statement-store/src/store_api.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 pub use crate::runtime_api::StatementSource;
-use crate::{Hash, Statement, Topic};
+use crate::{AccountId, Channel, Hash, Statement, Topic};
 
 /// Statement store error.
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
@@ -87,4 +87,12 @@ pub trait StatementStore: Send + Sync {
 
 	/// Remove a statement from the store.
 	fn remove(&self, hash: &Hash) -> Result<()>;
+
+	/// Return the priority of the statement in given channel for the given account, or `None` if
+	/// the statement doesn't have a priority or if there is no statement.
+	fn account_channel_priority(
+		&self,
+		account: &AccountId,
+		channel: &Channel,
+	) -> Result<Option<u32>>;
 }


### PR DESCRIPTION
We have a situation where the client might be reset but still needs to know what was the latest used priority in order to resume its process.

There might be ways to do without this, and instead use the UNIX time as priority but it is also maybe less convenient.

Do you think this new RPC makes sense?

cc @arkpar 