### PR TITLE
staking-async runtime: extended duration of the signed phase

### DIFF
--- a/substrate/frame/staking-async/runtimes/parachain/src/staking.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/staking.rs
@@ -31,7 +31,7 @@ use sp_runtime::{
 use xcm::latest::prelude::*;
 
 parameter_types! {
-	pub storage SignedPhase: u32 = 2 * MINUTES;
+	pub storage SignedPhase: u32 = 4 * MINUTES;
 	pub storage UnsignedPhase: u32 = MINUTES;
 	pub storage SignedValidationPhase: u32 = Pages::get(); // allow to verify  just a solution
 


### PR DESCRIPTION
For the staking-async test runtime,  we extend the duration of the signed phase from 2 to 4 minutes, in order to give enough time to the staking miner to mine, submit the score, verify it's on chan and then submit  all pages during the signed phase. 

While testing on CI / locally for a 32-page solution, the miner ends up submitting pages pretty close to the end of the signed phase itself.

Whereas this is a valuable scenario to test to prove miner's robustness, in the main happy path and while testing locally, we want the miner by default to have enough time to submit the whole solution and to be able to handle a re-tx if one/N pages fail to be submitted still within the same Signed phase cycle.
