### PR TITLE
revive-fixtures: Provide an env variable to disable compilation

### DIFF
--- a/substrate/frame/revive/fixtures/build.rs
+++ b/substrate/frame/revive/fixtures/build.rs
@@ -452,9 +452,9 @@ fn generate_fixture_location(temp_dir: &Path, out_dir: &Path, entries: &[Entry])
 
 	let (fixtures, fixtures_resolc) = if env::var(SKIP_PALLET_REVIVE_FIXTURES).is_err() {
 		(
-			format!(r#"include_bytes!(concat!("{}", "/", $name, ".polkavm")"#, out_dir.display()),
+			format!(r#"include_bytes!(concat!("{}", "/", $name, ".polkavm"))"#, out_dir.display()),
 			format!(
-				r#"include_bytes!(concat!("{}", "/", $name, ".resolc.polkavm")"#,
+				r#"include_bytes!(concat!("{}", "/", $name, ".resolc.polkavm"))"#,
 				out_dir.display()
 			),
 		)

--- a/substrate/frame/revive/fixtures/build.rs
+++ b/substrate/frame/revive/fixtures/build.rs
@@ -452,9 +452,12 @@ fn generate_fixture_location(temp_dir: &Path, out_dir: &Path, entries: &[Entry])
 
 	let (fixtures, fixtures_resolc) = if env::var(SKIP_PALLET_REVIVE_FIXTURES).is_err() {
 		(
-			format!(r#"include_bytes!(concat!("{}", "/", $name, ".polkavm"))"#, out_dir.display()),
 			format!(
-				r#"include_bytes!(concat!("{}", "/", $name, ".resolc.polkavm"))"#,
+				r#"Some(include_bytes!(concat!("{}", "/", $name, ".polkavm")))"#,
+				out_dir.display()
+			),
+			format!(
+				r#"Some(include_bytes!(concat!("{}", "/", $name, ".resolc.polkavm")))"#,
 				out_dir.display()
 			),
 		)

--- a/substrate/frame/revive/fixtures/build.rs
+++ b/substrate/frame/revive/fixtures/build.rs
@@ -28,6 +28,10 @@ use std::{
 const OVERRIDE_RUSTUP_TOOLCHAIN_ENV_VAR: &str = "PALLET_REVIVE_FIXTURES_RUSTUP_TOOLCHAIN";
 const OVERRIDE_STRIP_ENV_VAR: &str = "PALLET_REVIVE_FIXTURES_STRIP";
 const OVERRIDE_OPTIMIZE_ENV_VAR: &str = "PALLET_REVIVE_FIXTURES_OPTIMIZE";
+/// Do not build the fixtures, they will resolve to `None`.
+///
+/// Depending on the usage, they will probably panic at runtime.
+const SKIP_PALLET_REVIVE_FIXTURES: &str = "SKIP_PALLET_REVIVE_FIXTURES";
 
 /// A contract entry.
 #[derive(Clone)]
@@ -250,7 +254,10 @@ fn compile_with_standard_json(
 		.stderr(std::process::Stdio::piped())
 		.spawn()
 		.with_context(|| {
-			format!("Failed to execute {}. Make sure {} is installed.", compiler, compiler)
+			format!(
+				"Failed to execute {compiler}. Make sure {compiler} is installed or \
+				set env variable `{SKIP_PALLET_REVIVE_FIXTURES}=1` to skip fixtures compilation."
+			)
 		})?;
 
 	let mut stdin = compiler_output.stdin.as_ref().unwrap();
@@ -443,6 +450,18 @@ fn generate_fixture_location(temp_dir: &Path, out_dir: &Path, entries: &[Entry])
 	let mut file = fs::File::create(temp_dir.join("fixture_location.rs"))
 		.context("Failed to create fixture_location.rs")?;
 
+	let (fixtures, fixtures_resolc) = if env::var(SKIP_PALLET_REVIVE_FIXTURES).is_err() {
+		(
+			format!(r#"include_bytes!(concat!("{}", "/", $name, ".polkavm")"#, out_dir.display()),
+			format!(
+				r#"include_bytes!(concat!("{}", "/", $name, ".resolc.polkavm")"#,
+				out_dir.display()
+			),
+		)
+	} else {
+		("None".into(), "None".into())
+	};
+
 	write!(
 		file,
 		r#"
@@ -452,14 +471,14 @@ fn generate_fixture_location(temp_dir: &Path, out_dir: &Path, entries: &[Entry])
 			#[macro_export]
 			macro_rules! fixture {{
 				($name: literal) => {{
-					include_bytes!(concat!("{0}", "/", $name, ".polkavm"))
+					{fixtures}
 				}};
 			}}
 
 			#[macro_export]
 			macro_rules! fixture_resolc {{
 				($name: literal) => {{
-					include_bytes!(concat!("{0}", "/", $name, ".resolc.polkavm"))
+					{fixtures_resolc}
 				}};
 			}}
 		"#,
@@ -501,19 +520,21 @@ pub fn main() -> Result<()> {
 		return Ok(());
 	}
 
-	// Compile Rust contracts
-	let rust_entries: Vec<_> = entries
-		.iter()
-		.filter(|e| matches!(e.contract_type, ContractType::Rust))
-		.collect();
-	if !rust_entries.is_empty() {
-		create_cargo_toml(&fixtures_dir, rust_entries.into_iter(), &build_dir)?;
-		invoke_build(&build_dir)?;
-		write_output(&build_dir, &out_dir, entries.clone())?;
-	}
+	if env::var(SKIP_PALLET_REVIVE_FIXTURES).is_err() {
+		// Compile Rust contracts
+		let rust_entries: Vec<_> = entries
+			.iter()
+			.filter(|e| matches!(e.contract_type, ContractType::Rust))
+			.collect();
+		if !rust_entries.is_empty() {
+			create_cargo_toml(&fixtures_dir, rust_entries.into_iter(), &build_dir)?;
+			invoke_build(&build_dir)?;
+			write_output(&build_dir, &out_dir, entries.clone())?;
+		}
 
-	// Compile Solidity contracts
-	compile_solidity_contracts(&contracts_dir, &out_dir, &entries)?;
+		// Compile Solidity contracts
+		compile_solidity_contracts(&contracts_dir, &out_dir, &entries)?;
+	}
 
 	let temp_dir: PathBuf =
 		env::var("OUT_DIR").context("Failed to fetch `OUT_DIR` env variable")?.into();

--- a/substrate/frame/revive/fixtures/src/lib.rs
+++ b/substrate/frame/revive/fixtures/src/lib.rs
@@ -71,11 +71,19 @@ pub fn compile_module(fixture_name: &str) -> anyhow::Result<(Vec<u8>, sp_core::H
 /// available in no-std environments (runtime benchmarks).
 pub mod bench {
 	use alloc::vec::Vec;
-	pub const DUMMY: &[u8] = fixture!("dummy");
-	pub const NOOP: &[u8] = fixture!("noop");
+	pub const DUMMY: Option<&[u8]> = fixture!("dummy");
+	pub const NOOP: Option<&[u8]> = fixture!("noop");
+
+	pub fn dummy() -> &'static [u8] {
+		DUMMY.expect("`DUMMY` fixture not available, remove `SKIP_PALLET_REVIVE_FIXTURES` env variable to compile them.")
+	}
+
+	pub fn noop() -> &'static [u8] {
+		NOOP.expect("`NOOP` fixture not available, remove `SKIP_PALLET_REVIVE_FIXTURES` env variable to compile them.")
+	}
 
 	pub fn dummy_unique(replace_with: u32) -> Vec<u8> {
-		let mut dummy = DUMMY.to_vec();
+		let mut dummy = dummy().to_vec();
 		let idx = dummy
 			.windows(4)
 			.position(|w| w == &[0xDE, 0xAD, 0xBE, 0xEF])

--- a/substrate/frame/revive/src/call_builder.rs
+++ b/substrate/frame/revive/src/call_builder.rs
@@ -458,7 +458,7 @@ impl VmBinaryModule {
 
 	/// A contract code that calls the "noop" host function in a loop depending in the input.
 	pub fn noop() -> Self {
-		Self::new(bench_fixtures::NOOP.to_vec())
+		Self::new(bench_fixtures::noop().to_vec())
 	}
 
 	/// A contract code that does unaligned memory accessed in a loop.

--- a/substrate/frame/revive/src/call_builder.rs
+++ b/substrate/frame/revive/src/call_builder.rs
@@ -390,7 +390,7 @@ pub struct VmBinaryModule {
 impl VmBinaryModule {
 	/// Return a contract code that does nothing.
 	pub fn dummy() -> Self {
-		Self::new(bench_fixtures::DUMMY.to_vec())
+		Self::new(bench_fixtures::dummy().to_vec())
 	}
 
 	fn new(code: Vec<u8>) -> Self {


### PR DESCRIPTION
Right now `pallet-revive-fixtures` is always trying to build the fixtures. It requires `solc` and other stuff for compilation. If you are not requiring the fixtures, because you for example only run `cargo check`, this pull request introduces `SKIP_PALLET_REVIVE_FIXTURES`. When the environment variable is set, the compilation of the fixtures is skipped. It will set the fixtures to `None` and they will panic at runtime.

