### PR TITLE
network/sync: Fix justification response lost on peer disconnect

### DIFF
--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -837,7 +837,11 @@ where
 		}
 
 		self.strategy.remove_peer(&peer_id);
-		self.pending_responses.remove_all(&peer_id);
+		// NOTE: we intentionally do NOT call `self.pending_responses.remove_all(&peer_id)`
+		// here. The response from the request-response protocol may still arrive after
+		// the sync peer disconnects from the notifications protocol, and we want to
+		// process it (e.g. to not lose justification responses). The response handlers
+		// in the syncing strategies already handle the case where the peer is unknown.
 		self.event_streams
 			.retain(|stream| stream.unbounded_send(SyncEvent::PeerDisconnected(peer_id)).is_ok());
 	}

--- a/substrate/client/network/sync/src/justification_requests.rs
+++ b/substrate/client/network/sync/src/justification_requests.rs
@@ -215,6 +215,40 @@ impl<B: BlockT> ExtraRequests<B> {
 				metrics.failed.set(self.failed_requests.len().try_into().unwrap_or(u64::MAX));
 				metrics.pending.inc();
 			}
+		} else if let Some(r) = resp {
+			// The request may have been moved from `active_requests` to
+			// `pending_requests` by `peer_disconnected()` if the sync peer
+			// disconnect event from the notifications protocol was processed
+			// before this response from the request-response protocol arrived.
+			// Accept the valid justification in this case.
+			if let Some(pos) = self
+				.pending_requests
+				.iter()
+				.position(|r| !self.failed_requests.contains_key(r))
+			{
+				let request = self.pending_requests.remove(pos).expect(
+					"`pos` is a valid index in `pending_requests`; qed",
+				);
+				if let Some(metrics) = &self.metrics {
+					metrics.pending.dec();
+				}
+
+				trace!(target: LOG_TARGET,
+					"Queuing import of {} from disconnected peer {:?} for {:?}",
+					self.request_type_name, who, request,
+				);
+
+				if self.importing_requests.insert(request) {
+					if let Some(metrics) = &self.metrics {
+						metrics.importing.inc();
+					}
+				}
+				return Some((who, request.0, request.1, r));
+			}
+			trace!(target: LOG_TARGET,
+				"No active or pending {} request to {:?}",
+				self.request_type_name, who,
+			);
 		} else {
 			trace!(target: LOG_TARGET,
 				"No active {} request to {:?}",
@@ -523,6 +557,54 @@ mod tests {
 		}
 
 		QuickCheck::new().quickcheck(property as fn(ArbitraryPeers) -> bool)
+	}
+
+	#[test]
+	fn response_after_disconnect_is_accepted() {
+		let mut requests = ExtraRequests::<Block>::new("test", None);
+
+		let peer = PeerId::random();
+		let hash = Hash::random();
+		let request = (hash, 1u64);
+
+		// Schedule a request
+		requests.schedule(request, |a, b| Ok(a[0] >= b[0]));
+
+		// Create a peer and assign the request to it
+		let mut peers = HashMap::new();
+		peers.insert(
+			peer,
+			PeerSync {
+				peer_id: peer,
+				common_number: 0,
+				best_hash: Hash::random(),
+				best_number: 10,
+				state: PeerSyncState::Available,
+			},
+		);
+
+		let mut m = requests.matcher();
+		let (matched_peer, matched_request) = m.next(&peers).unwrap();
+		assert_eq!(matched_peer, peer);
+		assert_eq!(matched_request, request);
+		drop(m);
+
+		// Peer disconnects - request moved from active to pending
+		requests.peer_disconnected(&peer);
+		assert!(requests.active_requests.is_empty());
+		assert!(requests.pending_requests.contains(&request));
+
+		// Response arrives after disconnect - should still be accepted
+		let result = requests.on_response(peer, Some(42u32));
+		assert!(result.is_some());
+		let (resp_peer, resp_hash, resp_number, resp_data) = result.unwrap();
+		assert_eq!(resp_peer, peer);
+		assert_eq!(resp_hash, hash);
+		assert_eq!(resp_number, 1u64);
+		assert_eq!(resp_data, 42u32);
+
+		// The request should no longer be in pending
+		assert!(requests.pending_requests.is_empty());
 	}
 
 	#[test]

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -1394,8 +1394,12 @@ where
 					.collect()
 			}
 		} else {
-			// We don't know of this peer, so we also did not request anything from it.
-			return Err(BadPeer(*peer_id, rep::NOT_REQUESTED));
+			// The peer may have disconnected before the block response arrived.
+			trace!(
+				target: LOG_TARGET,
+				"Block data response from unknown (disconnected?) peer {peer_id:?}, ignoring",
+			);
+			return Ok(());
 		};
 
 		self.validate_and_queue_blocks(new_blocks, gap);
@@ -1453,58 +1457,72 @@ where
 		peer_id: PeerId,
 		response: BlockResponse<B>,
 	) -> Result<(), BadPeer> {
-		let peer = if let Some(peer) = self.peers.get_mut(&peer_id) {
-			peer
-		} else {
-			error!(
-				target: LOG_TARGET,
-				"💔 Called on_block_justification with a peer ID of an unknown peer",
-			);
-			return Ok(());
-		};
+		let justification = if let Some(peer) = self.peers.get_mut(&peer_id) {
+			self.allowed_requests.add(&peer_id);
+			if let PeerSyncState::DownloadingJustification(hash) = peer.state {
+				peer.state = PeerSyncState::Available;
 
-		self.allowed_requests.add(&peer_id);
-		if let PeerSyncState::DownloadingJustification(hash) = peer.state {
-			peer.state = PeerSyncState::Available;
+				// We only request one justification at a time
+				if let Some(block) = response.blocks.into_iter().next() {
+					if hash != block.hash {
+						warn!(
+							target: LOG_TARGET,
+							"💔 Invalid block justification provided by {}: requested: {:?} \
+							got: {:?}",
+							peer_id,
+							hash,
+							block.hash,
+						);
+						return Err(BadPeer(peer_id, rep::BAD_JUSTIFICATION));
+					}
 
-			// We only request one justification at a time
-			let justification = if let Some(block) = response.blocks.into_iter().next() {
-				if hash != block.hash {
-					warn!(
+					block
+						.justifications
+						.or_else(|| legacy_justification_mapping(block.justification))
+				} else {
+					// we might have asked the peer for a justification on a block that we
+					// assumed it had but didn't (regardless of whether it had a justification
+					// for it or not).
+					trace!(
 						target: LOG_TARGET,
-						"💔 Invalid block justification provided by {}: requested: {:?} got: {:?}",
-						peer_id,
-						hash,
-						block.hash,
+						"Peer {peer_id:?} provided empty response for justification request \
+						{hash:?}",
 					);
-					return Err(BadPeer(peer_id, rep::BAD_JUSTIFICATION));
+
+					None
 				}
-
-				block
-					.justifications
-					.or_else(|| legacy_justification_mapping(block.justification))
 			} else {
-				// we might have asked the peer for a justification on a block that we assumed it
-				// had but didn't (regardless of whether it had a justification for it or not).
-				trace!(
-					target: LOG_TARGET,
-					"Peer {peer_id:?} provided empty response for justification request {hash:?}",
-				);
-
-				None
-			};
-
-			if let Some((peer_id, hash, number, justifications)) =
-				self.extra_justifications.on_response(peer_id, justification)
-			{
-				self.actions.push(SyncingAction::ImportJustifications {
-					peer_id,
-					hash,
-					number,
-					justifications,
-				});
 				return Ok(());
 			}
+		} else {
+			// The peer has disconnected before the justification response arrived.
+			// Still try to process the justification via `on_response` which will
+			// check `pending_requests` for a request moved there by `peer_disconnected`.
+			trace!(
+				target: LOG_TARGET,
+				"Justification response from disconnected peer {peer_id:?}",
+			);
+
+			response
+				.blocks
+				.into_iter()
+				.next()
+				.and_then(|block| {
+					block
+						.justifications
+						.or_else(|| legacy_justification_mapping(block.justification))
+				})
+		};
+
+		if let Some((peer_id, hash, number, justifications)) =
+			self.extra_justifications.on_response(peer_id, justification)
+		{
+			self.actions.push(SyncingAction::ImportJustifications {
+				peer_id,
+				hash,
+				number,
+				justifications,
+			});
 		}
 
 		Ok(())


### PR DESCRIPTION
## Summary

Fixes #5414

When a sync peer disconnects (via the notifications protocol), any pending justification response from the request-response protocol was lost due to a race condition. This happened because:

1. `peer_disconnected()` moved the request from `active_requests` to `pending_requests`, but `on_response()` only checked `active_requests` — so a valid response arriving after disconnect was silently dropped.
2. `pending_responses.remove_all()` in `on_sync_peer_disconnected()` dropped the response future entirely, preventing the response from ever being delivered.

### Changes

- **`engine.rs`**: Don't call `pending_responses.remove_all()` when a sync peer disconnects. The response from the request-response protocol may still arrive and should be processed. The syncing strategy response handlers already handle the case where the peer is unknown.
- **`chain_sync.rs`**: Handle disconnected peers gracefully in `on_block_justification()` (extract and process the justification even if the peer is already gone) and in `on_block_data()` (log and ignore instead of treating as `BadPeer`).
- **`justification_requests.rs`**: In `on_response()`, when the request is not found in `active_requests` but a valid response is present, check `pending_requests` as a fallback (the request may have been moved there by `peer_disconnected()`).

## Test plan

- [x] Added `response_after_disconnect_is_accepted` unit test verifying that a justification response arriving after peer disconnect is properly accepted
- [x] All existing `justification_requests` tests pass
- [x] `cargo check -p sc-network-sync` passes
- [x] `cargo clippy -p sc-network-sync` passes with no warnings