### PR TITLE
Use correct polkadot repository

### DIFF
--- a/polkadot/scripts/packaging/polkadot.service
+++ b/polkadot/scripts/packaging/polkadot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Polkadot Node
 After=network.target
-Documentation=https://github.com/paritytech/polkadot
+Documentation=https://github.com/paritytech/polkadot-sdk
 
 [Service]
 EnvironmentFile=-/etc/default/polkadot


### PR DESCRIPTION
The link provided in the `Documentation` argument, leads to the old repository that is on `read-only` state
