### PR TITLE
FinalityNotification: Directly include stale blocks

### DIFF
--- a/cumulus/client/pov-recovery/src/tests.rs
+++ b/cumulus/client/pov-recovery/src/tests.rs
@@ -1203,7 +1203,7 @@ async fn candidate_is_finalized_while_awaiting_recovery() {
 	let (unpin_sender, _unpin_receiver) = sc_utils::mpsc::tracing_unbounded("test_unpin", 10);
 	finality_notifications_tx
 		.unbounded_send(FinalityNotification::from_summary(
-			FinalizeSummary { header: header.clone(), finalized: vec![], stale_heads: vec![] },
+			FinalizeSummary { header: header.clone(), finalized: vec![], stale_blocks: vec![] },
 			unpin_sender,
 		))
 		.unwrap();

--- a/prdoc/pr_9904.prdoc
+++ b/prdoc/pr_9904.prdoc
@@ -1,0 +1,24 @@
+title: 'FinalityNotification: Directly include stale blocks'
+doc:
+- audience: Node Dev
+  description: |-
+    The finality notification was already carrying the information about the stale heads. However, most users of the stale heads were expanding these stale heads to all the stale blocks. So, we were iterating the same forks multiple times in the node for each finality notification. Also in a possible future where we start actually pruning headers as well, expanding these forks would fail.
+
+    So, this pull request is changing the finality notification to directly carry the stale blocks (which were calculated any way already).
+crates:
+- name: cumulus-client-pov-recovery
+  bump: major
+- name: sc-client-api
+  bump: major
+- name: sc-consensus-babe
+  bump: major
+- name: sc-client-db
+  bump: major
+- name: mmr-gadget
+  bump: major
+- name: sc-rpc-spec-v2
+  bump: major
+- name: sc-service
+  bump: major
+- name: sp-blockchain
+  bump: major

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -79,6 +79,15 @@ pub struct ImportSummary<Block: BlockT> {
 	pub import_notification_action: ImportNotificationAction,
 }
 
+/// A stale block.
+#[derive(Clone, Debug)]
+pub struct StaleBlock<Block: BlockT> {
+	/// The hash of this block.
+	pub hash: Block::Hash,
+	/// Is this a head?
+	pub is_head: bool,
+}
+
 /// Finalization operation summary.
 ///
 /// Contains information about the block that just got finalized,
@@ -87,10 +96,11 @@ pub struct FinalizeSummary<Block: BlockT> {
 	/// Last finalized block header.
 	pub header: Block::Header,
 	/// Blocks that were finalized.
+	///
 	/// The last entry is the one that has been explicitly finalized.
 	pub finalized: Vec<Block::Hash>,
-	/// Heads that became stale during this finalization operation.
-	pub stale_heads: Vec<Block::Hash>,
+	/// Blocks that became stale during this finalization operation.
+	pub stale_blocks: Vec<StaleBlock<Block>>,
 }
 
 /// Import operation wrapper.

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -113,7 +113,7 @@ use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_application_crypto::AppCrypto;
 use sp_block_builder::BlockBuilder as BlockBuilderApi;
 use sp_blockchain::{
-	Backend as _, BlockStatus, Error as ClientError, ForkBackend, HeaderBackend, HeaderMetadata,
+	Backend as _, BlockStatus, Error as ClientError, HeaderBackend, HeaderMetadata,
 	Result as ClientResult,
 };
 use sp_consensus::{BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain};

--- a/substrate/client/consensus/babe/src/lib.rs
+++ b/substrate/client/consensus/babe/src/lib.rs
@@ -561,16 +561,7 @@ fn aux_storage_cleanup<C: HeaderMetadata<Block> + HeaderBackend<Block>, Block: B
 			.filter(|h| **h != notification.hash),
 	);
 
-	// Cleans data for stale forks.
-	let stale_forks = match client.expand_forks(&notification.stale_heads) {
-		Ok(stale_forks) => stale_forks,
-		Err(e) => {
-			warn!(target: LOG_TARGET, "{:?}", e);
-
-			Default::default()
-		},
-	};
-	hashes.extend(stale_forks.iter());
+	hashes.extend(notification.stale_blocks.iter().map(|b| b.hash));
 
 	hashes
 		.into_iter()

--- a/substrate/client/merkle-mountain-range/src/offchain_mmr.rs
+++ b/substrate/client/merkle-mountain-range/src/offchain_mmr.rs
@@ -25,7 +25,7 @@ use crate::{aux_schema, MmrClient, LOG_TARGET};
 use log::{debug, error, info, warn};
 use sc_client_api::{Backend, FinalityNotification};
 use sc_offchain::OffchainDb;
-use sp_blockchain::{CachedHeaderMetadata, ForkBackend};
+use sp_blockchain::CachedHeaderMetadata;
 use sp_consensus_beefy::MmrRootHash;
 use sp_core::offchain::{DbExternalities, StorageKind};
 use sp_mmr_primitives::{utils, utils::NodesUtils, MmrApi, NodeIndex};
@@ -33,7 +33,7 @@ use sp_runtime::{
 	traits::{Block, Header, NumberFor, One},
 	Saturating,
 };
-use std::{collections::VecDeque, default::Default, sync::Arc};
+use std::{collections::VecDeque, sync::Arc};
 
 /// `OffchainMMR` exposes MMR offchain canonicalization and pruning logic.
 pub struct OffchainMmr<B: Block, BE: Backend<B>, C> {

--- a/substrate/client/merkle-mountain-range/src/offchain_mmr.rs
+++ b/substrate/client/merkle-mountain-range/src/offchain_mmr.rs
@@ -273,14 +273,7 @@ where
 		self.write_gadget_state_or_log();
 
 		// Remove offchain MMR nodes for stale forks.
-		let stale_forks = self.client.expand_forks(&notification.stale_heads).unwrap_or_else(|e| {
-			warn!(target: LOG_TARGET, "{:?}", e);
-
-			Default::default()
-		});
-		for hash in stale_forks.iter() {
-			self.prune_branch(hash);
-		}
+		notification.stale_blocks.iter().for_each(|s| self.prune_branch(&s.hash));
 	}
 }
 

--- a/substrate/client/service/test/src/client/mod.rs
+++ b/substrate/client/service/test/src/client/mod.rs
@@ -134,18 +134,20 @@ fn block1(genesis_hash: Hash, backend: &InMemoryBackend<BlakeTwo256>) -> Vec<u8>
 	)
 }
 
+#[track_caller]
 fn finality_notification_check(
 	notifications: &mut FinalityNotifications<Block>,
 	finalized: &[Hash],
-	stale_heads: &[Hash],
+	stale_blocks: &[Hash],
 ) {
 	match notifications.try_recv() {
 		Ok(notif) => {
-			let stale_heads_expected: HashSet<_> = stale_heads.iter().collect();
-			let stale_heads: HashSet<_> = notif.stale_heads.iter().collect();
+			let stale_blocks_expected = HashSet::<H256>::from_iter(stale_blocks.iter().copied());
+			let stale_blocks = HashSet::from_iter(notif.stale_blocks.into_iter().map(|b| b.hash));
+
 			assert_eq!(notif.tree_route.as_ref(), &finalized[..finalized.len() - 1]);
 			assert_eq!(notif.hash, *finalized.last().unwrap());
-			assert_eq!(stale_heads, stale_heads_expected);
+			assert_eq!(stale_blocks, stale_blocks_expected);
 		},
 		Err(TryRecvError::Closed) => {
 			panic!("unexpected notification result, client send channel was closed")
@@ -1154,7 +1156,7 @@ fn importing_diverged_finalized_block_should_trigger_reorg() {
 
 	assert_eq!(client.chain_info().finalized_hash, b1.hash());
 
-	finality_notification_check(&mut finality_notifications, &[b1.hash()], &[a2.hash()]);
+	finality_notification_check(&mut finality_notifications, &[b1.hash()], &[a1.hash(), a2.hash()]);
 	assert!(matches!(finality_notifications.try_recv().unwrap_err(), TryRecvError::Empty));
 }
 
@@ -1228,6 +1230,8 @@ fn finalizing_diverged_block_should_trigger_reorg() {
 	// knowing about B2)
 	assert_eq!(client.chain_info().best_hash, b1.hash());
 
+	finality_notification_check(&mut finality_notifications, &[b1.hash()], &[a1.hash(), a2.hash()]);
+
 	// `SelectChain` should report B2 as best block though
 	assert_eq!(block_on(select_chain.best_chain()).unwrap().hash(), b2.hash());
 
@@ -1249,7 +1253,6 @@ fn finalizing_diverged_block_should_trigger_reorg() {
 
 	ClientExt::finalize_block(&client, b3.hash(), None).unwrap();
 
-	finality_notification_check(&mut finality_notifications, &[b1.hash()], &[a2.hash()]);
 	finality_notification_check(&mut finality_notifications, &[b2.hash(), b3.hash()], &[]);
 	assert!(matches!(finality_notifications.try_recv().unwrap_err(), TryRecvError::Empty));
 }
@@ -1368,14 +1371,15 @@ fn finality_notifications_content() {
 
 	ClientExt::finalize_block(&client, a2.hash(), None).unwrap();
 
-	// Import and finalize D4
-	block_on(client.import_as_final(BlockOrigin::Own, d4.clone())).unwrap();
-
 	finality_notification_check(
 		&mut finality_notifications,
 		&[a1.hash(), a2.hash()],
-		&[c1.hash(), b2.hash()],
+		&[c1.hash(), b1.hash(), b2.hash()],
 	);
+
+	// Import and finalize D4
+	block_on(client.import_as_final(BlockOrigin::Own, d4.clone())).unwrap();
+
 	finality_notification_check(&mut finality_notifications, &[d3.hash(), d4.hash()], &[a3.hash()]);
 	assert!(matches!(finality_notifications.try_recv().unwrap_err(), TryRecvError::Empty));
 }
@@ -1565,6 +1569,12 @@ fn doesnt_import_blocks_that_revert_finality() {
 	// B3 at the same height but that doesn't include it
 	ClientExt::finalize_block(&client, a2.hash(), None).unwrap();
 
+	finality_notification_check(
+		&mut finality_notifications,
+		&[a1.hash(), a2.hash()],
+		&[b1.hash(), b2.hash()],
+	);
+
 	let import_err = block_on(client.import(BlockOrigin::Own, b3)).err().unwrap();
 	let expected_err =
 		ConsensusError::ClientImport(sp_blockchain::Error::NotInFinalizedChain.to_string());
@@ -1605,8 +1615,6 @@ fn doesnt_import_blocks_that_revert_finality() {
 		.block;
 	block_on(client.import(BlockOrigin::Own, a3.clone())).unwrap();
 	ClientExt::finalize_block(&client, a3.hash(), None).unwrap();
-
-	finality_notification_check(&mut finality_notifications, &[a1.hash(), a2.hash()], &[b2.hash()]);
 
 	finality_notification_check(&mut finality_notifications, &[a3.hash()], &[]);
 


### PR DESCRIPTION
The finality notification was already carrying the information about the stale heads. However, most users of the stale heads were expanding these stale heads to all the stale blocks. So, we were iterating the same forks multiple times in the node for each finality notification. Also in a possible future where we start actually pruning headers as well, expanding these forks would fail.

So, this pull request is changing the finality notification to directly carry the stale blocks (which were calculated any way already).