### PR TITLE
FeeTracker: remove `get_min_fee_factor()`

### DIFF
--- a/bridges/modules/xcm-bridge-hub-router/src/benchmarking.rs
+++ b/bridges/modules/xcm-bridge-hub-router/src/benchmarking.rs
@@ -22,7 +22,7 @@ use crate::{Bridge, BridgeState, Call};
 use frame_benchmarking::{benchmarks_instance_pallet, BenchmarkError};
 use frame_support::traits::{EnsureOrigin, Get, Hooks, UnfilteredDispatchable};
 use polkadot_runtime_parachains::FeeTracker;
-use sp_runtime::traits::Zero;
+use sp_runtime::{traits::Zero, Saturating};
 use xcm::prelude::*;
 
 /// Pallet we're benchmarking here.
@@ -48,7 +48,7 @@ benchmarks_instance_pallet! {
 	on_initialize_when_non_congested {
 		Bridge::<T, I>::put(BridgeState {
 			is_congested: false,
-			delivery_fee_factor: crate::Pallet::<T, I>::MIN_FEE_FACTOR.mul(2.into()),
+			delivery_fee_factor: crate::Pallet::<T, I>::MIN_FEE_FACTOR.saturating_mul(2.into()),
 		});
 	}: {
 		crate::Pallet::<T, I>::on_initialize(Zero::zero())
@@ -57,7 +57,7 @@ benchmarks_instance_pallet! {
 	on_initialize_when_congested {
 		Bridge::<T, I>::put(BridgeState {
 			is_congested: false,
-			delivery_fee_factor: crate::Pallet::<T, I>::MIN_FEE_FACTOR.mul(2.into()),
+			delivery_fee_factor: crate::Pallet::<T, I>::MIN_FEE_FACTOR.saturating_mul(2.into()),
 		});
 		let _ = T::ensure_bridged_target_destination()?;
 		T::make_congested();

--- a/bridges/modules/xcm-bridge-hub-router/src/benchmarking.rs
+++ b/bridges/modules/xcm-bridge-hub-router/src/benchmarking.rs
@@ -18,9 +18,10 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use crate::{Bridge, BridgeState, Call, MINIMAL_DELIVERY_FEE_FACTOR};
+use crate::{Bridge, BridgeState, Call};
 use frame_benchmarking::{benchmarks_instance_pallet, BenchmarkError};
 use frame_support::traits::{EnsureOrigin, Get, Hooks, UnfilteredDispatchable};
+use polkadot_runtime_parachains::MIN_FEE_FACTOR;
 use sp_runtime::traits::Zero;
 use xcm::prelude::*;
 
@@ -47,7 +48,7 @@ benchmarks_instance_pallet! {
 	on_initialize_when_non_congested {
 		Bridge::<T, I>::put(BridgeState {
 			is_congested: false,
-			delivery_fee_factor: MINIMAL_DELIVERY_FEE_FACTOR + MINIMAL_DELIVERY_FEE_FACTOR,
+			delivery_fee_factor: MIN_FEE_FACTOR + MIN_FEE_FACTOR,
 		});
 	}: {
 		crate::Pallet::<T, I>::on_initialize(Zero::zero())
@@ -56,7 +57,7 @@ benchmarks_instance_pallet! {
 	on_initialize_when_congested {
 		Bridge::<T, I>::put(BridgeState {
 			is_congested: false,
-			delivery_fee_factor: MINIMAL_DELIVERY_FEE_FACTOR + MINIMAL_DELIVERY_FEE_FACTOR,
+			delivery_fee_factor: MIN_FEE_FACTOR + MIN_FEE_FACTOR,
 		});
 		let _ = T::ensure_bridged_target_destination()?;
 		T::make_congested();

--- a/bridges/modules/xcm-bridge-hub-router/src/benchmarking.rs
+++ b/bridges/modules/xcm-bridge-hub-router/src/benchmarking.rs
@@ -21,7 +21,7 @@
 use crate::{Bridge, BridgeState, Call};
 use frame_benchmarking::{benchmarks_instance_pallet, BenchmarkError};
 use frame_support::traits::{EnsureOrigin, Get, Hooks, UnfilteredDispatchable};
-use polkadot_runtime_parachains::MIN_FEE_FACTOR;
+use polkadot_runtime_parachains::FeeTracker;
 use sp_runtime::traits::Zero;
 use xcm::prelude::*;
 
@@ -48,7 +48,7 @@ benchmarks_instance_pallet! {
 	on_initialize_when_non_congested {
 		Bridge::<T, I>::put(BridgeState {
 			is_congested: false,
-			delivery_fee_factor: MIN_FEE_FACTOR + MIN_FEE_FACTOR,
+			delivery_fee_factor: crate::Pallet::<T, I>::MIN_FEE_FACTOR.mul(2.into()),
 		});
 	}: {
 		crate::Pallet::<T, I>::on_initialize(Zero::zero())
@@ -57,7 +57,7 @@ benchmarks_instance_pallet! {
 	on_initialize_when_congested {
 		Bridge::<T, I>::put(BridgeState {
 			is_congested: false,
-			delivery_fee_factor: MIN_FEE_FACTOR + MIN_FEE_FACTOR,
+			delivery_fee_factor: crate::Pallet::<T, I>::MIN_FEE_FACTOR.mul(2.into()),
 		});
 		let _ = T::ensure_bridged_target_destination()?;
 		T::make_congested();

--- a/bridges/modules/xcm-bridge-hub-router/src/lib.rs
+++ b/bridges/modules/xcm-bridge-hub-router/src/lib.rs
@@ -30,6 +30,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use bp_xcm_bridge_hub_router::MINIMAL_DELIVERY_FEE_FACTOR;
 pub use bp_xcm_bridge_hub_router::{BridgeState, XcmChannelStatusProvider};
 use codec::Encode;
 use frame_support::traits::Get;
@@ -433,6 +434,8 @@ impl<T: Config<I>, I: 'static> InspectMessageQueues for Pallet<T, I> {
 impl<T: Config<I>, I: 'static> FeeTracker for Pallet<T, I> {
 	type Id = ();
 
+	const MIN_FEE_FACTOR: FixedU128 = MINIMAL_DELIVERY_FEE_FACTOR;
+
 	fn get_fee_factor(_id: Self::Id) -> FixedU128 {
 		Self::bridge().delivery_fee_factor
 	}
@@ -452,7 +455,6 @@ mod tests {
 
 	use frame_support::traits::Hooks;
 	use frame_system::{EventRecord, Phase};
-	use polkadot_runtime_parachains::MIN_FEE_FACTOR;
 	use sp_runtime::traits::One;
 
 	fn congested_bridge(delivery_fee_factor: FixedU128) -> BridgeState {
@@ -466,7 +468,10 @@ mod tests {
 	#[test]
 	fn initial_fee_factor_is_one() {
 		run_test(|| {
-			assert_eq!(Bridge::<TestRuntime, ()>::get(), uncongested_bridge(MIN_FEE_FACTOR),);
+			assert_eq!(
+				Bridge::<TestRuntime, ()>::get(),
+				uncongested_bridge(Pallet::<TestRuntime, ()>::MIN_FEE_FACTOR),
+			);
 		})
 	}
 
@@ -504,13 +509,18 @@ mod tests {
 			Bridge::<TestRuntime, ()>::put(uncongested_bridge(initial_fee_factor));
 
 			// it should eventually decrease to one
-			while XcmBridgeHubRouter::bridge().delivery_fee_factor > MIN_FEE_FACTOR {
+			while XcmBridgeHubRouter::bridge().delivery_fee_factor >
+				Pallet::<TestRuntime, ()>::MIN_FEE_FACTOR
+			{
 				XcmBridgeHubRouter::on_initialize(One::one());
 			}
 
 			// verify that it doesn't decrease anymore
 			XcmBridgeHubRouter::on_initialize(One::one());
-			assert_eq!(XcmBridgeHubRouter::bridge(), uncongested_bridge(MIN_FEE_FACTOR));
+			assert_eq!(
+				XcmBridgeHubRouter::bridge(),
+				uncongested_bridge(Pallet::<TestRuntime, ()>::MIN_FEE_FACTOR)
+			);
 
 			// check emitted event
 			let first_system_event = System::events().first().cloned();
@@ -698,7 +708,9 @@ mod tests {
 	#[test]
 	fn sent_message_increases_factor_if_bridge_has_reported_congestion() {
 		run_test(|| {
-			Bridge::<TestRuntime, ()>::put(congested_bridge(MIN_FEE_FACTOR));
+			Bridge::<TestRuntime, ()>::put(congested_bridge(
+				Pallet::<TestRuntime, ()>::MIN_FEE_FACTOR,
+			));
 
 			let old_bridge = XcmBridgeHubRouter::bridge();
 			assert_ok!(send_xcm::<XcmBridgeHubRouter>(

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -53,7 +53,7 @@ use frame_support::{
 };
 use frame_system::{ensure_none, ensure_root, pallet_prelude::HeaderFor};
 use polkadot_parachain_primitives::primitives::RelayChainBlockNumber;
-use polkadot_runtime_parachains::{FeeTracker, MinFeeFactor};
+use polkadot_runtime_parachains::{FeeTracker, GetMinFeeFactor};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{Block as BlockT, BlockNumberProvider, Hash, One},
@@ -923,7 +923,7 @@ pub mod pallet {
 	/// The factor to multiply the base delivery fee by for UMP.
 	#[pallet::storage]
 	pub type UpwardDeliveryFeeFactor<T: Config> =
-		StorageValue<_, FixedU128, ValueQuery, MinFeeFactor>;
+		StorageValue<_, FixedU128, ValueQuery, GetMinFeeFactor<Pallet<T>>>;
 
 	/// The number of HRMP messages we observed in `on_initialize` and thus used that number for
 	/// announcing the weight of `on_initialize` and `on_finalize`.

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -53,7 +53,7 @@ use frame_support::{
 };
 use frame_system::{ensure_none, ensure_root, pallet_prelude::HeaderFor};
 use polkadot_parachain_primitives::primitives::RelayChainBlockNumber;
-use polkadot_runtime_parachains::FeeTracker;
+use polkadot_runtime_parachains::{FeeTracker, MinFeeFactor};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{Block as BlockT, BlockNumberProvider, Hash, One},
@@ -920,16 +920,10 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type PendingUpwardMessages<T: Config> = StorageValue<_, Vec<UpwardMessage>, ValueQuery>;
 
-	/// Initialization value for the delivery fee factor for UMP.
-	#[pallet::type_value]
-	pub fn UpwardInitialDeliveryFeeFactor() -> FixedU128 {
-		FixedU128::from_u32(1)
-	}
-
 	/// The factor to multiply the base delivery fee by for UMP.
 	#[pallet::storage]
 	pub type UpwardDeliveryFeeFactor<T: Config> =
-		StorageValue<_, FixedU128, ValueQuery, UpwardInitialDeliveryFeeFactor>;
+		StorageValue<_, FixedU128, ValueQuery, MinFeeFactor>;
 
 	/// The number of HRMP messages we observed in `on_initialize` and thus used that number for
 	/// announcing the weight of `on_initialize` and `on_finalize`.
@@ -1007,10 +1001,6 @@ impl<T: Config> Pallet<T> {
 
 impl<T: Config> FeeTracker for Pallet<T> {
 	type Id = ();
-
-	fn get_min_fee_factor() -> FixedU128 {
-		UpwardInitialDeliveryFeeFactor::get()
-	}
 
 	fn get_fee_factor(_id: Self::Id) -> FixedU128 {
 		UpwardDeliveryFeeFactor::<T>::get()

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -76,7 +76,7 @@ use frame_support::{
 };
 use pallet_message_queue::OnQueueChanged;
 use polkadot_runtime_common::xcm_sender::PriceForMessageDelivery;
-use polkadot_runtime_parachains::{FeeTracker, MinFeeFactor};
+use polkadot_runtime_parachains::{FeeTracker, GetMinFeeFactor};
 use scale_info::TypeInfo;
 use sp_core::MAX_POSSIBLE_ALLOCATION;
 use sp_runtime::{FixedU128, RuntimeDebug, WeakBoundedVec};
@@ -361,7 +361,7 @@ pub mod pallet {
 	/// The factor to multiply the base delivery fee by.
 	#[pallet::storage]
 	pub(super) type DeliveryFeeFactor<T: Config> =
-		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, MinFeeFactor>;
+		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, GetMinFeeFactor<Pallet<T>>>;
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -76,7 +76,7 @@ use frame_support::{
 };
 use pallet_message_queue::OnQueueChanged;
 use polkadot_runtime_common::xcm_sender::PriceForMessageDelivery;
-use polkadot_runtime_parachains::FeeTracker;
+use polkadot_runtime_parachains::{FeeTracker, MinFeeFactor};
 use scale_info::TypeInfo;
 use sp_core::MAX_POSSIBLE_ALLOCATION;
 use sp_runtime::{FixedU128, RuntimeDebug, WeakBoundedVec};
@@ -358,16 +358,10 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(super) type QueueSuspended<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-	/// Initialization value for the DeliveryFee factor.
-	#[pallet::type_value]
-	pub fn InitialFactor() -> FixedU128 {
-		FixedU128::from_u32(1)
-	}
-
 	/// The factor to multiply the base delivery fee by.
 	#[pallet::storage]
 	pub(super) type DeliveryFeeFactor<T: Config> =
-		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, InitialFactor>;
+		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, MinFeeFactor>;
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -1143,10 +1137,6 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 
 impl<T: Config> FeeTracker for Pallet<T> {
 	type Id = ParaId;
-
-	fn get_min_fee_factor() -> FixedU128 {
-		InitialFactor::get()
-	}
 
 	fn get_fee_factor(id: Self::Id) -> FixedU128 {
 		<DeliveryFeeFactor<T>>::get(id)

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -26,7 +26,6 @@ use frame_support::{
 	StorageNoopGuard,
 };
 use mock::{new_test_ext, ParachainSystem, RuntimeOrigin as Origin, Test, XcmpQueue};
-use polkadot_runtime_parachains::MIN_FEE_FACTOR;
 use sp_runtime::traits::{BadOrigin, Zero};
 use std::iter::{once, repeat};
 use xcm::{MAX_INSTRUCTIONS_TO_DECODE, MAX_XCM_DECODE_DEPTH};
@@ -940,8 +939,8 @@ fn verify_fee_factor_increase_and_decrease() {
 	xcmp_message.extend(versioned_xcm.encode());
 
 	new_test_ext().execute_with(|| {
-		let initial = MIN_FEE_FACTOR;
-		assert_eq!(DeliveryFeeFactor::<Test>::get(sibling_para_id), initial);
+		let initial = Pallet::<Test>::MIN_FEE_FACTOR;
+		assert_eq!(Pallet::<Test>::get_fee_factor(sibling_para_id), initial);
 
 		// Open channel so messages can actually be sent
 		ParachainSystem::open_custom_outbound_hrmp_channel_for_benchmarks_or_tests(

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -26,6 +26,7 @@ use frame_support::{
 	StorageNoopGuard,
 };
 use mock::{new_test_ext, ParachainSystem, RuntimeOrigin as Origin, Test, XcmpQueue};
+use polkadot_runtime_parachains::MIN_FEE_FACTOR;
 use sp_runtime::traits::{BadOrigin, Zero};
 use std::iter::{once, repeat};
 use xcm::{MAX_INSTRUCTIONS_TO_DECODE, MAX_XCM_DECODE_DEPTH};
@@ -939,7 +940,7 @@ fn verify_fee_factor_increase_and_decrease() {
 	xcmp_message.extend(versioned_xcm.encode());
 
 	new_test_ext().execute_with(|| {
-		let initial = InitialFactor::get();
+		let initial = MIN_FEE_FACTOR;
 		assert_eq!(DeliveryFeeFactor::<Test>::get(sibling_para_id), initial);
 
 		// Open channel so messages can actually be sent

--- a/polkadot/runtime/common/src/xcm_sender.rs
+++ b/polkadot/runtime/common/src/xcm_sender.rs
@@ -285,10 +285,6 @@ mod tests {
 	impl FeeTracker for TestFeeTracker {
 		type Id = ParaId;
 
-		fn get_min_fee_factor() -> FixedU128 {
-			unimplemented!()
-		}
-
 		fn get_fee_factor(_: Self::Id) -> FixedU128 {
 			FixedU128::from_rational(101, 100)
 		}

--- a/polkadot/runtime/parachains/src/dmp.rs
+++ b/polkadot/runtime/parachains/src/dmp.rs
@@ -44,7 +44,7 @@
 
 use crate::{
 	configuration::{self, HostConfiguration},
-	initializer, paras, FeeTracker,
+	initializer, paras, FeeTracker, MinFeeFactor,
 };
 use alloc::vec::Vec;
 use core::fmt;
@@ -140,16 +140,10 @@ pub mod pallet {
 	pub(crate) type DownwardMessageQueueHeads<T: Config> =
 		StorageMap<_, Twox64Concat, ParaId, Hash, ValueQuery>;
 
-	/// Initialization value for the DeliveryFee factor.
-	#[pallet::type_value]
-	pub fn InitialFactor() -> FixedU128 {
-		FixedU128::from_u32(1)
-	}
-
 	/// The factor to multiply the base delivery fee by.
 	#[pallet::storage]
 	pub(crate) type DeliveryFeeFactor<T: Config> =
-		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, InitialFactor>;
+		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, MinFeeFactor>;
 }
 /// Routines and getters related to downward message passing.
 impl<T: Config> Pallet<T> {
@@ -346,10 +340,6 @@ impl<T: Config> Pallet<T> {
 
 impl<T: Config> FeeTracker for Pallet<T> {
 	type Id = ParaId;
-
-	fn get_min_fee_factor() -> FixedU128 {
-		InitialFactor::get()
-	}
 
 	fn get_fee_factor(id: Self::Id) -> FixedU128 {
 		DeliveryFeeFactor::<T>::get(id)

--- a/polkadot/runtime/parachains/src/dmp.rs
+++ b/polkadot/runtime/parachains/src/dmp.rs
@@ -44,7 +44,7 @@
 
 use crate::{
 	configuration::{self, HostConfiguration},
-	initializer, paras, FeeTracker, MinFeeFactor,
+	initializer, paras, FeeTracker, GetMinFeeFactor,
 };
 use alloc::vec::Vec;
 use core::fmt;
@@ -143,7 +143,7 @@ pub mod pallet {
 	/// The factor to multiply the base delivery fee by.
 	#[pallet::storage]
 	pub(crate) type DeliveryFeeFactor<T: Config> =
-		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, MinFeeFactor>;
+		StorageMap<_, Twox64Concat, ParaId, FixedU128, ValueQuery, GetMinFeeFactor<Pallet<T>>>;
 }
 /// Routines and getters related to downward message passing.
 impl<T: Config> Pallet<T> {

--- a/polkadot/runtime/parachains/src/dmp/tests.rs
+++ b/polkadot/runtime/parachains/src/dmp/tests.rs
@@ -18,6 +18,7 @@ use super::*;
 use crate::{
 	configuration::ActiveConfig,
 	mock::{new_test_ext, Dmp, MockGenesisConfig, Paras, System, Test},
+	MIN_FEE_FACTOR,
 };
 use codec::Encode;
 use frame_support::assert_ok;
@@ -281,7 +282,7 @@ fn verify_fee_increase_and_decrease() {
 	new_test_ext(genesis).execute_with(|| {
 		register_paras(&[a]);
 
-		let initial = InitialFactor::get();
+		let initial = MIN_FEE_FACTOR;
 		assert_eq!(DeliveryFeeFactor::<Test>::get(a), initial);
 
 		// Under fee limit
@@ -290,7 +291,7 @@ fn verify_fee_increase_and_decrease() {
 
 		// Limit reached so fee is increased
 		queue_downward_message(a, vec![1]).unwrap();
-		let result = InitialFactor::get().saturating_mul(Dmp::EXPONENTIAL_FEE_BASE);
+		let result = MIN_FEE_FACTOR.saturating_mul(Dmp::EXPONENTIAL_FEE_BASE);
 		assert_eq!(DeliveryFeeFactor::<Test>::get(a), result);
 
 		Dmp::prune_dmq(a, 1);

--- a/polkadot/runtime/parachains/src/dmp/tests.rs
+++ b/polkadot/runtime/parachains/src/dmp/tests.rs
@@ -18,7 +18,6 @@ use super::*;
 use crate::{
 	configuration::ActiveConfig,
 	mock::{new_test_ext, Dmp, MockGenesisConfig, Paras, System, Test},
-	MIN_FEE_FACTOR,
 };
 use codec::Encode;
 use frame_support::assert_ok;
@@ -282,7 +281,7 @@ fn verify_fee_increase_and_decrease() {
 	new_test_ext(genesis).execute_with(|| {
 		register_paras(&[a]);
 
-		let initial = MIN_FEE_FACTOR;
+		let initial = Pallet::<Test>::MIN_FEE_FACTOR;
 		assert_eq!(DeliveryFeeFactor::<Test>::get(a), initial);
 
 		// Under fee limit
@@ -291,7 +290,7 @@ fn verify_fee_increase_and_decrease() {
 
 		// Limit reached so fee is increased
 		queue_downward_message(a, vec![1]).unwrap();
-		let result = MIN_FEE_FACTOR.saturating_mul(Dmp::EXPONENTIAL_FEE_BASE);
+		let result = Pallet::<Test>::MIN_FEE_FACTOR.saturating_mul(Dmp::EXPONENTIAL_FEE_BASE);
 		assert_eq!(DeliveryFeeFactor::<Test>::get(a), result);
 
 		Dmp::prune_dmq(a, 1);

--- a/polkadot/runtime/parachains/src/lib.rs
+++ b/polkadot/runtime/parachains/src/lib.rs
@@ -118,6 +118,7 @@ pub trait FeeTracker {
 	}
 }
 
+/// Helper struct used for accessing `FeeTracker::MIN_FEE_FACTOR`
 pub struct GetMinFeeFactor<T>(core::marker::PhantomData<T>);
 
 impl<T: FeeTracker> Get<FixedU128> for GetMinFeeFactor<T> {

--- a/polkadot/runtime/parachains/src/lib.rs
+++ b/polkadot/runtime/parachains/src/lib.rs
@@ -60,9 +60,6 @@ use polkadot_primitives::{HeadData, Id as ParaId, ValidationCode};
 use sp_arithmetic::traits::Saturating;
 use sp_runtime::{traits::Get, DispatchResult, FixedU128};
 
-// /// Minimal delivery fee factor.
-// pub const DEFAULT_MIN_FEE_FACTOR: FixedU128 = FixedU128::from_u32(1);
-
 /// Trait for tracking message delivery fees on a transport protocol.
 pub trait FeeTracker {
 	/// Type used for assigning different fee factors to different destinations
@@ -97,10 +94,13 @@ pub trait FeeTracker {
 	}
 
 	fn do_decrease_fee_factor(fee_factor: &mut FixedU128) -> bool {
+		const { assert!(Self::EXPONENTIAL_FEE_BASE.into_inner() >= FixedU128::from_u32(1).into_inner()) }
+
 		if *fee_factor == Self::MIN_FEE_FACTOR {
 			return false;
 		}
 
+		// This should never lead to a panic because of the static assert above.
 		*fee_factor = Self::MIN_FEE_FACTOR.max(*fee_factor / Self::EXPONENTIAL_FEE_BASE);
 		true
 	}

--- a/prdoc/pr_8528.prdoc
+++ b/prdoc/pr_8528.prdoc
@@ -1,0 +1,20 @@
+title: 'FeeTracker: remove `get_min_fee_factor()`'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Related to https://github.com/paritytech/polkadot-sdk/issues/8462
+
+    Follow-up for https://github.com/paritytech/polkadot-sdk/pull/8477
+
+    The minimal fee factor should always be 1
+crates:
+- name: pallet-xcm-bridge-hub-router
+  bump: patch
+- name: cumulus-pallet-parachain-system
+  bump: patch
+- name: cumulus-pallet-xcmp-queue
+  bump: patch
+- name: polkadot-runtime-common
+  bump: patch
+- name: polkadot-runtime-parachains
+  bump: patch

--- a/prdoc/pr_8528.prdoc
+++ b/prdoc/pr_8528.prdoc
@@ -9,12 +9,12 @@ doc:
     The minimal fee factor should always be 1
 crates:
 - name: pallet-xcm-bridge-hub-router
-  bump: patch
+  bump: major
 - name: cumulus-pallet-parachain-system
-  bump: patch
+  bump: major
 - name: cumulus-pallet-xcmp-queue
-  bump: patch
+  bump: major
 - name: polkadot-runtime-common
   bump: patch
 - name: polkadot-runtime-parachains
-  bump: patch
+  bump: major


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/8462

Follow-up for https://github.com/paritytech/polkadot-sdk/pull/8477

The minimal fee factor should always be 1


