### PR TITLE
Bridges: Fix - Improve try-state for pallet-xcm-bridge

### DIFF
--- a/bridges/modules/xcm-bridge/src/dispatcher.rs
+++ b/bridges/modules/xcm-bridge/src/dispatcher.rs
@@ -68,7 +68,7 @@ where
 
 	fn is_active(lane: Self::LaneId) -> bool {
 		Pallet::<T, I>::bridge_by_lane_id(&lane)
-			.and_then(|(_, bridge)| bridge.bridge_origin_relative_location.try_as().cloned().ok())
+			.and_then(|(_, bridge)| (*bridge.bridge_origin_relative_location).try_into().ok())
 			.map(|recipient: Location| !T::BlobDispatcher::is_congested(&recipient))
 			.unwrap_or(false)
 	}

--- a/bridges/modules/xcm-bridge/src/exporter.rs
+++ b/bridges/modules/xcm-bridge/src/exporter.rs
@@ -252,7 +252,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 
 		// else - suspend the bridge
-		let bridge_origin_relative_location = match bridge.bridge_origin_relative_location.try_as()
+		let result_bridge_origin_relative_location = (*bridge.bridge_origin_relative_location).clone().try_into();
+		let bridge_origin_relative_location = match &result_bridge_origin_relative_location
 		{
 			Ok(bridge_origin_relative_location) => bridge_origin_relative_location,
 			Err(_) => {
@@ -260,7 +261,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					target: LOG_TARGET,
 					"Failed to convert the bridge {:?} origin location {:?}",
 					bridge_id,
-					bridge.bridge_origin_relative_location,
+					bridge.bridge_origin_relative_location.clone(),
 				);
 
 				return


### PR DESCRIPTION
Fixing https://github.com/paritytech/polkadot-sdk/issues/8215 based on https://github.com/paritytech/polkadot-sdk/issues/8185: Improve try-state for pallet-xcm-bridge

It removes try_as and uses try_into implementation instead.