### PR TITLE
create reusable action for downloading old release binaries #11479

### DIFF
--- a/.github/actions/download-binaries/action.yml
+++ b/.github/actions/download-binaries/action.yml
@@ -1,0 +1,26 @@
+name: 'Download Old Release Binaries'
+description: 'Downloads specific polkadot binaries from a previous release'
+runs:
+  using: "composite"
+  steps:
+    - name: Download and Setup Binaries
+      shell: bash
+      run: |
+        BIN_DIR="$(pwd)/bin_old" 
+        mkdir -p $BIN_DIR 
+        for bin in polkadot polkadot-parachain; do 
+          OLD_NAME="$bin-old" 
+          echo "downloading $bin as $OLD_NAME in $BIN_DIR"; 
+          curl -L -o $BIN_DIR/$OLD_NAME https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/$bin 
+          chmod 755 $BIN_DIR/$OLD_NAME; 
+        done 
+        for bin in polkadot-execute-worker polkadot-prepare-worker; do 
+          OLD_NAME="$bin" 
+          echo "downloading $bin as $OLD_NAME in $BIN_DIR"; 
+          curl -L -o $BIN_DIR/$OLD_NAME https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/$bin 
+          chmod 755 $BIN_DIR/$OLD_NAME; 
+        done 
+        ls -ltr $BIN_DIR 
+        export PATH=$BIN_DIR:$PATH 
+        echo "PATH=$PATH" >> $GITHUB_ENV 
+        echo "OLD_SUFFIX=-old" >> $GITHUB_ENV 


### PR DESCRIPTION
This PR introduces a reusable composite action to handle the downloading and path setup of old Polkadot binaries (e.g., v1.7.0).
