### PR TITLE
Fix executor param fetching session index

### DIFF
--- a/polkadot/node/core/approval-voting/src/import.rs
+++ b/polkadot/node/core/approval-voting/src/import.rs
@@ -61,7 +61,7 @@ use super::approval_db::v3;
 use crate::{
 	backend::{Backend, OverlayedBackend},
 	criteria::{AssignmentCriteria, OurAssignment},
-	get_extended_session_info, get_session_info,
+	get_extended_session_info_by_index, get_session_info_by_index,
 	persisted_entries::CandidateEntry,
 };
 
@@ -220,7 +220,7 @@ async fn imported_block_info<Sender: SubsystemSender<RuntimeApiMessage>>(
 	};
 
 	let extended_session_info =
-		get_extended_session_info(env.runtime_info, sender, block_hash, session_index).await;
+		get_extended_session_info_by_index(env.runtime_info, sender, block_hash, session_index).await;
 	let enable_v2_assignments = extended_session_info.map_or(false, |extended_session_info| {
 		*extended_session_info
 			.node_features
@@ -229,7 +229,7 @@ async fn imported_block_info<Sender: SubsystemSender<RuntimeApiMessage>>(
 			.unwrap_or(&false)
 	});
 
-	let session_info = get_session_info(env.runtime_info, sender, block_hash, session_index)
+	let session_info = get_session_info_by_index(env.runtime_info, sender, block_hash, session_index)
 		.await
 		.ok_or(ImportedBlockInfoError::SessionInfoUnavailable)?;
 
@@ -456,7 +456,7 @@ pub(crate) async fn handle_new_head<
 		} = imported_block_info;
 
 		let session_info =
-			match get_session_info(session_info_provider, sender, head, session_index).await {
+			match get_session_info_by_index(session_info_provider, sender, head, session_index).await {
 				Some(session_info) => session_info,
 				None => return Ok(Vec::new()),
 			};

--- a/polkadot/node/core/approval-voting/src/lib.rs
+++ b/polkadot/node/core/approval-voting/src/lib.rs
@@ -851,6 +851,30 @@ async fn get_extended_session_info<'a, Sender>(
 	runtime_info: &'a mut RuntimeInfo,
 	sender: &mut Sender,
 	relay_parent: Hash,
+) -> Option<&'a ExtendedSessionInfo>
+where
+	Sender: SubsystemSender<RuntimeApiMessage>,
+{
+	match runtime_info
+		.get_session_info(sender, relay_parent)
+		.await
+	{
+		Ok(extended_info) => Some(&extended_info),
+		Err(_) => {
+			gum::debug!(
+				target: LOG_TARGET,
+				?relay_parent,
+				"Can't obtain SessionInfo or ExecutorParams"
+			);
+			None
+		},
+	}
+}
+
+async fn get_extended_session_info_by_index<'a, Sender>(
+	runtime_info: &'a mut RuntimeInfo,
+	sender: &mut Sender,
+	relay_parent: Hash,
 	session_index: SessionIndex,
 ) -> Option<&'a ExtendedSessionInfo>
 where
@@ -873,7 +897,7 @@ where
 	}
 }
 
-async fn get_session_info<'a, Sender>(
+async fn get_session_info_by_index<'a, Sender>(
 	runtime_info: &'a mut RuntimeInfo,
 	sender: &mut Sender,
 	relay_parent: Hash,
@@ -882,7 +906,7 @@ async fn get_session_info<'a, Sender>(
 where
 	Sender: SubsystemSender<RuntimeApiMessage>,
 {
-	get_extended_session_info(runtime_info, sender, relay_parent, session_index)
+	get_extended_session_info_by_index(runtime_info, sender, relay_parent, session_index)
 		.await
 		.map(|extended_info| &extended_info.session_info)
 }
@@ -976,7 +1000,7 @@ impl State {
 	where
 		Sender: SubsystemSender<RuntimeApiMessage>,
 	{
-		let session_info = match get_session_info(
+		let session_info = match get_session_info_by_index(
 			session_info_provider,
 			sender,
 			block_entry.parent_hash(),
@@ -1901,8 +1925,7 @@ async fn distribution_messages_for_activation<Sender: SubsystemSender<RuntimeApi
 											match get_extended_session_info(
 												session_info_provider,
 												sender,
-												block_entry.block_hash(),
-												block_entry.session(),
+												candidate_entry.candidate_receipt().descriptor().relay_parent(),
 											)
 											.await
 											{
@@ -2686,7 +2709,7 @@ where
 			)),
 	};
 
-	let session_info = match get_session_info(
+	let session_info = match get_session_info_by_index(
 		session_info_provider,
 		sender,
 		block_entry.parent_hash(),
@@ -3282,12 +3305,24 @@ async fn process_wakeup<Sender: SubsystemSender<RuntimeApiMessage>>(
 		_ => return Ok(Vec::new()),
 	};
 
-	let ExtendedSessionInfo { ref session_info, ref executor_params, .. } =
-		match get_extended_session_info(
+	let (no_show_slots, needed_approvals) =
+		match get_session_info_by_index(
 			session_info_provider,
 			sender,
 			block_entry.block_hash(),
 			block_entry.session(),
+		)
+		.await
+		{
+			Some(i) => (i.no_show_slots, i.needed_approvals),
+			None => return Ok(Vec::new()),
+		};
+
+	let ExtendedSessionInfo { ref executor_params, .. } = 
+		match get_extended_session_info(
+			session_info_provider,
+			sender,
+			candidate_entry.candidate_receipt().descriptor().relay_parent(),
 		)
 		.await
 		{
@@ -3298,7 +3333,7 @@ async fn process_wakeup<Sender: SubsystemSender<RuntimeApiMessage>>(
 	let block_tick = slot_number_to_tick(state.slot_duration_millis, block_entry.slot());
 	let no_show_duration = slot_number_to_tick(
 		state.slot_duration_millis,
-		Slot::from(u64::from(session_info.no_show_slots)),
+		Slot::from(u64::from(no_show_slots)),
 	);
 	let tranche_now = state.clock.tranche_now(state.slot_duration_millis, block_entry.slot());
 
@@ -3322,7 +3357,7 @@ async fn process_wakeup<Sender: SubsystemSender<RuntimeApiMessage>>(
 			tranche_now,
 			block_tick,
 			no_show_duration,
-			session_info.needed_approvals as _,
+			needed_approvals as _,
 		);
 
 		let should_trigger = should_trigger_assignment(
@@ -3742,7 +3777,7 @@ async fn issue_approval<
 		},
 	};
 
-	let session_info = match get_session_info(
+	let session_info = match get_session_info_by_index(
 		session_info_provider,
 		sender,
 		block_entry.parent_hash(),
@@ -3868,7 +3903,7 @@ async fn maybe_create_signature<
 		None => return Ok(sign_no_later_then),
 	};
 
-	let session_info = match get_session_info(
+	let session_info = match get_session_info_by_index(
 		session_info_provider,
 		sender,
 		block_entry.parent_hash(),


### PR DESCRIPTION
This aims to fix #4292 
We have three cases of candidate validation where a proper set of executor environment parameters should be used:
1) Backing, and we're currently doing the right thing, requesting the executor params at the relay parent at which the candidate was produced:
https://github.com/paritytech/polkadot-sdk/blob/e7f36ab82934a7142f3ebd7f8b5566f12f85339b/polkadot/node/core/backing/src/lib.rs#L1140-L1146
2) Approval voting, where a wrong session was used, and this PR fixes that;
3) Disputes, where the session index, again, is hopefully derived from the relay parent at which the candidate was produced:
https://github.com/paritytech/polkadot-sdk/blob/63958c454643ddafdde8be17af5334aa95954550/polkadot/node/subsystem-types/src/messages.rs#L295-L296

So, hopefully, this PR fixes the only wrong case and harmonizes the executor param fetching over all the existing use cases.