### PR TITLE
xcm: Do not require `Asset` to be sorted on `decode`

### DIFF
--- a/polkadot/xcm/src/v3/multiasset.rs
+++ b/polkadot/xcm/src/v3/multiasset.rs
@@ -587,10 +587,13 @@ impl MaxEncodedLen for MultiAssets {
 
 impl Decode for MultiAssets {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		let bounded_instructions =
+		let mut bounded_instructions =
 			BoundedVec::<MultiAsset, ConstU32<{ MAX_ITEMS_IN_MULTIASSETS as u32 }>>::decode(input)?;
+
+		bounded_instructions.sort();
+
 		Self::from_sorted_and_deduplicated(bounded_instructions.into_inner())
-			.map_err(|()| "Out of order".into())
+			.map_err(|()| "Duplicate items".into())
 	}
 }
 
@@ -682,6 +685,7 @@ impl MultiAssets {
 	pub fn from_sorted_and_deduplicated_skip_checks(r: Vec<MultiAsset>) -> Self {
 		Self::from_sorted_and_deduplicated(r).expect("Invalid input r is not sorted/deduped")
 	}
+
 	/// Create a new instance of `MultiAssets` from a `Vec<MultiAsset>` whose contents are sorted
 	/// and which contain no duplicates.
 	///

--- a/polkadot/xcm/src/v4/asset.rs
+++ b/polkadot/xcm/src/v4/asset.rs
@@ -624,10 +624,13 @@ impl MaxEncodedLen for Assets {
 
 impl Decode for Assets {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		let bounded_instructions =
+		let mut bounded_instructions =
 			BoundedVec::<Asset, ConstU32<{ MAX_ITEMS_IN_ASSETS as u32 }>>::decode(input)?;
+
+		bounded_instructions.sort();
+
 		Self::from_sorted_and_deduplicated(bounded_instructions.into_inner())
-			.map_err(|()| "Out of order".into())
+			.map_err(|()| "Duplicate items".into())
 	}
 }
 

--- a/polkadot/xcm/src/v5/asset.rs
+++ b/polkadot/xcm/src/v5/asset.rs
@@ -562,10 +562,13 @@ impl MaxEncodedLen for Assets {
 
 impl Decode for Assets {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		let bounded_instructions =
+		let mut bounded_instructions =
 			BoundedVec::<Asset, ConstU32<{ MAX_ITEMS_IN_ASSETS as u32 }>>::decode(input)?;
+
+		bounded_instructions.sort();
+
 		Self::from_sorted_and_deduplicated(bounded_instructions.into_inner())
-			.map_err(|()| "Out of order".into())
+			.map_err(|()| "Duplicate items".into())
 	}
 }
 

--- a/prdoc/pr_9842.prdoc
+++ b/prdoc/pr_9842.prdoc
@@ -1,0 +1,8 @@
+title: 'xcm: Do not require `Asset` to be sorted on `decode`'
+doc:
+- audience: Runtime User
+  description: |-
+    `Asset` was requiring that all the assets are sorted at decoding. This is quite confusing for people writingg frontends, because this is not really documented anywhere. There are also only at max 20 assets available, we can just make everyones life easier and always sort the assets after decoding.
+crates:
+- name: staging-xcm
+  bump: patch


### PR DESCRIPTION
`Asset` was requiring that all the assets are sorted at decoding. This is quite confusing for people writingg frontends, because this is not really documented anywhere. There are also only at max 20 assets available, we can just make everyones life easier and always sort the assets after decoding.


