### PR TITLE
Fix `zombienet-substrate-0002-validators-warp-sync`

### DIFF
--- a/substrate/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
+++ b/substrate/zombienet/0002-validators-warp-sync/test-validators-warp-sync.toml
@@ -18,6 +18,11 @@ chain_spec_path = "chain-spec.json"
   validator = true
   args = ["--log=beefy=debug", "--sync warp"]
 
+  [[relaychain.nodes]]
+  name = "other-validator"
+  validator = true
+  args = ["--log=beefy=debug", "--sync warp"]
+
   # we need at least 3 nodes for warp sync
   [[relaychain.nodes]]
   name = "charlie"

--- a/substrate/zombienet/0002-validators-warp-sync/test-validators-warp-sync.zndsl
+++ b/substrate/zombienet/0002-validators-warp-sync/test-validators-warp-sync.zndsl
@@ -31,6 +31,15 @@ bob: log line matches "Block history download is complete" within 120 seconds
 alice: reports block height is at least {{DB_BLOCK_HEIGHT}} within 10 seconds
 bob: reports block height is at least {{DB_BLOCK_HEIGHT}} within 10 seconds
 
+# We can be in a case where finality is lagging. For example:
+# Let's wait until finality works correctly.
+alice: reports substrate_block_height{status="finalized"} is at least {{DB_BLOCK_HEIGHT}} within 120 seconds
+bob: reports substrate_block_height{status="finalized"} is at least {{DB_BLOCK_HEIGHT}} within 120 seconds
+
+# Make sure that BEEFY voting started.
+alice: reports substrate_beefy_best_block is at least 1 within 60 seconds
+bob: reports substrate_beefy_best_block is at least 1 within 60 seconds
+# Make sure that BEEFY voting is advancing
 # In the worst case scenario, the validators should vote on 1 mandatory block each 6 seconds. And 1 era = 200 blocks.
 alice: reports substrate_beefy_best_block is at least {{200*180/6}} within 180 seconds
 bob: reports substrate_beefy_best_block is at least {{200*180/6}} within 180 seconds


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-sdk/issues/8871
Related to #8748

Fix `zombienet-substrate-0002-validators-warp-sync`