### PR TITLE
Introduce `ReplayProofSizeProvider`, `RecordingProofProvider` & transactional extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22812,6 +22812,7 @@ dependencies = [
  "sp-api",
  "sp-consensus",
  "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
  "sp-metadata-ir",
  "sp-runtime",
  "sp-state-machine",

--- a/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -412,6 +412,11 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 							&mut std::cell::RefCell::borrow_mut(&self.changes)
 						);
 
+						#crate_::Extensions::commit_transaction(
+							&mut std::cell::RefCell::borrow_mut(&self.extensions),
+							#crate_::TransactionType::Host,
+						);
+
 						// Will panic on an `Err` below, however we should call commit
 						// on the recorder and the changes together.
 						std::result::Result::and(res, std::result::Result::map_err(res2, drop))
@@ -424,6 +429,11 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 
 						let res2 = #crate_::OverlayedChanges::rollback_transaction(
 							&mut std::cell::RefCell::borrow_mut(&self.changes)
+						);
+
+						#crate_::Extensions::rollback_transaction(
+							&mut std::cell::RefCell::borrow_mut(&self.extensions),
+							#crate_::TransactionType::Host,
 						);
 
 						// Will panic on an `Err` below, however we should call commit
@@ -441,6 +451,11 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 					if let Some(recorder) = &self.recorder {
 						#crate_::ProofRecorder::<Block>::start_transaction(&recorder);
 					}
+
+					#crate_::Extensions::start_transaction(
+						&mut std::cell::RefCell::borrow_mut(&self.extensions),
+						#crate_::TransactionType::Host,
+					);
 				}
 			}
 		}

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -81,7 +81,7 @@ pub mod __private {
 	mod std_imports {
 		pub use hash_db::Hasher;
 		pub use sp_core::traits::CallContext;
-		pub use sp_externalities::{Extension, Extensions};
+		pub use sp_externalities::{Extension, Extensions, TransactionType};
 		pub use sp_runtime::StateVersion;
 		pub use sp_state_machine::{
 			Backend as StateBackend, InMemoryBackend, OverlayedChanges, StorageProof, TrieBackend,

--- a/substrate/primitives/api/test/Cargo.toml
+++ b/substrate/primitives/api/test/Cargo.toml
@@ -25,6 +25,7 @@ sc-block-builder = { workspace = true, default-features = true }
 scale-info = { features = ["derive"], workspace = true }
 sp-api = { workspace = true, default-features = true }
 sp-consensus = { workspace = true, default-features = true }
+sp-externalities = { workspace = true, default-features = true }
 sp-metadata-ir = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-state-machine = { workspace = true, default-features = true }

--- a/substrate/primitives/api/test/tests/runtime_calls.rs
+++ b/substrate/primitives/api/test/tests/runtime_calls.rs
@@ -15,10 +15,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::panic::UnwindSafe;
+use std::{
+	panic::UnwindSafe,
+	sync::{
+		atomic::{AtomicUsize, Ordering},
+		Arc,
+	},
+};
 
 use sc_block_builder::BlockBuilderBuilder;
 use sp_api::{ApiExt, Core, ProvideRuntimeApi};
+use sp_externalities::{decl_extension, TransactionType};
 use sp_runtime::{
 	traits::{HashingFor, Header as HeaderT},
 	TransactionOutcome,
@@ -182,14 +189,44 @@ fn disable_logging_works() {
 // Ensure that the type is not unwind safe!
 static_assertions::assert_not_impl_any!(<TestClient as ProvideRuntimeApi<_>>::Api: UnwindSafe);
 
+#[derive(Default)]
+struct TransactionTesterInner {
+	started: AtomicUsize,
+	committed: AtomicUsize,
+	rolled_back: AtomicUsize,
+}
+
+decl_extension! {
+	struct TransactionTester(Arc<TransactionTesterInner>);
+
+	impl TransactionTester {
+		fn start_transaction(&mut self, ty: TransactionType) {
+			assert_eq!(ty, TransactionType::Host);
+			self.0.started.fetch_add(1, Ordering::Relaxed);
+		}
+
+		fn commit_transaction(&mut self, ty: TransactionType) {
+			assert_eq!(ty, TransactionType::Host);
+			self.0.committed.fetch_add(1, Ordering::Relaxed);
+		}
+
+		fn rollback_transaction(&mut self, ty: TransactionType) {
+			assert_eq!(ty, TransactionType::Host);
+			self.0.rolled_back.fetch_add(1, Ordering::Relaxed);
+		}
+	}
+}
+
 #[test]
 fn ensure_transactional_works() {
 	const KEY: &[u8] = b"test";
 
 	let client = TestClientBuilder::new().build();
 	let best_hash = client.chain_info().best_hash;
+	let transaction_tester = Arc::new(TransactionTesterInner::default());
 
-	let runtime_api = client.runtime_api();
+	let mut runtime_api = client.runtime_api();
+	runtime_api.register_extension(TransactionTester(transaction_tester.clone()));
 	runtime_api.execute_in_transaction(|api| {
 		api.write_key_value(best_hash, KEY.to_vec(), vec![1, 2, 3], false).unwrap();
 
@@ -207,7 +244,8 @@ fn ensure_transactional_works() {
 		.unwrap();
 	assert_eq!(changes.main_storage_changes[0].1, Some(vec![1, 2, 3, 4]));
 
-	let runtime_api = client.runtime_api();
+	let mut runtime_api = client.runtime_api();
+	runtime_api.register_extension(TransactionTester(transaction_tester.clone()));
 	runtime_api.execute_in_transaction(|api| {
 		assert!(api.write_key_value(best_hash, KEY.to_vec(), vec![1, 2, 3], true).is_err());
 
@@ -218,4 +256,21 @@ fn ensure_transactional_works() {
 		.into_storage_changes(&client.state_at(best_hash).unwrap(), best_hash)
 		.unwrap();
 	assert_eq!(changes.main_storage_changes[0].1, Some(vec![1, 2, 3]));
+
+	let mut runtime_api = client.runtime_api();
+	runtime_api.register_extension(TransactionTester(transaction_tester.clone()));
+	runtime_api.execute_in_transaction(|api| {
+		assert!(api.write_key_value(best_hash, KEY.to_vec(), vec![1, 2], true).is_err());
+
+		TransactionOutcome::Rollback(())
+	});
+
+	let changes = runtime_api
+		.into_storage_changes(&client.state_at(best_hash).unwrap(), best_hash)
+		.unwrap();
+	assert!(changes.main_storage_changes.is_empty());
+
+	assert_eq!(transaction_tester.started.load(Ordering::Relaxed), 4);
+	assert_eq!(transaction_tester.committed.load(Ordering::Relaxed), 3);
+	assert_eq!(transaction_tester.rolled_back.load(Ordering::Relaxed), 1);
 }

--- a/substrate/primitives/externalities/src/extensions.rs
+++ b/substrate/primitives/externalities/src/extensions.rs
@@ -32,6 +32,27 @@ use core::{
 	ops::DerefMut,
 };
 
+/// Informs [`Extension`] about what type of transaction is started, committed or rolled back.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransactionType {
+	/// A transaction started by the host.
+	Host,
+	/// A transaction started by the runtime.
+	Runtime,
+}
+
+impl TransactionType {
+	/// Is `self` set to [`Self::Host`].
+	pub fn is_host(self) -> bool {
+		matches!(self, Self::Host)
+	}
+
+	/// Is `self` set to [`Self::Runtime`].
+	pub fn is_runtime(self) -> bool {
+		matches!(self, Self::Runtime)
+	}
+}
+
 /// Marker trait for types that should be registered as [`Externalities`](crate::Externalities)
 /// extension.
 ///
@@ -40,11 +61,26 @@ use core::{
 pub trait Extension: Send + 'static {
 	/// Return the extension as `&mut dyn Any`.
 	///
-	/// This is a trick to make the trait type castable into an `Any`.
+	/// This is a trick to make the trait type castable into an [`Any`].
 	fn as_mut_any(&mut self) -> &mut dyn Any;
 
 	/// Get the [`TypeId`] of this `Extension`.
 	fn type_id(&self) -> TypeId;
+
+	/// Start a transaction of type `ty`.
+	fn start_transaction(&mut self, ty: TransactionType) {
+		let _ty = ty;
+	}
+
+	/// Commit a transaction of type `ty`.
+	fn commit_transaction(&mut self, ty: TransactionType) {
+		let _ty = ty;
+	}
+
+	/// Rollback a transaction of type `ty`.
+	fn rollback_transaction(&mut self, ty: TransactionType) {
+		let _ty = ty;
+	}
 }
 
 impl Extension for Box<dyn Extension> {
@@ -54,6 +90,18 @@ impl Extension for Box<dyn Extension> {
 
 	fn type_id(&self) -> TypeId {
 		(**self).type_id()
+	}
+
+	fn start_transaction(&mut self, ty: TransactionType) {
+		(**self).start_transaction(ty);
+	}
+
+	fn commit_transaction(&mut self, ty: TransactionType) {
+		(**self).commit_transaction(ty);
+	}
+
+	fn rollback_transaction(&mut self, ty: TransactionType) {
+		(**self).rollback_transaction(ty);
 	}
 }
 
@@ -70,11 +118,37 @@ impl Extension for Box<dyn Extension> {
 ///     struct TestExt(String);
 /// }
 /// ```
+///
+/// The [`Extension`] trait provides hooks that are called when starting, committing or rolling back
+/// a transaction. These can be implemented with the macro as well:
+/// ```
+/// # use sp_externalities::decl_extension;
+/// decl_extension! {
+///     /// Some test extension
+///     struct TestExtWithCallback(String);
+///
+///     impl TestExtWithCallback {
+///         fn start_transaction(&mut self, ty: TransactionType) {
+///             // do something cool
+///         }
+///
+///         // The other methods `commit_transaction` and `rollback_transaction` can also
+///         // be implemented in the same way.
+///     }
+/// }
+/// ```
 #[macro_export]
 macro_rules! decl_extension {
 	(
 		$( #[ $attr:meta ] )*
 		$vis:vis struct $ext_name:ident ($inner:ty);
+		$(
+			impl $ext_name_impl:ident {
+				$(
+					$impls:tt
+				)*
+			}
+		)*
 	) => {
 		$( #[ $attr ] )*
 		$vis struct $ext_name (pub $inner);
@@ -87,6 +161,12 @@ macro_rules! decl_extension {
 			fn type_id(&self) -> core::any::TypeId {
 				core::any::Any::type_id(self)
 			}
+
+			$(
+				$(
+					$impls
+				)*
+			)*
 		}
 
 		impl core::ops::Deref for $ext_name {
@@ -219,6 +299,21 @@ impl Extensions {
 	/// instance found in `self`.
 	pub fn merge(&mut self, other: Self) {
 		self.extensions.extend(other.extensions);
+	}
+
+	/// Start a transaction of type `ty`.
+	pub fn start_transaction(&mut self, ty: TransactionType) {
+		self.extensions.values_mut().for_each(|e| e.start_transaction(ty));
+	}
+
+	/// Commit a transaction of type `ty`.
+	pub fn commit_transaction(&mut self, ty: TransactionType) {
+		self.extensions.values_mut().for_each(|e| e.commit_transaction(ty));
+	}
+
+	/// Rollback a transaction of type `ty`.
+	pub fn rollback_transaction(&mut self, ty: TransactionType) {
+		self.extensions.values_mut().for_each(|e| e.rollback_transaction(ty));
 	}
 }
 

--- a/substrate/primitives/externalities/src/lib.rs
+++ b/substrate/primitives/externalities/src/lib.rs
@@ -32,7 +32,7 @@ use core::any::{Any, TypeId};
 
 use sp_storage::{ChildInfo, StateVersion, TrackedStorageKey};
 
-pub use extensions::{Extension, ExtensionStore, Extensions};
+pub use extensions::{Extension, ExtensionStore, Extensions, TransactionType};
 pub use scope_limited::{set_and_run_with_externalities, with_externalities};
 
 mod extensions;

--- a/substrate/primitives/state-machine/src/ext.rs
+++ b/substrate/primitives/state-machine/src/ext.rs
@@ -29,7 +29,9 @@ use sp_core::hexdisplay::HexDisplay;
 use sp_core::storage::{
 	well_known_keys::is_child_storage_key, ChildInfo, StateVersion, TrackedStorageKey,
 };
-use sp_externalities::{Extension, ExtensionStore, Externalities, MultiRemovalResults};
+use sp_externalities::{
+	Extension, ExtensionStore, Externalities, MultiRemovalResults, TransactionType,
+};
 
 use crate::{trace, warn};
 use alloc::{boxed::Box, vec::Vec};
@@ -579,15 +581,34 @@ where
 	}
 
 	fn storage_start_transaction(&mut self) {
-		self.overlay.start_transaction()
+		self.overlay.start_transaction();
+
+		#[cfg(feature = "std")]
+		if let Some(exts) = self.extensions.as_mut() {
+			exts.start_transaction(TransactionType::Runtime);
+		}
 	}
 
 	fn storage_rollback_transaction(&mut self) -> Result<(), ()> {
-		self.overlay.rollback_transaction().map_err(|_| ())
+		self.overlay.rollback_transaction().map_err(|_| ())?;
+
+		#[cfg(feature = "std")]
+		if let Some(exts) = self.extensions.as_mut() {
+			exts.rollback_transaction(TransactionType::Runtime);
+		}
+
+		Ok(())
 	}
 
 	fn storage_commit_transaction(&mut self) -> Result<(), ()> {
-		self.overlay.commit_transaction().map_err(|_| ())
+		self.overlay.commit_transaction().map_err(|_| ())?;
+
+		#[cfg(feature = "std")]
+		if let Some(exts) = self.extensions.as_mut() {
+			exts.commit_transaction(TransactionType::Runtime);
+		}
+
+		Ok(())
 	}
 
 	fn wipe(&mut self) {

--- a/substrate/primitives/state-machine/src/overlayed_changes/mod.rs
+++ b/substrate/primitives/state-machine/src/overlayed_changes/mod.rs
@@ -31,11 +31,12 @@ use sp_core::{
 	storage::{well_known_keys::EXTRINSIC_INDEX, ChildInfo, StateVersion},
 };
 #[cfg(feature = "std")]
-use sp_externalities::{Extension, Extensions};
+use sp_externalities::{Extension, Extensions, TransactionType};
 use sp_trie::{empty_child_trie_root, LayoutV1};
 
 #[cfg(not(feature = "std"))]
 use alloc::collections::btree_map::BTreeMap as Map;
+use core::ops::DerefMut;
 #[cfg(feature = "std")]
 use std::collections::{hash_map::Entry as MapEntry, HashMap as Map};
 
@@ -817,6 +818,16 @@ pub enum OverlayedExtension<'a> {
 	Owned(Box<dyn Extension>),
 }
 
+#[cfg(feature = "std")]
+impl OverlayedExtension<'_> {
+	fn extension(&mut self) -> &mut dyn Extension {
+		match self {
+			Self::MutRef(ext) => *ext,
+			Self::Owned(ext) => &mut *ext,
+		}
+	}
+}
+
 /// Overlayed extensions which are sourced from [`Extensions`].
 ///
 /// The sourced extensions will be stored as mutable references,
@@ -869,6 +880,29 @@ impl<'a> OverlayedExtensions<'a> {
 	/// Returns `true` when there was an extension registered for the given `type_id`.
 	pub fn deregister(&mut self, type_id: TypeId) -> bool {
 		self.extensions.remove(&type_id).is_some()
+	}
+
+	/// Start a transaction.
+	///
+	/// The `ty` declares the type of transaction.
+	pub fn start_transaction(&mut self, ty: TransactionType) {
+		self.extensions.values_mut().for_each(|e| e.extension().start_transaction(ty));
+	}
+
+	/// Commit a transaction.
+	///
+	/// The `ty` declares the type of transaction.
+	pub fn commit_transaction(&mut self, ty: TransactionType) {
+		self.extensions.values_mut().for_each(|e| e.extension().commit_transaction(ty));
+	}
+
+	/// Rollback a transaction.
+	///
+	/// The `ty` declares the type of transaction.
+	pub fn rollback_transaction(&mut self, ty: TransactionType) {
+		self.extensions
+			.values_mut()
+			.for_each(|e| e.extension().rollback_transaction(ty));
 	}
 }
 

--- a/substrate/primitives/trie/src/lib.rs
+++ b/substrate/primitives/trie/src/lib.rs
@@ -188,6 +188,31 @@ pub trait TrieRecorderProvider<H: Hasher> {
 pub trait ProofSizeProvider {
 	/// Returns the storage proof size.
 	fn estimate_encoded_size(&self) -> usize;
+
+	/// Start a transaction.
+	///
+	/// `is_host` is set to `true` when the transaction was started by the host.
+	fn start_transaction(&mut self, is_host: bool) {
+		let _ = is_host;
+	}
+
+	/// Rollback the last transaction.
+	///
+	/// `is_host` is set to `true` when the transaction to rollback was started by the host.
+	///
+	/// If there is no active transaction, the call should be ignored.
+	fn rollback_transaction(&mut self, is_host: bool) {
+		let _ = is_host;
+	}
+
+	/// Commit the last transaction.
+	///
+	/// `is_host` is set to `true` when the transaction to commit was started by the host.
+	///
+	/// If there is no active transaction, the call should be ignored.
+	fn commit_transaction(&mut self, is_host: bool) {
+		let _ = is_host;
+	}
 }
 
 /// TrieDB error over `TrieConfiguration` trait.

--- a/substrate/primitives/trie/src/proof_size_extension.rs
+++ b/substrate/primitives/trie/src/proof_size_extension.rs
@@ -18,12 +18,29 @@
 //! Externalities extension that provides access to the current proof size
 //! of the underlying recorder.
 
+use parking_lot::Mutex;
+
 use crate::ProofSizeProvider;
+use std::{collections::VecDeque, sync::Arc};
 
 sp_externalities::decl_extension! {
 	/// The proof size extension to fetch the current storage proof size
 	/// in externalities.
 	pub struct ProofSizeExt(Box<dyn ProofSizeProvider + 'static + Sync + Send>);
+
+	impl ProofSizeExt {
+		fn start_transaction(&mut self, ty: sp_externalities::TransactionType) {
+			self.0.start_transaction(ty.is_host());
+		}
+
+		fn rollback_transaction(&mut self, ty: sp_externalities::TransactionType) {
+			self.0.rollback_transaction(ty.is_host());
+		}
+
+		fn commit_transaction(&mut self, ty: sp_externalities::TransactionType) {
+			self.0.commit_transaction(ty.is_host());
+		}
+	}
 }
 
 impl ProofSizeExt {
@@ -35,5 +52,431 @@ impl ProofSizeExt {
 	/// Returns the storage proof size.
 	pub fn storage_proof_size(&self) -> u64 {
 		self.0.estimate_encoded_size() as _
+	}
+}
+
+/// Proof size estimations as recorded by [`RecordingProofSizeProvider`].
+///
+/// Each item is the estimated proof size as observed when calling
+/// [`ProofSizeProvider::estimate_encoded_size`]. The items are ordered by t
+pub struct RecordedProofSizeEstimations(pub VecDeque<usize>);
+
+/// Inner structure of [`RecordingProofSizeProvider`].
+struct RecordingProofSizeProviderInner {
+	inner: Box<dyn ProofSizeProvider + Send + Sync>,
+	proof_size_estimations: Vec<Vec<usize>>,
+}
+
+/// An implementation of [`ProofSizeProvider`] that records the return value of the calls to
+/// [`ProofSizeProvider::estimate_encoded_size`].
+///
+/// Wraps an inner [`ProofSizeProvider`] that is used to get the actual encoded size estimations.
+/// Each estimation is recorded in the order it was observed.
+#[derive(Clone)]
+pub struct RecordingProofSizeProvider {
+	inner: Arc<Mutex<RecordingProofSizeProviderInner>>,
+}
+
+impl RecordingProofSizeProvider {
+	/// Creates a new instance of [`RecordingProofSizeProvider`].
+	pub fn new<T: ProofSizeProvider + Sync + Send + 'static>(recorder: T) -> Self {
+		Self {
+			inner: Arc::new(Mutex::new(RecordingProofSizeProviderInner {
+				inner: Box::new(recorder),
+				// Init the always existing transaction.
+				proof_size_estimations: vec![Vec::new()],
+			})),
+		}
+	}
+
+	/// Returns the recorded estimations returned by each call to
+	/// [`Self::estimate_encoded_size`].
+	pub fn recorded_estimations(&self) -> Vec<usize> {
+		self.inner.lock().proof_size_estimations.iter().flatten().copied().collect()
+	}
+}
+
+impl ProofSizeProvider for RecordingProofSizeProvider {
+	fn estimate_encoded_size(&self) -> usize {
+		let mut inner = self.inner.lock();
+
+		let estimation = inner.inner.estimate_encoded_size();
+
+		inner
+			.proof_size_estimations
+			.last_mut()
+			.expect("There is always at least one transaction open; qed")
+			.push(estimation);
+
+		estimation
+	}
+
+	fn start_transaction(&mut self, is_host: bool) {
+		// We don't care about runtime transactions, because they are part of the consensus critical
+		// path, that will always deterministically call this code.
+		if is_host {
+			self.inner.lock().proof_size_estimations.push(Default::default());
+		}
+	}
+
+	fn rollback_transaction(&mut self, is_host: bool) {
+		let mut inner = self.inner.lock();
+
+		// The host side transaction needs to be reverted, because this is only done when an
+		// entire execution is rolled back. So, the execution will never be part of the consensus
+		// critical path.
+		if is_host && inner.proof_size_estimations.len() > 1 {
+			inner.proof_size_estimations.pop();
+		}
+	}
+
+	fn commit_transaction(&mut self, is_host: bool) {
+		let mut inner = self.inner.lock();
+
+		if is_host && inner.proof_size_estimations.len() > 1 {
+			let last = inner
+				.proof_size_estimations
+				.pop()
+				.expect("There are more than one element in the vector; qed");
+
+			inner
+				.proof_size_estimations
+				.last_mut()
+				.expect("There are more than one element in the vector; qed")
+				.extend(last);
+		}
+	}
+}
+
+/// An implementation of [`ProofSizeProvider`] that replays estimations recorded by
+/// [`RecordingProofSizeProvider`].
+///
+/// The recorded estimations are removed as they are required by calls to
+/// [`Self::estimate_encoded_size`]. Will return `0` when all estimations are consumed.
+pub struct ReplayProofSizeProvider(Arc<Mutex<RecordedProofSizeEstimations>>);
+
+impl ReplayProofSizeProvider {
+	/// Creates a new instance from the given [`RecordedProofSizeEstimations`].
+	pub fn from_recorded(recorded: RecordedProofSizeEstimations) -> Self {
+		Self(Arc::new(Mutex::new(recorded)))
+	}
+}
+
+impl From<RecordedProofSizeEstimations> for ReplayProofSizeProvider {
+	fn from(value: RecordedProofSizeEstimations) -> Self {
+		Self::from_recorded(value)
+	}
+}
+
+impl ProofSizeProvider for ReplayProofSizeProvider {
+	fn estimate_encoded_size(&self) -> usize {
+		self.0.lock().0.pop_front().unwrap_or_default()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	// Mock ProofSizeProvider for testing
+	#[derive(Clone)]
+	struct MockProofSizeProvider {
+		size: Arc<AtomicUsize>,
+	}
+
+	impl MockProofSizeProvider {
+		fn new(initial_size: usize) -> Self {
+			Self { size: Arc::new(AtomicUsize::new(initial_size)) }
+		}
+
+		fn set_size(&self, new_size: usize) {
+			self.size.store(new_size, Ordering::Relaxed);
+		}
+	}
+
+	impl ProofSizeProvider for MockProofSizeProvider {
+		fn estimate_encoded_size(&self) -> usize {
+			self.size.load(Ordering::Relaxed)
+		}
+
+		fn start_transaction(&mut self, _is_host: bool) {}
+		fn rollback_transaction(&mut self, _is_host: bool) {}
+		fn commit_transaction(&mut self, _is_host: bool) {}
+	}
+
+	#[test]
+	fn recording_proof_size_provider_basic_functionality() {
+		let mock = MockProofSizeProvider::new(100);
+		let tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Initial state - no estimations recorded yet
+		assert_eq!(tracker.recorded_estimations(), Vec::<usize>::new());
+
+		// Call estimate_encoded_size and verify it's recorded
+		let size = tracker.estimate_encoded_size();
+		assert_eq!(size, 100);
+		assert_eq!(tracker.recorded_estimations(), vec![100]);
+
+		// Change the mock size and call again
+		mock.set_size(200);
+		let size = tracker.estimate_encoded_size();
+		assert_eq!(size, 200);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200]);
+
+		// Multiple calls with same size
+		let size = tracker.estimate_encoded_size();
+		assert_eq!(size, 200);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200, 200]);
+	}
+
+	#[test]
+	fn recording_proof_size_provider_host_transactions() {
+		let mock = MockProofSizeProvider::new(100);
+		let mut tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Record some estimations in the initial transaction
+		tracker.estimate_encoded_size();
+		tracker.estimate_encoded_size();
+		assert_eq!(tracker.recorded_estimations(), vec![100, 100]);
+
+		// Start a host transaction
+		tracker.start_transaction(true);
+		mock.set_size(200);
+		tracker.estimate_encoded_size();
+
+		// Should have 3 estimations total
+		assert_eq!(tracker.recorded_estimations(), vec![100, 100, 200]);
+
+		// Commit the host transaction
+		tracker.commit_transaction(true);
+
+		// All estimations should still be there
+		assert_eq!(tracker.recorded_estimations(), vec![100, 100, 200]);
+
+		// Add more estimations
+		mock.set_size(300);
+		tracker.estimate_encoded_size();
+		assert_eq!(tracker.recorded_estimations(), vec![100, 100, 200, 300]);
+	}
+
+	#[test]
+	fn recording_proof_size_provider_host_transaction_rollback() {
+		let mock = MockProofSizeProvider::new(100);
+		let mut tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Record some estimations in the initial transaction
+		tracker.estimate_encoded_size();
+		assert_eq!(tracker.recorded_estimations(), vec![100]);
+
+		// Start a host transaction
+		tracker.start_transaction(true);
+		mock.set_size(200);
+		tracker.estimate_encoded_size();
+		tracker.estimate_encoded_size();
+
+		// Should have 3 estimations total
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200, 200]);
+
+		// Rollback the host transaction
+		tracker.rollback_transaction(true);
+
+		// Should only have the original estimation
+		assert_eq!(tracker.recorded_estimations(), vec![100]);
+	}
+
+	#[test]
+	fn recording_proof_size_provider_runtime_transactions_ignored() {
+		let mock = MockProofSizeProvider::new(100);
+		let mut tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Record initial estimation
+		tracker.estimate_encoded_size();
+		assert_eq!(tracker.recorded_estimations(), vec![100]);
+
+		// Start a runtime transaction (is_host = false)
+		tracker.start_transaction(false);
+		mock.set_size(200);
+		tracker.estimate_encoded_size();
+
+		// Should have both estimations
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200]);
+
+		// Commit runtime transaction - should not affect recording
+		tracker.commit_transaction(false);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200]);
+
+		// Rollback runtime transaction - should not affect recording
+		tracker.rollback_transaction(false);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200]);
+	}
+
+	#[test]
+	fn recording_proof_size_provider_nested_host_transactions() {
+		let mock = MockProofSizeProvider::new(100);
+		let mut tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Initial estimation
+		tracker.estimate_encoded_size();
+		assert_eq!(tracker.recorded_estimations(), vec![100]);
+
+		// Start first host transaction
+		tracker.start_transaction(true);
+		mock.set_size(200);
+		tracker.estimate_encoded_size();
+
+		// Start nested host transaction
+		tracker.start_transaction(true);
+		mock.set_size(300);
+		tracker.estimate_encoded_size();
+
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200, 300]);
+
+		// Commit nested transaction
+		tracker.commit_transaction(true);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200, 300]);
+
+		// Commit outer transaction
+		tracker.commit_transaction(true);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200, 300]);
+	}
+
+	#[test]
+	fn recording_proof_size_provider_nested_host_transaction_rollback() {
+		let mock = MockProofSizeProvider::new(100);
+		let mut tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Initial estimation
+		tracker.estimate_encoded_size();
+
+		// Start first host transaction
+		tracker.start_transaction(true);
+		mock.set_size(200);
+		tracker.estimate_encoded_size();
+
+		// Start nested host transaction
+		tracker.start_transaction(true);
+		mock.set_size(300);
+		tracker.estimate_encoded_size();
+
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200, 300]);
+
+		// Rollback nested transaction
+		tracker.rollback_transaction(true);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 200]);
+
+		// Rollback outer transaction
+		tracker.rollback_transaction(true);
+		assert_eq!(tracker.recorded_estimations(), vec![100]);
+	}
+
+	#[test]
+	fn recording_proof_size_provider_rollback_on_base_transaction_does_nothing() {
+		let mock = MockProofSizeProvider::new(100);
+		let mut tracker = RecordingProofSizeProvider::new(mock.clone());
+
+		// Record some estimations
+		tracker.estimate_encoded_size();
+		tracker.estimate_encoded_size();
+		assert_eq!(tracker.recorded_estimations(), vec![100, 100]);
+
+		// Try to rollback the base transaction - should do nothing
+		tracker.rollback_transaction(true);
+		assert_eq!(tracker.recorded_estimations(), vec![100, 100]);
+	}
+
+	#[test]
+	fn recorded_proof_size_estimations_struct() {
+		let estimations = vec![100, 200, 300];
+		let recorded = RecordedProofSizeEstimations(estimations.into());
+		let expected: VecDeque<usize> = vec![100, 200, 300].into();
+		assert_eq!(recorded.0, expected);
+	}
+
+	#[test]
+	fn replay_proof_size_provider_basic_functionality() {
+		let estimations = vec![100, 200, 300, 150];
+		let recorded = RecordedProofSizeEstimations(estimations.into());
+		let replay = ReplayProofSizeProvider::from_recorded(recorded);
+
+		// Should replay estimations in order
+		assert_eq!(replay.estimate_encoded_size(), 100);
+		assert_eq!(replay.estimate_encoded_size(), 200);
+		assert_eq!(replay.estimate_encoded_size(), 300);
+		assert_eq!(replay.estimate_encoded_size(), 150);
+	}
+
+	#[test]
+	fn replay_proof_size_provider_exhausted_returns_zero() {
+		let estimations = vec![100, 200];
+		let recorded = RecordedProofSizeEstimations(estimations.into());
+		let replay = ReplayProofSizeProvider::from_recorded(recorded);
+
+		// Consume all estimations
+		assert_eq!(replay.estimate_encoded_size(), 100);
+		assert_eq!(replay.estimate_encoded_size(), 200);
+
+		// Should return 0 when exhausted
+		assert_eq!(replay.estimate_encoded_size(), 0);
+		assert_eq!(replay.estimate_encoded_size(), 0);
+	}
+
+	#[test]
+	fn replay_proof_size_provider_empty_returns_zero() {
+		let recorded = RecordedProofSizeEstimations(VecDeque::new());
+		let replay = ReplayProofSizeProvider::from_recorded(recorded);
+
+		// Should return 0 for empty estimations
+		assert_eq!(replay.estimate_encoded_size(), 0);
+		assert_eq!(replay.estimate_encoded_size(), 0);
+	}
+
+	#[test]
+	fn replay_proof_size_provider_from_trait() {
+		let estimations = vec![42, 84];
+		let recorded = RecordedProofSizeEstimations(estimations.into());
+		let replay: ReplayProofSizeProvider = recorded.into();
+
+		assert_eq!(replay.estimate_encoded_size(), 42);
+		assert_eq!(replay.estimate_encoded_size(), 84);
+		assert_eq!(replay.estimate_encoded_size(), 0);
+	}
+
+	#[test]
+	fn record_and_replay_integration() {
+		let mock = MockProofSizeProvider::new(100);
+		let recorder = RecordingProofSizeProvider::new(mock.clone());
+
+		// Record some estimations
+		// recorder.estimate_encoded_size();
+		mock.set_size(200);
+		recorder.estimate_encoded_size();
+		mock.set_size(300);
+		recorder.estimate_encoded_size();
+
+		// Get recorded estimations
+		let recorded_estimations = recorder.recorded_estimations();
+		assert_eq!(recorded_estimations, vec![100, 200, 300]);
+
+		// Create replay provider from recorded estimations
+		let recorded = RecordedProofSizeEstimations(recorded_estimations.into());
+		let replay = ReplayProofSizeProvider::from_recorded(recorded);
+
+		// Replay should return the same sequence
+		assert_eq!(replay.estimate_encoded_size(), 100);
+		assert_eq!(replay.estimate_encoded_size(), 200);
+		assert_eq!(replay.estimate_encoded_size(), 300);
+		assert_eq!(replay.estimate_encoded_size(), 0);
+	}
+
+	#[test]
+	fn replay_proof_size_provider_single_value() {
+		let estimations = vec![42];
+		let recorded = RecordedProofSizeEstimations(estimations.into());
+		let replay = ReplayProofSizeProvider::from_recorded(recorded);
+
+		// Should return the single value then default to 0
+		assert_eq!(replay.estimate_encoded_size(), 42);
+		assert_eq!(replay.estimate_encoded_size(), 0);
 	}
 }


### PR DESCRIPTION
The `ProofSizeExt` extension is used to serve the proof size to the runtime. It uses the proof recorder to request the current proof size. The `RecordingProofProvider` extension can record the calls to the proof size function. Later the `ReplayProofSizeProvider` can be used to replay these recorded proof sizes. So, the proof recorder is not required anymore.

Extensions are now also hooked into the transactional system. This means they are called when a new transaction is created and informed when a transaction is committed or reverted.

