### PR TITLE
add block hashes to the randomness used by hashmaps and friends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,7 +1829,7 @@ name = "binary-merkle-tree"
 version = "13.0.0"
 dependencies = [
  "array-bytes 6.2.2",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "log",
  "parity-scale-codec",
  "sp-core 28.0.0",
@@ -2361,7 +2361,7 @@ version = "0.7.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
@@ -4633,7 +4633,7 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "trie-db 0.30.0",
- "trie-standardmap",
+ "trie-standardmap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7672,10 +7672,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7d7786361d7425ae2fe4f9e407eb0efaa0840f5212d109cc018c40c35c6ab4"
 
 [[package]]
+name = "hash-db"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
+
+[[package]]
 name = "hash256-std-hasher"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "hash256-std-hasher"
+version = "0.15.2"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
 dependencies = [
  "crunchy",
 ]
@@ -9036,8 +9049,18 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ea4653859ca2266a86419d3f592d3f22e7a854b482f99180d2498507902048"
 dependencies = [
- "hash-db",
- "hash256-std-hasher",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "keccak-hasher"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
+dependencies = [
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "hash256-std-hasher 0.15.2 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "tiny-keccak",
 ]
 
@@ -10219,16 +10242,15 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memory-db"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6da20dba965bd218a14c3b335b90d3e07c09ede190c7c19b50deb23d418a322"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "hashbrown 0.15.3",
 ]
 
@@ -10776,7 +10798,7 @@ dependencies = [
  "derive_more 0.99.17",
  "fs_extra",
  "futures",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "kitchensink-runtime",
  "kvdb",
  "kvdb-rocksdb",
@@ -19418,7 +19440,7 @@ version = "0.35.0"
 dependencies = [
  "array-bytes 6.2.2",
  "criterion",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "kitchensink-runtime",
  "kvdb",
  "kvdb-memorydb",
@@ -22576,7 +22598,7 @@ name = "sp-api"
 version = "26.0.0"
 dependencies = [
  "docify",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -22599,7 +22621,7 @@ version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f84f09c4b928e814e07dede0ece91f1f6eae1bff946a0e5e4a76bed19a095f1"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -22933,8 +22955,8 @@ dependencies = [
  "dyn-clone",
  "ed25519-zebra 4.0.3",
  "futures",
- "hash-db",
- "hash256-std-hasher",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.5.0",
  "itertools 0.11.0",
  "k256",
@@ -22983,8 +23005,8 @@ dependencies = [
  "dyn-clonable",
  "ed25519-zebra 3.1.0",
  "futures",
- "hash-db",
- "hash256-std-hasher",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.4.0",
  "itertools 0.10.5",
  "k256",
@@ -23030,8 +23052,8 @@ dependencies = [
  "dyn-clonable",
  "ed25519-zebra 4.0.3",
  "futures",
- "hash-db",
- "hash256-std-hasher",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.4.0",
  "itertools 0.11.0",
  "k256",
@@ -23077,8 +23099,8 @@ dependencies = [
  "dyn-clonable",
  "ed25519-zebra 4.0.3",
  "futures",
- "hash-db",
- "hash256-std-hasher",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.5.0",
  "itertools 0.11.0",
  "k256",
@@ -23539,7 +23561,7 @@ dependencies = [
  "binary-merkle-tree",
  "docify",
  "either",
- "hash256-std-hasher",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples",
  "log",
  "num-traits",
@@ -23574,7 +23596,7 @@ checksum = "a6b85cb874b78ebb17307a910fc27edf259a0455ac5155d87eaed8754c037e07"
 dependencies = [
  "docify",
  "either",
- "hash256-std-hasher",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
@@ -23599,7 +23621,7 @@ checksum = "1c2a6148bf0ba74999ecfea9b4c1ade544f0663e0baba19630bb7761b2142b19"
 dependencies = [
  "docify",
  "either",
- "hash256-std-hasher",
+ "hash256-std-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples",
  "log",
  "num-traits",
@@ -23775,7 +23797,7 @@ dependencies = [
  "arbitrary",
  "array-bytes 6.2.2",
  "assert_matches",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -23798,7 +23820,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18084cb996c27d5d99a88750e0a8eb4af6870a40df97872a5923e6d293d95fb9"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -23819,7 +23841,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f6ac196ea92c4d0613c071e1a050765dbfa30107a990224a4aba02c7dbcd063"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -23978,7 +24000,8 @@ dependencies = [
  "ahash 0.8.11",
  "array-bytes 6.2.2",
  "criterion",
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "hashbrown 0.15.3",
  "memory-db 0.33.0",
  "nohash-hasher",
  "parity-scale-codec",
@@ -23994,8 +24017,8 @@ dependencies = [
  "tracing",
  "trie-bench",
  "trie-db 0.30.0",
- "trie-root",
- "trie-standardmap",
+ "trie-root 0.18.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "trie-standardmap 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -24005,7 +24028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87727eced997f14d0f79e3a5186a80e38a9de87f6e9dc0baea5ebf8b7f9d8b66"
 dependencies = [
  "ahash 0.8.11",
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "memory-db 0.32.0",
  "nohash-hasher",
@@ -24019,7 +24042,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.29.1",
- "trie-root",
+ "trie-root 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -24029,7 +24052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a61ab0c3e003f457203702e4753aa5fe9e762380543fada44650b1217e4aa5a5"
 dependencies = [
  "ahash 0.8.11",
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "memory-db 0.32.0",
  "nohash-hasher",
@@ -24043,7 +24066,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.29.1",
- "trie-root",
+ "trie-root 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -26557,17 +26580,16 @@ dependencies = [
 [[package]]
 name = "trie-bench"
 version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445f19cd0e58d9aef1eef590739fc10c4291611722c98f8995b70ce8529f198"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
 dependencies = [
  "criterion",
- "hash-db",
- "keccak-hasher",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "keccak-hasher 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "memory-db 0.33.0",
  "parity-scale-codec",
  "trie-db 0.30.0",
- "trie-root",
- "trie-standardmap",
+ "trie-root 0.18.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "trie-standardmap 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
 ]
 
 [[package]]
@@ -26576,7 +26598,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c992b4f40c234a074d48a757efeabb1a6be88af84c0c23f7ca158950cb0ae7f"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "rustc-hex",
  "smallvec",
@@ -26585,10 +26607,9 @@ dependencies = [
 [[package]]
 name = "trie-db"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0670ab45a6b7002c7df369fee950a27cf29ae0474343fd3a15aa15f691e7a6"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
  "log",
  "rustc-hex",
  "smallvec",
@@ -26600,7 +26621,15 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
 dependencies = [
- "hash-db",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "trie-root"
+version = "0.18.0"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
+dependencies = [
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
 ]
 
 [[package]]
@@ -26609,8 +26638,17 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684aafb332fae6f83d7fe10b3fbfdbe39a1b3234c4e2a618f030815838519516"
 dependencies = [
- "hash-db",
- "keccak-hasher",
+ "hash-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "trie-standardmap"
+version = "0.16.0"
+source = "git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher#eac0e001ff388dd038d96fe2b69cd82e64922238"
+dependencies = [
+ "hash-db 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
+ "keccak-hasher 0.16.0 (git+https://github.com/paritytech/trie.git?branch=alexggh/allow_usage_of_custom_hasher)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -841,7 +841,7 @@ governor = { version = "0.6.0" }
 gum = { path = "polkadot/node/gum", default-features = false, package = "tracing-gum" }
 gum-proc-macro = { path = "polkadot/node/gum/proc-macro", default-features = false, package = "tracing-gum-proc-macro" }
 handlebars = { version = "5.1.0" }
-hash-db = { version = "0.16.0", default-features = false }
+hash-db = { git = "https://github.com/paritytech/trie.git", branch = "alexggh/allow_usage_of_custom_hasher", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 hashbrown = "0.15.3"
 hex = { version = "0.4.3", default-features = false }
@@ -899,7 +899,7 @@ log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }
 memmap2 = { version = "0.9.3" }
-memory-db = { version = "0.33.0", default-features = false }
+memory-db = { git = "https://github.com/paritytech/trie.git", branch = "alexggh/allow_usage_of_custom_hasher", default-features = false }
 merkleized-metadata = { version = "0.5.0" }
 merlin = { version = "3.0", default-features = false }
 messages-relay = { path = "bridges/relays/messages" }
@@ -1431,9 +1431,9 @@ tracing-futures = { version = "0.2.4" }
 tracing-log = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.18" }
 tracking-allocator = { path = "polkadot/node/tracking-allocator", default-features = false, package = "staging-tracking-allocator" }
-trie-bench = { version = "0.41.0" }
-trie-db = { version = "0.30.0", default-features = false }
-trie-root = { version = "0.18.0", default-features = false }
+trie-bench = { git = "https://github.com/paritytech/trie.git", branch = "alexggh/allow_usage_of_custom_hasher"}
+trie-db = { git = "https://github.com/paritytech/trie.git", branch = "alexggh/allow_usage_of_custom_hasher", default-features = false }
+trie-root = { git = "https://github.com/paritytech/trie.git", branch = "alexggh/allow_usage_of_custom_hasher", default-features = false }
 trie-standardmap = { version = "0.16.0" }
 trybuild = { version = "1.0.103" }
 tt-call = { version = "1.0.8" }

--- a/bridges/bin/runtime-common/src/parachains_benchmarking.rs
+++ b/bridges/bin/runtime-common/src/parachains_benchmarking.rs
@@ -28,7 +28,7 @@ use bp_runtime::{grow_storage_value, record_all_trie_keys, Chain, UnverifiedStor
 use codec::Encode;
 use frame_support::traits::Get;
 use sp_std::prelude::*;
-use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
+use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, RandomState, TrieMut};
 
 /// Prepare proof of messages for the `receive_messages_proof` call.
 ///
@@ -52,7 +52,7 @@ where
 	let mut parachain_heads = Vec::with_capacity(parachains.len());
 	let mut storage_keys = Vec::with_capacity(parachains.len());
 	let mut state_root = Default::default();
-	let mut mdb = MemoryDB::default();
+	let mut mdb = MemoryDB::<_, RandomState>::default();
 	{
 		let mut trie =
 			TrieDBMutBuilderV1::<RelayBlockHasher>::new(&mut mdb, &mut state_root).build();

--- a/bridges/modules/messages/src/tests/messages_generation.rs
+++ b/bridges/modules/messages/src/tests/messages_generation.rs
@@ -26,7 +26,7 @@ use bp_runtime::{
 };
 use codec::Encode;
 use sp_std::{ops::RangeInclusive, prelude::*};
-use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
+use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, RandomState, TrieMut};
 
 /// Dummy message generation function.
 pub fn generate_dummy_message(_: MessageNonce) -> MessagePayload {
@@ -69,7 +69,7 @@ where
 	let message_count = message_nonces.end().saturating_sub(*message_nonces.start()) + 1;
 	let mut storage_keys = Vec::with_capacity(message_count as usize + 1);
 	let mut root = Default::default();
-	let mut mdb = MemoryDB::default();
+	let mut mdb = MemoryDB::<_, RandomState>::default();
 	{
 		let mut trie =
 			TrieDBMutBuilderV1::<HasherOf<BridgedChain>>::new(&mut mdb, &mut root).build();
@@ -152,7 +152,7 @@ where
 	let storage_key =
 		storage_keys::inbound_lane_data_key(ThisChain::WITH_CHAIN_MESSAGES_PALLET_NAME, &lane).0;
 	let mut root = Default::default();
-	let mut mdb = MemoryDB::default();
+	let mut mdb = MemoryDB::<_, RandomState>::default();
 	{
 		let mut trie =
 			TrieDBMutBuilderV1::<HasherOf<BridgedChain>>::new(&mut mdb, &mut root).build();

--- a/bridges/primitives/test-utils/src/lib.rs
+++ b/bridges/primitives/test-utils/src/lib.rs
@@ -27,7 +27,7 @@ use codec::Encode;
 use sp_consensus_grandpa::{AuthorityId, AuthoritySignature, AuthorityWeight, SetId};
 use sp_runtime::traits::{Header as HeaderT, One, Zero};
 use sp_std::prelude::*;
-use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
+use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, RandomState, TrieMut};
 
 // Re-export all our test account utilities
 pub use keyring::*;
@@ -176,7 +176,7 @@ pub fn prepare_parachain_heads_proof<H: HeaderT>(
 ) -> (H::Hash, ParaHeadsProof, Vec<(ParaId, ParaHash)>) {
 	let mut parachains = Vec::with_capacity(heads.len());
 	let mut root = Default::default();
-	let mut mdb = MemoryDB::default();
+	let mut mdb = MemoryDB::<_, RandomState>::default();
 	let mut storage_keys = vec![];
 	{
 		let mut trie = TrieDBMutBuilderV1::<H::Hashing>::new(&mut mdb, &mut root).build();

--- a/cumulus/pallets/parachain-system/Cargo.toml
+++ b/cumulus/pallets/parachain-system/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 bytes = { workspace = true }
 codec = { features = ["derive"], workspace = true }
 environmental = { workspace = true }
-hashbrown = { workspace = true }
+hashbrown = { workspace = true }	
 impl-trait-for-tuples = { workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }

--- a/cumulus/pallets/parachain-system/src/validate_block/implementation.rs
+++ b/cumulus/pallets/parachain-system/src/validate_block/implementation.rs
@@ -17,7 +17,9 @@
 //! The actual implementation of the validate block functionality.
 
 use super::{trie_cache, trie_recorder, MemoryOptimizedValidationParams};
-use crate::parachain_inherent::BasicParachainInherentData;
+use crate::{
+	parachain_inherent::BasicParachainInherentData, validate_block::build_seed_from_head_data,
+};
 use cumulus_primitives_core::{
 	relay_chain::Hash as RHash, ParachainBlockData, PersistedValidationData,
 };
@@ -141,6 +143,13 @@ where
 
 	let block_data = codec::decode_from_bytes::<ParachainBlockData<B>>(block_data)
 		.expect("Invalid parachain block data");
+
+	// Initialize hashmaps randomness.
+	sp_trie::add_extra_randomness(build_seed_from_head_data(
+		&block_data,
+		relay_parent_number,
+		relay_parent_storage_root,
+	));
 
 	let mut parent_header =
 		codec::decode_from_bytes::<B::Header>(parachain_head.clone()).expect("Invalid parent head");

--- a/cumulus/pallets/parachain-system/src/validate_block/mod.rs
+++ b/cumulus/pallets/parachain-system/src/validate_block/mod.rs
@@ -68,3 +68,36 @@ pub struct MemoryOptimizedValidationParams {
 	pub relay_parent_number: cumulus_primitives_core::relay_chain::BlockNumber,
 	pub relay_parent_storage_root: cumulus_primitives_core::relay_chain::Hash,
 }
+#[cfg(any(test, not(feature = "std")))]
+#[doc(hidden)]
+use crate::{BlockT, RelayChainBlockNumber};
+#[cfg(any(test, not(feature = "std")))]
+#[doc(hidden)]
+use cumulus_primitives_core::ParachainBlockData;
+/// Build a seed from the head data of the parachain block, use both the relay parent storage root
+/// and the hash of the blocks in the block data, to make sure the seed changes every block and that
+/// the user cannot find about it ahead of time.
+#[cfg(any(test, not(feature = "std")))]
+#[doc(hidden)]
+fn build_seed_from_head_data<B: BlockT>(
+	block_data: &ParachainBlockData<B>,
+	relay_parent_number: RelayChainBlockNumber,
+	relay_parent_storage_root: crate::relay_chain::Hash,
+) -> u64 {
+	let relay_parent_seed: u64 = relay_parent_storage_root.as_fixed_bytes()[..size_of::<u64>()]
+		.try_into()
+		.map(|bytes| u64::from_be_bytes(bytes))
+		.unwrap_or(relay_parent_number as u64);
+	let hash_seed: u64 = block_data
+		.blocks()
+		.iter()
+		.filter_map(|block| {
+			block.hash().as_ref()[..size_of::<u64>()]
+				.try_into()
+				.map(|bytes| u64::from_be_bytes(bytes))
+				.ok()
+		})
+		.fold(relay_parent_seed, |acc, hash| acc ^ hash);
+
+	hash_seed
+}

--- a/cumulus/pallets/parachain-system/src/validate_block/trie_cache.rs
+++ b/cumulus/pallets/parachain-system/src/validate_block/trie_cache.rs
@@ -20,15 +20,15 @@ use alloc::boxed::Box;
 use core::cell::{RefCell, RefMut};
 use hashbrown::{hash_map::Entry, HashMap};
 use sp_state_machine::TrieCacheProvider;
-use sp_trie::NodeCodec;
+use sp_trie::{NodeCodec, RandomState};
 use trie_db::{node::NodeOwned, Hasher};
 
 /// Special purpose trie cache implementation that is able to cache an unlimited number
 /// of values. To be used in `validate_block` to serve values and nodes that
 /// have already been loaded and decoded from the storage proof.
 pub struct TrieCache<'a, H: Hasher> {
-	node_cache: RefMut<'a, HashMap<H::Out, NodeOwned<H::Out>>>,
-	value_cache: Option<RefMut<'a, HashMap<Box<[u8]>, trie_db::CachedValue<H::Out>>>>,
+	node_cache: RefMut<'a, HashMap<H::Out, NodeOwned<H::Out>, RandomState>>,
+	value_cache: Option<RefMut<'a, HashMap<Box<[u8]>, trie_db::CachedValue<H::Out>, RandomState>>>,
 }
 
 impl<'a, H: Hasher> trie_db::TrieCache<NodeCodec<H>> for TrieCache<'a, H> {
@@ -65,14 +65,16 @@ impl<'a, H: Hasher> trie_db::TrieCache<NodeCodec<H>> for TrieCache<'a, H> {
 
 /// Provider of [`TrieCache`] instances.
 pub struct CacheProvider<H: Hasher> {
-	node_cache: RefCell<HashMap<H::Out, NodeOwned<H::Out>>>,
+	node_cache: RefCell<HashMap<H::Out, NodeOwned<H::Out>, RandomState>>,
 	/// Cache: `storage_root` => `storage_key` => `value`.
 	///
 	/// One `block` can for example use multiple tries (child tries) and we need to distinguish the
 	/// cached (`storage_key`, `value`) between them. For this we are using the `storage_root` to
 	/// distinguish them (even if the storage root is the same for two child tries, it just means
 	/// that both are exactly the same trie and there would happen no collision).
-	value_cache: RefCell<HashMap<H::Out, HashMap<Box<[u8]>, trie_db::CachedValue<H::Out>>>>,
+	value_cache: RefCell<
+		HashMap<H::Out, HashMap<Box<[u8]>, trie_db::CachedValue<H::Out>, RandomState>, RandomState>,
+	>,
 }
 
 impl<H: Hasher> CacheProvider<H> {

--- a/cumulus/pallets/parachain-system/src/validate_block/trie_recorder.rs
+++ b/cumulus/pallets/parachain-system/src/validate_block/trie_recorder.rs
@@ -26,7 +26,7 @@ use alloc::rc::Rc;
 
 use core::cell::{RefCell, RefMut};
 use hashbrown::{HashMap, HashSet};
-use sp_trie::{NodeCodec, ProofSizeProvider, StorageProof};
+use sp_trie::{NodeCodec, ProofSizeProvider, RandomState, StorageProof};
 use trie_db::{Hasher, RecordedForKey, TrieAccess};
 
 /// A trie recorder that only keeps track of the proof size.
@@ -34,9 +34,9 @@ use trie_db::{Hasher, RecordedForKey, TrieAccess};
 /// The internal size counting logic should align
 /// with ['sp_trie::recorder::Recorder'].
 pub struct SizeOnlyRecorder<'a, H: Hasher> {
-	seen_nodes: RefMut<'a, HashSet<H::Out>>,
+	seen_nodes: RefMut<'a, HashSet<H::Out, RandomState>>,
 	encoded_size: RefMut<'a, usize>,
-	recorded_keys: RefMut<'a, HashMap<Rc<[u8]>, RecordedForKey>>,
+	recorded_keys: RefMut<'a, HashMap<Rc<[u8]>, RecordedForKey, RandomState>>,
 }
 
 impl<'a, H: trie_db::Hasher> trie_db::TrieRecorder<H::Out> for SizeOnlyRecorder<'a, H> {
@@ -90,9 +90,9 @@ impl<'a, H: trie_db::Hasher> trie_db::TrieRecorder<H::Out> for SizeOnlyRecorder<
 
 #[derive(Clone)]
 pub struct SizeOnlyRecorderProvider<H: Hasher> {
-	seen_nodes: Rc<RefCell<HashSet<H::Out>>>,
+	seen_nodes: Rc<RefCell<HashSet<H::Out, RandomState>>>,
 	encoded_size: Rc<RefCell<usize>>,
-	recorded_keys: Rc<RefCell<HashMap<Rc<[u8]>, RecordedForKey>>>,
+	recorded_keys: Rc<RefCell<HashMap<Rc<[u8]>, RecordedForKey, RandomState>>>,
 }
 
 impl<H: Hasher> Default for SizeOnlyRecorderProvider<H> {

--- a/substrate/primitives/state-machine/src/trie_backend_essence.rs
+++ b/substrate/primitives/state-machine/src/trie_backend_essence.rs
@@ -27,7 +27,7 @@ use crate::{
 use alloc::sync::Arc;
 use alloc::{boxed::Box, vec::Vec};
 use codec::Codec;
-use core::marker::PhantomData;
+use core::{hash::BuildHasher, marker::PhantomData};
 use hash_db::{self, AsHashDB, HashDB, HashDBRef, Hasher, Prefix};
 #[cfg(feature = "std")]
 use parking_lot::RwLock;
@@ -795,9 +795,10 @@ impl<H: Hasher> TrieBackendStorage<H> for Arc<dyn Storage<H>> {
 	}
 }
 
-impl<H, KF> TrieBackendStorage<H> for sp_trie::GenericMemoryDB<H, KF>
+impl<H, KF, RS> TrieBackendStorage<H> for sp_trie::GenericMemoryDB<H, KF, RS>
 where
 	H: Hasher,
+	RS: BuildHasher + Send + Sync + Default,
 	KF: sp_trie::KeyFunction<H> + Send + Sync,
 {
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Result<Option<DBValue>> {

--- a/substrate/primitives/trie/Cargo.toml
+++ b/substrate/primitives/trie/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 ahash = { optional = true, workspace = true }
 codec = { workspace = true }
 hash-db = { workspace = true }
+hashbrown = { workspace = true }
 memory-db = { workspace = true }
 nohash-hasher = { optional = true, workspace = true }
 parking_lot = { optional = true, workspace = true, default-features = true }

--- a/substrate/primitives/trie/src/hasher_random_state.rs
+++ b/substrate/primitives/trie/src/hasher_random_state.rs
@@ -1,0 +1,123 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utility module to use a custom random state for HashMap and friends
+//! in a no_std environment.
+
+use core::{
+	hash::Hasher as CoreHasher,
+	sync::atomic::{AtomicU64, Ordering},
+};
+
+use core::hash::BuildHasher;
+use hashbrown::DefaultHashBuilder;
+
+// Extra randomness to be used besides the one provided by the `DefaultHashBuilder`.
+static EXTRA_RANDOMNESS: AtomicU64 = AtomicU64::new(0x082efa98ec4e6c89);
+
+/// Adds extra randomness to be used by all new instances of RandomState.
+pub fn add_extra_randomness(extra_randomness: u64) {
+	EXTRA_RANDOMNESS.store(extra_randomness, Ordering::Relaxed);
+}
+
+/// A wrapper around `DefaultHashBuilder` that adds extra randomness to the hashers it creates.
+#[derive(Copy, Clone, Debug)]
+pub struct RandomState {
+	default: DefaultHashBuilder,
+	extra_randomness: u64,
+}
+
+impl Default for RandomState {
+	#[inline(always)]
+	fn default() -> Self {
+		RandomState {
+			// DefaultHashBuild already uses a random seed, so we use that as the base.
+			default: DefaultHashBuilder::default(),
+			extra_randomness: EXTRA_RANDOMNESS.load(Ordering::Relaxed),
+		}
+	}
+}
+
+impl BuildHasher for RandomState {
+	type Hasher = <DefaultHashBuilder as BuildHasher>::Hasher;
+
+	#[inline(always)]
+	fn build_hasher(&self) -> Self::Hasher {
+		let mut hasher = self.default.build_hasher();
+		hasher.write_u64(self.extra_randomness);
+
+		hasher
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use core::hash::{BuildHasher, Hasher};
+
+	#[test]
+	fn hashbuilder_produces_same_result() {
+		let haser_builder = super::RandomState::default();
+		let mut hasher_1 = haser_builder.build_hasher();
+		let mut hasher_2 = haser_builder.build_hasher();
+
+		hasher_1.write_u32(8128);
+		hasher_2.write_u32(8128);
+
+		assert_eq!(hasher_1.finish(), hasher_2.finish());
+	}
+
+	#[test]
+	fn adding_randomness_does_not_affect_already_instantiated_builders() {
+		let hasher_builder = super::RandomState::default();
+		let mut hasher_1 = hasher_builder.build_hasher();
+
+		super::add_extra_randomness(12345678);
+		let builder_after_randomness_added = super::RandomState::default();
+		assert_eq!(builder_after_randomness_added.extra_randomness, 12345678);
+
+		let mut hasher_2 = hasher_builder.build_hasher();
+
+		hasher_1.write_u32(8128);
+		hasher_2.write_u32(8128);
+
+		assert_eq!(hasher_1.finish(), hasher_2.finish());
+	}
+
+	#[test]
+	fn sanity_check() {
+		let haser_builder = super::RandomState::default();
+		let mut hasher_create_manually =
+			hashbrown::HashMap::<u32, u32, _>::with_hasher(haser_builder);
+		let mut default_built = hashbrown::HashMap::<u32, u32, super::RandomState>::default();
+
+		for x in 0..100 {
+			default_built.insert(x, x * 2);
+			hasher_create_manually.insert(x, x * 2);
+		}
+		super::add_extra_randomness(12345678);
+
+		for x in 0..100 {
+			assert_eq!(default_built.get(&x), Some(&(x * 2)));
+			assert_eq!(hasher_create_manually.get(&x), Some(&(x * 2)));
+		}
+
+		for x in 100..200 {
+			assert_eq!(default_built.get(&x), None);
+			assert_eq!(hasher_create_manually.get(&x), None);
+		}
+	}
+}

--- a/substrate/test-utils/runtime/src/lib.rs
+++ b/substrate/test-utils/runtime/src/lib.rs
@@ -57,7 +57,7 @@ use sp_application_crypto::{bls381, ecdsa_bls381};
 use sp_core::{OpaqueMetadata, RuntimeDebug};
 use sp_trie::{
 	trie_types::{TrieDBBuilder, TrieDBMutBuilderV1},
-	PrefixedMemoryDB, StorageProof,
+	PrefixedMemoryDB, RandomState, StorageProof,
 };
 use trie_db::{Trie, TrieMut};
 
@@ -479,7 +479,7 @@ fn code_using_trie() -> u64 {
 	]
 	.to_vec();
 
-	let mut mdb = PrefixedMemoryDB::default();
+	let mut mdb = PrefixedMemoryDB::<_, RandomState>::default();
 	let mut root = core::default::Default::default();
 	{
 		let mut t = TrieDBMutBuilderV1::<Hashing>::new(&mut mdb, &mut root).build();


### PR DESCRIPTION
https://github.com/paritytech/polkadot-sdk/pull/8606 https://github.com/paritytech/trie/pull/221 replaced the usage of BTreeMap with HashMaps in validation context. The keys are already derived with a cryptographic hash function from user data, so users should not be able to manipulate it.

To be on safe side this PR also modifies the TrieCache, TrieRecorder and MemoryDB to use a hasher that on top of the default generated randomness also adds randomness generated from the hash of the relaychain and that of the parachain blocks, which is not something users can control or guess ahead of time.


