### PR TITLE
Replace `log` with `tracing` on `pallet-bridge-messages`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11537,7 +11537,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "pallet-balances",
  "pallet-bridge-grandpa",
  "parity-scale-codec",
@@ -11547,6 +11546,7 @@ dependencies = [
  "sp-runtime",
  "sp-std 14.0.0",
  "sp-trie",
+ "tracing",
 ]
 
 [[package]]

--- a/bridges/modules/messages/Cargo.toml
+++ b/bridges/modules/messages/Cargo.toml
@@ -12,8 +12,8 @@ workspace = true
 
 [dependencies]
 codec = { workspace = true }
-log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
+tracing = { workspace = true }
 
 # Bridge dependencies
 bp-header-chain = { workspace = true }
@@ -47,7 +47,6 @@ std = [
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
-	"log/std",
 	"pallet-balances/std",
 	"pallet-bridge-grandpa/std",
 	"scale-info/std",
@@ -56,6 +55,7 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-trie/std",
+	"tracing/std",
 ]
 runtime-benchmarks = [
 	"bp-runtime/test-helpers",

--- a/bridges/modules/messages/src/call_ext.rs
+++ b/bridges/modules/messages/src/call_ext.rs
@@ -189,10 +189,10 @@ impl<
 		let is_pallet_halted = Pallet::<T, I>::ensure_not_halted().is_err();
 		match self.call_info() {
 			Some(proof_info) if is_pallet_halted => {
-				log::trace!(
+				tracing::trace!(
 					target: LOG_TARGET,
-					"Rejecting messages transaction on halted pallet: {:?}",
-					proof_info
+					?proof_info,
+					"Rejecting messages transaction on halted pallet"
 				);
 
 				return sp_runtime::transaction_validity::InvalidTransaction::Call.into()
@@ -201,10 +201,10 @@ impl<
 				if proof_info
 					.is_obsolete(T::MessageDispatch::is_active(proof_info.base.lane_id)) =>
 			{
-				log::trace!(
+				tracing::trace!(
 					target: LOG_TARGET,
-					"Rejecting obsolete messages delivery transaction: {:?}",
-					proof_info
+					?proof_info,
+					"Rejecting obsolete messages delivery transaction"
 				);
 
 				return sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
@@ -212,10 +212,10 @@ impl<
 			Some(MessagesCallInfo::ReceiveMessagesDeliveryProof(proof_info))
 				if proof_info.is_obsolete() =>
 			{
-				log::trace!(
+				tracing::trace!(
 					target: LOG_TARGET,
-					"Rejecting obsolete messages confirmation transaction: {:?}",
-					proof_info,
+					?proof_info,
+					"Rejecting obsolete messages confirmation transaction"
 				);
 
 				return sp_runtime::transaction_validity::InvalidTransaction::Stale.into()

--- a/bridges/modules/messages/src/lib.rs
+++ b/bridges/modules/messages/src/lib.rs
@@ -249,7 +249,7 @@ pub mod pallet {
 			let (lane_id, lane_data) =
 				verify_and_decode_messages_proof::<T, I>(*proof, messages_count).map_err(
 					|err| {
-						log::trace!(target: LOG_TARGET, "Rejecting invalid messages proof: {:?}", err,);
+						tracing::trace!(target: LOG_TARGET, error=?err, "Rejecting invalid messages proof");
 
 						Error::<T, I>::InvalidMessagesProof
 					},
@@ -271,12 +271,12 @@ pub mod pallet {
 			if let Some(lane_state) = lane_data.lane_state {
 				let updated_latest_confirmed_nonce = lane.receive_state_update(lane_state);
 				if let Some(updated_latest_confirmed_nonce) = updated_latest_confirmed_nonce {
-					log::trace!(
+					tracing::trace!(
 						target: LOG_TARGET,
-						"Received lane {:?} state update: latest_confirmed_nonce={}. Unrewarded relayers: {:?}",
-						lane_id,
-						updated_latest_confirmed_nonce,
-						UnrewardedRelayersState::from(&lane.storage().data()),
+						?lane_id,
+						latest_confirmed_nonce=%updated_latest_confirmed_nonce,
+						unrewarded_relayers=?UnrewardedRelayersState::from(&lane.storage().data()),
+						"Received state update"
 					);
 				}
 			}
@@ -292,12 +292,12 @@ pub mod pallet {
 				// weight is not enough, let's move to next lane
 				let message_dispatch_weight = T::MessageDispatch::dispatch_weight(&mut message);
 				if message_dispatch_weight.any_gt(dispatch_weight_left) {
-					log::trace!(
+					tracing::trace!(
 						target: LOG_TARGET,
-						"Cannot dispatch any more messages on lane {:?}. Weight: declared={}, left={}",
-						lane_id,
-						message_dispatch_weight,
-						dispatch_weight_left,
+						?lane_id,
+						declared=%message_dispatch_weight,
+						left=%dispatch_weight_left,
+						"Cannot dispatch any more messages"
 					);
 
 					fail!(Error::<T, I>::InsufficientDispatchWeight);
@@ -339,13 +339,11 @@ pub mod pallet {
 				actual_weight,
 			);
 
-			log::debug!(
+			tracing::debug!(
 				target: LOG_TARGET,
-				"Received messages: total={}, valid={}. Weight used: {}/{}.",
-				total_messages,
-				valid_messages,
-				actual_weight,
-				declared_weight,
+				total=%total_messages,
+				valid=%valid_messages,
+				"Received messages. Weight used: {actual_weight}/{declared_weight}."
 			);
 
 			Self::deposit_event(Event::MessagesReceived(messages_received_status));
@@ -370,10 +368,10 @@ pub mod pallet {
 			let confirmation_relayer = ensure_signed(origin)?;
 			let (lane_id, lane_data) = proofs::verify_messages_delivery_proof::<T, I>(proof)
 				.map_err(|err| {
-					log::trace!(
+					tracing::trace!(
 						target: LOG_TARGET,
-						"Rejecting invalid messages delivery proof: {:?}",
-						err,
+						error=?err,
+						"Rejecting invalid messages delivery proof"
 					);
 
 					Error::<T, I>::InvalidMessagesDeliveryProof
@@ -421,11 +419,11 @@ pub mod pallet {
 				);
 			};
 
-			log::trace!(
+			tracing::trace!(
 				target: LOG_TARGET,
-				"Received messages delivery proof up to (and including) {} at lane {:?}",
-				last_delivered_nonce,
-				lane_id,
+				?lane_id,
+				%last_delivered_nonce,
+				"Received messages delivery proof up to (and including)"
 			);
 
 			// notify others about messages delivery
@@ -649,9 +647,12 @@ pub mod pallet {
 				}
 
 				if !unpruned_message_nonces.is_empty() {
-					log::warn!(
+					tracing::warn!(
 						target: LOG_TARGET,
-						"do_try_state_for_outbound_lanes for lane_id: {lane_id:?} with lane_data: {lane_data:?} found unpruned_message_nonces: {unpruned_message_nonces:?}",
+						?lane_id,
+						?lane_data,
+						?unpruned_message_nonces,
+						"do_try_state_for_outbound_lanes found",
 					);
 					unpruned_lanes.push((lane_id, lane_data, unpruned_message_nonces));
 				}
@@ -710,12 +711,11 @@ where
 		// return number of messages in the queue to let sender know about its state
 		let enqueued_messages = lane.data().queued_messages().saturating_len();
 
-		log::trace!(
+		tracing::trace!(
 			target: LOG_TARGET,
-			"Accepted message {} to lane {:?}. Message size: {:?}",
-			nonce,
-			args.lane_id,
-			message_len,
+			lane_id=?args.lane_id,
+			message_size=?message_len,
+			"Accepted message {nonce}"
 		);
 
 		Pallet::<T, I>::deposit_event(Event::MessageAccepted {

--- a/bridges/modules/messages/src/migration.rs
+++ b/bridges/modules/messages/src/migration.rs
@@ -116,8 +116,8 @@ pub mod v1 {
 			let number_of_inbound = InboundLanes::<T, I>::iter_keys().count();
 			let number_of_outbound = OutboundLanes::<T, I>::iter_keys().count();
 
-			log::info!(target: LOG_TARGET, "post-upgrade expects '{number_of_inbound_to_migrate}' inbound lanes to have been migrated.");
-			log::info!(target: LOG_TARGET, "post-upgrade expects '{number_of_outbound_to_migrate}' outbound lanes to have been migrated.");
+			tracing::info!(target: LOG_TARGET, "post-upgrade expects '{number_of_inbound_to_migrate}' inbound lanes to have been migrated.");
+			tracing::info!(target: LOG_TARGET, "post-upgrade expects '{number_of_outbound_to_migrate}' outbound lanes to have been migrated.");
 
 			frame_support::ensure!(
 				number_of_inbound_to_migrate as usize == number_of_inbound,
@@ -128,7 +128,7 @@ pub mod v1 {
 				"must migrate all `OutboundLanes`."
 			);
 
-			log::info!(target: LOG_TARGET, "migrated all.");
+			tracing::info!(target: LOG_TARGET, "migrated all.");
 			Ok(())
 		}
 	}

--- a/bridges/modules/messages/src/outbound_lane.rs
+++ b/bridges/modules/messages/src/outbound_lane.rs
@@ -155,11 +155,10 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 			// chain storage is corrupted, though) that the actual number of confirmed messages if
 			// larger than declared. This would mean that 'reward loop' will take more time than the
 			// weight formula accounts, so we can't allow that.
-			log::trace!(
+			tracing::trace!(
 				target: LOG_TARGET,
-				"Messages delivery proof contains too many messages to confirm: {} vs declared {}",
+				"Messages delivery proof contains too many messages to confirm: {} vs declared {max_allowed_messages}",
 				confirmed_messages.total_messages(),
-				max_allowed_messages,
 			);
 			return Err(ReceptionConfirmationError::TryingToConfirmMoreMessagesThanExpected)
 		}

--- a/prdoc/pr_9308.prdoc
+++ b/prdoc/pr_9308.prdoc
@@ -1,0 +1,8 @@
+title: Replace `log` with `tracing` on `pallet-bridge-messages`
+doc:
+- audience: Runtime Dev
+  description: This PR replaces `log` with `tracing` instrumentation on `pallet-bridge-messages`
+    by providing structured logging.
+crates:
+- name: pallet-bridge-messages
+  bump: minor


### PR DESCRIPTION
This PR replaces `log` with `tracing` instrumentation on `pallet-bridge-messages` by providing structured logging.

Partially addresses #9211 