### PR TITLE
use correct era planning config in westend-asset-hub

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -292,7 +292,8 @@ impl pallet_staking_async::Config for Runtime {
 	type EventListeners = (NominationPools, DelegatedStaking);
 	type WeightInfo = weights::pallet_staking_async::WeightInfo<Runtime>;
 	type MaxInvulnerables = frame_support::traits::ConstU32<20>;
-	type PlanningEraOffset = pallet_staking_async::PlanningEraOffsetOf<Runtime, RelaySessionDuration, ConstU32<5>>;
+	type PlanningEraOffset =
+		pallet_staking_async::PlanningEraOffsetOf<Runtime, RelaySessionDuration, ConstU32<5>>;
 	type RcClientInterface = StakingRcClient;
 	type MaxEraDuration = MaxEraDuration;
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::weights::pallet_staking_async;
+
 ///! Staking, and election related pallet configurations.
 use super::*;
 use cumulus_primitives_core::relay_chain::SessionIndex;
@@ -262,7 +264,6 @@ parameter_types! {
 	pub const MaxControllersInDeprecationBatch: u32 = 751;
 	// alias for 16, which is the max nominations per nominator in the runtime.
 	pub const MaxNominations: u32 = <NposCompactSolution16 as frame_election_provider_support::NposSolution>::LIMIT as u32;
-	pub storage PlanningEraOffset: u32 = prod_or_fast!(2, 1);
 	pub const MaxEraDuration: u64 = RelaySessionDuration::get() as u64 * RELAY_CHAIN_SLOT_DURATION_MILLIS as u64 * SessionsPerEra::get() as u64;
 }
 
@@ -293,7 +294,7 @@ impl pallet_staking_async::Config for Runtime {
 	type EventListeners = (NominationPools, DelegatedStaking);
 	type WeightInfo = weights::pallet_staking_async::WeightInfo<Runtime>;
 	type MaxInvulnerables = frame_support::traits::ConstU32<20>;
-	type PlanningEraOffset = PlanningEraOffset;
+	type PlanningEraOffset = pallet_staking_async::PlanningEraOffsetOf<Runtime, RelaySessionDuration, ConstU32<5>>;
 	type RcClientInterface = StakingRcClient;
 	type MaxEraDuration = MaxEraDuration;
 }

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::weights::pallet_staking_async;
-
 ///! Staking, and election related pallet configurations.
 use super::*;
 use cumulus_primitives_core::relay_chain::SessionIndex;


### PR DESCRIPTION
tiny mistake of the past, will use the automatic type rather than hard-coding it. 