### PR TITLE
cumulus: adjust unincluded segment size metric buckets

### DIFF
--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -740,10 +740,13 @@ impl ParachainInformantMetrics {
 		))?;
 		prometheus_registry.register(Box::new(parachain_block_authorship_duration.clone()))?;
 
-		let unincluded_segment_size = Histogram::with_opts(HistogramOpts::new(
-			"parachain_unincluded_segment_size",
-			"Number of blocks between best block and last included block",
-		).buckets((0..=24).into_iter().map(|i| i as f64).collect()))?;
+		let unincluded_segment_size = Histogram::with_opts(
+			HistogramOpts::new(
+				"parachain_unincluded_segment_size",
+				"Number of blocks between best block and last included block",
+			)
+			.buckets((0..=24).into_iter().map(|i| i as f64).collect()),
+		)?;
 		prometheus_registry.register(Box::new(unincluded_segment_size.clone()))?;
 
 		Ok(Self {

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -743,7 +743,7 @@ impl ParachainInformantMetrics {
 		let unincluded_segment_size = Histogram::with_opts(HistogramOpts::new(
 			"parachain_unincluded_segment_size",
 			"Number of blocks between best block and last included block",
-		))?;
+		).buckets((0..=24).into_iter().map(|i| i as f64).collect()))?;
 		prometheus_registry.register(Box::new(unincluded_segment_size.clone()))?;
 
 		Ok(Self {


### PR DESCRIPTION
Buckets for a maximum unincluded segment size of 24.