### PR TITLE
Handle and suppress "New unknown `FromSwarm` libp2p event" warning

### DIFF
--- a/substrate/client/network/src/discovery.rs
+++ b/substrate/client/network/src/discovery.rs
@@ -838,9 +838,14 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 
 				self.kademlia.on_swarm_event(FromSwarm::ExternalAddrConfirmed(e));
 			},
+			FromSwarm::NewExternalAddrOfPeer(e) => {
+				self.kademlia.on_swarm_event(FromSwarm::NewExternalAddrOfPeer(e));
+				self.mdns.on_swarm_event(FromSwarm::NewExternalAddrOfPeer(e));
+			},
 			event => {
 				debug!(target: LOG_TARGET, "New unknown `FromSwarm` libp2p event: {event:?}");
 				self.kademlia.on_swarm_event(event);
+				self.mdns.on_swarm_event(event);
 			},
 		}
 	}

--- a/substrate/client/network/src/peer_info.rs
+++ b/substrate/client/network/src/peer_info.rs
@@ -580,6 +580,10 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 						"Unknown peer {:?} to change address from {:?} to {:?}", peer_id, old, new);
 				}
 			},
+			FromSwarm::NewExternalAddrOfPeer(e) => {
+				self.ping.on_swarm_event(FromSwarm::NewExternalAddrOfPeer(e));
+				self.identify.on_swarm_event(FromSwarm::NewExternalAddrOfPeer(e));
+			},
 			event => {
 				debug!(target: LOG_TARGET, "New unknown `FromSwarm` libp2p event: {event:?}");
 				self.ping.on_swarm_event(event);

--- a/substrate/client/network/src/protocol/notifications/behaviour.rs
+++ b/substrate/client/network/src/protocol/notifications/behaviour.rs
@@ -1688,6 +1688,7 @@ impl NetworkBehaviour for Notifications {
 			FromSwarm::ExternalAddrConfirmed(_) => {},
 			FromSwarm::AddressChange(_) => {},
 			FromSwarm::NewListenAddr(_) => {},
+			FromSwarm::NewExternalAddrOfPeer(_) => {},
 			event => {
 				warn!(target: LOG_TARGET, "New unknown `FromSwarm` libp2p event: {event:?}");
 			},


### PR DESCRIPTION
Suppress annoying warning `New unknown FromSwarm libp2p event: NewExternalAddrOfPeer(NewExternalAddrOfPeer { peer_id: PeerId("..."), addr: "..." })`.

In `Notifications` behavior, where this warning is generated, the event does not provide useful information and can be safely ignored. In other behaviors it is passed through for possible future internal use by `libp2p`.

Close https://github.com/paritytech/polkadot-sdk/issues/7264.