### PR TITLE
Disable `experimental-collator-protocol` by default

### DIFF
--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -31,16 +31,13 @@ polkadot-node-subsystem-util = { workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }
 thiserror = { workspace = true }
 tokio-util = { workspace = true }
-# "tokio" and "sc-network-types" should have really been dev-dependencies but clippy is complaining that it's not used with
-# experimental-collator-protocol disabled, while the rust compiler claims that having optional
-# dev-dependencies is not possible.
-sc-network-types = { workspace = true, default-features = true }
-tokio = { features = ["macros"], workspace = true, default-features = true, optional = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
 rstest = { workspace = true }
+sc-network-types = { workspace = true, default-features = true }
 sp-tracing = { workspace = true }
+tokio = { features = ["macros"], workspace = true, default-features = true }
 
 codec = { features = ["std"], workspace = true, default-features = true }
 sc-keystore = { workspace = true, default-features = true }
@@ -53,6 +50,8 @@ polkadot-node-subsystem-test-helpers = { workspace = true }
 polkadot-primitives-test-helpers = { workspace = true }
 
 [features]
-# This is only for testing purposes, don't commit.
-default = ["experimental-collator-protocol"]
-experimental-collator-protocol = ["async-trait", "tokio"]
+default = []
+experimental-collator-protocol = [
+	"async-trait",
+]
+experimental = ["experimental-collator-protocol"]

--- a/polkadot/node/network/collator-protocol/src/lib.rs
+++ b/polkadot/node/network/collator-protocol/src/lib.rs
@@ -21,6 +21,11 @@
 #![deny(unused_crate_dependencies)]
 #![recursion_limit = "256"]
 
+#[cfg(test)]
+use sc_network_types as _;
+#[cfg(test)]
+use tokio as _;
+
 use std::{
 	collections::HashSet,
 	time::{Duration, Instant},

--- a/polkadot/node/network/collator-protocol/src/validator_side/claim_queue_state/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/claim_queue_state/mod.rs
@@ -17,14 +17,17 @@
 //! Helper structs used for tracking the state of the claim queue over a set of relay blocks.
 //! Refer to [`ClaimQueueState`] and [`PerLeafClaimQueueState`] for more details.
 
+#[cfg(feature = "experimental-collator-protocol")]
 use std::collections::HashSet;
 
 use polkadot_primitives::{CandidateHash, Hash, Id as ParaId};
 
 mod basic;
+#[cfg(feature = "experimental-collator-protocol")]
 mod per_leaf;
 
 pub(crate) use basic::ClaimQueueState;
+#[cfg(feature = "experimental-collator-protocol")]
 pub(crate) use per_leaf::PerLeafClaimQueueState;
 
 /// Represents the state of a claim.
@@ -37,18 +40,21 @@ enum ClaimState {
 	/// candidate hashes, but only about their number.
 	Pending(Option<CandidateHash>),
 	/// The candidate is seconded.
+	#[cfg(feature = "experimental-collator-protocol")]
 	Seconded(CandidateHash),
 }
 
 impl ClaimState {
 	fn candidate_hash(&self) -> Option<&CandidateHash> {
 		match self {
-			ClaimState::Pending(Some(candidate)) | ClaimState::Seconded(candidate) =>
-				Some(candidate),
+			ClaimState::Pending(Some(candidate)) => Some(candidate),
+			#[cfg(feature = "experimental-collator-protocol")]
+			ClaimState::Seconded(candidate) => Some(candidate),
 			_ => None,
 		}
 	}
 
+	#[cfg(feature = "experimental-collator-protocol")]
 	fn clone_or_default(&self, known_candidates: &HashSet<CandidateHash>) -> Self {
 		match self {
 			ClaimState::Pending(Some(candidate)) | ClaimState::Seconded(candidate)

--- a/polkadot/node/network/collator-protocol/src/validator_side/error.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/error.rs
@@ -19,7 +19,9 @@ use futures::channel::oneshot;
 
 use polkadot_node_subsystem::RuntimeApiError;
 use polkadot_node_subsystem_util::backing_implicit_view;
-use polkadot_primitives::{CandidateDescriptorVersion, Hash};
+use polkadot_primitives::CandidateDescriptorVersion;
+#[cfg(feature = "experimental-collator-protocol")]
+use polkadot_primitives::Hash;
 
 /// General result.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -91,9 +93,11 @@ pub enum SecondingError {
 	#[error("Invalid candidate receipt version {0:?}")]
 	InvalidReceiptVersion(CandidateDescriptorVersion),
 
+	#[cfg(feature = "experimental-collator-protocol")]
 	#[error("ParaId doesn't match the advertisement")]
 	ParaIdMismatch,
 
+	#[cfg(feature = "experimental-collator-protocol")]
 	#[error("Collation seconding blocked on parent being seconded: {0}")]
 	BlockedOnParent(Hash),
 }
@@ -102,17 +106,18 @@ impl SecondingError {
 	/// Returns true if an error indicates that a peer is malicious.
 	pub fn is_malicious(&self) -> bool {
 		use SecondingError::*;
-		matches!(
-			self,
+		match self {
 			PersistedValidationDataMismatch |
-				CandidateHashMismatch |
-				RelayParentMismatch |
-				ParentHeadDataMismatch |
-				InvalidCoreIndex(_, _) |
-				InvalidSessionIndex(_, _) |
-				InvalidReceiptVersion(_) |
-				ParaIdMismatch
-		)
+			CandidateHashMismatch |
+			RelayParentMismatch |
+			ParentHeadDataMismatch |
+			InvalidCoreIndex(_, _) |
+			InvalidSessionIndex(_, _) |
+			InvalidReceiptVersion(_) => true,
+			#[cfg(feature = "experimental-collator-protocol")]
+			ParaIdMismatch => true,
+			_ => false,
+		}
 	}
 }
 

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -65,6 +65,7 @@ pub mod error;
 mod metrics;
 
 use claim_queue_state::ClaimQueueState;
+#[cfg(feature = "experimental-collator-protocol")]
 pub(crate) use claim_queue_state::PerLeafClaimQueueState;
 pub use collation::BlockedCollationId;
 use collation::{

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
@@ -14,10 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-// See reasoning in Cargo.toml why these temporary useless imports are needed.
-use sc_network_types as _;
-use tokio as _;
-
 mod collation_manager;
 mod common;
 mod error;

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -230,3 +230,8 @@ runtime-metrics = [
 	"rococo-runtime?/runtime-metrics",
 	"westend-runtime?/runtime-metrics",
 ]
+
+experimental-collator-protocol = [
+	"polkadot-collator-protocol/experimental-collator-protocol",
+]
+experimental = ["experimental-collator-protocol"]

--- a/polkadot/node/service/src/overseer.rs
+++ b/polkadot/node/service/src/overseer.rs
@@ -304,6 +304,14 @@ where
 					))),
 				IsParachainNode::No =>
 					if experimental_collator_protocol {
+						#[cfg(not(feature = "experimental-collator-protocol"))]
+						return Err(Error::Overseer(SubsystemError::Context(
+							"The node has to be built with the `experimental-collator-protocol` \
+								feature enabled"
+								.to_owned(),
+						)));
+
+						#[cfg(feature = "experimental-collator-protocol")]
 						ProtocolSide::ValidatorExperimental {
 							keystore: keystore.clone(),
 							metrics: Metrics::register(registry)?,

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -548,7 +548,9 @@ experimental = [
 	"frame-support-procedural?/experimental",
 	"frame-support?/experimental",
 	"frame-system?/experimental",
+	"polkadot-collator-protocol?/experimental",
 	"polkadot-sdk-frame?/experimental",
+	"polkadot-service?/experimental",
 ]
 with-tracing = [
 	"frame-executive?/with-tracing",


### PR DESCRIPTION
Disable the `experimental-collator-protocol` feature flag by default for `polkadot-collator-protocol` while continuing to run the unit tests in the CI