### PR TITLE
sync-templates: install clang

### DIFF
--- a/.github/workflows/misc-sync-templates.yml
+++ b/.github/workflows/misc-sync-templates.yml
@@ -136,7 +136,6 @@ jobs:
           sudo apt install -y \
             protobuf-compiler \
             clang
-          ls -alh /usr/lib/
           rustup target add wasm32-unknown-unknown
           rustup component add rustfmt clippy rust-src
 


### PR DESCRIPTION
# Description

Syncing templates fail because of a what seems to be a clang error related to not finding clang on the machine.
I think installing it should do it.

## Integration

N/A

## Review Notes

Failing syncing templates job: https://github.com/paritytech/polkadot-sdk/actions/runs/21753944520/job/62761328858. Parachain-template passes because it doesn't try to build the node/runtime in the job I think, but it tries to do it in its CI, and fails there like for the other templates: https://github.com/paritytech/polkadot-sdk-parachain-template/actions/runs/21755132896/job/62763165787?pr=46.