### PR TITLE
Log candidate_hash for more steps on the path of a collation

### DIFF
--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -143,8 +143,15 @@ impl CollationGenerationSubsystem {
 			Ok(FromOrchestra::Communication {
 				msg: CollationGenerationMessage::SubmitCollation(params),
 			}) => {
+				let relay_parent = params.relay_parent;
+				let pov_hash = params.collation.proof_of_validity.clone().into_compressed().hash();
 				if let Err(err) = self.handle_submit_collation(params, ctx).await {
-					gum::error!(target: LOG_TARGET, ?err, "Failed to submit collation");
+					gum::error!(
+						target: LOG_TARGET,
+						?relay_parent,
+						?pov_hash,
+						?err,
+						"Failed to submit collation");
 				}
 
 				false

--- a/polkadot/node/core/candidate-validation/src/lib.rs
+++ b/polkadot/node/core/candidate-validation/src/lib.rs
@@ -990,7 +990,7 @@ async fn validate_candidate_exhaustive(
 		},
 		Ok(res) =>
 			if res.head_data.hash() != candidate_receipt.descriptor.para_head() {
-				gum::info!(target: LOG_TARGET, ?para_id, "Invalid candidate (para_head)");
+				gum::info!(target: LOG_TARGET, candidate_hash = ?candidate_receipt.hash(), ?para_id, "Invalid candidate (para_head)");
 				Ok(ValidationResult::Invalid(InvalidCandidate::ParaHeadHashMismatch))
 			} else {
 				let committed_candidate_receipt = CommittedCandidateReceipt {

--- a/polkadot/node/core/dispute-coordinator/src/db/v1.rs
+++ b/polkadot/node/core/dispute-coordinator/src/db/v1.rs
@@ -167,7 +167,7 @@ impl Backend for DbBackend {
 					);
 				},
 				BackendWriteOp::WriteCandidateVotes(session, candidate_hash, votes) => {
-					gum::trace!(target: LOG_TARGET, ?session, "Writing candidate votes");
+					gum::trace!(target: LOG_TARGET, ?session, ?candidate_hash, "Writing candidate votes");
 					tx.put_vec(
 						self.config.col_dispute_data,
 						&candidate_votes_key(session, &candidate_hash),

--- a/polkadot/node/core/dispute-coordinator/src/initialized.rs
+++ b/polkadot/node/core/dispute-coordinator/src/initialized.rs
@@ -878,6 +878,7 @@ impl Initialized {
 						gum::debug!(
 							target: LOG_TARGET,
 							session_index,
+							?candidate_hash,
 							"No votes found for candidate",
 						);
 					}

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -875,18 +875,29 @@ async fn send_collation(
 	let relay_parent = request.relay_parent();
 	let peer_id = request.peer_id();
 	let candidate_hash = receipt.hash();
-
+	let head = parent_head_data.hash();
+	let pov_hash = pov.hash();
 	let result = Ok(request_v2::CollationFetchingResponse::CollationWithParentHeadData {
 		receipt,
 		pov,
 		parent_head_data,
 	});
 
+	let para_id = request.para_id();
+
 	let response =
 		OutgoingResponse { result, reputation_changes: Vec::new(), sent_feedback: Some(tx) };
 
 	if let Err(_) = request.send_outgoing_response(response) {
-		gum::warn!(target: LOG_TARGET, "Sending collation response failed");
+		gum::warn!(
+			target: LOG_TARGET,
+			?relay_parent,
+			?candidate_hash,
+			?para_id,
+			?pov_hash,
+			?head,
+			"Sending collation response failed"
+		);
 	}
 
 	state.active_collation_fetches.push(

--- a/polkadot/primitives/src/v9/mod.rs
+++ b/polkadot/primitives/src/v9/mod.rs
@@ -2180,7 +2180,7 @@ impl<H> CandidateReceiptV2<H> {
 		&self.descriptor
 	}
 
-	/// Computes the blake2-256 hash of the receipt.
+	/// Computes the blake2-256 hash (aka `candidate_hash`) of the receipt.
 	pub fn hash(&self) -> CandidateHash
 	where
 		H: Encode,

--- a/prdoc/pr_9979.prdoc
+++ b/prdoc/pr_9979.prdoc
@@ -1,0 +1,20 @@
+title: '[log]: Log the `candidate_hash` in more places in the lifecycle of a parablock'
+doc:
+- audience: Node Dev
+  description: |-
+    It is extremely convenient to have `candidate_hash` printed in the path of a parachain block, 
+    it makes following its life cycle so much easier.
+
+    This PR ensures to log `candidate_hash` of a collation in more places.
+    
+crates:
+- name: polkadot-collator-protocol
+  bump: patch
+- name: polkadot-primitives
+  bump: patch
+- name: polkadot-node-core-dispute-coordinator
+  bump: patch
+- name: polkadot-node-core-candidate-validation
+  bump: patch
+- name: polkadot-node-collation-generation
+  bump: patch


### PR DESCRIPTION
# Motivation
I'm working on [Investigating causes for sub 100 block confidence](https://github.com/paritytech/polkadot-sdk/issues/9344) and **a big part of that is looking into logs** and the path of parablocks. I've already improved logging in these PRs:
* #9920
* #9921 
* #9927

But there were a few more places relating to the path of a para block (collation) where we did not log the `candidate_hash`.

**It is extremely convenient to have `candidate_hash` printed in the path of a parachain block**, it makes following its life cycle so much easier.