### PR TITLE
[Staking/AHM] Properly report weight of rc -> ah xcm back to the calls

### DIFF
--- a/substrate/frame/staking-async/rc-client/src/lib.rs
+++ b/substrate/frame/staking-async/rc-client/src/lib.rs
@@ -473,12 +473,28 @@ pub trait AHStakingInterface {
 	type MaxValidatorSet: Get<u32>;
 
 	/// New session report from the relay chain.
-	fn on_relay_session_report(report: SessionReport<Self::AccountId>);
+	fn on_relay_session_report(report: SessionReport<Self::AccountId>) -> Weight;
+
+	/// Return the weight of `on_relay_session_report` call without executing it.
+	///
+	/// This will return the worst case estimate of the wright. The actual execution will return the
+	/// accurate amount.
+	fn weigh_on_relay_session_report(report: &SessionReport<Self::AccountId>) -> Weight;
 
 	/// Report one or more offences on the relay chain.
+	fn on_new_offences(
+		slash_session: SessionIndex,
+		offences: Vec<Offence<Self::AccountId>>,
+	) -> Weight;
+
+	/// Return the weight of `on_new_offences` call without executing it.
 	///
-	/// This returns its consumed weight because its complexity is hard to measure.
-	fn on_new_offences(slash_session: SessionIndex, offences: Vec<Offence<Self::AccountId>>);
+	/// This will return the worst case estimate of the weight. The actual execution will return the
+	/// accurate amount.
+	fn weigh_on_new_offences(
+		slash_session: SessionIndex,
+		offences: &[Offence<Self::AccountId>],
+	) -> Weight;
 }
 
 /// The communication trait of `pallet-staking-async` -> `pallet-staking-async-rc-client`.
@@ -602,15 +618,15 @@ pub mod pallet {
 		#[pallet::weight(
 			// `LastSessionReportEndingIndex`: rw
 			// `IncompleteSessionReport`: rw
-			// NOTE: what happens inside `AHStakingInterface` is benchmarked and registered in `pallet-staking-async`
-			T::DbWeight::get().reads_writes(2, 2)
+			T::DbWeight::get().reads_writes(2, 2) + T::AHStakingInterface::weigh_on_relay_session_report(&report)
 		)]
 		pub fn relay_session_report(
 			origin: OriginFor<T>,
 			report: SessionReport<T::AccountId>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			log!(debug, "Received session report: {}", report);
 			T::RelayChainOrigin::ensure_origin_or_root(origin)?;
+			let local_weight = T::DbWeight::get().reads_writes(2, 2);
 
 			match LastSessionReportEndingIndex::<T>::get() {
 				None => {
@@ -638,7 +654,7 @@ pub mod pallet {
 					);
 					Self::deposit_event(Event::Unexpected(UnexpectedKind::SessionAlreadyProcessed));
 					IncompleteSessionReport::<T>::kill();
-					return Ok(());
+					return Ok(Some(local_weight).into());
 				},
 			}
 
@@ -661,35 +677,34 @@ pub mod pallet {
 					IncompleteSessionReport::<T>::get().is_none(),
 					"we have ::take() it above, we don't want to keep the old data"
 				);
-				return Ok(());
+				return Ok(().into());
 			}
 			let new_session_report = maybe_new_session_report.expect("checked above; qed");
 
 			if new_session_report.leftover {
 				// this is still not final -- buffer it.
 				IncompleteSessionReport::<T>::put(new_session_report);
+				Ok(().into())
 			} else {
 				// this is final, report it.
 				LastSessionReportEndingIndex::<T>::put(new_session_report.end_index);
-				T::AHStakingInterface::on_relay_session_report(new_session_report);
+				let weight = T::AHStakingInterface::on_relay_session_report(new_session_report);
+				Ok((Some(local_weight + weight)).into())
 			}
-
-			Ok(())
 		}
 
 		/// Called to report one or more new offenses on the relay chain.
 		#[pallet::call_index(1)]
 		#[pallet::weight(
-			// `on_new_offences` is benchmarked by `pallet-staking-async`
 			// events are free
 			// origin check is negligible.
-			Weight::default()
+			T::AHStakingInterface::weigh_on_new_offences(*slash_session, &offences)
 		)]
 		pub fn relay_new_offence(
 			origin: OriginFor<T>,
 			slash_session: SessionIndex,
 			offences: Vec<Offence<T::AccountId>>,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			log!(info, "Received new offence at slash_session: {:?}", slash_session);
 			T::RelayChainOrigin::ensure_origin_or_root(origin)?;
 
@@ -698,8 +713,8 @@ pub mod pallet {
 				offences_count: offences.len() as u32,
 			});
 
-			T::AHStakingInterface::on_new_offences(slash_session, offences);
-			Ok(())
+			let weight = T::AHStakingInterface::on_new_offences(slash_session, offences);
+			Ok(Some(weight).into())
 		}
 	}
 }

--- a/substrate/frame/staking-async/src/pallet/impls.rs
+++ b/substrate/frame/staking-async/src/pallet/impls.rs
@@ -1068,9 +1068,8 @@ impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 	/// 3. Activate Next Era: When we receive an activation timestamp in the session report, it
 	/// implies a new validator set has been applied, and we must increment the active era to keep
 	/// the systems in sync.
-	fn on_relay_session_report(report: rc_client::SessionReport<Self::AccountId>) {
+	fn on_relay_session_report(report: rc_client::SessionReport<Self::AccountId>) -> Weight {
 		log!(debug, "Received session report: {}", report,);
-		let consumed_weight = T::WeightInfo::rc_on_session_report();
 
 		let rc_client::SessionReport {
 			end_index,
@@ -1080,26 +1079,30 @@ impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 		} = report;
 		debug_assert!(!leftover);
 
+		// note: weight for `reward_active_era` is taken care of inside `end_session`
 		Eras::<T>::reward_active_era(validator_points.into_iter());
-		session_rotation::Rotator::<T>::end_session(end_index, activation_timestamp);
-		// NOTE: we might want to either return these weights so that they are registered in the
-		// rc-client pallet, or directly benchmarked there, such that we can use them in the
-		// "pre-dispatch" fashion. That said, since these are all `Mandatory` weights, it doesn't
-		// make that big of a difference.
-		Self::register_weight(consumed_weight);
+		session_rotation::Rotator::<T>::end_session(end_index, activation_timestamp)
+	}
+
+	fn weigh_on_relay_session_report(
+		_report: &rc_client::SessionReport<Self::AccountId>,
+	) -> Weight {
+		// worst case weight of this is always
+		T::WeightInfo::rc_on_session_report()
+			.saturating_add(T::WeightInfo::prune_era(ValidatorCount::<T>::get()))
 	}
 
 	fn on_new_offences(
 		slash_session: SessionIndex,
 		offences: Vec<rc_client::Offence<T::AccountId>>,
-	) {
+	) -> Weight {
 		log!(debug, "🦹 on_new_offences: {:?}", offences);
-		let consumed_weight = T::WeightInfo::rc_on_offence(offences.len() as u32);
+		let weight = T::WeightInfo::rc_on_offence(offences.len() as u32);
 
 		// Find the era to which offence belongs.
 		let Some(active_era) = ActiveEra::<T>::get() else {
 			log!(warn, "🦹 on_new_offences: no active era; ignoring offence");
-			return
+			return T::WeightInfo::rc_on_offence(0);
 		};
 
 		let active_era_start_session = Rotator::<T>::active_era_start_session_index();
@@ -1120,7 +1123,7 @@ impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 					// defensive: this implies offence is for a discarded era, and should already be
 					// filtered out.
 					log!(warn, "🦹 on_offence: no era found for slash_session; ignoring offence");
-					return
+					return T::WeightInfo::rc_on_offence(0);
 				},
 			}
 		};
@@ -1251,7 +1254,14 @@ impl<T: Config> rc_client::AHStakingInterface for Pallet<T> {
 			}
 		}
 
-		Self::register_weight(consumed_weight);
+		weight
+	}
+
+	fn weigh_on_new_offences(
+		_slash_session: SessionIndex,
+		offences: &[pallet_staking_async_rc_client::Offence<Self::AccountId>],
+	) -> Weight {
+		T::WeightInfo::rc_on_offence(offences.len() as u32)
 	}
 }
 

--- a/substrate/frame/staking-async/src/pallet/mod.rs
+++ b/substrate/frame/staking-async/src/pallet/mod.rs
@@ -1155,6 +1155,8 @@ pub mod pallet {
 		/// Something occurred that should never happen under normal operation.
 		/// Logged as an event for fail-safe observability.
 		Unexpected(UnexpectedKind),
+		/// An old era with the given index was pruned.
+		EraPruned { index: EraIndex },
 	}
 
 	/// Represents unexpected or invariant-breaking conditions encountered during execution.

--- a/substrate/frame/staking-async/src/session_rotation.rs
+++ b/substrate/frame/staking-async/src/session_rotation.rs
@@ -121,8 +121,8 @@ impl<T: Config> Eras<T> {
 		<ErasRewardPoints<T>>::remove(era);
 		<ErasTotalStake<T>>::remove(era);
 
-		// register the weight of the pruning.
-		Pallet::<T>::register_weight(T::WeightInfo::prune_era(ValidatorCount::<T>::get()));
+		// weight is registered in the main `relay_session_report` code path.
+		Pallet::<T>::deposit_event(Event::<T>::EraPruned { index: era });
 	}
 
 	pub(crate) fn set_validator_prefs(era: EraIndex, stash: &T::AccountId, prefs: ValidatorPrefs) {
@@ -552,10 +552,16 @@ impl<T: Config> Rotator<T> {
 	}
 
 	/// End the session and start the next one.
-	pub(crate) fn end_session(end_index: SessionIndex, activation_timestamp: Option<(u64, u32)>) {
+	pub(crate) fn end_session(
+		end_index: SessionIndex,
+		activation_timestamp: Option<(u64, u32)>,
+	) -> Weight {
+		// baseline weight -- if we start a new era, we will add the pruning weight to it.
+		let mut weight = T::WeightInfo::rc_on_session_report();
+
 		let Some(active_era) = ActiveEra::<T>::get() else {
 			defensive!("Active era must always be available.");
-			return;
+			return weight;
 		};
 		let current_planned_era = Self::is_planning();
 		let starting = end_index + 1;
@@ -576,6 +582,8 @@ impl<T: Config> Rotator<T> {
 			Some((time, id)) if Some(id) == current_planned_era => {
 				// We rotate the era if we have the activation timestamp.
 				Self::start_era(active_era, starting, time);
+				// accumulate pruning weight.
+				weight.saturating_accrue(T::WeightInfo::prune_era(ValidatorCount::<T>::get()));
 			},
 			Some((_time, id)) => {
 				// RC has done something wrong -- we received the wrong ID. Don't start a new era.
@@ -634,6 +642,8 @@ impl<T: Config> Rotator<T> {
 			active_era: Self::active_era(),
 			planned_era: Self::planned_era(),
 		});
+
+		weight
 	}
 
 	pub(crate) fn start_era(

--- a/substrate/frame/staking-async/src/tests/era_rotation.rs
+++ b/substrate/frame/staking-async/src/tests/era_rotation.rs
@@ -323,6 +323,15 @@ fn era_cleanup_history_depth_works() {
 		assert_ok!(Eras::<T>::era_present(2));
 		// ..
 		assert_ok!(Eras::<T>::era_present(HistoryDepth::get() + 1));
+		assert!(matches!(
+			&staking_events_since_last_call()[..],
+			&[
+				..,
+				Event::EraPaid { era_index: 80, validator_payout: 7500, remainder: 7500 },
+				Event::EraPruned { index: 0 },
+				Event::SessionRotated { starting_session: 243, active_era: 81, planned_era: 81 }
+			]
+		));
 
 		Session::roll_until_active_era(HistoryDepth::get() + 2);
 		assert_ok!(Eras::<T>::era_absent(1));
@@ -330,6 +339,15 @@ fn era_cleanup_history_depth_works() {
 		assert_ok!(Eras::<T>::era_present(3));
 		// ..
 		assert_ok!(Eras::<T>::era_present(HistoryDepth::get() + 2));
+		assert!(matches!(
+			&staking_events_since_last_call()[..],
+			&[
+				..,
+				Event::EraPaid { era_index: 81, validator_payout: 7500, remainder: 7500 },
+				Event::EraPruned { index: 1 },
+				Event::SessionRotated { starting_session: 246, active_era: 82, planned_era: 82 }
+			]
+		));
 	});
 }
 


### PR DESCRIPTION
Which will consequently make the XCM/MQ code path aware of the weights, which was previously not the case. 

Additionally, adds an event for when an era is pruned.