### PR TITLE
Snowbride: Fix alloy receipt verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,6 +3108,11 @@ dependencies = [
 name = "bridge-hub-westend-integration-tests"
 version = "1.0.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "alloy-trie",
  "asset-hub-westend-runtime",
  "bp-asset-hub-westend",
  "bridge-hub-common",
@@ -3131,6 +3136,7 @@ dependencies = [
  "snowbridge-core",
  "snowbridge-inbound-queue-primitives",
  "snowbridge-outbound-queue-primitives",
+ "snowbridge-pallet-ethereum-client-fixtures",
  "snowbridge-pallet-inbound-queue",
  "snowbridge-pallet-inbound-queue-fixtures",
  "snowbridge-pallet-inbound-queue-v2",
@@ -23609,7 +23615,10 @@ dependencies = [
 name = "snowbridge-pallet-inbound-queue-v2"
 version = "0.2.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-core",
+ "alloy-primitives",
+ "alloy-rlp",
  "bp-relayers",
  "frame-benchmarking",
  "frame-support",
@@ -23622,6 +23631,8 @@ dependencies = [
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "snowbridge-inbound-queue-primitives",
+ "snowbridge-pallet-ethereum-client",
+ "snowbridge-pallet-ethereum-client-fixtures",
  "snowbridge-pallet-inbound-queue-v2-fixtures",
  "snowbridge-test-utils",
  "sp-core 28.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -647,6 +647,7 @@ alloy-provider = { version = "1.8.3", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-rpc-types = { version = "1.8.3", default-features = false }
 alloy-signer-local = { version = "1.8.3", default-features = false }
+alloy-sol-types = { version = "1.5.7", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
 always-assert = { version = "0.1" }
 anyhow = { version = "1.0.81", default-features = false }

--- a/bridges/snowbridge/pallets/inbound-queue-v2/Cargo.toml
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/Cargo.toml
@@ -43,8 +43,13 @@ bp-relayers = { workspace = true }
 xcm = { workspace = true }
 
 [dev-dependencies]
+alloy-consensus = { workspace = true, features = ["std"] }
+alloy-primitives = { workspace = true, features = ["std"] }
+alloy-rlp = { workspace = true, features = ["std"] }
 frame-benchmarking = { workspace = true, default-features = true }
 hex-literal = { workspace = true, default-features = true }
+snowbridge-pallet-ethereum-client = { workspace = true, default-features = true }
+snowbridge-pallet-ethereum-client-fixtures = { workspace = true, default-features = true }
 snowbridge-test-utils = { workspace = true }
 sp-keyring = { workspace = true, default-features = true }
 
@@ -54,7 +59,10 @@ xcm-executor = { workspace = true }
 [features]
 default = ["std"]
 std = [
+	"alloy-consensus/std",
 	"alloy-core/std",
+	"alloy-primitives/std",
+	"alloy-rlp/std",
 	"bp-relayers/std",
 	"codec/std",
 	"frame-benchmarking/std",
@@ -84,6 +92,8 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"snowbridge-core/runtime-benchmarks",
 	"snowbridge-inbound-queue-primitives/runtime-benchmarks",
+	"snowbridge-pallet-ethereum-client-fixtures/runtime-benchmarks",
+	"snowbridge-pallet-ethereum-client/runtime-benchmarks",
 	"snowbridge-pallet-inbound-queue-v2-fixtures/runtime-benchmarks",
 	"snowbridge-test-utils/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
@@ -96,5 +106,6 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"pallet-balances/try-runtime",
 	"snowbridge-inbound-queue-primitives/try-runtime",
+	"snowbridge-pallet-ethereum-client/try-runtime",
 	"sp-runtime/try-runtime",
 ]

--- a/bridges/snowbridge/pallets/inbound-queue-v2/src/mock.rs
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/src/mock.rs
@@ -280,3 +280,102 @@ pub fn mock_event_log_v2() -> Log {
         tx_index: 0,
     }
 }
+
+pub mod exploit {
+	use super::*;
+
+	use frame_support::traits::ConstU32;
+	use hex_literal::hex;
+	use snowbridge_beacon_primitives::{Fork, ForkVersions};
+
+	type Block = frame_system::mocking::MockBlock<ExploitTest>;
+
+	frame_support::construct_runtime!(
+		pub enum ExploitTest
+		{
+			System: frame_system::{Pallet, Call, Storage, Event<T>},
+			Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+			EthereumBeaconClient: snowbridge_pallet_ethereum_client::{Pallet, Call, Storage, Event<T>},
+			InboundQueue: inbound_queue_v2::{Pallet, Call, Storage, Event<T>},
+		}
+	);
+
+	#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+	impl frame_system::Config for ExploitTest {
+		type AccountId = AccountId;
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type AccountData = pallet_balances::AccountData<u128>;
+		type Block = Block;
+	}
+
+	#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+	impl pallet_balances::Config for ExploitTest {
+		type Balance = Balance;
+		type ExistentialDeposit = ExistentialDeposit;
+		type AccountStore = System;
+	}
+
+	parameter_types! {
+		pub const ChainForkVersions: ForkVersions = ForkVersions {
+			genesis: Fork { version: hex!("00000000"), epoch: 0 },
+			altair: Fork { version: hex!("01000000"), epoch: 0 },
+			bellatrix: Fork { version: hex!("02000000"), epoch: 0 },
+			capella: Fork { version: hex!("03000000"), epoch: 0 },
+			deneb: Fork { version: hex!("04000000"), epoch: 0 },
+			electra: Fork { version: hex!("05000000"), epoch: 0 },
+			fulu: Fork { version: hex!("06000000"), epoch: 100_000_000 },
+		};
+	}
+
+	impl snowbridge_pallet_ethereum_client::Config for ExploitTest {
+		type RuntimeEvent = RuntimeEvent;
+		type ForkVersions = ChainForkVersions;
+		type FreeHeadersInterval = ConstU32<32>;
+		type WeightInfo = ();
+	}
+
+	impl inbound_queue_v2::Config for ExploitTest {
+		type RuntimeEvent = RuntimeEvent;
+		type Verifier = EthereumBeaconClient;
+		type GatewayAddress = GatewayAddress;
+		type MessageProcessor = (
+			DummyPrefix,
+			XcmMessageProcessor<
+				ExploitTest,
+				MockXcmSender,
+				MockXcmExecutor,
+				MessageToXcm<
+					CreateAssetCall,
+					EthereumNetwork,
+					LocalNetwork,
+					GatewayAddress,
+					InboundQueueLocation,
+					AssetHubParaId,
+					MockTokenIdConvert,
+					AccountId,
+				>,
+				MockAccountLocationConverter<AccountId>,
+				TargetLocation,
+			>,
+			DummySuffix,
+		);
+		#[cfg(feature = "runtime-benchmarks")]
+		type Helper = Test;
+		type WeightInfo = ();
+		type RewardKind = BridgeReward;
+		type DefaultRewardKind = SnowbridgeReward;
+		type RewardPayment = MockRewardLedger;
+	}
+
+	pub fn setup() {
+		System::set_block_number(1);
+	}
+
+	pub fn new_tester() -> sp_io::TestExternalities {
+		let storage =
+			frame_system::GenesisConfig::<ExploitTest>::default().build_storage().unwrap();
+		let mut ext: sp_io::TestExternalities = storage.into();
+		ext.execute_with(setup);
+		ext
+	}
+}

--- a/bridges/snowbridge/pallets/inbound-queue-v2/src/test.rs
+++ b/bridges/snowbridge/pallets/inbound-queue-v2/src/test.rs
@@ -528,3 +528,114 @@ fn tip_paid_out_when_no_relayer_fee() {
 		assert_eq!(Tips::<Test>::get(nonce), None);
 	});
 }
+
+#[test]
+fn poc_permissionless_forged_receipt_bypasses_verifier_and_injects_xcm() {
+	use crate::mock::exploit;
+	use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope};
+	use alloy_core::sol_types::{SolEvent, SolValue};
+	use alloy_primitives::{Address, Bytes, Log as AlloyLog, B256};
+	use frame_support::{assert_noop, assert_ok};
+	use snowbridge_inbound_queue_primitives::{receipt::verify_receipt_proof, v2::IGatewayV2};
+	use snowbridge_pallet_ethereum_client_fixtures::make_inbound_fixture;
+
+	exploit::new_tester().execute_with(|| {
+		let fixture = make_inbound_fixture();
+
+		let attacker: AccountId = Keyring::Eve.into();
+		let origin = exploit::RuntimeOrigin::signed(attacker.clone());
+
+		// Initialize the Ethereum light client storage with a real finalized header.
+		assert_ok!(exploit::EthereumBeaconClient::store_finalized_header(
+			fixture.finalized_header,
+			fixture.block_roots_root
+		));
+
+		// Unlimited mint ...
+		let token_key: [u8; 20] = [0x42; 20]; // the "token address" that the XCM will try to mint to the attacker
+		let token_value: u128 = 1_000_000_000_000_000_000u128;
+
+		// Minting to the attacker itself
+		let beneficiary: Location =
+			Location::new(0, [AccountId32 { network: None, id: attacker.clone().into() }]);
+
+		// Craft a valid raw XCM payload and ABI-encode a Gateway log carrying it
+		let xcm: Xcm<()> = vec![DepositAsset {
+			assets: Wild(AllCounted(1).into()),
+			beneficiary: beneficiary.clone(),
+		}]
+		.into();
+		let raw_xcm: Vec<u8> = VersionedXcm::V5(xcm).encode();
+
+		let gateway_h160 = crate::mock::GatewayAddress::get();
+		let sig = IGatewayV2::OutboundMessageAccepted::SIGNATURE_HASH;
+		let topics = vec![sp_core::H256::from_slice(sig.as_slice())];
+		let log_data = IGatewayV2::OutboundMessageAccepted {
+			nonce: 1337u64,
+			payload: IGatewayV2::Payload {
+				origin: Address::from_slice(&[0x11; 20]),
+				assets: vec![IGatewayV2::EthereumAsset {
+					kind: 0,
+					data: IGatewayV2::AsNativeTokenERC20 {
+						token_id: Address::from_slice(&token_key),
+						value: token_value,
+					}
+					.abi_encode()
+					.into(),
+				}],
+				xcm: IGatewayV2::Xcm { kind: 0, data: raw_xcm.clone().into() },
+				claimer: Bytes::new(),
+				value: 0,
+				executionFee: 1,
+				relayerFee: 0,
+			},
+		}
+		.encode_data();
+
+		let forged_event_log = snowbridge_inbound_queue_primitives::Log {
+			address: gateway_h160,
+			topics,
+			data: log_data.clone(),
+			tx_index: 0,
+		};
+
+		// Forge an Ethereum receipt containing that exact log.
+		let forged_receipt_log = AlloyLog::new_unchecked(
+			Address::from_slice(forged_event_log.address.as_bytes()),
+			vec![B256::from_slice(sig.as_slice())],
+			Bytes::copy_from_slice(&log_data),
+		);
+		let forged_receipt = ReceiptEnvelope::Legacy(
+			Receipt {
+				status: Eip658Value::success(),
+				cumulative_gas_used: 0,
+				logs: vec![forged_receipt_log],
+			}
+			.with_bloom(),
+		);
+		let forged_receipt_bytes = alloy_rlp::encode(&forged_receipt);
+
+		// Build a malicious receipt proof: a real receipts-trie root node + an extra "proof node"
+		// that is just the forged receipt RLP bytes.
+		let receipts_root = fixture.event.proof.execution_proof.execution_header.receipts_root();
+		let root_node = fixture.event.proof.receipt_proof[0].clone();
+		let exploit_proof_nodes = vec![root_node, forged_receipt_bytes.clone()];
+
+		// With the path check fix, this forged proof must never verify for any tx index.
+		for tx_index in 0u64..10_000u64 {
+			assert!(
+				verify_receipt_proof(receipts_root, tx_index, &exploit_proof_nodes).is_none(),
+				"forged proof unexpectedly verified at tx_index={tx_index}"
+			);
+		}
+
+		let mut forged_proof = fixture.event.proof;
+		forged_proof.receipt_proof = exploit_proof_nodes;
+
+		let forged_event = EventProof { event_log: forged_event_log, proof: forged_proof };
+		assert_noop!(
+			exploit::InboundQueue::submit(origin, Box::new(forged_event)),
+			Error::<exploit::ExploitTest>::Verification(VerificationError::InvalidProof)
+		);
+	});
+}

--- a/bridges/snowbridge/primitives/verification/src/receipt.rs
+++ b/bridges/snowbridge/primitives/verification/src/receipt.rs
@@ -24,7 +24,9 @@ pub fn verify_receipt_proof(
 	// already cryptographically verified during this traversal.
 	let value = match verify_proof(root, key, None, proof_nodes.iter()) {
 		Ok(()) => return None, // Exclusion proof - key does not exist
-		Err(ProofVerificationError::ValueMismatch { got: Some(v), expected: None, .. }) => {
+		Err(ProofVerificationError::ValueMismatch { path, got: Some(v), expected: None })
+			if path == key =>
+		{
 			v.to_vec()
 		},
 		Err(_) => return None,

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/Cargo.toml
@@ -11,6 +11,11 @@ publish = false
 workspace = true
 
 [dependencies]
+alloy-consensus = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
+alloy-sol-types = { workspace = true }
+alloy-trie = { workspace = true }
 codec = { workspace = true }
 hex-literal = { workspace = true, default-features = true }
 scale-info = { workspace = true }
@@ -45,12 +50,16 @@ cumulus-pallet-xcmp-queue = { workspace = true }
 emulated-integration-tests-common = { workspace = true }
 parachains-common = { workspace = true, default-features = true }
 rococo-westend-system-emulated-network = { workspace = true }
-testnet-parachains-constants = { features = ["rococo", "westend"], workspace = true, default-features = true }
+testnet-parachains-constants = { features = [
+	"rococo",
+	"westend",
+], workspace = true, default-features = true }
 
 # Snowbridge
 snowbridge-core = { workspace = true }
 snowbridge-inbound-queue-primitives = { workspace = true }
 snowbridge-outbound-queue-primitives = { workspace = true }
+snowbridge-pallet-ethereum-client-fixtures = { workspace = true }
 snowbridge-pallet-inbound-queue = { workspace = true }
 snowbridge-pallet-inbound-queue-fixtures = { workspace = true }
 snowbridge-pallet-inbound-queue-v2 = { workspace = true }

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod snowbridge_common;
 // mod snowbridge_v2_inbound;
 mod snowbridge_edge_case;
 mod snowbridge_v2_inbound;
+mod snowbridge_v2_inbound_edge_case;
 mod snowbridge_v2_inbound_to_rococo;
 mod snowbridge_v2_outbound;
 mod snowbridge_v2_outbound_edge_case;

--- a/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound_edge_case.rs
+++ b/cumulus/parachains/integration-tests/emulated/tests/bridges/bridge-hub-westend/src/tests/snowbridge_v2_inbound_edge_case.rs
@@ -1,0 +1,72 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope};
+use alloy_primitives::{Address, Bytes, Log as AlloyLog, B256};
+use alloy_sol_types::{SolEvent, SolValue};
+use emulated_integration_tests_common::snowbridge::WETH;
+use snowbridge_inbound_queue_primitives::v2::IGatewayV2;
+
+#[test]
+fn forged_receipt_proof_is_rejected_after_path_check_fix() {
+	let gateway = Address::from_slice(&[0x42; 20]);
+	let token_value: u128 = 2_000_000_000_000u128;
+	let sig = IGatewayV2::OutboundMessageAccepted::SIGNATURE_HASH;
+	let topics = vec![sp_core::H256::from_slice(sig.as_slice())];
+
+	let log_data = IGatewayV2::OutboundMessageAccepted {
+		nonce: 1337u64,
+		payload: IGatewayV2::Payload {
+			origin: Address::from_slice(&[0x11; 20]),
+			assets: vec![IGatewayV2::EthereumAsset {
+				kind: 0,
+				data: IGatewayV2::AsNativeTokenERC20 {
+					token_id: Address::from_slice(&WETH),
+					value: token_value,
+				}
+				.abi_encode()
+				.into(),
+			}],
+			xcm: IGatewayV2::Xcm { kind: 0, data: vec![1, 2, 3].into() },
+			claimer: Bytes::new(),
+			value: 0,
+			executionFee: 1,
+			relayerFee: 0,
+		},
+	}
+	.encode_data();
+
+	let forged_receipt_log = AlloyLog::new_unchecked(
+		gateway,
+		vec![B256::from_slice(sig.as_slice())],
+		Bytes::copy_from_slice(&log_data),
+	);
+	let forged_receipt = ReceiptEnvelope::Legacy(
+		Receipt {
+			status: Eip658Value::success(),
+			cumulative_gas_used: 0,
+			logs: vec![forged_receipt_log],
+		}
+		.with_bloom(),
+	);
+	let forged_receipt_bytes = alloy_rlp::encode(&forged_receipt);
+
+	let fixture = snowbridge_pallet_ethereum_client_fixtures::make_inbound_fixture();
+	let receipts_root = fixture.event.proof.execution_proof.execution_header.receipts_root();
+	let root_node = fixture.event.proof.receipt_proof[0].clone();
+	let exploit_proof_nodes = vec![root_node, forged_receipt_bytes];
+
+	for tx_index in 0u64..10_000u64 {
+		assert!(
+			snowbridge_inbound_queue_primitives::receipt::verify_receipt_proof(
+				receipts_root,
+				tx_index,
+				&exploit_proof_nodes,
+			)
+			.is_none(),
+			"forged proof unexpectedly verified at tx_index={tx_index}"
+		);
+	}
+
+	let _ = topics;
+}

--- a/prdoc/pr_11739.prdoc
+++ b/prdoc/pr_11739.prdoc
@@ -1,0 +1,18 @@
+title: "Snowbridge: tighten receipt proof validation path check"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Hardens Snowbridge receipt proof verification by only accepting the
+      `ValueMismatch { got: Some(_), expected: None }` extraction path when the
+      mismatch path equals the queried trie key.
+
+      This prevents malformed proofs from being interpreted as valid inclusion
+      proofs for a different key.
+
+      Adds regression coverage in both unit and integration tests to ensure
+      forged receipt proofs are rejected.
+
+crates:
+  - name: snowbridge-verification-primitives
+    bump: patch

--- a/prdoc/pr_11739.prdoc
+++ b/prdoc/pr_11739.prdoc
@@ -16,3 +16,7 @@ doc:
 crates:
   - name: snowbridge-verification-primitives
     bump: patch
+  - name: snowbridge-pallet-inbound-queue-v2
+    bump: none
+  - name: bridge-hub-westend-integration-tests
+    bump: none


### PR DESCRIPTION
### Context

Hardens Snowbridge receipt proof verification by only accepting the `ValueMismatch { got: Some(_), expected: None }` extraction path when the mismatch path equals the queried trie key.