### PR TITLE
Decrease too wide line in markdown

### DIFF
--- a/docs/contributor/DOCUMENTATION_GUIDELINES.md
+++ b/docs/contributor/DOCUMENTATION_GUIDELINES.md
@@ -1,7 +1,7 @@
 # Documentation Guidelines
 
-This document is focused on documenting parts of the Polkadot SDK that relate to its external API. The list of such crates can
-be found in [CODEOWNERS](/.github/CODEOWNERS). Search for the crates auto-assigned to the `docs-audit` team.
+This document is focused on documenting parts of the Polkadot SDK that relate to its external API. The list of such 
+crates can be found in [CODEOWNERS](/.github/CODEOWNERS). Search for the crates auto-assigned to the `docs-audit` team.
 
 These crates are used by external developers and need thorough documentation. They are the most concerned with FRAME
 development.

--- a/docs/contributor/DOCUMENTATION_GUIDELINES.md
+++ b/docs/contributor/DOCUMENTATION_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Documentation Guidelines
 
-This document is focused on documenting parts of the Polkadot SDK that relate to its external API. The list of such 
+This document is focused on documenting parts of the Polkadot SDK that relate to its external API. The list of such
 crates can be found in [CODEOWNERS](/.github/CODEOWNERS). Search for the crates auto-assigned to the `docs-audit` team.
 
 These crates are used by external developers and need thorough documentation. They are the most concerned with FRAME


### PR DESCRIPTION
In https://github.com/paritytech/polkadot-sdk/pull/8827 I wrote a line which was longer than CI markdown linter allowed (max 120 chars, width was 126)

This causes CI failure: https://github.com/paritytech/polkadot-sdk/actions/runs/15850370092/job/44682093959?pr=8939