### PR TITLE
release/build-macos-binaries: add missing FEATURES argument 

### DIFF
--- a/.github/scripts/release/build-macos-release.sh
+++ b/.github/scripts/release/build-macos-release.sh
@@ -14,12 +14,17 @@ PROFILE=${PROFILE:-production}
 # write, so make it relative to github workspace.
 ARTIFACTS=$GITHUB_WORKSPACE/artifacts/$BIN
 VERSION=$(git tag -l --contains HEAD | grep -E "^v.*")
+# must be given as feature1,feature2,feature3...
+FEATURES=$3
+if [ -n "$FEATURES" ]; then
+  FEATURES="--features ${FEATURES}"
+fi
 
 echo "Artifacts will be copied into $ARTIFACTS"
 mkdir -p "$ARTIFACTS"
 
 git log --pretty=oneline -n 1
-time cargo build --profile $PROFILE --locked --verbose --bin $BIN --package $PACKAGE
+time cargo build --profile $PROFILE --locked --verbose --bin $BIN --package $PACKAGE $FEATURES
 
 echo "Artifact target: $ARTIFACTS"
 

--- a/.github/workflows/release-reusable-rc-build.yml
+++ b/.github/workflows/release-reusable-rc-build.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Install pgpkkms
         run: |
           # Install pgpkms that is used to sign built artifacts
-          python3 -m pip  install "pgpkms @ git+https://github.com/paritytech-release/pgpkms.git@e7f806f99e9be5c52f0b4a536b7d4ef9c3e695ed"
+          python3 -m pip  install "pgpkms @ git+https://github.com/paritytech-release/pgpkms.git@e7f806f99e9be5c52f0b4a536b7d4ef9c3e695ed" --break-system-packages
 
       - name: Import gpg keys
         shell: bash


### PR DESCRIPTION
# Description

In #8755 we enabled release scripts to build binaries with certain features too, used especially for `polkadot-omni-node`. I missed to add the `FEATURES` argument to the build script used for macos:
https://github.com/paritytech/polkadot-sdk/pull/8755/files#diff-f4ebb5b55e4d2f4ec7ab5674ac3376839b13358d78935f9c388d79e75beeceb8R224

## Integration

N/A

## Review Notes

This must be merged to be able to build `polkadot-omni-node` binary with runtime-benchmarks feature on macos.
Fixed also the macos build per: https://github.com/paritytech/polkadot-sdk/pull/8815/commits/05502a350b5995c5b3386ef42bd608c88ec8f17c.