### PR TITLE
sync-templates: consider workspace lints

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -169,9 +169,13 @@ jobs:
           ]
           resolver = "2"
 
-          [workspace.dependencies]
           EOF
 
+          echo "$(toml get -r ../../Cargo.toml 'workspace.lints.rust' --output-toml)" >> Cargo.toml
+          echo "$(toml get -r ../../Cargo.toml 'workspace.lints.clippy' --output-toml)" >> Cargo.toml
+          echo "" >> Cargo.toml
+
+          echo "[workspace.dependencies]" >> Cargo.toml
           echo "$(toml get -r ./runtime/Cargo.toml 'package.name') = { path = \"./runtime\", default-features = false }" >> Cargo.toml
           echo "$(toml get -r ./pallets/template/Cargo.toml 'package.name') = { path = \"./pallets/template\", default-features = false }" >> Cargo.toml
 


### PR DESCRIPTION
# Description

Trying to sync temaplates with their dedicated repos. The job fails at some point because the templates' crates (runtime/node) use:
```toml
[lints]
workspace = true
```
but there is no lint directive in the worskpace's Cargo.toml.

This takes  the workspace lints existing in polkadot-sdk workspace's Cargo.toml and carries them to each template, in their workspace's Cargo.toml.

## Integration

N/A

## Review Notes

Error started here: https://github.com/paritytech/polkadot-sdk/actions/runs/21747118215/job/62737549819.
Testing the sync job based on this branch here: https://github.com/paritytech/polkadot-sdk/actions/runs/21748717584 - it fails, it appears there are some env protection rules (reasonable as well, we shouldn't be able to publish anything to the templates repo)