### PR TITLE
Remove ForeignAssetId associated type from ForeignAssetsConfig

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -570,10 +570,7 @@ parameter_types! {
 	pub const ForeignAssetsMetadataDepositPerByte: Balance = MetadataDepositPerByte::get();
 }
 
-impl pallet_assets_precompiles::ForeignAssetsConfig for Runtime {
-	// must match the AssetId type used by the `ForeignAssets` instance
-	type ForeignAssetId = <Runtime as pallet_assets::Config<ForeignAssetsInstance>>::AssetId;
-}
+impl pallet_assets_precompiles::ForeignAssetsConfig for Runtime {}
 
 /// Assets managed by some foreign location. Note: we do not declare a `ForeignAssetsCall` type, as
 /// this type is used in proxy definitions. We assume that a foreign location would not want to set

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1459,9 +1459,7 @@ impl pallet_multi_asset_bounties::Config for Runtime {
 	type BenchmarkHelper = PalletMultiAssetBountiesArguments;
 }
 
-impl pallet_assets_precompiles::ForeignAssetsConfig for Runtime {
-	type ForeignAssetId = u32;
-}
+impl pallet_assets_precompiles::ForeignAssetsConfig for Runtime {}
 
 impl pallet_tips::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/substrate/frame/assets/precompiles/src/foreign_assets_tests.rs
+++ b/substrate/frame/assets/precompiles/src/foreign_assets_tests.rs
@@ -20,7 +20,7 @@
 use super::*;
 use crate::{
 	foreign_assets::{pallet::Pallet as ForeignAssetsPallet, ForeignAssetId},
-	mock::{new_test_ext, Test},
+	mock::{new_test_ext, test_location, Test},
 };
 use frame_support::assert_ok;
 use pallet_assets::AssetsCallback;
@@ -28,7 +28,7 @@ use pallet_assets::AssetsCallback;
 #[test]
 fn asset_mapping_insert_works() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 123u32;
+		let asset_id = test_location(123);
 
 		// Insert mapping - now returns the allocated index
 		let asset_index = ForeignAssetsPallet::<Test>::insert_asset_mapping(&asset_id).unwrap();
@@ -37,7 +37,7 @@ fn asset_mapping_insert_works() {
 		assert_eq!(asset_index, 0);
 
 		// Verify both directions of lookup work
-		assert_eq!(ForeignAssetsPallet::<Test>::asset_id_of(asset_index), Some(asset_id));
+		assert_eq!(ForeignAssetsPallet::<Test>::asset_id_of(asset_index), Some(asset_id.clone()));
 		assert_eq!(ForeignAssetsPallet::<Test>::asset_index_of(&asset_id), Some(asset_index));
 	});
 }
@@ -45,9 +45,9 @@ fn asset_mapping_insert_works() {
 #[test]
 fn asset_mapping_insert_sequential_indices() {
 	new_test_ext().execute_with(|| {
-		let asset_id1 = 100u32;
-		let asset_id2 = 200u32;
-		let asset_id3 = 300u32;
+		let asset_id1 = test_location(100);
+		let asset_id2 = test_location(200);
+		let asset_id3 = test_location(300);
 
 		// Insert mappings - should get sequential indices
 		let index1 = ForeignAssetsPallet::<Test>::insert_asset_mapping(&asset_id1).unwrap();
@@ -68,7 +68,7 @@ fn asset_mapping_insert_sequential_indices() {
 #[test]
 fn asset_mapping_insert_prevents_duplicate_asset_id() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 123u32;
+		let asset_id = test_location(123);
 
 		// Insert first mapping
 		let index1 = ForeignAssetsPallet::<Test>::insert_asset_mapping(&asset_id).unwrap();
@@ -84,11 +84,11 @@ fn asset_mapping_insert_prevents_duplicate_asset_id() {
 #[test]
 fn asset_mapping_remove_works() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 123u32;
+		let asset_id = test_location(123);
 
 		// Insert and verify
 		let asset_index = ForeignAssetsPallet::<Test>::insert_asset_mapping(&asset_id).unwrap();
-		assert_eq!(ForeignAssetsPallet::<Test>::asset_id_of(asset_index), Some(asset_id));
+		assert_eq!(ForeignAssetsPallet::<Test>::asset_id_of(asset_index), Some(asset_id.clone()));
 
 		// Remove mapping
 		ForeignAssetsPallet::<Test>::remove_asset_mapping(&asset_id);
@@ -102,7 +102,7 @@ fn asset_mapping_remove_works() {
 #[test]
 fn asset_mapping_remove_nonexistent_is_safe() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 999u32;
+		let asset_id = test_location(999);
 
 		// Remove mapping that doesn't exist - should not panic
 		ForeignAssetsPallet::<Test>::remove_asset_mapping(&asset_id);
@@ -115,7 +115,7 @@ fn asset_mapping_remove_nonexistent_is_safe() {
 #[test]
 fn foreign_asset_callback_created_inserts_mapping() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 42u32;
+		let asset_id = test_location(42);
 		let owner = 123u64;
 
 		// Simulate asset creation callback
@@ -131,13 +131,13 @@ fn foreign_asset_callback_created_inserts_mapping() {
 #[test]
 fn foreign_asset_callback_destroyed_removes_mapping() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 42u32;
+		let asset_id = test_location(42);
 		let owner = 123u64;
 
 		// Setup: create asset mapping via callback
 		assert_ok!(ForeignAssetId::<Test>::created(&asset_id, &owner));
 		let asset_index = ForeignAssetsPallet::<Test>::asset_index_of(&asset_id).unwrap();
-		assert_eq!(ForeignAssetsPallet::<Test>::asset_id_of(asset_index), Some(asset_id));
+		assert_eq!(ForeignAssetsPallet::<Test>::asset_id_of(asset_index), Some(asset_id.clone()));
 
 		// Simulate asset destruction callback
 		assert_ok!(ForeignAssetId::<Test>::destroyed(&asset_id));
@@ -151,7 +151,7 @@ fn foreign_asset_callback_destroyed_removes_mapping() {
 #[test]
 fn foreign_asset_id_extractor_works_with_valid_mapping() {
 	new_test_ext().execute_with(|| {
-		let asset_id = 555u32;
+		let asset_id = test_location(555);
 
 		// Setup mapping - gets index 0
 		let asset_index = ForeignAssetsPallet::<Test>::insert_asset_mapping(&asset_id).unwrap();
@@ -205,17 +205,20 @@ fn next_asset_index_increments_correctly() {
 		assert_eq!(ForeignAssetsPallet::<Test>::next_asset_index(), 0);
 
 		// Insert first asset
-		let index1 = ForeignAssetsPallet::<Test>::insert_asset_mapping(&100u32).unwrap();
+		let index1 =
+			ForeignAssetsPallet::<Test>::insert_asset_mapping(&test_location(100)).unwrap();
 		assert_eq!(index1, 0);
 		assert_eq!(ForeignAssetsPallet::<Test>::next_asset_index(), 1);
 
 		// Insert second asset
-		let index2 = ForeignAssetsPallet::<Test>::insert_asset_mapping(&200u32).unwrap();
+		let index2 =
+			ForeignAssetsPallet::<Test>::insert_asset_mapping(&test_location(200)).unwrap();
 		assert_eq!(index2, 1);
 		assert_eq!(ForeignAssetsPallet::<Test>::next_asset_index(), 2);
 
 		// Insert third asset
-		let index3 = ForeignAssetsPallet::<Test>::insert_asset_mapping(&300u32).unwrap();
+		let index3 =
+			ForeignAssetsPallet::<Test>::insert_asset_mapping(&test_location(300)).unwrap();
 		assert_eq!(index3, 2);
 		assert_eq!(ForeignAssetsPallet::<Test>::next_asset_index(), 3);
 	});

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -92,18 +92,18 @@ impl<const P: u16> AssetPrecompileConfig for InlineIdConfig<P> {
 }
 
 /// An `AssetIdExtractor` that maps a local asset id (4 bytes taken from the address) to a foreign
-/// asset id.
+/// asset id (Location).
 pub struct ForeignAssetIdExtractor<Runtime, Instance = ()> {
 	_phantom: PhantomData<(Runtime, Instance)>,
 }
 
 impl<Runtime, Instance: 'static> AssetIdExtractor for ForeignAssetIdExtractor<Runtime, Instance>
 where
-	Runtime: pallet_assets::Config<Instance>
-		+ pallet::Config<ForeignAssetId = <Runtime as pallet_assets::Config<Instance>>::AssetId>
+	Runtime: pallet_assets::Config<Instance, AssetId = xcm::v5::Location>
+		+ pallet::Config
 		+ pallet_revive::Config,
 {
-	type AssetId = <Runtime as pallet_assets::Config<Instance>>::AssetId;
+	type AssetId = xcm::v5::Location;
 	fn asset_id_from_address(addr: &[u8; 20]) -> Result<Self::AssetId, Error> {
 		let bytes: [u8; 4] = addr[0..4].try_into().expect("slice is 4 bytes; qed");
 		let index = u32::from_be_bytes(bytes);
@@ -120,8 +120,8 @@ pub struct ForeignIdConfig<const PREFIX: u16, Runtime, Instance = ()> {
 impl<const P: u16, Runtime, Instance: 'static> AssetPrecompileConfig
 	for ForeignIdConfig<P, Runtime, Instance>
 where
-	Runtime: pallet_assets::Config<Instance>
-		+ pallet::Config<ForeignAssetId = <Runtime as pallet_assets::Config<Instance>>::AssetId>
+	Runtime: pallet_assets::Config<Instance, AssetId = xcm::v5::Location>
+		+ pallet::Config
 		+ pallet_revive::Config,
 {
 	const MATCHER: AddressMatcher = AddressMatcher::Prefix(core::num::NonZero::new(P).unwrap());

--- a/substrate/frame/assets/precompiles/src/migration_benchmarks.rs
+++ b/substrate/frame/assets/precompiles/src/migration_benchmarks.rs
@@ -26,11 +26,9 @@
 
 use crate::foreign_assets::pallet::{Config, Pallet};
 use frame_benchmarking::v2::*;
+use xcm::v5::{Junction, Location};
 
-#[benchmarks(
-	where
-		T::ForeignAssetId: From<u32>,
-)]
+#[benchmarks]
 mod benchmarks {
 	use super::*;
 
@@ -44,7 +42,7 @@ mod benchmarks {
 	/// - 1 write: ForeignAssetIdToAssetIndex
 	#[benchmark]
 	fn migrate_asset_step_migrate() {
-		let asset_id: T::ForeignAssetId = 1u32.into();
+		let asset_id = Location::new(1, [Junction::Parachain(1)]);
 
 		// Ensure no mapping exists
 		assert!(Pallet::<T>::asset_index_of(&asset_id).is_none());
@@ -64,7 +62,7 @@ mod benchmarks {
 	/// - 1 read: ForeignAssetIdToAssetIndex
 	#[benchmark]
 	fn migrate_asset_step_skip() {
-		let asset_id: T::ForeignAssetId = 2u32.into();
+		let asset_id = Location::new(1, [Junction::Parachain(2)]);
 
 		// Pre-create the mapping
 		let _ = Pallet::<T>::insert_asset_mapping(&asset_id);
@@ -82,7 +80,7 @@ mod benchmarks {
 	/// This measures the weight of a simple storage read returning None.
 	#[benchmark]
 	fn migrate_asset_step_finished() {
-		let nonexistent_id: T::ForeignAssetId = 999u32.into();
+		let nonexistent_id = Location::new(1, [Junction::Parachain(999)]);
 
 		#[block]
 		{

--- a/substrate/frame/assets/precompiles/src/migration_tests.rs
+++ b/substrate/frame/assets/precompiles/src/migration_tests.rs
@@ -119,9 +119,7 @@ impl pallet_assets::Config<ForeignAssetsInstance> for Test {
 	type BenchmarkHelper = LocationBenchmarkHelper;
 }
 
-impl pallet::Config for Test {
-	type ForeignAssetId = Location;
-}
+impl pallet::Config for Test {}
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();


### PR DESCRIPTION
## Summary
- Remove `ForeignAssetId` associated type from `pallet::Config` trait, hardcoding to `Location` instead
- Simplifies configuration since foreign assets are always identified by XCM Locations in practice
- Update storage types, mock, and tests to use `Location` directly

## Test plan
- [x] Existing tests pass with updated mock using `Location` as asset ID
- [ ] Review that the simplification doesn't break any downstream usage