### PR TITLE
[CI/CD] Fix build binary flow

### DIFF
--- a/.github/workflows/release-build-binary.yml
+++ b/.github/workflows/release-build-binary.yml
@@ -66,10 +66,11 @@ jobs:
           PROFILE=${{ inputs.profile }}
           if [ "${{ inputs.binary }}" = "polkadot" ]; then
               for binary in polkadot polkadot-prepare-worker polkadot-execute-worker; do
-                  echo "Building $binary..."
+                  echo "Building $binary with profile $PROFILE and features ${{ inputs.features }}"
                   ./.github/scripts/release/build-linux-release.sh $binary ${{ inputs.package }} ${{ inputs.features }}
               done
           else
+            echo "Building ${{ inputs.binary }} with profile $PROFILE and features ${{ inputs.features }}"
             ./.github/scripts/release/build-linux-release.sh ${{ inputs.binary }} ${{ inputs.package }} ${{ inputs.features }}
           fi
 

--- a/.github/workflows/release-build-binary.yml
+++ b/.github/workflows/release-build-binary.yml
@@ -67,10 +67,10 @@ jobs:
           if [ "${{ inputs.binary }}" = "polkadot" ]; then
               for binary in polkadot polkadot-prepare-worker polkadot-execute-worker; do
                   echo "Building $binary..."
-                  ./.github/scripts/release/build-linux-release.sh $binary ${{ inputs.package }} "${PROFILE}" ${{ inputs.features }}
+                  ./.github/scripts/release/build-linux-release.sh $binary ${{ inputs.package }} ${{ inputs.features }}
               done
           else
-            ./.github/scripts/release/build-linux-release.sh ${{ inputs.binary }} ${{ inputs.package }} "${PROFILE}" ${{ inputs.features }}
+            ./.github/scripts/release/build-linux-release.sh ${{ inputs.binary }} ${{ inputs.package }} ${{ inputs.features }}
           fi
 
       - name: Upload ${{ inputs.binary }} artifacts


### PR DESCRIPTION
This PR fixes build-binary flow, that is used to build a binary for the testing purposes from any branch. The issue was that there were too many input args for the build script.