### PR TITLE
statement-store: write global statement allowance in runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13910,6 +13910,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-statement-store",
+ "sp-storage 19.0.0",
 ]
 
 [[package]]

--- a/substrate/frame/statement/Cargo.toml
+++ b/substrate/frame/statement/Cargo.toml
@@ -25,6 +25,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-statement-store = { workspace = true }
+sp-storage = { workspace = true }
 
 [dev-dependencies]
 pallet-balances = { workspace = true, default-features = true }
@@ -43,6 +44,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-statement-store/std",
+	"sp-storage/std",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/substrate/frame/statement/src/lib.rs
+++ b/substrate/frame/statement/src/lib.rs
@@ -120,6 +120,27 @@ pub mod pallet {
 			log::trace!(target: LOG_TARGET, "Collecting statements at #{:?}", now);
 			Pallet::<T>::collect_statements();
 		}
+
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			use codec::Encode;
+			use sp_io;
+			use sp_storage::well_known_keys::STATEMENT_ALLOWANCE_GLOBAL;
+
+			let max_count: u32 = 100_000;
+			let max_size: u32 = 1_000_000;
+
+			let value = (max_count, max_size).encode();
+			sp_io::storage::set(STATEMENT_ALLOWANCE_GLOBAL, &value);
+
+			log::debug!(
+				target: LOG_TARGET,
+				"Wrote global statement allowance to well-known key: max_count={}, max_size={}",
+				max_count,
+				max_size
+			);
+
+			T::DbWeight::get().writes(1)
+		}
 	}
 }
 

--- a/substrate/primitives/storage/src/lib.rs
+++ b/substrate/primitives/storage/src/lib.rs
@@ -209,6 +209,11 @@ pub mod well_known_keys {
 	/// Encodes to `0x3a696e747261626c6f636b5f656e74726f7079`.
 	pub const INTRABLOCK_ENTROPY: &[u8] = b":intrablock_entropy";
 
+	/// Global statement allowance (max_count: u32, max_size: u32).
+	///
+	/// The value is SCALE-encoded as a tuple of two u32 values.
+	pub const STATEMENT_ALLOWANCE_GLOBAL: &[u8] = b":statement-allowance-global";
+
 	/// Prefix of child storage keys.
 	pub const CHILD_STORAGE_KEY_PREFIX: &[u8] = b":child_storage:";
 


### PR DESCRIPTION
# Description

Part of https://github.com/paritytech/polkadot-sdk/issues/10569

Adds runtime-side infrastructure for optimizing statement submission performance by writing statement allowances to well-known storage keys.

In the current phase we use a global allowance, but we'll switch to a per-account one further.

## Integration

This change is backward compatible and doesn't affect existing functionality

