### PR TITLE
refactor: replace ok().ok_or() with map_err for binary_search

### DIFF
--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -678,8 +678,7 @@ pub mod pallet {
 			let mut announcements = <Announcements<T, I>>::get();
 			let pos = announcements
 				.binary_search(&announcement)
-				.ok()
-				.ok_or(Error::<T, I>::MissingAnnouncement)?;
+				.map_err(|_| Error::<T, I>::MissingAnnouncement)?;
 			announcements.remove(pos);
 			<Announcements<T, I>>::put(announcements);
 
@@ -1064,8 +1063,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				for who in out_accounts.iter() {
 					let pos = accounts
 						.binary_search(who)
-						.ok()
-						.ok_or(Error::<T, I>::NotListedAsUnscrupulous)?;
+						.map_err(|_| Error::<T, I>::NotListedAsUnscrupulous)?;
 					accounts.remove(pos);
 				}
 				Ok(())
@@ -1076,8 +1074,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				for web in out_webs.iter() {
 					let pos = webs
 						.binary_search(web)
-						.ok()
-						.ok_or(Error::<T, I>::NotListedAsUnscrupulous)?;
+						.map_err(|_| Error::<T, I>::NotListedAsUnscrupulous)?;
 					webs.remove(pos);
 				}
 				Ok(())


### PR DESCRIPTION
What does this PR do?
This PR refactors several usages of binary_search(...).ok().ok_or(...) to use binary_search(...).map_err(|_| ...).

Why was this needed?
The previous pattern performs an unnecessary conversion from Result to Option and back to Result. Using map_err keeps the value in Result form and directly maps the error, which improves readability, avoids redundant conversions, and follows more idiomatic Rust practices.

What is the impact?
There is no change in behavior. The same error conditions and return values are preserved. This is purely a code quality and readability improvement.

What’s the best way to test this?
Existing tests already cover the affected logic (remove_announcement and remove_unscrupulous_items). Run cargo test and verify all tests pass.

Additional notes
This is a small refactor focused on improving code clarity and consistency.