### PR TITLE
Actually use RP offset in YAP parachain

### DIFF
--- a/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
@@ -132,7 +132,7 @@ const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
 
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included
 /// into the relay chain.
-const UNINCLUDED_SEGMENT_CAPACITY: u32 = 7;
+const UNINCLUDED_SEGMENT_CAPACITY: u32 = 10;
 
 /// Build with an offset of 1 behind the relay chain.
 const RELAY_PARENT_OFFSET: u32 = 1;

--- a/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
@@ -308,7 +308,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
-	type RelayParentOffset = ConstU32<0>;
+	type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
 }
 
 impl pallet_message_queue::Config for Runtime {

--- a/prdoc/pr_8745.prdoc
+++ b/prdoc/pr_8745.prdoc
@@ -1,8 +1,7 @@
-title: Actually use RP offset in YAP parachain
+title: Use correct relay parent offset in YAP parachain
 doc:
 - audience: Runtime Dev
-  description: 'When I merged #8299 I missed this part here, the offset should be
-    set to `RELAY_PARENT_OFFSET`.'
+  description: 'The relay parent offset in the yap parachain is now properly set to `RELAY_PARENT_OFFSET`.'
 crates:
 - name: yet-another-parachain-runtime
   bump: patch

--- a/prdoc/pr_8745.prdoc
+++ b/prdoc/pr_8745.prdoc
@@ -1,0 +1,8 @@
+title: Actually use RP offset in YAP parachain
+doc:
+- audience: Runtime Dev
+  description: 'When I merged #8299 I missed this part here, the offset should be
+    set to `RELAY_PARENT_OFFSET`.'
+crates:
+- name: yet-another-parachain-runtime
+  bump: patch


### PR DESCRIPTION
When I merged #8299 I missed this part here, the offset should be set to `RELAY_PARENT_OFFSET`.