### PR TITLE
statement-store: Fix node restart in mid-crush test

### DIFF
--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -230,7 +230,9 @@ pub(super) async fn spawn_network_with_injected_allowances(
 				.fold(p, |acc, &name| acc.with_collator(|n| n.with_name(name)))
 		})
 		.with_global_settings(|global_settings| {
-			global_settings.with_base_dir(base_dir.to_str().expect("Valid UTF-8 path"))
+			global_settings
+				.with_base_dir(base_dir.to_str().expect("Valid UTF-8 path"))
+				.with_tear_down_on_failure(false) // To allow restart nodes without failing in CI
 		})
 		.build()
 		.map_err(|e| {


### PR DESCRIPTION
# Description

A small fix to allow nodes to restart without failing in CI

## Integration

No integration needed