### PR TITLE
Account for PoV size when enqueing XCMP message

### DIFF
--- a/cumulus/pallets/xcmp-queue/src/weights_ext.rs
+++ b/cumulus/pallets/xcmp-queue/src/weights_ext.rs
@@ -63,6 +63,7 @@ pub trait WeightInfoExt: WeightInfo {
 		let pos_overhead = {
 			Self::enqueue_empty_xcmp_message_at(first_page_pos)
 				.saturating_sub(Self::enqueue_empty_xcmp_message_at(0))
+				.set_proof_size(first_page_pos as u64)
 		};
 
 		pages_overhead


### PR DESCRIPTION
Account for PoV size when enqueing XCMP message