### PR TITLE
rename the name of new staking pallets in all runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17363,9 +17363,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portpicker"
@@ -26128,9 +26128,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17363,9 +17363,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portpicker"
@@ -26128,9 +26128,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",

--- a/cumulus/pallets/ah-ops/src/benchmarking.rs
+++ b/cumulus/pallets/ah-ops/src/benchmarking.rs
@@ -30,7 +30,7 @@ pub mod benchmarks {
 		let _ = T::Currency::deposit_creating(&sender, ed + ed);
 		let _ = T::Currency::reserve(&sender, ed);
 		let block = T::RcBlockNumberProvider::current_block_number();
-		let para_id = ParaId::from(1);
+		let para_id = ParaId::from(1u16);
 		RcLeaseReserve::<T>::insert((block, para_id, &sender), ed);
 
 		assert_eq!(T::Currency::reserved_balance(&sender), ed);
@@ -49,7 +49,7 @@ pub mod benchmarks {
 		let _ = T::Currency::deposit_creating(&pot, ed + ed);
 		let _ = T::Currency::reserve(&pot, ed);
 		let block = T::RcBlockNumberProvider::current_block_number();
-		let para_id = ParaId::from(1);
+		let para_id = ParaId::from(1u16);
 		RcLeaseReserve::<T>::insert((block, para_id, &pot), ed);
 
 		let sender = account("sender", 0, 0);
@@ -72,7 +72,7 @@ pub mod benchmarks {
 		let _ = T::Currency::deposit_creating(&sender, ed + ed);
 		let _ = T::Currency::reserve(&sender, ed);
 		let block = T::RcBlockNumberProvider::current_block_number();
-		let para_id = ParaId::from(1);
+		let para_id = ParaId::from(1u16);
 		RcCrowdloanReserve::<T>::insert((block, para_id, &sender), ed);
 
 		assert_eq!(T::Currency::reserved_balance(&sender), ed);

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1430,8 +1430,8 @@ impl frame_support::traits::OnRuntimeUpgrade for RenameStakingPallets {
 	fn on_runtime_upgrade() -> Weight {
 		// CI-FAIL: set to the next spec of westend-ah.
 		if VERSION.spec_version == 1_018_008 {
-			// This pallet already has a bunch od data, we just ignore it. The rest have small amounts of data.
-			// frame_support::storage::migration::move_pallet(
+			// This pallet already has a bunch od data, we just ignore it. The rest have small
+			// amounts of data. frame_support::storage::migration::move_pallet(
 			// 	b"MultiBlockSigned",
 			// 	b"MultiBlockElectionSigned",
 			// );
@@ -1439,10 +1439,7 @@ impl frame_support::traits::OnRuntimeUpgrade for RenameStakingPallets {
 				b"StakingNextRcClient",
 				b"StakingRcClient",
 			);
-			frame_support::storage::migration::move_pallet(
-				b"MultiBlock",
-				b"MultiBlockElection",
-			);
+			frame_support::storage::migration::move_pallet(b"MultiBlock", b"MultiBlockElection");
 			frame_support::storage::migration::move_pallet(
 				b"MultiBlockUnsigned",
 				b"MultiBlockElectionUnsigned",

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1425,36 +1425,6 @@ impl EthExtra for EthExtraImpl {
 pub type UncheckedExtrinsic =
 	pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Signature, EthExtraImpl>;
 
-pub struct RenameStakingPallets;
-impl frame_support::traits::OnRuntimeUpgrade for RenameStakingPallets {
-	fn on_runtime_upgrade() -> Weight {
-		// CI-FAIL: set to the next spec of westend-ah.
-		if VERSION.spec_version == 1_018_008 {
-			// This pallet already has a bunch od data, we just ignore it. The rest have small
-			// amounts of data. frame_support::storage::migration::move_pallet(
-			// 	b"MultiBlockSigned",
-			// 	b"MultiBlockElectionSigned",
-			// );
-			frame_support::storage::migration::move_pallet(
-				b"StakingNextRcClient",
-				b"StakingRcClient",
-			);
-			frame_support::storage::migration::move_pallet(b"MultiBlock", b"MultiBlockElection");
-			frame_support::storage::migration::move_pallet(
-				b"MultiBlockUnsigned",
-				b"MultiBlockElectionUnsigned",
-			);
-			frame_support::storage::migration::move_pallet(
-				b"MultiBlockVerifier",
-				b"MultiBlockElectionVerifier",
-			);
-			<Weight as sp_runtime::traits::Bounded>::max_value()
-		} else {
-			Default::default()
-		}
-	}
-}
-
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
 	// v9420
@@ -1483,7 +1453,6 @@ pub type Migrations = (
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
-	RenameStakingPallets,
 );
 
 /// Asset Hub Westend has some undecodable storage, delete it.

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1347,13 +1347,13 @@ construct_runtime!(
 		FastUnstake: pallet_fast_unstake = 82,
 		VoterList: pallet_bags_list::<Instance1> = 83,
 		DelegatedStaking: pallet_delegated_staking = 84,
-		StakingNextRcClient: pallet_staking_async_rc_client = 89,
+		StakingRcClient: pallet_staking_async_rc_client = 89,
 
 		// Staking election apparatus.
-		MultiBlock: pallet_election_provider_multi_block = 85,
-		MultiBlockVerifier: pallet_election_provider_multi_block::verifier = 86,
-		MultiBlockUnsigned: pallet_election_provider_multi_block::unsigned = 87,
-		MultiBlockSigned: pallet_election_provider_multi_block::signed = 88,
+		MultiBlockElection: pallet_election_provider_multi_block = 85,
+		MultiBlockElectionVerifier: pallet_election_provider_multi_block::verifier = 86,
+		MultiBlockElectionUnsigned: pallet_election_provider_multi_block::unsigned = 87,
+		MultiBlockElectionSigned: pallet_election_provider_multi_block::signed = 88,
 
 		// Governance.
 		ConvictionVoting: pallet_conviction_voting = 90,
@@ -1425,6 +1425,39 @@ impl EthExtra for EthExtraImpl {
 pub type UncheckedExtrinsic =
 	pallet_revive::evm::runtime::UncheckedExtrinsic<Address, Signature, EthExtraImpl>;
 
+pub struct RenameStakingPallets;
+impl frame_support::traits::OnRuntimeUpgrade for RenameStakingPallets {
+	fn on_runtime_upgrade() -> Weight {
+		// CI-FAIL: set to the next spec of westend-ah.
+		if VERSION.spec_version == 1_018_008 {
+			// This pallet already has a bunch od data, we just ignore it. The rest have small amounts of data.
+			// frame_support::storage::migration::move_pallet(
+			// 	b"MultiBlockSigned",
+			// 	b"MultiBlockElectionSigned",
+			// );
+			frame_support::storage::migration::move_pallet(
+				b"StakingNextRcClient",
+				b"StakingRcClient",
+			);
+			frame_support::storage::migration::move_pallet(
+				b"MultiBlock",
+				b"MultiBlockElection",
+			);
+			frame_support::storage::migration::move_pallet(
+				b"MultiBlockUnsigned",
+				b"MultiBlockElectionUnsigned",
+			);
+			frame_support::storage::migration::move_pallet(
+				b"MultiBlockVerifier",
+				b"MultiBlockElectionVerifier",
+			);
+			<Weight as sp_runtime::traits::Bounded>::max_value()
+		} else {
+			Default::default()
+		}
+	}
+}
+
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
 	// v9420
@@ -1453,6 +1486,7 @@ pub type Migrations = (
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
+	RenameStakingPallets,
 );
 
 /// Asset Hub Westend has some undecodable storage, delete it.
@@ -1653,10 +1687,10 @@ mod benches {
 		[pallet_bags_list, VoterList]
 		[pallet_balances, Balances]
 		[pallet_conviction_voting, ConvictionVoting]
-		[pallet_election_provider_multi_block, MultiBlock]
-		[pallet_election_provider_multi_block_verifier, MultiBlockVerifier]
-		[pallet_election_provider_multi_block_unsigned, MultiBlockUnsigned]
-		[pallet_election_provider_multi_block_signed, MultiBlockSigned]
+		[pallet_election_provider_multi_block, MultiBlockElection]
+		[pallet_election_provider_multi_block_verifier, MultiBlockElectionVerifier]
+		[pallet_election_provider_multi_block_unsigned, MultiBlockElectionUnsigned]
+		[pallet_election_provider_multi_block_signed, MultiBlockElectionSigned]
 		[pallet_fast_unstake, FastUnstake]
 		[pallet_message_queue, MessageQueue]
 		[pallet_migrations, MultiBlockMigrations]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -100,7 +100,7 @@ impl multi_block::Config for Runtime {
 		EitherOfDiverse<EnsureRoot<AccountId>, EnsureSignedBy<WestendStakingMiner, AccountId>>;
 	type DataProvider = Staking;
 	type MinerConfig = Self;
-	type Verifier = MultiBlockVerifier;
+	type Verifier = MultiBlockElectionVerifier;
 	// we chill and do nothing in the fallback.
 	type Fallback = multi_block::Continue<Self>;
 	// Revert back to signed phase if nothing is submitted and queued, so we prolong the election.
@@ -113,7 +113,7 @@ impl multi_block::verifier::Config for Runtime {
 	type MaxWinnersPerPage = MaxWinnersPerPage;
 	type MaxBackersPerWinner = MaxBackersPerWinner;
 	type MaxBackersPerWinnerFinal = MaxBackersPerWinnerFinal;
-	type SolutionDataProvider = MultiBlockSigned;
+	type SolutionDataProvider = MultiBlockElectionSigned;
 	type SolutionImprovementThreshold = SolutionImprovementThreshold;
 	type WeightInfo = multi_block::weights::westend::MultiBlockVerifierWeightInfo<Self>;
 }
@@ -249,7 +249,7 @@ impl pallet_staking_async::Config for Runtime {
 	type AdminOrigin = EitherOf<EnsureRoot<AccountId>, StakingAdmin>;
 	type EraPayout = EraPayout;
 	type MaxExposurePageSize = MaxExposurePageSize;
-	type ElectionProvider = MultiBlock;
+	type ElectionProvider = MultiBlockElection;
 	type VoterList = VoterList;
 	type TargetList = UseValidatorsMap<Self>;
 	type MaxValidatorSet = MaxValidatorSet;
@@ -262,7 +262,7 @@ impl pallet_staking_async::Config for Runtime {
 	type MaxInvulnerables = frame_support::traits::ConstU32<20>;
 	type MaxDisabledValidators = ConstU32<100>;
 	type PlanningEraOffset = PlanningEraOffset;
-	type RcClientInterface = StakingNextRcClient;
+	type RcClientInterface = StakingRcClient;
 }
 
 impl pallet_staking_async_rc_client::Config for Runtime {

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2043,22 +2043,6 @@ parameter_types! {
 /// upgrades in case governance decides to do so. THE ORDER IS IMPORTANT.
 pub type Migrations = migrations::Unreleased;
 
-pub struct RenameAhClient;
-impl frame_support::traits::OnRuntimeUpgrade for RenameAhClient {
-	fn on_runtime_upgrade() -> Weight {
-		// CI-FAIL: set to the next spec of westend.
-		if VERSION.spec_version == 1_018_007 {
-			frame_support::storage::migration::move_pallet(
-				b"AssetHubStakingClient",
-				b"StakingAhClient",
-			);
-			<Weight as sp_runtime::traits::Bounded>::max_value()
-		} else {
-			Default::default()
-		}
-	}
-}
-
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]
 pub mod migrations {
@@ -2080,8 +2064,6 @@ pub mod migrations {
 		>,
 		// permanent
 		pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
-		// remove once done
-		RenameAhClient,
 	);
 }
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1295,7 +1295,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				matches!(
 					c,
 					RuntimeCall::Staking(..) |
-						RuntimeCall::Session(..) | RuntimeCall::Utility(..) |
+						RuntimeCall::Session(..) |
+						RuntimeCall::Utility(..) |
 						RuntimeCall::FastUnstake(..) |
 						RuntimeCall::VoterList(..) |
 						RuntimeCall::NominationPools(..)

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1171,13 +1171,13 @@ construct_runtime!(
 		FastUnstake: pallet_fast_unstake = 82,
 		VoterList: pallet_bags_list::<Instance1> = 83,
 		DelegatedStaking: pallet_delegated_staking = 84,
-		StakingNextRcClient: pallet_staking_async_rc_client = 89,
+		StakingRcClient: pallet_staking_async_rc_client = 89,
 
 		// Election apparatus.
-		MultiBlock: pallet_election_provider_multi_block = 85,
-		MultiBlockVerifier: pallet_election_provider_multi_block::verifier = 86,
-		MultiBlockUnsigned: pallet_election_provider_multi_block::unsigned = 87,
-		MultiBlockSigned: pallet_election_provider_multi_block::signed = 88,
+		MultiBlockElection: pallet_election_provider_multi_block = 85,
+		MultiBlockElectionVerifier: pallet_election_provider_multi_block::verifier = 86,
+		MultiBlockElectionUnsigned: pallet_election_provider_multi_block::unsigned = 87,
+		MultiBlockElectionSigned: pallet_election_provider_multi_block::signed = 88,
 
 		// Governance.
 		Preimage: pallet_preimage = 90,
@@ -1332,10 +1332,10 @@ mod benches {
 		[pallet_bags_list, VoterList]
 		[pallet_balances, Balances]
 		[pallet_conviction_voting, ConvictionVoting]
-		[pallet_election_provider_multi_block, MultiBlock]
-		[pallet_election_provider_multi_block_verifier, MultiBlockVerifier]
-		[pallet_election_provider_multi_block_unsigned, MultiBlockUnsigned]
-		[pallet_election_provider_multi_block_signed, MultiBlockSigned]
+		[pallet_election_provider_multi_block, MultiBlockElection]
+		[pallet_election_provider_multi_block_verifier, MultiBlockElectionVerifier]
+		[pallet_election_provider_multi_block_unsigned, MultiBlockElectionUnsigned]
+		[pallet_election_provider_multi_block_signed, MultiBlockElectionSigned]
 		[pallet_fast_unstake, FastUnstake]
 		[pallet_message_queue, MessageQueue]
 		[pallet_migrations, MultiBlockMigrations]

--- a/substrate/frame/staking-async/runtimes/parachain/src/staking.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/staking.rs
@@ -114,7 +114,7 @@ impl multi_block::Config for Runtime {
 	#[cfg(feature = "runtime-benchmarks")]
 	type Fallback = frame_election_provider_support::onchain::OnChainExecution<OnChainConfig>;
 	type MinerConfig = Self;
-	type Verifier = MultiBlockVerifier;
+	type Verifier = MultiBlockElectionVerifier;
 	type OnRoundRotation = multi_block::CleanRound<Self>;
 	type WeightInfo = multi_block::weights::polkadot::MultiBlockWeightInfo<Self>;
 }
@@ -123,7 +123,7 @@ impl multi_block::verifier::Config for Runtime {
 	type MaxWinnersPerPage = MaxWinnersPerPage;
 	type MaxBackersPerWinner = MaxBackersPerWinner;
 	type MaxBackersPerWinnerFinal = MaxBackersPerWinnerFinal;
-	type SolutionDataProvider = MultiBlockSigned;
+	type SolutionDataProvider = MultiBlockElectionSigned;
 	type SolutionImprovementThreshold = SolutionImprovementThreshold;
 	type WeightInfo = multi_block::weights::polkadot::MultiBlockVerifierWeightInfo<Self>;
 }
@@ -262,7 +262,7 @@ impl pallet_staking_async::Config for Runtime {
 	type AdminOrigin = EitherOf<EnsureRoot<AccountId>, StakingAdmin>;
 	type EraPayout = EraPayout;
 	type MaxExposurePageSize = MaxExposurePageSize;
-	type ElectionProvider = MultiBlock;
+	type ElectionProvider = MultiBlockElection;
 	type VoterList = VoterList;
 	type TargetList = UseValidatorsMap<Self>;
 	type MaxValidatorSet = MaxValidatorSet;
@@ -276,7 +276,7 @@ impl pallet_staking_async::Config for Runtime {
 	type MaxDisabledValidators = ConstU32<100>;
 	type PlanningEraOffset =
 		pallet_staking_async::PlanningEraOffsetOf<Self, RelaySessionDuration, ConstU32<10>>;
-	type RcClientInterface = StakingNextRcClient;
+	type RcClientInterface = StakingRcClient;
 }
 
 impl pallet_staking_async_rc_client::Config for Runtime {

--- a/substrate/frame/staking-async/runtimes/rc/src/genesis_config_presets.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/genesis_config_presets.rs
@@ -17,7 +17,7 @@
 //! Genesis configs presets for the Westend runtime
 
 use crate::{
-	AssetHubStakingClientConfig, BabeConfig, BalancesConfig, ConfigurationConfig, RegistrarConfig,
+	StakingAhClientConfig, BabeConfig, BalancesConfig, ConfigurationConfig, RegistrarConfig,
 	RuntimeGenesisConfig, SessionConfig, SessionKeys, SudoConfig, BABE_GENESIS_EPOCH_CONFIG,
 };
 #[cfg(not(feature = "std"))]
@@ -197,7 +197,7 @@ fn westend_testnet_genesis(
 		sudo: SudoConfig { key: Some(root_key) },
 		configuration: ConfigurationConfig { config: default_parachains_host_configuration() },
 		registrar: RegistrarConfig { next_free_para_id: polkadot_primitives::LOWEST_PUBLIC_ID },
-		asset_hub_staking_client: AssetHubStakingClientConfig {
+		staking_ah_client: StakingAhClientConfig {
 			operating_mode: pallet_staking_async_ah_client::OperatingMode::Active,
 			..Default::default()
 		}

--- a/substrate/frame/staking-async/runtimes/rc/src/genesis_config_presets.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/genesis_config_presets.rs
@@ -17,8 +17,8 @@
 //! Genesis configs presets for the Westend runtime
 
 use crate::{
-	StakingAhClientConfig, BabeConfig, BalancesConfig, ConfigurationConfig, RegistrarConfig,
-	RuntimeGenesisConfig, SessionConfig, SessionKeys, SudoConfig, BABE_GENESIS_EPOCH_CONFIG,
+	BabeConfig, BalancesConfig, ConfigurationConfig, RegistrarConfig, RuntimeGenesisConfig,
+	SessionConfig, SessionKeys, StakingAhClientConfig, SudoConfig, BABE_GENESIS_EPOCH_CONFIG,
 };
 #[cfg(not(feature = "std"))]
 use alloc::format;

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -497,7 +497,7 @@ impl pallet_timestamp::Config for Runtime {
 
 impl pallet_authorship::Config for Runtime {
 	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Babe>;
-	type EventHandler = AssetHubStakingClient;
+	type EventHandler = StakingAhClient;
 }
 
 parameter_types! {
@@ -524,7 +524,7 @@ impl sp_runtime::traits::Convert<AccountId, Option<AccountId>> for IdentityValid
 }
 
 /// A testing type that implements SessionManager, it receives a new validator set from
-/// `AssetHubStakingClient`, but it prevents them from being passed over to the session pallet and
+/// `StakingAhClient`, but it prevents them from being passed over to the session pallet and
 /// just uses the previous session keys.
 pub struct AckButPreviousSessionValidatorsPersist<I>(core::marker::PhantomData<I>);
 
@@ -559,7 +559,7 @@ impl pallet_session::Config for Runtime {
 	type ShouldEndSession = Babe;
 	type NextSessionRotation = Babe;
 	type SessionManager = AckButPreviousSessionValidatorsPersist<
-		session_historical::NoteHistoricalRoot<Self, AssetHubStakingClient>,
+		session_historical::NoteHistoricalRoot<Self, StakingAhClient>,
 	>;
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
@@ -941,7 +941,7 @@ impl pallet_treasury::Config for Runtime {
 impl pallet_offences::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type IdentificationTuple = session_historical::IdentificationTuple<Self>;
-	type OnOffenceHandler = AssetHubStakingClient;
+	type OnOffenceHandler = StakingAhClient;
 }
 
 impl pallet_authority_discovery::Config for Runtime {
@@ -1336,7 +1336,7 @@ impl parachains_inclusion::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type DisputesHandler = ParasDisputes;
 	type RewardValidators =
-		parachains_reward_points::RewardValidatorsWithEraPoints<Runtime, AssetHubStakingClient>;
+		parachains_reward_points::RewardValidatorsWithEraPoints<Runtime, StakingAhClient>;
 	type MessageQueue = MessageQueue;
 	type WeightInfo = weights::polkadot_runtime_parachains_inclusion::WeightInfo<Runtime>;
 }
@@ -1513,7 +1513,7 @@ impl assigned_slots::Config for Runtime {
 impl parachains_disputes::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RewardValidators =
-		parachains_reward_points::RewardValidatorsWithEraPoints<Runtime, AssetHubStakingClient>;
+		parachains_reward_points::RewardValidatorsWithEraPoints<Runtime, StakingAhClient>;
 	type SlashingHandler = parachains_slashing::SlashValidatorsForDisputes<ParasSlashing>;
 	type WeightInfo = weights::polkadot_runtime_parachains_disputes::WeightInfo<Runtime>;
 }
@@ -1822,7 +1822,7 @@ mod runtime {
 	pub type Coretime = coretime;
 
 	#[runtime::pallet_index(67)]
-	pub type AssetHubStakingClient = pallet_staking_async_ah_client;
+	pub type StakingAhClient = pallet_staking_async_ah_client;
 
 	// Migrations pallet
 	#[runtime::pallet_index(98)]


### PR DESCRIPTION
closes https://github.com/paritytech/polkadot-sdk/issues/8763

Needs to be merged after the base branch is merged, and timed for a RU when `Phase::Off`.

This will make the job of all tooling related to new staking pallets easier (such as https://github.com/polkadot-js/apps/issues/11401), ensuring the names in westend + test-runtimes are the same as what we intend to put in Polkadot and Kusama.