### PR TITLE
Allow create backport branches to unstable by A4-backport-unstable* tag

### DIFF
--- a/.github/scripts/common/lib.sh
+++ b/.github/scripts/common/lib.sh
@@ -530,7 +530,7 @@ parse_branch_names_from_backport_labels() {
   BRANCHES=""
 
   for label in $labels; do
-    if [[ "$label" =~ ^A4-backport-stable[0-9]{4}$ ]]; then
+    if [[ "$label" =~ ^A4-backport-(stable|unstable)[0-9]{4}$ ]]; then
       branch_name=$(sed 's/A4-backport-//' <<< "$label")
       BRANCHES+=" ${branch_name}"
     fi

--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -130,8 +130,8 @@ jobs:
           fi
           
           # Only enforce SemVer restrictions for backports targeting stable branches
-          if [[ "$BASE_BRANCH" != stable* ]]; then
-              echo "ℹ️ Branch '$BASE_BRANCH' is not a stable branch. Skipping SemVer backport-specific enforcements."
+          if [[ "$BASE_BRANCH" != stable* && "$BASE_BRANCH" != unstable* ]]; then
+              echo "ℹ️ Branch '$BASE_BRANCH' is not a (un)stable branch. Skipping SemVer backport-specific enforcements."
               exit 0
           fi
 

--- a/.github/workflows/command-backport.yml
+++ b/.github/workflows/command-backport.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
 
-          if echo "$LABELS" | grep -q '^A4-backport-stable'; then
+          if echo "$LABELS" | grep -qE '^A4-backport-(stable|unstable)'; then
             echo "found=true" >> $GITHUB_OUTPUT
             readarray -t labels_array <<< "$LABELS"
             echo "LABELS=${labels_array[@]}" >> $GITHUB_OUTPUT
@@ -97,7 +97,7 @@ jobs:
               "conflict_resolution": "draft_commit_conflicts"
             }
           copy_assignees: true
-          label_pattern: ^A4-backport-stable
+          label_pattern: ^A4-backport-(stable|unstable)
 
       - name: Label Backports
         if: ${{ steps.backport.outputs.created_pull_numbers != '' }}


### PR DESCRIPTION
In this [PR](https://github.com/paritytech/polkadot-sdk/pull/9139), I added the `A4-backport-unstable2507` label, but no backport branch was created for `unstable2507`.

Was this intentional or just an oversight or did I miss anything in the release channel?

cc: @EgorPopelyaev - this PR is just a blind draft (not sure if it works), probably more needs to be fixed and properly tested. If we really need this, could you please take it over the finish line? If not, just close it :)