### PR TITLE
[rk-cumulus-v3-integration branch] offset_relay_parent_find_descendants(): use max_relay_parent_session_age

### DIFF
--- a/cumulus/client/consensus/aura/src/collators/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/mod.rs
@@ -150,22 +150,18 @@ async fn check_validation_code_or_log(
 	}
 }
 
-/// Fetch scheduling lookahead at given relay parent.
-async fn scheduling_lookahead(
-	relay_parent: RelayHash,
+async fn check_parachain_host_runtime_api_version(
 	relay_client: &impl RelayChainInterface,
-) -> Option<u32> {
-	let runtime_api_version = relay_client
-		.version(relay_parent)
-		.await
-		.map_err(|e| {
-			tracing::error!(
-				target: super::LOG_TARGET,
-				error = ?e,
-				"Failed to fetch relay chain runtime version.",
-			)
-		})
-		.ok()?;
+	at: RelayHash,
+	min_parachain_host_runtime_api_version: u32,
+) -> Result<(), ()> {
+	let runtime_api_version = relay_client.version(at).await.map_err(|e| {
+		tracing::error!(
+			target: super::LOG_TARGET,
+			error = ?e,
+			"Failed to fetch relay chain runtime version.",
+		)
+	})?;
 
 	let parachain_host_runtime_api_version = runtime_api_version
 		.api_version(
@@ -173,24 +169,27 @@ async fn scheduling_lookahead(
 		)
 		.unwrap_or_default();
 
-	if parachain_host_runtime_api_version <
-		RuntimeApiRequest::SCHEDULING_LOOKAHEAD_RUNTIME_REQUIREMENT
-	{
-		return None;
+	if parachain_host_runtime_api_version < min_parachain_host_runtime_api_version {
+		return Err(());
 	}
 
-	match relay_client.scheduling_lookahead(relay_parent).await {
-		Ok(scheduling_lookahead) => Some(scheduling_lookahead),
-		Err(err) => {
-			tracing::error!(
-				target: crate::LOG_TARGET,
-				?err,
-				?relay_parent,
-				"Failed to fetch scheduling lookahead from relay chain",
-			);
-			None
-		},
-	}
+	Ok(())
+}
+
+/// Fetch scheduling lookahead at given relay parent.
+async fn scheduling_lookahead(
+	relay_parent: RelayHash,
+	relay_client: &impl RelayChainInterface,
+) -> Option<u32> {
+	let _ = check_parachain_host_runtime_api_version(
+		relay_client,
+		relay_parent,
+		RuntimeApiRequest::SCHEDULING_LOOKAHEAD_RUNTIME_REQUIREMENT,
+	)
+	.await
+	.ok()?;
+
+	relay_client.scheduling_lookahead(relay_parent).await.ok()
 }
 
 // Returns the claim queue at the given relay parent.
@@ -269,14 +268,11 @@ async fn find_parent<Block>(
 where
 	Block: BlockT,
 {
-	let parent_search_params = ParentSearchParams {
-		relay_parent,
-		para_id,
-		ancestry_lookback: scheduling_lookahead(relay_parent, relay_client)
-			.await
-			.unwrap_or(DEFAULT_SCHEDULING_LOOKAHEAD)
-			.saturating_sub(1) as usize,
-	};
+	let ancestry_lookback = scheduling_lookahead(relay_parent, relay_client)
+		.await
+		.unwrap_or(DEFAULT_SCHEDULING_LOOKAHEAD)
+		.saturating_sub(1) as usize;
+	let parent_search_params = ParentSearchParams { relay_parent, para_id, ancestry_lookback };
 
 	match cumulus_client_consensus_common::find_parent_for_building::<Block>(
 		parent_search_params,

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -235,11 +235,13 @@ where
 
 			let relay_parent_offset =
 				para_client.runtime_api().relay_parent_offset(best_hash).unwrap_or_default();
+			let max_relay_parent_session_age =
+				relay_client.max_relay_parent_session_age(descendants_start).await.unwrap_or(0);
 			let Ok(Some(rp_data)) = offset_relay_parent_find_descendants(
 				&mut relay_chain_data_cache,
 				descendants_start,
 				relay_parent_offset,
-				v3_enabled,
+				max_relay_parent_session_age,
 			)
 			.await
 			else {
@@ -579,64 +581,63 @@ fn adjust_para_to_relay_parent_slot(
 /// offset, collecting all blocks in between to maintain the chain of ancestry.
 pub(crate) async fn offset_relay_parent_find_descendants<RelayClient>(
 	relay_chain_data_cache: &mut RelayChainDataCache<RelayClient>,
-	relay_best_block: RelayHash,
+	scheduling_parent: RelayHash,
 	relay_parent_offset: u32,
-	v3_enabled: bool,
+	max_relay_parent_session_age: u32,
 ) -> Result<Option<RelayParentData>, ()>
 where
 	RelayClient: RelayChainInterface + Clone + 'static,
 {
-	let Ok(mut relay_header) = relay_chain_data_cache
-		.get_mut_relay_chain_data(relay_best_block)
-		.await
-		.map(|d| d.relay_parent_header.clone())
-	else {
-		tracing::error!(target: LOG_TARGET, ?relay_best_block, "Unable to fetch best relay chain block header.");
-		return Err(());
-	};
+	let current_relay_block =
+		relay_chain_data_cache.get_mut_relay_chain_data(scheduling_parent).await?;
+	let mut current_relay_header = current_relay_block.relay_parent_header.clone();
 
 	if relay_parent_offset == 0 {
-		return Ok(Some(RelayParentData::new(relay_header)));
+		return Ok(Some(RelayParentData::new(current_relay_header)));
 	}
 
-	if sc_consensus_babe::contains_epoch_change::<RelayBlock>(&relay_header) {
-		tracing::debug!(target: LOG_TARGET, ?relay_best_block, relay_best_block_number = relay_header.number(), "RC tip is a session change block, skipping.");
-		return Ok(None);
-	}
-
-	let mut required_ancestors: VecDeque<RelayHeader> = Default::default();
-	required_ancestors.push_front(relay_header.clone());
-	while required_ancestors.len() < relay_parent_offset as usize {
-		let next_header = relay_chain_data_cache
-			.get_mut_relay_chain_data(*relay_header.parent_hash())
-			.await?
-			.relay_parent_header
-			.clone();
-		// When V3 is not enabled, skip if any ancestor in the window has a session change.
-		// With V3 enabled, the scheduling proof header chain can span session boundaries.
-		if !v3_enabled && sc_consensus_babe::contains_epoch_change::<RelayBlock>(&next_header) {
-			tracing::debug!(target: LOG_TARGET, ?relay_best_block, ancestor = %next_header.hash(), ancestor_block_number = next_header.number(), "Ancestor of best block is in previous session.");
+	let mut relay_parent_descendants: VecDeque<RelayHeader> = Default::default();
+	let mut relay_parent_session_age = 0;
+	loop {
+		if current_relay_header.number == 0 {
 			return Ok(None);
 		}
-		required_ancestors.push_front(next_header.clone());
-		relay_header = next_header;
-	}
+		if sc_consensus_babe::contains_epoch_change::<RelayBlock>(&current_relay_header) {
+			relay_parent_session_age += 1;
+			if relay_parent_session_age > max_relay_parent_session_age {
+				tracing::debug!(target: LOG_TARGET,
+					?scheduling_parent,
+					ancestor = %current_relay_header.hash(),
+					ancestor_block_number = current_relay_header.number(),
+					"max_relay_parent_session_age exceeded."
+				);
+				return Ok(None);
+			}
+		}
+		if relay_parent_descendants.len() == relay_parent_offset as usize {
+			break;
+		}
 
-	let relay_parent = relay_chain_data_cache
-		.get_mut_relay_chain_data(*relay_header.parent_hash())
-		.await?
-		.relay_parent_header
-		.clone();
+		relay_parent_descendants.push_front(current_relay_header.clone());
+
+		let next_relay_block = relay_chain_data_cache
+			.get_mut_relay_chain_data(*current_relay_header.parent_hash())
+			.await?;
+		current_relay_header = next_relay_block.relay_parent_header.clone();
+	}
 
 	tracing::debug!(
 		target: LOG_TARGET,
-		relay_parent_hash = %relay_parent.hash(),
-		relay_parent_num = relay_parent.number(),
-		num_descendants = required_ancestors.len(),
+		relay_parent_hash = %current_relay_header.hash(),
+		relay_parent_num = current_relay_header.number(),
+		num_descendant = relay_parent_descendants.len(),
 		"Relay parent descendants."
 	);
 
-	Ok(Some(RelayParentData::new_with_descendants(relay_parent, required_ancestors.into())))
+	Ok(Some(RelayParentData::new_with_descendants(
+		current_relay_header,
+		relay_parent_descendants.into(),
+	)))
 }
 
 /// Return value of [`determine_core`].

--- a/cumulus/client/consensus/aura/src/collators/slot_based/relay_chain_data_cache.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/relay_chain_data_cache.rs
@@ -90,7 +90,7 @@ where
 		let Ok(Some(relay_parent_header)) =
 			self.relay_client.header(BlockId::Hash(relay_parent)).await
 		else {
-			tracing::warn!(target: crate::LOG_TARGET, "Unable to fetch latest relay chain block header.");
+			tracing::warn!(target: crate::LOG_TARGET, "Unable to fetch relay chain block header.");
 			return Err(());
 		};
 

--- a/cumulus/client/consensus/aura/src/collators/slot_based/tests.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/tests.rs
@@ -49,7 +49,7 @@ async fn offset_test_zero_offset() {
 
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 0, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 0, 0).await;
 	assert!(result.is_ok());
 	let data = result.unwrap().unwrap();
 	assert_eq!(data.descendants_len(), 0);
@@ -65,7 +65,7 @@ async fn offset_test_two_offset() {
 
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 2, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 2, 0).await;
 	assert!(result.is_ok());
 	let data = result.unwrap().unwrap();
 	assert_eq!(data.descendants_len(), 2);
@@ -84,7 +84,7 @@ async fn offset_test_five_offset() {
 
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 5, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 5, 0).await;
 	assert!(result.is_ok());
 	let data = result.unwrap().unwrap();
 	assert_eq!(data.descendants_len(), 5);
@@ -103,10 +103,10 @@ async fn offset_test_too_long() {
 
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, _best_hash, 200, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, _best_hash, 200, 0).await;
 	assert!(result.is_err());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, _best_hash, 101, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, _best_hash, 101, 0).await;
 	assert!(result.is_err());
 }
 
@@ -125,7 +125,7 @@ async fn offset_returns_none_when_rc_tip_has_epoch_change() {
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
 	// Skips regardless of v3_enabled
-	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 3, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 3, 0).await;
 	assert!(result.is_ok());
 	assert!(result.unwrap().is_none());
 }
@@ -144,7 +144,7 @@ async fn offset_allows_epoch_change_in_ancestors_when_v3(#[case] flags: &[HasEpo
 	let client = TestRelayClient::new(headers);
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 3, true).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 3, 1).await;
 	assert!(result.is_ok());
 	assert!(result.unwrap().is_some());
 }
@@ -163,7 +163,7 @@ async fn offset_skips_epoch_change_in_ancestors_when_not_v3(#[case] flags: &[Has
 	let client = TestRelayClient::new(headers);
 	let mut cache = RelayChainDataCache::new(client, 1.into());
 
-	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 3, false).await;
+	let result = offset_relay_parent_find_descendants(&mut cache, best_hash, 3, 0).await;
 	assert!(result.is_ok());
 	assert!(result.unwrap().is_none());
 }
@@ -677,6 +677,10 @@ impl RelayChainInterface for TestRelayClient {
 	}
 
 	async fn candidate_events(&self, _: RelayHash) -> RelayChainResult<Vec<CandidateEvent>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn max_relay_parent_session_age(&self, _at: RelayHash) -> RelayChainResult<u32> {
 		unimplemented!("Not needed for test")
 	}
 }

--- a/cumulus/client/consensus/common/src/parent_search.rs
+++ b/cumulus/client/consensus/common/src/parent_search.rs
@@ -275,10 +275,12 @@ fn is_relay_parent_in_ancestry<Block: BlockT>(
 	let relay_parent = cumulus_primitives_core::extract_relay_parent(digest);
 	let storage_root =
 		cumulus_primitives_core::rpsr_digest::extract_relay_parent_storage_root(digest)
-			.map(|(r, _)| r);
+			.map(|(storage_root, _)| storage_root);
+	if relay_parent.is_none() && storage_root.is_none() {
+		return false;
+	}
 
 	rp_ancestry.iter().any(|(rp_hash, rp_storage_root)| {
-		relay_parent.map_or(false, |rp| *rp_hash == rp) ||
-			storage_root.map_or(false, |sr| *rp_storage_root == sr)
+		Some(*rp_hash) == relay_parent || Some(*rp_storage_root) == storage_root
 	})
 }

--- a/cumulus/client/consensus/common/src/tests.rs
+++ b/cumulus/client/consensus/common/src/tests.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use codec::Encode;
 use cumulus_client_pov_recovery::RecoveryKind;
 use cumulus_primitives_core::{
-	relay_chain::{BlockId, BlockNumber, CoreState},
+	relay_chain::{BlockId, BlockNumber, CoreState, Hash},
 	CumulusDigestItem, InboundDownwardMessage, InboundHrmpMessage, PersistedValidationData,
 };
 use cumulus_relay_chain_interface::{
@@ -31,7 +31,7 @@ use cumulus_relay_chain_interface::{
 	ValidatorId,
 };
 use cumulus_test_client::{
-	runtime::{Block, Hash, Header},
+	runtime::{Block, Header},
 	Backend, Client, InitBlockBuilder, TestClientBuilder, TestClientBuilderExt,
 };
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
@@ -302,6 +302,10 @@ impl RelayChainInterface for Relaychain {
 	}
 
 	async fn candidate_events(&self, _: PHash) -> RelayChainResult<Vec<CandidateEvent>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn max_relay_parent_session_age(&self, _at: PHash) -> RelayChainResult<u32> {
 		unimplemented!("Not needed for test")
 	}
 }

--- a/cumulus/client/network/src/tests.rs
+++ b/cumulus/client/network/src/tests.rs
@@ -17,12 +17,12 @@
 
 use super::*;
 use async_trait::async_trait;
-use cumulus_primitives_core::relay_chain::{BlockId, CoreIndex};
+use cumulus_primitives_core::relay_chain::{BlockId, CoreIndex, Hash};
 use cumulus_relay_chain_inprocess_interface::{check_block_in_chain, BlockCheckStatus};
 use cumulus_relay_chain_interface::{
 	ChildInfo, OverseerHandle, PHeader, ParaId, RelayChainError, RelayChainResult,
 };
-use cumulus_test_service::runtime::{Block, Hash, Header};
+use cumulus_test_service::runtime::{Block, Header};
 use futures::{executor::block_on, poll, task::Poll, FutureExt, Stream, StreamExt};
 use parking_lot::Mutex;
 use polkadot_node_primitives::{SignedFullStatement, Statement};
@@ -361,6 +361,10 @@ impl RelayChainInterface for DummyRelayChainInterface {
 	}
 
 	async fn candidate_events(&self, _: PHash) -> RelayChainResult<Vec<CandidateEvent>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn max_relay_parent_session_age(&self, _at: PHash) -> RelayChainResult<u32> {
 		unimplemented!("Not needed for test")
 	}
 }

--- a/cumulus/client/pov-recovery/src/tests.rs
+++ b/cumulus/client/pov-recovery/src/tests.rs
@@ -528,6 +528,10 @@ impl RelayChainInterface for Relaychain {
 	async fn candidate_events(&self, _: PHash) -> RelayChainResult<Vec<CandidateEvent>> {
 		unimplemented!("Not needed for test");
 	}
+
+	async fn max_relay_parent_session_age(&self, _at: PHash) -> RelayChainResult<u32> {
+		unimplemented!("Not needed for test");
+	}
 }
 
 fn make_candidate_chain(candidate_number_range: Range<u32>) -> Vec<CommittedCandidateReceipt> {

--- a/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
@@ -348,6 +348,10 @@ impl RelayChainInterface for RelayChainInProcessInterface {
 	async fn candidate_events(&self, hash: PHash) -> RelayChainResult<Vec<CandidateEvent>> {
 		Ok(self.full_client.runtime_api().candidate_events(hash)?)
 	}
+
+	async fn max_relay_parent_session_age(&self, at: PHash) -> RelayChainResult<u32> {
+		Ok(self.full_client.runtime_api().max_relay_parent_session_age(at)?)
+	}
 }
 
 pub enum BlockCheckStatus {

--- a/cumulus/client/relay-chain-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-interface/src/lib.rs
@@ -259,6 +259,8 @@ pub trait RelayChainInterface: Send + Sync {
 	async fn scheduling_lookahead(&self, relay_parent: PHash) -> RelayChainResult<u32>;
 
 	async fn candidate_events(&self, at: RelayHash) -> RelayChainResult<Vec<CandidateEvent>>;
+
+	async fn max_relay_parent_session_age(&self, at: RelayHash) -> RelayChainResult<u32>;
 }
 
 #[async_trait]
@@ -429,6 +431,10 @@ where
 
 	async fn candidate_events(&self, at: RelayHash) -> RelayChainResult<Vec<CandidateEvent>> {
 		(**self).candidate_events(at).await
+	}
+
+	async fn max_relay_parent_session_age(&self, at: RelayHash) -> RelayChainResult<u32> {
+		(**self).max_relay_parent_session_age(at).await
 	}
 }
 

--- a/cumulus/client/relay-chain-rpc-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/lib.rs
@@ -306,4 +306,8 @@ impl RelayChainInterface for RelayChainRpcInterface {
 	) -> RelayChainResult<Vec<CandidateEvent>> {
 		self.rpc_client.parachain_host_candidate_events(relay_parent).await
 	}
+
+	async fn max_relay_parent_session_age(&self, at: RelayHash) -> RelayChainResult<u32> {
+		self.rpc_client.parachain_host_max_relay_parent_session_age(at).await
+	}
 }


### PR DESCRIPTION
Addresses one of the points in https://github.com/paritytech/polkadot-sdk/issues/11624