### PR TITLE
`trace_block`: Support overwriting the `execute_block`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
  "sc-service",
  "sc-sysinfo",
  "sc-telemetry",
+ "sc-tracing",
  "sc-transaction-pool",
  "sc-utils",
  "sp-api",
@@ -4597,6 +4598,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-transaction-pool",
+ "sp-trie",
 ]
 
 [[package]]

--- a/cumulus/client/service/Cargo.toml
+++ b/cumulus/client/service/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+
 name = "cumulus-client-service"
 version = "0.7.0"
 authors.workspace = true
@@ -26,6 +27,7 @@ sc-rpc = { workspace = true, default-features = true }
 sc-service = { workspace = true, default-features = true }
 sc-sysinfo = { workspace = true, default-features = true }
 sc-telemetry = { workspace = true, default-features = true }
+sc-tracing = { workspace = true, default-features = true }
 sc-transaction-pool = { workspace = true, default-features = true }
 sc-utils = { workspace = true, default-features = true }
 sp-api = { workspace = true, default-features = true }
@@ -33,6 +35,7 @@ sp-blockchain = { workspace = true, default-features = true }
 sp-consensus = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }
+sp-trie = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-transaction-pool = { workspace = true, default-features = true }
 

--- a/cumulus/client/service/src/lib.rs
+++ b/cumulus/client/service/src/lib.rs
@@ -46,14 +46,16 @@ use sc_network_sync::SyncingService;
 use sc_network_transactions::TransactionsHandlerController;
 use sc_service::{Configuration, SpawnTaskHandle, TaskManager, WarpSyncConfig};
 use sc_telemetry::{log, TelemetryWorkerHandle};
+use sc_tracing::block::TracingExecuteBlock;
 use sc_utils::mpsc::TracingUnboundedSender;
-use sp_api::ProvideRuntimeApi;
+use sp_api::{ApiExt, Core, ProofRecorder, ProvideRuntimeApi};
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
 use sp_core::Decode;
 use sp_runtime::{
 	traits::{Block as BlockT, BlockIdTo, Header},
 	SaturatedConversion, Saturating,
 };
+use sp_trie::proof_size_extension::ProofSizeExt;
 use std::{
 	sync::Arc,
 	time::{Duration, Instant},
@@ -613,5 +615,36 @@ impl ParachainInformantMetrics {
 			parachain_block_backed_duration: parachain_block_authorship_duration,
 			unincluded_segment_size,
 		})
+	}
+}
+
+/// Implementation of [`TracingExecuteBlock`] for parachains.
+///
+/// Ensures that all the required extensions required by parachain runtimes are registered and
+/// available.
+pub struct ParachainTracingExecuteBlock<Client> {
+	client: Arc<Client>,
+}
+
+impl<Client> ParachainTracingExecuteBlock<Client> {
+	/// Creates a new instance of `self`.
+	pub fn new(client: Arc<Client>) -> Self {
+		Self { client }
+	}
+}
+
+impl<Block, Client> TracingExecuteBlock<Block> for ParachainTracingExecuteBlock<Client>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + Send + Sync,
+	Client::Api: Core<Block>,
+{
+	fn execute_block(&self, parent_hash: Block::Hash, block: Block) -> sp_blockchain::Result<()> {
+		let mut runtime_api = self.client.runtime_api();
+		let storage_proof_recorder = ProofRecorder::<Block>::default();
+		runtime_api.register_extension(ProofSizeExt::new(storage_proof_recorder.clone()));
+		runtime_api.record_proof_with_recorder(storage_proof_recorder);
+
+		runtime_api.execute_block(parent_hash, block).map_err(Into::into)
 	}
 }

--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -31,7 +31,8 @@ use cumulus_client_bootnodes::{start_bootnode_tasks, StartBootnodeTasksParams};
 use cumulus_client_cli::CollatorOptions;
 use cumulus_client_service::{
 	build_network, build_relay_chain_interface, prepare_node_config, start_relay_chain_tasks,
-	BuildNetworkParams, CollatorSybilResistance, DARecoveryProfile, StartRelayChainTasksParams,
+	BuildNetworkParams, CollatorSybilResistance, DARecoveryProfile, ParachainTracingExecuteBlock,
+	StartRelayChainTasksParams,
 };
 use cumulus_primitives_core::{BlockT, GetParachainInfo, ParaId};
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface};
@@ -448,6 +449,9 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 				system_rpc_tx,
 				tx_handler_controller,
 				telemetry: telemetry.as_mut(),
+				tracing_execute_block: Some(Arc::new(ParachainTracingExecuteBlock::new(
+					client.clone(),
+				))),
 			})?;
 
 			if let Some(hwbench) = hwbench {

--- a/cumulus/polkadot-omni-node/lib/src/nodes/manual_seal.rs
+++ b/cumulus/polkadot-omni-node/lib/src/nodes/manual_seal.rs
@@ -21,6 +21,7 @@ use crate::common::{
 };
 use codec::Encode;
 use cumulus_client_parachain_inherent::{MockValidationDataInherentDataProvider, MockXcmConfig};
+use cumulus_client_service::ParachainTracingExecuteBlock;
 use cumulus_primitives_aura::AuraUnincludedSegmentApi;
 use cumulus_primitives_core::CollectCollationInfo;
 use futures::FutureExt;
@@ -283,6 +284,9 @@ impl<NodeSpec: NodeSpecT> ManualSealNode<NodeSpec> {
 			sync_service,
 			config,
 			telemetry: telemetry.as_mut(),
+			tracing_execute_block: Some(Arc::new(ParachainTracingExecuteBlock::new(
+				client.clone(),
+			))),
 		})?;
 
 		Ok(task_manager)

--- a/cumulus/test/service/src/lib.rs
+++ b/cumulus/test/service/src/lib.rs
@@ -52,7 +52,8 @@ use cumulus_client_consensus_common::ParachainBlockImport as TParachainBlockImpo
 use cumulus_client_pov_recovery::{RecoveryDelayRange, RecoveryHandle};
 use cumulus_client_service::{
 	build_network, prepare_node_config, start_relay_chain_tasks, BuildNetworkParams,
-	CollatorSybilResistance, DARecoveryProfile, StartRelayChainTasksParams,
+	CollatorSybilResistance, DARecoveryProfile, ParachainTracingExecuteBlock,
+	StartRelayChainTasksParams,
 };
 use cumulus_primitives_core::{relay_chain::ValidationCode, GetParachainInfo, ParaId};
 use cumulus_relay_chain_inprocess_interface::RelayChainInProcessInterface;
@@ -389,6 +390,7 @@ where
 		system_rpc_tx,
 		tx_handler_controller,
 		telemetry: None,
+		tracing_execute_block: Some(Arc::new(ParachainTracingExecuteBlock::new(client.clone()))),
 	})?;
 
 	let announce_block = {

--- a/polkadot/node/service/src/builder/mod.rs
+++ b/polkadot/node/service/src/builder/mod.rs
@@ -506,6 +506,7 @@ where
 			system_rpc_tx,
 			tx_handler_controller,
 			telemetry: telemetry.as_mut(),
+			tracing_execute_block: None,
 		})?;
 
 		if let Some(hwbench) = hwbench {

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -566,6 +566,7 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 		tx_handler_controller,
 		sync_service: sync_service.clone(),
 		telemetry: telemetry.as_mut(),
+		tracing_execute_block: None,
 	})?;
 
 	if let Some(hwbench) = hwbench {

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -37,6 +37,7 @@ use sc_client_api::{
 	StorageProvider,
 };
 use sc_rpc_api::state::ReadProof;
+use sc_tracing::block::TracingExecuteBlock;
 use sp_api::{CallApiAt, Metadata, ProvideRuntimeApi};
 use sp_blockchain::{
 	CachedHeaderMetadata, Error as ClientError, HeaderBackend, HeaderMetadata,
@@ -55,7 +56,7 @@ use sp_version::RuntimeVersion;
 /// The maximum time allowed for an RPC call when running without unsafe RPC enabled.
 const MAXIMUM_SAFE_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Ranges to query in state_queryStorage.
+/// Ranges to query in `state_queryStorage`.
 struct QueryStorageRange<Block: BlockT> {
 	/// Hashes of all the blocks in the range.
 	pub hashes: Vec<Block::Hash>,
@@ -65,7 +66,8 @@ struct QueryStorageRange<Block: BlockT> {
 pub struct FullState<BE, Block: BlockT, Client> {
 	client: Arc<Client>,
 	executor: SubscriptionTaskExecutor,
-	_phantom: PhantomData<(BE, Block)>,
+	block_execute: Option<Arc<dyn TracingExecuteBlock<Block>>>,
+	_phantom: PhantomData<BE>,
 }
 
 impl<BE, Block: BlockT, Client> FullState<BE, Block, Client>
@@ -78,8 +80,12 @@ where
 	Block: BlockT + 'static,
 {
 	/// Create new state API backend for full nodes.
-	pub fn new(client: Arc<Client>, executor: SubscriptionTaskExecutor) -> Self {
-		Self { client, executor, _phantom: PhantomData }
+	pub fn new(
+		client: Arc<Client>,
+		executor: SubscriptionTaskExecutor,
+		block_execute: Option<Arc<dyn TracingExecuteBlock<Block>>>,
+	) -> Self {
+		Self { client, executor, block_execute, _phantom: PhantomData }
 	}
 
 	/// Returns given block hash or best block hash if None is passed.
@@ -479,6 +485,7 @@ where
 			targets,
 			storage_keys,
 			methods,
+			self.block_execute.clone(),
 		)
 		.trace_block()
 		.map_err(|e| invalid_block::<Block>(block, None, e.to_string()))

--- a/substrate/client/rpc/src/state/tests.rs
+++ b/substrate/client/rpc/src/state/tests.rs
@@ -106,7 +106,7 @@ async fn should_return_storage_entries() {
 		.add_extra_child_storage(&child_info, KEY2.to_vec(), CHILD_VALUE2.to_vec())
 		.build();
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(Arc::new(client), test_executor());
+	let (_client, child) = new_full(Arc::new(client), test_executor(), None);
 
 	let keys = &[StorageKey(KEY1.to_vec()), StorageKey(KEY2.to_vec())];
 	assert_eq!(
@@ -137,7 +137,7 @@ async fn should_return_child_storage() {
 			.build(),
 	);
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(client, test_executor());
+	let (_client, child) = new_full(client, test_executor(), None);
 	let child_key = prefixed_storage_key();
 	let key = StorageKey(b"key".to_vec());
 
@@ -168,7 +168,7 @@ async fn should_return_child_storage_entries() {
 			.build(),
 	);
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(client, test_executor());
+	let (_client, child) = new_full(client, test_executor(), None);
 	let child_key = prefixed_storage_key();
 	let keys = vec![StorageKey(b"key1".to_vec()), StorageKey(b"key2".to_vec())];
 
@@ -199,7 +199,7 @@ async fn should_return_child_storage_entries() {
 async fn should_call_contract() {
 	let client = Arc::new(substrate_test_runtime_client::new());
 	let genesis_hash = client.genesis_hash();
-	let (client, _child) = new_full(client, test_executor());
+	let (client, _child) = new_full(client, test_executor(), None);
 
 	assert_matches!(
 		client.call("balanceOf".into(), Bytes(vec![1, 2, 3]), Some(genesis_hash).into()),
@@ -211,7 +211,7 @@ async fn should_call_contract() {
 async fn should_notify_about_storage_changes() {
 	let mut sub = {
 		let client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), test_executor());
+		let (api, _child) = new_full(client.clone(), test_executor(), None);
 		let mut api_rpc = api.into_rpc();
 		api_rpc.extensions_mut().insert(DenyUnsafe::No);
 
@@ -250,7 +250,7 @@ async fn should_notify_about_storage_changes() {
 async fn should_send_initial_storage_changes_and_notifications() {
 	let mut sub = {
 		let client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), test_executor());
+		let (api, _child) = new_full(client.clone(), test_executor(), None);
 
 		let alice_balance_key = [
 			sp_crypto_hashing::twox_128(b"System"),
@@ -300,7 +300,7 @@ async fn should_send_initial_storage_changes_and_notifications() {
 #[tokio::test]
 async fn should_query_storage() {
 	async fn run_tests(client: Arc<TestClient>) {
-		let (api, _child) = new_full(client.clone(), test_executor());
+		let (api, _child) = new_full(client.clone(), test_executor(), None);
 
 		let add_block = |index| {
 			let mut builder = BlockBuilderBuilder::new(&*client)
@@ -468,7 +468,7 @@ async fn should_query_storage() {
 #[tokio::test]
 async fn should_return_runtime_version() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client.clone(), test_executor());
+	let (api, _child) = new_full(client.clone(), test_executor(), None);
 
 	// it is basically json-encoded substrate_test_runtime_client::runtime::VERSION
 	let result = "{\"specName\":\"test\",\"implName\":\"parity-test\",\"authoringVersion\":1,\
@@ -491,7 +491,7 @@ async fn should_return_runtime_version() {
 async fn should_notify_on_runtime_version_initially() {
 	let mut sub = {
 		let client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client, test_executor());
+		let (api, _child) = new_full(client, test_executor(), None);
 		let mut api_rpc = api.into_rpc();
 		api_rpc.extensions_mut().insert(DenyUnsafe::No);
 
@@ -518,7 +518,7 @@ fn should_deserialize_storage_key() {
 #[tokio::test]
 async fn wildcard_storage_subscriptions_are_rpc_unsafe() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client, test_executor());
+	let (api, _child) = new_full(client, test_executor(), None);
 	let mut api_rpc = api.into_rpc();
 	api_rpc.extensions_mut().insert(DenyUnsafe::Yes);
 
@@ -529,7 +529,7 @@ async fn wildcard_storage_subscriptions_are_rpc_unsafe() {
 #[tokio::test]
 async fn concrete_storage_subscriptions_are_rpc_safe() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client, test_executor());
+	let (api, _child) = new_full(client, test_executor(), None);
 	let mut api_rpc = api.into_rpc();
 	api_rpc.extensions_mut().insert(DenyUnsafe::Yes);
 

--- a/substrate/client/tracing/src/block/mod.rs
+++ b/substrate/client/tracing/src/block/mod.rs
@@ -36,7 +36,7 @@ use tracing::{
 
 use crate::{SpanDatum, TraceEvent, Values};
 use sc_client_api::BlockBackend;
-use sp_api::{Core, Metadata, ProvideRuntimeApi};
+use sp_api::{Core, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_core::hexdisplay::HexDisplay;
 use sp_rpc::tracing::{BlockTrace, Span, TraceBlockResponse};
@@ -51,6 +51,43 @@ const DEFAULT_TARGETS: &str = "pallet,frame,state";
 const TRACE_TARGET: &str = "block_trace";
 // The name of a field required for all events.
 const REQUIRED_EVENT_FIELD: &str = "method";
+
+/// Something that can execute a block in a tracing context.
+///
+/// [`DefaultExecuteBlock`] provides a default implementation that simply forwards the block to
+/// [`Core::execute_block`] without any other changes.
+pub trait TracingExecuteBlock<Block: BlockT>: Send + Sync {
+	/// Execute the given `block` on top of the state of `parent_hash`.
+	///
+	/// The execution should be done sync on the same thread, because the caller will register
+	/// special tracing collectors.
+	fn execute_block(&self, parent_hash: Block::Hash, block: Block) -> sp_blockchain::Result<()>;
+}
+
+/// Default implementation of [`ExecuteBlock`].
+///
+/// Uses [`Core::execute_block`] to directly execute a block.
+struct DefaultExecuteBlock<Client> {
+	client: Arc<Client>,
+}
+
+impl<Client> DefaultExecuteBlock<Client> {
+	/// Creates a new instance.
+	pub fn new(client: Arc<Client>) -> Self {
+		Self { client }
+	}
+}
+
+impl<Client, Block> TracingExecuteBlock<Block> for DefaultExecuteBlock<Client>
+where
+	Client: ProvideRuntimeApi<Block> + Send + Sync + 'static,
+	Client::Api: Core<Block>,
+	Block: BlockT,
+{
+	fn execute_block(&self, parent_hash: Block::Hash, block: Block) -> sp_blockchain::Result<()> {
+		self.client.runtime_api().execute_block(parent_hash, block).map_err(Into::into)
+	}
+}
 
 /// Tracing Block Result type alias
 pub type TraceBlockResult<T> = Result<T, Error>;
@@ -96,11 +133,13 @@ impl Subscriber for BlockSubscriber {
 		if !metadata.is_span() && metadata.fields().field(REQUIRED_EVENT_FIELD).is_none() {
 			return false
 		}
+
 		for (target, level) in &self.targets {
 			if metadata.level() <= level && metadata.target().starts_with(target) {
 				return true
 			}
 		}
+
 		false
 	}
 
@@ -167,6 +206,7 @@ pub struct BlockExecutor<Block: BlockT, Client> {
 	targets: Option<String>,
 	storage_keys: Option<String>,
 	methods: Option<String>,
+	execute_block: Arc<dyn TracingExecuteBlock<Block>>,
 }
 
 impl<Block, Client> BlockExecutor<Block, Client>
@@ -178,7 +218,7 @@ where
 		+ Send
 		+ Sync
 		+ 'static,
-	Client::Api: Metadata<Block>,
+	Client::Api: Core<Block>,
 {
 	/// Create a new `BlockExecutor`
 	pub fn new(
@@ -187,8 +227,17 @@ where
 		targets: Option<String>,
 		storage_keys: Option<String>,
 		methods: Option<String>,
+		execute_block: Option<Arc<dyn TracingExecuteBlock<Block>>>,
 	) -> Self {
-		Self { client, block, targets, storage_keys, methods }
+		Self {
+			client: client.clone(),
+			block,
+			targets,
+			storage_keys,
+			methods,
+			execute_block: execute_block
+				.unwrap_or_else(|| Arc::new(DefaultExecuteBlock::new(client))),
+		}
 	}
 
 	/// Execute block, record all spans and events belonging to `Self::targets`
@@ -228,7 +277,7 @@ where
 			if let Err(e) = dispatcher::with_default(&dispatch, || {
 				let span = tracing::info_span!(target: TRACE_TARGET, "trace_block");
 				let _enter = span.enter();
-				self.client.runtime_api().execute_block(parent_hash, block)
+				self.execute_block.execute_block(parent_hash, block)
 			}) {
 				return Err(Error::Dispatch(format!(
 					"Failed to collect traces and execute block: {}",
@@ -311,6 +360,7 @@ fn patch_and_filter(mut span: SpanDatum, targets: &str) -> Option<Span> {
 			return None
 		}
 	}
+
 	Some(span.into())
 }
 
@@ -321,6 +371,7 @@ fn check_target(targets: &str, target: &str, level: &Level) -> bool {
 			return true
 		}
 	}
+
 	false
 }
 

--- a/substrate/frame/revive/dev-node/node/src/service.rs
+++ b/substrate/frame/revive/dev-node/node/src/service.rs
@@ -186,6 +186,7 @@ pub fn new_full<Network: sc_network::NetworkBackend<Block, <Block as BlockT>::Ha
 		sync_service,
 		config,
 		telemetry: telemetry.as_mut(),
+		tracing_execute_block: None,
 	})?;
 
 	let proposer = sc_basic_authorship::ProposerFactory::new(

--- a/templates/minimal/node/src/service.rs
+++ b/templates/minimal/node/src/service.rs
@@ -194,6 +194,7 @@ pub fn new_full<Network: sc_network::NetworkBackend<Block, <Block as BlockT>::Ha
 		sync_service,
 		config,
 		telemetry: telemetry.as_mut(),
+		tracing_execute_block: None,
 	})?;
 
 	let proposer = sc_basic_authorship::ProposerFactory::new(

--- a/templates/parachain/node/src/service.rs
+++ b/templates/parachain/node/src/service.rs
@@ -9,7 +9,7 @@ use parachain_template_runtime::{
 	opaque::{Block, Hash},
 };
 
-use polkadot_sdk::*;
+use polkadot_sdk::{cumulus_client_service::ParachainTracingExecuteBlock, *};
 
 // Cumulus Imports
 use cumulus_client_bootnodes::{start_bootnode_tasks, StartBootnodeTasksParams};
@@ -347,6 +347,7 @@ pub async fn start_parachain_node(
 		system_rpc_tx,
 		tx_handler_controller,
 		telemetry: telemetry.as_mut(),
+		tracing_execute_block: Some(Arc::new(ParachainTracingExecuteBlock::new(client.clone()))),
 	})?;
 
 	if let Some(hwbench) = hwbench {

--- a/templates/solochain/node/src/service.rs
+++ b/templates/solochain/node/src/service.rs
@@ -234,6 +234,7 @@ pub fn new_full<
 		sync_service: sync_service.clone(),
 		config,
 		telemetry: telemetry.as_mut(),
+		tracing_execute_block: None,
 	})?;
 
 	if role.is_authority() {


### PR DESCRIPTION
This is required for example for parachains that require special extensions to be registered (e.g. `ProofSizeExt`) to succeed the block execution.

This pull request changes the signature of `spawn_tasks` which now requires a `tracing_execute_block` parameter. If your chain is a solochain, just set the parameter to `None` or overwrite it if you need any special handling. For parachain builders, this value can be set to `cumulus_service::ParachainTracingExecuteBlock`.

