### PR TITLE
cumulus/metrics: Measure the time of including a tx in a backed block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,6 +4502,7 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-utils",
+ "schnellru",
  "sp-api 26.0.0",
  "sp-blockchain",
  "sp-consensus",

--- a/cumulus/client/relay-chain-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-interface/src/lib.rs
@@ -249,6 +249,7 @@ pub trait RelayChainInterface: Send + Sync {
 	/// Fetch the scheduling lookahead value.
 	async fn scheduling_lookahead(&self, relay_parent: PHash) -> RelayChainResult<u32>;
 
+	/// Fetch the candidate events for the given relay chain block.
 	async fn candidate_events(&self, at: RelayHash) -> RelayChainResult<Vec<CandidateEvent>>;
 }
 

--- a/cumulus/client/service/Cargo.toml
+++ b/cumulus/client/service/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 async-channel = { workspace = true }
 futures = { workspace = true }
 prometheus = { workspace = true }
+schnellru = { workspace = true }
 
 # Substrate
 sc-client-api = { workspace = true, default-features = true }

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -26,11 +26,11 @@ use cumulus_client_pov_recovery::{PoVRecovery, RecoveryDelayRange, RecoveryHandl
 use cumulus_primitives_core::{CollectCollationInfo, ParaId};
 pub use cumulus_primitives_proof_size_hostfunction::storage_proof_size;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
-use cumulus_relay_chain_interface::{RelayChainInterface, RelayChainResult};
+use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::{
 	build_minimal_relay_chain_node_light_client, build_minimal_relay_chain_node_with_rpc,
 };
-use futures::{channel::mpsc, StreamExt};
+use futures::{channel::mpsc, FutureExt, StreamExt};
 use polkadot_primitives::{vstaging::CandidateEvent, CollatorPair, OccupiedCoreAssumption};
 use prometheus::{Histogram, HistogramOpts, Registry};
 use sc_client_api::{
@@ -49,6 +49,7 @@ use sc_network_transactions::TransactionsHandlerController;
 use sc_service::{Configuration, SpawnTaskHandle, TaskManager, WarpSyncConfig};
 use sc_telemetry::{log, TelemetryWorkerHandle};
 use sc_utils::mpsc::TracingUnboundedSender;
+use schnellru::{ByLength, LruMap};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_core::{traits::SpawnNamed, Decode};
@@ -312,6 +313,19 @@ where
 	task_manager
 		.spawn_handle()
 		.spawn("parachain-informant", None, parachain_informant);
+
+	let parachain_rpc_metrics = parachain_rpc_metrics::<Block>(
+		relay_chain_interface.clone(),
+		rpc_transaction_v2_handles,
+		para_id,
+		prometheus_registry.map(ParachainRpcMetrics::new).transpose()?,
+	);
+	task_manager.spawn_handle().spawn("parachain-rpc-metrics", None, async move {
+		let result = parachain_rpc_metrics.await;
+		if result.is_err() {
+			log::error!(target: LOG_TARGET_SYNC, "Parachain RPC metrics stopped: {:?}", result);
+		}
+	});
 
 	Ok(())
 }
@@ -757,5 +771,118 @@ impl ParachainInformantMetrics {
 			parachain_block_backed_duration: parachain_block_authorship_duration,
 			unincluded_segment_size,
 		})
+	}
+}
+
+/// Metrics for the parachain RPC.
+struct ParachainRpcMetrics {
+	/// Time between the submission of a transaction and its inclusion in a backed block.
+	transaction_backed_duration: Histogram,
+}
+
+impl ParachainRpcMetrics {
+	fn new(prometheus_registry: &Registry) -> prometheus::Result<Self> {
+		let transaction_backed_duration = Histogram::with_opts(HistogramOpts::new(
+			"parachain_transaction_backed_duration",
+			"Time between the submission of a transaction and its inclusion in a backed block",
+		))?;
+		prometheus_registry.register(Box::new(transaction_backed_duration.clone()))?;
+
+		Ok(Self { transaction_backed_duration })
+	}
+}
+
+/// Task for monitoring the parachain RPC metrics.
+async fn parachain_rpc_metrics<Block: BlockT>(
+	relay_chain_interface: impl RelayChainInterface + Clone,
+	rpc_transaction_v2_handles: Vec<sc_service::TransactionMonitorHandle<Block::Hash>>,
+	para_id: ParaId,
+	metrics: Option<ParachainRpcMetrics>,
+) -> Result<(), RelayChainError> {
+	const LOG_TARGET: &str = "parachain_rpc_metrics";
+
+	let mut backed_blocks: LruMap<sp_core::H256, ()> = LruMap::new(ByLength::new(64));
+	let mut unresolved_tx: LruMap<sp_core::H256, Vec<Instant>> = LruMap::new(ByLength::new(64));
+
+	/// Convert the substrate block hash to a H256 hash without panics.
+	fn convert_to_h256<Block: BlockT>(
+		hash: &Block::Hash,
+	) -> Result<sp_core::H256, RelayChainError> {
+		if hash.as_ref().len() != 32 {
+			return Err(RelayChainError::GenericError(format!(
+				"Expected hash to be 32 bytes, got {} bytes",
+				hash.as_ref().len()
+			)));
+		}
+
+		Ok(sp_core::H256::from_slice(hash.as_ref()))
+	}
+
+	let mut import_notification_stream =
+		relay_chain_interface.import_notification_stream().await.inspect_err(|err| {
+			log::error!(
+				target: LOG_TARGET,
+				"Failed to get backed block stream: {err:?}"
+			);
+		})?;
+
+	let mut transaction_v2_handle =
+		Box::pin(futures::stream::select_all(rpc_transaction_v2_handles));
+
+	loop {
+		futures::select! {
+			notification = import_notification_stream.next().fuse() => {
+				let Some(notification) = notification else { return Ok(()) };
+
+				let Ok(events) = relay_chain_interface.candidate_events(notification.hash()).await else {
+					log::warn!(target: LOG_TARGET, "Failed to get candidate events for block {}", notification.hash());
+					continue
+				};
+
+				let blocks = events.into_iter().filter_map(|event| match event {
+					CandidateEvent::CandidateBacked(receipt, ..)
+						if receipt.descriptor.para_id() == para_id => {
+							Some(receipt.descriptor.para_head())
+						}
+					_ => None,
+				});
+
+				for block in blocks {
+					if backed_blocks.insert(block, ()) {
+						log::debug!(target: LOG_TARGET, "New backed block: {:?}", block);
+					}
+
+					if let Some(tx_times) = unresolved_tx.remove(&block) {
+						for submitted_at in tx_times {
+							if let Some(metrics) = &metrics {
+								metrics.transaction_backed_duration.observe(submitted_at.elapsed().as_secs_f64());
+							}
+						}
+					}
+				}
+			},
+
+			tx_event = transaction_v2_handle.next().fuse() => {
+				let Some(tx_event) = tx_event else { return Ok(()) };
+
+				match tx_event {
+					sc_service::TransactionMonitorEvent::InBlock { block_hash, submitted_at } => {
+						let block_hash = convert_to_h256::<Block>(&block_hash)?;
+
+						if backed_blocks.peek(&block_hash).is_some() {
+							if let Some(metrics) = &metrics {
+								metrics.transaction_backed_duration.observe(submitted_at.elapsed().as_secs_f64());
+							}
+						} else {
+							// Received the transaction before the block is backed.
+							unresolved_tx.get_or_insert(
+								block_hash,
+								|| Vec::new(),
+							).map(|pending| pending.push(submitted_at));
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -314,18 +314,20 @@ where
 		.spawn_handle()
 		.spawn("parachain-informant", None, parachain_informant);
 
-	let parachain_rpc_metrics = parachain_rpc_metrics::<Block>(
-		relay_chain_interface.clone(),
-		rpc_transaction_v2_handles,
-		para_id,
-		prometheus_registry.map(ParachainRpcMetrics::new).transpose()?,
-	);
-	task_manager.spawn_handle().spawn("parachain-rpc-metrics", None, async move {
-		let result = parachain_rpc_metrics.await;
-		if result.is_err() {
-			log::error!(target: LOG_TARGET_SYNC, "Parachain RPC metrics stopped: {:?}", result);
-		}
-	});
+	if !rpc_transaction_v2_handles.is_empty() {
+		let parachain_rpc_metrics = parachain_rpc_metrics::<Block>(
+			relay_chain_interface.clone(),
+			rpc_transaction_v2_handles,
+			para_id,
+			prometheus_registry.map(ParachainRpcMetrics::new).transpose()?,
+		);
+		task_manager.spawn_handle().spawn("parachain-rpc-metrics", None, async move {
+			let result = parachain_rpc_metrics.await;
+			if result.is_err() {
+				log::error!(target: LOG_TARGET_SYNC, "Parachain RPC metrics stopped: {:?}", result);
+			}
+		});
+	}
 
 	Ok(())
 }

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -118,6 +118,7 @@ pub struct StartRelayChainTasksParams<'a, Block: BlockT, Client, RCInterface> {
 	pub recovery_handle: Box<dyn RecoveryHandle>,
 	pub sync_service: Arc<SyncingService<Block>>,
 	pub prometheus_registry: Option<&'a Registry>,
+	pub rpc_transaction_v2_handles: Vec<sc_service::TransactionMonitorHandle<Block::Hash>>,
 }
 
 /// Parameters given to [`start_full_node`].
@@ -192,6 +193,7 @@ where
 		recovery_handle,
 		sync_service,
 		prometheus_registry,
+		rpc_transaction_v2_handles: vec![],
 	})?;
 
 	#[allow(deprecated)]
@@ -232,6 +234,7 @@ pub fn start_relay_chain_tasks<Block, Client, Backend, RCInterface>(
 		recovery_handle,
 		sync_service,
 		prometheus_registry,
+		rpc_transaction_v2_handles,
 	}: StartRelayChainTasksParams<Block, Client, RCInterface>,
 ) -> sc_service::error::Result<()>
 where
@@ -358,6 +361,7 @@ where
 		sync_service,
 		da_recovery_profile: DARecoveryProfile::FullNode,
 		prometheus_registry,
+		rpc_transaction_v2_handles: vec![],
 	})
 }
 

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -836,6 +836,8 @@ async fn parachain_rpc_metrics<Block: BlockT>(
 			notification = import_notification_stream.next().fuse() => {
 				let Some(notification) = notification else { return Ok(()) };
 
+				log::debug!(target: LOG_TARGET, "Received import notification for block {:?}", notification.hash());
+
 				let Ok(events) = relay_chain_interface.candidate_events(notification.hash()).await else {
 					log::warn!(target: LOG_TARGET, "Failed to get candidate events for block {}", notification.hash());
 					continue
@@ -848,6 +850,8 @@ async fn parachain_rpc_metrics<Block: BlockT>(
 						}
 					_ => None,
 				});
+
+				log::trace!(target: LOG_TARGET, "Relay block {:?} with backed blocks: {:?}", notification.hash(), blocks);
 
 				for block in blocks {
 					if backed_blocks.insert(block, ()) {
@@ -866,6 +870,8 @@ async fn parachain_rpc_metrics<Block: BlockT>(
 
 			tx_event = transaction_v2_handle.next().fuse() => {
 				let Some(tx_event) = tx_event else { return Ok(()) };
+
+				log::debug!(target: LOG_TARGET, "Received transaction event: {:?}", tx_event);
 
 				match tx_event {
 					sc_service::TransactionMonitorEvent::InBlock { block_hash, submitted_at } => {

--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -404,6 +404,7 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 				recovery_handle: Box::new(overseer_handle.clone()),
 				sync_service,
 				prometheus_registry: prometheus_registry.as_ref(),
+				rpc_transaction_v2_handles: spawn_result.transaction_v2_handles,
 			})?;
 
 			start_bootnode_tasks(StartBootnodeTasksParams {

--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -346,7 +346,7 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 				})
 			};
 
-			sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+			let spawn_result = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 				rpc_builder,
 				client: client.clone(),
 				transaction_pool: transaction_pool.clone(),

--- a/polkadot/node/service/src/builder/mod.rs
+++ b/polkadot/node/service/src/builder/mod.rs
@@ -498,7 +498,8 @@ where
 			system_rpc_tx,
 			tx_handler_controller,
 			telemetry: telemetry.as_mut(),
-		})?;
+		})?
+		.rpc_handlers;
 
 		if let Some(hwbench) = hwbench {
 			sc_sysinfo::print_hwbench(&hwbench);

--- a/substrate/client/rpc-spec-v2/src/transaction/metrics.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/metrics.rs
@@ -152,4 +152,9 @@ impl InstanceMetrics {
 			histogram.observe(self.submitted_at.elapsed().as_secs_f64());
 		}
 	}
+
+	/// Returns the time when the transaction was submitted.
+	pub fn submitted_at(&self) -> Instant {
+		self.submitted_at
+	}
 }

--- a/substrate/client/rpc-spec-v2/src/transaction/mod.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/mod.rs
@@ -39,5 +39,5 @@ pub mod transaction_broadcast;
 pub use api::{TransactionApiServer, TransactionBroadcastApiServer};
 pub use event::{TransactionBlock, TransactionDropped, TransactionError, TransactionEvent};
 pub use metrics::Metrics as TransactionMetrics;
-pub use transaction::Transaction;
+pub use transaction::{Transaction, TransactionMonitorEvent, TransactionMonitorHandle};
 pub use transaction_broadcast::TransactionBroadcast;

--- a/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use codec::Decode;
-use futures::{StreamExt, TryFutureExt};
+use futures::{Stream, StreamExt, TryFutureExt};
 use jsonrpsee::{core::async_trait, PendingSubscriptionSink};
 
 use super::metrics::{InstanceMetrics, Metrics};
@@ -252,4 +252,15 @@ pub enum TransactionMonitorEvent<Hash: Clone> {
 		/// The time when the transaction was submitted.
 		submitted_at: std::time::Instant,
 	},
+}
+
+impl<Hash: Clone> Stream for TransactionMonitorHandle<Hash> {
+	type Item = TransactionMonitorEvent<Hash>;
+
+	fn poll_next(
+		self: std::pin::Pin<&mut Self>,
+		cx: &mut std::task::Context<'_>,
+	) -> std::task::Poll<Option<Self::Item>> {
+		self.get_mut().0.poll_recv(cx)
+	}
 }

--- a/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
@@ -189,3 +189,42 @@ fn handle_event<Hash: Clone, BlockHash: Clone>(
 		TransactionStatus::Broadcast(_) => None,
 	}
 }
+
+/// Handle for the transaction monitor.
+pub struct TransactionMonitorHandle<Hash: Clone>(
+	tokio::sync::mpsc::Receiver<TransactionMonitorEvent<Hash>>,
+);
+
+/// An event emitted by the transaction monitor.
+///
+/// This is used to notify about the state of transactions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransactionMonitorEvent<Hash: Clone> {
+	/// A new transaction has been submitted.
+	Submitted {
+		/// The transaction ID.
+		id: u64,
+	},
+
+	/// The transaction has been included in a block.
+	InBlock {
+		/// The transaction ID.
+		id: u64,
+		/// The block hash where the transaction was included.
+		block_hash: Hash,
+	},
+
+	/// The transaction has been finalized.
+	Finalized {
+		/// The transaction ID.
+		id: u64,
+		/// The block hash where the transaction was finalized.
+		block_hash: Hash,
+	},
+
+	/// The transaction has been dropped from the pool.
+	Stopped {
+		/// The transaction ID.
+		id: u64,
+	},
+}

--- a/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
+++ b/substrate/client/rpc-spec-v2/src/transaction/transaction.rs
@@ -43,7 +43,7 @@ use sp_core::Bytes;
 use sp_runtime::traits::Block as BlockT;
 use std::sync::Arc;
 
-pub(crate) const LOG_TARGET: &str = "rpc-spec-v2";
+pub(crate) const LOG_TARGET: &str = "rpc-spec-v2::tx";
 
 /// An API for transaction RPC calls.
 pub struct Transaction<Pool, Client>
@@ -176,6 +176,7 @@ where
 											submitted_at,
 										})
 										.await;
+									log::trace!(target: LOG_TARGET, "Transaction included in block and notified: {:?}", hash);
 								}
 
 								event

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -463,10 +463,19 @@ pub struct SpawnTasksParams<'a, TBl: BlockT, TCl, TExPool, TRpc, Backend> {
 	pub telemetry: Option<&'a mut Telemetry>,
 }
 
+pub struct SpawnTaskHandlers<Block: BlockT> {
+	/// RPC handlers for the in-memory RPC server.
+	pub rpc_handlers: RpcHandlers,
+
+	/// Specific handler for the RPC transactions.
+	pub transaction_v2_handles:
+		Vec<sc_rpc_spec_v2::transaction::TransactionMonitorHandle<Block::Hash>>,
+}
+
 /// Spawn the tasks that are required to run a node.
 pub fn spawn_tasks<TBl, TBackend, TExPool, TRpc, TCl>(
 	params: SpawnTasksParams<TBl, TCl, TExPool, TRpc, TBackend>,
-) -> Result<RpcHandlers, Error>
+) -> Result<SpawnTaskHandlers<TBl>, Error>
 where
 	TCl: ProvideRuntimeApi<TBl>
 		+ HeaderMetadata<TBl, Error = sp_blockchain::Error>
@@ -628,7 +637,11 @@ where
 		rpc_id_provider,
 	)?;
 
+	let mut transaction_v2_handles = Vec::with_capacity(2);
+	transaction_v2_handles.push(rpc_server_handle.transaction_v2_handle);
+
 	let listen_addrs = rpc_server_handle
+		.server
 		.listen_addrs()
 		.into_iter()
 		.map(|socket_addr| {
@@ -639,7 +652,11 @@ where
 		.collect();
 
 	let in_memory_rpc = {
-		let mut module = gen_rpc_module()?;
+		let result = gen_rpc_module()?;
+		// Take in memory RPC into account.
+		transaction_v2_handles.push(result.transaction_v2_handle);
+
+		let mut module = result.module;
 		module.extensions_mut().insert(DenyUnsafe::No);
 		module
 	};
@@ -653,9 +670,9 @@ where
 		sc_informant::build(client.clone(), network, sync_service.clone()),
 	);
 
-	task_manager.keep_alive((config.base_path, rpc_server_handle));
+	task_manager.keep_alive((config.base_path, rpc_server_handle.server));
 
-	Ok(in_memory_rpc_handle)
+	Ok(SpawnTaskHandlers { rpc_handlers: in_memory_rpc_handle, transaction_v2_handles })
 }
 
 /// Returns a future that forwards imported transactions to the transaction networking protocol.
@@ -750,6 +767,14 @@ where
 	Ok(telemetry.handle())
 }
 
+pub struct RpcModuleData<TBl: BlockT> {
+	/// The RPC module used to instantiate the RPC server.
+	pub module: RpcModule<()>,
+
+	/// Specific handler for the RPC transactions.
+	pub transaction_v2_handle: sc_rpc_spec_v2::transaction::TransactionMonitorHandle<TBl::Hash>,
+}
+
 /// Generate RPC module using provided configuration
 pub fn gen_rpc_module<TBl, TBackend, TCl, TRpc, TExPool>(
 	spawn_handle: SpawnTaskHandle,
@@ -765,7 +790,7 @@ pub fn gen_rpc_module<TBl, TBackend, TCl, TRpc, TExPool>(
 	backend: Arc<TBackend>,
 	rpc_builder: &(dyn Fn(SubscriptionTaskExecutor) -> Result<RpcModule<TRpc>, Error>),
 	metrics: Option<sc_rpc_spec_v2::transaction::TransactionMetrics>,
-) -> Result<RpcModule<()>, Error>
+) -> Result<RpcModuleData<TBl>, Error>
 where
 	TBl: BlockT,
 	TCl: ProvideRuntimeApi<TBl>
@@ -816,13 +841,13 @@ where
 	)
 	.into_rpc();
 
-	let transaction_v2 = sc_rpc_spec_v2::transaction::Transaction::new(
+	let (transaction_v2, transaction_v2_handle) = sc_rpc_spec_v2::transaction::Transaction::new(
 		client.clone(),
 		transaction_pool.clone(),
 		task_executor.clone(),
 		metrics,
-	)
-	.into_rpc();
+	);
+	let transaction_v2 = transaction_v2.into_rpc();
 
 	let chain_head_v2 = sc_rpc_spec_v2::chain_head::ChainHead::new(
 		client.clone(),
@@ -893,7 +918,7 @@ where
 	let extra_rpcs = rpc_builder(task_executor.clone())?;
 	rpc_api.merge(extra_rpcs).map_err(|e| Error::Application(e.into()))?;
 
-	Ok(rpc_api)
+	Ok(RpcModuleData { module: rpc_api, transaction_v2_handle })
 }
 
 /// Parameters to pass into [`build_network`].

--- a/templates/parachain/node/src/service.rs
+++ b/templates/parachain/node/src/service.rs
@@ -327,7 +327,7 @@ pub async fn start_parachain_node(
 		})
 	};
 
-	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+	let spawn_result = sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		rpc_builder,
 		client: client.clone(),
 		transaction_pool: transaction_pool.clone(),
@@ -394,6 +394,7 @@ pub async fn start_parachain_node(
 		recovery_handle: Box::new(overseer_handle.clone()),
 		sync_service: sync_service.clone(),
 		prometheus_registry: prometheus_registry.as_ref(),
+		rpc_transaction_v2_handles: spawn_result.transaction_v2_handles,
 	})?;
 
 	start_bootnode_tasks(StartBootnodeTasksParams {


### PR DESCRIPTION
This PR introduces a metric in Cumulus to measure the time it took a transaction received on the RPC layer to be included a backed block.

- A new `TransactionMonitorHandle` is exposed from the transaction RPC V2 API to listen on monitoring events emitted by substrate
- The monitoring event contains the block of the transaction with the timestamp associated
- A cumulus task is added to group the backed events from the relay chain with the monitoring events exposed by the RPC layer
- The spawning of RPC `spawn_tasks` now returns the additional `TransactionMonitorHandle`
- The metric is exposed under the following histogram: `parachain_transaction_backed_duration`

## Testing Done
- Started a small network with 2 validators and 2 collators (charlie and dave -- using `small_network.toml` as base)
- Used subxt with a minimal working code to send a transaction to charlie
- Used the RPC-V2 API (ie ChainHeadBackend)

```rust
use std::sync::Arc;
use subxt::{
    OnlineClient, PolkadotConfig,
    backend::{chain_head::ChainHeadBackend, rpc::RpcClient},
};
use subxt_signer::sr25519::dev;

#[subxt::subxt(runtime_metadata_insecure_url = "ws://127.0.0.1:44919")]
pub mod polkadot {}

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let rpc = RpcClient::from_url("ws://127.0.0.1:44919".to_string()).await?;
    let backend = ChainHeadBackend::builder().build_with_background_driver(rpc.clone());
    let api: OnlineClient<PolkadotConfig> = OnlineClient::from_backend(Arc::new(backend)).await?;

    let from = dev::charlie();
    let dest = dev::dave().public_key().into();
    let tx = Box::new(polkadot::tx().balances().transfer_allow_death(dest, 10_000));
    api.tx()
        .sign_and_submit_then_watch_default(&tx, &from)
        .await?
        .wait_for_finalized_success()
        .await?;

    Ok(())
}
```
- After the transaction gets finalized:

```
parachain_transaction_backed_duration_sum{chain="asset-hub-rococo-local"} 13.097583666
parachain_transaction_backed_duration_count{chain="asset-hub-rococo-local"} 1
```

Closes https://github.com/paritytech/polkadot-sdk/issues/8383

cc @paritytech/sdk-node 

