### PR TITLE
[dnm] net: Improve connectivity to validators by establishing connections on

### DIFF
--- a/polkadot/node/network/availability-distribution/src/pov_requester/mod.rs
+++ b/polkadot/node/network/availability-distribution/src/pov_requester/mod.rs
@@ -66,7 +66,7 @@ pub async fn fetch_pov<Context>(
 
 	ctx.send_message(NetworkBridgeTxMessage::SendRequests(
 		vec![full_req],
-		IfDisconnected::ImmediateError,
+		IfDisconnected::TryConnect,
 	))
 	.await;
 

--- a/polkadot/node/network/availability-distribution/src/requester/fetch_task/mod.rs
+++ b/polkadot/node/network/availability-distribution/src/requester/fetch_task/mod.rs
@@ -358,11 +358,8 @@ impl RunningTask {
 
 		self.sender
 			.send(FromFetchTask::Message(
-				NetworkBridgeTxMessage::SendRequests(
-					vec![requests],
-					IfDisconnected::ImmediateError,
-				)
-				.into(),
+				NetworkBridgeTxMessage::SendRequests(vec![requests], IfDisconnected::TryConnect)
+					.into(),
 			))
 			.await
 			.map_err(|_| TaskError::ShuttingDown)?;

--- a/polkadot/node/network/availability-recovery/src/task/strategy/full.rs
+++ b/polkadot/node/network/availability-recovery/src/task/strategy/full.rs
@@ -86,7 +86,7 @@ impl<Sender: overseer::AvailabilityRecoverySenderTrait> RecoveryStrategy<Sender>
 			sender
 				.send_message(NetworkBridgeTxMessage::SendRequests(
 					vec![Requests::AvailableDataFetchingV1(req)],
-					IfDisconnected::ImmediateError,
+					IfDisconnected::TryConnect,
 				))
 				.await;
 

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -746,7 +746,7 @@ async fn request_collation(
 	sender
 		.send_message(NetworkBridgeTxMessage::SendRequests(
 			vec![requests],
-			IfDisconnected::ImmediateError,
+			IfDisconnected::TryConnect,
 		))
 		.await;
 	Ok(())

--- a/polkadot/node/network/statement-distribution/src/v2/mod.rs
+++ b/polkadot/node/network/statement-distribution/src/v2/mod.rs
@@ -2920,7 +2920,7 @@ pub(crate) async fn dispatch_requests<Context>(ctx: &mut Context, state: &mut St
 		// Peer is supposedly connected.
 		ctx.send_message(NetworkBridgeTxMessage::SendRequests(
 			vec![Requests::AttestedCandidateV2(request)],
-			IfDisconnected::ImmediateError,
+			IfDisconnected::TryConnect,
 		))
 		.await;
 	}

--- a/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
+++ b/substrate/client/consensus/beefy/src/communication/request_response/outgoing_requests_engine.rs
@@ -128,7 +128,7 @@ impl<B: Block, AuthorityId: AuthorityIdBound> OnDemandJustificationsEngine<B, Au
 			payload,
 			None,
 			tx,
-			IfDisconnected::ImmediateError,
+			IfDisconnected::TryConnect,
 		);
 
 		self.state = State::AwaitingResponse(peer, req_info, rx);

--- a/substrate/client/network/src/litep2p/shim/request_response/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/request_response/mod.rs
@@ -444,7 +444,7 @@ impl RequestResponseProtocol {
 							request,
 							tx,
 							None,
-							IfDisconnected::ImmediateError,
+							IfDisconnected::TryConnect,
 						);
 
 						// since remote peer doesn't support the main protocol (`self.protocol`),

--- a/substrate/client/network/src/request_responses.rs
+++ b/substrate/client/network/src/request_responses.rs
@@ -1002,7 +1002,7 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
 						// We can error if not connected because the
 						// previous attempt would have tried to establish a
 						// connection already or errored and we wouldn't have gotten here.
-						IfDisconnected::ImmediateError,
+						IfDisconnected::TryConnect,
 					);
 				}
 			}

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -899,7 +899,7 @@ where
 				self.state_request_protocol_name.clone(),
 				request.encode_to_vec(),
 				tx,
-				IfDisconnected::ImmediateError,
+				IfDisconnected::TryConnect,
 			);
 
 			SyncingAction::StartRequest {

--- a/substrate/client/network/sync/src/strategy/state.rs
+++ b/substrate/client/network/sync/src/strategy/state.rs
@@ -363,7 +363,7 @@ impl<B: BlockT> StateStrategy<B> {
 				self.protocol_name.clone(),
 				request.encode_to_vec(),
 				tx,
-				IfDisconnected::ImmediateError,
+				IfDisconnected::TryConnect,
 			);
 
 			SyncingAction::StartRequest {

--- a/substrate/client/network/sync/src/strategy/warp.rs
+++ b/substrate/client/network/sync/src/strategy/warp.rs
@@ -685,7 +685,7 @@ where
 					protocol_name,
 					request.encode(),
 					tx,
-					IfDisconnected::ImmediateError,
+					IfDisconnected::TryConnect,
 				);
 
 				SyncingAction::StartRequest {


### PR DESCRIPTION
This PR changes the behavior of returning immediate errors when attempting to submit requests.

In the past, substrate operated under the assumption that validator connections are stable. However, we have seen multiple cases in practice where validators will disconnect and reconnect. To minimize the downtime of the connection, the networking backend will attempt to reconnect to validators if they are disconnected.

This PR has subtle implications for the request-response protocols, which may lead to increased timeouts during the dialing process. 

Needed for testing:
- https://github.com/paritytech/polkadot-sdk/issues/8885

