### PR TITLE
staking-async: handle uninitialized state in try-state checks

### DIFF
--- a/prdoc/pr_9747.prdoc
+++ b/prdoc/pr_9747.prdoc
@@ -1,0 +1,9 @@
+title: 'staking-async: uninitialized state in try-state checks'
+doc:
+- audience: Runtime Dev
+  description: |-
+    - Add early return in do_try_state when pallet is uninitialized
+    - Add test for empty state validation
+crates:
+- name: pallet-staking-async
+  bump: patch

--- a/prdoc/pr_9747.prdoc
+++ b/prdoc/pr_9747.prdoc
@@ -1,4 +1,4 @@
-title: 'staking-async: uninitialized state in try-state checks'
+title: 'staking-async: handle uninitialized state in try-state checks'
 doc:
 - audience: Runtime Dev
   description: |-

--- a/substrate/frame/staking-async/src/pallet/impls.rs
+++ b/substrate/frame/staking-async/src/pallet/impls.rs
@@ -1937,8 +1937,8 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	/// Pre-condition: ActiveEra is Some.
 	/// Invariants:
+	/// * ActiveEra is Some.
 	/// * For each paged era exposed validator, check if the exposure total is sane (exposure.total
 	/// = exposure.own + exposure.own).
 	/// * Paged exposures metadata (`ErasStakersOverview`) matches the paged exposures state.

--- a/substrate/frame/staking-async/src/pallet/impls.rs
+++ b/substrate/frame/staking-async/src/pallet/impls.rs
@@ -1953,7 +1953,7 @@ impl<T: Config> Pallet<T> {
 		// we don't call this method. Otherwise, Eras::do_try_state enforces that both ActiveEra
 		// and CurrentEra are Some. Thus, we can safely unwrap here.
 		let era = ActiveEra::<T>::get()
-			.expect("ActiveEra must be set when checking paged exposures")
+			.ok_or(TryRuntimeError::Other("ActiveEra must be set when checking paged exposures"))?
 			.index;
 
 		let accumulator_default = PagedExposureMetadata {

--- a/substrate/frame/staking-async/src/pallet/impls.rs
+++ b/substrate/frame/staking-async/src/pallet/impls.rs
@@ -1951,7 +1951,7 @@ impl<T: Config> Pallet<T> {
 			BTreeMap::new();
 		// If the pallet is not initialized, we return immediately from pallet's do_try_state() and
 		// we don't call this method. Otherwise, Eras::do_try_state enforces that both ActiveEra
-		// and CurrentEra are Some. Thus, we can safely unwrap here.
+		// and CurrentEra are Some. Thus, we should never hit this error.
 		let era = ActiveEra::<T>::get()
 			.ok_or(TryRuntimeError::Other("ActiveEra must be set when checking paged exposures"))?
 			.index;

--- a/substrate/frame/staking-async/src/tests/mod.rs
+++ b/substrate/frame/staking-async/src/tests/mod.rs
@@ -45,6 +45,7 @@ mod force_unstake_kill_stash;
 mod ledger;
 mod payout_stakers;
 mod slashing;
+mod try_state;
 
 #[test]
 fn basic_setup_session_queuing_should_work() {

--- a/substrate/frame/staking-async/src/tests/try_state.rs
+++ b/substrate/frame/staking-async/src/tests/try_state.rs
@@ -1,0 +1,73 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for try-state checks.
+
+use super::*;
+use frame_support::assert_ok;
+
+#[test]
+fn try_state_works_with_uninitialized_pallet() {
+	sp_io::TestExternalities::default().execute_with(|| {
+		// Verify the pallet is uninitialized
+		assert!(ActiveEra::<Test>::get().is_none());
+		assert!(CurrentEra::<Test>::get().is_none());
+		assert_eq!(Bonded::<Test>::iter().count(), 0);
+		assert_eq!(Ledger::<Test>::iter().count(), 0);
+		assert_eq!(Validators::<Test>::iter().count(), 0);
+		assert_eq!(Nominators::<Test>::iter().count(), 0);
+
+		// Try-state should pass with uninitialized state
+		assert_ok!(Staking::do_try_state(System::block_number()));
+	});
+}
+
+#[test]
+fn try_state_detects_inconsistent_active_current_era() {
+	// Test that try-state fails if only one of ActiveEra or CurrentEra is set
+	ExtBuilder::default().has_stakers(false).build_and_execute(|| {
+		// Set only ActiveEra (CurrentEra remains None) - this violates the invariant
+		ActiveEra::<Test>::put(ActiveEraInfo { index: 1, start: None });
+		CurrentEra::<Test>::kill();
+
+		// Try-state should fail due to inconsistent state
+		assert!(Staking::do_try_state(System::block_number()).is_err());
+
+		// Now set only CurrentEra (ActiveEra None) - this also violates the invariant
+		ActiveEra::<Test>::kill();
+		CurrentEra::<Test>::put(1);
+
+		// Try-state should fail due to inconsistent state
+		assert!(Staking::do_try_state(System::block_number()).is_err());
+
+		// Both None should pass
+		ActiveEra::<Test>::kill();
+		CurrentEra::<Test>::kill();
+		assert_ok!(Staking::do_try_state(System::block_number()));
+
+		// Both Some should pass (assuming other invariants are met)
+		ActiveEra::<Test>::put(ActiveEraInfo { index: 1, start: None });
+		CurrentEra::<Test>::put(1);
+		// Need to set up bonded eras for this to pass
+		// With BondingDuration = 3 and ActiveEra = 1, BondedEras must contain [0, 1]
+		use frame_support::BoundedVec;
+		let bonded_eras: BoundedVec<(u32, u32), _> =
+			BoundedVec::try_from(vec![(0, 0), (1, 0)]).unwrap();
+		BondedEras::<Test>::put(bonded_eras);
+		assert_ok!(Staking::do_try_state(System::block_number()));
+	});
+}

--- a/substrate/frame/staking-async/src/tests/try_state.rs
+++ b/substrate/frame/staking-async/src/tests/try_state.rs
@@ -38,7 +38,6 @@ fn try_state_works_with_uninitialized_pallet() {
 
 #[test]
 fn try_state_detects_inconsistent_active_current_era() {
-	// Test that try-state fails if only one of ActiveEra or CurrentEra is set
 	ExtBuilder::default().has_stakers(false).build_and_execute(|| {
 		// Set only ActiveEra (CurrentEra remains None) - this violates the invariant
 		ActiveEra::<Test>::put(ActiveEraInfo { index: 1, start: None });
@@ -63,7 +62,6 @@ fn try_state_detects_inconsistent_active_current_era() {
 		ActiveEra::<Test>::put(ActiveEraInfo { index: 1, start: None });
 		CurrentEra::<Test>::put(1);
 		// Need to set up bonded eras for this to pass
-		// With BondingDuration = 3 and ActiveEra = 1, BondedEras must contain [0, 1]
 		use frame_support::BoundedVec;
 		let bonded_eras: BoundedVec<(u32, u32), _> =
 			BoundedVec::try_from(vec![(0, 0), (1, 0)]).unwrap();


### PR DESCRIPTION
- Add early return in do_try_state when pallet is uninitialized
- Add test for empty state validation

Followup of #9721 .
Once backported to `2507` and crate is published, should unlock https://github.com/polkadot-fellows/runtimes/pull/904 