### PR TITLE
Added `OnNewHead` to `pallet-bridge-parachains`

### DIFF
--- a/bridges/bin/runtime-common/src/mock.rs
+++ b/bridges/bin/runtime-common/src/mock.rs
@@ -185,6 +185,7 @@ impl pallet_bridge_parachains::Config for TestRuntime {
 	type HeadsToKeep = ConstU32<8>;
 	type MaxParaHeadDataSize = ConstU32<1024>;
 	type WeightInfo = pallet_bridge_parachains::weights::BridgeWeight<TestRuntime>;
+	type OnNewHead = ();
 }
 
 impl pallet_bridge_messages::Config for TestRuntime {

--- a/bridges/modules/parachains/src/lib.rs
+++ b/bridges/modules/parachains/src/lib.rs
@@ -32,7 +32,7 @@ use bp_parachains::{
 	ParaInfo, ParaStoredHeaderData, RelayBlockHash, RelayBlockHasher, RelayBlockNumber,
 	SubmitParachainHeadsInfo,
 };
-use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
+use bp_polkadot_core::parachains::{ParaHash, ParaHead, ParaHeadsProof, ParaId};
 use bp_runtime::{Chain, HashOf, HeaderId, HeaderIdOf, Parachain};
 use frame_support::{dispatch::PostDispatchInfo, DefaultNoBound};
 use pallet_bridge_grandpa::SubmitFinalityProofHelper;
@@ -76,7 +76,7 @@ struct UpdateParachainHeadArtifacts {
 pub mod pallet {
 	use super::*;
 	use bp_parachains::{
-		BestParaHeadHash, ImportedParaHeadsKeyProvider, ParaStoredHeaderDataBuilder,
+		BestParaHeadHash, ImportedParaHeadsKeyProvider, OnNewHead, ParaStoredHeaderDataBuilder,
 		ParasInfoKeyProvider,
 	};
 	use bp_runtime::{
@@ -252,6 +252,9 @@ pub mod pallet {
 		/// that exceeds this bound.
 		#[pallet::constant]
 		type MaxParaHeadDataSize: Get<u32>;
+
+		/// Runtime hook for when a parachain head is updated.
+		type OnNewHead: OnNewHead;
 	}
 
 	/// Optional pallet owner.
@@ -538,6 +541,7 @@ pub mod pallet {
 							HeaderId(relay_block_number, relay_block_hash),
 							parachain_head_data,
 							parachain_head_hash,
+							parachain_head,
 						)?;
 
 						if is_free {
@@ -638,6 +642,7 @@ pub mod pallet {
 			new_at_relay_block: HeaderId<RelayBlockHash, RelayBlockNumber>,
 			new_head_data: ParaStoredHeaderData,
 			new_head_hash: ParaHash,
+			new_head: ParaHead,
 		) -> Result<UpdateParachainHeadArtifacts, ()> {
 			// check if head has been already updated at better relay chain block. Without this
 			// check, we may import heads in random order
@@ -699,7 +704,7 @@ pub mod pallet {
 				next_imported_hash_position,
 				new_head_hash,
 			);
-			ImportedParaHeads::<T, I>::insert(parachain, new_head_hash, updated_head_data);
+			ImportedParaHeads::<T, I>::insert(parachain, new_head_hash, &updated_head_data);
 			log::trace!(
 				target: LOG_TARGET,
 				"Updated head of parachain {:?} to {} at relay block {}",
@@ -707,6 +712,9 @@ pub mod pallet {
 				new_head_hash,
 				new_at_relay_block.0,
 			);
+
+			// trigger callback
+			T::OnNewHead::on_new_head(parachain, &new_head);
 
 			// remove old head
 			let prune_happened = head_hash_to_prune.is_ok();

--- a/bridges/modules/parachains/src/lib.rs
+++ b/bridges/modules/parachains/src/lib.rs
@@ -823,6 +823,7 @@ pub fn initialize_for_benchmarks<T: Config<I>, I: 'static, PC: Parachain<Hash = 
 		relay_head.id(),
 		updated_head_data,
 		parachain_head.hash(),
+		parachain_head,
 	)
 	.expect("failed to insert parachain head in benchmarks");
 }

--- a/bridges/modules/parachains/src/mock.rs
+++ b/bridges/modules/parachains/src/mock.rs
@@ -215,6 +215,7 @@ impl pallet_bridge_parachains::Config for TestRuntime {
 	type ParaStoredHeaderDataBuilder = (Parachain1, Parachain2, Parachain3, BigParachain);
 	type HeadsToKeep = HeadsToKeep;
 	type MaxParaHeadDataSize = ConstU32<MAXIMAL_PARACHAIN_HEAD_DATA_SIZE>;
+	type OnNewHead = ();
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/bridges/modules/relayers/src/mock.rs
+++ b/bridges/modules/relayers/src/mock.rs
@@ -255,6 +255,7 @@ impl pallet_bridge_parachains::Config for TestRuntime {
 	type HeadsToKeep = ConstU32<8>;
 	type MaxParaHeadDataSize = ConstU32<1024>;
 	type WeightInfo = pallet_bridge_parachains::weights::BridgeWeight<TestRuntime>;
+	type OnNewHead = ();
 }
 
 impl pallet_bridge_messages::Config for TestRuntime {

--- a/bridges/primitives/parachains/src/lib.rs
+++ b/bridges/primitives/parachains/src/lib.rs
@@ -28,7 +28,7 @@ use bp_runtime::{
 	StorageMapKeyProvider,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{Blake2_128Concat, Twox64Concat};
+use frame_support::{weights::Weight, Blake2_128Concat, Twox64Concat};
 use scale_info::TypeInfo;
 use sp_core::storage::StorageKey;
 use sp_runtime::{traits::Header as HeaderT, RuntimeDebug};
@@ -190,5 +190,21 @@ impl ParaStoredHeaderDataBuilder for C {
 		)* );
 
 		None
+	}
+}
+
+/// Runtime hook for when a parachain head is updated.
+pub trait OnNewHead {
+	/// Called when a parachain head is updated.
+	/// Returns the weight consumed by this function.
+	fn on_new_head(id: ParaId, head: &ParaHead) -> Weight;
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(8)]
+impl OnNewHead for Tuple {
+	fn on_new_head(id: ParaId, head: &ParaHead) -> Weight {
+		let mut weight: Weight = Default::default();
+		for_tuples!( #( weight.saturating_accrue(Tuple::on_new_head(id, head)); )* );
+		weight
 	}
 }

--- a/bridges/primitives/polkadot-core/src/parachains.rs
+++ b/bridges/primitives/polkadot-core/src/parachains.rs
@@ -67,7 +67,17 @@ impl From<u32> for ParaId {
 ///
 /// The parachain head means (at least in Cumulus) a SCALE-encoded parachain header.
 #[derive(
-	PartialEq, Eq, Clone, PartialOrd, Ord, Encode, Decode, RuntimeDebug, TypeInfo, Default,
+	PartialEq,
+	Eq,
+	Clone,
+	PartialOrd,
+	Ord,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	RuntimeDebug,
+	TypeInfo,
+	Default,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash))]
 pub struct ParaHead(pub Vec<u8>);

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_common_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/bridge_common_config.rs
@@ -62,6 +62,7 @@ impl pallet_bridge_parachains::Config<BridgeParachainWestendInstance> for Runtim
 		SingleParaStoredHeaderDataBuilder<bp_bridge_hub_westend::BridgeHubWestend>;
 	type HeadsToKeep = ParachainHeadsToKeep;
 	type MaxParaHeadDataSize = MaxWestendParaHeadDataSize;
+	type OnNewHead = ();
 }
 
 /// Allows collect and claim rewards for relayers

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_rococo_config.rs
@@ -126,6 +126,7 @@ impl pallet_bridge_parachains::Config<BridgeParachainRococoInstance> for Runtime
 		SingleParaStoredHeaderDataBuilder<bp_bridge_hub_rococo::BridgeHubRococo>;
 	type HeadsToKeep = ParachainHeadsToKeep;
 	type MaxParaHeadDataSize = MaxRococoParaHeadDataSize;
+	type OnNewHead = ();
 }
 
 /// Add XCM messages support for BridgeHubWestend to support Westend->Rococo XCM messages

--- a/prdoc/pr_8531.prdoc
+++ b/prdoc/pr_8531.prdoc
@@ -9,10 +9,14 @@ crates:
 - name: pallet-bridge-parachains
   bump: major
 - name: bp-parachains
-  bump: major
+  bump: minor
 - name: bp-polkadot-core
-  bump: major
+  bump: minor
 - name: bridge-hub-rococo-runtime
-  bump: major
+  bump: minor
 - name: bridge-hub-westend-runtime
-  bump: major
+  bump: minor
+- name: bridge-runtime-common
+  bump: minor
+- name: pallet-bridge-relayers
+  bump: minor    

--- a/prdoc/pr_8531.prdoc
+++ b/prdoc/pr_8531.prdoc
@@ -2,11 +2,6 @@ title: Added `OnNewHead` to `pallet-bridge-parachains`
 doc:
 - audience: Runtime Dev
   description: |-
-    Relates to: https://github.com/paritytech/polkadot-sdk/pull/8326
-    Relates to: https://github.com/paritytech/polkadot-sdk/pull/6675
-
-    (Extracted from https://github.com/paritytech/polkadot-sdk/pull/8325)
-
     This PR introduces a new `OnNewHead` hook for `pallet-bridge-parachains`, which is triggered when a new parachain head is relayed.
 
     It will be used in conjunction with the [syncing mechanism](https://github.com/paritytech/polkadot-sdk/pull/8326), which sends relayed AssetHubRococo headers with `state_root`s to AssetHubWestend for message proof verification.

--- a/prdoc/pr_8531.prdoc
+++ b/prdoc/pr_8531.prdoc
@@ -1,0 +1,23 @@
+title: Added `OnNewHead` to `pallet-bridge-parachains`
+doc:
+- audience: Runtime Dev
+  description: |-
+    Relates to: https://github.com/paritytech/polkadot-sdk/pull/8326
+    Relates to: https://github.com/paritytech/polkadot-sdk/pull/6675
+
+    (Extracted from https://github.com/paritytech/polkadot-sdk/pull/8325)
+
+    This PR introduces a new `OnNewHead` hook for `pallet-bridge-parachains`, which is triggered when a new parachain head is relayed.
+
+    It will be used in conjunction with the [syncing mechanism](https://github.com/paritytech/polkadot-sdk/pull/8326), which sends relayed AssetHubRococo headers with `state_root`s to AssetHubWestend for message proof verification.
+crates:
+- name: pallet-bridge-parachains
+  bump: major
+- name: bp-parachains
+  bump: major
+- name: bp-polkadot-core
+  bump: major
+- name: bridge-hub-rococo-runtime
+  bump: major
+- name: bridge-hub-westend-runtime
+  bump: major


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/pull/8326
Relates to: https://github.com/paritytech/polkadot-sdk/pull/6675

(Extracted from https://github.com/paritytech/polkadot-sdk/pull/8325)

This PR introduces a new `OnNewHead` hook for `pallet-bridge-parachains`, which is triggered when a new parachain head is relayed.

It will be used in conjunction with the [syncing mechanism](https://github.com/paritytech/polkadot-sdk/pull/8326), which sends relayed AssetHubRococo headers with `state_root`s to AssetHubWestend for message proof verification.