### PR TITLE
fix: Update command.rs to fix typo in error message

### DIFF
--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -234,7 +234,7 @@ impl PalletCmd {
 			sp_core::defer::DeferGuard::new(move || {
 				log::error!(
 					target: LOG_TARGET,
-					"⚠️  Argument `--execution` is deprecated. Its value of `{exec}` has on effect.",
+					"⚠️  Argument `--execution` is deprecated. Its value of `{exec}` has no effect.",
 				)
 			})
 		});


### PR DESCRIPTION
# Description

Fix typo in error message so it makes sense.

## Review Notes

If you run benchmarking with the following:
```sh
cargo build --features runtime-benchmarks

./target/debug/polkadot benchmark pallet \
    --chain=dev \
    --steps=50 \
    --repeat=20 \
    --pallet=pallet_origin_and_gate \
    --extrinsic=dummy_benchmark \
    --execution=wasm \
    --wasm-execution=compiled
```

It outputs error:
```sh
2025-07-02 07:31:03.245 ERROR main polkadot_sdk_frame::benchmark::pallet: ⚠️  Argument `--execution` is deprecated. Its value of `wasm` has on effect.    
Error: 
   0: Invalid input: No benchmarks found which match your input. Try `--list --all` to list all available benchmarks.
```

I believe it's trying to say that because `--execution` is deprecated, it doesn't matter what value you provide for that option, as it'll have "no effect"

Since I'm an external contributors could the maintainer put the right label on this PR.

