### PR TITLE
ci: trigger zombienet tests if 'T18-zombienet_tests' label set

### DIFF
--- a/.github/workflows/zombienet-reusable-preflight.yml
+++ b/.github/workflows/zombienet-reusable-preflight.yml
@@ -116,6 +116,9 @@ jobs:
   #
   preflight:
     runs-on: ubuntu-latest
+    # TODO remove this condition once zombienet tests are stabilized
+    if: contains(github.event.pull_request.labels.*.name, 'T18-zombienet_tests')
+
     outputs:
       changes_substrate: ${{ steps.set_changes.outputs.substrate_any_changed || steps.set_changes.outputs.currentWorkflow_any_changed }}
       changes_cumulus: ${{ steps.set_changes.outputs.cumulus_any_changed || steps.set_changes.outputs.currentWorkflow_any_changed }}

--- a/.github/workflows/zombienet_cumulus.yml
+++ b/.github/workflows/zombienet_cumulus.yml
@@ -5,8 +5,8 @@ on:
   #push:
   #  branches:
   #    - master
-  #pull_request:
-  #  types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+   types: [opened, synchronize, reopened, ready_for_review, labeled]
   #merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zombienet_parachain-template.yml
+++ b/.github/workflows/zombienet_parachain-template.yml
@@ -5,8 +5,8 @@ on:
   #push:
   #  branches:
   #    - master
-  #pull_request:
-  #  types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+   types: [opened, synchronize, reopened, ready_for_review, labeled]
   #merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zombienet_polkadot.yml
+++ b/.github/workflows/zombienet_polkadot.yml
@@ -5,8 +5,8 @@ on:
   #push:
   #  branches:
   #    - master
-  #pull_request:
-  #  types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+   types: [opened, synchronize, reopened, ready_for_review, labeled]
   #merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zombienet_substrate.yml
+++ b/.github/workflows/zombienet_substrate.yml
@@ -5,8 +5,8 @@ on:
   #push:
   #  branches:
   #    - master
-  #pull_request:
-  #  types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+   types: [opened, synchronize, reopened, ready_for_review, labeled]
   #merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/zombienet-env
+++ b/.github/zombienet-env
@@ -8,4 +8,4 @@ RUN_IN_CI=1
 KUBERNETES_CPU_REQUEST=512m
 KUBERNETES_MEMORY_REQUEST=1Gi
 TEMP_IMAGES_BASE=europe-docker.pkg.dev/parity-ci-2024/temp-images
-FLAKY_TESTS="zombienet-polkadot-coretime-revenue, zombienet-polkadot-smoke-0003-deregister-register-validator, zombienet-polkadot-elastic-scaling-slot-based-12cores, zombienet-polkadot-elastic-scaling-doesnt-break-parachains, zombienet-polkadot-functional-duplicate-collations, zombienet-polkadot-functional-0002-parachains-disputes, zombienet-polkadot-functional-async-backing-6-seconds-rate, zombienet-polkadot-elastic-scaling-slot-based-3cores, zombienet-polkadot-malus-0001-dispute-valid, zombienet-substrate-0002-validators-warp-sync"
+FLAKY_TESTS="zombienet-polkadot-coretime-revenue, zombienet-polkadot-smoke-0003-deregister-register-validator"


### PR DESCRIPTION
# Description
Zombienet tests are no longer automatically triggered with polkadot-sdk CI because of their flakiness (see https://github.com/paritytech/polkadot-sdk/pull/8600).
This PR allows to conditionally trigger Zombienet tests if label 'T18-zombienet_tests' is set.
This is to have an option to trigger them anyway until they are stabilized.
It will help us to monitor the current status of the tests while stabilizing.