### PR TITLE
Add polkadot_parachain_peer_connectivity metric

### DIFF
--- a/prdoc/pr_8973.prdoc
+++ b/prdoc/pr_8973.prdoc
@@ -1,0 +1,14 @@
+title: Add polkadot_parachain_peer_connectivity metric
+doc:
+- audience: Node Dev
+  description: |-
+    # Description
+
+    Fixes https://github.com/paritytech/polkadot-sdk/issues/8911
+
+    ## Integration
+
+    Doesn't affect downstream projects.
+crates:
+- name: polkadot-network-bridge
+  bump: patch

--- a/prdoc/pr_8973.prdoc
+++ b/prdoc/pr_8973.prdoc
@@ -2,13 +2,8 @@ title: Add polkadot_parachain_peer_connectivity metric
 doc:
 - audience: Node Dev
   description: |-
-    # Description
+    Adds `polkadot_parachain_peer_connectivity` histogram metric to better understand connectivity patterns.
 
-    Fixes https://github.com/paritytech/polkadot-sdk/issues/8911
-
-    ## Integration
-
-    Doesn't affect downstream projects.
 crates:
 - name: polkadot-network-bridge
   bump: patch


### PR DESCRIPTION
# Description

Fixes https://github.com/paritytech/polkadot-sdk/issues/8911

Adds `polkadot_parachain_peer_connectivity` histogram metric to better understand connectivity patterns.

## Integration

Doesn't affect downstream projects. 