### PR TITLE
Adjust statement store configs to hold more data

### DIFF
--- a/prdoc/pr_9864.prdoc
+++ b/prdoc/pr_9864.prdoc
@@ -1,0 +1,14 @@
+title: Adjust statement store configs to hold more data
+doc:
+- audience: Node Operator
+  description: |-
+    # Description
+
+    This PR adjusts the statement store configuration, hardcoded in the networking component of the store, to enable the store to hold greater amounts of data, 2GiB worth of statement data to be exact.
+
+    Moreover, the networking config is adjusted to be able to process significantly more statements, as well as preventing the store from gossiping indefinitely after the LRU cache reaches capacity.
+crates:
+- name: sc-network-statement
+  bump: patch
+- name: sc-statement-store
+  bump: patch

--- a/substrate/client/network/statement/src/config.rs
+++ b/substrate/client/network/statement/src/config.rs
@@ -24,10 +24,10 @@ use std::time;
 pub(crate) const PROPAGATE_TIMEOUT: time::Duration = time::Duration::from_millis(1000);
 
 /// Maximum number of known statement hashes to keep for a peer.
-pub(crate) const MAX_KNOWN_STATEMENTS: usize = 10240;
+pub(crate) const MAX_KNOWN_STATEMENTS: usize = 4 * 1024 * 1024;
 
 /// Maximum allowed size for a statement notification.
 pub(crate) const MAX_STATEMENT_SIZE: u64 = 256 * 1024;
 
 /// Maximum number of statement validation request we keep at any moment.
-pub(crate) const MAX_PENDING_STATEMENTS: usize = 8192;
+pub(crate) const MAX_PENDING_STATEMENTS: usize = 2 * 1024 * 1024;

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -76,9 +76,13 @@ const CURRENT_VERSION: u32 = 1;
 
 const LOG_TARGET: &str = "statement-store";
 
-const DEFAULT_PURGE_AFTER_SEC: u64 = 2 * 24 * 60 * 60; //48h
-const DEFAULT_MAX_TOTAL_STATEMENTS: usize = 8192;
-const DEFAULT_MAX_TOTAL_SIZE: usize = 64 * 1024 * 1024;
+/// The amount of time an expired statement is kept before it is removed from the store entirely.
+pub const DEFAULT_PURGE_AFTER_SEC: u64 = 2 * 24 * 60 * 60; //48h
+/// The maximum number of statements the statement store can hold.
+pub const DEFAULT_MAX_TOTAL_STATEMENTS: usize = 4 * 1024 * 1024; // ~4 million
+/// The maximum amount of data the statement store can hold, regardless of the number of
+/// statements from which the data originates.
+pub const DEFAULT_MAX_TOTAL_SIZE: usize = 2 * 1024 * 1024 * 1024; // 2GiB
 
 const MAINTENANCE_PERIOD: std::time::Duration = std::time::Duration::from_secs(30);
 


### PR DESCRIPTION
# Description

This PR adjusts the statement store configuration, hardcoded in the networking component of the store, to enable the store to hold greater amounts of data, 2GiB worth of statement data to be exact.

Moreover, the networking config is adjusted to be able to process significantly more statements, as well as preventing the store from gossiping indefinitely after the LRU cache reaches capacity.