### PR TITLE
[stable2506] Use stable2506 branch instead of master to check benches

### DIFF
--- a/.github/workflows/tests-misc.yml
+++ b/.github/workflows/tests-misc.yml
@@ -3,7 +3,7 @@ name: tests misc
 on:
   push:
     branches:
-      - master
+      - stable2506
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        branch: [master, current]
+        branch: [stable2506, current]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -135,9 +135,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # if branch is master, use the branch, otherwise set empty string, so it uses the current context
+          # if branch is stable2506, use the branch, otherwise set empty string, so it uses the current context
           # either PR (including forks) or merge group (main repo)
-          ref: ${{ matrix.branch == 'master' && matrix.branch || '' }}
+          ref: ${{ matrix.branch == 'stable2506' && matrix.branch || '' }}
 
       - name: script
         run: |
@@ -166,11 +166,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download artifact (master run)
+      - name: Download artifact (stable2506 run)
         uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
-          name: cargo-check-benches-master-${{ github.sha }}
+          name: cargo-check-benches-stable2506-${{ github.sha }}
           path: ./artifacts/master
 
       - name: Download artifact (current run)
@@ -183,22 +183,22 @@ jobs:
       - name: script
         id: compare
         run: |
-          if [ "${{ github.ref_name }}" = "master" ]; then
-            echo -e "Exiting on master branch"
+          if [ "${{ github.ref_name }}" = "stable2506" ]; then
+            echo -e "Exiting on stabel branch"
             exit 0
           fi
 
           # fail if no artifacts
-          if [ ! -d ./artifacts/master ] || [ ! -d ./artifacts/current ]; then
+          if [ ! -d ./artifacts/stabel2506 ] || [ ! -d ./artifacts/current ]; then
             echo "No artifacts found"
             exit 1
           fi
 
           docker run --rm \
-          -v $PWD/artifacts/master:/artifacts/master \
+          -v $PWD/artifacts/stabel2506:/artifacts/stabel2506 \
           -v $PWD/artifacts/current:/artifacts/current \
           paritytech/node-bench-regression-guard:latest \
-          node-bench-regression-guard --reference /artifacts/master --compare-with /artifacts/current
+          node-bench-regression-guard --reference /artifacts/stabel2506 --compare-with /artifacts/current
 
           if [ $? -ne 0 ]; then
             FAILED_MSG='### node-bench-regression-guard failed ❌, check the regression in *cargo-check-benches* job'


### PR DESCRIPTION
This PR adjusts `cargo-check-benches` job so that it uses `stable` branch instead of `master` for the benches comparison 