### PR TITLE
[cmd-bot] Use cmd-bot branch for script execution

### DIFF
--- a/.github/workflows/cmd-run.yml
+++ b/.github/workflows/cmd-run.yml
@@ -202,18 +202,10 @@ jobs:
           git config user.name "cmd[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # if the user is not an org member, we need to use the bot's path from master to avoid unwanted modifications
-          if [ "${IS_ORG_MEMBER}" = "true" ]; then
-            # safe to run commands from current branch
-            echo "Using current .github for cmd-bot scripts"
-            BOT_PATH=.github
-          else
-            # going to run commands from cmd-bot
-            echo "Using cmd-bot branch for cmd-bot scripts"
-            TMP_DIR=/tmp/polkadot-sdk
-            git clone --depth 1 --branch cmd-bot https://github.com/paritytech/polkadot-sdk $TMP_DIR
-            BOT_PATH=$TMP_DIR/.github
-          fi
+          echo "Using cmd-bot branch for cmd-bot scripts"
+          TMP_DIR=/tmp/polkadot-sdk
+          git clone --depth 1 --branch cmd-bot https://github.com/paritytech/polkadot-sdk $TMP_DIR
+          BOT_PATH=$TMP_DIR/.github
 
           # install deps and run a command from master
           python3 -m pip install -r $BOT_PATH/scripts/generate-prdoc.requirements.txt


### PR DESCRIPTION
PR changes behaviour of cmd-bot so it uses cmd-bot branch for cmd-bot scripts when an external contributor runs a command.

cc https://github.com/paritytech/polkadot-sdk/pull/10394
cc https://github.com/paritytech/devops/issues/4663