### PR TITLE
[unstable2507] Update CI docker to bullseye-1.88.0-2025-06-27-v202507221446

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,1 +1,1 @@
-IMAGE="docker.io/paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202506301118"
+IMAGE="docker.io/paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202507221446"


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/pull/9600#issuecomment-3247943146
Initial requirement to introduce solc was explained here: https://github.com/paritytech/devops/issues/4193

Currently used docker version `docker.io/paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202506301118` is missing `solc` binary which causes CI failures and blocks existing backport PRs from merging

```
 error: failed to run custom build command for `pallet-revive-fixtures v0.1.0 (/__w/polkadot-sdk/polkadot-sdk/substrate/frame/revive/fixtures)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/__w/polkadot-sdk/polkadot-sdk/target/debug/build/pallet-revive-fixtures-8e520aa5e0f478d7/build-script-build` (exit status: 1)
  --- stdout
  cargo::rerun-if-env-changed=PALLET_REVIVE_FIXTURES_RUSTUP_TOOLCHAIN
  cargo::rerun-if-env-changed=PALLET_REVIVE_FIXTURES_STRIP
  cargo::rerun-if-env-changed=PALLET_REVIVE_FIXTURES_OPTIMIZE
  cargo::rerun-if-changed=/__w/polkadot-sdk/polkadot-sdk/target/pallet-revive-fixtures
  cargo::rerun-if-changed=/__w/polkadot-sdk/polkadot-sdk/substrate/frame/revive/fixtures
  cargo::rerun-if-changed=/__w/polkadot-sdk/polkadot-sdk/substrate/frame/revive/uapi

  --- stderr
  Error: Failed to execute solc. Make sure solc is installed.

  Caused by:
      No such file or directory (os error 2)
```

cc @pgherveou 