### PR TITLE
Measure block propagation time

### DIFF
--- a/substrate/client/consensus/common/src/import_queue.rs
+++ b/substrate/client/consensus/common/src/import_queue.rs
@@ -35,6 +35,7 @@ use std::{
 
 use sp_consensus::{error::Error as ConsensusError, BlockOrigin};
 use sp_runtime::{
+	codec::{Compact, Decode, Encode},
 	traits::{Block as BlockT, Header as _, NumberFor},
 	Justifications,
 };
@@ -415,6 +416,30 @@ pub(crate) async fn verify_single_block_metered<B: BlockT, V: Verifier<B>>(
 	}))
 }
 
+/// Unix millis from the first extrinsic (timestamp inherent).
+///
+/// Assumes: first extrinsic is `pallet_timestamp::set`
+fn block_timestamp_unix_ms<Block: BlockT>(body: &[Block::Extrinsic]) -> Option<u128> {
+	let encoded = body.first()?.encode();
+	let inner = peel_opaque_extrinsic_outer(encoded.as_slice());
+	let mut args = inner.get(1..)?.get(2..)?;
+	let moment = Compact::<u64>::decode(&mut args).ok()?;
+	Some(moment.0 as u128)
+}
+
+fn peel_opaque_extrinsic_outer(data: &[u8]) -> &[u8] {
+	let mut input = data;
+	let Ok(len_c) = Compact::<u32>::decode(&mut input) else {
+		return data;
+	};
+	let len = len_c.0 as usize;
+	if input.len() >= len {
+		&input[..len]
+	} else {
+		data
+	}
+}
+
 pub(crate) async fn import_single_block_metered<Block: BlockT>(
 	import_handle: &mut impl BlockImport<Block, Error = ConsensusError>,
 	import_parameters: SingleBlockImportParameters<Block>,
@@ -428,9 +453,11 @@ pub(crate) async fn import_single_block_metered<Block: BlockT>(
 	let number = *import_block.header.number();
 	let parent_hash = *import_block.header.parent_hash();
 
+	let block_ms = import_block.body.as_ref().and_then(|b| block_timestamp_unix_ms::<Block>(b));
 	let imported = import_handle.import_block(import_block).await;
 	if let Some(metrics) = metrics {
 		metrics.report_verification_and_import(started.elapsed() + verification_time);
+		metrics.report_block_propagation(block_ms);
 	}
 
 	import_handler::<Block>(number, hash, parent_hash, block_origin, imported)

--- a/substrate/client/consensus/common/src/metrics.rs
+++ b/substrate/client/consensus/common/src/metrics.rs
@@ -19,25 +19,28 @@
 //! Metering tools for consensus
 
 use prometheus_endpoint::{
-	register, CounterVec, Histogram, HistogramOpts, HistogramVec, Opts, PrometheusError, Registry,
-	U64,
+	exponential_buckets, register, CounterVec, Histogram, HistogramOpts, HistogramVec, Opts,
+	PrometheusError, Registry, U64,
 };
 
 use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::import_queue::{BlockImportError, BlockImportStatus};
 
 /// Generic Prometheus metrics for common consensus functionality.
 #[derive(Clone)]
-pub(crate) struct Metrics {
+pub struct Metrics {
 	pub import_queue_processed: CounterVec<U64>,
 	pub block_verification_time: HistogramVec,
 	pub block_verification_and_import_time: Histogram,
 	pub justification_import_time: Histogram,
+	pub block_propagation_time: Histogram,
 }
 
 impl Metrics {
-	pub(crate) fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+	/// Register all consensus import-queue and related Prometheus metrics on `registry`.
+	pub fn register(registry: &Registry) -> Result<Self, PrometheusError> {
 		Ok(Self {
 			import_queue_processed: register(
 				CounterVec::new(
@@ -73,6 +76,17 @@ impl Metrics {
 				))?,
 				registry,
 			)?,
+			block_propagation_time: register(
+				Histogram::with_opts(
+					HistogramOpts::new(
+						"substrate_block_propagation_time",
+						"Block propagation time in seconds: local wall clock when block import finishes minus \
+						 the timestamp from the block body.",
+					)
+					.buckets(exponential_buckets(0.001, 1.5, 25)?),
+				)?,
+				registry,
+			)?,
 		})
 	}
 
@@ -102,5 +116,15 @@ impl Metrics {
 
 	pub fn report_verification_and_import(&self, time: std::time::Duration) {
 		self.block_verification_and_import_time.observe(time.as_secs_f64());
+	}
+
+	/// Observe block propagation time
+	pub fn report_block_propagation(&self, block_unix_ms: Option<u128>) {
+		let Some(block_ms) = block_unix_ms else { return };
+		let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+			return;
+		};
+		let drift_ms = now.as_millis().saturating_sub(block_ms);
+		self.block_propagation_time.observe(drift_ms as f64 / 1000.0);
 	}
 }


### PR DESCRIPTION
## Summary
Adds a Prometheus histogram for **block propagation delay**: local wall time when import completes minus the **on-chain timestamp** read from the block body.

## Motivation
We want to understand how much time it takes for a block to propagate from author to nodes.  We know this is slower because blocks are only announced after import. This metric will be useful in the future to measure the improvement coming from announcing blocks before they are imported.

