### PR TITLE
Add duplicate dependencies check in CI

### DIFF
--- a/.github/scripts/check-duplicated-deps.py
+++ b/.github/scripts/check-duplicated-deps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""
+A script to check for duplicated dependencies across [dependencies] and [dev-dependencies]
+in all Cargo.toml files in the workspace.
+
+This is useful for CI to enforce clean separation between runtime and dev-only dependencies.
+
+A duplicated dependency is one that appears in both sections with the exact same configuration,
+which is usually unnecessary and should be avoided.
+
+# Example
+
+```sh
+python3 -m pip install toml
+.github/scripts/check-duplicated-deps.py
+"""
+
+#!/usr/bin/env python3
+import os
+import sys
+
+import toml
+
+
+def find_cargo_toml_files(root='.'):
+    cargo_files = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        if 'target' in dirnames:
+            dirnames.remove('target')
+        if 'Cargo.toml' in filenames:
+            cargo_files.append(os.path.join(dirpath, 'Cargo.toml'))
+    return cargo_files
+
+def parse_dependencies(file_path):
+    try:
+        data = toml.load(file_path)
+    except Exception as e:
+        print(f"Error parsing {file_path}: {e}", file=sys.stderr)
+        return {}, {}
+
+    deps = data.get("dependencies", {})
+    dev_deps = data.get("dev-dependencies", {})
+    return deps, dev_deps
+
+def format_dep_config(config):
+    if isinstance(config, str):
+        return {"version": config}
+    elif isinstance(config, dict):
+        return dict(sorted(config.items()))
+    else:
+        return {}
+
+def main():
+    files = find_cargo_toml_files()
+    any_duplicates = False
+
+    for file_path in files:
+        deps, dev_deps = parse_dependencies(file_path)
+
+        duplicates = []
+        for dep_name, dep_config in deps.items():
+            if dep_name in dev_deps:
+                config1 = format_dep_config(dep_config)
+                config2 = format_dep_config(dev_deps[dep_name])
+                if config1 == config2:
+                    duplicates.append(dep_name)
+
+        if duplicates:
+            any_duplicates = True
+            print(f"❌ Duplicated dependencies in {file_path}:")
+            for dep in sorted(duplicates):
+                print(f"   - {dep}")
+
+    if any_duplicates:
+        print("\n🚫 CI check failed due to duplicated dependencies.")
+        sys.exit(1)
+    else:
+        print("✅ No duplicated dependencies found.")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/tests-misc.yml
+++ b/.github/workflows/tests-misc.yml
@@ -394,6 +394,7 @@ jobs:
       - cargo-check-each-crate
       - test-deterministic-wasm
       - cargo-check-all-crate-macos
+      - check-duplicated-deps
       # - cargo-hfuzz remove from required for now, as it's flaky
     if: always() && !cancelled()
     steps:
@@ -406,3 +407,22 @@ jobs:
           else
             echo '### Good job! All the required jobs passed 🚀' >> $GITHUB_STEP_SUMMARY
           fi
+
+  check-duplicated-deps:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    if: ${{ needs.preflight.outputs.changes_rust }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: python3 -m pip install toml
+
+      - name: Run duplicated dependency check
+        run: python3 .github/scripts/check-duplicated-deps.py


### PR DESCRIPTION
# Description

Adds a duplicate dependencies check as part of the CI checks

A duplicate dependency is the one that is present in both `[dependencies]` and `[dev-dependencies]` section

This PR depends on https://github.com/paritytech/polkadot-sdk/pull/9233 to solve all duplicates before start running the new check in future PRs