### PR TITLE
refactor: pass Arc<SubstrateBlock> to update_latest

### DIFF
--- a/substrate/frame/revive/rpc/src/block_info_provider.rs
+++ b/substrate/frame/revive/rpc/src/block_info_provider.rs
@@ -30,7 +30,7 @@ use tokio::sync::RwLock;
 #[async_trait]
 pub trait BlockInfoProvider: Send + Sync {
 	/// Update the latest block
-	async fn update_latest(&self, block: SubstrateBlock, subscription_type: SubscriptionType);
+	async fn update_latest(&self, block: Arc<SubstrateBlock>, subscription_type: SubscriptionType);
 
 	/// Return the latest finalized block.
 	async fn latest_finalized_block(&self) -> Arc<SubstrateBlock>;
@@ -86,12 +86,12 @@ impl SubxtBlockInfoProvider {
 
 #[async_trait]
 impl BlockInfoProvider for SubxtBlockInfoProvider {
-	async fn update_latest(&self, block: SubstrateBlock, subscription_type: SubscriptionType) {
+	async fn update_latest(&self, block: Arc<SubstrateBlock>, subscription_type: SubscriptionType) {
 		let mut latest = match subscription_type {
 			SubscriptionType::FinalizedBlocks => self.latest_finalized_block.write().await,
 			SubscriptionType::BestBlocks => self.latest_block.write().await,
 		};
-		*latest = Arc::new(block);
+		*latest = block;
 	}
 
 	async fn latest_block(&self) -> Arc<SubstrateBlock> {
@@ -172,7 +172,7 @@ pub mod test {
 	impl BlockInfoProvider for MockBlockInfoProvider {
 		async fn update_latest(
 			&self,
-			_block: SubstrateBlock,
+			_block: Arc<SubstrateBlock>,
 			_subscription_type: SubscriptionType,
 		) {
 		}

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -365,7 +365,7 @@ impl Client {
 				.into_iter()
 				.unzip();
 
-			self.block_provider.update_latest(block, subscription_type).await;
+			self.block_provider.update_latest(Arc::new(block), subscription_type).await;
 			self.fee_history_provider.update_fee_history(&evm_block, &receipts).await;
 
 			// Only broadcast for best blocks to avoid duplicate notifications.


### PR DESCRIPTION
update_latest took ownership of the Substrateblock and wrapped it in Arc::new. During the rollback/revert operations a caller might try to update the latest block to a block obtained by block_by_number. If one of the "Best" or "Finalized" subscription is lagging this could make block_by_number to return an strong reference. This prevents the caller to update the best block since it will not be able to unwrap the strong reference.

Now we pass Arc directly, eliminating the unwrap/rewrap cycle.