### PR TITLE
Limit the number of signals per XCMP page

### DIFF
--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -929,7 +929,7 @@ impl<T: Config> XcmpMessageHandler for Pallet<T> {
 							},
 							Ok(ChannelSignal::Resume) => {
 								if meter.try_consume(T::WeightInfo::resume_channel()).is_err() {
-									defensive!("Not enough weight to process signal - dropping");
+									defensive!("Not enough weight to process resume signal - dropping");
 									break
 								}
 								Self::resume_channel(sender)

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -922,7 +922,7 @@ impl<T: Config> XcmpMessageHandler for Pallet<T> {
 						match ChannelSignal::decode(&mut data) {
 							Ok(ChannelSignal::Suspend) => {
 								if meter.try_consume(T::WeightInfo::suspend_channel()).is_err() {
-									defensive!("Not enough weight to process signal - dropping");
+									defensive!("Not enough weight to process suspend signal - dropping");
 									break
 								}
 								Self::suspend_channel(sender)

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -93,6 +93,8 @@ const LOG_TARGET: &str = "xcmp_queue";
 const DEFAULT_POV_SIZE: u64 = 64 * 1024; // 64 KB
 /// The size of an XCM messages batch.
 pub const XCM_BATCH_SIZE: usize = 250;
+/// The maximum number of signals that we can have in an XCMP page.
+pub const MAX_SIGNALS_PER_PAGE: usize = 3;
 
 /// Constants related to delivery fee calculation
 pub mod delivery_fee_constants {
@@ -913,28 +915,32 @@ impl<T: Config> XcmpMessageHandler for Pallet<T> {
 			};
 
 			match format {
-				XcmpMessageFormat::Signals =>
-					while !data.is_empty() {
-						if meter
-							.try_consume(
-								T::WeightInfo::suspend_channel()
-									.max(T::WeightInfo::resume_channel()),
-							)
-							.is_err()
-						{
-							defensive!("Not enough weight to process signals - dropping");
-							break
-						}
-
+				XcmpMessageFormat::Signals => {
+					let mut signal_count = 0;
+					while !data.is_empty() && signal_count < MAX_SIGNALS_PER_PAGE {
+						signal_count += 1;
 						match ChannelSignal::decode(&mut data) {
-							Ok(ChannelSignal::Suspend) => Self::suspend_channel(sender),
-							Ok(ChannelSignal::Resume) => Self::resume_channel(sender),
+							Ok(ChannelSignal::Suspend) => {
+								if meter.try_consume(T::WeightInfo::suspend_channel()).is_err() {
+									defensive!("Not enough weight to process signal - dropping");
+									break
+								}
+								Self::suspend_channel(sender)
+							},
+							Ok(ChannelSignal::Resume) => {
+								if meter.try_consume(T::WeightInfo::resume_channel()).is_err() {
+									defensive!("Not enough weight to process signal - dropping");
+									break
+								}
+								Self::resume_channel(sender)
+							},
 							Err(_) => {
 								defensive!("Undecodable channel signal - dropping");
 								break
 							},
 						}
-					},
+					}
+				},
 				XcmpMessageFormat::ConcatenatedVersionedXcm |
 				XcmpMessageFormat::ConcatenatedOpaqueVersionedXcm => {
 					let encoding = match format {

--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -922,14 +922,18 @@ impl<T: Config> XcmpMessageHandler for Pallet<T> {
 						match ChannelSignal::decode(&mut data) {
 							Ok(ChannelSignal::Suspend) => {
 								if meter.try_consume(T::WeightInfo::suspend_channel()).is_err() {
-									defensive!("Not enough weight to process suspend signal - dropping");
+									defensive!(
+										"Not enough weight to process suspend signal - dropping"
+									);
 									break
 								}
 								Self::suspend_channel(sender)
 							},
 							Ok(ChannelSignal::Resume) => {
 								if meter.try_consume(T::WeightInfo::resume_channel()).is_err() {
-									defensive!("Not enough weight to process resume signal - dropping");
+									defensive!(
+										"Not enough weight to process resume signal - dropping"
+									);
 									break
 								}
 								Self::resume_channel(sender)

--- a/prdoc/pr_9781.prdoc
+++ b/prdoc/pr_9781.prdoc
@@ -1,0 +1,10 @@
+title: Limit the number of signals per XCMP page
+doc:
+- audience: Runtime Dev
+  description: |-
+    Right now we have only 2 XCMP signals: `SuspendChannel` and `ResumeChannel` and we can write at most 1 per page.
+
+    Let's also add a limit when reading the signals in a page. Even if now 1 is enough, since in the future we might add more signals, let's have a limit of 3 per page.
+crates:
+- name: cumulus-pallet-xcmp-queue
+  bump: patch

--- a/prdoc/pr_9781.prdoc
+++ b/prdoc/pr_9781.prdoc
@@ -7,4 +7,4 @@ doc:
     Let's also add a limit when reading the signals in a page. Even if now 1 is enough, since in the future we might add more signals, let's have a limit of 3 per page.
 crates:
 - name: cumulus-pallet-xcmp-queue
-  bump: patch
+  bump: minor


### PR DESCRIPTION
Right now we have only 2 XCMP signals: `SuspendChannel` and `ResumeChannel` and we can write at most 1 per page.

Let's also add a limit when reading the signals in a page. Even if now 1 is enough, since in the future we might add more signals, let's have a limit of 3 per page.