### PR TITLE
sp-arithmetic: add checked functions and extend fuzzer coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22332,6 +22332,7 @@ dependencies = [
  "fraction",
  "honggfuzz",
  "num-bigint",
+ "num-traits",
  "sp-arithmetic 23.0.0",
 ]
 

--- a/substrate/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/substrate/primitives/arithmetic/fuzzer/Cargo.toml
@@ -40,9 +40,42 @@ path = "src/multiply_by_rational_with_rounding.rs"
 name = "fixed_point"
 path = "src/fixed_point.rs"
 
+[[bin]]
+name = "checked_mul_by_rational"
+path = "src/checked_mul_by_rational.rs"
+
+[[bin]]
+name = "per_thing_checked_from_rational"
+path = "src/per_thing_checked_from_rational.rs"
+
+[[bin]]
+name = "fixed_checked_ops"
+path = "src/fixed_checked_ops.rs"
+
+[[bin]]
+name = "per_thing_checked_arith"
+path = "src/per_thing_checked_arith.rs"
+
+[[bin]]
+name = "fixed_utils"
+path = "src/fixed_utils.rs"
+
+[[bin]]
+name = "fixed_to_perbill"
+path = "src/fixed_to_perbill.rs"
+
+[[bin]]
+name = "fixed_to_perthing"
+path = "src/fixed_to_perthing.rs"
+
+[[bin]]
+name = "fixed_rounding_ops"
+path = "src/fixed_rounding_ops.rs"
+
 [dependencies]
 arbitrary = { workspace = true }
 fraction = { workspace = true }
 honggfuzz = { workspace = true }
 num-bigint = { workspace = true }
+num-traits = { workspace = true }
 sp-arithmetic = { workspace = true, default-features = true }

--- a/substrate/primitives/arithmetic/fuzzer/src/checked_mul_by_rational.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/checked_mul_by_rational.rs
@@ -1,0 +1,108 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run checked_mul_by_rational`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug checked_mul_by_rational hfuzz_workspace/checked_mul_by_rational/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use honggfuzz::fuzz;
+use sp_arithmetic::{
+	helpers_128bit::{
+		checked_multiply_by_rational_with_rounding, multiply_by_rational_with_rounding,
+	},
+	ArithmeticError, Rounding,
+	Rounding::{Down, NearestPrefDown, NearestPrefUp, Up},
+};
+
+#[derive(Debug, Clone, Copy)]
+struct ArbitraryRounding(Rounding);
+
+impl arbitrary::Arbitrary<'_> for ArbitraryRounding {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(Self(match u.int_in_range(0..=3)? {
+			0 => Up,
+			1 => NearestPrefUp,
+			2 => Down,
+			3 => NearestPrefDown,
+			_ => unreachable!(),
+		}))
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (u128, u128, u128, ArbitraryRounding)| {
+			let (a, b, c, arbitrary_rounding) = data;
+			let r = arbitrary_rounding.0;
+
+			let checked_res = checked_multiply_by_rational_with_rounding(a, b, c, r);
+			let non_checked_res = multiply_by_rational_with_rounding(a, b, c, r);
+
+			if c == 0 {
+				assert_eq!(
+					checked_res,
+					Err(ArithmeticError::DivisionByZero),
+					"Denominator 0: checked failed. a={}, b={}, c={}, r={:?}",
+					a,
+					b,
+					c,
+					r
+				);
+				assert_eq!(
+					non_checked_res, None,
+					"Denominator 0: non-checked failed. a={}, b={}, c={}, r={:?}",
+					a, b, c, r
+				);
+			} else {
+				match non_checked_res {
+					Some(val_non_checked) => {
+						assert_eq!(
+							checked_res,
+							Ok(val_non_checked),
+							"Non-checked Some, Checked Ok mismatch. a={}, b={}, c={}, r={:?}",
+							a,
+							b,
+							c,
+							r
+						);
+					},
+					None => {
+						// This implies an overflow for the non-checked version.
+						assert_eq!(
+							checked_res,
+							Err(ArithmeticError::Overflow),
+							"Non-checked None, Checked Overflow mismatch. a={}, b={}, c={}, r={:?}",
+							a,
+							b,
+							c,
+							r
+						);
+					},
+				}
+			}
+		});
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/fixed_checked_ops.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/fixed_checked_ops.rs
@@ -1,0 +1,429 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run fixed_checked_ops`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug fixed_checked_ops hfuzz_workspace/fixed_checked_ops/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use honggfuzz::fuzz;
+use num_bigint::BigInt;
+use sp_arithmetic::{
+	traits::{Bounded, CheckedDiv, CheckedMul, One, Zero},
+	FixedI128, FixedI64, FixedPointNumber, FixedU128, FixedU64,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum FixedTypeSelector {
+	I64,
+	U64,
+	I128,
+	U128,
+}
+
+impl arbitrary::Arbitrary<'_> for FixedTypeSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=3)? {
+			0 => FixedTypeSelector::I64,
+			1 => FixedTypeSelector::U64,
+			2 => FixedTypeSelector::I128,
+			3 => FixedTypeSelector::U128,
+			_ => unreachable!(),
+		})
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Operation {
+	CheckedAdd,
+	CheckedSub,
+	CheckedMul,
+	CheckedDiv,
+	CheckedFromInteger,
+	CheckedFromRational,
+	CheckedMulInt,
+	CheckedDivInt,
+	CheckedSqrt,
+}
+
+impl arbitrary::Arbitrary<'_> for Operation {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=8)? {
+			0 => Operation::CheckedAdd,
+			1 => Operation::CheckedSub,
+			2 => Operation::CheckedMul,
+			3 => Operation::CheckedDiv,
+			4 => Operation::CheckedFromInteger,
+			5 => Operation::CheckedFromRational,
+			6 => Operation::CheckedMulInt,
+			7 => Operation::CheckedDivInt,
+			8 => Operation::CheckedSqrt,
+			_ => unreachable!(),
+		})
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (i128, i128, FixedTypeSelector, Operation)| {
+			let (val1_i128, val2_i128, type_selector, op_selector) = data;
+
+			match type_selector {
+				FixedTypeSelector::I64 => run_test::<FixedI64>(val1_i128, val2_i128, op_selector),
+				FixedTypeSelector::U64 => run_test::<FixedU64>(val1_i128, val2_i128, op_selector),
+				FixedTypeSelector::I128 => run_test::<FixedI128>(val1_i128, val2_i128, op_selector),
+				FixedTypeSelector::U128 => run_test::<FixedU128>(val1_i128, val2_i128, op_selector),
+			}
+		});
+	}
+}
+
+fn run_test<F: FixedPointNumber + core::fmt::Display>(v1: i128, v2: i128, op: Operation)
+where
+	F::Inner: TryInto<i128>
+		+ TryInto<u128>
+		+ TryFrom<i128>
+		+ Default
+		+ PartialOrd
+		+ Copy
+		+ Bounded
+		+ Zero
+		+ One
+		+ CheckedMul
+		+ CheckedDiv,
+	<F::Inner as TryInto<i128>>::Error: core::fmt::Debug,
+	<F::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+	<F::Inner as TryFrom<i128>>::Error: core::fmt::Debug,
+{
+	let fp1 = F::saturating_from_integer(v1);
+	let fp2 = F::saturating_from_integer(v2);
+	let div_big = BigInt::from(F::DIV.try_into().unwrap_or(1i128));
+	let max_inner_big = BigInt::from(F::Inner::max_value().try_into().unwrap_or(i128::MAX));
+	let min_inner_big = BigInt::from(F::Inner::min_value().try_into().unwrap_or(i128::MIN));
+
+	match op {
+		Operation::CheckedAdd => {
+			let res = fp1.checked_add(&fp2);
+			let fp1_inner_i128: i128 = fp1.into_inner().try_into().unwrap_or(Default::default());
+			let fp2_inner_i128: i128 = fp2.into_inner().try_into().unwrap_or(Default::default());
+			let fp1_inner_big = BigInt::from(fp1_inner_i128);
+			let fp2_inner_big = BigInt::from(fp2_inner_i128);
+			let expected_inner_big = fp1_inner_big + fp2_inner_big;
+
+			if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+				assert!(res.is_none(),
+					"Expected None for CheckedAdd overflow/underflow for {:?}, op: {:?}, v1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					v1,
+					v2
+				);
+			} else {
+				assert!(
+					res.is_some(),
+					"Expected Some for CheckedAdd for {:?}, op: {:?}, v1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					v1,
+					v2
+				);
+
+				if let Some(r) = res {
+					let result_inner_i128: i128 =
+						r.into_inner().try_into().unwrap_or(Default::default());
+					let result_inner_big = BigInt::from(result_inner_i128);
+					assert_eq!(
+						result_inner_big,
+						expected_inner_big,
+						"CheckedAdd result mismatch for {:?}, op: {:?}, v1: {}, v2: {}",
+						core::any::type_name::<F>(),
+						op,
+						v1,
+						v2
+					);
+				}
+			}
+		},
+		Operation::CheckedSub => {
+			let res = fp1.checked_sub(&fp2);
+			let fp1_inner_i128: i128 = fp1.into_inner().try_into().unwrap_or(Default::default());
+			let fp2_inner_i128: i128 = fp2.into_inner().try_into().unwrap_or(Default::default());
+			let fp1_inner_big = BigInt::from(fp1_inner_i128);
+			let fp2_inner_big = BigInt::from(fp2_inner_i128);
+			let expected_inner_big = fp1_inner_big - fp2_inner_big;
+
+			if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+				assert!(res.is_none(),
+					"Expected None for CheckedSub overflow/underflow for {:?}, op: {:?}, v1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					v1,
+					v2
+				);
+			} else {
+				assert!(
+					res.is_some(),
+					"Expected Some for CheckedSub for {:?}, op: {:?}, v1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					v1,
+					v2
+				);
+
+				if let Some(r) = res {
+					let result_inner_i128: i128 =
+						r.into_inner().try_into().unwrap_or(Default::default());
+					let result_inner_big = BigInt::from(result_inner_i128);
+
+					assert_eq!(
+						result_inner_big,
+						expected_inner_big,
+						"CheckedSub result mismatch for {:?}, op: {:?}, v1: {}, v2: {}",
+						core::any::type_name::<F>(),
+						op,
+						v1,
+						v2
+					);
+				}
+			}
+		},
+		Operation::CheckedMul => {
+			let res = fp1.checked_mul(&fp2);
+			let fp1_inner_i128: i128 = fp1.into_inner().try_into().unwrap_or(Default::default());
+			let fp2_inner_i128: i128 = fp2.into_inner().try_into().unwrap_or(Default::default());
+			let fp1_inner_big = BigInt::from(fp1_inner_i128);
+			let fp2_inner_big = BigInt::from(fp2_inner_i128);
+			let expected_inner_big = (fp1_inner_big * fp2_inner_big) / &div_big;
+
+			if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+				assert!(
+					res.is_none(),
+					"Expected None for CheckedMul overflow/underflow for {:?}, op: {:?}, v1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					v1,
+					v2
+				);
+			} else {
+				// If no overflow, it should succeed. The actual comparison of value is tricky due
+				// to rounding. For now, just check if it's Some when expected. A more precise check
+				// would involve replicating the internal rounding logic.
+			}
+		},
+		Operation::CheckedDiv => {
+			if fp2.is_zero() {
+				assert_eq!(
+					fp1.checked_div(&fp2),
+					None,
+					"Expected None for CheckedDiv by zero for {:?}, op: {:?}, v1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					v1,
+					v2
+				);
+			} else {
+				let res = fp1.checked_div(&fp2);
+				let fp1_inner_i128: i128 =
+					fp1.into_inner().try_into().unwrap_or(Default::default());
+				let fp2_inner_i128: i128 =
+					fp2.into_inner().try_into().unwrap_or(Default::default());
+				let fp1_inner_big = BigInt::from(fp1_inner_i128);
+				let fp2_inner_big = BigInt::from(fp2_inner_i128);
+				let expected_inner_big = (fp1_inner_big * &div_big) / fp2_inner_big;
+
+				if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+					assert!(
+						res.is_none(),
+						"Expected None for CheckedDiv overflow/underflow for {:?}, op: {:?}, v1: {}, v2: {}",
+						core::any::type_name::<F>(),
+						op,
+						v1,
+						v2
+					);
+				} else {
+					// Similar to CheckedMul, precise value checking is hard due to rounding.
+					// At least checking if it's Some when expected. To improve in the future.
+				}
+			}
+		},
+		Operation::CheckedFromInteger => {
+			match F::Inner::try_from(v1) {
+				Ok(inner_v1) => {
+					let res = F::checked_from_integer(inner_v1);
+					let v1_big = BigInt::from(v1);
+					let expected_inner_big = v1_big * &div_big;
+
+					if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+						assert!(
+							res.is_none(),
+							"Expected None for CheckedFromInteger overflow for {:?}, op: {:?}, v1: {}",
+							core::any::type_name::<F>(),
+							op,
+							v1
+						);
+					} else {
+						assert!(
+							res.is_some(),
+							"Expected Some for CheckedFromInteger for {:?}, op: {:?}, v1: {}",
+							core::any::type_name::<F>(),
+							op,
+							v1
+						);
+
+						if let Some(r) = res {
+							let result_inner_i128: i128 =
+								r.into_inner().try_into().unwrap_or(Default::default());
+							let result_inner_big = BigInt::from(result_inner_i128);
+							// `expected_inner_big` might differ slightly due to potential
+							// intermediate rounding differences between BigInt and the
+							// actual implementation. A tolerance might be needed for a
+							// perfect check, but this is a good start.
+							assert_eq!(
+								result_inner_big,
+								expected_inner_big,
+								"CheckedFromInteger result mismatch for {:?}, op: {:?}, v1: {}",
+								core::any::type_name::<F>(),
+								op,
+								v1
+							);
+						}
+					}
+				},
+				Err(_) => {
+					// If v1 doesn't fit in F::Inner, then checked_from_integer(v1) would
+					// conceptually overflow. We expect checked_from_integer to handle this,
+					// likely returning None. However, we can't call it directly. We assume the
+					// conceptual result is None. We can't easily assert anything about
+					// F::checked_from_integer itself here. This case highlights limitations of
+					// fuzzing across incompatible types.
+				},
+			}
+		},
+		Operation::CheckedFromRational => {
+			let n = v1;
+			let d = v2;
+			let res = F::checked_from_rational(n, d);
+
+			if d == 0 {
+				assert_eq!(
+					res,
+					None,
+					"Expected None for CheckedFromRational with d=0 for {:?}, op: {:?}, n: {}, d: {}",
+					core::any::type_name::<F>(),
+					op,
+					n,
+					d
+				);
+			} else {
+				let n_big = BigInt::from(n);
+				let d_big = BigInt::from(d);
+				let expected_inner_big = (n_big * &div_big) / d_big;
+				if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+					assert!(
+						res.is_none(),
+						"Expected None for CheckedFromRational overflow for {:?}, op: {:?}, n: {}, d: {}",
+						core::any::type_name::<F>(),
+						op,
+						n,
+						d
+					);
+				} else {
+					// Similar to CheckedMul, precise value checking is hard due to rounding.
+					// At least checking if it's Some when expected. To improve in the future.
+				}
+			}
+		},
+		Operation::CheckedMulInt => {
+			let res = fp1.checked_mul_int(v2);
+			let fp1_inner_i128: i128 = fp1.into_inner().try_into().unwrap_or(Default::default());
+			let fp1_inner_big = BigInt::from(fp1_inner_i128);
+			let v2_big = BigInt::from(v2);
+			let expected_int_val_big = (fp1_inner_big * v2_big) / &div_big;
+
+			if expected_int_val_big > BigInt::from(i128::MAX) ||
+				expected_int_val_big < BigInt::from(i128::MIN)
+			{
+				assert!(
+					res.is_none(),
+					"Expected None for CheckedMulInt overflow for {:?}, op: {:?}, fp1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					fp1,
+					v2
+				);
+			} else {
+				// Similar to CheckedMul, precise value checking is hard due to rounding.
+				// At least checking if it's Some when expected. To improve in the future.
+			}
+		},
+		Operation::CheckedDivInt => {
+			let res = fp1.checked_div_int(v2);
+			let fp1_inner_i128: i128 = fp1.into_inner().try_into().unwrap_or(Default::default());
+			let fp1_inner_big = BigInt::from(fp1_inner_i128);
+			let v2_big = BigInt::from(v2);
+			let expected_int_val_big = (&fp1_inner_big / &div_big) / v2_big;
+
+			if expected_int_val_big > BigInt::from(i128::MAX) ||
+				expected_int_val_big < BigInt::from(i128::MIN)
+			{
+				assert!(
+					res.is_none(),
+					"Expected None for CheckedDivInt overflow for {:?}, op: {:?}, fp1: {}, v2: {}",
+					core::any::type_name::<F>(),
+					op,
+					fp1,
+					v2
+				);
+			} else {
+				// Similar to CheckedMul, precise value checking is hard due to rounding/truncation.
+				// At least checking if it's Some when expected. To improve in the future.
+			}
+		},
+		Operation::CheckedSqrt => {
+			let res = fp1.checked_sqrt();
+			if fp1.is_negative() {
+				assert!(
+					res.is_none(),
+					"Expected None for CheckedSqrt of negative for {:?}, op: {:?}, fp1: {}",
+					core::any::type_name::<F>(),
+					op,
+					fp1
+				);
+			} else {
+				// Expected val: sqrt(fp1.inner * DIV) / DIV
+				//
+				// This is complex to verify perfectly due to integer sqrt and precision.
+				// For now, just ensure it's Some for non-negative, non-overflowing cases.
+				//
+				// In the future, an overflow check could be:
+				//   if fp1.inner * DIV overflows u128
+				// or
+				//   if result overflows
+				//
+				// At least checking if it's negative when unexpected. To improve in the future.
+			}
+		},
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/fixed_rounding_ops.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/fixed_rounding_ops.rs
@@ -1,0 +1,312 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run fixed_rounding_ops`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug fixed_rounding_ops hfuzz_workspace/fixed_rounding_ops/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use honggfuzz::fuzz;
+use num_bigint::BigInt;
+use sp_arithmetic::{
+	traits::{Bounded, One, Saturating, Zero},
+	FixedI128, FixedI64, FixedPointNumber, FixedU128, FixedU64, SignedRounding,
+	SignedRounding::*,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum FixedTypeSelector {
+	I64,
+	U64,
+	I128,
+	U128,
+}
+
+impl arbitrary::Arbitrary<'_> for FixedTypeSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=3)? {
+			0 => FixedTypeSelector::I64,
+			1 => FixedTypeSelector::U64,
+			2 => FixedTypeSelector::I128,
+			3 => FixedTypeSelector::U128,
+			_ => unreachable!(),
+		})
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ArbitrarySignedRounding(SignedRounding);
+
+impl arbitrary::Arbitrary<'_> for ArbitrarySignedRounding {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(Self(match u.int_in_range(0..=7)? {
+			0 => High,
+			1 => Low,
+			2 => NearestPrefHigh,
+			3 => NearestPrefLow,
+			4 => Major,
+			5 => Minor,
+			6 => NearestPrefMajor,
+			7 => NearestPrefMinor,
+			_ => unreachable!(),
+		}))
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RoundingOperationSelector {
+	Mul,
+	Div,
+}
+
+impl arbitrary::Arbitrary<'_> for RoundingOperationSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=1)? {
+			0 => RoundingOperationSelector::Mul,
+			1 => RoundingOperationSelector::Div,
+			_ => unreachable!(),
+		})
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (
+			i128,
+			i128,
+			FixedTypeSelector,
+			ArbitrarySignedRounding,
+			RoundingOperationSelector,
+		)| {
+			let (v1, v2, type_selector, arb_rounding, op_selector) = data;
+			let rounding_mode = arb_rounding.0;
+
+			match type_selector {
+				FixedTypeSelector::I64 => run_test::<FixedI64>(v1, v2, rounding_mode, op_selector),
+				FixedTypeSelector::U64 => run_test::<FixedU64>(v1, v2, rounding_mode, op_selector),
+				FixedTypeSelector::I128 =>
+					run_test::<FixedI128>(v1, v2, rounding_mode, op_selector),
+				FixedTypeSelector::U128 =>
+					run_test::<FixedU128>(v1, v2, rounding_mode, op_selector),
+			}
+		});
+	}
+}
+
+// Helper trait to access the const checked methods, as they are not on FixedPointNumber
+trait ConstCheckedRoundingOps<Rhs> {
+	fn const_checked_mul_with_rounding(&self, other: Rhs, rounding: SignedRounding) -> Option<Self>
+	where
+		Self: Sized;
+	fn checked_rounding_div(&self, other: Rhs, rounding: SignedRounding) -> Option<Self>
+	where
+		Self: Sized;
+}
+
+impl ConstCheckedRoundingOps<FixedI64> for FixedI64 {
+	fn const_checked_mul_with_rounding(
+		&self,
+		other: FixedI64,
+		rounding: SignedRounding,
+	) -> Option<Self> {
+		FixedI64::const_checked_mul_with_rounding(*self, other, rounding)
+	}
+	fn checked_rounding_div(&self, other: FixedI64, rounding: SignedRounding) -> Option<Self> {
+		FixedI64::checked_rounding_div(*self, other, rounding)
+	}
+}
+
+impl ConstCheckedRoundingOps<FixedU64> for FixedU64 {
+	fn const_checked_mul_with_rounding(
+		&self,
+		other: FixedU64,
+		rounding: SignedRounding,
+	) -> Option<Self> {
+		FixedU64::const_checked_mul_with_rounding(*self, other, rounding)
+	}
+	fn checked_rounding_div(&self, other: FixedU64, rounding: SignedRounding) -> Option<Self> {
+		FixedU64::checked_rounding_div(*self, other, rounding)
+	}
+}
+
+impl ConstCheckedRoundingOps<FixedI128> for FixedI128 {
+	fn const_checked_mul_with_rounding(
+		&self,
+		other: FixedI128,
+		rounding: SignedRounding,
+	) -> Option<Self> {
+		FixedI128::const_checked_mul_with_rounding(*self, other, rounding)
+	}
+	fn checked_rounding_div(&self, other: FixedI128, rounding: SignedRounding) -> Option<Self> {
+		FixedI128::checked_rounding_div(*self, other, rounding)
+	}
+}
+
+impl ConstCheckedRoundingOps<FixedU128> for FixedU128 {
+	fn const_checked_mul_with_rounding(
+		&self,
+		other: FixedU128,
+		rounding: SignedRounding,
+	) -> Option<Self> {
+		FixedU128::const_checked_mul_with_rounding(*self, other, rounding)
+	}
+	fn checked_rounding_div(&self, other: FixedU128, rounding: SignedRounding) -> Option<Self> {
+		FixedU128::checked_rounding_div(*self, other, rounding)
+	}
+}
+
+trait AbsExt {
+	fn abs_ext(self) -> Self;
+}
+impl AbsExt for i64 {
+	fn abs_ext(self) -> Self {
+		i64::saturating_abs(self)
+	}
+}
+impl AbsExt for u64 {
+	fn abs_ext(self) -> Self {
+		self
+	}
+}
+impl AbsExt for i128 {
+	fn abs_ext(self) -> Self {
+		i128::saturating_abs(self)
+	}
+}
+impl AbsExt for u128 {
+	fn abs_ext(self) -> Self {
+		self
+	}
+}
+
+fn run_test<F: FixedPointNumber + core::fmt::Display>(
+	v1: i128,
+	v2: i128,
+	rounding_mode: SignedRounding,
+	op: RoundingOperationSelector,
+) where
+	F::Inner: TryInto<i128> + Default + PartialOrd + Copy + Bounded + Zero + One,
+	<F::Inner as TryInto<i128>>::Error: core::fmt::Debug,
+	F: ConstCheckedRoundingOps<F>,
+	F::Inner: AbsExt,
+{
+	let fp1 = F::saturating_from_integer(v1);
+	let fp2 = F::saturating_from_integer(v2);
+
+	match op {
+		RoundingOperationSelector::Mul => {
+			let res = fp1.const_checked_mul_with_rounding(fp2, rounding_mode);
+			let fp1_inner_big =
+				BigInt::from(fp1.into_inner().try_into().unwrap_or(Default::default()));
+			let fp2_inner_big =
+				BigInt::from(fp2.into_inner().try_into().unwrap_or(Default::default()));
+			let div_big = BigInt::from(F::DIV.try_into().unwrap_or(1i128));
+			let expected_inner_big = (fp1_inner_big * fp2_inner_big) / &div_big;
+			let max_inner_big = BigInt::from(F::Inner::max_value().try_into().unwrap_or(i128::MAX));
+			let min_inner_big = BigInt::from(F::Inner::min_value().try_into().unwrap_or(i128::MIN));
+
+			if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+				assert!(
+					res.is_none(),
+					"Expected None for Mul overflow. fp1={}, fp2={}, rounding={:?}",
+					fp1,
+					fp2,
+					rounding_mode
+				);
+			} else {
+				if let Some(val) = res {
+					let default_res = fp1.checked_mul(&fp2);
+					if let Some(default_val) = default_res {
+						let inner_diff =
+							val.into_inner().saturating_sub(default_val.into_inner()).abs_ext();
+						assert!(
+							inner_diff <= F::Inner::one(),
+							"Mul rounding diff > 1 epsilon. fp1={}, fp2={}, rounding={:?}, default_res={:?}, specific_res={:?}",
+							fp1,
+							fp2,
+							rounding_mode,
+							default_val,
+							val);
+					}
+				}
+
+				// More precise checks could be added here based on rounding mode properties
+			}
+		},
+		RoundingOperationSelector::Div => {
+			if fp2.is_zero() {
+				assert_eq!(
+					fp1.checked_rounding_div(fp2, rounding_mode),
+					None,
+					"Expected None for Div by zero. fp1={}, fp2={}, rounding={:?}",
+					fp1,
+					fp2,
+					rounding_mode
+				);
+			} else {
+				let res = fp1.checked_rounding_div(fp2, rounding_mode);
+				let fp1_inner_big =
+					BigInt::from(fp1.into_inner().try_into().unwrap_or(Default::default()));
+				let fp2_inner_big =
+					BigInt::from(fp2.into_inner().try_into().unwrap_or(Default::default()));
+				let div_big = BigInt::from(F::DIV.try_into().unwrap_or(1i128));
+				let expected_inner_big = (fp1_inner_big * &div_big) / fp2_inner_big;
+				let max_inner_big =
+					BigInt::from(F::Inner::max_value().try_into().unwrap_or(i128::MAX));
+				let min_inner_big =
+					BigInt::from(F::Inner::min_value().try_into().unwrap_or(i128::MIN));
+
+				if expected_inner_big > max_inner_big || expected_inner_big < min_inner_big {
+					assert!(
+						res.is_none(),
+						"Expected None for Div overflow. fp1={}, fp2={}, rounding={:?}",
+						fp1,
+						fp2,
+						rounding_mode
+					);
+				} else {
+					if let Some(val) = res {
+						let default_res = fp1.checked_div(&fp2);
+						if let Some(default_val) = default_res {
+							let inner_diff =
+								val.into_inner().saturating_sub(default_val.into_inner()).abs_ext();
+							assert!(
+								inner_diff <= F::Inner::one(),
+								"Div rounding diff > 1 epsilon. fp1={}, fp2={}, rounding={:?}, default_res={:?}, specific_res={:?}",
+								fp1,
+								fp2,
+								rounding_mode,
+								default_val,
+								val
+							);
+						}
+					}
+
+					// More precise checks could be added here based on rounding mode properties
+				}
+			}
+		},
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/fixed_to_perbill.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/fixed_to_perbill.rs
@@ -1,0 +1,135 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run fixed_to_perbill`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug fixed_to_perbill hfuzz_workspace/fixed_to_perbill/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use honggfuzz::fuzz;
+use sp_arithmetic::{
+	traits::{One, Zero},
+	ArithmeticError, FixedI128, FixedI64, FixedPointNumber, FixedU128, FixedU64, Perbill,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum FixedTypeSelector {
+	I64,
+	U64,
+	I128,
+	U128,
+}
+
+impl arbitrary::Arbitrary<'_> for FixedTypeSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=3)? {
+			0 => FixedTypeSelector::I64,
+			1 => FixedTypeSelector::U64,
+			2 => FixedTypeSelector::I128,
+			3 => FixedTypeSelector::U128,
+			_ => unreachable!(),
+		})
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (i128, FixedTypeSelector)| {
+			let (val1_i128, type_selector) = data;
+
+			match type_selector {
+				FixedTypeSelector::I64 => run_test::<FixedI64>(val1_i128),
+				FixedTypeSelector::U64 => run_test::<FixedU64>(val1_i128),
+				FixedTypeSelector::I128 => run_test::<FixedI128>(val1_i128),
+				FixedTypeSelector::U128 => run_test::<FixedU128>(val1_i128),
+			}
+		});
+	}
+}
+
+// Need a helper trait because try_into_perbill is not on FixedPointNumber
+trait TryIntoPerbillHelper: FixedPointNumber + Sized {
+	fn try_into_perbill_inherent(self) -> Result<Perbill, ArithmeticError>;
+}
+
+impl TryIntoPerbillHelper for FixedI64 {
+	fn try_into_perbill_inherent(self) -> Result<Perbill, ArithmeticError> {
+		self.try_into_perbill()
+	}
+}
+
+impl TryIntoPerbillHelper for FixedU64 {
+	fn try_into_perbill_inherent(self) -> Result<Perbill, ArithmeticError> {
+		self.try_into_perbill()
+	}
+}
+
+impl TryIntoPerbillHelper for FixedI128 {
+	fn try_into_perbill_inherent(self) -> Result<Perbill, ArithmeticError> {
+		self.try_into_perbill()
+	}
+}
+
+impl TryIntoPerbillHelper for FixedU128 {
+	fn try_into_perbill_inherent(self) -> Result<Perbill, ArithmeticError> {
+		self.try_into_perbill()
+	}
+}
+
+fn run_test<F: FixedPointNumber + core::fmt::Display + TryIntoPerbillHelper>(v1: i128)
+where
+	F::Inner: PartialOrd + Copy + Zero + One,
+{
+	let fp1 = F::saturating_from_integer(v1);
+	let res = fp1.try_into_perbill_inherent();
+
+	if fp1 < F::zero() {
+		assert_eq!(res, Ok(Perbill::zero()), "try_into_perbill failed for negative. fp1={}", fp1);
+	} else if fp1 >= F::one() {
+		assert_eq!(res, Ok(Perbill::one()), "try_into_perbill failed for >= 1. fp1={}", fp1);
+	} else {
+		match res {
+			Ok(pb) => {
+				// Basic check: result should be <= Perbill::one()
+				assert!(
+					pb <= Perbill::one(),
+					"try_into_perbill result > 1. fp1={}, res={:?}",
+					fp1,
+					pb
+				);
+			},
+			Err(e) => {
+				// This error should only happen if the internal multiply_by_rational overflows,
+				// even though the conceptual value is between 0 and 1.
+				assert_eq!(
+					e,
+					ArithmeticError::Overflow,
+					"try_into_perbill unexpected error. fp1={}",
+					fp1
+				);
+			},
+		}
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/fixed_to_perthing.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/fixed_to_perthing.rs
@@ -1,0 +1,200 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run fixed_to_perthing`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug fixed_to_perthing hfuzz_workspace/fixed_to_perthing/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use core::convert::TryInto;
+use honggfuzz::fuzz;
+use sp_arithmetic::{
+	traits::{Bounded, One, Zero},
+	FixedI128, FixedI64, FixedPointNumber, FixedU128, FixedU64, PerThing, PerU16, Perbill, Percent,
+	Permill, Perquintill, Rounding,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum FixedTypeSelector {
+	I64,
+	U64,
+	I128,
+	U128,
+}
+
+impl arbitrary::Arbitrary<'_> for FixedTypeSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=3)? {
+			0 => FixedTypeSelector::I64,
+			1 => FixedTypeSelector::U64,
+			2 => FixedTypeSelector::I128,
+			3 => FixedTypeSelector::U128,
+			_ => unreachable!(),
+		})
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PerThingTypeSelector {
+	Percent,
+	Permill,
+	Perbill,
+	PerU16,
+	Perquintill,
+}
+
+impl arbitrary::Arbitrary<'_> for PerThingTypeSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=4)? {
+			0 => PerThingTypeSelector::Percent,
+			1 => PerThingTypeSelector::Permill,
+			2 => PerThingTypeSelector::Perbill,
+			3 => PerThingTypeSelector::PerU16,
+			4 => PerThingTypeSelector::Perquintill,
+			_ => unreachable!(),
+		})
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (i128, FixedTypeSelector, PerThingTypeSelector)| {
+			let (val1_i128, fixed_type_selector, per_thing_selector) = data;
+
+			match fixed_type_selector {
+				FixedTypeSelector::I64 => run_test::<FixedI64>(val1_i128, per_thing_selector),
+				FixedTypeSelector::U64 => run_test::<FixedU64>(val1_i128, per_thing_selector),
+				FixedTypeSelector::I128 => run_test::<FixedI128>(val1_i128, per_thing_selector),
+				FixedTypeSelector::U128 => run_test::<FixedU128>(val1_i128, per_thing_selector),
+			}
+		});
+	}
+}
+
+// Need a helper trait because try_into_perthing is not on FixedPointNumber
+trait TryIntoPerThingHelper: FixedPointNumber + Sized {
+	fn try_into_perthing_inherent<P: PerThing>(self) -> Result<P, P>
+	where
+		Self::Inner: TryInto<u128>,
+		<Self::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+		u128: TryInto<P::Inner> + TryInto<P::Upper>,
+		P::Inner: Into<u128>;
+}
+
+impl TryIntoPerThingHelper for FixedI64 {
+	fn try_into_perthing_inherent<P: PerThing>(self) -> Result<P, P>
+	where
+		Self::Inner: TryInto<u128>,
+		<Self::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+		u128: TryInto<P::Inner> + TryInto<P::Upper>,
+		P::Inner: Into<u128>,
+	{
+		self.try_into_perthing::<P>()
+	}
+}
+
+impl TryIntoPerThingHelper for FixedU64 {
+	fn try_into_perthing_inherent<P: PerThing>(self) -> Result<P, P>
+	where
+		Self::Inner: TryInto<u128>,
+		<Self::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+		u128: TryInto<P::Inner> + TryInto<P::Upper>,
+		P::Inner: Into<u128>,
+	{
+		self.try_into_perthing::<P>()
+	}
+}
+
+impl TryIntoPerThingHelper for FixedI128 {
+	fn try_into_perthing_inherent<P: PerThing>(self) -> Result<P, P>
+	where
+		Self::Inner: TryInto<u128>,
+		<Self::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+		u128: TryInto<P::Inner> + TryInto<P::Upper>,
+		P::Inner: Into<u128>,
+	{
+		self.try_into_perthing::<P>()
+	}
+}
+
+impl TryIntoPerThingHelper for FixedU128 {
+	fn try_into_perthing_inherent<P: PerThing>(self) -> Result<P, P>
+	where
+		Self::Inner: TryInto<u128>,
+		<Self::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+		u128: TryInto<P::Inner> + TryInto<P::Upper>,
+		P::Inner: Into<u128>,
+	{
+		self.try_into_perthing::<P>()
+	}
+}
+
+fn run_test<F>(v1: i128, per_thing_selector: PerThingTypeSelector)
+where
+	F: FixedPointNumber + core::fmt::Display + TryIntoPerThingHelper,
+	F::Inner: TryInto<u128> + PartialOrd + Copy + Bounded + Zero + One,
+	<F::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+{
+	match per_thing_selector {
+		PerThingTypeSelector::Percent => test_conversion::<F, Percent>(v1),
+		PerThingTypeSelector::Permill => test_conversion::<F, Permill>(v1),
+		PerThingTypeSelector::Perbill => test_conversion::<F, Perbill>(v1),
+		PerThingTypeSelector::PerU16 => test_conversion::<F, PerU16>(v1),
+		PerThingTypeSelector::Perquintill => test_conversion::<F, Perquintill>(v1),
+	}
+}
+
+fn test_conversion<F, P>(v1: i128)
+where
+	F: FixedPointNumber + core::fmt::Display + TryIntoPerThingHelper,
+	F::Inner: TryInto<u128> + PartialOrd + Copy + Bounded + Zero + One,
+	<F::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+	P: PerThing + Eq + core::fmt::Debug,
+	u128: TryInto<P::Inner> + TryInto<P::Upper>,
+	P::Inner: Into<u128> + PartialOrd + Copy + Zero + One,
+{
+	let fp1 = F::saturating_from_integer(v1);
+	let res = fp1.try_into_perthing_inherent::<P>();
+
+	if fp1 < F::zero() {
+		assert_eq!(res, Err(P::zero()), "try_into_perthing failed for negative. fp1={}", fp1);
+	} else if fp1 > F::one() {
+		assert_eq!(res, Err(P::one()), "try_into_perthing failed for > 1. fp1={}", fp1);
+	} else {
+		let f_inner_u128 = fp1.into_inner().try_into().unwrap_or(0);
+		let f_div_u128 = F::DIV.try_into().unwrap_or(1);
+		let expected_res = P::from_rational_with_rounding(f_inner_u128, f_div_u128, Rounding::Down);
+
+		// The P::from_rational call inside try_into_perthing might return Err(()) if
+		// the internal multiply_rational overflows. We expect our oracle `expected_res`
+		// to also return Err(()) in that case.
+		assert_eq!(
+			res.map_err(|_| ()),
+			expected_res.map_err(|_| ()),
+			"try_into_perthing mismatch. fp1={}",
+			fp1
+		);
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/fixed_utils.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/fixed_utils.rs
@@ -1,0 +1,197 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run fixed_utils`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug fixed_utils hfuzz_workspace/fixed_utils/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use core::{convert::TryInto, ops::Rem};
+use honggfuzz::fuzz;
+use sp_arithmetic::{
+	traits::{Bounded, One, Zero},
+	FixedI128, FixedI64, FixedPointNumber, FixedU128, FixedU64,
+};
+
+#[derive(Debug, Clone, Copy)]
+enum FixedTypeSelector {
+	I64,
+	U64,
+	I128,
+	U128,
+}
+
+impl arbitrary::Arbitrary<'_> for FixedTypeSelector {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=3)? {
+			0 => FixedTypeSelector::I64,
+			1 => FixedTypeSelector::U64,
+			2 => FixedTypeSelector::I128,
+			3 => FixedTypeSelector::U128,
+			_ => unreachable!(),
+		})
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FixedUtilOp {
+	Trunc,
+	Frac,
+	Ceil,
+	Floor,
+	Round,
+}
+
+impl arbitrary::Arbitrary<'_> for FixedUtilOp {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=4)? {
+			0 => FixedUtilOp::Trunc,
+			1 => FixedUtilOp::Frac,
+			2 => FixedUtilOp::Ceil,
+			3 => FixedUtilOp::Floor,
+			4 => FixedUtilOp::Round,
+			_ => unreachable!(),
+		})
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (i128, FixedTypeSelector, FixedUtilOp)| {
+			let (val1_i128, type_selector, op_selector) = data;
+
+			match type_selector {
+				FixedTypeSelector::I64 => run_test::<FixedI64>(val1_i128, op_selector),
+				FixedTypeSelector::U64 => run_test::<FixedU64>(val1_i128, op_selector),
+				FixedTypeSelector::I128 => run_test::<FixedI128>(val1_i128, op_selector),
+				FixedTypeSelector::U128 => run_test::<FixedU128>(val1_i128, op_selector),
+			}
+		});
+	}
+}
+
+fn run_test<F: FixedPointNumber + core::fmt::Display>(v1: i128, op: FixedUtilOp)
+where
+	F::Inner: TryInto<u128> + PartialOrd + Copy + Bounded + Zero + One + Rem<Output = F::Inner>,
+	<F::Inner as TryInto<u128>>::Error: core::fmt::Debug,
+{
+	let fp1 = F::saturating_from_integer(v1);
+
+	match op {
+		FixedUtilOp::Trunc => {
+			let trunc_val = fp1.trunc();
+			let is_multiple = trunc_val.into_inner() % F::DIV == F::Inner::zero();
+			assert!(
+				is_multiple,
+				"trunc() result not multiple of DIV. fp1={}, trunc={}",
+				fp1, trunc_val
+			);
+
+			let diff = fp1.saturating_sub(trunc_val).saturating_abs();
+			assert!(
+				diff < F::one(),
+				"trunc() difference >= 1.0. fp1={}, trunc={}, diff={}",
+				fp1,
+				trunc_val,
+				diff
+			);
+		},
+		FixedUtilOp::Frac => {
+			let frac_val = fp1.frac();
+			assert!(
+				frac_val >= F::zero(),
+				"frac() result negative. fp1={}, frac={}",
+				fp1,
+				frac_val
+			);
+			assert!(frac_val < F::one(), "frac() result >= 1.0. fp1={}, frac={}", fp1, frac_val);
+			assert!(fp1.trunc().frac().is_zero(), "trunc().frac() not zero. fp1={}", fp1);
+		},
+		FixedUtilOp::Ceil => {
+			let ceil_val = fp1.ceil();
+			assert!(ceil_val >= fp1, "ceil() result < input. fp1={}, ceil={}", fp1, ceil_val);
+
+			let is_multiple = ceil_val.into_inner() % F::DIV == F::Inner::zero();
+			assert!(
+				is_multiple,
+				"ceil() result not multiple of DIV. fp1={}, ceil={}",
+				fp1, ceil_val
+			);
+
+			let diff = ceil_val.saturating_sub(fp1);
+			assert!(
+				diff < F::one(),
+				"ceil() difference >= 1.0. fp1={}, ceil={}, diff={}",
+				fp1,
+				ceil_val,
+				diff
+			);
+		},
+		FixedUtilOp::Floor => {
+			let floor_val = fp1.floor();
+			assert!(floor_val <= fp1, "floor() result > input. fp1={}, floor={}", fp1, floor_val);
+
+			let is_multiple = floor_val.into_inner() % F::DIV == F::Inner::zero();
+			assert!(
+				is_multiple,
+				"floor() result not multiple of DIV. fp1={}, floor={}",
+				fp1, floor_val
+			);
+
+			let diff = fp1.saturating_sub(floor_val);
+			assert!(
+				diff < F::one(),
+				"floor() difference >= 1.0. fp1={}, floor={}, diff={}",
+				fp1,
+				floor_val,
+				diff
+			);
+		},
+		FixedUtilOp::Round => {
+			let round_val = fp1.round();
+			let is_multiple = round_val.into_inner() % F::DIV == F::Inner::zero();
+			assert!(
+				is_multiple,
+				"round() result not multiple of DIV. fp1={}, round={}",
+				fp1, round_val
+			);
+			assert!(
+				round_val == fp1.floor() || round_val == fp1.ceil(),
+				"round() not floor or ceil. fp1={}, round={}",
+				fp1,
+				round_val
+			);
+
+			let diff = fp1.saturating_sub(round_val).saturating_abs();
+			assert!(
+				diff <= F::saturating_from_rational(1, 2),
+				"round() difference > 0.5. fp1={}, round={}, diff={}",
+				fp1,
+				round_val,
+				diff
+			);
+		},
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/per_thing_checked_arith.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/per_thing_checked_arith.rs
@@ -1,0 +1,558 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run per_thing_checked_arith`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug per_thing_checked_arith hfuzz_workspace/per_thing_checked_arith/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use core::convert::{TryFrom, TryInto};
+use honggfuzz::fuzz;
+use num_bigint::BigUint;
+use num_traits::{
+	Bounded as NBounded, CheckedAdd as NCheckedAdd, CheckedDiv as NCheckedDiv,
+	CheckedMul as NCheckedMul, One as NOne, ToPrimitive, Zero as NZero,
+};
+use sp_arithmetic::{
+	ArithmeticError, PerThing, PerU16, Perbill, Percent, Permill, Perquintill, Rounding,
+	Rounding::{Down, NearestPrefDown, NearestPrefUp, Up},
+};
+
+#[derive(Debug, Clone, Copy)]
+struct ArbitraryRounding(Rounding);
+
+impl arbitrary::Arbitrary<'_> for ArbitraryRounding {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(Self(match u.int_in_range(0..=3)? {
+			0 => Up,
+			1 => NearestPrefUp,
+			2 => Down,
+			3 => NearestPrefDown,
+			_ => unreachable!(),
+		}))
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PerThingType {
+	Percent,
+	Permill,
+	Perbill,
+	PerU16,
+	Perquintill,
+}
+
+impl arbitrary::Arbitrary<'_> for PerThingType {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=4)? {
+			0 => PerThingType::Percent,
+			1 => PerThingType::Permill,
+			2 => PerThingType::Perbill,
+			3 => PerThingType::PerU16,
+			4 => PerThingType::Perquintill,
+			_ => unreachable!(),
+		})
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PerThingArithOp {
+	CheckedMulFloor,
+	CheckedMulCeil,
+	CheckedReciprocalMulFloor,
+	CheckedReciprocalMulCeil,
+	CheckedReciprocalMul,
+	CheckedSquare,
+	CheckedDivWithRounding,
+	CheckedIntDiv,
+}
+
+impl arbitrary::Arbitrary<'_> for PerThingArithOp {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=7)? {
+			0 => PerThingArithOp::CheckedMulFloor,
+			1 => PerThingArithOp::CheckedMulCeil,
+			2 => PerThingArithOp::CheckedReciprocalMulFloor,
+			3 => PerThingArithOp::CheckedReciprocalMulCeil,
+			4 => PerThingArithOp::CheckedReciprocalMul,
+			5 => PerThingArithOp::CheckedSquare,
+			6 => PerThingArithOp::CheckedDivWithRounding,
+			7 => PerThingArithOp::CheckedIntDiv,
+			_ => unreachable!(),
+		})
+	}
+}
+
+// Simulates checked_rational_mul_correction using BigUint
+fn oracle_checked_rational_mul_correction<P: PerThing>(
+	x_u64: u64,
+	numer_inner: P::Inner,
+	denom_inner: P::Inner,
+	rounding: Rounding,
+) -> Result<BigUint, ArithmeticError>
+where
+	P::Inner: Into<u128> + NZero + NOne + Copy + NBounded,
+	P::Upper: NBounded + TryFrom<BigUint> + Into<u128>,
+	<P::Upper as TryFrom<BigUint>>::Error: core::fmt::Debug,
+{
+	let zero_inner = P::Inner::zero();
+
+	if denom_inner == zero_inner {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+
+	let x_big = BigUint::from(x_u64);
+	let numer_big = BigUint::from(numer_inner.into());
+	let denom_big = BigUint::from(denom_inner.into());
+
+	if denom_big.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+
+	let rem_big = &x_big % &denom_big;
+	let rem_inner_big = rem_big;
+	let numer_upper_big = numer_big.clone();
+	let denom_upper_big = denom_big.clone();
+	let upper_max_big = BigUint::from(P::Upper::max_value().into());
+	let rem_mul_upper_big = &rem_inner_big * &numer_upper_big;
+
+	if rem_mul_upper_big > upper_max_big {
+		return Err(ArithmeticError::Overflow);
+	}
+
+	if denom_upper_big.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+
+	let rem_mul_div_upper_big = &rem_mul_upper_big / &denom_upper_big;
+	let remainder_upper_big = &rem_mul_upper_big % &denom_upper_big;
+	let inner_max_big = BigUint::from(P::Inner::max_value().into());
+	let mut correction_big = rem_mul_div_upper_big;
+	let one_big = BigUint::one();
+	let two_big = BigUint::from(2u32);
+	let threshold_big = &denom_upper_big / &two_big;
+	let tie_breaker_big = &denom_upper_big % &two_big;
+
+	match rounding {
+		Rounding::Down => {},
+		Rounding::Up =>
+			if !remainder_upper_big.is_zero() {
+				correction_big =
+					correction_big.checked_add(&one_big).ok_or(ArithmeticError::Overflow)?;
+			},
+		Rounding::NearestPrefDown =>
+			if remainder_upper_big > threshold_big {
+				correction_big =
+					correction_big.checked_add(&one_big).ok_or(ArithmeticError::Overflow)?;
+			},
+		Rounding::NearestPrefUp => {
+			let threshold_with_tie =
+				threshold_big.checked_add(&tie_breaker_big).ok_or(ArithmeticError::Overflow)?;
+			if remainder_upper_big >= threshold_with_tie {
+				correction_big =
+					correction_big.checked_add(&one_big).ok_or(ArithmeticError::Overflow)?;
+			}
+		},
+	}
+
+	if correction_big > inner_max_big {
+		return Err(ArithmeticError::Overflow);
+	}
+
+	Ok(correction_big)
+}
+
+// Simulates checked_overflow_prune_mul using BigUint
+fn oracle_checked_mul<P: PerThing>(
+	pt1: P,
+	int_operand: u64,
+	rounding: Rounding,
+) -> Result<u64, ArithmeticError>
+where
+	P::Inner: Into<u128> + NZero + NOne + Copy + NBounded + TryInto<u64>,
+	<P::Inner as TryInto<u64>>::Error: core::fmt::Debug,
+	P::Upper: NBounded + TryFrom<BigUint> + Into<u128>, // Added Into<u128>
+	<P::Upper as TryFrom<BigUint>>::Error: core::fmt::Debug,
+{
+	let accuracy_inner = P::ACCURACY;
+	let part_inner = pt1.deconstruct();
+
+	if accuracy_inner.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+
+	let accuracy_big = BigUint::from(accuracy_inner.into());
+	let part_big = BigUint::from(part_inner.into());
+	let x_big = BigUint::from(int_operand);
+
+	// Double check
+	if accuracy_big.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+	let correction_big = oracle_checked_rational_mul_correction::<P>(
+		int_operand,
+		part_inner,
+		accuracy_inner,
+		rounding,
+	)?;
+
+	let term1_big = &x_big / &accuracy_big;
+	let term2_big = term1_big.checked_mul(&part_big).ok_or(ArithmeticError::Overflow)?;
+
+	let final_result_big =
+		term2_big.checked_add(&correction_big).ok_or(ArithmeticError::Overflow)?;
+
+	final_result_big.to_u64().ok_or(ArithmeticError::Overflow)
+}
+
+// Simulates checked_saturating_reciprocal_mul using BigUint
+fn oracle_checked_reciprocal_mul<P: PerThing>(
+	pt1: P,
+	int_operand: u64,
+	rounding: Rounding,
+) -> Result<u64, ArithmeticError>
+where
+	P::Inner: Into<u128> + NZero + NOne + Copy + NBounded + TryInto<u64>,
+	<P::Inner as TryInto<u64>>::Error: core::fmt::Debug,
+	P::Upper: NBounded + TryFrom<BigUint> + Into<u128>,
+	<P::Upper as TryFrom<BigUint>>::Error: core::fmt::Debug,
+{
+	let part_inner = pt1.deconstruct();
+
+	if part_inner.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+
+	let accuracy_inner = P::ACCURACY;
+	let accuracy_big = BigUint::from(accuracy_inner.into());
+	let part_big = BigUint::from(part_inner.into());
+	let x_big = BigUint::from(int_operand);
+
+	// Double check
+	if part_big.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+
+	let correction_big = oracle_checked_rational_mul_correction::<P>(
+		int_operand,
+		accuracy_inner,
+		part_inner,
+		rounding,
+	)?;
+	let term1_big = &x_big / &part_big;
+	let term2_big = term1_big.checked_mul(&accuracy_big).ok_or(ArithmeticError::Overflow)?;
+	let final_result_big =
+		term2_big.checked_add(&correction_big).ok_or(ArithmeticError::Overflow)?;
+
+	Ok(final_result_big.to_u64().unwrap_or(u64::MAX))
+}
+
+// Simulates checked_from_rational_with_rounding using BigUint
+fn oracle_checked_from_rational_with_rounding<P: PerThing>(
+	p_big: BigUint,
+	q_big: BigUint,
+	rounding: Rounding,
+) -> Result<P, ArithmeticError>
+where
+	P::Inner: Into<u128> + NZero + NOne + Copy + NBounded + TryFrom<u128>,
+	<P::Inner as TryFrom<u128>>::Error: core::fmt::Debug,
+{
+	if q_big.is_zero() {
+		return Err(ArithmeticError::DivisionByZero);
+	}
+	if p_big > q_big {
+		return Err(ArithmeticError::Overflow);
+	}
+
+	let accuracy_big = BigUint::from(P::ACCURACY.into());
+	let inner_max_big = BigUint::from(P::Inner::max_value().into());
+	let num_intermediate = accuracy_big.checked_mul(&p_big).ok_or(ArithmeticError::Overflow)?;
+	let quotient = num_intermediate.checked_div(&q_big).ok_or(ArithmeticError::DivisionByZero)?;
+	let remainder = num_intermediate % &q_big;
+	let mut result_big = quotient;
+	let one_big = BigUint::one();
+	let two_big = BigUint::from(2u32);
+	let threshold_big = q_big.checked_div(&two_big).ok_or(ArithmeticError::Overflow)?;
+	let tie_breaker_big = q_big % &two_big;
+
+	match rounding {
+		Rounding::Down => {},
+		Rounding::Up =>
+			if !remainder.is_zero() {
+				result_big = result_big.checked_add(&one_big).ok_or(ArithmeticError::Overflow)?;
+			},
+		Rounding::NearestPrefDown =>
+			if remainder > threshold_big {
+				result_big = result_big.checked_add(&one_big).ok_or(ArithmeticError::Overflow)?;
+			},
+		Rounding::NearestPrefUp => {
+			let threshold_with_tie =
+				threshold_big.checked_add(&tie_breaker_big).ok_or(ArithmeticError::Overflow)?;
+			if remainder >= threshold_with_tie {
+				result_big = result_big.checked_add(&one_big).ok_or(ArithmeticError::Overflow)?;
+			}
+		},
+	}
+
+	if result_big > inner_max_big {
+		return Err(ArithmeticError::Overflow);
+	}
+
+	let result_inner = P::Inner::try_from(result_big.to_u128().ok_or(ArithmeticError::Overflow)?)
+		.map_err(|_| ArithmeticError::Overflow)?;
+
+	Ok(P::from_parts(result_inner))
+}
+
+// Simulates checked_square using BigUint
+fn oracle_checked_square<P: PerThing>(pt1: P) -> Result<P, ArithmeticError>
+where
+	P::Inner: Into<u128> + NZero + NOne + Copy + NBounded + TryFrom<u128>,
+	<P::Inner as TryFrom<u128>>::Error: core::fmt::Debug,
+	P::Upper: NBounded + TryFrom<BigUint> + Into<BigUint> + Copy + Into<u128>,
+	<P::Upper as TryFrom<BigUint>>::Error: core::fmt::Debug,
+{
+	let p_inner = pt1.deconstruct();
+	let q_inner = P::ACCURACY;
+	let p_upper_as_u128 = <P::Upper as Into<u128>>::into(P::Upper::from(p_inner));
+	let p_upper_big = BigUint::from(p_upper_as_u128);
+	let upper_max_big = BigUint::from(<P::Upper as Into<u128>>::into(P::Upper::max_value()));
+	let p_squared_big = p_upper_big.checked_mul(&p_upper_big).ok_or(ArithmeticError::Overflow)?;
+
+	if p_squared_big > upper_max_big {
+		return Err(ArithmeticError::Overflow);
+	}
+
+	let q_big = BigUint::from(q_inner.into());
+	let p_inner_big = BigUint::from(p_inner.into());
+	let p_inner_squared_big =
+		p_inner_big.checked_mul(&p_inner_big).ok_or(ArithmeticError::Overflow)?;
+
+	oracle_checked_from_rational_with_rounding::<P>(p_inner_squared_big, q_big, Rounding::Down)
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (
+			u64,
+			u64,
+			u64,
+			u64,
+			u64,
+			ArbitraryRounding,
+			PerThingType,
+			PerThingArithOp,
+		)| {
+			let (p1, q1, p2, q2, int_operand, arb_rounding, per_thing_type, operation) = data;
+			let rounding_mode = arb_rounding.0;
+			let safe_q1 = q1.max(1);
+			let safe_p1 = p1.min(safe_q1);
+			let safe_q2 = q2.max(1);
+			let safe_p2 = p2.min(safe_q2);
+
+			match per_thing_type {
+				PerThingType::Percent => run_test::<Percent>(
+					safe_p1,
+					safe_q1,
+					safe_p2,
+					safe_q2,
+					int_operand,
+					rounding_mode,
+					operation,
+				),
+				PerThingType::Permill => run_test::<Permill>(
+					safe_p1,
+					safe_q1,
+					safe_p2,
+					safe_q2,
+					int_operand,
+					rounding_mode,
+					operation,
+				),
+				PerThingType::Perbill => run_test::<Perbill>(
+					safe_p1,
+					safe_q1,
+					safe_p2,
+					safe_q2,
+					int_operand,
+					rounding_mode,
+					operation,
+				),
+				PerThingType::PerU16 => run_test::<PerU16>(
+					safe_p1,
+					safe_q1,
+					safe_p2,
+					safe_q2,
+					int_operand,
+					rounding_mode,
+					operation,
+				),
+				PerThingType::Perquintill => run_test::<Perquintill>(
+					safe_p1,
+					safe_q1,
+					safe_p2,
+					safe_q2,
+					int_operand,
+					rounding_mode,
+					operation,
+				),
+			}
+		});
+	}
+}
+
+fn run_test<P: PerThing>(
+	p1: u64,
+	q1: u64,
+	p2: u64,
+	q2: u64,
+	int_operand: u64,
+	rounding_mode: Rounding,
+	op: PerThingArithOp,
+) where
+	P::Inner: Into<u128>
+		+ sp_arithmetic::traits::Zero
+		+ sp_arithmetic::traits::One
+		+ PartialOrd
+		+ Copy
+		+ NBounded
+		+ TryInto<u64>
+		+ TryFrom<u128>,
+	<P::Inner as TryInto<u64>>::Error: core::fmt::Debug,
+	<P::Inner as TryFrom<u128>>::Error: core::fmt::Debug,
+	P::Upper: NBounded + TryFrom<BigUint> + Into<BigUint> + Copy + Into<u128>,
+	<P::Upper as TryFrom<BigUint>>::Error: core::fmt::Debug,
+	P: core::fmt::Debug,
+	u64: sp_arithmetic::per_things::MultiplyArg
+		+ sp_arithmetic::traits::UniqueSaturatedInto<P::Inner>
+		+ sp_arithmetic::traits::CheckedAdd
+		+ sp_arithmetic::traits::CheckedSub
+		+ sp_arithmetic::traits::CheckedMul
+		+ sp_arithmetic::traits::CheckedDiv,
+	P::Inner: Into<u64>
+		+ sp_arithmetic::traits::CheckedAdd
+		+ sp_arithmetic::traits::CheckedSub
+		+ sp_arithmetic::traits::CheckedMul
+		+ sp_arithmetic::traits::CheckedDiv,
+	P::Upper: sp_arithmetic::traits::CheckedMul<Output = P::Upper>
+		+ sp_arithmetic::traits::CheckedDiv<Output = P::Upper>
+		+ sp_arithmetic::traits::CheckedRem<Output = P::Upper>,
+	u64: sp_arithmetic::per_things::ReciprocalArg,
+{
+	let pt1 = P::from_rational_with_rounding(p1, q1, Rounding::Down).unwrap_or_else(|_| P::zero());
+	let pt2 = P::from_rational_with_rounding(p2, q2, Rounding::Down).unwrap_or_else(|_| P::zero());
+
+	match op {
+		PerThingArithOp::CheckedMulFloor => {
+			let res = pt1.checked_mul_floor(int_operand);
+			let oracle_res = oracle_checked_mul::<P>(pt1, int_operand, Rounding::Down);
+			assert_eq!(
+				res, oracle_res,
+				"CheckedMulFloor mismatch: pt1={:?}, int_operand={}, res={:?}, expected={:?}",
+				pt1, int_operand, res, oracle_res
+			);
+		},
+		PerThingArithOp::CheckedMulCeil => {
+			let res = pt1.checked_mul_ceil(int_operand);
+			let oracle_res = oracle_checked_mul::<P>(pt1, int_operand, Rounding::Up);
+			assert_eq!(
+				res, oracle_res,
+				"CheckedMulCeil mismatch: pt1={:?}, int_operand={}, res={:?}, expected={:?}",
+				pt1, int_operand, res, oracle_res
+			);
+		},
+		PerThingArithOp::CheckedReciprocalMulFloor => {
+			let res = pt1.checked_saturating_reciprocal_mul_floor(int_operand);
+			let oracle_res = oracle_checked_reciprocal_mul::<P>(pt1, int_operand, Rounding::Down);
+			assert_eq!(
+				res,
+				oracle_res,
+				"CheckedReciprocalMulFloor mismatch: pt1={:?}, int_operand={}, res={:?}, expected={:?}",
+				pt1,
+				int_operand,
+				res,
+				oracle_res
+			);
+		},
+		PerThingArithOp::CheckedReciprocalMulCeil => {
+			let res = pt1.checked_saturating_reciprocal_mul_ceil(int_operand);
+			let oracle_res = oracle_checked_reciprocal_mul::<P>(pt1, int_operand, Rounding::Up);
+			assert_eq!(
+				res,
+				oracle_res,
+				"CheckedReciprocalMulCeil mismatch: pt1={:?}, int_operand={}, res={:?}, expected={:?}",
+				pt1,
+				int_operand,
+				res,
+				oracle_res
+			);
+		},
+		PerThingArithOp::CheckedReciprocalMul => {
+			let res = pt1.checked_saturating_reciprocal_mul(int_operand);
+			let oracle_res =
+				oracle_checked_reciprocal_mul::<P>(pt1, int_operand, Rounding::NearestPrefUp);
+			assert_eq!(
+				res, oracle_res,
+				"CheckedReciprocalMul mismatch: pt1={:?}, int_operand={}, res={:?}, expected={:?}",
+				pt1, int_operand, res, oracle_res
+			);
+		},
+		PerThingArithOp::CheckedSquare => {
+			let res = pt1.checked_square();
+			let oracle_res = oracle_checked_square::<P>(pt1);
+			assert_eq!(
+				res, oracle_res,
+				"CheckedSquare mismatch: pt1={:?}, res={:?}, expected={:?}",
+				pt1, res, oracle_res
+			);
+		},
+		PerThingArithOp::CheckedDivWithRounding => {
+			let res = pt1.checked_div_with_rounding(pt2, rounding_mode);
+			let oracle_res = oracle_checked_from_rational_with_rounding::<P>(
+				BigUint::from(<P::Inner as Into<u128>>::into(pt1.deconstruct())),
+				BigUint::from(<P::Inner as Into<u128>>::into(pt2.deconstruct())),
+				rounding_mode,
+			);
+			assert_eq!(res,
+				oracle_res,
+				"CheckedDivWithRounding mismatch: pt1={:?}, pt2={:?}, rounding={:?}, res={:?}, expected={:?}",
+				pt1,
+				pt2,
+				rounding_mode,
+				res,
+				oracle_res
+			);
+		},
+		PerThingArithOp::CheckedIntDiv => {
+			let res = pt1.checked_int_div(pt2);
+			if pt2.is_zero() {
+				assert_eq!(res, Err(ArithmeticError::DivisionByZero));
+			} else {
+				let expected = pt1.deconstruct().checked_div(&pt2.deconstruct());
+				assert_eq!(res.ok(), expected);
+			}
+		},
+	}
+}

--- a/substrate/primitives/arithmetic/fuzzer/src/per_thing_checked_from_rational.rs
+++ b/substrate/primitives/arithmetic/fuzzer/src/per_thing_checked_from_rational.rs
@@ -1,0 +1,165 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Running
+//! Running this fuzzer can be done with `cargo hfuzz run per_thing_checked_from_rational`.
+//! `honggfuzz` CLI options can be used by setting `HFUZZ_RUN_ARGS`, such as `-n 4` to use 4
+//! threads.
+//!
+//! # Debugging a panic
+//! Once a panic is found, it can be debugged with
+//! `cargo hfuzz run-debug per_thing_checked_from_rational
+//! hfuzz_workspace/per_thing_checked_from_rational/*.fuzz`.
+//!
+//! # More information
+//! More information about `honggfuzz` can be found
+//! [here](https://docs.rs/honggfuzz/).
+
+use honggfuzz::fuzz;
+use sp_arithmetic::{
+	ArithmeticError, PerThing, PerU16, Perbill, Percent, Permill, Perquintill, Rounding,
+	Rounding::{Down, NearestPrefDown, NearestPrefUp, Up},
+};
+
+#[derive(Debug, Clone, Copy)]
+struct ArbitraryRounding(Rounding);
+
+impl arbitrary::Arbitrary<'_> for ArbitraryRounding {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(Self(match u.int_in_range(0..=3)? {
+			0 => Up,
+			1 => NearestPrefUp,
+			2 => Down,
+			3 => NearestPrefDown,
+			_ => unreachable!(),
+		}))
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PerThingType {
+	Percent,
+	Permill,
+	Perbill,
+	PerU16,
+	Perquintill,
+}
+
+impl arbitrary::Arbitrary<'_> for PerThingType {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+		Ok(match u.int_in_range(0..=4)? {
+			0 => PerThingType::Percent,
+			1 => PerThingType::Permill,
+			2 => PerThingType::Perbill,
+			3 => PerThingType::PerU16,
+			4 => PerThingType::Perquintill,
+			_ => unreachable!(),
+		})
+	}
+}
+
+fn main() {
+	loop {
+		fuzz!(|data: (u128, u128, ArbitraryRounding, PerThingType)| {
+			let (p_u128, q_u128, arbitrary_rounding, per_thing_type) = data;
+			let r = arbitrary_rounding.0;
+
+			// The PerThing::from_rational_with_rounding and its checked variant
+			// are generic over N for p and q. We'll use u128 for this fuzzer.
+			// If other types for N were needed, the input struct would need to change.
+			match per_thing_type {
+				PerThingType::Percent => check::<Percent>(p_u128, q_u128, r),
+				PerThingType::Permill => check::<Permill>(p_u128, q_u128, r),
+				PerThingType::Perbill => check::<Perbill>(p_u128, q_u128, r),
+				PerThingType::PerU16 => check::<PerU16>(p_u128, q_u128, r),
+				PerThingType::Perquintill => check::<Perquintill>(p_u128, q_u128, r),
+			}
+		});
+	}
+}
+
+fn check<P: PerThing>(p: u128, q: u128, r: Rounding)
+where
+	P::Inner:
+		Into<u128> + sp_arithmetic::traits::Zero + sp_arithmetic::traits::One + PartialOrd + Copy,
+	P: core::fmt::Debug,
+{
+	let checked_res = P::checked_from_rational_with_rounding(p, q, r);
+	let non_checked_res = P::from_rational_with_rounding(p, q, r);
+
+	if q == 0 {
+		assert_eq!(
+			checked_res,
+			Err(ArithmeticError::DivisionByZero),
+			"Denominator 0: checked failed. p={}, q={}, r={:?}, PerThingType: {:?}",
+			p,
+			q,
+			r,
+			core::any::type_name::<P>()
+		);
+		assert_eq!(
+			non_checked_res,
+			Err(()),
+			"Denominator 0: non-checked failed. p={}, q={}, r={:?}, PerThingType: {:?}",
+			p,
+			q,
+			r,
+			core::any::type_name::<P>()
+		);
+	} else if p > q {
+		assert_eq!(
+			checked_res,
+			Err(ArithmeticError::Overflow),
+			"p > q: checked failed. p={}, q={}, r={:?}, PerThingType: {:?}",
+			p,
+			q,
+			r,
+			core::any::type_name::<P>()
+		);
+		assert_eq!(
+			non_checked_res,
+			Err(()),
+			"p > q: non-checked failed. p={}, q={}, r={:?}, PerThingType: {:?}",
+			p,
+			q,
+			r,
+			core::any::type_name::<P>()
+		);
+	} else {
+		match non_checked_res {
+			Ok(val_non_checked) => {
+				assert_eq!(
+					checked_res.map(|v| v.deconstruct()),
+					Ok(val_non_checked.deconstruct()),
+					"Non-checked Ok, Checked Ok mismatch. p={}, q={}, r={:?}, PerThingType: {:?}",
+					p,
+					q,
+					r,
+					core::any::type_name::<P>()
+				);
+			},
+			Err(_) => {
+				assert_eq!(
+					checked_res,
+					Err(ArithmeticError::Overflow),
+					"Non-checked Err, Checked Overflow mismatch. p={}, q={}, r={:?}, PerThingType: {:?}",
+					p, q, r, core::any::type_name::<P>()
+				);
+			},
+		}
+	}
+}


### PR DESCRIPTION
# Description
This has been in my backlog for quite a while (in a simpler form, [see](https://github.com/paritytech/polkadot-sdk/pull/1936)), Finally got it in the shape I wanted for peer review and a few pair of eyes on the **TO TO/RESOLVE** pieces.

In addition to the implementation and changes, I have done a Security review on the whole sp-arithmetic crate. Once this is merged, it can be marked as audited (completely) and I am fine to review future changes in the crate to do a differential security review and maintain the status of fully audited as time goes.

## Integration
This PR adds more functions than it changes (removed nothing), once merged checked functions should be used instead of non checked ones when possible. The items in **TO TODO/RESOLVE** might introduce integration changes, I will update here once it is decided.

**IMPLEMENTED**
- `helpers_128bit.rs`:
	- Added `checked_multiply_by_rational_with_rounding`.
	- Proper use of `ArithmeticError`.
	- Added test for introduced checked versions.
- `per_things.rs`:
	- Added `checked_*` versions of `square`, `mul_floor`, `mul_ceil`, `overflow_prune_mul`, `rational_mul_correction` `saturating_reciprocal_mul`, `saturating_reciprocal_mul_floor`, `saturating_reciprocal_mul_ceil` and `from_rational_with_rounding` to the `PerThing` trait and their implementations within `implement_per_thing` the macro where it applies.
	- Added additional `checked_int_div` and `checked_div_with_rounding`.
	- Added tests for the newly `checked_*` additions in `checked_reciprocal_mul_works`, `checked_from_rational_works`, `checked_arithmetic_works` and `checked_int_div_works`.
	- Proper use of `ArithmeticError`.
	- Added test for introduced checked versions.
- `fixed_point.rs`:
	- Added `try_into_perbill` which is a checked version of `into_perbill`.
	- Added checked version of `from_rational_with_rounding`.
	- Proper use of `ArithmeticError`.
- `rational.rs`:
	- Added `checked_to_den` and `checked_lcm`.
	- Updated `checked_add` and `checked_sub` to follow the pattern of other checked versions.
	- Simplified import of `helpers_128bit`.
	- Proper use of `ArithmeticError`.
	- Added test for introduced checked versions.
- `fuzzing`:
	- `per_thing_checked_arith.rs`: Covers general `PerThing` checked arithmetic operations (`checked_mul_floor`, `checked_mul_ceil`, reciprocal multiplications, `checked_square`, `checked_div_with_rounding`, `checked_int_div`).
	- `fixed_utils.rs`: Covers `FixedPointNumber` utility functions (`trunc`, `frac`, `ceil`, `floor`, `round`).
	- `fixed_to_perbill.rs`: Covers conversions of `try_into_perbill`
	- `fixed_to_perthing.rs`: Covers conversions of `try_into_perthing`.
	- `fixed_rounding_ops.rs`: Specifically fuzzes `const_checked_mul_with_rounding` and `checked_rounding_div` for `FixedPointNumber` types, testing all 8 `SignedRounding` modes.
	- `per_thing_checked_from_rational.rs`: Covers `PerThing::checked_from_rational_with_rounding` comparing against the non-checked version and validating error handling.
	- `fixed_checked_ops.rs`: Covers core `FixedPointNumber` checked arithmetic operations (`add`, `sub`, `mul`, `div`, `from_integer`, `from_rational`, `mul_int`, `div_int`, `sqrt`) for `FixedI64`, `FixedU64`, `FixedI128`, and `FixedU128`, using `BigInt` for oracle comparisons and overflow detection.
	- `checked_mul_by_rational.rs`: Covers `helpers_128bit::checked_multiply_by_rational_with_rounding` with different rounding modes and error conditions (DivisionByZero, Overflow).

## Review Notes

I have introduced multiple checked functions in the main library where the was a risk/clarity of panic, as well as proper use of `ArithmeticError` and consistent import namespaces. The new checked functions are not complex as they should mimic the same behavior, the difference is relaying on safe functions and do not panic.

You will see in `per_thing_checked_arith.rs` an alternative approach I decided to try, and is the use of an "oracle" to tell what the *expected* outcome of an operation should be. Fuzzing is great at finding inputs that cause crashes (panics), but it doesn't inherently know if the *result* of a calculation is correct, especially for complex math. I think is important to be confident that they produce the *correct* numerical results according to mathematical rules and the specified rounding behavior.

I decided to use `BigFraction` / `BigInt` as they provide independent implementations of arbitrary-precision arithmetic, they aren't bound by the fixed precision or potential overflow limits of the `u128`, `FixedU64`, `Permill`, etc., types we are testing, I believe this would let compute most of the values with high-precision (I might be wrong and this backfires to me in the future :D ).

In older test, we test mathematical properties (like `(a/b)*b <= a` when rounding down, as seen in `per_thing_mult_fraction.rs`), this is also valuable but doesn't verify the exact output value like an oracle does which sometimes is important to test against. In `fixed_checked_ops.rs` the use of oracle paradigm is used as well, however, to properly test the behavior of each function requires more thought on the cases and vertices. I consider the tests in `fixed_checked_ops.rs` as a baseline and to be improved as time goes, left comments for future references.

**TO TODO/RESOLVE**
- `fixed_point.rs`:
	- Functions like `checked_from_rational`, `checked_mul_int`, `checked_div`, `checked_mul` can be changed to `checked_multiply_by_rational_with_rounding` version but it means changing the return from `Option<>` to `Result<>`, or keep backwards compability and wrap the `Result<>` back to `Option<>`.
		- If doing this requires fixing other parts of the SDK where the checked functions are used, I can work on doing the migration as part of the effort for this.
- `per_things.rs`:
	- Some asserts inside the `checked_reciprocal_mul_works` and `checked_arithmetic_works` fail only in PerU16 variations. I need to figure out why exactly is that happening only for this variant. This is the test output in case someone has an idea:

	```
		---- per_things::test_peru16::checked_arithmetic_works stdout ----

		thread 'per_things::test_peru16::checked_arithmetic_works' panicked at substrate/primitives/arithmetic/src/per_things.rs:2361:1:
		assertion `left == right` failed
		left: Ok(4)
		right: Ok(5)

		---- per_things::test_peru16::checked_reciprocal_mul_works stdout ----

		thread 'per_things::test_peru16::checked_reciprocal_mul_works' panicked at substrate/primitives/arithmetic/src/per_things.rs:2361:1:
		assertion `left == right` failed
		left: Ok(21)
		right: Ok(20)


		failures:
			per_things::test_peru16::checked_arithmetic_works
			per_things::test_peru16::checked_reciprocal_mul_works

	```

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
