### PR TITLE
StatementStore: readme update with dev node running guide

### DIFF
--- a/substrate/client/statement-store/README.md
+++ b/substrate/client/statement-store/README.md
@@ -77,7 +77,7 @@ Parameters:
   include any of the provided topics.
 
 ```rust
-let mut subscription: Subscription<Bytes> = rpc_client
+let mut subscription: Subscription<StatementEvent> = rpc_client
     .subscribe(
         "statement_subscribeStatement",
         rpc_params![TopicFilter::MatchAny(bounded_topics)],


### PR DESCRIPTION
Update  readme file of Statement store  to provide a guidance how to run a development node locally. 