### PR TITLE
cumulus tests: Improve prefix of the relay chain node

### DIFF
--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -288,6 +288,7 @@ async fn build_relay_chain_interface(
 			},
 			None,
 			polkadot_service::CollatorOverseerGen,
+			Some("Relaychain"),
 		)
 		.map_err(|e| RelayChainError::Application(Box::new(e) as Box<_>))?,
 		cumulus_client_cli::RelayChainMode::ExternalRpc(rpc_target_urls) =>


### PR DESCRIPTION
Instead of using the name of the node, we should use `Relaychain` as done by normal nodes. This makes it easier to read the logs.


