### PR TITLE
[FRAME] Add `AccountLike` trait and `#[pallet::as_account]` for custom origin account tracking

### DIFF
--- a/substrate/frame/collective/src/lib.rs
+++ b/substrate/frame/collective/src/lib.rs
@@ -151,6 +151,17 @@ pub enum RawOrigin<AccountId, I> {
 	_Phantom(PhantomData<I>),
 }
 
+impl<AccountId: Clone, I> frame_support::traits::AccountLike<AccountId>
+	for RawOrigin<AccountId, I>
+{
+	fn as_account(&self) -> Option<AccountId> {
+		match self {
+			RawOrigin::Member(who) => Some(who.clone()),
+			_ => None,
+		}
+	}
+}
+
 impl<AccountId, I> GetBacking for RawOrigin<AccountId, I> {
 	fn get_backing(&self) -> Option<Backing> {
 		match self {

--- a/substrate/frame/support/procedural/src/construct_runtime/expand/origin.rs
+++ b/substrate/frame/support/procedural/src/construct_runtime/expand/origin.rs
@@ -26,9 +26,14 @@ pub fn expand_outer_origin(
 	pallets: &[Pallet],
 	scrate: &TokenStream,
 ) -> syn::Result<TokenStream> {
+	let system_path = &system_pallet.path;
+
 	let mut caller_variants = TokenStream::new();
 	let mut pallet_conversions = TokenStream::new();
 	let mut query_origin_part_macros = Vec::new();
+	let mut as_account_arms = TokenStream::new();
+	let mut nonce_provider_arms = TokenStream::new();
+	let mut fee_payer_arms = TokenStream::new();
 
 	for pallet_decl in pallets.iter().filter(|pallet| pallet.name != SYSTEM_PALLET_NAME) {
 		if let Some(pallet_entry) = pallet_decl.find_part("Origin") {
@@ -64,10 +69,29 @@ pub fn expand_outer_origin(
 			query_origin_part_macros.push(quote! {
 				#path::__substrate_origin_check::is_origin_part_defined!(#name);
 			});
+
+			let attr = pallet_decl.get_attributes();
+			let pallet_type = match instance {
+				Some(inst) => quote! { #path::Pallet::<#runtime, #path::#inst> },
+				None => quote! { #path::Pallet::<#runtime> },
+			};
+			as_account_arms.extend(quote! {
+				#attr
+				OriginCaller::#name(o) =>
+					#pallet_type::__as_account_for_origin(o),
+			});
+			nonce_provider_arms.extend(quote! {
+				#attr
+				OriginCaller::#name(o) =>
+					#pallet_type::__nonce_provider_for_origin(o),
+			});
+			fee_payer_arms.extend(quote! {
+				#attr
+				OriginCaller::#name(o) =>
+					#pallet_type::__fee_payer_for_origin(o),
+			});
 		}
 	}
-
-	let system_path = &system_pallet.path;
 
 	let system_index = system_pallet.index;
 
@@ -229,6 +253,32 @@ pub fn expand_outer_origin(
 		impl From<#system_path::Origin<#runtime>> for OriginCaller {
 			fn from(x: #system_path::Origin<#runtime>) -> Self {
 				OriginCaller::system(x)
+			}
+		}
+
+		impl #scrate::traits::AccountLike<<#runtime as #system_path::Config>::AccountId> for OriginCaller {
+			fn as_account(&self) -> Option<<#runtime as #system_path::Config>::AccountId> {
+				match &self {
+					OriginCaller::system(o) => o.as_signed().cloned(),
+					#as_account_arms
+					OriginCaller::Void(v) => match *v {},
+				}
+			}
+
+			fn nonce_provider(&self) -> Option<<#runtime as #system_path::Config>::AccountId> {
+				match &self {
+					OriginCaller::system(o) => o.as_signed().cloned(),
+					#nonce_provider_arms
+					OriginCaller::Void(v) => match *v {},
+				}
+			}
+
+			fn fee_payer(&self) -> Option<<#runtime as #system_path::Config>::AccountId> {
+				match &self {
+					OriginCaller::system(o) => o.as_signed().cloned(),
+					#fee_payer_arms
+					OriginCaller::Void(v) => match *v {},
+				}
 			}
 		}
 

--- a/substrate/frame/support/procedural/src/pallet/expand/origin.rs
+++ b/substrate/frame/support/procedural/src/pallet/expand/origin.rs
@@ -20,7 +20,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{spanned::Spanned, Ident};
 
-/// expand the `is_origin_part_defined` macro.
+/// expand the `is_origin_part_defined` macro and the `AccountLike` impl.
 pub fn expand_origin(def: &mut Def) -> TokenStream {
 	let count = COUNTER.with(|counter| counter.borrow_mut().inc());
 	let macro_ident = Ident::new(&format!("__is_origin_part_defined_{}", count), def.item.span());
@@ -38,6 +38,8 @@ pub fn expand_origin(def: &mut Def) -> TokenStream {
 		TokenStream::new()
 	};
 
+	let account_like_impl = generate_account_like_impl(def);
+
 	quote! {
 		#[doc(hidden)]
 		pub mod __substrate_origin_check {
@@ -52,5 +54,294 @@ pub fn expand_origin(def: &mut Def) -> TokenStream {
 			#[doc(hidden)]
 			pub use #macro_ident as is_origin_part_defined;
 		}
+
+		#account_like_impl
+	}
+}
+
+fn generate_account_like_impl(def: &Def) -> TokenStream {
+	let origin_def = match &def.origin {
+		Some(o) => o,
+		None => return TokenStream::new(),
+	};
+
+	let frame_support = &def.frame_support;
+	let frame_system = &def.frame_system;
+	let span = def.item.span();
+
+	// Type alias origins: delegate to the `AccountLike` trait impl on the aliased type.
+	let is_type_alias = def
+		.item
+		.content
+		.as_ref()
+		.map(|(_, items)| {
+			items.iter().any(|item| {
+				if let syn::Item::Type(t) = item {
+					t.ident == "Origin"
+				} else {
+					false
+				}
+			})
+		})
+		.unwrap_or(false);
+
+	let type_impl_gen = &def.type_impl_generics(span);
+	let type_use_gen = &def.type_use_generics(span);
+	let where_clause = &def.config.where_clause;
+
+	if is_type_alias {
+		return quote! {
+			impl<#type_impl_gen> Pallet<#type_use_gen> #where_clause {
+				#[doc(hidden)]
+				pub fn __as_account_for_origin(
+					origin: &Origin<#type_use_gen>,
+				) -> Option<<T as #frame_system::Config>::AccountId> {
+					<Origin<#type_use_gen> as
+						#frame_support::traits::AccountLike<
+							<T as #frame_system::Config>::AccountId
+						>
+					>::as_account(origin)
+				}
+
+				#[doc(hidden)]
+				pub fn __nonce_provider_for_origin(
+					origin: &Origin<#type_use_gen>,
+				) -> Option<<T as #frame_system::Config>::AccountId> {
+					<Origin<#type_use_gen> as
+						#frame_support::traits::AccountLike<
+							<T as #frame_system::Config>::AccountId
+						>
+					>::nonce_provider(origin)
+				}
+
+				#[doc(hidden)]
+				pub fn __fee_payer_for_origin(
+					origin: &Origin<#type_use_gen>,
+				) -> Option<<T as #frame_system::Config>::AccountId> {
+					<Origin<#type_use_gen> as
+						#frame_support::traits::AccountLike<
+							<T as #frame_system::Config>::AccountId
+						>
+					>::fee_payer(origin)
+				}
+			}
+		};
+	}
+
+	// The origin type reference for method parameters.
+	let origin_type_ref = if origin_def.is_generic {
+		quote! { &Origin<#type_use_gen> }
+	} else {
+		quote! { &Origin }
+	};
+
+	// Generate getter functions and match arms for account_like_defs.
+	let mut getter_fns = TokenStream::new();
+	let mut as_account_match_arms = TokenStream::new();
+	let mut nonce_provider_match_arms = TokenStream::new();
+	let mut fee_payer_match_arms = TokenStream::new();
+
+	for al in &origin_def.account_like_defs {
+		let variant_ident = &al.variant_ident;
+		let expr = &al.expr;
+
+		let getter_name =
+			Ident::new(&format!("__as_account_for_{}", variant_ident), variant_ident.span());
+
+		let field_types: Vec<_> = al.fields.iter().map(|f| &f.ty).collect();
+		let field_bindings: Vec<_> = (0..al.fields.len())
+			.map(|i| Ident::new(&format!("field_{}", i), variant_ident.span()))
+			.collect();
+		let destructure = build_destructure_pattern(&al.fields, &field_bindings);
+
+		// Getter function on Pallet<T> — gives closures access to Self and T::AccountId.
+		getter_fns.extend(quote::quote_spanned!(expr.span() =>
+			impl<#type_impl_gen> Pallet<#type_use_gen> #where_clause {
+				#[doc(hidden)]
+				#[allow(non_snake_case)]
+				fn #getter_name() -> impl Fn(
+					#( &#field_types ),*
+				) -> Option<<T as #frame_system::Config>::AccountId> {
+					#expr
+				}
+			}
+		));
+
+		// as_account: all variants with #[pallet::as_account(...)]
+		as_account_match_arms.extend(quote! {
+			Origin::#variant_ident #destructure => {
+				let f = Pallet::<#type_use_gen>::#getter_name();
+				f(#( #field_bindings ),*)
+			},
+		});
+
+		// nonce_provider: only variants with #[pallet::nonce_provider]
+		if al.is_nonce_provider {
+			nonce_provider_match_arms.extend(quote! {
+				Origin::#variant_ident #destructure => {
+					let f = Pallet::<#type_use_gen>::#getter_name();
+					f(#( #field_bindings ),*)
+				},
+			});
+		}
+
+		// fee_payer: only variants with #[pallet::fee_payer]
+		if al.is_fee_payer {
+			fee_payer_match_arms.extend(quote! {
+				Origin::#variant_ident #destructure => {
+					let f = Pallet::<#type_use_gen>::#getter_name();
+					f(#( #field_bindings ),*)
+				},
+			});
+		}
+	}
+
+	// Generate method bodies for each of the three methods.
+	let has_as_account = !origin_def.account_like_defs.is_empty();
+	let has_nonce_providers = origin_def.account_like_defs.iter().any(|al| al.is_nonce_provider);
+	let has_fee_payers = origin_def.account_like_defs.iter().any(|al| al.is_fee_payer);
+
+	let as_account_body = if has_as_account {
+		quote! {
+			match origin {
+				#as_account_match_arms
+				_ => None,
+			}
+		}
+	} else {
+		quote! { None }
+	};
+
+	let nonce_provider_body = if has_nonce_providers {
+		quote! {
+			match origin {
+				#nonce_provider_match_arms
+				_ => None,
+			}
+		}
+	} else {
+		quote! { None }
+	};
+
+	let fee_payer_body = if has_fee_payers {
+		quote! {
+			match origin {
+				#fee_payer_match_arms
+				_ => None,
+			}
+		}
+	} else {
+		quote! { None }
+	};
+
+	let as_account_param =
+		if has_as_account { Ident::new("origin", span) } else { Ident::new("_origin", span) };
+	let nonce_provider_param =
+		if has_nonce_providers { Ident::new("origin", span) } else { Ident::new("_origin", span) };
+	let fee_payer_param =
+		if has_fee_payers { Ident::new("origin", span) } else { Ident::new("_origin", span) };
+
+	let pallet_methods = quote! {
+		#getter_fns
+
+		impl<#type_impl_gen> Pallet<#type_use_gen> #where_clause {
+			#[doc(hidden)]
+			pub fn __as_account_for_origin(
+				#as_account_param: #origin_type_ref,
+			) -> Option<<T as #frame_system::Config>::AccountId> {
+				#as_account_body
+			}
+
+			#[doc(hidden)]
+			pub fn __nonce_provider_for_origin(
+				#nonce_provider_param: #origin_type_ref,
+			) -> Option<<T as #frame_system::Config>::AccountId> {
+				#nonce_provider_body
+			}
+
+			#[doc(hidden)]
+			pub fn __fee_payer_for_origin(
+				#fee_payer_param: #origin_type_ref,
+			) -> Option<<T as #frame_system::Config>::AccountId> {
+				#fee_payer_body
+			}
+		}
+	};
+
+	// Generate AccountLike trait impl.
+	let trait_impl = if origin_def.is_generic {
+		let as_account_method = if has_as_account {
+			quote! {
+				fn as_account(&self) -> Option<<T as #frame_system::Config>::AccountId> {
+					Pallet::<#type_use_gen>::__as_account_for_origin(self)
+				}
+			}
+		} else {
+			TokenStream::new()
+		};
+		let nonce_provider_method = if has_nonce_providers {
+			quote! {
+				fn nonce_provider(&self) -> Option<<T as #frame_system::Config>::AccountId> {
+					Pallet::<#type_use_gen>::__nonce_provider_for_origin(self)
+				}
+			}
+		} else {
+			TokenStream::new()
+		};
+		let fee_payer_method = if has_fee_payers {
+			quote! {
+				fn fee_payer(&self) -> Option<<T as #frame_system::Config>::AccountId> {
+					Pallet::<#type_use_gen>::__fee_payer_for_origin(self)
+				}
+			}
+		} else {
+			TokenStream::new()
+		};
+
+		quote! {
+			impl<#type_impl_gen> #frame_support::traits::AccountLike<
+				<T as #frame_system::Config>::AccountId
+			> for Origin<#type_use_gen> #where_clause {
+				#as_account_method
+				#nonce_provider_method
+				#fee_payer_method
+			}
+		}
+	} else {
+		// For non-generic origins (like `enum Origin {..}`) we don't implement the `AccountLike`
+		// trait. Instead we rely on the generated code in the pallet, `__as_account_for_*` which is
+		// called in `__as_account_for_origin`. These are then used in the `AccountLike` impl on
+		// `OriginCaller` in `construct_runtime!`. We need to implement this trait here regardless
+		// to satisfy trait bounds on `CallerTrait`. This is why nobody should use `AccountLike`
+		// directly on origins and instead rely on methods exposed by `CallerTrait` on the
+		// `RuntimeOrigin`, which will be correct because they are generated as stated above in
+		// `construct_runtime!`.
+		//
+		// If we just got rid of the need to be able to access `T` in the closure, we could get rid
+		// of this, but we will lose the ability to access storage and other pallet methods inside
+		// natively.
+		quote! {
+			impl<AccountId> #frame_support::traits::AccountLike<AccountId> for Origin {}
+		}
+	};
+
+	quote! {
+		#pallet_methods
+		#trait_impl
+	}
+}
+
+fn build_destructure_pattern(fields: &syn::Fields, bindings: &[Ident]) -> TokenStream {
+	match fields {
+		syn::Fields::Named(named) => {
+			let field_names: Vec<_> = named.named.iter().map(|f| &f.ident).collect();
+			quote! { { #( #field_names: #bindings ),* } }
+		},
+		syn::Fields::Unnamed(_) => {
+			quote! { ( #( #bindings ),* ) }
+		},
+		syn::Fields::Unit => {
+			quote! {}
+		},
 	}
 }

--- a/substrate/frame/support/procedural/src/pallet/parse/origin.rs
+++ b/substrate/frame/support/procedural/src/pallet/parse/origin.rs
@@ -18,6 +18,21 @@
 use super::helper;
 use syn::spanned::Spanned;
 
+/// Per-variant account-like definition parsed from `#[pallet::as_account(...)]`
+/// and optional `#[pallet::nonce_provider]` / `#[pallet::fee_payer]` flags.
+pub struct OriginAccountLikeDef {
+	/// The variant identifier.
+	pub variant_ident: syn::Ident,
+	/// The fields of the variant (for generating destructure patterns).
+	pub fields: syn::Fields,
+	/// The user's closure/function expression for `as_account`.
+	pub expr: syn::Expr,
+	/// Whether this variant also has `#[pallet::nonce_provider]`.
+	pub is_nonce_provider: bool,
+	/// Whether this variant also has `#[pallet::fee_payer]`.
+	pub is_fee_payer: bool,
+}
+
 /// Definition of the pallet origin type.
 ///
 /// Either:
@@ -28,6 +43,8 @@ pub struct OriginDef {
 	pub is_generic: bool,
 	/// A set of usage of instance, must be check for consistency with trait.
 	pub instances: Vec<helper::InstanceUsage>,
+	/// Per-variant account-like defs. Only populated for enum origins.
+	pub account_like_defs: Vec<OriginAccountLikeDef>,
 }
 
 impl OriginDef {
@@ -63,6 +80,115 @@ impl OriginDef {
 			return Err(syn::Error::new(ident.span(), msg));
 		}
 
-		Ok(OriginDef { is_generic, instances })
+		let mut account_like_defs = vec![];
+
+		// Parse #[pallet::as_account(...)], #[pallet::nonce_provider], #[pallet::fee_payer]
+		// on enum variants. Only enum types are supported.
+		if let syn::Item::Enum(item_enum) = item {
+			for variant in item_enum.variants.iter_mut() {
+				let mut as_account_attr = None;
+				let mut as_account_count = 0;
+				let mut has_nonce_provider = false;
+				let mut has_fee_payer = false;
+				let mut nonce_provider_span = None;
+				let mut fee_payer_span = None;
+
+				// Find and extract the pallet attributes
+				variant.attrs.retain(|attr| {
+					if attr.path().segments.len() == 2 &&
+						attr.path().segments[0].ident == "pallet"
+					{
+						let attr_name = attr.path().segments[1].ident.to_string();
+						match attr_name.as_str() {
+							"as_account" => {
+								as_account_count += 1;
+								if as_account_attr.is_none() {
+									as_account_attr = Some(attr.clone());
+								}
+								return false; // remove from variant attrs
+							},
+							"nonce_provider" => {
+								has_nonce_provider = true;
+								nonce_provider_span = Some(attr.span());
+								return false;
+							},
+							"fee_payer" => {
+								has_fee_payer = true;
+								fee_payer_span = Some(attr.span());
+								return false;
+							},
+							_ => {},
+						}
+					}
+					true
+				});
+
+				if as_account_count > 1 {
+					return Err(syn::Error::new(
+						variant.ident.span(),
+						"Duplicate `#[pallet::as_account(...)]` attribute on variant",
+					));
+				}
+
+				// Validate: nonce_provider/fee_payer require as_account
+				if has_nonce_provider && as_account_attr.is_none() {
+					return Err(syn::Error::new(
+						nonce_provider_span.unwrap(),
+						"`#[pallet::nonce_provider]` requires `#[pallet::as_account(...)]` on the same variant",
+					));
+				}
+				if has_fee_payer && as_account_attr.is_none() {
+					return Err(syn::Error::new(
+						fee_payer_span.unwrap(),
+						"`#[pallet::fee_payer]` requires `#[pallet::as_account(...)]` on the same variant",
+					));
+				}
+
+				if let Some(account_attr) = as_account_attr {
+					let expr: syn::Expr = account_attr.parse_args()?;
+					account_like_defs.push(OriginAccountLikeDef {
+						variant_ident: variant.ident.clone(),
+						fields: variant.fields.clone(),
+						expr,
+						is_nonce_provider: has_nonce_provider,
+						is_fee_payer: has_fee_payer,
+					});
+				}
+			}
+		}
+
+		// Reject `pallet::as_account`, `pallet::nonce_provider`, and `pallet::fee_payer`
+		// on non-enum origins (structs and type aliases).
+		if !matches!(item, syn::Item::Enum(_)) {
+			let check_attrs = |attrs: &[syn::Attribute]| -> syn::Result<()> {
+				for attr in attrs {
+					if attr.path().segments.len() == 2 &&
+						attr.path().segments[0].ident == "pallet"
+					{
+						let attr_name = attr.path().segments[1].ident.to_string();
+						if matches!(
+							attr_name.as_str(),
+							"as_account" | "nonce_provider" | "fee_payer"
+						) {
+							return Err(syn::Error::new(
+								attr.span(),
+								format!(
+									"`#[pallet::{}]` is only supported on enum origin variants",
+									attr_name,
+								),
+							));
+						}
+					}
+				}
+				Ok(())
+			};
+			match item {
+				syn::Item::Struct(s) => check_attrs(&s.attrs)?,
+				syn::Item::Type(t) => check_attrs(&t.attrs)?,
+				_ => {},
+			}
+		}
+
+		Ok(OriginDef { is_generic, instances, account_like_defs })
 	}
 }

--- a/substrate/frame/support/src/dispatch.rs
+++ b/substrate/frame/support/src/dispatch.rs
@@ -121,6 +121,20 @@ impl<AccountId> RawOrigin<AccountId> {
 	}
 }
 
+impl<AccountId: Clone> crate::traits::AccountLike<AccountId> for RawOrigin<AccountId> {
+	fn as_account(&self) -> Option<AccountId> {
+		self.as_signed().cloned()
+	}
+
+	fn nonce_provider(&self) -> Option<AccountId> {
+		self.as_signed().cloned()
+	}
+
+	fn fee_payer(&self) -> Option<AccountId> {
+		self.as_signed().cloned()
+	}
+}
+
 /// A type that can be used as a parameter in a dispatchable function.
 ///
 /// When using `decl_module` all arguments for call functions must implement this trait.
@@ -740,7 +754,7 @@ mod weight_tests {
 		#[pallet::disable_frame_system_supertrait_check]
 		pub trait Config: 'static {
 			type Block: Parameter + sp_runtime::traits::Block;
-			type AccountId;
+			type AccountId: Clone;
 			type Balance;
 			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
 			type RuntimeOrigin;

--- a/substrate/frame/support/src/storage/generator/mod.rs
+++ b/substrate/frame/support/src/storage/generator/mod.rs
@@ -60,7 +60,7 @@ mod tests {
 		#[pallet::disable_frame_system_supertrait_check]
 		pub trait Config: 'static {
 			type Block: sp_runtime::traits::Block;
-			type AccountId;
+			type AccountId: Clone;
 			type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
 			type RuntimeOrigin;
 			type RuntimeCall;

--- a/substrate/frame/support/src/tests/mod.rs
+++ b/substrate/frame/support/src/tests/mod.rs
@@ -63,7 +63,7 @@ pub mod frame_system {
 	pub trait Config: 'static {
 		#[pallet::no_default]
 		type Block: Parameter + sp_runtime::traits::Block;
-		type AccountId;
+		type AccountId: Clone;
 		#[pallet::no_default_bounds]
 		type BaseCallFilter: crate::traits::Contains<Self::RuntimeCall>;
 		#[pallet::no_default_bounds]

--- a/substrate/frame/support/src/traits.rs
+++ b/substrate/frame/support/src/traits.rs
@@ -108,7 +108,7 @@ pub use dispatch::EnsureOneOf;
 pub use dispatch::{
 	AsEnsureOriginWithArg, Authorize, CallerTrait, EitherOf, EitherOfDiverse, EnsureOrigin,
 	EnsureOriginEqualOrHigherPrivilege, EnsureOriginWithArg, MapSuccess, NeverEnsureOrigin,
-	OriginTrait, TryMapSuccess, TryWithMorphedArg, UnfilteredDispatchable,
+	AccountLike, OriginTrait, TryMapSuccess, TryWithMorphedArg, UnfilteredDispatchable,
 };
 
 mod voting;

--- a/substrate/frame/support/src/traits/dispatch.rs
+++ b/substrate/frame/support/src/traits/dispatch.rs
@@ -455,7 +455,9 @@ pub trait UnfilteredDispatchable {
 /// Unlike `OriginTrait` impls, this does not include any kind of dispatch/call filter. Also, this
 /// trait is more flexible in terms of how it can be used: it is a `Parameter` and `Member`, so it
 /// can be used as dispatchable parameters as well as in storage items.
-pub trait CallerTrait<AccountId>: Parameter + Member + From<RawOrigin<AccountId>> {
+pub trait CallerTrait<AccountId>:
+	Parameter + Member + From<RawOrigin<AccountId>> + AccountLike<AccountId>
+{
 	/// Extract the signer from the message if it is a `Signed` origin.
 	fn into_system(self) -> Option<RawOrigin<AccountId>>;
 
@@ -475,6 +477,108 @@ pub trait CallerTrait<AccountId>: Parameter + Member + From<RawOrigin<AccountId>
 	/// Returns `true` if `self` is a system `None` origin, `None` otherwise.
 	fn is_none(&self) -> bool {
 		self.as_system_ref().map_or(false, RawOrigin::is_none)
+	}
+}
+
+/// Trait for pallet `Origin` types that represent account-like entities.
+///
+/// Origins that are "like accounts" can expose an account (through `as_account`) which can be used
+/// in various authentication and validation work in runtime code. Additionally, if an origin which
+/// exposes an account can also mark that account to be used for nonce checking or fee payment.
+///
+/// # How this trait is used
+///
+/// This trait is **not meant to be called directly** on individual pallet origin types. Instead, it
+/// is a building block used by the FRAME macros: the `#[pallet]` macro generates an `AccountLike`
+/// impl on each pallet's `Origin` type, and `construct_runtime!` composes those per-pallet impls
+/// into the [`CallerTrait`] implementation on `OriginCaller`. Consumer code (e.g. other pallets
+/// which want to authorize other origins besides `Signed` to run something) accesses account
+/// information through `origin.caller().as_account()`, which goes through `CallerTrait` →
+/// `AccountLike` on `OriginCaller`, not on individual pallet origins.
+///
+/// There is native support for nonce checking and fee payment in FRAME extensions. `CheckNonce` and
+/// the `ChargeTransactionPayment` family of `TransactionExtension`s use the
+/// `origin.caller().nonce_provider()` and `origin.caller().fee_payer()` respectively to understand
+/// if their logic needs to run for a given origin.
+///
+/// For non-generic enum origins (those without `<T: Config>`), the `AccountLike` impl on the origin
+/// type itself uses default implementations (returning `None`), because the `as_account` closures
+/// may need access to `Pallet<T>`, which is not available without `T`. The runtime-level
+/// `OriginCaller` path works correctly because `construct_runtime!` routes through
+/// `Pallet::<T>::__as_account_for_origin()` which has `T` in scope.
+///
+/// Right now, there is no weight associated with `as_account`, so closures **must not access
+/// storage as this can lead to unaccounted weight**. Currently there is no use case for accessing
+/// storage for computing an associated account in an origin and, if there was, it could be done by
+/// the `TransactionExtension` computing the origin and it can be stored as data inside the origin
+/// type.
+///
+/// # Pallet macro attributes
+///
+/// For **enum origins**: implemented automatically by the `#[pallet]` macro. Pallet developers
+/// annotate individual enum variants with `#[pallet::as_account(|fields...| -> Option<AccountId>)]`
+/// and optionally `#[pallet::nonce_provider]` and/or `#[pallet::fee_payer]` flags.
+///
+/// **Important:** `#[pallet::nonce_provider]` and `#[pallet::fee_payer]` reuse the closure provided
+/// to `#[pallet::as_account(...)]` so they cannot accept their own closure. When present, they
+/// cause [`nonce_provider()`](AccountLike::nonce_provider) /
+/// [`fee_payer()`](AccountLike::fee_payer) to return the same value as
+/// [`as_account()`](AccountLike::as_account) for that variant.
+///
+/// For **type alias origins** (e.g. `type Origin<T> = CustomOrigin<...>`): the aliased type must
+/// implement this trait. The generated code delegates to the trait impl.
+///
+/// # When to use this
+///
+/// These attributes are intended for pallet developers who:
+///
+/// 1. Want custom origins to participate in the standard
+/// [`CheckNonce`](frame_system::extensions::check_nonce) and/or
+/// [`ChargeTransactionPayment`](pallet_transaction_payment) extensions without writing custom
+/// transaction extensions. They handle the simple case where a custom origin maps directly to an
+/// account.
+/// 2. Want custom origins which can be interpreted as an account or have an associated account to
+/// be allowed to run in their pallet call context.
+///
+/// Using `#[pallet::nonce_provider]` without `#[pallet::fee_payer]` means the origin's transactions
+/// will have nonce tracking but no fee payment — the developer must provide their own spam
+/// protection mechanism.
+///
+/// Using `#[pallet::fee_payer]` without `#[pallet::nonce_provider]` means fees are charged but
+/// there is no replay protection — the developer must provide their own replay protection (e.g.
+/// single-use transactions or a custom nonce scheme).
+pub trait AccountLike<AccountId> {
+	/// Return the `AccountId` this origin maps to, if any.
+	///
+	/// IMPORTANT!
+	///
+	/// Do **not** do any storage access in this function, it does not track weight!
+	fn as_account(&self) -> Option<AccountId> {
+		None
+	}
+
+	/// Return the `AccountId` to use for nonce tracking, if this origin participates.
+	///
+	/// When derived via `#[pallet::nonce_provider]`, this returns the same value as
+	/// [`as_account()`](AccountLike::as_account).
+	///
+	/// IMPORTANT!
+	///
+	/// Do **not** do any storage access in this function, it does not track weight!
+	fn nonce_provider(&self) -> Option<AccountId> {
+		None
+	}
+
+	/// Return the `AccountId` to charge fees from, if this origin participates.
+	///
+	/// When derived via `#[pallet::fee_payer]`, this returns the same value as
+	/// [`as_account()`](AccountLike::as_account).
+	///
+	/// IMPORTANT!
+	///
+	/// Do **not** do any storage access in this function, it does not track weight!
+	fn fee_payer(&self) -> Option<AccountId> {
+		None
 	}
 }
 

--- a/substrate/frame/support/test/tests/account_like.rs
+++ b/substrate/frame/support/test/tests/account_like.rs
@@ -1,0 +1,1151 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for `#[pallet::as_account(...)]`, `#[pallet::nonce_provider]`, and
+//! `#[pallet::fee_payer]` on pallet origin enum variants.
+
+use frame_support::{
+	derive_impl,
+	traits::AccountLike,
+};
+use sp_runtime::{generic, traits::BlakeTwo256};
+
+/// Pallet 1: Generic enum origin with `as_account` + `nonce_provider` on some variants.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet1 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		Member(T::AccountId),
+		Admin,
+	}
+}
+
+/// Pallet 2: Generic enum origin with multiple fields.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet2 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|account, _data| Some(account.clone()))]
+		#[pallet::nonce_provider]
+		#[pallet::fee_payer]
+		WithData(T::AccountId, u32),
+		#[pallet::as_account(|_a, _b| None)]
+		NoAccount(u32, u64),
+	}
+}
+
+/// Pallet 3: Non-generic enum origin (governance-style, no `as_account`).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet3 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin {
+		StakingAdmin,
+		Treasurer,
+	}
+}
+
+/// Pallet 4: Struct origin (no `as_account` possible).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet4 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub struct Origin<T>(pub PhantomData<T>);
+}
+
+/// Pallet 5: Function reference instead of closure.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet5 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		fn nonce_for_member(who: &T::AccountId) -> Option<T::AccountId> {
+			Some(who.clone())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(Self::nonce_for_member)]
+		#[pallet::nonce_provider]
+		#[pallet::fee_payer]
+		Member(T::AccountId),
+	}
+}
+
+/// Pallet 6: Instanced pallet origin.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet6 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T, I = ()>(_);
+
+	#[pallet::config]
+	pub trait Config<I: 'static = ()>: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	#[scale_info(skip_type_params(T, I))]
+	pub enum Origin<T: Config<I>, I: 'static = ()> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		Member(T::AccountId),
+		#[allow(dead_code)]
+		_Phantom(PhantomData<(T, I)>),
+	}
+}
+
+/// Pallet 7: Generic enum origin with `as_account` on ALL variants.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet7 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		#[pallet::fee_payer]
+		Member(T::AccountId),
+		#[pallet::as_account(|who, _data| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		MemberWithData(T::AccountId, u32),
+		#[pallet::as_account(|_a, _b| None)]
+		Anonymous(u32, u64),
+	}
+}
+
+/// Pallet 8: Non-generic enum origin with `as_account` on multiple variants.
+/// Closures access `Self` (= `Pallet<T>`) to derive AccountId from concrete fields.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet8 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	/// Storage mapping from u32 council IDs to AccountIds.
+	#[pallet::storage]
+	pub type CouncilAccounts<T: Config> =
+		StorageMap<_, Twox64Concat, u32, T::AccountId>;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn account_for_council(id: &u32) -> Option<T::AccountId> {
+			CouncilAccounts::<T>::get(id)
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin {
+		#[pallet::as_account(|id| Self::account_for_council(id))]
+		#[pallet::nonce_provider]
+		Council(u32),
+		#[pallet::as_account(|_count, _threshold| None)]
+		Members(u32, u32),
+		TechCommittee,
+	}
+}
+
+/// Pallet 9: Instanced pallet with a type alias origin (mirrors pallet_collective).
+/// The aliased `RawOrigin` implements `AccountLike`, so the type alias delegation
+/// returns `Some(account)` for the `Member` variant.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet9 {
+	use core::marker::PhantomData;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T, I = ()>(_);
+
+	#[pallet::config]
+	pub trait Config<I: 'static = ()>: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	/// A collective-style RawOrigin with an instance parameter.
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	#[scale_info(skip_type_params(I))]
+	#[codec(mel_bound(AccountId: MaxEncodedLen))]
+	pub enum RawOrigin<AccountId, I> {
+		Members(u32, u32),
+		Member(AccountId),
+		_Phantom(PhantomData<I>),
+	}
+
+	impl<AccountId: Clone, I> frame_support::traits::AccountLike<AccountId>
+		for RawOrigin<AccountId, I>
+	{
+		fn as_account(&self) -> Option<AccountId> {
+			match self {
+				RawOrigin::Member(who) => Some(who.clone()),
+				_ => None,
+			}
+		}
+
+		fn nonce_provider(&self) -> Option<AccountId> {
+			match self {
+				RawOrigin::Member(who) => Some(who.clone()),
+				_ => None,
+			}
+		}
+	}
+
+	/// Type alias origin, just like pallet_collective.
+	#[pallet::origin]
+	pub type Origin<T, I = ()> = RawOrigin<<T as frame_system::Config>::AccountId, I>;
+}
+
+/// Pallet 10: Type alias origin with a custom type that manually implements `AccountLike`.
+/// Verifies that `__as_account_for_origin` delegates to the trait impl on the aliased type.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet10 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	/// A custom origin type with a manual `AccountLike` implementation.
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum CustomOrigin<AccountId> {
+		Admin(AccountId),
+		Root,
+	}
+
+	impl<AccountId: Clone> frame_support::traits::AccountLike<AccountId>
+		for CustomOrigin<AccountId>
+	{
+		fn as_account(&self) -> Option<AccountId> {
+			match self {
+				CustomOrigin::Admin(who) => Some(who.clone()),
+				CustomOrigin::Root => None,
+			}
+		}
+
+		fn nonce_provider(&self) -> Option<AccountId> {
+			match self {
+				CustomOrigin::Admin(who) => Some(who.clone()),
+				CustomOrigin::Root => None,
+			}
+		}
+
+		fn fee_payer(&self) -> Option<AccountId> {
+			match self {
+				CustomOrigin::Admin(who) => Some(who.clone()),
+				CustomOrigin::Root => None,
+			}
+		}
+	}
+
+	#[pallet::origin]
+	pub type Origin<T> = CustomOrigin<<T as frame_system::Config>::AccountId>;
+}
+
+/// Pallet 11: as_account only (no nonce_provider, no fee_payer).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet11 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		Member(T::AccountId),
+		Admin,
+	}
+}
+
+/// Pallet 12: as_account + fee_payer only (no nonce_provider).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet12 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::fee_payer]
+		Member(T::AccountId),
+		Admin,
+	}
+}
+
+/// Pallet 13: as_account on a unit variant (zero fields).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet13 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		Member(T::AccountId),
+		#[pallet::as_account(|| None)]
+		Admin,
+	}
+}
+
+/// Pallet 14: as_account on a named-fields variant (struct-like).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet14 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who, _rank| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		#[pallet::fee_payer]
+		Member { who: T::AccountId, rank: u32 },
+		Admin,
+	}
+}
+
+/// Pallet 15: Has an Origin enum with variant `Delegate(AccountId, u32)`.
+/// The `as_account` closure returns Some(account) — uses the first field.
+#[frame_support::pallet(dev_mode)]
+pub mod pallet15 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		/// Shared variant name with pallet16, but different closure logic:
+		/// returns the account from field 0, ignoring the u32 weight field.
+		#[pallet::as_account(|who, _weight| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		Delegate(T::AccountId, u32),
+		/// A variant unique to pallet15.
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::fee_payer]
+		Treasurer(T::AccountId),
+	}
+}
+
+/// Pallet 16: Also has an Origin enum with variant `Delegate(AccountId, u32)`.
+/// The `as_account` closure returns None when the second field is 0 (disabled delegate).
+#[frame_support::pallet(dev_mode)]
+pub mod pallet16 {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		/// Shared variant name with pallet15, but different closure logic:
+		/// returns None when the power field is 0 (disabled delegate).
+		#[pallet::as_account(|who, power| if *power > 0 { Some(who.clone()) } else { None })]
+		#[pallet::nonce_provider]
+		#[pallet::fee_payer]
+		Delegate(T::AccountId, u32),
+		/// A variant unique to pallet16.
+		Spectator,
+	}
+}
+
+pub type AccountId = u64;
+pub type Header = generic::Header<u32, BlakeTwo256>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u64, RuntimeCall, (), ()>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+
+frame_support::construct_runtime!(
+	pub enum Runtime {
+		System: frame_system,
+		Pallet1: pallet1,
+		Pallet2: pallet2,
+		Pallet3: pallet3,
+		Pallet4: pallet4,
+		Pallet5: pallet5,
+		Pallet6: pallet6,
+		Pallet6Instance2: pallet6::<Instance2>,
+		Pallet7: pallet7,
+		Pallet8: pallet8,
+		Pallet9: pallet9,
+		Pallet9Instance2: pallet9::<Instance2>,
+		Pallet10: pallet10,
+		Pallet11: pallet11,
+		Pallet12: pallet12,
+		Pallet13: pallet13,
+		Pallet14: pallet14,
+		Pallet15: pallet15,
+		Pallet16: pallet16,
+	}
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Runtime {
+	type Block = Block;
+}
+
+impl pallet1::Config for Runtime {}
+impl pallet2::Config for Runtime {}
+impl pallet3::Config for Runtime {}
+impl pallet4::Config for Runtime {}
+impl pallet5::Config for Runtime {}
+impl pallet6::Config for Runtime {}
+impl pallet6::Config<frame_support::instances::Instance2> for Runtime {}
+impl pallet7::Config for Runtime {}
+impl pallet8::Config for Runtime {}
+impl pallet9::Config for Runtime {}
+impl pallet9::Config<frame_support::instances::Instance2> for Runtime {}
+impl pallet10::Config for Runtime {}
+impl pallet11::Config for Runtime {}
+impl pallet12::Config for Runtime {}
+impl pallet13::Config for Runtime {}
+impl pallet14::Config for Runtime {}
+impl pallet15::Config for Runtime {}
+impl pallet16::Config for Runtime {}
+
+// =============================================================================
+// Tests for as_account
+// =============================================================================
+
+#[test]
+fn test_system_origin_as_account() {
+	use frame_system::RawOrigin;
+
+	assert_eq!(OriginCaller::system(RawOrigin::Signed(42)).as_account(), Some(42u64));
+	assert_eq!(OriginCaller::system(RawOrigin::Root).as_account(), None);
+	assert_eq!(OriginCaller::system(RawOrigin::None).as_account(), None);
+}
+
+#[test]
+fn test_system_origin_nonce_provider() {
+	use frame_system::RawOrigin;
+
+	assert_eq!(OriginCaller::system(RawOrigin::Signed(42)).nonce_provider(), Some(42u64));
+	assert_eq!(OriginCaller::system(RawOrigin::Root).nonce_provider(), None);
+	assert_eq!(OriginCaller::system(RawOrigin::None).nonce_provider(), None);
+}
+
+#[test]
+fn test_system_origin_fee_payer() {
+	use frame_system::RawOrigin;
+
+	assert_eq!(OriginCaller::system(RawOrigin::Signed(42)).fee_payer(), Some(42u64));
+	assert_eq!(OriginCaller::system(RawOrigin::Root).fee_payer(), None);
+	assert_eq!(OriginCaller::system(RawOrigin::None).fee_payer(), None);
+}
+
+#[test]
+fn test_enum_origin_with_as_account() {
+	// Pallet1: Member has as_account + nonce_provider
+	assert_eq!(
+		OriginCaller::Pallet1(pallet1::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(OriginCaller::Pallet1(pallet1::Origin::Admin).as_account(), None);
+
+	assert_eq!(
+		OriginCaller::Pallet1(pallet1::Origin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(OriginCaller::Pallet1(pallet1::Origin::Admin).nonce_provider(), None);
+
+	// No fee_payer on pallet1
+	assert_eq!(
+		OriginCaller::Pallet1(pallet1::Origin::Member(42)).fee_payer(),
+		None
+	);
+}
+
+#[test]
+fn test_enum_origin_multiple_fields() {
+	// Pallet2: WithData has as_account + nonce_provider + fee_payer
+	assert_eq!(
+		OriginCaller::Pallet2(pallet2::Origin::WithData(42, 100)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet2(pallet2::Origin::WithData(42, 100)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet2(pallet2::Origin::WithData(42, 100)).fee_payer(),
+		Some(42u64)
+	);
+
+	// NoAccount has as_account (returning None) but no nonce_provider/fee_payer flags
+	assert_eq!(
+		OriginCaller::Pallet2(pallet2::Origin::NoAccount(1, 2)).as_account(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet2(pallet2::Origin::NoAccount(1, 2)).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet2(pallet2::Origin::NoAccount(1, 2)).fee_payer(),
+		None
+	);
+}
+
+#[test]
+fn test_non_generic_enum_origin() {
+	assert_eq!(
+		OriginCaller::Pallet3(pallet3::Origin::StakingAdmin).as_account(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet3(pallet3::Origin::Treasurer).as_account(),
+		None
+	);
+}
+
+#[test]
+fn test_struct_origin() {
+	use core::marker::PhantomData;
+
+	assert_eq!(
+		OriginCaller::Pallet4(pallet4::Origin(PhantomData)).as_account(),
+		None
+	);
+}
+
+#[test]
+fn test_function_reference_as_account() {
+	assert_eq!(
+		OriginCaller::Pallet5(pallet5::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet5(pallet5::Origin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet5(pallet5::Origin::Member(42)).fee_payer(),
+		Some(42u64)
+	);
+}
+
+#[test]
+fn test_instanced_origin() {
+	assert_eq!(
+		OriginCaller::Pallet6(pallet6::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet6(pallet6::Origin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet6Instance2(pallet6::Origin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+}
+
+#[test]
+fn test_account_like_trait_directly() {
+	assert_eq!(
+		AccountLike::as_account(&pallet1::Origin::<Runtime>::Member(42)),
+		Some(42u64)
+	);
+	assert_eq!(
+		AccountLike::as_account(&pallet1::Origin::<Runtime>::Admin),
+		None
+	);
+	assert_eq!(
+		AccountLike::nonce_provider(&pallet1::Origin::<Runtime>::Member(42)),
+		Some(42u64)
+	);
+	assert_eq!(
+		AccountLike::fee_payer(&pallet1::Origin::<Runtime>::Member(42)),
+		None
+	);
+}
+
+#[test]
+fn test_generic_enum_all_variants_as_account() {
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::Member(42)).fee_payer(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::MemberWithData(99, 7)).as_account(),
+		Some(99u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::MemberWithData(99, 7)).nonce_provider(),
+		Some(99u64)
+	);
+	// MemberWithData does NOT have fee_payer
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::MemberWithData(99, 7)).fee_payer(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet7(pallet7::Origin::Anonymous(1, 2)).as_account(),
+		None
+	);
+}
+
+#[test]
+fn test_non_generic_enum_with_storage() {
+	use sp_runtime::BuildStorage;
+
+	let t = RuntimeGenesisConfig { ..Default::default() }.build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		pallet8::CouncilAccounts::<Runtime>::insert(1u32, 42u64);
+
+		assert_eq!(
+			OriginCaller::Pallet8(pallet8::Origin::Council(1)).as_account(),
+			Some(42u64)
+		);
+		assert_eq!(
+			OriginCaller::Pallet8(pallet8::Origin::Council(1)).nonce_provider(),
+			Some(42u64)
+		);
+		assert_eq!(
+			OriginCaller::Pallet8(pallet8::Origin::Council(999)).as_account(),
+			None
+		);
+		assert_eq!(
+			OriginCaller::Pallet8(pallet8::Origin::Members(3, 5)).as_account(),
+			None
+		);
+		assert_eq!(
+			OriginCaller::Pallet8(pallet8::Origin::TechCommittee).as_account(),
+			None
+		);
+	});
+}
+
+#[test]
+fn test_existing_pallets_unaffected() {
+	assert_eq!(
+		OriginCaller::Pallet3(pallet3::Origin::StakingAdmin).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet4(pallet4::Origin(core::marker::PhantomData)).nonce_provider(),
+		None
+	);
+}
+
+#[test]
+fn test_type_alias_origin_delegates_to_account_like() {
+	use pallet9::RawOrigin;
+
+	assert_eq!(
+		OriginCaller::Pallet9(RawOrigin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet9(RawOrigin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet9(RawOrigin::Members(3, 5)).as_account(),
+		None
+	);
+
+	assert_eq!(
+		OriginCaller::Pallet9Instance2(RawOrigin::Member(99)).nonce_provider(),
+		Some(99u64)
+	);
+}
+
+#[test]
+fn test_type_alias_custom_origin_with_manual_account_like() {
+	use pallet10::CustomOrigin;
+
+	assert_eq!(
+		OriginCaller::Pallet10(CustomOrigin::Admin(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet10(CustomOrigin::Admin(42)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet10(CustomOrigin::Admin(42)).fee_payer(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet10(CustomOrigin::Root).as_account(),
+		None
+	);
+}
+
+// =============================================================================
+// Tests for as_account without flags (pallet11)
+// =============================================================================
+
+#[test]
+fn test_as_account_only_no_flags() {
+	// Pallet11: Member has as_account but no nonce_provider or fee_payer
+	assert_eq!(
+		OriginCaller::Pallet11(pallet11::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet11(pallet11::Origin::Member(42)).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet11(pallet11::Origin::Member(42)).fee_payer(),
+		None
+	);
+}
+
+// =============================================================================
+// Tests for as_account + fee_payer only (pallet12)
+// =============================================================================
+
+#[test]
+fn test_as_account_with_fee_payer_only() {
+	// Pallet12: Member has as_account + fee_payer but no nonce_provider
+	assert_eq!(
+		OriginCaller::Pallet12(pallet12::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet12(pallet12::Origin::Member(42)).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet12(pallet12::Origin::Member(42)).fee_payer(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet12(pallet12::Origin::Admin).fee_payer(),
+		None
+	);
+}
+
+// =============================================================================
+// Tests for unit variant with as_account (pallet13)
+// =============================================================================
+
+#[test]
+fn test_as_account_unit_variant() {
+	// Pallet13: Member has as_account + nonce_provider, Admin has as_account returning None
+	assert_eq!(
+		OriginCaller::Pallet13(pallet13::Origin::Member(42)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet13(pallet13::Origin::Member(42)).nonce_provider(),
+		Some(42u64)
+	);
+	// Admin is a unit variant with as_account(|| None)
+	assert_eq!(
+		OriginCaller::Pallet13(pallet13::Origin::Admin).as_account(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet13(pallet13::Origin::Admin).nonce_provider(),
+		None
+	);
+}
+
+// =============================================================================
+// Tests for named-fields variant with as_account (pallet14)
+// =============================================================================
+
+#[test]
+fn test_as_account_named_fields_variant() {
+	// Pallet14: Member { who, rank } has as_account + nonce_provider + fee_payer
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Member { who: 42, rank: 3 }).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Member { who: 42, rank: 3 }).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Member { who: 42, rank: 3 }).fee_payer(),
+		Some(42u64)
+	);
+	// Different rank, same account
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Member { who: 42, rank: 99 }).as_account(),
+		Some(42u64)
+	);
+	// Admin has no as_account
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Admin).as_account(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Admin).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet14(pallet14::Origin::Admin).fee_payer(),
+		None
+	);
+}
+
+// =============================================================================
+// Test: two pallets with identically-named Origin enums and shared variant names
+// =============================================================================
+
+#[test]
+fn test_same_origin_and_variant_names_are_independent() {
+	// pallet15::Origin::Delegate always returns Some(account), ignoring the weight field.
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Delegate(42, 0)).as_account(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Delegate(42, 999)).as_account(),
+		Some(42u64)
+	);
+	// pallet15::Delegate has nonce_provider but NOT fee_payer.
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Delegate(42, 0)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Delegate(42, 0)).fee_payer(),
+		None
+	);
+	// pallet15::Treasurer has fee_payer but NOT nonce_provider.
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Treasurer(7)).as_account(),
+		Some(7u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Treasurer(7)).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet15(pallet15::Origin::Treasurer(7)).fee_payer(),
+		Some(7u64)
+	);
+
+	// pallet16::Origin::Delegate returns None when power == 0 (disabled delegate).
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Delegate(42, 0)).as_account(),
+		None
+	);
+	// pallet16::Delegate returns Some when power > 0.
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Delegate(42, 5)).as_account(),
+		Some(42u64)
+	);
+	// pallet16::Delegate has all three flags, but they all use the same closure.
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Delegate(42, 5)).nonce_provider(),
+		Some(42u64)
+	);
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Delegate(42, 5)).fee_payer(),
+		Some(42u64)
+	);
+	// Disabled delegate: all return None.
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Delegate(42, 0)).nonce_provider(),
+		None
+	);
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Delegate(42, 0)).fee_payer(),
+		None
+	);
+	// pallet16::Spectator has no as_account at all.
+	assert_eq!(
+		OriginCaller::Pallet16(pallet16::Origin::Spectator).as_account(),
+		None
+	);
+}
+
+// =============================================================================
+// Test: direct AccountLike trait on non-generic origin type (pallet8)
+// =============================================================================
+
+#[test]
+fn test_non_generic_origin_account_like_trait_directly() {
+	// For non-generic enum origins, the AccountLike trait impl on the origin type
+	// itself uses default implementations (returns None), because the closures need
+	// access to T. The actual behavior is routed through OriginCaller.
+	assert_eq!(AccountLike::<u64>::as_account(&pallet8::Origin::Council(1)), None);
+	assert_eq!(AccountLike::<u64>::nonce_provider(&pallet8::Origin::Council(1)), None);
+	assert_eq!(AccountLike::<u64>::fee_payer(&pallet8::Origin::Council(1)), None);
+
+	// But through OriginCaller, it works correctly (with storage).
+	use sp_runtime::BuildStorage;
+	let t = RuntimeGenesisConfig { ..Default::default() }.build_storage().unwrap();
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		pallet8::CouncilAccounts::<Runtime>::insert(1u32, 42u64);
+		assert_eq!(
+			OriginCaller::Pallet8(pallet8::Origin::Council(1)).as_account(),
+			Some(42u64)
+		);
+	});
+}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_duplicate.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_duplicate.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Two `#[pallet::as_account(...)]` on the same variant should produce a duplicate error.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::as_account(|who| Some(who.clone()))]
+		Member(T::AccountId),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_duplicate.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_duplicate.stderr
@@ -1,0 +1,5 @@
+error: Duplicate `#[pallet::as_account(...)]` attribute on variant
+  --> tests/pallet_ui/as_account_duplicate.rs:41:3
+   |
+41 |         Member(T::AccountId),
+   |         ^^^^^^

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_no_args.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_no_args.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::as_account]` without parenthesized arguments should fail.
+// The attribute requires a closure or function expression.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account]
+		Member(T::AccountId),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_no_args.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_no_args.stderr
@@ -1,0 +1,5 @@
+error: expected attribute arguments in parentheses: #[pallet::as_account(...)]
+  --> tests/pallet_ui/as_account_no_args.rs:40:5
+   |
+40 |         #[pallet::as_account]
+   |           ^^^^^^^^^^^^^^^^^^

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_on_struct.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_on_struct.rs
@@ -1,0 +1,44 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::as_account(...)]` on a struct origin should fail, because
+// the attribute is stripped during enum variant processing and a struct has no variants.
+// Instead this should produce a syn parse error about unknown attribute.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	#[pallet::as_account(|_| None)]
+	pub struct Origin<T>(pub PhantomData<T>);
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_on_struct.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_on_struct.stderr
@@ -1,0 +1,5 @@
+error: `#[pallet::as_account]` is only supported on enum origin variants
+  --> tests/pallet_ui/as_account_on_struct.rs:40:2
+   |
+40 |     #[pallet::as_account(|_| None)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::as_account]` closure with too many arguments for a single-field variant.
+// The variant has 1 field but the closure takes 2 arguments.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|a, b| None)]
+		Member(T::AccountId),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args.stderr
@@ -1,0 +1,17 @@
+error: unused import: `frame_system::pallet_prelude::*`
+  --> tests/pallet_ui/as_account_too_many_args.rs:24:6
+   |
+24 |     use frame_system::pallet_prelude::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
+
+error[E0593]: closure is expected to take 1 argument, but it takes 2 arguments
+  --> tests/pallet_ui/as_account_too_many_args.rs:40:24
+   |
+40 |         #[pallet::as_account(|a, b| None)]
+   |                              ^-----
+   |                              |
+   |                              expected closure that takes 1 argument
+   |                              takes 2 arguments

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args_unit.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args_unit.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::as_account]` closure with too many arguments for a unit variant.
+// The variant has 0 fields but the closure takes 1 argument.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|x| None)]
+		Admin,
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args_unit.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_too_many_args_unit.stderr
@@ -1,0 +1,77 @@
+error: unused import: `frame_system::pallet_prelude::*`
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:24:6
+   |
+24 |     use frame_system::pallet_prelude::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
+
+error[E0392]: type parameter `T` is never used
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:39:18
+   |
+39 |     pub enum Origin<T: Config> {
+   |                     ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0593]: closure is expected to take 0 arguments, but it takes 1 argument
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:40:24
+   |
+40 |         #[pallet::as_account(|x| None)]
+   |                              ^--
+   |                              |
+   |                              expected closure that takes 0 arguments
+   |                              takes 1 argument
+
+error[E0283]: type annotations needed
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:37:3
+   |
+37 |         Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+   |         ^^^^^ cannot infer type
+   |
+   = note: cannot satisfy `_: pallet::Config`
+note: required by a bound in `Origin::Admin`
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:39:21
+   |
+39 |     pub enum Origin<T: Config> {
+   |                        ^^^^^^ required by this bound in `Origin::Admin`
+40 |         #[pallet::as_account(|x| None)]
+41 |         Admin,
+   |         ----- required by a bound in this unit variant
+
+error[E0283]: type annotations needed
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:39:11
+   |
+39 |       pub enum Origin<T: Config> {
+   |  ______________^
+40 | |         #[pallet::as_account(|x| None)]
+41 | |         Admin,
+   | |_____________^ cannot infer type for type parameter `T` declared on the enum `Origin`
+   |
+   = note: cannot satisfy `_: pallet::Config`
+note: required by a bound in `Origin::Admin`
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:39:21
+   |
+39 |     pub enum Origin<T: Config> {
+   |                        ^^^^^^ required by this bound in `Origin::Admin`
+40 |         #[pallet::as_account(|x| None)]
+41 |         Admin,
+   |         ----- required by a bound in this unit variant
+
+error[E0283]: type annotations needed
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:21:1
+   |
+21 | #[frame_support::pallet(dev_mode)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot satisfy `_: pallet::Config`
+note: required by a bound in `Origin::Admin`
+  --> tests/pallet_ui/as_account_too_many_args_unit.rs:39:21
+   |
+39 |     pub enum Origin<T: Config> {
+   |                        ^^^^^^ required by this bound in `Origin::Admin`
+40 |         #[pallet::as_account(|x| None)]
+41 |         Admin,
+   |         ----- required by a bound in this unit variant
+   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_type_alias_no_impl.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_type_alias_no_impl.rs
@@ -1,0 +1,56 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Type alias origin where the aliased type does NOT implement `AccountLike`.
+// This should fail to compile because the generated code delegates to
+// `AccountLike::nonce_provider` on the aliased type.
+
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum CustomOrigin<AccountId> {
+		Admin(AccountId),
+		Root,
+	}
+
+	// Note: no AccountLike impl for CustomOrigin — should fail to compile.
+
+	#[pallet::origin]
+	pub type Origin<T> = CustomOrigin<<T as frame_system::Config>::AccountId>;
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_type_alias_no_impl.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_type_alias_no_impl.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `CustomOrigin<<T as Config>::AccountId>: AccountLike<...>` is not satisfied
+  --> tests/pallet_ui/as_account_type_alias_no_impl.rs:25:1
+   |
+25 | #[frame_support::pallet(dev_mode)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `AccountLike<<T as frame_system::Config>::AccountId>` is not implemented for `CustomOrigin<<T as frame_system::Config>::AccountId>`
+   = help: the trait `AccountLike<AccountId>` is implemented for `RawOrigin<AccountId>`
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: this error originates in the attribute macro `frame_support::pallet` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_arity.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_arity.rs
@@ -1,0 +1,45 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::as_account]` closure with wrong number of arguments for the variant fields.
+// The variant has 2 fields but the closure takes 1 argument.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		WithData(T::AccountId, u32),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_arity.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_arity.stderr
@@ -1,0 +1,17 @@
+error: unused import: `frame_system::pallet_prelude::*`
+  --> tests/pallet_ui/as_account_wrong_arity.rs:24:6
+   |
+24 |     use frame_system::pallet_prelude::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
+
+error[E0593]: closure is expected to take 2 arguments, but it takes 1 argument
+  --> tests/pallet_ui/as_account_wrong_arity.rs:40:24
+   |
+40 |         #[pallet::as_account(|who| Some(who.clone()))]
+   |                              ^----
+   |                              |
+   |                              expected closure that takes 2 arguments
+   |                              takes 1 argument

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_return_type.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_return_type.rs
@@ -1,0 +1,46 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::as_account]` closure returning the wrong type.
+// Should return `Option<T::AccountId>` but returns `bool`.
+// The compiler will emit a type mismatch error.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|_who| true)]
+		Member(T::AccountId),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_return_type.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/as_account_wrong_return_type.stderr
@@ -1,0 +1,17 @@
+error: unused import: `frame_system::pallet_prelude::*`
+  --> tests/pallet_ui/as_account_wrong_return_type.rs:25:6
+   |
+25 |     use frame_system::pallet_prelude::*;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D unused-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(unused_imports)]`
+
+error[E0308]: mismatched types
+  --> tests/pallet_ui/as_account_wrong_return_type.rs:41:31
+   |
+41 |         #[pallet::as_account(|_who| true)]
+   |                                     ^^^^ expected `Option<<T as Config>::AccountId>`, found `bool`
+   |
+   = note: expected enum `std::option::Option<<T as frame_system::Config>::AccountId>`
+              found type `bool`

--- a/substrate/frame/support/test/tests/pallet_ui/authorize_wrong_weight_info.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/authorize_wrong_weight_info.stderr
@@ -2,4 +2,4 @@ error[E0599]: no function or associated item named `authorize_call1` found for a
   --> tests/pallet_ui/authorize_wrong_weight_info.rs:39:10
    |
 39 |         pub fn call1(origin: OriginFor<T>, a: u32) -> DispatchResult {
-   |                ^^^^^ function or associated item not found in `<T as pallet::Config>::WeightInfo`
+   |                ^^^^^ function or associated item not found in `<T as Config>::WeightInfo`

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -16,8 +16,9 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound.rs:38:36
    |
 38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
-   |                                          ^^^^ the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
+   |                                          ^^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
+   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`
 

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -16,8 +16,9 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound_2.rs:38:36
    |
 38 |         pub fn foo(origin: OriginFor<T>, _bar: T::Bar) -> DispatchResultWithPostInfo {
-   |                                          ^^^^ the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
+   |                                          ^^^^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
+   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`
 

--- a/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.stderr
@@ -16,8 +16,9 @@ error[E0277]: `Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/call_argument_invalid_bound_3.rs:40:36
    |
 40 |         pub fn foo(origin: OriginFor<T>, _bar: Bar) -> DispatchResultWithPostInfo {
-   |                                          ^^^^ the trait `std::fmt::Debug` is not implemented for `Bar`
+   |                                          ^^^^ `Bar` cannot be formatted using `{:?}`
    |
+   = help: the trait `std::fmt::Debug` is not implemented for `Bar`
    = note: add `#[derive(Debug)]` to `Bar` or manually `impl std::fmt::Debug for Bar`
    = note: required for `&Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&Bar` to `&dyn std::fmt::Debug`

--- a/substrate/frame/support/test/tests/pallet_ui/call_span_for_error.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_span_for_error.stderr
@@ -1,26 +1,26 @@
 error[E0308]: mismatched types
- --> tests/pallet_ui/call_span_for_error.rs:32:15
-  |
- 32 |             return Err(DispatchError::BadOrigin);
-    |                    --- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `DispatchErrorWithPostInfo<...>`, found `DispatchError`
-    |                    |
-    |                    arguments to this enum variant are incorrect
-    |
-    = note: expected struct `DispatchErrorWithPostInfo<PostDispatchInfo>`
-                 found enum `frame_support::pallet_prelude::DispatchError`
+  --> tests/pallet_ui/call_span_for_error.rs:32:15
+   |
+32 |             return Err(DispatchError::BadOrigin);
+   |                    --- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `DispatchErrorWithPostInfo<...>`, found `DispatchError`
+   |                    |
+   |                    arguments to this enum variant are incorrect
+   |
+   = note: expected struct `DispatchErrorWithPostInfo<PostDispatchInfo>`
+                found enum `frame_support::pallet_prelude::DispatchError`
 help: the type constructed contains `frame_support::pallet_prelude::DispatchError` due to the type of the argument passed
-   --> tests/pallet_ui/call_span_for_error.rs:32:11
-    |
- 32 |             return Err(DispatchError::BadOrigin);
-    |                    ^^^^------------------------^
-    |                        |
-    |                        this argument influences the type of `Err`
+  --> tests/pallet_ui/call_span_for_error.rs:32:11
+   |
+32 |             return Err(DispatchError::BadOrigin);
+   |                    ^^^^------------------------^
+   |                        |
+   |                        this argument influences the type of `Err`
 note: tuple variant defined here
-   --> $RUST/core/src/result.rs
-    |
-    |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
-    |     ^^^
+  --> $RUST/core/src/result.rs
+   |
+   |     Err(#[stable(feature = "rust1", since = "1.0.0")] E),
+   |     ^^^
 help: call `Into::into` on this expression to convert `frame_support::pallet_prelude::DispatchError` into `DispatchErrorWithPostInfo<PostDispatchInfo>`
-    |
- 32 |             return Err(DispatchError::BadOrigin.into());
-    |                                                +++++++
+   |
+32 |             return Err(DispatchError::BadOrigin.into());
+   |                                                +++++++

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_inherited_invalid2.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_inherited_invalid2.stderr
@@ -1,10 +1,10 @@
-error[E0425]: cannot find type `prefix` in this scope
+error[E0412]: cannot find type `prefix` in this scope
   --> tests/pallet_ui/call_weight_inherited_invalid2.rs:39:24
    |
 39 |     #[pallet::call(weight(prefix))]
    |                           ^^^^^^ not found in this scope
 
-error[E0425]: cannot find type `prefix` in this scope
+error[E0412]: cannot find type `prefix` in this scope
   --> tests/pallet_ui/call_weight_inherited_invalid2.rs:60:26
    |
 60 |     #[pallet::call(weight = prefix)]

--- a/substrate/frame/support/test/tests/pallet_ui/call_weight_inherited_invalid4.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/call_weight_inherited_invalid4.stderr
@@ -2,10 +2,10 @@ error[E0599]: no function or associated item named `foo` found for associated ty
   --> tests/pallet_ui/call_weight_inherited_invalid4.rs:41:10
    |
 41 |         pub fn foo(_: OriginFor<T>) -> DispatchResult {
-   |                ^^^ function or associated item not found in `<T as parentheses::Config>::WeightInfo`
+   |                ^^^ function or associated item not found in `<T as Config>::WeightInfo`
 
 error[E0599]: no function or associated item named `foo` found for associated type `<T as assign::Config>::WeightInfo` in the current scope
   --> tests/pallet_ui/call_weight_inherited_invalid4.rs:62:10
    |
 62 |         pub fn foo(_: OriginFor<T>) -> DispatchResult {
-   |                ^^^ function or associated item not found in `<T as assign::Config>::WeightInfo`
+   |                ^^^ function or associated item not found in `<T as Config>::WeightInfo`

--- a/substrate/frame/support/test/tests/pallet_ui/compare_unset_storage_version.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/compare_unset_storage_version.stderr
@@ -1,13 +1,13 @@
 error[E0369]: binary operation `!=` cannot be applied to type `NoStorageVersionSet`
- --> tests/pallet_ui/compare_unset_storage_version.rs:32:39
-  |
- 32 |             if Self::in_code_storage_version() != Self::on_chain_storage_version() {
-    |                ------------------------------- ^^ -------------------------------- StorageVersion
-    |                |
-    |                NoStorageVersionSet
-    |
-note: `NoStorageVersionSet` does not implement `PartialEq<StorageVersion>`
-   --> $WORKSPACE/substrate/frame/support/src/traits/metadata.rs
-    |
-    | pub struct NoStorageVersionSet;
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `NoStorageVersionSet` is defined in another crate
+  --> tests/pallet_ui/compare_unset_storage_version.rs:32:39
+   |
+32 |             if Self::in_code_storage_version() != Self::on_chain_storage_version() {
+   |                ------------------------------- ^^ -------------------------------- StorageVersion
+   |                |
+   |                NoStorageVersionSet
+   |
+note: the foreign item type `NoStorageVersionSet` doesn't implement `PartialEq<StorageVersion>`
+  --> $WORKSPACE/substrate/frame/support/src/traits/metadata.rs
+   |
+   | pub struct NoStorageVersionSet;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not implement `PartialEq<StorageVersion>`

--- a/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/dev_mode_without_arg_max_encoded_len.stderr
@@ -42,8 +42,7 @@ error[E0277]: the trait bound `Vec<u8>: MaxEncodedLen` is not satisfied
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ...)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ..., ...)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
            and $N others
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageMyStorage<T>, Vec<u8>>` to implement `StorageInfoTrait`
-   = note: consider using `--verbose` to print the full type name to the console

--- a/substrate/frame/support/test/tests/pallet_ui/duplicate_storage_prefix.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/duplicate_storage_prefix.stderr
@@ -22,25 +22,25 @@ error: Duplicate storage prefixes found for `CounterForBar`
 36 |     type CounterForBar<T> = StorageValue<_, u16>;
    |          ^^^^^^^^^^^^^
 
-error[E0425]: cannot find type `_GeneratedPrefixForStorageFoo` in this scope
+error[E0412]: cannot find type `_GeneratedPrefixForStorageFoo` in this scope
   --> tests/pallet_ui/duplicate_storage_prefix.rs:29:7
    |
 29 |     type Foo<T> = StorageValue<_, u8>;
    |          ^^^ not found in this scope
 
-error[E0425]: cannot find type `_GeneratedPrefixForStorageNotFoo` in this scope
+error[E0412]: cannot find type `_GeneratedPrefixForStorageNotFoo` in this scope
   --> tests/pallet_ui/duplicate_storage_prefix.rs:33:7
    |
 33 |     type NotFoo<T> = StorageValue<_, u16>;
    |          ^^^^^^ not found in this scope
 
-error[E0425]: cannot find type `_GeneratedPrefixForStorageCounterForBar` in this scope
+error[E0412]: cannot find type `_GeneratedPrefixForStorageCounterForBar` in this scope
   --> tests/pallet_ui/duplicate_storage_prefix.rs:36:7
    |
 36 |     type CounterForBar<T> = StorageValue<_, u16>;
    |          ^^^^^^^^^^^^^ not found in this scope
 
-error[E0425]: cannot find type `_GeneratedPrefixForStorageBar` in this scope
+error[E0412]: cannot find type `_GeneratedPrefixForStorageBar` in this scope
   --> tests/pallet_ui/duplicate_storage_prefix.rs:39:7
    |
 39 |     type Bar<T> = CountedStorageMap<_, Twox64Concat, u16, u16>;

--- a/substrate/frame/support/test/tests/pallet_ui/error_does_not_derive_pallet_error.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/error_does_not_derive_pallet_error.stderr
@@ -2,13 +2,8 @@ error[E0277]: the trait bound `MyError: PalletError` is not satisfied
   --> tests/pallet_ui/error_does_not_derive_pallet_error.rs:29:15
    |
 29 |         CustomError(crate::MyError),
-   |                     ^^^^^^^^^^^^^^ unsatisfied trait bound
+   |                     ^^^^^^^^^^^^^^ the trait `PalletError` is not implemented for `MyError`
    |
-help: the trait `PalletError` is not implemented for `MyError`
-  --> tests/pallet_ui/error_does_not_derive_pallet_error.rs:34:1
-   |
-34 | enum MyError {}
-   | ^^^^^^^^^^^^
    = help: the following other types implement trait `PalletError`:
              ()
              (TupleElement0, TupleElement1)
@@ -16,7 +11,6 @@ help: the trait `PalletError` is not implemented for `MyError`
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ...)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ..., ...)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
            and $N others
-   = note: consider using `--verbose` to print the full type name to the console

--- a/substrate/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/event_field_not_member.stderr
@@ -14,7 +14,8 @@ error[E0277]: `<T as pallet::Config>::Bar` doesn't implement `std::fmt::Debug`
   --> tests/pallet_ui/event_field_not_member.rs:40:7
    |
 40 |         B { b: T::Bar },
-   |             ^ the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
+   |             ^ `<T as pallet::Config>::Bar` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
+   = help: the trait `std::fmt::Debug` is not implemented for `<T as pallet::Config>::Bar`
    = note: required for `&<T as pallet::Config>::Bar` to implement `std::fmt::Debug`
    = note: required for the cast from `&&<T as pallet::Config>::Bar` to `&dyn std::fmt::Debug`

--- a/substrate/frame/support/test/tests/pallet_ui/fee_payer_without_as_account.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/fee_payer_without_as_account.rs
@@ -1,0 +1,44 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::fee_payer]` without `#[pallet::as_account(...)]` should fail.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::fee_payer]
+		Member(T::AccountId),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/fee_payer_without_as_account.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/fee_payer_without_as_account.stderr
@@ -1,0 +1,5 @@
+error: `#[pallet::fee_payer]` requires `#[pallet::as_account(...)]` on the same variant
+  --> tests/pallet_ui/fee_payer_without_as_account.rs:39:3
+   |
+39 |         #[pallet::fee_payer]
+   |         ^

--- a/substrate/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/hooks_invalid_item.stderr
@@ -1,15 +1,15 @@
 error[E0107]: missing generics for trait `Hooks`
- --> tests/pallet_ui/hooks_invalid_item.rs:29:18
-  |
- 29 |     impl<T: Config> Hooks for Pallet<T> {}
-    |                     ^^^^^ expected 1 generic argument
-    |
+  --> tests/pallet_ui/hooks_invalid_item.rs:29:18
+   |
+29 |     impl<T: Config> Hooks for Pallet<T> {}
+   |                     ^^^^^ expected 1 generic argument
+   |
 note: trait defined here, with 1 generic parameter: `BlockNumber`
-   --> $WORKSPACE/substrate/frame/support/src/traits/hooks.rs
-    |
-    | pub trait Hooks<BlockNumber> {
-    |           ^^^^^ -----------
+  --> $WORKSPACE/substrate/frame/support/src/traits/hooks.rs
+   |
+   | pub trait Hooks<BlockNumber> {
+   |           ^^^^^ -----------
 help: add missing generic argument
-    |
- 29 |     impl<T: Config> Hooks<BlockNumber> for Pallet<T> {}
-    |                          +++++++++++++
+   |
+29 |     impl<T: Config> Hooks<BlockNumber> for Pallet<T> {}
+   |                          +++++++++++++

--- a/substrate/frame/support/test/tests/pallet_ui/mod_not_inlined.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/mod_not_inlined.stderr
@@ -1,4 +1,4 @@
-error[E0658]: file modules in proc macro input are unstable
+error[E0658]: non-inline modules in proc macro input are unstable
   --> tests/pallet_ui/mod_not_inlined.rs:19:1
    |
 19 | mod foo;

--- a/substrate/frame/support/test/tests/pallet_ui/nonce_provider_without_as_account.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/nonce_provider_without_as_account.rs
@@ -1,0 +1,44 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// `#[pallet::nonce_provider]` without `#[pallet::as_account(...)]` should fail.
+
+#[frame_support::pallet(dev_mode)]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::nonce_provider]
+		Member(T::AccountId),
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/nonce_provider_without_as_account.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/nonce_provider_without_as_account.stderr
@@ -1,0 +1,5 @@
+error: `#[pallet::nonce_provider]` requires `#[pallet::as_account(...)]` on the same variant
+  --> tests/pallet_ui/nonce_provider_without_as_account.rs:39:3
+   |
+39 |         #[pallet::nonce_provider]
+   |         ^

--- a/substrate/frame/support/test/tests/pallet_ui/pass/as_account_basic.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/as_account_basic.rs
@@ -1,0 +1,51 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Verify a basic pallet with `#[pallet::as_account]` compiles successfully.
+
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		Member(T::AccountId),
+		Admin,
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/pass/as_account_named_fields.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/as_account_named_fields.rs
@@ -1,0 +1,52 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Verify `#[pallet::as_account]` on a named-fields variant (struct-like) compiles successfully.
+// The closure receives references to each named field.
+
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who, _rank| Some(who.clone()))]
+		Member { who: T::AccountId, rank: u32 },
+		Admin,
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/pass/as_account_non_generic.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/as_account_non_generic.rs
@@ -1,0 +1,61 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Verify a non-generic enum origin with `#[pallet::as_account]` compiles.
+// The closure accesses `Self` (= `Pallet<T>`) to convert concrete fields to AccountId.
+
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::storage]
+	pub type CouncilAccounts<T: Config> = StorageMap<_, Twox64Concat, u32, T::AccountId>;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn account_for_council(id: &u32) -> Option<T::AccountId> {
+			CouncilAccounts::<T>::get(id)
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin {
+		#[pallet::as_account(|id| Self::account_for_council(id))]
+		Council(u32),
+		Admin,
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/pass/as_account_type_alias.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/as_account_type_alias.rs
@@ -1,0 +1,64 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Type alias origin where the aliased type implements `AccountLike`.
+// This should compile successfully - the generated code delegates to the trait impl.
+
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum CustomOrigin<AccountId> {
+		Admin(AccountId),
+		Root,
+	}
+
+	impl<AccountId: Clone> frame_support::traits::AccountLike<AccountId>
+		for CustomOrigin<AccountId>
+	{
+		fn as_account(&self) -> Option<AccountId> {
+			match self {
+				CustomOrigin::Admin(who) => Some(who.clone()),
+				CustomOrigin::Root => None,
+			}
+		}
+	}
+
+	#[pallet::origin]
+	pub type Origin<T> = CustomOrigin<<T as frame_system::Config>::AccountId>;
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/pass/as_account_unit_variant.rs
+++ b/substrate/frame/support/test/tests/pallet_ui/pass/as_account_unit_variant.rs
@@ -1,0 +1,53 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Verify `#[pallet::as_account]` on a unit variant (zero fields) compiles successfully.
+// The closure takes no arguments and returns `Option<AccountId>`.
+
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		#[pallet::as_account(|who| Some(who.clone()))]
+		Member(T::AccountId),
+		#[pallet::as_account(|| None)]
+		Admin,
+	}
+}
+
+fn main() {}

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.stderr
@@ -1,40 +1,24 @@
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
- --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
-  |
- 27 |       #[pallet::without_storage_info]
-    |  _______________^
- 28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
- 29 | |
- 30 | |     #[pallet::hooks]
-...   |
- 38 | |     #[pallet::storage]
- 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-    | |____________^ unsatisfied trait bound
-    |
-help: the trait `WrapperTypeDecode` is not implemented for `Bar`
-   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-    |
- 36 |     struct Bar;
-    |     ^^^^^^^^^^
-help: the following other types implement trait `WrapperTypeDecode`
-   --> $WORKSPACE/substrate/primitives/core/src/lib.rs
-    |
-    | impl codec::WrapperTypeDecode for Bytes {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes`
-    |
-   ::: $CARGO/parity-scale-codec-3.7.5/src/codec.rs
-    |
-    | impl<T> WrapperTypeDecode for Box<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Box<T>`
-...
-    | impl<T> WrapperTypeDecode for Rc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<T>`
-...
-    | impl<T> WrapperTypeDecode for Arc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Arc<T>`
-    = note: required for `Bar` to implement `Decode`
-    = note: required for `Bar` to implement `FullCodec`
-    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
+   |
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+   |
+   = help: the following other types implement trait `WrapperTypeDecode`:
+             Arc<T>
+             Box<T>
+             Rc<T>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
@@ -47,13 +31,8 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
-help: the trait `EncodeLike` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
              `&T` implements `EncodeLike<T>`
@@ -67,7 +46,6 @@ help: the trait `EncodeLike` is not implemented for `Bar`
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:27:12
@@ -80,13 +58,8 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
-help: the trait `WrapperTypeEncode` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
              &mut T
@@ -108,13 +81,8 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `TypeInfo` is not implemented for `Bar`
    |
-help: the trait `TypeInfo` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `TypeInfo`:
              &T
              &mut T
@@ -129,37 +97,21 @@ help: the trait `TypeInfo` is not implemented for `Bar`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
- --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
-  |
- 38 |       #[pallet::storage]
-    |  _______________^
- 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-    | |____________^ unsatisfied trait bound
-    |
-help: the trait `WrapperTypeDecode` is not implemented for `Bar`
-   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-    |
- 36 |     struct Bar;
-    |     ^^^^^^^^^^
-help: the following other types implement trait `WrapperTypeDecode`
-   --> $WORKSPACE/substrate/primitives/core/src/lib.rs
-    |
-    | impl codec::WrapperTypeDecode for Bytes {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes`
-    |
-   ::: $CARGO/parity-scale-codec-3.7.5/src/codec.rs
-    |
-    | impl<T> WrapperTypeDecode for Box<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Box<T>`
-...
-    | impl<T> WrapperTypeDecode for Rc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<T>`
-...
-    | impl<T> WrapperTypeDecode for Arc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Arc<T>`
-    = note: required for `Bar` to implement `Decode`
-    = note: required for `Bar` to implement `FullCodec`
-    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
+   |
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<Value = Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+   |
+   = help: the following other types implement trait `WrapperTypeDecode`:
+             Arc<T>
+             Box<T>
+             Rc<T>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
@@ -167,13 +119,8 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
-help: the trait `EncodeLike` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
              `&T` implements `EncodeLike<T>`
@@ -187,7 +134,6 @@ help: the trait `EncodeLike` is not implemented for `Bar`
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
@@ -195,13 +141,8 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
-help: the trait `WrapperTypeEncode` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
              &mut T
@@ -216,92 +157,3 @@ help: the trait `WrapperTypeEncode` is not implemented for `Bar`
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
-
-error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
- --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
-  |
- 38 |       #[pallet::storage]
-    |  _______________^
- 39 | |     type Foo<T> = StorageValue<Value = Bar>;
-    | |____________^ unsatisfied trait bound
-    |
-help: the trait `WrapperTypeDecode` is not implemented for `Bar`
-   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-    |
- 36 |     struct Bar;
-    |     ^^^^^^^^^^
-help: the following other types implement trait `WrapperTypeDecode`
-   --> $WORKSPACE/substrate/primitives/core/src/lib.rs
-    |
-    | impl codec::WrapperTypeDecode for Bytes {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes`
-    |
-   ::: $CARGO/parity-scale-codec-3.7.5/src/codec.rs
-    |
-    | impl<T> WrapperTypeDecode for Box<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Box<T>`
-...
-    | impl<T> WrapperTypeDecode for Rc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<T>`
-...
-    | impl<T> WrapperTypeDecode for Arc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Arc<T>`
-    = note: required for `Bar` to implement `Decode`
-    = note: required for `Bar` to implement `FullCodec`
-    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-
-error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
-   |
-38 |       #[pallet::storage]
-   |  _______________^
-39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
-   |
-help: the trait `EncodeLike` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
-   = help: the following other types implement trait `EncodeLike<T>`:
-             `&&T` implements `EncodeLike<T>`
-             `&T` implements `EncodeLike<T>`
-             `&T` implements `EncodeLike`
-             `&[(K, V)]` implements `EncodeLike<BTreeMap<LikeK, LikeV>>`
-             `&[(T,)]` implements `EncodeLike<BTreeSet<LikeT>>`
-             `&[(T,)]` implements `EncodeLike<BinaryHeap<LikeT>>`
-             `&[(T,)]` implements `EncodeLike<LinkedList<LikeT>>`
-             `&[T]` implements `EncodeLike<Vec<U>>`
-           and $N others
-   = note: required for `Bar` to implement `FullEncode`
-   = note: required for `Bar` to implement `FullCodec`
-   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: consider using `--verbose` to print the full type name to the console
-
-error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:38:12
-   |
-38 |       #[pallet::storage]
-   |  _______________^
-39 | |     type Foo<T> = StorageValue<Value = Bar>;
-   | |____________^ unsatisfied trait bound
-   |
-help: the trait `WrapperTypeEncode` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
-   = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
-             Box<T>
-             Cow<'_, T>
-             Rc<T>
-             Vec<T>
-             bytes::bytes::Bytes
-           and $N others
-   = note: required for `Bar` to implement `Encode`
-   = note: required for `Bar` to implement `FullEncode`
-   = note: required for `Bar` to implement `FullCodec`
-   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`

--- a/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.stderr
@@ -1,40 +1,24 @@
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
- --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
-  |
- 27 |       #[pallet::without_storage_info]
-    |  _______________^
- 28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
- 29 | |
- 30 | |     #[pallet::hooks]
-...   |
- 38 | |     #[pallet::storage]
- 39 | |     type Foo<T> = StorageValue<_, Bar>;
-    | |____________^ unsatisfied trait bound
-    |
-help: the trait `WrapperTypeDecode` is not implemented for `Bar`
-   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-    |
- 36 |     struct Bar;
-    |     ^^^^^^^^^^
-help: the following other types implement trait `WrapperTypeDecode`
-   --> $WORKSPACE/substrate/primitives/core/src/lib.rs
-    |
-    | impl codec::WrapperTypeDecode for Bytes {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes`
-    |
-   ::: $CARGO/parity-scale-codec-3.7.5/src/codec.rs
-    |
-    | impl<T> WrapperTypeDecode for Box<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Box<T>`
-...
-    | impl<T> WrapperTypeDecode for Rc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<T>`
-...
-    | impl<T> WrapperTypeDecode for Arc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Arc<T>`
-    = note: required for `Bar` to implement `Decode`
-    = note: required for `Bar` to implement `FullCodec`
-    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
+   |
+27 |       #[pallet::without_storage_info]
+   |  _______________^
+28 | |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+29 | |
+30 | |     #[pallet::hooks]
+...  |
+38 | |     #[pallet::storage]
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+   |
+   = help: the following other types implement trait `WrapperTypeDecode`:
+             Arc<T>
+             Box<T>
+             Rc<T>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
@@ -47,13 +31,8 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
-help: the trait `EncodeLike` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
              `&T` implements `EncodeLike<T>`
@@ -67,7 +46,6 @@ help: the trait `EncodeLike` is not implemented for `Bar`
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `PartialStorageInfoTrait`
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:27:12
@@ -80,13 +58,8 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
-help: the trait `WrapperTypeEncode` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
              &mut T
@@ -108,13 +81,8 @@ error[E0277]: the trait bound `Bar: TypeInfo` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `TypeInfo` is not implemented for `Bar`
    |
-help: the trait `TypeInfo` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `TypeInfo`:
              &T
              &mut T
@@ -129,37 +97,21 @@ help: the trait `TypeInfo` is not implemented for `Bar`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
- --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
-  |
- 38 |       #[pallet::storage]
-    |  _______________^
- 39 | |     type Foo<T> = StorageValue<_, Bar>;
-    | |____________^ unsatisfied trait bound
-    |
-help: the trait `WrapperTypeDecode` is not implemented for `Bar`
-   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-    |
- 36 |     struct Bar;
-    |     ^^^^^^^^^^
-help: the following other types implement trait `WrapperTypeDecode`
-   --> $WORKSPACE/substrate/primitives/core/src/lib.rs
-    |
-    | impl codec::WrapperTypeDecode for Bytes {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes`
-    |
-   ::: $CARGO/parity-scale-codec-3.7.5/src/codec.rs
-    |
-    | impl<T> WrapperTypeDecode for Box<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Box<T>`
-...
-    | impl<T> WrapperTypeDecode for Rc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<T>`
-...
-    | impl<T> WrapperTypeDecode for Arc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Arc<T>`
-    = note: required for `Bar` to implement `Decode`
-    = note: required for `Bar` to implement `FullCodec`
-    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
+  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
+   |
+38 |       #[pallet::storage]
+   |  _______________^
+39 | |     type Foo<T> = StorageValue<_, Bar>;
+   | |____________^ the trait `WrapperTypeDecode` is not implemented for `Bar`
+   |
+   = help: the following other types implement trait `WrapperTypeDecode`:
+             Arc<T>
+             Box<T>
+             Rc<T>
+             frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes
+   = note: required for `Bar` to implement `Decode`
+   = note: required for `Bar` to implement `FullCodec`
+   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
 
 error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
@@ -167,13 +119,8 @@ error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `EncodeLike` is not implemented for `Bar`
    |
-help: the trait `EncodeLike` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `EncodeLike<T>`:
              `&&T` implements `EncodeLike<T>`
              `&T` implements `EncodeLike<T>`
@@ -187,7 +134,6 @@ help: the trait `EncodeLike` is not implemented for `Bar`
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
@@ -195,13 +141,8 @@ error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
 38 |       #[pallet::storage]
    |  _______________^
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `WrapperTypeEncode` is not implemented for `Bar`
    |
-help: the trait `WrapperTypeEncode` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
              &mut T
@@ -216,92 +157,3 @@ help: the trait `WrapperTypeEncode` is not implemented for `Bar`
    = note: required for `Bar` to implement `FullEncode`
    = note: required for `Bar` to implement `FullCodec`
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageEntryMetadataBuilder`
-
-error[E0277]: the trait bound `Bar: WrapperTypeDecode` is not satisfied
- --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
-  |
- 38 |       #[pallet::storage]
-    |  _______________^
- 39 | |     type Foo<T> = StorageValue<_, Bar>;
-    | |____________^ unsatisfied trait bound
-    |
-help: the trait `WrapperTypeDecode` is not implemented for `Bar`
-   --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-    |
- 36 |     struct Bar;
-    |     ^^^^^^^^^^
-help: the following other types implement trait `WrapperTypeDecode`
-   --> $WORKSPACE/substrate/primitives/core/src/lib.rs
-    |
-    | impl codec::WrapperTypeDecode for Bytes {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `frame_support::sp_runtime::sp_application_crypto::sp_core::Bytes`
-    |
-   ::: $CARGO/parity-scale-codec-3.7.5/src/codec.rs
-    |
-    | impl<T> WrapperTypeDecode for Box<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Box<T>`
-...
-    | impl<T> WrapperTypeDecode for Rc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<T>`
-...
-    | impl<T> WrapperTypeDecode for Arc<T> {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Arc<T>`
-    = note: required for `Bar` to implement `Decode`
-    = note: required for `Bar` to implement `FullCodec`
-    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-
-error[E0277]: the trait bound `Bar: EncodeLike` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
-   |
-38 |       #[pallet::storage]
-   |  _______________^
-39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
-   |
-help: the trait `EncodeLike` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
-   = help: the following other types implement trait `EncodeLike<T>`:
-             `&&T` implements `EncodeLike<T>`
-             `&T` implements `EncodeLike<T>`
-             `&T` implements `EncodeLike`
-             `&[(K, V)]` implements `EncodeLike<BTreeMap<LikeK, LikeV>>`
-             `&[(T,)]` implements `EncodeLike<BTreeSet<LikeT>>`
-             `&[(T,)]` implements `EncodeLike<BinaryHeap<LikeT>>`
-             `&[(T,)]` implements `EncodeLike<LinkedList<LikeT>>`
-             `&[T]` implements `EncodeLike<Vec<U>>`
-           and $N others
-   = note: required for `Bar` to implement `FullEncode`
-   = note: required for `Bar` to implement `FullCodec`
-   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`
-   = note: consider using `--verbose` to print the full type name to the console
-
-error[E0277]: the trait bound `Bar: WrapperTypeEncode` is not satisfied
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:38:12
-   |
-38 |       #[pallet::storage]
-   |  _______________^
-39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
-   |
-help: the trait `WrapperTypeEncode` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_ensure_span_are_ok_on_wrong_gen_unnamed.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
-   = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
-             Box<T>
-             Cow<'_, T>
-             Rc<T>
-             Vec<T>
-             bytes::bytes::Bytes
-           and $N others
-   = note: required for `Bar` to implement `Encode`
-   = note: required for `Bar` to implement `FullEncode`
-   = note: required for `Bar` to implement `FullCodec`
-   = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `TryDecodeEntireStorage`

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied.stderr
@@ -9,13 +9,8 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
 ...  |
 38 | |     #[pallet::storage]
 39 | |     type Foo<T> = StorageValue<_, Bar>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
-help: the trait `MaxEncodedLen` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_info_unsatisfied.rs:36:2
-   |
-36 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `MaxEncodedLen`:
              ()
              (TupleElement0, TupleElement1)
@@ -23,8 +18,7 @@ help: the trait `MaxEncodedLen` is not implemented for `Bar`
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ...)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ..., ...)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
            and $N others
    = note: required for `frame_support::pallet_prelude::StorageValue<_GeneratedPrefixForStorageFoo<T>, Bar>` to implement `StorageInfoTrait`
-   = note: consider using `--verbose` to print the full type name to the console

--- a/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -9,13 +9,8 @@ error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
 ...  |
 41 | |     #[pallet::storage]
 42 | |     type Foo<T> = StorageNMap<_, Key<Twox64Concat, Bar>, u32>;
-   | |____________^ unsatisfied trait bound
+   | |____________^ the trait `MaxEncodedLen` is not implemented for `Bar`
    |
-help: the trait `MaxEncodedLen` is not implemented for `Bar`
-  --> tests/pallet_ui/storage_info_unsatisfied_nmap.rs:39:2
-   |
-39 |     struct Bar;
-   |     ^^^^^^^^^^
    = help: the following other types implement trait `MaxEncodedLen`:
              ()
              (TupleElement0, TupleElement1)
@@ -23,8 +18,8 @@ help: the trait `MaxEncodedLen` is not implemented for `Bar`
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
              (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ...)
-             (TupleElement0, TupleElement1, TupleElement2, ..., ..., ..., ..., ...)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
+             (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
            and $N others
    = note: required for `NMapKey<frame_support::Twox64Concat, Bar>` to implement `KeyGeneratorMaxEncodedLen`
    = note: required for `StorageNMap<_GeneratedPrefixForStorageFoo<T>, Key<..., ...>, u32>` to implement `StorageInfoTrait`

--- a/substrate/frame/support/test/tests/pallet_ui/type_value_error_in_block.stderr
+++ b/substrate/frame/support/test/tests/pallet_ui/type_value_error_in_block.stderr
@@ -1,11 +1,11 @@
 error[E0599]: no function or associated item named `new` found for type `u32` in the current scope
- --> tests/pallet_ui/type_value_error_in_block.rs:37:8
-  |
- 37 |         u32::new()
-    |              ^^^ function or associated item not found in `u32`
-    |
+  --> tests/pallet_ui/type_value_error_in_block.rs:37:8
+   |
+37 |         u32::new()
+   |              ^^^ function or associated item not found in `u32`
+   |
 help: there is a method `ne` with a similar name, but with different arguments
-   --> $RUST/core/src/cmp.rs
-    |
-    |     fn ne(&self, other: &Rhs) -> bool {
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> $RUST/core/src/cmp.rs
+   |
+   |     fn ne(&self, other: &Rhs) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/substrate/frame/system/benchmarking/src/extensions.rs
+++ b/substrate/frame/system/benchmarking/src/extensions.rs
@@ -33,9 +33,7 @@ use frame_system::{
 };
 use sp_runtime::{
 	generic::Era,
-	traits::{
-		AsSystemOriginSigner, AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable, Get,
-	},
+	traits::{AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable, Get},
 };
 
 pub struct Pallet<T: Config>(System<T>);
@@ -43,7 +41,7 @@ pub struct Pallet<T: Config>(System<T>);
 #[benchmarks(where
 	T: Send + Sync,
     T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + AsTransactionAuthorizedOrigin + Clone,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsTransactionAuthorizedOrigin + Clone,
 )]
 mod benchmarks {
 	use super::*;

--- a/substrate/frame/system/src/extensions/check_nonce.rs
+++ b/substrate/frame/system/src/extensions/check_nonce.rs
@@ -23,10 +23,11 @@ use crate::Config;
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{dispatch::DispatchInfo, pallet_prelude::TransactionSource, DebugNoBound};
 use scale_info::TypeInfo;
+use frame_support::traits::{AccountLike, OriginTrait};
 use sp_runtime::{
 	traits::{
-		AsSystemOriginSigner, CheckedAdd, DispatchInfoOf, Dispatchable, One, PostDispatchInfoOf,
-		TransactionExtension, ValidateResult, Zero,
+		CheckedAdd, DispatchInfoOf, Dispatchable, One, PostDispatchInfoOf, TransactionExtension,
+		ValidateResult, Zero,
 	},
 	transaction_validity::{
 		InvalidTransaction, TransactionLongevity, TransactionValidityError, ValidTransaction,
@@ -139,7 +140,7 @@ pub enum Pre {
 impl<T: Config> TransactionExtension<T::RuntimeCall> for CheckNonce<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo>,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: Clone,
 {
 	const IDENTIFIER: &'static str = "CheckNonce";
 	type Implicit = ();
@@ -160,10 +161,11 @@ where
 		_inherited_implication: &impl Encode,
 		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
-		let Some(who) = origin.as_system_origin_signer() else {
+		let Some(who) = origin.caller().nonce_provider() else {
 			return Ok((Default::default(), Val::Refund(self.weight(call)), origin));
 		};
-		let ValidNonceInfo { provides, requires } = Self::validate_nonce_for_account(who, self.0)?;
+		let ValidNonceInfo { provides, requires } =
+			Self::validate_nonce_for_account(&who, self.0)?;
 
 		let validity = ValidTransaction {
 			priority: 0,
@@ -173,7 +175,7 @@ where
 			propagate: true,
 		};
 
-		Ok((validity, Val::CheckNonce(who.clone()), origin))
+		Ok((validity, Val::CheckNonce(who), origin))
 	}
 
 	fn prepare(
@@ -440,6 +442,206 @@ mod tests {
 			.unwrap();
 
 			assert_eq!(post_info.actual_weight, Some(info.call_weight));
+		})
+	}
+
+	fn custom_origin_member(who: u64) -> <Test as Config>::RuntimeOrigin {
+		crate::mocking::pallet_with_custom_origin::Origin::<Test>::Member(who).into()
+	}
+
+	fn custom_origin_council() -> <Test as Config>::RuntimeOrigin {
+		crate::mocking::pallet_with_custom_origin::Origin::<Test>::Council.into()
+	}
+
+	#[test]
+	fn custom_origin_nonce_checked() {
+		new_test_ext().execute_with(|| {
+			crate::Account::<Test>::insert(
+				1,
+				crate::AccountInfo {
+					nonce: 1u64.into(),
+					consumers: 0,
+					providers: 1,
+					sufficients: 0,
+					data: 0,
+				},
+			);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+			assert_ok!(CheckNonce::<Test>(1u64.into()).validate_and_prepare(
+				custom_origin_member(1),
+				CALL,
+				&info,
+				len,
+				0,
+			));
+			assert_eq!(crate::Account::<Test>::get(1).nonce, 2u64.into());
+		})
+	}
+
+	#[test]
+	fn custom_origin_without_nonce_provider_skipped() {
+		new_test_ext().execute_with(|| {
+			let ext = CheckNonce::<Test>(1u64.into());
+
+			let mut info = CALL.get_dispatch_info();
+			info.extension_weight = ext.weight(CALL);
+
+			assert!(info.extension_weight != Weight::zero());
+
+			let len = CALL.encoded_size();
+			let (pre, _origin) =
+				ext.validate_and_prepare(custom_origin_council(), CALL, &info, len, 0).unwrap();
+
+			let pd_res = Ok(());
+			let mut post_info = frame_support::dispatch::PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+
+			<CheckNonce<Test> as TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+
+			// Weight should be refunded since nonce was not checked.
+			assert_eq!(post_info.actual_weight, Some(info.call_weight));
+		})
+	}
+
+	#[test]
+	fn custom_origin_stale_nonce() {
+		new_test_ext().execute_with(|| {
+			crate::Account::<Test>::insert(
+				1,
+				crate::AccountInfo {
+					nonce: 5u64.into(),
+					consumers: 0,
+					providers: 1,
+					sufficients: 0,
+					data: 0,
+				},
+			);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+			assert_storage_noop!({
+				assert_eq!(
+					CheckNonce::<Test>(3u64.into())
+						.validate_and_prepare(custom_origin_member(1), CALL, &info, len, 0)
+						.unwrap_err(),
+					TransactionValidityError::Invalid(InvalidTransaction::Stale)
+				);
+			});
+		})
+	}
+
+	#[test]
+	fn custom_origin_future_nonce() {
+		new_test_ext().execute_with(|| {
+			crate::Account::<Test>::insert(
+				1,
+				crate::AccountInfo {
+					nonce: 1u64.into(),
+					consumers: 0,
+					providers: 1,
+					sufficients: 0,
+					data: 0,
+				},
+			);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+			// validate_only succeeds for future nonce
+			assert_ok!(CheckNonce::<Test>(5u64.into()).validate_only(
+				custom_origin_member(1),
+				CALL,
+				&info,
+				len,
+				External,
+				0,
+			));
+			// validate_and_prepare fails at prepare step
+			assert_eq!(
+				CheckNonce::<Test>(5u64.into())
+					.validate_and_prepare(custom_origin_member(1), CALL, &info, len, 0)
+					.unwrap_err(),
+				TransactionValidityError::Invalid(InvalidTransaction::Future)
+			);
+		})
+	}
+
+	#[test]
+	fn custom_origin_requires_provider() {
+		new_test_ext().execute_with(|| {
+			// Account with providers=0 and sufficients=0
+			crate::Account::<Test>::insert(
+				1,
+				crate::AccountInfo {
+					nonce: 1u64.into(),
+					consumers: 0,
+					providers: 0,
+					sufficients: 0,
+					data: 0,
+				},
+			);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+			assert_storage_noop!({
+				assert_eq!(
+					CheckNonce::<Test>(1u64.into())
+						.validate_and_prepare(custom_origin_member(1), CALL, &info, len, 0)
+						.unwrap_err(),
+					TransactionValidityError::Invalid(InvalidTransaction::Payment)
+				);
+			});
+		})
+	}
+
+	#[test]
+	fn custom_origin_preserves_account_data() {
+		new_test_ext().execute_with(|| {
+			crate::Account::<Test>::insert(
+				1,
+				crate::AccountInfo {
+					nonce: 1u64.into(),
+					consumers: 0,
+					providers: 1,
+					sufficients: 0,
+					data: 0,
+				},
+			);
+			let info = DispatchInfo::default();
+			let len = 0_usize;
+			// run the validation step
+			let (_, val, origin) = CheckNonce::<Test>(1u64.into())
+				.validate(
+					custom_origin_member(1),
+					CALL,
+					&info,
+					len,
+					(),
+					&TxBaseImplication(CALL),
+					External,
+				)
+				.unwrap();
+			// mutate AccountData for the caller
+			crate::Account::<Test>::mutate(1, |info| {
+				info.data = 42;
+			});
+			// run the preparation step
+			assert_ok!(CheckNonce::<Test>(1u64.into()).prepare(val, &origin, CALL, &info, len));
+			// only the nonce should be altered by the preparation step
+			let expected_info = crate::AccountInfo {
+				nonce: 2u64.into(),
+				consumers: 0,
+				providers: 1,
+				sufficients: 0,
+				data: 42,
+			};
+			assert_eq!(crate::Account::<Test>::get(1), expected_info);
 		})
 	}
 }

--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -1458,6 +1458,24 @@ where
 	}
 }
 
+#[docify::export]
+/// Ensure that the origin `o` represents either a signed extrinsic (i.e. transaction) or some other
+/// origin (e.g. a custom pallet origin authorized by a `TransactionExtension`) which can be
+/// interpreted as an account via [`AccountLike::as_account()`](frame_support::traits::AccountLike).
+///
+/// This accepts any origin whose [`CallerTrait::as_account()`](frame_support::traits::CallerTrait)
+/// returns `Some`, including `Signed` origins and custom pallet origins annotated with
+/// `#[pallet::as_account(...)]`.
+///
+/// Returns `Ok` with the account extracted from the origin or an `Err` otherwise.
+pub fn ensure_account<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<AccountId, BadOrigin>
+where
+	OuterOrigin: OriginTrait<AccountId = AccountId>,
+{
+	use frame_support::traits::AccountLike;
+	o.into_caller().as_account().ok_or(BadOrigin)
+}
+
 /// Ensure that the origin `o` represents either a signed extrinsic (i.e. transaction) or the root.
 /// Returns `Ok` with the account that signed the extrinsic, `None` if it was root,  or an `Err`
 /// otherwise.

--- a/substrate/frame/system/src/mock.rs
+++ b/substrate/frame/system/src/mock.rs
@@ -25,6 +25,7 @@ frame_support::construct_runtime!(
 	pub enum Test
 	{
 		System: frame_system,
+		PalletWithCustomOrigin: crate::mocking::pallet_with_custom_origin,
 	}
 );
 
@@ -102,6 +103,8 @@ impl Config for Test {
 	type MultiBlockMigrator = MockedMigrator;
 	type Nonce = TypeWithDefault<u64, DefaultNonceProvider>;
 }
+
+impl crate::mocking::pallet_with_custom_origin::Config for Test {}
 
 parameter_types! {
 	pub static Ongoing: bool = false;

--- a/substrate/frame/system/src/mocking.rs
+++ b/substrate/frame/system/src/mocking.rs
@@ -45,3 +45,57 @@ pub type MockBlockU128<T> = generic::Block<
 	generic::Header<u128, sp_runtime::traits::BlakeTwo256>,
 	MockUncheckedExtrinsic<T>,
 >;
+
+/// A minimal pallet with a custom origin for testing `AccountLike` integration
+/// with `CheckNonce` and transaction payment extensions.
+///
+/// Variants cover every combination of `as_account`, `nonce_provider`, and `fee_payer`:
+/// - `Member(AccountId)`: `as_account` + `nonce_provider` + `fee_payer`
+/// - `NonceOnly(AccountId)`: `as_account` + `nonce_provider`
+/// - `FeeOnly(AccountId)`: `as_account` + `fee_payer`
+/// - `NonPaying(AccountId)`: `as_account` only (no nonce/fee)
+/// - `Council`: no account mapping at all
+#[frame_support::pallet(dev_mode)]
+pub mod pallet_with_custom_origin {
+	use crate as frame_system;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		pub fn noop(_origin: OriginFor<T>) -> DispatchResult {
+			Ok(())
+		}
+	}
+
+	#[pallet::origin]
+	#[derive(
+		Clone, PartialEq, Eq, Debug, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen, TypeInfo,
+	)]
+	pub enum Origin<T: Config> {
+		/// A member with full account integration (nonce + fee payment).
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		#[pallet::fee_payer]
+		Member(T::AccountId),
+		/// An account origin that only participates in nonce tracking (no fee payment).
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::nonce_provider]
+		NonceOnly(T::AccountId),
+		/// An account origin that only pays fees (no nonce tracking).
+		#[pallet::as_account(|who| Some(who.clone()))]
+		#[pallet::fee_payer]
+		FeeOnly(T::AccountId),
+		/// An account origin that does NOT participate in nonce/fee tracking.
+		#[pallet::as_account(|who| Some(who.clone()))]
+		NonPaying(T::AccountId),
+		/// A governance-style origin with no account mapping.
+		Council,
+	}
+}

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -851,6 +851,47 @@ fn ensure_signed_stuff_works() {
 	}
 }
 
+#[test]
+fn ensure_account_works_for_signed_origin() {
+	assert_eq!(ensure_account(RuntimeOrigin::signed(42)).unwrap(), 42u64);
+}
+
+#[test]
+fn ensure_account_fails_for_root() {
+	assert!(ensure_account(RuntimeOrigin::root()).is_err());
+}
+
+#[test]
+fn ensure_account_fails_for_none() {
+	assert!(ensure_account(RuntimeOrigin::none()).is_err());
+}
+
+#[test]
+fn ensure_account_works_for_custom_origin_with_as_account() {
+	use crate::mocking::pallet_with_custom_origin::Origin;
+
+	// All variants with #[pallet::as_account] should return Ok with the correct account.
+	let member: RuntimeOrigin = Origin::<Test>::Member(99).into();
+	assert_eq!(ensure_account(member).unwrap(), 99u64);
+
+	let nonce_only: RuntimeOrigin = Origin::<Test>::NonceOnly(7).into();
+	assert_eq!(ensure_account(nonce_only).unwrap(), 7u64);
+
+	let fee_only: RuntimeOrigin = Origin::<Test>::FeeOnly(3).into();
+	assert_eq!(ensure_account(fee_only).unwrap(), 3u64);
+
+	let non_paying: RuntimeOrigin = Origin::<Test>::NonPaying(55).into();
+	assert_eq!(ensure_account(non_paying).unwrap(), 55u64);
+}
+
+#[test]
+fn ensure_account_fails_for_custom_origin_without_as_account() {
+	// Council has no #[pallet::as_account], so as_account() returns None.
+	let council: RuntimeOrigin =
+		crate::mocking::pallet_with_custom_origin::Origin::<Test>::Council.into();
+	assert!(ensure_account(council).is_err());
+}
+
 pub fn from_actual_ref_time(ref_time: Option<u64>) -> PostDispatchInfo {
 	PostDispatchInfo {
 		actual_weight: ref_time.map(|t| Weight::from_all(t)),

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/benchmarking.rs
@@ -28,7 +28,7 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 use sp_runtime::traits::{
-	AsSystemOriginSigner, AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable,
+	AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable,
 };
 
 #[benchmarks(where
@@ -36,7 +36,7 @@ use sp_runtime::traits::{
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 	BalanceOf<T>: Send + Sync + From<u64>,
 	T::AssetId: Send + Sync,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: Clone,
 )]
 mod benchmarks {
 	use super::*;

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -48,15 +48,15 @@ use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{
 	dispatch::{DispatchInfo, DispatchResult, PostDispatchInfo},
 	pallet_prelude::TransactionSource,
-	traits::IsType,
+	traits::{AccountLike, IsType, OriginTrait},
 	DefaultNoBound,
 };
 use pallet_transaction_payment::{ChargeTransactionPayment, OnChargeTransaction};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
-		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, RefundWeight,
-		TransactionExtension, ValidateResult, Zero,
+		DispatchInfoOf, Dispatchable, PostDispatchInfoOf, RefundWeight, TransactionExtension,
+		ValidateResult, Zero,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
 };
@@ -287,7 +287,7 @@ where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 	BalanceOf<T>: Send + Sync + From<u64>,
 	T::AssetId: Send + Sync,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: Clone,
 {
 	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
 	type Implicit = ();
@@ -312,7 +312,7 @@ where
 		_inherited_implication: &impl Encode,
 		_source: TransactionSource,
 	) -> ValidateResult<Self::Val, T::RuntimeCall> {
-		let Some(who) = origin.as_system_origin_signer() else {
+		let Some(who) = origin.caller().fee_payer() else {
 			return Ok((ValidTransaction::default(), Val::NoCharge, origin));
 		};
 		// Non-mutating call of `compute_fee` to calculate the fee used in the transaction priority.
@@ -320,7 +320,7 @@ where
 		self.can_withdraw_fee(&who, call, info, fee)?;
 		let priority = ChargeTransactionPayment::<T>::get_priority(info, len, self.tip, fee);
 		let validity = ValidTransaction { priority, ..Default::default() };
-		let val = Val::Charge { tip: self.tip, who: who.clone(), fee };
+		let val = Val::Charge { tip: self.tip, who, fee };
 		Ok((validity, val, origin))
 	}
 

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/mock.rs
@@ -57,6 +57,7 @@ frame_support::construct_runtime!(
 		PoolAssets: pallet_assets::<Instance2>,
 		AssetConversion: pallet_asset_conversion,
 		AssetTxPayment: pallet_asset_conversion_tx_payment,
+		CustomOriginPallet: frame_system::mocking::pallet_with_custom_origin,
 	}
 );
 
@@ -294,6 +295,8 @@ impl WeightInfo for MockWeights {
 		Weight::from_parts(20, 0)
 	}
 }
+
+impl frame_system::mocking::pallet_with_custom_origin::Config for Runtime {}
 
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/tests.rs
@@ -1050,3 +1050,90 @@ fn transaction_payment_rejects_reduced_to_zero_in_asset() {
 			assert!(result.is_err(), "Validation should reject ReducedToZero.");
 		});
 }
+
+#[test]
+fn pallet_origin_with_fee_payer_charges_native_fees() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = CALL.encoded_size();
+
+			let balance_before = Balances::free_balance(1);
+
+			// Member(1) has fee_payer returning Some(1), so native fees should be charged.
+			let origin: RuntimeOrigin =
+				frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::Member(1).into();
+			let (pre, _origin) =
+				ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// Balance should have decreased.
+			assert!(Balances::free_balance(1) < balance_before);
+
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<ChargeAssetTxPayment<Runtime> as TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+		});
+}
+
+#[test]
+fn pallet_origin_without_fee_payer_skips_fees() {
+	let base_weight = 5;
+	let balance_factor = 100;
+	ExtBuilder::default()
+		.balance_factor(balance_factor)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = CALL.encoded_size();
+
+			let balance_before = Balances::free_balance(1);
+
+			// NonPaying(1) has as_account but NOT fee_payer, so no fees charged.
+			let origin: RuntimeOrigin =
+				frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::NonPaying(1).into();
+			let (pre, _origin) =
+				ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// Balance should be unchanged.
+			assert_eq!(Balances::free_balance(1), balance_before);
+
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<ChargeAssetTxPayment<Runtime> as TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+
+			// Extension weight should be refunded since NoCharge path was taken.
+			assert_eq!(post_info.actual_weight, Some(info.call_weight));
+		});
+}

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/benchmarking.rs
@@ -28,7 +28,7 @@ use frame_support::{
 };
 use frame_system::RawOrigin;
 use sp_runtime::traits::{
-	AsSystemOriginSigner, AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable,
+	AsTransactionAuthorizedOrigin, DispatchTransaction, Dispatchable,
 };
 
 #[benchmarks(where
@@ -37,7 +37,7 @@ use sp_runtime::traits::{
 	AssetBalanceOf<T>: Send + Sync,
 	BalanceOf<T>: Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>>,
 	ChargeAssetIdOf<T>: Send + Sync,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: Clone,
     Credit<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
 )]
 mod benchmarks {

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
@@ -44,7 +44,7 @@ use frame_support::{
 			fungibles::{Balanced, Credit, Inspect},
 			WithdrawConsequence,
 		},
-		IsType,
+		AccountLike, IsType, OriginTrait,
 	},
 	DefaultNoBound,
 };
@@ -52,8 +52,8 @@ use pallet_transaction_payment::OnChargeTransaction;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{
-		AsSystemOriginSigner, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, RefundWeight,
-		TransactionExtension, Zero,
+		DispatchInfoOf, Dispatchable, PostDispatchInfoOf, RefundWeight, TransactionExtension,
+		Zero,
 	},
 	transaction_validity::{InvalidTransaction, TransactionValidityError, ValidTransaction},
 };
@@ -302,7 +302,7 @@ where
 	BalanceOf<T>: Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>>,
 	ChargeAssetIdOf<T>: Send + Sync,
 	Credit<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
-	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
+	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: Clone,
 {
 	const IDENTIFIER: &'static str = "ChargeAssetTxPayment";
 	type Implicit = ();
@@ -331,14 +331,14 @@ where
 		TransactionValidityError,
 	> {
 		use pallet_transaction_payment::ChargeTransactionPayment;
-		let Some(who) = origin.as_system_origin_signer() else {
+		let Some(who) = origin.caller().fee_payer() else {
 			return Ok((ValidTransaction::default(), Val::NoCharge, origin));
 		};
 		// Non-mutating call of `compute_fee` to calculate the fee used in the transaction priority.
 		let fee = pallet_transaction_payment::Pallet::<T>::compute_fee(len as u32, info, self.tip);
 		self.can_withdraw_fee(&who, call, info, fee)?;
 		let priority = ChargeTransactionPayment::<T>::get_priority(info, len, self.tip, fee);
-		let val = Val::Charge { tip: self.tip, who: who.clone(), fee };
+		let val = Val::Charge { tip: self.tip, who, fee };
 		let validity = ValidTransaction { priority, ..Default::default() };
 		Ok((validity, val, origin))
 	}

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/mock.rs
@@ -43,6 +43,7 @@ frame_support::construct_runtime!(
 		Assets: pallet_assets,
 		Authorship: pallet_authorship,
 		AssetTxPayment: pallet_asset_tx_payment,
+		CustomOriginPallet: frame_system::mocking::pallet_with_custom_origin,
 	}
 );
 
@@ -194,6 +195,8 @@ impl WeightInfo for MockWeights {
 		Weight::from_parts(20, 0)
 	}
 }
+
+impl frame_system::mocking::pallet_with_custom_origin::Config for Runtime {}
 
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/tests.rs
@@ -649,3 +649,86 @@ fn no_fee_and_no_weight_for_other_origins() {
 		assert_eq!(post_info.actual_weight, Some(info.call_weight));
 	})
 }
+
+#[test]
+fn pallet_origin_with_fee_payer_charges_native_fees() {
+	ExtBuilder::default()
+		.balance_factor(100)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = CALL.encoded_size();
+
+			let balance_before = Balances::free_balance(1);
+
+			// Member(1) has fee_payer returning Some(1), so native fees should be charged.
+			let origin: RuntimeOrigin =
+				frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::Member(1).into();
+			let (pre, _origin) =
+				ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// Balance should have decreased.
+			assert!(Balances::free_balance(1) < balance_before);
+
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<ChargeAssetTxPayment<Runtime> as TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+		});
+}
+
+#[test]
+fn pallet_origin_without_fee_payer_skips_fees() {
+	ExtBuilder::default()
+		.balance_factor(100)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = CALL.encoded_size();
+
+			let balance_before = Balances::free_balance(1);
+
+			// NonPaying(1) has as_account but NOT fee_payer, so no fees charged.
+			let origin: RuntimeOrigin =
+				frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::NonPaying(1).into();
+			let (pre, _origin) =
+				ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// Balance should be unchanged.
+			assert_eq!(Balances::free_balance(1), balance_before);
+
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<ChargeAssetTxPayment<Runtime> as TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+
+			// Extension weight should be refunded since NoCharge path was taken.
+			assert_eq!(post_info.actual_weight, Some(info.call_weight));
+		});
+}

--- a/substrate/frame/transaction-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/src/lib.rs
@@ -55,7 +55,7 @@ use frame_support::{
 		DispatchClass, DispatchInfo, DispatchResult, GetDispatchInfo, Pays, PostDispatchInfo,
 	},
 	pallet_prelude::TransactionSource,
-	traits::{Defensive, EstimateCallFee, Get, Imbalance, SuppressedDrop},
+	traits::{AccountLike, Defensive, EstimateCallFee, Get, Imbalance, OriginTrait, SuppressedDrop},
 	weights::{Weight, WeightToFee},
 	DebugNoBound,
 };
@@ -1015,7 +1015,7 @@ where
 		(ValidTransaction, Self::Val, <T::RuntimeCall as Dispatchable>::RuntimeOrigin),
 		TransactionValidityError,
 	> {
-		let Ok(who) = frame_system::ensure_signed(origin.clone()) else {
+		let Some(who) = origin.caller().fee_payer() else {
 			return Ok((ValidTransaction::default(), Val::NoCharge, origin));
 		};
 		let fee_with_tip = self.can_withdraw_fee(&who, call, info, len)?;

--- a/substrate/frame/transaction-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/src/mock.rs
@@ -35,6 +35,7 @@ frame_support::construct_runtime!(
 		System: system,
 		Balances: pallet_balances,
 		TransactionPayment: pallet_transaction_payment::{Pallet, Storage, Event<T>},
+		CustomOriginPallet: frame_system::mocking::pallet_with_custom_origin,
 	}
 );
 
@@ -127,6 +128,8 @@ impl WeightInfo for MockWeights {
 		Weight::from_parts(10, 0)
 	}
 }
+
+impl frame_system::mocking::pallet_with_custom_origin::Config for Runtime {}
 
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/substrate/frame/transaction-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/src/tests.rs
@@ -915,3 +915,179 @@ fn fungible_adapter_no_zero_refund_action() {
 		);
 	});
 }
+
+#[test]
+fn pallet_origin_with_fee_payer_charges_fees() {
+	ExtBuilder::default()
+		.balance_factor(10)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			// So events are emitted
+			System::set_block_number(10);
+
+			let ext = Ext::from(0);
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = 10;
+
+			// FeePayer(1) has fee_payer returning Some(1), so fees should be charged.
+			let origin: RuntimeOrigin = frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::Member(1).into();
+			let (pre, _origin) = ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// base_weight(5) + byte_fee(10) + call_weight(5) + ext_weight(10) = 30
+			assert_eq!(Balances::free_balance(1), 100 - 5 - 10 - 5 - 10);
+
+			// post_dispatch should also work.
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<Ext as sp_runtime::traits::TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+
+			// Fee event should have been deposited.
+			assert!(System::events().iter().any(|record| matches!(
+				record.event,
+				RuntimeEvent::TransactionPayment(crate::Event::TransactionFeePaid { who: 1, .. })
+			)));
+		});
+}
+
+#[test]
+fn pallet_origin_with_fee_payer_and_tip_charges_correctly() {
+	ExtBuilder::default()
+		.balance_factor(10)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let tip = 7u64;
+			let ext = Ext::from(tip);
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = 10;
+
+			let origin: RuntimeOrigin = frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::Member(2).into();
+			let (pre, _origin) = ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// base_weight(5) + byte_fee(10) + call_weight(5) + ext_weight(10) + tip(7) = 37
+			assert_eq!(Balances::free_balance(2), 200 - 5 - 10 - 5 - 10 - 7);
+
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<Ext as sp_runtime::traits::TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+		});
+}
+
+#[test]
+fn pallet_origin_without_fee_payer_skips_fees() {
+	ExtBuilder::default()
+		.balance_factor(10)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let ext = Ext::from(0);
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = 10;
+
+			// NonFeePayer(1) has as_account returning Some(1) but NOT fee_payer,
+			// so fee_payer() returns None and no fees should be charged.
+			let origin: RuntimeOrigin = frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::NonPaying(1).into();
+			let (pre, _origin) = ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// Balance should be unchanged — no fees charged.
+			assert_eq!(Balances::free_balance(1), 100);
+
+			// post_dispatch should refund extension weight.
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<Ext as sp_runtime::traits::TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+
+			// Extension weight should be refunded since NoCharge path was taken.
+			assert_eq!(post_info.actual_weight, Some(info.call_weight));
+		});
+}
+
+#[test]
+fn pallet_admin_origin_skips_fees() {
+	ExtBuilder::default()
+		.balance_factor(10)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let ext = Ext::from(0);
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = 10;
+
+			// Council has no as_account at all, so fee_payer() returns None.
+			let origin: RuntimeOrigin = frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::Council.into();
+			let (pre, _origin) = ext.validate_and_prepare(origin, CALL, &info, len, 0).unwrap();
+
+			// post_dispatch should refund extension weight.
+			let pd_res = Ok(());
+			let mut post_info = PostDispatchInfo {
+				actual_weight: Some(info.total_weight()),
+				pays_fee: Default::default(),
+			};
+			<Ext as sp_runtime::traits::TransactionExtension<RuntimeCall>>::post_dispatch(
+				pre,
+				&info,
+				&mut post_info,
+				len,
+				&pd_res,
+			)
+			.unwrap();
+
+			assert_eq!(post_info.actual_weight, Some(info.call_weight));
+		});
+}
+
+#[test]
+fn pallet_origin_fee_payer_insufficient_balance() {
+	ExtBuilder::default()
+		.balance_factor(10)
+		.base_weight(Weight::from_parts(5, 0))
+		.build()
+		.execute_with(|| {
+			let ext = Ext::from(0);
+			let mut info = info_from_weight(Weight::from_parts(5, 0));
+			info.extension_weight = ext.weight(CALL);
+			let len = 10;
+
+			// Account 99 has no balance (not in genesis). fee_payer() returns Some(99)
+			// but the account can't pay, so validate_and_prepare should fail.
+			let origin: RuntimeOrigin =
+				frame_system::mocking::pallet_with_custom_origin::Origin::<Runtime>::Member(99)
+					.into();
+			assert!(ext.validate_and_prepare(origin, CALL, &info, len, 0).is_err());
+		});
+}


### PR DESCRIPTION
This PR introduces the `AccountLike` trait and `#[pallet::as_account(...)]` attribute for pallet
origin enum variants, enabling custom origins to expose an account and independently opt into nonce
tracking and fee payment. This extends account-like behavior beyond just
`frame_system::RawOrigin::Signed` as pallets with custom origins can now specify which account (if
any) should be used for identity, nonce management, and/or fee charging per origin variant.

## Motivation

Currently, nonce tracking and fee payment only work for `Signed` origins from `frame_system`.
Pallets like `pallet_collective` define custom origins (e.g. `Member(AccountId)`) that carry an
account but have no way to participate in nonce-based replay protection or fee charging. Presently,
such pallets would need to define their own transaction extension just for the replay protection
when they actually don't want to build and maintain this custom logic. The `AccountLike` trait and
its macro attributes provide the infrastructure for pallets to opt in to these basic functions as
well as expose accounts in their origins for other pallets to use them.

## Usage

### Enum origins with `#[pallet::as_account]`

```rust
#[pallet::origin]
pub enum Origin<T: Config> {
    // Closure receives variant fields by reference, returns an account that can be associated with
    // this origin, if any.
    // The `nonce_provider` flag opts in to system-wide nonce tracking (i.e. via `CheckNonce`).
    // The `fee_payer` flag opts in to system-wide fee charging (i.e. via
    // `ChargeTransactionPayment` or other similar extensions configured at the runtime level).
    #[pallet::as_account(|who| Some(who.clone()))]
    #[pallet::nonce_provider]
    #[pallet::fee_payer]
    Member(T::AccountId),

    // Multiple fields passed into the closure.
    #[pallet::as_account(|account, _data| Some(account.clone()))]
    #[pallet::nonce_provider]
    WithData(T::AccountId, u32),

    // No attribute will not associate anything, to all three methods return `None`.
    Admin,
}
```

Function references and `Self::method()` calls also work:

```rust
#[pallet::origin]
pub enum Origin {
    #[pallet::as_account(|id| Self::account_for_council(id))]
    #[pallet::nonce_provider]
    Council(u32),
    TechCommittee,
}
```

### Authorizing custom origins

Instead of the traditional `ensure_signed` origin guard we usually see in pallet calls, pallets can
now allow custom origins which expose an account to work without any extra logic for managing the
actual origins, which depend on the runtime definition. The account is the common denominator for
most calls, which means extrinsics can use `as_account` to extract the information about the caller.
For ease of use, this PR also introduces `ensure_account`, which is an expansion of `ensure_signed`
and authorizes both `Signed` origins as well as custom origins which expose an account.

### Combinations of attributes

Variants can opt into any combination:
- `as_account`: exposes an account but no nonce tracking or fee payment; both are left to the
  pallet to handle in their `TransactionExtension`.
- `as_account` + `nonce_provider`: nonce tracked but fees not charged from this origin; spam
  protection must be guaranteed by another entity.
- `as_account` + `fee_payer`: fees charged but no nonce tracking; replay protection must be
  guaranteed by another entity.
- `as_account` + `nonce_provider` + `fee_payer`: full account-like behavior; functions like a
  `Signed` origin, but can pass through `ensure_*` guards that a `Signed` origin cannot.

`nonce_provider` and `fee_payer` require `as_account` on the same variant. Both reuse the closure
provided to `as_account` as they do not accept their own closure.

NOTE: Using `nonce_provider` without `fee_payer` means the origin's transactions will have nonce
tracking but no fee payment, the developer must provide their own spam protection. Using
`fee_payer` without `nonce_provider` means fees are charged but there is no replay protection. The
developer must provide their own (e.g. single-use transactions or a custom nonce scheme).

### Type alias origins

Type alias origins (e.g. `type Origin<T, I> = RawOrigin<AccountId, I>` in `pallet-collectives`)
delegate to the `AccountLike` trait impl on the aliased type. The aliased type must implement
`AccountLike<AccountId>`. Ideally we will move away from type alias origins in the future.

## Implementation

### `AccountLike` trait

Defined in `frame_support::traits::dispatch`, with default implementations returning `None`:

```rust
pub trait AccountLike<AccountId> {
    fn as_account(&self) -> Option<AccountId> { None }
    fn nonce_provider(&self) -> Option<AccountId> { None }
    fn fee_payer(&self) -> Option<AccountId> { None }
}
```

This trait is not meant to be called directly on individual pallet origin types. It is a building
block used by the FRAME macros, specifically the `#[pallet]` macro generates an `AccountLike` impl
on each pallet's `Origin` type, and `construct_runtime!` composes those per-pallet impls into the
`CallerTrait` implementation on `OriginCaller`. Consumer code (e.g. `CheckNonce`,
`ChargeTransactionPayment`) accesses account information through `origin.caller().nonce_provider()`
/ `origin.caller().fee_payer()`, which goes through `CallerTrait` → `AccountLike` on `OriginCaller`,
not on individual pallet origins.

### `CheckNonce`/`ChargeTransactionPayment` integration

`frame_system::RawOrigin<AccountId>` implements the `AccountLike` trait, returning the inner account
for `Signed` variants on all three methods. This makes this change backwards compatible in terms of
nonce checking and fee payment.

`CheckNonce` uses `origin.caller().nonce_provider()` instead of `origin.as_system_origin_signer()`
to determine which account (if any) to track nonces for. Custom origins with
`#[pallet::nonce_provider]` participate automatically; those without are skipped. The
`AsSystemOriginSigner` bound is removed from the `TransactionExtension` impl.

`ChargeTransactionPayment` (and its asset variants) uses `origin.caller().fee_payer()` instead of
`ensure_signed()` / `as_system_origin_signer()` to determine which account to charge fees from.
Custom origins with `#[pallet::fee_payer]` participate automatically; those without skip fee
charging.
