### PR TITLE
docs/elastic: Align unincluded with expected formula

### DIFF
--- a/docs/sdk/src/guides/enable_elastic_scaling.rs
+++ b/docs/sdk/src/guides/enable_elastic_scaling.rs
@@ -133,9 +133,13 @@
 //! ```ignore
 //! impl pallet_aura::Config for Runtime {
 //!     // ...
+//!     type AllowMultipleBlocksPerSlot = ConstBool<true>;
 //!     type SlotDuration = ConstU64<SLOT_DURATION>;
 //! }
 //! ```
+//!
+//! `AllowMultipleBlocksPerSlot` must be set to `true` for elastic scaling, as multiple parachain
+//! blocks are authored within the same slot.
 //!
 //! The slot duration determines the length of each author's turn and is decoupled from the block
 //! production interval. During their slot, authors are allowed to produce multiple blocks. **The


### PR DESCRIPTION
Tiny update for the elastic scaling documentation / guideline:
- UNINCLUDED_SEGMENT_CAPACITY formula is updated to the latest expected values 
- mention the multiple blocks per slot must be set

cc @sandreim @skunert  🙏 