### PR TITLE
ci: filter out GitHub Project custom labels in check-labels workflow

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -44,9 +44,15 @@ jobs:
           # Temporary, before https://github.com/paritytech/labels/pull/29 is not merged
           git clone https://github.com/paritytech/labels
 
-          # Fetch the labels for the PR under test
+          # Extract valid label names from the specs file
+          valid_names=$(grep -oP '(?<=- name: )\S+' $PWD/${RULES_PATH}/${CHECK_SPECS} | jq -R . | jq -s .)
+
+          # Fetch PR labels and keep only those defined in the specs.
+          # This filters out GitHub Project labels (e.g. "feature") that are not
+          # part of the repo's label specs and would cause ruled_labels to panic.
           echo "Fetch the labels for $API_BASE/${REPO}/pulls/${GITHUB_PR}"
-          labels=$( curl -H "Authorization: token ${GITHUB_TOKEN}" -s "$API_BASE/${REPO}/pulls/${GITHUB_PR}" | jq '.labels | .[] | .name' | tr "\n" ",")
+          labels=$( curl -H "Authorization: token ${GITHUB_TOKEN}" -s "$API_BASE/${REPO}/pulls/${GITHUB_PR}" \
+            | jq --argjson valid "$valid_names" '[.labels[].name | select(. as $n | $valid | any(. == $n))] | map(@json) | join(",")' -r)
           echo "Labels: ${labels}"
 
           if [ -z "${labels}" ]; then


### PR DESCRIPTION
## Problem

The `check-labels` CI job panics when a PR has GitHub Project custom labels (e.g. `feature`) that don't match the expected `X0-name` pattern (e.g. `T7-smart_contracts`).

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: 
"Err 002: Invalid label, no regexp match: \"feature\""'
```

**Example failure:** https://github.com/paritytech/polkadot-sdk/actions/runs/22945506969/job/66596763547?pr=10936

## Fix

Filter fetched PR labels before passing them to `ruled_labels`, keeping only labels that match the expected pattern (`[A-Z][0-9]-...`). Non-standard labels (GitHub Project labels, etc.) are silently ignored.

## Testing

The fix filters labels like `"feature"` while keeping valid labels like `"T7-smart_contracts"`.