### PR TITLE
[AHM]: Final Staking Configs for Westend Migration

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -15,12 +15,12 @@
 
 ///! Staking, and election related pallet configurations.
 use super::*;
+use core::marker::PhantomData;
 use cumulus_primitives_core::relay_chain::SessionIndex;
 use frame_election_provider_support::{
 	bounds::{ElectionBounds, ElectionBoundsBuilder},
 	onchain, ElectionDataProvider, SequentialPhragmen,
 };
-use core::marker::PhantomData;
 use frame_support::traits::{ConstU128, EitherOf};
 use pallet_election_provider_multi_block::{
 	self as multi_block, weights::measured, SolutionAccuracyOf,
@@ -33,50 +33,45 @@ use sp_runtime::{
 use westend_runtime_constants::time::EPOCH_DURATION_IN_SLOTS;
 
 parameter_types! {
-	pub const EpochDuration: u64 = prod_or_fast!(
-		EPOCH_DURATION_IN_SLOTS as u64,
-		2 * MINUTES as u64
-	);
-
-	// phase durations. 1/4 of the last session for each.
-	pub SignedPhase: u32 = prod_or_fast!(
-		EPOCH_DURATION_IN_SLOTS / 4,
-		(1 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
-	);
-	pub UnsignedPhase: u32 = prod_or_fast!(
-		EPOCH_DURATION_IN_SLOTS / 4,
-		(1 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
-	);
+	/// Number of election pages that we operate upon. 32 * 6s block = 192s 3.2min stanpshot
+	pub storage Pages: u32 = 32;
 
 	/// Compatible with Polkadot, we allow up to 22_500 nominators to be considered for election
-	pub const MaxElectingVoters: u32 = 22_500;
+	pub storage MaxElectingVoters: u32 = 22_500;
 
 	/// Maximum number of validators that we may want to elect. 1000 is the end target.
 	pub const MaxValidatorSet: u32 = 1000;
 
-	/// Number of election pages that we operate upon.
-	pub const Pages: u32 = 64;
-
 	/// Number of nominators per page of the snapshot, and consequently number of backers in the solution.
-	pub const VoterSnapshotPerBlock: u32 = MaxElectingVoters::get() / Pages::get();
+	pub VoterSnapshotPerBlock: u32 = MaxElectingVoters::get() / Pages::get();
 
 	/// Number of validators per page of the snapshot.
-	pub const TargetSnapshotPerBlock: u32 = MaxValidatorSet::get();
+	pub TargetSnapshotPerBlock: u32 = MaxValidatorSet::get();
+
+	// 10 mins for each pages
+	pub storage SignedPhase: u32 = prod_or_fast!(
+		10 * MINUTES,
+		1 * MINUTES
+	);
+	pub storage UnsignedPhase: u32 = prod_or_fast!(
+		10 * MINUTES,
+		(1 * MINUTES)
+	);
+
+	/// validate up to 4 signed solution. Each solution.
+	pub storage SignedValidationPhase: u32 = Pages::get() * 4;
 
 	/// In each page, we may observe up to all of the validators.
-	pub const MaxWinnersPerPage: u32 = MaxValidatorSet::get();
+	pub storage MaxWinnersPerPage: u32 = MaxValidatorSet::get();
 
 	/// In each page of the election, we allow up to all of the nominators of that page to be present.
-	pub const MaxBackersPerWinner: u32 = VoterSnapshotPerBlock::get();
+	pub storage MaxBackersPerWinner: u32 = VoterSnapshotPerBlock::get();
 
-	/// Total number of backers per winner across all pages. This is not used in the code yet.
-	pub const MaxBackersPerWinnerFinal: u32 = 512;
+	/// Total number of backers per winner across all pages.
+	pub storage MaxBackersPerWinnerFinal: u32 = VoterSnapshotPerBlock::get();
 
 	/// Size of the exposures. This should be small enough to make the reward payouts feasible.
-	pub const MaxExposurePageSize: u32 = 64;
-
-	/// validate up to 4 signed solution.
-	pub const SignedValidationPhase: u32 = Pages::get() * 4;
+	pub storage MaxExposurePageSize: u32 = 64;
 
 	/// Each solution is considered "better" if it is 0.01% better.
 	pub SolutionImprovementThreshold: Perbill = Perbill::from_rational(1u32, 10_000);
@@ -85,7 +80,9 @@ parameter_types! {
 frame_election_provider_support::generate_solution_type!(
 	#[compact]
 	pub struct NposCompactSolution16::<
-		VoterIndex = u16,
+		// allows up to 4bn nominators
+		VoterIndex = u32,
+		// allows up to 64k validators
 		TargetIndex = u16,
 		Accuracy = sp_runtime::PerU16,
 		MaxVoters = VoterSnapshotPerBlock,
@@ -111,6 +108,12 @@ impl onchain::Config for OnChainSeqPhragmen {
 	type MaxWinnersPerPage = MaxWinnersPerPage;
 }
 
+parameter_types! {
+	// https://westend.subscan.io/account/5GBoBNFP9TA7nAk82i6SUZJimerbdhxaRgyC2PVcdYQMdb8e
+	pub const WestendStakingMiner: AccountId = AccountId::from(hex_literal::hex!("b65991822483a6c3bd24b1dcf6afd3e270525da1f9c8c22a4373d1e1079e236a"));
+}
+
+
 impl multi_block::Config for Runtime {
 	type Pages = Pages;
 	type UnsignedPhase = UnsignedPhase;
@@ -118,17 +121,17 @@ impl multi_block::Config for Runtime {
 	type SignedValidationPhase = SignedValidationPhase;
 	type VoterSnapshotPerBlock = VoterSnapshotPerBlock;
 	type TargetSnapshotPerBlock = TargetSnapshotPerBlock;
-	// TODO: Donal/Kian revert this once we have sudo again.
-	// type AdminOrigin = EnsureRoot<AccountId>;
-	type AdminOrigin = EnsureSigned<AccountId>;
+	type AdminOrigin =
+		EitherOf<EnsureRoot<AccountId>, EnsureSignedBy<WestendStakingMiner, AccountId>>;
 	type DataProvider = Staking;
-	type Fallback = multi_block::Continue<Self>;
 	type MinerConfig = Self;
 	type Verifier = MultiBlockVerifier;
-	type WeightInfo = measured::pallet_election_provider_multi_block::SubstrateWeight<Self>;
-
-	// Dont know about these ones, just making it compile:
+	// we chill and do nothing in the fallback.
+	type Fallback = multi_block::Continue<Self>;
+	// Revert back to signed phase if nothing is submitted and queued, so we prolong the election.
 	type AreWeDone = multi_block::RevertToSignedIfNotQueuedOf<Self>;
+	// TODO: double check they are right.
+	type WeightInfo = measured::pallet_election_provider_multi_block::SubstrateWeight<Self>;
 }
 
 impl multi_block::verifier::Config for Runtime {
@@ -137,6 +140,7 @@ impl multi_block::verifier::Config for Runtime {
 	type MaxBackersPerWinnerFinal = MaxBackersPerWinnerFinal;
 	type SolutionDataProvider = MultiBlockSigned;
 	type SolutionImprovementThreshold = SolutionImprovementThreshold;
+	// TODO: double check they are right.
 	type WeightInfo =
 		measured::pallet_election_provider_multi_block_verifier::SubstrateWeight<Self>;
 }
@@ -160,22 +164,25 @@ impl multi_block::signed::Config for Runtime {
 	type RewardBase = RewardBase;
 	type MaxSubmissions = MaxSubmissions;
 	type EstimateCallFee = TransactionPayment;
+	// TODO: double check they are right.
 	type WeightInfo = measured::pallet_election_provider_multi_block_signed::SubstrateWeight<Self>;
 }
 
 parameter_types! {
 	/// Priority of the offchain miner transactions.
 	pub MinerTxPriority: TransactionPriority = TransactionPriority::max_value() / 2;
-
-	/// 1 hour session, 15 minutes unsigned phase, 4 offchain executions.
+	/// Try and run the OCW miner 4 times during the unisgned phase.
 	pub OffchainRepeat: BlockNumber = UnsignedPhase::get() / 4;
+	/// Ask OCW miner for just a 4, out of the 32, page solution.
+	pub storage MinerPages: u32 = 4;
 }
 
 impl multi_block::unsigned::Config for Runtime {
-	type MinerPages = ConstU32<2>; // TODO review
+	type MinerPages = MinerPages;
 	type OffchainSolver = SequentialPhragmen<AccountId, SolutionAccuracyOf<Runtime>>;
 	type MinerTxPriority = MinerTxPriority;
 	type OffchainRepeat = OffchainRepeat;
+	// TODO: double check they are right.
 	type WeightInfo =
 		measured::pallet_election_provider_multi_block_unsigned::SubstrateWeight<Self>;
 }
@@ -251,10 +258,8 @@ parameter_types! {
 	pub const BondingDuration: sp_staking::EraIndex = 2;
 	// 1 era in which slashes can be cancelled (6 hours).
 	pub const SlashDeferDuration: sp_staking::EraIndex = 1;
-	// Note: this is not really correct as Max Nominators is (MaxExposurePageSize * page_count) but
-	// this is an unbounded number. We just set it to a reasonably high value, 1 full page
-	// of nominators.
 	pub const MaxControllersInDeprecationBatch: u32 = 751;
+	// alias for 16, which is the max nominations per nominator in the runtime.
 	pub const MaxNominations: u32 = <NposCompactSolution16 as frame_election_provider_support::NposSolution>::LIMIT as u32;
 }
 
@@ -299,14 +304,14 @@ impl pallet_staking_async_rc_client::Config for Runtime {
 #[derive(Encode, Decode)]
 // Call indices taken from westend-next runtime.
 pub enum RelayChainRuntimePallets {
-	// FAIL-CI ggwpez
+	// Audit: index of `AssetHubStakingClient` in westend.
 	#[codec(index = 67)]
 	AhClient(AhClientCalls),
 }
 
 #[derive(Encode, Decode)]
 pub enum AhClientCalls {
-	// FAIL-CI ggwpez check this shit
+	// index of `fn validator_set` in `staking-async-ah-client`. It has only one call.
 	#[codec(index = 0)]
 	ValidatorSet(rc_client::ValidatorSetReport<AccountId>),
 }
@@ -314,6 +319,7 @@ pub enum AhClientCalls {
 use pallet_staking_async_rc_client as rc_client;
 use xcm::latest::{prelude::*, SendXcm};
 
+// CI-FAIL: @kianenigma port over the new xcm configs from https://github.com/paritytech/polkadot-sdk/pull/8422
 pub struct XcmToRelayChain<T: SendXcm>(PhantomData<T>);
 impl<T: SendXcm> rc_client::SendToRelayChain for XcmToRelayChain<T> {
 	type AccountId = AccountId;

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -785,21 +785,20 @@ impl pallet_staking::Config for Runtime {
 
 #[derive(Encode, Decode)]
 enum AssetHubRuntimePallets<AccountId> {
-	// TODO - AHM: check index
+	// Audit: `StakingNextRcClient` in asset-hub-westend
 	#[codec(index = 89)]
 	RcClient(RcClientCalls<AccountId>),
 }
 
 #[derive(Encode, Decode)]
 enum RcClientCalls<AccountId> {
-	// TODO - AHM: check index
 	#[codec(index = 0)]
 	RelaySessionReport(rc_client::SessionReport<AccountId>),
-	// TODO - AHM: check index
 	#[codec(index = 1)]
 	RelayNewOffence(SessionIndex, Vec<rc_client::Offence<AccountId>>),
 }
 
+// CI-FAIL: @kianenigma port over the new xcm configs from https://github.com/paritytech/polkadot-sdk/pull/8422
 pub struct AssetHubLocation;
 impl Get<Location> for AssetHubLocation {
 	fn get() -> Location {
@@ -871,7 +870,7 @@ impl frame_support::traits::EnsureOrigin<RuntimeOrigin> for EnsureAssetHub {
 	}
 }
 
-// TODO - AHM: this pallet is currently in place, but does nothing. Upon AHM, it should become
+// Note - AHM: this pallet is currently in place, but does nothing. Upon AHM, it should become
 // activated. Note that it is used as `SessionManager`, but since its mode is `Passive`, it will
 // delegate all of its tasks to `Fallback`, which is again `Staking`.
 impl ah_client::Config for Runtime {

--- a/substrate/frame/election-provider-multi-block/src/unsigned/miner.rs
+++ b/substrate/frame/election-provider-multi-block/src/unsigned/miner.rs
@@ -189,11 +189,10 @@ pub trait MinerConfig {
 	///
 	/// Should equal to the onchain value set in `Verifier::Config`.
 	type MaxBackersPerWinnerFinal: Get<u32>;
-	/// Maximum number of backers, per winner, per page.
-
-	/// Maximum number of pages that we may compute.
+	/// **Maximum** number of pages that we may compute.
 	///
 	/// Must be the same as configured in the [`crate::Config`].
+	/// TODO: rename to `MaxPages` for more clarity. Won't do now to not break the miner right before WND migration.
 	type Pages: Get<u32>;
 	/// Maximum number of voters per snapshot page.
 	///


### PR DESCRIPTION
- [ ] needs https://github.com/paritytech/polkadot-sdk/pull/8409 and https://github.com/paritytech/polkadot-sdk/pull/8422 to have a cleaner XCM sending interface. If not, I will copy-pasta everything last minute again
- [ ] Would be cool to add presets to westend-ah to run with many stakers, as we do in `pallet-staking-async/runtimes/parachain`. Would also help with benchmarking.
- [x] Revise all configs, make them configurable. for now, I just used `pub storage`, not going down the rabbit hole of pallet-parameters. 
  - [ ] Also revise `ElectionOffset`, once the above PR is merged. 
- [ ] Update all weights one last time.