### PR TITLE
Staking (EPMB): Add defensive error handling to voter snapshot creation and solution verification

### DIFF
--- a/prdoc/pr_8687.prdoc
+++ b/prdoc/pr_8687.prdoc
@@ -3,12 +3,12 @@ title: 'Staking (EPMB): Add defensive error handling to voter snapshot creation 
 doc:
 - audience: Runtime Dev
   description: |-
-    Replace unwrap() with defensive_unwrap_or_default() in the on_initialize path of the
+    - Replace unwrap() with defensive_unwrap_or_default() in the on_initialize path of the
     election-provider-multiblock pallet to gracefully handle runtime misconfigurations where voter
     snapshot conversion fails, preventing potential panics during block initialization.
-
-    Replace unwrap() with defensive_unwrap_or(u32::MAX) to ensure solution fails verification
+    - Replace unwrap() with defensive_unwrap_or(u32::MAX) to ensure solution fails verification
     gracefully when desired_targets is unavailable rather than panicking.
+    - Add error events for failed target and voter snapshots
 crates:
 - name: pallet-election-provider-multi-block
-  bump: minor
+  bump: major

--- a/prdoc/pr_8687.prdoc
+++ b/prdoc/pr_8687.prdoc
@@ -1,4 +1,4 @@
-title: 'Staking (EPMB): Add defensive error handling to voter snapshot creation'
+title: 'Staking (EPMB): Add defensive error handling to voter snapshot creation and solution verification'
 
 doc:
 - audience: Runtime Dev
@@ -6,6 +6,9 @@ doc:
     Replace unwrap() with defensive_unwrap_or_default() in the on_initialize path of the
     election-provider-multiblock pallet to gracefully handle runtime misconfigurations where voter
     snapshot conversion fails, preventing potential panics during block initialization.
+
+    Replace unwrap() with defensive_unwrap_or(u32::MAX) to ensure solution fails verification
+    gracefully when desired_targets is unavailable rather than panicking.
 crates:
 - name: pallet-election-provider-multi-block
   bump: minor

--- a/prdoc/pr_8687.prdoc
+++ b/prdoc/pr_8687.prdoc
@@ -3,9 +3,7 @@ title: 'Staking (EPMB): Add defensive error handling to voter snapshot creation 
 doc:
 - audience: Runtime Dev
   description: |-
-    - Replace unwrap() with defensive_unwrap_or_default() in the on_initialize path of the
-    election-provider-multiblock pallet to gracefully handle runtime misconfigurations where voter
-    snapshot conversion fails, preventing potential panics during block initialization.
+    - Refactor snapshot creation to emit events and triggers defensive panic on failure
     - Replace unwrap() with defensive_unwrap_or(u32::MAX) to ensure solution fails verification
     gracefully when desired_targets is unavailable rather than panicking.
     - Add error events for failed target and voter snapshots

--- a/prdoc/pr_8687.prdoc
+++ b/prdoc/pr_8687.prdoc
@@ -1,0 +1,11 @@
+title: 'Staking (EPMB): Add defensive error handling to voter snapshot creation'
+
+doc:
+- audience: Runtime Dev
+  description: |-
+    Replace unwrap() with defensive_unwrap_or_default() in the on_initialize path of the
+    election-provider-multiblock pallet to gracefully handle runtime misconfigurations where voter
+    snapshot conversion fails, preventing potential panics during block initialization.
+crates:
+- name: pallet-election-provider-multi-block
+  bump: minor

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -665,14 +665,6 @@ pub mod pallet {
 				},
 				Phase::Snapshot(x) => {
 					// create voter snapshot.
-					// Note that `create_voters_snapshot_paged()` can return an error in two cases:
-					// 1. debug assertion in `election_voters()` if the final result violate bounds.
-					//    Which will never happen since no size bound is provided.
-					// 2. the try_into() conversion fails when converting `Vec<VoterOf<T>>` to
-					//    `BoundedVec<_, T::VoterSnapshotPerBlock>`
-					// - This is a runtime configuration issue!
-					// We go for a graceful degradation in release builds (empty snapshot if we
-					// can't create a voter snapshot).
 					Self::create_voters_snapshot_paged(x).defensive_unwrap_or_default();
 					T::WeightInfo::on_initialize_into_snapshot_rest()
 				},

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -664,7 +664,7 @@ pub mod pallet {
 					T::WeightInfo::on_initialize_into_snapshot_msp()
 				},
 				Phase::Snapshot(x) => {
-					// create voter snapshot.
+					// create voter snapshot
 					Self::create_voters_snapshot_paged(x).defensive_unwrap_or_default();
 					T::WeightInfo::on_initialize_into_snapshot_rest()
 				},

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -1877,7 +1877,6 @@ mod phase_rotation {
 				roll_to(15);
 				assert_ok!(Snapshot::<Runtime>::ensure_snapshot(true, Pages::get()));
 				assert_eq!(MultiBlock::current_phase(), Phase::Signed(4));
-
 				assert_eq!(
 					multi_block_events_since_last_call(),
 					vec![
@@ -1888,6 +1887,7 @@ mod phase_rotation {
 						}
 					]
 				);
+				assert_eq!(MultiBlock::round(), 0);
 
 				roll_to(19);
 				assert_eq!(MultiBlock::current_phase(), Phase::Signed(0));

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -664,8 +664,16 @@ pub mod pallet {
 					T::WeightInfo::on_initialize_into_snapshot_msp()
 				},
 				Phase::Snapshot(x) => {
-					// create voter snapshot
-					Self::create_voters_snapshot_paged(x).unwrap();
+					// create voter snapshot.
+					// Note that `create_voters_snapshot_paged()` can return an error in two cases:
+					// 1. debug assertion in `election_voters()` if the final result violate bounds.
+					//    Which will never happen since no size bound is provided.
+					// 2. the try_into() conversion fails when converting `Vec<VoterOf<T>>` to
+					//    `BoundedVec<_, T::VoterSnapshotPerBlock>`
+					// - This is a runtime configuration issue!
+					// We go for a graceful degradation in release builds (empty snapshot if we
+					// can't create a voter snapshot).
+					Self::create_voters_snapshot_paged(x).defensive_unwrap_or_default();
 					T::WeightInfo::on_initialize_into_snapshot_rest()
 				},
 				_ => T::WeightInfo::on_initialize_nothing(),
@@ -1291,8 +1299,15 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), ElectionError<T>> {
 		let count = T::VoterSnapshotPerBlock::get();
 		let bounds = DataProviderBounds { count: Some(count.into()), size: None };
+		// This function is called on the `on-init` path, so we must be careful with error handling.
+		// Note that since no size bound is provided, `electing_voters()`—bug aside— will never fail
+		// due to a bound violation. The current implementation in the staking pallet has a debug
+		// assertion <=> the bound is violated so we should be safe here.
 		let voters: BoundedVec<_, T::VoterSnapshotPerBlock> =
 			T::DataProvider::electing_voters(bounds, remaining)
+				// the try_into() can actually fail unlike `electing_voters()` (e.g. due to runtime
+				// misconfiguration) so this needs to be handled defensively by the caller in
+				// the `on-init` path.
 				.and_then(|v| v.try_into().map_err(|_| "try-into failed"))
 				.map_err(ElectionError::DataProvider)?;
 

--- a/substrate/frame/election-provider-multi-block/src/mock/staking.rs
+++ b/substrate/frame/election-provider-multi-block/src/mock/staking.rs
@@ -49,6 +49,7 @@ frame_support::parameter_types! {
 	pub static EpochLength: u64 = 30;
 
 	pub static LastIteratedVoterIndex: Option<usize> = None;
+	pub static FailVotersSnapshot: bool = false;
 }
 
 pub struct MockStaking;
@@ -83,6 +84,11 @@ impl ElectionDataProvider for MockStaking {
 		Vec<(AccountId, VoteWeight, BoundedVec<AccountId, Self::MaxVotesPerVoter>)>,
 	> {
 		let mut voters = Voters::get();
+
+		// Add conditional bounds check for testing voter snapshot failures
+		if FailVotersSnapshot::get() && bounds.slice_exhausted(&voters) {
+			return Err("Voters too big")
+		}
 
 		// jump to the first non-iterated, if this is a follow up.
 		if let Some(index) = LastIteratedVoterIndex::get() {

--- a/substrate/frame/election-provider-multi-block/src/mock/staking.rs
+++ b/substrate/frame/election-provider-multi-block/src/mock/staking.rs
@@ -49,7 +49,6 @@ frame_support::parameter_types! {
 	pub static EpochLength: u64 = 30;
 
 	pub static LastIteratedVoterIndex: Option<usize> = None;
-	pub static FailVotersSnapshot: bool = false;
 }
 
 pub struct MockStaking;
@@ -84,11 +83,6 @@ impl ElectionDataProvider for MockStaking {
 		Vec<(AccountId, VoteWeight, BoundedVec<AccountId, Self::MaxVotesPerVoter>)>,
 	> {
 		let mut voters = Voters::get();
-
-		// Add conditional bounds check for testing voter snapshot failures
-		if FailVotersSnapshot::get() && bounds.slice_exhausted(&voters) {
-			return Err("Voters too big")
-		}
 
 		// jump to the first non-iterated, if this is a follow up.
 		if let Some(index) = LastIteratedVoterIndex::get() {

--- a/substrate/frame/election-provider-multi-block/src/verifier/impls.rs
+++ b/substrate/frame/election-provider-multi-block/src/verifier/impls.rs
@@ -799,9 +799,6 @@ impl<T: Config> Pallet<T> {
 	fn finalize_async_verification(claimed_score: ElectionScore) -> Result<(), FeasibilityError> {
 		let outcome = QueuedSolution::<T>::compute_invalid_score()
 			.and_then(|(final_score, winner_count)| {
-				// Using `Bounded::max_value()` as the fallback ensures the solution will fail
-				// verification and  the solution gets rejected with
-				// `FeasibilityError::WrongWinnerCount`.
 				let desired_targets =
 					crate::Snapshot::<T>::desired_targets().defensive_unwrap_or(u32::MAX);
 				// claimed_score checked prior in seal_unverified_solution

--- a/substrate/frame/election-provider-multi-block/src/verifier/impls.rs
+++ b/substrate/frame/election-provider-multi-block/src/verifier/impls.rs
@@ -799,7 +799,11 @@ impl<T: Config> Pallet<T> {
 	fn finalize_async_verification(claimed_score: ElectionScore) -> Result<(), FeasibilityError> {
 		let outcome = QueuedSolution::<T>::compute_invalid_score()
 			.and_then(|(final_score, winner_count)| {
-				let desired_targets = crate::Snapshot::<T>::desired_targets().unwrap();
+				// Using `Bounded::max_value()` as the fallback ensures the solution will fail
+				// verification and  the solution gets rejected with
+				// `FeasibilityError::WrongWinnerCount`.
+				let desired_targets =
+					crate::Snapshot::<T>::desired_targets().defensive_unwrap_or(u32::MAX);
 				// claimed_score checked prior in seal_unverified_solution
 				match (final_score == claimed_score, winner_count == desired_targets) {
 					(true, true) => {


### PR DESCRIPTION
- Refactor snapshot creation to emit events and triggers defensive panic on failure
- Replace unwrap() with defensive_unwrap_or(u32::MAX) to ensure solution fails verification gracefully when desired_targets is unavailable rather than panicking.
- Add error events for failed target and voter snapshots

Close #8685.
