### PR TITLE
[pallet-revive] fix extension weight

### DIFF
--- a/substrate/frame/revive/rpc/src/fee_history_provider.rs
+++ b/substrate/frame/revive/rpc/src/fee_history_provider.rs
@@ -25,9 +25,9 @@ const CACHE_SIZE: u32 = 1024;
 
 #[derive(Default, Clone)]
 struct FeeHistoryCacheItem {
-	base_fee: u64,
+	base_fee: u128,
 	gas_used_ratio: f64,
-	rewards: Vec<u64>,
+	rewards: Vec<u128>,
 }
 
 /// Manages the fee history cache.
@@ -47,17 +47,17 @@ impl FeeHistoryProvider {
 		let block_number: SubstrateBlockNumber =
 			block.number.try_into().expect("Block number is always valid");
 
-		let base_fee = block.base_fee_per_gas.unwrap_or_default().as_u64();
-		let gas_used = block.gas_used.as_u64();
-		let gas_used_ratio = (gas_used as f64) / (block.gas_limit.as_u64() as f64);
+		let base_fee = block.base_fee_per_gas.unwrap_or_default().as_u128();
+		let gas_used = block.gas_used.as_u128();
+		let gas_used_ratio = (gas_used as f64) / (block.gas_limit.as_u128() as f64);
 		let mut result = FeeHistoryCacheItem { base_fee, gas_used_ratio, rewards: vec![] };
 
 		let mut receipts = receipts
 			.iter()
 			.map(|receipt| {
-				let gas_used = receipt.gas_used.as_u64();
+				let gas_used = receipt.gas_used.as_u128();
 				let effective_reward =
-					receipt.effective_gas_price.as_u64().saturating_sub(base_fee);
+					receipt.effective_gas_price.as_u128().saturating_sub(base_fee);
 				(gas_used, effective_reward)
 			})
 			.collect::<Vec<_>>();
@@ -67,8 +67,8 @@ impl FeeHistoryProvider {
 		result.rewards = reward_percentiles
 			.into_iter()
 			.filter_map(|p| {
-				let target_gas = (p * gas_used as f64 / 100f64) as u64;
-				let mut sum_gas = 0u64;
+				let target_gas = (p * gas_used as f64 / 100f64) as u128;
+				let mut sum_gas = 0u128;
 				for (gas_used, reward) in &receipts {
 					sum_gas += gas_used;
 					if target_gas <= sum_gas {

--- a/substrate/frame/revive/rpc/src/fee_history_provider.rs
+++ b/substrate/frame/revive/rpc/src/fee_history_provider.rs
@@ -25,9 +25,9 @@ const CACHE_SIZE: u32 = 1024;
 
 #[derive(Default, Clone)]
 struct FeeHistoryCacheItem {
-	base_fee: u128,
+	base_fee: u64,
 	gas_used_ratio: f64,
-	rewards: Vec<u128>,
+	rewards: Vec<u64>,
 }
 
 /// Manages the fee history cache.
@@ -47,17 +47,17 @@ impl FeeHistoryProvider {
 		let block_number: SubstrateBlockNumber =
 			block.number.try_into().expect("Block number is always valid");
 
-		let base_fee = block.base_fee_per_gas.unwrap_or_default().as_u128();
-		let gas_used = block.gas_used.as_u128();
-		let gas_used_ratio = (gas_used as f64) / (block.gas_limit.as_u128() as f64);
+		let base_fee = block.base_fee_per_gas.unwrap_or_default().as_u64();
+		let gas_used = block.gas_used.as_u64();
+		let gas_used_ratio = (gas_used as f64) / (block.gas_limit.as_u64() as f64);
 		let mut result = FeeHistoryCacheItem { base_fee, gas_used_ratio, rewards: vec![] };
 
 		let mut receipts = receipts
 			.iter()
 			.map(|receipt| {
-				let gas_used = receipt.gas_used.as_u128();
+				let gas_used = receipt.gas_used.as_u64();
 				let effective_reward =
-					receipt.effective_gas_price.as_u128().saturating_sub(base_fee);
+					receipt.effective_gas_price.as_u64().saturating_sub(base_fee);
 				(gas_used, effective_reward)
 			})
 			.collect::<Vec<_>>();
@@ -67,8 +67,8 @@ impl FeeHistoryProvider {
 		result.rewards = reward_percentiles
 			.into_iter()
 			.filter_map(|p| {
-				let target_gas = (p * gas_used as f64 / 100f64) as u128;
-				let mut sum_gas = 0u128;
+				let target_gas = (p * gas_used as f64 / 100f64) as u64;
+				let mut sum_gas = 0u64;
 				for (gas_used, reward) in &receipts {
 					sum_gas += gas_used;
 					if target_gas <= sum_gas {

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -20,8 +20,8 @@ use crate::{
 		api::{GenericTransaction, TransactionSigned},
 		GasEncoder,
 	},
-	AccountIdOf, AddressMapper, BalanceOf, Config, ConversionPrecision, MomentOf,
-	OnChargeTransactionBalanceOf, Pallet, LOG_TARGET, RUNTIME_PALLETS_ADDR,
+	AccountIdOf, AddressMapper, BalanceOf, Config, ConversionPrecision, MomentOf, Pallet,
+	LOG_TARGET, RUNTIME_PALLETS_ADDR,
 };
 use alloc::vec::Vec;
 use codec::{Decode, DecodeLimit, DecodeWithMemTracking, Encode};
@@ -30,6 +30,7 @@ use frame_support::{
 	traits::{InherentBuilder, IsSubType, SignedTransactionBuilder},
 	MAX_EXTRINSIC_DEPTH,
 };
+use pallet_transaction_payment::OnChargeTransaction;
 use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_core::{Get, H256, U256};
 use sp_runtime::{
@@ -117,6 +118,8 @@ impl<Address: TypeInfo, Signature: TypeInfo, E: EthExtra> ExtrinsicCall
 		self.0.call()
 	}
 }
+
+type OnChargeTransactionBalanceOf<T> = <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance;
 
 impl<LookupSource, Signature, E, Lookup> Checkable<Lookup>
 	for UncheckedExtrinsic<LookupSource, Signature, E>

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -20,8 +20,8 @@ use crate::{
 		api::{GenericTransaction, TransactionSigned},
 		GasEncoder,
 	},
-	AccountIdOf, AddressMapper, BalanceOf, Config, ConversionPrecision, MomentOf, Pallet,
-	LOG_TARGET, RUNTIME_PALLETS_ADDR,
+	AccountIdOf, AddressMapper, BalanceOf, Config, ConversionPrecision, MomentOf,
+	OnChargeTransactionBalanceOf, Pallet, LOG_TARGET, RUNTIME_PALLETS_ADDR,
 };
 use alloc::vec::Vec;
 use codec::{Decode, DecodeLimit, DecodeWithMemTracking, Encode};
@@ -30,7 +30,6 @@ use frame_support::{
 	traits::{InherentBuilder, IsSubType, SignedTransactionBuilder},
 	MAX_EXTRINSIC_DEPTH,
 };
-use pallet_transaction_payment::OnChargeTransaction;
 use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_core::{Get, H256, U256};
 use sp_runtime::{
@@ -118,8 +117,6 @@ impl<Address: TypeInfo, Signature: TypeInfo, E: EthExtra> ExtrinsicCall
 		self.0.call()
 	}
 }
-
-type OnChargeTransactionBalanceOf<T> = <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance;
 
 impl<LookupSource, Signature, E, Lookup> Checkable<Lookup>
 	for UncheckedExtrinsic<LookupSource, Signature, E>

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1176,7 +1176,7 @@ where
 	pub fn dry_run_eth_transact(
 		mut tx: GenericTransaction,
 		gas_limit: Weight,
-		tx_fee: impl Fn(Call<T>, <T as Config>::RuntimeCall) -> BalanceOf<T>,
+		tx_fee: impl Fn(<T as Config>::RuntimeCall, <T as Config>::RuntimeCall) -> BalanceOf<T>,
 	) -> Result<EthTransactInfo<BalanceOf<T>>, EthTransactError>
 	where
 		<T as frame_system::Config>::RuntimeCall:
@@ -1390,7 +1390,7 @@ where
 
 		let eth_transact_call =
 			crate::Call::<T>::eth_transact { payload: unsigned_tx.dummy_signed_payload() };
-		let fee = tx_fee(eth_transact_call, dispatch_call);
+		let fee = tx_fee(eth_transact_call.into(), dispatch_call);
 		let raw_gas = Self::evm_fee_to_gas(fee);
 		let eth_gas =
 			T::EthGasEncoder::encode(raw_gas, result.gas_required, result.storage_deposit);
@@ -1760,11 +1760,7 @@ macro_rules! impl_runtime_apis_plus_revive {
 						sp_runtime::traits::Block as BlockT
 					};
 
-					let tx_fee = |eth_transact_call, dispatch_call: <Self as $crate::frame_system::Config>::RuntimeCall| {
-						// Build the eth_transact call
-						let call =
-							<Self as $crate::frame_system::Config>::RuntimeCall::from(eth_transact_call);
-
+					let tx_fee = |call: <Self as $crate::frame_system::Config>::RuntimeCall, dispatch_call: <Self as $crate::frame_system::Config>::RuntimeCall| {
 						// Get the dispatch info of the actual call dispatched
 						let mut dispatch_info = dispatch_call.get_dispatch_info();
 						dispatch_info.extension_weight =

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -76,6 +76,7 @@ use frame_system::{
 	pallet_prelude::{BlockNumberFor, OriginFor},
 	Pallet as System,
 };
+use pallet_transaction_payment::OnChargeTransaction;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{BadOrigin, Bounded, Convert, Dispatchable, Saturating, Zero},
@@ -106,6 +107,7 @@ pub type BalanceOf<T> =
 type TrieId = BoundedVec<u8, ConstU32<128>>;
 type CodeVec = BoundedVec<u8, ConstU32<{ limits::code::BLOB_BYTES }>>;
 type ImmutableData = BoundedVec<u8, ConstU32<{ limits::IMMUTABLE_BYTES }>>;
+pub(crate) type OnChargeTransactionBalanceOf<T> = <<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance;
 
 /// Used as a sentinel value when reading and writing contract memory.
 ///
@@ -1181,6 +1183,8 @@ where
 	where
 		<T as frame_system::Config>::RuntimeCall:
 			Dispatchable<Info = frame_support::dispatch::DispatchInfo>,
+		T: pallet_transaction_payment::Config,
+		OnChargeTransactionBalanceOf<T>: Into<BalanceOf<T>>,
 		<T as Config>::RuntimeCall: From<crate::Call<T>>,
 		<T as Config>::RuntimeCall: Encode,
 		T::Nonce: Into<U256>,
@@ -1441,13 +1445,24 @@ where
 	}
 
 	/// Get the block gas limit.
-	pub fn evm_block_gas_limit() -> U256 {
+	pub fn evm_block_gas_limit() -> U256
+	where
+		<T as frame_system::Config>::RuntimeCall:
+			Dispatchable<Info = frame_support::dispatch::DispatchInfo>,
+		T: pallet_transaction_payment::Config,
+		OnChargeTransactionBalanceOf<T>: Into<BalanceOf<T>>,
+	{
 		let max_block_weight = T::BlockWeights::get()
 			.get(DispatchClass::Normal)
 			.max_total
 			.unwrap_or_else(|| T::BlockWeights::get().max_block);
 
+		let length_fee = pallet_transaction_payment::Pallet::<T>::length_to_fee(
+			5 * 1024 * 1024, // 5 MB
+		);
+
 		Self::evm_gas_from_weight(max_block_weight)
+			.saturating_add(Self::evm_fee_to_gas(length_fee.into()))
 	}
 
 	/// Get the gas price.

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1761,6 +1761,8 @@ macro_rules! impl_runtime_apis_plus_revive {
 					};
 
 					let tx_fee = |call: <Self as $crate::frame_system::Config>::RuntimeCall, dispatch_call: <Self as $crate::frame_system::Config>::RuntimeCall| {
+						use $crate::frame_support::dispatch::GetDispatchInfo;
+
 						// Get the dispatch info of the actual call dispatched
 						let mut dispatch_info = dispatch_call.get_dispatch_info();
 						dispatch_info.extension_weight =


### PR DESCRIPTION
- Use the extension_weight of the eth transact, not the transformed one in both the dry-run and Checkable trait
