### PR TITLE
xcm-emulator: advance relay block number by relay_blocks_per_para_block

### DIFF
--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-rococo/src/lib.rs
@@ -27,7 +27,6 @@ use emulated_integration_tests_common::{
 	impl_assets_helpers_for_parachain, impl_assets_helpers_for_system_parachain,
 	impl_bridge_helpers_for_chain, impl_foreign_assets_helpers_for_parachain,
 	impl_xcm_helpers_for_parachain, impls::Parachain, xcm_emulator::decl_test_parachains,
-	AuraDigestProvider,
 };
 use rococo_emulated_chain::Rococo;
 
@@ -44,7 +43,6 @@ decl_test_parachains! {
 			LocationToAccountId: asset_hub_rococo_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: asset_hub_rococo_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 			AdditionalInherentCode: (),
 		},
 		pallets = {

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/assets/asset-hub-westend/src/lib.rs
@@ -27,7 +27,6 @@ use emulated_integration_tests_common::{
 	impl_assets_helpers_for_parachain, impl_assets_helpers_for_system_parachain,
 	impl_bridge_helpers_for_chain, impl_foreign_assets_helpers_for_parachain,
 	impl_xcm_helpers_for_parachain, impls::Parachain, xcm_emulator::decl_test_parachains,
-	AuraDigestProvider,
 };
 use westend_emulated_chain::Westend;
 
@@ -44,7 +43,6 @@ decl_test_parachains! {
 			LocationToAccountId: asset_hub_westend_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: asset_hub_westend_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 			AdditionalInherentCode: (),
 		},
 		pallets = {

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-rococo/src/lib.rs
@@ -29,7 +29,6 @@ use frame_support::traits::OnInitialize;
 use emulated_integration_tests_common::{
 	impl_accounts_helpers_for_parachain, impl_assert_events_helpers_for_parachain,
 	impl_xcm_helpers_for_parachain, impls::Parachain, xcm_emulator::decl_test_parachains,
-	AuraDigestProvider,
 };
 
 // BridgeHubRococo Parachain declaration
@@ -45,7 +44,6 @@ decl_test_parachains! {
 			LocationToAccountId: bridge_hub_rococo_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: bridge_hub_rococo_runtime::ParachainInfo,
 			MessageOrigin: bridge_hub_common::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: bridge_hub_rococo_runtime::PolkadotXcm,

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/bridges/bridge-hub-westend/src/lib.rs
@@ -28,7 +28,6 @@ use frame_support::traits::OnInitialize;
 use emulated_integration_tests_common::{
 	impl_accounts_helpers_for_parachain, impl_assert_events_helpers_for_parachain,
 	impl_xcm_helpers_for_parachain, impls::Parachain, xcm_emulator::decl_test_parachains,
-	AuraDigestProvider,
 };
 
 // BridgeHubWestend Parachain declaration
@@ -44,7 +43,6 @@ decl_test_parachains! {
 			LocationToAccountId: bridge_hub_westend_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: bridge_hub_westend_runtime::ParachainInfo,
 			MessageOrigin: bridge_hub_common::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: bridge_hub_westend_runtime::PolkadotXcm,

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/collectives/collectives-westend/src/lib.rs
@@ -23,7 +23,7 @@ use frame_support::traits::OnInitialize;
 // Cumulus
 use emulated_integration_tests_common::{
 	impl_accounts_helpers_for_parachain, impl_assert_events_helpers_for_parachain,
-	impls::Parachain, xcm_emulator::decl_test_parachains, AuraDigestProvider,
+	impls::Parachain, xcm_emulator::decl_test_parachains,
 };
 
 // CollectivesWestend Parachain declaration
@@ -39,7 +39,6 @@ decl_test_parachains! {
 			LocationToAccountId: collectives_westend_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: collectives_westend_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: collectives_westend_runtime::PolkadotXcm,

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/coretime/coretime-westend/src/lib.rs
@@ -23,7 +23,7 @@ use frame_support::traits::OnInitialize;
 // Cumulus
 use emulated_integration_tests_common::{
 	impl_accounts_helpers_for_parachain, impl_assert_events_helpers_for_parachain,
-	impls::Parachain, xcm_emulator::decl_test_parachains, AuraDigestProvider,
+	impls::Parachain, xcm_emulator::decl_test_parachains,
 };
 
 // CoretimeWestend Parachain declaration
@@ -39,7 +39,6 @@ decl_test_parachains! {
 			LocationToAccountId: coretime_westend_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: coretime_westend_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: coretime_westend_runtime::PolkadotXcm,

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/people/people-westend/src/lib.rs
@@ -22,7 +22,7 @@ use frame_support::traits::OnInitialize;
 // Cumulus
 use emulated_integration_tests_common::{
 	impl_accounts_helpers_for_parachain, impl_assert_events_helpers_for_parachain,
-	impls::Parachain, xcm_emulator::decl_test_parachains, AuraDigestProvider,
+	impls::Parachain, xcm_emulator::decl_test_parachains,
 };
 
 // PeopleWestend Parachain declaration
@@ -38,7 +38,6 @@ decl_test_parachains! {
 			LocationToAccountId: people_westend_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: people_westend_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: people_westend_runtime::PolkadotXcm,

--- a/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -31,7 +31,6 @@ use emulated_integration_tests_common::{
 	impl_xcm_helpers_for_parachain,
 	impls::{NetworkId, Parachain},
 	xcm_emulator::decl_test_parachains,
-	AuraDigestProvider,
 };
 
 // Polkadot
@@ -54,7 +53,6 @@ decl_test_parachains! {
 			LocationToAccountId: penpal_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: penpal_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: penpal_runtime::PolkadotXcm,
@@ -79,7 +77,6 @@ decl_test_parachains! {
 			LocationToAccountId: penpal_runtime::xcm_config::LocationToAccountId,
 			ParachainInfo: penpal_runtime::ParachainInfo,
 			MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
-			DigestProvider: AuraDigestProvider,
 		},
 		pallets = {
 			PolkadotXcm: penpal_runtime::PolkadotXcm,

--- a/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/common/src/lib.rs
@@ -17,8 +17,6 @@ pub mod impls;
 pub mod macros;
 pub mod xcm_helpers;
 
-use codec::Encode;
-use cumulus_primitives_core::relay_chain::Slot;
 pub use xcm_emulator;
 pub use xcm_simulator;
 
@@ -30,7 +28,7 @@ use sp_consensus_babe::AuthorityId as BabeId;
 use sp_consensus_beefy::ecdsa_crypto::AuthorityId as BeefyId;
 use sp_core::storage::Storage;
 use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
-use sp_runtime::{traits::AccountIdConversion, BuildStorage, Digest, DigestItem};
+use sp_runtime::{traits::AccountIdConversion, BuildStorage};
 
 // Polkadot
 use parachains_common::BlockNumber;
@@ -40,8 +38,6 @@ use polkadot_runtime_parachains::configuration::HostConfiguration;
 // Cumulus
 use parachains_common::{AccountId, AuraId};
 use polkadot_primitives::{AssignmentId, ValidatorId};
-use sp_runtime::traits::Convert;
-use xcm_emulator::{RelayBlockNumber, AURA_ENGINE_ID};
 
 pub const XCM_V2: u32 = 2;
 pub const XCM_V3: u32 = 3;
@@ -66,22 +62,6 @@ pub const PENPAL_B_ID: u32 = 2001;
 pub const ASSET_HUB_ROCOCO_ID: u32 = 1000;
 pub const ASSET_HUB_WESTEND_ID: u32 = 1000;
 pub const ASSETS_PALLET_ID: u8 = 50;
-
-pub struct AuraDigestProvider<const PARA_SLOT_DURATION_MILLIS: u64 = 6000>;
-
-impl<const PARA_SLOT_DURATION_MILLIS: u64> Convert<(BlockNumber, RelayBlockNumber), Digest>
-	for AuraDigestProvider<PARA_SLOT_DURATION_MILLIS>
-{
-	fn convert((_, relay_block_number): (BlockNumber, RelayBlockNumber)) -> Digest {
-		let slot: Slot = (relay_block_number as u64 *
-			xcm_emulator::RELAY_CHAIN_SLOT_DURATION_MILLIS /
-			PARA_SLOT_DURATION_MILLIS)
-			.into();
-		let mut digest = Digest::default();
-		digest.logs.push(DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode()));
-		digest
-	}
-}
 
 parameter_types! {
 	pub PenpalALocation: xcm::v5::Location

--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -288,10 +288,6 @@ pub trait Parachain: Chain {
 	type ParachainInfo: Get<ParaId>;
 	type ParachainSystem;
 	type MessageProcessor: ProcessMessage + ServiceQueues;
-	type DigestProvider: Convert<
-		(BlockNumberFor<Self::Runtime>, BlockNumberFor<Self::Runtime>),
-		Digest,
-	>;
 	type AdditionalInherentCode: AdditionalInherentCode;
 
 	fn init();
@@ -628,7 +624,6 @@ macro_rules! decl_test_parachains {
 					LocationToAccountId: $location_to_account:path,
 					ParachainInfo: $parachain_info:path,
 					MessageOrigin: $message_origin:path,
-					$( DigestProvider: $digest_provider:ty,)?
 					$( AdditionalInherentCode: $additional_inherent_code:ty,)?
 				},
 				pallets = {
@@ -670,7 +665,6 @@ macro_rules! decl_test_parachains {
 				type ParachainSystem = $crate::ParachainSystemPallet<<Self as $crate::Chain>::Runtime>;
 				type ParachainInfo = $parachain_info;
 				type MessageProcessor = $crate::DefaultParaMessageProcessor<$name<N>, $message_origin>;
-				$crate::decl_test_parachains!(@inner_digest_provider $($digest_provider)?);
 				$crate::decl_test_parachains!(@inner_additional_inherent_code $($additional_inherent_code)?);
 
 				// We run an empty block during initialisation to open HRMP channels
@@ -692,7 +686,7 @@ macro_rules! decl_test_parachains {
 
 				fn new_block() {
 					use $crate::{
-						Dispatchable, Chain, Convert, TestExt, Zero, AdditionalInherentCode,
+						Dispatchable, Chain, TestExt, Zero, AdditionalInherentCode,
 						RELAY_CHAIN_SLOT_DURATION_MILLIS
 					};
 
@@ -720,8 +714,16 @@ macro_rules! decl_test_parachains {
 							.clone()
 						);
 
-						// Initialze `System`.
-						let digest = <Self as Parachain>::DigestProvider::convert((block_number, relay_block_number));
+						// Build aura digest: derive para slot from relay block number and slot durations.
+						let aura_slot: $crate::Slot = (relay_block_number as u64
+							* RELAY_CHAIN_SLOT_DURATION_MILLIS
+							/ slot_duration)
+							.into();
+						let mut digest = $crate::Digest::default();
+						digest.logs.push($crate::DigestItem::PreRuntime(
+							$crate::AURA_ENGINE_ID,
+							$crate::Encode::encode(&aura_slot),
+						));
 						<Self as Chain>::System::initialize(&block_number, &parent_head_data.hash(), &digest);
 
 						// Process `on_initialize` for all pallets except `System`.
@@ -821,8 +823,6 @@ macro_rules! decl_test_parachains {
 			$crate::__impl_check_assertion!($name, N);
 		)+
 	};
-	( @inner_digest_provider $digest_provider:ty ) => { type DigestProvider = $digest_provider; };
-	( @inner_digest_provider /* none */ ) => { type DigestProvider = (); };
 	( @inner_additional_inherent_code $additional_inherent_code:ty ) => { type AdditionalInherentCode = $additional_inherent_code; };
 	( @inner_additional_inherent_code /* none */ ) => { type AdditionalInherentCode = (); };
 }

--- a/prdoc/pr_11031.prdoc
+++ b/prdoc/pr_11031.prdoc
@@ -7,13 +7,14 @@ doc:
     `FixedVelocityConsensusHook` derives a parachain slot that doesn't match `CurrentSlot`.
 
     Fix by advancing the relay block number by `slot_duration / RELAY_CHAIN_SLOT_DURATION_MILLIS`
-    per parachain block (instead of always +1), matching the real-world ratio and the dev mode
-    inherent data provider logic. The timestamp now uses the relay chain slot duration directly.
+    per parachain block (instead of always +1), and computing the aura digest slot inline using
+    both durations. This removes the `DigestProvider` associated type from the `Parachain` trait
+    and the `AuraDigestProvider` struct — the emulator now handles the digest automatically.
 
-    `AuraDigestProvider` gains a const generic `PARA_SLOT_DURATION_MILLIS` (default 6000) so the
-    digest slot is scaled to match the parachain's actual slot duration.
+    Downstream users must remove `DigestProvider: AuraDigestProvider,` from their
+    `decl_test_parachains!` invocations.
 crates:
 - name: xcm-emulator
-  bump: minor
+  bump: major
 - name: emulated-integration-tests-common
-  bump: minor
+  bump: major


### PR DESCRIPTION
After `AuraDigestProvider` was introduced, emulated integration tests for parachains with   `slot_duration != relay_slot_duration` (e.g. 12s Polkadot/Kusama chains) panic because `FixedVelocityConsensusHook` derives a parachain slot that doesn't match `CurrentSlot`.      
                                                                                             
Fix by advancing the relay block number by `slot_duration / RELAY_CHAIN_SLOT_DURATION_MILLIS` per parachain block (instead of always +1), and computing the aura digest slot inline using  both durations. 
This removes the `DigestProvider` associated type from the `Parachain` trait  and the `AuraDigestProvider` struct — the emulator now handles the digest automatically.     
                                                                                             
Downstream users must remove `DigestProvider: AuraDigestProvider,` from their `decl_test_parachains!` invocations.                                                         

