### PR TITLE
Cache locally controlled validator indices in `dispute-coordinator`

### DIFF
--- a/polkadot/node/core/dispute-coordinator/src/import.rs
+++ b/polkadot/node/core/dispute-coordinator/src/import.rs
@@ -36,11 +36,10 @@ use polkadot_node_subsystem_util::runtime::RuntimeInfo;
 use polkadot_primitives::{
 	vstaging::CandidateReceiptV2 as CandidateReceipt, CandidateHash, DisputeStatement,
 	ExecutorParams, Hash, IndexedVec, SessionIndex, SessionInfo, ValidDisputeStatementKind,
-	ValidatorId, ValidatorIndex, ValidatorPair, ValidatorSignature,
+	ValidatorId, ValidatorIndex, ValidatorSignature,
 };
-use sc_keystore::LocalKeystore;
 
-use crate::LOG_TARGET;
+use crate::{initialized::ControlledValidatorIndices, LOG_TARGET};
 
 /// (Session) environment of a candidate.
 pub struct CandidateEnvironment<'a> {
@@ -63,12 +62,12 @@ impl<'a> CandidateEnvironment<'a> {
 	///
 	/// Return: `None` in case session is outside of session window.
 	pub async fn new<Context>(
-		keystore: &LocalKeystore,
 		ctx: &mut Context,
 		runtime_info: &'a mut RuntimeInfo,
 		session_index: SessionIndex,
 		relay_parent: Hash,
 		disabled_offchain: impl IntoIterator<Item = ValidatorIndex>,
+		controlled_indices: &mut ControlledValidatorIndices,
 	) -> Option<CandidateEnvironment<'a>> {
 		let disabled_onchain = runtime_info
 			.get_disabled_validators(ctx.sender(), relay_parent)
@@ -105,7 +104,8 @@ impl<'a> CandidateEnvironment<'a> {
 			d
 		};
 
-		let controlled_indices = find_controlled_validator_indices(keystore, &session.validators);
+		let controlled_indices = controlled_indices.get(session_index, &session.validators).clone();
+
 		Some(Self { session_index, session, executor_params, controlled_indices, disabled_indices })
 	}
 
@@ -631,23 +631,4 @@ impl ImportResult {
 			None
 		}
 	}
-}
-
-/// Find indices controlled by this validator.
-///
-/// That is all `ValidatorIndex`es we have private keys for. Usually this will only be one.
-fn find_controlled_validator_indices(
-	keystore: &LocalKeystore,
-	validators: &IndexedVec<ValidatorIndex, ValidatorId>,
-) -> HashSet<ValidatorIndex> {
-	let mut controlled = HashSet::new();
-	for (index, validator) in validators.iter().enumerate() {
-		if keystore.key_pair::<ValidatorPair>(validator).ok().flatten().is_none() {
-			continue
-		}
-
-		controlled.insert(ValidatorIndex(index as _));
-	}
-
-	controlled
 }

--- a/polkadot/node/core/dispute-coordinator/src/lib.rs
+++ b/polkadot/node/core/dispute-coordinator/src/lib.rs
@@ -60,6 +60,7 @@ use fatality::Split;
 
 use self::{
 	import::{CandidateEnvironment, CandidateVoteState},
+	initialized::ControlledValidatorIndices,
 	participation::{ParticipationPriority, ParticipationRequest},
 	spam_slots::{SpamSlots, UnconfirmedDisputes},
 };
@@ -236,6 +237,7 @@ impl DisputeCoordinatorSubsystem {
 				highest_session_seen,
 				gaps_in_cache,
 				offchain_disabled_validators,
+				controlled_validator_indices,
 			) = match self
 				.handle_startup(ctx, first_leaf.clone(), &mut runtime_info, &mut overlay_db, clock)
 				.await
@@ -263,6 +265,7 @@ impl DisputeCoordinatorSubsystem {
 					highest_session_seen,
 					gaps_in_cache,
 					offchain_disabled_validators,
+					controlled_validator_indices,
 				),
 				backend,
 			)))
@@ -289,6 +292,7 @@ impl DisputeCoordinatorSubsystem {
 		SessionIndex,
 		bool,
 		initialized::OffchainDisabledValidators,
+		ControlledValidatorIndices,
 	)> {
 		let now = clock.now();
 
@@ -357,16 +361,18 @@ impl DisputeCoordinatorSubsystem {
 
 		let mut participation_requests = Vec::new();
 		let mut spam_disputes: UnconfirmedDisputes = UnconfirmedDisputes::new();
+		let mut controlled_indecies =
+			crate::initialized::ControlledValidatorIndices::new(self.keystore.clone());
 		let leaf_hash = initial_head.hash;
 		let (scraper, votes) = ChainScraper::new(ctx.sender(), initial_head).await?;
 		for ((session, ref candidate_hash), _) in active_disputes {
 			let env = match CandidateEnvironment::new(
-				&self.keystore,
 				ctx,
 				runtime_info,
 				highest_session,
 				leaf_hash,
 				offchain_disabled_validators.iter(session),
+				&mut controlled_indecies,
 			)
 			.await
 			{
@@ -452,6 +458,7 @@ impl DisputeCoordinatorSubsystem {
 			highest_session,
 			gap_in_cache,
 			offchain_disabled_validators,
+			controlled_indecies,
 		))
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/8823