### PR TITLE
[Release| CI/CD] Add missing permissions to the docker publishing jobs

### DIFF
--- a/.github/workflows/release-70_combined-publish-release.yml
+++ b/.github/workflows/release-70_combined-publish-release.yml
@@ -106,6 +106,8 @@ jobs:
       version: ${{ inputs.version }}
       stable_tag: ${{ needs.promote-rc-to-final.outputs.final_tag }}
     secrets: inherit
+    permissions:
+      contents: write
 
   publish-docker-polkadot-parachain:
     name: Publish Docker image - polkadot-parachain
@@ -121,6 +123,8 @@ jobs:
       version: ${{ inputs.version }}
       stable_tag: ${{ needs.promote-rc-to-final.outputs.final_tag }}
     secrets: inherit
+    permissions:
+      contents: write
 
   publish-docker-polkadot-omni-node:
     name: Publish Docker image - polkadot-omni-node
@@ -136,6 +140,8 @@ jobs:
       version: ${{ inputs.version }}
       stable_tag: ${{ needs.promote-rc-to-final.outputs.final_tag }}
     secrets: inherit
+    permissions:
+      contents: write
 
   publish-docker-chain-spec-builder:
     name: Publish Docker image - chain-spec-builder
@@ -151,3 +157,5 @@ jobs:
       version: ${{ inputs.version }}
       stable_tag: ${{ needs.promote-rc-to-final.outputs.final_tag }}
     secrets: inherit
+    permissions:
+      contents: write


### PR DESCRIPTION
This PR fixes the issue with missing permissions in the Combined Publish Release flow. [Example](https://github.com/paritytech-release/polkadot-sdk/actions/runs/21358125800)