### PR TITLE
Bring back NativeToForeign storage in EthereumSystem to be more resilient against changes

### DIFF
--- a/bridges/snowbridge/pallets/system-v2/src/lib.rs
+++ b/bridges/snowbridge/pallets/system-v2/src/lib.rs
@@ -46,7 +46,7 @@ use snowbridge_outbound_queue_primitives::{
 use snowbridge_pallet_system::ForeignToNativeId;
 use sp_core::{H160, H256};
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::MaybeConvert;
+use sp_runtime::traits::{MaybeConvert, MaybeEquivalence};
 use sp_std::prelude::*;
 use xcm::prelude::*;
 use xcm_executor::traits::ConvertLocation;
@@ -316,6 +316,15 @@ pub mod pallet {
 	impl<T: Config> MaybeConvert<TokenId, Location> for Pallet<T> {
 		fn maybe_convert(foreign_id: TokenId) -> Option<Location> {
 			snowbridge_pallet_system::Pallet::<T>::maybe_convert(foreign_id)
+		}
+	}
+
+	impl<T: Config> MaybeEquivalence<TokenId, Location> for Pallet<T> {
+		fn convert(foreign_id: &TokenId) -> Option<Location> {
+			snowbridge_pallet_system::Pallet::<T>::convert(foreign_id)
+		}
+		fn convert_back(location: &Location) -> Option<TokenId> {
+			snowbridge_pallet_system::Pallet::<T>::convert_back(location)
 		}
 	}
 }

--- a/bridges/snowbridge/pallets/system-v2/src/tests.rs
+++ b/bridges/snowbridge/pallets/system-v2/src/tests.rs
@@ -139,6 +139,11 @@ fn register_all_tokens_succeeds() {
 				EthereumSystemV2::location_to_message_origin(tc.native.clone()).unwrap();
 
 			assert_eq!(
+				NativeToForeignId::<Test>::get(reanchored_location.clone()),
+				Some(foreign_token_id)
+			);
+
+			assert_eq!(
 				ForeignToNativeId::<Test>::get(foreign_token_id),
 				Some(reanchored_location.clone())
 			);

--- a/bridges/snowbridge/pallets/system/src/lib.rs
+++ b/bridges/snowbridge/pallets/system/src/lib.rs
@@ -52,7 +52,7 @@ use snowbridge_outbound_queue_primitives::{
 };
 use sp_core::{RuntimeDebug, H160, H256};
 use sp_io::hashing::blake2_256;
-use sp_runtime::{traits::MaybeConvert, DispatchError, SaturatedConversion};
+use sp_runtime::{traits::{MaybeConvert, MaybeEquivalence}, DispatchError, SaturatedConversion};
 use sp_std::prelude::*;
 use xcm::prelude::*;
 use xcm_executor::traits::ConvertLocation;
@@ -232,6 +232,11 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type ForeignToNativeId<T: Config> =
 		StorageMap<_, Blake2_128Concat, TokenId, Location, OptionQuery>;
+
+	/// Lookup table for native location relative to ethereum to foreign token ID
+	#[pallet::storage]
+	pub type NativeToForeignId<T: Config> =
+		StorageMap<_, Blake2_128Concat, Location, TokenId, OptionQuery>;
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]
@@ -489,6 +494,7 @@ pub mod pallet {
 				.ok_or(Error::<T>::LocationConversionFailed)?;
 
 			if !ForeignToNativeId::<T>::contains_key(token_id) {
+				NativeToForeignId::<T>::insert(location.clone(), token_id);
 				ForeignToNativeId::<T>::insert(token_id, location.clone());
 			}
 
@@ -532,6 +538,15 @@ pub mod pallet {
 	impl<T: Config> MaybeConvert<TokenId, Location> for Pallet<T> {
 		fn maybe_convert(foreign_id: TokenId) -> Option<Location> {
 			ForeignToNativeId::<T>::get(foreign_id)
+		}
+	}
+
+	impl<T: Config> MaybeEquivalence<TokenId, Location> for Pallet<T> {
+		fn convert(foreign_id: &TokenId) -> Option<Location> {
+			ForeignToNativeId::<T>::get(foreign_id)
+		}
+		fn convert_back(location: &Location) -> Option<TokenId> {
+			NativeToForeignId::<T>::get(location)
 		}
 	}
 }

--- a/bridges/snowbridge/primitives/outbound-queue/src/v1/converter/tests.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v1/converter/tests.rs
@@ -62,9 +62,12 @@ impl SendMessageFeeProvider for MockErrOutboundQueue {
 }
 
 pub struct MockTokenIdConvert;
-impl MaybeConvert<TokenId, Location> for MockTokenIdConvert {
-	fn maybe_convert(_id: TokenId) -> Option<Location> {
+impl MaybeEquivalence<TokenId, Location> for MockTokenIdConvert {
+	fn convert(_id: &TokenId) -> Option<Location> {
 		Some(Location::new(1, [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH))]))
+	}
+	fn convert_back(_loc: &Location) -> Option<TokenId> {
+		Some(1)
 	}
 }
 

--- a/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/convert.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/convert.rs
@@ -14,7 +14,7 @@ use crate::v2::{
 
 use crate::v2::convert::XcmConverterError::{AssetResolutionFailed, FilterDoesNotConsumeAllAssets};
 use sp_core::H160;
-use sp_runtime::traits::MaybeConvert;
+use sp_runtime::traits::{MaybeConvert, MaybeEquivalence};
 use sp_std::{iter::Peekable, marker::PhantomData, prelude::*};
 use xcm::prelude::*;
 use xcm_executor::traits::ConvertLocation;
@@ -64,7 +64,7 @@ pub struct XcmConverter<'a, ConvertAssetId, Call> {
 }
 impl<'a, ConvertAssetId, Call> XcmConverter<'a, ConvertAssetId, Call>
 where
-	ConvertAssetId: MaybeConvert<TokenId, Location>,
+	ConvertAssetId: MaybeEquivalence<TokenId, Location>,
 {
 	pub fn new(message: &'a Xcm<Call>, ethereum_network: NetworkId) -> Self {
 		Self {
@@ -173,8 +173,7 @@ where
 			ensure!(amount > 0, ZeroAssetTransfer);
 
 			// Ensure PNA already registered
-			let token_id = TokenIdOf::convert_location(&asset_id).ok_or(InvalidAsset)?;
-			ConvertAssetId::maybe_convert(token_id).ok_or(InvalidAsset)?;
+			let token_id = ConvertAssetId::convert_back(&asset_id).ok_or(InvalidAsset)?;
 
 			commands.push(Command::MintForeignToken { token_id, recipient, amount });
 		}

--- a/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/mod.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/mod.rs
@@ -15,7 +15,7 @@ use frame_support::{
 	traits::{Contains, Get, ProcessMessageError},
 };
 use snowbridge_core::{ParaId, TokenId};
-use sp_runtime::traits::MaybeConvert;
+use sp_runtime::traits::{MaybeConvert, MaybeEquivalence};
 use sp_std::{marker::PhantomData, ops::ControlFlow, prelude::*};
 use xcm::prelude::*;
 use xcm_builder::{CreateMatcher, ExporterFor, MatchXcm};
@@ -53,7 +53,7 @@ where
 	UniversalLocation: Get<InteriorLocation>,
 	EthereumNetwork: Get<NetworkId>,
 	OutboundQueue: SendMessage,
-	ConvertAssetId: MaybeConvert<TokenId, Location>,
+	ConvertAssetId: MaybeEquivalence<TokenId, Location>,
 	AssetHubParaId: Get<ParaId>,
 {
 	type Ticket = (Vec<u8>, XcmHash);

--- a/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/tests.rs
+++ b/bridges/snowbridge/primitives/outbound-queue/src/v2/converter/tests.rs
@@ -62,9 +62,12 @@ impl SendMessageFeeProvider for MockErrOutboundQueue {
 }
 
 pub struct MockTokenIdConvert;
-impl MaybeConvert<TokenId, Location> for MockTokenIdConvert {
-	fn maybe_convert(_id: TokenId) -> Option<Location> {
+impl MaybeEquivalence<TokenId, Location> for MockTokenIdConvert {
+	fn convert(_id: &TokenId) -> Option<Location> {
 		Some(Location::new(1, [GlobalConsensus(ByGenesis(WESTEND_GENESIS_HASH))]))
+	}
+	fn convert_back(_loc: &Location) -> Option<TokenId> {
+		Some(1)
 	}
 }
 


### PR DESCRIPTION
This PR brings back the storage removed in https://github.com/paritytech/polkadot-sdk/pull/8473. The motivation on that PR was that the storage was not used, and it was true. However I think it should be used to have a more resilient structure against potential breaking changes in the future. The rationale is the following:

A) If any of the HashedDescription or xcm locations changes there is a quite complex migration to be performed without this PR. It would involve both migrating bridgehub storages and ethereum mappings in a coordinated manner.

B) With this new PR, there is no downside besides having to store a few more bytes in EthereumSystem. The exporter has exactly the same amount of reads (as we were already checking whether the asset existed in EthereumSystem). This PR maintains the HashedDescription implementation when the asset is registered, but from there on, it relies on EthereumSystem to do the converion Location->TokenId. Now any of the above breaking changes does not imply a migration, as the hash would still match the old one.

I am making this PR as draft as I want to gather feedback. Obviously there are a few TODOs yet that I will implement if the feedback is positive

# Checklist

* [ ] Migration to re-populate NativeToForeign
* [ ] Adapt tests
* [ ] Adapt benchmarks (if needed)
