### PR TITLE
Introduce `unapplied_slashes_v2` Runtime API

### DIFF
--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -165,6 +165,9 @@ where
 				self.requests_cache.cache_disputes(relay_parent, disputes),
 			UnappliedSlashes(relay_parent, unapplied_slashes) =>
 				self.requests_cache.cache_unapplied_slashes(relay_parent, unapplied_slashes),
+			UnappliedSlashesV2(relay_parent, unapplied_slashes_v2) => self
+				.requests_cache
+				.cache_unapplied_slashes_v2(relay_parent, unapplied_slashes_v2),
 			KeyOwnershipProof(relay_parent, validator_id, key_ownership_proof) => self
 				.requests_cache
 				.cache_key_ownership_proof((relay_parent, validator_id), key_ownership_proof),
@@ -313,6 +316,8 @@ where
 				query!(disputes(), sender).map(|sender| Request::Disputes(sender)),
 			Request::UnappliedSlashes(sender) =>
 				query!(unapplied_slashes(), sender).map(|sender| Request::UnappliedSlashes(sender)),
+			Request::UnappliedSlashesV2(sender) => query!(unapplied_slashes_v2(), sender)
+				.map(|sender| Request::UnappliedSlashesV2(sender)),
 			Request::KeyOwnershipProof(validator_id, sender) =>
 				query!(key_ownership_proof(validator_id), sender)
 					.map(|sender| Request::KeyOwnershipProof(validator_id, sender)),
@@ -720,6 +725,12 @@ where
 			ver = Request::PARAIDS_RUNTIME_REQUIREMENT,
 			sender,
 			result = (index)
+		),
+		Request::UnappliedSlashesV2(sender) => query!(
+			UnappliedSlashesV2,
+			unapplied_slashes_v2(),
+			ver = Request::UNAPPLIED_SLASHES_V2_RUNTIME_REQUIREMENT,
+			sender
 		),
 	}
 }

--- a/polkadot/node/core/runtime-api/src/tests.rs
+++ b/polkadot/node/core/runtime-api/src/tests.rs
@@ -225,7 +225,7 @@ impl RuntimeApiSubsystemClient for MockSubsystemClient {
 	async fn unapplied_slashes(
 		&self,
 		_: Hash,
-	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>, ApiError> {
+	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>, ApiError> {
 		todo!("Not required for tests")
 	}
 

--- a/polkadot/node/service/src/fake_runtime_api.rs
+++ b/polkadot/node/service/src/fake_runtime_api.rs
@@ -218,6 +218,11 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn unapplied_slashes(
+		) -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)> {
+			unimplemented!()
+		}
+
+		fn unapplied_slashes_v2(
 		) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
 			unimplemented!()
 		}

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -739,7 +739,7 @@ pub enum RuntimeApiRequest {
 	/// Returns a list of validators that lost a past session dispute and need to be slashed.
 	/// `V5`
 	UnappliedSlashes(
-		RuntimeApiSender<Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>>,
+		RuntimeApiSender<Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>>,
 	),
 	/// Returns a merkle proof of a validator session key.
 	/// `V5`
@@ -784,6 +784,11 @@ pub enum RuntimeApiRequest {
 	/// Get the paraids at the relay parent.
 	/// `V14`
 	ParaIds(SessionIndex, RuntimeApiSender<Vec<ParaId>>),
+	/// Returns a list of validators that lost a past session dispute and need to be slashed (v2).
+	/// `V14`
+	UnappliedSlashesV2(
+		RuntimeApiSender<Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>>,
+	),
 }
 
 impl RuntimeApiRequest {
@@ -836,6 +841,9 @@ impl RuntimeApiRequest {
 
 	/// `ParaIds`
 	pub const PARAIDS_RUNTIME_REQUIREMENT: u32 = 14;
+
+	/// `UnappliedSlashesV2`
+	pub const UNAPPLIED_SLASHES_V2_RUNTIME_REQUIREMENT: u32 = 14;
 }
 
 /// A message to the Runtime API subsystem.

--- a/polkadot/node/subsystem-types/src/runtime_client.rs
+++ b/polkadot/node/subsystem-types/src/runtime_client.rs
@@ -246,6 +246,12 @@ pub trait RuntimeApiSubsystemClient {
 	async fn unapplied_slashes(
 		&self,
 		at: Hash,
+	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>, ApiError>;
+
+	/// Returns a list of validators that lost a past session dispute and need to be slashed (v2).
+	async fn unapplied_slashes_v2(
+		&self,
+		at: Hash,
 	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>, ApiError>;
 
 	/// Returns a merkle proof of a validator session key in a past session.
@@ -564,8 +570,15 @@ where
 	async fn unapplied_slashes(
 		&self,
 		at: Hash,
-	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>, ApiError> {
+	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>, ApiError> {
 		self.client.runtime_api().unapplied_slashes(at)
+	}
+
+	async fn unapplied_slashes_v2(
+		&self,
+		at: Hash,
+	) -> Result<Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>, ApiError> {
+		self.client.runtime_api().unapplied_slashes_v2(at)
 	}
 
 	async fn key_ownership_proof(

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -306,7 +306,8 @@ specialize_requests! {
 		-> Option<ValidationCodeHash>; ValidationCodeHash;
 	fn request_on_chain_votes() -> Option<ScrapedOnChainVotes>; FetchOnChainVotes;
 	fn request_session_executor_params(session_index: SessionIndex) -> Option<ExecutorParams>;SessionExecutorParams;
-	fn request_unapplied_slashes() -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>; UnappliedSlashes;
+	fn request_unapplied_slashes() -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>; UnappliedSlashes;
+	fn request_unapplied_slashes_v2() -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>; UnappliedSlashesV2;
 	fn request_key_ownership_proof(validator_id: ValidatorId) -> Option<slashing::OpaqueKeyOwnershipProof>; KeyOwnershipProof;
 	fn request_submit_report_dispute_lost(dp: slashing::DisputeProof, okop: slashing::OpaqueKeyOwnershipProof) -> Option<()>; SubmitReportDisputeLost;
 	fn request_disabled_validators() -> Vec<ValidatorIndex>; DisabledValidators;

--- a/polkadot/node/subsystem-util/src/runtime/mod.rs
+++ b/polkadot/node/subsystem-util/src/runtime/mod.rs
@@ -45,7 +45,8 @@ use crate::{
 	request_disabled_validators, request_from_runtime, request_key_ownership_proof,
 	request_node_features, request_on_chain_votes, request_session_executor_params,
 	request_session_index_for_child, request_session_info, request_submit_report_dispute_lost,
-	request_unapplied_slashes, request_validation_code_by_hash, request_validator_groups,
+	request_unapplied_slashes, request_unapplied_slashes_v2, request_validation_code_by_hash,
+	request_validator_groups,
 };
 
 /// Errors that can happen on runtime fetches.
@@ -424,6 +425,8 @@ where
 }
 
 /// Fetch a list of `PendingSlashes` from the runtime.
+/// Will fallback to `unapplied_slashes` if the runtime does not
+/// support `unapplied_slashes_v2`.
 pub async fn get_unapplied_slashes<Sender>(
 	sender: &mut Sender,
 	relay_parent: Hash,
@@ -431,7 +434,29 @@ pub async fn get_unapplied_slashes<Sender>(
 where
 	Sender: SubsystemSender<RuntimeApiMessage>,
 {
-	recv_runtime(request_unapplied_slashes(relay_parent, sender).await).await
+	match recv_runtime(request_unapplied_slashes_v2(relay_parent, sender).await).await {
+		Ok(v2) => Ok(v2),
+		Err(Error::RuntimeRequest(RuntimeApiError::NotSupported { .. })) => {
+			// Fallback to legacy unapplied_slashes
+			let legacy =
+				recv_runtime(request_unapplied_slashes(relay_parent, sender).await).await?;
+			// Convert legacy slashes to PendingSlashes
+			Ok(legacy
+				.into_iter()
+				.map(|(session, candidate_hash, legacy_slash)| {
+					(
+						session,
+						candidate_hash,
+						slashing::PendingSlashes {
+							keys: legacy_slash.keys,
+							kind: legacy_slash.kind.into(),
+						},
+					)
+				})
+				.collect())
+		},
+		Err(e) => Err(e),
+	}
 }
 
 /// Generate validator key ownership proof.

--- a/polkadot/primitives/src/runtime_api.rs
+++ b/polkadot/primitives/src/runtime_api.rs
@@ -232,8 +232,9 @@ sp_api::decl_runtime_apis! {
 		fn session_executor_params(session_index: SessionIndex) -> Option<ExecutorParams>;
 
 		/// Returns a list of validators that lost a past session dispute and need to be slashed.
-		/// NOTE: This function is only available since parachain host version 5.
-		fn unapplied_slashes() -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>;
+		/// 
+		/// Deprecated. Use `unapplied_slashes_v2` instead.
+		fn unapplied_slashes() -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>;
 
 		/// Returns a merkle proof of a validator session key.
 		/// NOTE: This function is only available since parachain host version 5.
@@ -316,5 +317,8 @@ sp_api::decl_runtime_apis! {
 		#[api_version(14)]
 		fn para_ids() -> Vec<ppp::Id>;
 
+		/***** Added in v14 *****/
+		/// Returns a list of validators that lost a past session dispute and need to be slashed.
+		fn unapplied_slashes_v2() -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>;
 	}
 }

--- a/polkadot/primitives/src/v9/slashing.rs
+++ b/polkadot/primitives/src/v9/slashing.rs
@@ -71,6 +71,21 @@ pub struct DisputeProof {
 }
 
 /// Slashes that are waiting to be applied once we have validator key
+/// identification. 
+/// 
+/// Legacy version. We need to keep this around for backwards compatibility.
+/// Once old nodes are no longer supported, we can remove it along with the 
+/// `UnappliedSlashes` runtime API.
+#[derive(Encode, Decode, TypeInfo, Debug, Clone)]
+pub struct LegacyPendingSlashes {
+	/// Indices and keys of the validators who lost a dispute and are pending
+	/// slashes.
+	pub keys: BTreeMap<ValidatorIndex, ValidatorId>,
+	/// The dispute outcome.
+	pub kind: SlashingOffenceKind,
+}
+
+/// Slashes that are waiting to be applied once we have validator key
 /// identification.
 #[derive(Encode, Decode, TypeInfo, Debug, Clone)]
 pub struct PendingSlashes {

--- a/polkadot/runtime/parachains/src/runtime_api_impl/v13.rs
+++ b/polkadot/runtime/parachains/src/runtime_api_impl/v13.rs
@@ -375,6 +375,21 @@ pub fn session_executor_params<T: session_info::Config>(
 
 /// Implementation of `unapplied_slashes` runtime API
 pub fn unapplied_slashes<T: disputes::slashing::Config>(
+) -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)> {
+	disputes::slashing::Pallet::<T>::unapplied_slashes()
+		.into_iter()
+		.filter_map(|(session, candidate_hash, pending_slash)| {
+			let legacy_pending_slash = slashing::LegacyPendingSlashes {
+				keys: pending_slash.keys,
+				kind: pending_slash.kind.try_into().ok()?,
+			};
+			Some((session, candidate_hash, legacy_pending_slash))
+		})
+		.collect()
+}
+
+/// Implementation of `unapplied_slashes_v2` runtime API
+pub fn unapplied_slashes_v2<T: disputes::slashing::Config>(
 ) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
 	disputes::slashing::Pallet::<T>::unapplied_slashes()
 }

--- a/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -16,11 +16,18 @@
 
 //! Put implementations of functions from staging APIs here.
 
-use crate::{initializer, paras};
+use crate::{disputes, initializer, paras};
 use alloc::vec::Vec;
 
-use polkadot_primitives::Id as ParaId;
+use polkadot_primitives::{slashing, CandidateHash, Id as ParaId, SessionIndex};
 
+/// Implementation of `para_ids` runtime API
 pub fn para_ids<T: initializer::Config>() -> Vec<ParaId> {
 	paras::Heads::<T>::iter_keys().collect()
+}
+
+/// Implementation of `unapplied_slashes_v2` runtime API
+pub fn unapplied_slashes_v2<T: disputes::slashing::Config>(
+) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
+	disputes::slashing::Pallet::<T>::unapplied_slashes()
 }

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2120,8 +2120,13 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn unapplied_slashes(
-		) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
+		) -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)> {
 			parachains_runtime_api_impl::unapplied_slashes::<Runtime>()
+		}
+
+		fn unapplied_slashes_v2(
+		) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
+			parachains_runtime_api_impl::unapplied_slashes_v2::<Runtime>()
 		}
 
 		fn key_ownership_proof(

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -1068,7 +1068,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn unapplied_slashes(
-		) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
+		) -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)> {
 			runtime_impl::unapplied_slashes::<Runtime>()
 		}
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2356,8 +2356,13 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn unapplied_slashes(
-		) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
+		) -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)> {
 			parachains_runtime_api_impl::unapplied_slashes::<Runtime>()
+		}
+
+		fn unapplied_slashes_v2(
+		) -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)> {
+			parachains_runtime_api_impl::unapplied_slashes_v2::<Runtime>()
 		}
 
 		fn key_ownership_proof(


### PR DESCRIPTION
This PR fixes restores and deprecates the `unapplied_slashes` Runtime API to use the legacy `PendingSlashes` primitive so we don't break older nodes. Broken in https://github.com/paritytech/polkadot-sdk/pull/9443 .

Also introduce the new `unapplied_slashes_v2` API that makes use of the new primitive.
