### PR TITLE
[wip] litep2p/discovery: Bump the external addresses to track to 64

### DIFF
--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -71,7 +71,7 @@ const MDNS_QUERY_INTERVAL: Duration = Duration::from_secs(30);
 const GET_RECORD_REDUNDANCY_FACTOR: usize = 4;
 
 /// The maximum number of tracked external addresses we allow.
-const MAX_EXTERNAL_ADDRESSES: u32 = 32;
+const MAX_EXTERNAL_ADDRESSES: u32 = 64;
 
 /// Number of times observed address is received from different peers before it is confirmed as
 /// external.


### PR DESCRIPTION
This PR bumps the number of tracked external addresses we allow from 32 to 64.

This is in response to the increased stored addresses in LiteP2P Kademlia to 32 (from a lower number of just a few that would get overwritten).

cc: https://github.com/paritytech/polkadot-sdk/issues/8474
 