### PR TITLE
pallet-conviction-voting: Migrate pallet-conviction-voting to using fungible traits

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
@@ -48,7 +48,8 @@ mod impls;
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
+	type Fungible = Balances;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
 	type MaxTurnout =

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1273,12 +1273,14 @@ parameter_types! {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations =
+	type Migrations = (
 		assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesMigration<
 			Runtime,
 			ForeignAssetsInstance,
 			migrations::AssetHubWestendForeignAssetsReservesProvider,
-		>;
+		>,
+		pallet_conviction_voting::migrations::v1::LazyMigrationV0ToV1<Runtime, (), Balances>,
+	);
 	// Benchmarks need mocked migrations to guarantee that they succeed.
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_conviction_voting.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_conviction_voting.rs
@@ -210,4 +210,9 @@ impl<T: frame_system::Config> pallet_conviction_voting::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn v1_migration_step() -> Weight {
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }

--- a/polkadot/runtime/rococo/src/governance/mod.rs
+++ b/polkadot/runtime/rococo/src/governance/mod.rs
@@ -41,7 +41,8 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
+	type Fungible = Balances;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
 	type MaxTurnout =

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -98,7 +98,7 @@ use frame_support::{
 		fungible::HoldConsideration, tokens::UnityOrOuterConversion, Contains, EitherOf,
 		EitherOfDiverse, EnsureOrigin, EnsureOriginWithArg, EverythingBut, InstanceFilter,
 		KeyOwnerProofSystem, LinearStoragePrice, PrivilegeCmp, ProcessMessage, ProcessMessageError,
-		StorageMapShim, WithdrawReasons,
+		StorageMapShim, VariantCountOf, WithdrawReasons,
 	},
 	weights::{ConstantMultiplier, WeightMeter},
 	PalletId,
@@ -414,10 +414,10 @@ impl pallet_balances::Config for Runtime {
 	type MaxReserves = MaxReserves;
 	type ReserveIdentifier = [u8; 8];
 	type WeightInfo = weights::pallet_balances_balances::WeightInfo<Runtime>;
-	type FreezeIdentifier = ();
+	type FreezeIdentifier = RuntimeFreezeReason;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
-	type MaxFreezes = ConstU32<1>;
+	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
 	type DoneSlashHandler = ();
 }
 
@@ -1456,7 +1456,10 @@ parameter_types! {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = pallet_identity::migration::v2::LazyMigrationV1ToV2<Runtime>;
+	type Migrations = (
+		pallet_identity::migration::v2::LazyMigrationV1ToV2<Runtime>,
+		pallet_conviction_voting::migrations::v1::LazyMigrationV0ToV1<Runtime, (), Balances>,
+	);
 	// Benchmarks need mocked migrations to guarantee that they succeed.
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;

--- a/polkadot/runtime/rococo/src/weights/pallet_conviction_voting.rs
+++ b/polkadot/runtime/rococo/src/weights/pallet_conviction_voting.rs
@@ -201,4 +201,9 @@ impl<T: frame_system::Config> pallet_conviction_voting::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn v1_migration_step() -> Weight {
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }

--- a/polkadot/runtime/westend/src/governance/mod.rs
+++ b/polkadot/runtime/westend/src/governance/mod.rs
@@ -38,7 +38,8 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
+	type Fungible = Balances;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
 	type MaxTurnout =

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -1752,7 +1752,10 @@ parameter_types! {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = pallet_identity::migration::v2::LazyMigrationV1ToV2<Runtime>;
+	type Migrations = (
+		pallet_identity::migration::v2::LazyMigrationV1ToV2<Runtime>,
+		pallet_conviction_voting::migrations::v1::LazyMigrationV0ToV1<Runtime, (), Balances>,
+	);
 	// Benchmarks need mocked migrations to guarantee that they succeed.
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;

--- a/polkadot/runtime/westend/src/weights/pallet_conviction_voting.rs
+++ b/polkadot/runtime/westend/src/weights/pallet_conviction_voting.rs
@@ -201,4 +201,9 @@ impl<T: frame_system::Config> pallet_conviction_voting::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn v1_migration_step() -> Weight {
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }

--- a/prdoc/pr_11142.prdoc
+++ b/prdoc/pr_11142.prdoc
@@ -1,0 +1,25 @@
+title: Migrate pallet-conviction-voting to using fungible traits
+doc:
+- audience: Todo
+  description: |-
+    Migrate pallet-conviction-voting from Currency/LockableCurrency traits to fungible traits (freezes), as part of #226.
+
+    Locks are replaced with freezes (fungible::MutateFreeze), which are identical in operation in that they both prevent balance from dropping below a threshold without partitioning into separate pools.
+
+      Changes
+
+      - Replace type Currency with type Fungible + type RuntimeFreezeReason in the pallet's Config trait
+      - Add FreezeReason::ConvictionVoting composite enum
+      - Convert all lock operations (set_lock, extend_lock, remove_lock) to freeze equivalents (set_freeze, extend_freeze, thaw)
+      - Add SteppedMigration (LazyMigrationV0ToV1) to convert existing locks to freezes at runtime upgrade
+      - Add v1_migration_step benchmark for the migration
+      - Bump storage version to 1
+crates:
+- name: asset-hub-westend-runtime
+  bump: major
+- name: rococo-runtime
+  bump: major
+- name: westend-runtime
+  bump: major
+- name: pallet-conviction-voting
+  bump: major

--- a/prdoc/pr_11142.prdoc
+++ b/prdoc/pr_11142.prdoc
@@ -1,19 +1,8 @@
 title: Migrate pallet-conviction-voting to using fungible traits
 doc:
-- audience: Todo
+- audience: Runtime Dev
   description: |-
-    Migrate pallet-conviction-voting from Currency/LockableCurrency traits to fungible traits (freezes), as part of #226.
-
-    Locks are replaced with freezes (fungible::MutateFreeze), which are identical in operation in that they both prevent balance from dropping below a threshold without partitioning into separate pools.
-
-      Changes
-
-      - Replace type Currency with type Fungible + type RuntimeFreezeReason in the pallet's Config trait
-      - Add FreezeReason::ConvictionVoting composite enum
-      - Convert all lock operations (set_lock, extend_lock, remove_lock) to freeze equivalents (set_freeze, extend_freeze, thaw)
-      - Add SteppedMigration (LazyMigrationV0ToV1) to convert existing locks to freezes at runtime upgrade
-      - Add v1_migration_step benchmark for the migration
-      - Bump storage version to 1
+    Migrate pallet-conviction-voting from Currency/LockableCurrency traits to fungible traits (freezes).
 crates:
 - name: asset-hub-westend-runtime
   bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1016,7 +1016,8 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = pallet_conviction_voting::weights::SubstrateWeight<Self>;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
+	type Fungible = Balances;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
 	type MaxTurnout = frame_support::traits::TotalIssuanceOf<Balances, Self::AccountId>;

--- a/substrate/frame/conviction-voting/Cargo.toml
+++ b/substrate/frame/conviction-voting/Cargo.toml
@@ -21,6 +21,7 @@ codec = { features = ["derive", "max-encoded-len"], workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+pallet-balances = { optional = true, workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { features = ["derive"], optional = true, workspace = true, default-features = true }
 sp-io = { workspace = true }
@@ -37,7 +38,7 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-support/std",
 	"frame-system/std",
-	"pallet-balances/std",
+	"pallet-balances?/std",
 	"scale-info/std",
 	"serde",
 	"sp-core/std",
@@ -54,6 +55,6 @@ runtime-benchmarks = [
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
-	"pallet-balances/try-runtime",
+	"pallet-balances?/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -70,8 +70,9 @@ pub type BlockNumberFor<T, I> =
 	<<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
-pub type BalanceOf<T, I = ()> =
-	<<T as Config<I>>::Fungible as fungible::Inspect<<T as frame_system::Config>::AccountId>>::Balance;
+pub type BalanceOf<T, I = ()> = <<T as Config<I>>::Fungible as fungible::Inspect<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
 pub type VotingOf<T, I = ()> = Voting<
 	BalanceOf<T, I>,
 	<T as frame_system::Config>::AccountId,

--- a/substrate/frame/conviction-voting/src/migrations.rs
+++ b/substrate/frame/conviction-voting/src/migrations.rs
@@ -1,0 +1,140 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Storage migrations for the conviction-voting pallet.
+
+/// The old lock identifier used by the Currency-based implementation.
+pub const CONVICTION_VOTING_ID: frame_support::traits::LockIdentifier = *b"pyconvot";
+
+pub mod v1 {
+	use super::*;
+	use crate::{pallet::FreezeReason, weights::WeightInfo, BalanceOf, ClassLocksFor, Config};
+	use frame_support::{
+		migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
+		pallet_prelude::PhantomData,
+		traits::{fungible::MutateFreeze, LockableCurrency},
+		weights::WeightMeter,
+	};
+	use sp_runtime::traits::Zero;
+
+	#[cfg(feature = "try-runtime")]
+	use {alloc::vec::Vec, codec::Encode};
+
+	const PALLET_MIGRATIONS_ID: &[u8; 24] = b"pallet-conviction-voting";
+
+	/// Migrates lock-based balance freezing to the new fungible freeze mechanism.
+	///
+	/// For each account in `ClassLocksFor`, this migration:
+	/// 1. Computes the maximum lock amount across all classes
+	/// 2. Removes the old Currency lock
+	/// 3. Sets a new fungible freeze with the same amount
+	pub struct LazyMigrationV0ToV1<T, I, OldCurrency>(PhantomData<(T, I, OldCurrency)>);
+
+	impl<T, I, OldCurrency> SteppedMigration for LazyMigrationV0ToV1<T, I, OldCurrency>
+	where
+		T: Config<I>,
+		I: 'static,
+		OldCurrency: LockableCurrency<T::AccountId, Balance = BalanceOf<T, I>>,
+	{
+		type Cursor = T::AccountId;
+		type Identifier = MigrationId<24>;
+
+		fn id() -> Self::Identifier {
+			MigrationId { pallet_id: *PALLET_MIGRATIONS_ID, version_from: 0, version_to: 1 }
+		}
+
+		fn step(
+			mut cursor: Option<Self::Cursor>,
+			meter: &mut WeightMeter,
+		) -> Result<Option<Self::Cursor>, SteppedMigrationError> {
+			let required = T::WeightInfo::v1_migration_step();
+			if meter.remaining().any_lt(required) {
+				return Err(SteppedMigrationError::InsufficientWeight { required });
+			}
+
+			loop {
+				if meter.try_consume(required).is_err() {
+					break;
+				}
+
+				let mut iter = if let Some(ref last_key) = cursor {
+					ClassLocksFor::<T, I>::iter_from(ClassLocksFor::<T, I>::hashed_key_for(
+						last_key,
+					))
+				} else {
+					ClassLocksFor::<T, I>::iter()
+				};
+
+				if let Some((who, locks)) = iter.next() {
+					// Compute the max lock amount across all classes.
+					let max_lock =
+						locks.iter().map(|(_, amount)| *amount).max().unwrap_or(Zero::zero());
+
+					// Remove the old Currency lock.
+					OldCurrency::remove_lock(CONVICTION_VOTING_ID, &who);
+
+					// Set the new freeze if there's a non-zero amount.
+					if !max_lock.is_zero() {
+						T::Fungible::set_freeze(
+							&FreezeReason::ConvictionVoting.into(),
+							&who,
+							max_lock,
+						)
+						.map_err(|_| SteppedMigrationError::Failed)?;
+					}
+
+					cursor = Some(who);
+				} else {
+					cursor = None;
+					break;
+				}
+			}
+
+			Ok(cursor)
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, frame_support::sp_runtime::TryRuntimeError> {
+			let count = ClassLocksFor::<T, I>::iter().count() as u32;
+			frame_support::log::info!(
+				target: "runtime::conviction-voting",
+				"pre_upgrade: {} accounts with class locks",
+				count,
+			);
+			Ok(count.encode())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(prev: Vec<u8>) -> Result<(), frame_support::sp_runtime::TryRuntimeError> {
+			use codec::Decode;
+			let prev_count =
+				u32::decode(&mut &prev[..]).expect("Failed to decode previous migration state");
+			let post_count = ClassLocksFor::<T, I>::iter().count() as u32;
+			assert_eq!(
+				prev_count, post_count,
+				"Migration error: account count changed from {} to {}",
+				prev_count, post_count,
+			);
+			frame_support::log::info!(
+				target: "runtime::conviction-voting",
+				"post_upgrade: successfully migrated {} accounts from locks to freezes",
+				post_count,
+			);
+			Ok(())
+		}
+	}
+}

--- a/substrate/frame/conviction-voting/src/tests.rs
+++ b/substrate/frame/conviction-voting/src/tests.rs
@@ -21,7 +21,7 @@ use std::{cell::RefCell, collections::BTreeMap};
 
 use frame_support::{
 	assert_noop, assert_ok, derive_impl, parameter_types,
-	traits::{ConstU32, ConstU64, Contains, Polling, VoteTally},
+	traits::{ConstU32, ConstU64, Contains, Polling, VariantCountOf, VoteTally},
 };
 use sp_runtime::BuildStorage;
 
@@ -57,6 +57,8 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxFreezes = VariantCountOf<RuntimeFreezeReason>;
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -150,7 +152,8 @@ impl Polling<TallyOf<Test>> for TestPolls {
 
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = pallet_balances::Pallet<Self>;
+	type Fungible = pallet_balances::Pallet<Self>;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = ConstU64<3>;
 	type MaxVotes = ConstU32<3>;
 	type WeightInfo = ();

--- a/substrate/frame/conviction-voting/src/weights.rs
+++ b/substrate/frame/conviction-voting/src/weights.rs
@@ -79,6 +79,7 @@ pub trait WeightInfo {
 	fn delegate(r: u32, ) -> Weight;
 	fn undelegate(r: u32, ) -> Weight;
 	fn unlock() -> Weight;
+	fn v1_migration_step() -> Weight;
 }
 
 /// Weights for `pallet_conviction_voting` using the Substrate node and recommended hardware.
@@ -237,6 +238,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
+	fn v1_migration_step() -> Weight {
+		// ClassLocksFor read + Locks remove + Freezes write
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -392,6 +399,12 @@ impl WeightInfo for () {
 		// Minimum execution time: 83_405_000 picoseconds.
 		Weight::from_parts(92_198_000, 30706)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	fn v1_migration_step() -> Weight {
+		// ClassLocksFor read + Locks remove + Freezes write
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 }

--- a/substrate/frame/staking-async/runtimes/parachain/src/governance/mod.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/governance/mod.rs
@@ -53,7 +53,8 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
+	type Fungible = Balances;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
 	type MaxTurnout =

--- a/substrate/frame/staking-async/runtimes/parachain/src/weights/pallet_conviction_voting.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/weights/pallet_conviction_voting.rs
@@ -192,4 +192,9 @@ impl<T: frame_system::Config> pallet_conviction_voting::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn v1_migration_step() -> Weight {
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }

--- a/substrate/frame/staking-async/runtimes/rc/src/governance/mod.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/governance/mod.rs
@@ -38,7 +38,8 @@ parameter_types! {
 impl pallet_conviction_voting::Config for Runtime {
 	type WeightInfo = weights::pallet_conviction_voting::WeightInfo<Self>;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
+	type Fungible = Balances;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type VoteLockingPeriod = VoteLockingPeriod;
 	type MaxVotes = ConstU32<512>;
 	type MaxTurnout =

--- a/substrate/frame/staking-async/runtimes/rc/src/weights/pallet_conviction_voting.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/weights/pallet_conviction_voting.rs
@@ -201,4 +201,9 @@ impl<T: frame_system::Config> pallet_conviction_voting::WeightInfo for WeightInf
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
+	fn v1_migration_step() -> Weight {
+		Weight::from_parts(50_000_000, 30706)
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().writes(3))
+	}
 }


### PR DESCRIPTION
Migrate pallet-conviction-voting from Currency/LockableCurrency traits to fungible traits (freezes), as part of #226.

Locks are replaced with freezes (fungible::MutateFreeze), which are identical in operation in that they both prevent balance from dropping below a threshold without partitioning into separate pools.

  Changes

  - Replace type Currency with type Fungible + type RuntimeFreezeReason in the pallet's Config trait
  - Add FreezeReason::ConvictionVoting composite enum
  - Convert all lock operations (set_lock, extend_lock, remove_lock) to freeze equivalents (set_freeze, extend_freeze, thaw)
  - Add SteppedMigration (LazyMigrationV0ToV1) to convert existing locks to freezes at runtime upgrade
  - Add v1_migration_step benchmark for the migration
  - Bump storage version to 1
