### PR TITLE
check semver: Update parity-publish v0.10.6 -> v0.10.10

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -79,12 +79,10 @@ jobs:
           rustup default $TOOLCHAIN
           rustup target add wasm32-unknown-unknown --toolchain $TOOLCHAIN
           rustup component add rust-src --toolchain $TOOLCHAIN
-          cargo +stable --version
-          cargo +nightly --version
 
       - name: Install parity-publish
         run: |
-          apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config libssl-dev
+          apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
           # Set the target dir to cache the build.
           CARGO_TARGET_DIR=./target/ cargo install parity-publish@0.10.10 --locked -q
 


### PR DESCRIPTION
Fix failing semver check due to old compiled-in cargo in parity-publish by:
1. Upgrading `parity-publish` to the latest version.
2. Fixing its build dependencies installation with `apt-get`.

```
Error: failed to load manifest for workspace member `/__w/polkadot-sdk/polkadot-sdk/bridges/bin/runtime-common`
referenced by workspace at `/__w/polkadot-sdk/polkadot-sdk/Cargo.toml`

Caused by:
    0: failed to load manifest for dependency `bp-header-chain`
    ...
   23: failed to load manifest for dependency `pallet-revive`
   24: failed to parse manifest at `/__w/polkadot-sdk/polkadot-sdk/substrate/frame/revive/Cargo.toml`
   25: feature `edition2024` is required
       
       The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0).
       Consider adding `cargo-features = ["edition2024"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
```