### PR TITLE
docs(balances): fix broken links and correct trait name in README

### DIFF
--- a/substrate/frame/balances/README.md
+++ b/substrate/frame/balances/README.md
@@ -51,18 +51,14 @@ always operate over the same funds, so they "overlay" rather than "stack".
 
 The Balances module provides implementations for the following traits. If these traits provide the functionality that
 you need, then you can avoid coupling with the Balances module.
+> **Note:** The `Currency`, `ReservableCurrency`, and `LockableCurrency` traits are deprecated. New code should use the [`fungible`](https://docs.rs/frame-support/latest/frame_support/traits/tokens/fungible/index.html) traits instead.
 
-- [`Currency`](https://docs.rs/frame-support/latest/frame_support/traits/trait.Currency.html): Functions for dealing
-with a fungible assets system.
-- [`ReservableCurrency`](https://docs.rs/frame-support/latest/frame_support/traits/trait.ReservableCurrency.html):
-Functions for dealing with assets that can be reserved from an account.
-- [`LockableCurrency`](https://docs.rs/frame-support/latest/frame_support/traits/trait.LockableCurrency.html): Functions
-for dealing with accounts that allow liquidity restrictions.
-- [`Imbalance`](https://docs.rs/frame-support/latest/frame_support/traits/trait.Imbalance.html): Functions for handling
-imbalances between total issuance in the system and account balances. Must be used when a function creates new funds
-(e.g. a reward) or destroys some funds (e.g. a system fee).
-- [`IsDeadAccount`](https://docs.rs/frame-support/latest/frame_support/traits/trait.IsDeadAccount.html): Determiner to
-say whether a given account is unused.
+- [`Currency`](https://docs.rs/frame-support/latest/frame_support/traits/tokens/currency/trait.Currency.html) ⚠️ **Deprecated**: Functions for dealing with a fungible assets system.
+- [`ReservableCurrency`](https://docs.rs/frame-support/latest/frame_support/traits/tokens/currency/trait.ReservableCurrency.html) ⚠️ **Deprecated**: Functions for dealing with assets that can be reserved from an account.
+- [`LockableCurrency`](https://docs.rs/frame-support/latest/frame_support/traits/tokens/currency/trait.LockableCurrency.html) ⚠️ **Deprecated**: Functions for dealing with accounts that allow liquidity restrictions.
+- [`Imbalance`](https://docs.rs/frame-support/latest/frame_support/traits/tokens/imbalance/trait.Imbalance.html): Functions for handling imbalances between total issuance in the system and account balances. Must be used when a function creates new funds (e.g. a reward) or destroys some funds (e.g. a system fee).
+- [`OnKilledAccount`](https://docs.rs/frame-support/latest/frame_support/traits/trait.OnKilledAccount.html): Hook that gets called when an account is killed/reaped (removed from the system).
+
 
 ## Interface
 


### PR DESCRIPTION
# Description

Fixes broken documentation links in the Balances module README and corrects the trait name from `IsDeadAccount` (which doesn't exist) to `OnKilledAccount` (the correct trait). Also adds deprecation warnings for Currency-related traits to guide developers to use the newer `fungible` traits instead.

## Integration

No integration needed - this is a documentation-only change. The `R0-no-crate-publish-required` label applies to this PR.

## Review Notes

This PR fixes documentation issues in `substrate/frame/balances/README.md`:

- **Fixed broken links**: Added proper markdown links with URLs to trait documentation (e.g., `[Currency](https://docs.rs/frame-support/...)`)
- **Corrected trait name**: Changed `IsDeadAccount` → `OnKilledAccount`. Verified that `OnKilledAccount` is the correct trait name  and `IsDeadAccount` does not exist in the codebase
- **Added deprecation warnings**: Added deprecation notices (⚠️ **Deprecated**) for `Currency`, `ReservableCurrency`, and `LockableCurrency` traits with a note directing developers to use the [`fungible`](https://docs.rs/frame-support/latest/frame_support/traits/tokens/fungible/index.html) traits instead

No code changes, only documentation improvements.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required)
    * External contributors: Use `/cmd label <label-name>` to add labels
    * Maintainers can also add labels manually
* [x] I have made corresponding changes to the documentation (if applicable)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)