### PR TITLE
network/litep2p: Switch to system DNS resolver

### DIFF
--- a/prdoc/pr_9321.prdoc
+++ b/prdoc/pr_9321.prdoc
@@ -1,0 +1,10 @@
+title: 'network/litep2p: Switch to system DNS resolver'
+doc:
+- audience: Node Dev
+  description: |-
+    Switch to system DNS resolver instead of 8.8.8.8 that litep2p uses by default. This enables full administrator control of what upstream DNS servers to use, including resolution of local names using custom DNS servers.
+
+    Fixes https://github.com/paritytech/polkadot-sdk/issues/9298.
+crates:
+- name: sc-network
+  bump: patch

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -517,6 +517,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 				Some(crate::MAX_CONNECTIONS_ESTABLISHED_INCOMING as usize),
 			))
 			.with_keep_alive_timeout(network_config.idle_connection_timeout)
+			// Use system DNS resolver to enable intranet domain resolution and administrator
+			// control over DNS lookup.
+			.with_system_resolver()
 			.with_executor(executor);
 
 		if let Some(config) = maybe_mdns_config {


### PR DESCRIPTION
Switch to system DNS resolver instead of 8.8.8.8 that litep2p uses by default. This enables full administrator control of what upstream DNS servers to use, including resolution of local names using custom DNS servers.

Fixes https://github.com/paritytech/polkadot-sdk/issues/9298.