### PR TITLE
State sync write db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19425,6 +19425,7 @@ dependencies = [
  "sp-trie 29.0.0",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime",
+ "trie-db 0.30.0",
 ]
 
 [[package]]
@@ -19459,6 +19460,7 @@ dependencies = [
  "substrate-test-runtime-client",
  "sysinfo",
  "tempfile",
+ "trie-db 0.30.0",
 ]
 
 [[package]]
@@ -20167,6 +20169,7 @@ dependencies = [
  "async-trait",
  "fork-tree",
  "futures",
+ "hash-db",
  "log",
  "mockall",
  "parity-scale-codec",
@@ -20188,13 +20191,16 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
  "sp-test-primitives",
  "sp-tracing 16.0.0",
+ "sp-trie 29.0.0",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
+ "trie-db 0.30.0",
 ]
 
 [[package]]
@@ -20536,6 +20542,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "trie-db 0.30.0",
 ]
 
 [[package]]

--- a/substrate/client/api/Cargo.toml
+++ b/substrate/client/api/Cargo.toml
@@ -36,6 +36,7 @@ sp-runtime = { workspace = true }
 sp-state-machine = { workspace = true, default-features = true }
 sp-storage = { workspace = true, default-features = true }
 sp-trie = { workspace = true, default-features = true }
+trie-db = { workspace = true }
 
 [dev-dependencies]
 substrate-test-runtime = { workspace = true }

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -35,10 +35,14 @@ use sp_state_machine::{
 };
 use sp_storage::{ChildInfo, StorageData, StorageKey};
 pub use sp_trie::MerkleValue;
+use trie_db::NibbleVec;
 
 use crate::{blockchain::Backend as BlockchainBackend, UsageInfo};
 
 pub use sp_state_machine::{Backend as StateBackend, BackendTransaction, KeyValueStates};
+
+// error[E0658]: associated type defaults are unstable
+type HashDbEmplaceBatch<B> = Vec<(NibbleVec, <B as BlockT>::Hash, Vec<u8>)>;
 
 /// Extracts the state backend type for the given backend.
 pub type StateBackendFor<B, Block> = <B as Backend<Block>>::State;
@@ -195,6 +199,9 @@ pub trait BlockImportOperation<Block: BlockT> {
 		storage: Storage,
 		state_version: StateVersion,
 	) -> sp_blockchain::Result<Block::Hash>;
+
+	/// Fix "State already discarded" after state sync
+	fn set_state_sync_done(&mut self);
 
 	/// Set storage changes.
 	fn update_storage(
@@ -668,6 +675,11 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 
 	/// Tells whether the backend requires full-sync mode.
 	fn requires_full_sync(&self) -> bool;
+
+	/// TODO: ProofProviderHashDb
+	fn hash_db_contains(&self, prefix: &NibbleVec, hash: &Block::Hash) -> bool;
+	/// TODO: ProofProviderHashDb
+	fn hash_db_emplace_batch(&self, batch: HashDbEmplaceBatch<Block>) -> sp_blockchain::Result<()>;
 }
 
 /// Mark for all Backend implementations, that are making use of state data, stored locally.

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -44,6 +44,10 @@ use crate::{
 	leaves::LeafSet,
 	TrieCacheContext, UsageInfo,
 };
+use trie_db::NibbleVec;
+
+// error[E0658]: associated type defaults are unstable
+type HashDbEmplaceBatch<B> = Vec<(NibbleVec, <B as BlockT>::Hash, Vec<u8>)>;
 
 struct PendingBlock<B: BlockT> {
 	block: StoredBlock<B>,
@@ -547,6 +551,10 @@ impl<Block: BlockT> backend::BlockImportOperation<Block> for BlockImportOperatio
 		self.apply_storage(storage, true, state_version)
 	}
 
+	fn set_state_sync_done(&mut self) {
+		todo!()
+	}
+
 	fn insert_aux<I>(&mut self, ops: I) -> sp_blockchain::Result<()>
 	where
 		I: IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
@@ -779,6 +787,16 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 	fn unpin_block(&self, hash: <Block as BlockT>::Hash) {
 		let mut blocks = self.pinned_blocks.write();
 		blocks.entry(hash).and_modify(|counter| *counter -= 1).or_insert(-1);
+	}
+
+	fn hash_db_contains(&self, _prefix: &NibbleVec, _hash: &Block::Hash) -> bool {
+		todo!();
+	}
+	fn hash_db_emplace_batch(
+		&self,
+		_batch: HashDbEmplaceBatch<Block>,
+	) -> sp_blockchain::Result<()> {
+		todo!();
 	}
 }
 

--- a/substrate/client/api/src/proof_provider.rs
+++ b/substrate/client/api/src/proof_provider.rs
@@ -21,9 +21,21 @@ use crate::{CompactProof, StorageProof};
 use sp_runtime::traits::Block as BlockT;
 use sp_state_machine::{KeyValueStates, KeyValueStorageLevel};
 use sp_storage::ChildInfo;
+use trie_db::NibbleVec;
+
+// error[E0658]: associated type defaults are unstable
+type HashDbEmplaceBatch<B> = Vec<(NibbleVec, <B as BlockT>::Hash, Vec<u8>)>;
+
+/// Direct hash db interface for state sync.
+pub trait ProofProviderHashDb<B: BlockT> {
+	/// Check node already exists in db.
+	fn hash_db_contains(&self, prefix: &NibbleVec, hash: &B::Hash) -> bool;
+	/// Save batch of nodes to db.
+	fn hash_db_emplace_batch(&self, batch: HashDbEmplaceBatch<B>) -> sp_blockchain::Result<()>;
+}
 
 /// Interface for providing block proving utilities.
-pub trait ProofProvider<Block: BlockT> {
+pub trait ProofProvider<Block: BlockT>: ProofProviderHashDb<Block> {
 	/// Reads storage value at a given block + key, returning read proof.
 	fn read_proof(
 		&self,

--- a/substrate/client/consensus/common/src/block_import.rs
+++ b/substrate/client/consensus/common/src/block_import.rs
@@ -133,6 +133,7 @@ pub struct ImportedState<B: BlockT> {
 	pub block: B::Hash,
 	/// State keys and values.
 	pub state: sp_state_machine::KeyValueStates,
+	pub written: bool,
 }
 
 impl<B: BlockT> std::fmt::Debug for ImportedState<B> {

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -44,6 +44,7 @@ sp-runtime = { workspace = true, default-features = true }
 sp-state-machine = { workspace = true, default-features = true }
 sp-trie = { workspace = true, default-features = true }
 sysinfo = { workspace = true }
+trie-db = { workspace = true }
 
 [dev-dependencies]
 array-bytes = { workspace = true, default-features = true }

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -93,6 +93,8 @@ use sp_state_machine::{
 	StorageValue, UsageInfo as StateUsageInfo,
 };
 use sp_trie::{cache::SharedTrieCache, prefixed_key, MemoryDB, MerkleValue, PrefixedMemoryDB};
+use std::borrow::Cow;
+use trie_db::NibbleVec;
 use utils::BLOCK_GAP_CURRENT_VERSION;
 
 // Re-export the Database trait so that one can pass an implementation of it.
@@ -100,6 +102,9 @@ pub use sc_state_db::PruningMode;
 pub use sp_database::Database;
 
 pub use bench::BenchmarkingState;
+
+// error[E0658]: associated type defaults are unstable
+type HashDbEmplaceBatch<B> = Vec<(NibbleVec, <B as BlockT>::Hash, Vec<u8>)>;
 
 const CACHE_HEADERS: usize = 8;
 
@@ -937,6 +942,10 @@ impl<Block: BlockT> sc_client_api::backend::BlockImportOperation<Block>
 		Ok(root)
 	}
 
+	fn set_state_sync_done(&mut self) {
+		self.commit_state = true;
+	}
+
 	fn set_genesis_state(
 		&mut self,
 		storage: Storage,
@@ -1005,15 +1014,21 @@ struct StorageDb<Block: BlockT> {
 	prefix_keys: bool,
 }
 
+impl<Block: BlockT> StorageDb<Block> {
+	fn state_key<'a>(&self, prefix: Prefix, hash: &'a Block::Hash) -> Cow<'a, [u8]> {
+		if self.prefix_keys {
+			Cow::Owned(prefixed_key::<HashingFor<Block>>(hash, prefix))
+		} else {
+			Cow::Borrowed(hash.as_ref())
+		}
+	}
+}
+
 impl<Block: BlockT> sp_state_machine::Storage<HashingFor<Block>> for StorageDb<Block> {
 	fn get(&self, key: &Block::Hash, prefix: Prefix) -> Result<Option<DBValue>, String> {
-		if self.prefix_keys {
-			let key = prefixed_key::<HashingFor<Block>>(key, prefix);
-			self.state_db.get(&key, self)
-		} else {
-			self.state_db.get(key.as_ref(), self)
-		}
-		.map_err(|e| format!("Database backend error: {e:?}"))
+		self.state_db
+			.get(self.state_key(prefix, key).as_ref(), self)
+			.map_err(|e| format!("Database backend error: {e:?}"))
 	}
 }
 
@@ -2631,6 +2646,28 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 		if self.blocks_pruning != BlocksPruning::KeepAll {
 			self.blockchain.unpin(hash);
 		}
+	}
+
+	fn hash_db_contains(&self, prefix: &NibbleVec, hash: &Block::Hash) -> bool {
+		// TODO: don't read value, just check key exists
+		sp_state_machine::Storage::get(self.storage.as_ref(), hash, prefix.as_prefix())
+			.map(|x| x.is_some())
+			.unwrap_or(false)
+	}
+	fn hash_db_emplace_batch(&self, batch: HashDbEmplaceBatch<Block>) -> sp_blockchain::Result<()> {
+		self.storage.db.commit(Transaction(
+			batch
+				.into_iter()
+				.map(|(prefix, hash, value)| {
+					sp_database::Change::Set(
+						columns::STATE,
+						self.storage.state_key(prefix.as_prefix(), &hash).into_owned(),
+						value,
+					)
+				})
+				.collect(),
+		))?;
+		Ok(())
 	}
 }
 

--- a/substrate/client/network/sync/Cargo.toml
+++ b/substrate/client/network/sync/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { workspace = true }
 codec = { features = ["derive"], workspace = true, default-features = true }
 fork-tree = { workspace = true, default-features = true }
 futures = { workspace = true }
+hash-db = { workspace = true }
 log = { workspace = true, default-features = true }
 mockall = { workspace = true }
 prometheus-endpoint = { workspace = true, default-features = true }
@@ -40,9 +41,12 @@ sp-consensus = { workspace = true, default-features = true }
 sp-consensus-grandpa = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
+sp-state-machine = { workspace = true }
+sp-trie = { workspace = true }
 thiserror = { workspace = true }
 tokio = { features = ["macros", "time"], workspace = true, default-features = true }
 tokio-stream = { workspace = true }
+trie-db = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/substrate/client/network/sync/src/strategy/state.rs
+++ b/substrate/client/network/sync/src/strategy/state.rs
@@ -711,7 +711,8 @@ mod test {
 		let header = block.header().clone();
 		let hash = header.hash();
 		let body = Some(block.extrinsics().iter().cloned().collect::<Vec<_>>());
-		let state = ImportedState { block: hash, state: KeyValueStates(Vec::new()) };
+		let state =
+			ImportedState { block: hash, state: KeyValueStates(Vec::new()), written: false };
 		let justifications = Some(Justifications::from((*b"FRNK", Vec::new())));
 
 		// Prepare `StateSync`

--- a/substrate/client/network/sync/src/strategy/state_sync.rs
+++ b/substrate/client/network/sync/src/strategy/state_sync.rs
@@ -24,15 +24,26 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use log::debug;
-use sc_client_api::{CompactProof, KeyValueStates, ProofProvider};
+use sc_client_api::{CompactProof, KeyValueStates, ProofProviderHashDb};
 use sc_consensus::ImportedState;
 use smallvec::SmallVec;
 use sp_core::storage::well_known_keys;
+use sp_runtime::traits::HashingFor;
 use sp_runtime::{
 	traits::{Block as BlockT, Header, NumberFor},
 	Justifications,
 };
 use std::{collections::HashMap, fmt, sync::Arc};
+use trie_db::node::Node;
+use trie_db::node::NodeHandle;
+use trie_db::node::Value;
+use trie_db::NibbleSlice;
+use trie_db::NibbleVec;
+use trie_db::NodeCodec;
+use trie_db::TrieLayout;
+
+// error[E0658]: associated type defaults are unstable
+type HashDbEmplaceBatch<B> = Vec<(NibbleVec, <B as BlockT>::Hash, Vec<u8>)>;
 
 /// Generic state sync provider. Used for mocking in tests.
 pub trait StateSyncProvider<B: BlockT>: Send + Sync {
@@ -136,6 +147,137 @@ impl<B: BlockT> StateSyncMetadata<B> {
 	}
 }
 
+type Layout<B> = sp_state_machine::LayoutV0<HashingFor<B>>;
+type LayoutCodec<B> = <Layout<B> as TrieLayout>::Codec;
+type ProofDb<B> = sp_state_machine::MemoryDB<HashingFor<B>>;
+
+fn as_hash<B: BlockT>(slice: &[u8]) -> B::Hash {
+	let mut hash = B::Hash::default();
+	assert_eq!(slice.len(), hash.as_ref().len());
+	hash.as_mut().copy_from_slice(slice);
+	hash
+}
+
+struct LevelNode<B: BlockT> {
+	hash: B::Hash,
+	encoded: Vec<u8>,
+	prefix_nibbles: usize,
+	branches: SmallVec<[(u8, B::Hash); 16]>,
+}
+
+enum LevelState<B: BlockT> {
+	Root(B::Hash),
+	ChildHash(NibbleVec, B::Hash),
+	ValueHash(B::Hash),
+	Value,
+	Branch(B::Hash),
+	Pop,
+	End,
+}
+
+struct Level<B: BlockT> {
+	allow_child: bool,
+	state: LevelState<B>,
+	stack: Vec<LevelNode<B>>,
+	prefix: NibbleVec,
+}
+impl<B: BlockT> Level<B> {
+	fn new(allow_child: bool, prefix: NibbleVec, root: B::Hash) -> Self {
+		Self { allow_child, state: LevelState::Root(root), stack: vec![], prefix }
+	}
+	// ChildHash | ValueHash | Value | Branch | Pop -> Branch | End
+	fn next_branch(&mut self) {
+		let is_value = matches!(
+			self.state,
+			LevelState::ChildHash(_, _) | LevelState::ValueHash(_) | LevelState::Value
+		);
+		let is_branch = matches!(self.state, LevelState::Branch(_) | LevelState::Pop);
+		assert!(is_value || is_branch);
+		if is_branch {
+			self.prefix.pop().unwrap();
+		}
+		self.state = if let Some((i, hash)) = self.stack.last_mut().unwrap().branches.pop() {
+			self.prefix.push(i);
+			LevelState::Branch(hash)
+		} else {
+			let node = self.stack.last().unwrap();
+			self.prefix.drop_lasts(node.prefix_nibbles);
+			LevelState::End
+		};
+	}
+	// Root | Branch -> ChildHash | ValueHash | Value
+	fn push(&mut self, encoded: Vec<u8>) {
+		let hash = match &self.state {
+			LevelState::Root(hash) | LevelState::Branch(hash) => *hash,
+			_ => panic!(),
+		};
+		let node = LayoutCodec::<B>::decode(&encoded).unwrap();
+		let (prefix, value, branches) = match &node {
+			Node::Empty => (None, None, None),
+			Node::Leaf(prefix, value) => (Some(prefix), Some(value), None),
+			Node::Extension(_, _) => panic!(),
+			Node::Branch(branches, value) => (None, value.as_ref(), Some(branches)),
+			Node::NibbledBranch(prefix, branches, value) => {
+				(Some(prefix), value.as_ref(), Some(branches))
+			},
+		};
+		let prefix_nibbles = if let Some(prefix) = prefix {
+			self.prefix.append_partial(prefix.right());
+			prefix.len()
+		} else {
+			0
+		};
+		let branches = branches
+			.map(|branches| {
+				branches
+					.iter()
+					.enumerate()
+					.rev()
+					.filter_map(|(i, branch)| {
+						if let Some(NodeHandle::Hash(hash)) = branch {
+							Some((i as u8, as_hash::<B>(hash)))
+						} else {
+							None
+						}
+					})
+					.collect()
+			})
+			.unwrap_or_default();
+		self.state = if let Some(value) = value {
+			let key = self.prefix.as_prefix().0;
+			if self.allow_child && well_known_keys::is_child_storage_key(key) {
+				let value = if let Value::Inline(value) = value {
+					value
+				} else {
+					panic!();
+				};
+				assert!(well_known_keys::is_default_child_storage_key(key));
+				let prefix = NibbleVec::from(NibbleSlice::new(
+					&key[well_known_keys::DEFAULT_CHILD_STORAGE_KEY_PREFIX.len()..],
+				));
+				LevelState::ChildHash(prefix, as_hash::<B>(value))
+			} else {
+				match value {
+					Value::Inline(_) => LevelState::Value,
+					Value::Node(hash) => LevelState::ValueHash(as_hash::<B>(hash)),
+				}
+			}
+		} else {
+			LevelState::Value
+		};
+		self.stack.push(LevelNode { hash, encoded, prefix_nibbles, branches });
+	}
+	// End -> Pop -> Branch | End
+	fn pop(&mut self) {
+		assert!(matches!(self.state, LevelState::End));
+		let node = self.stack.pop().unwrap();
+		if !self.stack.is_empty() {
+			self.state = LevelState::Pop;
+			self.next_branch();
+		}
+	}
+}
+
 /// State sync state machine.
 ///
 /// Accumulates partial state data until it is ready to be imported.
@@ -143,12 +285,14 @@ pub struct StateSync<B: BlockT, Client> {
 	metadata: StateSyncMetadata<B>,
 	state: HashMap<Vec<u8>, (Vec<(Vec<u8>, Vec<u8>)>, Vec<Vec<u8>>)>,
 	client: Arc<Client>,
+	levels: SmallVec<[Level<B>; 2]>,
+	null_hash: B::Hash,
 }
 
 impl<B, Client> StateSync<B, Client>
 where
 	B: BlockT,
-	Client: ProofProvider<B> + Send + Sync + 'static,
+	Client: ProofProviderHashDb<B> + Send + Sync + 'static,
 {
 	///  Create a new instance.
 	pub fn new(
@@ -158,7 +302,7 @@ where
 		target_justifications: Option<Justifications>,
 		skip_proof: bool,
 	) -> Self {
-		Self {
+		let mut sync = Self {
 			client,
 			metadata: StateSyncMetadata {
 				last_key: SmallVec::default(),
@@ -170,7 +314,14 @@ where
 				skip_proof,
 			},
 			state: HashMap::default(),
+			levels: SmallVec::default(),
+			null_hash: LayoutCodec::<B>::hashed_null_node(),
+		};
+		if !skip_proof {
+			sync.levels
+				.push(Level::new(true, NibbleVec::new(), sync.metadata.target_root()));
 		}
+		sync
 	}
 
 	fn process_state_key_values(
@@ -205,7 +356,7 @@ where
 		}
 	}
 
-	fn process_state_verified(&mut self, values: KeyValueStates) {
+	fn _process_state_verified(&mut self, values: KeyValueStates) {
 		for values in values.0 {
 			self.process_state_key_values(values.state_root, values.key_values);
 		}
@@ -246,12 +397,82 @@ where
 		}
 		complete
 	}
+
+	fn on_proof_response(&mut self, proof: &ProofDb<B>) -> bool {
+		use hash_db::HashDBRef;
+		let is_known =
+			|client: &Arc<Client>, null_hash: &B::Hash, prefix: &NibbleVec, hash: &B::Hash| {
+				hash == null_hash || client.hash_db_contains(prefix, hash)
+			};
+		let mut batch: HashDbEmplaceBatch<B> = vec![];
+		'outer: while let Some(level) = self.levels.last_mut() {
+			if let LevelState::Root(hash) = &level.state {
+				if let Some(value) = proof.get(hash, level.prefix.as_prefix()) {
+					level.push(value);
+				} else {
+					break 'outer;
+				}
+			}
+			while let Some(node) = level.stack.last_mut() {
+				match &mut level.state {
+					LevelState::Root(_) => panic!(),
+					LevelState::ChildHash(prefix, hash) => {
+						if !is_known(&self.client, &self.null_hash, prefix, hash) {
+							let child_level = Level::new(false, std::mem::take(prefix), *hash);
+							level.next_branch();
+							self.levels.push(child_level);
+						} else {
+							level.next_branch();
+						}
+						continue 'outer;
+					},
+					LevelState::ValueHash(hash) => {
+						if !is_known(&self.client, &self.null_hash, &level.prefix, hash) {
+							if let Some(value) = proof.get(hash, level.prefix.as_prefix()) {
+								batch.push((level.prefix.clone(), *hash, value));
+							} else {
+								break 'outer;
+							}
+						}
+						level.next_branch();
+					},
+					LevelState::Value => {
+						level.next_branch();
+					},
+					LevelState::Branch(hash) => {
+						if !is_known(&self.client, &self.null_hash, &level.prefix, hash) {
+							if let Some(value) = proof.get(hash, level.prefix.as_prefix()) {
+								level.push(value);
+								continue;
+							} else {
+								break 'outer;
+							}
+						} else {
+							level.next_branch();
+						}
+					},
+					LevelState::Pop => panic!(),
+					LevelState::End => {
+						batch.push((
+							level.prefix.clone(),
+							node.hash,
+							std::mem::take(&mut node.encoded),
+						));
+						level.pop();
+					},
+				}
+			}
+			self.levels.pop();
+		}
+		self.client.hash_db_emplace_batch(batch).unwrap();
+		self.levels.is_empty()
+	}
 }
 
 impl<B, Client> StateSyncProvider<B> for StateSync<B, Client>
 where
 	B: BlockT,
-	Client: ProofProvider<B> + Send + Sync + 'static,
+	Client: ProofProviderHashDb<B> + Send + Sync + 'static,
 {
 	///  Validate and import a state response.
 	fn import(&mut self, response: StateResponse) -> ImportResult<B> {
@@ -273,30 +494,24 @@ where
 					return ImportResult::BadResponse
 				},
 			};
-			let (values, completed) = match self.client.verify_range_proof(
-				self.metadata.target_root(),
-				proof,
-				self.metadata.last_key.as_slice(),
+
+			let mut proof_db = ProofDb::<B>::new(&[]);
+			if let Err(e) = sp_trie::decode_compact::<Layout<B>, _, _>(
+				&mut proof_db,
+				proof.iter_compact_encoded_nodes(),
+				Some(&self.metadata.target_root()),
 			) {
-				Err(e) => {
-					debug!(
-						target: LOG_TARGET,
-						"StateResponse failed proof verification: {}",
-						e,
-					);
-					return ImportResult::BadResponse
-				},
-				Ok(values) => values,
-			};
-			debug!(target: LOG_TARGET, "Imported with {} keys", values.len());
-
-			let complete = completed == 0;
-			if !complete && !values.update_last_key(completed, &mut self.metadata.last_key) {
-				debug!(target: LOG_TARGET, "Error updating key cursor, depth: {}", completed);
-			};
-
-			self.process_state_verified(values);
+				debug!(
+					target: LOG_TARGET,
+					"StateResponse proof decode error: {}",
+					e,
+				);
+				return ImportResult::BadResponse;
+			}
 			self.metadata.imported_bytes += proof_size;
+			let complete = self.on_proof_response(&proof_db);
+			self.metadata.last_key =
+				self.levels.iter().map(|level| level.prefix.inner().to_vec()).collect();
 			complete
 		} else {
 			self.process_state_unverified(response)
@@ -307,7 +522,11 @@ where
 			ImportResult::Import(
 				target_hash,
 				self.metadata.target_header.clone(),
-				ImportedState { block: target_hash, state: std::mem::take(&mut self.state).into() },
+				ImportedState {
+					block: target_hash,
+					state: std::mem::take(&mut self.state).into(),
+					written: !self.metadata.skip_proof,
+				},
 				self.metadata.target_body.clone(),
 				self.metadata.target_justifications.clone(),
 			)

--- a/substrate/client/service/Cargo.toml
+++ b/substrate/client/service/Cargo.toml
@@ -73,6 +73,7 @@ thiserror = { workspace = true }
 tokio = { features = ["parking_lot", "rt-multi-thread", "time"], workspace = true, default-features = true }
 tracing = { workspace = true, default-features = true }
 tracing-futures = { workspace = true }
+trie-db = { workspace = true }
 
 [dev-dependencies]
 substrate-test-runtime = { workspace = true }

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -41,7 +41,7 @@ use sc_client_api::{
 	execution_extensions::ExecutionExtensions,
 	notifications::{StorageEventStream, StorageNotifications},
 	CallExecutor, ExecutorProvider, KeysIter, OnFinalityAction, OnImportAction, PairsIter,
-	ProofProvider, TrieCacheContext, UnpinWorkerMessage, UsageProvider,
+	ProofProvider, ProofProviderHashDb, TrieCacheContext, UnpinWorkerMessage, UsageProvider,
 };
 use sc_consensus::{
 	BlockCheckParams, BlockImportParams, ForkChoiceStrategy, ImportResult, StateAction,
@@ -57,6 +57,7 @@ use sp_blockchain::{
 	HeaderBackend as ChainHeaderBackend, HeaderMetadata, Info as BlockchainInfo,
 };
 use sp_consensus::{BlockOrigin, BlockStatus, Error as ConsensusError};
+use trie_db::NibbleVec;
 
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 use sp_core::{
@@ -87,6 +88,9 @@ use std::{
 
 use super::call_executor::LocalCallExecutor;
 use sp_core::traits::CodeExecutor;
+
+// error[E0658]: associated type defaults are unstable
+type HashDbEmplaceBatch<B> = Vec<(NibbleVec, <B as BlockT>::Hash, Vec<u8>)>;
 
 type NotificationSinks<T> = Mutex<Vec<TracingUnboundedSender<T>>>;
 
@@ -609,6 +613,10 @@ where
 						operation.op.update_transaction_index(tx_index)?;
 
 						Some((main_sc, child_sc))
+					},
+					sc_consensus::StorageChanges::Import(changes) if changes.written => {
+						operation.op.set_state_sync_done();
+						None
 					},
 					sc_consensus::StorageChanges::Import(changes) => {
 						let mut storage = sp_storage::Storage::default();
@@ -1196,6 +1204,20 @@ where
 	/// Get usage info about current client.
 	fn usage_info(&self) -> ClientInfo<Block> {
 		ClientInfo { chain: self.chain_info(), usage: self.backend.usage_info() }
+	}
+}
+
+impl<B, E, Block, RA> ProofProviderHashDb<Block> for Client<B, E, Block, RA>
+where
+	B: backend::Backend<Block>,
+	E: CallExecutor<Block>,
+	Block: BlockT,
+{
+	fn hash_db_contains(&self, prefix: &NibbleVec, hash: &Block::Hash) -> bool {
+		self.backend.hash_db_contains(prefix, hash)
+	}
+	fn hash_db_emplace_batch(&self, batch: HashDbEmplaceBatch<Block>) -> sp_blockchain::Result<()> {
+		self.backend.hash_db_emplace_batch(batch)
 	}
 }
 


### PR DESCRIPTION
# Description
Currently state sync accumulates all key-values in memory and only writes them to disk at the end.
This increases memory usage and can cause out-of-memory crash.
Also re-encoding key-values to trie nodes may be inconsistent (e.g. state v0 to v1 migration).
State sync `no_proof=false` mode responses contain original encoded trie nodes,
which can be recursively verified (block header state root hash) and written to database.

### Related issues
- #5053
- #5862
- #4

## Integration
This PR changes implementation of `StateSync` component of `sc-network-sync` crate.
Some related interfaces are also changed and propagated, to allow `StateSync` read/write `STATE` database column and mark state as available:
- `sc-client-api`: `ProofProvider`, `ProofProviderHashDb`, `Backend`
- `sc-consensus`: `ImportedState`
- `sc-client-db`: `Backend`
- `sc-service`: `Client`

## Review Notes
- `no_proof=false` contain original encoded trie nodes.
- Trie nodes are written to database in such order that parent true node is written after it's optional hashed value and child trie nodes.
- If prefix+hash (polkadot-sdk `STATE ` column contains trie prefix, which allows duplicate hash keys, but is expected to speed up rocksdb access pattern) is already in database, we can skip downloading that subtree.
- Incrementally traverse trie nodes as new responses with next trie nodes arrive.
- Write completed subtree nodes to database.
- Mark state as available after database contains all trie nodes.
- State sync needs two functions to interact with database, `contains` and `emplace_batch`.
- Trie node:
  - Can have `:child_storage:default:` trie **root** (separate tree).
  - Can have hashed value.
  - Can have hashed child trie **nodes** (same tree).
  - Can have prefix for value and children.
  - Children add their index as nibble to prefix.
- `Level`
  - Stack of `Level` for top/root trie and nested `:child_storage:default:`.
  - Has stack of child trie nodes.
  - Reuse and mutate prefix buffer.
  - Can push root or child trie node to stack, will transition to one of `ChildHash` or `ValueHash` or `Value` state.
  - Can search next child node, will transition to `Branch` or `End` state.
  - Can pop trie node after checking it's child trie root, hashed value and all child trie nodes, will transition to `Pop` state, then search next child node of parent.

### Notes
- todo: Code comments and documentation?
- need-help: Not sure about naming types/functions/...
- need-help: Should I reuse existing crate/trait `ProofProviderHashDb`, or where to add it?
- assume: Inline trie child node can't contain hash.
- assume: polkadot-sdk only supports `:child_storage:default:` of `:child_storage:` prefix.
- assume: State sync `import` can't abort sync due to invalid state root or database write error.
- improvement: May use `database.contains` instead of `database.get` when read value is not used.

# Checklist
* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
  * [x] I tested by state syncing one local network node from another.
    * [x] I tested trie with state v1 hashed values.
    * [x] I tested trie with `:child_storage:default:`.
    * [x] I tested with responses containing one new key-value, syncing one key at a time to validate transitions.
