### PR TITLE
pallet-assets-holder: improve hold availability.

### DIFF
--- a/substrate/frame/assets-holder/src/impl_fungibles.rs
+++ b/substrate/frame/assets-holder/src/impl_fungibles.rs
@@ -133,9 +133,9 @@ impl<T: Config<I>, I: 'static> InspectHold<T::AccountId> for Pallet<T, I> {
 			.unwrap_or_else(Zero::zero)
 	}
 
-	fn hold_available(asset: Self::AssetId, reason: &Self::Reason, who: &T::AccountId) -> bool {
-		pallet_assets::Account::<T, I>::contains_key(asset.clone(), who)
-	}
+	// fn hold_available(asset: Self::AssetId, reason: &Self::Reason, who: &T::AccountId) -> bool {
+	// 	pallet_assets::Account::<T, I>::contains_key(asset.clone(), who)
+	// }
 }
 
 impl<T: Config<I>, I: 'static> Unbalanced<T::AccountId> for Pallet<T, I> {


### PR DESCRIPTION
The default implementation of `hold_available` is true, but in our case we should ensure the account exists.

cc @muharem @pandres95 

But there is still some behavior which are not so great like `transfer_and_hold` with a precision best effort: you would expect that it would transfer, then hold at least the sent amount minus the minimum balance. But no because the implementation is:
https://github.com/paritytech/polkadot-sdk/blob/1e7f00e5b035826f0001b15ea9ba2b0dcdc91224/substrate/frame/support/src/traits/tokens/fungibles/hold.rs#L445-L465

The abstraction of those functions is always difficult to grasp to me, like here it says: transfer and hold, but actually it doesn't do something equivalent to a transfer and then a hold.