### PR TITLE
bitfield_distribution: fix subsystem clogged at begining of a session

### DIFF
--- a/polkadot/node/network/protocol/src/grid_topology.rs
+++ b/polkadot/node/network/protocol/src/grid_topology.rs
@@ -496,6 +496,11 @@ impl SessionBoundGridTopologyStorage {
 		&self.current_topology.entry
 	}
 
+	/// Returns the current session index.
+	pub fn get_current_session_index(&self) -> SessionIndex {
+		self.current_topology.session_index
+	}
+
 	/// Access the current grid topology mutably. Dangerous and intended
 	/// to be used in tests.
 	pub fn get_current_topology_mut(&mut self) -> &mut SessionGridTopologyEntry {


### PR DESCRIPTION
`handle_peer_view_change` gets called on NewGossipTopology with the existing view of the peer to cover for the case when the topology might arrive late, but in that case in the view will contain old blocks from previous session, so since the X/Y neighbour change because of the topology change you end up sending a lot of messages for blocks before the session changed.

Fix it by checking the send message only for relay chains that are in the same session as the current topology.