### PR TITLE
Fix definition of held balance

### DIFF
--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -1080,7 +1080,7 @@ impl Default for Forcing {
 ///
 /// Active exposure is the exposure of the validator set currently validating, i.e. in
 /// `active_era`. It can differ from the latest planned exposure in `current_era`.
-#[deprecated(note = "Use `ExistenceOf` or `ExistenceOrLegacyExposureOf` instead")]
+#[deprecated(note = "Use `DefaultExposureOf` instead")]
 pub struct ExposureOf<T>(core::marker::PhantomData<T>);
 
 #[allow(deprecated)]

--- a/substrate/frame/support/src/traits/tokens/fungible/mod.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/mod.rs
@@ -51,8 +51,9 @@
 //!   distinct from the Spendable Balance, which represents how much Balance the user can actually
 //!   transfer.
 //!
-//! - **Held Balance**: Held balance still belongs to the account holder, but is suspended. It can
-//!   be slashed, but only after all the free balance has been slashed.
+//! - **Held Balance**: Held balance still belongs to the account holder, but is suspended — it
+//!   cannot be transferred or used for most operations. It may be slashed by the pallet that placed
+//!   the hold.
 //!
 //!   Multiple holds stack rather than overlay. This means that if an account has
 //!   3 holds for 100 units, the account can spend its funds for any reason down to 300 units, at


### PR DESCRIPTION
## Changes
- Updated the `Held Balance` definition to reflect the current behavior. The previous explanation was accurate when staking used locks (which were part of the free balance), but since [staking now uses holds](https://github.com/paritytech/polkadot-sdk/pull/5501), the old definition is misleading.
This issue was originally pointed out by @michalisFr [here](https://github.com/w3f/polkadot-wiki/pull/6793#discussion_r2231472702).
- Fixed a broken reference in the deprecated doc for `ExposureOf`, which was (ironically) pointing to a non-existent type named `ExistenceOf`. This slipped in during our [mega async staking PR](https://github.com/paritytech/polkadot-sdk/pull/8127).