### PR TITLE
Remove asset location check for compatibility

### DIFF
--- a/bridges/snowbridge/primitives/outbound-queue/src/v1/converter/mod.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v1/converter/mod.rs
@@ -413,9 +413,7 @@ where
 
 		let token_id = TokenIdOf::convert_location(&asset_id).ok_or(InvalidAsset)?;
 
-		let expected_asset_id = ConvertAssetId::convert(&token_id).ok_or(InvalidAsset)?;
-
-		ensure!(asset_id == expected_asset_id, InvalidAsset);
+		ConvertAssetId::convert(&token_id).ok_or(InvalidAsset)?;
 
 		// Check if there is a SetTopic and skip over it if found.
 		let topic_id = match_expression!(self.next()?, SetTopic(id), id).ok_or(SetTopicExpected)?;

--- a/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/convert.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/convert.rs
@@ -174,8 +174,7 @@ where
 
 			// Ensure PNA already registered
 			let token_id = TokenIdOf::convert_location(&asset_id).ok_or(InvalidAsset)?;
-			let expected_asset_id = ConvertAssetId::convert(&token_id).ok_or(InvalidAsset)?;
-			ensure!(asset_id == expected_asset_id, InvalidAsset);
+			ConvertAssetId::convert(&token_id).ok_or(InvalidAsset)?;
 
 			commands.push(Command::MintForeignToken { token_id, recipient, amount });
 		}


### PR DESCRIPTION


The `TokenIdOf` [convert](https://github.com/paritytech/polkadot-sdk/blob/4b83d24f4bc96a7b17964be94b178dd7b8f873b5/bridges/snowbridge/primitives/core/src/location.rs#L40) is XCM version-agnostic, meaning we will get the same token ID for both V5 and legacy V4 asset. However, the extra check will break since we store the V4 location in [storage](https://github.com/paritytech/polkadot-sdk/blob/4b83d24f4bc96a7b17964be94b178dd7b8f873b5/bridges/snowbridge/pallets/system/src/lib.rs#L540).

Therefore, we should remove this check for compatibility.