### PR TITLE
sc-network: fix 'occured' -> 'occurred' in event.rs doc comment

### DIFF
--- a/substrate/client/network/src/event.rs
+++ b/substrate/client/network/src/event.rs
@@ -56,7 +56,7 @@ pub enum DhtEvent {
 	/// Successfully started providing the given key.
 	StartedProviding(Key),
 
-	/// An error occured while registering as a content provider on the DHT.
+	/// An error occurred while registering as a content provider on the DHT.
 	StartProvidingFailed(Key),
 
 	/// The DHT received a put record request.


### PR DESCRIPTION
Doc comment in `substrate/client/network/src/event.rs` line 59 reads `An error occured while registering`. Fixed to `occurred`. Comment-only change.