### PR TITLE
Fixed westend asset hub ID

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1720,7 +1720,7 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 			ParachainInfo::parachain_id()
 		}
 	}
-	
+
 	impl cumulus_primitives_aura::AuraUnincludedSegmentApi<Block> for Runtime {
 		fn can_build_upon(
 			included_hash: <Block as BlockT>::Hash,

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1715,6 +1715,12 @@ pallet_revive::impl_runtime_apis_plus_revive!(
 		}
 	}
 
+	impl cumulus_primitives_core::GetParachainInfo<Block> for Runtime {
+		fn parachain_id() -> ParaId {
+			ParachainInfo::parachain_id()
+		}
+	}
+	
 	impl cumulus_primitives_aura::AuraUnincludedSegmentApi<Block> for Runtime {
 		fn can_build_upon(
 			included_hash: <Block as BlockT>::Hash,

--- a/prdoc/pr_9191.prdoc
+++ b/prdoc/pr_9191.prdoc
@@ -1,0 +1,8 @@
+title: Fixed westend asset hub ID
+doc:
+- audience: Runtime Dev
+  description: |-
+    Added cumulus_primitives_core::GetParachainInfo impl to the AHW runtime to get the parachain ID.
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch

--- a/prdoc/pr_9191.prdoc
+++ b/prdoc/pr_9191.prdoc
@@ -5,4 +5,4 @@ doc:
     Added cumulus_primitives_core::GetParachainInfo impl to the AHW runtime to get the parachain ID.
 crates:
 - name: asset-hub-westend-runtime
-  bump: patch
+  bump: minor


### PR DESCRIPTION
Addresses #9190 by adding cumulus_primitives_core::GetParachainInfo impl to the AHW runtime.