### PR TITLE
omni-node: always enable runtime-benchmarks node functionality

### DIFF
--- a/cumulus/polkadot-omni-node/Cargo.toml
+++ b/cumulus/polkadot-omni-node/Cargo.toml
@@ -17,7 +17,7 @@ color-eyre = { workspace = true }
 
 # Local
 polkadot-jemalloc-shim = { workspace = true }
-polkadot-omni-node-lib = { workspace = true, features = ["rococo-native", "westend-native"] }
+polkadot-omni-node-lib = { workspace = true, features = ["rococo-native", "westend-native", "runtime-benchmarks"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 polkadot-jemalloc-shim = { workspace = true, features = ["jemalloc-allocator"] }

--- a/cumulus/polkadot-omni-node/lib/Cargo.toml
+++ b/cumulus/polkadot-omni-node/lib/Cargo.toml
@@ -33,9 +33,9 @@ scale-info = { workspace = true }
 subxt-metadata = { workspace = true, default-features = true }
 
 # Substrate
-frame-benchmarking = { optional = true, workspace = true, default-features = true }
+frame-benchmarking = { workspace = true, default-features = true }
 frame-benchmarking-cli = { workspace = true, default-features = true }
-frame-support = { optional = true, workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 frame-system-rpc-runtime-api = { workspace = true, default-features = true }
 frame-try-runtime = { optional = true, workspace = true, default-features = true }
 pallet-transaction-payment = { workspace = true, default-features = true }
@@ -119,16 +119,14 @@ default = []
 rococo-native = ["polkadot-cli/rococo-native"]
 westend-native = ["polkadot-cli/westend-native"]
 runtime-benchmarks = [
-	"cumulus-primitives-core/runtime-benchmarks",
-	"frame-benchmarking-cli/runtime-benchmarks",
-	"frame-benchmarking/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"pallet-transaction-payment/runtime-benchmarks",
-	"polkadot-cli/runtime-benchmarks",
-	"polkadot-primitives/runtime-benchmarks",
+	# Only enable sc-client-db/runtime-benchmarks which is needed for storage
+	# benchmarks (expose_db, expose_storage, expose_shared_trie_cache).
+	# Avoid enabling frame-benchmarking/runtime-benchmarks or frame-support/runtime-benchmarks
+	# here, as those cascade (via proc-macros) into all pallets compiled in the same build,
+	# forcing embedded runtimes (e.g. in polkadot-parachain) to also be compiled with
+	# runtime-benchmarks. The benchmarking host functions and the Benchmark runtime API are
+	# both available from frame-benchmarking without that feature flag.
 	"sc-client-db/runtime-benchmarks",
-	"sc-service/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/cumulus/polkadot-omni-node/lib/src/command.rs
+++ b/cumulus/polkadot-omni-node/lib/src/command.rs
@@ -31,12 +31,10 @@ use crate::{
 	runtime::BlockNumber,
 };
 use clap::{CommandFactory, FromArgMatches};
-#[cfg(feature = "runtime-benchmarks")]
 use cumulus_client_service::storage_proof_size::HostFunctions as ReclaimHostFunctions;
 use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use log::info;
 use sc_cli::{Result, SubstrateCli};
-#[cfg(feature = "runtime-benchmarks")]
 use sp_runtime::traits::HashingFor;
 
 /// Structure that can be used in order to provide customizers for different functionalities of the
@@ -228,7 +226,6 @@ where
 		Some(Subcommand::Benchmark(cmd)) => {
 			// Switch on the concrete benchmark sub-command-
 			match cmd {
-				#[cfg(feature = "runtime-benchmarks")]
 				BenchmarkCmd::Pallet(cmd) => {
 					let chain = cmd
 						.shared_params
@@ -280,8 +277,8 @@ where
 				},
 				#[allow(unreachable_patterns)]
 				_ => Err("Benchmarking sub-command unsupported or compilation feature missing. \
-					Make sure to compile omni-node with --features=runtime-benchmarks \
-					to enable all supported benchmarks."
+					Storage benchmarks require the binary to be compiled with \
+					--features=runtime-benchmarks."
 					.into()),
 			}
 		},

--- a/cumulus/polkadot-omni-node/lib/src/common/types.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/types.rs
@@ -28,12 +28,7 @@ pub use parachains_common_types::{AccountId, Balance, Hash, Nonce};
 type Header<BlockNumber> = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block<BlockNumber> = generic::Block<Header<BlockNumber>, UncheckedExtrinsic>;
 
-#[cfg(not(feature = "runtime-benchmarks"))]
-pub type ParachainHostFunctions = (
-	cumulus_client_service::ParachainHostFunctions,
-	sp_statement_store::runtime_api::HostFunctions,
-);
-#[cfg(feature = "runtime-benchmarks")]
+// Always include benchmarking host functions.
 pub type ParachainHostFunctions = (
 	cumulus_client_service::ParachainHostFunctions,
 	sp_statement_store::runtime_api::HostFunctions,

--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -210,7 +210,6 @@ macro_rules! impl_node_runtime_apis {
 				}
 			}
 
-			#[cfg(feature = "runtime-benchmarks")]
 			impl frame_benchmarking::Benchmark<$block> for $runtime {
 				fn benchmark_metadata(_: bool) -> (
 					Vec<frame_benchmarking::BenchmarkList>,


### PR DESCRIPTION
closes #8741

This PR makes benchmarking always available in `polkadot-omni-node` by default while decoupling the `runtime-benchmarks` feature from embedded runtimes, limiting it only to storage benchmarking—thereby removing unnecessary feature cascades and ensuring correct separation between node capabilities and runtime requirement