### PR TITLE
Snowbridge: Use AH as the origin for V2

### DIFF
--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/send_message_impl.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/send_message_impl.rs
@@ -8,12 +8,15 @@ use frame_support::{
 	ensure,
 	traits::{EnqueueMessage, Get},
 };
+use snowbridge_core::AgentIdOf;
 use snowbridge_outbound_queue_primitives::{
 	v2::{Message, SendMessage},
 	SendError,
 };
 use sp_core::H256;
 use sp_runtime::BoundedVec;
+use xcm::{latest::ParentThen, prelude::Parachain};
+use xcm_executor::traits::ConvertLocation;
 
 impl<T> SendMessage for Pallet<T>
 where
@@ -33,7 +36,12 @@ where
 	}
 
 	fn deliver(ticket: Self::Ticket) -> Result<H256, SendError> {
-		let origin = AggregateMessageOrigin::SnowbridgeV2(ticket.origin);
+		// Todo: Inject the AH Location as a type parameter, with the agent the same as in V1
+		let asset_hub_agent_id =
+			AgentIdOf::convert_location(&ParentThen(Parachain(1000_u32.into()).into()).into())
+				.ok_or(SendError::InvalidOrigin)?;
+
+		let origin = AggregateMessageOrigin::SnowbridgeV2(asset_hub_agent_id);
 
 		let message =
 			BoundedVec::try_from(ticket.encode()).map_err(|_| SendError::MessageTooLarge)?;

--- a/bridges/snowbridge/pallets/outbound-queue-v2/src/send_message_impl.rs
+++ b/bridges/snowbridge/pallets/outbound-queue-v2/src/send_message_impl.rs
@@ -36,7 +36,7 @@ where
 	}
 
 	fn deliver(ticket: Self::Ticket) -> Result<H256, SendError> {
-		// Todo: Inject the AH Location as a type parameter, with the agent the same as in V1
+		// Todo: Inject AH as a type parameter, and the agent_id should be same as in V1
 		let asset_hub_agent_id =
 			AgentIdOf::convert_location(&ParentThen(Parachain(1000_u32.into()).into()).into())
 				.ok_or(SendError::InvalidOrigin)?;


### PR DESCRIPTION


# Description

In V1, the origin of AggregateMessageOrigin is the channel ID (i.e., AH). In V2, however, the origin is the actual sender’s origin, passed through AliasOrigin from the source chain.

A potential issue here is that there could be hundreds or even thousands of unique user origins, which might become a burden for the message queue.

Since the original sender’s origin is already included in the message [here](https://github.com/paritytech/polkadot-sdk/blob/f239e76aadf90ed1023debaef155710239f9d865/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/convert.rs#L303) and will be forwarded to Ethereum, it doesn’t need to remain the origin when enqueued into the message queue.

Therefore, in this PR, we’re restricting the enqueued origin to the AH.





