### PR TITLE
ci: change nextest test-threads to num-cpus

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,7 +21,7 @@ retries = 5
 # The number of threads to run tests with. Supported values are either an integer or
 # the string "num-cpus". Can be overridden through the `--test-threads` option.
 # test-threads = "num-cpus"
-test-threads = 20
+test-threads = "num-cpus"
 
 # The number of threads required for each test. This is generally used in overrides to
 # mark certain tests as heavier than others. However, it can also be set as a global parameter.


### PR DESCRIPTION
Test if "num-cpus" option is faster