### PR TITLE
[CI] add timeout to allow alloy to process the logs

### DIFF
--- a/.github/scripts/process-logs-zombienet-sdk.sh
+++ b/.github/scripts/process-logs-zombienet-sdk.sh
@@ -105,3 +105,6 @@ jq -r '.paras // .parachains | to_entries[] | "\(.key)"' "$ZOMBIE_JSON" | while 
   done
   echo ""
 done
+
+# sleep for a minute to give alloy time to forward logs
+sleep 60


### PR DESCRIPTION
CI fix to give time to process zombienet's logs.

cc https://github.com/paritytech/devops/issues/4229