### PR TITLE
reenable 0001-parachains-pvf

### DIFF
--- a/.github/zombienet-flaky-tests
+++ b/.github/zombienet-flaky-tests
@@ -4,7 +4,6 @@ zombienet-polkadot-elastic-scaling-slot-based-12cores
 zombienet-polkadot-functional-0002-parachains-disputes
 zombienet-polkadot-functional-0004-parachains-disputes-garbage-candidate
 zombienet-polkadot-disputes-slashing
-zombienet-polkadot-functional-0001-parachains-pvf
 zombienet-polkadot-functional-spam-statement-distribution-requests
 zombienet-polkadot-misc-0001-parachains-paritydb
 zombienet-polkadot-functional-duplicate-collations

--- a/polkadot/zombienet_tests/functional/0001-parachains-pvf.zndsl
+++ b/polkadot/zombienet_tests/functional/0001-parachains-pvf.zndsl
@@ -74,11 +74,11 @@ one: reports histogram polkadot_pvf_execution_time has at least 1 samples in buc
 two: reports histogram polkadot_pvf_execution_time has at least 1 samples in buckets ["0.1", "0.5", "1", "2"] within 10 seconds
 
 # Check if we have no samples > 2s.
-alice: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-bob: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-charlie: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-dave: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-ferdie: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-eve: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-one: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
-two: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["3", "4", "5", "6", "+Inf"] within 10 seconds
+alice: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+bob: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+charlie: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+dave: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+ferdie: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+eve: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+one: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds
+two: reports histogram polkadot_pvf_execution_time has 0 samples in buckets ["4", "5", "6", "+Inf"] within 10 seconds


### PR DESCRIPTION
Fixes: https://github.com/paritytech/polkadot-sdk/issues/8940.

All failure seems to be because occasionally we have 1 occurence in the 3 bucket, since the default backing timeout on polkadot is 2.5 it does makes sense to allow items in the 3 bucket as well.