### PR TITLE
Multisig::as_multi_threshold_1: Send `MultisigExecuted` event

### DIFF
--- a/prdoc/pr_8925.prdoc
+++ b/prdoc/pr_8925.prdoc
@@ -1,0 +1,10 @@
+title: 'Multisig::as_multi_threshold_1: Send `MultisigExecuted` event'
+doc:
+- audience: Runtime User
+  description: |-
+    So the behavior is the same as `as_multi` when it comes to sending an event.
+
+    Closes: https://github.com/paritytech/polkadot-sdk/issues/8924
+crates:
+- name: pallet-multisig
+  bump: patch

--- a/substrate/frame/multisig/src/tests.rs
+++ b/substrate/frame/multisig/src/tests.rs
@@ -595,6 +595,16 @@ fn multisig_1_of_3_works() {
 			call_transfer(6, 15)
 		));
 
+		System::assert_last_event(
+			pallet_multisig::Event::MultisigExecuted {
+				approving: 1,
+				timepoint: now(),
+				multisig: multi,
+				call_hash: hash,
+				result: Ok(()),
+			}
+			.into(),
+		);
 		assert_eq!(Balances::free_balance(6), 15);
 	});
 }


### PR DESCRIPTION
So the behavior is the same as `as_multi` when it comes to sending an event.

Closes: https://github.com/paritytech/polkadot-sdk/issues/8924