### PR TITLE
ci: switch tests to new runners

### DIFF
--- a/.github/workflows/reusable-preflight.yml
+++ b/.github/workflows/reusable-preflight.yml
@@ -41,6 +41,19 @@ on:
           parity-oldlinux
           By default we use spot machines that can be terminated at any time.
           Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
+      # New is used only during transition to the new runners
+      RUNNER_NEW:
+        value: ${{ jobs.preflight.outputs.RUNNER }}
+        description: |
+          Main runner for resource-intensive tasks
+          By default we use spot machines that can be terminated at any time.
+          Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
+      RUNNER_OLDLINUX_NEW:
+        value: ${{ jobs.preflight.outputs.RUNNER_OLDLINUX }}
+        description: |
+          parity-oldlinux
+          By default we use spot machines that can be terminated at any time.
+          Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
       RUNNER_DEFAULT:
         value: ${{ jobs.preflight.outputs.RUNNER_DEFAULT }}
         description: "Relatively lightweight runner. When `ubuntu-latest` is not enough"

--- a/.github/workflows/reusable-preflight.yml
+++ b/.github/workflows/reusable-preflight.yml
@@ -71,7 +71,6 @@ on:
         description: "Sha of the current revision, 8-symbols long"
 
 jobs:
-
   #
   #
   #
@@ -86,7 +85,9 @@ jobs:
       # Runners
       # https://github.com/paritytech/ci_cd/wiki/GitHub#paritytech-self-hosted-runners
       RUNNER: ${{ steps.set_runner.outputs.RUNNER }}
+      RUNNER_NEW: ${{ steps.set_runner.outputs.RUNNER_NEW }}
       RUNNER_OLDLINUX: ${{ steps.set_runner.outputs.RUNNER_OLDLINUX }}
+      RUNNER_OLDLINUX_NEW: ${{ steps.set_runner.outputs.RUNNER_OLDLINUX_NEW }}
       RUNNER_DEFAULT: ${{ steps.set_runner.outputs.RUNNER_DEFAULT }}
       RUNNER_WEIGHTS: ${{ steps.set_runner.outputs.RUNNER_WEIGHTS }}
       RUNNER_BENCHMARK: ${{ steps.set_runner.outputs.RUNNER_BENCHMARK }}
@@ -99,7 +100,6 @@ jobs:
       COMMIT_SHA_SHORT: ${{ steps.set_vars.outputs.COMMIT_SHA_SHORT }}
 
     steps:
-
       - uses: actions/checkout@v4
 
       #
@@ -153,9 +153,13 @@ jobs:
           if [[ $GITHUB_REF_NAME == *"gh-readonly-queue"* ]]; then
             echo "RUNNER=parity-large-persistent" >> $GITHUB_OUTPUT
             echo "RUNNER_OLDLINUX=parity-oldlinux-persistent" >> $GITHUB_OUTPUT
+            echo "RUNNER_NEW=parity-large-persistent-new" >> $GITHUB_OUTPUT
+            echo "RUNNER_OLDLINUX_NEW=parity-oldlinux-persistent-new" >> $GITHUB_OUTPUT
           else
             echo "RUNNER=parity-large" >> $GITHUB_OUTPUT
             echo "RUNNER_OLDLINUX=parity-oldlinux" >> $GITHUB_OUTPUT
+            echo "RUNNER_NEW=parity-large-new" >> $GITHUB_OUTPUT
+            echo "RUNNER_OLDLINUX_NEW=parity-oldlinux-new" >> $GITHUB_OUTPUT
           fi
 
       #
@@ -174,7 +178,6 @@ jobs:
           #
           export REF_NAME=${{ github.ref_name }}
           echo "REF_SLUG=${REF_NAME//\//_}" >> $GITHUB_OUTPUT
-
 
       - name: log
         shell: bash

--- a/.github/workflows/reusable-preflight.yml
+++ b/.github/workflows/reusable-preflight.yml
@@ -43,13 +43,13 @@ on:
           Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
       # New is used only during transition to the new runners
       RUNNER_NEW:
-        value: ${{ jobs.preflight.outputs.RUNNER }}
+        value: ${{ jobs.preflight.outputs.RUNNER_NEW }}
         description: |
           Main runner for resource-intensive tasks
           By default we use spot machines that can be terminated at any time.
           Merge queues use persistent runners to avoid kicking off from queue when the runner is terminated.
       RUNNER_OLDLINUX_NEW:
-        value: ${{ jobs.preflight.outputs.RUNNER_OLDLINUX }}
+        value: ${{ jobs.preflight.outputs.RUNNER_OLDLINUX_NEW }}
         description: |
           parity-oldlinux
           By default we use spot machines that can be terminated at any time.

--- a/.github/workflows/tests-linux-stable-xp.yml
+++ b/.github/workflows/tests-linux-stable-xp.yml
@@ -16,6 +16,7 @@ jobs:
   isdraft:
     uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
+    needs: isdraft
     uses: ./.github/workflows/reusable-preflight.yml
 
   # No filter for 'all_security_features_work' and 'nonexistent_cache_dir'

--- a/.github/workflows/tests-linux-stable-xp.yml
+++ b/.github/workflows/tests-linux-stable-xp.yml
@@ -13,6 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  isdraft:
+    uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
     uses: ./.github/workflows/reusable-preflight.yml
 

--- a/.github/workflows/tests-linux-stable-xp.yml
+++ b/.github/workflows/tests-linux-stable-xp.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
     needs: isdraft
+    if: false
     uses: ./.github/workflows/reusable-preflight.yml
 
   # No filter for 'all_security_features_work' and 'nonexistent_cache_dir'

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -16,7 +16,7 @@ jobs:
   # isdraft:
   #   uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
-    needs: isdraft
+    # needs: isdraft
     uses: ./.github/workflows/reusable-preflight.yml
 
   test-linux-stable-int:

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -13,10 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # isdraft:
-  #   uses: ./.github/workflows/reusable-isdraft.yml
+  isdraft:
+    uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
-    # needs: isdraft
+    needs: isdraft
     uses: ./.github/workflows/reusable-preflight.yml
 
   test-linux-stable-int:

--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  isdraft:
-    uses: ./.github/workflows/reusable-isdraft.yml
+  # isdraft:
+  #   uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
     needs: isdraft
     uses: ./.github/workflows/reusable-preflight.yml
@@ -22,7 +22,7 @@ jobs:
   test-linux-stable-int:
     needs: [preflight]
     if: ${{ needs.preflight.outputs.changes_rust }}
-    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    runs-on: ${{ needs.preflight.outputs.RUNNER_NEW }}
     timeout-minutes: 60
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -50,7 +50,7 @@ jobs:
   test-linux-stable-runtime-benchmarks:
     needs: [preflight]
     if: ${{ needs.preflight.outputs.changes_rust }}
-    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    runs-on: ${{ needs.preflight.outputs.RUNNER_NEW }}
     timeout-minutes: 60
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
@@ -83,13 +83,13 @@ jobs:
         partition: [1/3, 2/3, 3/3]
         runners:
           [
-            "${{ needs.preflight.outputs.RUNNER }}",
-            "${{ needs.preflight.outputs.RUNNER_OLDLINUX }}",
+            "${{ needs.preflight.outputs.RUNNER_NEW }}",
+            "${{ needs.preflight.outputs.RUNNER_OLDLINUX_NEW }}",
           ]
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
       # needed for tests that use unshare syscall
-      options: --security-opt seccomp=unconfined
+      options: --privileged
     env:
       RUST_TOOLCHAIN: stable
       # Enable debug assertions since we are running optimized builds for testing
@@ -124,16 +124,14 @@ jobs:
 
   # some tests do not run with `try-runtime` feature enabled
   # https://github.com/paritytech/polkadot-sdk/pull/4251#discussion_r1624282143
-  #
-  # all_security_features_work and nonexistent_cache_dir are currently skipped
-  # becuase runners don't have the necessary permissions to run them
   test-linux-stable-no-try-runtime:
     needs: [preflight]
     if: ${{ needs.preflight.outputs.changes_rust }}
-    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    runs-on: ${{ needs.preflight.outputs.RUNNER_NEW }}
     timeout-minutes: 60
     container:
       image: ${{ needs.preflight.outputs.IMAGE }}
+      options: --privileged
     strategy:
       fail-fast: false
       matrix:
@@ -155,8 +153,7 @@ jobs:
                    --no-fail-fast \
                    --cargo-quiet \
                    --features experimental,ci-only-tests \
-                   --filter-expr " !test(/all_security_features_work/) - test(/nonexistent_cache_dir/)" \
-                   --partition count:${{ matrix.partition }} \
+                   --partition count:${{ matrix.partition }}
       - name: Stop all workflows if failed
         if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/workflow-stopper


### PR DESCRIPTION
PR switches test-linux-stable to new runners.

cc https://github.com/paritytech/devops/issues/3875