### PR TITLE
frame-system: Only enable special benchmarking code when running in `no_std`

### DIFF
--- a/cumulus/pallets/parachain-system/src/tests.rs
+++ b/cumulus/pallets/parachain-system/src/tests.rs
@@ -1553,6 +1553,7 @@ fn receive_hrmp_many() {
 }
 
 #[test]
+#[cfg(not(feature = "runtime-benchmarks"))]
 fn upgrade_version_checks_should_work() {
 	use codec::Encode;
 	use sp_version::RuntimeVersion;

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2341,12 +2341,12 @@ impl<T: Config> Pallet<T> {
 			};
 
 			cfg_if::cfg_if! {
-				if #[cfg(all(feature = "runtime-benchmarks", not(test), not(feature = "std")))] {
+				if #[cfg(all(feature = "runtime-benchmarks", not(test)))] {
 					// Let's ensure the compiler doesn't optimize our fetching of the runtime version away.
 					core::hint::black_box((new_version, current_version));
 				} else {
 					if new_version.spec_name != current_version.spec_name {
-						return CanSetCodeResult::InvalidVersion( Error::<T>::InvalidSpecName)
+						return CanSetCodeResult::InvalidVersion(Error::<T>::InvalidSpecName)
 					}
 
 					if new_version.spec_version <= current_version.spec_version {


### PR DESCRIPTION
This fixes `cargo test -p cumulus-pallet-parachain-system --features runtime-benchmarks`


