### PR TITLE
aura/slot_based: Fix effective slot deadline using relay parent offset

### DIFF
--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -188,40 +188,47 @@ where
 			collator_util::Collator::<Block, P, _, _, _, _, _>::new(params)
 		};
 
-		// Tracker helper to ensure we do not build an extra block at slot boundaries
-		// with edge-cases of importing blocks after the `slot_timer` ticks.
+		// Prevents a "stale parent" race condition that degrades block confidence.
 		//
-		// The following scenarios are degrading block confidence (happening on the same instance):
+		// Block production is driven by two decoupled clocks:
+		//  I. Aura slot (wall clock): Triggers wake-ups and enforces a 1-second hard deadline
+		//     at the end of the slot to safely stop authoring.
+		//  II. Parachain slot: Derived from the imported relay parent, which determines if we
+		//     can build or not.
 		//
-		//                 [ wall slot | para slot | next wall slot]
-		// opportunity 1:  [ 803       |       803 |         490ms ]
-		// 	  - The wall slot is behind the para slot deduced by the relay block
-		// 	  - The next slot 804 arrives in 490ms leaving no room for the 1s authoring duration
-		//    - collator must skip the building the first block for this relay block
+		// Because network imports race against the local wall clock, a node running
+		// elastic scaling can easily desync.
 		//
-		// 	opportunity 2-10: [ 804       |       803 |         6s ]
-		//    - This is the proper case where we have sufficient time to build and build 10 blocks
+		// Timeline of the failure scenario (observed on yap-polkadot):
 		//
-		//  opportunity 11-12: [ 804      |       803 |         990ms-500ms ]
-		//   - At this point we skip building the last 2 blocks to give room for the 1s authoring
-		//     duration before the next slot arrives.
+		//  - T0: Aura 803 begins. The relay parent is still old (0xA). The node skips.
 		//
-		//  opportunity 13:    [ 805      |       803 |         6s ]
-		//   - The new relay block was not imported soon enough, therefore we detect the same relay
-		//     parent that we just skipped. Since the import of a new block is usually ~15ms after
-		//     the wall slot ticks.
-		//   - We don't want to build on this relay parent and instead skip until the next relay
-		//     block arrives.
+		//  - T1 (soft failure): Aura 803 last block production opportunity. Relay parent 0xB
+		//    (para slot 803) is picked. However, aura 803 now has < 1000ms remaining. The 1s
+		//    deadline triggers, skipping the block.
+		//
+		//  - T2: Aura 804 begins. The node successfully builds 10 blocks on 0xB. As aura 804
+		//    ends, the 1s deadline triggers again, skipping the final 2 cores.
+		//
+		//  - T3 (critical failure): Aura 805 begins. The wall clock resets, the next aura slot
+		//    arrives in 6000ms. However, the network hasn't delivered a new relay parent yet.
+		//    Because the timer reset, the deadline check passes, and the node erroneously
+		//    builds a stale block on top of 0xB.
+		//
+		// To prevent T1, we rely on the 1-second hard deadline to skip block production.
+		//
+		// To prevent T3, we track the relay parent hash and whether we've already built and
+		// terminated on it. If the relay parent hasn't changed since our last terminated build,
+		// we skip production until the network delivers a new relay block.
+		//
+		// See: https://github.com/paritytech/polkadot-sdk/pull/11453
 		struct ParentTracker {
 			/// Hash of the relay block.
 			hash: Option<H256>,
-			/// True if the collator built a block for the current relay parent, false otherwise.
-			///
-			/// This state is needed, otherwise the opportunity 1 might mark the block as
-			/// terminated wrongfully.
+			/// True if the collator built a block for the current relay parent.
+			/// Needed so that T1 (first opportunity skip) doesn't wrongfully mark as terminated.
 			has_built: bool,
-			/// True if the collator adjusted the slot timer and decided there is no time to build
-			/// a block, false otherwise. This is set to true on opportunity 11.
+			/// True if the slot timer determined there is no time left to build.
 			has_terminated: bool,
 		}
 


### PR DESCRIPTION
This PR addresses two issues with the collators building blocks:
- Issue 1: Skipping the first block of the slot:
   - Wall clock (slot) 803, parachain slot 803
   - last reported slot is 803, next slot 804, remaining 491ms => deadline = 491 - 1000 = 0 (skipps the block)
- Issue 2: Wrongfully building the first block of the next slot:
   - Wall clock 805, parachain slot 803 (relay chain not yet imported, same parent same paraslot outdated) 
   - last reported slot is 805, next slot 806, remaining 6s, deadline = 6s - 1s = 5s => builds block

When issue 1 happens, the collator A is building less blocks than expected degrading the block times.

When issue 2 happens, the collator A is competing (outside of his slot) with another collator B. Since both collators are building their blocks at roughly the same time, it is a matter of chance which one gets backed first by the relay chain.

However, in 95% of incidents, collator B's block will get backed by the relay chain. 
Collator A is at the end of his slot (one block past it, in fact), while collator B has a fresh connection with the backing group. One theory is that connections might degrade over time and that could explain why collator B block gets backed 95% of incidents. 

**This exposes the Issue 3 (unaddressed in this PR)**:
- T0: Collator A advertises its block 0xA (build wrongfully)
- T0: Collator B advertises at the same height the block 0xB 
- T1: Collator B imports the block 0xA as best then starts building 9 other blocks on this fork
- T2: Relay chain backs 0xB invalidating and degrading the block confidence


## Root Cause

Because we use an RP offset=1, we only start building on top of `relay_parent=0xa052…1016 relay_parent_num=30397129` when `#30397130 (0xa052…1016 → 0x201f…fc48)` gets imported.

Node 3 was building properly 10 blocks, skipping 2. Then on the next block production opportunity, the relay block import races with building:
- at `10:20:31.002` we start building the 11 block outside our slot because we still build on top of `30397128`
- at `10:20:31.017` node imports relay 30397130 which would have seen best as `30397129` and detect the paraslot change

## Logs

### Node 3 

```rust

// Skips first block opportunity
10:20:24.501
aura::cumulus: [Parachain] New block production opportunity. slot_duration=SlotDuration(6000) 
  aura_slot=Slot(295623803) relay_parent=0xf970…0b74 relay_parent_num=30397128
    slot=Slot(295623803)
  duration_until_next_slot=491.263683ms
  Adjusted proposal duration. duration=None
  
10:20:25.002
aura::cumulus: [Parachain] New block production opportunity. slot_duration=SlotDuration(6000)
  aura_slot=Slot(295623804) relay_parent=0xf970…0b74 relay_parent_num=30397128
    slot=Slot(295623803)
  duration_until_next_slot=5.992199112s 
  Adjusted proposal duration. duration=Some(493ms)

// Builds 9 more blocks

// Skips 2 blocks
10:20:30.000
aura::cumulus: [Parachain] New block production opportunity. slot_duration=SlotDuration(6000)
  aura_slot=Slot(295623804)  relay_parent=0xf970…0b74 relay_parent_num=30397128
  duration_until_next_slot=993.059675ms
  Adjusted proposal duration. duration=None
  
10:20:30.500
aura::cumulus: [Parachain] New block production opportunity. slot_duration=SlotDuration(6000)
  aura_slot=Slot(295623804) relay_parent=0xf970…0b74 relay_parent_num=30397128
  duration_until_next_slot=493.092078ms
  Adjusted proposal duration. duration=None

// The issue happens here, aura_slot is the wall clock which gets incremented
// while the relay parent stays fixed and results into paraslot 803
// when in fact relay has changed and this node did not see it yet.
//
// Sufficient time to build: allows building wrongfully

10:20:31.002
aura::cumulus: [Parachain] New block production opportunity. slot_duration=SlotDuration(6000)
  aura_slot=Slot(295623805) relay_parent=0xf970…0b74 relay_parent_num=30397128
       slot=Slot(295623803)
  duration_until_next_slot=5.991286702s
  Adjusted proposal duration. duration=Some(492ms)
```


### Node 1 Imports

```
10:20:24.419 [Relaychain] 🏆 Imported #30397129 (0xf970…0b74 → 0xa052…1016)
10:20:30.960 [Relaychain] 🏆 Imported #30397130 (0xa052…1016 → 0x201f…fc48)
10:20:36.522 [Relaychain] 🏆 Imported #30397131 (0x201f…fc48 → 0xd6b3…5527)
```

### Node 3 Imports

```
10:20:24.378 [Relaychain] 🏆 Imported #30397129 (0xf970…0b74 → 0xa052…1016)
10:20:31.017 [Relaychain] 🏆 Imported #30397130 (0xa052…1016 → 0x201f…fc48)
10:20:36.524 [Relaychain] 🏆 Imported #30397131 (0x201f…fc48 → 0xd6b3…5527)
```


This has been detected using:
- https://github.com/paritytech/polkadot-sdk/issues/11377#issuecomment-4089898206
- https://github.com/lexnv/block-confidence-monitor and manual inspection of incidents


### Testing Done
- have added unit tests
- deployment in progress to double check block confidence

cc @sandreim @skunert 