### PR TITLE
[poc] frame/revive: ETH block storage 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,24 +5983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethereum"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
-dependencies = [
- "bytes",
- "ethereum-types",
- "hash-db",
- "hash256-std-hasher",
- "k256",
- "parity-scale-codec",
- "rlp 0.6.1",
- "scale-info",
- "sha3",
- "trie-root",
-]
-
-[[package]]
 name = "ethereum-standards"
 version = "0.1.0"
 dependencies = [
@@ -12863,7 +12845,6 @@ dependencies = [
  "assert_matches",
  "derive_more 0.99.17",
  "environmental",
- "ethereum",
  "ethereum-standards",
  "ethereum-types",
  "frame-benchmarking",
@@ -18218,19 +18199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
-dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,6 +5983,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
+dependencies = [
+ "bytes",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "k256",
+ "parity-scale-codec",
+ "rlp 0.6.1",
+ "scale-info",
+ "sha3",
+ "trie-root",
+]
+
+[[package]]
 name = "ethereum-standards"
 version = "0.1.0"
 dependencies = [
@@ -12845,6 +12863,7 @@ dependencies = [
  "assert_matches",
  "derive_more 0.99.17",
  "environmental",
+ "ethereum",
  "ethereum-standards",
  "ethereum-types",
  "frame-benchmarking",
@@ -18199,7 +18218,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
+ "rlp-derive",
  "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -792,6 +792,7 @@ environmental = { version = "1.1.4", default-features = false }
 equivocation-detector = { path = "bridges/relays/equivocation" }
 ethabi = { version = "2.0.0", default-features = false, package = "ethabi-decode" }
 ethbloom = { version = "0.14.1", default-features = false }
+ethereum = { version = "0.18.2", default-features = false }
 ethereum-types = { version = "0.15.1", default-features = false }
 exit-future = { version = "0.2.0" }
 expander = { version = "2.0.0" }

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -49,6 +49,7 @@ pallet-revive-fixtures = { workspace = true, optional = true }
 pallet-revive-proc-macro = { workspace = true }
 pallet-revive-uapi = { workspace = true, features = ["scale"] }
 pallet-transaction-payment = { workspace = true }
+pallet-timestamp = { workspace = true, default-features = true }
 ripemd = { workspace = true }
 sp-api = { workspace = true }
 sp-arithmetic = { workspace = true }
@@ -72,7 +73,6 @@ serde_json = { workspace = true }
 pallet-balances = { workspace = true, default-features = true }
 pallet-proxy = { workspace = true, default-features = true }
 pallet-revive-fixtures = { workspace = true, default-features = true }
-pallet-timestamp = { workspace = true, default-features = true }
 pallet-utility = { workspace = true, default-features = true }
 sp-keystore = { workspace = true, default-features = true }
 sp-tracing = { workspace = true, default-features = true }

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -21,7 +21,7 @@ alloy-core = { workspace = true, features = ["sol-types"] }
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
 derive_more = { workspace = true, features = ["from", "try_into"] }
 environmental = { workspace = true }
-ethereum = { workspace = true, features = ["with-scale"] }
+# ethereum = { workspace = true, features = ["with-scale"] }
 ethereum-standards = { workspace = true }
 ethereum-types = { workspace = true, features = ["codec", "rlp", "serialize"] }
 hex-literal = { workspace = true }

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -21,6 +21,7 @@ alloy-core = { workspace = true, features = ["sol-types"] }
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
 derive_more = { workspace = true, features = ["from", "try_into"] }
 environmental = { workspace = true }
+ethereum = { workspace = true, features = ["with-scale"] }
 ethereum-standards = { workspace = true }
 ethereum-types = { workspace = true, features = ["codec", "rlp", "serialize"] }
 hex-literal = { workspace = true }

--- a/substrate/frame/revive/rpc/src/receipt_extractor.rs
+++ b/substrate/frame/revive/rpc/src/receipt_extractor.rs
@@ -104,8 +104,12 @@ impl ReceiptExtractor {
 		let events = ext.events().await?;
 
 		let success = events.has::<ExtrinsicSuccess>().inspect_err(|err| {
-		log::debug!(target: LOG_TARGET, "Failed to lookup for ExtrinsicSuccess event in block {block_number}: {err:?}")
-	})?;
+			log::debug!(
+				target: LOG_TARGET,
+				"Failed to lookup for ExtrinsicSuccess event in block {block_number}: {err:?}"
+			);
+		})?;
+
 		let tx_fees = events
 		.find_first::<TransactionFeePaid>()?
 		.ok_or(ClientError::TxFeeNotFound)

--- a/substrate/frame/revive/src/evm/api/rpc_types_gen.rs
+++ b/substrate/frame/revive/src/evm/api/rpc_types_gen.rs
@@ -74,7 +74,9 @@ fn deserialize_input_or_data<'d, D: Deserializer<'d>>(d: D) -> Result<InputOrDat
 }
 
 /// Block object
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Block {
 	/// Base fee per gas
 	#[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -398,7 +400,9 @@ impl Default for SyncingStatus {
 }
 
 /// Transaction information
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct TransactionInfo {
 	/// block hash
 	#[serde(rename = "blockHash")]
@@ -480,7 +484,9 @@ pub enum BlockTag {
 /// Filter Topics
 pub type FilterTopics = Vec<FilterTopic>;
 
-#[derive(Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq)]
+#[derive(
+	Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 #[serde(untagged)]
 pub enum HashesOrTransactionInfos {
 	/// Transaction hashes
@@ -540,7 +546,9 @@ pub struct SyncingProgress {
 }
 
 /// EIP-1559 transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction1559Unsigned {
 	/// accessList
 	/// EIP-2930 access list
@@ -580,7 +588,9 @@ pub struct Transaction1559Unsigned {
 }
 
 /// EIP-2930 transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction2930Unsigned {
 	/// accessList
 	/// EIP-2930 access list
@@ -609,7 +619,9 @@ pub struct Transaction2930Unsigned {
 }
 
 /// EIP-4844 transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction4844Unsigned {
 	/// accessList
 	/// EIP-2930 access list
@@ -651,7 +663,9 @@ pub struct Transaction4844Unsigned {
 }
 
 /// Legacy transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct TransactionLegacyUnsigned {
 	/// chainId
 	/// Chain ID that this transaction is valid on.
@@ -675,7 +689,9 @@ pub struct TransactionLegacyUnsigned {
 	pub value: U256,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq)]
+#[derive(
+	Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 #[serde(untagged)]
 pub enum TransactionSigned {
 	Transaction4844Signed(Transaction4844Signed),
@@ -690,7 +706,9 @@ impl Default for TransactionSigned {
 }
 
 /// Validator withdrawal
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Withdrawal {
 	/// recipient address for withdrawal value
 	pub address: Address,
@@ -729,7 +747,9 @@ impl Default for FilterTopic {
 }
 
 /// Signed 1559 Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction1559Signed {
 	#[serde(flatten)]
 	pub transaction_1559_unsigned: Transaction1559Unsigned,
@@ -749,7 +769,9 @@ pub struct Transaction1559Signed {
 }
 
 /// Signed 2930 Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction2930Signed {
 	#[serde(flatten)]
 	pub transaction_2930_unsigned: Transaction2930Unsigned,
@@ -769,7 +791,9 @@ pub struct Transaction2930Signed {
 }
 
 /// Signed 4844 Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction4844Signed {
 	#[serde(flatten)]
 	pub transaction_4844_unsigned: Transaction4844Unsigned,
@@ -784,7 +808,9 @@ pub struct Transaction4844Signed {
 }
 
 /// Signed Legacy Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct TransactionLegacySigned {
 	#[serde(flatten)]
 	pub transaction_legacy_unsigned: TransactionLegacyUnsigned,

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -142,8 +142,15 @@ where
 
 	fn check(self, lookup: &Lookup) -> Result<Self::Checked, TransactionValidityError> {
 		if !self.0.is_signed() {
-			if let Some(crate::Call::eth_transact { payload }) = self.0.function.is_sub_type() {
-				let checked = E::try_into_checked_extrinsic(payload.to_vec(), self.encoded_size())?;
+			if let Some(crate::Call::eth_transact { payload, raw_bytes }) =
+				self.0.function.is_sub_type()
+			{
+				let checked = E::try_into_checked_extrinsic(
+					payload.to_vec(),
+					raw_bytes.to_vec(),
+					self.encoded_size(),
+				)?;
+
 				return Ok(checked)
 			};
 		}
@@ -270,11 +277,10 @@ pub trait EthExtra {
 	///
 	/// # Parameters
 	/// - `payload`: The RLP-encoded Ethereum transaction.
-	/// - `gas_limit`: The gas limit for the extrinsic
-	/// - `storage_deposit_limit`: The storage deposit limit for the extrinsic,
-	/// - `encoded_len`: The encoded length of the extrinsic.
+	/// - `raw_bytes`: The raw bytes of the Ethereum transaction.
 	fn try_into_checked_extrinsic(
 		payload: Vec<u8>,
+		raw_bytes: Vec<u8>,
 		encoded_len: usize,
 	) -> Result<
 		CheckedExtrinsic<AccountIdOf<Self::Config>, CallOf<Self::Config>, Self::Extension>,

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -569,7 +569,10 @@ mod test {
 				let payload = account
 					.sign_transaction(tx.clone().try_into_unsigned().unwrap())
 					.signed_payload();
-				let call = RuntimeCall::Contracts(crate::Call::eth_transact { payload });
+				let call = RuntimeCall::Contracts(crate::Call::eth_transact {
+					payload,
+					raw_bytes: vec![],
+				});
 
 				let encoded_len = call.encoded_size();
 				let uxt: Ex = generic::UncheckedExtrinsic::new_bare(call).into();

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -280,7 +280,7 @@ pub trait EthExtra {
 	/// - `raw_bytes`: The raw bytes of the Ethereum transaction.
 	fn try_into_checked_extrinsic(
 		payload: Vec<u8>,
-		raw_bytes: Vec<u8>,
+		_raw_bytes: Vec<u8>,
 		encoded_len: usize,
 	) -> Result<
 		CheckedExtrinsic<AccountIdOf<Self::Config>, CallOf<Self::Config>, Self::Extension>,

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -598,9 +598,10 @@ pub mod pallet {
 
 		// TODO: Does it hold water?
 		frame_system::Event<T>: TryFrom<<T as frame_system::Config>::RuntimeEvent>,
+		frame_system::Event<T>: TryFrom<<T as pallet_transaction_payment::Config>::RuntimeEvent>,
+
 		// frame_system::Event<T>: TryFrom<<T as
 		// pallet_transaction_payment::Config>::RuntimeEvent>,
-
 		// pallet_transaction_payment::Event::TransactionFeePaid
 
 		// type RuntimeEvent: From<Event<Self>> + IsType<<Self as
@@ -611,6 +612,12 @@ pub mod pallet {
 		BalanceOf<T>: Into<U256> + TryFrom<U256>,
 		MomentOf<T>: Into<U256>,
 		T::Hash: frame_support::traits::IsType<H256>,
+
+		// For ETH block gas limit
+		<T as frame_system::Config>::RuntimeCall:
+			Dispatchable<Info = frame_support::dispatch::DispatchInfo>,
+		T: pallet_transaction_payment::Config,
+		OnChargeTransactionBalanceOf<T>: Into<BalanceOf<T>>,
 	{
 		fn on_idle(_block: BlockNumberFor<T>, limit: Weight) -> Weight {
 			let mut meter = WeightMeter::with_limit(limit);
@@ -802,6 +809,7 @@ pub mod pallet {
 				.unzip();
 
 			// Build EVM block.
+			let gas_limit = Self::evm_block_gas_limit();
 		}
 
 		fn integrity_test() {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -551,6 +551,15 @@ pub mod pallet {
 			meter.consumed()
 		}
 
+		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
+			Weight::zero()
+		}
+
+		fn on_finalize(_: BlockNumberFor<T>) {
+			// ensure we never go to trie with these values.
+			// <Pending<T>>::kill();
+		}
+
 		fn integrity_test() {
 			use limits::code::STATIC_MEMORY_BYTES;
 

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -563,6 +563,7 @@ pub mod pallet {
 	// TODO: This should be bounded at a constant length.
 	#[pallet::storage]
 	#[pallet::unbounded]
+	#[pallet::getter(fn current_eth_block)]
 	pub type CurrentEthBlock<T: Config> = StorageValue<_, EthBlock>;
 	// /// The current Ethereum receipts.
 	// #[pallet::storage]
@@ -622,6 +623,9 @@ pub mod pallet {
 		}
 
 		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
+			// let eth_block = CurrentEthBlock::<T>::get();
+			// let parent_state_root = storage::root(sp_runtime::StateVersion::V1);
+
 			// TODO: Return proper weight.
 			Weight::zero()
 		}
@@ -2011,6 +2015,11 @@ sp_api::decl_runtime_apis! {
 		/// See [`crate::Pallet::dry_run_eth_transact`]
 		fn eth_transact(tx: GenericTransaction, raw_bytes: Vec<u8>) -> Result<EthTransactInfo<Balance>, EthTransactError>;
 
+		/// Fetch the current ETH block from storage.
+		///
+		/// This does not contain the state and transaction roots yet.
+		fn eth_block() -> EthBlock;
+
 		/// Upload new code without instantiating a contract from it.
 		///
 		/// See [`crate::Pallet::bare_upload_code`].
@@ -2174,6 +2183,10 @@ macro_rules! impl_runtime_apis_plus_revive {
 					let blockweights: $crate::BlockWeights =
 						<Self as $crate::frame_system::Config>::BlockWeights::get();
 					$crate::Pallet::<Self>::dry_run_eth_transact(tx, blockweights.max_block, tx_fee)
+				}
+
+				fn eth_block() -> EthBlock {
+					$crate::Pallet::<Self>::current_eth_block()
 				}
 
 				fn call(

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -34,7 +34,7 @@ mod storage;
 #[cfg(test)]
 mod tests;
 mod transient_storage;
-mod types;
+// mod types;
 mod vm;
 
 pub mod evm;
@@ -56,7 +56,7 @@ use crate::{
 		meter::Meter as StorageMeter, AccountInfo, AccountType, ContractInfo, DeletionQueueManager,
 	},
 	tracing::if_tracing,
-	types::BlockV3,
+	// types::BlockV3,
 	vm::{CodeInfo, ContractBlob, RuntimeCosts},
 };
 
@@ -556,9 +556,9 @@ pub mod pallet {
 	// pub type Pending<T: Config> =
 	// 	CountedStorageMap<_, Identity, u32, (Transaction, TransactionStatus, Receipt), OptionQuery>;
 
-	/// The current Ethereum block.
-	#[pallet::storage]
-	pub type CurrentBlock<T: Config> = StorageValue<_, BlockV3>;
+	// /// The current Ethereum block.
+	// #[pallet::storage]
+	// pub type CurrentBlock<T: Config> = StorageValue<_, BlockV3>;
 
 	// TODO: This should be bounded at a constant length.
 	#[pallet::storage]

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -570,6 +570,10 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type CurrentBlock<T: Config> = StorageValue<_, BlockV3>;
 
+	// TODO: This should be bounded at a constant length.
+	#[pallet::storage]
+	#[pallet::unbounded]
+	pub type CurrentEthBlock<T: Config> = StorageValue<_, EthBlock>;
 	// /// The current Ethereum receipts.
 	// #[pallet::storage]
 	// pub type CurrentReceipts<T: Config> = StorageValue<_, BoundedVec<ReceiptV4, ConstU32<1024>>>;
@@ -884,6 +888,8 @@ pub mod pallet {
 				transactions,
 				..Default::default()
 			};
+
+			CurrentEthBlock::<T>::put(eth_block);
 		}
 
 		fn integrity_test() {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -622,7 +622,7 @@ pub mod pallet {
 			meter.consumed()
 		}
 
-		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
 			// let eth_block = CurrentEthBlock::<T>::get();
 			// let parent_state_root = storage::root(sp_runtime::StateVersion::V1);
 
@@ -662,9 +662,7 @@ pub mod pallet {
 					// 	}
 					// }
 
-					if let Some(crate::Call::eth_transact { payload, raw_bytes }) =
-						call.is_sub_type()
-					{
+					if let Some(crate::Call::eth_transact { payload, .. }) = call.is_sub_type() {
 						Some((index, (payload.clone(), Vec::new())))
 					} else {
 						None

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -724,6 +724,7 @@ pub mod pallet {
 				let tx_info =
 					GenericTransaction::from_signed(signed_tx.clone(), base_gas_price, Some(from));
 				// TODO: Compute gas correctly.
+				let gas_price = U256::from(0);
 				let gas_used = U256::from(0);
 
 				let logs = events
@@ -750,6 +751,36 @@ pub mod pallet {
 						}
 					})
 					.collect::<Vec<_>>();
+
+				let contract_address = if tx_info.to.is_none() {
+					Some(create1(
+						&from,
+						tx_info
+							.nonce
+							.unwrap_or_default()
+							.try_into()
+							// TODO: Do not panic!
+							.expect("Nonce is a valid u32; qed"),
+						// .map_err(|_| ClientError::ConversionFailed)?,
+					))
+				} else {
+					None
+				};
+
+				let receipt = ReceiptInfo::new(
+					block_hash.into(),
+					block_number.into(),
+					contract_address,
+					from,
+					logs,
+					tx_info.to,
+					gas_price,
+					gas_used,
+					success,
+					transaction_hash,
+					transaction_index.into(),
+					tx_info.r#type.unwrap_or_default(),
+				);
 
 				// let success = events.iter().any(|event| {
 				// 	if let <T as Config>::RuntimeEvent::System(

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1824,6 +1824,15 @@ sp_api::decl_runtime_apis! {
 	}
 }
 
+// fn decode_eth_transaction(raw_bytes: &[u8]) -> Result<ethereum::TransactionV3, EthTransactError>
+// { 	let transaction = ethereum::TransactionV3::decode(&mut &raw_bytes[..])
+// 		.map_err(|_| EthTransactError::Message("Failed to decode transaction".into()))?;
+
+// 	let transaction_hash = transaction.hash();
+
+// 	Ok(transaction)
+// }
+
 /// This macro wraps substrate's `impl_runtime_apis!` and implements `pallet_revive` runtime APIs.
 ///
 /// # Parameters
@@ -1875,6 +1884,14 @@ macro_rules! impl_runtime_apis_plus_revive {
 						sp_runtime::traits::TransactionExtension,
 						sp_runtime::traits::Block as BlockT
 					};
+
+					// // Decode eth raw bytes to a transaction.
+					// let eth_tx = ethereum::TransactionV3::decode(&mut &raw_bytes[..])
+					// 	.map_err(|_| $crate::EthTransactError::Message("Failed to decode transaction".into()))?;
+
+					// let transaction_hash = eth_tx.hash();
+					// // let transaction_index = Pending::<T>::count();
+
 
 					let tx_fee = |call: <Self as $crate::frame_system::Config>::RuntimeCall, dispatch_call: <Self as $crate::frame_system::Config>::RuntimeCall| {
 						use $crate::frame_support::dispatch::GetDispatchInfo;

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -34,6 +34,7 @@ mod storage;
 #[cfg(test)]
 mod tests;
 mod transient_storage;
+mod types;
 mod vm;
 
 pub mod evm;
@@ -54,11 +55,16 @@ use crate::{
 		meter::Meter as StorageMeter, AccountInfo, AccountType, ContractInfo, DeletionQueueManager,
 	},
 	tracing::if_tracing,
+	types::{BlockV3, ReceiptV4},
 	vm::{CodeInfo, ContractBlob, RuntimeCosts},
 };
 use alloc::{boxed::Box, format, vec};
 use codec::{Codec, Decode, Encode};
 use environmental::*;
+// use ethereum::{
+// 	AccessListItem, BlockV3 as Block, LegacyTransactionMessage, Log, ReceiptV4 as Receipt,
+// 	TransactionAction, TransactionV3 as Transaction,
+// };
 use frame_support::{
 	dispatch::{
 		DispatchErrorWithPostInfo, DispatchResultWithPostInfo, GetDispatchInfo, Pays,
@@ -542,6 +548,30 @@ pub mod pallet {
 			}
 		}
 	}
+
+	// /// Mapping from transaction index to transaction in the current building block.
+	// #[pallet::storage]
+	// pub type Pending<T: Config> =
+	// 	CountedStorageMap<_, Identity, u32, (Transaction, TransactionStatus, Receipt), OptionQuery>;
+
+	/// The current Ethereum block.
+	#[pallet::storage]
+	pub type CurrentBlock<T: Config> = StorageValue<_, BlockV3>;
+
+	// /// The current Ethereum receipts.
+	// #[pallet::storage]
+	// pub type CurrentReceipts<T: Config> = StorageValue<_, BoundedVec<ReceiptV4, ConstU32<1024>>>;
+
+	/// The current transaction statuses.
+	///
+	/// TODO: Bounded Vec length must be a constant on the pallet itself.
+	// #[pallet::storage]
+	// pub type CurrentTransactionStatuses<T: Config> =
+	// 	StorageValue<_, BoundedVec<TransactionStatus, ConstU32<1024>>>;
+
+	// Mapping for block number and hashes.
+	#[pallet::storage]
+	pub type BlockHash<T: Config> = StorageMap<_, Twox64Concat, U256, H256, ValueQuery>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {

--- a/substrate/frame/revive/src/types.rs
+++ b/substrate/frame/revive/src/types.rs
@@ -1,0 +1,82 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Codec, Decode, Encode};
+use scale_info::TypeInfo;
+use std::ops::Deref;
+
+/// Wrapper for BlockV3 that implements `MaxEncodedLen`.
+#[derive(Debug, Clone, PartialEq, Encode, Decode, TypeInfo)]
+pub struct BlockV3(ethereum::BlockV3);
+
+impl codec::MaxEncodedLen for BlockV3 {
+	fn max_encoded_len() -> usize {
+		usize::MAX
+	}
+}
+
+// Passthrough implementations for Encode and Decode
+impl From<ethereum::BlockV3> for BlockV3 {
+	fn from(block: ethereum::BlockV3) -> Self {
+		BlockV3(block)
+	}
+}
+
+impl From<BlockV3> for ethereum::BlockV3 {
+	fn from(wrapper: BlockV3) -> Self {
+		wrapper.0
+	}
+}
+
+impl Deref for BlockV3 {
+	type Target = ethereum::BlockV3;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+/// Wrapper for ReceiptV4 that implements `MaxEncodedLen`.
+#[derive(Debug, Clone, PartialEq, Encode, Decode, TypeInfo)]
+pub struct ReceiptV4(ethereum::ReceiptV4);
+
+impl codec::MaxEncodedLen for ReceiptV4 {
+	fn max_encoded_len() -> usize {
+		usize::MAX
+	}
+}
+
+// Passthrough implementations for Encode and Decode
+impl From<ethereum::ReceiptV4> for ReceiptV4 {
+	fn from(block: ethereum::ReceiptV4) -> Self {
+		ReceiptV4(block)
+	}
+}
+
+impl From<ReceiptV4> for ethereum::ReceiptV4 {
+	fn from(wrapper: ReceiptV4) -> Self {
+		wrapper.0
+	}
+}
+
+impl Deref for ReceiptV4 {
+	type Target = ethereum::ReceiptV4;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}

--- a/substrate/frame/revive/src/types.rs
+++ b/substrate/frame/revive/src/types.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use codec::{Codec, Decode, Encode};
+use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use std::ops::Deref;
 


### PR DESCRIPTION
PoC to store/reconstruct the ETH block storage inside the pallet revive.

The bulk of the changes are isolated to the `fn on_finalize(_: BlockNumberFor<T>)` hook (we can ignore almost everything else):
- Extrinsic of the current block is decoded and filtered by the EthTransact call
- Emitted events are associated with the transaction index to capture the Eth Logs (needed for receipts)
- This aims to reconstruct the SignedTransaction and ReceiptInfo
- ETH block is constructed **without** state root and extrinsic root
  - It looks like we don't have access to that bit of information from the `on_finalize` hook
  - There might be a way to fetch the state root of the previous block at `on_initialize` hook (offhand not sure if we can fetch the extrinsic root this way)
  - Could we avoid the computation of the merkle root for these? I expect it will negatively impact the performance
- ETH block is then exposed by a new runtime API `Revive_eth_block`.

There are a few caveats to consider:
- the performance of the pallet/reviev is impacted by traversing all extrinsics and decoding them
  - This is currently done via the frame_system pallets' : `frame_system::Pallet::<T>::extrinsic_count()` and `frame_system::Pallet::<T>::extrinsic_data(index)`
  - We'll need to rethink this if it turns out the performance is impacted past expectations. Currently, we can capture the pallet call's `pub fn eth_transact` result. However, the user is then responsible for signing the transaction and submitting it to the chain. If the user omits to do so, we can potentially have unbounded growth. Even so, we'll need to ensure that the `EthTransact` call is included in the block (ie the user can choose to submit it many blocks later). We could also explore the transaction extensions for this part.
- Events are also traversed from the block. Currently, I don't see a way to associate them with a specific transaction.
  - We could extend the `ContractEmitted` events with the transaction hash (but we might still need to traverse them to obtain the `TransactionFeePaid`)
- The following are not included: `TransactionFeePaid` event, log index (fallbacks to zero)
- The code is not panic-proof
 
Part of: https://github.com/paritytech/contract-issues/issues/139

cc @lrubasze @skunert @athei 
 
 
