### PR TITLE
Missing sign_with forward call

### DIFF
--- a/substrate/primitives/keystore/src/lib.rs
+++ b/substrate/primitives/keystore/src/lib.rs
@@ -677,6 +677,16 @@ impl<T: Keystore + ?Sized> Keystore for Arc<T> {
 	fn has_keys(&self, public_keys: &[(Vec<u8>, KeyTypeId)]) -> bool {
 		(**self).has_keys(public_keys)
 	}
+
+	fn sign_with(
+		&self,
+		id: KeyTypeId,
+		crypto_id: CryptoTypeId,
+		public: &[u8],
+		msg: &[u8],
+	) -> Result<Option<Vec<u8>>, Error> {
+		(**self).sign_with(id, crypto_id, public, msg)
+	}
 }
 
 /// A shared pointer to a keystore implementation.


### PR DESCRIPTION
As a follow-up of the discussion https://github.com/paritytech/polkadot-sdk/pull/8707#discussion_r2682026297, I am extracting a missing forward call to a separate PR so we can deliver it independently.

Context:
When keystore is used by some component (like BEEFY) via Arc, then calls of `sign_with` function are forwarded to default trait implementation. It is not working, when custom keystore with custom `sign_with` implementation is used.