### PR TITLE
fix collators-basic-reputation-persistence-test, disable internal mon…

### DIFF
--- a/polkadot/zombienet-sdk-tests/tests/functional/collators_reputation_persistence.rs
+++ b/polkadot/zombienet-sdk-tests/tests/functional/collators_reputation_persistence.rs
@@ -118,6 +118,13 @@ async fn comprehensive_reputation_persistence_test() -> Result<(), anyhow::Error
 				])
 				.with_collator(|n| n.with_name("collator-2"))
 		})
+		.with_global_settings(|global_settings| {
+			let global_settings = match std::env::var("ZOMBIENET_SDK_BASE_DIR") {
+				Ok(val) => global_settings.with_base_dir(val),
+				_ => global_settings,
+			};
+			global_settings.with_tear_down_on_failure(false)
+		})
 		.build()
 		.map_err(|e| {
 			let errs = e.into_iter().map(|e| e.to_string()).collect::<Vec<_>>().join(" ");


### PR DESCRIPTION
This test is most of the time failing,  because the _internal monitoring of zombienet_  is tear down the network when we restart the node. This pr disable this monitoring (tracking the  needed changes in zombienet-sdk [here](https://github.com/paritytech/zombienet-sdk/issues/519)).

https://paritytech.github.io/zombienet-jobs-monitor/web/?search=zombienet-polkadot-collators-basic-reputation-persistence&startDate=2026-02-24&endDate=2026-03-03&mergeQueueOnly=true

<img width="1028" height="183" alt="Image" src="https://github.com/user-attachments/assets/13e53f1b-89a9-487d-a2f5-1c1576f0e42e" />
