### PR TITLE
Lexnv/minimal poc block storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12887,6 +12887,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-tracing 16.0.0",
+ "sp-trie",
  "substrate-bn",
  "subxt-signer 0.41.0",
 ]

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -38,6 +38,7 @@ rand_pcg = { workspace = true, optional = true }
 rlp = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["alloc", "derive"], workspace = true, default-features = false }
+sp-trie = { workspace = true }
 
 # Polkadot SDK Dependencies
 bn = { workspace = true }
@@ -54,7 +55,8 @@ sp-arithmetic = { workspace = true }
 sp-consensus-aura = { workspace = true, optional = true }
 sp-consensus-babe = { workspace = true, optional = true }
 sp-consensus-slots = { workspace = true, optional = true }
-sp-core = { workspace = true }
+# TODO: Is this feature safe? Was it tested? Why experimental? Better to just use alloy-trie/core?
+sp-core = { workspace = true, features = ["bls-experimental", "bandersnatch-experimental"] }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 subxt-signer = { workspace = true, optional = true, features = ["unstable-eth"] }

--- a/substrate/frame/revive/src/evm/api/rlp_codec.rs
+++ b/substrate/frame/revive/src/evm/api/rlp_codec.rs
@@ -99,6 +99,23 @@ impl TransactionSigned {
 			_ => rlp::decode::<TransactionLegacySigned>(data).map(Into::into),
 		}
 	}
+
+	/// Encode the Ethereum transaction into bytes.
+	pub fn encode_2718(&self) -> Vec<u8> {
+		use alloc::vec;
+		use TransactionSigned::*;
+
+		match self {
+			Transaction2930Signed(ref tx) =>
+				vec![TYPE_EIP2930].into_iter().chain(rlp::encode(tx).into_iter()).collect(),
+			Transaction1559Signed(ref tx) =>
+				vec![TYPE_EIP1559].into_iter().chain(rlp::encode(tx).into_iter()).collect(),
+			Transaction4844Signed(ref tx) =>
+				vec![TYPE_EIP4844].into_iter().chain(rlp::encode(tx).into_iter()).collect(),
+			TransactionLegacySigned(ref tx) =>
+				vec![0].into_iter().chain(rlp::encode(tx).into_iter()).collect(),
+		}
+	}
 }
 
 impl TransactionUnsigned {

--- a/substrate/frame/revive/src/evm/api/rpc_types_gen.rs
+++ b/substrate/frame/revive/src/evm/api/rpc_types_gen.rs
@@ -74,7 +74,9 @@ fn deserialize_input_or_data<'d, D: Deserializer<'d>>(d: D) -> Result<InputOrDat
 }
 
 /// Block object
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Block {
 	/// Base fee per gas
 	#[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -398,7 +400,9 @@ impl Default for SyncingStatus {
 }
 
 /// Transaction information
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct TransactionInfo {
 	/// block hash
 	#[serde(rename = "blockHash")]
@@ -480,7 +484,9 @@ pub enum BlockTag {
 /// Filter Topics
 pub type FilterTopics = Vec<FilterTopic>;
 
-#[derive(Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq)]
+#[derive(
+	Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 #[serde(untagged)]
 pub enum HashesOrTransactionInfos {
 	/// Transaction hashes
@@ -540,7 +546,9 @@ pub struct SyncingProgress {
 }
 
 /// EIP-1559 transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction1559Unsigned {
 	/// accessList
 	/// EIP-2930 access list
@@ -580,7 +588,9 @@ pub struct Transaction1559Unsigned {
 }
 
 /// EIP-2930 transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction2930Unsigned {
 	/// accessList
 	/// EIP-2930 access list
@@ -609,7 +619,9 @@ pub struct Transaction2930Unsigned {
 }
 
 /// EIP-4844 transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction4844Unsigned {
 	/// accessList
 	/// EIP-2930 access list
@@ -651,7 +663,9 @@ pub struct Transaction4844Unsigned {
 }
 
 /// Legacy transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct TransactionLegacyUnsigned {
 	/// chainId
 	/// Chain ID that this transaction is valid on.
@@ -675,7 +689,9 @@ pub struct TransactionLegacyUnsigned {
 	pub value: U256,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq)]
+#[derive(
+	Debug, Clone, Serialize, Deserialize, From, TryInto, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 #[serde(untagged)]
 pub enum TransactionSigned {
 	Transaction4844Signed(Transaction4844Signed),
@@ -690,7 +706,9 @@ impl Default for TransactionSigned {
 }
 
 /// Validator withdrawal
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Withdrawal {
 	/// recipient address for withdrawal value
 	pub address: Address,
@@ -729,7 +747,9 @@ impl Default for FilterTopic {
 }
 
 /// Signed 1559 Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction1559Signed {
 	#[serde(flatten)]
 	pub transaction_1559_unsigned: Transaction1559Unsigned,
@@ -749,7 +769,9 @@ pub struct Transaction1559Signed {
 }
 
 /// Signed 2930 Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction2930Signed {
 	#[serde(flatten)]
 	pub transaction_2930_unsigned: Transaction2930Unsigned,
@@ -769,7 +791,9 @@ pub struct Transaction2930Signed {
 }
 
 /// Signed 4844 Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct Transaction4844Signed {
 	#[serde(flatten)]
 	pub transaction_4844_unsigned: Transaction4844Unsigned,
@@ -784,7 +808,9 @@ pub struct Transaction4844Signed {
 }
 
 /// Signed Legacy Transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(
+	Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq, TypeInfo, Encode, Decode,
+)]
 pub struct TransactionLegacySigned {
 	#[serde(flatten)]
 	pub transaction_legacy_unsigned: TransactionLegacyUnsigned,

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -346,6 +346,7 @@ pub trait EthExtra {
 					gas_limit,
 					storage_deposit_limit,
 					data,
+					payload,
 				}
 				.into()
 			}
@@ -367,6 +368,7 @@ pub trait EthExtra {
 				storage_deposit_limit,
 				code: code.to_vec(),
 				data: data.to_vec(),
+				payload,
 			}
 			.into()
 		};

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -869,6 +869,7 @@ pub mod pallet {
 			#[pallet::compact] storage_deposit_limit: BalanceOf<T>,
 			code: Vec<u8>,
 			data: Vec<u8>,
+			payload: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
 			let code_len = code.len() as u32;
 			let data_len = data.len() as u32;
@@ -910,6 +911,7 @@ pub mod pallet {
 			gas_limit: Weight,
 			#[pallet::compact] storage_deposit_limit: BalanceOf<T>,
 			data: Vec<u8>,
+			payload: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
 			let mut output = Self::bare_call(
 				origin,
@@ -1355,6 +1357,10 @@ where
 						gas_limit,
 						storage_deposit_limit,
 						data: input.clone(),
+						// Since this is a dry run, we don't need to pass the signed transaction
+						// payload. Instead, use an empty vector. The signed transaction
+						// will be provided by the user when the tx is submitted.
+						payload: Vec::new(),
 					}
 					.into();
 					(result, dispatch_call)
@@ -1419,6 +1425,10 @@ where
 						storage_deposit_limit,
 						code: code.to_vec(),
 						data: data.to_vec(),
+						// Since this is a dry run, we don't need to pass the signed transaction
+						// payload. Instead, use an empty vector. The signed transaction
+						// will be provided by the user when the tx is submitted.
+						payload: Vec::new(),
 					}
 					.into();
 				(result, dispatch_call)

--- a/substrate/frame/revive/src/test_utils/builder.rs
+++ b/substrate/frame/revive/src/test_utils/builder.rs
@@ -242,6 +242,7 @@ builder!(
 		gas_limit: Weight,
 		storage_deposit_limit: BalanceOf<T>,
 		data: Vec<u8>,
+		payload: Vec<u8>,
 	) -> DispatchResultWithPostInfo;
 
 	/// Create a [`EthCallBuilder`] with default values.
@@ -253,6 +254,7 @@ builder!(
 			gas_limit: GAS_LIMIT,
 			storage_deposit_limit: deposit_limit::<T>(),
 			data: vec![],
+			payload: vec![],
 		}
 	}
 );

--- a/substrate/primitives/core/src/lib.rs
+++ b/substrate/primitives/core/src/lib.rs
@@ -61,7 +61,7 @@ pub use paste;
 mod address_uri;
 pub mod defer;
 pub mod hash;
-#[cfg(not(substrate_runtime))]
+// #[cfg(not(substrate_runtime))]
 mod hasher;
 pub mod offchain;
 pub mod proof_of_possession;
@@ -93,7 +93,8 @@ pub use crypto::{ByteArray, DeriveJunction, Pair, Public};
 
 #[cfg(not(substrate_runtime))]
 pub use self::hasher::blake2::Blake2Hasher;
-#[cfg(not(substrate_runtime))]
+// TODO: Is this sane?
+// #[cfg(not(substrate_runtime))]
 pub use self::hasher::keccak::KeccakHasher;
 pub use hash_db::Hasher;
 


### PR DESCRIPTION
This PoC collects the EVM submitted transaction in the following way:
- the signed transaction bytes are propagated through the eth_call and eth_instantiate_with_code
- the `deposit_event` stores in the `InflightEvents` storage map the emitted events of the current inflight transaction
- when the transaction is completed, the available data is placed into InflightTransactions
  -  This maps the transaction index to the transaction payload, the events emitted by the transaction, the status of the transaction (success or not), and the gas consumed.

The `on_finalize` hook is responsible for:
- reconstructing the receipt info for transactions
- building the transaction root

Next Steps:
- build receipt root in a similar manner
- determine if sp-core experimental features are suitable or switch to allow-trie
- ensure the roots are computed correctly
- the state root should be the root of the substrate block, is that info available during the `on_finalize` hook?
- build the block from available info

Builds upon https://github.com/paritytech/polkadot-sdk/pull/9413

Part of: https://github.com/paritytech/contract-issues/issues/139