### PR TITLE
check-semver: enable the support for edition 2024

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TOOLCHAIN: nightly-2024-11-19
+  TOOLCHAIN: nightly-2025-01-26
 
 jobs:
   isdraft:
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install parity-publish
         # Set the target dir to cache the build.
-        run: CARGO_TARGET_DIR=./target/ cargo install parity-publish@0.10.4 --locked -q
+        run: CARGO_TARGET_DIR=./target/ cargo install parity-publish@0.10.5 --locked -q
 
       - name: Get original PR number
         shell: bash


### PR DESCRIPTION
# Description

`check-semver` job fails since some time in the majority of the PRs, and the issue has been tracked down to an indirect dependency which is based on edition 2024 rust, which can not compile successfully with the current nightly.

## Integration

N/A

## Review Notes

- Updated parity-publish: https://github.com/paritytech/parity-publish/pull/58
- This PR completes the circle and makes check-semver functional again
- Tested already these changes here: https://github.com/paritytech/polkadot-sdk/actions/runs/16909276800/workflow