### PR TITLE
fix: publish-check-compile.yml

### DIFF
--- a/.github/workflows/publish-check-compile.yml
+++ b/.github/workflows/publish-check-compile.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: install parity-publish
         run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
+          apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
           cargo install parity-publish@0.10.10 --locked -q
 
       - name: set current PR's prdoc name in a variable


### PR DESCRIPTION
This is fix for failing job:
https://github.com/paritytech/polkadot-sdk/actions/runs/22578558700/job/65404381763?pr=10215

<img width="2079" height="544" alt="image" src="https://github.com/user-attachments/assets/37d07015-fa22-4079-ab3f-8315dcf1565c" />


Inspired by: https://github.com/paritytech/polkadot-sdk/pull/11223