### PR TITLE
Always send full parent header, not only hash, part of collation response

### DIFF
--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -508,11 +508,8 @@ async fn distribute_collation<Context>(
 		state.collation_result_senders.insert(candidate_hash, result_sender);
 	}
 
-	let parent_head_data = if elastic_scaling {
-		ParentHeadData::WithData { hash: parent_head_data_hash, head_data: parent_head_data }
-	} else {
-		ParentHeadData::OnlyHash(parent_head_data_hash)
-	};
+	let parent_head_data =
+		ParentHeadData::WithData { hash: parent_head_data_hash, head_data: parent_head_data };
 
 	let para_head = receipt.descriptor.para_head();
 	per_relay_parent.collations.insert(


### PR DESCRIPTION
Implementation of https://github.com/paritytech/polkadot-sdk/issues/7733

# Changes
Instead of **conditionally** sending the full parent header in the collation response we now **always** send it (never the has of it).