### PR TITLE
ParachainSystem: Do not emit the `SelectCore` digest

### DIFF
--- a/cumulus/pallets/parachain-system/src/lib.rs
+++ b/cumulus/pallets/parachain-system/src/lib.rs
@@ -585,16 +585,6 @@ pub mod pallet {
 			// Always try to read `UpgradeGoAhead` in `on_finalize`.
 			weight += T::DbWeight::get().reads(1);
 
-			// Post a digest that contains the information for selecting a core.
-			let selected_core = T::SelectCore::selected_core();
-			frame_system::Pallet::<T>::deposit_log(
-				cumulus_primitives_core::CumulusDigestItem::SelectCore {
-					selector: selected_core.0,
-					claim_queue_offset: selected_core.1,
-				}
-				.to_digest_item(),
-			);
-
 			weight
 		}
 	}

--- a/prdoc/pr_8903.prdoc
+++ b/prdoc/pr_8903.prdoc
@@ -3,8 +3,6 @@ doc:
 - audience: Runtime Dev
   description: |-
     This will be moved into an inherent digest.
-
-    As preparation for: https://github.com/paritytech/polkadot-sdk/issues/8893
 crates:
 - name: cumulus-pallet-parachain-system
   bump: patch

--- a/prdoc/pr_8903.prdoc
+++ b/prdoc/pr_8903.prdoc
@@ -1,0 +1,10 @@
+title: 'ParachainSystem: Do not emit the `SelectCore` digest'
+doc:
+- audience: Runtime Dev
+  description: |-
+    This will be moved into an inherent digest.
+
+    As preparation for: https://github.com/paritytech/polkadot-sdk/issues/8893
+crates:
+- name: cumulus-pallet-parachain-system
+  bump: patch


### PR DESCRIPTION
This will be moved into an inherent digest.

As preparation for: https://github.com/paritytech/polkadot-sdk/issues/8893