### PR TITLE
Allow locking to bump consumer without limits

### DIFF
--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -1152,7 +1152,7 @@ pub mod pallet {
 				}
 				after_frozen = b.frozen;
 			});
-			// debug_assert!(res.is_ok());
+			debug_assert!(res.is_ok());
 			if let Ok((_, maybe_dust)) = res {
 				debug_assert!(maybe_dust.is_none(), "Not altering main balance; qed");
 			}

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -1152,7 +1152,7 @@ pub mod pallet {
 				}
 				after_frozen = b.frozen;
 			});
-			debug_assert!(res.is_ok());
+			// debug_assert!(res.is_ok());
 			if let Ok((_, maybe_dust)) = res {
 				debug_assert!(maybe_dust.is_none(), "Not altering main balance; qed");
 			}

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -1057,7 +1057,7 @@ pub mod pallet {
 					frame_system::Pallet::<T>::dec_consumers(who);
 				}
 				if !did_consume && does_consume {
-					frame_system::Pallet::<T>::inc_consumers(who)?;
+					frame_system::Pallet::<T>::inc_consumers_without_limit(who)?;
 				}
 				if does_consume && frame_system::Pallet::<T>::consumers(who) == 0 {
 					// NOTE: This is a failsafe and should not happen for normal accounts. A normal

--- a/substrate/frame/balances/src/tests/consumer_limit_tests.rs
+++ b/substrate/frame/balances/src/tests/consumer_limit_tests.rs
@@ -1,0 +1,115 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for consumer limit behavior in balance locks.
+
+use super::*;
+use frame_support::traits::{Currency, Get, LockIdentifier, LockableCurrency, WithdrawReasons};
+
+const ID_1: LockIdentifier = *b"1       ";
+const ID_2: LockIdentifier = *b"2       ";
+
+#[test]
+fn lock_should_work_when_consumer_limit_nearly_reached() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build()
+		.execute_with(|| {
+			// Account 1 starts with 100 balance, which gives them a provider ref
+			Balances::make_free_balance_be(&1, 100);
+
+			assert_eq!(System::providers(&1), 1);
+			assert_eq!(System::consumers(&1), 0);
+
+			let max_consumers: u32 = <Test as frame_system::Config>::MaxConsumers::get();
+			for _ in 0..(max_consumers - 1) {
+				assert_ok!(System::inc_consumers(&1));
+			}
+			assert_eq!(System::consumers(&1), max_consumers - 1);
+
+			// Setting a lock should still work - this should consume the last available consumer
+			// ref because frozen balance > 0 makes the account a consumer
+			Balances::set_lock(ID_1, &1, 20, WithdrawReasons::all());
+
+			// Verify the lock was set correctly
+			assert_eq!(Balances::locks(&1).len(), 1);
+			assert_eq!(Balances::locks(&1)[0].amount, 20);
+
+			// Account should now have 16 consumer refs (15 + 1 from the lock)
+			assert_eq!(System::consumers(&1), max_consumers);
+
+			// Lock is represented as frozen balance
+			assert_eq!(get_test_account_data(1).frozen, 20);
+
+			// creating a new lock with higher value
+			Balances::set_lock(ID_2, &1, 30, WithdrawReasons::all());
+			assert_eq!(Balances::locks(&1).len(), 2);
+			assert_eq!(Balances::locks(&1)[0].amount, 20);
+			assert_eq!(Balances::locks(&1)[1].amount, 30);
+
+			// frozen amount is max of locks.
+			assert_eq!(get_test_account_data(1).frozen, 30);
+		});
+}
+
+#[test]
+fn lock_behavior_when_consumer_limit_fully_exhausted() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build()
+		.execute_with(|| {
+			// Account 1 starts with 100 balance
+			Balances::make_free_balance_be(&1, 100);
+			assert_eq!(System::providers(&1), 1);
+			assert_eq!(System::consumers(&1), 0);
+
+			// Fill up all 16 consumer refs.
+			// Note: asset pallets prevents all the consumers to be filled and leaves one untouched.
+			// But other operations in the runtime, notably `uniques::set_accept_ownership` might.
+			let max_consumers: u32 = <Test as frame_system::Config>::MaxConsumers::get();
+			for _ in 0..max_consumers {
+				assert_ok!(System::inc_consumers(&1));
+			}
+			assert_eq!(System::consumers(&1), max_consumers);
+
+			// We cannot manually increment consumers beyond the limit
+			assert_noop!(System::inc_consumers(&1), DispatchError::TooManyConsumers);
+
+			// Although without limits it would work
+			frame_support::hypothetically!({
+				assert_ok!(System::inc_consumers_without_limit(&1));
+			});
+
+			// Now try to set a lock - this will create the lock, but fail to update the frozen
+			// amount.
+			Balances::set_lock(ID_1, &1, 20, WithdrawReasons::all());
+			assert_eq!(Balances::locks(&1).len(), 1);
+			assert_eq!(Balances::locks(&1)[0].amount, 20);
+
+			// frozen amount is not updated.
+			assert_eq!(get_test_account_data(1).frozen, 0);
+
+			// And this allows the account to transfer (almost) all funds out of the account
+			assert_ok!(Balances::transfer_allow_death(
+				frame_system::RawOrigin::Signed(1).into(),
+				2,
+				90,
+			));
+		});
+}

--- a/substrate/frame/balances/src/tests/consumer_limit_tests.rs
+++ b/substrate/frame/balances/src/tests/consumer_limit_tests.rs
@@ -102,14 +102,13 @@ fn lock_behavior_when_consumer_limit_fully_exhausted() {
 			assert_eq!(Balances::locks(&1).len(), 1);
 			assert_eq!(Balances::locks(&1)[0].amount, 20);
 
-			// frozen amount is not updated.
-			assert_eq!(get_test_account_data(1).frozen, 0);
+			// frozen amount is also updated
+			assert_eq!(get_test_account_data(1).frozen, 20);
 
-			// And this allows the account to transfer (almost) all funds out of the account
-			assert_ok!(Balances::transfer_allow_death(
-				frame_system::RawOrigin::Signed(1).into(),
-				2,
-				90,
-			));
+			// And this account cannot transfer any funds out.
+			assert_noop!(
+				Balances::transfer_allow_death(frame_system::RawOrigin::Signed(1).into(), 2, 90,),
+				DispatchError::Token(TokenError::Frozen)
+			);
 		});
 }

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -1383,22 +1383,22 @@ fn freezing_and_locking_should_work() {
 			assert_eq!(System::consumers(&1), 1);
 
 			// Frozen and locked balances update correctly.
-			assert_eq!(Balances::account(&1).frozen, 5);
+			assert_eq!(get_test_account_data(1).frozen, 5);
 			assert_ok!(<Balances as fungible::MutateFreeze<_>>::set_freeze(&TestId::Foo, &1, 6));
-			assert_eq!(Balances::account(&1).frozen, 6);
+			assert_eq!(get_test_account_data(1).frozen, 6);
 			assert_ok!(<Balances as fungible::MutateFreeze<_>>::set_freeze(&TestId::Foo, &1, 4));
-			assert_eq!(Balances::account(&1).frozen, 5);
+			assert_eq!(get_test_account_data(1).frozen, 5);
 			Balances::set_lock(ID_1, &1, 3, WithdrawReasons::all());
-			assert_eq!(Balances::account(&1).frozen, 4);
+			assert_eq!(get_test_account_data(1).frozen, 4);
 			Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all());
-			assert_eq!(Balances::account(&1).frozen, 5);
+			assert_eq!(get_test_account_data(1).frozen, 5);
 
 			// Locks update correctly.
 			Balances::remove_lock(ID_1, &1);
-			assert_eq!(Balances::account(&1).frozen, 4);
+			assert_eq!(get_test_account_data(1).frozen, 4);
 			assert_eq!(System::consumers(&1), 1);
 			assert_ok!(<Balances as fungible::MutateFreeze<_>>::set_freeze(&TestId::Foo, &1, 0));
-			assert_eq!(Balances::account(&1).frozen, 0);
+			assert_eq!(get_test_account_data(1).frozen, 0);
 			assert_eq!(System::consumers(&1), 0);
 		});
 }

--- a/substrate/frame/balances/src/tests/dispatchable_tests.rs
+++ b/substrate/frame/balances/src/tests/dispatchable_tests.rs
@@ -214,11 +214,11 @@ fn upgrade_accounts_should_work() {
 					Ok(())
 				}
 			));
-			assert!(!Balances::account(&7).flags.is_new_logic());
+			assert!(!get_test_account_data(7).flags.is_new_logic());
 			assert_eq!(System::providers(&7), 1);
 			assert_eq!(System::consumers(&7), 0);
 			assert_ok!(Balances::upgrade_accounts(Some(1).into(), vec![7]));
-			assert!(Balances::account(&7).flags.is_new_logic());
+			assert!(get_test_account_data(7).flags.is_new_logic());
 			assert_eq!(System::providers(&7), 1);
 			assert_eq!(System::consumers(&7), 1);
 

--- a/substrate/frame/balances/src/tests/fungible_tests.rs
+++ b/substrate/frame/balances/src/tests/fungible_tests.rs
@@ -227,11 +227,11 @@ fn freezing_and_holds_should_overlap() {
 		.build_and_execute_with(|| {
 			assert_ok!(Balances::set_freeze(&TestId::Foo, &1, 10));
 			assert_ok!(Balances::hold(&TestId::Foo, &1, 9));
-			assert_eq!(Balances::account(&1).free, 1);
+			assert_eq!(get_test_account_data(1).free, 1);
 			assert_eq!(System::consumers(&1), 1);
-			assert_eq!(Balances::account(&1).free, 1);
-			assert_eq!(Balances::account(&1).frozen, 10);
-			assert_eq!(Balances::account(&1).reserved, 9);
+			assert_eq!(get_test_account_data(1).free, 1);
+			assert_eq!(get_test_account_data(1).frozen, 10);
+			assert_eq!(get_test_account_data(1).reserved, 9);
 			assert_eq!(Balances::total_balance_on_hold(&1), 9);
 		});
 }
@@ -305,7 +305,7 @@ fn thaw_should_work() {
 			assert_ok!(Balances::thaw(&TestId::Foo, &1));
 			assert_eq!(System::consumers(&1), 0);
 			assert_eq!(Balances::balance_frozen(&TestId::Foo, &1), 0);
-			assert_eq!(Balances::account(&1).frozen, 0);
+			assert_eq!(get_test_account_data(1).frozen, 0);
 			assert_ok!(<Balances as fungible::Mutate<_>>::transfer(&1, &2, 10, Expendable));
 		});
 }
@@ -320,7 +320,7 @@ fn set_freeze_zero_should_work() {
 			assert_ok!(Balances::set_freeze(&TestId::Foo, &1, 0));
 			assert_eq!(System::consumers(&1), 0);
 			assert_eq!(Balances::balance_frozen(&TestId::Foo, &1), 0);
-			assert_eq!(Balances::account(&1).frozen, 0);
+			assert_eq!(get_test_account_data(1).frozen, 0);
 			assert_ok!(<Balances as fungible::Mutate<_>>::transfer(&1, &2, 10, Expendable));
 		});
 }
@@ -349,7 +349,7 @@ fn extend_freeze_should_work() {
 		.build_and_execute_with(|| {
 			assert_ok!(Balances::set_freeze(&TestId::Foo, &1, 5));
 			assert_ok!(Balances::extend_freeze(&TestId::Foo, &1, 10));
-			assert_eq!(Balances::account(&1).frozen, 10);
+			assert_eq!(get_test_account_data(1).frozen, 10);
 			assert_eq!(Balances::balance_frozen(&TestId::Foo, &1), 10);
 			assert_noop!(
 				<Balances as fungible::Mutate<_>>::transfer(&1, &2, 1, Expendable),
@@ -483,16 +483,16 @@ fn withdraw_precision_exact_works() {
 		.monied(true)
 		.build_and_execute_with(|| {
 			assert_ok!(Balances::set_freeze(&TestId::Foo, &1, 10));
-			assert_eq!(Balances::account(&1).free, 10);
-			assert_eq!(Balances::account(&1).frozen, 10);
+			assert_eq!(get_test_account_data(1).free, 10);
+			assert_eq!(get_test_account_data(1).frozen, 10);
 
 			// `BestEffort` will not reduce anything
 			assert_ok!(<Balances as fungible::Balanced<_>>::withdraw(
 				&1, 5, BestEffort, Preserve, Polite
 			));
 
-			assert_eq!(Balances::account(&1).free, 10);
-			assert_eq!(Balances::account(&1).frozen, 10);
+			assert_eq!(get_test_account_data(1).free, 10);
+			assert_eq!(get_test_account_data(1).frozen, 10);
 
 			assert_noop!(
 				<Balances as fungible::Balanced<_>>::withdraw(&1, 5, Exact, Preserve, Polite),

--- a/substrate/frame/balances/src/tests/general_tests.rs
+++ b/substrate/frame/balances/src/tests/general_tests.rs
@@ -19,7 +19,9 @@
 
 use crate::{
 	system::AccountInfo,
-	tests::{ensure_ti_valid, Balances, ExtBuilder, System, Test, TestId, UseSystem},
+	tests::{
+		ensure_ti_valid, get_test_account, Balances, ExtBuilder, System, Test, TestId, UseSystem,
+	},
 	AccountData, ExtraFlags, TotalIssuance,
 };
 use frame_support::{
@@ -50,7 +52,7 @@ fn regression_historic_acc_does_not_evaporate_reserve() {
 		System::dec_consumers(&alice);
 
 		assert_eq!(
-			System::account(&alice),
+			get_test_account(alice),
 			AccountInfo {
 				data: AccountData {
 					free: 90,

--- a/substrate/frame/balances/src/tests/mod.rs
+++ b/substrate/frame/balances/src/tests/mod.rs
@@ -46,13 +46,13 @@ use sp_runtime::{
 };
 use std::collections::BTreeSet;
 
+mod consumer_limit_tests;
 mod currency_tests;
 mod dispatchable_tests;
 mod fungible_conformance_tests;
 mod fungible_tests;
 mod general_tests;
 mod reentrancy_tests;
-mod consumer_limit_tests;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 

--- a/substrate/frame/balances/src/tests/mod.rs
+++ b/substrate/frame/balances/src/tests/mod.rs
@@ -356,8 +356,6 @@ fn check_whitelist() {
 
 /// This pallet runs tests twice, once with system as `type AccountStore` and once this pallet. This
 /// function will return the right value based on the `UseSystem` flag.
-///
-/// TODO: should use these in all tests.
 pub(crate) fn get_test_account_data(who: AccountId) -> AccountData<Balance> {
 	if UseSystem::get() {
 		<SystemAccountStore as StoredMap<_, _>>::get(&who)

--- a/substrate/frame/support/src/traits/tokens/currency/lockable.rs
+++ b/substrate/frame/support/src/traits/tokens/currency/lockable.rs
@@ -25,6 +25,9 @@ use crate::{dispatch::DispatchResult, traits::misc::Get};
 pub type LockIdentifier = [u8; 8];
 
 /// A currency whose accounts can have liquidity restrictions.
+///
+/// Note: Consider using [`crate::traits::fungible::MutateFreeze`] (and family) as it returns a
+/// `Result`, and is therefore much safer to use.
 pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// The quantity used to denote time; usually just a `BlockNumber`.
 	type Moment;


### PR DESCRIPTION
Locking is a system-level operation, and can only increment the consumer limit at most once. Therefore, it should use `inc_consumer_without_limits`. 



Beyond this, this PR: 
* demonstrates that the freeze behavior is consistent
* uses the correct way to get the account data in tests
* adds an `Unexpected` event instead of a silent `debug_assert!`. 