### PR TITLE
broker: include sale_id in SaleInitialized event (#6354)

### DIFF
--- a/substrate/frame/broker/src/lib.rs
+++ b/substrate/frame/broker/src/lib.rs
@@ -318,6 +318,9 @@ pub mod pallet {
 		},
 		/// A new sale has been initialized.
 		SaleInitialized {
+			/// Identifier of the sale period. This is the first timeslice (`region_begin`) for which
+			/// regions are being sold and uniquely identifies the sale.
+			sale_id: Timeslice,
 			/// The relay block number at which the sale will/did start.
 			sale_start: RelayBlockNumberOf<T>,
 			/// The length in relay chain blocks of the Leadin Period (where the price is

--- a/substrate/frame/broker/src/tick_impls.rs
+++ b/substrate/frame/broker/src/tick_impls.rs
@@ -267,6 +267,7 @@ impl<T: Config> Pallet<T> {
 		Self::renew_cores(&new_sale);
 
 		Self::deposit_event(Event::SaleInitialized {
+			sale_id: region_begin,
 			sale_start,
 			leadin_length,
 			start_price: Self::sale_price(&new_sale, now),


### PR DESCRIPTION
Adds sale_id: Timeslice to the SaleInitialized event and emits it as region_begin.\n\nRationale:\n- Consumers can uniquely identify the sale period via sale_id without reconstructing it.\n\nBreaking change:\n- Event schema change (SaleInitialized gains a new field). Downstream event matchers should be updated.\n\nChecklist:\n- [x] builds locally for pallet-broker\n\nResolves: #6354