### PR TITLE
DNM: PoC for `SwapAssetAdapter` to use hold and release pattern

### DIFF
--- a/substrate/frame/asset-conversion/ops/src/tests.rs
+++ b/substrate/frame/asset-conversion/ops/src/tests.rs
@@ -63,13 +63,15 @@ fn migrate_pool_account_id_with_native() {
 		));
 
 		// assert user's balance.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &user), 10000 + ed);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &user), 1000 - 10);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &user), 10000 + ed);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &user), 1000 - 10);
 		assert_eq!(PoolAssets::balance(lp_token, &user), 216);
 
 		// record total issuances before migration.
-		let total_issuance_token1 = NativeAndAssets::total_issuance(token_1.clone());
-		let total_issuance_token2 = NativeAndAssets::total_issuance(token_2.clone());
+		let total_issuance_token1 =
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_1.clone());
+		let total_issuance_token2 =
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_2.clone());
 		let total_issuance_lp_token = PoolAssets::total_issuance(lp_token);
 
 		let pool_account = PoolLocator::address(&pool_id).unwrap();
@@ -78,8 +80,14 @@ fn migrate_pool_account_id_with_native() {
 		assert_eq!(pool_account, prior_pool_account);
 
 		// assert pool's balances before migration.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &prior_pool_account), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &prior_pool_account), 10);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &prior_pool_account),
+			10000
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &prior_pool_account),
+			10
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &prior_pool_account), 100);
 
 		// migrate.
@@ -90,23 +98,41 @@ fn migrate_pool_account_id_with_native() {
 		));
 
 		// assert user's balance has not changed.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &user), 10000 + ed);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &user), 1000 - 10);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &user), 10000 + ed);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &user), 1000 - 10);
 		assert_eq!(PoolAssets::balance(lp_token, &user), 216);
 
 		// assert pool's balance on new account id is same as on prior account id.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &new_pool_account), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &new_pool_account), 10);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &new_pool_account),
+			10000
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &new_pool_account),
+			10
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &new_pool_account), 100);
 
 		// assert pool's balance on prior account id is zero.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &prior_pool_account), 0);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &prior_pool_account), 0);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &prior_pool_account),
+			0
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &prior_pool_account),
+			0
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &prior_pool_account), 0);
 
 		// assert total issuance has not changed.
-		assert_eq!(total_issuance_token1, NativeAndAssets::total_issuance(token_1));
-		assert_eq!(total_issuance_token2, NativeAndAssets::total_issuance(token_2));
+		assert_eq!(
+			total_issuance_token1,
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_1)
+		);
+		assert_eq!(
+			total_issuance_token2,
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_2)
+		);
 		assert_eq!(total_issuance_lp_token, PoolAssets::total_issuance(lp_token));
 	});
 }
@@ -147,13 +173,15 @@ fn migrate_pool_account_id_with_insufficient_assets() {
 		));
 
 		// assert user's balance.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &user), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &user), 1000 - 10);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &user), 10000);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &user), 1000 - 10);
 		assert_eq!(PoolAssets::balance(lp_token, &user), 216);
 
 		// record total issuances before migration.
-		let total_issuance_token1 = NativeAndAssets::total_issuance(token_1.clone());
-		let total_issuance_token2 = NativeAndAssets::total_issuance(token_2.clone());
+		let total_issuance_token1 =
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_1.clone());
+		let total_issuance_token2 =
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_2.clone());
 		let total_issuance_lp_token = PoolAssets::total_issuance(lp_token);
 
 		let pool_account = PoolLocator::address(&pool_id).unwrap();
@@ -162,8 +190,14 @@ fn migrate_pool_account_id_with_insufficient_assets() {
 		assert_eq!(pool_account, prior_pool_account);
 
 		// assert pool's balances before migration.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &prior_pool_account), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &prior_pool_account), 10);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &prior_pool_account),
+			10000
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &prior_pool_account),
+			10
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &prior_pool_account), 100);
 
 		// migrate.
@@ -174,23 +208,41 @@ fn migrate_pool_account_id_with_insufficient_assets() {
 		));
 
 		// assert user's balance has not changed.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &user), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &user), 1000 - 10);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &user), 10000);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &user), 1000 - 10);
 		assert_eq!(PoolAssets::balance(lp_token, &user), 216);
 
 		// assert pool's balance on new account id is same as on prior account id.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &new_pool_account), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &new_pool_account), 10);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &new_pool_account),
+			10000
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &new_pool_account),
+			10
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &new_pool_account), 100);
 
 		// assert pool's balance on prior account id is zero.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &prior_pool_account), 0);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &prior_pool_account), 0);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &prior_pool_account),
+			0
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &prior_pool_account),
+			0
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &prior_pool_account), 0);
 
 		// assert total issuance has not changed.
-		assert_eq!(total_issuance_token1, NativeAndAssets::total_issuance(token_1));
-		assert_eq!(total_issuance_token2, NativeAndAssets::total_issuance(token_2));
+		assert_eq!(
+			total_issuance_token1,
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_1)
+		);
+		assert_eq!(
+			total_issuance_token2,
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_2)
+		);
 		assert_eq!(total_issuance_lp_token, PoolAssets::total_issuance(lp_token));
 	});
 }
@@ -231,13 +283,15 @@ fn migrate_pool_account_id_with_sufficient_assets() {
 		));
 
 		// assert user's balance.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &user), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &user), 1000 - 10);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &user), 10000);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &user), 1000 - 10);
 		assert_eq!(PoolAssets::balance(lp_token, &user), 216);
 
 		// record total issuances before migration.
-		let total_issuance_token1 = NativeAndAssets::total_issuance(token_1.clone());
-		let total_issuance_token2 = NativeAndAssets::total_issuance(token_2.clone());
+		let total_issuance_token1 =
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_1.clone());
+		let total_issuance_token2 =
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_2.clone());
 		let total_issuance_lp_token = PoolAssets::total_issuance(lp_token);
 
 		let pool_account = PoolLocator::address(&pool_id).unwrap();
@@ -246,8 +300,14 @@ fn migrate_pool_account_id_with_sufficient_assets() {
 		assert_eq!(pool_account, prior_pool_account);
 
 		// assert pool's balances before migration.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &prior_pool_account), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &prior_pool_account), 10);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &prior_pool_account),
+			10000
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &prior_pool_account),
+			10
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &prior_pool_account), 100);
 
 		// migrate.
@@ -258,23 +318,41 @@ fn migrate_pool_account_id_with_sufficient_assets() {
 		));
 
 		// assert user's balance has not changed.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &user), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &user), 1000 - 10);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &user), 10000);
+		assert_eq!(<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &user), 1000 - 10);
 		assert_eq!(PoolAssets::balance(lp_token, &user), 216);
 
 		// assert pool's balance on new account id is same as on prior account id.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &new_pool_account), 10000);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &new_pool_account), 10);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &new_pool_account),
+			10000
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &new_pool_account),
+			10
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &new_pool_account), 100);
 
 		// assert pool's balance on prior account id is zero.
-		assert_eq!(NativeAndAssets::balance(token_1.clone(), &prior_pool_account), 0);
-		assert_eq!(NativeAndAssets::balance(token_2.clone(), &prior_pool_account), 0);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_1.clone(), &prior_pool_account),
+			0
+		);
+		assert_eq!(
+			<NativeAndAssets as Inspect<u64>>::balance(token_2.clone(), &prior_pool_account),
+			0
+		);
 		assert_eq!(PoolAssets::balance(lp_token, &prior_pool_account), 0);
 
 		// assert total issuance has not changed.
-		assert_eq!(total_issuance_token1, NativeAndAssets::total_issuance(token_1));
-		assert_eq!(total_issuance_token2, NativeAndAssets::total_issuance(token_2));
+		assert_eq!(
+			total_issuance_token1,
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_1)
+		);
+		assert_eq!(
+			total_issuance_token2,
+			<NativeAndAssets as Inspect<u64>>::total_issuance(token_2)
+		);
 		assert_eq!(total_issuance_lp_token, PoolAssets::total_issuance(lp_token));
 	});
 }

--- a/substrate/frame/asset-conversion/src/tests.rs
+++ b/substrate/frame/asset-conversion/src/tests.rs
@@ -81,7 +81,7 @@ fn create_tokens_with_ed(owner: u128, tokens: Vec<NativeOrWithId<u32>>, ed: u128
 }
 
 fn balance(owner: u128, token_id: NativeOrWithId<u32>) -> u128 {
-	<<Test as Config>::Assets>::balance(token_id, &owner)
+	<<Test as Config>::Assets as Inspect<u128>>::balance(token_id, &owner)
 }
 
 fn pool_balance(owner: u128, token_id: u32) -> u128 {
@@ -89,7 +89,7 @@ fn pool_balance(owner: u128, token_id: u32) -> u128 {
 }
 
 fn get_native_ed() -> u128 {
-	<<Test as Config>::Assets>::minimum_balance(NativeOrWithId::Native)
+	<<Test as Config>::Assets as Inspect<u128>>::minimum_balance(NativeOrWithId::Native)
 }
 
 macro_rules! bvec {

--- a/substrate/frame/support/src/traits/tokens/fungible/union_of.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/union_of.rs
@@ -195,6 +195,45 @@ impl<
 	}
 }
 
+impl<Left: fungible::Inspect<AccountId>, Right, Criterion, AssetKind, AccountId>
+	fungible::Inspect<AccountId> for UnionOf<Left, Right, Criterion, AssetKind, AccountId>
+{
+	type Balance = Left::Balance;
+
+	fn total_issuance() -> Self::Balance {
+		<Left as fungible::Inspect<AccountId>>::total_issuance()
+	}
+	fn active_issuance() -> Self::Balance {
+		<Left as fungible::Inspect<AccountId>>::active_issuance()
+	}
+	fn minimum_balance() -> Self::Balance {
+		<Left as fungible::Inspect<AccountId>>::minimum_balance()
+	}
+	fn balance(who: &AccountId) -> Self::Balance {
+		<Left as fungible::Inspect<AccountId>>::balance(who)
+	}
+	fn total_balance(who: &AccountId) -> Self::Balance {
+		<Left as fungible::Inspect<AccountId>>::total_balance(who)
+	}
+	fn reducible_balance(
+		who: &AccountId,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Self::Balance {
+		<Left as fungible::Inspect<AccountId>>::reducible_balance(who, preservation, force)
+	}
+	fn can_deposit(
+		who: &AccountId,
+		amount: Self::Balance,
+		provenance: Provenance,
+	) -> DepositConsequence {
+		<Left as fungible::Inspect<AccountId>>::can_deposit(who, amount, provenance)
+	}
+	fn can_withdraw(who: &AccountId, amount: Self::Balance) -> WithdrawConsequence<Self::Balance> {
+		<Left as fungible::Inspect<AccountId>>::can_withdraw(who, amount)
+	}
+}
+
 impl<
 		Left: fungible::InspectHold<AccountId>,
 		Right: fungibles::InspectHold<AccountId, Balance = Left::Balance, Reason = Left::Reason>,
@@ -256,6 +295,28 @@ impl<
 			Right(a) =>
 				<Right as fungibles::InspectHold<AccountId>>::can_hold(a, reason, who, amount),
 		}
+	}
+}
+
+impl<Left: fungible::InspectHold<AccountId>, Right, Criterion, AssetKind, AccountId>
+	fungible::InspectHold<AccountId> for UnionOf<Left, Right, Criterion, AssetKind, AccountId>
+{
+	type Reason = Left::Reason;
+
+	fn reducible_total_balance_on_hold(who: &AccountId, force: Fortitude) -> Self::Balance {
+		<Left as fungible::InspectHold<AccountId>>::reducible_total_balance_on_hold(who, force)
+	}
+	fn hold_available(reason: &Self::Reason, who: &AccountId) -> bool {
+		<Left as fungible::InspectHold<AccountId>>::hold_available(reason, who)
+	}
+	fn total_balance_on_hold(who: &AccountId) -> Self::Balance {
+		<Left as fungible::InspectHold<AccountId>>::total_balance_on_hold(who)
+	}
+	fn balance_on_hold(reason: &Self::Reason, who: &AccountId) -> Self::Balance {
+		<Left as fungible::InspectHold<AccountId>>::balance_on_hold(reason, who)
+	}
+	fn can_hold(reason: &Self::Reason, who: &AccountId, amount: Self::Balance) -> bool {
+		<Left as fungible::InspectHold<AccountId>>::can_hold(reason, who, amount)
 	}
 }
 
@@ -365,6 +426,48 @@ impl<
 	}
 }
 
+impl<Left: fungible::Unbalanced<AccountId>, Right, Criterion, AssetKind, AccountId>
+	fungible::Unbalanced<AccountId> for UnionOf<Left, Right, Criterion, AssetKind, AccountId>
+{
+	fn handle_dust(dust: fungible::Dust<AccountId, Self>)
+	where
+		Self: Sized,
+	{
+		<Left as fungible::Unbalanced<AccountId>>::handle_dust(fungible::Dust(dust.0))
+	}
+	fn write_balance(
+		who: &AccountId,
+		amount: Self::Balance,
+	) -> Result<Option<Self::Balance>, DispatchError> {
+		<Left as fungible::Unbalanced<AccountId>>::write_balance(who, amount)
+	}
+	fn set_total_issuance(amount: Self::Balance) -> () {
+		<Left as fungible::Unbalanced<AccountId>>::set_total_issuance(amount)
+	}
+	fn decrease_balance(
+		who: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::Unbalanced<AccountId>>::decrease_balance(
+			who,
+			amount,
+			precision,
+			preservation,
+			force,
+		)
+	}
+	fn increase_balance(
+		who: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::Unbalanced<AccountId>>::increase_balance(who, amount, precision)
+	}
+}
+
 impl<
 		Left: fungible::UnbalancedHold<AccountId>,
 		Right: fungibles::UnbalancedHold<AccountId, Balance = Left::Balance, Reason = Left::Reason>,
@@ -419,6 +522,38 @@ impl<
 				a, reason, who, amount, precision,
 			),
 		}
+	}
+}
+
+impl<Left: fungible::UnbalancedHold<AccountId>, Right, Criterion, AssetKind, AccountId>
+	fungible::UnbalancedHold<AccountId> for UnionOf<Left, Right, Criterion, AssetKind, AccountId>
+{
+	fn set_balance_on_hold(
+		reason: &Self::Reason,
+		who: &AccountId,
+		amount: Self::Balance,
+	) -> DispatchResult {
+		<Left as fungible::UnbalancedHold<AccountId>>::set_balance_on_hold(reason, who, amount)
+	}
+	fn decrease_balance_on_hold(
+		reason: &Self::Reason,
+		who: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::UnbalancedHold<AccountId>>::decrease_balance_on_hold(
+			reason, who, amount, precision,
+		)
+	}
+	fn increase_balance_on_hold(
+		reason: &Self::Reason,
+		who: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::UnbalancedHold<AccountId>>::increase_balance_on_hold(
+			reason, who, amount, precision,
+		)
 	}
 }
 
@@ -615,6 +750,63 @@ impl<
 				force,
 			),
 		}
+	}
+}
+
+impl<Left: fungible::MutateHold<AccountId>, Right, Criterion, AssetKind, AccountId>
+	fungible::MutateHold<AccountId> for UnionOf<Left, Right, Criterion, AssetKind, AccountId>
+{
+	fn hold(reason: &Self::Reason, who: &AccountId, amount: Self::Balance) -> DispatchResult {
+		<Left as fungible::MutateHold<AccountId>>::hold(reason, who, amount)
+	}
+	fn release(
+		reason: &Self::Reason,
+		who: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::MutateHold<AccountId>>::release(reason, who, amount, precision)
+	}
+	fn burn_held(
+		reason: &Self::Reason,
+		who: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+		force: Fortitude,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::MutateHold<AccountId>>::burn_held(reason, who, amount, precision, force)
+	}
+	fn transfer_on_hold(
+		reason: &Self::Reason,
+		source: &AccountId,
+		dest: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+		mode: Restriction,
+		force: Fortitude,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::MutateHold<AccountId>>::transfer_on_hold(
+			reason, source, dest, amount, precision, mode, force,
+		)
+	}
+	fn transfer_and_hold(
+		reason: &Self::Reason,
+		source: &AccountId,
+		dest: &AccountId,
+		amount: Self::Balance,
+		precision: Precision,
+		preservation: Preservation,
+		force: Fortitude,
+	) -> Result<Self::Balance, DispatchError> {
+		<Left as fungible::MutateHold<AccountId>>::transfer_and_hold(
+			reason,
+			source,
+			dest,
+			amount,
+			precision,
+			preservation,
+			force,
+		)
 	}
 }
 

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
@@ -100,7 +100,7 @@ parameter_types! {
 
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Runtime {
-	type ExistentialDeposit = ConstU64<10>;
+	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 }
 


### PR DESCRIPTION
We don't want to merge it yet. Just to show how it will work and that it passes all tests. Building on https://github.com/paritytech/polkadot-sdk/pull/9590

For accounts that only hold a sufficient asset but no native balance we need to get creative: We **increase** the pre dispatch fee by the ed. This is because even when increasing the `providers` of an account, dusting will still happen when an account is below ed. Hence we need to make sure that in addition to the actual fee there is at least the ed inside the hold. Pallet's wont touch the ed as long as they use `KeepAlive` when transferring from the hold.