### PR TITLE
[cmd-bot] Move cmd output to artifacts 

### DIFF
--- a/.github/scripts/cmd/cmd.py
+++ b/.github/scripts/cmd/cmd.py
@@ -112,14 +112,14 @@ def main():
         runtimesMatrix = {x['name']: x for x in runtimesMatrix}
         print(f'Filtered out runtimes: {runtimesMatrix}')
 
-        compile_bencher = os.system(f"cargo install --path substrate/utils/frame/omni-bencher --locked --profile {profile}")
+        compile_bencher = os.system(f"cargo install -q --path substrate/utils/frame/omni-bencher --locked --profile {profile}")
         if compile_bencher != 0:
             print_and_log('❌ Failed to compile frame-omni-bencher')
             sys.exit(1)
 
         # loop over remaining runtimes to collect available pallets
         for runtime in runtimesMatrix.values():
-            build_command = f"forklift cargo build -p {runtime['package']} --profile {profile} --features={runtime['bench_features']}"
+            build_command = f"forklift cargo build -q -p {runtime['package']} --profile {profile} --features={runtime['bench_features']}"
             print(f'-- building "{runtime["name"]}" with `{build_command}`')
             build_status = os.system(build_command)
             if build_status != 0:

--- a/.github/scripts/cmd/test_cmd.py
+++ b/.github/scripts/cmd/test_cmd.py
@@ -117,10 +117,10 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p kitchensink-runtime --profile production --features=runtime-benchmarks"),
-                call("forklift cargo build -p westend-runtime --profile production --features=runtime-benchmarks"),
-                call("forklift cargo build -p rococo-runtime --profile production --features=runtime-benchmarks"),
-                call("forklift cargo build -p asset-hub-westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p kitchensink-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p rococo-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p asset-hub-westend-runtime --profile production --features=runtime-benchmarks"),
 
                 call(get_mock_bench_output(
                     runtime='kitchensink',
@@ -170,7 +170,7 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p westend-runtime --profile production --features=runtime-benchmarks"),
 
                 # Westend runtime calls
                 call(get_mock_bench_output(
@@ -213,7 +213,7 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p westend-runtime --profile production --features=runtime-benchmarks"),
 
                 # Westend runtime calls
                 call(get_mock_bench_output(
@@ -250,8 +250,8 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p westend-runtime --profile production --features=runtime-benchmarks"),
-                call("forklift cargo build -p rococo-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p rococo-runtime --profile production --features=runtime-benchmarks"),
                 # Westend runtime calls
                 call(get_mock_bench_output(
                     runtime='westend',
@@ -309,7 +309,7 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p kitchensink-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p kitchensink-runtime --profile production --features=runtime-benchmarks"),
                 # Westend runtime calls
                 call(get_mock_bench_output(
                     runtime='kitchensink',
@@ -344,7 +344,7 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p asset-hub-westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p asset-hub-westend-runtime --profile production --features=runtime-benchmarks"),
                 # Asset-hub-westend runtime calls
                 call(get_mock_bench_output(
                     runtime='asset-hub-westend',
@@ -379,7 +379,7 @@ class TestCmd(unittest.TestCase):
 
             expected_calls = [
                 # Build calls
-                call("forklift cargo build -p asset-hub-westend-runtime --profile production --features=runtime-benchmarks"),
+                call("forklift cargo build -q -p asset-hub-westend-runtime --profile production --features=runtime-benchmarks"),
                 # Asset-hub-westend runtime calls
                 call(get_mock_bench_output(
                     runtime='asset-hub-westend',

--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -176,8 +176,9 @@ jobs:
           # install deps and run a command from master
           python3 -m pip install -r $BOT_PATH/scripts/generate-prdoc.requirements.txt
           python3 $BOT_PATH/scripts/cmd/cmd.py $CMD $PR_ARG
-          git status
-          git diff
+          # commented in order to not exceed output size
+          # git status
+          # git diff
 
           if [ -f /tmp/cmd/command_output.log ]; then
             CMD_OUTPUT=$(cat /tmp/cmd/command_output.log)

--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -176,7 +176,6 @@ jobs:
           # install deps and run a command from master
           python3 -m pip install -r $BOT_PATH/scripts/generate-prdoc.requirements.txt
           python3 $BOT_PATH/scripts/cmd/cmd.py $CMD $PR_ARG
-          # commented in order to not exceed output size
           git status > /tmp/cmd/git_status.log
           git diff > /tmp/cmd/git_diff.log
 

--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -177,8 +177,8 @@ jobs:
           python3 -m pip install -r $BOT_PATH/scripts/generate-prdoc.requirements.txt
           python3 $BOT_PATH/scripts/cmd/cmd.py $CMD $PR_ARG
           # commented in order to not exceed output size
-          # git status
-          # git diff
+          git status > /tmp/cmd/git_status.log
+          git diff > /tmp/cmd/git_diff.log
 
           if [ -f /tmp/cmd/command_output.log ]; then
             CMD_OUTPUT=$(cat /tmp/cmd/command_output.log)
@@ -207,6 +207,18 @@ jobs:
         with:
           name: command-diff
           path: /tmp/cmd/command_diff.patch
+
+      - name: Upload git status
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-status
+          path: /tmp/cmd/git_status.log
+
+      - name: Upload git diff
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-diff
+          path: /tmp/cmd/git_diff.log
 
       - name: Install subweight for bench
         if: startsWith(github.event.inputs.cmd, 'bench')


### PR DESCRIPTION
PR removes some output for cmd-bot and moves it into artifacts.

cc https://github.com/paritytech/polkadot-sdk/issues/8195