### PR TITLE
[Release|CI/CD] Add node version to the release announcement

### DIFF
--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -38,19 +38,29 @@ jobs:
         #     pre-releases: false
 
     steps:
-      - name: Extract version from release body
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Extract node version
         id: extract_version
         run: |
-          body=$(jq -r '.release.body' "$GITHUB_EVENT_PATH")
+          # body=$(jq -r '.release.body' "$GITHUB_EVENT_PATH")
 
-          # Look for node version in the release body
-          if [[ $body =~ polkadot-(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
-            version="${BASH_REMATCH[1]}"
-            echo "Extracted node version: $version"
-            echo "node_version=$version" >> $GITHUB_OUTPUT
-          else
-            echo "Could not find a version matching polkadot-vX.XX.X in the release body."
-          fi
+          # # Look for node version in the release body
+          # if [[ $body =~ polkadot-(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          #   version="${BASH_REMATCH[1]}"
+          #   echo "Extracted node version: $version"
+          #   echo "node_version=$version" >> $GITHUB_OUTPUT
+          # else
+          #   echo "Could not find a version matching polkadot-vX.XX.X in the release body."
+          # fi
+          . ./.github/scripts/common/lib.sh
+
+          version=v$(get_polkadot_node_version_from_code)
+          echo "Extracted node version: $version"
+          echo "node_version=$version" >> $GITHUB_OUTPUT
 
       - name: Matrix notification to ${{ matrix.channel.name }}
         if: github.event.release.prerelease == false || matrix.channel.pre-release

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -42,10 +42,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          echo "${{ github.event.release.body}}" > release_body.txt
+          # printf '%s' "${{ github.event.release.body }}" > release_body.txt
 
-          # Use grep and sed to extract the version from the release body
-          VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
+          # Use extract the node version from the release body
+          # VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
+          VERSION=$(version=$(printf '%s' "${{ github.event.release.body }}" | grep -oE 'polkadot-(v[0-9]+\.[0-9]+\.[0-9]+)' | head -n1 | sed 's/polkadot-//'))
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
       # - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -42,23 +42,23 @@ jobs:
         shell: bash
         run: |
           set -e
-          echo ${{ github.event.release.body}} >> release_body.txt
+          echo "${{ github.event.release.body}}" > release_body.txt
 
           # Use grep and sed to extract the version from the release body
           VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Matrix notification to ${{ matrix.channel.name }}
-        if: github.event.release.prerelease == false || matrix.channel.pre-release
-        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-        with:
-          room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
-          server: m.parity.io
-          message: |
-            @room
+      # - name: Matrix notification to ${{ matrix.channel.name }}
+      #   if: github.event.release.prerelease == false || matrix.channel.pre-release
+      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+      #   with:
+      #     room_id: ${{ matrix.channel.room }}
+      #     access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
+      #     server: m.parity.io
+      #     message: |
+      #       @room
 
-            A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
-            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
-            Node version: ${{ steps.extract_version.outputs.node_version }}
-            -----
+      #       A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
+      #       Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
+      #       Node version: ${{ steps.extract_version.outputs.node_version }}
+      #       -----

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -13,28 +13,25 @@ jobs:
       matrix:
         channel:
           # Internal
-          # - name: "RelEng: Polkadot Release Coordination"
-          #   room: '!cqAmzdIcbOFwrdrubV:parity.io'
-          #   pre-release: true
-          - name: "Team: RelEng Internal"
-            room: '!GvAyzgCDgaVrvibaAF:parity.io'
+          - name: "RelEng: Polkadot Release Coordination"
+            room: '!cqAmzdIcbOFwrdrubV:parity.io'
             pre-release: true
 
          # External
-          # - name: 'Ledger <> Polkadot Coordination'
-          #   room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
-          #   pre-release: true
+          - name: 'Ledger <> Polkadot Coordination'
+            room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
+            pre-release: true
 
-          # # Public
-          # - name: '#polkadotvalidatorlounge:web3.foundation'
-          #   room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
-          #   pre-releases: false
-          # - name: '#polkadot-announcements:parity.io'
-          #   room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
-          #   pre-releases: false
-          # - name: '#kusama-announce:parity.io'
-          #   room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
-          #   pre-releases: false
+         # Public
+          - name: '#polkadotvalidatorlounge:web3.foundation'
+            room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
+            pre-releases: false
+          - name: '#polkadot-announcements:parity.io'
+            room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
+            pre-releases: false
+          - name: '#kusama-announce:parity.io'
+            room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
+            pre-releases: false
 
     steps:
       - name: Extract version from release body

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -40,44 +40,30 @@ jobs:
     steps:
       - name: Extract version from release body
         id: extract_version
-        # env:
-        #   RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          # Extract node version from release body
-          # echo "${{ env.RELEASE_BODY }}" | tee release_body.txt
+          body=$(jq -r '.release.body' "$GITHUB_EVENT_PATH")
 
-          # VERSION=$(cat release_body.txt | grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | sed 's/polkadot-//')
+          # Look for node version in the release body
+          if [[ $body =~ polkadot-(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            version="${BASH_REMATCH[1]}"
+            echo "Extracted node version: $version"
+            echo "node_version=$version" >> $GITHUB_OUTPUT
+          else
+            echo "Could not find a version matching polkadot-vX.XX.X in the release body."
+          fi
 
-          # if [ -z "$VERSION" ]; then
-          #   echo "Error: Could not extract version from release body"
-          # fi
+      - name: Matrix notification to ${{ matrix.channel.name }}
+        if: github.event.release.prerelease == false || matrix.channel.pre-release
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+        with:
+          room_id: ${{ matrix.channel.room }}
+          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
+          server: m.parity.io
+          message: |
+            @room
 
-          # echo "Extracted node version: $VERSION"
-          # echo "node_version=$VERSION" >> $GITHUB_OUTPUT
+            A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
+            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/>
+            Node version: ${{ steps.extract_version.outputs.node_version }}
 
-            body=$(jq -r '.release.body' "$GITHUB_EVENT_PATH")
-
-            # Look for node version in the release body
-            if [[ $body =~ polkadot-(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
-              version="${BASH_REMATCH[1]}"
-              echo "Extracted node version: $version"
-              echo "node_version=$version" >> $GITHUB_OUTPUT
-            else
-              echo "Could not find a version matching polkadot-vX.XX.X in the release body."
-            fi
-
-      # - name: Matrix notification to ${{ matrix.channel.name }}
-      #   if: github.event.release.prerelease == false || matrix.channel.pre-release
-      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-      #   with:
-      #     room_id: ${{ matrix.channel.room }}
-      #     access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
-      #     server: m.parity.io
-      #     message: |
-      #       @room
-
-      #       A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
-      #       Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/>
-      #       Node version: ${{ steps.extract_version.outputs.node_version }}
-
-      #       -----
+            -----

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -50,17 +50,17 @@ jobs:
           echo "Extracted node version: $VERSION"
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
-      # - name: Matrix notification to ${{ matrix.channel.name }}
-      #   if: github.event.release.prerelease == false || matrix.channel.pre-release
-      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-      #   with:
-      #     room_id: ${{ matrix.channel.room }}
-      #     access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
-      #     server: m.parity.io
-      #     message: |
-      #       @room
+      - name: Matrix notification to ${{ matrix.channel.name }}
+        if: github.event.release.prerelease == false || matrix.channel.pre-release
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+        with:
+          room_id: ${{ matrix.channel.room }}
+          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
+          server: m.parity.io
+          message: |
+            @room
 
-      #       A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
-      #       Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
-      #       Node version: ${{ steps.extract_version.outputs.node_version }}
-      #       -----
+            A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
+            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
+            Node version: ${{ steps.extract_version.outputs.node_version }}
+            -----

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -37,16 +37,17 @@ jobs:
           #   pre-releases: false
 
     steps:
-      - name: Extract Polkadot Version
+      - name: Extract version from release body
         id: extract_version
-        shell: bash
         run: |
-          set -e
-          echo "${{ github.event.release.body }}" > release_body.txt
+          # Extract node version from release body
+          VERSION=$(echo "${{ github.event.release.body }}" | grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | sed 's/polkadot-//')
 
-          # Use extract the node version from the release body
-          VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
-          # VERSION=$(printf '%s' "${{ github.event.release.body }}" | grep -oE 'polkadot-(v[0-9]+\.[0-9]+\.[0-9]+)' | head -n1 | sed 's/polkadot-//')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Could not extract version from release body"
+          fi
+
+          echo "Extracted node version: $VERSION"
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
       # - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          printf '%s' "${{ github.event.release.body }}" > release_body.txt
+          echo "${{ github.event.release.body }}" > release_body.txt
 
           # Use extract the node version from the release body
           VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -13,25 +13,28 @@ jobs:
       matrix:
         channel:
           # Internal
-          - name: "RelEng: Polkadot Release Coordination"
-            room: '!cqAmzdIcbOFwrdrubV:parity.io'
+          # - name: "RelEng: Polkadot Release Coordination"
+          #   room: '!cqAmzdIcbOFwrdrubV:parity.io'
+          #   pre-release: true
+          - name: "Team: RelEng Internal"
+            room: '!GvAyzgCDgaVrvibaAF:parity.io'
             pre-release: true
 
          # External
-          - name: 'Ledger <> Polkadot Coordination'
-            room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
-            pre-release: true
+          # - name: 'Ledger <> Polkadot Coordination'
+          #   room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
+          #   pre-release: true
 
-          # Public
-          - name: '#polkadotvalidatorlounge:web3.foundation'
-            room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
-            pre-releases: false
-          - name: '#polkadot-announcements:parity.io'
-            room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
-            pre-releases: false
-          - name: '#kusama-announce:parity.io'
-            room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
-            pre-releases: false
+          # # Public
+          # - name: '#polkadotvalidatorlounge:web3.foundation'
+          #   room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
+          #   pre-releases: false
+          # - name: '#polkadot-announcements:parity.io'
+          #   room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
+          #   pre-releases: false
+          # - name: '#kusama-announce:parity.io'
+          #   room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
+          #   pre-releases: false
 
     steps:
       - name: Extract Polkadot Version

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -61,6 +61,7 @@ jobs:
             @room
 
             A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
-            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
+            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/>
             Node version: ${{ steps.extract_version.outputs.node_version }}
+
             -----

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -34,6 +34,17 @@ jobs:
             pre-releases: false
 
     steps:
+      - name: Extract Polkadot Version
+        id: extract_version
+        shell: bash
+        run: |
+          set -e
+          echo ${{ github.event.release.body}} >> release_body.txt
+
+          # Use grep and sed to extract the version from the release body
+          VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
+          echo "node_version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Matrix notification to ${{ matrix.channel.name }}
         if: github.event.release.prerelease == false || matrix.channel.pre-release
         uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
@@ -46,5 +57,5 @@ jobs:
 
             A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
             Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
-
+            Node version: ${{ steps.extract_version.outputs.node_version }}
             -----

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -42,11 +42,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          # printf '%s' "${{ github.event.release.body }}" > release_body.txt
+          printf '%s' "${{ github.event.release.body }}" > release_body.txt
 
           # Use extract the node version from the release body
-          # VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
-          VERSION=$(printf '%s' "${{ github.event.release.body }}" | grep -oE 'polkadot-(v[0-9]+\.[0-9]+\.[0-9]+)' | head -n1 | sed 's/polkadot-//')
+          VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
+          # VERSION=$(printf '%s' "${{ github.event.release.body }}" | grep -oE 'polkadot-(v[0-9]+\.[0-9]+\.[0-9]+)' | head -n1 | sed 's/polkadot-//')
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
       # - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -36,9 +36,11 @@ jobs:
     steps:
       - name: Extract version from release body
         id: extract_version
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           # Extract node version from release body
-          VERSION=$(echo "${{ github.event.release.body }}" | grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | sed 's/polkadot-//')
+          VERSION=$(echo "${{ env.RELEASE_BODY }}" | grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | sed 's/polkadot-//')
 
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract version from release body"

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -40,20 +40,31 @@ jobs:
     steps:
       - name: Extract version from release body
         id: extract_version
-        env:
-          RELEASE_BODY: ${{ github.event.release.body }}
+        # env:
+        #   RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           # Extract node version from release body
-          echo "${{ env.RELEASE_BODY }}" | tee release_body.txt
+          # echo "${{ env.RELEASE_BODY }}" | tee release_body.txt
 
-          VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -1 | sed 's/polkadot-//')
+          # VERSION=$(cat release_body.txt | grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | sed 's/polkadot-//')
 
-          if [ -z "$VERSION" ]; then
-            echo "Error: Could not extract version from release body"
-          fi
+          # if [ -z "$VERSION" ]; then
+          #   echo "Error: Could not extract version from release body"
+          # fi
 
-          echo "Extracted node version: $VERSION"
-          echo "node_version=$VERSION" >> $GITHUB_OUTPUT
+          # echo "Extracted node version: $VERSION"
+          # echo "node_version=$VERSION" >> $GITHUB_OUTPUT
+
+            body=$(jq -r '.release.body' "$GITHUB_EVENT_PATH")
+
+            # Look for node version in the release body
+            if [[ $body =~ polkadot-(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
+              version="${BASH_REMATCH[1]}"
+              echo "Extracted node version: $version"
+              echo "node_version=$version" >> $GITHUB_OUTPUT
+            else
+              echo "Could not find a version matching polkadot-vX.XX.X in the release body."
+            fi
 
       # - name: Matrix notification to ${{ matrix.channel.name }}
       #   if: github.event.release.prerelease == false || matrix.channel.pre-release

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -12,30 +12,26 @@ jobs:
     strategy:
       matrix:
         channel:
-          # Internal
-          # - name: "RelEng: Polkadot Release Coordination"
-          #   room: '!cqAmzdIcbOFwrdrubV:parity.io'
-          #   pre-release: true
-
-          - name: "Team: RelEng Internal"
-            room: '!GvAyzgCDgaVrvibaAF:parity.io'
+         # Internal
+          - name: "RelEng: Polkadot Release Coordination"
+            room: '!cqAmzdIcbOFwrdrubV:parity.io'
             pre-release: true
 
          # External
-        #   - name: 'Ledger <> Polkadot Coordination'
-        #     room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
-        #     pre-release: true
+          - name: 'Ledger <> Polkadot Coordination'
+            room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
+            pre-release: true
 
-        #  # Public
-        #   - name: '#polkadotvalidatorlounge:web3.foundation'
-        #     room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
-        #     pre-releases: false
-        #   - name: '#polkadot-announcements:parity.io'
-        #     room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
-        #     pre-releases: false
-        #   - name: '#kusama-announce:parity.io'
-        #     room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
-        #     pre-releases: false
+         # Public
+          - name: '#polkadotvalidatorlounge:web3.foundation'
+            room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
+            pre-releases: false
+          - name: '#polkadot-announcements:parity.io'
+            room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
+            pre-releases: false
+          - name: '#kusama-announce:parity.io'
+            room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
+            pre-releases: false
 
     steps:
       - name: Checkout
@@ -46,16 +42,6 @@ jobs:
       - name: Extract node version
         id: extract_version
         run: |
-          # body=$(jq -r '.release.body' "$GITHUB_EVENT_PATH")
-
-          # # Look for node version in the release body
-          # if [[ $body =~ polkadot-(v[0-9]+\.[0-9]+\.[0-9]+) ]]; then
-          #   version="${BASH_REMATCH[1]}"
-          #   echo "Extracted node version: $version"
-          #   echo "node_version=$version" >> $GITHUB_OUTPUT
-          # else
-          #   echo "Could not find a version matching polkadot-vX.XX.X in the release body."
-          # fi
           . ./.github/scripts/common/lib.sh
 
           version=v$(get_polkadot_node_version_from_code)

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -46,7 +46,7 @@ jobs:
 
           # Use extract the node version from the release body
           # VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -n1 | sed 's/polkadot-//')
-          VERSION=$(version=$(printf '%s' "${{ github.event.release.body }}" | grep -oE 'polkadot-(v[0-9]+\.[0-9]+\.[0-9]+)' | head -n1 | sed 's/polkadot-//'))
+          VERSION=$(printf '%s' "${{ github.event.release.body }}" | grep -oE 'polkadot-(v[0-9]+\.[0-9]+\.[0-9]+)' | head -n1 | sed 's/polkadot-//')
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
       # - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-99_notif-published.yml
+++ b/.github/workflows/release-99_notif-published.yml
@@ -13,25 +13,29 @@ jobs:
       matrix:
         channel:
           # Internal
-          - name: "RelEng: Polkadot Release Coordination"
-            room: '!cqAmzdIcbOFwrdrubV:parity.io'
+          # - name: "RelEng: Polkadot Release Coordination"
+          #   room: '!cqAmzdIcbOFwrdrubV:parity.io'
+          #   pre-release: true
+
+          - name: "Team: RelEng Internal"
+            room: '!GvAyzgCDgaVrvibaAF:parity.io'
             pre-release: true
 
          # External
-          - name: 'Ledger <> Polkadot Coordination'
-            room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
-            pre-release: true
+        #   - name: 'Ledger <> Polkadot Coordination'
+        #     room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
+        #     pre-release: true
 
-         # Public
-          - name: '#polkadotvalidatorlounge:web3.foundation'
-            room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
-            pre-releases: false
-          - name: '#polkadot-announcements:parity.io'
-            room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
-            pre-releases: false
-          - name: '#kusama-announce:parity.io'
-            room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
-            pre-releases: false
+        #  # Public
+        #   - name: '#polkadotvalidatorlounge:web3.foundation'
+        #     room: '!NZrbtteFeqYKCUGQtr:matrix.parity.io'
+        #     pre-releases: false
+        #   - name: '#polkadot-announcements:parity.io'
+        #     room: '!UqHPWiCBGZWxrmYBkF:matrix.parity.io'
+        #     pre-releases: false
+        #   - name: '#kusama-announce:parity.io'
+        #     room: '!FMwxpQnYhRCNDRsYGI:matrix.parity.io'
+        #     pre-releases: false
 
     steps:
       - name: Extract version from release body
@@ -40,7 +44,9 @@ jobs:
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           # Extract node version from release body
-          VERSION=$(echo "${{ env.RELEASE_BODY }}" | grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1 | sed 's/polkadot-//')
+          echo "${{ env.RELEASE_BODY }}" | tee release_body.txt
+
+          VERSION=$(grep -o 'polkadot-v[0-9]\+\.[0-9]\+\.[0-9]\+' release_body.txt | head -1 | sed 's/polkadot-//')
 
           if [ -z "$VERSION" ]; then
             echo "Error: Could not extract version from release body"
@@ -49,18 +55,18 @@ jobs:
           echo "Extracted node version: $VERSION"
           echo "node_version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Matrix notification to ${{ matrix.channel.name }}
-        if: github.event.release.prerelease == false || matrix.channel.pre-release
-        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-        with:
-          room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
-          server: m.parity.io
-          message: |
-            @room
+      # - name: Matrix notification to ${{ matrix.channel.name }}
+      #   if: github.event.release.prerelease == false || matrix.channel.pre-release
+      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+      #   with:
+      #     room_id: ${{ matrix.channel.room }}
+      #     access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
+      #     server: m.parity.io
+      #     message: |
+      #       @room
 
-            A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
-            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/>
-            Node version: ${{ steps.extract_version.outputs.node_version }}
+      #       A new node release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
+      #       Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/>
+      #       Node version: ${{ steps.extract_version.outputs.node_version }}
 
-            -----
+      #       -----


### PR DESCRIPTION
This PR adds a node version to the announcement message sent to the matrix channels, when the new stable release is published.
<img width="834" height="178" alt="Screenshot 2025-07-28 at 14 09 03" src="https://github.com/user-attachments/assets/8b27997f-55f5-47d5-8538-e1cde420b8b0" />


Closes: https://github.com/paritytech/release-engineering/issues/268