### PR TITLE
Add safe.directory in failure handler

### DIFF
--- a/.github/workflows/release-80_publish-crates.yml
+++ b/.github/workflows/release-80_publish-crates.yml
@@ -379,7 +379,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           echo "Job failed. Pushing branch '$CRATES_RELEASE_BRANCH' to origin (paritytech-release) to preserve state for resume..."
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           # Restore origin to the fork repo in case it was changed by the upstream push step
           git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "$CRATES_RELEASE_BRANCH" --force-with-lease


### PR DESCRIPTION
## Summary                                                                       
  - Fix resume validation in publish crates workflow by using local ref check (`git
   branch -r`) instead of `git ls-remote`, which fails because                     
  `persist-credentials: false` prevents remote access                              
                                                                                   
  ## Context                  
  - Failed run: https://github.com/paritytech-release/polkadot-sdk/actions/runs/236
  20337279/job/68797902086#step:25:20