### PR TITLE
Add legacy NegativeImbalance support to DAP and DAP satellite

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/governance/mod.rs
@@ -90,7 +90,7 @@ impl pallet_referenda::Config for Runtime {
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumCanceller>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, ReferendumKiller>;
-	type Slash = Treasury;
+	type Slash = pallet_dap::DapLegacyAdapter<Runtime, Balances>;
 	type Votes = pallet_conviction_voting::VotesOf<Runtime>;
 	type Tally = pallet_conviction_voting::TallyOf<Runtime>;
 	type SubmissionDeposit = SubmissionDeposit;

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
@@ -32,7 +32,7 @@ pub mod origins;
 mod tracks;
 
 use super::*;
-use crate::xcm_config::{FellowshipAdminBodyId, LocationToAccountId, WndAssetHub};
+use crate::xcm_config::{FellowshipAdminBodyId, WndAssetHub};
 use frame_support::traits::{EitherOf, MapSuccess, TryMapSuccess};
 use frame_system::EnsureRootWithSuccess;
 pub use origins::pallet_origins as pallet_ambassador_origins;

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/ambassador/mod.rs
@@ -145,7 +145,7 @@ impl pallet_referenda::Config<AmbassadorReferendaInstance> for Runtime {
 	>;
 	type CancelOrigin = EitherOf<EnsureRoot<AccountId>, EnsureHeadAmbassadorsVoice>;
 	type KillOrigin = EitherOf<EnsureRoot<AccountId>, EnsureHeadAmbassadorsVoice>;
-	type Slash = ToParentTreasury<WestendTreasuryAccount, LocationToAccountId, Runtime>;
+	type Slash = pallet_dap_satellite::DapSatelliteLegacyAdapter<Runtime, Balances>;
 	type Votes = pallet_ranked_collective::Votes;
 	type Tally = pallet_ranked_collective::TallyOf<Runtime, AmbassadorCollectiveInstance>;
 	type SubmissionDeposit = SubmissionDeposit;

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
@@ -97,7 +97,7 @@ impl pallet_referenda::Config<FellowshipReferendaInstance> for Runtime {
 	>;
 	type CancelOrigin = Architects;
 	type KillOrigin = Masters;
-	type Slash = ToParentTreasury<WestendTreasuryAccount, LocationToAccountId, Runtime>;
+	type Slash = pallet_dap_satellite::DapSatelliteLegacyAdapter<Runtime, Balances>;
 	type Votes = pallet_ranked_collective::Votes;
 	type Tally = pallet_ranked_collective::TallyOf<Runtime, FellowshipCollectiveInstance>;
 	type SubmissionDeposit = ConstU128<0>;

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/fellowship/mod.rs
@@ -20,10 +20,9 @@ mod origins;
 mod tracks;
 use crate::{
 	weights,
-	xcm_config::{FellowshipAdminBodyId, LocationToAccountId, TreasurerBodyId, UsdtAssetHub},
+	xcm_config::{FellowshipAdminBodyId, TreasurerBodyId, UsdtAssetHub},
 	AccountId, AssetRate, Balance, Balances, FellowshipReferenda, GovernanceLocation,
-	ParachainInfo, Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Scheduler,
-	WestendTreasuryAccount, DAYS,
+	ParachainInfo, Preimage, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, Scheduler, DAYS,
 };
 use cumulus_primitives_core::ParaId;
 use frame_support::{
@@ -41,7 +40,6 @@ pub use origins::{
 };
 use pallet_ranked_collective::EnsureOfRank;
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
-use parachains_common::impls::ToParentTreasury;
 use polkadot_runtime_common::impls::{
 	ContainsParts, LocatableAssetConverter, VersionedLocatableAsset, VersionedLocationConverter,
 };

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -613,7 +613,7 @@ impl pallet_alliance::Config for Runtime {
 	type MembershipManager = RootOrAllianceTwoThirdsMajority;
 	type AnnouncementOrigin = RootOrAllianceTwoThirdsMajority;
 	type Currency = Balances;
-	type Slashed = ToParentTreasury<WestendTreasuryAccount, LocationToAccountId, Runtime>;
+	type Slashed = pallet_dap_satellite::DapSatelliteLegacyAdapter<Runtime, Balances>;
 	type InitializeMembers = AllianceMotion;
 	type MembershipChanged = AllianceMotion;
 	type RetirementPeriod = AllianceRetirementPeriod;

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -89,10 +89,8 @@ use frame_system::{
 };
 pub use parachains_common as common;
 use parachains_common::{
-	impls::{DealWithFees, ToParentTreasury},
-	message_queue::*,
-	AccountId, AuraId, Balance, BlockNumber, Hash, Header, Nonce, Signature,
-	AVERAGE_ON_INITIALIZE_RATIO, NORMAL_DISPATCH_RATIO,
+	impls::DealWithFees, message_queue::*, AccountId, AuraId, Balance, BlockNumber, Hash, Header,
+	Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO, NORMAL_DISPATCH_RATIO,
 };
 use testnet_parachains_constants::westend::{
 	account::*, consensus::*, currency::*, fee::WeightToFee, time::*,

--- a/cumulus/parachains/runtimes/people/people-westend/src/people.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/people.rs
@@ -14,14 +14,13 @@
 // limitations under the License.
 
 use super::*;
-use crate::xcm_config::LocationToAccountId;
 use codec::{Decode, Encode, MaxEncodedLen};
 use enumflags2::{bitflags, BitFlags};
 use frame_support::{
 	parameter_types, traits::ConstU32, CloneNoBound, DebugNoBound, EqNoBound, PartialEqNoBound,
 };
 use pallet_identity::{Data, IdentityInformationProvider};
-use parachains_common::{impls::ToParentTreasury, DAYS};
+use parachains_common::DAYS;
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{AccountIdConversion, Verify},

--- a/cumulus/parachains/runtimes/people/people-westend/src/people.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/people.rs
@@ -51,7 +51,7 @@ impl pallet_identity::Config for Runtime {
 	type MaxSubAccounts = ConstU32<100>;
 	type IdentityInformation = IdentityInfo;
 	type MaxRegistrars = ConstU32<20>;
-	type Slashed = ToParentTreasury<RelayTreasuryAccount, LocationToAccountId, Runtime>;
+	type Slashed = pallet_dap_satellite::DapSatelliteLegacyAdapter<Runtime, Balances>;
 	type ForceOrigin = EnsureRoot<Self::AccountId>;
 	type RegistrarOrigin = EnsureRoot<Self::AccountId>;
 	type OffchainSignature = Signature;

--- a/prdoc/pr_11716.prdoc
+++ b/prdoc/pr_11716.prdoc
@@ -1,0 +1,20 @@
+title: Add legacy NegativeImbalance support to DAP and DAP satellite
+doc:
+- audience: Runtime Dev
+  description: |-
+    Add `DapLegacyAdapter` and `DapSatelliteLegacyAdapter` wrapper structs that implement `OnUnbalanced<NegativeImbalance>` from the legacy `Currency` trait, bridging pallets not yet migrated to fungible traits.
+
+    Wire Westend runtimes: AH referenda slash to DAP, collectives (fellowship, ambassador, alliance) and people identity slash to DAP satellite.
+
+    Closes #11704.
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch
+- name: collectives-westend-runtime
+  bump: patch
+- name: people-westend-runtime
+  bump: patch
+- name: pallet-dap-satellite
+  bump: patch
+- name: pallet-dap
+  bump: patch

--- a/prdoc/pr_11716.prdoc
+++ b/prdoc/pr_11716.prdoc
@@ -15,6 +15,6 @@ crates:
 - name: people-westend-runtime
   bump: patch
 - name: pallet-dap-satellite
-  bump: patch
+  bump: minor
 - name: pallet-dap
-  bump: patch
+  bump: minor

--- a/substrate/frame/dap-satellite/src/lib.rs
+++ b/substrate/frame/dap-satellite/src/lib.rs
@@ -198,9 +198,14 @@ impl<T: Config> OnUnbalanced<CreditOf<T>> for Pallet<T> {
 /// Type alias for legacy `NegativeImbalance` from the `Currency` trait.
 type LegacyNegativeImbalance<A, C> = <C as Currency<A>>::NegativeImbalance;
 
-/// Legacy adapter: redirects `NegativeImbalance` from the `Currency` trait to the DAP satellite.
+/// Adapter that redirects `NegativeImbalance` from the legacy `Currency` trait to the DAP
+/// satellite.
 ///
-/// Temporary — will be removed when all consumer pallets migrate to fungible traits.
+/// Cannot be implemented directly on `Pallet<T>` because the compiler cannot prove that
+/// `<C as Currency>::NegativeImbalance` and `fungible::Credit` are always distinct types,
+/// so two `OnUnbalanced` impls on the same struct are rejected.
+///
+/// Will be removed once all consumer pallets migrate to fungible traits.
 ///
 /// # Example
 /// ```ignore

--- a/substrate/frame/dap-satellite/src/lib.rs
+++ b/substrate/frame/dap-satellite/src/lib.rs
@@ -57,7 +57,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{
 		fungible::{Balanced, Credit, Inspect, Unbalanced},
-		Imbalance, OnUnbalanced,
+		Currency, Imbalance, OnUnbalanced,
 	},
 	PalletId,
 };
@@ -171,10 +171,8 @@ where
 /// Use this on system chains (not AssetHub) or Relay Chain to collect imbalances
 /// (e.g. coretime revenue, tx fees, dust removal) that would otherwise be burned.
 ///
-/// Only the new fungible `Credit` type is supported. An `OnUnbalanced<NegativeImbalance>` impl
-/// for the old `Currency` trait is not provided because there are no active consumers: all pallets
-/// that could produce `NegativeImbalance` on satellite chains (staking, identity,
-/// election-provider, ...) are either deprecated, or already use the new fungible traits.
+/// For pallets still using the legacy `Currency` trait (e.g. `pallet_identity`), use
+/// [`DapSatelliteLegacyAdapter`] instead.
 impl<T: Config> OnUnbalanced<CreditOf<T>> for Pallet<T> {
 	fn on_nonzero_unbalanced(amount: CreditOf<T>) {
 		let satellite = Self::satellite_account();
@@ -193,6 +191,36 @@ impl<T: Config> OnUnbalanced<CreditOf<T>> for Pallet<T> {
 		log::debug!(
 			target: LOG_TARGET,
 			"💸 Deposited {numeric_amount:?} to DAP satellite"
+		);
+	}
+}
+
+/// Type alias for legacy `NegativeImbalance` from the `Currency` trait.
+type LegacyNegativeImbalance<A, C> = <C as Currency<A>>::NegativeImbalance;
+
+/// Legacy adapter: redirects `NegativeImbalance` from the `Currency` trait to the DAP satellite.
+///
+/// Temporary — will be removed when all consumer pallets migrate to fungible traits.
+///
+/// # Example
+/// ```ignore
+/// type Slashed = pallet_dap_satellite::DapSatelliteLegacyAdapter<Runtime, Balances>;
+/// ```
+pub struct DapSatelliteLegacyAdapter<T, C>(core::marker::PhantomData<(T, C)>);
+
+impl<T: Config, C> OnUnbalanced<LegacyNegativeImbalance<T::AccountId, C>>
+	for DapSatelliteLegacyAdapter<T, C>
+where
+	C: Currency<T::AccountId>,
+{
+	fn on_nonzero_unbalanced(amount: LegacyNegativeImbalance<T::AccountId, C>) {
+		let satellite = Pallet::<T>::satellite_account();
+		let numeric_amount = amount.peek();
+		// NOTE: resolve_creating is infallible.
+		C::resolve_creating(&satellite, amount);
+		log::debug!(
+			target: LOG_TARGET,
+			"💸 Deposited (legacy) {numeric_amount:?} to DAP satellite"
 		);
 	}
 }

--- a/substrate/frame/dap-satellite/src/tests/on_unbalanced.rs
+++ b/substrate/frame/dap-satellite/src/tests/on_unbalanced.rs
@@ -23,11 +23,12 @@ use frame_support::{
 	traits::{
 		fungible::{Balanced, Inspect, Mutate},
 		tokens::{Fortitude, Precision, Preservation},
-		OnUnbalanced,
+		Currency, OnUnbalanced,
 	},
 };
 
 type DapSatellitePallet = crate::Pallet<Test>;
+type DapSatelliteLegacy = crate::DapSatelliteLegacyAdapter<Test, Balances>;
 
 #[test]
 fn on_unbalanced_deposits_to_satellite() {
@@ -187,5 +188,30 @@ fn on_unbalanced_multiple_dust_removals_accumulate_to_satellite() {
 
 		// And: total issuance unchanged (dust moved, not destroyed).
 		assert_eq!(<Balances as Inspect<_>>::total_issuance(), issuance_before);
+	});
+}
+
+#[test]
+fn legacy_adapter_redirects_slash_to_satellite() {
+	new_test_ext(true).execute_with(|| {
+		let satellite = DapSatellitePallet::satellite_account();
+		let ed = <Balances as Inspect<_>>::minimum_balance();
+
+		// Given: satellite has ED, user 1 has 100
+		assert_eq!(Balances::free_balance(satellite), ed);
+		let initial_total = <Balances as Inspect<_>>::total_issuance();
+
+		// When: legacy slash via Currency::slash -> DapSatelliteLegacyAdapter
+		let (imbalance, _) = <Balances as Currency<_>>::slash(&1, 30);
+		DapSatelliteLegacy::on_unbalanced(imbalance);
+
+		// Then: satellite accumulated the slash
+		assert_eq!(Balances::free_balance(satellite), ed + 30);
+
+		// And: user lost the slashed amount
+		assert_eq!(Balances::free_balance(1), 100 - 30);
+
+		// And: total issuance unchanged (funds moved, not destroyed)
+		assert_eq!(<Balances as Inspect<_>>::total_issuance(), initial_total);
 	});
 }

--- a/substrate/frame/dap/src/lib.rs
+++ b/substrate/frame/dap/src/lib.rs
@@ -53,7 +53,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{
 		fungible::{Balanced, Credit, Inspect, Mutate, Unbalanced},
-		Imbalance, OnUnbalanced, Time,
+		Currency, Imbalance, OnUnbalanced, Time,
 	},
 	PalletId,
 };
@@ -395,11 +395,11 @@ pub mod pallet {
 /// Type alias for credit (negative imbalance - funds that were slashed/removed).
 pub type CreditOf<T> = Credit<<T as frame_system::Config>::AccountId, <T as Config>::Currency>;
 
-/// Implementation of OnUnbalanced for the fungible::Balanced trait.
+/// Implementation of `OnUnbalanced` for the `fungible::Balanced` trait.
 /// Example: use as `type Slash = Dap` in staking-async config.
 ///
-/// Only the new fungible `Credit` type is supported. An `OnUnbalanced<NegativeImbalance>` impl
-/// for the old `Currency` trait is not provided because there are no consumers.
+/// For pallets still using the legacy `Currency` trait (e.g. `pallet_referenda`),
+/// use [`DapLegacyAdapter`] instead.
 impl<T: Config> OnUnbalanced<CreditOf<T>> for Pallet<T> {
 	fn on_nonzero_unbalanced(amount: CreditOf<T>) {
 		let buffer = Self::buffer_account();
@@ -424,6 +424,36 @@ impl<T: Config> OnUnbalanced<CreditOf<T>> for Pallet<T> {
 					"💸 Deposited slash of {numeric_amount:?} to DAP buffer"
 				);
 			});
+	}
+}
+
+/// Type alias for legacy `NegativeImbalance` from the `Currency` trait.
+type LegacyNegativeImbalance<A, C> = <C as Currency<A>>::NegativeImbalance;
+
+/// Legacy adapter: redirects `NegativeImbalance` from the `Currency` trait to the DAP buffer.
+///
+/// Temporary — will be removed when all consumer pallets migrate to fungible traits.
+///
+/// # Example
+/// ```ignore
+/// type Slash = pallet_dap::DapLegacyAdapter<Runtime, Balances>;
+/// ```
+pub struct DapLegacyAdapter<T, C>(core::marker::PhantomData<(T, C)>);
+
+impl<T: Config, C> OnUnbalanced<LegacyNegativeImbalance<T::AccountId, C>> for DapLegacyAdapter<T, C>
+where
+	C: Currency<T::AccountId, Balance = BalanceOf<T>>,
+{
+	fn on_nonzero_unbalanced(amount: LegacyNegativeImbalance<T::AccountId, C>) {
+		let buffer = Pallet::<T>::buffer_account();
+		let numeric_amount = amount.peek();
+		// NOTE: resolve_creating is infallible.
+		C::resolve_creating(&buffer, amount);
+		Pallet::<T>::deactivate_buffer_funds(numeric_amount);
+		log::debug!(
+			target: LOG_TARGET,
+			"💸 Deposited (legacy) slash of {numeric_amount:?} to DAP buffer"
+		);
 	}
 }
 

--- a/substrate/frame/dap/src/lib.rs
+++ b/substrate/frame/dap/src/lib.rs
@@ -430,9 +430,13 @@ impl<T: Config> OnUnbalanced<CreditOf<T>> for Pallet<T> {
 /// Type alias for legacy `NegativeImbalance` from the `Currency` trait.
 type LegacyNegativeImbalance<A, C> = <C as Currency<A>>::NegativeImbalance;
 
-/// Legacy adapter: redirects `NegativeImbalance` from the `Currency` trait to the DAP buffer.
+/// Adapter that redirects `NegativeImbalance` from the legacy `Currency` trait to the DAP buffer.
 ///
-/// Temporary — will be removed when all consumer pallets migrate to fungible traits.
+/// Cannot be implemented directly on `Pallet<T>` because the compiler cannot prove that
+/// `<C as Currency>::NegativeImbalance` and `fungible::Credit` are always distinct types,
+/// so two `OnUnbalanced` impls on the same struct are rejected.
+///
+/// Will be removed once all consumer pallets migrate to fungible traits.
 ///
 /// # Example
 /// ```ignore

--- a/substrate/frame/dap/src/tests/on_unbalanced.rs
+++ b/substrate/frame/dap/src/tests/on_unbalanced.rs
@@ -21,10 +21,11 @@ use crate::mock::{build_and_execute, set_default_budget_allocation, Balances, Te
 use frame_support::traits::{
 	fungible::{Balanced, Inspect},
 	tokens::{Fortitude, Precision, Preservation},
-	OnUnbalanced,
+	Currency, OnUnbalanced,
 };
 
 type DapPallet = crate::Pallet<Test>;
+type DapLegacy = crate::DapLegacyAdapter<Test, Balances>;
 
 #[test]
 #[should_panic(expected = "Failed to deposit slash to DAP buffer")]
@@ -138,7 +139,7 @@ fn slash_to_dap_accumulates_multiple_slashes_to_buffer() {
 		assert_eq!(<Balances as Inspect<_>>::active_issuance(), initial_active - 100);
 
 		// When: slash with zero amount (no-op)
-		let credit = Balances::issue(0);
+		let credit = <Balances as Balanced<_>>::issue(0);
 		DapPallet::on_unbalanced(credit);
 
 		// Then: buffer unchanged (still ED + 100)
@@ -149,5 +150,36 @@ fn slash_to_dap_accumulates_multiple_slashes_to_buffer() {
 
 		// And: active issuance decreased by 100 (funds deactivated in DAP buffer)
 		assert_eq!(<Balances as Inspect<_>>::active_issuance(), initial_active - 100);
+	});
+}
+
+#[test]
+fn legacy_adapter_redirects_slash_to_buffer() {
+	build_and_execute(true, || {
+		set_default_budget_allocation();
+
+		let buffer = DapPallet::buffer_account();
+		let ed = <Balances as Inspect<_>>::minimum_balance();
+
+		// Given: buffer has ED, alice has 100
+		assert_eq!(Balances::free_balance(buffer), ed);
+		let initial_active = <Balances as Inspect<_>>::active_issuance();
+		let initial_total = <Balances as Inspect<_>>::total_issuance();
+
+		// When: legacy slash via Currency::slash -> DapLegacyAdapter
+		let (imbalance, _) = <Balances as Currency<_>>::slash(&1, 30);
+		DapLegacy::on_unbalanced(imbalance);
+
+		// Then: buffer accumulated the slash
+		assert_eq!(Balances::free_balance(buffer), ed + 30);
+
+		// And: alice lost the slashed amount
+		assert_eq!(Balances::free_balance(1), 100 - 30);
+
+		// And: total issuance unchanged (funds moved, not destroyed)
+		assert_eq!(<Balances as Inspect<_>>::total_issuance(), initial_total);
+
+		// And: active issuance decreased by 30 (funds deactivated in DAP buffer)
+		assert_eq!(<Balances as Inspect<_>>::active_issuance(), initial_active - 30);
 	});
 }


### PR DESCRIPTION
Add `DapLegacyAdapter` and `DapSatelliteLegacyAdapter` wrapper structs that implement `OnUnbalanced<NegativeImbalance>` from the legacy `Currency` trait, bridging pallets not yet migrated to fungible traits.

Wire Westend runtimes: AH referenda slash to DAP, collectives (fellowship, ambassador, alliance) and people identity slash to DAP satellite.

Closes #11704.



