### PR TITLE
Snowbridge: ERC20TokenHandler

### DIFF
--- a/bridges/snowbridge/pallets/inbound-queue-v2/src/mock.rs
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/src/mock.rs
@@ -103,6 +103,17 @@ parameter_types! {
 	pub const CreateAssetDeposit: u128 = 10_000_000_000u128;
 }
 
+pub struct MockTokenHandler;
+impl ERC20TokenHandler for MockTokenHandler {
+	fn store(_: H160, _: u64) {
+		return
+	}
+
+	fn get(_: H160) -> Option<u64> {
+		None
+	}
+}
+
 impl inbound_queue_v2::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Verifier = MockVerifier;
@@ -129,6 +140,7 @@ impl inbound_queue_v2::Config for Test {
 	type RewardKind = BridgeReward;
 	type DefaultRewardKind = SnowbridgeReward;
 	type RewardPayment = MockRewardLedger;
+	type TokenHandler = MockTokenHandler;
 }
 
 pub fn setup() {

--- a/bridges/snowbridge/pallets/system-v2/src/lib.rs
+++ b/bridges/snowbridge/pallets/system-v2/src/lib.rs
@@ -37,7 +37,7 @@ use snowbridge_core::{
 		AddTip, MessageId,
 		MessageId::{Inbound, Outbound},
 	},
-	AgentIdOf as LocationHashOf, AssetMetadata, TokenId, TokenIdOf,
+	AgentIdOf as LocationHashOf, AssetMetadata, ERC20TokenHandler, TokenId, TokenIdOf,
 };
 use snowbridge_outbound_queue_primitives::{
 	v2::{Command, Initializer, Message, SendMessage},
@@ -140,6 +140,11 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type LostTips<T: Config> =
 		StorageMap<_, Blake2_128Concat, AccountIdOf<T>, u128, ValueQuery>;
+
+	/// Registered ERC-20 tokens
+	#[pallet::storage]
+	pub type RegistedERC20Tokens<T: Config> =
+		StorageMap<_, Blake2_128Concat, H160, u64, OptionQuery>;
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
@@ -316,6 +321,15 @@ pub mod pallet {
 	impl<T: Config> MaybeConvert<TokenId, Location> for Pallet<T> {
 		fn maybe_convert(foreign_id: TokenId) -> Option<Location> {
 			snowbridge_pallet_system::Pallet::<T>::maybe_convert(foreign_id)
+		}
+	}
+
+	impl<T: Config> ERC20TokenHandler for Pallet<T> {
+		fn store(address: H160, gas_cost: u64) {
+			RegistedERC20Tokens::<T>::insert(address, gas_cost)
+		}
+		fn get(address: H160) -> Option<u64> {
+			RegistedERC20Tokens::<T>::get(address)
 		}
 	}
 }

--- a/bridges/snowbridge/primitives/core/src/lib.rs
+++ b/bridges/snowbridge/primitives/core/src/lib.rs
@@ -26,7 +26,7 @@ use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use frame_support::{traits::Contains, BoundedVec};
 use hex_literal::hex;
 use scale_info::TypeInfo;
-use sp_core::{ConstU32, H256};
+use sp_core::{ConstU32, H160, H256};
 use sp_io::hashing::keccak_256;
 use sp_runtime::{traits::AccountIdConversion, RuntimeDebug};
 use sp_std::prelude::*;
@@ -197,4 +197,12 @@ where
 	AssetTransactor::check_out(origin, fee, &dummy_context);
 	AssetTransactor::withdraw_asset(fee, origin, None)?;
 	Ok(())
+}
+
+/// ERC20TokenHandler
+pub trait ERC20TokenHandler {
+	/// Store token address and the gas cost
+	fn store(address: H160, gas_cost: u64);
+	/// Retrieve gas cost by token address
+	fn get(address: H160) -> Option<u64>;
 }

--- a/bridges/snowbridge/primitives/inbound-queue/src/v2/converter.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/v2/converter.rs
@@ -128,7 +128,7 @@ where
 
 		let mut remote_xcm: Xcm<()> = match &message.xcm {
 			XcmPayload::Raw(raw) => Self::decode_raw_xcm(raw),
-			XcmPayload::CreateAsset { token, network } => Self::make_create_asset_xcm(
+			XcmPayload::CreateAsset { token, network, .. } => Self::make_create_asset_xcm(
 				token,
 				*network,
 				message.value,

--- a/bridges/snowbridge/primitives/inbound-queue/src/v2/message.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/v2/message.rs
@@ -34,6 +34,7 @@ sol! {
 		struct XcmCreateAsset {
 			address token;
 			uint8 network;
+			uint64 gas_cost;
 		}
 		struct Payload {
 			address origin;
@@ -85,7 +86,7 @@ pub enum XcmPayload {
 	/// Represents raw XCM bytes
 	Raw(Vec<u8>),
 	/// A token registration template
-	CreateAsset { token: H160, network: Network },
+	CreateAsset { token: H160, network: Network, gas_cost: u64 },
 }
 
 /// Network enum for cross-chain message destination
@@ -206,7 +207,11 @@ impl TryFrom<&IGatewayV2::Payload> for XcmPayload {
 					0 => Network::Polkadot,
 					_ => return Err(MessageDecodeError),
 				};
-				XcmPayload::CreateAsset { token: H160::from(create_asset.token.as_ref()), network }
+				XcmPayload::CreateAsset {
+					token: H160::from(create_asset.token.as_ref()),
+					network,
+					gas_cost: create_asset.gas_cost,
+				}
 			},
 			_ => return Err(MessageDecodeError),
 		};

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/bridge_to_ethereum_config.rs
@@ -31,7 +31,7 @@ use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::{gwei, meth, AllowSiblingsOnly, PricingParameters, Rewards};
 use snowbridge_outbound_queue_primitives::{
 	v1::{ConstantGasMeter, EthereumBlobExporter},
-	v2::{ConstantGasMeter as ConstantGasMeterV2, EthereumBlobExporter as EthereumBlobExporterV2},
+	v2::{ERC20TokenGasMeter, EthereumBlobExporter as EthereumBlobExporterV2},
 };
 use sp_core::H160;
 use sp_runtime::{
@@ -155,6 +155,7 @@ impl snowbridge_pallet_inbound_queue_v2::Config for Runtime {
 	type RewardKind = BridgeReward;
 	type DefaultRewardKind = SnowbridgeReward;
 	type RewardPayment = BridgeRelayers;
+	type TokenHandler = EthereumSystemV2;
 }
 
 impl snowbridge_pallet_outbound_queue::Config for Runtime {
@@ -184,7 +185,7 @@ impl snowbridge_pallet_outbound_queue_v2::Config for Runtime {
 	// rs` show that the `process` function consumes less than 1% of the block capacity, which is
 	// safe enough.
 	type MaxMessagesPerBlock = ConstU32<32>;
-	type GasMeter = ConstantGasMeterV2;
+	type GasMeter = ERC20TokenGasMeter<EthereumSystemV2>;
 	type Balance = Balance;
 	type WeightToFee = WeightToFee;
 	type Verifier = snowbridge_pallet_ethereum_client::Pallet<Runtime>;


### PR DESCRIPTION
### Context

To make the gas cost of `UnlockNativeToken` configurable - I'd assume the current default of 200_000 from `ConstantGasMeter` [here](https://github.com/paritytech/polkadot-sdk/blob/3288aa33b535e66578d93dc1bea6091c572854ad/bridges/snowbridge/primitives/outbound-queue/src/v2/message.rs#L297) is too high for most tokens.  In most cases, 100_000 should be sufficient.

Another concern is that supporting a complex ERC-20 token with a transfer gas cost exceeding 200_000 would require a runtime migration - which isn't ideal.

The idea is to allow users provide this value when calling `register_token` from Ethereum,  so we can store it on a per-token basis and use it later when constructing the outbound transfer message.

This also simplifies fee estimation, as we can directly use this configured value in offchain calculations.

Requires:

https://github.com/Snowfork/snowbridge/pull/1513