### PR TITLE
Disable check-runtime-migration

### DIFF
--- a/.github/workflows/check-runtime-migration.yml
+++ b/.github/workflows/check-runtime-migration.yml
@@ -28,7 +28,9 @@ jobs:
   # More info can be found here: https://github.com/paritytech/polkadot/pull/5865
   check-runtime-migration:
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
-    if: ${{ needs.preflight.outputs.changes_rust }}
+    # TODO re-enable westend state is fully broken since we dropped some messages on latest upgrade
+    if: false
+    # if: ${{ needs.preflight.outputs.changes_rust }}
     # We need to set this to rather long to allow the snapshot to be created, but the average time
     # should be much lower.
     timeout-minutes: 60

--- a/prdoc/pr_8547.prdoc
+++ b/prdoc/pr_8547.prdoc
@@ -1,0 +1,7 @@
+title: Disable check-runtime-migration
+doc:
+- audience: Runtime Dev
+  description: |-
+    westend state is fully broken since we dropped some messages on latest upgrade
+    I am disabling this job for now until we can resolve the issue
+crates: []


### PR DESCRIPTION
westend state is fully broken since we dropped some messages on latest upgrade
I am disabling this job for now until we can resolve the issue

