### PR TITLE
add serialization support for dynamic_params macro and AggregateKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9172,6 +9172,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_pcg",
  "scale-info",
+ "serde",
  "serde_json",
  "sp-debug-derive 14.0.0",
  "static_assertions",

--- a/substrate/frame/parameters/Cargo.toml
+++ b/substrate/frame/parameters/Cargo.toml
@@ -12,7 +12,7 @@ codec = { features = ["max-encoded-len"], workspace = true }
 docify = { workspace = true }
 paste = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
-serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
+serde = { optional = true, workspace = true }
 
 frame-benchmarking = { optional = true, workspace = true }
 frame-support = { features = ["experimental"], workspace = true }
@@ -27,13 +27,15 @@ sp-io = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]
+serde = ["dep:serde"]
 std = [
 	"codec/std",
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
 	"scale-info/std",
-	"serde",
+	"serde?/std",
+	"serde?/derive",
 	"sp-core/std",
 	"sp-runtime/std",
 ]


### PR DESCRIPTION
# Description
This PR is attempt at #9714. 

## Review Notes

It adds conditional serialization support for `dynamic_params` macro by accepting a third argument as an expression `serializable = <bool>`. The parameter is made optional to ensure backward compatibility.

Apart from that, I have modified `pallet-parameters` with following changes:
1. Changes related to make `RuntimeParameters` serializable are behind `serde` feature.
2. The existing `serde` feature in `pallet-parameter` now is refactored as following: 
      a) `serde` crate is still optional but without default features and derive feature. 
      b) the default features (`std`) and `derive` features are enabled if `std` feature  of `pallet-parameters`.

I have not modified any runtime to enable `pallet-parameter`'s `serde` feature. Since due to feature unification it will be applied for every runtime and the substrate runtime contains few parameters which does not implement `Serialize`.

### TODO:
- [ ] Tests

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: ask maintainers to put the right label on your PR.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
