### PR TITLE
sp-io/crypto: add Ethereum address recover method

### DIFF
--- a/substrate/frame/revive/src/evm/api/signature.rs
+++ b/substrate/frame/revive/src/evm/api/signature.rs
@@ -167,8 +167,9 @@ impl TransactionSigned {
 
 		let hash = keccak_256(&bytes);
 		let mut addr = H160::default();
-		let pk = secp256k1_ecdsa_recover(&signature, &hash).map_err(|_| ())?;
-		addr.assign_from_slice(&keccak_256(&pk[..])[12..]);
+		addr.assign_from_slice(
+			&secp256k1_ecdsa_recover_address(&signature, &hash).map_err(|_| ())?,
+		);
 		Ok(addr)
 	}
 }

--- a/substrate/frame/revive/src/evm/api/signature.rs
+++ b/substrate/frame/revive/src/evm/api/signature.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 use sp_core::{H160, U256};
-use sp_io::{crypto::secp256k1_ecdsa_recover, hashing::keccak_256};
+use sp_io::{crypto::secp256k1_ecdsa_recover_address, hashing::keccak_256};
 
 impl TransactionLegacySigned {
 	/// Get the recovery ID from the signed transaction.

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -1272,6 +1272,24 @@ pub trait Crypto {
 		Ok(res)
 	}
 
+	/// Recover an Ethereum address from a SECP256k1 ECDSA signature.
+	///
+	/// - `sig` is passed in RSV format. V should be either `0/1` or `27/28`.
+	/// - `msg` is the blake2-256 hash of the message.
+	///
+	/// Returns `Err` if the signature is bad, otherwise the 20-bytes address.
+	///
+	/// It can handle non-standard overflowing signatures.
+	fn secp256k1_ecdsa_recover_address(
+		sig: PassPointerAndRead<&[u8; 65], 65>,
+		msg: PassPointerAndRead<&[u8; 32], 32>,
+	) -> AllocateAndReturnByCodec<Result<[u8; 20], EcdsaVerifyError>> {
+		let mut addr = [0; 20];
+		let pk = secp256k1_ecdsa_recover(sig, msg)?;
+		addr.copy_from_slice(&sp_crypto_hashing::keccak_256(&pk[..])[12..]);
+		Ok(addr)
+	}
+
 	/// Verify and recover a SECP256k1 ECDSA signature.
 	///
 	/// - `sig` is passed in RSV format. V should be either `0/1` or `27/28`.


### PR DESCRIPTION
# Description

Closes #9785 .

Adds a new crypto host function that recovers a sender Ethereum address from a secp256k1 ecdsa signature.

## Integration

Developers can override the new crypto host function to recover sender Ethereum addresses from signatures. This is especially useful in testing environments when needing to impersonate certain senders when not owning their private key.

## Review Notes

TODO:
- add prdoc

The new crypto host function is added to be able to customize the recovery of the ETH address from a given signature. If there is another way where I can customize certain logic executed on the runtime, I would be interested, but based on my understanding there isn't. The constrains of the customization should consider that the runtime containing pallet-revive should not be rebuilt to enable it, and ideally the custom way of doing the recovery should not be baked by default into the runtime (triggered under certain test related circumstances).