### PR TITLE
WIP: pallet-revive: Raise contract size limit to one megabyte and raise call depth to 25

### DIFF
--- a/substrate/frame/revive/fixtures/contracts/call_and_returncode.rs
+++ b/substrate/frame/revive/fixtures/contracts/call_and_returncode.rs
@@ -21,6 +21,8 @@
 #![no_main]
 include!("../panic_handler.rs");
 
+polkavm_derive::min_stack_size!(256 * 1024);
+
 use uapi::{input, u256_bytes, HostFn, HostFnImpl as api};
 
 #[no_mangle]
@@ -38,7 +40,7 @@ pub extern "C" fn call() {
 	);
 
 	// the first 4 bytes are reserved for the return code
-	let mut output = [0u8; 512];
+	let mut output = [0u8; 128 * 1024];
 	let output_ptr = &mut &mut output[4..];
 
 	let code = match api::call(

--- a/substrate/frame/revive/fixtures/contracts/oom_ro.rs
+++ b/substrate/frame/revive/fixtures/contracts/oom_ro.rs
@@ -25,7 +25,7 @@ include!("../panic_handler.rs");
 
 use uapi::{HostFn, HostFnImpl as api, ReturnFlags};
 
-static BUFFER: [u8; 1025 * 1024] = [0; 1025 * 1024];
+static BUFFER: [u8; 1024 * 1024] = [0; 1024 * 1024];
 
 #[no_mangle]
 #[polkavm_derive::polkavm_export]

--- a/substrate/frame/revive/fixtures/contracts/oom_rw_trailing.rs
+++ b/substrate/frame/revive/fixtures/contracts/oom_rw_trailing.rs
@@ -25,9 +25,9 @@ include!("../panic_handler.rs");
 
 use uapi::{HostFn, HostFnImpl as api, ReturnFlags};
 
-static mut BUFFER: [u8; 2 * 1025 * 1024] = [0; 2 * 1025 * 1024];
+static mut BUFFER: [u8; 2 * 1024 * 1024] = [0; 2 * 1024 * 1024];
 
-unsafe fn buffer() -> &'static [u8; 2 * 1025 * 1024] {
+unsafe fn buffer() -> &'static [u8; 2 * 1024 * 1024] {
 	let ptr = core::ptr::addr_of!(BUFFER);
 	&*ptr
 }

--- a/substrate/frame/revive/fixtures/contracts/return_sized.rs
+++ b/substrate/frame/revive/fixtures/contracts/return_sized.rs
@@ -15,29 +15,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This creates a large rw section but with its contents
-//! included into the blob. It should be rejected for its
-//! blob size.
-
 #![no_std]
 #![no_main]
 include!("../panic_handler.rs");
 
-use uapi::{HostFn, HostFnImpl as api, ReturnFlags};
+polkavm_derive::min_stack_size!(512 * 1024);
 
-static mut BUFFER: [u8; 1024 * 1024] = [42; 1024 * 1024];
-
-unsafe fn buffer() -> &'static [u8; 1024 * 1024] {
-	let ptr = core::ptr::addr_of!(BUFFER);
-	&*ptr
-}
-
-#[no_mangle]
-#[polkavm_derive::polkavm_export]
-pub unsafe extern "C" fn call_never() {
-	// make sure the buffer is not optimized away
-	api::return_value(ReturnFlags::empty(), buffer());
-}
+use uapi::{ReturnFlags, input, HostFn, HostFnImpl as api};
 
 #[no_mangle]
 #[polkavm_derive::polkavm_export]
@@ -45,4 +29,12 @@ pub extern "C" fn deploy() {}
 
 #[no_mangle]
 #[polkavm_derive::polkavm_export]
-pub extern "C" fn call() {}
+pub extern "C" fn call() {
+	input!(
+		return_size: u32,
+	);
+
+	let return_buf = [42u8; 256 * 1024];
+	api::return_value(ReturnFlags::empty(), &return_buf[..return_size as usize])
+
+}

--- a/substrate/frame/revive/src/benchmarking.rs
+++ b/substrate/frame/revive/src/benchmarking.rs
@@ -124,9 +124,7 @@ mod benchmarks {
 	// is not in the first basic block is never read. We are primarily interested in the
 	// `proof_size` result of this benchmark.
 	#[benchmark(pov_mode = Measured)]
-	fn call_with_code_per_byte(
-		c: Linear<0, { limits::code::STATIC_MEMORY_BYTES / limits::code::BYTES_PER_INSTRUCTION }>,
-	) -> Result<(), BenchmarkError> {
+	fn call_with_code_per_byte(c: Linear<0, { 100 * 1024 }>) -> Result<(), BenchmarkError> {
 		let instance =
 			Contract::<T>::with_caller(whitelisted_caller(), VmBinaryModule::sized(c), vec![])?;
 		let value = Pallet::<T>::min_balance();
@@ -184,8 +182,8 @@ mod benchmarks {
 	// `i`: Size of the input in bytes.
 	#[benchmark(pov_mode = Measured)]
 	fn instantiate_with_code(
-		c: Linear<0, { limits::code::STATIC_MEMORY_BYTES / limits::code::BYTES_PER_INSTRUCTION }>,
-		i: Linear<0, { limits::code::BLOB_BYTES }>,
+		c: Linear<0, { 100 * 1024 }>,
+		i: Linear<0, { limits::CALLDATA_BYTES }>,
 	) {
 		let input = vec![42u8; i as usize];
 		let salt = [42u8; 32];
@@ -223,7 +221,7 @@ mod benchmarks {
 	// `i`: Size of the input in bytes.
 	// `s`: Size of e salt in bytes.
 	#[benchmark(pov_mode = Measured)]
-	fn instantiate(i: Linear<0, { limits::code::BLOB_BYTES }>) -> Result<(), BenchmarkError> {
+	fn instantiate(i: Linear<0, { limits::CALLDATA_BYTES }>) -> Result<(), BenchmarkError> {
 		let input = vec![42u8; i as usize];
 		let salt = [42u8; 32];
 		let value = Pallet::<T>::min_balance();
@@ -310,9 +308,7 @@ mod benchmarks {
 	// It creates a maximum number of metering blocks per byte.
 	// `c`: Size of the code in bytes.
 	#[benchmark(pov_mode = Measured)]
-	fn upload_code(
-		c: Linear<0, { limits::code::STATIC_MEMORY_BYTES / limits::code::BYTES_PER_INSTRUCTION }>,
-	) {
+	fn upload_code(c: Linear<0, { 100 * 1024 }>) {
 		let caller = whitelisted_caller();
 		T::Currency::set_balance(&caller, caller_funding::<T>());
 		let VmBinaryModule { code, hash, .. } = VmBinaryModule::sized(c);
@@ -933,7 +929,7 @@ mod benchmarks {
 	}
 
 	#[benchmark(pov_mode = Measured)]
-	fn seal_return(n: Linear<0, { limits::code::BLOB_BYTES - 4 }>) {
+	fn seal_return(n: Linear<0, { limits::CALLDATA_BYTES }>) {
 		build_runtime!(runtime, memory: [n.to_le_bytes(), vec![42u8; n as usize], ]);
 
 		let result;
@@ -1590,7 +1586,7 @@ mod benchmarks {
 	// d: 1 if the associated pre-compile has a contract info that needs to be loaded
 	// i: size of the input data
 	#[benchmark(pov_mode = Measured)]
-	fn seal_call_precompile(d: Linear<0, 1>, i: Linear<0, { limits::code::BLOB_BYTES }>) {
+	fn seal_call_precompile(d: Linear<0, 1>, i: Linear<0, { limits::CALLDATA_BYTES - 100 }>) {
 		use alloy_core::sol_types::SolInterface;
 		use precompiles::{BenchmarkNoInfo, BenchmarkWithInfo, BuiltinPrecompile, IBenchmarking};
 
@@ -1610,7 +1606,7 @@ mod benchmarks {
 		let value_len = value_bytes.len() as u32;
 
 		let input_bytes = IBenchmarking::IBenchmarkingCalls::bench(IBenchmarking::benchCall {
-			input: vec![42; i as usize].into(),
+			input: vec![42_u8; i as usize].into(),
 		})
 		.abi_encode();
 		let input_len = input_bytes.len() as u32;
@@ -1689,7 +1685,7 @@ mod benchmarks {
 	// t: value to transfer
 	// i: size of input in bytes
 	#[benchmark(pov_mode = Measured)]
-	fn seal_instantiate(i: Linear<0, { limits::code::BLOB_BYTES }>) -> Result<(), BenchmarkError> {
+	fn seal_instantiate(i: Linear<0, { limits::CALLDATA_BYTES }>) -> Result<(), BenchmarkError> {
 		let code = VmBinaryModule::dummy();
 		let hash = Contract::<T>::with_index(1, VmBinaryModule::dummy(), vec![])?.info()?.code_hash;
 		let hash_bytes = hash.encode();

--- a/substrate/frame/revive/src/call_builder.rs
+++ b/substrate/frame/revive/src/call_builder.rs
@@ -39,7 +39,7 @@ use alloc::{vec, vec::Vec};
 use frame_support::{storage::child, traits::fungible::Mutate};
 use frame_system::RawOrigin;
 use pallet_revive_fixtures::bench as bench_fixtures;
-use sp_core::{Get, H160, H256, U256};
+use sp_core::{H160, H256, U256};
 use sp_io::hashing::keccak_256;
 use sp_runtime::traits::{Bounded, Hash};
 
@@ -202,8 +202,7 @@ where
 
 /// The deposit limit we use for benchmarks.
 pub fn default_deposit_limit<T: Config>() -> BalanceOf<T> {
-	(T::DepositPerByte::get() * 1024u32.into() * 1024u32.into()) +
-		T::DepositPerItem::get() * 1024u32.into()
+	<BalanceOf<T>>::max_value()
 }
 
 /// The funding that each account that either calls or instantiates contracts is funded with.

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -393,7 +393,7 @@ pub mod pallet {
 		DecodingFailed = 0x0A,
 		/// Contract trapped during execution.
 		ContractTrapped = 0x0B,
-		/// The size defined in `T::MaxValueSize` was exceeded.
+		/// Event body or storage item exceeds [`limit::PAYLOAD_BYTES`].
 		ValueTooLarge = 0x0C,
 		/// Termination of a contract is not allowed while the contract is already
 		/// on the call stack. Can be triggered by `seal_terminate`.
@@ -472,8 +472,12 @@ pub mod pallet {
 		InvalidGenericTransaction = 0x2D,
 		/// The refcount of a code either over or underflowed.
 		RefcountOverOrUnderflow = 0x2E,
-		/// Unsupported precompile address
+		/// Unsupported precompile address.
 		UnsupportedPrecompileAddress = 0x2F,
+		/// The calldata exceeds [`limits::CALLDATA_BYTES`].
+		CallDataTooLarge = 0x30,
+		/// The return data exceeds [`limits::CALLDATA_BYTES`].
+		ReturnDataTooLarge = 0x31,
 	}
 
 	/// A reason for the pallet contracts placing a hold on funds.
@@ -552,51 +556,29 @@ pub mod pallet {
 		}
 
 		fn integrity_test() {
-			use limits::code::STATIC_MEMORY_BYTES;
-
 			assert!(T::ChainId::get() > 0, "ChainId must be greater than 0");
 
 			// The memory available in the block building runtime
 			let max_runtime_mem: u32 = T::RuntimeMemory::get();
-			// The root frame is not accounted in CALL_STACK_DEPTH
-			let max_call_depth =
-				limits::CALL_STACK_DEPTH.checked_add(1).expect("CallStack size is too big");
-			// Transient storage uses a BTreeMap, which has overhead compared to the raw size of
-			// key-value data. To ensure safety, a margin of 2x the raw key-value size is used.
-			let max_transient_storage_size = limits::TRANSIENT_STORAGE_BYTES
-				.checked_mul(2)
-				.expect("MaxTransientStorageSize is too large");
 
 			// We only allow 50% of the runtime memory to be utilized by the contracts call
 			// stack, keeping the rest for other facilities, such as PoV, etc.
 			const TOTAL_MEMORY_DEVIDER: u32 = 2;
 
-			// The inefficiencies of the freeing-bump allocator
-			// being used in the client for the runtime memory allocations, could lead to possible
-			// memory allocations grow up to `x4` times in some extreme cases.
-			const MEMORY_ALLOCATOR_INEFFICENCY_DEVIDER: u32 = 4;
+			// Check that the configured memory limits fit into runtime memory.
+			//
+			// Dynamic allocations are not available, yet. Hence they are not taken into
+			// consideration here.
+			let memory_left = i64::from(max_runtime_mem)
+				.saturating_div(TOTAL_MEMORY_DEVIDER.into())
+				.saturating_sub(limits::MEMORY_REQUIRED.into());
 
-			// Check that the configured `STATIC_MEMORY_BYTES` fits into runtime memory.
-			//
-			// `STATIC_MEMORY_BYTES` is the amount of memory that a contract can consume
-			// in memory and is enforced at upload time.
-			//
-			// Dynamic allocations are not available, yet. Hence are not taken into consideration
-			// here.
-			let static_memory_limit = max_runtime_mem
-				.saturating_div(TOTAL_MEMORY_DEVIDER)
-				.saturating_sub(max_transient_storage_size)
-				.saturating_div(max_call_depth)
-				.saturating_sub(STATIC_MEMORY_BYTES)
-				.saturating_div(MEMORY_ALLOCATOR_INEFFICENCY_DEVIDER);
+			log::debug!(target: LOG_TARGET, "Integrity check: memory_left={} KB", memory_left / 1024);
 
 			assert!(
-				STATIC_MEMORY_BYTES < static_memory_limit,
-				"Given `CallStack` height {:?}, `STATIC_MEMORY_LIMIT` should be set less than {:?} \
-				 (current value is {:?}), to avoid possible runtime oom issues.",
-				max_call_depth,
-				static_memory_limit,
-				STATIC_MEMORY_BYTES,
+				memory_left >= 0,
+				"Runtime does not have enough memory for current limits. Additional runtime memory required: {} KB",
+				memory_left.saturating_mul(TOTAL_MEMORY_DEVIDER.into()).abs() / 1024
 			);
 
 			// Validators are configured to be able to use more memory than block builders. This is

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -3357,6 +3357,35 @@ fn balance_api_returns_free_balance() {
 }
 
 #[test]
+fn call_depth_is_enforced() {
+	let (binary, _code_hash) = compile_module("recurse").unwrap();
+	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		let extra_recursions = 1024;
+
+		let Contract { addr, .. } =
+			builder::bare_instantiate(Code::Upload(binary.to_vec())).build_and_unwrap_contract();
+
+		// takes the number of recursions
+		// returns the number of left over recursions
+		assert_eq!(
+			u32::from_le_bytes(
+				builder::bare_call(addr)
+					.data((limits::CALL_STACK_DEPTH + extra_recursions).encode())
+					.build_and_unwrap_result()
+					.data
+					.try_into()
+					.unwrap()
+			),
+			// + 1 because when the call depth is reached the caller contract is trapped without
+			// the ability to return any data. hence the last call frame is untracked.
+			extra_recursions + 1,
+		);
+	});
+}
+
+#[test]
 fn gas_consumed_is_linear_for_nested_calls() {
 	let (code, _code_hash) = compile_module("recurse").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
@@ -3370,7 +3399,10 @@ fn gas_consumed_is_linear_for_nested_calls() {
 				.iter()
 				.map(|i| {
 					let result = builder::bare_call(addr).data(i.encode()).build();
-					assert_ok!(result.result);
+					assert_eq!(
+						u32::from_le_bytes(result.result.unwrap().data.try_into().unwrap()),
+						0
+					);
 					result.gas_consumed
 				})
 				.collect::<Vec<_>>()
@@ -4782,6 +4814,38 @@ fn precompiles_work() {
 			Panic::from(PanicKind::ResourceError).abi_encode(),
 			RuntimeReturnCode::CalleeReverted,
 		),
+		(
+			INoInfo::INoInfoCalls::passData(INoInfo::passDataCall {
+				inputLen: limits::CALLDATA_BYTES,
+			})
+			.abi_encode(),
+			Vec::new(),
+			RuntimeReturnCode::Success,
+		),
+		(
+			INoInfo::INoInfoCalls::passData(INoInfo::passDataCall {
+				inputLen: limits::CALLDATA_BYTES + 1,
+			})
+			.abi_encode(),
+			Vec::new(),
+			RuntimeReturnCode::CalleeTrapped,
+		),
+		(
+			INoInfo::INoInfoCalls::returnData(INoInfo::returnDataCall {
+				returnLen: limits::CALLDATA_BYTES - 4,
+			})
+			.abi_encode(),
+			vec![42u8; limits::CALLDATA_BYTES as usize - 4],
+			RuntimeReturnCode::Success,
+		),
+		(
+			INoInfo::INoInfoCalls::returnData(INoInfo::returnDataCall {
+				returnLen: limits::CALLDATA_BYTES + 1,
+			})
+			.abi_encode(),
+			vec![],
+			RuntimeReturnCode::CalleeTrapped,
+		),
 	];
 
 	for (input, output, error_code) in cases {
@@ -4931,5 +4995,143 @@ fn code_size_for_precompiles_works() {
 		builder::bare_call(addr)
 			.data((&builtin_precompile, 5u64).encode())
 			.build_and_unwrap_result();
+	});
+}
+
+#[test]
+fn call_data_limit_is_enforced_subcalls() {
+	let (code, _code_hash) = compile_module("call_with_input_size").unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000);
+		let Contract { addr, .. } =
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
+
+		let cases: Vec<(u32, Box<dyn FnOnce(_)>)> = vec![
+			(
+				0_u32,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				1_u32,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				limits::CALLDATA_BYTES,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				limits::CALLDATA_BYTES + 1,
+				Box::new(|result| {
+					assert_err!(result, <Error<Test>>::CallDataTooLarge);
+				}),
+			),
+		];
+
+		for (callee_input_size, assert_result) in cases {
+			let result = builder::bare_call(addr).data(callee_input_size.encode()).build().result;
+			assert_result(result);
+		}
+	});
+}
+
+#[test]
+fn call_data_limit_is_enforced_root_call() {
+	let (code, _code_hash) = compile_module("dummy").unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000);
+		let Contract { addr, .. } =
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
+
+		let cases: Vec<(H160, u32, Box<dyn FnOnce(_)>)> = vec![
+			(
+				addr,
+				0_u32,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				addr,
+				1_u32,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				addr,
+				limits::CALLDATA_BYTES,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				addr,
+				limits::CALLDATA_BYTES + 1,
+				Box::new(|result| {
+					assert_err!(result, <Error<Test>>::CallDataTooLarge);
+				}),
+			),
+			(
+				// limit is not enforced when tx calls EOA
+				BOB_ADDR,
+				limits::CALLDATA_BYTES + 1,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+		];
+
+		for (addr, callee_input_size, assert_result) in cases {
+			let result = builder::bare_call(addr)
+				.data(vec![42; callee_input_size as usize])
+				.build()
+				.result;
+			assert_result(result);
+		}
+	});
+}
+
+#[test]
+fn return_data_limit_is_enforced() {
+	let (code, _code_hash) = compile_module("return_sized").unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000);
+		let Contract { addr, .. } =
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
+
+		let cases: Vec<(u32, Box<dyn FnOnce(_)>)> = vec![
+			(
+				1_u32,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				limits::CALLDATA_BYTES,
+				Box::new(|result| {
+					assert_ok!(result);
+				}),
+			),
+			(
+				limits::CALLDATA_BYTES + 1,
+				Box::new(|result| {
+					assert_err!(result, <Error<Test>>::ReturnDataTooLarge);
+				}),
+			),
+		];
+
+		for (return_size, assert_result) in cases {
+			let result = builder::bare_call(addr).data(return_size.encode()).build().result;
+			assert_result(result);
+		}
 	});
 }

--- a/substrate/frame/revive/src/tests/precompiles.rs
+++ b/substrate/frame/revive/src/tests/precompiles.rs
@@ -20,7 +20,7 @@
 use crate::{
 	exec::{ErrorOrigin, ExecError},
 	precompiles::{AddressMatcher, Error, Ext, ExtWithInfo, Precompile, Token},
-	Config, DispatchError, Origin, Weight,
+	Config, DispatchError, Origin, Weight, U256,
 };
 use alloc::vec::Vec;
 use alloy_core::{
@@ -44,6 +44,8 @@ sol! {
 		function errors() external;
 		function consumeMaxGas() external;
 		function callRuntime(bytes memory call) external;
+		function passData(uint32 inputLen) external;
+		function returnData(uint32 returnLen) external returns (bytes);
 	}
 }
 
@@ -105,6 +107,20 @@ impl<T: Config> Precompile for NoInfo<T> {
 						Err(Error::Error(ExecError { error: e.error, origin: ErrorOrigin::Caller })),
 				}
 			},
+			INoInfoCalls::passData(INoInfo::passDataCall { inputLen }) => {
+				env.call(
+					Weight::MAX,
+					U256::MAX,
+					&env.address(),
+					0.into(),
+					vec![42; *inputLen as usize],
+					true,
+					false,
+				)?;
+				Ok(Vec::new())
+			},
+			INoInfoCalls::returnData(INoInfo::returnDataCall { returnLen }) =>
+				Ok(vec![42; *returnLen as usize]),
 		}
 	}
 }


### PR DESCRIPTION
This PR changes the contract code limit from roughly 100KiB to exactly 1MiB. It also raises the call stack depth from 5 to 25.

Those limits were in place because of memory constraints within the runtime. We work around them in those ways:
1) Removing the 4x safety margin for allocations which is no longer needed due to the new allocator.
2) Limiting the size of the compilation cache to a fixed size.
3) Resetting the compilation cache and flat map every time we call into a new contract.

## 1MiB contracts

This is large enough so that all known contracts won't fail for size issues anymore. 

The new limit is also much simpler to understand since it does not depend on the number of instructions. Just those two constraints:
```
PVM_BLOB.len() < 1 MiB
PVM_BLOB.len() + (rw/ro/stack) < 1MiB + 512KiB
```

This means:
1) A contract is guaranteed to have at least 512KiB of memory available.
2) A contract that is smaller in code can use more memory.
3) Limit is exactly 1MiB unless a user manually increase the memory usage of a contract to be larger than 512KiB. 

## Call stack depth `5 -> 25`

The limit of `5` was problematic because there are use cases which require deeper stacks. With the raise to `25` there should be no benign use cases anymore that won't work.

Please note that even with the low limit of `25` contracts are not vulnerable to stack depth exhaustion attacks: We do trap the caller's context when the depth limit is reached. This is different from Eth where this error can be handled and failure to do so leaves the contract vulnerable.

## TODO

We are still missing the actual things that make those bigger contracts possible. However, all the calculations are in place.

- [ ] Make use of https://github.com/paritytech/polkavm/issues/315
- [ ] Wait for new PolkaVM release with above changes
- [ ] Either wait for https://github.com/paritytech/polkadot-sdk/pull/8992 to be merged or be sure that we don't a large safety margin for the current one