### PR TITLE
[stable2509] Make local repo sync as a separate step

### DIFF
--- a/.github/workflows/release-reusable-publish-packages.yml
+++ b/.github/workflows/release-reusable-publish-packages.yml
@@ -130,12 +130,10 @@ jobs:
           mkdir -p "$LOCAL_REPO_PATH/conf"
           cp ${{ github.workspace }}/.github/scripts/release/distributions "$LOCAL_REPO_PATH/conf/distributions"
 
-      - name: Sync repo, import keys, sign, and update metadata
+      - name: Sync local repo
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          PGP_KMS_KEY: ${{ secrets.PGP_KMS_KEY }}
-          PGP_KMS_HASH: ${{ secrets.PGP_KMS_HASH }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_RELEASE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_RELEASE_SECRET_ACCESS_KEY }}
         run: |
           # --- Sync Repo from S3 ---
           mkdir -p "$LOCAL_REPO_PATH"
@@ -146,7 +144,13 @@ jobs:
           elif [[ "${{ inputs.package_type }}" == "rpm" ]]; then
             aws s3 sync "$AWS_REPO_PATH" "$LOCAL_REPO_PATH" || true
           fi
-
+      - name: Add packages to local repo, sign, and update metadata
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          PGP_KMS_KEY: ${{ secrets.PGP_KMS_KEY }}
+          PGP_KMS_HASH: ${{ secrets.PGP_KMS_HASH }}
+        run: |
           . ./.github/scripts/common/lib.sh
           import_gpg_keys
 


### PR DESCRIPTION
Moving sync of the local deb/rpm repos to a separate step as it needs another AWS keys