### PR TITLE
Fix flaky test `zombienet-polkadot-elastic-scaling-slot-based-3cores`

### DIFF
--- a/polkadot/zombienet-sdk-tests/tests/elastic_scaling/slot_based_3cores.rs
+++ b/polkadot/zombienet-sdk-tests/tests/elastic_scaling/slot_based_3cores.rs
@@ -102,7 +102,7 @@ async fn slot_based_3cores_test() -> Result<(), anyhow::Error> {
 	// Note that only blocks after the first session change and blocks that don't contain a session
 	// change will be counted.
 	// Since the calculated backed candidate count is theoretical and the CI tests are observed to
-	// occasionally fail, let's apply 10% tolerance to the expected range: 39 - 10% = 35
+	// occasionally fail, let's apply 12.5% tolerance to the expected range: 39 - 12.5% =~ 34
 	assert_para_throughput(
 		&relay_client,
 		15,


### PR DESCRIPTION
We had 4 failures in the last 90 runs of `zombienet-polkadot-elastic-scaling-slot-based-3cores` test where the assetion fails by `1` (34 blocks)


https://paritytech.github.io/zombienet-jobs-monitor/web/?search=based-3cores&mergeQueueOnly=true
<img width="1011" height="183" alt="image" src="https://github.com/user-attachments/assets/07123449-29a0-4f69-bc2d-9c3bc4b865ae" />

https://github.com/paritytech/polkadot-sdk/actions/runs/21035251168/job/60482637320
https://github.com/paritytech/polkadot-sdk/actions/runs/20923519106/job/60116752831
https://github.com/paritytech/polkadot-sdk/actions/runs/20432629082/job/58707838790
https://github.com/paritytech/polkadot-sdk/actions/runs/20264366293/job/58185559463

And since we already have some margin we can adjust to remove this flakyness.

ping @alindima  