### PR TITLE
Do not send both `assign_cores` calls in parallel

### DIFF
--- a/cumulus/zombienet/zombienet-sdk-helpers/src/lib.rs
+++ b/cumulus/zombienet/zombienet-sdk-helpers/src/lib.rs
@@ -462,7 +462,7 @@ pub async fn assert_para_is_registered(
 /// To assign these extra `2` cores, the call would look like this:
 ///
 /// ```ignore
-/// assign_core(&relay_client, PARA_ID, vec![0, 1])
+/// assign_cores(&relay_client, PARA_ID, vec![0, 1])
 /// ```
 ///
 /// The cores `2` and `3` are assigned to the parachains by Zombienet.

--- a/polkadot/zombienet-sdk-tests/tests/elastic_scaling/slot_based_3cores.rs
+++ b/polkadot/zombienet-sdk-tests/tests/elastic_scaling/slot_based_3cores.rs
@@ -92,12 +92,10 @@ async fn slot_based_3cores_test() -> Result<(), anyhow::Error> {
 	let relay_client: OnlineClient<PolkadotConfig> = relay_node.wait_client().await?;
 
 	// Assign two extra cores to each parachain.
-	let (r1, r2) = tokio::join!(
-		assign_cores(&relay_client, 2100, vec![0, 1]),
-		assign_cores(&relay_client, 2200, vec![2, 3])
-	);
-	r1?;
-	r2?;
+	// We need to execute both call one after another to ensure that the internal logic fetches the
+	// correct nonce.
+	assign_cores(&relay_client, 2100, vec![0, 1]).await?;
+	assign_cores(&relay_client, 2200, vec![2, 3]).await?;
 
 	// Expect a backed candidate count of at least 39 for each parachain in 15 relay chain blocks
 	// (2.6 candidates per para per relay chain block).


### PR DESCRIPTION
The internal logic fetches the `nonce` of the sender and this will lead to both transaction using the same `nonce`. Ultimately this leads to the node rejecting one of the transactions because both transactions look like the same transaction to the node.

Closes: https://github.com/paritytech/polkadot-sdk/issues/10536