### PR TITLE
sc-network: reopen reserved litep2p peers immediately after close

### DIFF
--- a/substrate/client/network/src/litep2p/shim/notification/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/mod.rs
@@ -323,9 +323,20 @@ impl NotificationService for NotificationProtocol {
 						log::trace!(target: LOG_TARGET, "{}: substream closed for {peer:?}", self.protocol);
 
 						self.metrics.register_substream_closed(&self.protocol);
-						self.peerset.report_substream_closed(peer.into());
+						let peer_id = peer.into();
+						self.peerset.report_substream_closed(peer_id);
 
-						if self.pending_cancels.remove(&peer) {
+						let was_pending_cancel = self.pending_cancels.remove(&peer);
+
+						if !was_pending_cancel {
+							if let Some(command) =
+								self.peerset.try_reopen_reserved_peer_after_close(peer_id)
+							{
+								self.on_peerset_command(command).await;
+							}
+						}
+
+						if was_pending_cancel {
 							log::debug!(
 								target: LOG_TARGET,
 								"{}: substream closed to canceled peer ({peer:?})",
@@ -334,7 +345,7 @@ impl NotificationService for NotificationProtocol {
 							continue
 						}
 
-						return Some(SubstrateNotificationEvent::NotificationStreamClosed { peer: peer.into() })
+						return Some(SubstrateNotificationEvent::NotificationStreamClosed { peer: peer_id })
 					}
 					NotificationEvent::NotificationStreamOpenFailure {
 						peer,

--- a/substrate/client/network/src/litep2p/shim/notification/peerset.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/peerset.rs
@@ -542,8 +542,8 @@ impl Peerset {
 		match &state {
 			// close was initiated either by remote ([`PeerState::Connected`]) or local node
 			// ([`PeerState::Closing`]) and it was a non-reserved peer
-			PeerState::Connected { direction: Direction::Inbound(Reserved::No) } |
-			PeerState::Closing { direction: Direction::Inbound(Reserved::No) } => {
+			PeerState::Connected { direction: Direction::Inbound(Reserved::No) }
+			| PeerState::Closing { direction: Direction::Inbound(Reserved::No) } => {
 				log::trace!(
 					target: LOG_TARGET,
 					"{}: inbound substream closed to non-reserved peer {peer:?}: {state:?}",
@@ -559,8 +559,8 @@ impl Peerset {
 			},
 			// close was initiated either by remote ([`PeerState::Connected`]) or local node
 			// ([`PeerState::Closing`]) and it was a non-reserved peer
-			PeerState::Connected { direction: Direction::Outbound(Reserved::No) } |
-			PeerState::Closing { direction: Direction::Outbound(Reserved::No) } => {
+			PeerState::Connected { direction: Direction::Outbound(Reserved::No) }
+			| PeerState::Closing { direction: Direction::Outbound(Reserved::No) } => {
 				log::trace!(
 					target: LOG_TARGET,
 					"{}: outbound substream closed to non-reserved peer {peer:?} {state:?}",
@@ -603,6 +603,35 @@ impl Peerset {
 			Delay::new(DEFAULT_BACKOFF).await;
 			(peer, DISCONNECT_ADJUSTMENT)
 		}));
+	}
+
+	/// Try to immediately reopen a reserved peer after a close event.
+	///
+	/// The close path still keeps the delayed disconnect penalty, but reserved peers should not
+	/// have to wait for the generic allocator/backoff path before a fresh outbound open attempt is
+	/// issued.
+	pub(crate) fn try_reopen_reserved_peer_after_close(
+		&mut self,
+		peer: PeerId,
+	) -> Option<PeersetNotificationCommand> {
+		if !self.reserved_peers.contains(&peer) || self.peerstore_handle.is_banned(&peer) {
+			return None;
+		}
+
+		if !matches!(self.peers.get(&peer), Some(PeerState::Backoff)) {
+			return None;
+		}
+
+		log::trace!(
+			target: LOG_TARGET,
+			"{}: immediately reopen reserved peer {peer:?}",
+			self.protocol,
+		);
+
+		self.peers
+			.insert(peer, PeerState::Opening { direction: Direction::Outbound(Reserved::Yes) });
+
+		Some(PeersetNotificationCommand::open_substream(vec![peer]))
 	}
 
 	/// Report to [`Peerset`] that an inbound substream was opened and that it should validate it.
@@ -792,8 +821,8 @@ impl Peerset {
 				_ => {},
 			},
 			// reserved peers do not require change in the slot counts
-			Some(PeerState::Opening { direction: Direction::Inbound(Reserved::Yes) }) |
-			Some(PeerState::Opening { direction: Direction::Outbound(Reserved::Yes) }) => {
+			Some(PeerState::Opening { direction: Direction::Inbound(Reserved::Yes) })
+			| Some(PeerState::Opening { direction: Direction::Outbound(Reserved::Yes) }) => {
 				log::debug!(
 					target: LOG_TARGET,
 					"{}: substream open failure for reserved peer {peer:?}",
@@ -885,10 +914,10 @@ impl Peerset {
 			match self.peers.get_mut(peer) {
 				Some(PeerState::Disconnected | PeerState::Backoff) => {},
 				Some(
-					PeerState::Opening { ref mut direction } |
-					PeerState::Connected { ref mut direction } |
-					PeerState::Canceled { ref mut direction } |
-					PeerState::Closing { ref mut direction },
+					PeerState::Opening { ref mut direction }
+					| PeerState::Connected { ref mut direction }
+					| PeerState::Canceled { ref mut direction }
+					| PeerState::Closing { ref mut direction },
 				) => {
 					*direction = match direction {
 						Direction::Inbound(Reserved::No) => {
@@ -1441,8 +1470,8 @@ impl Stream for Peerset {
 							.peers
 							.iter()
 							.filter_map(|(peer, state)| {
-								(!self.reserved_peers.contains(peer) &&
-									std::matches!(state, PeerState::Connected { .. }))
+								(!self.reserved_peers.contains(peer)
+									&& std::matches!(state, PeerState::Connected { .. }))
 								.then_some(*peer)
 							})
 							.collect::<Vec<_>>();

--- a/substrate/client/network/src/litep2p/shim/notification/tests/fuzz.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/tests/fuzz.rs
@@ -187,15 +187,31 @@ async fn test_once() {
 					if let Some(peer) = open.keys().choose(&mut rng).copied() {
 						let _ = open.remove(&peer).unwrap();
 						peerset.report_substream_closed(peer);
-						assert!(closed.insert(peer));
+
+						if let Some(command) = peerset.try_reopen_reserved_peer_after_close(peer) {
+							assert!(command.close_peers.is_empty());
+							assert_eq!(command.open_peers, vec![peer]);
+							closed.remove(&peer);
+							opening.insert(peer, Direction::Outbound);
+						} else {
+							assert!(closed.insert(peer));
+						}
 					}
 				},
 				// substream was closed by local node
 				5 => {
 					if let Some(peer) = closing.iter().choose(&mut rng).copied() {
 						assert!(closing.remove(&peer));
-						assert!(closed.insert(peer));
 						peerset.report_substream_closed(peer);
+
+						if let Some(command) = peerset.try_reopen_reserved_peer_after_close(peer) {
+							assert!(command.close_peers.is_empty());
+							assert_eq!(command.open_peers, vec![peer]);
+							closed.remove(&peer);
+							opening.insert(peer, Direction::Outbound);
+						} else {
+							assert!(closed.insert(peer));
+						}
 					}
 				},
 				// random connected peer was disconnected by the protocol

--- a/substrate/client/network/src/litep2p/shim/notification/tests/mod.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/tests/mod.rs
@@ -20,3 +20,5 @@
 mod fuzz;
 #[cfg(test)]
 mod peerset;
+#[cfg(test)]
+mod protocol;

--- a/substrate/client/network/src/litep2p/shim/notification/tests/peerset.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/tests/peerset.rs
@@ -23,6 +23,7 @@ use crate::{
 			Direction, OpenResult, PeerState, Peerset, PeersetCommand, Reserved,
 		},
 	},
+	peer_store::PeerStoreProvider,
 	service::traits::{self, ValidationResult},
 	ProtocolName,
 };
@@ -30,6 +31,7 @@ use crate::{
 use futures::prelude::*;
 use litep2p::protocol::notification::NotificationError;
 
+use sc_network_common::types::ReputationChange;
 use sc_network_types::PeerId;
 
 use std::{
@@ -624,9 +626,151 @@ async fn opening_peer_gets_canceled_and_disconnected() {
 
 	// report close event to `Peerset` and verify state
 	peerset.report_substream_closed(peer);
+	assert!(peerset.try_reopen_reserved_peer_after_close(peer).is_none());
 	assert_eq!(peerset.num_out(), 0);
 	assert_eq!(num_connected.load(Ordering::SeqCst), 0);
 	assert_eq!(peerset.peers().get(&peer), Some(&PeerState::Backoff));
+}
+
+#[tokio::test]
+async fn reserved_peer_close_triggers_immediate_reopen() {
+	sp_tracing::try_init_simple();
+
+	let peerstore_handle = Arc::new(peerstore_handle_test());
+	let reserved_peer = PeerId::random();
+	let reserved_peers = HashSet::from_iter([reserved_peer]);
+	let num_connected = Arc::new(Default::default());
+	let (mut peerset, _to_peerset) = Peerset::new(
+		ProtocolName::from("/notif/1"),
+		0,
+		0,
+		true,
+		reserved_peers,
+		Arc::clone(&num_connected),
+		peerstore_handle,
+	);
+
+	match peerset.next().await {
+		Some(command) => {
+			assert!(command.close_peers.is_empty());
+			assert_eq!(command.open_peers, vec![reserved_peer]);
+		},
+		event => panic!("invalid event: {event:?}"),
+	}
+
+	assert!(std::matches!(
+		peerset.report_substream_opened(reserved_peer, traits::Direction::Outbound),
+		OpenResult::Accept { .. }
+	));
+	assert_eq!(
+		peerset.peers().get(&reserved_peer),
+		Some(&PeerState::Connected { direction: Direction::Outbound(Reserved::Yes) })
+	);
+	assert_eq!(num_connected.load(Ordering::SeqCst), 1);
+
+	peerset.report_substream_closed(reserved_peer);
+
+	let command = peerset
+		.try_reopen_reserved_peer_after_close(reserved_peer)
+		.expect("reserved peer should be reopened immediately");
+	assert!(command.close_peers.is_empty());
+	assert_eq!(command.open_peers, vec![reserved_peer]);
+	assert_eq!(
+		peerset.peers().get(&reserved_peer),
+		Some(&PeerState::Opening { direction: Direction::Outbound(Reserved::Yes) })
+	);
+	assert_eq!(num_connected.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn removed_reserved_peer_close_does_not_immediate_reopen() {
+	sp_tracing::try_init_simple();
+
+	let peerstore_handle = Arc::new(peerstore_handle_test());
+	let reserved_peer = PeerId::random();
+	let reserved_peers = HashSet::from_iter([reserved_peer]);
+	let (mut peerset, to_peerset) = Peerset::new(
+		ProtocolName::from("/notif/1"),
+		0,
+		0,
+		false,
+		reserved_peers,
+		Default::default(),
+		peerstore_handle,
+	);
+
+	match peerset.next().await {
+		Some(command) => {
+			assert!(command.close_peers.is_empty());
+			assert_eq!(command.open_peers, vec![reserved_peer]);
+		},
+		event => panic!("invalid event: {event:?}"),
+	}
+
+	assert!(std::matches!(
+		peerset.report_substream_opened(reserved_peer, traits::Direction::Outbound),
+		OpenResult::Accept { .. }
+	));
+
+	to_peerset
+		.unbounded_send(PeersetCommand::RemoveReservedPeers {
+			peers: HashSet::from_iter([reserved_peer]),
+		})
+		.unwrap();
+
+	match peerset.next().await {
+		Some(command) => {
+			assert!(command.open_peers.is_empty());
+			assert_eq!(command.close_peers, vec![reserved_peer]);
+		},
+		event => panic!("invalid event: {event:?}"),
+	}
+
+	assert!(!peerset.reserved_peers().contains(&reserved_peer));
+
+	peerset.report_substream_closed(reserved_peer);
+
+	assert!(peerset.try_reopen_reserved_peer_after_close(reserved_peer).is_none());
+	assert_eq!(peerset.peers().get(&reserved_peer), Some(&PeerState::Backoff));
+}
+
+#[tokio::test]
+async fn banned_reserved_peer_close_does_not_immediate_reopen() {
+	sp_tracing::try_init_simple();
+
+	let peerstore_handle = Arc::new(peerstore_handle_test());
+	let reserved_peer = PeerId::random();
+	let reserved_peers = HashSet::from_iter([reserved_peer]);
+	let (mut peerset, _to_peerset) = Peerset::new(
+		ProtocolName::from("/notif/1"),
+		0,
+		0,
+		true,
+		reserved_peers,
+		Default::default(),
+		peerstore_handle.clone(),
+	);
+
+	match peerset.next().await {
+		Some(command) => {
+			assert!(command.close_peers.is_empty());
+			assert_eq!(command.open_peers, vec![reserved_peer]);
+		},
+		event => panic!("invalid event: {event:?}"),
+	}
+
+	assert!(std::matches!(
+		peerset.report_substream_opened(reserved_peer, traits::Direction::Outbound),
+		OpenResult::Accept { .. }
+	));
+
+	peerstore_handle.report_peer(reserved_peer, ReputationChange::new_fatal(""));
+	assert!(peerstore_handle.is_banned(&reserved_peer));
+
+	peerset.report_substream_closed(reserved_peer);
+
+	assert!(peerset.try_reopen_reserved_peer_after_close(reserved_peer).is_none());
+	assert_eq!(peerset.peers().get(&reserved_peer), Some(&PeerState::Backoff));
 }
 
 #[tokio::test]

--- a/substrate/client/network/src/litep2p/shim/notification/tests/protocol.rs
+++ b/substrate/client/network/src/litep2p/shim/notification/tests/protocol.rs
@@ -1,0 +1,443 @@
+// This file is part of Substrate.
+//
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+	config::{MultiaddrWithPeerId, NonReservedPeerMode, NotificationHandshake, SetConfig},
+	litep2p::{
+		peerstore::peerstore_handle_test,
+		shim::notification::{config::NotificationProtocolConfig, peerset::PeersetCommand},
+	},
+	service::{
+		metrics::NotificationMetrics,
+		traits::{
+			NotificationEvent as SubstrateNotificationEvent, NotificationService, ValidationResult,
+		},
+	},
+	ProtocolName,
+};
+
+use futures::StreamExt;
+use litep2p::{
+	config::ConfigBuilder as Litep2pConfigBuilder,
+	protocol::notification::{
+		Config as Litep2pNotificationConfig, NotificationEvent as Litep2pNotificationEvent,
+		NotificationHandle, ValidationResult as Litep2pValidationResult,
+	},
+	transport::tcp::config::Config as TcpConfig,
+	Litep2p, Litep2pEvent,
+};
+use sc_network_types::{multiaddr::Multiaddr, PeerId};
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+const PROTOCOL_NAME: &str = "/notif/1";
+const HANDSHAKE: &[u8] = &[1, 2, 3, 4];
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const INITIAL_EVENT_TIMEOUT: Duration = Duration::from_secs(10);
+const NO_USER_EVENT_GRACE: Duration = Duration::from_millis(250);
+const FAST_REOPEN_TIMEOUT: Duration = Duration::from_secs(4);
+const CANCEL_QUIET_PERIOD: Duration = Duration::from_secs(2);
+
+async fn make_raw_litep2p() -> (Litep2p, NotificationHandle) {
+	let (config, handle) = Litep2pNotificationConfig::new(
+		litep2p::types::protocol::ProtocolName::from(PROTOCOL_NAME),
+		1024,
+		HANDSHAKE.to_vec(),
+		Vec::new(),
+		false,
+		64,
+		64,
+		true,
+	);
+
+	let litep2p = Litep2p::new(
+		Litep2pConfigBuilder::new()
+			.with_tcp(TcpConfig {
+				listen_addresses: vec![
+					"/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+					"/ip6/::1/tcp/0".parse().unwrap(),
+				],
+				..Default::default()
+			})
+			.with_notification_protocol(config)
+			.build(),
+	)
+	.unwrap();
+
+	(litep2p, handle)
+}
+
+async fn make_notification_protocol_litep2p(
+	set_config: SetConfig,
+) -> (
+	Litep2p,
+	Box<dyn NotificationService>,
+	crate::litep2p::shim::notification::config::ProtocolControlHandle,
+) {
+	let (config, protocol) = NotificationProtocolConfig::new(
+		ProtocolName::from(PROTOCOL_NAME),
+		Vec::new(),
+		1024,
+		Some(NotificationHandshake::from_bytes(HANDSHAKE.to_vec())),
+		set_config,
+		NotificationMetrics::new(None),
+		Arc::new(peerstore_handle_test()),
+	);
+
+	let control = config.handle.clone();
+	let litep2p = Litep2p::new(
+		Litep2pConfigBuilder::new()
+			.with_tcp(TcpConfig {
+				listen_addresses: vec![
+					"/ip4/127.0.0.1/tcp/0".parse().unwrap(),
+					"/ip6/::1/tcp/0".parse().unwrap(),
+				],
+				..Default::default()
+			})
+			.with_notification_protocol(config.config)
+			.build(),
+	)
+	.unwrap();
+
+	(litep2p, protocol, control)
+}
+
+async fn connect_peers(lhs: &mut Litep2p, rhs: &mut Litep2p) {
+	let rhs_address = rhs
+		.listen_addresses()
+		.find(|address| address.to_string().starts_with("/ip4/"))
+		.or_else(|| rhs.listen_addresses().next())
+		.expect("litep2p should expose at least one listen address")
+		.clone();
+	lhs.dial_address(rhs_address).await.unwrap();
+
+	let mut lhs_connected = false;
+	let mut rhs_connected = false;
+
+	while !lhs_connected || !rhs_connected {
+		tokio::select! {
+			event = lhs.next_event() => match event.unwrap() {
+				Litep2pEvent::ConnectionEstablished { .. } => lhs_connected = true,
+				_ => {}
+			},
+			event = rhs.next_event() => match event.unwrap() {
+				Litep2pEvent::ConnectionEstablished { .. } => rhs_connected = true,
+				_ => {}
+			},
+		}
+	}
+}
+
+#[tokio::test]
+async fn notification_protocol_reserved_close_reopens_immediately() {
+	sp_tracing::try_init_simple();
+
+	let (mut remote_litep2p, mut remote_handle) = make_raw_litep2p().await;
+	let remote_peer: PeerId = (*remote_litep2p.local_peer_id()).into();
+	let remote_litep2p_address = remote_litep2p
+		.listen_addresses()
+		.find(|address| address.to_string().starts_with("/ip4/"))
+		.or_else(|| remote_litep2p.listen_addresses().next())
+		.expect("litep2p should expose at least one listen address")
+		.clone();
+
+	let (mut protocol_litep2p, mut protocol, control) =
+		make_notification_protocol_litep2p(SetConfig {
+			in_peers: 1,
+			out_peers: 0,
+			reserved_nodes: Vec::new(),
+			non_reserved_mode: NonReservedPeerMode::Accept,
+		})
+		.await;
+	let protocol_peer: PeerId = (*protocol_litep2p.local_peer_id()).into();
+	assert!(
+		protocol_litep2p
+			.add_known_address(remote_peer.into(), std::iter::once(remote_litep2p_address))
+			> 0
+	);
+
+	tokio::time::timeout(
+		CONNECT_TIMEOUT,
+		connect_peers(&mut protocol_litep2p, &mut remote_litep2p),
+	)
+	.await
+	.expect("litep2p peers should establish a loopback connection for the protocol test");
+
+	let protocol_driver =
+		tokio::spawn(async move { while let Some(_) = protocol_litep2p.next_event().await {} });
+	let remote_driver =
+		tokio::spawn(async move { while let Some(_) = remote_litep2p.next_event().await {} });
+
+	remote_handle.open_substream(protocol_peer.into()).await.unwrap();
+
+	let mut protocol_opened = false;
+	let mut remote_open_events = 0usize;
+
+	tokio::time::timeout(INITIAL_EVENT_TIMEOUT, async {
+		loop {
+			tokio::select! {
+				event = protocol.next_event() => match event.unwrap() {
+					SubstrateNotificationEvent::ValidateInboundSubstream {
+						peer,
+						handshake,
+						result_tx,
+					} => {
+						assert_eq!(peer, remote_peer);
+						assert_eq!(handshake, HANDSHAKE);
+						result_tx.send(ValidationResult::Accept).unwrap();
+					},
+					SubstrateNotificationEvent::NotificationStreamOpened {
+						peer,
+						direction,
+						handshake,
+						negotiated_fallback,
+					} => {
+						assert_eq!(peer, remote_peer);
+						assert!(direction.is_inbound());
+						assert_eq!(handshake, HANDSHAKE);
+						assert!(negotiated_fallback.is_none());
+						protocol_opened = true;
+						if protocol_opened && remote_open_events == 1 {
+							break;
+						}
+					},
+					event => panic!("unexpected protocol event before initial open: {event:?}"),
+				},
+				event = remote_handle.next() => match event.unwrap() {
+					Litep2pNotificationEvent::ValidateSubstream { peer, handshake, .. } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						assert_eq!(handshake, HANDSHAKE);
+						remote_handle.send_validation_result(peer, Litep2pValidationResult::Accept);
+					},
+					Litep2pNotificationEvent::NotificationStreamOpened { peer, handshake, .. } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						assert_eq!(handshake, HANDSHAKE);
+						remote_open_events += 1;
+						if protocol_opened && remote_open_events == 1 {
+							break;
+						}
+					},
+					event => panic!("unexpected remote event before initial open: {event:?}"),
+				},
+			}
+		}
+	})
+	.await
+	.expect("initial inbound open should complete");
+
+	control
+		.tx
+		.unbounded_send(PeersetCommand::AddReservedPeers {
+			peers: HashSet::from_iter([remote_peer]),
+		})
+		.unwrap();
+
+	match tokio::time::timeout(NO_USER_EVENT_GRACE, protocol.next_event()).await {
+		Err(_) => {},
+		Ok(Some(event)) => {
+			panic!("unexpected protocol event while marking the peer reserved: {event:?}")
+		},
+		Ok(None) => panic!("notification protocol terminated unexpectedly"),
+	}
+
+	remote_handle.close_substream(protocol_peer.into()).await;
+
+	let mut saw_close = false;
+	let mut saw_reopen_validate = false;
+
+	tokio::time::timeout(FAST_REOPEN_TIMEOUT, async {
+		loop {
+			tokio::select! {
+				event = protocol.next_event() => match event.unwrap() {
+					SubstrateNotificationEvent::NotificationStreamClosed { peer } => {
+						assert_eq!(peer, remote_peer);
+						saw_close = true;
+					},
+					SubstrateNotificationEvent::NotificationStreamOpened {
+						peer,
+						direction,
+						handshake,
+						negotiated_fallback,
+					} => {
+						assert!(saw_close, "reopen should be reported only after the close event");
+						assert_eq!(peer, remote_peer);
+						assert!(!direction.is_inbound());
+						assert_eq!(handshake, HANDSHAKE);
+						assert!(negotiated_fallback.is_none());
+						break;
+					},
+					event => panic!("unexpected protocol event after remote close: {event:?}"),
+				},
+				event = remote_handle.next() => match event.unwrap() {
+					Litep2pNotificationEvent::ValidateSubstream { peer, handshake, .. } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						assert_eq!(handshake, HANDSHAKE);
+						saw_reopen_validate = true;
+						remote_handle.send_validation_result(peer, Litep2pValidationResult::Accept);
+					},
+					Litep2pNotificationEvent::NotificationStreamOpened { peer, handshake, .. } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						assert_eq!(handshake, HANDSHAKE);
+						remote_open_events += 1;
+					},
+					Litep2pNotificationEvent::NotificationStreamClosed { peer } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+					},
+					Litep2pNotificationEvent::NotificationReceived { .. } => {}
+					event => panic!("unexpected remote event after remote close: {event:?}"),
+				},
+			}
+		}
+	})
+	.await
+	.expect("reserved peer should reopen before the 5s generic backoff expires");
+
+	assert!(saw_close);
+	assert!(saw_reopen_validate);
+	assert!(remote_open_events >= 1);
+
+	protocol_driver.abort();
+	remote_driver.abort();
+}
+
+#[tokio::test]
+async fn notification_protocol_cancel_close_does_not_immediate_reopen() {
+	sp_tracing::try_init_simple();
+
+	let (mut remote_litep2p, mut remote_handle) = make_raw_litep2p().await;
+	let remote_peer: PeerId = (*remote_litep2p.local_peer_id()).into();
+	let remote_litep2p_address = remote_litep2p
+		.listen_addresses()
+		.find(|address| address.to_string().starts_with("/ip4/"))
+		.or_else(|| remote_litep2p.listen_addresses().next())
+		.expect("litep2p should expose at least one listen address")
+		.clone();
+	let remote_address: Multiaddr = remote_litep2p_address.clone().into();
+
+	let (mut protocol_litep2p, mut protocol, control) =
+		make_notification_protocol_litep2p(SetConfig {
+			in_peers: 0,
+			out_peers: 0,
+			reserved_nodes: vec![MultiaddrWithPeerId {
+				multiaddr: remote_address,
+				peer_id: remote_peer,
+			}],
+			non_reserved_mode: NonReservedPeerMode::Deny,
+		})
+		.await;
+	let protocol_peer: PeerId = (*protocol_litep2p.local_peer_id()).into();
+	assert!(
+		protocol_litep2p
+			.add_known_address(remote_peer.into(), std::iter::once(remote_litep2p_address))
+			> 0
+	);
+
+	tokio::time::timeout(
+		CONNECT_TIMEOUT,
+		connect_peers(&mut protocol_litep2p, &mut remote_litep2p),
+	)
+	.await
+	.expect("litep2p peers should establish a loopback connection for the protocol test");
+
+	let protocol_driver =
+		tokio::spawn(async move { while let Some(_) = protocol_litep2p.next_event().await {} });
+	let remote_driver =
+		tokio::spawn(async move { while let Some(_) = remote_litep2p.next_event().await {} });
+
+	let validation_peer = tokio::time::timeout(INITIAL_EVENT_TIMEOUT, async {
+		loop {
+			tokio::select! {
+				event = protocol.next_event() => match event.unwrap() {
+					event => panic!("unexpected protocol event before remote validation: {event:?}"),
+				},
+				event = remote_handle.next() => match event.unwrap() {
+					Litep2pNotificationEvent::ValidateSubstream { peer, handshake, .. } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						assert_eq!(handshake, HANDSHAKE);
+						break peer;
+					},
+					event => panic!("unexpected remote event before remote validation: {event:?}"),
+				},
+			}
+		}
+	})
+	.await
+	.expect("initial validation should arrive");
+
+	control
+		.tx
+		.unbounded_send(PeersetCommand::RemoveReservedPeers {
+			peers: HashSet::from_iter([remote_peer]),
+		})
+		.unwrap();
+	control
+		.tx
+		.unbounded_send(PeersetCommand::AddReservedPeers {
+			peers: HashSet::from_iter([remote_peer]),
+		})
+		.unwrap();
+
+	match tokio::time::timeout(NO_USER_EVENT_GRACE, protocol.next_event()).await {
+		Err(_) => {},
+		Ok(Some(event)) => {
+			panic!("unexpected protocol event while processing cancel/re-add commands: {event:?}")
+		},
+		Ok(None) => panic!("notification protocol terminated unexpectedly"),
+	}
+
+	remote_handle.send_validation_result(validation_peer, Litep2pValidationResult::Accept);
+
+	let mut saw_remote_close = false;
+	let outcome = tokio::time::timeout(CANCEL_QUIET_PERIOD, async {
+		loop {
+			tokio::select! {
+				event = protocol.next_event() => match event {
+					Some(event) => panic!("unexpected protocol event after cancel-driven close: {event:?}"),
+					None => panic!("notification protocol terminated unexpectedly"),
+				},
+				event = remote_handle.next() => match event.unwrap() {
+					Litep2pNotificationEvent::NotificationStreamOpened { peer, handshake, .. } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						assert_eq!(handshake, HANDSHAKE);
+					},
+					Litep2pNotificationEvent::NotificationStreamClosed { peer } => {
+						assert_eq!(Into::<PeerId>::into(peer), protocol_peer);
+						saw_remote_close = true;
+					},
+					Litep2pNotificationEvent::ValidateSubstream { peer, .. } => {
+						panic!(
+							"cancel-driven close should not immediate-reopen reserved peer {peer:?}"
+						);
+					},
+					Litep2pNotificationEvent::NotificationReceived { .. } => {}
+					event => panic!("unexpected remote event after cancel-driven close: {event:?}"),
+				},
+			}
+		}
+	})
+	.await;
+
+	assert!(
+		outcome.is_err(),
+		"cancel-driven close should stay quiet until the normal 5s backoff path, not reopen inside the 2s quiet window"
+	);
+	assert!(saw_remote_close, "remote side should observe the canceled substream closing");
+
+	protocol_driver.abort();
+	remote_driver.abort();
+}


### PR DESCRIPTION

## Summary

Fixes `#11540` by issuing one immediate reopen attempt when a currently reserved litep2p notification substream closes, instead of waiting for the generic backoff allocator path.

- keep the fix inside the notification shim
- preserve the existing delayed disconnect penalty and generic open-failure behavior
- skip the fast reopen path for cancel-driven closes
- add peerset, fuzz, and protocol-level regression coverage for both the happy path and the nearby cancel path

## Why This Shape

The issue is a notification-layer liveness hole, not a transport dedup problem.

`litep2p` can already promote or reuse a healthy connection. What is missing is a prompt notification-substream reopen intent after a reserved peer closes. This patch supplies exactly that one-shot intent and leaves the rest of the retry policy untouched.

That keeps the PR reviewer-friendly:

- no transport rewrite
- no sync-engine redesign
- no special-casing of generic `NotificationStreamOpenFailure`
- if the immediate reopen later fails, the existing open-failure backoff path still takes over

## What Changed

- in `NotificationStreamClosed`, report the close, account for `pending_cancels`, and only then trigger an immediate reopen for non-cancel reserved closes
- add `Peerset::try_reopen_reserved_peer_after_close(...)`, gated by:
  - current reserved membership
  - not banned
  - state is exactly `Backoff`
- keep the delayed disconnect penalty untouched even when the fast reopen path is taken
- update the fuzz model so reserved close can move directly back into `opening`
- add direct protocol-level integration coverage using real `Litep2p + NotificationProtocol`

## Tests

- `cargo test -p sc-network reserved_peer_close_triggers_immediate_reopen -- --nocapture`
- `cargo test -p sc-network removed_reserved_peer_close_does_not_immediate_reopen -- --nocapture`
- `cargo test -p sc-network banned_reserved_peer_close_does_not_immediate_reopen -- --nocapture`
- `cargo test -p sc-network peerset:: -- --nocapture`
- `cargo test -p sc-network notification_protocol_reserved_close_reopens_immediately -- --nocapture`
- `cargo test -p sc-network notification_protocol_cancel_close_does_not_immediate_reopen -- --nocapture`
- `cargo test -p sc-network run -- --nocapture`
- `cargo test -p sc-network --no-run`
- `git diff --check`

## Test Stability

The protocol-level tests were also hardened after review so they are easier to trust in CI:

- prefer IPv4 loopback addresses when dual-stack listen addresses are available
- wrap peer connection setup in an explicit `10s` timeout so failures fail fast instead of hanging
- replace timeout magic numbers with named constants for the open, quiet, and reopen windows
- rerun the two protocol tests in a `10x` stress loop (`20` total executions) after the harness change

I also rescanned `substrate/client/network/src/litep2p/shim/notification/tests/` after that pass. The only wall-clock / address-order sensitive file in this test module is `tests/protocol.rs`; `tests/peerset.rs` and `tests/fuzz.rs` stay fully state-driven, so no wider anti-flake patch was needed.

## Notes

- The cancel-path guard matters: a close that only completes a locally requested cancel should not immediately reopen the peer.
- The new protocol tests are meant to prove both sides of the boundary:
  - normal reserved close reopens before the generic `5s` backoff window
  - cancel-driven close stays quiet until the normal path takes over

## References

- Issue report:
  - `https://github.com/paritytech/polkadot-sdk/issues/11540`
- Maintainer discussion that narrowed the root cause to notification-layer backoff after close, rather than transport dedup teardown:
  - `https://github.com/paritytech/polkadot-sdk/issues/11540#issuecomment-4153765351`
- Tokio `select!` docs on polling order and the effect of `biased;`, which is part of why an event-path reopen is cleaner than only shrinking a timer:
  - `https://docs.rs/tokio/latest/tokio/macro.select.html`
