### PR TITLE
poc: async backpressure for transaction notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19825,6 +19825,7 @@ dependencies = [
  "sp-consensus",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "tokio",
 ]
 
 [[package]]

--- a/substrate/client/network/transactions/Cargo.toml
+++ b/substrate/client/network/transactions/Cargo.toml
@@ -28,3 +28,4 @@ sc-network-types = { workspace = true, default-features = true }
 sc-utils = { workspace = true, default-features = true }
 sp-consensus = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
+tokio = { features = ["macros"], workspace = true, default-features = true }

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -681,7 +681,14 @@ pub async fn propagate_transaction_notifications<Block, ExPool>(
 			notification = notifications.next() => {
 				let Some(hash) = notification else { return };
 
-				tx_handler_controller.propagate_transaction(hash);
+				let mut hashes = Vec::with_capacity(8);
+				hashes.push(hash);
+				// Drain the notifications that are readily available on `notifications`.
+				while let Some(hash) = notifications.next().now_or_never().flatten() {
+					hashes.push(hash);
+				}
+
+				tx_handler_controller.propagate_transaction(hashes);
 
 				tx_imported = true;
 			},

--- a/substrate/client/transaction-pool/tests/zombienet/network-specs/rococo-local-high-pool-limit-fatp.toml
+++ b/substrate/client/transaction-pool/tests/zombienet/network-specs/rococo-local-high-pool-limit-fatp.toml
@@ -9,11 +9,14 @@ default_args = [
 	"--pool-kbytes 2048000",
 	"--pool-limit 500000",
 	"--pool-type=fork-aware",
+
 	"--rpc-max-connections 15000",
 	"--rpc-max-response-size 150",
 	"--rpc-max-subscriptions-per-connection=128000",
+
 	"--state-pruning=1024",
-	"-lsync=info",
+	"-lsync=trace",
+	"-lsub-libp2p=trace",
 	"-ltxpool=debug",
 ]
 [relaychain.genesis.runtimeGenesis.patch.balances]


### PR DESCRIPTION
This is a proof of concept/poc for for sending notifications asynchronously.

There are several benefits to this:
- notifications are sent in a background task using FuturesUnordered, allowing for parallel handling
- No twicking of constants or increase memory usage
- Uses natural backpressure, ideally every notif protocol wants this (ie, spamming disputes)

While this is still a PoC, there are a few areas that could be improved:
- No timeout for sending transactions to a peer (average time for the scenario led to 130us during each async call, with a peak of 1ms)
- Consider switching the interval timer to use Tokio interval
- Make sure tokio::select! is handled safely to avoid panics
- the transaction pool might not always have all transactions available
- Improve error handling for cases when peers disconnect or async sends fail
- Batching in substrate/client/service/src/builder.rs could be optimized (if further needed)

cc @lrubasze @skunert
