### PR TITLE
Fix slot-based collator panic during warp sync (#11072)

### DIFF
--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -201,9 +201,8 @@ where
 		loop {
 			// We wait here until the next slot arrives.
 			if slot_timer.wait_until_next_slot().await.is_err() {
-				tracing::warn!(target: LOG_TARGET, "Unable to wait for next slot, retrying...");
-				tokio::time::sleep(Duration::from_secs(1)).await;
-				continue;
+				tracing::error!(target: LOG_TARGET, "Unable to wait for next slot.");
+				return;
 			};
 
 			let Ok(relay_best_hash) = relay_client.best_block_hash().await else {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/slot_timer.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/slot_timer.rs
@@ -354,7 +354,7 @@ where
 		let slot_duration = match crate::slot_duration(&*self.client) {
 			Ok(d) => d,
 			Err(error) => {
-				tracing::warn!(target: LOG_TARGET, %error, "Failed to fetch slot duration from runtime.");
+				tracing::error!(target: LOG_TARGET, %error, "Failed to fetch slot duration from runtime.");
 				return Err(());
 			},
 		};


### PR DESCRIPTION
When a parachain collator starts with `--authoring=slot-based` and performs warp sync, the `slot-based-block-builder` essential task immediately calls `slot_duration()` which requires `AuraApi_slot_duration`. During warp sync the runtime isn't ready, so this fails and the task returns, shutting down the node.

The lookahead collator avoids this by calling `wait_for_aura()` before starting. This PR adds an equivalent guard to the slot-based collator.

### Manual test
Before the fix the collator panicked after the relay chain warp sync with AuraApi_slot_duration not available, which does not occur anymore now.
```
 ./target/release/polkadot-parachain \                                                                                                                                                                                                                                                                          
    --chain asset-hub-polkadot \
    --sync warp \
    --authoring=slot-based \
    --tmp -- --sync warp
```
Closes #11072.