### PR TITLE
Added pallet-root-offences to Westend RC runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27163,6 +27163,7 @@ dependencies = [
  "pallet-proxy",
  "pallet-recovery",
  "pallet-referenda",
+ "pallet-root-offences",
  "pallet-root-testing",
  "pallet-scheduler",
  "pallet-session",

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -79,6 +79,7 @@ pallet-preimage = { workspace = true }
 pallet-proxy = { workspace = true }
 pallet-recovery = { workspace = true }
 pallet-referenda = { workspace = true }
+pallet-root-offences = { workspace = true }
 pallet-root-testing = { workspace = true }
 pallet-scheduler = { workspace = true }
 pallet-session = { workspace = true }
@@ -177,6 +178,7 @@ std = [
 	"pallet-proxy/std",
 	"pallet-recovery/std",
 	"pallet-referenda/std",
+	"pallet-root-offences/std",
 	"pallet-root-testing/std",
 	"pallet-scheduler/std",
 	"pallet-session-benchmarking?/std",
@@ -265,6 +267,7 @@ runtime-benchmarks = [
 	"pallet-proxy/runtime-benchmarks",
 	"pallet-recovery/runtime-benchmarks",
 	"pallet-referenda/runtime-benchmarks",
+	"pallet-root-offences/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
 	"pallet-session-benchmarking/runtime-benchmarks",
 	"pallet-session/runtime-benchmarks",
@@ -327,6 +330,7 @@ try-runtime = [
 	"pallet-proxy/try-runtime",
 	"pallet-recovery/try-runtime",
 	"pallet-referenda/try-runtime",
+	"pallet-root-offences/try-runtime",
 	"pallet-root-testing/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-session/try-runtime",

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1740,6 +1740,12 @@ impl pallet_root_testing::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 }
 
+impl pallet_root_offences::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type OffenceHandler = StakingAhClient;
+	type ReportOffence = Offences;
+}
+
 parameter_types! {
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * BlockWeights::get().max_block;
 }
@@ -2015,6 +2021,10 @@ mod runtime {
 
 	#[runtime::pallet_index(104)]
 	pub type VerifySignature = pallet_verify_signature::Pallet<Runtime>;
+
+	// Root offences pallet
+	#[runtime::pallet_index(105)]
+	pub type RootOffences = pallet_root_offences;
 
 	// BEEFY Bridges support.
 	#[runtime::pallet_index(200)]

--- a/prdoc/pr_9799.prdoc
+++ b/prdoc/pr_9799.prdoc
@@ -1,10 +1,7 @@
-title: Added pallet-root-offences to Westend RC runtime
+title: Added pallet-root-offences to Westend relay-chain runtime
 doc:
 - audience: Runtime Dev
-  description: "Needed to let us test a manual slash on Westend relay-chain and see\
-    \ what happens in terms of UI, indexers etc on the revamped [PJS's staking async\
-    \ page](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-asset-hub-rpc.polkadot.io#/staking-async)\
-    \ \U0001F37F "
+  description: "Needed to let us test a manual slash on Westend relay-chain."
 crates:
 - name: westend-runtime
   bump: major

--- a/prdoc/pr_9799.prdoc
+++ b/prdoc/pr_9799.prdoc
@@ -1,0 +1,10 @@
+title: Added pallet-root-offences to Westend RC runtime
+doc:
+- audience: Runtime Dev
+  description: "Needed to let us test a manual slash on Westend relay-chain and see\
+    \ what happens in terms of UI, indexers etc on the revamped [PJS's staking async\
+    \ page](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-asset-hub-rpc.polkadot.io#/staking-async)\
+    \ \U0001F37F "
+crates:
+- name: westend-runtime
+  bump: major


### PR DESCRIPTION
Needed to let us test a manual slash on Westend relay-chain and see what happens in terms of UI, indexers etc on the revamped [PJS's staking async page](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-asset-hub-rpc.polkadot.io#/staking-async) 🍿 