### PR TITLE
Bump PARENT_SEARCH_DEPTH 

### DIFF
--- a/cumulus/client/consensus/aura/src/collators/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/mod.rs
@@ -43,14 +43,14 @@ pub mod basic;
 pub mod lookahead;
 pub mod slot_based;
 
-// This is an arbitrary value which is likely guaranteed to exceed any reasonable
-// limit, as it would correspond to 30 non-included blocks.
+// This is an arbitrary value which is guaranteed to exceed the required depth for 500ms blocks
+// built with a relay parent offset of 1.
 //
 // Since we only search for parent blocks which have already been imported,
 // we can guarantee that all imported blocks respect the unincluded segment
 // rules specified by the parachain's runtime and thus will never be too deep. This is just an extra
 // sanity check.
-const PARENT_SEARCH_DEPTH: usize = 30;
+const PARENT_SEARCH_DEPTH: usize = 40;
 
 /// Check the `local_validation_code_hash` against the validation code hash in the relay chain
 /// state.


### PR DESCRIPTION
A chain needs to have the `UNINCLUDED_SEGMENT_CAPACITY` configured to  `(2 + RELAY_PARENT_OFFSET) *
BLOCK_PROCESSING_VELOCITY + 1`.

When the parachain is configured to build 12 blocks per relay parent and the relay parent offset is 1, this number(37) is higher than the current `PARENT_SEARCH_DEPTH=30`. 

This PR raises the limit to be sufficient for the larger unincluded segment.