### PR TITLE
Fix: RFC: Ordered Spend Payouts

### DIFF
--- a/substrate/frame/treasury/src/lib.rs
+++ b/substrate/frame/treasury/src/lib.rs
@@ -440,6 +440,8 @@ pub mod pallet {
 		EarlyPayout,
 		/// The payment has already been attempted.
 		AlreadyAttempted,
+		/// There is another matured spend with a lower index that must be claimed first.
+		SpendNotInOrder,
 		/// There was some issue with the mechanism of payment.
 		PayoutError,
 		/// The payout was not yet attempted/claimed.
@@ -732,11 +734,23 @@ pub mod pallet {
 		///
 		/// Emits [`Event::Paid`] if successful.
 		#[pallet::call_index(6)]
-		#[pallet::weight(T::WeightInfo::payout())]
+		#[pallet::weight(
+			T::WeightInfo::payout()
+				.saturating_add(T::DbWeight::get().reads(index.saturating_sub(1).into()))
+		)]
 		pub fn payout(origin: OriginFor<T>, index: SpendIndex) -> DispatchResult {
 			ensure_signed(origin)?;
 			let mut spend = Spends::<T, I>::get(index).ok_or(Error::<T, I>::InvalidIndex)?;
 			let now = T::BlockNumberProvider::current_block_number();
+			for earlier_index in 0..index {
+				let Some(earlier_spend) = Spends::<T, I>::get(earlier_index) else {
+					continue;
+				};
+				let is_earlier_claimable = now >= earlier_spend.valid_from &&
+					earlier_spend.expire_at > now &&
+					matches!(earlier_spend.status, PaymentState::Pending | PaymentState::Failed);
+				ensure!(!is_earlier_claimable, Error::<T, I>::SpendNotInOrder);
+			}
 			ensure!(now >= spend.valid_from, Error::<T, I>::EarlyPayout);
 			ensure!(spend.expire_at > now, Error::<T, I>::SpendExpired);
 			ensure!(

--- a/substrate/frame/treasury/src/tests.rs
+++ b/substrate/frame/treasury/src/tests.rs
@@ -672,6 +672,28 @@ fn spend_payout_works() {
 }
 
 #[test]
+fn spend_payout_must_follow_earlier_mature_spends() {
+	ExtBuilder::default().build().execute_with(|| {
+		System::set_block_number(1);
+		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(6), None));
+		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(7), None));
+		assert_ok!(Treasury::spend(RuntimeOrigin::signed(10), Box::new(1), 2, Box::new(8), None));
+
+		assert_noop!(
+			Treasury::payout(RuntimeOrigin::signed(1), 2),
+			Error::<Test, _>::SpendNotInOrder
+		);
+		assert_ok!(Treasury::payout(RuntimeOrigin::signed(1), 0));
+		assert_noop!(
+			Treasury::payout(RuntimeOrigin::signed(1), 2),
+			Error::<Test, _>::SpendNotInOrder
+		);
+		assert_ok!(Treasury::payout(RuntimeOrigin::signed(1), 1));
+		assert_ok!(Treasury::payout(RuntimeOrigin::signed(1), 2));
+	});
+}
+
+#[test]
 fn payout_extends_expiry() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(<Test as Config>::PayoutPeriod::get(), 5);


### PR DESCRIPTION
Draft fix for https://github.com/paritytech/polkadot-sdk/issues/11100

Draft prepared via targeted patch mode.
Validation command not configured in automation.

Changed files:
- `substrate/frame/treasury/src/lib.rs`
- `substrate/frame/treasury/src/tests.rs`
