### PR TITLE
Replace `log` with `tracing` on `pallet-bridge-grandpa`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11516,7 +11516,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "parity-scale-codec",
  "scale-info",
  "sp-consensus-grandpa",
@@ -11524,6 +11523,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 14.0.0",
+ "tracing",
 ]
 
 [[package]]

--- a/bridges/modules/grandpa/Cargo.toml
+++ b/bridges/modules/grandpa/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 
 [dependencies]
 codec = { workspace = true }
-log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
+tracing = { workspace = true }
 
 # Bridge Dependencies
 bp-header-chain = { workspace = true }
@@ -47,11 +47,11 @@ std = [
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
-	"log/std",
 	"scale-info/std",
 	"sp-consensus-grandpa/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"tracing/std",
 ]
 runtime-benchmarks = [
 	"bp-test-utils",

--- a/bridges/modules/grandpa/src/call_ext.rs
+++ b/bridges/modules/grandpa/src/call_ext.rs
@@ -101,8 +101,10 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 				if improved_by < free_headers_interval.into() {
 					tracing::trace!(
 						target: crate::LOG_TARGET,
+						?improved_by,
+						%free_headers_interval,
 						"Cannot accept free {:?} header {:?}. Too small difference \
-						between submitted headers: {improved_by:?} vs {free_headers_interval}",
+						between submitted headers",
 						T::BridgedChain::ID,
 						call_info.block_number,
 					);

--- a/bridges/modules/grandpa/src/call_ext.rs
+++ b/bridges/modules/grandpa/src/call_ext.rs
@@ -87,9 +87,9 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 		if !Self::has_free_header_slots() {
 			tracing::trace!(
 				target: crate::LOG_TARGET,
-				"Cannot accept free {:?} header {:?}. No more free slots remaining",
-				T::BridgedChain::ID,
-				call_info.block_number,
+				chain_id=?T::BridgedChain::ID,
+				block_number=?call_info.block_number,
+				"Cannot accept free header. No more free slots remaining"
 			);
 
 			return Err(Error::<T, I>::FreeHeadersLimitExceded);
@@ -101,12 +101,11 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 				if improved_by < free_headers_interval.into() {
 					tracing::trace!(
 						target: crate::LOG_TARGET,
+						chain_id=?T::BridgedChain::ID,
+						block_number=?call_info.block_number,
 						?improved_by,
 						%free_headers_interval,
-						"Cannot accept free {:?} header {:?}. Too small difference \
-						between submitted headers",
-						T::BridgedChain::ID,
-						call_info.block_number,
+						"Cannot accept free header. Too small difference between submitted headers"
 					);
 
 					return Err(Error::<T, I>::BelowFreeHeaderInterval);

--- a/bridges/modules/grandpa/src/call_ext.rs
+++ b/bridges/modules/grandpa/src/call_ext.rs
@@ -85,7 +85,7 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 
 		// else - if we can not accept more free headers, "reject" the transaction
 		if !Self::has_free_header_slots() {
-			log::trace!(
+			tracing::trace!(
 				target: crate::LOG_TARGET,
 				"Cannot accept free {:?} header {:?}. No more free slots remaining",
 				T::BridgedChain::ID,
@@ -99,14 +99,12 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 		if !call_info.is_mandatory {
 			if let Some(free_headers_interval) = T::FreeHeadersInterval::get() {
 				if improved_by < free_headers_interval.into() {
-					log::trace!(
+					tracing::trace!(
 						target: crate::LOG_TARGET,
 						"Cannot accept free {:?} header {:?}. Too small difference \
-						between submitted headers: {:?} vs {}",
+						between submitted headers: {improved_by:?} vs {free_headers_interval}",
 						T::BridgedChain::ID,
 						call_info.block_number,
-						improved_by,
-						free_headers_interval,
 					);
 
 					return Err(Error::<T, I>::BelowFreeHeaderInterval);
@@ -137,10 +135,10 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 		current_set_id: Option<SetId>,
 	) -> Result<BlockNumberOf<T::BridgedChain>, Error<T, I>> {
 		let best_finalized = BestFinalized::<T, I>::get().ok_or_else(|| {
-			log::trace!(
+			tracing::trace!(
 				target: crate::LOG_TARGET,
-				"Cannot finalize header {:?} because pallet is not yet initialized",
-				finality_target,
+				header=?finality_target,
+				"Cannot finalize header because pallet is not yet initialized"
 			);
 			<Error<T, I>>::NotInitialized
 		})?;
@@ -148,11 +146,11 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 		let improved_by = match finality_target.checked_sub(&best_finalized.number()) {
 			Some(improved_by) if improved_by > Zero::zero() => improved_by,
 			_ => {
-				log::trace!(
+				tracing::trace!(
 					target: crate::LOG_TARGET,
-					"Cannot finalize obsolete header: bundled {:?}, best {:?}",
-					finality_target,
-					best_finalized,
+					bundled=?finality_target,
+					best=?best_finalized,
+					"Cannot finalize obsolete header"
 				);
 
 				return Err(Error::<T, I>::OldHeader)
@@ -162,11 +160,11 @@ impl<T: Config<I>, I: 'static> SubmitFinalityProofHelper<T, I> {
 		if let Some(current_set_id) = current_set_id {
 			let actual_set_id = <CurrentAuthoritySet<T, I>>::get().set_id;
 			if current_set_id != actual_set_id {
-				log::trace!(
+				tracing::trace!(
 					target: crate::LOG_TARGET,
-					"Cannot finalize header signed by unknown authority set: bundled {:?}, best {:?}",
-					current_set_id,
-					actual_set_id,
+					bundled=?current_set_id,
+					best=?actual_set_id,
+					"Cannot finalize header signed by unknown authority set"
 				);
 
 				return Err(Error::<T, I>::InvalidAuthoritySetId)

--- a/bridges/modules/grandpa/src/lib.rs
+++ b/bridges/modules/grandpa/src/lib.rs
@@ -335,8 +335,8 @@ pub mod pallet {
 			tracing::info!(
 				target: LOG_TARGET,
 				?hash,
-				"Successfully imported finalized header! Free: {}",
-				if may_refund_call_fee { "Yes" } else { "No" },
+				?pays_fee,
+				"Successfully imported finalized header!"
 			);
 
 			// the proof size component of the call weight assumes that there are
@@ -731,7 +731,8 @@ pub mod pallet {
 			.inspect_err(|_| {
 				tracing::error!(
 					target: LOG_TARGET,
-					"Failed to initialize bridge. Number of authorities in the set {authority_set_length} is larger than the configured value {}",
+					%authority_set_length,
+					"Failed to initialize bridge. Number of authorities in the set is larger than the configured value {}",
 					T::BridgedChain::MAX_AUTHORITIES_COUNT,
 				);
 			})?;

--- a/bridges/modules/grandpa/src/lib.rs
+++ b/bridges/modules/grandpa/src/lib.rs
@@ -219,10 +219,10 @@ pub mod pallet {
 			ensure!(init_allowed, <Error<T, I>>::AlreadyInitialized);
 			initialize_bridge::<T, I>(init_data.clone())?;
 
-			log::info!(
+			tracing::info!(
 				target: LOG_TARGET,
-				"Pallet has been initialized with the following parameters: {:?}",
-				init_data
+				parameters=?init_data,
+				"Pallet has been initialized"
 			);
 
 			Ok(().into())
@@ -292,10 +292,10 @@ pub mod pallet {
 			ensure_signed(origin)?;
 
 			let (hash, number) = (finality_target.hash(), *finality_target.number());
-			log::trace!(
+			tracing::trace!(
 				target: LOG_TARGET,
-				"Going to try and finalize header {:?}",
-				finality_target
+				header=?finality_target,
+				"Going to try and finalize header"
 			);
 
 			// it checks whether the `number` is better than the current best block number
@@ -332,10 +332,10 @@ pub mod pallet {
 			// to pay for the transaction.
 			let pays_fee = if may_refund_call_fee { Pays::No } else { Pays::Yes };
 
-			log::info!(
+			tracing::info!(
 				target: LOG_TARGET,
-				"Successfully imported finalized header with hash {:?}! Free: {}",
-				hash,
+				?hash,
+				"Successfully imported finalized header! Free: {}",
 				if may_refund_call_fee { "Yes" } else { "No" },
 			);
 
@@ -656,12 +656,12 @@ pub mod pallet {
 
 		<CurrentAuthoritySet<T, I>>::put(&next_authorities);
 
-		log::info!(
+		tracing::info!(
 			target: LOG_TARGET,
-			"Transitioned from authority set {} to {}! New authorities are: {:?}",
-			old_current_set_id,
-			new_current_set_id,
-			next_authorities,
+			%old_current_set_id,
+			%new_current_set_id,
+			?next_authorities,
+			"Transitioned from authority set!"
 		);
 
 		Ok(Some(next_authorities.into()))
@@ -687,11 +687,11 @@ pub mod pallet {
 			justification,
 		)
 		.map_err(|e| {
-			log::error!(
+			tracing::error!(
 				target: LOG_TARGET,
-				"Received invalid justification for {:?}: {:?}",
-				hash,
-				e,
+				error=?e,
+				?hash,
+				"Received invalid justification"
 			);
 			<Error<T, I>>::InvalidJustification
 		})?)
@@ -714,7 +714,7 @@ pub mod pallet {
 		// Update ring buffer pointer and remove old header.
 		<ImportedHashesPointer<T, I>>::put((index + 1) % T::HeadersToKeep::get());
 		if let Ok(hash) = pruning {
-			log::debug!(target: LOG_TARGET, "Pruning old header: {:?}.", hash);
+			tracing::debug!(target: LOG_TARGET, ?hash, "Pruning old header.");
 			<ImportedHeaders<T, I>>::remove(hash);
 		}
 	}
@@ -729,10 +729,9 @@ pub mod pallet {
 		let authority_set_length = authority_list.len();
 		let authority_set = StoredAuthoritySet::<T, I>::try_new(authority_list, set_id)
 			.inspect_err(|_| {
-				log::error!(
+				tracing::error!(
 					target: LOG_TARGET,
-					"Failed to initialize bridge. Number of authorities in the set {} is larger than the configured value {}",
-					authority_set_length,
+					"Failed to initialize bridge. Number of authorities in the set {authority_set_length} is larger than the configured value {}",
 					T::BridgedChain::MAX_AUTHORITIES_COUNT,
 				);
 			})?;

--- a/bridges/modules/grandpa/src/lib.rs
+++ b/bridges/modules/grandpa/src/lib.rs
@@ -732,8 +732,8 @@ pub mod pallet {
 				tracing::error!(
 					target: LOG_TARGET,
 					%authority_set_length,
-					"Failed to initialize bridge. Number of authorities in the set is larger than the configured value {}",
-					T::BridgedChain::MAX_AUTHORITIES_COUNT,
+					max_count=%T::BridgedChain::MAX_AUTHORITIES_COUNT,
+					"Failed to initialize bridge. Number of authorities in the set is larger than the configured value"
 				);
 			})?;
 		let initial_hash = header.hash();

--- a/prdoc/pr_9294.prdoc
+++ b/prdoc/pr_9294.prdoc
@@ -1,0 +1,8 @@
+title: Replace `log` with `tracing` on `pallet-bridge-grandpa`
+doc:
+- audience: Runtime Dev
+  description: This PR replaces `log` with `tracing` instrumentation on `pallet-bridge-grandpa`
+    by providing structured logging.
+crates:
+- name: bridge-runtime-common
+  bump: minor

--- a/prdoc/pr_9294.prdoc
+++ b/prdoc/pr_9294.prdoc
@@ -4,5 +4,5 @@ doc:
   description: This PR replaces `log` with `tracing` instrumentation on `pallet-bridge-grandpa`
     by providing structured logging.
 crates:
-- name: bridge-runtime-common
+- name: pallet-bridge-grandpa
   bump: minor


### PR DESCRIPTION
This PR replaces `log` with `tracing` instrumentation on `pallet-bridge-grandpa` by providing structured logging.

Partially addresses #9211 