### PR TITLE
Minor Typo Fixes in Documentation and Comments

### DIFF
--- a/bridges/relays/lib-substrate-relay/src/finality/source.rs
+++ b/bridges/relays/lib-substrate-relay/src/finality/source.rs
@@ -87,7 +87,7 @@ impl<P: SubstrateFinalitySyncPipeline, SourceClnt: Client<P::SourceChain>>
 			self.persistent_proofs_stream(block_number + One::one()).await?.fuse();
 		let next_ephemeral_proof = self.ephemeral_proofs_stream(block_number).await?.fuse();
 
-		// in perfect world we'll need to return justfication for the requested `block_number`
+		// in perfect world we'll need to return justification for the requested `block_number`
 		let (header, maybe_proof) = self.header_and_finality_proof(block_number).await?;
 		if let Some(proof) = maybe_proof {
 			return Ok((header, proof))

--- a/docs/sdk/src/guides/your_first_node.rs
+++ b/docs/sdk/src/guides/your_first_node.rs
@@ -330,7 +330,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	// This is a regresion test so that we still remain compatible with runtimes that use
+	// This is a regression test so that we still remain compatible with runtimes that use
 	// `para-id` in chain specs, instead of implementing the
 	// `cumulus_primitives_core::GetParachainInfo`.
 	async fn omni_node_dev_mode_works_without_getparachaininfo() {

--- a/docs/sdk/src/reference_docs/extrinsic_encoding.rs
+++ b/docs/sdk/src/reference_docs/extrinsic_encoding.rs
@@ -201,7 +201,7 @@
 //! ```
 //!
 //! The bytes representing `call_data` and `transaction_extensions_extra` can be obtained as
-//! descibed above. `transaction_extensions_implicit` is constructed by SCALE encoding the
+//! described above. `transaction_extensions_implicit` is constructed by SCALE encoding the
 //! ["implicit" data][sp_runtime::traits::TransactionExtension::Implicit] for each transaction
 //! extension that the chain is using, in order.
 //!
@@ -214,7 +214,7 @@
 //!
 //! A General transaction does not have a signature method hardcoded in the check logic of the
 //! extrinsic, such as a traditionally signed transaction. Instead, general transactions should have
-//! one or more extensions in the transaction extension pipeline that auhtorize origins in some way,
+//! one or more extensions in the transaction extension pipeline that authorize origins in some way,
 //! one of which could be the traditional signature check that happens for all signed transactions
 //! in the [Checkable](sp_runtime::traits::Checkable) implementation of
 //! [UncheckedExtrinsic](sp_runtime::generic::UncheckedExtrinsic). Therefore, it is up to each


### PR DESCRIPTION


---


**Description:**  
This pull request addresses minor typographical errors in documentation and code comments across several files.  
- Corrects spelling and formatting in Rust doc comments and test descriptions.


---

