### PR TITLE
MMR: check `verify_ancestor()` output

### DIFF
--- a/prdoc/pr_11738.prdoc
+++ b/prdoc/pr_11738.prdoc
@@ -1,0 +1,7 @@
+title: 'MMR: check `verify_ancestor()` output'
+doc:
+- audience: Runtime Dev
+  description: 'MMR: check `verify_ancestor()` output'
+crates:
+- name: pallet-mmr
+  bump: patch

--- a/substrate/frame/merkle-mountain-range/src/mmr/mmr.rs
+++ b/substrate/frame/merkle-mountain-range/src/mmr/mmr.rs
@@ -104,9 +104,13 @@ where
 		raw_ancestry_proof.prev_peaks.clone(),
 	)
 	.map_err(|e| Error::Verify.log_debug(e))?;
-	raw_ancestry_proof
+
+	let is_valid = raw_ancestry_proof
 		.verify_ancestor(Node::Hash(root), prev_root.clone())
 		.map_err(|e| Error::Verify.log_debug(e))?;
+	if !is_valid {
+		return Err(Error::Verify.log_debug("invalid ancestry proof"));
+	}
 
 	Ok(prev_root.hash())
 }

--- a/substrate/frame/merkle-mountain-range/src/tests.rs
+++ b/substrate/frame/merkle-mountain-range/src/tests.rs
@@ -813,9 +813,15 @@ fn generating_and_verifying_ancestry_proofs_works_correctly() {
 				Pallet::<Test>::generate_ancestry_proof(prev_block_number as u64, None).unwrap();
 			assert!(Pallet::<Test>::is_ancestry_proof_optimal(&proof));
 			assert_eq!(
-				Pallet::<Test>::verify_ancestry_proof(root, proof),
+				Pallet::<Test>::verify_ancestry_proof(root, proof.clone()),
 				Ok(prev_roots[prev_block_number - 1])
 			);
+
+			let mut invalid_proof = proof;
+			for peak in invalid_proof.prev_peaks.iter_mut() {
+				*peak = H256::default();
+			}
+			assert!(Pallet::<Test>::verify_ancestry_proof(root, invalid_proof).is_err());
 		}
 
 		// Check that we can't generate ancestry proofs for a future block.


### PR DESCRIPTION
MMR: check `verify_ancestor()` output