### PR TITLE
substrate/cli: raise --max-runtime-instances cap to 128

### DIFF
--- a/substrate/client/cli/src/params/runtime_params.rs
+++ b/substrate/client/cli/src/params/runtime_params.rs
@@ -22,9 +22,9 @@ use std::str::FromStr;
 /// Parameters used to config runtime.
 #[derive(Debug, Clone, Args)]
 pub struct RuntimeParams {
-	/// The size of the instances cache for each runtime [max: 32].
+	/// The size of the instances cache for each runtime [max: 128].
 	///
-	/// Values higher than 32 are illegal.
+	/// Values higher than 128 are illegal.
 	#[arg(long, default_value_t = 8, value_parser = parse_max_runtime_instances)]
 	pub max_runtime_instances: usize,
 
@@ -37,8 +37,8 @@ fn parse_max_runtime_instances(s: &str) -> Result<usize, String> {
 	let max_runtime_instances = usize::from_str(s)
 		.map_err(|_err| format!("Illegal `--max-runtime-instances` value: {s}"))?;
 
-	if max_runtime_instances > 32 {
-		Err(format!("Illegal `--max-runtime-instances` value: {max_runtime_instances} is more than the allowed maximum of `32` "))
+	if max_runtime_instances > 128 {
+		Err(format!("Illegal `--max-runtime-instances` value: {max_runtime_instances} is more than the allowed maximum of `128` "))
 	} else {
 		Ok(max_runtime_instances)
 	}


### PR DESCRIPTION
## Summary
Raise the hard cap for `--max-runtime-instances` from `32` to `128` in the CLI runtime params parser.

## What changed
- Updated help text from `max: 32` to `max: 128`
- Updated validation message from `Values higher than 32 are illegal.` to `Values higher than 128 are illegal.`
- Updated parser guard in `parse_max_runtime_instances` from `> 32` to `> 128`
- Updated error text maximum from `32` to `128`

File changed:
- `substrate/client/cli/src/params/runtime_params.rs`

## Behavior
- `--max-runtime-instances 128` is accepted
- `--max-runtime-instances 129` remains rejected
- Default value remains unchanged (`8`)

## Motivation
Some node deployments need a larger runtime instance cache for throughput-sensitive workloads. This change increases configurability while preserving an explicit upper bound and existing validation semantics.