### PR TITLE
More versatile benchmark assertion in `pallet-migrations`

### DIFF
--- a/substrate/frame/migrations/src/benchmarking.rs
+++ b/substrate/frame/migrations/src/benchmarking.rs
@@ -27,6 +27,10 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
+fn assert_has_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
+}
+
 #[benchmarks]
 mod benches {
 	use super::*;
@@ -149,7 +153,7 @@ mod benches {
 			Pallet::<T>::exec_migration(c, false, &mut meter);
 		}
 
-		assert_last_event::<T>(Event::UpgradeFailed {}.into());
+		assert_has_event::<T>(Event::UpgradeFailed {}.into());
 
 		Ok(())
 	}


### PR DESCRIPTION
# Description

In the case of a custom `FailedMigrationHandler` the assumption that the event `Event::UpgradeFailed` would be the last emitted during a failed migration is restrictive.
For instance in Moonbeam, the custom handler forces the chain to enter maintenance mode, which emits a series of events on top of the above-mentioned event, leading to the failure of the benchmark.

```rust
pub struct EnterMaintenanceModeOnFailedMigration;
impl frame_support::migrations::FailedMigrationHandler for EnterMaintenanceModeOnFailedMigration {
	fn failed(migration: Option<u32>) -> frame_support::migrations::FailedMigrationHandling {
		// Log information about the failed migration
		log::error!(
			target: "runtime::migrations",
			"Migration {:?} failed - activating maintenance mode and continuing",
			migration
		);

		// Enable maintenance mode using the internal function.
		MaintenanceMode::force_enter_maintenance_mode();

		// We choose to ignore the failed migration, allowing the chain to continue operating
		// in maintenance mode rather than completely halting execution
		frame_support::migrations::FailedMigrationHandling::Ignore
	}
}
```

Which invokes `moonkit`'s.

```rust
impl<T: Config> Pallet<T> {
		/// Internal function to force the chain into maintenance mode without an origin check.
		pub fn force_enter_maintenance_mode() {
			// Write to storage
			MaintenanceMode::<T>::put(true);

			// Suspend XCM execution
			#[cfg(feature = "xcm-support")]
			if let Err(error) = T::XcmExecutionManager::suspend_xcm_execution() {
				// Deposit event about failure but still return the error to the caller
				<Pallet<T>>::deposit_event(Event::FailedToSuspendIdleXcmExecution { error });
			}

			// Event
			<Pallet<T>>::deposit_event(Event::EnteredMaintenanceMode);
		}
	}
```

The proposed solution is to just check for the presence of an event `Event::UpgradeFailed`, without assuming that it would be the last emitted.

## Integration

No special requirements.

## Review Notes

Minor change.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [x] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

