### PR TITLE
statement-store: reject statement peers during major sync

### DIFF
--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -835,25 +835,15 @@ where
 				}
 			},
 			NotificationEvent::NotificationStreamClosed { peer } => {
-				let _peer = self.peers.remove(&peer);
-				if _peer.is_none() {
+				let had_peer_state = self.peers.contains_key(&peer)
+					|| self.pending_initial_syncs.contains_key(&peer);
+				if !had_peer_state {
 					log::trace!(
 						target: LOG_TARGET,
 						"{peer}: Statement stream closed after peer state was already cleaned up"
 					);
 				}
-				if let Some(pending) = self.pending_initial_syncs.remove(&peer) {
-					self.metrics.as_ref().map(|metrics| {
-						metrics.initial_sync_peers_active.dec();
-						metrics
-							.initial_sync_duration_seconds
-							.observe(pending.started_at.elapsed().as_secs_f64());
-					});
-				}
-				self.initial_sync_peer_queue.retain(|p| *p != peer);
-				self.metrics.as_ref().map(|metrics| {
-					metrics.peers_connected.set(self.peers.len() as u64);
-				});
+				self.cleanup_peer_state(peer, false);
 			},
 			NotificationEvent::NotificationReceived { peer, notification } => {
 				let bytes_received = notification.len() as u64;
@@ -868,7 +858,7 @@ where
 						"{peer}: Disconnecting peer that sent statements while major syncing or offline"
 					);
 					self.network.disconnect_peer(peer, self.protocol_name.clone());
-					self.cleanup_peer_state(peer, true);
+					self.cleanup_peer_state(peer, false);
 					return;
 				}
 
@@ -2578,6 +2568,8 @@ mod tests {
 	async fn disconnects_existing_peer_that_sends_while_offline() {
 		let (mut handler, _statement_store, network, _notification_service, _queue_receiver) =
 			build_handler();
+		let registry = Registry::new();
+		handler.metrics = Some(Metrics::register(&registry).unwrap());
 
 		let peer_id = *handler.peers.keys().next().unwrap();
 		handler.pending_initial_syncs.insert(
@@ -2585,6 +2577,7 @@ mod tests {
 			PendingInitialSync { hashes: vec![[7u8; 32]], started_at: Instant::now() },
 		);
 		handler.initial_sync_peer_queue.push_back(peer_id);
+		handler.metrics.as_ref().unwrap().initial_sync_peers_active.inc();
 
 		let mut statement = Statement::new();
 		statement.set_plain_data(b"offline-live-message".to_vec());
@@ -2601,6 +2594,17 @@ mod tests {
 		assert!(network.get_disconnected_peers().contains(&peer_id));
 		assert!(!handler.peers.contains_key(&peer_id));
 		assert!(!handler.pending_initial_syncs.contains_key(&peer_id));
+		assert_eq!(handler.metrics.as_ref().unwrap().initial_sync_peers_active.get(), 0);
+		assert_eq!(
+			handler
+				.metrics
+				.as_ref()
+				.unwrap()
+				.initial_sync_duration_seconds
+				.get_sample_count(),
+			0,
+			"Unavailable receives must not be recorded as completed initial syncs"
+		);
 	}
 
 	#[tokio::test]
@@ -2863,6 +2867,8 @@ mod tests {
 	async fn disconnects_existing_peer_that_sends_during_major_sync() {
 		let (mut handler, statement_store, network, _notification_service, _queue_receiver) =
 			build_handler();
+		let registry = Registry::new();
+		handler.metrics = Some(Metrics::register(&registry).unwrap());
 
 		let peer_id = *handler.peers.keys().next().unwrap();
 		let existing_pending = vec![[7u8; 32]];
@@ -2871,6 +2877,7 @@ mod tests {
 			PendingInitialSync { hashes: existing_pending.clone(), started_at: Instant::now() },
 		);
 		handler.initial_sync_peer_queue.push_back(peer_id);
+		handler.metrics.as_ref().unwrap().initial_sync_peers_active.inc();
 
 		let mut statement = Statement::new();
 		statement.set_plain_data(b"major-sync-live-message".to_vec());
@@ -2897,6 +2904,64 @@ mod tests {
 		assert!(
 			!handler.initial_sync_peer_queue.contains(&peer_id),
 			"Peer should be removed from the initial sync queue"
+		);
+		assert_eq!(handler.metrics.as_ref().unwrap().initial_sync_peers_active.get(), 0);
+		assert_eq!(
+			handler
+				.metrics
+				.as_ref()
+				.unwrap()
+				.initial_sync_duration_seconds
+				.get_sample_count(),
+			0,
+			"Unavailable peers must not be recorded as completed initial syncs"
+		);
+	}
+
+	#[tokio::test]
+	async fn stream_close_during_initial_sync_does_not_record_completion() {
+		let (mut handler, statement_store, _network, _notification_service, _sync) =
+			build_handler_no_peers();
+		let registry = Registry::new();
+		handler.metrics = Some(Metrics::register(&registry).unwrap());
+
+		let mut statement = Statement::new();
+		statement.set_plain_data(b"stream-close-before-sync-complete".to_vec());
+		let hash = statement.hash();
+		statement_store.statements.lock().unwrap().insert(hash, statement);
+
+		let peer_id = PeerId::random();
+		handler
+			.handle_notification_event(NotificationEvent::NotificationStreamOpened {
+				peer: peer_id,
+				direction: sc_network::service::traits::Direction::Inbound,
+				handshake: vec![],
+				negotiated_fallback: None,
+			})
+			.await;
+
+		assert!(handler.pending_initial_syncs.contains_key(&peer_id));
+		assert_eq!(handler.metrics.as_ref().unwrap().initial_sync_peers_active.get(), 1);
+
+		handler
+			.handle_notification_event(NotificationEvent::NotificationStreamClosed {
+				peer: peer_id,
+			})
+			.await;
+
+		assert!(!handler.peers.contains_key(&peer_id));
+		assert!(!handler.pending_initial_syncs.contains_key(&peer_id));
+		assert!(!handler.initial_sync_peer_queue.contains(&peer_id));
+		assert_eq!(handler.metrics.as_ref().unwrap().initial_sync_peers_active.get(), 0);
+		assert_eq!(
+			handler
+				.metrics
+				.as_ref()
+				.unwrap()
+				.initial_sync_duration_seconds
+				.get_sample_count(),
+			0,
+			"A closed stream must not be recorded as a completed initial sync"
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes #11411 and the adjacent statement-handler lifecycle holes it exposed by preventing peers from remaining in a half-connected statement-protocol state while the node is unavailable.

The core repair is still the original major-sync fix:

1. Reject inbound statement substreams while the handler is unavailable.
2. Disconnect statement streams that still open while unavailable.
3. Disconnect already-connected peers that send statements while unavailable, and clean up their local statement-handler state.

Follow-up reviewer passes then closed the same half-connected state in nearby paths:

- offline transitions,
- async send failures,
- outbound interruption,
- duplicate and stale reopen events,
- initial-sync fetch failures,
- and false completion metrics on aborted cleanup paths.

## Why this is needed

Today a peer can end up in a broader half-connected state:

- the statement stream is open,
- live statements are rejected or interrupted while the node is unavailable,
- peers opened during that window may never get a clean initial-sync replay path if cleanup is incomplete,
- and there is no later replay trigger.

That means statements can be missed permanently even though the peer still looks connected.

A key detail here is that gating only newly opening peers is not sufficient. Peers that were already connected before major sync starts can still hit the same loss window once sync state changes, and later reviewer passes found equivalent stale-state variants after send failures and reopen races.

## Why disconnect instead of silently ignoring

Silently ignoring statements preserves the broken state: the peer stays connected on the statement protocol, but cannot contribute live statements and does not get a clean catch-up path.

Disconnecting is the smallest fix that reuses the existing lifecycle:

- reject statement traffic while unavailable,
- clean up local statement-handler state eagerly,
- let the peer reconnect once the node is ready again,
- and reuse the normal stream-open path to queue initial sync.

## Tests

This branch now adds regression coverage for:

- rejecting inbound statement substreams during major sync,
- rejecting inbound statement substreams while offline,
- disconnecting streams that open during major sync,
- disconnecting streams that open while offline,
- reconnecting after sync exit and re-queuing initial sync,
- preserving the normal open path outside major sync,
- disconnecting already-open peers that send while unavailable,
- send failure retry and cleanup,
- interrupted outbound propagation cleanup,
- duplicate stream-open state replacement,
- stale unavailable reopen cleanup,
- initial-sync fetch failure cleanup,
- and ensuring aborted initial sync cleanup does not inflate completion metrics.

## Validation

- `rustfmt --edition 2021 substrate/client/network/statement/src/lib.rs`
- `git diff --check -- substrate/client/network/statement/src/lib.rs`
- `cargo check -p sc-network-statement --lib`
- `cargo test -p sc-network-statement --lib -- --nocapture`

Validation was completed in a Linux-native WSL checkout with real symlinks preserved. Earlier Windows-backed checkout failures were environment-specific and are no longer the limiting factor for this branch.