### PR TITLE
[pallet-revive] impl_revive_api macro

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1483,7 +1483,6 @@ mod benches {
 pallet_revive::impl_runtime_apis_plus_revive!(
 	Runtime,
 	Executive,
-	UncheckedExtrinsic,
 	EthExtraImpl,
 
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1480,7 +1480,13 @@ mod benches {
 	);
 }
 
-impl_runtime_apis! {
+pallet_revive::impl_runtime_apis_plus_revive!(
+	Runtime,
+	Balance,
+	Executive,
+	UncheckedExtrinsic,
+	EthExtraImpl,
+
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
 		fn slot_duration() -> sp_consensus_aura::SlotDuration {
 			sp_consensus_aura::SlotDuration::from_millis(SLOT_DURATION)
@@ -2286,12 +2292,7 @@ impl_runtime_apis! {
 			genesis_config_presets::preset_names()
 		}
 	}
-
-	impl pallet_revive::ReviveApi<Block, AccountId, Balance, Nonce, BlockNumber> for Runtime
-	{
-		pallet_revive::impl_revive_api!(Balance, Executive, UncheckedExtrinsic, EthExtraImpl);
-	}
-}
+);
 
 cumulus_pallet_parachain_system::register_validate_block! {
 	Runtime = Runtime,

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -42,7 +42,7 @@ use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::{AggregateMessageOrigin, ClaimQueueOffset, CoreSelector, ParaId};
 use frame_support::{
 	construct_runtime, derive_impl,
-	dispatch::{DispatchClass, DispatchInfo},
+	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	ord_parameter_types, parameter_types,
 	traits::{
@@ -62,7 +62,7 @@ use frame_system::{
 };
 use pallet_asset_conversion_tx_payment::SwapAssetAdapter;
 use pallet_nfts::{DestroyWitness, PalletFeatures};
-use pallet_revive::{evm::runtime::EthExtra, AddressMapper, NonceAlreadyIncremented};
+use pallet_revive::evm::runtime::EthExtra;
 use pallet_xcm::EnsureXcm;
 use parachains_common::{
 	impls::DealWithFees, message_queue::*, AccountId, AssetIdForTrustBackedAssets, AuraId, Balance,
@@ -70,12 +70,10 @@ use parachains_common::{
 	NORMAL_DISPATCH_RATIO,
 };
 use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, U256};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	generic, impl_opaque_keys,
-	traits::{
-		AccountIdConversion, BlakeTwo256, Block as BlockT, Saturating, TransactionExtension, Verify,
-	},
+	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, Saturating, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, Perbill, Permill, RuntimeDebug,
 };
@@ -2291,180 +2289,7 @@ impl_runtime_apis! {
 
 	impl pallet_revive::ReviveApi<Block, AccountId, Balance, Nonce, BlockNumber> for Runtime
 	{
-		fn balance(address: H160) -> U256 {
-			Revive::evm_balance(&address)
-		}
-
-		fn block_gas_limit() -> U256 {
-			Revive::evm_block_gas_limit()
-		}
-
-		fn gas_price() -> U256 {
-			Revive::evm_gas_price()
-		}
-
-		fn nonce(address: H160) -> Nonce {
-			let account = <Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&address);
-			System::account_nonce(account)
-		}
-
-		fn eth_transact(tx: pallet_revive::evm::GenericTransaction) -> Result<pallet_revive::EthTransactInfo<Balance>, pallet_revive::EthTransactError>
-		{
-			let blockweights: BlockWeights = <Runtime as frame_system::Config>::BlockWeights::get();
-			let tx_fee = |pallet_call, mut dispatch_info: DispatchInfo| {
-				let call = RuntimeCall::Revive(pallet_call);
-				dispatch_info.extension_weight = EthExtraImpl::get_eth_extension(0, 0u32.into()).weight(&call);
-				let uxt: UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
-
-				pallet_transaction_payment::Pallet::<Runtime>::compute_fee(
-					uxt.encoded_size() as u32,
-					&dispatch_info,
-					0u32.into(),
-				)
-			};
-
-			Revive::bare_eth_transact(tx, blockweights.max_block, tx_fee)
-		}
-
-		fn call(
-			origin: AccountId,
-			dest: H160,
-			value: Balance,
-			gas_limit: Option<Weight>,
-			storage_deposit_limit: Option<Balance>,
-			input_data: Vec<u8>,
-		) -> pallet_revive::ContractResult<pallet_revive::ExecReturnValue, Balance> {
-			let blockweights= <Runtime as frame_system::Config>::BlockWeights::get();
-			Revive::bare_call(
-				RuntimeOrigin::signed(origin),
-				dest,
-				value,
-				gas_limit.unwrap_or(blockweights.max_block),
-				pallet_revive::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
-				input_data,
-			)
-		}
-
-		fn instantiate(
-			origin: AccountId,
-			value: Balance,
-			gas_limit: Option<Weight>,
-			storage_deposit_limit: Option<Balance>,
-			code: pallet_revive::Code,
-			data: Vec<u8>,
-			salt: Option<[u8; 32]>,
-		) -> pallet_revive::ContractResult<pallet_revive::InstantiateReturnValue, Balance>
-		{
-			let blockweights= <Runtime as frame_system::Config>::BlockWeights::get();
-			Revive::bare_instantiate(
-				RuntimeOrigin::signed(origin),
-				value,
-				gas_limit.unwrap_or(blockweights.max_block),
-				pallet_revive::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
-				code,
-				data,
-				salt,
-				NonceAlreadyIncremented::No,
-			)
-		}
-
-		fn upload_code(
-			origin: AccountId,
-			code: Vec<u8>,
-			storage_deposit_limit: Option<Balance>,
-		) -> pallet_revive::CodeUploadResult<Balance>
-		{
-			Revive::bare_upload_code(
-				RuntimeOrigin::signed(origin),
-				code,
-				storage_deposit_limit.unwrap_or(u128::MAX),
-			)
-		}
-
-		fn get_storage(
-			address: H160,
-			key: [u8; 32],
-		) -> pallet_revive::GetStorageResult {
-			Revive::get_storage(
-				address,
-				key
-			)
-		}
-
-		fn get_storage_var_key(
-			address: H160,
-			key: Vec<u8>,
-		) -> pallet_revive::GetStorageResult {
-			Revive::get_storage_var_key(
-				address,
-				key
-			)
-		}
-
-		fn trace_block(
-			block: Block,
-			tracer_type: pallet_revive::evm::TracerType,
-		) -> Vec<(u32, pallet_revive::evm::Trace)> {
-			use pallet_revive::tracing::trace;
-			let mut tracer = Revive::evm_tracer(tracer_type);
-			let mut traces = vec![];
-			let (header, extrinsics) = block.deconstruct();
-			Executive::initialize_block(&header);
-			for (index, ext) in extrinsics.into_iter().enumerate() {
-				trace(tracer.as_tracing(), || {
-					let _ = Executive::apply_extrinsic(ext);
-				});
-
-				if let Some(tx_trace) = tracer.collect_trace() {
-					traces.push((index as u32, tx_trace));
-				}
-			}
-
-			traces
-		}
-
-		fn trace_tx(
-			block: Block,
-			tx_index: u32,
-			tracer_type: pallet_revive::evm::TracerType,
-		) -> Option<pallet_revive::evm::Trace> {
-			use pallet_revive::tracing::trace;
-			let mut tracer = Revive::evm_tracer(tracer_type);
-			let (header, extrinsics) = block.deconstruct();
-
-			Executive::initialize_block(&header);
-			for (index, ext) in extrinsics.into_iter().enumerate() {
-				if index as u32 == tx_index {
-				trace(tracer.as_tracing(), || {
-						let _ = Executive::apply_extrinsic(ext);
-					});
-					break;
-				} else {
-					let _ = Executive::apply_extrinsic(ext);
-				}
-			}
-
-			tracer.collect_trace()
-		}
-
-		fn trace_call(
-			tx: pallet_revive::evm::GenericTransaction,
-			tracer_type: pallet_revive::evm::TracerType,
-			)
-			-> Result<pallet_revive::evm::Trace, pallet_revive::EthTransactError>
-		{
-			use pallet_revive::tracing::trace;
-			let mut tracer = Revive::evm_tracer(tracer_type);
-			let result = trace(tracer.as_tracing(), || Self::eth_transact(tx));
-
-			if let Some(trace) = tracer.collect_trace() {
-				Ok(trace)
-			} else if let Err(err) = result {
-				Err(err)
-			} else {
-				Ok(tracer.empty_trace())
-			}
-		}
+		pallet_revive::impl_revive_api!(Balance, Executive, UncheckedExtrinsic, EthExtraImpl);
 	}
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1482,7 +1482,6 @@ mod benches {
 
 pallet_revive::impl_runtime_apis_plus_revive!(
 	Runtime,
-	Balance,
 	Executive,
 	UncheckedExtrinsic,
 	EthExtraImpl,

--- a/prdoc/pr_8652.prdoc
+++ b/prdoc/pr_8652.prdoc
@@ -1,0 +1,10 @@
+title: '[pallet-revive] impl_revive_api macro'
+doc:
+- audience: Runtime Dev
+  description: Move pallet-revive runtime api implementation in a macro, so that we
+    don't repeat the code for every runtime.
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch
+- name: pallet-revive
+  bump: patch

--- a/prdoc/pr_8652.prdoc
+++ b/prdoc/pr_8652.prdoc
@@ -7,4 +7,4 @@ crates:
 - name: asset-hub-westend-runtime
   bump: patch
 - name: pallet-revive
-  bump: patch
+  bump: minor

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -40,7 +40,7 @@ use frame_election_provider_support::{
 };
 use frame_support::{
 	derive_impl,
-	dispatch::{DispatchClass, DispatchInfo},
+	dispatch::DispatchClass,
 	dynamic_params::{dynamic_pallet_params, dynamic_params},
 	genesis_builder_helper::{build_state, get_preset},
 	instances::{Instance1, Instance2},
@@ -85,10 +85,8 @@ use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use pallet_nfts::PalletFeatures;
 use pallet_nis::WithMaximumOf;
 use pallet_nomination_pools::PoolId;
-use pallet_revive::{evm::runtime::EthExtra, AddressMapper, NonceAlreadyIncremented};
+use pallet_revive::evm::runtime::EthExtra;
 use pallet_session::historical as pallet_session_historical;
-use sp_core::U256;
-use sp_runtime::traits::TransactionExtension;
 // Can't use `FungibleAdapter` here until Treasury pallet migrates to fungibles
 // <https://github.com/paritytech/polkadot-sdk/issues/226>
 use pallet_broker::TaskId;
@@ -103,7 +101,7 @@ use sp_consensus_beefy::{
 	mmr::MmrLeafVersion,
 };
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
-use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_inherents::{CheckInherentsResult, InherentData};
 use sp_runtime::{
 	curve::PiecewiseLinear,
@@ -3372,178 +3370,7 @@ impl_runtime_apis! {
 
 	impl pallet_revive::ReviveApi<Block, AccountId, Balance, Nonce, BlockNumber> for Runtime
 	{
-		fn balance(address: H160) -> U256 {
-			Revive::evm_balance(&address)
-		}
-
-		fn block_gas_limit() -> U256 {
-			Revive::evm_block_gas_limit()
-		}
-
-		fn gas_price() -> U256 {
-			Revive::evm_gas_price()
-		}
-
-		fn nonce(address: H160) -> Nonce {
-			let account = <Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&address);
-			System::account_nonce(account)
-		}
-
-		fn eth_transact(tx: pallet_revive::evm::GenericTransaction) -> Result<pallet_revive::EthTransactInfo<Balance>, pallet_revive::EthTransactError>
-		{
-			let blockweights: BlockWeights = <Runtime as frame_system::Config>::BlockWeights::get();
-			let tx_fee = |pallet_call, mut dispatch_info: DispatchInfo| {
-				let call = RuntimeCall::Revive(pallet_call);
-				dispatch_info.extension_weight = EthExtraImpl::get_eth_extension(0, 0u32.into()).weight(&call);
-				let uxt: UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
-
-				pallet_transaction_payment::Pallet::<Runtime>::compute_fee(
-					uxt.encoded_size() as u32,
-					&dispatch_info,
-					0u32.into(),
-				)
-			};
-
-			Revive::bare_eth_transact(tx, blockweights.max_block, tx_fee)
-		}
-
-		fn call(
-			origin: AccountId,
-			dest: H160,
-			value: Balance,
-			gas_limit: Option<Weight>,
-			storage_deposit_limit: Option<Balance>,
-			input_data: Vec<u8>,
-		) -> pallet_revive::ContractResult<pallet_revive::ExecReturnValue, Balance> {
-			Revive::bare_call(
-				RuntimeOrigin::signed(origin),
-				dest,
-				value,
-				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
-				pallet_revive::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
-				input_data,
-			)
-		}
-
-		fn instantiate(
-			origin: AccountId,
-			value: Balance,
-			gas_limit: Option<Weight>,
-			storage_deposit_limit: Option<Balance>,
-			code: pallet_revive::Code,
-			data: Vec<u8>,
-			salt: Option<[u8; 32]>,
-		) -> pallet_revive::ContractResult<pallet_revive::InstantiateReturnValue, Balance>
-		{
-			Revive::bare_instantiate(
-				RuntimeOrigin::signed(origin),
-				value,
-				gas_limit.unwrap_or(RuntimeBlockWeights::get().max_block),
-				pallet_revive::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
-				code,
-				data,
-				salt,
-				NonceAlreadyIncremented::No,
-			)
-		}
-
-		fn upload_code(
-			origin: AccountId,
-			code: Vec<u8>,
-			storage_deposit_limit: Option<Balance>,
-		) -> pallet_revive::CodeUploadResult<Balance>
-		{
-			Revive::bare_upload_code(
-				RuntimeOrigin::signed(origin),
-				code,
-				storage_deposit_limit.unwrap_or(u128::MAX),
-			)
-		}
-
-		fn get_storage_var_key(
-			address: H160,
-			key: Vec<u8>,
-		) -> pallet_revive::GetStorageResult {
-			Revive::get_storage_var_key(
-				address,
-				key
-			)
-		}
-
-		fn get_storage(
-			address: H160,
-			key: [u8; 32],
-		) -> pallet_revive::GetStorageResult {
-			Revive::get_storage(
-				address,
-				key
-			)
-		}
-
-		fn trace_block(
-			block: Block,
-			tracer_type: pallet_revive::evm::TracerType,
-		) -> Vec<(u32, pallet_revive::evm::Trace)> {
-			use pallet_revive::tracing::trace;
-			let mut tracer = Revive::evm_tracer(tracer_type);
-			let mut traces = vec![];
-			let (header, extrinsics) = block.deconstruct();
-			Executive::initialize_block(&header);
-			for (index, ext) in extrinsics.into_iter().enumerate() {
-				trace(tracer.as_tracing(), || {
-					let _ = Executive::apply_extrinsic(ext);
-				});
-
-				if let Some(tx_trace) = tracer.collect_trace() {
-					traces.push((index as u32, tx_trace));
-				}
-			}
-
-			traces
-		}
-
-		fn trace_tx(
-			block: Block,
-			tx_index: u32,
-			tracer_type: pallet_revive::evm::TracerType,
-		) -> Option<pallet_revive::evm::Trace> {
-			use pallet_revive::tracing::trace;
-			let mut tracer = Revive::evm_tracer(tracer_type);
-			let (header, extrinsics) = block.deconstruct();
-
-			Executive::initialize_block(&header);
-			for (index, ext) in extrinsics.into_iter().enumerate() {
-				if index as u32 == tx_index {
-				trace(tracer.as_tracing(), || {
-						let _ = Executive::apply_extrinsic(ext);
-					});
-					break;
-				} else {
-					let _ = Executive::apply_extrinsic(ext);
-				}
-			}
-
-			tracer.collect_trace()
-		}
-
-		fn trace_call(
-			tx: pallet_revive::evm::GenericTransaction,
-			tracer_type: pallet_revive::evm::TracerType,
-			)
-			-> Result<pallet_revive::evm::Trace, pallet_revive::EthTransactError>
-		{
-			use pallet_revive::tracing::trace;
-			let mut tracer = Revive::evm_tracer(tracer_type);
-			let result = trace(tracer.as_tracing(), || Self::eth_transact(tx));
-
-			if let Some(trace) = tracer.collect_trace() {
-				Ok(trace)
-			} else if let Err(err) = result {
-				Err(err)
-			} else {
-				Ok(tracer.empty_trace())
-			}
-		}
+		pallet_revive::impl_revive_api!(Balance, Executive, UncheckedExtrinsic, EthExtraImpl);
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3053,7 +3053,6 @@ mod benches {
 
 pallet_revive::impl_runtime_apis_plus_revive!(
 	Runtime,
-	Balance,
 	Executive,
 	UncheckedExtrinsic,
 	EthExtraImpl,

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3054,7 +3054,6 @@ mod benches {
 pallet_revive::impl_runtime_apis_plus_revive!(
 	Runtime,
 	Executive,
-	UncheckedExtrinsic,
 	EthExtraImpl,
 
 	impl sp_api::Core<Block> for Runtime {

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3051,7 +3051,13 @@ mod benches {
 	);
 }
 
-impl_runtime_apis! {
+pallet_revive::impl_runtime_apis_plus_revive!(
+	Runtime,
+	Balance,
+	Executive,
+	UncheckedExtrinsic,
+	EthExtraImpl,
+
 	impl sp_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
 			VERSION
@@ -3366,11 +3372,6 @@ impl_runtime_apis! {
 				key
 			)
 		}
-	}
-
-	impl pallet_revive::ReviveApi<Block, AccountId, Balance, Nonce, BlockNumber> for Runtime
-	{
-		pallet_revive::impl_revive_api!(Balance, Executive, UncheckedExtrinsic, EthExtraImpl);
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
@@ -3733,7 +3734,8 @@ impl_runtime_apis! {
 			genesis_config_presets::preset_names()
 		}
 	}
-}
+
+);
 
 #[cfg(test)]
 mod tests {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1643,188 +1643,202 @@ sp_api::decl_runtime_apis! {
 }
 
 #[macro_export]
-macro_rules! impl_revive_api {
-	($Balance: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty) => {
-		fn balance(address: $crate::H160) -> $crate::U256 {
-			$crate::Pallet::<Self>::evm_balance(&address)
-		}
+macro_rules! impl_runtime_apis_plus_revive {
+	($Runtime: ty, $Balance: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty,  $($rest:tt)* ) => {
 
-		fn block_gas_limit() -> $crate::U256 {
-			$crate::Pallet::<Self>::evm_block_gas_limit()
-		}
+		impl_runtime_apis! {
+			$($rest)*
 
-		fn gas_price() -> $crate::U256 {
-			$crate::Pallet::<Self>::evm_gas_price()
-		}
-
-		fn nonce(address: $crate::H160) -> <Self as $crate::frame_system::Config>::Nonce {
-			use $crate::AddressMapper;
-			let account = <Self as $crate::Config>::AddressMapper::to_account_id(&address);
-			$crate::frame_system::Pallet::<Self>::account_nonce(account)
-		}
-
-		fn eth_transact(
-			tx: $crate::evm::GenericTransaction,
-		) -> Result<$crate::EthTransactInfo<$Balance>, $crate::EthTransactError> {
-			use $crate::{
-				codec::Encode, evm::runtime::EthExtra, frame_support::traits::Get,
-				sp_runtime::traits::TransactionExtension,
-			};
-
-			let tx_fee = |pallet_call, mut dispatch_info: $crate::DispatchInfo| {
-				let call = <Self as $crate::frame_system::Config>::RuntimeCall::from(pallet_call);
-				dispatch_info.extension_weight =
-					<$EthExtra>::get_eth_extension(0, 0u32.into()).weight(&call);
-				let uxt: $UncheckedExtrinsic =
-					$crate::sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
-
-				$crate::pallet_transaction_payment::Pallet::<Self>::compute_fee(
-					uxt.encoded_size() as u32,
-					&dispatch_info,
-					0u32.into(),
-				)
-			};
-
-			let blockweights: $crate::BlockWeights =
-				<Self as $crate::frame_system::Config>::BlockWeights::get();
-			$crate::Pallet::<Self>::bare_eth_transact(tx, blockweights.max_block, tx_fee)
-		}
-
-		fn call(
-			origin: <Self as $crate::frame_system::Config>::AccountId,
-			dest: $crate::H160,
-			value: $Balance,
-			gas_limit: Option<$crate::Weight>,
-			storage_deposit_limit: Option<$Balance>,
-			input_data: Vec<u8>,
-		) -> $crate::ContractResult<$crate::ExecReturnValue, $Balance> {
-			use $crate::frame_support::traits::Get;
-			let blockweights: $crate::BlockWeights =
-				<Self as $crate::frame_system::Config>::BlockWeights::get();
-
-			let origin = <Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
-			$crate::Pallet::<Self>::bare_call(
-				origin,
-				dest,
-				value,
-				gas_limit.unwrap_or(blockweights.max_block),
-				$crate::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
-				input_data,
-			)
-		}
-
-		fn instantiate(
-			origin: <Self as $crate::frame_system::Config>::AccountId,
-			value: $Balance,
-			gas_limit: Option<$crate::Weight>,
-			storage_deposit_limit: Option<$Balance>,
-			code: $crate::Code,
-			data: Vec<u8>,
-			salt: Option<[u8; 32]>,
-		) -> $crate::ContractResult<$crate::InstantiateReturnValue, $Balance> {
-			use $crate::frame_support::traits::Get;
-			let blockweights: $crate::BlockWeights =
-				<Self as $crate::frame_system::Config>::BlockWeights::get();
-
-			let origin = <Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
-			$crate::Pallet::<Self>::bare_instantiate(
-				origin,
-				value,
-				gas_limit.unwrap_or(blockweights.max_block),
-				$crate::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
-				code,
-				data,
-				salt,
-				$crate::NonceAlreadyIncremented::No,
-			)
-		}
-
-		fn upload_code(
-			origin: <Self as $crate::frame_system::Config>::AccountId,
-			code: Vec<u8>,
-			storage_deposit_limit: Option<$Balance>,
-		) -> $crate::CodeUploadResult<$Balance> {
-			let origin = <Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
-			$crate::Pallet::<Self>::bare_upload_code(
-				origin,
-				code,
-				storage_deposit_limit.unwrap_or(u128::MAX),
-			)
-		}
-
-		fn get_storage_var_key(address: $crate::H160, key: Vec<u8>) -> $crate::GetStorageResult {
-			$crate::Pallet::<Self>::get_storage_var_key(address, key)
-		}
-
-		fn get_storage(address: $crate::H160, key: [u8; 32]) -> $crate::GetStorageResult {
-			$crate::Pallet::<Self>::get_storage(address, key)
-		}
-
-		fn trace_block(
-			block: <Self as $crate::frame_system::Config>::Block,
-			tracer_type: $crate::evm::TracerType,
-		) -> Vec<(u32, $crate::evm::Trace)> {
-			use $crate::{sp_runtime::traits::Block, tracing::trace};
-			let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
-			let mut traces = vec![];
-			let (header, extrinsics) = block.deconstruct();
-			<$Executive>::initialize_block(&header);
-			for (index, ext) in extrinsics.into_iter().enumerate() {
-				let t = tracer.as_tracing();
-				trace(t, || {
-					let _ = <$Executive>::apply_extrinsic(ext);
-				});
-
-				if let Some(tx_trace) = tracer.collect_trace() {
-					traces.push((index as u32, tx_trace));
+			impl pallet_revive::ReviveApi<Block, AccountId, Balance, Nonce, BlockNumber> for $Runtime {
+				fn balance(address: $crate::H160) -> $crate::U256 {
+					$crate::Pallet::<Self>::evm_balance(&address)
 				}
-			}
 
-			traces
-		}
+				fn block_gas_limit() -> $crate::U256 {
+					$crate::Pallet::<Self>::evm_block_gas_limit()
+				}
 
-		fn trace_tx(
-			block: <Self as $crate::frame_system::Config>::Block,
-			tx_index: u32,
-			tracer_type: $crate::evm::TracerType,
-		) -> Option<$crate::evm::Trace> {
-			use $crate::{sp_runtime::traits::Block, tracing::trace};
+				fn gas_price() -> $crate::U256 {
+					$crate::Pallet::<Self>::evm_gas_price()
+				}
 
-			let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
-			let (header, extrinsics) = block.deconstruct();
+				fn nonce(address: $crate::H160) -> <Self as $crate::frame_system::Config>::Nonce {
+					use $crate::AddressMapper;
+					let account = <Self as $crate::Config>::AddressMapper::to_account_id(&address);
+					$crate::frame_system::Pallet::<Self>::account_nonce(account)
+				}
 
-			<$Executive>::initialize_block(&header);
-			for (index, ext) in extrinsics.into_iter().enumerate() {
-				if index as u32 == tx_index {
+				fn eth_transact(
+					tx: $crate::evm::GenericTransaction,
+				) -> Result<$crate::EthTransactInfo<$Balance>, $crate::EthTransactError> {
+					use $crate::{
+						codec::Encode, evm::runtime::EthExtra, frame_support::traits::Get,
+						sp_runtime::traits::TransactionExtension,
+					};
+
+					let tx_fee = |pallet_call, mut dispatch_info: $crate::DispatchInfo| {
+						let call =
+							<Self as $crate::frame_system::Config>::RuntimeCall::from(pallet_call);
+						dispatch_info.extension_weight =
+							<$EthExtra>::get_eth_extension(0, 0u32.into()).weight(&call);
+						let uxt: $UncheckedExtrinsic =
+							$crate::sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
+
+						$crate::pallet_transaction_payment::Pallet::<Self>::compute_fee(
+							uxt.encoded_size() as u32,
+							&dispatch_info,
+							0u32.into(),
+						)
+					};
+
+					let blockweights: $crate::BlockWeights =
+						<Self as $crate::frame_system::Config>::BlockWeights::get();
+					$crate::Pallet::<Self>::bare_eth_transact(tx, blockweights.max_block, tx_fee)
+				}
+
+				fn call(
+					origin: <Self as $crate::frame_system::Config>::AccountId,
+					dest: $crate::H160,
+					value: $Balance,
+					gas_limit: Option<$crate::Weight>,
+					storage_deposit_limit: Option<$Balance>,
+					input_data: Vec<u8>,
+				) -> $crate::ContractResult<$crate::ExecReturnValue, $Balance> {
+					use $crate::frame_support::traits::Get;
+					let blockweights: $crate::BlockWeights =
+						<Self as $crate::frame_system::Config>::BlockWeights::get();
+
+					let origin =
+						<Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
+					$crate::Pallet::<Self>::bare_call(
+						origin,
+						dest,
+						value,
+						gas_limit.unwrap_or(blockweights.max_block),
+						$crate::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
+						input_data,
+					)
+				}
+
+				fn instantiate(
+					origin: <Self as $crate::frame_system::Config>::AccountId,
+					value: $Balance,
+					gas_limit: Option<$crate::Weight>,
+					storage_deposit_limit: Option<$Balance>,
+					code: $crate::Code,
+					data: Vec<u8>,
+					salt: Option<[u8; 32]>,
+				) -> $crate::ContractResult<$crate::InstantiateReturnValue, $Balance> {
+					use $crate::frame_support::traits::Get;
+					let blockweights: $crate::BlockWeights =
+						<Self as $crate::frame_system::Config>::BlockWeights::get();
+
+					let origin =
+						<Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
+					$crate::Pallet::<Self>::bare_instantiate(
+						origin,
+						value,
+						gas_limit.unwrap_or(blockweights.max_block),
+						$crate::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
+						code,
+						data,
+						salt,
+						$crate::NonceAlreadyIncremented::No,
+					)
+				}
+
+				fn upload_code(
+					origin: <Self as $crate::frame_system::Config>::AccountId,
+					code: Vec<u8>,
+					storage_deposit_limit: Option<$Balance>,
+				) -> $crate::CodeUploadResult<$Balance> {
+					let origin =
+						<Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
+					$crate::Pallet::<Self>::bare_upload_code(
+						origin,
+						code,
+						storage_deposit_limit.unwrap_or(u128::MAX),
+					)
+				}
+
+				fn get_storage_var_key(
+					address: $crate::H160,
+					key: Vec<u8>,
+				) -> $crate::GetStorageResult {
+					$crate::Pallet::<Self>::get_storage_var_key(address, key)
+				}
+
+				fn get_storage(address: $crate::H160, key: [u8; 32]) -> $crate::GetStorageResult {
+					$crate::Pallet::<Self>::get_storage(address, key)
+				}
+
+				fn trace_block(
+					block: <Self as $crate::frame_system::Config>::Block,
+					tracer_type: $crate::evm::TracerType,
+				) -> Vec<(u32, $crate::evm::Trace)> {
+					use $crate::{sp_runtime::traits::Block, tracing::trace};
+					let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
+					let mut traces = vec![];
+					let (header, extrinsics) = block.deconstruct();
+					<$Executive>::initialize_block(&header);
+					for (index, ext) in extrinsics.into_iter().enumerate() {
+						let t = tracer.as_tracing();
+						trace(t, || {
+							let _ = <$Executive>::apply_extrinsic(ext);
+						});
+
+						if let Some(tx_trace) = tracer.collect_trace() {
+							traces.push((index as u32, tx_trace));
+						}
+					}
+
+					traces
+				}
+
+				fn trace_tx(
+					block: <Self as $crate::frame_system::Config>::Block,
+					tx_index: u32,
+					tracer_type: $crate::evm::TracerType,
+				) -> Option<$crate::evm::Trace> {
+					use $crate::{sp_runtime::traits::Block, tracing::trace};
+
+					let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
+					let (header, extrinsics) = block.deconstruct();
+
+					<$Executive>::initialize_block(&header);
+					for (index, ext) in extrinsics.into_iter().enumerate() {
+						if index as u32 == tx_index {
+							let t = tracer.as_tracing();
+							trace(t, || {
+								let _ = <$Executive>::apply_extrinsic(ext);
+							});
+							break;
+						} else {
+							let _ = <$Executive>::apply_extrinsic(ext);
+						}
+					}
+
+					tracer.collect_trace()
+				}
+
+				fn trace_call(
+					tx: $crate::evm::GenericTransaction,
+					tracer_type: $crate::evm::TracerType,
+				) -> Result<$crate::evm::Trace, $crate::EthTransactError> {
+					use $crate::tracing::trace;
+					let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
 					let t = tracer.as_tracing();
-					trace(t, || {
-						let _ = <$Executive>::apply_extrinsic(ext);
-					});
-					break;
-				} else {
-					let _ = <$Executive>::apply_extrinsic(ext);
+
+					let result = trace(t, || Self::eth_transact(tx));
+
+					if let Some(trace) = tracer.collect_trace() {
+						Ok(trace)
+					} else if let Err(err) = result {
+						Err(err)
+					} else {
+						Ok(tracer.empty_trace())
+					}
 				}
-			}
-
-			tracer.collect_trace()
-		}
-
-		fn trace_call(
-			tx: $crate::evm::GenericTransaction,
-			tracer_type: $crate::evm::TracerType,
-		) -> Result<$crate::evm::Trace, $crate::EthTransactError> {
-			use $crate::tracing::trace;
-			let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
-			let t = tracer.as_tracing();
-
-			let result = trace(t, || Self::eth_transact(tx));
-
-			if let Some(trace) = tracer.collect_trace() {
-				Ok(trace)
-			} else if let Err(err) = result {
-				Err(err)
-			} else {
-				Ok(tracer.empty_trace())
 			}
 		}
 	};

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1644,7 +1644,7 @@ sp_api::decl_runtime_apis! {
 
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_revive {
-	($Runtime: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty,  $($rest:tt)* ) => {
+	($Runtime: ty, $Executive: ty, $EthExtra: ty,  $($rest:tt)* ) => {
 
 		impl_runtime_apis! {
 			$($rest)*
@@ -1674,6 +1674,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 					use $crate::{
 						codec::Encode, evm::runtime::EthExtra, frame_support::traits::Get,
 						sp_runtime::traits::TransactionExtension,
+						sp_runtime::traits::Block as BlockT
 					};
 
 					let tx_fee = |pallet_call, mut dispatch_info: $crate::DispatchInfo| {
@@ -1681,7 +1682,8 @@ macro_rules! impl_runtime_apis_plus_revive {
 							<Self as $crate::frame_system::Config>::RuntimeCall::from(pallet_call);
 						dispatch_info.extension_weight =
 							<$EthExtra>::get_eth_extension(0, 0u32.into()).weight(&call);
-						let uxt: $UncheckedExtrinsic =
+
+						let uxt: <Block as BlockT>::Extrinsic =
 							$crate::sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
 
 						$crate::pallet_transaction_payment::Pallet::<Self>::compute_fee(

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -86,10 +86,13 @@ pub use crate::{
 	exec::{MomentOf, Origin},
 	pallet::*,
 };
-pub use frame_support::{dispatch::DispatchInfo, weights::Weight};
-pub use frame_system;
+pub use codec;
+pub use frame_support::{self, dispatch::DispatchInfo, weights::Weight};
+pub use frame_system::{self, limits::BlockWeights};
+pub use pallet_transaction_payment;
 pub use primitives::*;
 pub use sp_core::{H160, H256, U256};
+pub use sp_runtime;
 pub use weights::WeightInfo;
 
 #[cfg(doc)]
@@ -1639,12 +1642,6 @@ sp_api::decl_runtime_apis! {
 	}
 }
 
-pub use codec;
-pub use frame_support;
-pub use frame_system::limits::BlockWeights;
-pub use pallet_transaction_payment;
-pub use sp_runtime;
-
 #[macro_export]
 macro_rules! impl_revive_api {
 	($Balance: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty) => {
@@ -1670,7 +1667,8 @@ macro_rules! impl_revive_api {
 			tx: $crate::evm::GenericTransaction,
 		) -> Result<$crate::EthTransactInfo<$Balance>, $crate::EthTransactError> {
 			use $crate::{
-				codec::Encode, evm::runtime::EthExtra, sp_runtime::traits::TransactionExtension,
+				codec::Encode, evm::runtime::EthExtra, frame_support::traits::Get,
+				sp_runtime::traits::TransactionExtension,
 			};
 
 			let tx_fee = |pallet_call, mut dispatch_info: $crate::DispatchInfo| {
@@ -1687,7 +1685,6 @@ macro_rules! impl_revive_api {
 				)
 			};
 
-			use $crate::frame_support::traits::Get;
 			let blockweights: $crate::BlockWeights =
 				<Self as $crate::frame_system::Config>::BlockWeights::get();
 			$crate::Pallet::<Self>::bare_eth_transact(tx, blockweights.max_block, tx_fee)

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1642,6 +1642,15 @@ sp_api::decl_runtime_apis! {
 	}
 }
 
+/// This macro wraps substrate's `impl_runtime_apis!` and implements `pallet_revive` runtime APIs.
+///
+/// # Parameters
+/// - `$Runtime`: The runtime type to implement the APIs for.
+/// - `$Executive`: The Executive type of the runtime.
+/// - `$EthExtra`: Type for additional Ethereum runtime extension.
+/// - `$($rest:tt)*`: Remaining input to be forwarded to the underlying `impl_runtime_apis!`.
+#[macro_export]
+macro_rules! impl_runtime_apis_plus_revive {
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_revive {
 	($Runtime: ty, $Executive: ty, $EthExtra: ty,  $($rest:tt)* ) => {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1651,7 +1651,7 @@ sp_api::decl_runtime_apis! {
 /// - `$($rest:tt)*`: Remaining input to be forwarded to the underlying `impl_runtime_apis!`.
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_revive {
-	($Runtime: ty, $Executive: ty, $EthExtra: ty,  $($rest:tt)* ) => {
+	($Runtime: ty, $Executive: ty, $EthExtra: ty, $($rest:tt)*) => {
 
 		impl_runtime_apis! {
 			$($rest)*

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1644,7 +1644,7 @@ sp_api::decl_runtime_apis! {
 
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_revive {
-	($Runtime: ty, $Balance: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty,  $($rest:tt)* ) => {
+	($Runtime: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty,  $($rest:tt)* ) => {
 
 		impl_runtime_apis! {
 			$($rest)*
@@ -1670,7 +1670,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 
 				fn eth_transact(
 					tx: $crate::evm::GenericTransaction,
-				) -> Result<$crate::EthTransactInfo<$Balance>, $crate::EthTransactError> {
+				) -> Result<$crate::EthTransactInfo<Balance>, $crate::EthTransactError> {
 					use $crate::{
 						codec::Encode, evm::runtime::EthExtra, frame_support::traits::Get,
 						sp_runtime::traits::TransactionExtension,
@@ -1699,11 +1699,11 @@ macro_rules! impl_runtime_apis_plus_revive {
 				fn call(
 					origin: <Self as $crate::frame_system::Config>::AccountId,
 					dest: $crate::H160,
-					value: $Balance,
+					value: Balance,
 					gas_limit: Option<$crate::Weight>,
-					storage_deposit_limit: Option<$Balance>,
+					storage_deposit_limit: Option<Balance>,
 					input_data: Vec<u8>,
-				) -> $crate::ContractResult<$crate::ExecReturnValue, $Balance> {
+				) -> $crate::ContractResult<$crate::ExecReturnValue, Balance> {
 					use $crate::frame_support::traits::Get;
 					let blockweights: $crate::BlockWeights =
 						<Self as $crate::frame_system::Config>::BlockWeights::get();
@@ -1722,13 +1722,13 @@ macro_rules! impl_runtime_apis_plus_revive {
 
 				fn instantiate(
 					origin: <Self as $crate::frame_system::Config>::AccountId,
-					value: $Balance,
+					value: Balance,
 					gas_limit: Option<$crate::Weight>,
-					storage_deposit_limit: Option<$Balance>,
+					storage_deposit_limit: Option<Balance>,
 					code: $crate::Code,
 					data: Vec<u8>,
 					salt: Option<[u8; 32]>,
-				) -> $crate::ContractResult<$crate::InstantiateReturnValue, $Balance> {
+				) -> $crate::ContractResult<$crate::InstantiateReturnValue, Balance> {
 					use $crate::frame_support::traits::Get;
 					let blockweights: $crate::BlockWeights =
 						<Self as $crate::frame_system::Config>::BlockWeights::get();
@@ -1750,8 +1750,8 @@ macro_rules! impl_runtime_apis_plus_revive {
 				fn upload_code(
 					origin: <Self as $crate::frame_system::Config>::AccountId,
 					code: Vec<u8>,
-					storage_deposit_limit: Option<$Balance>,
-				) -> $crate::CodeUploadResult<$Balance> {
+					storage_deposit_limit: Option<Balance>,
+				) -> $crate::CodeUploadResult<Balance> {
 					let origin =
 						<Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
 					$crate::Pallet::<Self>::bare_upload_code(

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1651,8 +1651,6 @@ sp_api::decl_runtime_apis! {
 /// - `$($rest:tt)*`: Remaining input to be forwarded to the underlying `impl_runtime_apis!`.
 #[macro_export]
 macro_rules! impl_runtime_apis_plus_revive {
-#[macro_export]
-macro_rules! impl_runtime_apis_plus_revive {
 	($Runtime: ty, $Executive: ty, $EthExtra: ty,  $($rest:tt)* ) => {
 
 		impl_runtime_apis! {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -57,7 +57,7 @@ use codec::{Codec, Decode, Encode};
 use environmental::*;
 use frame_support::{
 	dispatch::{
-		DispatchErrorWithPostInfo, DispatchInfo, DispatchResultWithPostInfo, GetDispatchInfo, Pays,
+		DispatchErrorWithPostInfo, DispatchResultWithPostInfo, GetDispatchInfo, Pays,
 		PostDispatchInfo, RawOrigin,
 	},
 	ensure,
@@ -67,7 +67,7 @@ use frame_support::{
 		tokens::{Fortitude::Polite, Preservation::Preserve},
 		ConstU32, ConstU64, Contains, EnsureOrigin, Get, IsType, OriginTrait, Time,
 	},
-	weights::{Weight, WeightMeter},
+	weights::WeightMeter,
 	BoundedVec, RuntimeDebugNoBound,
 };
 use frame_system::{
@@ -76,7 +76,6 @@ use frame_system::{
 	Pallet as System,
 };
 use scale_info::TypeInfo;
-use sp_core::{H160, H256, U256};
 use sp_runtime::{
 	traits::{BadOrigin, Bounded, Convert, Dispatchable, Saturating, Zero},
 	AccountId32, DispatchError,
@@ -87,7 +86,10 @@ pub use crate::{
 	exec::{MomentOf, Origin},
 	pallet::*,
 };
+pub use frame_support::{dispatch::DispatchInfo, weights::Weight};
+pub use frame_system;
 pub use primitives::*;
+pub use sp_core::{H160, H256, U256};
 pub use weights::WeightInfo;
 
 #[cfg(doc)]
@@ -1635,4 +1637,198 @@ sp_api::decl_runtime_apis! {
 		fn trace_call(tx: GenericTransaction, config: TracerType) -> Result<Trace, EthTransactError>;
 
 	}
+}
+
+pub use codec;
+pub use frame_support;
+pub use frame_system::limits::BlockWeights;
+pub use pallet_transaction_payment;
+pub use sp_runtime;
+
+#[macro_export]
+macro_rules! impl_revive_api {
+	($Balance: ty, $Executive: ty, $UncheckedExtrinsic: ty, $EthExtra: ty) => {
+		fn balance(address: $crate::H160) -> $crate::U256 {
+			$crate::Pallet::<Self>::evm_balance(&address)
+		}
+
+		fn block_gas_limit() -> $crate::U256 {
+			$crate::Pallet::<Self>::evm_block_gas_limit()
+		}
+
+		fn gas_price() -> $crate::U256 {
+			$crate::Pallet::<Self>::evm_gas_price()
+		}
+
+		fn nonce(address: $crate::H160) -> <Self as $crate::frame_system::Config>::Nonce {
+			use $crate::AddressMapper;
+			let account = <Self as $crate::Config>::AddressMapper::to_account_id(&address);
+			$crate::frame_system::Pallet::<Self>::account_nonce(account)
+		}
+
+		fn eth_transact(
+			tx: $crate::evm::GenericTransaction,
+		) -> Result<$crate::EthTransactInfo<$Balance>, $crate::EthTransactError> {
+			use $crate::{
+				codec::Encode, evm::runtime::EthExtra, sp_runtime::traits::TransactionExtension,
+			};
+
+			let tx_fee = |pallet_call, mut dispatch_info: $crate::DispatchInfo| {
+				let call = <Self as $crate::frame_system::Config>::RuntimeCall::from(pallet_call);
+				dispatch_info.extension_weight =
+					<$EthExtra>::get_eth_extension(0, 0u32.into()).weight(&call);
+				let uxt: $UncheckedExtrinsic =
+					$crate::sp_runtime::generic::UncheckedExtrinsic::new_bare(call).into();
+
+				$crate::pallet_transaction_payment::Pallet::<Self>::compute_fee(
+					uxt.encoded_size() as u32,
+					&dispatch_info,
+					0u32.into(),
+				)
+			};
+
+			use $crate::frame_support::traits::Get;
+			let blockweights: $crate::BlockWeights =
+				<Self as $crate::frame_system::Config>::BlockWeights::get();
+			$crate::Pallet::<Self>::bare_eth_transact(tx, blockweights.max_block, tx_fee)
+		}
+
+		fn call(
+			origin: <Self as $crate::frame_system::Config>::AccountId,
+			dest: $crate::H160,
+			value: $Balance,
+			gas_limit: Option<$crate::Weight>,
+			storage_deposit_limit: Option<$Balance>,
+			input_data: Vec<u8>,
+		) -> $crate::ContractResult<$crate::ExecReturnValue, $Balance> {
+			use $crate::frame_support::traits::Get;
+			let blockweights: $crate::BlockWeights =
+				<Self as $crate::frame_system::Config>::BlockWeights::get();
+
+			let origin = <Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
+			$crate::Pallet::<Self>::bare_call(
+				origin,
+				dest,
+				value,
+				gas_limit.unwrap_or(blockweights.max_block),
+				$crate::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
+				input_data,
+			)
+		}
+
+		fn instantiate(
+			origin: <Self as $crate::frame_system::Config>::AccountId,
+			value: $Balance,
+			gas_limit: Option<$crate::Weight>,
+			storage_deposit_limit: Option<$Balance>,
+			code: $crate::Code,
+			data: Vec<u8>,
+			salt: Option<[u8; 32]>,
+		) -> $crate::ContractResult<$crate::InstantiateReturnValue, $Balance> {
+			use $crate::frame_support::traits::Get;
+			let blockweights: $crate::BlockWeights =
+				<Self as $crate::frame_system::Config>::BlockWeights::get();
+
+			let origin = <Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
+			$crate::Pallet::<Self>::bare_instantiate(
+				origin,
+				value,
+				gas_limit.unwrap_or(blockweights.max_block),
+				$crate::DepositLimit::Balance(storage_deposit_limit.unwrap_or(u128::MAX)),
+				code,
+				data,
+				salt,
+				$crate::NonceAlreadyIncremented::No,
+			)
+		}
+
+		fn upload_code(
+			origin: <Self as $crate::frame_system::Config>::AccountId,
+			code: Vec<u8>,
+			storage_deposit_limit: Option<$Balance>,
+		) -> $crate::CodeUploadResult<$Balance> {
+			let origin = <Self as $crate::frame_system::Config>::RuntimeOrigin::signed(origin);
+			$crate::Pallet::<Self>::bare_upload_code(
+				origin,
+				code,
+				storage_deposit_limit.unwrap_or(u128::MAX),
+			)
+		}
+
+		fn get_storage_var_key(address: $crate::H160, key: Vec<u8>) -> $crate::GetStorageResult {
+			$crate::Pallet::<Self>::get_storage_var_key(address, key)
+		}
+
+		fn get_storage(address: $crate::H160, key: [u8; 32]) -> $crate::GetStorageResult {
+			$crate::Pallet::<Self>::get_storage(address, key)
+		}
+
+		fn trace_block(
+			block: <Self as $crate::frame_system::Config>::Block,
+			tracer_type: $crate::evm::TracerType,
+		) -> Vec<(u32, $crate::evm::Trace)> {
+			use $crate::{sp_runtime::traits::Block, tracing::trace};
+			let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
+			let mut traces = vec![];
+			let (header, extrinsics) = block.deconstruct();
+			<$Executive>::initialize_block(&header);
+			for (index, ext) in extrinsics.into_iter().enumerate() {
+				let t = tracer.as_tracing();
+				trace(t, || {
+					let _ = <$Executive>::apply_extrinsic(ext);
+				});
+
+				if let Some(tx_trace) = tracer.collect_trace() {
+					traces.push((index as u32, tx_trace));
+				}
+			}
+
+			traces
+		}
+
+		fn trace_tx(
+			block: <Self as $crate::frame_system::Config>::Block,
+			tx_index: u32,
+			tracer_type: $crate::evm::TracerType,
+		) -> Option<$crate::evm::Trace> {
+			use $crate::{sp_runtime::traits::Block, tracing::trace};
+
+			let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
+			let (header, extrinsics) = block.deconstruct();
+
+			<$Executive>::initialize_block(&header);
+			for (index, ext) in extrinsics.into_iter().enumerate() {
+				if index as u32 == tx_index {
+					let t = tracer.as_tracing();
+					trace(t, || {
+						let _ = <$Executive>::apply_extrinsic(ext);
+					});
+					break;
+				} else {
+					let _ = <$Executive>::apply_extrinsic(ext);
+				}
+			}
+
+			tracer.collect_trace()
+		}
+
+		fn trace_call(
+			tx: $crate::evm::GenericTransaction,
+			tracer_type: $crate::evm::TracerType,
+		) -> Result<$crate::evm::Trace, $crate::EthTransactError> {
+			use $crate::tracing::trace;
+			let mut tracer = $crate::Pallet::<Self>::evm_tracer(tracer_type);
+			let t = tracer.as_tracing();
+
+			let result = trace(t, || Self::eth_transact(tx));
+
+			if let Some(trace) = tracer.collect_trace() {
+				Ok(trace)
+			} else if let Err(err) = result {
+				Err(err)
+			} else {
+				Ok(tracer.empty_trace())
+			}
+		}
+	};
 }

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1669,7 +1669,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 					$crate::Pallet::<Self>::evm_gas_price()
 				}
 
-				fn nonce(address: $crate::H160) -> <Self as $crate::frame_system::Config>::Nonce {
+				fn nonce(address: $crate::H160) -> Nonce {
 					use $crate::AddressMapper;
 					let account = <Self as $crate::Config>::AddressMapper::to_account_id(&address);
 					$crate::frame_system::Pallet::<Self>::account_nonce(account)
@@ -1706,7 +1706,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 				}
 
 				fn call(
-					origin: <Self as $crate::frame_system::Config>::AccountId,
+					origin: AccountId,
 					dest: $crate::H160,
 					value: Balance,
 					gas_limit: Option<$crate::Weight>,
@@ -1730,7 +1730,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 				}
 
 				fn instantiate(
-					origin: <Self as $crate::frame_system::Config>::AccountId,
+					origin: AccountId,
 					value: Balance,
 					gas_limit: Option<$crate::Weight>,
 					storage_deposit_limit: Option<Balance>,
@@ -1757,7 +1757,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 				}
 
 				fn upload_code(
-					origin: <Self as $crate::frame_system::Config>::AccountId,
+					origin: AccountId,
 					code: Vec<u8>,
 					storage_deposit_limit: Option<Balance>,
 				) -> $crate::CodeUploadResult<Balance> {
@@ -1782,7 +1782,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 				}
 
 				fn trace_block(
-					block: <Self as $crate::frame_system::Config>::Block,
+					block: Block,
 					tracer_type: $crate::evm::TracerType,
 				) -> Vec<(u32, $crate::evm::Trace)> {
 					use $crate::{sp_runtime::traits::Block, tracing::trace};
@@ -1805,7 +1805,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 				}
 
 				fn trace_tx(
-					block: <Self as $crate::frame_system::Config>::Block,
+					block: Block,
 					tx_index: u32,
 					tracer_type: $crate::evm::TracerType,
 				) -> Option<$crate::evm::Trace> {


### PR DESCRIPTION
Move pallet-revive runtime api implementation in a macro, so that we don't repeat the code for every runtime.