### PR TITLE
fix zombienet ci, remove merge_group listener

### DIFF
--- a/.github/workflows/zombienet_cumulus.yml
+++ b/.github/workflows/zombienet_cumulus.yml
@@ -23,7 +23,7 @@ on:
         description: "Run tests which names match this pattern (also flaky)"
         default: ""
         required: false
-  merge_group:
+
 concurrency:
   group: cumulus-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/zombienet_parachain-template.yml
+++ b/.github/workflows/zombienet_parachain-template.yml
@@ -23,7 +23,7 @@ on:
         description: "Run tests which names match this pattern (also flaky)"
         default: ""
         required: false
-  merge_group:
+
 concurrency:
   group: parachain-template-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/zombienet_polkadot.yml
+++ b/.github/workflows/zombienet_polkadot.yml
@@ -23,7 +23,7 @@ on:
         description: "Run tests which names match this pattern (also flaky)"
         default: ""
         required: false
-  merge_group:
+
 concurrency:
   group: polkadot-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/zombienet_substrate.yml
+++ b/.github/workflows/zombienet_substrate.yml
@@ -23,7 +23,7 @@ on:
         description: "Run tests which names match this pattern (also flaky)"
         default: ""
         required: false
-  merge_group:
+
 concurrency:
   group: substrate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Remove `merge_group` listener since the zombienet workflows are currently _call_ from the `build` job.
This was causing failures like:

https://github.com/paritytech/polkadot-sdk/actions/runs/18858082286/job/53810567441
https://github.com/paritytech/polkadot-sdk/actions/runs/18786371402/job/53605598204

Thx!