### PR TITLE
network/kad: Increase memory store capacity for providers

### DIFF
--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -299,6 +299,12 @@ impl Discovery {
 				.with_known_peers(known_peers)
 				.with_protocol_names(protocol_names)
 				.with_incoming_records_validation_mode(IncomingRecordValidationMode::Manual)
+				// Enough time to keep the parachain bootnode record for two 4-hour epochs
+				.with_provider_record_ttl(Duration::from_secs(10 * 3600))
+				// Refresh next epoch provider record 30 minutes before next 4-hour epoch comes.
+				.with_provider_refresh_interval(Duration::from_secs(12600))
+				// Enough keys for 13 parachains on a testnet with fast runtime (1-min epoch).
+				.with_max_provider_keys(10000)
 				.build()
 		};
 


### PR DESCRIPTION
Increase Kademlia memory store capacity for DHT content providers (used by parachain DHT-based bootnodes) and reduce provider republish interval & TTL. This is needed to support testnets with 1-minute fast runtime and up to 13 parachains.

Parameters set:
- 10000 provider keys per node
- 10h provider record TTL
- 3.5h provider republish interval

Closes https://github.com/paritytech/litep2p/issues/405.