### PR TITLE
zombinet/tests: Bump block height required timeout to 90s from 60s

### DIFF
--- a/substrate/zombienet/0003-block-building-warp-sync/test-block-building-warp-sync.zndsl
+++ b/substrate/zombienet/0003-block-building-warp-sync/test-block-building-warp-sync.zndsl
@@ -17,17 +17,17 @@ dave: reports peers count is at least 2 within 60 seconds
 
 
 # db snapshot has {{DB_BLOCK_HEIGHT}} blocks
-alice: reports block height is at least {{DB_BLOCK_HEIGHT}} within 60 seconds
-bob: reports block height is at least {{DB_BLOCK_HEIGHT}} within 60 seconds
-charlie: reports block height is at least {{DB_BLOCK_HEIGHT}} within 60 seconds
+alice: reports block height is at least {{DB_BLOCK_HEIGHT}} within 90 seconds
+bob: reports block height is at least {{DB_BLOCK_HEIGHT}} within 90 seconds
+charlie: reports block height is at least {{DB_BLOCK_HEIGHT}} within 90 seconds
 
-alice: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 75 seconds
-bob: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 75 seconds
-charlie: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 75 seconds
+alice: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 90 seconds
+bob: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 90 seconds
+charlie: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 90 seconds
 
 dave: reports block height is at least 1 within 60 seconds
-dave: reports block height is at least {{DB_BLOCK_HEIGHT}} within 60 seconds
-dave: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 60 seconds
+dave: reports block height is at least {{DB_BLOCK_HEIGHT}} within 90 seconds
+dave: reports block height is greater than {{DB_BLOCK_HEIGHT}} within 90 seconds
 
 dave: log line matches "Warp sync is complete" within 60 seconds
 # State sync is logically part of warp sync


### PR DESCRIPTION
This PR increases the timeout constants of [zombienet-substrate-0003-block-building-warp-sync](https://github.com/paritytech/polkadot-sdk/actions/runs/17918143346/job/50948132110#logs) from 60 seconds to 90 seconds.

During an unrelated PR change, the CI must have been under heavy load:

```
2025-09-22T14:44:51.407Z zombie::network-node [bob] Current value: 56687 for metric block height, keep trying...

	 Error:  
		 [bob] Timeout(60), "getting desired metric value 56687 within 60 secs".

┌──────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ 9/22/2025, 2:44:51 PM        │ ❌ bob: reports block height is greater than 56687 within 60 seconds (60001ms)                     │
└──────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘
2025-09-22T14:44:51.745Z zombie::network-node returning for: block_height{status="best"} from ns: substrate
```

Offhand, the test appears to have passed if it had been given another 6 seconds in the timeout. To err on the safer side, the timeout is bumped by 30s. 

It is not entirely clear why these errors started to manifest (ci changes probably), since we had to bump some other rust tests as well:
- https://github.com/paritytech/polkadot-sdk/pull/9810

cc @paritytech/networking 