### PR TITLE
introduce `revive.instantiateWithCodeAs`

### DIFF
--- a/substrate/frame/revive/src/test_utils/builder.rs
+++ b/substrate/frame/revive/src/test_utils/builder.rs
@@ -126,6 +126,33 @@ builder!(
 );
 
 builder!(
+	instantiate_with_code_as(
+		origin: OriginFor<T>,
+		value: BalanceOf<T>,
+		weight_limit: Weight,
+		storage_deposit_limit: BalanceOf<T>,
+		code: Vec<u8>,
+		data: Vec<u8>,
+		salt: Option<[u8; 32]>,
+		account: T::AccountId,
+	) -> DispatchResultWithPostInfo;
+
+	/// Create an [`InstantiateWithCodeAsBuilder`] with default values.
+	pub fn instantiate_with_code_as(origin: OriginFor<T>, code: Vec<u8>, account: T::AccountId) -> Self {
+		Self {
+			origin,
+			value: 0u32.into(),
+			weight_limit: WEIGHT_LIMIT,
+			storage_deposit_limit: deposit_limit::<T>(),
+			code,
+			data: vec![],
+			salt: Some([0; 32]),
+			account,
+		}
+	}
+);
+
+builder!(
 	bare_instantiate(
 		origin: OriginFor<T>,
 		evm_value: U256,

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -241,6 +241,14 @@ pub(crate) mod builder {
 		InstantiateBuilder::<Test>::instantiate(RuntimeOrigin::signed(ALICE), code_hash)
 	}
 
+	pub fn instantiate_with_code_as(code: Vec<u8>, account: sp_runtime::AccountId32) -> InstantiateWithCodeAsBuilder<Test> {
+		InstantiateWithCodeAsBuilder::<Test>::instantiate_with_code_as(
+			RuntimeOrigin::signed(ALICE),
+			code,
+			account,
+		)
+	}
+
 	pub fn call(dest: H160) -> CallBuilder<Test> {
 		CallBuilder::<Test>::call(RuntimeOrigin::signed(ALICE), dest)
 	}

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -2935,6 +2935,30 @@ fn signed_cannot_set_code() {
 }
 
 #[test]
+fn signed_cannot_instantiate_with_code_as_origin() {
+	let (binary, _) = compile_module("dummy").unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		assert_err_ignore_postinfo!(
+			builder::instantiate_with_code_as(binary, BOB).build(),
+			DispatchError::BadOrigin
+		);
+	});
+}
+
+#[test]
+fn root_can_instantiate_with_code_as_origin() {
+	let (binary, _) = compile_module("dummy").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&BOB, 1_000_000);
+
+		// Root can instantiate on behalf of BOB
+		assert_ok!(builder::instantiate_with_code_as(binary, BOB).origin(RuntimeOrigin::root()).build());
+	});
+}
+
+#[test]
 fn none_cannot_call_code() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_err_ignore_postinfo!(


### PR DESCRIPTION
## Summary

Added a new root-only call `instantiate_with_code_as` that allows governance to instantiate contracts on behalf of a specified account.

## Changes

### Core Implementation
- **`substrate/frame/revive/src/lib.rs`**
  - Added `instantiate_with_code_as` call (index 13)
  - Requires `root` origin via `ensure_root()`
  - Accepts `T::AccountId` parameter and converts to `RawOrigin::Signed(account)` for instantiation
  - All deposits, fees, and ownership are attributed to the specified account

### Test Support
- **`substrate/frame/revive/src/test_utils/builder.rs`**
  - Added `InstantiateWithCodeAsBuilder` for fluent test API

- **`substrate/frame/revive/src/tests.rs`**
  - Added convenience wrapper `instantiate_with_code_as()` defaulting origin to ALICE

- **`substrate/frame/revive/src/tests/pvm.rs`**
  - Added `signed_cannot_instantiate_with_code_as_origin` - verifies non-root origins are rejected
  - Added `root_can_instantiate_with_code_as_origin` - verifies root can instantiate on behalf of another account

## Use Cases

Please refer to https://github.com/paritytech/contract-issues/issues/263

