### PR TITLE
Update `ci-unified` image to rust 1.92

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,1 +1,1 @@
-IMAGE="docker.io/paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202511141243"
+IMAGE="docker.io/paritytech/ci-unified:bullseye-1.92.0-2026-01-14-v202601151240"


### PR DESCRIPTION
`bullseye-1.92.0-2026-01-14-v202601151240`
- rust stable 1.92.0
- rust nightly 2026-01-14
- removed `xargo` ([error[E0308]: mismatched types](https://github.com/paritytech/dockerfiles/actions/runs/21002347518/job/60375509584#step:4:11602))

see [test PR](https://github.com/paritytech/polkadot-sdk/pull/10811) with workflow stopper disabled