### PR TITLE
[WIP] Default listen addresses: use `here` instead of `wildcard`

### DIFF
--- a/substrate/client/cli/src/params/network_params.rs
+++ b/substrate/client/cli/src/params/network_params.rs
@@ -208,20 +208,20 @@ impl NetworkParams {
 			if is_validator || is_dev {
 				vec![
 					Multiaddr::empty()
-						.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 0].into()))
+						.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 1].into()))
 						.with(Protocol::Tcp(port)),
 					Multiaddr::empty()
-						.with(Protocol::Ip4([0, 0, 0, 0].into()))
+						.with(Protocol::Ip4([127, 0, 0, 1].into()))
 						.with(Protocol::Tcp(port)),
 				]
 			} else {
 				vec![
 					Multiaddr::empty()
-						.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 0].into()))
+						.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 1].into()))
 						.with(Protocol::Tcp(port))
 						.with(Protocol::Ws(Cow::Borrowed("/"))),
 					Multiaddr::empty()
-						.with(Protocol::Ip4([0, 0, 0, 0].into()))
+						.with(Protocol::Ip4([127, 0, 0, 1].into()))
 						.with(Protocol::Tcp(port))
 						.with(Protocol::Ws(Cow::Borrowed("/"))),
 				]

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -59,7 +59,7 @@ use std::{
 };
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p::discovery";
+const LOG_TARGET: &str = "sub-litep2p::discovery";
 
 /// Kademlia query interval.
 const KADEMLIA_QUERY_INTERVAL: Duration = Duration::from_secs(5);

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -134,7 +134,7 @@ impl Executor for Litep2pExecutor {
 }
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p";
+const LOG_TARGET: &str = "sub-litep2p";
 
 /// Peer context.
 struct ConnectionContext {

--- a/substrate/client/network/src/litep2p/peerstore.rs
+++ b/substrate/client/network/src/litep2p/peerstore.rs
@@ -40,7 +40,7 @@ use std::{
 };
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p::peerstore";
+const LOG_TARGET: &str = "sub-litep2p::peerstore";
 
 /// We don't accept nodes whose reputation is under this value.
 pub const BANNED_THRESHOLD: i32 = 71 * (i32::MIN / 100);

--- a/substrate/client/network/src/litep2p/service.rs
+++ b/substrate/client/network/src/litep2p/service.rs
@@ -59,7 +59,7 @@ use std::{
 };
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p";
+const LOG_TARGET: &str = "sub-litep2p";
 
 /// Commands sent by [`Litep2pNetworkService`] to
 /// [`Litep2pNetworkBackend`](super::Litep2pNetworkBackend).

--- a/substrate/client/network/src/litep2p/shim/bitswap.rs
+++ b/substrate/client/network/src/litep2p/shim/bitswap.rs
@@ -29,7 +29,7 @@ use sp_runtime::traits::Block as BlockT;
 use std::{future::Future, pin::Pin, sync::Arc};
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p::bitswap";
+const LOG_TARGET: &str = "sub-litep2p::bitswap";
 
 pub struct BitswapServer<Block: BlockT> {
 	/// Bitswap handle.

--- a/substrate/client/network/src/litep2p/shim/notification/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/mod.rs
@@ -47,7 +47,7 @@ pub mod peerset;
 mod tests;
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p::notification";
+const LOG_TARGET: &str = "sub-litep2p::notification";
 
 /// Wrapper over `litep2p`'s notification sink.
 pub struct Litep2pMessageSink {

--- a/substrate/client/network/src/litep2p/shim/notification/peerset.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/peerset.rs
@@ -64,7 +64,7 @@ use std::{
 };
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p::peerset";
+const LOG_TARGET: &str = "sub-litep2p::peerset";
 
 /// Default backoff for connection re-attempts.
 const DEFAULT_BACKOFF: Duration = Duration::from_secs(5);

--- a/substrate/client/network/src/litep2p/shim/request_response/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/request_response/mod.rs
@@ -52,7 +52,7 @@ mod metrics;
 mod tests;
 
 /// Logging target for the file.
-const LOG_TARGET: &str = "sub-libp2p::request-response";
+const LOG_TARGET: &str = "sub-litep2p::request-response";
 
 /// Type containing information related to an outbound request.
 #[derive(Debug)]


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/8918

macOS generally supports IPv6, but its implementation might not be as flexible as some other operating systems when it comes to wildcard usage in certain contexts.

In this scenario using wildcard leads to collators being unable to start sometimes.

Using `here` instead of `wildcard` works.