### PR TITLE
polkadot: fix peer view update

### DIFF
--- a/polkadot/node/network/bridge/src/rx/mod.rs
+++ b/polkadot/node/network/bridge/src/rx/mod.rs
@@ -970,6 +970,8 @@ fn update_our_view<Context>(
 
 	let v2_collation_peers = filter_by_peer_version(&collation_peers, CollationVersion::V2.into());
 
+	let v3_collation_peers = filter_by_peer_version(&collation_peers, CollationVersion::V3.into());
+
 	let v3_validation_peers =
 		filter_by_peer_version(&validation_peers, ValidationVersion::V3.into());
 
@@ -986,6 +988,13 @@ fn update_our_view<Context>(
 		metrics,
 		notification_sinks,
 	);
+
+	send_collation_message_v3(
+		v3_collation_peers,
+		WireMessage::ViewUpdate(new_view.clone()),
+		metrics,
+		notification_sinks,
+	);;
 
 	send_validation_message_v3(
 		v3_validation_peers,


### PR DESCRIPTION
# Description

Peer view update is necessary for V3 collator protocol, for the collation peer set, to prep the collators when needing to know how to advertise collations, based on relay parent they are building against.

## Integration

N/A

## Review Notes

Fixes para throughput issues in relation to low latency support.