### PR TITLE
Fix broken link to call_ext.rs in parachains README

### DIFF
--- a/bridges/modules/parachains/README.md
+++ b/bridges/modules/parachains/README.md
@@ -71,7 +71,7 @@ It'd be better for anyone (for chain and for submitters) to reject all transacti
 already known parachain heads to the pallet. This way, we leave block space to other useful transactions and
 we don't charge concurrent submitters for their honest actions.
 
-To deal with that, we have a [signed extension](./src/call_ext) that may be added to the runtime.
+To deal with that, we have a [signed extension](./src/call_ext.rs) that may be added to the runtime.
 It does exactly what is required - rejects all transactions with already known heads. The submitter
 pays nothing for such transactions - they're simply removed from the transaction pool, when the block
 is built.


### PR DESCRIPTION
# Description

Fixed broken link to signed extension file in bridges/modules/parachains/README.md:
- Was: [signed extension](./src/call_ext)
- Now: [signed extension](./src/call_ext.rs)

Now the link correctly points to the existing call_ext.rs file, which improves navigation and prevents errors when viewing the documentation.

# Checklist

* [ ] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!

✄ -----------------------------------------------------------------------------
