### PR TITLE
Support Aura to Babe chain upgrades

### DIFF
--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -292,13 +292,13 @@ where
 			// on-chain data.
 			collator.collator_service().check_block_status(parent_hash, &parent_header);
 
-			let Ok(relay_slot) =
+			let Ok(Some(pre_digest)) =
 				sc_consensus_babe::find_pre_digest::<RelayBlock>(relay_parent_header)
-					.map(|babe_pre_digest| babe_pre_digest.slot())
 			else {
 				tracing::error!(target: crate::LOG_TARGET, "Relay chain does not contain babe slot. This should never happen.");
 				continue;
 			};
+			let relay_slot = pre_digest.slot();
 
 			let included_header_hash = included_header.hash();
 

--- a/cumulus/client/consensus/common/src/lib.rs
+++ b/cumulus/client/consensus/common/src/lib.rs
@@ -237,13 +237,14 @@ pub fn relay_slot_and_timestamp(
 	relay_chain_slot_duration: Duration,
 ) -> Option<(Slot, Timestamp)> {
 	sc_consensus_babe::find_pre_digest::<PBlock>(relay_parent_header)
+		.ok()
+		.flatten()
 		.map(|babe_pre_digest| {
 			let slot = babe_pre_digest.slot();
 			let t = Timestamp::new(relay_chain_slot_duration.as_millis() as u64 * *slot);
 
 			(slot, t)
 		})
-		.ok()
 }
 
 /// Reads abridged host configuration from the relay chain storage at the given relay parent.

--- a/substrate/client/consensus/babe/src/verification.rs
+++ b/substrate/client/consensus/babe/src/verification.rs
@@ -70,7 +70,9 @@ pub(super) fn check_header<B: BlockT + Sized>(
 	let VerificationParams { mut header, pre_digest, slot_now, epoch } = params;
 
 	let authorities = &epoch.authorities;
-	let pre_digest = pre_digest.map(Ok).unwrap_or_else(|| find_pre_digest::<B>(&header))?;
+	let pre_digest = pre_digest.map(Ok).unwrap_or_else(|| {
+		find_pre_digest::<B>(&header)?.ok_or(babe_err(Error::NoPreRuntimeDigest))
+	})?;
 
 	trace!(target: LOG_TARGET, "Checking header");
 	let seal = header

--- a/substrate/client/consensus/manual-seal/src/consensus/babe.rs
+++ b/substrate/client/consensus/manual-seal/src/consensus/babe.rs
@@ -102,7 +102,8 @@ where
 		import_params.finalized = false;
 		import_params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
-		let pre_digest = find_pre_digest::<B>(&import_params.header)?;
+		let pre_digest = find_pre_digest::<B>(&import_params.header)?
+			.ok_or_else(|| format!("{}", sc_consensus_babe::Error::<B>::NoPreRuntimeDigest))?;
 
 		let parent_hash = import_params.header.parent_hash();
 		let parent = self

--- a/substrate/client/consensus/manual-seal/src/consensus/timestamp.rs
+++ b/substrate/client/consensus/manual-seal/src/consensus/timestamp.rs
@@ -65,6 +65,9 @@ impl SlotTimestampProvider {
 		let time = Self::with_header(&client, slot_duration, |header| {
 			let slot_number = *sc_consensus_babe::find_pre_digest::<B>(&header)
 				.map_err(|err| format!("{}", err))?
+				// If babe pre-genesis is missing (e.g. genesis or aura -> babe migration),
+				// just use the default.
+				.unwrap_or_default()
 				.slot();
 			Ok(slot_number)
 		})?;

--- a/substrate/frame/babe/src/lib.rs
+++ b/substrate/frame/babe/src/lib.rs
@@ -935,11 +935,14 @@ impl<T: Config> OnTimestampSet<T::Moment> for Pallet<T> {
 		let timestamp_slot = moment / slot_duration;
 		let timestamp_slot = Slot::from(timestamp_slot.saturated_into::<u64>());
 
-		assert_eq!(
-			CurrentSlot::<T>::get(),
-			timestamp_slot,
-			"Timestamp slot must match `CurrentSlot`"
-		);
+		if CurrentSlot::<T>::get() != timestamp_slot {
+			log::warn!(
+				target: LOG_TARGET,
+				"Timestamp slot {:?} does not match `CurrentSlot` {:?}!",
+				timestamp_slot,
+				CurrentSlot::<T>::get(),
+			);
+		}
 	}
 }
 

--- a/substrate/primitives/consensus/babe/src/digests.rs
+++ b/substrate/primitives/consensus/babe/src/digests.rs
@@ -42,7 +42,7 @@ pub struct PrimaryPreDigest {
 }
 
 /// BABE secondary slot assignment pre-digest.
-#[derive(Clone, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
+#[derive(Clone, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Default)]
 pub struct SecondaryPlainPreDigest {
 	/// Authority index
 	///
@@ -80,6 +80,16 @@ pub enum PreDigest {
 	/// A secondary deterministic slot assignment with VRF outputs.
 	#[codec(index = 3)]
 	SecondaryVRF(SecondaryVRFPreDigest),
+}
+
+/// Default to use on Genesis or first Babe block.
+impl Default for PreDigest {
+	fn default() -> Self {
+		PreDigest::SecondaryPlain(SecondaryPlainPreDigest {
+			authority_index: Default::default(),
+			slot: Default::default(),
+		})
+	}
 }
 
 impl PreDigest {


### PR DESCRIPTION
# Description

Many blockchains begin with a permissioned validator set (Aura), sacrificing decentralisation for ease of upgrade, and later transition to a permissionless validator set (Babe), as decentralisation becomes a priority.

Polkadot SDK in its current state does not support this natural progression from, due to three hard coded assumptions that the parent of the first Babe block will be block 0. Chains wishing to perform this upgrade must re-genesis, fracturing chain history and making the upgrade process unnecessarily cumbersome.

In this PR, I propose replacing these hard coded checks for parent block zero with something more flexible, to allow Aura -> Babe runtime upgrades.

# Review Notes

## Note 

The modifications in this PR are the shortest path changes I made to achieve successful Aura -> Babe runtime upgrades in my local environment. They work, but I acknowledge may not be the "best" solution. I am open to suggestions for how we can go about this in a more elegant way.

## `fn find_pre_digest`

`fn find_pre_digest` states in its doc-comment: `"Pre-runtime digests are mandatory, the function will return Err if none is found."`. However makes an exception to this rule when the parent block number is zero, instead returning a "Default" value for the digest when the header block is zero:

https://github.com/paritytech/polkadot-sdk/blob/caf999310df66b790c7f26b0227a51068ba441fc/substrate/client/consensus/babe/src/lib.rs#L899-L909

Because it is possible for the pre-runtime digest to be missing, I suggest modifying the return value of this fn to `Result<Option<PreDigest>, ...>`, returning `Ok(None)` if the pre-runtime digest is missing and allowing the caller to decide what to do in that case. Most of the time, the caller will choose to `.unwrap_or_default`. 

## `fn epoch_descriptor_for_child_of`

This fn also handles the special case of the parent being block zero: 

https://github.com/paritytech/polkadot-sdk/blob/caf999310df66b790c7f26b0227a51068ba441fc/substrate/client/consensus/epochs/src/lib.rs#L536-L550

In the context of an Aura -> Babe upgrade, this causes an error to be returned here:

https://github.com/paritytech/polkadot-sdk/blob/caf999310df66b790c7f26b0227a51068ba441fc/substrate/client/consensus/babe/src/lib.rs#L749-L760

As a way to unblock Aura -> Babe, I have just replaced `.ok_or(ConsensusError::InvalidAuthoritiesSet) ` with `.unwrap_or(ViableEpochDescriptor::UnimportedGenesis(slot)))` on line 759. I'm open to other solutions here.

## `fn import_block`

Hard coded to return zero instead of calling `aux_schema::load_block_weight` here:

https://github.com/paritytech/polkadot-sdk/blob/caf999310df66b790c7f26b0227a51068ba441fc/substrate/client/consensus/babe/src/lib.rs#L1482-L1493

Which otherwise would return an error. I have modified the error handling for the `aux_schema::load_block_weight` call to log a warning and return zero instead of propagating the error. Open to suggestions for how this might be achieved in a cleaner way.

## Integration

`pub fn find_pre_digest` function signature changed to return `Result<Option<PreDigest>, Error<B>>`. Function returns `Ok(None)` if no pre-digest is found at the given header.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [x] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  * Open to suggestions how tests could be added for this PR. 

You can remove the "Checklist" section once all have been checked. Thank you for your contribution!