### PR TITLE
ci: Use `--locked` for cargo doc steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       image: ${{ needs.preflight.outputs.IMAGE }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - run: forklift cargo test --doc --workspace
+      - run: forklift cargo test --doc --workspace --locked
         id: required
         env:
           RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
@@ -47,7 +47,7 @@ jobs:
       image: ${{ needs.preflight.outputs.IMAGE }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - run: forklift cargo doc --all-features --workspace --no-deps
+      - run: forklift cargo doc --all-features --workspace --no-deps --locked
         id: required
         env:
           SKIP_WASM_BUILD: 1


### PR DESCRIPTION
This PR adds the `--locked` option to the cargo doc tests.

Detected by running the CI on PR: https://github.com/paritytech/polkadot-sdk/actions/runs/17972092266/job/51117118432

```rust
error[E0277]: the trait bound `BoundedVec<u8, v3::MaxPalletNameLen>: JsonSchema` is not satisfied
   --> polkadot/xcm/src/v3/mod.rs:228:12
    |
228 |     pub name: BoundedVec<u8, MaxPalletNameLen>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `JsonSchema` is not implemented for `BoundedVec<u8, v3::MaxPalletNameLen>`
    |
note: there are multiple different versions of crate `schemars` in the dependency graph
   --> /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/schemars-0.8.22/src/lib.rs:133:1
    |
133 | pub trait JsonSchema {
    | ^^^^^^^^^^^^^^^^^^^^ this is the required trait
    |
   ::: polkadot/xcm/src/v3/junction.rs:49:44
    |
49  | #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
    |                                            -------- one version of crate `schemars` used here, as a direct dependency of the current crate
    |
   ::: polkadot/xcm/src/lib.rs:31:5
```

Thanks @bkchr for the suggestion here 🙏 

This has been detected while working on:
- https://github.com/paritytech/polkadot-sdk/pull/9418