### PR TITLE
 Bridges: Fix - Improve try-state for pallet-xcm-bridge

### DIFF
--- a/bridges/modules/xcm-bridge/src/lib.rs
+++ b/bridges/modules/xcm-bridge/src/lib.rs
@@ -761,14 +761,14 @@ pub mod pallet {
 
 			// check that `locations` are convertible to the `latest` XCM.
 			let bridge_origin_relative_location_as_latest: &Location =
-				bridge.bridge_origin_relative_location.try_as().map_err(|_| {
+				&(*bridge.bridge_origin_relative_location).try_into().map_err(|_| {
 					"`bridge.bridge_origin_relative_location` cannot be converted to the `latest` XCM, needs migration!"
 				})?;
-			let bridge_origin_universal_location_as_latest: &InteriorLocation = bridge.bridge_origin_universal_location
-				.try_as()
+			let bridge_origin_universal_location_as_latest: &InteriorLocation = &(*bridge.bridge_origin_universal_location)
+				.try_into()
 				.map_err(|_| "`bridge.bridge_origin_universal_location` cannot be converted to the `latest` XCM, needs migration!")?;
-			let bridge_destination_universal_location_as_latest: &InteriorLocation = bridge.bridge_destination_universal_location
-				.try_as()
+			let bridge_destination_universal_location_as_latest: &InteriorLocation = &(*bridge.bridge_destination_universal_location)
+				.try_into()
 				.map_err(|_| "`bridge.bridge_destination_universal_location` cannot be converted to the `latest` XCM, needs migration!")?;
 
 			// check `BridgeId` does not change

--- a/bridges/modules/xcm-bridge/src/tests.rs
+++ b/bridges/modules/xcm-bridge/src/tests.rs
@@ -874,15 +874,21 @@ fn do_try_state_works() {
 		test_bridge_state(
 			bridge_id,
 			Bridge {
-				bridge_origin_relative_location: Box::new(VersionedLocation::from(
-					bridge_origin_relative_location.clone(),
-				).into_version(XCM_VERSION - 1).unwrap()),
-				bridge_origin_universal_location: Box::new(VersionedInteriorLocation::from(
-					bridge_origin_universal_location.clone(),
-				).into_version(XCM_VERSION - 1).unwrap()),
-				bridge_destination_universal_location: Box::new(VersionedInteriorLocation::from(
-					bridge_destination_universal_location.clone(),
-				).into_version(XCM_VERSION - 1).unwrap()),
+				bridge_origin_relative_location: Box::new(
+					VersionedLocation::from(bridge_origin_relative_location.clone())
+						.into_version(XCM_VERSION - 1)
+						.unwrap(),
+				),
+				bridge_origin_universal_location: Box::new(
+					VersionedInteriorLocation::from(bridge_origin_universal_location.clone())
+						.into_version(XCM_VERSION - 1)
+						.unwrap(),
+				),
+				bridge_destination_universal_location: Box::new(
+					VersionedInteriorLocation::from(bridge_destination_universal_location.clone())
+						.into_version(XCM_VERSION - 1)
+						.unwrap(),
+				),
 				state: BridgeState::Opened,
 				deposit: Some(Deposit::new(bridge_owner_account, Zero::zero())),
 				lane_id,

--- a/bridges/modules/xcm-bridge/src/tests.rs
+++ b/bridges/modules/xcm-bridge/src/tests.rs
@@ -860,7 +860,7 @@ fn do_try_state_works() {
 					bridge_destination_universal_location.clone(),
 				)),
 				state: BridgeState::Opened,
-				deposit: Some(Deposit::new(bridge_owner_account, Zero::zero())),
+				deposit: Some(Deposit::new(bridge_owner_account.clone(), Zero::zero())),
 				lane_id,
 				maybe_notify: None,
 			},
@@ -869,6 +869,30 @@ fn do_try_state_works() {
 			Some(TryRuntimeError::Other("Outbound lane not found!")),
 		);
 		cleanup(bridge_id, vec![lane_id, lane_id_mismatch]);
+
+		// ok state with old XCM version
+		test_bridge_state(
+			bridge_id,
+			Bridge {
+				bridge_origin_relative_location: Box::new(VersionedLocation::from(
+					bridge_origin_relative_location.clone(),
+				).into_version(XCM_VERSION - 1).unwrap()),
+				bridge_origin_universal_location: Box::new(VersionedInteriorLocation::from(
+					bridge_origin_universal_location.clone(),
+				).into_version(XCM_VERSION - 1).unwrap()),
+				bridge_destination_universal_location: Box::new(VersionedInteriorLocation::from(
+					bridge_destination_universal_location.clone(),
+				).into_version(XCM_VERSION - 1).unwrap()),
+				state: BridgeState::Opened,
+				deposit: Some(Deposit::new(bridge_owner_account, Zero::zero())),
+				lane_id,
+				maybe_notify: None,
+			},
+			(lane_id, bridge_id),
+			(lane_id, lane_id),
+			None,
+		);
+		cleanup(bridge_id, vec![lane_id]);
 
 		// missing bridge for inbound lane
 		let lanes_manager = LanesManagerOf::<TestRuntime, ()>::new();

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/tests/tests.rs
@@ -1114,7 +1114,7 @@ mod asset_hub_rococo_tests {
 			Box::new(bridging::to_westend::AssetHubWestend::get()),
 			XCM_VERSION,
 		)
-			.expect("version saved!");
+		.expect("version saved!");
 		TestBridgingConfig {
 			bridged_network: bridging::to_westend::WestendNetwork::get(),
 			// Local AH para_id.
@@ -1134,7 +1134,10 @@ mod asset_hub_rococo_tests {
 
 	#[test]
 	fn receive_reserve_asset_deposited_wnd_from_asset_hub_westend_fees_paid_by_pool_swap_works() {
-		fn test_with(bridging_cfg: impl Fn() -> TestBridgingConfig, bridge_instance: InteriorLocation) {
+		fn test_with(
+			bridging_cfg: impl Fn() -> TestBridgingConfig,
+			bridge_instance: InteriorLocation,
+		) {
 			const BLOCK_AUTHOR_ACCOUNT: [u8; 32] = [13; 32];
 			let block_author_account = AccountId::from(BLOCK_AUTHOR_ACCOUNT);
 			let staking_pot = StakingPot::get();
@@ -1207,9 +1210,21 @@ mod asset_hub_rococo_tests {
 		}
 
 		// The bridge with BHs is working.
-		test_with(bridging_to_asset_hub_westend, [PalletInstance(bp_bridge_hub_rococo::WITH_BRIDGE_ROCOCO_TO_WESTEND_MESSAGES_PALLET_INDEX)].into());
+		test_with(
+			bridging_to_asset_hub_westend,
+			[PalletInstance(
+				bp_bridge_hub_rococo::WITH_BRIDGE_ROCOCO_TO_WESTEND_MESSAGES_PALLET_INDEX,
+			)]
+			.into(),
+		);
 		// The bridge with direct AHs is working.
-		test_with(direct_bridging_to_asset_hub_westend, [PalletInstance(bp_asset_hub_rococo::WITH_BRIDGE_ROCOCO_TO_WESTEND_MESSAGES_PALLET_INDEX)].into());
+		test_with(
+			direct_bridging_to_asset_hub_westend,
+			[PalletInstance(
+				bp_asset_hub_rococo::WITH_BRIDGE_ROCOCO_TO_WESTEND_MESSAGES_PALLET_INDEX,
+			)]
+			.into(),
+		);
 	}
 
 	#[test]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
@@ -1199,7 +1199,7 @@ fn direct_bridging_to_asset_hub_rococo() -> TestBridgingConfig {
 		Box::new(bridging::to_rococo::AssetHubRococo::get()),
 		XCM_VERSION,
 	)
-		.expect("version saved!");
+	.expect("version saved!");
 	TestBridgingConfig {
 		bridged_network: bridging::to_rococo::RococoNetwork::get(),
 		// Local AH para_id.
@@ -1252,13 +1252,19 @@ fn receive_reserve_asset_deposited_roc_from_asset_hub_rococo_fees_paid_by_pool_s
 
 		let foreign_asset_id_location = xcm::v5::Location::new(
 			2,
-			[xcm::v5::Junction::GlobalConsensus(xcm::v5::NetworkId::ByGenesis(ROCOCO_GENESIS_HASH))],
+			[xcm::v5::Junction::GlobalConsensus(xcm::v5::NetworkId::ByGenesis(
+				ROCOCO_GENESIS_HASH,
+			))],
 		);
 		let foreign_asset_id_minimum_balance = 1_000_000_000;
 		// sovereign account as a foreign asset owner (can be whoever for this scenario)
-		let foreign_asset_owner = LocationToAccountId::convert_location(&Location::parent()).unwrap();
-		let foreign_asset_create_params =
-			(foreign_asset_owner, foreign_asset_id_location.clone(), foreign_asset_id_minimum_balance);
+		let foreign_asset_owner =
+			LocationToAccountId::convert_location(&Location::parent()).unwrap();
+		let foreign_asset_create_params = (
+			foreign_asset_owner,
+			foreign_asset_id_location.clone(),
+			foreign_asset_id_minimum_balance,
+		);
 
 		asset_test_utils::test_cases_over_bridge::receive_reserve_asset_deposited_from_different_consensus_works::<
 			Runtime,
@@ -1316,9 +1322,19 @@ fn receive_reserve_asset_deposited_roc_from_asset_hub_rococo_fees_paid_by_pool_s
 	}
 
 	// The bridge with BHs is working.
-	test_with(bridging_to_asset_hub_rococo, [PalletInstance(bp_bridge_hub_westend::WITH_BRIDGE_WESTEND_TO_ROCOCO_MESSAGES_PALLET_INDEX)].into());
+	test_with(
+		bridging_to_asset_hub_rococo,
+		[PalletInstance(
+			bp_bridge_hub_westend::WITH_BRIDGE_WESTEND_TO_ROCOCO_MESSAGES_PALLET_INDEX,
+		)]
+		.into(),
+	);
 	// The bridge with direct AHs is working.
-	test_with(direct_bridging_to_asset_hub_rococo, [PalletInstance(bp_asset_hub_westend::WITH_BRIDGE_WESTEND_TO_ROCOCO_MESSAGES_PALLET_INDEX)].into());
+	test_with(
+		direct_bridging_to_asset_hub_rococo,
+		[PalletInstance(bp_asset_hub_westend::WITH_BRIDGE_WESTEND_TO_ROCOCO_MESSAGES_PALLET_INDEX)]
+			.into(),
+	);
 }
 
 #[test]


### PR DESCRIPTION
Fixing https://github.com/paritytech/polkadot-sdk/issues/8215 based on https://github.com/paritytech/polkadot-sdk/issues/8185: Improve try-state for pallet-xcm-bridge

It removes try_as and uses try_into implementation instead.

After adding test case where VersionedLocation* to have (XCM_VERSION - 1) is , the test case fails.

![after-adding-test-before-fix](https://github.com/user-attachments/assets/0672c677-fc50-4b1e-b636-7b6f23e4092d)


After adding the fix, by removing try_as and replacing with try_into, test case passed:
![after-adding-fix](https://github.com/user-attachments/assets/18452881-23e5-4563-b08f-47d4e0ef4be3)
