### PR TITLE
Allow to configure worst-case-processor in inbound queue plus refund

### DIFF
--- a/bridges/snowbridge/primitives/inbound-queue/src/v2/processor.rs
+++ b/bridges/snowbridge/primitives/inbound-queue/src/v2/processor.rs
@@ -33,10 +33,10 @@ where
 	fn process_message(
 		relayer: AccountId,
 		message: Message,
-	) -> Result<[u8; 32], MessageProcessorError> {
+	) -> Result<([u8; 32], Option<Weight>), MessageProcessorError> {
 		// Process the message and return its ID
 		let id = Self::process_xcm(relayer, message)?;
-		Ok(id)
+		Ok((id, None))
 	}
 }
 


### PR DESCRIPTION
# Description

This PR allows to configure a `worst_case_message_processor_weight` for `snowbridge-inbound-queue-v2`. In the case several processors are added, this allows to indicate the weight annotation to take the worst case, and refund the weight if the worst-case-processor has not been used.

For what is worth I added an optional weight parameter that `process_message` can return now. If set to None, this indicates the willingness of not correcting the annotated weight. If set to some weight, this weight will be used to refund the relayer for using the non-worst-case-processor.

The default implementation for `worst_case_message_processor_weight` is set 0 weight. This might be a valid use case for runtimes (like bridgehub) that have a single processor, and whose benchmark already indicates the worst_case.

