### PR TITLE
Move connected peers metric to sync component

### DIFF
--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -572,7 +572,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 			Arc::new(Litep2pBandwidthSink { sink: litep2p.bandwidth_sink() });
 
 		if let Some(registry) = &params.metrics_registry {
-			MetricSources::register(registry, bandwidth, Arc::clone(&num_connected))?;
+			MetricSources::register(registry, bandwidth)?;
 		}
 
 		Ok(Self {

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -564,7 +564,6 @@ where
 				registry,
 				MetricSources {
 					bandwidth: bandwidth.clone(),
-					connected_peers: num_connected.clone(),
 				},
 			)?),
 			None => None,

--- a/substrate/client/network/src/service/metrics.rs
+++ b/substrate/client/network/src/service/metrics.rs
@@ -20,15 +20,12 @@ use crate::{service::traits::BandwidthSink, ProtocolName};
 
 use prometheus_endpoint::{
 	self as prometheus, Counter, CounterVec, Gauge, GaugeVec, HistogramOpts, MetricSource, Opts,
-	PrometheusError, Registry, SourcedCounter, SourcedGauge, U64,
+	PrometheusError, Registry, SourcedCounter, U64,
 };
 
 use std::{
 	str,
-	sync::{
-		atomic::{AtomicUsize, Ordering},
-		Arc,
-	},
+	sync::Arc,
 };
 
 pub use prometheus_endpoint::{Histogram, HistogramVec};
@@ -36,7 +33,6 @@ pub use prometheus_endpoint::{Histogram, HistogramVec};
 /// Registers all networking metrics with the given registry.
 pub fn register(registry: &Registry, sources: MetricSources) -> Result<Metrics, PrometheusError> {
 	BandwidthCounters::register(registry, sources.bandwidth)?;
-	NumConnectedGauge::register(registry, sources.connected_peers)?;
 	Metrics::register(registry)
 }
 
@@ -48,17 +44,14 @@ pub fn register_without_sources(registry: &Registry) -> Result<Metrics, Promethe
 /// Predefined metric sources that are fed directly into prometheus.
 pub struct MetricSources {
 	pub bandwidth: Arc<dyn BandwidthSink>,
-	pub connected_peers: Arc<AtomicUsize>,
 }
 
 impl MetricSources {
 	pub fn register(
 		registry: &Registry,
 		bandwidth: Arc<dyn BandwidthSink>,
-		connected_peers: Arc<AtomicUsize>,
 	) -> Result<(), PrometheusError> {
-		BandwidthCounters::register(registry, bandwidth)?;
-		NumConnectedGauge::register(registry, connected_peers)
+		BandwidthCounters::register(registry, bandwidth)
 	}
 }
 
@@ -278,34 +271,6 @@ impl MetricSource for BandwidthCounters {
 	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
 		set(&["in"], self.0.total_inbound());
 		set(&["out"], self.0.total_outbound());
-	}
-}
-
-/// The connected peers metric.
-#[derive(Clone)]
-pub struct NumConnectedGauge(Arc<AtomicUsize>);
-
-impl NumConnectedGauge {
-	/// Registers the `MajorSyncingGauge` metric whose value is
-	/// obtained from the given `AtomicUsize`.
-	fn register(registry: &Registry, value: Arc<AtomicUsize>) -> Result<(), PrometheusError> {
-		prometheus::register(
-			SourcedGauge::new(
-				&Opts::new("substrate_sub_libp2p_peers_count", "Number of connected peers"),
-				NumConnectedGauge(value),
-			)?,
-			registry,
-		)?;
-
-		Ok(())
-	}
-}
-
-impl MetricSource for NumConnectedGauge {
-	type N = u64;
-
-	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
-		set(&[], self.0.load(Ordering::Relaxed) as u64);
 	}
 }
 

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -111,8 +111,13 @@ struct Metrics {
 }
 
 impl Metrics {
-	fn register(r: &Registry, major_syncing: Arc<AtomicBool>) -> Result<Self, PrometheusError> {
+	fn register(
+		r: &Registry,
+		major_syncing: Arc<AtomicBool>,
+		num_connected: Arc<AtomicUsize>,
+	) -> Result<Self, PrometheusError> {
 		MajorSyncingGauge::register(r, major_syncing)?;
+		NumConnectedGauge::register(r, num_connected)?;
 		Ok(Self {
 			peers: {
 				let g = Gauge::new("substrate_sync_peers", "Number of peers we sync with")?;
@@ -160,6 +165,35 @@ impl MajorSyncingGauge {
 }
 
 impl MetricSource for MajorSyncingGauge {
+	type N = u64;
+
+	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
+		set(&[], self.0.load(Ordering::Relaxed) as u64);
+	}
+}
+
+/// The connected peers metric.
+#[derive(Clone)]
+struct NumConnectedGauge(Arc<AtomicUsize>);
+
+impl NumConnectedGauge {
+	fn register(registry: &Registry, value: Arc<AtomicUsize>) -> Result<(), PrometheusError> {
+		prometheus_endpoint::register(
+			SourcedGauge::new(
+				&Opts::new(
+					"substrate_sub_libp2p_peers_count",
+					"Number of connected peers",
+				),
+				NumConnectedGauge(value),
+			)?,
+			registry,
+		)?;
+
+		Ok(())
+	}
+}
+
+impl MetricSource for NumConnectedGauge {
 	type N = u64;
 
 	fn collect(&self, mut set: impl FnMut(&[&str], Self::N)) {
@@ -394,7 +428,7 @@ where
 				tick_timeout,
 				peer_store_handle,
 				metrics: if let Some(r) = metrics_registry {
-					match Metrics::register(r, is_major_syncing.clone()) {
+					match Metrics::register(r, is_major_syncing.clone(), num_connected.clone()) {
 						Ok(metrics) => Some(metrics),
 						Err(err) => {
 							log::error!(target: LOG_TARGET, "Failed to register metrics {err:?}");


### PR DESCRIPTION
## Summary

Closes #5024

The `substrate_sub_libp2p_peers_count` metric was defined in `sc-network` but its data source (`num_connected: Arc<AtomicUsize>`) is owned and maintained by `SyncingEngine` — it is incremented on `peer_connected` and decremented on `peer_disconnected`. This creates a misleading ownership boundary where the metric lives in one crate but is entirely driven by another.

This PR moves the metric registration to `sc-network-sync` where the data naturally lives, co-locating the gauge with the code that updates it.

## Changes

- **`substrate/client/network/src/service.rs`** — Removed the `peers_count` metric registration and the associated `Arc<AtomicUsize>` plumbing from `NetworkWorker`.
- **`substrate/client/network/src/service/metrics.rs`** — Removed the `peers_count` gauge definition from the network metrics struct.
- **`substrate/client/network-sync/src/engine.rs`** — Added the `peers_count` Prometheus gauge registration in `SyncingEngine`, updating it alongside the existing `num_connected` atomic counter on peer connect/disconnect events.
- **`substrate/client/network-sync/src/metrics.rs`** — Added the `peers_count` gauge field to the sync metrics struct.

## Test plan

- [ ] Verify `substrate_sub_libp2p_peers_count` metric is still exposed on the Prometheus endpoint after starting a node
- [ ] Confirm the metric correctly increments/decrements as peers connect and disconnect
- [ ] Run existing network and sync tests: `cargo test -p sc-network` and `cargo test -p sc-network-sync`
- [ ] Ensure no duplicate metric registration errors at startup