### PR TITLE
Based on enabled statement store PR: make default behavior configurable: enable by default only in polkadot-parachain.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15517,6 +15517,7 @@ dependencies = [
  "asset-hub-westend-runtime",
  "bridge-hub-rococo-runtime",
  "bridge-hub-westend-runtime",
+ "clap",
  "collectives-westend-runtime",
  "color-eyre",
  "coretime-rococo-runtime",

--- a/cumulus/polkadot-omni-node/lib/src/common/mod.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/mod.rs
@@ -116,8 +116,8 @@ pub struct NodeExtraArgs {
 	/// If set, each `PoV` build by the node will be exported to this folder.
 	pub export_pov: Option<PathBuf>,
 
-	/// Disable the statement store.
-	pub disable_statement_store: bool,
+	/// Enable the statement store.
+	pub enable_statement_store: bool,
 
 	/// The maximum percentage of the maximum PoV size that the collator can use.
 	/// It will be removed once <https://github.com/paritytech/polkadot-sdk/issues/6020> is fixed.

--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -286,7 +286,7 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 			.await
 			.map_err(|e| sc_service::Error::Application(Box::new(e) as Box<_>))?;
 
-			let statement_store = if !node_extra_args.disable_statement_store {
+			let statement_store = if node_extra_args.enable_statement_store {
 				let statement_store = sc_statement_store::Store::new_shared(
 					&parachain_config.data_path,
 					Default::default(),

--- a/cumulus/polkadot-omni-node/src/main.rs
+++ b/cumulus/polkadot-omni-node/src/main.rs
@@ -22,8 +22,8 @@
 #![warn(unused_extern_crates)]
 
 use polkadot_omni_node_lib::{
-	chain_spec::DiskChainSpecLoader, run, runtime::DefaultRuntimeResolver, CliConfig as CliConfigT,
-	RunConfig, NODE_VERSION,
+	chain_spec::DiskChainSpecLoader, cli::DisableStatementStoreByDefault, run,
+	runtime::DefaultRuntimeResolver, CliConfig as CliConfigT, RunConfig, NODE_VERSION,
 };
 
 struct CliConfig;
@@ -45,6 +45,8 @@ impl CliConfigT for CliConfig {
 	fn copyright_start_year() -> u16 {
 		2017
 	}
+
+	type StatementStoreDefault = DisableStatementStoreByDefault;
 }
 
 fn main() -> color_eyre::eyre::Result<()> {

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -17,6 +17,7 @@ name = "polkadot-parachain"
 path = "src/main.rs"
 
 [dependencies]
+clap = { features = ["derive"], workspace = true }
 color-eyre = { workspace = true }
 hex-literal = { workspace = true, default-features = true }
 log = { workspace = true, default-features = true }

--- a/cumulus/polkadot-parachain/src/main.rs
+++ b/cumulus/polkadot-parachain/src/main.rs
@@ -21,7 +21,9 @@
 
 mod chain_spec;
 
-use polkadot_omni_node_lib::{run, CliConfig as CliConfigT, RunConfig, NODE_VERSION};
+use polkadot_omni_node_lib::{
+	cli::EnableStatementStoreByDefault, run, CliConfig as CliConfigT, RunConfig, NODE_VERSION,
+};
 
 struct CliConfig;
 
@@ -42,6 +44,20 @@ impl CliConfigT for CliConfig {
 	fn copyright_start_year() -> u16 {
 		2017
 	}
+
+	type StatementStoreDefault = EnableStatementStoreByDefault;
+}
+
+/// Extra command line arguments for the node.
+#[derive(clap::Parser)]
+pub struct ExtraCliArgs {
+	/// Disable the statement store.
+	///
+	/// The statement store is an off-chain data-store for signed statements accessible via RPC
+	/// and OCW.
+	/// It uses the runtime api to get the allowance associated to an account.
+	#[arg(long)]
+	disable_statement_store: bool,
 }
 
 fn main() -> color_eyre::eyre::Result<()> {


### PR DESCRIPTION
Another way to add the statement-store in the omni-node: Have a new configurable CLI in `CliConfig` and allow nodes to choose the default behavior: enabled by default or disabled by default.