### PR TITLE
[pallet-revive] fix CodeInfo owner

### DIFF
--- a/prdoc/pr_9744.prdoc
+++ b/prdoc/pr_9744.prdoc
@@ -1,0 +1,9 @@
+title: '[pallet-revive] fix CodeInfo owner'
+doc:
+- audience: Runtime Dev
+  description: Fix CodeInfo owner, it should always be set to the origin of the transaction
+crates:
+- name: pallet-revive-fixtures
+  bump: patch
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/fixtures/contracts/CallerWithConstructor.sol
+++ b/substrate/frame/revive/fixtures/contracts/CallerWithConstructor.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+contract CallerWithConstructor {
+    CallerWithConstructorCallee callee;
+
+    constructor() {
+      callee = new CallerWithConstructorCallee();
+    }
+
+    function callBar() public view returns (uint) {
+      return callee.bar();
+    }
+}
+
+contract CallerWithConstructorCallee {
+    function bar() public pure returns (uint) {
+      return 42;
+    }
+}
+

--- a/substrate/frame/revive/fixtures/src/lib.rs
+++ b/substrate/frame/revive/fixtures/src/lib.rs
@@ -50,9 +50,11 @@ pub fn compile_module_with_type(
 	fixture_name: &str,
 	fixture_type: FixtureType,
 ) -> anyhow::Result<(Vec<u8>, sp_core::H256)> {
+	use anyhow::Context;
 	let out_dir: std::path::PathBuf = FIXTURE_DIR.into();
 	let fixture_path = out_dir.join(format!("{fixture_name}{}", fixture_type.file_extension()));
-	let binary = std::fs::read(fixture_path)?;
+	let binary = std::fs::read(&fixture_path)
+		.with_context(|| format!("Failed to load fixture {fixture_path:?}"))?;
 	let code_hash = sp_io::hashing::keccak_256(&binary);
 	Ok((binary, sp_core::H256(code_hash)))
 }

--- a/substrate/frame/revive/src/test_utils/builder.rs
+++ b/substrate/frame/revive/src/test_utils/builder.rs
@@ -141,6 +141,14 @@ builder!(
 		bump_nonce: BumpNonce,
 	) -> ContractResult<InstantiateReturnValue, BalanceOf<T>>;
 
+	pub fn concat_evm_data(mut self, more_data: &[u8]) -> Self {
+		let Code::Upload(code) = &mut self.code else {
+			panic!("concat_evm_data should only be used with Code::Upload");
+		};
+		code.extend_from_slice(more_data);
+		self
+	}
+
 	/// Set the call's evm_value using a native_value amount.
 	pub fn native_value(mut self, value: BalanceOf<T>) -> Self {
 		self.evm_value = Pallet::<T>::convert_native_to_evm(value);

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use alloy_core::{
 	primitives::{Bytes, FixedBytes, U256},
-	sol_types::{SolCall, SolConstructor, SolInterface},
+	sol_types::{SolCall, SolInterface},
 };
 use frame_support::{assert_err, traits::fungible::Mutate};
 use pallet_revive_fixtures::{compile_module_with_type, Callee, Caller, FixtureType};

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use alloy_core::{
 	primitives::{Bytes, FixedBytes, U256},
-	sol_types::SolCall,
+	sol_types::{SolCall, SolConstructor, SolInterface},
 };
 use frame_support::{assert_err, traits::fungible::Mutate};
 use pallet_revive_fixtures::{compile_module_with_type, Callee, Caller, FixtureType};
@@ -451,5 +451,25 @@ fn create2_works() {
 		let echo_output = Callee::echoCall::abi_decode_returns(&echo_result.data).unwrap();
 
 		assert_eq!(magic_number, echo_output, "Callee.echo must return 42");
+	});
+}
+
+#[test]
+fn instantiate_from_constructor_works() {
+	use pallet_revive_fixtures::CallerWithConstructor::*;
+
+	let (caller_code, _) =
+		compile_module_with_type("CallerWithConstructor", FixtureType::Solc).unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000);
+
+		let Contract { addr, .. } =
+			builder::bare_instantiate(Code::Upload(caller_code)).build_and_unwrap_contract();
+
+		let data = CallerWithConstructorCalls::callBar(callBarCall {}).abi_encode();
+		let result = builder::bare_call(addr).data(data).build_and_unwrap_result();
+		let result = callBarCall::abi_decode_returns(&result.data).unwrap();
+		assert_eq!(result, U256::from(42));
 	});
 }


### PR DESCRIPTION
Fix CodeInfo owner, it should always be set to the origin of the transaction