### PR TITLE
[Release|CI/CD] Run workspace check only for parallel publishing

### DIFF
--- a/.github/workflows/release-80_publish-crates.yml
+++ b/.github/workflows/release-80_publish-crates.yml
@@ -281,7 +281,7 @@ jobs:
           echo "Cargo.lock updated"
 
       - name: Verify workspace compiles
-        if: inputs.resume_from == 'full' || inputs.resume_from == 'apply'
+        if: (inputs.resume_from == 'full' || inputs.resume_from == 'apply') && inputs.publish_jobs > 0
         env:
           SKIP_WASM_BUILD: 1
         run: |


### PR DESCRIPTION
This adjustment will let to trigger the workspace check only for the parallel publishing, we don't need it in sequential case, cause crates are going to be checked on cargo publish one by one