### PR TITLE
pr_8838.prdoc: oversight fix: major -> minor

### DIFF
--- a/prdoc/pr_8838.prdoc
+++ b/prdoc/pr_8838.prdoc
@@ -4,4 +4,4 @@ doc:
   description: This PR changes the default transaction pool to the fork aware implementation. The old implementation can be still used with `--pool-type=single-state` command line argument.
 crates:
 - name: sc-cli
-  bump: major
+  bump: minor


### PR DESCRIPTION
This fixes the [pr_8838.prdoc](https://github.com/paritytech/polkadot-sdk/blob/cf5a24ecc5802ecf78d943f9723b6f4ccdc0ddfa/prdoc/pr_8838.prdoc#L7). I somehow forgotten to fix this [here](https://github.com/paritytech/polkadot-sdk/pull/8838#discussion_r2152760564).