### PR TITLE
Allow setting idle connection timeout value in custom node implementations

### DIFF
--- a/substrate/client/cli/src/params/network_params.rs
+++ b/substrate/client/cli/src/params/network_params.rs
@@ -31,7 +31,12 @@ use sc_service::{
 	config::{Multiaddr, MultiaddrWithPeerId},
 	ChainSpec, ChainType,
 };
-use std::{borrow::Cow, num::NonZeroUsize, path::PathBuf};
+use std::{borrow::Cow, num::NonZeroUsize, path::PathBuf, time::Duration};
+
+/// Default timeout for idle connections of 10 seconds is good enough for most networks.
+/// It doesn't make sense to expose it as a CLI parameter on individual nodes, but customizations
+/// are possible in custom nodes through [`NetworkConfiguration`].
+const DEFAULT_IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Parameters used to create the network configuration.
 #[derive(Debug, Clone, Args)]
@@ -273,6 +278,7 @@ impl NetworkParams {
 				enable_mdns: !is_dev && !self.no_mdns,
 				allow_private_ip,
 			},
+			idle_connection_timeout: DEFAULT_IDLE_CONNECTION_TIMEOUT,
 			max_parallel_downloads: self.max_parallel_downloads,
 			max_blocks_per_request: self.max_blocks_per_request,
 			min_peers_to_start_warp_sync: None,

--- a/substrate/client/network/src/config.rs
+++ b/substrate/client/network/src/config.rs
@@ -66,6 +66,7 @@ use std::{
 	pin::Pin,
 	str::{self, FromStr},
 	sync::Arc,
+	time::Duration,
 };
 
 /// Protocol name prefix, transmitted on the wire for legacy protocol names.
@@ -620,6 +621,9 @@ pub struct NetworkConfiguration {
 	/// Configuration for the transport layer.
 	pub transport: TransportConfig,
 
+	/// Idle connection timeout.
+	pub idle_connection_timeout: Duration,
+
 	/// Maximum number of peers to ask the same blocks in parallel.
 	pub max_parallel_downloads: u32,
 
@@ -677,6 +681,7 @@ impl NetworkConfiguration {
 			client_version: client_version.into(),
 			node_name: node_name.into(),
 			transport: TransportConfig::Normal { enable_mdns: false, allow_private_ip: true },
+			idle_connection_timeout: Duration::from_secs(10),
 			max_parallel_downloads: 5,
 			max_blocks_per_request: 64,
 			min_peers_to_start_warp_sync: None,

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -99,9 +99,6 @@ mod peerstore;
 mod service;
 mod shim;
 
-/// Timeout for connection waiting new substreams.
-const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(10);
-
 /// Litep2p bandwidth sink.
 struct Litep2pBandwidthSink {
 	sink: litep2p::BandwidthSink,
@@ -519,9 +516,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 			.with_connection_limits(ConnectionLimitsConfig::default().max_incoming_connections(
 				Some(crate::MAX_CONNECTIONS_ESTABLISHED_INCOMING as usize),
 			))
-			// This has the same effect as `libp2p::Swarm::with_idle_connection_timeout` which is
-			// set to 10 seconds as well.
-			.with_keep_alive_timeout(KEEP_ALIVE_TIMEOUT)
+			.with_keep_alive_timeout(network_config.idle_connection_timeout)
 			.with_executor(executor);
 
 		if let Some(config) = maybe_mdns_config {

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -549,7 +549,7 @@ where
 					// necessary. See <https://github.com/paritytech/substrate/pull/6080>
 					.with_per_connection_event_buffer_size(24)
 					.with_max_negotiating_inbound_streams(2048)
-					.with_idle_connection_timeout(Duration::from_secs(10));
+					.with_idle_connection_timeout(network_config.idle_connection_timeout);
 
 				Swarm::new(transport, behaviour, local_peer_id, config)
 			};


### PR DESCRIPTION
Allow setting idle connection timeout value. This can be helpful in custom networks to allow maintaining long-lived connections.