### PR TITLE
feat(cumulus): Adds support for additional relay state keys in parachain validation data inherent

### DIFF
--- a/cumulus/client/consensus/aura/src/collator.rs
+++ b/cumulus/client/consensus/aura/src/collator.rs
@@ -137,6 +137,7 @@ where
 			relay_parent_descendants
 				.map(RelayParentData::into_inherent_descendant_list)
 				.unwrap_or_default(),
+			Vec::new(),
 		)
 		.await;
 

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -368,6 +368,7 @@ where
 					parent_hash,
 					slot_claim.timestamp(),
 					Some(rp_data),
+					Vec::new(),
 				)
 				.await
 			{

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -368,7 +368,6 @@ where
 					parent_hash,
 					slot_claim.timestamp(),
 					Some(rp_data),
-					Vec::new(),
 				)
 				.await
 			{

--- a/prdoc/pr_9262.prdoc
+++ b/prdoc/pr_9262.prdoc
@@ -1,0 +1,10 @@
+title: 'Adds support for additional relay state keys in parachain validation data inherent'
+doc:
+- audience: Node Dev
+  description: |-
+    Adds the possibility for parachain clients to collect additional relay state keys into the validation data inherent.
+crates:
+- name: cumulus-client-consensus-aura
+  bump: patch
+- name: cumulus-client-parachain-inherent
+  bump: major


### PR DESCRIPTION
Adds the possibility for parachain clients to collect additional relay state keys into the validation data inherent.

With this change, other consensus engines can collect additional relay keys into the parachain inherent data:
```rs
let paras_inherent_data = ParachainInherentDataProvider::create_at(
  relay_parent,
  relay_client,
  validation_data,
  para_id,
  vec![
     relay_well_known_keys::EPOCH_INDEX.to_vec() // <----- Example
  ],
)
.await;
```