### PR TITLE
make assert_expected_events fail on missing event

### DIFF
--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -1301,12 +1301,14 @@ macro_rules! assert_expected_events {
 		$(
 			// We'll store a string representation of the first partially matching event.
 			let mut failure_message: Option<String> = None;
+			let mut event_received = false;
 			for index in 0..events.len() {
 				let event = &events[index];
 				match event {
 					$event_pat => {
 						let mut event_meets_conditions = true;
 						let mut conditions_message: Vec<String> = Vec::new();
+						event_received = true;
 
 						$(
 							if !$condition {
@@ -1346,7 +1348,7 @@ macro_rules! assert_expected_events {
 				}
 			}
 
-			if failure_message.is_some() {
+			if !event_received || failure_message.is_some() {
 				// No event matching the pattern was found.
 				messages.push(
 					format!(


### PR DESCRIPTION
# Description

Currently `assert_expected_events` does not fail (but it should) in case there is an event missing due to not matching the requested pattern

eg. in the example below, the test will succeed whether `success == true` or `success == false`, since if there is an event matching the pattern, it will succed as expected, but if there is no event matching the pattern, it will silently pass through.
```
assert_expected_events!(
		AssetHubRococo,
		vec![
			RuntimeEvent::MessageQueue(
				pallet_message_queue::Event::Processed { success: true, .. }
			) => {},
		]
	);
```

## Review Notes
I was looking for a way to implement some unit tests for the macro in the `xcm-emulator` crate itself but many traits that are invloved like `Chain`, `TestExt`, `Network` and the fact that `assert_expected_events` internally calls `let mut events = <$chain as $crate::Chain>::events();`  it requires a lot of mocking code (not really possible to override traits etc due to `crate::` designation )

I think this macro could benefit from changing its interface to allow passing `events` vec via parameters but that is a major change and would not allow for backports. It can be done in a separate PR of course if you also like the idea, 

eg proposed new usage (not part of this PR, just idea for future)
```
assert_expected_events!(
		<AssetHubRococo as Chain>::events(),
		vec![
			RuntimeEvent::MessageQueue(
				pallet_message_queue::Event::Processed { success: true, .. }
			) => {},
		]
	);
```
