### PR TITLE
pallet_revive: support uploading EVM bytecode via upload_code

### DIFF
--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -489,7 +489,7 @@ impl ExtBuilder {
 	}
 }
 
-fn initialize_block(number: u64) {
+pub fn initialize_block(number: u64) {
 	System::reset_events();
 	System::initialize(&number, &[0u8; 32].into(), &Default::default());
 }


### PR DESCRIPTION
Fixes https://github.com/paritytech/contract-issues/issues/182

Add support for EVM bytecode to the _upload_code_ extrinsic. Tests in issue https://github.com/paritytech/contract-issues/issues/182 send _hardhat_setCode_, which uses revive's upload_code API; this change makes that flow accept and store EVM bytecode.

Add a unit test that validates the new behavior.

Note: This PR targets the anp-dirty-node branch.