### PR TITLE
grandpa: add schedule_change_incrementing_set_id for session-less runtimes

### DIFF
--- a/substrate/frame/grandpa/src/lib.rs
+++ b/substrate/frame/grandpa/src/lib.rs
@@ -509,6 +509,11 @@ impl<T: Config> Pallet<T> {
 	///
 	/// No change should be signaled while any change is pending. Returns
 	/// an error if a change is already pending.
+	///
+	/// **Important:** This method does NOT increment `CurrentSetId`. If your
+	/// runtime does not use `pallet_session` (which handles the set_id
+	/// increment in `on_new_session`), use
+	/// [`Self::schedule_change_incrementing_set_id`] instead.
 	pub fn schedule_change(
 		next_authorities: AuthorityList,
 		in_blocks: BlockNumberFor<T>,
@@ -546,6 +551,30 @@ impl<T: Config> Pallet<T> {
 		} else {
 			Err(Error::<T>::ChangePending.into())
 		}
+	}
+
+	/// Schedule a GRANDPA authority change and increment `CurrentSetId`.
+	///
+	/// This is the correct API for runtimes that manage authority rotation
+	/// directly (without `pallet_session`). Using bare `schedule_change()`
+	/// without incrementing `CurrentSetId` causes the GRANDPA voter to
+	/// get out of sync — it will keep voting with the old set_id while
+	/// the runtime has already enacted the new authority set.
+	///
+	/// Returns the new `SetId` on success.
+	///
+	/// See <https://github.com/paritytech/polkadot-sdk/issues/7363>.
+	pub fn schedule_change_incrementing_set_id(
+		next_authorities: AuthorityList,
+		in_blocks: BlockNumberFor<T>,
+		forced: Option<BlockNumberFor<T>>,
+	) -> Result<SetId, DispatchError> {
+		Self::schedule_change(next_authorities, in_blocks, forced)?;
+		let new_set_id = CurrentSetId::<T>::mutate(|id| {
+			*id += 1;
+			*id
+		});
+		Ok(new_set_id)
 	}
 
 	/// Deposit one of this module's logs.


### PR DESCRIPTION
## Summary

Adds `schedule_change_incrementing_set_id()` to `pallet_grandpa` — a wrapper around `schedule_change()` that also increments `CurrentSetId`. This is the correct API for runtimes that rotate GRANDPA authorities without `pallet_session`.

Fixes #7363

## Problem

`schedule_change()` does not increment `CurrentSetId`. When called from `pallet_session::on_new_session`, this is fine — `on_new_session` handles the increment. But runtimes that manage authority rotation directly (common in partner chains and permissioned networks) have no clean way to advance the set_id.

Without the set_id increment:
1. The runtime schedules new authorities via `schedule_change()`
2. `on_finalize` enacts the change — new authorities are written to storage
3. But `CurrentSetId` still reflects the old set
4. The GRANDPA voter rejects votes signed with the new set_id
5. **Finality stalls permanently**

We hit this running [Materios](https://github.com/Flux-Point-Studios/materios), a Cardano partner chain with Aura+GRANDPA and no `pallet_session`. Our `rotate_authorities` extrinsic called `schedule_change()` directly, and GRANDPA finality broke on every authority rotation until we manually wrote `CurrentSetId` via raw storage.

## Changes

1. **New method:** `Pallet::<T>::schedule_change_incrementing_set_id(authorities, delay, forced)` — calls `schedule_change()` then increments and returns the new `SetId`
2. **Doc warning on `schedule_change()`** — points session-less runtimes to the new method

## Why not modify `schedule_change` directly?

`on_new_session` already increments `set_id` before calling `schedule_change`. Making `schedule_change` always increment would double-count for every runtime using `pallet_session`. A separate method preserves backward compatibility.

## Test plan

- [x] Existing GRANDPA tests pass unchanged (they use `pallet_session` path)
- [x] The new method is a thin wrapper — `schedule_change` + `CurrentSetId::mutate`
- [x] Verified in production on a 4-validator Aura+GRANDPA partner chain

## Context from #7363

@blakebyrnes and @andresilva discussed this exact issue. @andresilva identified three sub-problems; this PR addresses the first: providing a public API that correctly advances set_id for non-session runtimes.