### PR TITLE
Fix `MaxEncodedLen` implementation for `Error` enum

### DIFF
--- a/polkadot/xcm/src/v3/traits.rs
+++ b/polkadot/xcm/src/v3/traits.rs
@@ -32,7 +32,18 @@ use super::*;
 /// Error codes used in XCM. The first errors codes have explicit indices and are part of the XCM
 /// format. Those trailing are merely part of the XCM implementation; there is no expectation that
 /// they will retain the same index over time.
-#[derive(Copy, Clone, Encode, Decode, DecodeWithMemTracking, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(
+	Copy,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	Debug,
+	TypeInfo,
+	MaxEncodedLen,
+)]
 #[scale_info(replace_segment("staging_xcm", "xcm"))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Error {
@@ -207,14 +218,6 @@ impl TryFrom<NewError> for Error {
 			NotDepositable => Self::NotDepositable,
 			_ => return Err(()),
 		})
-	}
-}
-
-impl MaxEncodedLen for Error {
-	fn max_encoded_len() -> usize {
-		// TODO: max_encoded_len doesn't quite work here as it tries to take notice of the fields
-		// marked `codec(skip)`. We can hard-code it with the right answer for now.
-		1
 	}
 }
 

--- a/polkadot/xcm/src/v5/traits.rs
+++ b/polkadot/xcm/src/v5/traits.rs
@@ -28,7 +28,18 @@ use super::*;
 /// Error codes used in XCM. The first errors codes have explicit indices and are part of the XCM
 /// format. Those trailing are merely part of the XCM implementation; there is no expectation that
 /// they will retain the same index over time.
-#[derive(Copy, Clone, Encode, Decode, DecodeWithMemTracking, Eq, PartialEq, Debug, TypeInfo)]
+#[derive(
+	Copy,
+	Clone,
+	Encode,
+	Decode,
+	DecodeWithMemTracking,
+	Eq,
+	PartialEq,
+	Debug,
+	TypeInfo,
+	MaxEncodedLen,
+)]
 #[scale_info(replace_segment("staging_xcm", "xcm"))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Error {
@@ -213,14 +224,6 @@ impl TryFrom<OldError> for Error {
 			WeightNotComputable => Self::WeightNotComputable,
 			ExceedsStackLimit => Self::ExceedsStackLimit,
 		})
-	}
-}
-
-impl MaxEncodedLen for Error {
-	fn max_encoded_len() -> usize {
-		// TODO: max_encoded_len doesn't quite work here as it tries to take notice of the fields
-		// marked `codec(skip)`. We can hard-code it with the right answer for now.
-		1 + Weight::max_encoded_len()
 	}
 }
 

--- a/polkadot/xcm/src/v5/traits.rs
+++ b/polkadot/xcm/src/v5/traits.rs
@@ -218,6 +218,8 @@ impl TryFrom<OldError> for Error {
 
 impl MaxEncodedLen for Error {
 	fn max_encoded_len() -> usize {
+		// TODO: max_encoded_len doesn't quite work here as it tries to take notice of the fields
+		// marked `codec(skip)`. We can hard-code it with the right answer for now.
 		1 + Weight::max_encoded_len()
 	}
 }

--- a/polkadot/xcm/src/v5/traits.rs
+++ b/polkadot/xcm/src/v5/traits.rs
@@ -218,9 +218,8 @@ impl TryFrom<OldError> for Error {
 
 impl MaxEncodedLen for Error {
 	fn max_encoded_len() -> usize {
-		// TODO: max_encoded_len doesn't quite work here as it tries to take notice of the fields
-		// marked `codec(skip)`. We can hard-code it with the right answer for now.
-		1
+		// 1 byte for enum discriminant + largest variant data
+		1 + Weight::max_encoded_len().max(u64::max_encoded_len())
 	}
 }
 

--- a/polkadot/xcm/src/v5/traits.rs
+++ b/polkadot/xcm/src/v5/traits.rs
@@ -218,8 +218,7 @@ impl TryFrom<OldError> for Error {
 
 impl MaxEncodedLen for Error {
 	fn max_encoded_len() -> usize {
-		// 1 byte for enum discriminant + largest variant data
-		1 + Weight::max_encoded_len().max(u64::max_encoded_len())
+		1 + Weight::max_encoded_len()
 	}
 }
 

--- a/prdoc/pr_9084.prdoc
+++ b/prdoc/pr_9084.prdoc
@@ -1,0 +1,8 @@
+title: Fix `MaxEncodedLen` implementation for `Error` enum
+doc:
+- audience: Runtime Dev
+  description: Updates the `MaxEncodedLen` implementation for the XCM `Error` enum to
+    correctly calculate the maximum encoded size.
+crates:
+- name: staging-xcm
+  bump: patch


### PR DESCRIPTION
Updates the `MaxEncodedLen` implementation for the XCM `Error` enum by switching to a derived implementation, which correctly calculates the maximum encoded size instead of returning a hardcoded value of `1`.

This change partially addresses issue #323 related to improving size bounding and metadata accuracy in runtime pallets.

## Problem

The previous manual implementation returned only `1` byte, accounting solely for the enum discriminant, while ignoring encoded data in some variants:

* `WeightLimitReached(Weight)` encodes a `Weight` value
* `Trap(u64)` encodes a `u64` value

This underestimated the size and could lead to incorrect proof or buffer size calculations.

## Solution

Use `#[derive(MaxEncodedLen)]` along with other relevant derives on the `Error` enum to:

* Automatically compute the maximum encoded length, correctly including all encoded fields
* Respect `#[codec(skip)]` annotations to exclude fields from the calculation

The derived implementation properly accounts for the largest variant (`WeightLimitReached(Weight)`), ensuring accurate size estimations.

## Testing

* [x] Existing XCM tests pass
* [x] No breaking changes to public API