### PR TITLE
Add cargo udeps as a new CI check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,13 +99,34 @@ jobs:
         with:
           app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
           app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
-  # name of this job must be unique across all workflows
-  # otherwise GitHub will mark all these jobs as required
+
+  cargo-udeps:
+    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    needs: [preflight]
+    if: ${{ needs.preflight.outputs.changes_rust }}
+    timeout-minutes: 60
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    env:
+      SKIP_WASM_BUILD: 1
+    steps:
+      - uses: actions/checkout@6d193bf28034eafb982f37bd894289fe649468fc # v4.1.7
+      - name: Run cargo-udeps (workspace)
+        id: required
+        run: |
+          cargo install cargo-udeps --locked
+          cargo +nightly udeps --workspace --all-features --all-targets --exclude polkadot-zombienet-sdk-tests --quiet
+      - name: Stop all workflows if failed
+        if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/workflow-stopper
+        with:
+          app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
+          app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
+
   confirm-required-checks-passed:
     runs-on: ubuntu-latest
     name: All checks passed
-    # If any new job gets added, be sure to add it to this array
-    needs: [cargo-clippy, check-try-runtime, check-core-crypto-features]
+    needs: [cargo-clippy, check-try-runtime, check-core-crypto-features, cargo-udeps]
     if: always() && !cancelled()
     steps:
       - run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,15 +4679,11 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
- "cumulus-test-client",
- "cumulus-test-relay-sproof-builder",
- "cumulus-test-runtime",
  "futures",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-node-subsystem-test-helpers",
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-client-api 28.0.0",
@@ -4819,9 +4815,6 @@ name = "cumulus-client-consensus-relay-chain"
 version = "0.7.0"
 dependencies = [
  "async-trait",
- "cumulus-client-consensus-common",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
  "futures",
  "parking_lot 0.12.3",
  "sc-consensus",
@@ -4959,7 +4952,6 @@ version = "0.7.0"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
- "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-client-pov-recovery",
@@ -5502,7 +5494,6 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core 28.0.0",
  "sp-io 30.0.0",
- "sp-keyring",
  "sp-runtime 31.0.1",
  "sp-state-machine 0.35.0",
  "sp-trie 29.0.0",
@@ -14503,7 +14494,6 @@ name = "pallet-staking-async"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.11.3",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
@@ -14803,7 +14793,6 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "tiny-keccak",
  "tokio",
  "xcm-runtime-apis",
 ]
@@ -15733,7 +15722,6 @@ dependencies = [
  "sp-offchain",
  "sp-runtime 31.0.1",
  "sp-session",
- "sp-statement-store",
  "sp-storage 19.0.0",
  "sp-transaction-pool",
  "sp-version 29.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1581,3 +1581,6 @@ twox-hash = { opt-level = 3 }
 wasmi = { opt-level = 3 }
 x25519-dalek = { opt-level = 3 }
 zeroize = { opt-level = 3 }
+
+[workspace.metadata.cargo-udeps.ignore]
+normal = ["aquamarine"]

--- a/cumulus/client/collator/Cargo.toml
+++ b/cumulus/client/collator/Cargo.toml
@@ -42,11 +42,3 @@ async-trait = { workspace = true }
 sp-maybe-compressed-blob = { workspace = true, default-features = true }
 sp-state-machine = { workspace = true, default-features = true }
 sp-tracing = { workspace = true, default-features = true }
-
-# Polkadot
-polkadot-node-subsystem-test-helpers = { workspace = true }
-
-# Cumulus
-cumulus-test-client = { workspace = true }
-cumulus-test-relay-sproof-builder = { workspace = true, default-features = true }
-cumulus-test-runtime = { workspace = true }

--- a/cumulus/client/consensus/relay-chain/Cargo.toml
+++ b/cumulus/client/consensus/relay-chain/Cargo.toml
@@ -27,8 +27,3 @@ sp-consensus = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-inherents = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
-
-# Cumulus
-cumulus-client-consensus-common = { workspace = true, default-features = true }
-cumulus-primitives-core = { workspace = true, default-features = true }
-cumulus-relay-chain-interface = { workspace = true, default-features = true }

--- a/cumulus/client/service/Cargo.toml
+++ b/cumulus/client/service/Cargo.toml
@@ -47,7 +47,6 @@ polkadot-primitives = { workspace = true, default-features = true }
 
 # Cumulus
 cumulus-client-cli = { workspace = true, default-features = true }
-cumulus-client-collator = { workspace = true, default-features = true }
 cumulus-client-consensus-common = { workspace = true, default-features = true }
 cumulus-client-network = { workspace = true, default-features = true }
 cumulus-client-pov-recovery = { workspace = true, default-features = true }

--- a/cumulus/parachains/runtimes/people/people-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/people/people-westend/Cargo.toml
@@ -55,7 +55,6 @@ sp-keyring = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-statement-store = { workspace = true }
 sp-storage = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
@@ -151,7 +150,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-statement-store/std",
 	"sp-storage/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",

--- a/cumulus/polkadot-omni-node/Cargo.toml
+++ b/cumulus/polkadot-omni-node/Cargo.toml
@@ -37,3 +37,6 @@ runtime-benchmarks = [
 try-runtime = [
 	"polkadot-omni-node-lib/try-runtime",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["polkadot-jemalloc-shim"]

--- a/cumulus/polkadot-omni-node/lib/Cargo.toml
+++ b/cumulus/polkadot-omni-node/lib/Cargo.toml
@@ -146,3 +146,6 @@ try-runtime = [
 	"polkadot-cli/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["assert_cmd", "wait-timeout"]

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -105,3 +105,6 @@ fast-runtime = [
 	"bridge-hub-westend-runtime/fast-runtime",
 	"coretime-westend-runtime/fast-runtime",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["polkadot-jemalloc-shim"]

--- a/cumulus/test/relay-sproof-builder/Cargo.toml
+++ b/cumulus/test/relay-sproof-builder/Cargo.toml
@@ -18,7 +18,6 @@ codec = { features = ["derive"], workspace = true }
 sp-consensus-babe = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
-sp-keyring = { workspace = true }
 sp-runtime = { workspace = true }
 sp-state-machine = { workspace = true }
 sp-trie = { workspace = true }
@@ -41,7 +40,6 @@ std = [
 	"sp-consensus-babe/std",
 	"sp-core/std",
 	"sp-io/std",
-	"sp-keyring/std",
 	"sp-runtime/std",
 	"sp-state-machine/std",
 	"sp-trie/std",

--- a/polkadot/Cargo.toml
+++ b/polkadot/Cargo.toml
@@ -110,3 +110,6 @@ metadata-hash = [
 # Enables timeout-based tests supposed to be run only in CI environment as they may be flaky
 # when run locally depending on system load
 ci-only-tests = ["polkadot-node-core-pvf/ci-only-tests"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["polkadot-jemalloc-shim"]

--- a/polkadot/jemalloc-shim/Cargo.toml
+++ b/polkadot/jemalloc-shim/Cargo.toml
@@ -29,3 +29,11 @@ jemalloc-allocator = [
 	"polkadot-node-core-pvf/jemalloc-allocator",
 	"polkadot-overseer/jemalloc-allocator",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = [
+	"polkadot-cli",
+	"polkadot-node-core-pvf",
+	"polkadot-node-core-pvf-prepare-worker",
+	"polkadot-overseer",
+]

--- a/polkadot/node/core/pvf/Cargo.toml
+++ b/polkadot/node/core/pvf/Cargo.toml
@@ -75,3 +75,6 @@ test-utils = [
 	"dep:polkadot-node-core-pvf-prepare-worker",
 	"dep:sp-maybe-compressed-blob",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["polkadot-node-core-pvf-prepare-worker"]

--- a/polkadot/node/malus/Cargo.toml
+++ b/polkadot/node/malus/Cargo.toml
@@ -61,3 +61,6 @@ substrate-build-script-utils = { workspace = true, default-features = true }
 [features]
 default = []
 fast-runtime = ["polkadot-cli/fast-runtime"]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["polkadot-node-subsystem-test-helpers"]

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -43,3 +43,6 @@ runtime-benchmarks = [
 	"polkadot-test-service/runtime-benchmarks",
 	"sc-service/runtime-benchmarks",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["polkadot-test-service", "prometheus-parse"]

--- a/polkadot/parachain/test-parachains/adder/Cargo.toml
+++ b/polkadot/parachain/test-parachains/adder/Cargo.toml
@@ -26,3 +26,6 @@ substrate-wasm-builder = { workspace = true, default-features = true }
 [features]
 default = ["std"]
 std = ["codec/std", "polkadot-parachain-primitives/std", "sp-io/std"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["dlmalloc", "polkadot-parachain-primitives"]

--- a/polkadot/parachain/test-parachains/undying/Cargo.toml
+++ b/polkadot/parachain/test-parachains/undying/Cargo.toml
@@ -34,3 +34,6 @@ std = [
 	"polkadot-primitives/std",
 	"sp-io/std",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["dlmalloc", "polkadot-parachain-primitives"]

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -168,3 +168,6 @@ runtime-metrics = [
 	"polkadot-runtime-metrics/runtime-metrics",
 	"sp-tracing/with-tracing",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["pretty_assertions", "thousands"]

--- a/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
+++ b/polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml
@@ -64,3 +64,6 @@ runtime-benchmarks = [
 	"xcm-executor/runtime-benchmarks",
 	"xcm/runtime-benchmarks",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["honggfuzz"]

--- a/prdoc/pr_9792.prdoc
+++ b/prdoc/pr_9792.prdoc
@@ -1,0 +1,106 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "ci: add a cargo-udeps check for unused dependencies"
+
+doc:
+  - audience: [Node Dev, Runtime Dev]
+    description: |-
+      Adds `cargo-udeps` to the `Checks` workflow so that dependencies which are declared but never
+      linked are caught in CI instead of accumulating.
+
+      The unused dependencies it reported across the workspace are removed in this PR. No public API
+      is affected: every removed dependency was non-optional, so no implicit feature disappears, and
+      no feature list entries were changed.
+
+      Dependencies that `cargo-udeps` cannot see are declared through
+      `[package.metadata.cargo-udeps.ignore]`. These fall into a few structural categories the tool
+      has no way of detecting: crates linked purely for a side effect (allocator shims), crates used
+      only under `cfg(doc)` or behind `cfg` gates that `--all-features` compiles out, dependencies
+      that exist only to forward a feature, and UI/test harnesses driven by build machinery.
+
+crates:
+  - name: cumulus-client-collator
+    bump: patch
+  - name: cumulus-client-consensus-relay-chain
+    bump: patch
+  - name: cumulus-client-service
+    bump: patch
+  - name: cumulus-test-relay-sproof-builder
+    bump: patch
+  - name: pallet-staking-async
+    bump: patch
+  - name: pallet-staking-async-rc-runtime
+    bump: patch
+  - name: people-westend-runtime
+    bump: patch
+  - name: frame-election-provider-solution-type
+    bump: none
+  - name: frame-storage-access-test-runtime
+    bump: none
+  - name: frame-support
+    bump: none
+  - name: frame-support-procedural
+    bump: none
+  - name: frame-support-test
+    bump: none
+  - name: pallet-contracts-uapi
+    bump: none
+  - name: pallet-meta-tx
+    bump: none
+  - name: pallet-revive-fixtures
+    bump: none
+  - name: pallet-revive-uapi
+    bump: none
+  - name: pallet-staking-async-ah-client
+    bump: none
+  - name: pallet-staking-async-parachain-runtime
+    bump: none
+  - name: pallet-staking-async-preset-store
+    bump: none
+  - name: polkadot
+    bump: none
+  - name: polkadot-jemalloc-shim
+    bump: none
+  - name: polkadot-node-core-pvf
+    bump: none
+  - name: polkadot-node-metrics
+    bump: none
+  - name: polkadot-omni-node
+    bump: none
+  - name: polkadot-omni-node-lib
+    bump: none
+  - name: polkadot-parachain-bin
+    bump: none
+  - name: polkadot-runtime-parachains
+    bump: none
+  - name: polkadot-test-malus
+    bump: none
+  - name: sc-runtime-test
+    bump: none
+  - name: sp-api
+    bump: none
+  - name: sp-api-test
+    bump: none
+  - name: sp-core
+    bump: none
+  - name: sp-mmr-primitives
+    bump: none
+  - name: sp-runtime
+    bump: none
+  - name: sp-runtime-interface
+    bump: none
+  - name: sp-storage
+    bump: none
+  - name: sp-weights
+    bump: none
+  - name: substrate-frame-rpc-support
+    bump: none
+  - name: substrate-test-runtime
+    bump: none
+  - name: test-parachain-adder
+    bump: none
+  - name: test-parachain-undying
+    bump: none
+  - name: xcm-simulator-fuzzer
+    bump: none

--- a/substrate/client/executor/runtime-test/Cargo.toml
+++ b/substrate/client/executor/runtime-test/Cargo.toml
@@ -35,3 +35,9 @@ std = [
 	"sp-virtualization/std",
 	"substrate-wasm-builder",
 ]
+
+# `sp-virtualization` is used from inside `sp_core::wasm_export_functions!`, whose bodies expand
+# behind `#[cfg(not(feature = "std"))]`. The check runs with `--all-features`, so the only use site
+# is compiled out and cannot be seen.
+[package.metadata.cargo-udeps.ignore]
+normal = ["sp-virtualization"]

--- a/substrate/frame/contracts/uapi/Cargo.toml
+++ b/substrate/frame/contracts/uapi/Cargo.toml
@@ -23,3 +23,6 @@ scale-info = { features = ["derive"], optional = true, workspace = true }
 [features]
 default = ["scale"]
 scale = ["dep:codec", "scale-info"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["paste"]

--- a/substrate/frame/election-provider-support/solution-type/Cargo.toml
+++ b/substrate/frame/election-provider-support/solution-type/Cargo.toml
@@ -33,3 +33,12 @@ sp-arithmetic = { workspace = true, default-features = true }
 frame-election-provider-support = { workspace = true, default-features = true, features = ["std"] }
 frame-support = { workspace = true, default-features = true }
 trybuild = { workspace = true }
+
+[package.metadata.cargo-udeps.ignore]
+development = [
+	"frame-election-provider-support",
+	"frame-support",
+	"scale-info",
+	"sp-arithmetic",
+	"trybuild",
+]

--- a/substrate/frame/meta-tx/Cargo.toml
+++ b/substrate/frame/meta-tx/Cargo.toml
@@ -63,3 +63,6 @@ try-runtime = [
 	"pallet-verify-signature/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["sp-keyring"]

--- a/substrate/frame/revive/fixtures/Cargo.toml
+++ b/substrate/frame/revive/fixtures/Cargo.toml
@@ -52,3 +52,6 @@ std = [
 	"sp-io",
 	"toml",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+build = ["pallet-revive-uapi"]

--- a/substrate/frame/revive/uapi/Cargo.toml
+++ b/substrate/frame/revive/uapi/Cargo.toml
@@ -33,3 +33,6 @@ polkavm-derive = { workspace = true }
 default = ["scale"]
 scale = ["dep:codec", "scale-info"]
 precompiles-sol-interfaces = ["alloy-core"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["pallet-revive-proc-macro"]

--- a/substrate/frame/staking-async/Cargo.toml
+++ b/substrate/frame/staking-async/Cargo.toml
@@ -39,7 +39,6 @@ frame-benchmarking = { optional = true, workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-env_logger = { workspace = true }
 frame-benchmarking = { workspace = true, default-features = true }
 frame-support = { features = ["experimental"], workspace = true, default-features = true }
 pallet-bags-list = { workspace = true, default-features = true }

--- a/substrate/frame/staking-async/ah-client/Cargo.toml
+++ b/substrate/frame/staking-async/ah-client/Cargo.toml
@@ -63,3 +63,6 @@ try-runtime = [
 
 [dev-dependencies]
 sp-io = { workspace = true }
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["frame-benchmarking"]

--- a/substrate/frame/staking-async/runtimes/parachain/Cargo.toml
+++ b/substrate/frame/staking-async/runtimes/parachain/Cargo.toml
@@ -398,3 +398,10 @@ metadata-hash = ["substrate-wasm-builder/metadata-hash"]
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
 on-chain-release-build = ["metadata-hash"]
+
+[package.metadata.cargo-udeps.ignore]
+development = [
+	"asset-test-utils",
+	"pallet-bags-list-remote-tests",
+	"parachains-runtimes-test-utils",
+]

--- a/substrate/frame/staking-async/runtimes/preset-store/Cargo.toml
+++ b/substrate/frame/staking-async/runtimes/preset-store/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"pallet-staking-async-ah-client/std",
 	"scale-info/std",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["pallet-staking-async-ah-client"]

--- a/substrate/frame/staking-async/runtimes/rc/Cargo.toml
+++ b/substrate/frame/staking-async/runtimes/rc/Cargo.toml
@@ -121,7 +121,6 @@ remote-externalities = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 sp-keyring = { workspace = true, default-features = true }
 sp-tracing = { workspace = true }
-tiny-keccak = { features = ["keccak"], workspace = true }
 tokio = { features = ["macros"], workspace = true, default-features = true }
 
 [build-dependencies]

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -113,3 +113,7 @@ full-metadata-docs = ["scale-info/docs"]
 # pallets in a runtime grows. Does increase the compile time!
 tuples-96 = ["frame-support-procedural/tuples-96"]
 tuples-128 = ["frame-support-procedural/tuples-128"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["sp-debug-derive"]
+development = ["sp-timestamp"]

--- a/substrate/frame/support/procedural/Cargo.toml
+++ b/substrate/frame/support/procedural/Cargo.toml
@@ -70,3 +70,6 @@ experimental = []
 # pallets in a runtime grows. Does increase the compile time!
 tuples-96 = []
 tuples-128 = []
+
+[package.metadata.cargo-udeps.ignore]
+development = ["frame-benchmarking", "pretty_assertions"]

--- a/substrate/frame/support/test/Cargo.toml
+++ b/substrate/frame/support/test/Cargo.toml
@@ -81,3 +81,6 @@ frame-feature-testing-2 = []
 # Disable ui tests
 disable-ui-tests = []
 no-metadata-docs = ["frame-support/no-metadata-docs"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["frame-benchmarking", "rustversion", "test-pallet", "trybuild"]

--- a/substrate/primitives/api/Cargo.toml
+++ b/substrate/primitives/api/Cargo.toml
@@ -66,3 +66,6 @@ disable-logging = ["log/max_level_off"]
 # Do not report the documentation in the metadata.
 no-metadata-docs = ["sp-api-proc-macro/no-metadata-docs"]
 frame-metadata = ["sp-metadata-ir"]
+
+[package.metadata.cargo-udeps.ignore]
+development = ["sp-test-primitives"]

--- a/substrate/primitives/api/test/Cargo.toml
+++ b/substrate/primitives/api/test/Cargo.toml
@@ -45,3 +45,6 @@ static_assertions = { workspace = true, default-features = true }
 [features]
 enable-staging-api = []
 disable-ui-tests = []
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["rustversion", "trybuild"]

--- a/substrate/primitives/core/Cargo.toml
+++ b/substrate/primitives/core/Cargo.toml
@@ -158,3 +158,6 @@ bls-experimental = ["sha2", "w3f-bls"]
 # It should not be used in production since the implementation and interface may still
 # be subject to significant changes.
 bandersnatch-experimental = ["ark-vrf"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["k256", "sp-debug-derive"]

--- a/substrate/primitives/merkle-mountain-range/Cargo.toml
+++ b/substrate/primitives/merkle-mountain-range/Cargo.toml
@@ -46,3 +46,6 @@ std = [
 
 # Serde support without relying on std features.
 serde = ["dep:serde", "scale-info/serde", "sp-core/serde", "sp-runtime/serde"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["sp-debug-derive"]

--- a/substrate/primitives/runtime-interface/Cargo.toml
+++ b/substrate/primitives/runtime-interface/Cargo.toml
@@ -59,3 +59,10 @@ std = [
 # Disables static assertions in `impls.rs` that checks the word size. To prevent any footgun, the
 # check is changed into a runtime check.
 disable_target_static_assertions = []
+
+[package.metadata.cargo-udeps.ignore]
+development = [
+	"sp-io",
+	"sp-runtime-interface-test-wasm",
+	"sp-state-machine",
+]

--- a/substrate/primitives/runtime/Cargo.toml
+++ b/substrate/primitives/runtime/Cargo.toml
@@ -104,3 +104,8 @@ bls-experimental = [
 	"sp-io/bls-experimental",
 	"substrate-test-runtime-client/bls-experimental",
 ]
+
+# `simple-mermaid` is only referenced from the mermaid doc attribute in
+# `generic/unchecked_extrinsic.rs`, which is currently commented out, so no code path reaches it.
+[package.metadata.cargo-udeps.ignore]
+normal = ["simple-mermaid"]

--- a/substrate/primitives/storage/Cargo.toml
+++ b/substrate/primitives/storage/Cargo.toml
@@ -29,3 +29,6 @@ std = ["codec/std", "impl-serde/std", "serde/std", "sp-debug-derive/std"]
 
 # Serde support without relying on std features.
 serde = ["dep:serde", "impl-serde"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["sp-debug-derive"]

--- a/substrate/primitives/weights/Cargo.toml
+++ b/substrate/primitives/weights/Cargo.toml
@@ -48,3 +48,6 @@ serde = [
 ]
 
 json-schema = ["dep:schemars"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["sp-debug-derive"]

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -129,3 +129,6 @@ disable-logging = ["sp-api/disable-logging"]
 # It should not be used in production since the implementation and interface may still
 # be subject to significant changes.
 bls-experimental = ["sp-application-crypto/bls-experimental"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["sp-debug-derive"]

--- a/substrate/utils/frame/rpc/support/Cargo.toml
+++ b/substrate/utils/frame/rpc/support/Cargo.toml
@@ -29,3 +29,6 @@ jsonrpsee = { features = ["jsonrpsee-types", "ws-client"], workspace = true }
 sp-core = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 tokio = { workspace = true, default-features = true }
+
+[package.metadata.cargo-udeps.ignore]
+development = ["frame-system"]

--- a/substrate/utils/frame/storage-access-test-runtime/Cargo.toml
+++ b/substrate/utils/frame/storage-access-test-runtime/Cargo.toml
@@ -40,3 +40,6 @@ runtime-benchmarks = [
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["cumulus-pallet-parachain-system"]


### PR DESCRIPTION
# Description

This PR removes unused dependencies, marks some others to be ignored, and introduces a `cargo-udeps` check in CI to prevent regressions.

It finalizes my work started in [#9235](https://github.com/paritytech/polkadot-sdk/pull/9235), ensuring all unnecessary dependencies are cleaned up across the project.

**Note:** Since there are well known false positives I've checked each one and ignore the ones that we are 100% are false positives

Closes: [#6906](https://github.com/paritytech/polkadot-sdk/issues/6906)
