### PR TITLE
fix(revive-dev-node): fix instant seal

### DIFF
--- a/substrate/frame/revive/dev-node/node/src/command.rs
+++ b/substrate/frame/revive/dev-node/node/src/command.rs
@@ -126,10 +126,12 @@ pub fn run() -> sc_cli::Result<()> {
 				match config.network.network_backend {
 					sc_network::config::NetworkBackendType::Libp2p =>
 						service::new_full::<sc_network::NetworkWorker<_, _>>(config, cli.consensus)
+						.await
 							.map_err(sc_cli::Error::Service),
 					sc_network::config::NetworkBackendType::Litep2p => service::new_full::<
 						sc_network::Litep2pNetworkBackend,
 					>(config, cli.consensus)
+					.await
 					.map_err(sc_cli::Error::Service),
 				}
 			})


### PR DESCRIPTION
### Description
This applies the fix for `instant-seal` from #9207 to the `revive-dev-node`