### PR TITLE
`fatxpool`: buckets for event-timings metrics adjusted

### DIFF
--- a/prdoc/pr_9495.prdoc
+++ b/prdoc/pr_9495.prdoc
@@ -3,7 +3,6 @@ doc:
 - audience: Node Dev
   description: |-
     This PR adjusts the buckets for transactions' event-timings metrics  as requested in #9158 for reliability dashboard.
-    Metrics were initially introduced in #7355.
 
     fixes: #9158
 crates:

--- a/prdoc/pr_9495.prdoc
+++ b/prdoc/pr_9495.prdoc
@@ -1,0 +1,11 @@
+title: '`fatxpool`: buckets for event-timings metrics adjusted'
+doc:
+- audience: Node Dev
+  description: |-
+    This PR adjusts the buckets for transactions' event-timings metrics  as requested in #9158 for reliability dashboard.
+    Metrics were initially introduced in #7355.
+
+    fixes: #9158
+crates:
+- name: sc-transaction-pool
+  bump: minor

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -163,11 +163,15 @@ impl EventsHistograms {
 				registry,
 			)?,
 			finalized: register(
-				Histogram::with_opts(histogram_opts!(
-					"substrate_sub_txpool_timing_event_finalized",
-					"Histogram of timings for reporting Finalized event",
-					linear_buckets(0.0, 40.0, 20).unwrap()
-				))?,
+				Histogram::with_opts(
+					histogram_opts!(
+						"substrate_sub_txpool_timing_event_finalized",
+						"Histogram of timings for reporting Finalized event"
+					).buckets([
+						linear_buckets(0.0, 5.0, 8).unwrap(),  // 0, 5, 10, 15, 20, 25, 30, 35
+						linear_buckets(40.0, 40.0, 19).unwrap() // 40, 80, 120, ..., 760
+					].concat())
+				)?,
 				registry,
 			)?,
 			usurped: register(

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -139,11 +139,20 @@ impl EventsHistograms {
 				registry,
 			)?,
 			in_block: register(
-				Histogram::with_opts(histogram_opts!(
-					"substrate_sub_txpool_timing_event_in_block",
-					"Histogram of timings for reporting InBlock event",
-					linear_buckets(0.0, 3.0, 20).unwrap()
-				))?,
+				Histogram::with_opts(
+					histogram_opts!(
+						"substrate_sub_txpool_timing_event_in_block",
+						"Histogram of timings for reporting InBlock event"
+					)
+					.buckets(
+						[
+							linear_buckets(0.0, 3.0, 20).unwrap(),
+							// requested in #9158
+							vec![60.0, 75.0, 90.0, 120.0, 180.0],
+						]
+						.concat(),
+					),
+				)?,
 				registry,
 			)?,
 			retracted: register(
@@ -167,35 +176,67 @@ impl EventsHistograms {
 					histogram_opts!(
 						"substrate_sub_txpool_timing_event_finalized",
 						"Histogram of timings for reporting Finalized event"
-					).buckets([
-						linear_buckets(0.0, 5.0, 8).unwrap(),  // 0, 5, 10, 15, 20, 25, 30, 35
-						linear_buckets(40.0, 40.0, 19).unwrap() // 40, 80, 120, ..., 760
-					].concat())
+					)
+					.buckets(
+						[
+							// requested in #9158
+							linear_buckets(0.0, 5.0, 8).unwrap(),
+							linear_buckets(40.0, 40.0, 19).unwrap(),
+						]
+						.concat(),
+					),
 				)?,
 				registry,
 			)?,
 			usurped: register(
-				Histogram::with_opts(histogram_opts!(
-					"substrate_sub_txpool_timing_event_usurped",
-					"Histogram of timings for reporting Usurped event",
-					linear_buckets(0.0, 3.0, 20).unwrap()
-				))?,
+				Histogram::with_opts(
+					histogram_opts!(
+						"substrate_sub_txpool_timing_event_usurped",
+						"Histogram of timings for reporting Usurped event"
+					)
+					.buckets(
+						[
+							linear_buckets(0.0, 3.0, 20).unwrap(),
+							// requested in #9158
+							vec![60.0, 75.0, 90.0, 120.0, 180.0],
+						]
+						.concat(),
+					),
+				)?,
 				registry,
 			)?,
 			dropped: register(
-				Histogram::with_opts(histogram_opts!(
-					"substrate_sub_txpool_timing_event_dropped",
-					"Histogram of timings for reporting Dropped event",
-					linear_buckets(0.0, 3.0, 20).unwrap()
-				))?,
+				Histogram::with_opts(
+					histogram_opts!(
+						"substrate_sub_txpool_timing_event_dropped",
+						"Histogram of timings for reporting Dropped event"
+					)
+					.buckets(
+						[
+							linear_buckets(0.0, 3.0, 20).unwrap(),
+							// requested in #9158
+							vec![60.0, 75.0, 90.0, 120.0, 180.0],
+						]
+						.concat(),
+					),
+				)?,
 				registry,
 			)?,
 			invalid: register(
-				Histogram::with_opts(histogram_opts!(
-					"substrate_sub_txpool_timing_event_invalid",
-					"Histogram of timings for reporting Invalid event",
-					linear_buckets(0.0, 3.0, 20).unwrap()
-				))?,
+				Histogram::with_opts(
+					histogram_opts!(
+						"substrate_sub_txpool_timing_event_invalid",
+						"Histogram of timings for reporting Invalid event"
+					)
+					.buckets(
+						[
+							linear_buckets(0.0, 3.0, 20).unwrap(),
+							// requested in #9158
+							vec![60.0, 75.0, 90.0, 120.0, 180.0],
+						]
+						.concat(),
+					),
+				)?,
 				registry,
 			)?,
 		})


### PR DESCRIPTION
This PR adjusts the buckets for transactions' event-timings metrics  as requested in #9158 for reliability dashboard.
Metrics were initially introduced in #7355. 

fixes: #9158