### PR TITLE
executor:  log host alloc/dealloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19513,6 +19513,7 @@ version = "0.29.0"
 dependencies = [
  "polkavm",
  "sc-allocator",
+ "sp-crypto-hashing 0.1.0",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface 20.0.0",
  "thiserror 1.0.65",

--- a/substrate/client/executor/common/Cargo.toml
+++ b/substrate/client/executor/common/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 polkavm = { workspace = true }
+sp-crypto-hashing = { workspace = true }
 sc-allocator = { workspace = true, default-features = true }
 sp-maybe-compressed-blob = { workspace = true, default-features = true }
 sp-wasm-interface = { workspace = true, default-features = true }


### PR DESCRIPTION
# Description

Testing allocation patterns in the context of #8992 required adding some debug logs to trace the calls into host allocator `allocate` or `deallocate` functions, while also tracking which runtime did the call (as code hash), which instance of the runtime, and which is the order of the allocator calls (since the logs associated to allocator calls can show up out of order in the node logs).

## Integration

Node developers can track host allocator calls and map them to certain runtimes' instances.

## Review Notes

TODO: some more testing of how the logs look like