### PR TITLE
pallet-xcm: fix authorized_alias benchmarks

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm/src/benchmarking.rs
@@ -607,7 +607,7 @@ mod benchmarks {
 					tracing::error!(
 						target: "xcm::benchmarking::pallet_xcm::add_authorized_alias",
 						?origin,
-						"try_origin failed", 
+						"try_origin failed",
 					);
 					BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX))
 				})?

--- a/polkadot/xcm/pallet-xcm/src/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm/src/benchmarking.rs
@@ -603,11 +603,17 @@ mod benchmarks {
 		let origin = RawOrigin::Signed(who.clone());
 		let origin_location: VersionedLocation =
 			T::ExecuteXcmOrigin::try_origin(origin.clone().into())
-				.map_err(|_| BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)))?
+				.map_err(|_| {
+					tracing::error!(
+						target: "xcm::benchmarking::pallet_xcm::add_authorized_alias",
+						"try_origin with origin {:?} failed", origin,
+					);
+					BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX))
+				})?
 				.into();
 
 		// Give some multiple of ED
-		let balance = T::ExistentialDeposit::get() * 1000u32.into();
+		let balance = T::ExistentialDeposit::get() * 1000000u32.into();
 		let _ =
 			<pallet_balances::Pallet::<T> as frame_support::traits::Currency<_>>::make_free_balance_be(&who, balance);
 
@@ -620,8 +626,15 @@ mod benchmarks {
 			let aliaser = OriginAliaser { location: alias, expiry: None };
 			existing_aliases.try_push(aliaser).unwrap()
 		}
-		let ticket = TicketOf::<T>::new(&who, aliasers_footprint(existing_aliases.len()))
-			.map_err(|_| BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX)))?;
+		let footprint = aliasers_footprint(existing_aliases.len());
+		let ticket = TicketOf::<T>::new(&who, footprint).map_err(|e| {
+			tracing::error!(
+				target: "xcm::benchmarking::pallet_xcm::add_authorized_alias",
+				"could not create ticket for {:?} footprint {:?}, error: {:?}",
+				who, footprint,	e,
+			);
+			BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX))
+		})?;
 		let entry = AuthorizedAliasesEntry { aliasers: existing_aliases, ticket };
 		AuthorizedAliases::<T>::insert(&origin_location, entry);
 
@@ -642,17 +655,29 @@ mod benchmarks {
 		let origin = RawOrigin::Signed(who.clone());
 		let error = BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX));
 		let origin_location =
-			T::ExecuteXcmOrigin::try_origin(origin.clone().into()).map_err(|_| error.clone())?;
+			T::ExecuteXcmOrigin::try_origin(origin.clone().into()).map_err(|_| {
+				tracing::error!(
+					target: "xcm::benchmarking::pallet_xcm::remove_authorized_alias",
+					"try_origin with origin {:?} failed", origin,
+				);
+				error.clone()
+			})?;
 		// remove `network` from inner `AccountId32` for easier matching of automatic AccountId ->
 		// Location conversions.
 		let origin_location: VersionedLocation = match origin_location.unpack() {
 			(0, [AccountId32 { network: _, id }]) =>
 				Location::new(0, [AccountId32 { network: None, id: *id }]).into(),
-			_ => return Err(error.clone()),
+			_ => {
+				tracing::error!(
+					target: "xcm::benchmarking::pallet_xcm::remove_authorized_alias",
+					"unexpected origin {:?} failed", origin_location,
+				);
+				return Err(error.clone())
+			},
 		};
 
 		// Give some multiple of ED
-		let balance = T::ExistentialDeposit::get() * 1000u32.into();
+		let balance = T::ExistentialDeposit::get() * 1000000u32.into();
 		let _ =
 			<pallet_balances::Pallet::<T> as frame_support::traits::Currency<_>>::make_free_balance_be(&who, balance);
 
@@ -665,8 +690,15 @@ mod benchmarks {
 			let aliaser = OriginAliaser { location: alias, expiry: None };
 			existing_aliases.try_push(aliaser).unwrap()
 		}
-		let ticket = TicketOf::<T>::new(&who, aliasers_footprint(existing_aliases.len()))
-			.map_err(|_| error)?;
+		let footprint = aliasers_footprint(existing_aliases.len());
+		let ticket = TicketOf::<T>::new(&who, footprint).map_err(|_| {
+			tracing::error!(
+				target: "xcm::benchmarking::pallet_xcm::remove_authorized_alias",
+				"could not create ticket for {:?} footprint {:?}, error: {:?}",
+				who, footprint, error,
+			);
+			error
+		})?;
 		let entry = AuthorizedAliasesEntry { aliasers: existing_aliases, ticket };
 		AuthorizedAliases::<T>::insert(&origin_location, entry);
 

--- a/polkadot/xcm/pallet-xcm/src/benchmarking.rs
+++ b/polkadot/xcm/pallet-xcm/src/benchmarking.rs
@@ -606,7 +606,8 @@ mod benchmarks {
 				.map_err(|_| {
 					tracing::error!(
 						target: "xcm::benchmarking::pallet_xcm::add_authorized_alias",
-						"try_origin with origin {:?} failed", origin,
+						?origin,
+						"try_origin failed", 
 					);
 					BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX))
 				})?
@@ -630,8 +631,10 @@ mod benchmarks {
 		let ticket = TicketOf::<T>::new(&who, footprint).map_err(|e| {
 			tracing::error!(
 				target: "xcm::benchmarking::pallet_xcm::add_authorized_alias",
-				"could not create ticket for {:?} footprint {:?}, error: {:?}",
-				who, footprint,	e,
+				?who,
+				?footprint,
+				error=?e,
+				"could not create ticket",
 			);
 			BenchmarkError::Override(BenchmarkResult::from_weight(Weight::MAX))
 		})?;
@@ -658,7 +661,8 @@ mod benchmarks {
 			T::ExecuteXcmOrigin::try_origin(origin.clone().into()).map_err(|_| {
 				tracing::error!(
 					target: "xcm::benchmarking::pallet_xcm::remove_authorized_alias",
-					"try_origin with origin {:?} failed", origin,
+					?origin,
+					"try_origin failed",
 				);
 				error.clone()
 			})?;
@@ -670,7 +674,8 @@ mod benchmarks {
 			_ => {
 				tracing::error!(
 					target: "xcm::benchmarking::pallet_xcm::remove_authorized_alias",
-					"unexpected origin {:?} failed", origin_location,
+					?origin_location,
+					"unexpected origin failed",
 				);
 				return Err(error.clone())
 			},
@@ -691,11 +696,13 @@ mod benchmarks {
 			existing_aliases.try_push(aliaser).unwrap()
 		}
 		let footprint = aliasers_footprint(existing_aliases.len());
-		let ticket = TicketOf::<T>::new(&who, footprint).map_err(|_| {
+		let ticket = TicketOf::<T>::new(&who, footprint).map_err(|e| {
 			tracing::error!(
 				target: "xcm::benchmarking::pallet_xcm::remove_authorized_alias",
-				"could not create ticket for {:?} footprint {:?}, error: {:?}",
-				who, footprint, error,
+				?who,
+				?footprint,
+				error=?e,
+				"could not create ticket",
 			);
 			error
 		})?;

--- a/prdoc/pr_9445.prdoc
+++ b/prdoc/pr_9445.prdoc
@@ -1,0 +1,10 @@
+title: "pallet-xcm: fix authorized_alias benchmarks"
+
+doc:
+  - audience: Runtime Dev
+    description: |-
+      Depending on runtime configuration of ED and storage deposits, the old benchmark code did not set up enough funds to cover authorized aliases storage deposits. Fix it by adding more funds as part of benchmark setup.
+
+crates:
+- name: pallet-xcm
+  bump: patch


### PR DESCRIPTION
Depending on runtime configuration of ED and storage deposits, the old benchmark code did not set up enough funds to cover authorized aliases storage deposits.

Fix it by adding more funds as part of benchmark setup.