### PR TITLE
Properly fix template generation

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -179,7 +179,7 @@ jobs:
           echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\", default-features = false }" >> Cargo.toml
           echo "$(toml get -r ./pallets/template/Cargo.toml 'package.name') = { path = \"./pallets/template\", default-features = false }" >> Cargo.toml
 
-          # Add rofile configurations
+          # Add profile configurations
           cat << EOF >> Cargo.toml
 
           [profile.release]

--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -178,6 +178,20 @@ jobs:
 
           echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\", default-features = false }" >> Cargo.toml
           echo "$(toml get -r ./pallets/template/Cargo.toml 'package.name') = { path = \"./pallets/template\", default-features = false }" >> Cargo.toml
+
+          # Add rofile configurations
+          cat << EOF >> Cargo.toml
+
+          [profile.release]
+          opt-level = 3
+          panic = "unwind"
+
+          [profile.production]
+          codegen-units = 1
+          inherits = "release"
+          lto = true
+          EOF
+
         shell: bash
         working-directory: polkadot-sdk/templates/${{ matrix.template }}/
       - name: Update workspace configuration

--- a/templates/parachain/Cargo.toml
+++ b/templates/parachain/Cargo.toml
@@ -14,12 +14,3 @@ docify = { workspace = true }
 
 [features]
 generate-readme = []
-
-[profile.release]
-opt-level = 3
-panic = "unwind"
-
-[profile.production]
-codegen-units = 1
-inherits = "release"
-lto = true


### PR DESCRIPTION
This one properly addresses https://github.com/paritytech/polkadot-sdk/pull/8378
Now template `Cargo.toml` wll be populated during release time so we dont need to alter it in sdk