### PR TITLE
feat: add collator peer ID to ParachainInherentData

### DIFF
--- a/cumulus/client/parachain-inherent/src/lib.rs
+++ b/cumulus/client/parachain-inherent/src/lib.rs
@@ -208,6 +208,7 @@ impl ParachainInherentDataProvider {
 			validation_data: validation_data.clone(),
 			relay_chain_state,
 			relay_parent_descendants,
+			collator_peer_id: None,
 		})
 	}
 }

--- a/cumulus/client/parachain-inherent/src/mock.rs
+++ b/cumulus/client/parachain-inherent/src/mock.rs
@@ -241,6 +241,7 @@ impl<R: Send + Sync + GenerateRandomness<u64>> InherentDataProvider
 			horizontal_messages,
 			relay_chain_state: proof,
 			relay_parent_descendants: Default::default(),
+			collator_peer_id: None,
 		};
 
 		parachain_inherent_data.provide_inherent_data(inherent_data).await

--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -639,6 +639,7 @@ pub mod pallet {
 				downward_messages,
 				horizontal_messages,
 				relay_parent_descendants,
+				collator_peer_id: _,
 			} = data;
 
 			// Check that the associated relay chain block number is as expected.

--- a/cumulus/pallets/parachain-system/src/mock.rs
+++ b/cumulus/pallets/parachain-system/src/mock.rs
@@ -422,6 +422,7 @@ impl BlockTests {
 					downward_messages: Default::default(),
 					horizontal_messages: Default::default(),
 					relay_parent_descendants: Default::default(),
+					collator_peer_id: None,
 				};
 				if let Some(ref hook) = self.inherent_data_hook {
 					hook(self, relay_parent_number, &mut system_inherent_data);

--- a/cumulus/pallets/parachain-system/src/tests.rs
+++ b/cumulus/pallets/parachain-system/src/tests.rs
@@ -56,6 +56,7 @@ fn test_inherent_compatibility() {
 				downward_messages: Default::default(),
 				horizontal_messages: Default::default(),
 				relay_parent_descendants: Default::default(),
+				collator_peer_id: None,
 			},
 		)
 		.expect("Put validation function params failed");
@@ -80,6 +81,7 @@ fn test_inherent_compatibility() {
 		downward_messages: Default::default(),
 		horizontal_messages: Default::default(),
 		relay_parent_descendants: Default::default(),
+		collator_peer_id: None,
 	};
 	let _ = futures::executor::block_on(
 		data.provide_inherent_data(&mut valid_inherent_data_full_compatibility),

--- a/cumulus/parachains/runtimes/test-utils/src/lib.rs
+++ b/cumulus/parachains/runtimes/test-utils/src/lib.rs
@@ -347,6 +347,7 @@ where
 				downward_messages: Default::default(),
 				horizontal_messages: Default::default(),
 				relay_parent_descendants: Default::default(),
+				collator_peer_id: None,
 			};
 
 			let _ = cumulus_pallet_parachain_system::Pallet::<Runtime>::set_validation_data(
@@ -710,6 +711,7 @@ pub fn mock_open_hrmp_channel<
 			downward_messages: Default::default(),
 			horizontal_messages: Default::default(),
 			relay_parent_descendants: Default::default(),
+			collator_peer_id: None,
 		};
 		inherent_data
 			.put_data(

--- a/cumulus/primitives/parachain-inherent/src/lib.rs
+++ b/cumulus/primitives/parachain-inherent/src/lib.rs
@@ -30,7 +30,9 @@
 extern crate alloc;
 
 use cumulus_primitives_core::{
-	relay_chain::{BlakeTwo256, Hash as RelayHash, HashT as _, Header as RelayHeader},
+	relay_chain::{
+		vstaging::ApprovedPeerId, BlakeTwo256, Hash as RelayHash, HashT as _, Header as RelayHeader,
+	},
 	InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
 };
 
@@ -44,7 +46,7 @@ pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"sysi1338";
 
 /// Legacy ParachainInherentData that is kept around for backward compatibility.
 /// Can be removed once we can safely assume that parachain nodes provide the
-/// `relay_parent_descendants` field.
+/// `relay_parent_descendants` and `collator_peer_id` fields.
 pub mod v0 {
 	use alloc::{collections::BTreeMap, vec::Vec};
 	use cumulus_primitives_core::{
@@ -115,6 +117,9 @@ pub struct ParachainInherentData {
 	/// This information is used to ensure that a parachain node builds blocks
 	/// at a specified offset from the chain tip rather than directly at the tip.
 	pub relay_parent_descendants: Vec<RelayHeader>,
+	/// Contains the collator peer ID, which is later sent by the parachain to the
+	/// relay chain via a UMP signal to promote the reputation of the given peer ID.
+	pub collator_peer_id: Option<ApprovedPeerId>,
 }
 
 // Upgrades the ParachainInherentData v0 to the newest format.
@@ -126,6 +131,7 @@ impl Into<ParachainInherentData> for v0::ParachainInherentData {
 			downward_messages: self.downward_messages,
 			horizontal_messages: self.horizontal_messages,
 			relay_parent_descendants: Vec::new(),
+			collator_peer_id: None,
 		}
 	}
 }

--- a/cumulus/test/client/src/block_builder.rs
+++ b/cumulus/test/client/src/block_builder.rs
@@ -123,6 +123,7 @@ fn init_block_builder(
 				downward_messages: Default::default(),
 				horizontal_messages: Default::default(),
 				relay_parent_descendants: Default::default(),
+				collator_peer_id: None,
 			},
 		)
 		.expect("Put validation function params failed");

--- a/cumulus/test/service/src/bench_utils.rs
+++ b/cumulus/test/service/src/bench_utils.rs
@@ -99,6 +99,7 @@ pub fn extrinsic_set_validation_data(
 		downward_messages: Default::default(),
 		horizontal_messages: Default::default(),
 		relay_parent_descendants: Default::default(),
+		collator_peer_id: None,
 	};
 
 	cumulus_test_runtime::UncheckedExtrinsic::new_bare(

--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -1200,6 +1200,7 @@ macro_rules! decl_test_networks {
 						downward_messages: Default::default(),
 						horizontal_messages: Default::default(),
 						relay_parent_descendants: Default::default(),
+						collator_peer_id: None,
 					}
 				}
 			}

--- a/prdoc/pr_8708.prdoc
+++ b/prdoc/pr_8708.prdoc
@@ -16,6 +16,6 @@ crates:
   - name: parachains-runtimes-test-utils
     bump: patch
   - name: cumulus-primitives-parachain-inherent
-    bump: patch
+    bump: major
   - name: xcm-emulator
     bump: patch

--- a/prdoc/pr_8708.prdoc
+++ b/prdoc/pr_8708.prdoc
@@ -3,8 +3,8 @@ title: "feat: add collator peer ID to ParachainInherentData"
 doc:
   - audience: Runtime Dev
     description: |
-      Adds an optional collator_peer_id field to the new version of ParachainInherentData
-      introduced in PR #8299. The field is currently unused and defaults to None, but is
+      Adds an optional `collator_peer_id` field to the new version of `ParachainInherentData`
+      introduced in PR #8299. The field is currently unused and defaults to `None`, but is
       included proactively to avoid creating another inherent data version in the future.
       This sets the stage for sending collator peer IDs via UMP signals in upcoming work.
 

--- a/prdoc/pr_8708.prdoc
+++ b/prdoc/pr_8708.prdoc
@@ -11,7 +11,7 @@ doc:
 crates:
   - name: cumulus-client-parachain-inherent
     bump: patch
-  - name: cumulus-client-parachain-inherent
+  - name: cumulus-pallet-parachain-system
     bump: patch
   - name: parachains-runtimes-test-utils
     bump: patch

--- a/prdoc/pr_8708.prdoc
+++ b/prdoc/pr_8708.prdoc
@@ -1,0 +1,21 @@
+title: "feat: add collator peer ID to ParachainInherentData"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Adds an optional collator_peer_id field to the new version of ParachainInherentData
+      introduced in PR #8299. The field is currently unused and defaults to None, but is
+      included proactively to avoid creating another inherent data version in the future.
+      This sets the stage for sending collator peer IDs via UMP signals in upcoming work.
+
+crates:
+  - name: cumulus-client-parachain-inherent
+    bump: patch
+  - name: cumulus-client-parachain-inherent
+    bump: patch
+  - name: parachains-runtimes-test-utils
+    bump: patch
+  - name: cumulus-primitives-parachain-inherent
+    bump: patch
+  - name: xcm-emulator
+    bump: patch


### PR DESCRIPTION
## Issue
[[#7749] Collator Protocol Revamp: send PeerId via UMP](https://github.com/paritytech/polkadot-sdk/issues/7749)

## Description
Adds an optional `collator_peer_id` field to the new version of `ParachainInherentData` struct from [PR #8299](https://github.com/paritytech/polkadot-sdk/pull/8299). This field is currently unused and defaults to `None`, but is added proactively to avoid introducing yet another version of the inherent data after the current release.

## Next Steps
### In a follow-up PR:
- Populate `collator_peer_id` on the collator side;
- Handle the field in the `parachain-system` pallet and sends a UMP signal to the relay chain.