### PR TITLE
ci: fix cargo-check-all-crate-macos

### DIFF
--- a/.github/workflows/tests-misc.yml
+++ b/.github/workflows/tests-misc.yml
@@ -14,10 +14,10 @@ concurrency:
 # Jobs in this workflow depend on each other, only for limiting peak amount of spawned workers
 
 jobs:
-  # isdraft:
-  #   uses: ./.github/workflows/reusable-isdraft.yml
+  isdraft:
+    uses: ./.github/workflows/reusable-isdraft.yml
   preflight:
-    # needs: isdraft
+    needs: isdraft
     uses: ./.github/workflows/reusable-preflight.yml
 
   # more information about this job can be found here:


### PR DESCRIPTION
Our mac runners have bash version 3.x, fixing by installing cargo manually.
fix https://github.com/paritytech/devops/issues/4514