### PR TITLE
dispute-coordinator: handle race with offchain disabling

### DIFF
--- a/polkadot/node/core/dispute-coordinator/src/initialized.rs
+++ b/polkadot/node/core/dispute-coordinator/src/initialized.rs
@@ -1597,7 +1597,6 @@ impl Initialized {
 				votes.invalid.iter().all(|(_, validator_index, _)| {
 					self.offchain_disabled_validators.is_disabled(session, *validator_index)
 				}) {
-
 				disputes_to_remove.push((*dispute_session, *candidate_hash));
 
 				gum::info!(

--- a/polkadot/node/core/dispute-coordinator/src/initialized.rs
+++ b/polkadot/node/core/dispute-coordinator/src/initialized.rs
@@ -1409,6 +1409,13 @@ impl Initialized {
 			self.metrics.on_concluded_invalid();
 		}
 
+		// After validators are disabled, revisit active disputes to unactivate those where all
+		// raising parties are now disabled
+		if import_result.is_freshly_concluded_for() || import_result.is_freshly_concluded_against()
+		{
+			self.revisit_active_disputes_after_disabling(overlay_db, session)?;
+		}
+
 		// Only write when votes have changed.
 		if let Some(votes) = import_result.into_updated_votes() {
 			overlay_db.write_candidate_votes(session, candidate_hash, votes.into());
@@ -1766,5 +1773,77 @@ impl OffchainDisabledValidators {
 				.chain(e.against_valid.iter())
 				.map(|(i, _)| *i)
 		})
+	}
+
+	/// Check if a validator is disabled for a given session.
+	pub fn is_disabled(
+		&self,
+		session_index: SessionIndex,
+		validator_index: ValidatorIndex,
+	) -> bool {
+		self.per_session
+			.get(&session_index)
+			.map(|session_disputes| {
+				session_disputes.backers_for_invalid.peek(&validator_index).is_some() ||
+					session_disputes.for_invalid.peek(&validator_index).is_some() ||
+					session_disputes.against_valid.peek(&validator_index).is_some()
+			})
+			.unwrap_or(false)
+	}
+}
+
+impl Initialized {
+	/// Revisit active non-confirmed disputes after validators have been disabled.
+	/// Unactivates disputes where all raising parties (invalid voters) are now disabled.
+	fn revisit_active_disputes_after_disabling(
+		&mut self,
+		overlay_db: &mut OverlayedBackend<'_, impl Backend>,
+		session: SessionIndex,
+	) -> FatalResult<()> {
+		let mut recent_disputes = overlay_db.load_recent_disputes()?.unwrap_or_default();
+		let mut disputes_to_remove = Vec::new();
+
+		// Create session bounds for efficient iteration
+		let session_start = (session, CandidateHash(Hash::repeat_byte(0x00)));
+		let session_end = (session + 1, CandidateHash(Hash::repeat_byte(0x00)));
+
+		for ((dispute_session, candidate_hash), status) in
+			recent_disputes.range(&session_start..&session_end)
+		{
+			debug_assert_eq!(session, *dispute_session);
+			// Only check unconfirmed
+			if !status.is_confirmed_concluded() {
+				if let Some(votes) =
+					overlay_db.load_candidate_votes(*dispute_session, candidate_hash)?
+				{
+					// Check if all invalid voters (raising parties) are disabled
+					if !votes.invalid.is_empty() &&
+						votes.invalid.iter().all(|(_, validator_index, _)| {
+							self.offchain_disabled_validators.is_disabled(session, *validator_index)
+						}) {
+						disputes_to_remove.push((*dispute_session, *candidate_hash));
+						self.metrics.on_unactivated_dispute();
+
+						gum::info!(
+							target: LOG_TARGET,
+							session = dispute_session,
+							?candidate_hash,
+							invalid_voters = ?votes.invalid.iter().map(|(_, idx, _)| *idx).collect::<Vec<_>>(),
+							"Unactivating dispute where all raising parties are now disabled"
+						);
+					}
+				}
+			}
+		}
+
+		// Remove them from RecentDisputes (setting status to inactive)
+		if !disputes_to_remove.is_empty() {
+			for key in disputes_to_remove {
+				recent_disputes.remove(&key);
+			}
+			overlay_db.write_recent_disputes(recent_disputes);
+		}
+
+		Ok(())
 	}
 }

--- a/polkadot/node/core/dispute-coordinator/src/metrics.rs
+++ b/polkadot/node/core/dispute-coordinator/src/metrics.rs
@@ -32,6 +32,8 @@ struct MetricsInner {
 	vote_cleanup_time: prometheus::Histogram,
 	/// Number of refrained participations.
 	refrained_participations: prometheus::Counter<prometheus::U64>,
+	/// Number of unactivated disputes.
+	unactivated: prometheus::Counter<prometheus::U64>,
 	/// Distribution of participation durations.
 	participation_durations: prometheus::Histogram,
 	/// Measures the duration of the full participation pipeline: From when
@@ -136,6 +138,12 @@ impl Metrics {
 			metrics.participation_best_effort_queue_size.set(size);
 		}
 	}
+
+	pub(crate) fn on_unactivated_dispute(&self) {
+		if let Some(metrics) = &self.0 {
+			metrics.unactivated.inc();
+		}
+	}
 }
 
 impl metrics::Metrics for Metrics {
@@ -222,13 +230,20 @@ impl metrics::Metrics for Metrics {
 				registry,
 			)?,
 			participation_priority_queue_size: prometheus::register(
-				prometheus::Gauge::new("polkadot_parachain_dispute_participation_priority_queue_size", 
+				prometheus::Gauge::new("polkadot_parachain_dispute_participation_priority_queue_size",
 				"Number of disputes waiting for local participation in the priority queue.")?,
 				registry,
 			)?,
 			participation_best_effort_queue_size: prometheus::register(
-				prometheus::Gauge::new("polkadot_parachain_dispute_participation_best_effort_queue_size", 
+				prometheus::Gauge::new("polkadot_parachain_dispute_participation_best_effort_queue_size",
 				"Number of disputes waiting for local participation in the best effort queue.")?,
+				registry,
+			)?,
+			unactivated: prometheus::register(
+				prometheus::Counter::with_opts(prometheus::Opts::new(
+					"polkadot_parachain_dispute_unactivated_total",
+					"Total number of disputes that were unactivated due to all raising parties being disabled.",
+				))?,
 				registry,
 			)?,
 		};

--- a/polkadot/node/core/dispute-coordinator/src/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/tests.rs
@@ -4389,3 +4389,203 @@ async fn handle_disabled_validators_queries(
 		}
 	);
 }
+
+/// Test for the functionality that unactivates disputes when all raising parties are disabled.
+///
+/// This test verifies the implementation where:
+/// 1. Multiple disputes are raised by the same validator (validator 0)
+/// 2. When one dispute concludes against that validator, they get disabled
+/// 3. All other active disputes in that session where this validator was the sole raising party
+///    should be unactivated (removed from recent_disputes)
+#[test]
+fn disputes_unactivated_when_all_raising_parties_disabled() {
+	test_harness(|mut test_state, mut virtual_overseer| {
+		Box::pin(async move {
+			let session = 1;
+
+			test_state.handle_resume_sync(&mut virtual_overseer, session).await;
+
+			let candidate_receipt_a = make_valid_candidate_receipt();
+			let candidate_hash_a = candidate_receipt_a.hash();
+
+			let mut candidate_receipt_b = make_valid_candidate_receipt();
+			candidate_receipt_b.descriptor.set_pov_hash(Hash::from(
+				[0xFF; 32], // Altering this receipt so its hash will be changed
+			));
+			let candidate_hash_b = candidate_receipt_b.hash();
+
+			// activate leaf - with both candidates included
+			test_state
+				.activate_leaf_at_session(
+					&mut virtual_overseer,
+					session,
+					1,
+					vec![
+						make_candidate_included_event(candidate_receipt_a.clone()),
+						make_candidate_included_event(candidate_receipt_b.clone()),
+					],
+				)
+				.await;
+
+			// Import first dispute with validator 2 as the sole invalid voter
+			let (valid_vote, invalid_vote) = generate_opposing_votes_pair(
+				&test_state,
+				ValidatorIndex(1),
+				ValidatorIndex(2),
+				candidate_hash_a,
+				session,
+				VoteType::Explicit,
+			)
+			.await;
+
+			let (pending_confirmation, confirmation_rx) = oneshot::channel();
+			let pending_confirmation = Some(pending_confirmation);
+
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: DisputeCoordinatorMessage::ImportStatements {
+						candidate_receipt: candidate_receipt_a.clone(),
+						session,
+						statements: vec![
+							(valid_vote, ValidatorIndex(1)),
+							(invalid_vote, ValidatorIndex(2)),
+						],
+						pending_confirmation,
+					},
+				})
+				.await;
+
+			handle_disabled_validators_queries(&mut virtual_overseer, Vec::new()).await;
+			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash_a, HashMap::new())
+				.await;
+
+			assert_eq!(confirmation_rx.await, Ok(ImportStatementsResult::ValidImport));
+
+			participation_with_distribution(
+				&mut virtual_overseer,
+				&candidate_hash_a,
+				candidate_receipt_a.commitments_hash,
+			)
+			.await;
+
+			// Import second dispute with same validator 2 as invalid voter
+			let (valid_vote, invalid_vote) = generate_opposing_votes_pair(
+				&test_state,
+				ValidatorIndex(3),
+				ValidatorIndex(2),
+				candidate_hash_b,
+				session,
+				VoteType::Explicit,
+			)
+			.await;
+
+			let (pending_confirmation, confirmation_rx) = oneshot::channel();
+			let pending_confirmation = Some(pending_confirmation);
+
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: DisputeCoordinatorMessage::ImportStatements {
+						candidate_receipt: candidate_receipt_b.clone(),
+						session,
+						statements: vec![
+							(valid_vote, ValidatorIndex(3)),
+							(invalid_vote, ValidatorIndex(2)),
+						],
+						pending_confirmation,
+					},
+				})
+				.await;
+
+			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash_b, HashMap::new())
+				.await;
+
+			assert_eq!(confirmation_rx.await, Ok(ImportStatementsResult::ValidImport));
+
+			participation_with_distribution(
+				&mut virtual_overseer,
+				&candidate_hash_b,
+				candidate_receipt_b.commitments_hash,
+			)
+			.await;
+
+			// Verify we have 2 active disputes
+			{
+				let (tx, rx) = oneshot::channel();
+				virtual_overseer
+					.send(FromOrchestra::Communication {
+						msg: DisputeCoordinatorMessage::ActiveDisputes(tx),
+					})
+					.await;
+				assert_eq!(rx.await.unwrap().len(), 2);
+			}
+
+			// Import enough valid votes to conclude dispute A as valid (disabling validator 2)
+			let mut additional_votes = vec![];
+			for i in 3..8 {
+				let vote = test_state.issue_explicit_statement_with_index(
+					ValidatorIndex(i),
+					candidate_hash_a,
+					session,
+					true,
+				);
+				additional_votes.push((vote, ValidatorIndex(i)));
+			}
+
+			let (pending_confirmation, confirmation_rx) = oneshot::channel();
+			let pending_confirmation = Some(pending_confirmation);
+
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: DisputeCoordinatorMessage::ImportStatements {
+						candidate_receipt: candidate_receipt_a.clone(),
+						session,
+						statements: additional_votes,
+						pending_confirmation,
+					},
+				})
+				.await;
+
+			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash_a, HashMap::new())
+				.await;
+			assert_eq!(confirmation_rx.await, Ok(ImportStatementsResult::ValidImport));
+
+			// Verify one dispute got deactivated
+			{
+				let (tx, rx) = oneshot::channel();
+				virtual_overseer
+					.send(FromOrchestra::Communication {
+						msg: DisputeCoordinatorMessage::RecentDisputes(tx),
+					})
+					.await;
+				assert_eq!(rx.await.unwrap().len(), 1);
+			}
+			// and we can finalize the chain
+			{
+				let (tx, rx) = oneshot::channel();
+
+				let base_hash = Hash::repeat_byte(0x0f);
+				let block_hash_a = Hash::repeat_byte(0x0a);
+
+				virtual_overseer
+					.send(FromOrchestra::Communication {
+						msg: DisputeCoordinatorMessage::DetermineUndisputedChain {
+							base: (10, base_hash),
+							block_descriptions: vec![BlockDescription {
+								block_hash: block_hash_a,
+								session,
+								candidates: vec![candidate_hash_a, candidate_hash_b],
+							}],
+							tx,
+						},
+					})
+					.await;
+
+				assert_eq!(rx.await.unwrap(), (11, block_hash_a));
+			}
+
+			virtual_overseer.send(FromOrchestra::Signal(OverseerSignal::Conclude)).await;
+
+			test_state
+		})
+	});
+}

--- a/polkadot/node/core/dispute-coordinator/src/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/tests.rs
@@ -4393,12 +4393,13 @@ async fn handle_disabled_validators_queries(
 /// Test for the functionality that unactivates disputes when all raising parties are disabled.
 ///
 /// This test verifies the implementation where:
-/// 1. Multiple disputes are raised by the same validator:
-///    candidate C is raised by 2 and 5
+/// 1. Multiple disputes are raised by the same validator: candidate C is raised by 2 and 5
 ///    candidate A and B are raised by 2
 /// 2. When one dispute (A) concludes against that validator, it gets disabled.
 /// 3. All other active disputes in that session where this validator was the sole raising party
 ///    should be unactivated (B).
+/// 4. Disputes can become active again if non-disabled validators vote against them or if the
+///    dispute gets confirmed.
 #[test]
 fn disputes_unactivated_when_all_raising_parties_disabled() {
 	test_harness(|mut test_state, mut virtual_overseer| {
@@ -4502,7 +4503,7 @@ fn disputes_unactivated_when_all_raising_parties_disabled() {
 						candidate_receipt: candidate_receipt_b.clone(),
 						session,
 						statements: vec![
-							(valid_vote, ValidatorIndex(3)),
+							(valid_vote.clone(), ValidatorIndex(3)),
 							(invalid_vote, ValidatorIndex(2)),
 						],
 						pending_confirmation,
@@ -4655,6 +4656,69 @@ fn disputes_unactivated_when_all_raising_parties_disabled() {
 					.await;
 
 				assert_eq!(rx.await.unwrap(), (11, block_hash_a));
+			}
+
+			// Now let's import a vote against B from non-disabled validator 5
+			let invalid_vote_from_5 = test_state.issue_explicit_statement_with_index(
+				ValidatorIndex(5),
+				candidate_hash_b,
+				session,
+				false,
+			);
+
+			let (pending_confirmation, confirmation_rx) = oneshot::channel();
+			let pending_confirmation = Some(pending_confirmation);
+
+			virtual_overseer
+				.send(FromOrchestra::Communication {
+					msg: DisputeCoordinatorMessage::ImportStatements {
+						candidate_receipt: candidate_receipt_b.clone(),
+						session,
+						statements: vec![
+							(valid_vote, ValidatorIndex(3)),
+							(invalid_vote_from_5, ValidatorIndex(5)),
+						],
+						pending_confirmation,
+					},
+				})
+				.await;
+
+			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash_b, HashMap::new())
+				.await;
+			assert_eq!(confirmation_rx.await, Ok(ImportStatementsResult::ValidImport));
+
+			// Verify dispute B is now active again
+			{
+				let (tx, rx) = oneshot::channel();
+				virtual_overseer
+					.send(FromOrchestra::Communication {
+						msg: DisputeCoordinatorMessage::RecentDisputes(tx),
+					})
+					.await;
+				assert_eq!(rx.await.unwrap().len(), 3);
+			}
+			// and we can't finalize the chain with A and B anymore
+			{
+				let (tx, rx) = oneshot::channel();
+
+				let base_hash = Hash::repeat_byte(0x0f);
+				let block_hash_a = Hash::repeat_byte(0x0a);
+
+				virtual_overseer
+					.send(FromOrchestra::Communication {
+						msg: DisputeCoordinatorMessage::DetermineUndisputedChain {
+							base: (10, base_hash),
+							block_descriptions: vec![BlockDescription {
+								block_hash: block_hash_a,
+								session,
+								candidates: vec![candidate_hash_a, candidate_hash_b],
+							}],
+							tx,
+						},
+					})
+					.await;
+
+				assert_eq!(rx.await.unwrap(), (10, base_hash));
 			}
 
 			virtual_overseer.send(FromOrchestra::Signal(OverseerSignal::Conclude)).await;

--- a/polkadot/node/core/dispute-coordinator/src/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/tests.rs
@@ -4393,10 +4393,12 @@ async fn handle_disabled_validators_queries(
 /// Test for the functionality that unactivates disputes when all raising parties are disabled.
 ///
 /// This test verifies the implementation where:
-/// 1. Multiple disputes are raised by the same validator
-/// 2. When one dispute concludes against that validator, they get disabled
+/// 1. Multiple disputes are raised by the same validator:
+///    candidate C is raised by 2 and 5
+///    candidate A and B are raised by 2
+/// 2. When one dispute (A) concludes against that validator, it gets disabled.
 /// 3. All other active disputes in that session where this validator was the sole raising party
-///    should be unactivated (removed from recent_disputes)
+///    should be unactivated (B).
 #[test]
 fn disputes_unactivated_when_all_raising_parties_disabled() {
 	test_harness(|mut test_state, mut virtual_overseer| {

--- a/prdoc/pr_9050.prdoc
+++ b/prdoc/pr_9050.prdoc
@@ -1,0 +1,10 @@
+title: "dispute-coordinator: handle race with offchain disabling"
+
+doc:
+  - audience: Node Dev
+    description: |
+      Fixes a potential race with off-chain disabling when we learned about disablement after importing a dispute from that validator.
+
+crates:
+- name: polkadot-node-core-dispute-coordinator
+  bump: patch


### PR DESCRIPTION
Fixes a potential race with off-chain disabling when we learned about disablement after importing a dispute from that validator.

I think there's no need to handle startup to do deactivation. This will be only relevant for when a node upgrades to the release with a fix and writing a migration for that seems like an overkill since this scenario is very low probability.