### PR TITLE
Remove free balance check in `prepare_unlock`

### DIFF
--- a/polkadot/xcm/pallet-xcm/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/src/lib.rs
@@ -3733,7 +3733,6 @@ impl<T: Config> xcm_executor::traits::AssetLock for Pallet<T> {
 		use xcm_executor::traits::LockError::*;
 		let sovereign_account = T::SovereignAccountOf::convert_location(&owner).ok_or(BadOwner)?;
 		let amount = T::CurrencyMatcher::matches_fungible(&asset).ok_or(UnknownAsset)?;
-		ensure!(T::Currency::free_balance(&sovereign_account) >= amount, AssetNotOwned);
 		let locks = LockedFungibles::<T>::get(&sovereign_account).unwrap_or_default();
 		let item_index =
 			locks.iter().position(|x| x.1.try_as::<_>() == Ok(&unlocker)).ok_or(NotLocked)?;

--- a/prdoc/pr_9489.prdoc
+++ b/prdoc/pr_9489.prdoc
@@ -1,0 +1,8 @@
+title: Remove free balance check in prepare_unlock
+doc:
+- audience: Runtime Dev
+  description: The free balance check during unlocking is unnecessary since a lock can cover both free and reserved 
+    balances. Removing it allows locks to be cleared even if part of the locked funds is reserved or already slashed.
+crates:
+- name: pallet-xcm
+  bump: patch


### PR DESCRIPTION
The free balance check during unlocking is unnecessary since a lock can cover both free and reserved balances. Removing it allows locks to be cleared even if part of the locked funds is reserved or already slashed.