### PR TITLE
Add remove_by method in runtime interface and extension.

### DIFF
--- a/substrate/primitives/statement-store/src/runtime_api.rs
+++ b/substrate/primitives/statement-store/src/runtime_api.rs
@@ -224,4 +224,11 @@ pub trait StatementStore {
 			store.remove(hash).unwrap_or_default()
 		}
 	}
+
+	/// Remove all statements from the store that were posted by the given public key.
+	fn remove_by(&mut self, who: PassPointerAndReadCopy<[u8; 32], 32>) {
+		if let Some(StatementStoreExt(store)) = self.extension::<StatementStoreExt>() {
+			store.remove_by(who).unwrap_or_default()
+		}
+	}
 }

--- a/substrate/primitives/statement-store/src/store_api.rs
+++ b/substrate/primitives/statement-store/src/store_api.rs
@@ -104,4 +104,7 @@ pub trait StatementStore: Send + Sync {
 
 	/// Remove a statement from the store.
 	fn remove(&self, hash: &Hash) -> Result<()>;
+
+	/// Remove all statements authored by `who`.
+	fn remove_by(&self, who: [u8; 32]) -> Result<()>;
 }


### PR DESCRIPTION
Currently the runtime is responsible to remove statements from the store. this is the only for the statements to expire and not grow indefinitely until the store gobal limits.

If we use a statements store with 4GiB of statements, the method `statements` and `remove` to query and remove statements from the offchain worker is unusable given `statements` cannot be called.

I introduce the method `remove_by` which is safe.

Later we can also introduce a method `valid_statement_change` which resize the usage of the statement store of one account given a new usage. But I don't have time for this now.

There are some other possibilities:
* Do no make the runtime responsible of cleaning the store: make the statement store clean the statements after some duration like 7 days.
* Make the user responsible to refresh their statements. The statement store would clean statements by order of insertion. User with remaining allowance must resubmit their statements regularly. (the pace depends on how fast the allowance of user is changing in the runtime).