### PR TITLE
[pallet-revive] Re-export account and code info structs

### DIFF
--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -496,13 +496,13 @@ pub mod pallet {
 	#[pallet::storage]
 	pub(crate) type PristineCode<T: Config> = StorageMap<_, Identity, H256, CodeVec>;
 
-/// A mapping from a contract's code hash to its code info.
-#[pallet::storage]
-pub(crate) type CodeInfoOf<T: Config> = StorageMap<_, Identity, H256, CodeInfo<T>>;
+	/// A mapping from a contract's code hash to its code info.
+	#[pallet::storage]
+	pub(crate) type CodeInfoOf<T: Config> = StorageMap<_, Identity, H256, CodeInfo<T>>;
 
-/// The data associated to a contract or externally owned account.
-#[pallet::storage]
-pub(crate) type AccountInfoOf<T: Config> = StorageMap<_, Identity, H160, AccountInfo<T>>;
+	/// The data associated to a contract or externally owned account.
+	#[pallet::storage]
+	pub(crate) type AccountInfoOf<T: Config> = StorageMap<_, Identity, H160, AccountInfo<T>>;
 
 	/// The immutable data associated with a given account.
 	#[pallet::storage]


### PR DESCRIPTION
Are you up for re-exporting these info structs publicly? We query the following storage items in `cargo contract info` and use the result to compile information about an on-chain contract:

```
/// A mapping from a contract's code hash to its code info.
#[pallet::storage]
pub(crate) type CodeInfoOf<T: Config> = StorageMap<_, Identity, H256, CodeInfo<T>>;

/// The data associated to a contract or externally owned account.
#[pallet::storage]
pub(crate) type AccountInfoOf<T: Config> = StorageMap<_, Identity, H160, AccountInfo<T>>;
```

Making them public would allow us to depend on the re-exports, avoiding having to copy them.

cc @athei @pgherveou