### PR TITLE
pallet_revive: Enforce storage deposit limit on plain transfer

### DIFF
--- a/prdoc/pr_9416.prdoc
+++ b/prdoc/pr_9416.prdoc
@@ -1,0 +1,10 @@
+title: 'pallet_revive: Enforce storage deposit limit on plain transfer'
+doc:
+- audience: Runtime Dev
+  description: |-
+    The existential deposit to create a new account is part of the storage deposit. Hence if the storage deposit limit is too low to create a new account we fail the transaction. However, this limit was not enforced for plain transfers. The reason is that we only enforce the limit at the end of each frame. But for plain transfers (transferring to a non contract) there is no frame.
+
+    This PR fixes the situation by enforcing the limit when transferring the existential deposit in order to create a new account.
+crates:
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1093,11 +1093,7 @@ where
 
 		let try_call = || {
 			let origin = Origin::from_runtime_origin(origin)?;
-			let mut storage_meter = match storage_deposit_limit {
-				DepositLimit::Balance(limit) => StorageMeter::new(limit),
-				DepositLimit::UnsafeOnlyForDryRun =>
-					StorageMeter::new_unchecked(BalanceOf::<T>::max_value()),
-			};
+			let mut storage_meter = StorageMeter::new(storage_deposit_limit.limit());
 			let result = ExecStack::<T, ContractBlob<T>>::run_call(
 				origin.clone(),
 				dest,
@@ -1152,11 +1148,7 @@ where
 		let mut gas_meter = GasMeter::new(gas_limit);
 		let mut storage_deposit = Default::default();
 		let unchecked_deposit_limit = storage_deposit_limit.is_unchecked();
-		let mut storage_deposit_limit = match storage_deposit_limit {
-			DepositLimit::Balance(limit) => limit,
-			DepositLimit::UnsafeOnlyForDryRun => BalanceOf::<T>::max_value(),
-		};
-
+		let mut storage_deposit_limit = storage_deposit_limit.limit();
 		let try_instantiate = || {
 			let instantiate_account = T::InstantiateOrigin::ensure_origin(origin.clone())?;
 
@@ -1177,12 +1169,7 @@ where
 					(ContractBlob::from_storage(code_hash, &mut gas_meter)?, Default::default()),
 			};
 			let instantiate_origin = Origin::from_account_id(instantiate_account.clone());
-			let mut storage_meter = if unchecked_deposit_limit {
-				StorageMeter::new_unchecked(storage_deposit_limit)
-			} else {
-				StorageMeter::new(storage_deposit_limit)
-			};
-
+			let mut storage_meter = StorageMeter::new(storage_deposit_limit);
 			let result = ExecStack::<T, ContractBlob<T>>::run_instantiate(
 				instantiate_account,
 				executable,

--- a/substrate/frame/revive/src/primitives.rs
+++ b/substrate/frame/revive/src/primitives.rs
@@ -23,6 +23,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::weights::Weight;
 use pallet_revive_uapi::ReturnFlags;
 use scale_info::TypeInfo;
+use sp_arithmetic::traits::Bounded;
 use sp_core::Get;
 use sp_runtime::{
 	traits::{One, Saturating, Zero},
@@ -50,6 +51,15 @@ impl<T> DepositLimit<T> {
 impl<T> From<T> for DepositLimit<T> {
 	fn from(value: T) -> Self {
 		Self::Balance(value)
+	}
+}
+
+impl<T: Bounded + Copy> DepositLimit<T> {
+	pub fn limit(&self) -> T {
+		match self {
+			Self::UnsafeOnlyForDryRun => T::max_value(),
+			Self::Balance(limit) => *limit,
+		}
 	}
 }
 

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -32,7 +32,7 @@ use crate::{
 	weights::WeightInfo,
 	AccountId32Mapper, AccountInfo, AccountInfoOf, BalanceOf, BalanceWithDust, BumpNonce, Code,
 	CodeInfoOf, Config, ContractInfo, DeletionQueueCounter, DepositLimit, Error, EthTransactError,
-	HoldReason, Origin, Pallet, PristineCode, H160,
+	HoldReason, Origin, Pallet, PristineCode, StorageDeposit, H160,
 };
 use assert_matches::assert_matches;
 use codec::Encode;
@@ -600,6 +600,41 @@ fn contract_call_transfer_with_dust_works() {
 		assert_ok!(builder::call(addr_caller).data((balance, addr_callee).encode()).build());
 
 		assert_eq!(Pallet::<Test>::evm_balance(&addr_callee), balance);
+	});
+}
+
+#[test]
+fn deposit_limit_enforced_on_plain_transfer() {
+	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+		let _ = <Test as Config>::Currency::set_balance(&BOB, 1_000_000);
+
+		// sending balance to a frew account should fail when the limit is lower than the ed
+		let result = builder::bare_call(CHARLIE_ADDR)
+			.native_value(1)
+			.storage_deposit_limit(190.into())
+			.build();
+		assert_err!(result.result, <Error<Test>>::StorageDepositLimitExhausted);
+		assert_eq!(result.storage_deposit, StorageDeposit::Charge(0));
+		assert_eq!(test_utils::get_balance(&CHARLIE), 0);
+
+		// works when the account is prefunded
+		let result = builder::bare_call(BOB_ADDR)
+			.native_value(1)
+			.storage_deposit_limit(0.into())
+			.build();
+		assert_ok!(result.result);
+		assert_eq!(result.storage_deposit, StorageDeposit::Charge(0));
+		assert_eq!(test_utils::get_balance(&BOB), 1_000_001);
+
+		// also works allowing enough deposit
+		let result = builder::bare_call(CHARLIE_ADDR)
+			.native_value(1)
+			.storage_deposit_limit(200.into())
+			.build();
+		assert_ok!(result.result);
+		assert_eq!(result.storage_deposit, StorageDeposit::Charge(200));
+		assert_eq!(test_utils::get_balance(&CHARLIE), 201);
 	});
 }
 

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -609,7 +609,7 @@ fn deposit_limit_enforced_on_plain_transfer() {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
 		let _ = <Test as Config>::Currency::set_balance(&BOB, 1_000_000);
 
-		// sending balance to a frew account should fail when the limit is lower than the ed
+		// sending balance to a new account should fail when the limit is lower than the ed
 		let result = builder::bare_call(CHARLIE_ADDR)
 			.native_value(1)
 			.storage_deposit_limit(190.into())


### PR DESCRIPTION
The existential deposit to create a new account is part of the storage deposit. Hence if the storage deposit limit is too low to create a new account we fail the transaction. However, this limit was not enforced for plain transfers. The reason is that we only enforce the limit at the end of each frame. But for plain transfers (transferring to a non contract) there is no frame.

This PR fixes the situation by enforcing the limit when transferring the existential deposit in order to create a new account.