### PR TITLE
pallet-bags-list: Emit `ScoreUpdated` event only if it has changed

### DIFF
--- a/prdoc/pr_9166.prdoc
+++ b/prdoc/pr_9166.prdoc
@@ -1,8 +1,8 @@
 title: 'pallet-bags-list: Emit `ScoreUpdated` event only if it has changed'
 doc:
-- audience: Todo
+- audience: Runtime Dev
   description: |-
-    quick follow-up to https://github.com/paritytech/polkadot-sdk/pull/8684, ensuring all blocks don't have x events when the feature is enabled (as it is now in WAH)
+    follow-up to https://github.com/paritytech/polkadot-sdk/pull/8684, ensuring all blocks don't have x events when auto-rebag feature is enabled.
 crates:
 - name: pallet-bags-list
   bump: patch

--- a/prdoc/pr_9166.prdoc
+++ b/prdoc/pr_9166.prdoc
@@ -1,0 +1,8 @@
+title: 'pallet-bags-list: Emit `ScoreUpdated` event only if it has changed'
+doc:
+- audience: Todo
+  description: |-
+    quick follow-up to https://github.com/paritytech/polkadot-sdk/pull/8684, ensuring all blocks don't have x events when the feature is enabled (as it is now in WAH)
+crates:
+- name: pallet-bags-list
+  bump: patch

--- a/substrate/bin/node/bench/src/import.rs
+++ b/substrate/bin/node/bench/src/import.rs
@@ -135,10 +135,9 @@ impl core::Benchmark for ImportBenchmark {
 						//    - 2x deposit (Balances::Deposit and Treasury::Deposit) for depositing
 						//      the transaction fee into the treasury
 						//    - extrinsic success
-						// +3 Bags List events from on_idle hook
 						assert_eq!(
 							kitchensink_runtime::System::events().len(),
-							(self.block.extrinsics.len() - 2) * 9 + 2 + 3,
+							(self.block.extrinsics.len() - 2) * 9 + 2,
 						);
 					},
 					BlockType::Noop => {

--- a/substrate/frame/bags-list/src/lib.rs
+++ b/substrate/frame/bags-list/src/lib.rs
@@ -553,13 +553,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> Result<Option<(T::Score, T::Score)>, ListError> {
 		// If no voter at that node, don't do anything. the caller just wasted the fee to call this.
 		let node = list::Node::<T, I>::get(&account).ok_or(ListError::NodeNotFound)?;
+		if node.score != new_score {
+			Self::deposit_event(Event::<T, I>::ScoreUpdated { who: account.clone(), new_score });
+		}
 		let maybe_movement = List::update_position_for(node, new_score);
 		if let Some((from, to)) = maybe_movement {
 			Self::deposit_event(Event::<T, I>::Rebagged { who: account.clone(), from, to });
 		};
-		if node.score != new_score {
-			Self::deposit_event(Event::<T, I>::ScoreUpdated { who: account.clone(), new_score });
-		}
 		Ok(maybe_movement)
 	}
 

--- a/substrate/frame/bags-list/src/lib.rs
+++ b/substrate/frame/bags-list/src/lib.rs
@@ -557,7 +557,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		if let Some((from, to)) = maybe_movement {
 			Self::deposit_event(Event::<T, I>::Rebagged { who: account.clone(), from, to });
 		};
-		Self::deposit_event(Event::<T, I>::ScoreUpdated { who: account.clone(), new_score });
+		if node.score != new_score {
+			Self::deposit_event(Event::<T, I>::ScoreUpdated { who: account.clone(), new_score });
+		}
 		Ok(maybe_movement)
 	}
 


### PR DESCRIPTION
quick follow-up to https://github.com/paritytech/polkadot-sdk/pull/8684, ensuring all blocks don't have x events when the feature is enabled (as it is now in WAH)

