### PR TITLE
[pallet-revive] Add `evm` feature flag to `pallet-revive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13048,6 +13048,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_pcg",
  "revm",
+ "revm-primitives",
  "ripemd",
  "rlp 0.6.1",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1030,7 +1030,7 @@ pallet-ranked-collective = { path = "substrate/frame/ranked-collective", default
 pallet-recovery = { path = "substrate/frame/recovery", default-features = false }
 pallet-referenda = { path = "substrate/frame/referenda", default-features = false }
 pallet-remark = { default-features = false, path = "substrate/frame/remark" }
-pallet-revive = { path = "substrate/frame/revive", default-features = false }
+pallet-revive = { path = "substrate/frame/revive", default-features = false, features = ["evm"] }
 pallet-revive-eth-rpc = { path = "substrate/frame/revive/rpc", default-features = false }
 pallet-revive-fixtures = { path = "substrate/frame/revive/fixtures", default-features = false }
 pallet-revive-proc-macro = { path = "substrate/frame/revive/proc-macro", default-features = false }
@@ -1191,6 +1191,7 @@ relay-substrate-client = { path = "bridges/relays/client-substrate" }
 relay-utils = { path = "bridges/relays/utils" }
 remote-externalities = { path = "substrate/utils/frame/remote-externalities", default-features = false, package = "frame-remote-externalities" }
 revm = { version = "27.0.2", default-features = false }
+revm-primitives = { version = "20.2.1", default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
 rlp = { version = "0.6.1", default-features = false }
 rococo-emulated-chain = { path = "cumulus/parachains/integration-tests/emulated/chains/relays/rococo" }

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -35,7 +35,8 @@ polkavm = { version = "0.27.0", default-features = false }
 polkavm-common = { version = "0.27.0", default-features = false, features = ["alloc"] }
 rand = { workspace = true, optional = true }
 rand_pcg = { workspace = true, optional = true }
-revm = { workspace = true }
+revm = { workspace = true, optional = true }
+revm-primitives = { workspace = true }
 rlp = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["alloc", "derive"], workspace = true, default-features = false }
@@ -99,7 +100,8 @@ std = [
 	"polkavm-common/std",
 	"polkavm/std",
 	"rand?/std",
-	"revm/std",
+	"revm?/std",
+	"revm-primitives/std",
 	"ripemd/std",
 	"rlp/std",
 	"scale-info/std",
@@ -133,6 +135,7 @@ runtime-benchmarks = [
 	"sp-consensus-babe",
 	"sp-consensus-slots",
 	"sp-runtime/runtime-benchmarks",
+	"revm",
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -143,4 +146,7 @@ try-runtime = [
 	"pallet-transaction-payment/try-runtime",
 	"pallet-utility/try-runtime",
 	"sp-runtime/try-runtime",
+]
+evm = [
+	"revm",
 ]

--- a/substrate/frame/revive/src/benchmarking.rs
+++ b/substrate/frame/revive/src/benchmarking.rs
@@ -2304,6 +2304,7 @@ mod benchmarks {
 	}
 
 	/// Benchmark the cost of executing `r` noop (JUMPDEST) instructions.
+	#[cfg(feature = "revm")]
 	#[benchmark(pov_mode = Measured)]
 	fn evm_opcode(r: Linear<0, 10_000>) -> Result<(), BenchmarkError> {
 		let module = VmBinaryModule::evm_noop(r);

--- a/substrate/frame/revive/src/call_builder.rs
+++ b/substrate/frame/revive/src/call_builder.rs
@@ -417,6 +417,7 @@ impl VmBinaryModule {
 	}
 
 	// Same as [`Self::sized`] but using EVM bytecode.
+	#[cfg(feature = "evm")]
 	pub fn evm_sized(size: u32) -> Self {
 		use revm::bytecode::opcode::STOP;
 		let code = vec![STOP; size as usize];
@@ -486,6 +487,7 @@ impl VmBinaryModule {
 	}
 
 	/// An evm contract that executes `size` JUMPDEST instructions.
+	#[cfg(feature = "revm")]
 	pub fn evm_noop(size: u32) -> Self {
 		use revm::bytecode::opcode::JUMPDEST;
 

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1265,6 +1265,7 @@ where
 				let contract_info = frame.contract_info();
 				// if we are dealing with EVM bytecode
 				// We upload the new runtime code, and update the code
+				#[cfg(feature = "evm")]
 				if !is_pvm {
 					// Only keep return data for tracing
 					let data = if crate::tracing::if_tracing(|_| {}).is_none() {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -623,6 +623,10 @@ pub mod pallet {
 								log::error!(target: LOG_TARGET, "Failed to create PVM ContractBlob for {address:?}: {err:?}");
 							})
 						} else {
+							#[cfg(not(feature = "evm"))]
+							panic!("Found contract blob with EVM bytecode, but feature `evm` is not enabled.");
+
+							#[cfg(feature = "evm")]
 							ContractBlob::<T>::from_evm_runtime_code(code.clone(), account_id).inspect_err(|err| {
 								log::error!(target: LOG_TARGET, "Failed to create EVM ContractBlob for {address:?}: {err:?}");
 							})

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -18,6 +18,8 @@
 mod pallet_dummy;
 mod precompiles;
 mod pvm;
+
+#[cfg(feature = "evm")]
 mod sol;
 
 use crate::{
@@ -457,6 +459,7 @@ impl Default for Origin<Test> {
 }
 
 #[test]
+#[cfg(feature = "evm")]
 fn ext_builder_with_genesis_config_works() {
 	let pvm_contract = Account {
 		address: BOB_ADDR,

--- a/substrate/frame/revive/src/tests/sol/block_info.rs
+++ b/substrate/frame/revive/src/tests/sol/block_info.rs
@@ -20,9 +20,11 @@
 use crate::{
 	test_utils::{builder::Contract, ALICE},
 	tests::{builder, Contracts, ExtBuilder, System, Test, Timestamp},
-	vm::evm::{U256Converter, BASE_FEE, DIFFICULTY},
 	Code, Config,
 };
+
+#[cfg(feature = "evm")]
+use crate::vm::evm::{U256Converter, BASE_FEE, DIFFICULTY};
 
 use alloy_core::{primitives::U256, sol_types::SolInterface};
 use frame_support::traits::fungible::Mutate;
@@ -150,6 +152,7 @@ fn gaslimit_works() {
 
 /// Tests that the basefee opcode works as expected.
 #[test]
+#[cfg(feature = "evm")]
 fn basefee_works() {
 	for fixture_type in [FixtureType::Solc, FixtureType::Resolc] {
 		let (code, _) = compile_module_with_type("BlockInfo", fixture_type).unwrap();
@@ -171,6 +174,7 @@ fn basefee_works() {
 
 /// Tests that the difficulty opcode works as expected.
 #[test]
+#[cfg(feature = "evm")]
 fn difficulty_works() {
 	for fixture_type in [FixtureType::Solc, FixtureType::Resolc] {
 		let (code, _) = compile_module_with_type("BlockInfo", fixture_type).unwrap();

--- a/substrate/frame/revive/src/tests/sol/system.rs
+++ b/substrate/frame/revive/src/tests/sol/system.rs
@@ -28,7 +28,7 @@ use pallet_revive_fixtures::{
 	compile_module_with_type, Callee, FixtureType, System as SystemFixture,
 };
 use pretty_assertions::assert_eq;
-use revm::primitives::Bytes;
+use revm_primitives::Bytes;
 use sp_core::H160;
 use sp_io::hashing::keccak_256;
 


### PR DESCRIPTION
@athei @pgherveou Are you up for putting `revm` behind a feature flag? If yes, I'd take care of the failing CI.

Since you added the `revm` dep, 76 more child deps are pulled in for `pallet-revive`. We are noticing this in ink! with increased build times for anything related to our testing frameworks.

Besides the testing frameworks, the core ink! stuff still has some deps on `pallet-revive`. We are planning to change that in the future, but the build times for contracts have also increased significantly for the moment.