### PR TITLE
[asset-conversion-pallet] quote respects minimum balance

### DIFF
--- a/prdoc/pr_11761.prdoc
+++ b/prdoc/pr_11761.prdoc
@@ -1,0 +1,19 @@
+title: 'asset-conversion-pallet: quote respects minimum balance'
+
+doc:
+  - audience: [Runtime Dev, Runtime User]
+    description: |
+      Quote functions (`quote_price_exact_tokens_for_tokens`, `quote_price_tokens_for_exact_tokens`)
+      now return `None` when the computed output exceeds what the pool can actually withdraw while
+      staying alive.
+
+      Swap execution withdraws from pools with `Preserve` preservation, meaning the pool must retain
+      at least `min_balance`. The quote functions did not account for this, so they could return a
+      price for a swap that would fail at execution.
+
+      Both quote functions now check the output against `reducible_balance(Preserve, Polite)` — the
+      same preservation level the swap uses.
+
+crates:
+  - name: pallet-asset-conversion
+    bump: patch

--- a/substrate/frame/asset-conversion/src/lib.rs
+++ b/substrate/frame/asset-conversion/src/lib.rs
@@ -1414,16 +1414,26 @@ pub mod pallet {
 			let pool_account = T::PoolLocator::pool_address(&asset1, &asset2).ok()?;
 
 			let balance1 = Self::get_balance(&pool_account, asset1);
-			let balance2 = Self::get_balance(&pool_account, asset2);
-			if !balance1.is_zero() {
-				if include_fee {
-					Self::get_amount_out(&amount, &balance1, &balance2).ok()
-				} else {
-					Self::quote(&amount, &balance1, &balance2).ok()
-				}
-			} else {
-				None
+			let balance2 = Self::get_balance(&pool_account, asset2.clone());
+
+			if balance1.is_zero() {
+				return None;
 			}
+
+			let amount_out = if include_fee {
+				Self::get_amount_out(&amount, &balance1, &balance2).ok()?
+			} else {
+				Self::quote(&amount, &balance1, &balance2).ok()?
+			};
+
+			// Swap withdrawals from pools use `keep_alive=true` (Preserve). Use the same
+			// preservation level to determine the actual withdrawable amount.
+			let max_output = T::Assets::reducible_balance(asset2, &pool_account, Preserve, Polite);
+			if amount_out > max_output {
+				return None;
+			}
+
+			Some(amount_out)
 		}
 
 		/// Gets a quote for swapping `amount` of `asset1` for an exact amount of `asset2`.
@@ -1442,15 +1452,23 @@ pub mod pallet {
 			let pool_account = T::PoolLocator::pool_address(&asset1, &asset2).ok()?;
 
 			let balance1 = Self::get_balance(&pool_account, asset1);
-			let balance2 = Self::get_balance(&pool_account, asset2);
-			if !balance1.is_zero() {
-				if include_fee {
-					Self::get_amount_in(&amount, &balance1, &balance2).ok()
-				} else {
-					Self::quote(&amount, &balance2, &balance1).ok()
-				}
+			let balance2 = Self::get_balance(&pool_account, asset2.clone());
+
+			if balance1.is_zero() {
+				return None;
+			}
+
+			// Swap withdrawals from pools use `keep_alive=true` (Preserve). Use the same
+			// preservation level to determine the actual withdrawable amount.
+			let max_output = T::Assets::reducible_balance(asset2, &pool_account, Preserve, Polite);
+			if amount > max_output {
+				return None;
+			}
+
+			if include_fee {
+				Self::get_amount_in(&amount, &balance1, &balance2).ok()
 			} else {
-				None
+				Self::quote(&amount, &balance2, &balance1).ok()
 			}
 		}
 	}

--- a/substrate/frame/asset-conversion/src/tests.rs
+++ b/substrate/frame/asset-conversion/src/tests.rs
@@ -1055,6 +1055,16 @@ fn quote_price_returns_none_when_output_exceeds_pool_withdrawable() {
 			),
 			None
 		);
+		// Also without fees.
+		assert_eq!(
+			AssetConversion::quote_price_exact_tokens_for_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				1_005_018,
+				false,
+			),
+			None
+		);
 		// input=1_005_017, output=1000 ≤ 1000, must return Some.
 		assert!(AssetConversion::quote_price_exact_tokens_for_tokens(
 			token_1.clone(),

--- a/substrate/frame/asset-conversion/src/tests.rs
+++ b/substrate/frame/asset-conversion/src/tests.rs
@@ -1044,21 +1044,22 @@ fn quote_price_returns_none_when_output_exceeds_pool_withdrawable() {
 		.is_some());
 
 		// quote_price_exact_tokens_for_tokens: given input, computed output must fit.
-		// Very large input produces output > 1000, must return None.
+		// With reserves (1_000_000, 2_000), fee=0.3%, and max_output=1000:
+		// input=1_005_018, output=1001 > 1000, must return None.
 		assert_eq!(
 			AssetConversion::quote_price_exact_tokens_for_tokens(
 				token_1.clone(),
 				token_2.clone(),
-				5_000_000,
+				1_005_018,
 				true,
 			),
 			None
 		);
-		// Moderate input should produce output within limit and return Some.
+		// input=1_005_017, output=1000 ≤ 1000, must return Some.
 		assert!(AssetConversion::quote_price_exact_tokens_for_tokens(
 			token_1.clone(),
 			token_2.clone(),
-			100_000,
+			1_005_017,
 			true,
 		)
 		.is_some());
@@ -1066,9 +1067,7 @@ fn quote_price_returns_none_when_output_exceeds_pool_withdrawable() {
 }
 
 #[test]
-fn quote_price_returns_none_but_previously_would_return_some() {
-	// Regression test: before the fix, quote would return Some(value) even though the
-	// actual swap would fail because the pool cannot deliver while staying alive.
+fn quote_price_returns_none_swap_fails() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
 		let token_1 = NativeOrWithId::Native;

--- a/substrate/frame/asset-conversion/src/tests.rs
+++ b/substrate/frame/asset-conversion/src/tests.rs
@@ -983,6 +983,154 @@ fn quote_price_tokens_for_exact_tokens_matches_execution() {
 }
 
 #[test]
+fn quote_price_returns_none_when_output_exceeds_pool_withdrawable() {
+	new_test_ext().execute_with(|| {
+		let user = 1;
+		let token_1 = NativeOrWithId::Native;
+		let token_2 = NativeOrWithId::WithId(2);
+		let ed = 1000;
+
+		create_tokens_with_ed(user, vec![token_2.clone()], ed);
+		assert_ok!(AssetConversion::create_pool(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone())
+		));
+
+		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), user, 10_000_000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), 2, user, 10_000));
+
+		assert_ok!(AssetConversion::add_liquidity(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone()),
+			1_000_000,
+			2_000,
+			1,
+			1,
+			user,
+		));
+		// Pool has 1_000_000 native and 2_000 of asset2 (min_balance=1000).
+		// Pool can only send out up to 2_000 - 1_000 = 1_000 of asset2 while staying alive.
+
+		// quote_price_tokens_for_exact_tokens: requesting exact output.
+		// Requesting 1001 of asset2 exceeds available (1000), must return None.
+		assert_eq!(
+			AssetConversion::quote_price_tokens_for_exact_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				1001,
+				true,
+			),
+			None
+		);
+		// Also without fees.
+		assert_eq!(
+			AssetConversion::quote_price_tokens_for_exact_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				1001,
+				false,
+			),
+			None
+		);
+		// Requesting exactly 1000 should succeed (at the boundary).
+		assert!(AssetConversion::quote_price_tokens_for_exact_tokens(
+			token_1.clone(),
+			token_2.clone(),
+			1000,
+			true,
+		)
+		.is_some());
+
+		// quote_price_exact_tokens_for_tokens: given input, computed output must fit.
+		// Very large input produces output > 1000, must return None.
+		assert_eq!(
+			AssetConversion::quote_price_exact_tokens_for_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				5_000_000,
+				true,
+			),
+			None
+		);
+		// Moderate input should produce output within limit and return Some.
+		assert!(AssetConversion::quote_price_exact_tokens_for_tokens(
+			token_1.clone(),
+			token_2.clone(),
+			100_000,
+			true,
+		)
+		.is_some());
+	});
+}
+
+#[test]
+fn quote_price_returns_none_but_previously_would_return_some() {
+	// Regression test: before the fix, quote would return Some(value) even though the
+	// actual swap would fail because the pool cannot deliver while staying alive.
+	new_test_ext().execute_with(|| {
+		let user = 1;
+		let token_1 = NativeOrWithId::Native;
+		let token_2 = NativeOrWithId::WithId(2);
+		let ed = 1000;
+
+		create_tokens_with_ed(user, vec![token_2.clone()], ed);
+		assert_ok!(AssetConversion::create_pool(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone())
+		));
+
+		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), user, 10_000_000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), 2, user, 10_000));
+
+		assert_ok!(AssetConversion::add_liquidity(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone()),
+			1_000_000,
+			2_000,
+			1,
+			1,
+			user,
+		));
+
+		// The AMM formula can compute a price for 1001 output (it's below reserve of 2000),
+		// but the pool can only deliver 1000 (2000 - 1000 min_balance).
+		// Verify the raw AMM math would produce a result...
+		let (reserve_in, reserve_out) =
+			AssetConversion::get_reserves(token_1.clone(), token_2.clone()).unwrap();
+		assert!(Pallet::<Test>::get_amount_in(&1001, &reserve_in, &reserve_out).is_ok());
+		// ...but the quote correctly returns None.
+		assert_eq!(
+			AssetConversion::quote_price_tokens_for_exact_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				1001,
+				true,
+			),
+			None
+		);
+
+		// And verify the actual swap would indeed fail.
+		let swapper = 3;
+		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), swapper, 10_000_000));
+		assert_noop!(
+			AssetConversion::swap_tokens_for_exact_tokens(
+				RuntimeOrigin::signed(swapper),
+				bvec![token_1.clone(), token_2.clone()],
+				1001,
+				10_000_000,
+				swapper,
+				false,
+			),
+			TokenError::NotExpendable
+		);
+	});
+}
+
+#[test]
 fn can_swap_with_native() {
 	new_test_ext().execute_with(|| {
 		let user = 1;


### PR DESCRIPTION
Quote functions (`quote_price_exact_tokens_for_tokens`, `quote_price_tokens_for_exact_tokens`) now return `None` when the computed output exceeds what the pool can actually withdraw while staying alive.

Swap execution withdraws from pools with `Preserve` preservation, meaning the pool must retain at least `min_balance`. The quote functions did not account for this, so they could return a price for a swap that would fail at execution.

Both quote functions now check the output against `reducible_balance(Preserve, Polite)` - the same preservation level the swap uses.