### PR TITLE
Bump parity-publish to 0.10.13

### DIFF
--- a/.github/workflows/release-80_publish-crates.yml
+++ b/.github/workflows/release-80_publish-crates.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Install parity-publish
         run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
-          cargo install parity-publish@0.10.12 --locked -q
+          cargo install parity-publish@0.10.13 --locked -q
 
       - name: Run parity-publish plan
         if: inputs.resume_from == 'full'


### PR DESCRIPTION
## Summary
- Bumps `parity-publish` from `0.10.12` to `0.10.13` in the release publish crates workflow
- Increases wait time between crate releases from 15s to 60s because of the 429 response after making release process faster