### PR TITLE
consensus/aura: warn when force-authoring is enabled

### DIFF
--- a/substrate/client/consensus/aura/src/lib.rs
+++ b/substrate/client/consensus/aura/src/lib.rs
@@ -190,6 +190,16 @@ where
 	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
 	Error: std::error::Error + Send + From<ConsensusError> + 'static,
 {
+	if force_authoring {
+		log::warn!(
+			target: LOG_TARGET,
+			"⚠️  Force-authoring is ENABLED. This node will produce blocks in every slot \
+			regardless of whether it is the designated author. In multi-validator networks, \
+			this causes competing forks and prevents GRANDPA finality. \
+			Only use --force-authoring on single-validator dev chains.",
+		);
+	}
+
 	let worker = build_aura_worker::<P, _, _, _, _, _, _, _, _>(BuildAuraWorkerParams {
 		client,
 		block_import,


### PR DESCRIPTION
## Summary

Adds a startup warning log when `--force-authoring` is enabled in Aura consensus. In multi-validator networks, this flag causes the node to produce blocks in every slot regardless of slot ownership, leading to competing forks that prevent GRANDPA finality.

## Context

We discovered this while running a 4-validator [Materios](https://github.com/Flux-Point-Studios/materios) partner chain (Aura + GRANDPA, `polkadot-stable2409-5`). One node had `--force-authoring` set — the chain forked silently and finality stalled for hours before we traced it to this flag. There was no warning in logs and no documentation about the multi-validator risk.

The flag currently bypasses the Aura slot ownership check without any guard or diagnostic output. This makes it a silent footgun for anyone running a multi-validator network.

Related: #5624 (block production/forking issues)

## Changes

- Added a `log::warn!` in `start_aura()` when `force_authoring` is true
- The warning explains the fork/finality risk and recommends restricting the flag to single-validator dev chains
- No behavioral change — just a diagnostic warning

## Test plan

- [x] Verified the warning is emitted at startup when `--force-authoring` is passed
- [x] Verified no warning is emitted when `--force-authoring` is not passed
- [x] Existing Aura tests pass (all tests use `force_authoring: false`)