### PR TITLE
[Solution 1] Revert xcm precompile call with a verbose error

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/precompiles.rs
+++ b/polkadot/xcm/pallet-xcm/src/precompiles.rs
@@ -19,7 +19,7 @@ use codec::{DecodeAll, DecodeLimit, Encode};
 use core::{fmt, marker::PhantomData, num::NonZero};
 use pallet_revive::{
 	precompiles::{
-		alloy::{self, sol_types::SolValue},
+		alloy::{self, sol_types::{Revert, SolValue}},
 		AddressMatcher, Error, Ext, Precompile,
 	},
 	DispatchInfo, Origin,
@@ -35,7 +35,9 @@ const LOG_TARGET: &str = "xcm::precompiles";
 
 fn revert(error: &impl fmt::Debug, message: &str) -> Error {
 	error!(target: LOG_TARGET, ?error, "{}", message);
-	Error::Revert(format!("{:?}",error).into())
+	Error::Revert(Revert {
+		reason:format!("{:?}",error)
+	})
 }
 
 pub struct XcmPrecompile<T>(PhantomData<T>);
@@ -509,6 +511,7 @@ mod test {
 				Ok(value) => value,
 				Err(err) => panic!("XcmExecutePrecompile call failed with error: {err:?}"),
 			};
+
 			assert!(return_value.did_revert());
 			assert_eq!(Balances::total_balance(&ALICE), CUSTOM_INITIAL_BALANCE);
 			assert_eq!(Balances::total_balance(&BOB), CUSTOM_INITIAL_BALANCE);

--- a/polkadot/xcm/pallet-xcm/src/precompiles.rs
+++ b/polkadot/xcm/pallet-xcm/src/precompiles.rs
@@ -35,7 +35,7 @@ const LOG_TARGET: &str = "xcm::precompiles";
 
 fn revert(error: &impl fmt::Debug, message: &str) -> Error {
 	error!(target: LOG_TARGET, ?error, "{}", message);
-	Error::Revert(message.into())
+	Error::Revert(format!("{:?}",error).into())
 }
 
 pub struct XcmPrecompile<T>(PhantomData<T>);


### PR DESCRIPTION
This PR improves error handling for the XCM precompile by returning detailed error information instead of generic error messages.


before

```rust
fn revert(error: &impl fmt::Debug, message: &str) -> Error {
	error!(target: LOG_TARGET, ?error, "{}", message);
	Error::Revert(message.into())
}
```


after
```rust

fn revert(error: &impl fmt::Debug, message: &str) -> Error {
	error!(target: LOG_TARGET, ?error, "{}", message);
	Error::Revert(Revert {
		reason:format!("{:?}",error)
	})
}
```

This change significantly improves the developer experience by providing actionable error information instead of generic failure messages, while maintaining the simplicity of string-based error reporting. This approach still places some burden on developers to interpret error details, but provides substantially more useful information than generic error messages. Additionally it also requires developer to parse strings as opposed to concrete errors e.g. `XcmPrecompileError(error)`.