### PR TITLE
Handle invulnerable AH collators with priority in collator-protocol/validator-side

### DIFF
--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -2443,7 +2443,7 @@ fn can_accept_new_collator_connection(
 		target: LOG_TARGET,
 		?new_peer_id,
 		?ah_invulnerables,
-		?currently_connected,
+		currently_connected=currently_connected.len(),
 		?connection_limit,
 		"Checking if we can accept a new collator connection",
 	);

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -1493,6 +1493,12 @@ async fn handle_network_msg<Context>(
 				&state.peer_data,
 				&state.ah_invulnerables,
 			) {
+				gum::debug!(
+					target: LOG_TARGET,
+					?peer_id,
+					?observed_role,
+					"Peer connection refused, no slots for invulnerable AssetHub collators",
+				);
 				disconnect_peer(ctx.sender(), peer_id).await;
 				return Ok(())
 			}
@@ -2433,5 +2439,14 @@ fn can_accept_new_collator_connection(
 	let connection_limit =
 		max_accepted_connections - ah_invulnerables.len() + ah_invulnerables_connected;
 
-	currently_connected.len() >= connection_limit
+	gum::trace!(
+		target: LOG_TARGET,
+		?new_peer_id,
+		?ah_invulnerables,
+		?currently_connected,
+		?connection_limit,
+		"Checking if we can accept a new collator connection",
+	);
+
+	currently_connected.len() < connection_limit
 }

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -405,6 +405,9 @@ struct State {
 
 	/// Aggregated reputation change
 	reputation: ReputationAggregator,
+
+	/// List of invulnerable collators. They are handled with a priority.
+	invulnerables: HashSet<PeerId>,
 }
 
 impl State {
@@ -1600,6 +1603,7 @@ pub(crate) async fn run<Context>(
 	keystore: KeystorePtr,
 	eviction_policy: crate::CollatorEvictionPolicy,
 	metrics: Metrics,
+	invulnerables: HashSet<PeerId>,
 ) -> std::result::Result<(), std::convert::Infallible> {
 	run_inner(
 		ctx,
@@ -1608,6 +1612,7 @@ pub(crate) async fn run<Context>(
 		metrics,
 		ReputationAggregator::default(),
 		REPUTATION_CHANGE_INTERVAL,
+		invulnerables,
 	)
 	.await
 }
@@ -1620,11 +1625,12 @@ async fn run_inner<Context>(
 	metrics: Metrics,
 	reputation: ReputationAggregator,
 	reputation_interval: Duration,
+	invulnerables: HashSet<PeerId>,
 ) -> std::result::Result<(), std::convert::Infallible> {
 	let new_reputation_delay = || futures_timer::Delay::new(reputation_interval).fuse();
 	let mut reputation_delay = new_reputation_delay();
 
-	let mut state = State { metrics, reputation, ..Default::default() };
+	let mut state = State { metrics, reputation, invulnerables, ..Default::default() };
 
 	let next_inactivity_stream = tick_stream(ACTIVITY_POLL);
 	futures::pin_mut!(next_inactivity_stream);

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -406,8 +406,8 @@ struct State {
 	/// Aggregated reputation change
 	reputation: ReputationAggregator,
 
-	/// List of invulnerable collators. They are handled with a priority.
-	invulnerables: HashSet<PeerId>,
+	/// List of invulnerable AssetHub collators. They are handled with a priority.
+	ah_invulnerables: HashSet<PeerId>,
 }
 
 impl State {
@@ -1603,7 +1603,7 @@ pub(crate) async fn run<Context>(
 	keystore: KeystorePtr,
 	eviction_policy: crate::CollatorEvictionPolicy,
 	metrics: Metrics,
-	invulnerables: HashSet<PeerId>,
+	ah_invulnerables: HashSet<PeerId>,
 ) -> std::result::Result<(), std::convert::Infallible> {
 	run_inner(
 		ctx,
@@ -1612,7 +1612,7 @@ pub(crate) async fn run<Context>(
 		metrics,
 		ReputationAggregator::default(),
 		REPUTATION_CHANGE_INTERVAL,
-		invulnerables,
+		ah_invulnerables,
 	)
 	.await
 }
@@ -1625,12 +1625,12 @@ async fn run_inner<Context>(
 	metrics: Metrics,
 	reputation: ReputationAggregator,
 	reputation_interval: Duration,
-	invulnerables: HashSet<PeerId>,
+	ah_invulnerables: HashSet<PeerId>,
 ) -> std::result::Result<(), std::convert::Infallible> {
 	let new_reputation_delay = || futures_timer::Delay::new(reputation_interval).fuse();
 	let mut reputation_delay = new_reputation_delay();
 
-	let mut state = State { metrics, reputation, invulnerables, ..Default::default() };
+	let mut state = State { metrics, reputation, ah_invulnerables, ..Default::default() };
 
 	let next_inactivity_stream = tick_stream(ACTIVITY_POLL);
 	futures::pin_mut!(next_inactivity_stream);

--- a/polkadot/node/network/collator-protocol/src/validator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/tests/mod.rs
@@ -205,6 +205,7 @@ struct TestHarness {
 
 fn test_harness<T: Future<Output = VirtualOverseer>>(
 	reputation: ReputationAggregator,
+	ah_invulnerable_collators: HashSet<PeerId>,
 	test: impl FnOnce(TestHarness) -> T,
 ) {
 	sp_tracing::init_for_tests();
@@ -232,6 +233,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		Metrics::default(),
 		reputation,
 		REPUTATION_CHANGE_TEST_INTERVAL,
+		ah_invulnerable_collators,
 	);
 
 	let test_fut = test(TestHarness { virtual_overseer, keystore });
@@ -470,7 +472,7 @@ async fn advertise_collation(
 fn collator_authentication_verification_works() {
 	let test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let peer_b = PeerId::random();
@@ -520,7 +522,7 @@ fn collator_authentication_verification_works() {
 fn fetch_one_collation_at_a_time_for_v1_advertisement() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 		let second = Hash::from_low_u64_be(test_state.relay_parent.to_low_u64_be() - 1);
 		let relay_parent = test_state.relay_parent;
@@ -606,7 +608,7 @@ fn fetch_one_collation_at_a_time_for_v1_advertisement() {
 fn fetches_next_collation() {
 	let mut test_state = TestState::with_one_scheduled_para();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let first = test_state.relay_parent;
@@ -723,7 +725,7 @@ fn fetches_next_collation() {
 fn reject_connection_to_next_group() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let relay_parent = test_state.relay_parent;
@@ -762,7 +764,7 @@ fn reject_connection_to_next_group() {
 fn fetch_next_collation_on_invalid_collation() {
 	let mut test_state = TestState::with_one_scheduled_para();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let relay_parent = test_state.relay_parent;
@@ -860,7 +862,7 @@ fn fetch_next_collation_on_invalid_collation() {
 fn inactive_disconnected() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair = CollatorPair::generate().0;
@@ -899,7 +901,7 @@ fn inactive_disconnected() {
 fn activity_extends_life() {
 	let mut test_state = TestState::with_one_scheduled_para();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair = CollatorPair::generate().0;
@@ -974,7 +976,7 @@ fn activity_extends_life() {
 fn disconnect_if_no_declare() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let relay_parent = test_state.relay_parent;
@@ -1003,7 +1005,7 @@ fn disconnect_if_no_declare() {
 fn disconnect_if_wrong_declare() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 		let pair = CollatorPair::generate().0;
 		let peer_b = PeerId::random();
@@ -1055,7 +1057,7 @@ fn disconnect_if_wrong_declare() {
 fn delay_reputation_change() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| false), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| false), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 		let pair = CollatorPair::generate().0;
 		let peer_b = PeerId::random();
@@ -1131,7 +1133,7 @@ fn delay_reputation_change() {
 fn view_change_clears_old_collators() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair = CollatorPair::generate().0;

--- a/polkadot/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
@@ -465,7 +465,7 @@ async fn send_collation_and_assert_processing(
 fn v1_advertisement_accepted_and_seconded() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -544,7 +544,7 @@ fn v1_advertisement_accepted_and_seconded() {
 fn v1_advertisement_rejected_on_non_active_leaf() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -586,7 +586,7 @@ fn v1_advertisement_rejected_on_non_active_leaf() {
 fn accept_advertisements_from_implicit_view() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -689,7 +689,7 @@ fn accept_advertisements_from_implicit_view() {
 fn second_multiple_candidates_per_relay_parent() {
 	let mut test_state = TestState::with_one_scheduled_para();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair = CollatorPair::generate().0;
@@ -778,7 +778,7 @@ fn second_multiple_candidates_per_relay_parent() {
 fn fetched_collation_sanity_check() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair = CollatorPair::generate().0;
@@ -889,7 +889,7 @@ fn fetched_collation_sanity_check() {
 fn sanity_check_invalid_parent_head_data() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair = CollatorPair::generate().0;
@@ -1009,7 +1009,7 @@ fn sanity_check_invalid_parent_head_data() {
 fn advertisement_spam_protection() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -1083,7 +1083,7 @@ fn advertisement_spam_protection() {
 fn child_blocked_from_seconding_by_parent(#[case] valid_parent: bool) {
 	let mut test_state = TestState::with_one_scheduled_para();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair = CollatorPair::generate().0;
@@ -1391,7 +1391,7 @@ fn v2_descriptor(#[case] v2_feature_enabled: bool) {
 		test_state.node_features = NodeFeatures::EMPTY;
 	}
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -1499,7 +1499,7 @@ fn v2_descriptor(#[case] v2_feature_enabled: bool) {
 fn invalid_v2_descriptor() {
 	let mut test_state = TestState::default();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, .. } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -1605,7 +1605,7 @@ fn invalid_v2_descriptor() {
 fn fair_collation_fetches() {
 	let mut test_state = TestState::with_shared_core();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let head_b = Hash::from_low_u64_be(128);
@@ -1707,7 +1707,7 @@ fn fair_collation_fetches() {
 fn collation_fetching_prefer_entries_earlier_in_claim_queue() {
 	let mut test_state = TestState::with_shared_core();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -1882,7 +1882,7 @@ fn collation_fetching_prefer_entries_earlier_in_claim_queue() {
 fn collation_fetching_considers_advertisements_from_the_whole_view() {
 	let mut test_state = TestState::with_shared_core();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -2021,7 +2021,7 @@ fn collation_fetching_considers_advertisements_from_the_whole_view() {
 fn collation_fetching_fairness_handles_old_claims() {
 	let mut test_state = TestState::with_shared_core();
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let pair_a = CollatorPair::generate().0;
@@ -2179,7 +2179,7 @@ fn claims_below_are_counted_correctly() {
 	test_state.claim_queue = claim_queue;
 	test_state.scheduling_lookahead = 2;
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let hash_a = Hash::from_low_u64_be(test_state.relay_parent.to_low_u64_be() - 1);
@@ -2269,7 +2269,7 @@ fn claims_above_are_counted_correctly() {
 	test_state.claim_queue = claim_queue;
 	test_state.scheduling_lookahead = 2;
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let hash_a = Hash::from_low_u64_be(test_state.relay_parent.to_low_u64_be() - 1); // block 0
@@ -2374,7 +2374,7 @@ fn claim_fills_last_free_slot() {
 	test_state.claim_queue = claim_queue;
 	test_state.scheduling_lookahead = 2;
 
-	test_harness(ReputationAggregator::new(|_| true), |test_harness| async move {
+	test_harness(ReputationAggregator::new(|_| true), HashSet::new(), |test_harness| async move {
 		let TestHarness { mut virtual_overseer, keystore } = test_harness;
 
 		let hash_a = Hash::from_low_u64_be(test_state.relay_parent.to_low_u64_be() - 1); // block 0

--- a/polkadot/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/tests/prospective_parachains.rs
@@ -2464,7 +2464,6 @@ fn claim_fills_last_free_slot() {
 }
 
 mod ah_stop_gap {
-
 	use super::*;
 
 	#[test]
@@ -2542,6 +2541,141 @@ mod ah_stop_gap {
 					CollatorPair::generate().0,
 					ASSET_HUB_PARA_ID,
 					CollationVersion::V2,
+				)
+				.await;
+
+				test_helpers::Yield::new().await;
+				assert_matches!(virtual_overseer.recv().now_or_never(), None);
+
+				virtual_overseer
+			},
+		);
+	}
+
+	#[test]
+	fn invulnerable_collations_are_preferred_over_permissionless_ones() {
+		let mut test_state = TestState::with_one_scheduled_para();
+		let invulnerable_collator = PeerId::random();
+		let invulnerables = HashSet::from_iter([invulnerable_collator.clone()]);
+
+		let mut claim_queue = BTreeMap::new();
+		claim_queue.insert(
+			CoreIndex(0),
+			VecDeque::from_iter(
+				[ASSET_HUB_PARA_ID, ASSET_HUB_PARA_ID, ASSET_HUB_PARA_ID].into_iter(),
+			),
+		);
+		test_state.claim_queue = claim_queue;
+		test_state.chain_ids = vec![ASSET_HUB_PARA_ID];
+
+		test_harness(
+			ReputationAggregator::new(|_| true),
+			invulnerables,
+			|test_harness| async move {
+				let TestHarness { mut virtual_overseer, keystore } = test_harness;
+
+				// let head = Hash::from_low_u64_be(test_state.relay_parent.to_low_u64_be() - 1);
+				let head = test_state.relay_parent;
+
+				update_view(&mut virtual_overseer, &mut test_state, vec![(head, 1)]).await;
+
+				let permissionless_collator = PeerId::random();
+				connect_and_declare_collator(
+					&mut virtual_overseer,
+					permissionless_collator,
+					CollatorPair::generate().0,
+					ASSET_HUB_PARA_ID,
+					CollationVersion::V2,
+				)
+				.await;
+
+				//connecting an invulnerable collator should succeed
+				connect_and_declare_collator(
+					&mut virtual_overseer,
+					invulnerable_collator.clone(),
+					CollatorPair::generate().0,
+					ASSET_HUB_PARA_ID,
+					CollationVersion::V2,
+				)
+				.await;
+
+				// permissionless makes an advertisement
+				let permissionless_head_data = HeadData(vec![0u8]);
+				let permissionless_head_data_hash = permissionless_head_data.hash();
+				let (permissionless_candidate, permissionless_commitments) =
+					create_dummy_candidate_and_commitments(
+						ASSET_HUB_PARA_ID,
+						permissionless_head_data,
+						head,
+					);
+				advertise_collation(
+					&mut virtual_overseer,
+					permissionless_collator,
+					head,
+					Some((permissionless_candidate.hash(), permissionless_head_data_hash)),
+				)
+				.await;
+
+				// nothing happens yet
+				test_helpers::Yield::new().await;
+				assert_matches!(virtual_overseer.recv().now_or_never(), None);
+
+				// invulnerable makes an advertisement and it's fetched
+				submit_second_and_assert(
+					&mut virtual_overseer,
+					keystore.clone(),
+					ASSET_HUB_PARA_ID,
+					head,
+					invulnerable_collator,
+					HeadData(vec![1 as u8]),
+				)
+				.await;
+
+				// disconnect the invulnerable because it will time out and interfere with the test
+				overseer_send(
+					&mut virtual_overseer,
+					CollatorProtocolMessage::NetworkBridgeUpdate(
+						NetworkBridgeEvent::PeerDisconnected(invulnerable_collator),
+					),
+				)
+				.await;
+
+				// sleep 1 sec, to kick off held off processing
+				std::thread::sleep(std::time::Duration::from_secs(1));
+
+				// the one from the permissionless is also fetched
+				assert_matches!(
+					overseer_recv(&mut virtual_overseer).await,
+					AllMessages::CandidateBacking(
+						CandidateBackingMessage::CanSecond(request, tx),
+					) => {
+						assert_eq!(request.candidate_hash, permissionless_candidate.hash());
+						assert_eq!(request.candidate_para_id, ASSET_HUB_PARA_ID);
+						assert_eq!(request.parent_head_data_hash, permissionless_head_data_hash);
+						tx.send(true).expect("receiving side should be alive");
+					}
+				);
+
+				let response_channel = assert_fetch_collation_request(
+					&mut virtual_overseer,
+					head,
+					ASSET_HUB_PARA_ID,
+					Some(permissionless_candidate.hash()),
+				)
+				.await;
+
+				let pov = PoV { block_data: BlockData(vec![1]) };
+
+				send_collation_and_assert_processing(
+					&mut virtual_overseer,
+					keystore,
+					head,
+					ASSET_HUB_PARA_ID,
+					permissionless_collator,
+					response_channel,
+					permissionless_candidate,
+					permissionless_commitments,
+					pov,
 				)
 				.await;
 

--- a/polkadot/node/network/protocol/src/peer_set.rs
+++ b/polkadot/node/network/protocol/src/peer_set.rs
@@ -39,6 +39,9 @@ const LEGACY_COLLATION_PROTOCOL_VERSION_V1: u32 = 1;
 /// Max notification size is currently constant.
 pub const MAX_NOTIFICATION_SIZE: u64 = 100 * 1024;
 
+/// Maximum allowed incoming connection streams for validator nodes.
+pub const MAX_AUTHORITY_INCOMING_STREAMS: u32 = 100;
+
 /// The peer-sets and thus the protocols which are used for the network.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
 pub enum PeerSet {
@@ -114,7 +117,11 @@ impl PeerSet {
 					SetConfig {
 						// Non-authority nodes don't need to accept incoming connections on this
 						// peer set:
-						in_peers: if is_authority == IsAuthority::Yes { 100 } else { 0 },
+						in_peers: if is_authority == IsAuthority::Yes {
+							MAX_AUTHORITY_INCOMING_STREAMS
+						} else {
+							0
+						},
 						out_peers: 0,
 						reserved_nodes: Vec::new(),
 						non_reserved_mode: if is_authority == IsAuthority::Yes {


### PR DESCRIPTION
Implements priority handling of invulnerable AH collators which consists of:
1. Connection management - there is a connection limit in the networking stack of 100 peers after which no new connections are accepted. To make sure that the invulnerable collators can always connect to the validators permissionless collators are getting disconnected one the connection count is close to the limit.
2. Collations from permissionless collators are held off for some time before processing so that the invulnerables have got a chance to put a collation on their own.

TODOs:
- [ ] Add the invulnerables list.
- [ ] Test if the change works for collators claiming positions further into the CQ.