### PR TITLE
cumulus/fix: Allow block-announce to exist in the background of minimal relay chains

### DIFF
--- a/cumulus/client/relay-chain-minimal-node/src/network.rs
+++ b/cumulus/client/relay-chain-minimal-node/src/network.rs
@@ -44,7 +44,7 @@ pub(crate) fn build_collator_network<Network: NetworkBackend<Block, Hash>>(
 	notification_metrics: NotificationMetrics,
 ) -> Result<(Arc<dyn NetworkService>, Arc<dyn sp_consensus::SyncOracle + Send + Sync>), Error> {
 	let protocol_id = config.protocol_id();
-	let (block_announce_config, _notification_service) = get_block_announce_proto_config::<Network>(
+	let (block_announce_config, notification_service) = get_block_announce_proto_config::<Network>(
 		protocol_id.clone(),
 		&None,
 		Roles::from(&config.role),
@@ -90,7 +90,21 @@ pub(crate) fn build_collator_network<Network: NetworkBackend<Block, Hash>>(
 	// issue, and ideally we would like to fix the network future to take as little time as
 	// possible, but we also take the extra harm-prevention measure to execute the networking
 	// future using `spawn_blocking`.
-	spawn_handle.spawn_blocking("network-worker", Some("networking"), network_worker.run());
+	spawn_handle.spawn_blocking("network-worker", Some("networking"), async move {
+		// The notification service must be kept alive to allow litep2p to handle
+		// requests under the hood. It has been noted that without the notification
+		// service of the `/block-announces/1` protocol, collators are not advertised
+		// and their produced blocks do not propagate:
+		// https://github.com/paritytech/polkadot-sdk/issues/8474
+		//
+		// This is because the full nodes on the relay chain will attempt to establish
+		// a connection to the minimal relay chain. By dropping the notification service,
+		// litep2p would terminate the background task which handles the `/block-announces/1`
+		// notification protocol. The downstream effect of this is that the full node
+		// would ban and disconnect the the minimal relay chain node.
+		let _notification_service = notification_service;
+		network_worker.run().await;
+	});
 
 	Ok((network_service, Arc::new(SyncOracle {})))
 }

--- a/prdoc/pr_8514.prdoc
+++ b/prdoc/pr_8514.prdoc
@@ -1,0 +1,15 @@
+title: Allow block-announce to exist in the background of minimal relay chains
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      This PR fixes an issue with the collators that would not get advertised.
+      The issue relates to the /block-announces/1 protocol for the litep2p network backends.
+      Previously, the notification service handle was dropped, causing the litep2p backend to
+      terminate the long-running task that handled the /block-announces/1 protocol.
+      This represents a subtle difference between libp2p and litep2p, where libp2p would continue
+      to operate the protocol under the hood even without the respective handle.
+
+crates:
+  - name: sc-network
+    bump: minor

--- a/prdoc/pr_8514.prdoc
+++ b/prdoc/pr_8514.prdoc
@@ -11,5 +11,5 @@ doc:
       to operate the protocol under the hood even without the respective handle.
 
 crates:
-  - name: sc-network
+  - name: cumulus-relay-chain-minimal-node
     bump: minor


### PR DESCRIPTION
This PR fixes an issue with the collators that would not get advertised.

The issue relates to the `/block-announces/1` protocol for the litep2p network backends. 
Previously, the notification service handle was dropped, causing the litep2p backend to terminate the long-running task that handled the `/block-announces/1` protocol. This represents a subtle difference between libp2p and litep2p, where libp2p would continue to operate the protocol under the hood even without the respective handle:

```
// Logs extracted from the libp2p node showing that 
sub-libp2p::notification::service: [Relaychain] /b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe/block-announces/1: notification received from PeerId("12D3KooWBjWQRpVLUWMUuDVcYEDokuReQHMxqMJrrHjwTve2CGhG")
```

The downstream effect of stopping the notification protocol is that full nodes that attempt to negotiate the protocol would disconnect and ban minimal relay chain nodes that do not handle the process. This cascades into the ability of the collators to advertise blocks: 

```
[Parachain] Authority Discovery couldn't resolve Public(70c2e207db27de34e4aff1dcf370419e575e7712bda507b9ca8e3bd1ddf8bf6e (5EcZ7UwY...))

parachain::validator-discovery: [Parachain] New ConnectToValidators request peer_set=Collation requested=5 failed_to_resolve=5
```
## Testing Done

The CPU is still reduced from 7.5% to 1.87%:
![Screenshot 2025-05-13 at 18 30 37](https://github.com/user-attachments/assets/2d75fad9-71a2-4806-91c7-ac17aad2f77b)

Thanks to @paulormart for confirming the fix 🙏 

Closes: https://github.com/paritytech/polkadot-sdk/issues/8474