### PR TITLE
[CI] Sanity check that generated weights also compile for short benchmarks

### DIFF
--- a/.github/workflows/check-frame-omni-bencher.yml
+++ b/.github/workflows/check-frame-omni-bencher.yml
@@ -112,6 +112,12 @@ jobs:
 
           echo "Running command: $cmd"
           eval "$cmd"
+
+          # WIP: just to see where the weight files were generated
+          git status
+
+          echo "Compiling PACKAGE_NAME=$PACKAGE_NAME with fresh generated weights..."
+          forklift cargo build --release --locked -p $PACKAGE_NAME --features=${{ matrix.runtime.bench_features }} --quiet
       - name: Stop all workflows if failed
         if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/workflow-stopper


### PR DESCRIPTION
We have short benchmarks that ensure we can generate weights for runtimes.  
However, we never check whether those generated weights can actually compile with the runtimes.

This PR aims to prevent unexpected issues like this one: https://github.com/paritytech/polkadot-sdk/issues/8334, which can occur when benchmarking code is changed without updating the corresponding weight traits.

## TODO
- [ ] fix the same for fellows