### PR TITLE
increase session index cache

### DIFF
--- a/polkadot/node/subsystem-util/src/runtime/mod.rs
+++ b/polkadot/node/subsystem-util/src/runtime/mod.rs
@@ -16,6 +16,7 @@
 
 //! Convenient interface to runtime information.
 
+use polkadot_node_primitives::MAX_FINALITY_LAG;
 use schnellru::{ByLength, LruMap};
 
 use codec::Encode;
@@ -135,7 +136,7 @@ impl RuntimeInfo {
 	/// Create with more elaborate configuration options.
 	pub fn new_with_config(cfg: Config) -> Self {
 		Self {
-			session_index_cache: LruMap::new(ByLength::new(cfg.session_cache_lru_size.max(10))),
+			session_index_cache: LruMap::new(ByLength::new(2 * MAX_FINALITY_LAG)),
 			session_info_cache: LruMap::new(ByLength::new(cfg.session_cache_lru_size)),
 			disabled_validators_cache: LruMap::new(ByLength::new(100)),
 			pinned_blocks: LruMap::new(ByLength::new(cfg.session_cache_lru_size)),

--- a/polkadot/node/subsystem-util/src/runtime/mod.rs
+++ b/polkadot/node/subsystem-util/src/runtime/mod.rs
@@ -136,7 +136,12 @@ impl RuntimeInfo {
 	/// Create with more elaborate configuration options.
 	pub fn new_with_config(cfg: Config) -> Self {
 		Self {
-			session_index_cache: LruMap::new(ByLength::new(cfg.session_cache_lru_size.max(2 * MAX_FINALITY_LAG))),
+			// Usually messages are processed for blocks pointing to hashes from last finalized
+			// block to to best, so make this cache large enough to hold at least this amount of
+			// hashes, so that we get the benefit of caching even when finality lag is large.
+			session_index_cache: LruMap::new(ByLength::new(
+				cfg.session_cache_lru_size.max(2 * MAX_FINALITY_LAG),
+			)),
 			session_info_cache: LruMap::new(ByLength::new(cfg.session_cache_lru_size)),
 			disabled_validators_cache: LruMap::new(ByLength::new(100)),
 			pinned_blocks: LruMap::new(ByLength::new(cfg.session_cache_lru_size)),

--- a/polkadot/node/subsystem-util/src/runtime/mod.rs
+++ b/polkadot/node/subsystem-util/src/runtime/mod.rs
@@ -136,7 +136,7 @@ impl RuntimeInfo {
 	/// Create with more elaborate configuration options.
 	pub fn new_with_config(cfg: Config) -> Self {
 		Self {
-			session_index_cache: LruMap::new(ByLength::new(2 * MAX_FINALITY_LAG)),
+			session_index_cache: LruMap::new(ByLength::new(cfg.session_cache_lru_size.max(2 * MAX_FINALITY_LAG))),
 			session_info_cache: LruMap::new(ByLength::new(cfg.session_cache_lru_size)),
 			disabled_validators_cache: LruMap::new(ByLength::new(100)),
 			pinned_blocks: LruMap::new(ByLength::new(cfg.session_cache_lru_size)),

--- a/prdoc/pr_8832.prdoc
+++ b/prdoc/pr_8832.prdoc
@@ -1,0 +1,10 @@
+title: increase session index cache
+doc:
+- audience: Node Dev
+  description: |-
+    A 10 session index cache is not enough when you run under intense pressure and finality is lagg since you will end requesting the session index for blocks older than that. So let's make this cache larger to achieve its purpose even under intense load when it actually matters more to be faster.
+
+    The session_index_cache keeps a Hash and a u32, so that's about 36 bytes per entry, with this increase it can grow up to 65k which is not that big in my book.
+crates:
+- name: polkadot-node-subsystem-util
+  bump: patch


### PR DESCRIPTION
A 10 session index cache is not enough when you run under intense pressure and finality is lagg since you will end requesting the session index for blocks older than that. So let's make this cache larger to achieve its purpose even under intense load when it actually matters more to be faster.

The session_index_cache keeps a Hash and a u32, so that's about 36 bytes per entry, with this increase it can grow up to 65k which is not that big in my book.
