### PR TITLE
feat: aura slot durations tracker

### DIFF
--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -70,7 +70,7 @@ use alloc::{vec, vec::Vec};
 use frame_support::{derive_impl, traits::OnRuntimeUpgrade, PalletId};
 use sp_api::{decl_runtime_apis, impl_runtime_apis};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{ConstBool, ConstU32, ConstU64, OpaqueMetadata};
+use sp_core::{ConstBool, ConstU32, Get, OpaqueMetadata};
 
 use sp_runtime::{
 	generic, impl_opaque_keys,
@@ -389,7 +389,21 @@ impl pallet_aura::Config for Runtime {
 	type AllowMultipleBlocksPerSlot = ConstBool<false>;
 	#[cfg(not(feature = "sync-backing"))]
 	type AllowMultipleBlocksPerSlot = ConstBool<true>;
-	type SlotDuration = ConstU64<SLOT_DURATION>;
+	type SlotDuration = TestRuntimeSlotDuration;
+}
+
+const HALVE_SLOT_DURATION_KEY: &[u8] = b"halve_slot_duration";
+
+pub struct TestRuntimeSlotDuration;
+
+impl Get<u64> for TestRuntimeSlotDuration {
+	fn get() -> u64 {
+		if sp_io::storage::get(HALVE_SLOT_DURATION_KEY).is_some() {
+			SLOT_DURATION / 2
+		} else {
+			SLOT_DURATION
+		}
+	}
 }
 
 impl test_pallet::Config for Runtime {}
@@ -519,7 +533,7 @@ impl_runtime_apis! {
 
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
 		fn slot_duration() -> sp_consensus_aura::SlotDuration {
-			sp_consensus_aura::SlotDuration::from_millis(SLOT_DURATION)
+			sp_consensus_aura::SlotDuration::from_millis(TestRuntimeSlotDuration::get())
 		}
 
 		fn authorities() -> Vec<AuraId> {

--- a/cumulus/test/runtime/src/test_pallet.rs
+++ b/cumulus/test/runtime/src/test_pallet.rs
@@ -23,7 +23,7 @@ pub const TEST_RUNTIME_UPGRADE_KEY: &[u8] = b"+test_runtime_upgrade_key+";
 
 #[frame_support::pallet(dev_mode)]
 pub mod pallet {
-	use crate::test_pallet::TEST_RUNTIME_UPGRADE_KEY;
+	use crate::{test_pallet::TEST_RUNTIME_UPGRADE_KEY, HALVE_SLOT_DURATION_KEY};
 	use alloc::vec;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
@@ -103,6 +103,13 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn remove_value_from_map(_: OriginFor<T>, key: u32) -> DispatchResult {
 			TestMap::<T>::remove(key);
+			Ok(())
+		}
+
+		/// Halves the slot duration for the test runtime.
+		#[pallet::weight(0)]
+		pub fn halve_slot_duration(_: OriginFor<T>) -> DispatchResult {
+			sp_io::storage::set(HALVE_SLOT_DURATION_KEY, &vec![0u8; 1]);
 			Ok(())
 		}
 	}

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/aura_slot_duration_change.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/aura_slot_duration_change.rs
@@ -1,0 +1,132 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use tokio::time::Duration;
+
+use crate::utils::{initialize_network, BEST_BLOCK_METRIC};
+
+use cumulus_zombienet_sdk_helpers::assert_para_throughput;
+use polkadot_primitives::Id as ParaId;
+use zombienet_orchestrator::network::node::LogLineCountOptions;
+use zombienet_sdk::{
+	subxt::{self, dynamic::Value, OnlineClient, PolkadotConfig, SubstrateConfig},
+	subxt_signer::sr25519::dev,
+	NetworkConfig, NetworkConfigBuilder,
+};
+
+const PARA_ID: u32 = 2000;
+
+// This test makes sure that parachain nodes can keep synchronizing after the slot duration
+// changes.
+#[tokio::test(flavor = "multi_thread")]
+async fn aura_slot_duration_change() -> Result<(), anyhow::Error> {
+	let _ = env_logger::try_init_from_env(
+		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+	);
+
+	log::info!("Spawning network");
+	let config = build_network_config().await?;
+	let network = initialize_network(config).await?;
+
+	let relay_alice = network.get_node("alice")?;
+	let relay_client: OnlineClient<PolkadotConfig> = relay_alice.wait_client().await?;
+
+	log::info!("Ensuring parachain making progress");
+	assert_para_throughput(
+		&relay_client,
+		20,
+		[(ParaId::from(PARA_ID), 2..40)].into_iter().collect(),
+	)
+	.await?;
+
+	log::info!("Ensuring dave reports expected block height");
+	assert!(network
+		.get_node("dave")?
+		.wait_metric_with_timeout(BEST_BLOCK_METRIC, |b| b >= 7.0, 250u64)
+		.await
+		.is_ok());
+
+	// Change the slot duration.
+	log::info!("Submitting extrinsic to halve the slot duration");
+	let call = subxt::dynamic::tx("TestPallet", "halve_slot_duration", Vec::<Value>::new());
+	let charlie_client: OnlineClient<SubstrateConfig> =
+		network.get_node("charlie")?.wait_client().await?;
+	let res = charlie_client
+		.tx()
+		.sign_and_submit_then_watch_default(&call, &dev::alice())
+		.await;
+	assert!(res.is_ok(), "Extrinsic failed to submit: {:?}", res.unwrap_err());
+	res.unwrap().wait_for_finalized_success().await.unwrap();
+	log::info!("Extrinsic finalized");
+
+	log::info!("Ensuring dave reports expected block height after slot duration change");
+	assert!(network
+		.get_node("dave")?
+		.wait_metric_with_timeout(BEST_BLOCK_METRIC, |b| b >= 45.0, 250u64)
+		.await
+		.is_ok());
+
+	// Check that the slot duration change was correctly detected.
+	let result = network
+		.get_node("dave")?
+		.wait_log_line_count_with_timeout(
+			"Slot duration changed from 6000ms to 3000ms",
+			false,
+			LogLineCountOptions::new(|n| n == 1, Duration::from_secs(0), false),
+		)
+		.await?;
+	assert!(result.success(), "Did not detect slot duration change");
+
+	Ok(())
+}
+
+async fn build_network_config() -> Result<NetworkConfig, anyhow::Error> {
+	// images are not relevant for `native`, but we leave it here in case we use `k8s` some day
+	let images = zombienet_sdk::environment::get_images_from_env();
+	log::info!("Using images: {images:?}");
+
+	// Network setup:
+	// - relaychain nodes:
+	// 	 - alice   - validator
+	// 	 - bob     - validator
+	// - parachain nodes
+	//   - charlie - validator
+	//   - dave    - full node; synchronizes only with charlie
+	let config = NetworkConfigBuilder::new()
+		.with_relaychain(|r| {
+			r.with_chain("rococo-local")
+				.with_default_command("polkadot")
+				.with_default_image(images.polkadot.as_str())
+				.with_default_args(vec![("-lparachain=debug").into()])
+				.with_node(|node| node.with_name("alice"))
+				.with_node(|node| node.with_name("bob"))
+		})
+		.with_parachain(|p| {
+			p.with_id(PARA_ID)
+				.with_default_command("test-parachain")
+				.with_default_image(images.cumulus.as_str())
+				.with_collator(|n| {
+					n.with_name("charlie")
+						.validator(true)
+						.with_args(vec![("-lparachain=debug").into()])
+				})
+				.with_collator(|n| {
+					n.with_name("dave").validator(false).with_args(vec![
+						("--reserved-only").into(),
+						("--reserved-nodes", "{{ZOMBIE:charlie:multiaddr}}").into(),
+					])
+				})
+		})
+		.with_global_settings(|global_settings| match std::env::var("ZOMBIENET_SDK_BASE_DIR") {
+			Ok(val) => global_settings.with_base_dir(val),
+			_ => global_settings,
+		})
+		.build()
+		.map_err(|e| {
+			let errs = e.into_iter().map(|e| e.to_string()).collect::<Vec<_>>().join(" ");
+			anyhow!("config errs: {errs}")
+		})?;
+
+	Ok(config)
+}

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/mod.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (C) Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
+mod aura_slot_duration_change;
 mod bootnodes;
 mod elastic_scaling;
 mod full_node_catching_up;

--- a/substrate/client/consensus/aura/src/authorities_tracker.rs
+++ b/substrate/client/consensus/aura/src/authorities_tracker.rs
@@ -125,7 +125,7 @@ where
 				format!("Could not find authorities for block {hash:?} at number {number}: {e}")
 			})?
 			.ok_or_else(|| {
-				format!("Authorities for block {hash:?} at number {number} not found in",)
+				format!("Authorities for block {hash:?} at number {number} not found in tracker")
 			})?;
 		Ok(node.data.clone())
 	}
@@ -168,9 +168,7 @@ where
 
 		self.authorities
 			.write()
-			.import(hash, number, authorities, &|_, _| {
-				Ok::<_, fork_tree::Error<sp_blockchain::Error>>(true)
-			})
+			.import(hash, number, authorities, &|_, _| Ok::<_, sp_blockchain::Error>(true))
 			.map_err(|e| {
 				format!("Could not import authorities for block {hash:?} at number {number}: {e}")
 			})?;
@@ -184,7 +182,7 @@ where
 		let mut authorities_cache = self.authorities.write();
 		let _pruned = authorities_cache
 			.prune(&info.finalized_hash, &info.finalized_number, &is_descendent_of, &|_| true)
-			.map_err(|e| e.to_string())?;
+			.map_err(|e| format!("Failed to prune finalized in authorities tracker: {e:?}"))?;
 		Ok(())
 	}
 }

--- a/substrate/client/consensus/aura/src/lib.rs
+++ b/substrate/client/consensus/aura/src/lib.rs
@@ -54,6 +54,7 @@ use sp_runtime::traits::{Block as BlockT, Header, Member, NumberFor};
 
 mod authorities_tracker;
 mod import_queue;
+mod slot_duration_tracker;
 pub mod standalone;
 
 pub use crate::standalone::{find_pre_digest, slot_duration};
@@ -63,6 +64,7 @@ pub use import_queue::{
 	ImportQueueParams,
 };
 pub use sc_consensus_slots::SlotProportion;
+pub use slot_duration_tracker::SlotDurationTracker;
 pub use sp_consensus::SyncOracle;
 pub use sp_consensus_aura::{
 	digests::CompatibleDigestItem,

--- a/substrate/client/consensus/aura/src/slot_duration_tracker.rs
+++ b/substrate/client/consensus/aura/src/slot_duration_tracker.rs
@@ -1,0 +1,202 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Module implementing the logic for verifying and importing AuRa blocks.
+
+use std::{fmt::Debug, sync::Arc};
+
+use codec::Codec;
+use fork_tree::ForkTree;
+use parking_lot::RwLock;
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::{HeaderBackend, HeaderMetadata};
+use sp_consensus_aura::{AuraApi, SlotDuration};
+use sp_core::Pair;
+use sp_runtime::traits::{Block, Header, NumberFor};
+
+use crate::AuthorityId;
+
+/// AURA slot duration tracker. Updates slot duration based on information from the runtime.
+pub struct SlotDurationTracker<P, B: Block, C> {
+	slot_durations: RwLock<ForkTree<B::Hash, NumberFor<B>, SlotDuration>>,
+	client: Arc<C>,
+	_phantom: std::marker::PhantomData<P>,
+}
+
+impl<P: Pair, B: Block, C> SlotDurationTracker<P, B, C>
+where
+	C: HeaderBackend<B> + HeaderMetadata<B, Error = sp_blockchain::Error> + ProvideRuntimeApi<B>,
+	P::Public: Codec + Debug,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+{
+	/// Create a new `SlotDurationTracker`.
+	pub fn new(client: Arc<C>) -> Result<Self, String> {
+		let finalized_hash = client.info().finalized_hash;
+		let mut slot_durations = ForkTree::new();
+		for mut hash in
+			client.leaf_hashes().map_err(|e| format!("Could not get leaf hashes: {e}"))?
+		{
+			// Import the entire chain back to the first imported ancestor, or to the last finalized
+			// block if there is no imported ancestor. The chain must be imported in order, from
+			// first block to last.
+			let mut chain = Vec::new();
+			loop {
+				let header = client
+					.header(hash)
+					.map_err(|e| format!("Could not get header for {hash:?}: {e}"))?
+					.ok_or_else(|| format!("Header for {hash:?} not found"))?;
+				let number = *header.number();
+				let is_descendent_of = sc_client_api::utils::is_descendent_of(&*client, None);
+				let existing_node = slot_durations
+					.find_node_where(&hash, &number, &is_descendent_of, &|_| true)
+					.map_err(|e| {
+						format!("Could not find slot duration for block {hash:?} at number {number}: {e}")
+					})?;
+				if existing_node.is_some() {
+					// We have already imported this part of the chain.
+					break;
+				}
+				chain.push((number, hash));
+				if hash == finalized_hash {
+					break;
+				}
+				hash = *header.parent_hash();
+			}
+			let mut last_imported_slot_duration = None;
+			for (number, hash) in chain.into_iter().rev() {
+				let slot_duration = client.runtime_api().slot_duration(hash).map_err(|e| {
+					format!("Could not get slot duration from runtime at {hash:?}: {e}")
+				})?;
+				if Some(&slot_duration) != last_imported_slot_duration.as_ref() {
+					last_imported_slot_duration = Some(slot_duration.clone());
+					let is_descendent_of = sc_client_api::utils::is_descendent_of(&*client, None);
+					slot_durations.import(hash, number, slot_duration, &is_descendent_of).map_err(
+						|e| {
+							format!("Could not import slot duration for block {hash:?} at number {number}: {e}")
+						},
+					)?;
+				}
+			}
+		}
+		Ok(Self {
+			slot_durations: RwLock::new(slot_durations),
+			client,
+			_phantom: std::marker::PhantomData,
+		})
+	}
+}
+
+impl<P, B, C> SlotDurationTracker<P, B, C>
+where
+	P: Pair,
+	B: Block,
+	C: HeaderBackend<B> + HeaderMetadata<B, Error = sp_blockchain::Error> + ProvideRuntimeApi<B>,
+	P::Public: Codec + Debug,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+{
+	/// Fetch the slot duration from the tracker, if available. If not available, return an error.
+	pub fn fetch(&self, header: &B::Header) -> Result<SlotDuration, String> {
+		let hash = header.hash();
+		let number = *header.number();
+		let parent_hash = *header.parent_hash();
+		let is_descendent_of =
+			sc_client_api::utils::is_descendent_of(&*self.client, Some((hash, parent_hash)));
+		Ok(self
+			.slot_durations
+			.read()
+			.find_node_where(&hash, &number, &is_descendent_of, &|_| true)
+			.map_err(|e| {
+				format!("Could not find slot duration for block {hash:?} at number {number}: {e}")
+			})?
+			.ok_or_else(|| {
+				format!("Slot duration for block {hash:?} at number {number} not found in tracker")
+			})?
+			.data
+			.clone())
+	}
+
+	/// Import the slot duration from the runtime for the given header.
+	pub fn import(
+		&self,
+		post_header: &B::Header,
+		import: SlotDurationImport,
+	) -> Result<(), String> {
+		let hash = post_header.hash();
+		let number = *post_header.number();
+		let parent_hash = *post_header.parent_hash();
+		let current_slot_duration = self.fetch(post_header).ok();
+		let new_slot_duration = self
+			.client
+			.runtime_api()
+			.slot_duration(hash)
+			.map_err(|e| format!("Could not get slot duration from runtime at {hash}: {e}"))?;
+		if Some(&new_slot_duration) == current_slot_duration.as_ref() {
+			// No change.
+			return Ok(());
+		}
+		log::info!(
+			"Slot duration changed from {} to {}ms",
+			current_slot_duration
+				.map(|d| format!("{}ms", d.as_millis()))
+				.unwrap_or_else(|| "unknown".to_string()),
+			new_slot_duration.as_millis(),
+		);
+		let result = match import {
+			SlotDurationImport::WithParent => {
+				self.prune_finalized()?;
+				let is_descendent_of = sc_client_api::utils::is_descendent_of(
+					&*self.client,
+					Some((hash, parent_hash)),
+				);
+				self.slot_durations.write().import(
+					hash,
+					number,
+					new_slot_duration,
+					&is_descendent_of,
+				)
+			},
+			SlotDurationImport::WithoutParent =>
+				self.slot_durations.write().import(hash, number, new_slot_duration, &|_, _| {
+					Ok::<_, sp_blockchain::Error>(true)
+				}),
+		};
+		result.map_err(|e| {
+			format!("Could not import slot duration for block {hash:?} at number {number}: {e}")
+		})?;
+		Ok(())
+	}
+
+	fn prune_finalized(&self) -> Result<(), String> {
+		let is_descendent_of = sc_client_api::utils::is_descendent_of(&*self.client, None);
+		let info = self.client.info();
+		let _pruned = self
+			.slot_durations
+			.write()
+			.prune(&info.finalized_hash, &info.finalized_number, &is_descendent_of, &|_| true)
+			.map_err(|e| format!("Failed to prune finalized in slot duration tracker: {e:?}"))?;
+		Ok(())
+	}
+}
+
+/// How to import slot durations.
+pub enum SlotDurationImport {
+	/// Assume that the parent of the current block is already imported.
+	WithParent,
+	/// Do not assume that the parent of the current block is already imported.
+	WithoutParent,
+}

--- a/templates/solochain/node/src/service.rs
+++ b/templates/solochain/node/src/service.rs
@@ -2,7 +2,7 @@
 
 use futures::FutureExt;
 use sc_client_api::{Backend, BlockBackend};
-use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
+use sc_consensus_aura::{ImportQueueParams, SlotDurationTracker, SlotProportion, StartAuraParams};
 use sc_consensus_grandpa::SharedVoterState;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncConfig};
 use sc_telemetry::{Telemetry, TelemetryWorker};
@@ -83,29 +83,26 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		telemetry.as_ref().map(|x| x.handle()),
 	)?;
 
-	let cidp_client = client.clone();
+	let slot_duration_tracker = Arc::new(SlotDurationTracker::new(client.clone())?);
+
 	let import_queue =
 		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _>(ImportQueueParams {
 			block_import: grandpa_block_import.clone(),
 			justification_import: Some(Box::new(grandpa_block_import.clone())),
 			client: client.clone(),
-			create_inherent_data_providers: move |parent_hash, _| {
-				let cidp_client = cidp_client.clone();
-				async move {
-					let slot_duration = sc_consensus_aura::standalone::slot_duration_at(
-						&*cidp_client,
-						parent_hash,
-					)?;
-					let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+			slot_duration_tracker: slot_duration_tracker.clone(),
+			create_inherent_data_providers: move |_, header| {
+				let slot_duration_tracker = slot_duration_tracker.clone();
+				let slot_duration = slot_duration_tracker.fetch(&header)?;
+				let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
 
-					let slot =
+				let slot =
 						sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
 							*timestamp,
 							slot_duration,
 						);
 
-					Ok((slot, timestamp))
-				}
+				async move { Ok((slot, timestamp)) }
 			},
 			spawner: &task_manager.spawn_essential_handle(),
 			registry: config.prometheus_registry(),
@@ -122,7 +119,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, ServiceError> {
 		keystore_container,
 		select_chain,
 		transaction_pool,
-		other: (grandpa_block_import, grandpa_link, telemetry),
+		other: (aura_block_import, grandpa_link, telemetry),
 	})
 }
 


### PR DESCRIPTION
Similar to https://github.com/paritytech/polkadot-sdk/pull/9707, but for slot duration tracking rather than authorities. The point is to avoid runtime calls in the verifier. Adds a test which changes the aura slot duration dynamically.