### PR TITLE
Westend governance authorize_upgrade integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5872,12 +5872,15 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "frame-support",
+ "frame-system",
  "hex-literal",
  "pallet-asset-conversion",
  "pallet-assets",
  "pallet-balances",
  "pallet-bridge-messages",
  "pallet-message-queue",
+ "pallet-preimage",
+ "pallet-whitelist",
  "pallet-xcm",
  "pallet-xcm-bridge-hub",
  "parachains-common",
@@ -7511,6 +7514,25 @@ dependencies = [
  "staging-xcm-executor",
  "substrate-wasm-builder",
  "testnet-parachains-constants",
+]
+
+[[package]]
+name = "governance-westend-integration-tests"
+version = "0.0.0"
+dependencies = [
+ "collectives-westend-runtime",
+ "emulated-integration-tests-common",
+ "frame-support",
+ "frame-system",
+ "pallet-utility",
+ "pallet-whitelist",
+ "pallet-xcm",
+ "parity-scale-codec",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "staging-xcm",
+ "westend-runtime",
+ "westend-system-emulated-network",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
 	"cumulus/parachains/integration-tests/emulated/tests/collectives/collectives-westend",
 	"cumulus/parachains/integration-tests/emulated/tests/coretime/coretime-rococo",
 	"cumulus/parachains/integration-tests/emulated/tests/coretime/coretime-westend",
+	"cumulus/parachains/integration-tests/emulated/tests/governance/westend",
 	"cumulus/parachains/integration-tests/emulated/tests/people/people-rococo",
 	"cumulus/parachains/integration-tests/emulated/tests/people/people-westend",
 	"cumulus/parachains/pallets/collective-content",

--- a/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/common/Cargo.toml
@@ -18,10 +18,13 @@ paste = { workspace = true, default-features = true }
 
 # Substrate
 frame-support = { workspace = true, default-features = true }
+frame-system = { workspace = true, default-features = true }
 pallet-asset-conversion = { workspace = true, default-features = true }
 pallet-assets = { workspace = true, default-features = true }
 pallet-balances = { workspace = true, default-features = true }
 pallet-message-queue = { workspace = true, default-features = true }
+pallet-preimage = { workspace = true, default-features = true }
+pallet-whitelist = { workspace = true, default-features = true }
 sc-consensus-grandpa = { workspace = true, default-features = true }
 sp-authority-discovery = { workspace = true, default-features = true }
 sp-consensus-babe = { workspace = true, default-features = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/governance/westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/governance/westend/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "governance-westend-integration-tests"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+description = "Westend governance integration tests with xcm-emulator"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+codec = { workspace = true, default-features = true }
+
+# Substrate
+frame-support = { workspace = true, default-features = true }
+frame-system = { workspace = true, default-features = true }
+pallet-utility = { workspace = true, default-features = true }
+pallet-whitelist = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+
+pallet-xcm = { workspace = true, default-features = true }
+xcm = { workspace = true, default-features = true }
+
+emulated-integration-tests-common = { workspace = true }
+
+# Local
+collectives-westend-runtime = { workspace = true }
+westend-runtime = { workspace = true }
+westend-system-emulated-network = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/governance/westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/governance/westend/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright (C) Parity Technologies and the various Polkadot contributors, see Contributions.md
+// for a list of specific contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod imports {
+	pub(crate) use emulated_integration_tests_common::{
+		impls::{assert_expected_events, bx, TestExt},
+		xcm_emulator::Chain,
+	};
+	pub(crate) use frame_support::assert_ok;
+	pub(crate) use sp_runtime::traits::Dispatchable;
+	pub(crate) use westend_system_emulated_network::CollectivesWestendPara as CollectivesWestend;
+	pub(crate) use xcm::{latest::prelude::*, VersionedLocation, VersionedXcm};
+}
+
+#[cfg(test)]
+mod common;
+
+#[cfg(test)]
+mod open_gov_on_relay;

--- a/cumulus/parachains/integration-tests/emulated/tests/governance/westend/src/open_gov_on_relay.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/governance/westend/src/open_gov_on_relay.rs
@@ -1,0 +1,208 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::{common::*, imports::*};
+use codec::Encode;
+use emulated_integration_tests_common::{
+	impls::RelayChain,
+	xcm_emulator::{Chain, Parachain, TestExt},
+	xcm_helpers::{
+		build_xcm_send_authorize_upgrade_call, dispatch_note_preimage_call,
+		dispatch_whitelisted_call_with_preimage,
+	},
+};
+use frame_support::assert_err;
+use sp_runtime::DispatchError;
+use westend_runtime::governance::pallet_custom_origins::Origin;
+use westend_system_emulated_network::{
+	AssetHubWestendPara as AssetHubWestend, BridgeHubWestendPara as BridgeHubWestend,
+	CoretimeWestendPara as CoretimeWestend, PeopleWestendPara as PeopleWestend,
+	WestendRelay as Westend,
+};
+
+use westend_system_emulated_network::westend_emulated_chain::westend_runtime::Dmp;
+
+#[test]
+fn relaychain_can_authorize_upgrade_for_itself() {
+	let code_hash = [1u8; 32].into();
+	type WestendRuntime = <Westend as Chain>::Runtime;
+	type WestendRuntimeCall = <Westend as Chain>::RuntimeCall;
+	type WestendRuntimeOrigin = <Westend as Chain>::RuntimeOrigin;
+
+	let authorize_upgrade =
+		WestendRuntimeCall::Utility(pallet_utility::Call::<WestendRuntime>::force_batch {
+			calls: vec![
+				// upgrade the relaychain
+				WestendRuntimeCall::System(frame_system::Call::authorize_upgrade { code_hash }),
+			],
+		});
+
+	// bad origin
+	let invalid_origin: WestendRuntimeOrigin = Origin::StakingAdmin.into();
+	// ok origin
+	let ok_origin: WestendRuntimeOrigin = Origin::WhitelistedCaller.into();
+
+	// store preimage
+	let call_hash = dispatch_note_preimage_call::<Westend>(authorize_upgrade.clone());
+
+	// Err - when dispatch non-whitelisted
+	assert_err!(
+		dispatch_whitelisted_call_with_preimage::<Westend>(
+			authorize_upgrade.clone(),
+			ok_origin.clone()
+		),
+		DispatchError::Module(sp_runtime::ModuleError {
+			index: 36,
+			error: [3, 0, 0, 0],
+			message: Some("CallIsNotWhitelisted")
+		})
+	);
+
+	// whitelist
+	collectives_send_whitelist(Location::parent(), || {
+		WestendRuntimeCall::Whitelist(pallet_whitelist::Call::<WestendRuntime>::whitelist_call {
+			call_hash,
+		})
+		.encode()
+	});
+
+	// Err - when dispatch wrong origin
+	assert_err!(
+		dispatch_whitelisted_call_with_preimage::<Westend>(
+			authorize_upgrade.clone(),
+			invalid_origin
+		),
+		DispatchError::BadOrigin
+	);
+
+	// check before
+	Westend::execute_with(|| assert!(<Westend as Chain>::System::authorized_upgrade().is_none()));
+
+	// ok - authorized
+	assert_ok!(dispatch_whitelisted_call_with_preimage::<Westend>(authorize_upgrade, ok_origin));
+
+	// check after - authorized
+	Westend::execute_with(|| assert!(<Westend as Chain>::System::authorized_upgrade().is_some()));
+}
+
+#[test]
+fn relaychain_can_authorize_upgrade_for_system_chains() {
+	type WestendRuntime = <Westend as Chain>::Runtime;
+	type WestendRuntimeCall = <Westend as Chain>::RuntimeCall;
+	type WestendRuntimeOrigin = <Westend as Chain>::RuntimeOrigin;
+
+	Westend::execute_with(|| {
+		Dmp::make_parachain_reachable(AssetHubWestend::para_id());
+		Dmp::make_parachain_reachable(BridgeHubWestend::para_id());
+		Dmp::make_parachain_reachable(CollectivesWestend::para_id());
+		Dmp::make_parachain_reachable(CoretimeWestend::para_id());
+		Dmp::make_parachain_reachable(PeopleWestend::para_id());
+	});
+
+	let authorize_upgrade =
+		WestendRuntimeCall::Utility(pallet_utility::Call::<WestendRuntime>::force_batch {
+			calls: vec![
+				build_xcm_send_authorize_upgrade_call::<Westend, AssetHubWestend>(
+					Westend::child_location_of(AssetHubWestend::para_id()),
+				),
+				build_xcm_send_authorize_upgrade_call::<Westend, BridgeHubWestend>(
+					Westend::child_location_of(BridgeHubWestend::para_id()),
+				),
+				build_xcm_send_authorize_upgrade_call::<Westend, CollectivesWestend>(
+					Westend::child_location_of(CollectivesWestend::para_id()),
+				),
+				build_xcm_send_authorize_upgrade_call::<Westend, CoretimeWestend>(
+					Westend::child_location_of(CoretimeWestend::para_id()),
+				),
+				build_xcm_send_authorize_upgrade_call::<Westend, PeopleWestend>(
+					Westend::child_location_of(PeopleWestend::para_id()),
+				),
+			],
+		});
+
+	// bad origin
+	let invalid_origin: WestendRuntimeOrigin = Origin::StakingAdmin.into();
+	// ok origin
+	let ok_origin: WestendRuntimeOrigin = Origin::WhitelistedCaller.into();
+
+	// store preimage
+	let call_hash = dispatch_note_preimage_call::<Westend>(authorize_upgrade.clone());
+
+	// Err - when dispatch non-whitelisted
+	assert_err!(
+		dispatch_whitelisted_call_with_preimage::<Westend>(
+			authorize_upgrade.clone(),
+			ok_origin.clone()
+		),
+		DispatchError::Module(sp_runtime::ModuleError {
+			index: 36,
+			error: [3, 0, 0, 0],
+			message: Some("CallIsNotWhitelisted")
+		})
+	);
+
+	// whitelist
+	collectives_send_whitelist(Location::parent(), || {
+		WestendRuntimeCall::Whitelist(pallet_whitelist::Call::<WestendRuntime>::whitelist_call {
+			call_hash,
+		})
+		.encode()
+	});
+
+	// Err - when dispatch wrong origin
+	assert_err!(
+		dispatch_whitelisted_call_with_preimage::<Westend>(
+			authorize_upgrade.clone(),
+			invalid_origin
+		),
+		DispatchError::BadOrigin
+	);
+
+	// check before
+	AssetHubWestend::execute_with(|| {
+		assert!(<AssetHubWestend as Chain>::System::authorized_upgrade().is_none())
+	});
+	BridgeHubWestend::execute_with(|| {
+		assert!(<BridgeHubWestend as Chain>::System::authorized_upgrade().is_none())
+	});
+	CollectivesWestend::execute_with(|| {
+		assert!(<CollectivesWestend as Chain>::System::authorized_upgrade().is_none())
+	});
+	CoretimeWestend::execute_with(|| {
+		assert!(<CoretimeWestend as Chain>::System::authorized_upgrade().is_none())
+	});
+	PeopleWestend::execute_with(|| {
+		assert!(<PeopleWestend as Chain>::System::authorized_upgrade().is_none())
+	});
+
+	// ok - authorized
+	assert_ok!(dispatch_whitelisted_call_with_preimage::<Westend>(authorize_upgrade, ok_origin));
+
+	AssetHubWestend::execute_with(|| {
+		assert!(<AssetHubWestend as Chain>::System::authorized_upgrade().is_some())
+	});
+	// check after - authorized
+	BridgeHubWestend::execute_with(|| {
+		assert!(<BridgeHubWestend as Chain>::System::authorized_upgrade().is_some())
+	});
+	CollectivesWestend::execute_with(|| {
+		assert!(<CollectivesWestend as Chain>::System::authorized_upgrade().is_some())
+	});
+	CoretimeWestend::execute_with(|| {
+		assert!(<CoretimeWestend as Chain>::System::authorized_upgrade().is_some())
+	});
+	PeopleWestend::execute_with(|| {
+		assert!(<PeopleWestend as Chain>::System::authorized_upgrade().is_some())
+	});
+}


### PR DESCRIPTION
Introduces integration tests covering `authorize_upgrade` with whitelisting via Collectives for Westend network:
- relay chain authorizes upgrade for itself
- relay chain authorizes upgrades for all system chains