### PR TITLE
statement-store: remove outdated benchmarks

### DIFF
--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store_bench.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store_bench.rs
@@ -4,14 +4,14 @@
 // Benchmarking statement store performance
 
 use anyhow::anyhow;
-use codec::{Decode, Encode};
+use codec::Encode;
 use futures::stream::{FuturesUnordered, StreamExt};
-use log::{debug, info, trace};
+use log::{debug, info};
 use sc_statement_store::{DEFAULT_MAX_TOTAL_SIZE, DEFAULT_MAX_TOTAL_STATEMENTS};
 use sp_core::{blake2_256, hexdisplay::HexDisplay, sr25519, Bytes, Pair};
 use sp_statement_store::{
-	statement_allowance_key, Channel, Statement, StatementAllowance, StatementEvent, SubmitResult,
-	Topic, TopicFilter,
+	statement_allowance_key, Statement, StatementAllowance, StatementEvent, SubmitResult, Topic,
+	TopicFilter,
 };
 use std::{
 	cell::Cell,
@@ -26,138 +26,7 @@ use zombienet_sdk::{
 	LocalFileSystem, Network, NetworkConfigBuilder,
 };
 
-const GROUP_SIZE: u32 = 6;
-const PARTICIPANT_SIZE: u32 = GROUP_SIZE * 8333; // Target ~50,000 total
-const MESSAGE_SIZE: usize = 512;
-const MESSAGE_COUNT: usize = 1;
-const RETRY_DELAY_MS: u64 = 500;
-const SUBSCRIBE_TIMEOUT_SECS: u64 = 200;
 const RPC_POOL_SIZE: usize = 10000;
-
-/// Single-node benchmark.
-///
-/// Tests statement-store performance of a single node without relying on statement gossip between
-/// nodes. Measures the maximum speed of statement exchange. Network spawned with only 2 collator
-/// nodes. All participants connect to one collator node, allowing them to fetch new statements
-/// immediately without waiting for propagation.
-///
-/// # Output
-/// Logs aggregated statistics across all participants:
-/// - Average messages sent/received per participant
-/// - Execution time (min/avg/max) across all participants
-/// - Retry attempts (min/avg/max) needed for statement propagation
-#[tokio::test(flavor = "multi_thread")]
-async fn statement_store_one_node_bench() -> Result<(), anyhow::Error> {
-	let _ = env_logger::try_init_from_env(
-		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-	);
-
-	let collator_names = ["alice", "bob"];
-	let network = spawn_network(&collator_names, PARTICIPANT_SIZE).await?;
-
-	info!("Starting statement store benchmark with {} participants", PARTICIPANT_SIZE);
-
-	let target_node = collator_names[0];
-	let node = network.get_node(target_node)?;
-
-	let mut rpc_pool = Vec::with_capacity(RPC_POOL_SIZE);
-	for _ in 0..RPC_POOL_SIZE {
-		rpc_pool.push(node.rpc().await?);
-	}
-	info!("Created RPC connection pool with {} connections to {}", RPC_POOL_SIZE, target_node);
-
-	let mut participants = Vec::with_capacity(PARTICIPANT_SIZE as usize);
-	for i in 0..(PARTICIPANT_SIZE) as usize {
-		participants.push(Participant::new(i as u32, rpc_pool[i % RPC_POOL_SIZE].clone()));
-	}
-
-	let handles: Vec<_> = participants
-		.into_iter()
-		.map(|mut p| tokio::spawn(async move { p.run().await }))
-		.collect();
-
-	let mut all_stats = Vec::new();
-	for handle in handles {
-		let stats = handle.await??;
-		all_stats.push(stats);
-	}
-
-	let aggregated_stats = ParticipantStats::aggregate(all_stats);
-	aggregated_stats.log_summary();
-
-	Ok(())
-}
-
-/// Multi-node benchmark.
-///
-/// Tests statement store performance with participants distributed across multiple collator nodes.
-/// No two participants in a group are connected to the same node, so statements must be propagated
-/// to other nodes before being received. Network spawned with 6 collator nodes. Each participant in
-/// a group connects to a different collator node
-///
-/// # Output
-/// Logs aggregated statistics across all participants:
-/// - Average messages sent/received per participant
-/// - Execution time (min/avg/max) across all participants
-/// - Retry attempts (min/avg/max) needed for statement propagation
-#[tokio::test(flavor = "multi_thread")]
-async fn statement_store_many_nodes_bench() -> Result<(), anyhow::Error> {
-	let _ = env_logger::try_init_from_env(
-		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-	);
-
-	let collator_names = ["alice", "bob", "charlie", "dave", "eve", "ferdie"];
-	let network = spawn_network(&collator_names, PARTICIPANT_SIZE).await?;
-
-	info!("Starting statement store benchmark with {} participants", PARTICIPANT_SIZE);
-
-	let mut rpc_pools: Vec<Vec<RpcClient>> = Vec::new();
-
-	for &name in &collator_names {
-		let node = network.get_node(name)?;
-		let mut pool = Vec::with_capacity(RPC_POOL_SIZE);
-		for _ in 0..RPC_POOL_SIZE {
-			pool.push(node.rpc().await?);
-		}
-		rpc_pools.push(pool);
-	}
-
-	info!(
-		"Created RPC connection pool: {} connections x {} nodes = {} total",
-		RPC_POOL_SIZE,
-		collator_names.len(),
-		RPC_POOL_SIZE * collator_names.len()
-	);
-
-	let mut participants = Vec::with_capacity(PARTICIPANT_SIZE as usize);
-	for i in 0..(PARTICIPANT_SIZE) as usize {
-		let node_idx = i % collator_names.len();
-		let conn_idx = (i / collator_names.len()) % RPC_POOL_SIZE;
-		participants.push(Participant::new(i as u32, rpc_pools[node_idx][conn_idx].clone()));
-	}
-	info!(
-		"{} participants were distributed across {} nodes: {} participants per node",
-		PARTICIPANT_SIZE,
-		collator_names.len(),
-		PARTICIPANT_SIZE as usize / collator_names.len()
-	);
-
-	let handles: Vec<_> = participants
-		.into_iter()
-		.map(|mut participant| tokio::spawn(async move { participant.run().await }))
-		.collect();
-
-	let mut all_stats = Vec::new();
-	for handle in handles {
-		let stats = handle.await??;
-		all_stats.push(stats);
-	}
-
-	let aggregated_stats = ParticipantStats::aggregate(all_stats);
-	aggregated_stats.log_summary();
-
-	Ok(())
-}
 
 /// Memory stress benchmark.
 ///
@@ -195,12 +64,12 @@ async fn statement_store_memory_stress_bench() -> Result<(), anyhow::Error> {
 	info!("Created RPC connection pool with {} connections to {}", RPC_POOL_SIZE, target_node);
 
 	let num_collators = collator_names.len() as u64;
-	let propogation_capacity = submit_capacity * (num_collators - 1); // 5x per node
+	let propagation_capacity = submit_capacity * (num_collators - 1); // 5x per node
 	let start_time = std::time::Instant::now();
 
 	info!(
 		"Starting memory stress benchmark with {} tasks, each submitting {} statements of {}B payload, total submit capacity per node: {}, total propagation capacity: {}",
-		total_tasks, statements_per_task, payload_size, submit_capacity, propogation_capacity
+		total_tasks, statements_per_task, payload_size, submit_capacity, propagation_capacity
 	);
 
 	for idx in 0..total_tasks {
@@ -239,11 +108,8 @@ async fn statement_store_memory_stress_bench() -> Result<(), anyhow::Error> {
 						break;
 					}
 
-					info!(
-						"Failed to submit statement, retrying in {}ms: {:?}",
-						RETRY_DELAY_MS, err
-					);
-					tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
+					info!("Failed to submit statement, retrying in {}ms: {:?}", 500, err);
+					tokio::time::sleep(Duration::from_millis(500)).await;
 				}
 			}
 		});
@@ -318,7 +184,7 @@ async fn statement_store_memory_stress_bench() -> Result<(), anyhow::Error> {
 			assert_eq!(sub_name, prop_name);
 
 			let sub_percentage = sub_count * 100 / submit_capacity;
-			let prop_percentage = prop_count * 100 / propogation_capacity;
+			let prop_percentage = prop_count * 100 / propagation_capacity;
 
 			info!(
 				"         {:<8}  {:>8} {:>3}% {:>8}/s   {:>8} {:>3}% {:>8}/s",
@@ -409,7 +275,7 @@ pub async fn spawn_network(
 	let chain_spec_path = create_chain_spec_with_allowances(participant_count, &base_dir)?;
 	// Headroom for the ~5,000 subscriptions that
 	// actually end up on each pooled conn (500 participants * 10 subscriptions each)
-	let max_subs_per_conn = PARTICIPANT_SIZE / RPC_POOL_SIZE as u32 * 16;
+	let max_subs_per_conn = participant_count / RPC_POOL_SIZE as u32 * 16;
 
 	let config = NetworkConfigBuilder::new()
 		.with_relaychain(|r| {
@@ -431,7 +297,7 @@ pub async fn spawn_network(
 					"--max-runtime-instances=32".into(),
 					"-linfo,statement-store=info,statement-gossip=info".into(),
 					"--enable-statement-store".into(),
-					format!("--rpc-max-connections={}", PARTICIPANT_SIZE + 1000).as_str().into(),
+					format!("--rpc-max-connections={}", participant_count + 1000).as_str().into(),
 					format!("--rpc-max-subscriptions-per-connection={max_subs_per_conn}")
 						.as_str()
 						.into(),
@@ -457,410 +323,6 @@ pub async fn spawn_network(
 	assert!(network.wait_until_is_up(60).await.is_ok());
 
 	Ok(network)
-}
-
-#[derive(Encode, Decode, Debug, Clone)]
-struct StatementMessage {
-	message_id: u32,
-	data: Vec<u8>,
-}
-
-#[derive(Debug, Clone)]
-struct ParticipantStats {
-	total_time: Duration,
-	sent_count: u32,
-	received_count: u32,
-	retry_count: u32,
-}
-
-#[derive(Debug)]
-struct AggregatedStats {
-	participants: u32,
-	sent: u32,
-	received: u32,
-	min_time: Duration,
-	max_time: Duration,
-	avg_time: Duration,
-	min_retries: u32,
-	max_retries: u32,
-	avg_retries: u32,
-}
-
-impl ParticipantStats {
-	fn aggregate(all_stats: Vec<ParticipantStats>) -> AggregatedStats {
-		let participants = all_stats.len() as u32;
-		let sent = all_stats.iter().map(|s| s.sent_count).sum::<u32>() / participants;
-		let received = all_stats.iter().map(|s| s.received_count).sum::<u32>() / participants;
-
-		let min_time = all_stats.iter().map(|s| s.total_time).min().unwrap_or(Duration::ZERO);
-		let max_time = all_stats.iter().map(|s| s.total_time).max().unwrap_or(Duration::ZERO);
-		let avg_time = Duration::from_secs_f64(
-			all_stats.iter().map(|s| s.total_time.as_secs_f64()).sum::<f64>() / participants as f64,
-		);
-
-		let min_retries = all_stats.iter().map(|s| s.retry_count).min().unwrap_or(0);
-		let max_retries = all_stats.iter().map(|s| s.retry_count).max().unwrap_or(0);
-		let avg_retries = all_stats.iter().map(|s| s.retry_count).sum::<u32>() / participants;
-
-		AggregatedStats {
-			participants,
-			sent,
-			received,
-			min_time,
-			max_time,
-			avg_time,
-			min_retries,
-			max_retries,
-			avg_retries,
-		}
-	}
-}
-
-impl AggregatedStats {
-	fn log_summary(&self) {
-		info!("Statement store benchmark completed with {} participants", self.participants);
-		info!(
-			"Participants: {}, each sent: {}, received: {}",
-			self.participants, self.sent, self.received
-		);
-		info!("Summary        min       avg       max");
-		info!(
-			" {:<8} {:>8}  {:>8}  {:>8}",
-			"time, s",
-			self.min_time.as_secs(),
-			self.avg_time.as_secs(),
-			self.max_time.as_secs(),
-		);
-		info!(
-			" {:<8} {:>8}  {:>8}  {:>8}",
-			"retries", self.min_retries, self.avg_retries, self.max_retries
-		);
-	}
-}
-
-struct Participant {
-	idx: u32,
-	keyring: sr25519::Pair,
-	session_key: sr25519::Pair,
-	group_members: Vec<u32>,
-	session_keys: HashMap<u32, sr25519::Public>,
-	sent_messages: HashMap<(u32, u32), bool>,
-	received_messages: HashMap<(u32, u32), bool>,
-	sent_count: u32,
-	received_count: u32,
-	pending_messages: HashMap<u32, Option<u32>>,
-	retry_count: u32,
-	rpc_client: RpcClient,
-}
-
-impl Participant {
-	fn log_target(&self) -> String {
-		format!("participant_{}", self.idx)
-	}
-
-	fn new(idx: u32, rpc_client: RpcClient) -> Self {
-		debug!(target: &format!("participant_{idx}"), "Initializing participant {}", idx);
-		let keyring = get_keypair(idx);
-		let (session_key, _) = sr25519::Pair::generate();
-
-		let group_start = (idx / GROUP_SIZE) * GROUP_SIZE;
-		let group_end = group_start + GROUP_SIZE;
-		let group_members: Vec<u32> = (group_start..group_end).filter(|&i| i != idx).collect();
-
-		Self {
-			keyring,
-			session_key,
-			idx,
-			group_members,
-			session_keys: HashMap::new(),
-			sent_messages: HashMap::new(),
-			received_messages: HashMap::new(),
-			pending_messages: HashMap::new(),
-			sent_count: 0,
-			received_count: 0,
-			retry_count: 0,
-			rpc_client,
-		}
-	}
-
-	async fn statement_submit(&mut self, statement: Statement) -> Result<(), anyhow::Error> {
-		let statement_bytes: Bytes = statement.encode().into();
-		let _: SubmitResult = self
-			.rpc_client
-			.request("statement_submit", rpc_params![statement_bytes])
-			.await?;
-
-		self.sent_count += 1;
-		trace!(target: &self.log_target(), "Submitted statement (counter: {})", self.sent_count);
-
-		Ok(())
-	}
-
-	fn create_session_key_statement(&self) -> Statement {
-		let mut statement = Statement::new();
-		statement.set_channel(channel_public_key());
-		statement.set_expiry_from_parts(u32::MAX, self.sent_count);
-		statement.set_topic(0, topic_public_key());
-		statement.set_topic(1, topic_idx(self.idx));
-		statement.set_plain_data(self.session_key.public().to_vec());
-		statement.sign_sr25519_private(&self.keyring);
-
-		statement
-	}
-
-	fn create_message_statement(&mut self, receiver_idx: u32) -> Option<(Statement, u32)> {
-		let receiver_session_key = self.session_keys.get(&receiver_idx)?;
-
-		let message_id = self.sent_count;
-		let mut data = vec![0u8; MESSAGE_SIZE];
-		for (i, byte) in data.iter_mut().enumerate() {
-			*byte = (i % 256) as u8; // Simple pattern for testing
-		}
-
-		let request = StatementMessage { message_id, data };
-		let request_data = request.encode();
-		let mut statement = Statement::new();
-
-		let topic0 = topic_message();
-		let topic1 = topic_pair(&self.session_key.public(), receiver_session_key);
-		let channel = channel_message(&self.session_key.public(), receiver_session_key);
-
-		statement.set_topic(0, topic0);
-		statement.set_topic(1, topic1);
-		statement.set_channel(channel);
-		statement.set_expiry_from_parts(u32::MAX, self.sent_count);
-		statement.set_plain_data(request_data);
-		statement.sign_sr25519_private(&self.keyring);
-
-		Some((statement, message_id))
-	}
-
-	async fn send_session_key(&mut self) -> Result<(), anyhow::Error> {
-		let statement = self.create_session_key_statement();
-		self.statement_submit(statement).await
-	}
-
-	async fn receive_session_keys(&mut self) -> Result<(), anyhow::Error> {
-		let pending = self.group_members.clone();
-
-		let mut subscriptions = Vec::new();
-
-		trace!(target: &self.log_target(), "Pending session keys to receive: {:?}", pending.len());
-
-		for idx in &pending {
-			let subscription = self
-				.rpc_client
-				.subscribe::<StatementEvent>(
-					"statement_subscribeStatement",
-					rpc_params![TopicFilter::MatchAll(
-						vec![topic_public_key(), topic_idx(*idx)].try_into().expect("Two topics")
-					)],
-					"statement_unsubscribeStatement",
-				)
-				.await?;
-			subscriptions.push((*idx, subscription));
-		}
-
-		let mut futures: FuturesUnordered<_> = subscriptions
-			.into_iter()
-			.map(|(idx, mut subscription)| async move {
-				let mut batch;
-				loop {
-					let item =
-						timeout(Duration::from_secs(SUBSCRIBE_TIMEOUT_SECS), subscription.next())
-							.await
-							.map_err(|_| anyhow!("Timeout waiting for session key"))?
-							.ok_or_else(|| anyhow!("Subscription ended unexpectedly"))?
-							.map_err(|e| anyhow!("Subscription error: {}", e))?;
-					let StatementEvent::NewStatements { statements, .. } = item;
-					if statements.is_empty() {
-						continue; // Ignore empty batches
-					} else {
-						batch = statements;
-						break;
-					}
-				}
-
-				if batch.len() != 1 {
-					return Err(anyhow!("Expected exactly one statement, got: {}", batch.len()));
-				}
-
-				let statement = Statement::decode(&mut &batch.remove(0)[..])
-					.map_err(|e| anyhow!("Failed to decode statement: {}", e))?;
-				let data = statement.data().ok_or_else(|| anyhow!("Statement missing data"))?;
-				let session_key = sr25519::Public::from_raw(
-					data[..].try_into().map_err(|_| anyhow!("Invalid session key length"))?,
-				);
-				Ok::<_, anyhow::Error>((idx, session_key))
-			})
-			.collect();
-
-		while let Some(result) = futures.next().await {
-			let (idx, session_key) = result?;
-			self.session_keys.insert(idx, session_key);
-		}
-
-		assert_eq!(
-			self.session_keys.len(),
-			self.group_members.len(),
-			"Not every session key received"
-		);
-
-		Ok(())
-	}
-
-	async fn send_messages(&mut self, round: usize) -> Result<(), anyhow::Error> {
-		let group_members = self.group_members.clone();
-		for receiver_idx in group_members {
-			let (statement, request_id) =
-				self.create_message_statement(receiver_idx).expect("Receiver must present");
-			self.statement_submit(statement).await?;
-			self.sent_messages.insert((receiver_idx, request_id), false);
-		}
-
-		assert_eq!(
-			self.sent_messages.len(),
-			self.group_members.len() * (round + 1),
-			"Not every request sent"
-		);
-
-		Ok(())
-	}
-
-	async fn receive_messages(&mut self, round: usize) -> Result<(), anyhow::Error> {
-		let pending: Vec<(u32, sr25519::Public)> =
-			self.session_keys.iter().map(|(&idx, &key)| (idx, key)).collect();
-		let own_session_key = self.session_key.public();
-
-		let mut subscriptions = Vec::new();
-
-		for &(sender_idx, sender_session_key) in &pending {
-			let subscription = self
-				.rpc_client
-				.subscribe::<StatementEvent>(
-					"statement_subscribeStatement",
-					rpc_params![TopicFilter::MatchAll(
-						vec![topic_message(), topic_pair(&sender_session_key, &own_session_key)]
-							.try_into()
-							.expect("Two topics")
-					)],
-					"statement_unsubscribeStatement",
-				)
-				.await?;
-			subscriptions.push((sender_idx, subscription));
-		}
-
-		let mut futures: FuturesUnordered<_> = subscriptions
-			.into_iter()
-			.map(|(sender_idx, mut subscription)| async move {
-				let mut batch;
-				loop {
-					let item =
-						timeout(Duration::from_secs(SUBSCRIBE_TIMEOUT_SECS), subscription.next())
-							.await
-							.map_err(|_| anyhow!("Timeout waiting for message"))?
-							.ok_or_else(|| anyhow!("Subscription ended unexpectedly"))?
-							.map_err(|e| anyhow!("Subscription error: {}", e))?;
-					batch = match item {
-						StatementEvent::NewStatements { statements: batch, .. } => batch,
-					};
-					if batch.is_empty() {
-						continue; // Ignore empty batches
-					} else {
-						break;
-					}
-				}
-				if batch.len() != 1 {
-					return Err(anyhow!("Expected exactly one statement, got: {}", batch.len()));
-				}
-				let statement = Statement::decode(&mut &batch.remove(0)[..])
-					.map_err(|e| anyhow!("Failed to decode statement: {}", e))?;
-				let data = statement.data().ok_or_else(|| anyhow!("Statement missing data"))?;
-				let req = StatementMessage::decode(&mut &data[..])
-					.map_err(|e| anyhow!("Failed to decode message: {}", e))?;
-				Ok::<_, anyhow::Error>((sender_idx, req.message_id))
-			})
-			.collect();
-
-		while let Some(result) = futures.next().await {
-			let (sender_idx, message_id) = result?;
-			if let std::collections::hash_map::Entry::Vacant(e) =
-				self.received_messages.entry((sender_idx, message_id))
-			{
-				e.insert(false);
-				self.pending_messages.insert(sender_idx, Some(message_id));
-			}
-		}
-
-		assert_eq!(
-			self.received_messages.len(),
-			self.group_members.len() * (round + 1),
-			"Not every request received"
-		);
-		assert_eq!(
-			self.pending_messages.values().filter(|i| i.is_some()).count(),
-			self.group_members.len(),
-			"Not every request received"
-		);
-		Ok(())
-	}
-
-	async fn run(&mut self) -> Result<ParticipantStats, anyhow::Error> {
-		let start_time = std::time::Instant::now();
-
-		debug!(target: &self.log_target(), "Session keys exchange");
-		self.send_session_key().await?;
-		trace!(target: &self.log_target(), "Session keys sent, receiving session keys");
-		self.receive_session_keys().await?;
-		trace!(target: &self.log_target(), "Session keys received");
-
-		for round in 0..MESSAGE_COUNT {
-			debug!(target: &self.log_target(), "Messages exchange, round {}", round + 1);
-			self.send_messages(round).await?;
-			trace!(target: &self.log_target(), "Messages requests started");
-			self.receive_messages(round).await?;
-		}
-
-		let elapsed = start_time.elapsed();
-
-		Ok(ParticipantStats {
-			total_time: elapsed,
-			sent_count: self.sent_count,
-			received_count: self.received_count,
-			retry_count: self.retry_count,
-		})
-	}
-}
-
-fn topic_public_key() -> Topic {
-	blake2_256(b"public key").into()
-}
-
-fn topic_idx(idx: u32) -> Topic {
-	blake2_256(&idx.to_le_bytes()).into()
-}
-
-fn topic_pair(sender: &sr25519::Public, receiver: &sr25519::Public) -> Topic {
-	let mut data = Vec::new();
-	data.extend_from_slice(sender.as_ref());
-	data.extend_from_slice(receiver.as_ref());
-	blake2_256(&data).into()
-}
-
-fn topic_message() -> Topic {
-	blake2_256(b"message").into()
-}
-
-fn channel_public_key() -> Channel {
-	[0u8; 32]
-}
-
-fn channel_message(sender: &sr25519::Public, receiver: &sr25519::Public) -> Channel {
-	let mut data = Vec::new();
-	data.extend_from_slice(b"message");
-	data.extend_from_slice(sender.as_ref());
-	data.extend_from_slice(receiver.as_ref());
-	blake2_256(&data)
 }
 
 pub fn get_keypair(idx: u32) -> sr25519::Pair {


### PR DESCRIPTION
`statement_store_one_node_bench` and `statement_store_many_nodes_bench` served their purposes well, but they are now outdated and should be replaced with latency benchmark.