### PR TITLE
Align parameters for `EventEmitter::emit_sent_event`

### DIFF
--- a/polkadot/xcm/xcm-executor/src/traits/event_emitter.rs
+++ b/polkadot/xcm/xcm-executor/src/traits/event_emitter.rs
@@ -29,7 +29,8 @@ pub trait EventEmitter {
 	/// - `origin`: The origin location of the XCM.
 	/// - `destination`: The target location where the message is sent.
 	/// - `message`: `Some(Xcm)` for `pallet_xcm::Event::Sent`, `None` for other events to reduce
-	/// - `message_id`: A unique identifier for the XCM. storage.
+	///   storage.
+	/// - `message_id`: A unique identifier for the XCM.
 	fn emit_sent_event(
 		origin: Location,
 		destination: Location,

--- a/prdoc/pr_9057.prdoc
+++ b/prdoc/pr_9057.prdoc
@@ -1,0 +1,8 @@
+title: Align parameters for `EventEmitter::emit_sent_event`
+doc:
+- audience: Runtime Dev
+  description: Corrected markdown and indentation for the `emit_sent_event` function
+    parameters in the `EventEmitter` trait documentation for better readability.
+crates:
+- name: staging-xcm-executor
+  bump: none


### PR DESCRIPTION
Corrected markdown and indentation for the `emit_sent_event` function parameters in the `EventEmitter` trait documentation for better readability.