### PR TITLE
tests: Ensure tests are started on port 0 for TCP

### DIFF
--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -765,7 +765,6 @@ impl TestNodeBuilder {
 		relay_chain_config.network.node_name =
 			format!("{} (relay chain)", relay_chain_config.network.node_name);
 
-		let multiaddr = parachain_config.network.listen_addresses[0].clone();
 		let (task_manager, client, network, rpc_handlers, transaction_pool, backend) =
 			match relay_chain_config.network.network_backend {
 				sc_network::config::NetworkBackendType::Libp2p =>

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -916,34 +916,6 @@ pub fn node_config(
 	})
 }
 
-/// Extract the multiaddr from the network service.
-async fn extract_multiaddr(network: Arc<dyn NetworkService>) -> Multiaddr {
-	loop {
-		// Litep2p provides instantly the listen address of the TCP protocol and
-		// ditched the `/0` port used by the `node_config` function.
-		//
-		// Libp2p backend needs to be polled in a separate tokio task a few times
-		// before the listen address is available. The address is made available
-		// through the `SwarmEvent::NewListenAddr` event.
-		let listen_addresses = network.listen_addresses();
-		println!("Node is listening on: {:?}", listen_addresses);
-
-		// The network backend must produce a valid TCP port.
-		match listen_addresses.into_iter().find(|addr| {
-			addr.iter().any(|protocol| match protocol {
-				multiaddr::Protocol::Tcp(port) => port > 0,
-				_ => false,
-			})
-		}) {
-			Some(multiaddr) => return multiaddr,
-			None => {
-				tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-				continue;
-			},
-		}
-	}
-}
-
 impl TestNode {
 	/// Wait for `count` blocks to be imported in the node and then exit. This function will not
 	/// return if no blocks are ever created, thus you should restrict the maximum amount of time of

--- a/polkadot/node/metrics/src/tests.rs
+++ b/polkadot/node/metrics/src/tests.rs
@@ -45,13 +45,13 @@ async fn runtime_can_publish_metrics() {
 	builder.init().expect("Failed to set up the logger");
 
 	// Start validator Alice.
-	let alice = run_validator_node(alice_config, None);
+	let alice = run_validator_node(alice_config, None).await;
 
 	let bob_config =
 		node_config(|| {}, tokio::runtime::Handle::current(), Bob, vec![alice.addr.clone()], true);
 
 	// Start validator Bob.
-	let _bob = run_validator_node(bob_config, None);
+	let _bob = run_validator_node(bob_config, None).await;
 
 	// Wait for Alice to see two finalized blocks.
 	alice.wait_for_finalized_blocks(2).await;

--- a/polkadot/node/test/service/src/lib.rs
+++ b/polkadot/node/test/service/src/lib.rs
@@ -255,7 +255,6 @@ pub async fn get_listen_address(network: Arc<dyn NetworkService>) -> sc_network:
 		// before the listen address is available. The address is made available
 		// through the `SwarmEvent::NewListenAddr` event.
 		let listen_addresses = network.listen_addresses();
-		println!("Node is listening on: {:?}", listen_addresses);
 
 		// The network backend must produce a valid TCP port.
 		match listen_addresses.into_iter().find(|addr| {
@@ -289,7 +288,6 @@ pub async fn run_validator_node(
 	let overseer_handle = overseer_handle.expect("test node must have an overseer handle");
 	let peer_id = network.local_peer_id();
 	let multiaddr = get_listen_address(network).await;
-	println!("Node is ready with multiaddrs: {:?}", multiaddr);
 
 	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
 
@@ -328,7 +326,6 @@ pub async fn run_collator_node(
 	let peer_id = network.local_peer_id();
 
 	let multiaddr = get_listen_address(network).await;
-	println!("Node is ready with multiaddrs: {:?}", multiaddr);
 	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
 
 	PolkadotTestNode { task_manager, client, overseer_handle, addr, rpc_handlers }

--- a/polkadot/node/test/service/src/lib.rs
+++ b/polkadot/node/test/service/src/lib.rs
@@ -40,7 +40,9 @@ use sc_chain_spec::ChainSpec;
 use sc_client_api::BlockchainEvents;
 use sc_network::{
 	config::{NetworkConfiguration, TransportConfig},
-	multiaddr, NetworkStateInfo,
+	multiaddr,
+	service::traits::NetworkService,
+	NetworkStateInfo,
 };
 use sc_service::{
 	config::{
@@ -183,9 +185,9 @@ pub fn node_config(
 
 	network_config.allow_non_globals_in_dht = true;
 
-	let addr: multiaddr::Multiaddr = format!("/ip4/127.0.0.1/tcp/{}", rand::random::<u16>())
-		.parse()
-		.expect("valid address; qed");
+	// Libp2p needs to know the local address on which it should listen for incoming connections,
+	// while Litep2p will use `/ip4/127.0.0.1/tcp/0` by default.
+	let addr: multiaddr::Multiaddr = "/ip4/127.0.0.1/tcp/0".parse().expect("valid address; qed");
 	network_config.listen_addresses.push(addr.clone());
 	network_config.public_addresses.push(addr);
 	network_config.transport =
@@ -241,12 +243,41 @@ pub fn node_config(
 	}
 }
 
+/// Get the listen multiaddr from the network service.
+///
+/// The address is used to connect to the node.
+pub async fn get_listen_address(network: Arc<dyn NetworkService>) -> sc_network::Multiaddr {
+	loop {
+		// Litep2p provides instantly the listen address of the TCP protocol and
+		// ditched the `/0` port used by the `node_config` function.
+		//
+		// Libp2p backend needs to be polled in a separate tokio task a few times
+		// before the listen address is available. The address is made available
+		// through the `SwarmEvent::NewListenAddr` event.
+		let listen_addresses = network.listen_addresses();
+		println!("Node is listening on: {:?}", listen_addresses);
+
+		// The network backend must produce a valid TCP port.
+		match listen_addresses.into_iter().find(|addr| {
+			addr.iter().any(|protocol| match protocol {
+				multiaddr::Protocol::Tcp(port) => port > 0,
+				_ => false,
+			})
+		}) {
+			Some(multiaddr) => return multiaddr,
+			None => {
+				tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+				continue;
+			},
+		}
+	}
+}
+
 /// Run a test validator node that uses the test runtime and specified `config`.
-pub fn run_validator_node(
+pub async fn run_validator_node(
 	config: Configuration,
 	worker_program_path: Option<PathBuf>,
 ) -> PolkadotTestNode {
-	let multiaddr = config.network.listen_addresses[0].clone();
 	let NewFull { task_manager, client, network, rpc_handlers, overseer_handle, .. } = new_full(
 		config,
 		IsParachainNode::No,
@@ -257,6 +288,9 @@ pub fn run_validator_node(
 
 	let overseer_handle = overseer_handle.expect("test node must have an overseer handle");
 	let peer_id = network.local_peer_id();
+	let multiaddr = get_listen_address(network).await;
+	println!("Node is ready with multiaddrs: {:?}", multiaddr);
+
 	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
 
 	PolkadotTestNode { task_manager, client, overseer_handle, addr, rpc_handlers }
@@ -274,7 +308,7 @@ pub fn run_validator_node(
 ///
 /// The collator functionality still needs to be registered at the node! This can be done using
 /// [`PolkadotTestNode::register_collator`].
-pub fn run_collator_node(
+pub async fn run_collator_node(
 	tokio_handle: tokio::runtime::Handle,
 	key: Sr25519Keyring,
 	storage_update_func: impl Fn(),
@@ -282,7 +316,6 @@ pub fn run_collator_node(
 	collator_pair: CollatorPair,
 ) -> PolkadotTestNode {
 	let config = node_config(storage_update_func, tokio_handle, key, boot_nodes, false);
-	let multiaddr = config.network.listen_addresses[0].clone();
 	let NewFull { task_manager, client, network, rpc_handlers, overseer_handle, .. } = new_full(
 		config,
 		IsParachainNode::Collator(collator_pair),
@@ -293,6 +326,9 @@ pub fn run_collator_node(
 
 	let overseer_handle = overseer_handle.expect("test node must have an overseer handle");
 	let peer_id = network.local_peer_id();
+
+	let multiaddr = get_listen_address(network).await;
+	println!("Node is ready with multiaddrs: {:?}", multiaddr);
 	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
 
 	PolkadotTestNode { task_manager, client, overseer_handle, addr, rpc_handlers }

--- a/polkadot/node/test/service/tests/build-blocks.rs
+++ b/polkadot/node/test/service/tests/build-blocks.rs
@@ -30,7 +30,7 @@ async fn ensure_test_service_build_blocks() {
 		Vec::new(),
 		true,
 	);
-	let mut alice = run_validator_node(alice_config, None);
+	let mut alice = run_validator_node(alice_config, None).await;
 
 	let bob_config = node_config(
 		|| {},
@@ -39,7 +39,7 @@ async fn ensure_test_service_build_blocks() {
 		vec![alice.addr.clone()],
 		true,
 	);
-	let mut bob = run_validator_node(bob_config, None);
+	let mut bob = run_validator_node(bob_config, None).await;
 
 	{
 		let t1 = future::join(alice.wait_for_blocks(3), bob.wait_for_blocks(3)).fuse();

--- a/polkadot/node/test/service/tests/call-function.rs
+++ b/polkadot/node/test/service/tests/call-function.rs
@@ -22,7 +22,7 @@ async fn call_function_actually_work() {
 	let alice_config =
 		node_config(|| {}, tokio::runtime::Handle::current(), Alice, Vec::new(), true);
 
-	let alice = run_validator_node(alice_config, None);
+	let alice = run_validator_node(alice_config, None).await;
 
 	let function =
 		polkadot_test_runtime::RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {

--- a/polkadot/parachain/test-parachains/adder/collator/tests/integration.rs
+++ b/polkadot/parachain/test-parachains/adder/collator/tests/integration.rs
@@ -44,7 +44,8 @@ async fn collating_using_adder_collator() {
 	workers_path.pop();
 
 	// start alice
-	let alice = polkadot_test_service::run_validator_node(alice_config, Some(workers_path.clone()));
+	let alice =
+		polkadot_test_service::run_validator_node(alice_config, Some(workers_path.clone())).await;
 
 	let bob_config = polkadot_test_service::node_config(
 		|| {},
@@ -55,7 +56,7 @@ async fn collating_using_adder_collator() {
 	);
 
 	// start bob
-	let bob = polkadot_test_service::run_validator_node(bob_config, Some(workers_path));
+	let bob = polkadot_test_service::run_validator_node(bob_config, Some(workers_path)).await;
 
 	let collator = test_parachain_adder_collator::Collator::new();
 
@@ -72,7 +73,8 @@ async fn collating_using_adder_collator() {
 		|| {},
 		vec![alice.addr.clone(), bob.addr.clone()],
 		collator.collator_key(),
-	);
+	)
+	.await;
 
 	charlie
 		.register_collator(

--- a/polkadot/parachain/test-parachains/undying/collator/tests/integration.rs
+++ b/polkadot/parachain/test-parachains/undying/collator/tests/integration.rs
@@ -49,7 +49,8 @@ async fn collating_using_undying_collator() {
 	workers_path.pop();
 
 	// start alice
-	let alice = polkadot_test_service::run_validator_node(alice_config, Some(workers_path.clone()));
+	let alice =
+		polkadot_test_service::run_validator_node(alice_config, Some(workers_path.clone())).await;
 
 	let bob_config = polkadot_test_service::node_config(
 		|| {},
@@ -60,7 +61,7 @@ async fn collating_using_undying_collator() {
 	);
 
 	// start bob
-	let bob = polkadot_test_service::run_validator_node(bob_config, Some(workers_path));
+	let bob = polkadot_test_service::run_validator_node(bob_config, Some(workers_path)).await;
 
 	let collator = test_parachain_undying_collator::Collator::new(1_000, 1, false);
 
@@ -77,7 +78,8 @@ async fn collating_using_undying_collator() {
 		|| {},
 		vec![alice.addr.clone(), bob.addr.clone()],
 		collator.collator_key(),
-	);
+	)
+	.await;
 
 	charlie
 		.register_collator(


### PR DESCRIPTION
This PR ensures tests start on port 0. Then the listen address is extracted from the running node, as opposed to assuming it is always the first element in our array of listen addresses.

This PR enhances the robustness of the polkadot/testing subsystem by eliminating the possibility of random port collisions.

Closes https://github.com/paritytech/polkadot-sdk/issues/8691
