### PR TITLE
Add all touched crates in #8327 to prdoc to fix release issue

### DIFF
--- a/prdoc/pr_8327.prdoc
+++ b/prdoc/pr_8327.prdoc
@@ -11,3 +11,14 @@ doc:
 crates:
   - name: sp-metadata-ir
     bump: major
+  - name: pallet-example-view-functions
+    bump: major
+  - name: frame-support
+    bump: major
+  - name: frame-support-procedural
+    bump: major
+  - name: frame-support-test
+    bump: major
+  - name: sp-api-proc-macro
+    bump: major
+  

--- a/prdoc/pr_8441.prdoc
+++ b/prdoc/pr_8441.prdoc
@@ -1,0 +1,8 @@
+title: Update prdoc in 8327 to fix release issue
+
+doc:
+  - audience: Node Operator
+    description: |
+      Update the prdoc in 8327 to fix a release issue.
+
+crates: [ ]


### PR DESCRIPTION
The prdoc from #8327 did not reference all crates that were touched. I added them here.