### PR TITLE
Zombienet: Fix compilation, weight_required -> gas_required

### DIFF
--- a/polkadot/zombienet-sdk-tests/tests/parachains/weights.rs
+++ b/polkadot/zombienet-sdk-tests/tests/parachains/weights.rs
@@ -306,7 +306,7 @@ async fn instantiate_params(
 
 	// Make sure we have enough gas and multiply by 4, since without it the calls fail not enough
 	// gas.
-	Ok((dry_run.weight_required.ref_time * 4, dry_run.weight_required.proof_size * 4, deposit * 4))
+	Ok((dry_run.gas_required.ref_time * 4, dry_run.gas_required.proof_size * 4, deposit * 4))
 }
 
 async fn call_params(
@@ -323,7 +323,7 @@ async fn call_params(
 		StorageDeposit::Refund(_) => 0,
 	};
 
-	Ok((dry_run.weight_required.ref_time, dry_run.weight_required.proof_size, deposit))
+	Ok((dry_run.gas_required.ref_time, dry_run.gas_required.proof_size, deposit))
 }
 
 async fn call_contract(


### PR DESCRIPTION
Tried to compile zombienet-sdk tests locally, failed with an error.