### PR TITLE
Fix statement store deadlock

### DIFF
--- a/prdoc/pr_9861.prdoc
+++ b/prdoc/pr_9861.prdoc
@@ -1,7 +1,7 @@
 title: Fix deadlock in statement store
 
 doc:
-  - audience: Node Dev, Runtime Dev, Node Operator
+  - audience: [Node Dev, Runtime Dev, Node Operator]
     description: |
       Fix a deadlock in the statement store that could occur under high load.
 

--- a/prdoc/pr_9861.prdoc
+++ b/prdoc/pr_9861.prdoc
@@ -1,0 +1,10 @@
+title: Fix deadlock in statement store
+
+doc:
+  - audience: Node Dev, Runtime Dev, Node Operator
+    description: |
+      Fix a deadlock in the statement store that could occur under high load.
+
+crates:
+- name: sc-statement-store
+  bump: patch

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -671,8 +671,7 @@ impl Store {
 	/// Perform periodic store maintenance
 	pub fn maintain(&self) {
 		log::trace!(target: LOG_TARGET, "Started store maintenance");
-		let mut index = self.index.write();
-		let deleted = index.maintain(self.timestamp());
+		let deleted = self.index.write().maintain(self.timestamp());
 		let deleted: Vec<_> =
 			deleted.into_iter().map(|hash| (col::EXPIRED, hash.to_vec(), None)).collect();
 		let count = deleted.len() as u64;
@@ -685,8 +684,8 @@ impl Store {
 			target: LOG_TARGET,
 			"Completed store maintenance. Purged: {}, Active: {}, Expired: {}",
 			count,
-			index.entries.len(),
-			index.expired.len()
+			self.index.read().entries.len(),
+			self.index.read().expired.len()
 		);
 	}
 

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -671,7 +671,8 @@ impl Store {
 	/// Perform periodic store maintenance
 	pub fn maintain(&self) {
 		log::trace!(target: LOG_TARGET, "Started store maintenance");
-		let deleted = self.index.write().maintain(self.timestamp());
+		let mut index = self.index.write();
+		let deleted = index.maintain(self.timestamp());
 		let deleted: Vec<_> =
 			deleted.into_iter().map(|hash| (col::EXPIRED, hash.to_vec(), None)).collect();
 		let count = deleted.len() as u64;
@@ -684,8 +685,8 @@ impl Store {
 			target: LOG_TARGET,
 			"Completed store maintenance. Purged: {}, Active: {}, Expired: {}",
 			count,
-			self.index.read().entries.len(),
-			self.index.read().expired.len()
+			index.entries.len(),
+			index.expired.len()
 		);
 	}
 
@@ -764,7 +765,7 @@ impl StatementStore for Store {
 	fn statements(&self) -> Result<Vec<(Hash, Statement)>> {
 		let index = self.index.read();
 		let mut result = Vec::with_capacity(index.entries.len());
-		for h in self.index.read().entries.keys() {
+		for h in index.entries.keys() {
 			let encoded = self.db.get(col::STATEMENTS, h).map_err(|e| Error::Db(e.to_string()))?;
 			if let Some(encoded) = encoded {
 				if let Ok(statement) = Statement::decode(&mut encoded.as_slice()) {


### PR DESCRIPTION
We are doing 2 reads in one time. But this is not good.

Per parking lot doc:

```
/// This lock uses a task-fair locking policy which avoids both reader and
/// writer starvation. This means that readers trying to acquire the lock will
/// block even if the lock is unlocked when there are writers waiting to acquire
/// the lock. Because of this, attempts to recursively acquire a read lock
/// within a single thread may result in a deadlock.
```