### PR TITLE
add  flag to collator

### DIFF
--- a/substrate/frame/staking-async/runtimes/papi-tests/zn-m.toml
+++ b/substrate/frame/staking-async/runtimes/papi-tests/zn-m.toml
@@ -35,5 +35,6 @@ command = "polkadot-parachain"
 name = "charlie"
 rpc_port = 9946
 args = [
+	"--authoring=slot-based",
 	"-lruntime::system=debug,runtime::multiblock-election=trace,runtime::staking=debug,runtime::staking::rc-client=trace,runtime::rc-client=debug",
 ]

--- a/substrate/frame/staking-async/runtimes/papi-tests/zn-s.toml
+++ b/substrate/frame/staking-async/runtimes/papi-tests/zn-s.toml
@@ -27,5 +27,6 @@ command = "polkadot-parachain"
 name = "charlie"
 rpc_port = 9946
 args = [
+	"--authoring=slot-based",
 	"-lruntime::system=debug,runtime::multiblock-election=trace,runtime::staking=debug,runtime::staking::rc-client=trace,runtime::rc-client=debug,xcm=debug,parachain-system=debug,runtime=info",
 ]


### PR DESCRIPTION
Fix #11236

Add flag `"--authoring=slot-based"` to collaltors to produce blocks at 6s rate.

Fix for https://github.com/paritytech/polkadot-staking-miner/actions/workflows/nightly.yml
