### PR TITLE
Snowbridge Inbound Queue V2 relayer tip payout fix

### DIFF
--- a/bridges/snowbridge/pallets/inbound-queue-v2/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/src/lib.rs
@@ -257,7 +257,9 @@ pub mod pallet {
 				})?;
 
 			// Pay relayer reward
-			if !relayer_fee.is_zero() {
+			let tip = Tips::<T>::take(nonce).unwrap_or_default();
+			let total_tip = relayer_fee.saturating_add(tip);
+			if total_tip > 0 {
 				T::RewardPayment::register_reward(
 					&relayer,
 					T::DefaultRewardKind::get(),

--- a/bridges/snowbridge/pallets/inbound-queue-v2/src/lib.rs
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/src/lib.rs
@@ -260,11 +260,7 @@ pub mod pallet {
 			let tip = Tips::<T>::take(nonce).unwrap_or_default();
 			let total_tip = relayer_fee.saturating_add(tip);
 			if total_tip > 0 {
-				T::RewardPayment::register_reward(
-					&relayer,
-					T::DefaultRewardKind::get(),
-					relayer_fee,
-				);
+				T::RewardPayment::register_reward(&relayer, T::DefaultRewardKind::get(), total_tip);
 			}
 
 			Self::deposit_event(Event::MessageReceived { nonce, message_id });

--- a/bridges/snowbridge/test-utils/src/mock_rewards.rs
+++ b/bridges/snowbridge/test-utils/src/mock_rewards.rs
@@ -50,6 +50,7 @@ impl From<BridgeReward> for RewardsAccountParams<u64> {
 
 parameter_types! {
 	pub static RegisteredRewardsCount: u128 = 0;
+	pub static RegisteredRewardAmount: u128 = 0;
 }
 
 pub struct MockRewardLedger;
@@ -58,8 +59,9 @@ impl RewardLedger<sp_runtime::AccountId32, BridgeReward, u128> for MockRewardLed
 	fn register_reward(
 		_relayer: &sp_runtime::AccountId32,
 		_reward: BridgeReward,
-		_reward_balance: u128,
+		reward_balance: u128,
 	) {
 		RegisteredRewardsCount::set(RegisteredRewardsCount::get().saturating_add(1));
+		RegisteredRewardAmount::set(reward_balance);
 	}
 }


### PR DESCRIPTION
# Description

Fixes a bug where Snowbridge Inbound V2 tips were not paid out to the relayer.

## Review Notes

Any tips added to a message in the Inbound Queue v2 (Ethereum to Polkadot direction), were burned and added to storage, but never paid out to the relayer. This PR fixes this bug by adding the tip to the relayer fee.