### PR TITLE
do not trigger zombienet workflows on 'labeled'

### DIFF
--- a/.github/workflows/zombienet_cumulus.yml
+++ b/.github/workflows/zombienet_cumulus.yml
@@ -12,7 +12,7 @@ on:
    branches:
      - master
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zombienet_parachain-template.yml
+++ b/.github/workflows/zombienet_parachain-template.yml
@@ -12,7 +12,7 @@ on:
    branches:
      - master
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zombienet_polkadot.yml
+++ b/.github/workflows/zombienet_polkadot.yml
@@ -12,7 +12,7 @@ on:
    branches:
      - master
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/zombienet_substrate.yml
+++ b/.github/workflows/zombienet_substrate.yml
@@ -12,7 +12,7 @@ on:
    branches:
      - master
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
At some point of the stabilization process we added the 'labeled' to the list of events that trigger the zombienet workflows. This is not needed anymore and also is causing failures because the _artifacts_ could be  expired ([example](https://github.com/paritytech/polkadot-sdk/actions/runs/16529272288/job/46752021278?pr=9286#step:6:127)).

Thx!