### PR TITLE
[AHM] Staking async fixes for XCM and election planning

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -1648,6 +1648,15 @@ impl<T: Config> UpwardMessageSender for Pallet<T> {
 	fn send_upward_message(message: UpwardMessage) -> Result<(u32, XcmHash), MessageSendError> {
 		Self::send_upward_message(message)
 	}
+
+	fn check_size(size: usize) -> Result<(), ()> {
+		let cfg = HostConfiguration::<T>::get().ok_or(())?;
+		if size > cfg.max_upward_message_size as usize {
+			Err(())
+		} else {
+			Ok(())
+		}
+	}
 }
 
 impl<T: Config> InspectMessageQueues for Pallet<T> {

--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -155,10 +155,18 @@ pub trait UpwardMessageSender {
 	/// be dispatched or an error if the message cannot be sent.
 	/// return the hash of the message sent
 	fn send_upward_message(msg: UpwardMessage) -> Result<(u32, XcmHash), MessageSendError>;
+
+	/// Check whether the message size is acceptable for the channel.
+	fn check_size(size: usize) -> Result<(), ()>;
 }
+
 impl UpwardMessageSender for () {
 	fn send_upward_message(_msg: UpwardMessage) -> Result<(u32, XcmHash), MessageSendError> {
 		Err(MessageSendError::NoChannel)
+	}
+
+	fn check_size(_size: usize) -> Result<(), ()> {
+		Err(())
 	}
 }
 

--- a/cumulus/primitives/utility/src/lib.rs
+++ b/cumulus/primitives/utility/src/lib.rs
@@ -77,6 +77,9 @@ where
 				.map_err(|()| SendError::ExceedsMaxMessageSize)?;
 			let data = versioned_xcm.encode();
 
+			// check if the `UpwardsMessageSender` may also complain about the size
+			T::check_size(data.len()).map_err(|_| SendError::ExceedsMaxMessageSize)?;
+
 			Ok((data, price))
 		} else {
 			// Anything else is unhandled. This includes a message that is not meant for us.

--- a/substrate/frame/staking-async/ah-client/src/lib.rs
+++ b/substrate/frame/staking-async/ah-client/src/lib.rs
@@ -430,7 +430,7 @@ pub mod pallet {
 			report: rc_client::ValidatorSetReport<T::AccountId>,
 		) -> DispatchResult {
 			// Ensure the origin is one of Root or whatever is representing AssetHub.
-			log!(info, "Received new validator set report {:?}", report);
+			log!(debug, "Received new validator set report {}", report);
 			T::AssetHubOrigin::ensure_origin_or_root(origin)?;
 
 			// Check the operating mode.

--- a/substrate/frame/staking-async/ahm-test/src/ah/mock.rs
+++ b/substrate/frame/staking-async/ahm-test/src/ah/mock.rs
@@ -316,8 +316,8 @@ impl multi_block::signed::Config for Runtime {
 parameter_types! {
 	pub static BondingDuration: u32 = 3;
 	pub static SlashDeferredDuration: u32 = 2;
-	pub static SessionsPerEra: u32 = 6;
-	pub static PlanningEraOffset: u32 = 1;
+	pub static RelaySessionsPerEra: u32 = 6;
+	pub static PlanningEraOffset: u32 = 2;
 }
 
 impl pallet_staking_async::Config for Runtime {
@@ -326,7 +326,7 @@ impl pallet_staking_async::Config for Runtime {
 
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type BondingDuration = BondingDuration;
-	type SessionsPerEra = SessionsPerEra;
+	type RelaySessionsPerEra = RelaySessionsPerEra;
 	type PlanningEraOffset = PlanningEraOffset;
 
 	type Currency = Balances;

--- a/substrate/frame/staking-async/ahm-test/src/lib.rs
+++ b/substrate/frame/staking-async/ahm-test/src/lib.rs
@@ -185,7 +185,7 @@ mod tests {
 			rc::roll_until_matches(
 				|| {
 					pallet_session::CurrentIndex::<rc::Runtime>::get() ==
-						current_session + ah::SessionsPerEra::get() + 1
+						current_session + ah::RelaySessionsPerEra::get() + 1
 				},
 				true,
 			);

--- a/substrate/frame/staking-async/rc-client/src/lib.rs
+++ b/substrate/frame/staking-async/rc-client/src/lib.rs
@@ -152,7 +152,7 @@ pub trait SendToRelayChain {
 	fn validator_set(report: ValidatorSetReport<Self::AccountId>);
 }
 
-#[derive(Encode, Decode, DecodeWithMemTracking, Debug, Clone, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, TypeInfo)]
 /// A report about a new validator set. This is sent from AH -> RC.
 pub struct ValidatorSetReport<AccountId> {
 	/// The new validator set.
@@ -172,6 +172,28 @@ pub struct ValidatorSetReport<AccountId> {
 	pub prune_up_to: Option<SessionIndex>,
 	/// Same semantics as [`SessionReport::leftover`].
 	pub leftover: bool,
+}
+
+impl<AccountId: core::fmt::Debug> core::fmt::Debug for ValidatorSetReport<AccountId> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("ValidatorSetReport")
+			.field("new_validator_set", &self.new_validator_set)
+			.field("id", &self.id)
+			.field("prune_up_to", &self.prune_up_to)
+			.field("leftover", &self.leftover)
+			.finish()
+	}
+}
+
+impl<AccountId> core::fmt::Display for ValidatorSetReport<AccountId> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("ValidatorSetReport")
+			.field("new_validator_set", &self.new_validator_set.len())
+			.field("id", &self.id)
+			.field("prune_up_to", &self.prune_up_to)
+			.field("leftover", &self.leftover)
+			.finish()
+	}
 }
 
 impl<AccountId> ValidatorSetReport<AccountId> {
@@ -196,7 +218,7 @@ impl<AccountId> ValidatorSetReport<AccountId> {
 		Ok(self)
 	}
 
-	/// Split self into `count` number of pieces.
+	/// Split self into chunks of `chunk_size` element.
 	pub fn split(self, chunk_size: usize) -> Vec<Self>
 	where
 		AccountId: Clone,
@@ -213,9 +235,7 @@ impl<AccountId> ValidatorSetReport<AccountId> {
 	}
 }
 
-#[derive(
-	Encode, Decode, DecodeWithMemTracking, Debug, Clone, PartialEq, TypeInfo, MaxEncodedLen,
-)]
+#[derive(Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
 /// The information that is sent from RC -> AH on session end.
 pub struct SessionReport<AccountId> {
 	/// The session that is ending.
@@ -244,6 +264,28 @@ pub struct SessionReport<AccountId> {
 	///
 	/// Upon processing, this should always be true, and it should be ignored.
 	pub leftover: bool,
+}
+
+impl<AccountId: core::fmt::Debug> core::fmt::Debug for SessionReport<AccountId> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("SessionReport")
+			.field("end_index", &self.end_index)
+			.field("validator_points", &self.validator_points)
+			.field("activation_timestamp", &self.activation_timestamp)
+			.field("leftover", &self.leftover)
+			.finish()
+	}
+}
+
+impl<AccountId> core::fmt::Display for SessionReport<AccountId> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("SessionReport")
+			.field("end_index", &self.end_index)
+			.field("validator_points", &self.validator_points.len())
+			.field("activation_timestamp", &self.activation_timestamp)
+			.field("leftover", &self.leftover)
+			.finish()
+	}
 }
 
 impl<AccountId> SessionReport<AccountId> {
@@ -435,7 +477,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			report: SessionReport<T::AccountId>,
 		) -> DispatchResult {
-			log!(info, "Received session report: {:?}", report);
+			log!(debug, "Received session report: {}", report);
 			T::RelayChainOrigin::ensure_origin_or_root(origin)?;
 
 			match LastSessionReportEndingIndex::<T>::get() {

--- a/substrate/frame/staking-async/runtimes/parachain/build-and-run-zn.sh
+++ b/substrate/frame/staking-async/runtimes/parachain/build-and-run-zn.sh
@@ -19,10 +19,8 @@ RUST_LOG=${LOG} ../../../../../target/release/chain-spec-builder \
     --runtime ../../../../../target/release/wbuild/pallet-staking-async-parachain-runtime/pallet_staking_async_parachain_runtime.compact.compressed.wasm \
     --relay-chain rococo-local \
     --para-id 1100 \
-    named-preset dot_size
-    # named-preset ksm_size
-    # named-preset development
-    # change this as per your needs ^^^
+    named-preset ksm_size
+    # change this as per your needs ^^^ options: development / dot_size / ksm_size
 mv ./chain_spec.json ./parachain.json
 
 echo "✅ creating rc chain specs"

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -38,7 +38,9 @@ extern crate alloc;
 
 use alloc::{vec, vec::Vec};
 use assets_common::{
+	foreign_creators::ForeignCreators,
 	local_and_foreign_assets::{LocalFromLeft, TargetFromLeft},
+	matching::{FromNetwork, FromSiblingParachain},
 	AssetIdForPoolAssets, AssetIdForPoolAssetsConvert, AssetIdForTrustBackedAssetsConvert,
 };
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
@@ -74,8 +76,11 @@ use parachains_common::{
 	BlockNumber, CollectionId, Hash, Header, ItemId, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
 	NORMAL_DISPATCH_RATIO,
 };
+use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+#[cfg(any(feature = "std", test))]
+pub use sp_runtime::BuildStorage;
 use sp_runtime::{
 	generic, impl_opaque_keys,
 	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, ConvertInto, Verify},
@@ -88,24 +93,15 @@ use sp_version::RuntimeVersion;
 use testnet_parachains_constants::westend::{
 	consensus::*, currency::*, fee::WeightToFee, snowbridge::EthereumNetwork, time::*,
 };
-use xcm_config::{
-	ForeignAssetsConvertedConcreteId, LocationToAccountId, PoolAssetsConvertedConcreteId,
-	PoolAssetsPalletLocation, TrustBackedAssetsConvertedConcreteId,
-	TrustBackedAssetsPalletLocation, WestendLocation, XcmOriginToTransactDispatchOrigin,
-};
-
-#[cfg(any(feature = "std", test))]
-pub use sp_runtime::BuildStorage;
-
-use assets_common::{
-	foreign_creators::ForeignCreators,
-	matching::{FromNetwork, FromSiblingParachain},
-};
-use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use xcm::{
 	latest::prelude::AssetId,
 	prelude::{VersionedAsset, VersionedAssetId, VersionedAssets, VersionedLocation, VersionedXcm},
+};
+use xcm_config::{
+	ForeignAssetsConvertedConcreteId, LocationToAccountId, PoolAssetsConvertedConcreteId,
+	PoolAssetsPalletLocation, TrustBackedAssetsConvertedConcreteId,
+	TrustBackedAssetsPalletLocation, WestendLocation, XcmOriginToTransactDispatchOrigin,
 };
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -137,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("asset-hub-next"),
 	impl_name: alloc::borrow::Cow::Borrowed("asset-hub-next"),
 	authoring_version: 1,
-	spec_version: 1_017_007,
+	spec_version: 1_000_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 16,

--- a/substrate/frame/staking-async/runtimes/parachain/zombienet-staking-runtimes.toml
+++ b/substrate/frame/staking-async/runtimes/parachain/zombienet-staking-runtimes.toml
@@ -12,7 +12,7 @@ name = "bob"
 validator = true
 rpc_port = 9955
 args = [
-	"-lruntime::system=debug,runtime::session=trace,runtime::staking::ah-client=trace",
+	"-lruntime::system=debug,runtime::session=trace,runtime::staking::ah-client=trace,runtime::ah-client=debug"
 ]
 
 [[parachains]]
@@ -23,5 +23,5 @@ chain_spec_path = "./parachain.json"
 name = "charlie"
 rpc_port = 9966
 args = [
-	"-lruntime::system=debug,runtime::multiblock-election=debug,runtime::staking=debug,runtime::staking::rc-client=trace",
+	"-lruntime::system=debug,runtime::multiblock-election=debug,runtime::staking=debug,runtime::staking::rc-client=trace,runtime::rc-client=debug",
 ]

--- a/substrate/frame/staking-async/runtimes/rc/src/genesis_config_presets.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/genesis_config_presets.rs
@@ -107,6 +107,7 @@ fn default_parachains_host_configuration(
 		max_head_data_size: 32 * 1024,
 		max_upward_queue_count: 8,
 		max_upward_queue_size: 1024 * 1024,
+		// NOTE: these can be tweaked to mimic the XCM message splitting.
 		max_downward_message_size: 1024 * 1024,
 		max_upward_message_size: 50 * 1024,
 		max_upward_message_num_per_candidate: 5,

--- a/substrate/frame/staking-async/src/lib.rs
+++ b/substrate/frame/staking-async/src/lib.rs
@@ -80,13 +80,14 @@ use frame_support::{
 	BoundedVec, DebugNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 	WeakBoundedVec,
 };
+use frame_system::pallet_prelude::BlockNumberFor;
 use ledger::LedgerIntegrityState;
 use scale_info::TypeInfo;
 use sp_runtime::{
-	traits::{AtLeast32BitUnsigned, StaticLookup},
-	BoundedBTreeMap, Perbill, RuntimeDebug,
+	traits::{AtLeast32BitUnsigned, One, StaticLookup, UniqueSaturatedInto},
+	BoundedBTreeMap, Perbill, RuntimeDebug, Saturating,
 };
-use sp_staking::{EraIndex, ExposurePage, PagedExposureMetadata};
+use sp_staking::{EraIndex, ExposurePage, PagedExposureMetadata, SessionIndex};
 pub use sp_staking::{Exposure, IndividualExposure, StakerStatus};
 pub use weights::WeightInfo;
 
@@ -420,5 +421,29 @@ impl<T: Config> Contains<T::AccountId> for AllStakers<T> {
 	/// - `false` otherwise.
 	fn contains(account: &T::AccountId) -> bool {
 		Ledger::<T>::contains_key(account)
+	}
+}
+
+/// A smart type to determine the [`Config::PlanningEraOffset`], given:
+///
+/// * Expected relay session duration
+/// * Time taking into consideration for XCM sending
+///
+/// It will use the estimated election duration, the relay session duration, and add one as it knows
+/// the relay chain will want to buffer validators for one session. This is needed because we this
+/// in our calculation based on the "active era".
+pub struct PlanningEraOffsetOf<T, RS, S>(core::marker::PhantomData<(T, RS, S)>);
+impl<T: Config, RS: Get<BlockNumberFor<T>>, S: Get<BlockNumberFor<T>>> Get<SessionIndex>
+	for PlanningEraOffsetOf<T, RS, S>
+{
+	fn get() -> SessionIndex {
+		let election_duration = <T::ElectionProvider as ElectionProvider>::duration_with_export();
+		let sessions_needed = (election_duration + S::get()) / RS::get();
+		// add one, because we know the RC session pallet wants to buffer for one session, and
+		// another one cause we will receive activation report one session after that.
+		sessions_needed
+			.saturating_add(One::one())
+			.saturating_add(One::one())
+			.unique_saturated_into()
 	}
 }

--- a/substrate/frame/staking-async/src/mock.rs
+++ b/substrate/frame/staking-async/src/mock.rs
@@ -34,7 +34,7 @@ use frame_support::{
 };
 use frame_system::{pallet_prelude::BlockNumberFor, EnsureRoot, EnsureSignedBy};
 use pallet_staking_async_rc_client as rc_client;
-use sp_core::ConstBool;
+use sp_core::{ConstBool, ConstU64};
 use sp_io;
 use sp_npos_elections::BalancingConfig;
 use sp_runtime::{traits::Zero, BuildStorage};
@@ -61,6 +61,22 @@ pub(crate) type AccountId = <Runtime as frame_system::Config>::AccountId;
 pub(crate) type BlockNumber = BlockNumberFor<Runtime>;
 pub(crate) type Balance = <Runtime as pallet_balances::Config>::Balance;
 
+#[derive(Clone, Copy)]
+pub enum PlanningEraMode {
+	Fixed(SessionIndex),
+	Smart,
+}
+
+pub struct PlanningEraOffset;
+impl Get<SessionIndex> for PlanningEraOffset {
+	fn get() -> SessionIndex {
+		match PlanningEraModeVal::get() {
+			PlanningEraMode::Fixed(value) => value,
+			PlanningEraMode::Smart => crate::PlanningEraOffsetOf::<T, Period, ConstU64<0>>::get(),
+		}
+	}
+}
+
 parameter_types! {
 	pub static ExistentialDeposit: Balance = 1;
 	pub static SlashDeferDuration: EraIndex = 0;
@@ -73,9 +89,9 @@ parameter_types! {
 	pub static MaxValidatorSet: u32 = 100;
 	pub static ElectionsBounds: ElectionBounds = ElectionBoundsBuilder::default().build();
 	pub static AbsoluteMaxNominations: u32 = 16;
-	pub static PlanningEraOffset: u32 = 1;
+	pub static PlanningEraModeVal: PlanningEraMode = PlanningEraMode::Fixed(2);
 	// Session configs
-	pub static SessionsPerEra: SessionIndex = 3;
+	pub static RelaySessionsPerEra: SessionIndex = 3;
 	pub static Period: BlockNumber = 5;
 	pub static Offset: BlockNumber = 0;
 }
@@ -129,7 +145,8 @@ parameter_types! {
 	pub static Pages: PageIndex = 1;
 	pub static MaxBackersPerWinner: u32 = 256;
 	pub static MaxWinnersPerPage: u32 = MaxValidatorSet::get();
-	pub static StartReceived: bool = false;
+	pub static StartReceived: Option<BlockNumber> = None;
+	pub static ElectionDelay: BlockNumber = 0;
 }
 
 pub type InnerElection = onchain::OnChainExecution<OnChainSeqPhragmen>;
@@ -164,22 +181,23 @@ impl ElectionProvider for TestElectionProvider {
 
 	fn elect(page: PageIndex) -> Result<BoundedSupportsOf<Self>, Self::Error> {
 		if page == 0 {
-			StartReceived::set(false);
+			StartReceived::set(None);
 		}
 		InnerElection::elect(page)
 	}
 	fn start() -> Result<(), Self::Error> {
-		StartReceived::set(true);
+		StartReceived::set(Some(System::block_number()));
 		Ok(())
 	}
 	fn duration() -> Self::BlockNumber {
-		InnerElection::duration()
+		InnerElection::duration() + ElectionDelay::get()
 	}
 	fn status() -> Result<bool, ()> {
-		if StartReceived::get() {
-			Ok(true)
-		} else {
-			Err(())
+		let now = System::block_number();
+		match StartReceived::get() {
+			Some(at) if now - at >= ElectionDelay::get() => Ok(true),
+			Some(_) => Ok(false),
+			None => Err(()),
 		}
 	}
 }
@@ -336,7 +354,7 @@ pub mod session_mock {
 			id: u32,
 			prune_up_to: Option<u32>,
 		) {
-			log::debug!(target: "runtime::session_mock", "Received validator set: {:?}", new_validator_set);
+			log::debug!(target: "runtime::staking-async::session_mock", "Received validator set: {:?}", new_validator_set);
 			let now = System::block_number();
 			// store the report for further inspection.
 			ReceivedValidatorSets::mutate(|reports| {
@@ -388,7 +406,7 @@ impl crate::pallet::pallet::Config for Test {
 	type Currency = Balances;
 	type RewardRemainder = RewardRemainderMock;
 	type Reward = MockReward;
-	type SessionsPerEra = SessionsPerEra;
+	type RelaySessionsPerEra = RelaySessionsPerEra;
 	type SlashDeferDuration = SlashDeferDuration;
 	type AdminOrigin = EitherOfDiverse<EnsureRoot<AccountId>, EnsureSignedBy<One, AccountId>>;
 	type EraPayout = OneTokenPerMillisecond;
@@ -485,7 +503,15 @@ impl ExtBuilder {
 		self
 	}
 	pub(crate) fn planning_era_offset(self, offset: SessionIndex) -> Self {
-		PlanningEraOffset::set(offset);
+		PlanningEraModeVal::set(PlanningEraMode::Fixed(offset));
+		self
+	}
+	pub fn smart_era_planner(self) -> Self {
+		PlanningEraModeVal::set(PlanningEraMode::Smart);
+		self
+	}
+	pub fn election_delay(self, delay: BlockNumber) -> Self {
+		ElectionDelay::set(delay);
 		self
 	}
 	pub(crate) fn nominate(mut self, nominate: bool) -> Self {
@@ -510,7 +536,7 @@ impl ExtBuilder {
 		self
 	}
 	pub(crate) fn session_per_era(self, length: SessionIndex) -> Self {
-		SessionsPerEra::set(length);
+		RelaySessionsPerEra::set(length);
 		self
 	}
 	pub(crate) fn period(self, length: BlockNumber) -> Self {
@@ -739,7 +765,7 @@ pub(crate) fn time_per_session() -> u64 {
 
 /// Time it takes to finish an era.
 pub(crate) fn time_per_era() -> u64 {
-	time_per_session() * SessionsPerEra::get() as u64
+	time_per_session() * RelaySessionsPerEra::get() as u64
 }
 
 pub(crate) fn reward_all_elected() {

--- a/substrate/frame/staking-async/src/pallet/impls.rs
+++ b/substrate/frame/staking-async/src/pallet/impls.rs
@@ -1063,7 +1063,7 @@ impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 	/// implies a new validator set has been applied, and we must increment the active era to keep
 	/// the systems in sync.
 	fn on_relay_session_report(report: rc_client::SessionReport<Self::AccountId>) {
-		log!(debug, "session report received\n{:?}", report,);
+		log!(debug, "session report received: {}", report,);
 		let consumed_weight = T::WeightInfo::rc_on_session_report();
 
 		let rc_client::SessionReport {

--- a/substrate/frame/staking-async/src/pallet/mod.rs
+++ b/substrate/frame/staking-async/src/pallet/mod.rs
@@ -185,9 +185,9 @@ pub mod pallet {
 		#[pallet::no_default_bounds]
 		type Reward: OnUnbalanced<PositiveImbalanceOf<Self>>;
 
-		/// Number of sessions per era.
+		/// Number of sessions per era, as per the preferences of the relay chain.
 		#[pallet::constant]
-		type SessionsPerEra: Get<SessionIndex>;
+		type RelaySessionsPerEra: Get<SessionIndex>;
 
 		/// Number of sessions before the end of an era when the election for the next era will
 		/// start.
@@ -195,11 +195,11 @@ pub mod pallet {
 		/// - This determines how many sessions **before** the last session of the era the staking
 		///   election process should begin.
 		/// - The value is bounded between **1** (election starts at the beginning of the last
-		///   session) and `SessionsPerEra` (election starts at the beginning of the first session
-		///   of the era).
+		///   session) and `RelaySessionsPerEra` (election starts at the beginning of the first
+		///   session of the era).
 		///
 		/// ### Example:
-		/// - If `SessionsPerEra = 6` and `PlanningEraOffset = 1`, the election starts at the
+		/// - If `RelaySessionsPerEra = 6` and `PlanningEraOffset = 1`, the election starts at the
 		///   beginning of session `6 - 1 = 5`.
 		/// - If `PlanningEraOffset = 6`, the election starts at the beginning of session `6 - 6 =
 		///   0`, meaning it starts at the very beginning of the era.
@@ -353,7 +353,7 @@ pub mod pallet {
 		impl frame_system::DefaultConfig for TestDefaultConfig {}
 
 		parameter_types! {
-			pub const SessionsPerEra: SessionIndex = 3;
+			pub const RelaySessionsPerEra: SessionIndex = 3;
 			pub const BondingDuration: EraIndex = 3;
 		}
 
@@ -368,7 +368,7 @@ pub mod pallet {
 			type RewardRemainder = ();
 			type Slash = ();
 			type Reward = ();
-			type SessionsPerEra = SessionsPerEra;
+			type RelaySessionsPerEra = RelaySessionsPerEra;
 			type BondingDuration = BondingDuration;
 			type PlanningEraOffset = ConstU32<1>;
 			type SlashDeferDuration = ();

--- a/substrate/frame/staking-async/src/session_rotation.rs
+++ b/substrate/frame/staking-async/src/session_rotation.rs
@@ -719,14 +719,14 @@ impl<T: Config> Rotator<T> {
 
 	/// Returns whether we are at the session where we should plan the new era.
 	fn is_plan_era_deadline(start_session: SessionIndex) -> bool {
-		let planning_era_offset = T::PlanningEraOffset::get().min(T::SessionsPerEra::get());
+		let planning_era_offset = T::PlanningEraOffset::get().min(T::RelaySessionsPerEra::get());
 		// session at which we should plan the new era.
-		let target_plan_era_session = T::SessionsPerEra::get().saturating_sub(planning_era_offset);
+		let target_plan_era_session =
+			T::RelaySessionsPerEra::get().saturating_sub(planning_era_offset);
 		let era_start_session = Self::active_era_start_session_index();
 
 		// progress of the active era in sessions.
-		let session_progress =
-			start_session.saturating_add(1).defensive_saturating_sub(era_start_session);
+		let session_progress = start_session.defensive_saturating_sub(era_start_session);
 
 		log!(
 			debug,

--- a/substrate/frame/staking-async/src/tests/election_provider.rs
+++ b/substrate/frame/staking-async/src/tests/election_provider.rs
@@ -24,7 +24,7 @@ use substrate_test_utils::assert_eq_uvec;
 use crate::tests::session_mock::ReceivedValidatorSets;
 
 #[test]
-fn planning_era_offset_less_works() {
+fn planning_era_offset_less_0() {
 	// same as `basic_setup_sessions_per_era`, but notice how `PagedElectionProceeded` happens
 	// one session later, and planning era is incremented one session later
 	ExtBuilder::default()
@@ -32,8 +32,62 @@ fn planning_era_offset_less_works() {
 		.planning_era_offset(0)
 		.no_flush_events()
 		.build_and_execute(|| {
-			// this essentially makes the session duration 7, because the mock session will buffer
-			// for one session before activating the era.
+			// this essentially makes the session duration 8. After 6 sessions we realize we have do
+			// start an election (since offset = 0), then it is queued for one session (7), and then
+			// activated (8).
+			assert_eq!(Session::current_index(), 8);
+			assert_eq!(active_era(), 1);
+
+			assert_eq!(
+				staking_events_since_last_call(),
+				vec![
+					Event::SessionRotated { starting_session: 1, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 2, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 3, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 4, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 5, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 6, active_era: 0, planned_era: 1 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 7, active_era: 0, planned_era: 1 },
+					Event::EraPaid { era_index: 0, validator_payout: 20000, remainder: 20000 },
+					Event::SessionRotated { starting_session: 8, active_era: 1, planned_era: 1 }
+				]
+			);
+
+			Session::roll_until_active_era(2);
+			assert_eq!(Session::current_index(), 16);
+			assert_eq!(active_era(), 2);
+
+			assert_eq!(
+				staking_events_since_last_call(),
+				vec![
+					Event::SessionRotated { starting_session: 9, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 10, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 11, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 12, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 13, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 14, active_era: 1, planned_era: 2 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 15, active_era: 1, planned_era: 2 },
+					Event::EraPaid { era_index: 1, validator_payout: 20000, remainder: 20000 },
+					Event::SessionRotated { starting_session: 16, active_era: 2, planned_era: 2 }
+				]
+			);
+		});
+}
+
+#[test]
+fn planning_era_offset_works_1() {
+	// same as `basic_setup_sessions_per_era`, but notice how `PagedElectionProceeded` happens
+	// one session later, and planning era is incremented one session later
+	ExtBuilder::default()
+		.session_per_era(6)
+		.planning_era_offset(1)
+		.no_flush_events()
+		.build_and_execute(|| {
+			// this essentially makes the session duration 7. After 5 sessions we realize we have do
+			// start an election (since offset = 1), then it is queued for one session (6), and then
+			// activated (7).
 			assert_eq!(Session::current_index(), 7);
 			assert_eq!(active_era(), 1);
 
@@ -74,14 +128,108 @@ fn planning_era_offset_less_works() {
 }
 
 #[test]
-fn planning_era_offset_more_works() {
+fn planning_era_offset_works_2() {
 	ExtBuilder::default()
 		.session_per_era(6)
 		.planning_era_offset(2)
 		.no_flush_events()
 		.build_and_execute(|| {
-			// This effectively makes the era one session shorter.
-			assert_eq!(Session::current_index(), 5);
+			// start election at 4, and send it over. Buffered at 6, activated at 6. This is the
+			// expected behavior, and the default in `mock.rs`.
+			assert_eq!(Session::current_index(), 6);
+			assert_eq!(active_era(), 1);
+
+			assert_eq!(
+				staking_events_since_last_call(),
+				vec![
+					Event::SessionRotated { starting_session: 1, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 2, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 3, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 4, active_era: 0, planned_era: 1 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 5, active_era: 0, planned_era: 1 },
+					Event::EraPaid { era_index: 0, validator_payout: 15000, remainder: 15000 },
+					Event::SessionRotated { starting_session: 6, active_era: 1, planned_era: 1 }
+				]
+			);
+
+			Session::roll_until_active_era(2);
+			assert_eq!(Session::current_index(), 12);
+			assert_eq!(active_era(), 2);
+
+			assert_eq!(
+				staking_events_since_last_call(),
+				vec![
+					Event::SessionRotated { starting_session: 7, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 8, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 9, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 10, active_era: 1, planned_era: 2 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 11, active_era: 1, planned_era: 2 },
+					Event::EraPaid { era_index: 1, validator_payout: 15000, remainder: 15000 },
+					Event::SessionRotated { starting_session: 12, active_era: 2, planned_era: 2 }
+				]
+			);
+		});
+}
+
+#[test]
+fn planning_era_offset_works_smart() {
+	ExtBuilder::default()
+		.session_per_era(6)
+		.smart_era_planner()
+		.no_flush_events()
+		.build_and_execute(|| {
+			// This works exactly the same as offset = 2, which means we send and rotate validators
+			// such that the era duration remains 6 sessions.
+			assert_eq!(Session::current_index(), 6);
+			assert_eq!(active_era(), 1);
+
+			assert_eq!(
+				staking_events_since_last_call(),
+				vec![
+					Event::SessionRotated { starting_session: 1, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 2, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 3, active_era: 0, planned_era: 0 },
+					Event::SessionRotated { starting_session: 4, active_era: 0, planned_era: 1 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 5, active_era: 0, planned_era: 1 },
+					Event::EraPaid { era_index: 0, validator_payout: 15000, remainder: 15000 },
+					Event::SessionRotated { starting_session: 6, active_era: 1, planned_era: 1 }
+				]
+			);
+
+			Session::roll_until_active_era(2);
+			assert_eq!(Session::current_index(), 12);
+			assert_eq!(active_era(), 2);
+
+			assert_eq!(
+				staking_events_since_last_call(),
+				vec![
+					Event::SessionRotated { starting_session: 7, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 8, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 9, active_era: 1, planned_era: 1 },
+					Event::SessionRotated { starting_session: 10, active_era: 1, planned_era: 2 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 11, active_era: 1, planned_era: 2 },
+					Event::EraPaid { era_index: 1, validator_payout: 15000, remainder: 15000 },
+					Event::SessionRotated { starting_session: 12, active_era: 2, planned_era: 2 }
+				]
+			);
+		});
+}
+
+#[test]
+fn planning_era_offset_works_smart_with_delay() {
+	ExtBuilder::default()
+		.session_per_era(6)
+		.election_delay(7)
+		.smart_era_planner()
+		.no_flush_events()
+		.build_and_execute(|| {
+			// Same as above, but now election takes more time, more than 1 session to be exact.
+			// Notice how the era duration is kept at 6.
+			assert_eq!(Session::current_index(), 6);
 			assert_eq!(active_era(), 1);
 
 			assert_eq!(
@@ -90,27 +238,29 @@ fn planning_era_offset_more_works() {
 					Event::SessionRotated { starting_session: 1, active_era: 0, planned_era: 0 },
 					Event::SessionRotated { starting_session: 2, active_era: 0, planned_era: 0 },
 					Event::SessionRotated { starting_session: 3, active_era: 0, planned_era: 1 },
-					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
 					Event::SessionRotated { starting_session: 4, active_era: 0, planned_era: 1 },
-					Event::EraPaid { era_index: 0, validator_payout: 12500, remainder: 12500 },
-					Event::SessionRotated { starting_session: 5, active_era: 1, planned_era: 1 }
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 5, active_era: 0, planned_era: 1 },
+					Event::EraPaid { era_index: 0, validator_payout: 15000, remainder: 15000 },
+					Event::SessionRotated { starting_session: 6, active_era: 1, planned_era: 1 }
 				]
 			);
 
 			Session::roll_until_active_era(2);
-			assert_eq!(Session::current_index(), 10);
+			assert_eq!(Session::current_index(), 12);
 			assert_eq!(active_era(), 2);
 
 			assert_eq!(
 				staking_events_since_last_call(),
 				vec![
-					Event::SessionRotated { starting_session: 6, active_era: 1, planned_era: 1 },
 					Event::SessionRotated { starting_session: 7, active_era: 1, planned_era: 1 },
-					Event::SessionRotated { starting_session: 8, active_era: 1, planned_era: 2 },
-					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 8, active_era: 1, planned_era: 1 },
 					Event::SessionRotated { starting_session: 9, active_era: 1, planned_era: 2 },
-					Event::EraPaid { era_index: 1, validator_payout: 12500, remainder: 12500 },
-					Event::SessionRotated { starting_session: 10, active_era: 2, planned_era: 2 }
+					Event::SessionRotated { starting_session: 10, active_era: 1, planned_era: 2 },
+					Event::PagedElectionProceeded { page: 0, result: Ok(2) },
+					Event::SessionRotated { starting_session: 11, active_era: 1, planned_era: 2 },
+					Event::EraPaid { era_index: 1, validator_payout: 15000, remainder: 15000 },
+					Event::SessionRotated { starting_session: 12, active_era: 2, planned_era: 2 }
 				]
 			);
 		});
@@ -426,7 +576,7 @@ mod paged_on_initialize_era_election_planner {
 
 				// we will start the next election at the start of block 20
 				assert_eq!(System::block_number(), 15);
-				assert_eq!(PlanningEraOffset::get(), 1);
+				assert_eq!(PlanningEraOffset::get(), 2);
 
 				// genesis validators are now in place.
 				assert_eq!(current_era(), 1);
@@ -541,7 +691,7 @@ mod paged_on_initialize_era_election_planner {
 
 				// we will start the next election at the start of block 20
 				assert_eq!(System::block_number(), 15);
-				assert_eq!(PlanningEraOffset::get(), 1);
+				assert_eq!(PlanningEraOffset::get(), 2);
 
 				// 1. election signal is sent here,
 				Session::roll_until(20);


### PR DESCRIPTION
This PR brings a few small fixes related to the XCM messages of stkaing-async, among other small fixes: 


* [x] Allows `xcm::validate` to check the message size, and we actually now act upon it in the `staking-async-rc/parachain-runtime`s. The code is a bit duplicate now, and there is a TOOD about how to better refactor it later.
* [x] Part of this work is backported separately as https://github.com/paritytech/polkadot-sdk/pull/8409
* [x] It brings a default `EraElectionPlannerOf` which should be the right tool to use to ensure elections always happen in time, with an educated guess based on `ElectionProvider::duration` rather than a random number.
* [x] It adds a few unit tests about the above
* [x] It silences some logs that were needlessly `INFO`, and makes the printing of some types a bit more CLI friendly.
* [x] Renames `type SessionDuration` in `staking-async` to `type RelaySessionDuration` for better clarity. 