### PR TITLE
Fix bridges integration test failure for the Westend network

### DIFF
--- a/bridges/testing/environments/rococo-westend/bridge_hub_westend_local_network.toml
+++ b/bridges/testing/environments/rococo-westend/bridge_hub_westend_local_network.toml
@@ -59,14 +59,16 @@ cumulus_based = true
 	rpc_port = 9010
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
 	args = [
-		"-lparachain=debug,xcm=trace,runtime::bridge=trace,txpool=trace"
+		"-lparachain=debug,xcm=trace,runtime::bridge=trace,txpool=trace",
+		"--authoring", "slot-based"
 	]
 
 	[[parachains.collators]]
 	name = "asset-hub-westend-collator2"
 	command = "{{POLKADOT_PARACHAIN_BINARY}}"
 	args = [
-		"-lparachain=debug,xcm=trace,runtime::bridge=trace,txpool=trace"
+		"-lparachain=debug,xcm=trace,runtime::bridge=trace,txpool=trace",
+		"--authoring", "slot-based"
 	]
 
 #[[hrmp_channels]]


### PR DESCRIPTION
## Description

  Fix bridges **integration test failure** for the Westend network by using the slot-based collator for asset-hub-westend nodes.

  The `asset-hub-westend` runtime configures `RelayParentOffset = 1` (at `cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs:138`) in this [commit](https://github.com/paritytech/polkadot-sdk/commit/8e911a6ebc6965480621db8e89b1ecb157df9eba) , which  requires relay parent descendant headers in the parachain inherent data. However, the **zombienet** test was launching the collators with the default look ahead authoring policy, which passes an empty `relay_parent_descendants` vec. This caused a runtime panic on every block build attempt:

```
  Unable to verify provided relay parent descendants.
  expected_rp_descendants_num: 1
  error: InvalidNumberOfDescendants { expected: 2, received: 0 }
```

  The parachain remained stuck at block #0, failing the test assertion:
  asset-hub-westend-collator1: reports block height is at least 10 within 180 seconds

  Only the slot-based collator (`collators/slot_based/block_builder_task.rs`) calls `create_inherent_data_with_rp_offset()` with the required descendant data. The look ahead and basic collators call `create_inherent_data()` which passes `None`.

## Integration

This change only affects a zombienet test TOML configuration file. No crate changes.

## Review Notes

  The fix adds "--authoring", "slot-based" to both asset-hub-westend-collator1 and asset-hub-westend-collator2 in
  bridges/testing/environments/rococo-westend/bridge_hub_westend_local_network.toml.

  This is only needed for the Westend side because:
  - asset-hub-westend has RelayParentOffset = ConstU32<1> — requires descendant headers
  - asset-hub-rococo has RelayParentOffset = ConstU32<0> — no descendant verification, works with any collator

  The Rococo TOML (bridge_hub_rococo_local_network.toml) is unchanged since its asset-hub runtime doesn't require relay parent descendants.