### PR TITLE
[Release|CI] - Remove unwanted changes from post-crates release workflow

### DIFF
--- a/.github/workflows/release-60_post-crates-release-activities.yml
+++ b/.github/workflows/release-60_post-crates-release-activities.yml
@@ -178,14 +178,6 @@ jobs:
 
           reorder_prdocs "$VERSION"
 
-      - name: Replace path dependencies
-        run: |
-          echo "Running replace-all-path-deps.sh..."
-          bash scripts/release/replace-all-path-deps.sh
-
-          # Show git diff to see what changed
-          git diff --stat
-
       - name: Remove versions where path deps are present
         run: |
           echo "Running delete-versions-if-path-is-present.sh..."
@@ -209,19 +201,7 @@ jobs:
       - name: Run Zepter - check issues
         run: |
           echo "Running zepter run check to identify issues..."
-          zepter run check || echo "Zepter found issues that need to be fixed"
-
-      - name: Run Zepter - fix issues
-        run: |
-          echo "Running zepter to fix issues..."
-          zepter || echo "Zepter fix completed"
-          # Show git diff to see what changed
-          git diff --stat
-
-      - name: Run Zepter - verify fixes
-        run: |
-          echo "Running zepter run check again to verify fixes..."
-          zepter run check || echo "There are still issues to fix manually"
+          zepter run check || echo "Zepter found issues - these should be fixed in a separate PR"
 
       - name: Run taplo - check formatting
         run: |


### PR DESCRIPTION
## Summary
- Remove `replace-all-path-deps.sh` step that was converting `path = "..."` to `workspace = true` in all child Cargo.tomls
- Remove zepter `--fix` step that was adding explicit `default-features = false` to ~140+ files as a cosmetic fix
- Keep zepter check (without fix) so issues are still reported in the log
- Keep `delete-versions-if-path-is-present.sh` and `delete-version-from-umbrella.sh` (these clean up parity-publish version artifacts)
- Keep taplo formatting (ordering changes are fine)

These changes were producing unwanted diffs in the post-crates release PR (e.g. #11549), as flagged in review.

## Test plan
- [ ] Run the post-crates release workflow on a test release and verify the resulting PR only contains version bumps, spec bumps, prdoc moves, and taplo formatting