### PR TITLE
Charge deposit based on key length

### DIFF
--- a/prdoc/pr_8648.prdoc
+++ b/prdoc/pr_8648.prdoc
@@ -1,0 +1,10 @@
+title: Charge deposit based on key length
+doc:
+- audience: Runtime Dev
+  description: We were only charging storage deposit based on value length but not
+    based on key length. Since we allow for variable length keys this has to be done.
+    Needs to be back ported since changing this in an already deployed system will
+    be nasty.
+crates:
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/src/storage.rs
+++ b/substrate/frame/revive/src/storage.rs
@@ -188,6 +188,7 @@ impl<T: Config> ContractInfo<T> {
 
 		if let Some(storage_meter) = storage_meter {
 			let mut diff = meter::Diff::default();
+			let key_len = key.len() as u32;
 			match (old_len, new_value.as_ref().map(|v| v.len() as u32)) {
 				(Some(old_len), Some(new_len)) =>
 					if new_len > old_len {
@@ -196,11 +197,11 @@ impl<T: Config> ContractInfo<T> {
 						diff.bytes_removed = old_len - new_len;
 					},
 				(None, Some(new_len)) => {
-					diff.bytes_added = new_len;
+					diff.bytes_added = new_len.saturating_add(key_len);
 					diff.items_added = 1;
 				},
 				(Some(old_len), None) => {
-					diff.bytes_removed = old_len;
+					diff.bytes_removed = old_len.saturating_add(key_len);
 					diff.items_removed = 1;
 				},
 				(None, None) => (),


### PR DESCRIPTION
We were only charging storage deposit based on value length but not based on key length. Since we allow for variable length keys this has to be done. Needs to be back ported since changing this in an already deployed system will be nasty.