### PR TITLE
Allow specifying a storage deposit payer for calls

### DIFF
--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -346,6 +346,7 @@ pub trait EthExtra {
 					gas_limit,
 					storage_deposit_limit,
 					data,
+					storage_deposit_payer: None
 				}
 				.into()
 			}
@@ -601,7 +602,8 @@ mod test {
 				value: tx.value.unwrap_or_default().as_u64().into(),
 				data: tx.input.to_vec(),
 				gas_limit,
-				storage_deposit_limit
+				storage_deposit_limit,
+				storage_deposit_payer: None
 			}
 			.into()
 		);

--- a/substrate/frame/revive/src/impl_fungibles.rs
+++ b/substrate/frame/revive/src/impl_fungibles.rs
@@ -81,6 +81,7 @@ where
 				<<T as pallet::Config>::Currency as fungible::Inspect<_>>::total_issuance(),
 			),
 			data,
+			None
 		);
 		if let Ok(return_value) = result {
 			if let Ok(eu256) = EU256::abi_decode_validate(&return_value.data) {
@@ -117,6 +118,7 @@ where
 				<<T as pallet::Config>::Currency as fungible::Inspect<_>>::total_issuance(),
 			),
 			data,
+			None
 		);
 		if let Ok(return_value) = result {
 			if let Ok(eu256) = EU256::abi_decode_validate(&return_value.data) {
@@ -192,6 +194,7 @@ where
 				<<T as pallet::Config>::Currency as fungible::Inspect<_>>::total_issuance(),
 			),
 			data,
+			None
 		);
 		log::trace!(target: "whatiwant", "{gas_consumed}");
 		if let Ok(return_value) = result {
@@ -229,6 +232,7 @@ where
 				<<T as pallet::Config>::Currency as fungible::Inspect<_>>::total_issuance(),
 			),
 			data,
+			None
 		);
 		if let Ok(return_value) = result {
 			if return_value.did_revert() {

--- a/substrate/frame/revive/src/test_utils/builder.rs
+++ b/substrate/frame/revive/src/test_utils/builder.rs
@@ -185,6 +185,7 @@ builder!(
 		gas_limit: Weight,
 		storage_deposit_limit: BalanceOf<T>,
 		data: Vec<u8>,
+		storage_deposit_payer: Option<T::AccountId>,
 	) -> DispatchResultWithPostInfo;
 
 	/// Create a [`CallBuilder`] with default values.
@@ -196,6 +197,7 @@ builder!(
 			gas_limit: GAS_LIMIT,
 			storage_deposit_limit: deposit_limit::<T>(),
 			data: vec![],
+			storage_deposit_payer: None
 		}
 	}
 );
@@ -208,6 +210,7 @@ builder!(
 		gas_limit: Weight,
 		storage_deposit_limit: DepositLimit<BalanceOf<T>>,
 		data: Vec<u8>,
+		storage_deposit_payer: Option<OriginFor<T>>,
 	) -> ContractResult<ExecReturnValue, BalanceOf<T>>;
 
 	/// Set the call's evm_value using a native_value amount.
@@ -230,6 +233,7 @@ builder!(
 			gas_limit: GAS_LIMIT,
 			storage_deposit_limit: DepositLimit::Balance(deposit_limit::<T>()),
 			data: vec![],
+			storage_deposit_payer: None
 		}
 	}
 );
@@ -242,6 +246,7 @@ builder!(
 		gas_limit: Weight,
 		storage_deposit_limit: BalanceOf<T>,
 		data: Vec<u8>,
+		storage_deposit_payer: Option<T::AccountId>,
 	) -> DispatchResultWithPostInfo;
 
 	/// Create a [`EthCallBuilder`] with default values.
@@ -253,6 +258,7 @@ builder!(
 			gas_limit: GAS_LIMIT,
 			storage_deposit_limit: deposit_limit::<T>(),
 			data: vec![],
+			storage_deposit_payer: None,
 		}
 	}
 );

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -1815,6 +1815,7 @@ fn call_runtime_reentrancy_guarded() {
 			gas_limit: GAS_LIMIT / 3,
 			storage_deposit_limit: deposit_limit::<Test>(),
 			data: vec![],
+			storage_deposit_payer: None
 		})
 		.encode();
 


### PR DESCRIPTION
Iintroduces a new optional parameter, **`storage_deposit_payer`**, to the `bare_call` function. This allows a different account to be specified to pay for storage deposits, rather than defaulting to the transaction's origin.
