### PR TITLE
Bridges: Fix - Improve try-state for pallet-xcm-bridge

### DIFF
--- a/bridges/modules/xcm-bridge/src/lib.rs
+++ b/bridges/modules/xcm-bridge/src/lib.rs
@@ -761,15 +761,17 @@ pub mod pallet {
 
 			// check that `locations` are convertible to the `latest` XCM.
 			let bridge_origin_relative_location_as_latest: &Location =
-				bridge.bridge_origin_relative_location.try_as().map_err(|_| {
+				&(*bridge.bridge_origin_relative_location).try_into().map_err(|_| {
 					"`bridge.bridge_origin_relative_location` cannot be converted to the `latest` XCM, needs migration!"
 				})?;
-			let bridge_origin_universal_location_as_latest: &InteriorLocation = bridge.bridge_origin_universal_location
-				.try_as()
-				.map_err(|_| "`bridge.bridge_origin_universal_location` cannot be converted to the `latest` XCM, needs migration!")?;
-			let bridge_destination_universal_location_as_latest: &InteriorLocation = bridge.bridge_destination_universal_location
-				.try_as()
-				.map_err(|_| "`bridge.bridge_destination_universal_location` cannot be converted to the `latest` XCM, needs migration!")?;
+			let bridge_origin_universal_location_as_latest: &InteriorLocation =
+				&(*bridge.bridge_origin_universal_location).try_into().map_err(|_| {
+					"`bridge.bridge_origin_universal_location` cannot be converted to the `latest` XCM, needs migration!"
+				})?;
+			let bridge_destination_universal_location_as_latest: &InteriorLocation =
+				&(*bridge.bridge_destination_universal_location).try_into().map_err(|_| {
+					"`bridge.bridge_destination_universal_location` cannot be converted to the `latest` XCM, needs migration!"
+				})?;
 
 			// check `BridgeId` does not change
 			ensure!(

--- a/bridges/modules/xcm-bridge/src/tests.rs
+++ b/bridges/modules/xcm-bridge/src/tests.rs
@@ -860,7 +860,7 @@ fn do_try_state_works() {
 					bridge_destination_universal_location.clone(),
 				)),
 				state: BridgeState::Opened,
-				deposit: Some(Deposit::new(bridge_owner_account, Zero::zero())),
+				deposit: Some(Deposit::new(bridge_owner_account.clone(), Zero::zero())),
 				lane_id,
 				maybe_notify: None,
 			},
@@ -869,6 +869,36 @@ fn do_try_state_works() {
 			Some(TryRuntimeError::Other("Outbound lane not found!")),
 		);
 		cleanup(bridge_id, vec![lane_id, lane_id_mismatch]);
+
+		// ok state with old XCM version
+		test_bridge_state(
+			bridge_id,
+			Bridge {
+				bridge_origin_relative_location: Box::new(
+					VersionedLocation::from(bridge_origin_relative_location.clone())
+						.into_version(XCM_VERSION - 1)
+						.unwrap(),
+				),
+				bridge_origin_universal_location: Box::new(
+					VersionedInteriorLocation::from(bridge_origin_universal_location.clone())
+						.into_version(XCM_VERSION - 1)
+						.unwrap(),
+				),
+				bridge_destination_universal_location: Box::new(
+					VersionedInteriorLocation::from(bridge_destination_universal_location.clone())
+						.into_version(XCM_VERSION - 1)
+						.unwrap(),
+				),
+				state: BridgeState::Opened,
+				deposit: Some(Deposit::new(bridge_owner_account, Zero::zero())),
+				lane_id,
+				maybe_notify: None,
+			},
+			(lane_id, bridge_id),
+			(lane_id, lane_id),
+			None,
+		);
+		cleanup(bridge_id, vec![lane_id]);
 
 		// missing bridge for inbound lane
 		let lanes_manager = LanesManagerOf::<TestRuntime, ()>::new();


### PR DESCRIPTION
Fixing https://github.com/paritytech/polkadot-sdk/issues/8215 based on https://github.com/paritytech/polkadot-sdk/issues/8185: Improve try-state for pallet-xcm-bridge

It removes try_as and uses try_into implementation instead.

After adding test case where VersionedLocation* to have (XCM_VERSION - 1) is , the test case fails.

![after-adding-test-before-fix](https://github.com/user-attachments/assets/0672c677-fc50-4b1e-b636-7b6f23e4092d)


After adding the fix, by removing try_as and replacing with try_into, test case passed:
![after-adding-fix](https://github.com/user-attachments/assets/18452881-23e5-4563-b08f-47d4e0ef4be3)
