### PR TITLE
Remove zombienet-sdk dev-dep from sc-transaction-pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21420,7 +21420,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.19",
  "zombienet-configuration",
- "zombienet-sdk",
 ]
 
 [[package]]

--- a/substrate/client/transaction-pool/Cargo.toml
+++ b/substrate/client/transaction-pool/Cargo.toml
@@ -65,4 +65,4 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 txtesttool = { workspace = true }
 zombienet-configuration = { workspace = true }
-zombienet-sdk = { workspace = true }
+


### PR DESCRIPTION
## Summary
- Removes `zombienet-sdk` from `[dev-dependencies]` in `sc-transaction-pool` to fix crate publishing failure
- `zombienet-sdk v0.4.7` transitively depends on `sp-core v38.1.0` → `substrate-bip39 ^0.6.0` (locked to `0.6.0`), which conflicts with workspace `sp-core v40.0.0` → `substrate-bip39 ^0.6.1` during `cargo publish` resolution