### PR TITLE
doc: add link to multi-block migration example. Resolves a TODO by ad…

### DIFF
--- a/substrate/frame/examples/single-block-migrations/src/lib.rs
+++ b/substrate/frame/examples/single-block-migrations/src/lib.rs
@@ -35,7 +35,8 @@
 //! If weight is a concern or you are not sure which type of migration to use, you should probably
 //! use a multi-block migration.
 //!
-//! TODO: Link above to multi-block migration example.
+//! See the [`pallet-example-mbm`](https://paritytech.github.io/polkadot-sdk/master/pallet_example_mbm/index.html)
+//! pallet for an example of a multi-block migration.
 //!
 //! ## Pallet Overview
 //!


### PR DESCRIPTION
…ding a documentation link from the single-block migrations pallet to the multi-block migrations example pallet.



✄ -----------------------------------------------------------------------------

# Description

﻿Resolves a documentation TODO in `pallet-example-single-block-migrations` by adding
 a link to the `pallet-example-mbm` documentation.

 The TODO requested linking to the multi-block migration example from the warning
 about single-block migrations potentially exceeding block weight limits

## Integration

﻿N/A - documentation only change, no crate API changes

## Review Notes

﻿ Uses external URL (matching repo convention) since pallet-example-mbm is not a dependency of this crate.


✄ -----------------------------------------------------------------------------
