### PR TITLE
[pallet-revive] Fix assertion message

### DIFF
--- a/substrate/frame/revive/src/migrations/v2.rs
+++ b/substrate/frame/revive/src/migrations/v2.rs
@@ -250,7 +250,7 @@ impl<T: Config> Migration<T> {
 				behaviour_version: old_code_info.behaviour_version,
 				code_type: BytecodeType::Pvm,
 			},
-			"Migration failed: deposit mismatch for key {code_hash:?}",
+			"Migration failed: CodeInfo mismatch for key {code_hash:?}",
 		);
 	}
 }


### PR DESCRIPTION
# Description
For below assertion, it looks like the message is inaccurate. the message always says "deposit mismatch" even when other fields fail (owner, refcount, code_len, etc.). This could be misleading.
```rust
assert_eq!(
			migrated,
			new::CodeInfo {
				owner: old_code_info.owner.clone(),
				deposit: old_code_info.deposit,
				refcount: old_code_info.refcount,
				code_len: old_code_info.code_len,
				behaviour_version: old_code_info.behaviour_version,
				code_type: BytecodeType::Pvm,
			},
			"Migration failed: deposit mismatch for key {code_hash:?}",
		);
```
