### PR TITLE
Reject delegatecall into precompiles via PrecompileDelegateDenied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11973,6 +11973,7 @@ dependencies = [
  "pallet-assets",
  "pallet-balances",
  "pallet-revive",
+ "pallet-revive-fixtures",
  "parity-scale-codec",
  "scale-info",
  "sp-core 28.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14943,6 +14943,7 @@ dependencies = [
  "pallet-assets",
  "pallet-balances",
  "pallet-revive",
+ "pallet-revive-fixtures",
  "pallet-timestamp",
  "pallet-xcm",
  "parity-scale-codec",

--- a/polkadot/xcm/pallet-xcm/precompiles/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/precompiles/Cargo.toml
@@ -29,6 +29,7 @@ xcm-executor = { workspace = true }
 frame-system = { workspace = true, default-features = true }
 pallet-assets = { workspace = true, default-features = true }
 pallet-balances = { workspace = true, default-features = true }
+pallet-revive-fixtures = { workspace = true, default-features = true }
 pallet-timestamp = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true, default-features = true }
 scale-info = { workspace = true, default-features = true }

--- a/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
@@ -75,6 +75,11 @@ where
 		input: &Self::Interface,
 		env: &mut impl Ext<T = Self::T>,
 	) -> Result<Vec<u8>, Error> {
+		frame_support::ensure!(
+			!env.is_delegate_call(),
+			pallet_revive::Error::<Self::T>::PrecompileDelegateDenied,
+		);
+
 		let origin = env.caller();
 		let frame_origin = match origin {
 			Origin::Root => RawOrigin::Root.into(),
@@ -82,9 +87,6 @@ where
 		};
 
 		match input {
-			_ if env.is_delegate_call() => {
-				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into())
-			},
 			IXcmCalls::send(_) | IXcmCalls::execute(_) if env.is_read_only() => {
 				Err(Error::Error(pallet_revive::Error::<Self::T>::StateChangeDenied.into()))
 			},

--- a/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
@@ -82,8 +82,9 @@ where
 		};
 
 		match input {
-			_ if env.is_delegate_call() =>
-				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into()),
+			_ if env.is_delegate_call() => {
+				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into())
+			},
 			IXcmCalls::send(_) | IXcmCalls::execute(_) if env.is_read_only() => {
 				Err(Error::Error(pallet_revive::Error::<Self::T>::StateChangeDenied.into()))
 			},

--- a/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
@@ -44,7 +44,6 @@ mod mock;
 mod tests;
 
 const LOG_TARGET: &str = "xcm::precompiles";
-const ERR_DELEGATE_CALL: &str = "Cannot be called via delegate call";
 
 fn revert(error: &impl fmt::Debug, message: &str) -> Error {
 	error!(target: LOG_TARGET, ?error, "{}", message);
@@ -83,9 +82,8 @@ where
 		};
 
 		match input {
-			_ if env.is_delegate_call() => {
-				Err(Error::Revert(ERR_DELEGATE_CALL.into()))
-			},
+			_ if env.is_delegate_call() =>
+				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into()),
 			IXcmCalls::send(_) | IXcmCalls::execute(_) if env.is_read_only() => {
 				Err(Error::Error(pallet_revive::Error::<Self::T>::StateChangeDenied.into()))
 			},

--- a/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
+++ b/polkadot/xcm/pallet-xcm/precompiles/src/lib.rs
@@ -44,6 +44,7 @@ mod mock;
 mod tests;
 
 const LOG_TARGET: &str = "xcm::precompiles";
+const ERR_DELEGATE_CALL: &str = "Cannot be called via delegate call";
 
 fn revert(error: &impl fmt::Debug, message: &str) -> Error {
 	error!(target: LOG_TARGET, ?error, "{}", message);
@@ -82,6 +83,9 @@ where
 		};
 
 		match input {
+			_ if env.is_delegate_call() => {
+				Err(Error::Revert(ERR_DELEGATE_CALL.into()))
+			},
 			IXcmCalls::send(_) | IXcmCalls::execute(_) if env.is_read_only() => {
 				Err(Error::Error(pallet_revive::Error::<Self::T>::StateChangeDenied.into()))
 			},

--- a/polkadot/xcm/pallet-xcm/precompiles/src/tests.rs
+++ b/polkadot/xcm/pallet-xcm/precompiles/src/tests.rs
@@ -25,11 +25,11 @@ use pallet_revive::{
 	precompiles::{
 		alloy::{
 			hex,
-			sol_types::{SolInterface, SolValue},
+			sol_types::{SolCall, SolInterface, SolValue},
 		},
 		H160,
 	},
-	ExecConfig, TransactionLimits, U256,
+	Code, ExecConfig, TransactionLimits, U256,
 };
 use polkadot_parachain_primitives::primitives::Id as ParaId;
 use sp_runtime::traits::AccountIdConversion;
@@ -745,5 +745,68 @@ fn weight_fails_on_old_version() {
 			Err(err) => panic!("XcmExecutePrecompile Failed to decode weight with error {err:?}"),
 		};
 		assert!(result.did_revert());
+	});
+}
+
+alloy::sol! {
+	interface ICaller {
+		function delegate(address callee, bytes data, uint64 gas) external returns (bool success, bytes output);
+	}
+}
+
+/// The delegatecall guard rejects all calls via delegatecall.
+#[test]
+fn delegatecall_is_rejected() {
+	let balances = vec![(ALICE, 1_000_000_000_000_000u128)];
+	new_test_ext_with_balances(balances).execute_with(|| {
+		let xcm_precompile_addr = H160::from(
+			hex::const_decode_to_array(b"00000000000000000000000000000000000A0000").unwrap(),
+		);
+
+		let (init_code, _) = pallet_revive_fixtures::compile_module_with_type(
+			"Caller",
+			pallet_revive_fixtures::FixtureType::Solc,
+		)
+		.expect("Caller fixture must be compiled");
+		let caller_addr = pallet_revive::Pallet::<Test>::bare_instantiate(
+			RuntimeOrigin::signed(ALICE),
+			0u32.into(),
+			TransactionLimits::WeightAndDeposit {
+				weight_limit: Weight::MAX,
+				deposit_limit: u128::MAX,
+			},
+			Code::Upload(init_code),
+			vec![],
+			None,
+			&ExecConfig::new_substrate_tx(),
+		)
+		.result
+		.expect("Caller deployment must succeed")
+		.addr;
+
+		let calldata = ICaller::delegateCall {
+			callee: alloy::primitives::Address::from(xcm_precompile_addr.0),
+			data: IXcm::weighMessageCall { message: Default::default() }.abi_encode().into(),
+			gas: u64::MAX,
+		}
+		.abi_encode();
+
+		let result = pallet_revive::Pallet::<Test>::bare_call(
+			RuntimeOrigin::signed(ALICE),
+			caller_addr,
+			U256::zero(),
+			TransactionLimits::WeightAndDeposit {
+				weight_limit: Weight::MAX,
+				deposit_limit: u128::MAX,
+			},
+			calldata,
+			&ExecConfig::new_substrate_tx(),
+		)
+		.result
+		.expect("outer call must succeed");
+
+		let ret = ICaller::delegateCall::abi_decode_returns(&result.data)
+			.expect("return must decode as (bool, bytes)");
+		assert!(!ret.success, "DELEGATECALL to XCM precompile must be rejected");
 	});
 }

--- a/polkadot/xcm/pallet-xcm/precompiles/src/tests.rs
+++ b/polkadot/xcm/pallet-xcm/precompiles/src/tests.rs
@@ -808,5 +808,13 @@ fn delegatecall_is_rejected() {
 		let ret = ICaller::delegateCall::abi_decode_returns(&result.data)
 			.expect("return must decode as (bool, bytes)");
 		assert!(!ret.success, "DELEGATECALL to XCM precompile must be rejected");
+		// PrecompileDelegateDenied is an Error::Error (trap), not an Error::Revert, so the
+		// inner call produces no output data. A Solidity-level revert would include
+		// ABI-encoded reason bytes.
+		assert!(
+			ret.output.is_empty(),
+			"expected empty output from PrecompileDelegateDenied trap, got {} bytes",
+			ret.output.len(),
+		);
 	});
 }

--- a/prdoc/pr_11715.prdoc
+++ b/prdoc/pr_11715.prdoc
@@ -1,0 +1,30 @@
+title: Reject delegatecall into precompiles via PrecompileDelegateDenied
+doc:
+- audience: Runtime Dev
+  description: "## Summary\n\n- Add delegatecall guard to the ERC20 assets precompile\
+    \ and XCM precompile, matching the existing pattern in the vesting and asset-conversion\
+    \ precompiles\n- Converge asset-conversion precompile from `Error::Revert(string)`\
+    \ to `Error::Error(PrecompileDelegateDenied)` for consistency across all precompiles\n\
+    - Add delegatecall rejection test for the XCM precompile\n\n## Motivation\n\n\
+    Delegatecall to precompiles allows a malicious contract to execute precompile\
+    \ logic in a misleading caller context. The precompiles derive caller identity\
+    \ from `env.caller()`, which during delegatecall returns the original caller \u2014\
+    \ letting the intermediary contract act on the caller's assets or send XCM on\
+    \ their behalf. There is no legitimate use case for delegatecalling into these\
+    \ precompiles.\n\n## Changes\n\n- `substrate/frame/assets/precompiles/src/lib.rs`\
+    \ \u2014 add `PrecompileDelegateDenied` guard\n- `substrate/frame/asset-conversion/precompiles/src/lib.rs`\
+    \ \u2014 replace `Error::Revert(ERR_DELEGATE_CALL)` with `PrecompileDelegateDenied`,\
+    \ remove unused const\n- `polkadot/xcm/pallet-xcm/precompiles/src/lib.rs` \u2014\
+    \ add `PrecompileDelegateDenied` guard\n- `polkadot/xcm/pallet-xcm/precompiles/src/tests.rs`\
+    \ \u2014 add `delegatecall_is_rejected` test\n- `polkadot/xcm/pallet-xcm/precompiles/Cargo.toml`\
+    \ \u2014 add `pallet-revive-fixtures` dev-dependency\n\n## Test plan\n\n- [x]\
+    \ `cargo test -p pallet-xcm-precompiles` \u2014 13 tests pass, including new `delegatecall_is_rejected`\n\
+    - [x] `cargo test -p pallet-asset-conversion-precompiles` \u2014 18 tests pass\n\
+    - [x] `cargo test -p pallet-assets-precompiles` \u2014 66 tests pass"
+crates:
+- name: pallet-xcm-precompiles
+  bump: minor
+- name: pallet-asset-conversion-precompiles
+  bump: minor
+- name: pallet-assets-precompiles
+  bump: minor

--- a/substrate/frame/asset-conversion/precompiles/Cargo.toml
+++ b/substrate/frame/asset-conversion/precompiles/Cargo.toml
@@ -28,6 +28,7 @@ sp-runtime = { workspace = true }
 [dev-dependencies]
 pallet-assets = { workspace = true, default-features = true }
 pallet-balances = { workspace = true, default-features = true }
+pallet-revive-fixtures = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }
 
 [features]

--- a/substrate/frame/asset-conversion/precompiles/src/lib.rs
+++ b/substrate/frame/asset-conversion/precompiles/src/lib.rs
@@ -136,10 +136,12 @@ where
 	) -> Result<Vec<u8>, Error> {
 		use IAssetConversion::IAssetConversionCalls;
 
+		frame_support::ensure!(
+			!env.is_delegate_call(),
+			pallet_revive::Error::<Self::T>::PrecompileDelegateDenied,
+		);
+
 		match input {
-			_ if env.is_delegate_call() => {
-				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into())
-			},
 			IAssetConversionCalls::swapExactTokensForTokens(_) |
 			IAssetConversionCalls::swapTokensForExactTokens(_)
 				if env.is_read_only() =>

--- a/substrate/frame/asset-conversion/precompiles/src/lib.rs
+++ b/substrate/frame/asset-conversion/precompiles/src/lib.rs
@@ -137,7 +137,8 @@ where
 		use IAssetConversion::IAssetConversionCalls;
 
 		match input {
-			_ if env.is_delegate_call() => Err(Error::Revert(ERR_DELEGATE_CALL.into())),
+			_ if env.is_delegate_call() =>
+				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into()),
 			IAssetConversionCalls::swapExactTokensForTokens(_) |
 			IAssetConversionCalls::swapTokensForExactTokens(_)
 				if env.is_read_only() =>
@@ -164,7 +165,6 @@ const ERR_INVALID_CALLER: &str = "Invalid caller";
 const ERR_BALANCE_CONVERSION_FAILED: &str = "Balance conversion failed";
 const ERR_POOL_NOT_FOUND: &str = "Pool does not exist or has no liquidity";
 const ERR_PATH_TOO_LONG: &str = "Swap path exceeds MaxSwapPathLength";
-const ERR_DELEGATE_CALL: &str = "Cannot be called via delegate call";
 const ERR_INVALID_ASSET_ENCODING: &str = "Failed to SCALE-decode asset kind";
 
 impl<const ADDRESS: u16, Runtime> AssetConversion<ADDRESS, Runtime>

--- a/substrate/frame/asset-conversion/precompiles/src/lib.rs
+++ b/substrate/frame/asset-conversion/precompiles/src/lib.rs
@@ -137,8 +137,9 @@ where
 		use IAssetConversion::IAssetConversionCalls;
 
 		match input {
-			_ if env.is_delegate_call() =>
-				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into()),
+			_ if env.is_delegate_call() => {
+				Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into())
+			},
 			IAssetConversionCalls::swapExactTokensForTokens(_) |
 			IAssetConversionCalls::swapTokensForExactTokens(_)
 				if env.is_read_only() =>

--- a/substrate/frame/asset-conversion/precompiles/src/tests.rs
+++ b/substrate/frame/asset-conversion/precompiles/src/tests.rs
@@ -26,7 +26,10 @@ use frame_support::{
 	assert_ok,
 	traits::{fungibles::Inspect, tokens::fungible::NativeOrWithId},
 };
-use pallet_revive::{precompiles::TransactionLimits, AddressMapper, ExecConfig};
+use pallet_revive::{
+	precompiles::{alloy::sol_types::SolCall, TransactionLimits},
+	AddressMapper, Code, ExecConfig,
+};
 use sp_runtime::Weight;
 
 /// SCALE-encode asset kinds for use in precompile calls.
@@ -351,5 +354,87 @@ fn quote_fails_with_invalid_encoding() {
 		let failed =
 			result.result.is_err() || result.result.as_ref().map_or(false, |v| v.did_revert());
 		assert!(failed, "quote with invalid SCALE encoding must fail");
+	});
+}
+
+alloy::sol! {
+	interface ICaller {
+		function delegate(address callee, bytes data, uint64 gas) external returns (bool success, bytes output);
+	}
+}
+
+/// The delegatecall guard rejects all calls via delegatecall.
+#[test]
+fn delegatecall_is_rejected() {
+	new_test_ext().execute_with(|| {
+		let deployer = 123456789u64;
+		use frame_support::traits::{fungible::Mutate, Currency};
+		pallet_balances::Pallet::<Test>::make_free_balance_be(&deployer, 1_000_000_000_000_000u64);
+
+		// Initialize pallet-revive's internal account (needed for storage deposits).
+		let revive_account = pallet_revive::Pallet::<Test>::account_id();
+		pallet_balances::Pallet::<Test>::mint_into(
+			&revive_account,
+			<Test as pallet_balances::Config>::ExistentialDeposit::get(),
+		)
+		.unwrap();
+
+		let (init_code, _) = pallet_revive_fixtures::compile_module_with_type(
+			"Caller",
+			pallet_revive_fixtures::FixtureType::Solc,
+		)
+		.expect("Caller fixture must be compiled");
+		let caller_addr = pallet_revive::Pallet::<Test>::bare_instantiate(
+			RuntimeOrigin::signed(deployer),
+			0u64.into(),
+			TransactionLimits::WeightAndDeposit {
+				weight_limit: Weight::MAX,
+				deposit_limit: u64::MAX,
+			},
+			Code::Upload(init_code),
+			vec![],
+			None,
+			&ExecConfig::new_substrate_tx(),
+		)
+		.result
+		.expect("Caller deployment must succeed")
+		.addr;
+
+		let calldata = ICaller::delegateCall {
+			callee: alloy::primitives::Address::from(precompile_address().0),
+			data: IAssetConversion::quoteExactTokensForTokensCall {
+				asset1: encode_native().into(),
+				asset2: encode_asset(1).into(),
+				amount: U256::from(100),
+				includeFee: true,
+			}
+			.abi_encode()
+			.into(),
+			gas: u64::MAX,
+		}
+		.abi_encode();
+
+		let result = pallet_revive::Pallet::<Test>::bare_call(
+			RuntimeOrigin::signed(deployer),
+			caller_addr,
+			0u64.into(),
+			TransactionLimits::WeightAndDeposit {
+				weight_limit: Weight::MAX,
+				deposit_limit: u64::MAX,
+			},
+			calldata,
+			&ExecConfig::new_substrate_tx(),
+		)
+		.result
+		.expect("outer call must succeed");
+
+		let ret = ICaller::delegateCall::abi_decode_returns(&result.data)
+			.expect("return must decode as (bool, bytes)");
+		assert!(!ret.success, "DELEGATECALL to asset-conversion precompile must be rejected");
+		assert!(
+			ret.output.is_empty(),
+			"expected empty output from PrecompileDelegateDenied trap, got {} bytes",
+			ret.output.len(),
+		);
 	});
 }

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -160,9 +160,10 @@ where
 		input: &Self::Interface,
 		env: &mut impl Ext<T = Self::T>,
 	) -> Result<Vec<u8>, Error> {
-		if env.is_delegate_call() {
-			return Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into());
-		}
+		frame_support::ensure!(
+			!env.is_delegate_call(),
+			pallet_revive::Error::<Self::T>::PrecompileDelegateDenied,
+		);
 
 		let asset_id = PrecompileConfig::AssetIdExtractor::asset_id_from_address(address)?.into();
 		let contract_addr = H160::from(*address);

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -161,7 +161,7 @@ where
 		env: &mut impl Ext<T = Self::T>,
 	) -> Result<Vec<u8>, Error> {
 		if env.is_delegate_call() {
-			return Err(Error::Revert(Revert { reason: ERR_DELEGATECALL_DENIED.into() }));
+			return Err(pallet_revive::Error::<Self::T>::PrecompileDelegateDenied.into());
 		}
 
 		let asset_id = PrecompileConfig::AssetIdExtractor::asset_id_from_address(address)?.into();

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -201,7 +201,6 @@ where
 	}
 }
 
-const ERR_DELEGATECALL_DENIED: &str = "Cannot be called via delegatecall";
 const ERR_INVALID_CALLER: &str = "Invalid caller";
 const ERR_BALANCE_CONVERSION_FAILED: &str = "Balance conversion failed";
 


### PR DESCRIPTION
## Summary

- Add delegatecall guard to the ERC20 assets precompile and XCM precompile, matching the existing pattern in the vesting and asset-conversion precompiles
- Converge asset-conversion precompile from `Error::Revert(string)` to `Error::Error(PrecompileDelegateDenied)` for consistency across all precompiles
- Add delegatecall rejection test for the XCM precompile

## Motivation

Delegatecall to precompiles allows a malicious contract to execute precompile logic in a misleading caller context. The precompiles derive caller identity from `env.caller()`, which during delegatecall returns the original caller — letting the intermediary contract act on the caller's assets or send XCM on their behalf. There is no legitimate use case for delegatecalling into these precompiles.

## Changes

- `substrate/frame/assets/precompiles/src/lib.rs` — add `PrecompileDelegateDenied` guard
- `substrate/frame/asset-conversion/precompiles/src/lib.rs` — replace `Error::Revert(ERR_DELEGATE_CALL)` with `PrecompileDelegateDenied`, remove unused const
- `polkadot/xcm/pallet-xcm/precompiles/src/lib.rs` — add `PrecompileDelegateDenied` guard
- `polkadot/xcm/pallet-xcm/precompiles/src/tests.rs` — add `delegatecall_is_rejected` test
- `polkadot/xcm/pallet-xcm/precompiles/Cargo.toml` — add `pallet-revive-fixtures` dev-dependency

## Test plan

- [x] `cargo test -p pallet-xcm-precompiles` — 13 tests pass, including new `delegatecall_is_rejected`
- [x] `cargo test -p pallet-asset-conversion-precompiles` — 18 tests pass
- [x] `cargo test -p pallet-assets-precompiles` — 66 tests pass
