### PR TITLE
fix getstorage tests

### DIFF
--- a/substrate/frame/revive/rpc/src/client/runtime_api.rs
+++ b/substrate/frame/revive/rpc/src/client/runtime_api.rs
@@ -54,8 +54,19 @@ impl RuntimeApi {
 	) -> Result<Option<Vec<u8>>, ClientError> {
 		let contract_address = contract_address.0.into();
 		let payload = subxt_client::apis().revive_api().get_storage(contract_address, key);
-		let result = self.0.call(payload).await?.map_err(|_| ClientError::ContractNotFound)?;
-		Ok(result)
+		let result = self.0.call(payload).await?;
+
+		// If contract doesn't exist at the queried block, return None (empty storage)
+		// instead of throwing "Contract not found" error as specified in the Ethereum spec
+		// https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat
+		// https://www.quicknode.com/docs/ethereum/eth_getStorageAt
+		match result {
+			Ok(storage_value) => Ok(storage_value),
+			Err(_contract_access_error) => {
+				// Contract didn't exist at this historical block - return empty storage
+				Ok(None)
+			}
+		}
 	}
 
 	/// Dry run a transaction and returns the [`EthTransactInfo`] for the transaction.

--- a/substrate/frame/revive/rpc/src/lib.rs
+++ b/substrate/frame/revive/rpc/src/lib.rs
@@ -427,7 +427,9 @@ impl EthRpcServer for EthRpcServerImpl {
 		let hash = self.client.block_hash_for_tag(block).await?;
 		let runtime_api = self.client.runtime_api(hash);
 		let bytes = runtime_api.get_storage(address, storage_slot.to_big_endian()).await?;
-		Ok(bytes.unwrap_or_default().into())
+		// Return 32-byte zero value for empty storage (Ethereum spec compliance)
+		// https://www.quicknode.com/docs/ethereum/eth_getStorageAt
+		Ok(bytes.unwrap_or_else(|| vec![0u8; 32]).into())
 	}
 
 	async fn get_transaction_by_block_hash_and_index(


### PR DESCRIPTION
Currently runtime rejects if the contract isn't found, but it should just return empty hash as in https://www.quicknode.com/docs/ethereum/eth_getStorageAt

Closes https://github.com/paritytech/hardhat-polkadot/issues/324