### PR TITLE
network: Add Prometheus metrics to Bitswap server

### DIFF
--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -609,8 +609,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 	/// Create Bitswap server.
 	fn bitswap_server(
 		client: Arc<dyn BlockBackend<B> + Send + Sync>,
+		prometheus_registry: Option<&Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Self::BitswapConfig) {
-		BitswapServer::new(client)
+		BitswapServer::new(client, prometheus_registry)
 	}
 
 	/// Create notification protocol configuration for `protocol`.

--- a/substrate/client/network/src/litep2p/shim/bitswap.rs
+++ b/substrate/client/network/src/litep2p/shim/bitswap.rs
@@ -23,6 +23,7 @@ use futures::StreamExt;
 use litep2p::protocol::libp2p::bitswap::{
 	BitswapEvent, BitswapHandle, BlockPresenceType, Config, ResponseType, WantType,
 };
+use prometheus_endpoint::{register, Counter, PrometheusError, Registry, U64};
 
 use sc_client_api::BlockBackend;
 use sp_runtime::traits::Block as BlockT;
@@ -32,21 +33,89 @@ use std::{future::Future, pin::Pin, sync::Arc};
 /// Logging target for the file.
 const LOG_TARGET: &str = "sub-libp2p::bitswap";
 
+/// Prometheus metrics for the Bitswap server.
+#[derive(Clone)]
+struct Metrics {
+	/// Total incoming requests.
+	requests_received: Counter<U64>,
+	/// Total CIDs requested.
+	cids_requested: Counter<U64>,
+	/// Blocks found and sent.
+	blocks_sent: Counter<U64>,
+	/// Bytes of block data sent.
+	blocks_sent_bytes: Counter<U64>,
+	/// CIDs not found (DontHave responses).
+	blocks_not_found: Counter<U64>,
+}
+
+impl Metrics {
+	fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			requests_received: register(
+				Counter::new(
+					"substrate_bitswap_requests_received_total",
+					"Total number of Bitswap requests received",
+				)?,
+				registry,
+			)?,
+			cids_requested: register(
+				Counter::new(
+					"substrate_bitswap_cids_requested_total",
+					"Total number of CIDs requested via Bitswap",
+				)?,
+				registry,
+			)?,
+			blocks_sent: register(
+				Counter::new(
+					"substrate_bitswap_blocks_sent_total",
+					"Total number of blocks sent via Bitswap",
+				)?,
+				registry,
+			)?,
+			blocks_sent_bytes: register(
+				Counter::new(
+					"substrate_bitswap_blocks_sent_bytes_total",
+					"Total bytes of block data sent via Bitswap",
+				)?,
+				registry,
+			)?,
+			blocks_not_found: register(
+				Counter::new(
+					"substrate_bitswap_blocks_not_found_total",
+					"Total number of CIDs not found (DontHave responses)",
+				)?,
+				registry,
+			)?,
+		})
+	}
+}
+
 pub struct BitswapServer<Block: BlockT> {
 	/// Bitswap handle.
 	handle: BitswapHandle,
 
 	/// Blockchain client.
 	client: Arc<dyn BlockBackend<Block> + Send + Sync>,
+
+	/// Prometheus metrics.
+	metrics: Option<Metrics>,
 }
 
 impl<Block: BlockT> BitswapServer<Block> {
 	/// Create new [`BitswapServer`].
 	pub fn new(
 		client: Arc<dyn BlockBackend<Block> + Send + Sync>,
+		prometheus_registry: Option<&Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Config) {
 		let (config, handle) = Config::new();
-		let bitswap = Self { client, handle };
+		let metrics = prometheus_registry
+			.map(Metrics::register)
+			.transpose()
+			.unwrap_or_else(|e| {
+				log::warn!(target: LOG_TARGET, "Failed to register bitswap metrics: {e}");
+				None
+			});
+		let bitswap = Self { client, handle, metrics };
 
 		(Box::pin(async move { bitswap.run().await }), config)
 	}
@@ -58,6 +127,11 @@ impl<Block: BlockT> BitswapServer<Block> {
 			match event {
 				BitswapEvent::Request { peer, cids } => {
 					log::debug!(target: LOG_TARGET, "handle bitswap request from {peer:?} for {cids:?}");
+
+					if let Some(ref metrics) = self.metrics {
+						metrics.requests_received.inc();
+						metrics.cids_requested.inc_by(cids.len() as u64);
+					}
 
 					let response: Vec<ResponseType> = cids
 						.into_iter()
@@ -77,6 +151,18 @@ impl<Block: BlockT> BitswapServer<Block> {
 								Some(transaction) => {
 									log::trace!(target: LOG_TARGET, "found cid {cid:?}, hash {hash:?}");
 
+									if let Some(ref metrics) = self.metrics {
+										match want_type {
+											WantType::Block => {
+												metrics.blocks_sent.inc();
+												metrics
+													.blocks_sent_bytes
+													.inc_by(transaction.len() as u64);
+											},
+											_ => {},
+										}
+									}
+
 									match want_type {
 										WantType::Block => {
 											ResponseType::Block { cid, block: transaction }
@@ -89,6 +175,10 @@ impl<Block: BlockT> BitswapServer<Block> {
 								},
 								None => {
 									log::trace!(target: LOG_TARGET, "missing cid {cid:?}, hash {hash:?}");
+
+									if let Some(ref metrics) = self.metrics {
+										metrics.blocks_not_found.inc();
+									}
 
 									ResponseType::Presence {
 										cid,

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -199,6 +199,7 @@ where
 
 	fn bitswap_server(
 		client: Arc<dyn BlockBackend<B> + Send + Sync>,
+		_prometheus_registry: Option<&Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Self::BitswapConfig) {
 		let (handler, protocol_config) = BitswapRequestHandler::new(client.clone());
 

--- a/substrate/client/network/src/service/traits.rs
+++ b/substrate/client/network/src/service/traits.rs
@@ -146,6 +146,7 @@ pub trait NetworkBackend<B: BlockT + 'static, H: ExHashT>: Send + 'static {
 	/// Create Bitswap server.
 	fn bitswap_server(
 		client: Arc<dyn BlockBackend<B> + Send + Sync>,
+		prometheus_registry: Option<&Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Self::BitswapConfig);
 
 	/// Create notification protocol configuration and an associated `NotificationService`

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -1214,7 +1214,7 @@ where
 	net_config.add_request_response_protocol(light_client_request_protocol_config);
 
 	let bitswap_config = ipfs_server.then(|| {
-		let (handler, config) = Net::bitswap_server(client.clone());
+		let (handler, config) = Net::bitswap_server(client.clone(), metrics_registry);
 		spawn_handle.spawn("bitswap-request-handler", Some("networking"), handler);
 
 		config


### PR DESCRIPTION
## Summary

- Add Prometheus counters to the litep2p Bitswap server for monitoring IPFS data serving
- Thread `Option<&Registry>` through `NetworkBackend::bitswap_server()` trait method
- Register metrics in the litep2p implementation; libp2p implementation ignores the registry for now

### Metrics added

| Counter | Description |
|---------|-------------|
| `substrate_bitswap_requests_received_total` | Incoming Bitswap requests |
| `substrate_bitswap_cids_requested_total` | Total CIDs requested |
| `substrate_bitswap_blocks_sent_total` | Blocks found and sent |
| `substrate_bitswap_blocks_sent_bytes_total` | Bytes of block data sent |
| `substrate_bitswap_blocks_not_found_total` | CIDs not found (DontHave) |

### Motivation

Chains using litep2p's Bitswap (e.g., Polkadot Bulletin Chain with `--ipfs-server`) have no visibility into IPFS serving activity. These counters enable monitoring request volume, hit/miss rates, and data throughput.

Ref: https://github.com/paritytech/litep2p/pull/557#issuecomment-4049684492 — litep2p maintainer suggested metrics belong on the substrate side.

## Test plan

- [x] `cargo check -p sc-network` passes
- [x] `cargo check -p sc-service` passes