### PR TITLE
fatxpool: instant seal support

### DIFF
--- a/prdoc/pr_9338.prdoc
+++ b/prdoc/pr_9338.prdoc
@@ -2,19 +2,7 @@ title: 'fatxpool: manual seal support'
 doc:
 - audience: Node Dev
   description: |-
-    This PR introduces creation of view for genesis block during instantiation of `fatxpool`. This is intended to fix an instant-seal nodes, where block building is [triggered](https://github.com/paritytech/polkadot-sdk/blob/73b44193c8e66acd699f04265027289d030f6c66/substrate/client/consensus/manual-seal/src/lib.rs#L238) via transaction import. Without views, no event is generated on this stream when transaction is submitted.
-
-    ##### Notes for reviewers
-    Views is injected once after an empty fatxpool is instantiated by any of `new_*` functions. Small refactor was done to re-use the code. Tests were adjusted to match new behavior.
-
-    Seems that it is the easiest fix that we can do.
-
-
-    Todo:
-    [ ] run integrations tests,
-    [x] confirm the fix with minimal-node,
-
-    Fixes: #9323
+    This PR introduces creation of view for genesis block during instantiation of `fatxpool`. This is intended to fix an instant-seal nodes, where block building is triggered  via transaction import.
 crates:
 - name: sc-transaction-pool
   bump: patch

--- a/prdoc/pr_9338.prdoc
+++ b/prdoc/pr_9338.prdoc
@@ -2,7 +2,7 @@ title: 'fatxpool: manual seal support'
 doc:
 - audience: Node Dev
   description: |-
-    This PR introduces creation of view for genesis block during instantiation of `fatxpool`. This is intended to fix an instant-seal nodes, where block building is triggered  via transaction import.
+    This PR introduces creation of view for known best block during instantiation of `fatxpool`. This is intended to fix an instant-seal nodes, where block building is triggered  via transaction import.
 crates:
 - name: sc-transaction-pool
   bump: patch

--- a/prdoc/pr_9338.prdoc
+++ b/prdoc/pr_9338.prdoc
@@ -1,0 +1,20 @@
+title: 'fatxpool: manual seal support'
+doc:
+- audience: Node Dev
+  description: |-
+    This PR introduces creation of view for genesis block during instantiation of `fatxpool`. This is intended to fix an instant-seal nodes, where block building is [triggered](https://github.com/paritytech/polkadot-sdk/blob/73b44193c8e66acd699f04265027289d030f6c66/substrate/client/consensus/manual-seal/src/lib.rs#L238) via transaction import. Without views, no event is generated on this stream when transaction is submitted.
+
+    ##### Notes for reviewers
+    Views is injected once after an empty fatxpool is instantiated by any of `new_*` functions. Small refactor was done to re-use the code. Tests were adjusted to match new behavior.
+
+    Seems that it is the easiest fix that we can do.
+
+
+    Todo:
+    [ ] run integrations tests,
+    [x] confirm the fix with minimal-node,
+
+    Fixes: #9323
+crates:
+- name: sc-transaction-pool
+  bump: patch

--- a/prdoc/pr_9338.prdoc
+++ b/prdoc/pr_9338.prdoc
@@ -1,4 +1,4 @@
-title: 'fatxpool: manual seal support'
+title: 'fatxpool: instant seal support'
 doc:
 - audience: Node Dev
   description: |-

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -208,7 +208,7 @@ where
 	ChainApi: graph::ChainApi<Block = Block> + 'static,
 	<Block as BlockT>::Hash: Unpin,
 {
-	// Injects a view fore genesis block to self.
+	// Injects a view for genesis block to self.
 	//
 	// Helper for the pool new methods.
 	fn inject_genesis_view(self) -> Self {

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -215,10 +215,10 @@ where
 		if let Some(block_number) =
 			self.api.block_id_to_number(&BlockId::Hash(initial_view_hash)).ok().flatten()
 		{
-			let at_genesis = HashAndNumber { number: block_number, hash: initial_view_hash };
+			let at_best = HashAndNumber { number: block_number, hash: initial_view_hash };
 			let tree_route =
-				&TreeRoute::new(vec![at_genesis.clone()], 0).expect("tree route is correct. qed");
-			let view = self.build_and_plug_view(None, &at_genesis, &tree_route);
+				&TreeRoute::new(vec![at_best.clone()], 0).expect("tree route is correct; qed");
+			let view = self.build_and_plug_view(None, &at_best, &tree_route);
 			self.view_store.insert_new_view_sync(view.into(), &tree_route);
 			trace!(target: LOG_TARGET, ?block_number, ?initial_view_hash, "fatp::injected initial view");
 		};

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -208,7 +208,7 @@ where
 	ChainApi: graph::ChainApi<Block = Block> + 'static,
 	<Block as BlockT>::Hash: Unpin,
 {
-	// Injects a view for genesis block to self.
+	// Injects a view for the given block to self.
 	//
 	// Helper for the pool new methods.
 	fn inject_initial_view(self, initial_view_hash: Block::Hash) -> Self {

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view_store.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view_store.rs
@@ -521,13 +521,7 @@ where
 
 	/// Inserts new view into the view store.
 	///
-	/// All the views associated with the blocks which are on enacted path (including common
-	/// ancestor) will be:
-	/// - moved to the inactive views set (`inactive_views`),
-	/// - removed from the multi view listeners.
-	///
-	/// The `most_recent_view` is updated with the reference to the newly inserted view.
-	///
+	/// Refer to [`Self::insert_new_view_sync`] more details.
 	/// If there are any pending tx replacments, they are applied to the new view.
 	#[instrument(level = Level::TRACE, skip_all, target = "txpool", name = "view_store::insert_new_view")]
 	pub(super) async fn insert_new_view(
@@ -548,6 +542,14 @@ where
 		);
 	}
 
+	/// Inserts new view into the view store.
+	///
+	/// All the views associated with the blocks which are on enacted path (including common
+	/// ancestor) will be:
+	/// - moved to the inactive views set (`inactive_views`),
+	/// - removed from the multi view listeners.
+	///
+	/// The `most_recent_view` is updated with the reference to the newly inserted view.
 	pub(super) fn insert_new_view_sync(
 		&self,
 		view: Arc<View<ChainApi>>,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view_store.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view_store.rs
@@ -538,7 +538,21 @@ where
 		self.apply_pending_tx_replacements(view.clone()).await;
 
 		let start = Instant::now();
+		self.insert_new_view_sync(view, tree_route);
 
+		debug!(
+			target: LOG_TARGET,
+			inactive_views = ?self.inactive_views.read().keys(),
+			duration = ?start.elapsed(),
+			"insert_new_view"
+		);
+	}
+
+	pub(super) fn insert_new_view_sync(
+		&self,
+		view: Arc<View<ChainApi>>,
+		tree_route: &TreeRoute<Block>,
+	) {
 		//note: most_recent_view must be synced with changes in in/active_views.
 		{
 			let mut most_recent_view_lock = self.most_recent_view.write();
@@ -556,12 +570,6 @@ where
 			active_views.insert(view.at.hash, view.clone());
 			most_recent_view_lock.replace(view.clone());
 		};
-		debug!(
-			target: LOG_TARGET,
-			inactive_views = ?self.inactive_views.read().keys(),
-			duration = ?start.elapsed(),
-			"insert_new_view"
-		);
 	}
 
 	/// Returns an optional reference to the view at given hash.

--- a/substrate/client/transaction-pool/tests/fatp.rs
+++ b/substrate/client/transaction-pool/tests/fatp.rs
@@ -2549,12 +2549,7 @@ fn fatp_ready_light_fallback_gets_triggered() {
 	// the finalized block for the search of the best view, and coincidentaly, that's the only view
 	// of the tree route, being the view created for NBB `header01b`. The returned ready txs are the
 	// ones left in the best view's pool after prunning the txs.
-	let mut ready_iterator = pool.ready_at_light(header03b.hash()).now_or_never().unwrap();
-	let ready01 = ready_iterator.next();
-	assert_eq!(ready01.unwrap().hash, api.hash_and_length(&xt3).0);
-	let ready02 = ready_iterator.next();
-	assert_eq!(ready02.unwrap().hash, api.hash_and_length(&xt4).0);
-	assert!(ready_iterator.next().is_none());
+	assert_ready_at_light_iterator!(header03b.hash(), pool, [xt3, xt4]);
 }
 
 #[test]

--- a/substrate/client/transaction-pool/tests/fatp.rs
+++ b/substrate/client/transaction-pool/tests/fatp.rs
@@ -2372,7 +2372,7 @@ fn fatp_ready_light_most_recent_view_long_fork_retracted_works() {
 	let results = block_on(futures::future::join_all(submissions));
 	assert!(results.iter().all(|r| { r.is_ok() }));
 
-	// dirty hack to remove genesis view, so we can check fallback to most-recent-view at header01b.
+	// dirty hack to remove genesis view, so we can check fallback to most-recent-view at header03b.
 	let header01a = api.push_block_with_parent(genesis, vec![], true);
 	let event = finalized_block_event(&pool, genesis, header01a.hash());
 	block_on(pool.maintain(event));

--- a/substrate/client/transaction-pool/tests/fatp.rs
+++ b/substrate/client/transaction-pool/tests/fatp.rs
@@ -1185,6 +1185,7 @@ fn fatp_no_view_pool_watcher_two_finalized_in_different_block() {
 	assert_eq!(
 		xt1_status,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header03.hash(), 0)),
 			TransactionStatus::Finalized((header03.hash(), 0))
 		]
@@ -1197,6 +1198,7 @@ fn fatp_no_view_pool_watcher_two_finalized_in_different_block() {
 	assert_eq!(
 		xt0_status,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header02.hash(), 2)),
 			TransactionStatus::Finalized((header02.hash(), 2))
 		]
@@ -1208,6 +1210,7 @@ fn fatp_no_view_pool_watcher_two_finalized_in_different_block() {
 	assert_eq!(
 		xt2_status,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header02.hash(), 1)),
 			TransactionStatus::Finalized((header02.hash(), 1))
 		]
@@ -1240,7 +1243,7 @@ fn fatp_watcher_in_block_across_many_blocks() {
 	let _ = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt2.clone())).unwrap();
 	//note 1: transaction is not submitted to views that are not at the tip of the fork
 	assert_eq!(pool.active_views_count(), 1);
-	assert_eq!(pool.inactive_views_count(), 1);
+	assert_eq!(pool.inactive_views_count(), 2); //gensis + 01
 	assert_pool_status!(header02.hash(), &pool, 3, 0);
 
 	let header03 = api.push_block(3, vec![xt0.clone()], true);
@@ -1284,7 +1287,7 @@ fn fatp_watcher_in_block_across_many_blocks2() {
 	let _ = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt2.clone())).unwrap();
 	//note 1: transaction is not submitted to views that are not at the tip of the fork
 	assert_eq!(pool.active_views_count(), 1);
-	assert_eq!(pool.inactive_views_count(), 1);
+	assert_eq!(pool.inactive_views_count(), 2); //genesis + 01
 	assert_pool_status!(header02.hash(), &pool, 3, 0);
 
 	let header03 = api.push_block(3, vec![xt0.clone()], true);
@@ -1457,6 +1460,7 @@ fn fatp_watcher_finalizing_forks() {
 	assert_eq!(
 		xt0_status,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header01.hash(), 0)),
 			TransactionStatus::Finalized((header01.hash(), 0)),
 		]
@@ -1551,6 +1555,7 @@ fn fatp_watcher_best_block_after_finalized2() {
 	assert_eq!(
 		xt0_events,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header01.hash(), 0)),
 			TransactionStatus::Finalized((header01.hash(), 0)),
 		]
@@ -1594,6 +1599,7 @@ fn fatp_watcher_switching_fork_multiple_times_works() {
 	assert_eq!(
 		xt0_status,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header01a.hash(), 0)),
 			TransactionStatus::InBlock((header01b.hash(), 0)),
 			TransactionStatus::Finalized((header01b.hash(), 0)),
@@ -1708,6 +1714,7 @@ fn fatp_watcher_delayed_finalization_does_not_retract() {
 	assert_eq!(
 		xt0_status,
 		vec![
+			TransactionStatus::Ready,
 			TransactionStatus::InBlock((header02.hash(), 0)),
 			TransactionStatus::Finalized((header02.hash(), 0)),
 		]
@@ -2340,6 +2347,50 @@ fn fatp_ready_light_long_fork_works() {
 }
 
 #[test]
+fn fatp_ready_light_most_recent_view_long_fork_retracted_works() {
+	sp_tracing::try_init_simple();
+
+	let (pool, api, _) = pool();
+	api.set_nonce(api.genesis_hash(), Bob.into(), 200);
+	api.set_nonce(api.genesis_hash(), Charlie.into(), 200);
+	api.set_nonce(api.genesis_hash(), Dave.into(), 200);
+	api.set_nonce(api.genesis_hash(), Eve.into(), 200);
+
+	let genesis = api.genesis_hash();
+
+	let xt0 = uxt(Alice, 200);
+	let xt1 = uxt(Bob, 200);
+	let xt2 = uxt(Charlie, 200);
+	let xt3 = uxt(Dave, 200);
+	let xt4 = uxt(Eve, 200);
+
+	let submissions = vec![pool.submit_at(
+		genesis,
+		SOURCE,
+		vec![xt0.clone(), xt1.clone(), xt2.clone(), xt3.clone()],
+	)];
+	let results = block_on(futures::future::join_all(submissions));
+	assert!(results.iter().all(|r| { r.is_ok() }));
+
+	// dirty hack to remove genesis view, so we can check fallback to most-recent-view at header01b.
+	let header01a = api.push_block_with_parent(genesis, vec![], true);
+	let event = finalized_block_event(&pool, genesis, header01a.hash());
+	block_on(pool.maintain(event));
+
+	let header02a = api.push_block_with_parent(header01a.hash(), vec![xt4.clone()], true);
+	let event = new_best_block_event(&pool, Some(genesis), header02a.hash());
+	block_on(pool.maintain(event));
+
+	let header01b = api.push_block_with_parent(genesis, vec![xt0.clone()], true);
+	let header02b = api.push_block_with_parent(header01b.hash(), vec![xt1.clone()], true);
+	let header03b = api.push_block_with_parent(header02b.hash(), vec![xt2.clone()], true);
+
+	// Returns the most recent view (`header02a`) ready transactions set.
+	let ready_iterator = pool.ready_at_light(header03b.hash()).now_or_never().unwrap();
+	assert_eq!(ready_iterator.count(), 4);
+}
+
+#[test]
 fn fatp_ready_light_long_fork_retracted_works() {
 	sp_tracing::try_init_simple();
 
@@ -2373,9 +2424,9 @@ fn fatp_ready_light_long_fork_retracted_works() {
 	let header02b = api.push_block_with_parent(header01b.hash(), vec![xt1.clone()], true);
 	let header03b = api.push_block_with_parent(header02b.hash(), vec![xt2.clone()], true);
 
-	// Returns the most recent view (`header01a`) ready transactions set.
+	// Returns the genesis view ready transactions set with fork txs removed.
 	let ready_iterator = pool.ready_at_light(header03b.hash()).now_or_never().unwrap();
-	assert_eq!(ready_iterator.count(), 4);
+	assert_eq!(ready_iterator.count(), 1);
 
 	let event = new_best_block_event(&pool, Some(header01a.hash()), header01b.hash());
 	block_on(pool.maintain(event));
@@ -2386,6 +2437,63 @@ fn fatp_ready_light_long_fork_retracted_works() {
 	let ready02 = ready_iterator.next();
 	assert_eq!(ready02.unwrap().hash, api.hash_and_length(&xt4).0);
 	assert!(ready_iterator.next().is_none());
+}
+
+#[test]
+fn fatp_ready_light_fallback_for_most_recent_view_gets_triggered() {
+	sp_tracing::try_init_simple();
+
+	let (pool, api, _) = pool();
+	api.set_nonce(api.genesis_hash(), Bob.into(), 200);
+	api.set_nonce(api.genesis_hash(), Charlie.into(), 200);
+	api.set_nonce(api.genesis_hash(), Dave.into(), 200);
+	api.set_nonce(api.genesis_hash(), Eve.into(), 200);
+
+	let genesis = api.genesis_hash();
+
+	let xt0 = uxt(Alice, 200);
+	let xt1 = uxt(Bob, 200);
+	let xt2 = uxt(Charlie, 200);
+	let xt3 = uxt(Dave, 200);
+	let xt4 = uxt(Eve, 200);
+
+	let submissions = vec![pool.submit_at(genesis, SOURCE, vec![xt0.clone(), xt1.clone()])];
+	let results = block_on(futures::future::join_all(submissions));
+	assert!(results.iter().all(|r| { r.is_ok() }));
+
+	// dirty hack to remove genesis view, so we can check fallback to most-recent-view at header01b.
+	let header01a = api.push_block_with_parent(genesis, vec![], true);
+	let event = finalized_block_event(&pool, genesis, header01a.hash());
+	block_on(pool.maintain(event));
+
+	let header02a = api.push_block_with_parent(header01a.hash(), vec![xt4.clone()], true);
+	let event = new_best_block_event(&pool, Some(genesis), header02a.hash());
+	block_on(pool.maintain(event));
+
+	let header01b = api.push_block_with_parent(genesis, vec![xt0.clone()], true);
+	// Call `ready_at_light` at genesis direct descendent, even if not notified as best or
+	// finalized. Should still return ready txs based on the most recent view processed by the
+	// txpool.
+	let ready_iterator = pool.ready_at_light(header01b.hash()).now_or_never().unwrap();
+	assert_eq!(ready_iterator.count(), 2);
+
+	let header02b = api.push_block_with_parent(header01b.hash(), vec![xt1.clone()], true);
+	let header03b = api.push_block_with_parent(header02b.hash(), vec![xt2.clone()], true);
+
+	// Submit a few more tx to the pool.
+	let submissions = vec![pool.submit_at(
+		// `at` is ignored.
+		genesis,
+		SOURCE,
+		vec![xt2.clone(), xt3.clone()],
+	)];
+	let results = block_on(futures::future::join_all(submissions));
+	assert!(results.iter().all(|r| { r.is_ok() }));
+
+	// Calling `ready_at_light` now on the last block of a fork, with no block notified as best.
+	// We should still get the ready txs from the most recent view processed by the txpool,
+	// but now with a few more txs which were submitted previously.
+	assert_ready_at_light_iterator!(header03b.hash(), pool, [xt0, xt1, xt2, xt3]);
 }
 
 #[test]
@@ -2416,15 +2524,15 @@ fn fatp_ready_light_fallback_gets_triggered() {
 
 	let header01b = api.push_block_with_parent(genesis, vec![xt0.clone()], true);
 	// Call `ready_at_light` at genesis direct descendent, even if not notified as best or
-	// finalized. Should still return ready txs based on the most recent view processed by the
-	// txpool.
+	// finalized. Should still return ready txs based on the view for genesis, taking into account
+	// transactions from 01b block.
 	let ready_iterator = pool.ready_at_light(header01b.hash()).now_or_never().unwrap();
-	assert_eq!(ready_iterator.count(), 2);
+	assert_eq!(ready_iterator.count(), 1);
 
 	let header02b = api.push_block_with_parent(header01b.hash(), vec![xt1.clone()], true);
 	let header03b = api.push_block_with_parent(header02b.hash(), vec![xt2.clone()], true);
 
-	// Submit a few more txs to the pool.
+	// Submit a few more tx to the pool.
 	let submissions = vec![pool.submit_at(
 		// `at` is ignored.
 		genesis,
@@ -2434,18 +2542,12 @@ fn fatp_ready_light_fallback_gets_triggered() {
 	let results = block_on(futures::future::join_all(submissions));
 	assert!(results.iter().all(|r| { r.is_ok() }));
 
-	// Calling `ready_at_light` now on the last block of a fork, with no block notified as best.
-	// We should still get the ready txs from the most recent view processed by the txpool,
-	// but now with a few more txs which were submitted previously.
-	let ready_iterator = pool.ready_at_light(header03b.hash()).now_or_never().unwrap();
-	assert_eq!(ready_iterator.count(), 4);
-
-	let event = new_best_block_event(&pool, Some(header01a.hash()), header01b.hash());
+	let event = finalized_block_event(&pool, header01a.hash(), header01b.hash());
 	block_on(pool.maintain(event));
 
-	// Calling `ready_at_light` on the new best block (`header03b`) should consider its fork up to
+	// Calling `ready_at_light` on the new block (`header03b`) should consider its fork up to
 	// the finalized block for the search of the best view, and coincidentaly, that's the only view
-	// of the tree route, being the view created for NBB `header03b`. The returned ready txs are the
+	// of the tree route, being the view created for NBB `header01b`. The returned ready txs are the
 	// ones left in the best view's pool after prunning the txs.
 	let mut ready_iterator = pool.ready_at_light(header03b.hash()).now_or_never().unwrap();
 	let ready01 = ready_iterator.next();

--- a/substrate/client/transaction-pool/tests/fatp_common/mod.rs
+++ b/substrate/client/transaction-pool/tests/fatp_common/mod.rs
@@ -199,6 +199,20 @@ macro_rules! assert_pool_status {
 }
 
 #[macro_export]
+macro_rules! assert_ready_at_light_iterator {
+	($hash:expr, $pool:expr, [$( $xt:expr ),*]) => {{
+		let ready_iterator = $pool.ready_at_light($hash).now_or_never().unwrap();
+		let expected = vec![ $($pool.api().hash_and_length(&$xt).0),*];
+		let output: Vec<_> = ready_iterator.collect();
+		tracing::debug!(target: LOG_TARGET, ?expected, "expected");
+		tracing::debug!(target: LOG_TARGET, ?output, "output");
+		let output = output.into_iter().map(|t|t.hash).collect::<Vec<_>>();
+		assert_eq!(expected.len(), output.len());
+		assert_eq!(output,expected);
+	}};
+}
+
+#[macro_export]
 macro_rules! assert_ready_iterator {
 	($hash:expr, $pool:expr, [$( $xt:expr ),*]) => {{
 		let ready_iterator = $pool.ready_at($hash).now_or_never().unwrap();

--- a/substrate/client/transaction-pool/tests/fatp_invalid.rs
+++ b/substrate/client/transaction-pool/tests/fatp_invalid.rs
@@ -373,33 +373,15 @@ fn fatp_watcher_invalid_single_revalidation2() {
 	let xt0 = uxt(Alice, 200);
 	let xt0_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt0.clone())).unwrap();
 	assert_eq!(block_on(pool.mempool_len()), (0, 1));
-	api.add_invalid(&xt0);
-
-	let header01 = api.push_block(1, vec![], true);
-	let event = new_best_block_event(&pool, None, header01.hash());
-	block_on(pool.maintain(event));
-
-	let xt0_events = futures::executor::block_on_stream(xt0_watcher).collect::<Vec<_>>();
-	debug!(target: LOG_TARGET, ?xt0_events, "xt0_events");
-	assert_eq!(xt0_events, vec![TransactionStatus::Invalid]);
-	assert_eq!(block_on(pool.mempool_len()), (0, 0));
-}
-
-#[test]
-fn fatp_watcher_invalid_single_revalidation3() {
-	sp_tracing::try_init_simple();
-
-	let (pool, api, _) = pool();
-
-	let xt0 = uxt(Alice, 150);
-	let xt0_watcher = block_on(pool.submit_and_watch(invalid_hash(), SOURCE, xt0.clone())).unwrap();
-	assert_eq!(block_on(pool.mempool_len()), (0, 1));
 
 	let header01 = api.push_block(1, vec![], true);
 	let event = finalized_block_event(&pool, api.genesis_hash(), header01.hash());
 	block_on(pool.maintain(event));
+	api.add_invalid(&xt0);
 
-	// wait 10 blocks for revalidation
+	// note: the tx will be revalidated in view::revalidation, not in mempool revalidation (which
+	// would required watingin 10 blocks).
+	// waiting 10 blocks is excessive, but we may want to keep it.
 	let mut prev_header = header01;
 	for n in 2..=11 {
 		let header = api.push_block(n, vec![], true);
@@ -410,7 +392,7 @@ fn fatp_watcher_invalid_single_revalidation3() {
 
 	let xt0_events = futures::executor::block_on_stream(xt0_watcher).collect::<Vec<_>>();
 	debug!(target: LOG_TARGET, ?xt0_events, "xt0_events");
-	assert_eq!(xt0_events, vec![TransactionStatus::Invalid]);
+	assert_eq!(xt0_events, vec![TransactionStatus::Ready, TransactionStatus::Invalid]);
 	assert_eq!(block_on(pool.mempool_len()), (0, 0));
 }
 

--- a/substrate/client/transaction-pool/tests/fatp_invalid.rs
+++ b/substrate/client/transaction-pool/tests/fatp_invalid.rs
@@ -380,7 +380,7 @@ fn fatp_watcher_invalid_single_revalidation2() {
 	api.add_invalid(&xt0);
 
 	// note: the tx will be revalidated in view::revalidation, not in mempool revalidation (which
-	// would required watingin 10 blocks).
+	// would require waiting 10 blocks).
 	// waiting 10 blocks is excessive, but we may want to keep it.
 	let mut prev_header = header01;
 	for n in 2..=11 {


### PR DESCRIPTION
This PR introduces creation of view for known best block during instantiation of `fatxpool`. This is intended to fix an instant-seal nodes, where block building is [triggered](https://github.com/paritytech/polkadot-sdk/blob/73b44193c8e66acd699f04265027289d030f6c66/substrate/client/consensus/manual-seal/src/lib.rs#L238) via transaction import. Without views, no event is generated on this stream when transaction is submitted.

##### Notes for reviewers
View is injected once after an empty fatxpool is instantiated by any of `new_*` functions. Small refactor was done to re-use the code. Tests were adjusted to match new behavior.

Seems that it is the easiest fix that we can do.


Todo:
- [x] run integrations tests,
- [x] confirm the fix with minimal-node,

Fixes: #9323