### PR TITLE
[DNM] Westend: Reduce backoff duration to 1s and expose logs when peers are backedoff

### DIFF
--- a/substrate/client/network/src/litep2p/shim/notification/peerset.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/peerset.rs
@@ -642,7 +642,7 @@ impl Peerset {
 			// available), accept the peer and then just ignore the back-off timer when it expires
 			PeerState::Backoff => {
 				if !is_reserved_peer && self.num_in == self.max_in {
-					log::trace!(
+					log::warn!(
 						target: LOG_TARGET,
 						"{}: ({peer:?}) is backed-off and cannot accept, reject inbound substream",
 						self.protocol,
@@ -737,7 +737,7 @@ impl Peerset {
 			return ValidationResult::Accept;
 		}
 
-		log::trace!(
+		log::warn!(
 			target: LOG_TARGET,
 			"{}: reject {peer:?}, not a reserved peer and no free inbound slots",
 			self.protocol,

--- a/substrate/client/network/src/litep2p/shim/notification/peerset.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/peerset.rs
@@ -67,10 +67,10 @@ use std::{
 const LOG_TARGET: &str = "sub-libp2p::peerset";
 
 /// Default backoff for connection re-attempts.
-const DEFAULT_BACKOFF: Duration = Duration::from_secs(5);
+const DEFAULT_BACKOFF: Duration = Duration::from_secs(1);
 
 /// Open failure backoff.
-const OPEN_FAILURE_BACKOFF: Duration = Duration::from_secs(5);
+const OPEN_FAILURE_BACKOFF: Duration = Duration::from_secs(1);
 
 /// Slot allocation frequency.
 ///

--- a/substrate/client/network/src/litep2p/shim/notification/peerset.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/peerset.rs
@@ -799,6 +799,9 @@ impl Peerset {
 					"{}: substream open failure for reserved peer {peer:?}",
 					self.protocol,
 				);
+
+				// Do not backoff reserved peers.
+				return;
 			},
 			state => {
 				log::debug!(


### PR DESCRIPTION
Part of testing why we see unstable block times where collations were not advertised

