### PR TITLE
EPMB: ensure to have enough funds for benchmarking

### DIFF
--- a/prdoc/pr_9772.prdoc
+++ b/prdoc/pr_9772.prdoc
@@ -1,0 +1,10 @@
+title: 'EPMB: ensure to have enough funds for benchmarking'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Fix `pallet_election_provider_multi_block_signed::register_eject` benchmark failing on KAHM due to `funded_account()` function not providing enough balance to cover the required deposits.
+
+    The fix ensures that benchmark accounts have sufficient funds to cover the worst-case deposit scenario (registration + all pages submission) with a consistent safety margin.
+crates:
+- name: pallet-election-provider-multi-block
+  bump: patch

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -1471,9 +1471,10 @@ where
 		use frame_support::traits::fungible::{Inspect, Mutate};
 		let who: T::AccountId = frame_benchmarking::account(seed, index, 777);
 		whitelist!(who);
-		let balance = signed::Pallet::<T>::deposit_for(who.clone(), T::Pages::get()) *
-			1000u32.into() +
-			T::Currency::minimum_balance();
+		let max_deposit = signed::Pallet::<T>::deposit_for(who.clone(), T::Pages::get());
+		let balance = max_deposit
+			.saturating_mul(1000u32.into())
+			.saturating_add(T::Currency::minimum_balance());
 		T::Currency::mint_into(&who, balance).unwrap();
 		who
 	}

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -1471,7 +1471,9 @@ where
 		use frame_support::traits::fungible::{Inspect, Mutate};
 		let who: T::AccountId = frame_benchmarking::account(seed, index, 777);
 		whitelist!(who);
-		let balance = T::Currency::minimum_balance() * 1_0000_0000u32.into();
+		let balance = signed::Pallet::<T>::deposit_for(who.clone(), T::Pages::get()) *
+			1000u32.into() +
+			T::Currency::minimum_balance();
 		T::Currency::mint_into(&who, balance).unwrap();
 		who
 	}

--- a/substrate/frame/election-provider-multi-block/src/lib.rs
+++ b/substrate/frame/election-provider-multi-block/src/lib.rs
@@ -1472,9 +1472,7 @@ where
 		let who: T::AccountId = frame_benchmarking::account(seed, index, 777);
 		whitelist!(who);
 		let max_deposit = signed::Pallet::<T>::deposit_for(who.clone(), T::Pages::get());
-		let balance = max_deposit
-			.saturating_mul(1000u32.into())
-			.saturating_add(T::Currency::minimum_balance());
+		let balance = max_deposit.saturating_add(T::Currency::minimum_balance());
 		T::Currency::mint_into(&who, balance).unwrap();
 		who
 	}


### PR DESCRIPTION
Fix `pallet_election_provider_multi_block_signed::register_eject` benchmark failing on KAHM due to `funded_account()` function not providing enough balance to cover the required deposits. See for example [here](https://github.com/polkadot-fellows/runtimes/actions/runs/17765363309/job/50487393309?pr=856).

The fix ensures that benchmark accounts have sufficient funds to cover the worst-case deposit scenario (registration + all pages submission) 
