### PR TITLE
fix: :bug: use `MaxKeys` from `pallet-im-online`'s Config trait instead of hardcoded one in benchmarks

### DIFF
--- a/substrate/frame/im-online/src/benchmarking.rs
+++ b/substrate/frame/im-online/src/benchmarking.rs
@@ -29,8 +29,6 @@ use sp_runtime::{
 
 use crate::*;
 
-const MAX_KEYS: u32 = 1000;
-
 pub fn create_heartbeat<T: Config>(
 	k: u32,
 ) -> Result<
@@ -67,7 +65,7 @@ mod benchmarks {
 	use super::*;
 
 	#[benchmark(extra)]
-	fn heartbeat(k: Linear<1, MAX_KEYS>) -> Result<(), BenchmarkError> {
+	fn heartbeat(k: Linear<1, { <T as Config>::MaxKeys::get() }>) -> Result<(), BenchmarkError> {
 		let (input_heartbeat, signature) = create_heartbeat::<T>(k)?;
 
 		#[extrinsic_call]
@@ -77,7 +75,9 @@ mod benchmarks {
 	}
 
 	#[benchmark(extra)]
-	fn validate_unsigned(k: Linear<1, MAX_KEYS>) -> Result<(), BenchmarkError> {
+	fn validate_unsigned(
+		k: Linear<1, { <T as Config>::MaxKeys::get() }>,
+	) -> Result<(), BenchmarkError> {
 		let (input_heartbeat, signature) = create_heartbeat::<T>(k)?;
 		let call = Call::heartbeat { heartbeat: input_heartbeat, signature };
 
@@ -91,7 +91,9 @@ mod benchmarks {
 	}
 
 	#[benchmark]
-	fn validate_unsigned_and_then_heartbeat(k: Linear<1, MAX_KEYS>) -> Result<(), BenchmarkError> {
+	fn validate_unsigned_and_then_heartbeat(
+		k: Linear<1, { <T as Config>::MaxKeys::get() }>,
+	) -> Result<(), BenchmarkError> {
 		let (input_heartbeat, signature) = create_heartbeat::<T>(k)?;
 		let call = Call::heartbeat { heartbeat: input_heartbeat, signature };
 		let call_enc = call.encode();


### PR DESCRIPTION
This PR is a simple fix for issue #9324, by making the benchmarks of `pallet-im-online` linear up to `pallet_im_online::Config::MaxKeys` instead of the hardcoded constant `MAX_KEYS = 1000`.