### PR TITLE
[pvf-worker] Refactor execute request handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15452,6 +15452,7 @@ dependencies = [
  "libc",
  "nix 0.29.0",
  "parity-scale-codec",
+ "polkadot-node-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-executor 0.32.0",

--- a/polkadot/node/core/pvf/common/Cargo.toml
+++ b/polkadot/node/core/pvf/common/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 
 codec = { features = ["derive"], workspace = true }
 
+polkadot-node-primitives = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }
 

--- a/polkadot/node/core/pvf/common/src/execute.rs
+++ b/polkadot/node/core/pvf/common/src/execute.rs
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::error::InternalValidationError;
+use crate::{error::InternalValidationError, ArtifactChecksum};
 use codec::{Decode, Encode};
+use polkadot_node_primitives::PoV;
 use polkadot_parachain_primitives::primitives::ValidationResult;
-use polkadot_primitives::ExecutorParams;
+use polkadot_primitives::{ExecutorParams, PersistedValidationData};
 use std::time::Duration;
 
 /// The payload of the one-time handshake that is done when a worker process is created. Carries
@@ -26,6 +27,19 @@ use std::time::Duration;
 pub struct Handshake {
 	/// The executor parameters.
 	pub executor_params: ExecutorParams,
+}
+
+/// A request to execute a PVF. Contains all the data needed for validation.
+#[derive(Encode, Decode)]
+pub struct ExecuteRequest {
+	/// The persisted validation data.
+	pub pvd: PersistedValidationData,
+	/// The proof-of-validity.
+	pub pov: PoV,
+	/// The execution timeout.
+	pub execution_timeout: Duration,
+	/// The checksum of the artifact to execute.
+	pub artifact_checksum: ArtifactChecksum,
 }
 
 /// The response from the execution worker.

--- a/polkadot/node/core/pvf/execute-worker/src/lib.rs
+++ b/polkadot/node/core/pvf/execute-worker/src/lib.rs
@@ -91,40 +91,17 @@ fn recv_execute_handshake(stream: &mut UnixStream) -> io::Result<Handshake> {
 fn recv_request(
 	stream: &mut UnixStream,
 ) -> io::Result<(PersistedValidationData, PoV, Duration, ArtifactChecksum)> {
-	let pvd = framed_recv_blocking(stream)?;
-	let pvd = PersistedValidationData::decode(&mut &pvd[..]).map_err(|_| {
+	use polkadot_node_core_pvf_common::execute::ExecuteRequest;
+
+	let request_bytes = framed_recv_blocking(stream)?;
+	let request = ExecuteRequest::decode(&mut &request_bytes[..]).map_err(|_| {
 		io::Error::new(
 			io::ErrorKind::Other,
-			"execute pvf recv_request: failed to decode persisted validation data".to_string(),
+			"execute pvf recv_request: failed to decode ExecuteRequest".to_string(),
 		)
 	})?;
 
-	let pov = framed_recv_blocking(stream)?;
-	let pov = PoV::decode(&mut &pov[..]).map_err(|_| {
-		io::Error::new(
-			io::ErrorKind::Other,
-			"execute pvf recv_request: failed to decode PoV".to_string(),
-		)
-	})?;
-
-	let execution_timeout = framed_recv_blocking(stream)?;
-	let execution_timeout = Duration::decode(&mut &execution_timeout[..]).map_err(|_| {
-		io::Error::new(
-			io::ErrorKind::Other,
-			"execute pvf recv_request: failed to decode duration".to_string(),
-		)
-	})?;
-
-	let artifact_checksum = framed_recv_blocking(stream)?;
-	let artifact_checksum =
-		ArtifactChecksum::decode(&mut &artifact_checksum[..]).map_err(|_| {
-			io::Error::new(
-				io::ErrorKind::Other,
-				"execute pvf recv_request: failed to decode artifact checksum".to_string(),
-			)
-		})?;
-
-	Ok((pvd, pov, execution_timeout, artifact_checksum))
+	Ok((request.pvd, request.pov, request.execution_timeout, request.artifact_checksum))
 }
 
 /// Sends an error to the host and returns the original error wrapped in `io::Error`.

--- a/polkadot/node/core/pvf/src/execute/worker_interface.rs
+++ b/polkadot/node/core/pvf/src/execute/worker_interface.rs
@@ -295,10 +295,13 @@ async fn send_request(
 	execution_timeout: Duration,
 	artifact_checksum: ArtifactChecksum,
 ) -> io::Result<()> {
-	framed_send(stream, &pvd.encode()).await?;
-	framed_send(stream, &pov.encode()).await?;
-	framed_send(stream, &execution_timeout.encode()).await?;
-	framed_send(stream, &artifact_checksum.encode()).await
+	let request = polkadot_node_core_pvf_common::execute::ExecuteRequest {
+		pvd: (*pvd).clone(),
+		pov: (*pov).clone(),
+		execution_timeout,
+		artifact_checksum,
+	};
+	framed_send(stream, &request.encode()).await
 }
 
 async fn recv_result(stream: &mut UnixStream) -> io::Result<Result<WorkerResponse, WorkerError>> {


### PR DESCRIPTION
# Description

Fixes https://github.com/paritytech/polkadot-sdk/issues/8886

PVF execution worker communication was organized into a single ExecuteRequest struct. This should improve performance: one encode/decode operation instead of four. Also, no more chance of ordering mistakes.



## Integration

This is an internal refactoring of the PVF execution worker. Downstream projects will not need any code changes.
