### PR TITLE
Remove whitespaces added by macros due to token re-parsing

### DIFF
--- a/prdoc/pr_9354.prdoc
+++ b/prdoc/pr_9354.prdoc
@@ -2,9 +2,7 @@ title: Remove whitespaces added by macros due to token re-parsing
 doc:
 - audience: Runtime Dev
   description: |-
-    Relates to: https://github.com/paritytech/polkadot-sdk/issues/9336, https://github.com/paritytech/polkadot-sdk/pull/7321
-
-    This PR aims to normalize result of `stringify` in scenarios when used inside nested macros to stringify token streams for benchmarking related code. Different versions of rust can include, or not, "space" characters around tokens like `<`,`>`,`::` so we are just removing additional spaces.
+    Normalize result of `stringify` in scenarios when used inside nested macros to stringify token streams for benchmarking framework
 crates:
 - name: frame-benchmarking
   bump: patch

--- a/prdoc/pr_9354.prdoc
+++ b/prdoc/pr_9354.prdoc
@@ -1,0 +1,10 @@
+title: Remove whitespaces added by macros due to token re-parsing
+doc:
+- audience: Runtime Dev
+  description: |-
+    Relates to: https://github.com/paritytech/polkadot-sdk/issues/9336, https://github.com/paritytech/polkadot-sdk/pull/7321
+
+    This PR aims to normalize result of `stringify` in scenarios when used inside nested macros to stringify token streams for benchmarking related code. Different versions of rust can include, or not, "space" characters around tokens like `<`,`>`,`::` so we are just removing additional spaces.
+crates:
+- name: frame-benchmarking
+  bump: patch

--- a/substrate/frame/benchmarking/src/v1.rs
+++ b/substrate/frame/benchmarking/src/v1.rs
@@ -1818,8 +1818,8 @@ pub fn show_benchmark_debug_info(
 #[macro_export]
 macro_rules! add_benchmark {
 	( $params:ident, $batches:ident, $name:path, $location:ty ) => {
-		let name_string = stringify!($name).as_bytes();
-		let instance_string = stringify!($location).as_bytes();
+		let pallet_string = stringify!($name).replace(" ", "").into_bytes();
+		let instance_string = stringify!($location).replace(" ", "").into_bytes();
 		let (config, whitelist) = $params;
 		let $crate::BenchmarkConfig {
 			pallet,
@@ -1829,7 +1829,7 @@ macro_rules! add_benchmark {
 			verify,
 			internal_repeats,
 		} = config;
-		if &pallet[..] == &name_string[..] && &instance[..] == &instance_string[..] {
+		if &pallet[..] == &pallet_string[..] && &instance[..] == &instance_string[..] {
 			let benchmark_result = <$location as $crate::Benchmarking>::run_benchmark(
 				&benchmark[..],
 				&selected_components[..],
@@ -1852,7 +1852,7 @@ macro_rules! add_benchmark {
 				},
 				Err($crate::BenchmarkError::Stop(e)) => {
 					$crate::show_benchmark_debug_info(
-						instance_string,
+						&instance_string,
 						benchmark,
 						selected_components,
 						verify,
@@ -1883,8 +1883,8 @@ macro_rules! add_benchmark {
 
 			if let Some(final_results) = final_results {
 				$batches.push($crate::BenchmarkBatch {
-					pallet: name_string.to_vec(),
-					instance: instance_string.to_vec(),
+					pallet: pallet_string,
+					instance: instance_string,
 					benchmark: benchmark.clone(),
 					results: final_results,
 				});
@@ -1915,12 +1915,12 @@ macro_rules! add_benchmark {
 #[macro_export]
 macro_rules! list_benchmark {
 	( $list:ident, $extra:ident, $name:path, $location:ty ) => {
-		let pallet_string = stringify!($name).as_bytes();
-		let instance_string = stringify!($location).as_bytes();
+		let pallet_string = stringify!($name).replace(" ", "").into_bytes();
+		let instance_string = stringify!($location).replace(" ", "").into_bytes();
 		let benchmarks = <$location as $crate::Benchmarking>::benchmarks($extra);
 		let pallet_benchmarks = $crate::BenchmarkList {
-			pallet: pallet_string.to_vec(),
-			instance: instance_string.to_vec(),
+			pallet: pallet_string,
+			instance: instance_string,
 			benchmarks: benchmarks.to_vec(),
 		};
 		$list.push(pallet_benchmarks)


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/issues/9336, https://github.com/paritytech/polkadot-sdk/pull/7321

This PR aims to normalize result of `stringify` in scenarios when used inside nested macros to stringify token streams for benchmarking framework. Different versions of rust can include, or not, "space" characters around tokens like `<`,`>`,`::` so we are just removing additional spaces.

