### PR TITLE
[Release|CI/CD] Fix syncing in the release flow

### DIFF
--- a/.github/workflows/release-30_publish_release_draft.yml
+++ b/.github/workflows/release-30_publish_release_draft.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   check-synchronization:
     uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
+    secrets:
+      fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
 
   validate-inputs:
     needs: [ check-synchronization ]

--- a/.github/workflows/release-31_promote-rc-to-final.yml
+++ b/.github/workflows/release-31_promote-rc-to-final.yml
@@ -23,6 +23,8 @@ jobs:
 
   check-synchronization:
     uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
+    secrets:
+      fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
 
   validate-inputs:
     needs: [ check-synchronization ]

--- a/.github/workflows/release-40_publish-deb-package.yml
+++ b/.github/workflows/release-40_publish-deb-package.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   check-synchronization:
     uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
+    secrets:
+      fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
 
   validate-inputs:
     needs: [check-synchronization]

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -66,6 +66,8 @@ env:
 jobs:
   check-synchronization:
     uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
+    secrets:
+      fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
 
   validate-inputs:
     needs: [check-synchronization]


### PR DESCRIPTION
This PR adds a fix for the release pipelines. The sync flow needs a secrete to be passed when it is called from another flow and syncing between release org and the main repo is needed.
Missing secrets were added to the appropriate flows.