### PR TITLE
[pallet-revive] Allows setting evm balance for non-existing account

### DIFF
--- a/prdoc/pr_9911.prdoc
+++ b/prdoc/pr_9911.prdoc
@@ -1,0 +1,9 @@
+title: '[pallet-revive] Allows setting evm balance for non-existing account'
+doc:
+- audience: Runtime User
+  description: |-
+    Allows calling set_evm_balance for a non-existing account on pallet-revive.
+
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1566,8 +1566,12 @@ where
 			.map_err(|_| <Error<T>>::BalanceConversionFailed)?;
 		let account_id = T::AddressMapper::to_account_id(&address);
 		T::Currency::set_balance(&account_id, balance);
-		AccountInfoOf::<T>::mutate(address, |account| {
-			account.as_mut().map(|a| a.dust = dust);
+		AccountInfoOf::<T>::mutate(&address, |account| {
+			if let Some(account) = account {
+				account.dust = dust;
+			} else {
+				*account = Some(AccountInfo { dust, ..Default::default() });
+			}
 		});
 
 		Ok(())

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -198,6 +198,17 @@ fn eth_call_transfer_with_dust_works() {
 }
 
 #[test]
+fn set_evm_balance_for_eoa_works() {
+	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
+		let native_with_dust = BalanceWithDust::new_unchecked::<Test>(100, 10);
+		let evm_balance = Pallet::<Test>::convert_native_to_evm(native_with_dust);
+		let _ = Pallet::<Test>::set_evm_balance(&ALICE_ADDR, evm_balance);
+
+		assert_eq!(Pallet::<Test>::evm_balance(&ALICE_ADDR), evm_balance);
+	});
+}
+
+#[test]
 fn set_evm_balance_works() {
 	let (binary, _) = compile_module("dummy").unwrap();
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {


### PR DESCRIPTION
Allows calling set_evm_balance for a non-existing account on pallet-revive.
It is needed by foundry to inject EVM accounts. 
