### PR TITLE
add missing derive of DecodeWithMemTracking for types

### DIFF
--- a/prdoc/pr_10781.prdoc
+++ b/prdoc/pr_10781.prdoc
@@ -1,0 +1,10 @@
+title: 'Derive DecodeWithMemTracking'
+doc:
+  - audience: Runtime Dev
+    description: |-
+      - Derive `DecodeWithMemTracking` on structs
+crates:
+  - name: sp-core
+    bump: minor
+  - name: sp-mmr-primitives
+    bump: minor

--- a/substrate/primitives/core/src/sr25519.rs
+++ b/substrate/primitives/core/src/sr25519.rs
@@ -36,7 +36,7 @@ use schnorrkel::{
 };
 
 use crate::crypto::{CryptoType, CryptoTypeId, Derive, Public as TraitPublic, SignatureBytes};
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 #[cfg(all(not(feature = "std"), feature = "serde"))]
@@ -383,7 +383,9 @@ pub mod vrf {
 	}
 
 	/// VRF signature data
-	#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo)]
+	#[derive(
+		Clone, Debug, PartialEq, Eq, Encode, Decode, MaxEncodedLen, TypeInfo, DecodeWithMemTracking,
+	)]
 	pub struct VrfSignature {
 		/// VRF pre-output.
 		pub pre_output: VrfPreOutput,
@@ -422,6 +424,8 @@ pub mod vrf {
 		}
 	}
 
+	impl DecodeWithMemTracking for VrfPreOutput {}
+
 	/// VRF proof type suitable for schnorrkel operations.
 	#[derive(Clone, Debug, PartialEq, Eq)]
 	pub struct VrfProof(pub schnorrkel::vrf::VRFProof);
@@ -452,6 +456,8 @@ pub mod vrf {
 			Self::Identity::type_info()
 		}
 	}
+
+	impl DecodeWithMemTracking for VrfProof {}
 
 	#[cfg(feature = "full_crypto")]
 	impl VrfCrypto for Pair {

--- a/substrate/primitives/merkle-mountain-range/src/lib.rs
+++ b/substrate/primitives/merkle-mountain-range/src/lib.rs
@@ -144,7 +144,16 @@ impl FullLeaf for OpaqueLeaf {
 ///
 /// It is different from [`OpaqueLeaf`], because it does implement `Codec`
 /// and the encoding has to match raw `Vec<u8>` encoding.
-#[derive(codec::Encode, codec::Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
+#[derive(
+	codec::Encode,
+	codec::Decode,
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	TypeInfo,
+	codec::DecodeWithMemTracking,
+)]
 pub struct EncodableOpaqueLeaf(pub Vec<u8>);
 
 impl EncodableOpaqueLeaf {
@@ -351,7 +360,16 @@ impl_leaf_data_for_tuple!(A:0, B:1, C:2, D:3);
 impl_leaf_data_for_tuple!(A:0, B:1, C:2, D:3, E:4);
 
 /// An MMR proof data for a group of leaves.
-#[derive(codec::Encode, codec::Decode, Debug, Clone, PartialEq, Eq, TypeInfo)]
+#[derive(
+	codec::Encode,
+	codec::Decode,
+	Debug,
+	Clone,
+	PartialEq,
+	Eq,
+	TypeInfo,
+	codec::DecodeWithMemTracking,
+)]
 pub struct LeafProof<Hash> {
 	/// The indices of the leaves the proof is for.
 	pub leaf_indices: Vec<LeafIndex>,


### PR DESCRIPTION
Derive DecodeWithMemTracking for few more structs