### PR TITLE
ci: handle error in subsystem-benchmark

### DIFF
--- a/.github/workflows/benchmarks-subsystem.yml
+++ b/.github/workflows/benchmarks-subsystem.yml
@@ -66,7 +66,8 @@ jobs:
         id: run-benchmarks
         run: |
           forklift cargo bench -p ${{ matrix.features.name }} --bench ${{ matrix.features.bench }} --features subsystem-benchmarks || echo "error"
-          ls -lsa ./charts
+          # fails if file not found
+          ls -lsa ./charts | grep json
 
       - name: Upload artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
Add error handling to the benchmark run command.

сс https://github.com/paritytech/devops/issues/4746

cc @AndreiEres 
