### PR TITLE
CheckWeight: Take transaction length into account during validation

### DIFF
--- a/prdoc/pr_9907.prdoc
+++ b/prdoc/pr_9907.prdoc
@@ -1,11 +1,7 @@
 title: 'CheckWeight: Take transaction length into account during validation'
 doc:
 - audience: Runtime Dev
-  description: During validation of extrinsics we currently check that the benchmarked
-    weight does not exceed the overall block limit for the given extrinsic class.  For
-    the proof weight, this should also take into account the length of the transaction.
-    This creates parity with the checks we already do at extrinsic application time
-    where we take the length [into account](https://github.com/paritytech/polkadot-sdk/blob/7086502b242c7984a13e198d2373e69a640e5c58/substrate/frame/system/src/extensions/check_weight.rs#L166-L166).
+  description: The `CheckWeight` extension now takes the length into account when checking whether a transaction fits into a block at validation time.
 crates:
 - name: frame-system
   bump: patch

--- a/prdoc/pr_9907.prdoc
+++ b/prdoc/pr_9907.prdoc
@@ -1,0 +1,11 @@
+title: 'CheckWeight: Take transaction length into account during validation'
+doc:
+- audience: Runtime Dev
+  description: During validation of extrinsics we currently check that the benchmarked
+    weight does not exceed the overall block limit for the given extrinsic class.  For
+    the proof weight, this should also take into account the length of the transaction.
+    This creates parity with the checks we already do at extrinsic application time
+    where we take the length [into account](https://github.com/paritytech/polkadot-sdk/blob/7086502b242c7984a13e198d2373e69a640e5c58/substrate/frame/system/src/extensions/check_weight.rs#L166-L166).
+crates:
+- name: frame-system
+  bump: patch

--- a/substrate/frame/system/src/extensions/check_weight.rs
+++ b/substrate/frame/system/src/extensions/check_weight.rs
@@ -54,7 +54,7 @@ where
 	) -> Result<(), TransactionValidityError> {
 		let max = T::BlockWeights::get().get(info.class).max_extrinsic;
 		let total_weight_including_length =
-			info.total_weight().add_proof_size(len.try_into().unwrap_or(u64::MAX));
+			info.total_weight().add_proof_size(len as u64);
 		match max {
 			Some(max) if total_weight_including_length.any_gt(max) => {
 				log::debug!(

--- a/substrate/frame/system/src/extensions/check_weight.rs
+++ b/substrate/frame/system/src/extensions/check_weight.rs
@@ -53,8 +53,7 @@ where
 		len: usize,
 	) -> Result<(), TransactionValidityError> {
 		let max = T::BlockWeights::get().get(info.class).max_extrinsic;
-		let total_weight_including_length =
-			info.total_weight().add_proof_size(len as u64);
+		let total_weight_including_length = info.total_weight().add_proof_size(len as u64);
 		match max {
 			Some(max) if total_weight_including_length.any_gt(max) => {
 				log::debug!(

--- a/substrate/frame/system/src/extensions/check_weight.rs
+++ b/substrate/frame/system/src/extensions/check_weight.rs
@@ -963,7 +963,7 @@ mod tests {
 			let max_proof_size = max_extrinsic.proof_size() as usize;
 			// Extrinsic weight that fits without length
 			let info = DispatchInfo {
-				call_weight: max_extrinsic.clone().set_proof_size(0),
+				call_weight: max_extrinsic.set_proof_size(0),
 				class: DispatchClass::Normal,
 				..Default::default()
 			};


### PR DESCRIPTION
During validation of extrinsics we currently check that the benchmarked weight does not exceed the overall block limit for the given extrinsic class.  For the proof weight, this should also take into account the length of the transaction. This creates parity with the checks we already do at extrinsic application time where we take the length [into account](https://github.com/paritytech/polkadot-sdk/blob/7086502b242c7984a13e198d2373e69a640e5c58/substrate/frame/system/src/extensions/check_weight.rs#L166-L166).