### PR TITLE
Support maps for `#[pallet::whitelist_storage]`

### DIFF
--- a/substrate/client/db/src/bench.rs
+++ b/substrate/client/db/src/bench.rs
@@ -69,6 +69,9 @@ struct KeyTracker {
 	/// We track the total number of reads and writes to these keys,
 	/// not de-duplicated for repeats.
 	child_keys: LinkedHashMap<Vec<u8>, LinkedHashMap<Vec<u8>, TrackedStorageKey>>,
+	/// Whitelisted key prefixes. Any tracked key starting with one of these prefixes
+	/// will be marked as whitelisted.
+	whitelisted_prefixes: Vec<Vec<u8>>,
 }
 
 /// State that manages the backend database reference. Allows runtime to control the database.
@@ -149,6 +152,7 @@ impl<Hasher: Hash> BenchmarkingState<Hasher> {
 				main_keys: Default::default(),
 				child_keys: Default::default(),
 				enable_tracking,
+				whitelisted_prefixes: Vec::new(),
 			})),
 			whitelist: Default::default(),
 			proof_recorder: record_proof.then(Default::default),
@@ -213,6 +217,7 @@ impl<Hasher: Hash> BenchmarkingState<Hasher> {
 		let mut key_tracker = self.key_tracker.lock();
 		key_tracker.main_keys = LinkedHashMap::new();
 		key_tracker.child_keys = LinkedHashMap::new();
+		key_tracker.whitelisted_prefixes = Vec::new();
 		key_tracker.add_whitelist(&self.whitelist.borrow());
 	}
 
@@ -232,10 +237,31 @@ impl<Hasher: Hash> BenchmarkingState<Hasher> {
 impl KeyTracker {
 	fn add_whitelist(&mut self, whitelist: &[TrackedStorageKey]) {
 		whitelist.iter().for_each(|key| {
+			// Store the whitelist key as a prefix for prefix-based matching.
+			let prefix = key.key.clone();
+			if !self.whitelisted_prefixes.iter().any(|p| *p == prefix) {
+				self.whitelisted_prefixes.push(prefix);
+			}
+
+			// Insert as exact whitelisted entry (existing behavior).
 			let mut whitelisted = TrackedStorageKey::new(key.key.clone());
 			whitelisted.whitelist();
 			self.main_keys.insert(key.key.clone(), whitelisted);
+
+			// Mark any existing tracked keys that start with this whitelist key as
+			// whitelisted.
+			let whitelist_key = &key.key;
+			for (tracked_key, tracker) in self.main_keys.iter_mut() {
+				if tracked_key.starts_with(whitelist_key) && !tracker.whitelisted {
+					tracker.whitelist();
+				}
+			}
 		});
+	}
+
+	/// Check if a key falls under any whitelisted prefix.
+	fn is_prefix_whitelisted(&self, key: &[u8]) -> bool {
+		self.whitelisted_prefixes.iter().any(|prefix| key.starts_with(prefix))
 	}
 
 	// Childtrie is identified by its storage key (i.e. `ChildInfo::storage_key`)
@@ -243,6 +269,10 @@ impl KeyTracker {
 		if !self.enable_tracking {
 			return;
 		}
+
+		// Pre-compute prefix whitelist check for new keys (main trie only).
+		let prefix_whitelisted =
+			childtrie.is_none() && self.is_prefix_whitelisted(key);
 
 		let child_key_tracker = &mut self.child_keys;
 		let main_key_tracker = &mut self.main_keys;
@@ -257,6 +287,9 @@ impl KeyTracker {
 			None => {
 				let mut has_been_read = TrackedStorageKey::new(key.to_vec());
 				has_been_read.add_read();
+				if prefix_whitelisted {
+					has_been_read.whitelist();
+				}
 				key_tracker.insert(key.to_vec(), has_been_read);
 				true
 			},
@@ -285,6 +318,10 @@ impl KeyTracker {
 			return;
 		}
 
+		// Pre-compute prefix whitelist check for new keys (main trie only).
+		let prefix_whitelisted =
+			childtrie.is_none() && self.is_prefix_whitelisted(key);
+
 		let child_key_tracker = &mut self.child_keys;
 		let main_key_tracker = &mut self.main_keys;
 
@@ -299,6 +336,9 @@ impl KeyTracker {
 			None => {
 				let mut has_been_written = TrackedStorageKey::new(key.to_vec());
 				has_been_written.add_write();
+				if prefix_whitelisted {
+					has_been_written.whitelist();
+				}
 				key_tracker.insert(key.to_vec(), has_been_written);
 				true
 			},

--- a/substrate/frame/benchmarking/src/tests.rs
+++ b/substrate/frame/benchmarking/src/tests.rs
@@ -45,6 +45,11 @@ mod pallet_test {
 	#[pallet::storage]
 	pub(crate) type Value<T: Config> = StorageValue<_, u32, OptionQuery>;
 
+	/// A storage map with whitelist_storage to test prefix-based whitelisting.
+	#[pallet::storage]
+	#[pallet::whitelist_storage]
+	pub(crate) type Map<T: Config> = StorageMap<_, Blake2_128Concat, u32, u32, OptionQuery>;
+
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		pub fn set_value(origin: OriginFor<T>, n: u32) -> DispatchResult {
@@ -420,4 +425,33 @@ mod benchmarks {
 			assert_eq!(got, output);
 		});
 	}
+}
+
+#[test]
+fn whitelist_storage_maps_includes_prefix() {
+	use frame_support::traits::WhitelistedStorageKeys;
+	use sp_core::hexdisplay::HexDisplay;
+	use std::collections::BTreeSet;
+
+	// Get all whitelisted keys from the test pallet.
+	let whitelist: BTreeSet<String> = AllPalletsWithSystem::whitelisted_storage_keys()
+		.iter()
+		.map(|s| HexDisplay::from(&s.key).to_string())
+		.collect();
+
+	// The Map storage in pallet_test should be whitelisted.
+	// Its prefix is twox_128("TestPallet") ++ twox_128("Map").
+	let pallet_prefix = sp_io::hashing::twox_128(b"TestPallet");
+	let storage_prefix = sp_io::hashing::twox_128(b"Map");
+	let mut expected_prefix = Vec::new();
+	expected_prefix.extend_from_slice(&pallet_prefix);
+	expected_prefix.extend_from_slice(&storage_prefix);
+	let expected_hex = HexDisplay::from(&expected_prefix).to_string();
+
+	assert!(
+		whitelist.contains(&expected_hex),
+		"Map prefix {} should be in whitelist, but whitelist is: {:?}",
+		expected_hex,
+		whitelist,
+	);
 }

--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -351,6 +351,17 @@ pub trait Benchmarking {
 		self.set_whitelist(whitelist);
 	}
 
+	/// Add a storage key prefix to the whitelist. All keys starting with this prefix
+	/// will be treated as whitelisted.
+	fn add_prefix_to_whitelist(&mut self, prefix: PassFatPointerAndRead<Vec<u8>>) {
+		let mut whitelist = self.get_whitelist();
+		let key: TrackedStorageKey = prefix.to_vec().into();
+		if !whitelist.iter().any(|x| x.key == key.key) {
+			whitelist.push(key);
+		}
+		self.set_whitelist(whitelist);
+	}
+
 	fn get_read_and_written_keys(
 		&self,
 	) -> AllocateAndReturnByCodec<Vec<(Vec<u8>, u32, u32, bool)>> {

--- a/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::pallet::{expand::merge_where_clauses, Def};
+use crate::pallet::{expand::merge_where_clauses, parse::storage::Metadata, Def};
 use frame_support_procedural_tools::get_doc_literals;
 
 /// * Add derive trait on Pallet
@@ -179,10 +179,41 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 			)
 		};
 
-	let whitelisted_storage_idents: Vec<syn::Ident> = def
+	// Separate whitelisted storages into values (exact key) and maps (prefix key).
+	let whitelisted_value_idents: Vec<syn::Ident> = def
 		.storages
 		.iter()
-		.filter_map(|s| s.whitelisted.then(|| s.ident.clone()))
+		.filter_map(|s| {
+			s.whitelisted
+				.then(|| matches!(s.metadata, Metadata::Value { .. }).then(|| s.ident.clone()))
+				.flatten()
+		})
+		.collect();
+
+	let whitelisted_map_key_tokens: Vec<proc_macro2::TokenStream> = def
+		.storages
+		.iter()
+		.filter_map(|s| {
+			if !s.whitelisted {
+				return None;
+			}
+			match &s.metadata {
+				Metadata::Value { .. } => None,
+				Metadata::Map { .. } |
+				Metadata::CountedMap { .. } |
+				Metadata::DoubleMap { .. } |
+				Metadata::NMap { .. } |
+				Metadata::CountedNMap { .. } => {
+					let prefix_struct = syn::Ident::new(
+						&format!("_GeneratedPrefixForStorage{}", s.ident),
+						s.ident.span(),
+					);
+					Some(quote::quote! {
+						<#prefix_struct<#type_use_gen> as #frame_support::traits::StorageInstance>::prefix_hash().to_vec()
+					})
+				},
+			}
+		})
 		.collect();
 
 	let whitelisted_storage_keys_impl = quote::quote![
@@ -190,9 +221,20 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		impl<#type_impl_gen> WhitelistedStorageKeys for #pallet_ident<#type_use_gen> #storages_where_clauses {
 			fn whitelisted_storage_keys() -> #frame_support::__private::Vec<TrackedStorageKey> {
 				use #frame_support::__private::vec;
-				vec![#(
-					TrackedStorageKey::new(#whitelisted_storage_idents::<#type_use_gen>::hashed_key().to_vec())
-				),*]
+				let mut keys = #frame_support::__private::Vec::new();
+				// Whitelist storage values by exact key.
+				#(
+					keys.push(TrackedStorageKey::new(
+						#whitelisted_value_idents::<#type_use_gen>::hashed_key().to_vec()
+					));
+				)*
+				// Whitelist storage maps by prefix key.
+				#(
+					keys.push(TrackedStorageKey::new(
+						#whitelisted_map_key_tokens
+					));
+				)*
+				keys
 			}
 		}
 	];


### PR DESCRIPTION
## Summary

Closes #7421

This PR extends the `#[pallet::whitelist_storage]` attribute to support `StorageMap`, `StorageDoubleMap`, `StorageNMap`, and `CountedStorageMap` in addition to the already supported `StorageValue`.

### Approach

- **Value storage items** (`StorageValue`) continue to whitelist by exact `hashed_key()` as before.
- **Map storage items** (`StorageMap`, `StorageDoubleMap`, `StorageNMap`, `CountedStorageMap`) are whitelisted by their **prefix hash** using the generated `_GeneratedPrefixForStorage` struct's `final_prefix()`. This means all entries under the map prefix are whitelisted, rather than requiring individual key registration.
- A new `add_prefix_to_whitelist()` runtime interface is added alongside the existing `add_to_whitelist()`, and `KeyTracker` in the benchmarking DB backend (`sc-client-db`) now tracks `whitelisted_prefixes` separately, performing prefix matching in `add_read_key` / `add_write_key`.

### Changes

| File | What changed |
|------|-------------|
| `substrate/frame/support/procedural/src/pallet/expand/pallet_struct.rs` | Separate codegen for value vs. map whitelisted storage items |
| `substrate/client/db/src/bench.rs` | `whitelisted_prefixes` field + prefix matching logic |
| `substrate/frame/benchmarking/src/utils.rs` | New `add_prefix_to_whitelist()` host function |
| `substrate/frame/benchmarking/src/tests.rs` | Test: `StorageMap` with `#[pallet::whitelist_storage]` + prefix verification |

This follows the direction discussed by @gui1117 and @bkchr in the previously closed PR #9206.