### PR TITLE
network/tests: Increase test timeout to fix flaky CI

### DIFF
--- a/substrate/client/network/src/protocol/notifications/tests/conformance.rs
+++ b/substrate/client/network/src/protocol/notifications/tests/conformance.rs
@@ -522,7 +522,7 @@ async fn libp2p_disconnects_litep2p_substream() {
 	libp2p.dial(address).unwrap();
 
 	// Disarm first timer interval.
-	let mut timer = tokio::time::interval(std::time::Duration::from_secs(5));
+	let mut timer = tokio::time::interval(std::time::Duration::from_secs(60));
 	timer.tick().await;
 
 	let mut notification_count = 0;


### PR DESCRIPTION
This PR bumps the `libp2p_disconnects_litep2p_substream` test timeout from 5 seconds to 1 minute.

Under load, the test may not have sufficient time to establish connectivity and complete the test within the allotted time.

cc @paritytech/networking 