### PR TITLE
pallet-referenda: Migrate from Currency reserves to fungible holds

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
@@ -88,7 +88,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
@@ -135,7 +135,7 @@ impl pallet_referenda::Config<AmbassadorReferendaInstance> for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	// A proposal can be submitted by a member of the Ambassador Program of
 	// [ranks::SENIOR_AMBASSADOR_TIER_3] rank or higher.
 	type SubmitOrigin = pallet_ranked_collective::EnsureMember<

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
@@ -80,7 +80,7 @@ impl pallet_referenda::Config<FellowshipReferendaInstance> for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	// Fellows can submit proposals.
 	type SubmitOrigin = EitherOf<
 		pallet_ranked_collective::EnsureMember<Runtime, FellowshipCollectiveInstance, 3>,

--- a/polkadot/runtime/rococo/src/governance/fellowship.rs
+++ b/polkadot/runtime/rococo/src/governance/fellowship.rs
@@ -299,7 +299,7 @@ impl pallet_referenda::Config<FellowshipReferendaInstance> for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	type SubmitOrigin =
 		pallet_ranked_collective::EnsureMember<Runtime, FellowshipCollectiveInstance, 1>;
 	type CancelOrigin = FellowshipExperts;

--- a/polkadot/runtime/rococo/src/governance/mod.rs
+++ b/polkadot/runtime/rococo/src/governance/mod.rs
@@ -79,7 +79,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;

--- a/polkadot/runtime/westend/src/governance/mod.rs
+++ b/polkadot/runtime/westend/src/governance/mod.rs
@@ -83,7 +83,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1051,7 +1051,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = pallet_balances::Pallet<Self>;
+	type NativeBalance = pallet_balances::Pallet<Self>;
 	type SubmitOrigin = EnsureSigned<AccountId>;
 	type CancelOrigin = EnsureRoot<AccountId>;
 	type KillOrigin = EnsureRoot<AccountId>;

--- a/substrate/frame/referenda/src/lib.rs
+++ b/substrate/frame/referenda/src/lib.rs
@@ -140,7 +140,7 @@ pub mod pallet {
 	/// A reason for holding funds.
 	/// Creates a hold reason for this pallet that is aggregated by `construct_runtime`.
 	#[pallet::composite_enum]
-	pub enum HoldReason {
+	pub enum HoldReason<I: 'static = ()> {
 		/// The account has deposited tokens to place a decision deposit.
 		DecisionDeposit,
 	}
@@ -174,8 +174,8 @@ pub mod pallet {
 		type NativeBalance: Inspect<Self::AccountId>
 			+ Mutate<Self::AccountId>
 			+ Balanced<Self::AccountId>
-			+ InspectHold<Self::AccountId, Reason: From<HoldReason>>
-			+ MutateHold<Self::AccountId, Reason: From<HoldReason>>;
+			+ InspectHold<Self::AccountId, Reason: From<HoldReason<I>>>
+			+ MutateHold<Self::AccountId, Reason: From<HoldReason<I>>>;
 		// Origins and unbalances.
 		/// Origin from which proposals may be submitted.
 		type SubmitOrigin: EnsureOriginWithArg<
@@ -1302,7 +1302,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		who: T::AccountId,
 		amount: BalanceOf<T, I>,
 	) -> Result<Deposit<T::AccountId, BalanceOf<T, I>>, DispatchError> {
-		T::NativeBalance::hold(&HoldReason::DecisionDeposit.into(), &who, amount)?;
+		T::NativeBalance::hold(&HoldReason::<I>::DecisionDeposit.into(), &who, amount)?;
 		Ok(Deposit { who, amount })
 	}
 
@@ -1312,7 +1312,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> Result<(), DispatchError> {
 		if let Some(Deposit { who, amount }) = deposit {
 			T::NativeBalance::release(
-				&HoldReason::DecisionDeposit.into(),
+				&HoldReason::<I>::DecisionDeposit.into(),
 				&who,
 				amount,
 				Precision::BestEffort,
@@ -1327,7 +1327,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> Result<(), DispatchError> {
 		if let Some(Deposit { who, amount }) = deposit {
 			T::NativeBalance::burn_held(
-				&HoldReason::DecisionDeposit.into(),
+				&HoldReason::<I>::DecisionDeposit.into(),
 				&who,
 				amount,
 				Precision::Exact,

--- a/substrate/frame/referenda/src/lib.rs
+++ b/substrate/frame/referenda/src/lib.rs
@@ -73,14 +73,14 @@ use frame_support::{
 	dispatch::DispatchResult,
 	ensure,
 	traits::{
+		fungible::{Balanced, Inspect, InspectHold, Mutate, MutateHold},
 		schedule::{
 			v3::{Anon as ScheduleAnon, Named as ScheduleNamed},
 			DispatchTime,
 		},
+		tokens::{Fortitude, Precision},
 		LockIdentifier, OnUnbalanced, OriginTrait, PollStatus, Polling, QueryPreimage,
 		StorePreimage, VoteTally,
-		fungible::{Balanced, Inspect, InspectHold, Mutate, MutateHold},
-		tokens::{Precision, Fortitude},
 	},
 	BoundedVec,
 };
@@ -99,11 +99,10 @@ use self::branch::{BeginDecidingBranch, OneFewerDecidingBranch, ServiceBranch};
 pub use self::{
 	pallet::*,
 	types::{
-		BalanceOf, BlockNumberFor, BoundedCallOf, CallOf, ConstTrackInfo, Curve, DecidingStatus,
-		DecidingStatusOf, Deposit, InsertSorted, DebtOf, PalletsOriginOf,
-		ReferendumIndex, ReferendumInfo, ReferendumInfoOf, ReferendumStatus, ReferendumStatusOf,
-		ScheduleAddressOf, StringLike, TallyOf, Track, TrackIdOf, TrackInfo, TrackInfoOf,
-		TracksInfo, VotesOf,
+		BalanceOf, BlockNumberFor, BoundedCallOf, CallOf, ConstTrackInfo, Curve, DebtOf,
+		DecidingStatus, DecidingStatusOf, Deposit, InsertSorted, PalletsOriginOf, ReferendumIndex,
+		ReferendumInfo, ReferendumInfoOf, ReferendumStatus, ReferendumStatusOf, ScheduleAddressOf,
+		StringLike, TallyOf, Track, TrackIdOf, TrackInfo, TrackInfoOf, TracksInfo, VotesOf,
 	},
 	weights::WeightInfo,
 };
@@ -1308,17 +1307,32 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	/// Return a deposit, if `Some`.
-	fn refund_deposit(deposit: Option<Deposit<T::AccountId, BalanceOf<T, I>>>) -> Result<(), DispatchError> {
+	fn refund_deposit(
+		deposit: Option<Deposit<T::AccountId, BalanceOf<T, I>>>,
+	) -> Result<(), DispatchError> {
 		if let Some(Deposit { who, amount }) = deposit {
-			T::NativeBalance::release(&HoldReason::DecisionDeposit.into(), &who, amount, Precision::BestEffort)?;
+			T::NativeBalance::release(
+				&HoldReason::DecisionDeposit.into(),
+				&who,
+				amount,
+				Precision::BestEffort,
+			)?;
 		}
 		Ok(())
 	}
 
 	/// Slash a deposit, if `Some`.
-	fn slash_deposit(deposit: Option<Deposit<T::AccountId, BalanceOf<T, I>>>) -> Result<(), DispatchError> {
+	fn slash_deposit(
+		deposit: Option<Deposit<T::AccountId, BalanceOf<T, I>>>,
+	) -> Result<(), DispatchError> {
 		if let Some(Deposit { who, amount }) = deposit {
-			T::NativeBalance::burn_held(&HoldReason::DecisionDeposit.into(), &who, amount, Precision::Exact, Fortitude::Force)?;
+			T::NativeBalance::burn_held(
+				&HoldReason::DecisionDeposit.into(),
+				&who,
+				amount,
+				Precision::Exact,
+				Fortitude::Force,
+			)?;
 			Self::deposit_event(Event::<T, I>::DepositSlashed { who, amount });
 		}
 		Ok(())

--- a/substrate/frame/referenda/src/lib.rs
+++ b/substrate/frame/referenda/src/lib.rs
@@ -1326,14 +1326,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		deposit: Option<Deposit<T::AccountId, BalanceOf<T, I>>>,
 	) -> Result<(), DispatchError> {
 		if let Some(Deposit { who, amount }) = deposit {
-			T::NativeBalance::burn_held(
+			let amount_burned = T::NativeBalance::burn_held(
 				&HoldReason::<I>::DecisionDeposit.into(),
 				&who,
 				amount,
-				Precision::Exact,
+				Precision::BestEffort,
 				Fortitude::Force,
 			)?;
-			Self::deposit_event(Event::<T, I>::DepositSlashed { who, amount });
+			Self::deposit_event(Event::<T, I>::DepositSlashed { who, amount: amount_burned });
 		}
 		Ok(())
 	}

--- a/substrate/frame/referenda/src/lib.rs
+++ b/substrate/frame/referenda/src/lib.rs
@@ -131,7 +131,7 @@ pub mod pallet {
 	};
 
 	/// The in-code storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]

--- a/substrate/frame/referenda/src/migration.rs
+++ b/substrate/frame/referenda/src/migration.rs
@@ -733,11 +733,6 @@ pub mod test {
 			// Verify storage version updated to 2
 			assert_eq!(Pallet::<T, ()>::on_chain_storage_version(), 2);
 
-			// Note: In modern pallet-balances, holds ARE reserves under the hood.
-			// After migration, the funds are held with HoldReason::DecisionDeposit,
-			// which means they still appear in reserved_balance (since holds use the reserved
-			// mechanism). The key change is that now they are TRACKED with a specific reason.
-
 			// Verify holds are now in place with the correct reason
 			let submitter_held = <Balances<T> as InspectHold<u64>>::balance_on_hold(
 				&HoldReason::DecisionDeposit.into(),

--- a/substrate/frame/referenda/src/migration.rs
+++ b/substrate/frame/referenda/src/migration.rs
@@ -470,8 +470,7 @@ pub mod v2_mbm {
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
 			let (pre_referendum_count, pre_deposit_count): (u32, u32) =
-				Decode::decode(&mut &state[..])
-					.expect("failed to decode pre_upgrade state");
+				Decode::decode(&mut &state[..]).expect("failed to decode pre_upgrade state");
 
 			// Verify referendum count unchanged
 			let post_referendum_count = ReferendumInfoFor::<T, I>::iter().count() as u32;
@@ -866,7 +865,9 @@ pub mod test {
 				// Should return InsufficientWeight error
 				assert!(matches!(
 					result,
-					Err(frame_support::migrations::SteppedMigrationError::InsufficientWeight { .. })
+					Err(
+						frame_support::migrations::SteppedMigrationError::InsufficientWeight { .. }
+					)
 				));
 			});
 		}

--- a/substrate/frame/referenda/src/mock.rs
+++ b/substrate/frame/referenda/src/mock.rs
@@ -196,7 +196,7 @@ impl Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = pallet_balances::Pallet<Self>;
+	type NativeBalance = pallet_balances::Pallet<Self>;
 	type SubmitOrigin = frame_system::EnsureSigned<u64>;
 	type CancelOrigin = EnsureSignedBy<Four, u64>;
 	type KillOrigin = EnsureRoot<u64>;

--- a/substrate/frame/referenda/src/tests.rs
+++ b/substrate/frame/referenda/src/tests.rs
@@ -426,7 +426,10 @@ fn decision_deposit_errors_work() {
 			h,
 			DispatchTime::At(10),
 		));
-		assert_noop!(Referenda::place_decision_deposit(RuntimeOrigin::signed(10), 0), TokenError::FundsUnavailable);
+		assert_noop!(
+			Referenda::place_decision_deposit(RuntimeOrigin::signed(10), 0),
+			TokenError::FundsUnavailable
+		);
 
 		assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(2), 0));
 		let e = Error::<Test>::HasDeposit;

--- a/substrate/frame/referenda/src/tests.rs
+++ b/substrate/frame/referenda/src/tests.rs
@@ -22,8 +22,7 @@ use crate::mock::{RefState::*, *};
 use assert_matches::assert_matches;
 use codec::Decode;
 use frame_support::{assert_noop, assert_ok, dispatch::RawOrigin, traits::Contains};
-use pallet_balances::Error as BalancesError;
-use sp_runtime::DispatchError::BadOrigin;
+use sp_runtime::{DispatchError::BadOrigin, TokenError};
 
 #[test]
 fn params_should_work() {
@@ -409,7 +408,7 @@ fn submit_errors_work() {
 				h,
 				DispatchTime::At(10),
 			),
-			BalancesError::<Test>::InsufficientBalance
+			TokenError::FundsUnavailable
 		);
 	});
 }
@@ -427,8 +426,7 @@ fn decision_deposit_errors_work() {
 			h,
 			DispatchTime::At(10),
 		));
-		let e = BalancesError::<Test>::InsufficientBalance;
-		assert_noop!(Referenda::place_decision_deposit(RuntimeOrigin::signed(10), 0), e);
+		assert_noop!(Referenda::place_decision_deposit(RuntimeOrigin::signed(10), 0), TokenError::FundsUnavailable);
 
 		assert_ok!(Referenda::place_decision_deposit(RuntimeOrigin::signed(2), 0));
 		let e = Error::<Test>::HasDeposit;

--- a/substrate/frame/referenda/src/types.rs
+++ b/substrate/frame/referenda/src/types.rs
@@ -22,7 +22,11 @@ use alloc::borrow::Cow;
 use codec::{Compact, Decode, DecodeWithMemTracking, Encode, EncodeLike, Input, MaxEncodedLen};
 use core::fmt::Debug;
 use frame_support::{
-	traits::{fungible::{Inspect, Debt}, schedule::v3::Anon, Bounded},
+	traits::{
+		fungible::{Debt, Inspect},
+		schedule::v3::Anon,
+		Bounded,
+	},
 	Parameter,
 };
 use scale_info::{Type, TypeInfo};
@@ -35,9 +39,8 @@ pub type BalanceOf<T, I = ()> =
 pub type BlockNumberFor<T, I> =
 	<<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
-	pub type DebtOf<T, I = ()> = Debt<
-    <T as frame_system::Config>::AccountId,
-    <T as Config<I>>::NativeBalance>;
+pub type DebtOf<T, I = ()> =
+	Debt<<T as frame_system::Config>::AccountId, <T as Config<I>>::NativeBalance>;
 pub type CallOf<T, I> = <T as Config<I>>::RuntimeCall;
 pub type BoundedCallOf<T, I> =
 	Bounded<<T as Config<I>>::RuntimeCall, <T as frame_system::Config>::Hashing>;

--- a/substrate/frame/referenda/src/types.rs
+++ b/substrate/frame/referenda/src/types.rs
@@ -22,7 +22,7 @@ use alloc::borrow::Cow;
 use codec::{Compact, Decode, DecodeWithMemTracking, Encode, EncodeLike, Input, MaxEncodedLen};
 use core::fmt::Debug;
 use frame_support::{
-	traits::{schedule::v3::Anon, Bounded},
+	traits::{fungible::{Inspect, Debt}, schedule::v3::Anon, Bounded},
 	Parameter,
 };
 use scale_info::{Type, TypeInfo};
@@ -30,14 +30,14 @@ use sp_arithmetic::{Rounding::*, SignedRounding::*};
 use sp_runtime::{FixedI64, PerThing};
 
 pub type BalanceOf<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+	<<T as Config<I>>::NativeBalance as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 
 pub type BlockNumberFor<T, I> =
 	<<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
-pub type NegativeImbalanceOf<T, I> = <<T as Config<I>>::Currency as Currency<
-	<T as frame_system::Config>::AccountId,
->>::NegativeImbalance;
+	pub type DebtOf<T, I = ()> = Debt<
+    <T as frame_system::Config>::AccountId,
+    <T as Config<I>>::NativeBalance>;
 pub type CallOf<T, I> = <T as Config<I>>::RuntimeCall;
 pub type BoundedCallOf<T, I> =
 	Bounded<<T as Config<I>>::RuntimeCall, <T as frame_system::Config>::Hashing>;

--- a/substrate/frame/staking-async/runtimes/parachain/src/governance/mod.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/governance/mod.rs
@@ -93,7 +93,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;

--- a/substrate/frame/staking-async/runtimes/rc/src/governance/mod.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/governance/mod.rs
@@ -83,7 +83,7 @@ impl pallet_referenda::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeEvent = RuntimeEvent;
 	type Scheduler = Scheduler;
-	type Currency = Balances;
+	type NativeBalance = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;


### PR DESCRIPTION
### Summary

This PR migrates `pallet-referenda` from the deprecated `Currency` trait with anonymous reserves to the modern `fungible` traits with typed holds, bumping the storage version from v1 to v2. This is part of the umbrella task  #226.

### Changes

#### Config Updates

- Replaced `Currency` with `NativeBalance` using the new fungible traits:
  - `fungible::Inspect`
  - `fungible::Mutate`
  - `fungible::Balanced`
  - `fungible::InspectHold`
  - `fungible::MutateHold`
- Added `HoldReason::DecisionDeposit` composite enum for tracking deposit holds with a specific reason

#### Storage Migration (v1 → v2)

Added `MigrateV1ToV2<T, I, OldCurrency>` migration that:

1. Iterates through all existing referenda (Ongoing, Approved, Rejected, Cancelled, TimedOut)
2. For each deposit (submission and decision deposits):
   - Unreserves the old anonymous reserved balance using the legacy `ReservableCurrency` trait
   - Places a new hold with `HoldReason::DecisionDeposit` using the new `MutateHold` trait
3. Updates storage version from 1 to 2

The migration gracefully handles edge cases:
- Skips execution if not on version 1
- Logs warnings if unreserve is incomplete
- Logs errors if hold placement fails
- Properly handles `Killed` referenda (no deposits to migrate)
- Includes `try-runtime` hooks for pre/post upgrade verification

#### Runtime Integration

To use this migration in your runtime:

```rust
pub type Migrations = (
    pallet_referenda::migration::v2::MigrateV1ToV2<Runtime, (), Balances>,
);
```

### Testing

Added comprehensive test coverage:
- `migration_v1_to_v2_works` - Tests full migration flow with multiple referendum types (Ongoing, Approved, TimedOut)
- `migration_v1_to_v2_skips_if_not_v1` - Verifies migration is skipped when not on version 1
- `migration_v1_to_v2_handles_killed_referendum` - Tests handling of killed referenda with no deposits

### Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [x] My PR follows the [labeling requirements](
https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process
) of this project (at minimum one label for `T` required)
    * External contributors: Use `/cmd label <label-name>` to add labels
    * Maintainers can also add labels manually
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
