### PR TITLE
pallet-balances: Do not create account in benchmarking

### DIFF
--- a/prdoc/pr_8932.prdoc
+++ b/prdoc/pr_8932.prdoc
@@ -1,0 +1,11 @@
+title: 'pallet-balances: Do not create account in benchmarking'
+doc:
+- audience: Runtime Dev
+  description: |-
+    This particular benchmark is about benchmarking the account creation, so we should not create it before :)
+
+
+    Closes: https://github.com/paritytech/polkadot-sdk/issues/8927
+crates:
+- name: pallet-balances
+  bump: patch

--- a/substrate/frame/balances/src/benchmarking.rs
+++ b/substrate/frame/balances/src/benchmarking.rs
@@ -127,10 +127,8 @@ mod benchmarks {
 		let user: T::AccountId = account("user", 0, SEED);
 		let user_lookup = T::Lookup::unlookup(user.clone());
 
-		// Give the user some initial balance.
 		let existential_deposit: T::Balance = minimum_balance::<T, I>();
 		let balance_amount = existential_deposit.saturating_mul(ED_MULTIPLIER.into());
-		let _ = <Balances<T, I> as Currency<_>>::make_free_balance_be(&user, balance_amount);
 
 		#[extrinsic_call]
 		force_set_balance(RawOrigin::Root, user_lookup, balance_amount);


### PR DESCRIPTION
This particular benchmark is about benchmarking the account creation, so we should not create it before :)


Closes: https://github.com/paritytech/polkadot-sdk/issues/8927