### PR TITLE
Refactor/use is empty runtime api

### DIFF
--- a/docs/contributor/container.md
+++ b/docs/contributor/container.md
@@ -1,10 +1,10 @@
 # Using Containers
 
-Using containers via **Podman** or **Docker** brings benefit, whether it is to build a container image or run a node
+Using containers via **Podman** or **Docker** brings benefits, whether it is to build a container image or run a node
 while keeping a minimum footprint on your local system.
 
-This document mentions using `podman` or `docker`. Those are usually interchangeable and it is encouraged using
-preferably **Podman**. If you have podman installed and want to use all the commands mentioned below, you can simply
+This document mentions using `podman` or `docker`. These are usually interchangeable and using
+**Podman** is preferred. If you have podman installed and want to use all the commands mentioned below, you can simply
 create an alias with `alias docker=podman`.
 
 There are a few options to build a node within a container and inject a binary inside an image.
@@ -53,13 +53,13 @@ ARTIFACTS_FOLDER=./target/release /docker/scripts/build-injected.sh
 
 ## Container build
 
-Alternatively, you can build an image with a builder pattern. This options takes a while but offers a simple method for
+Alternatively, you can build an image with a builder pattern. This option takes a while but offers a simple method for
 anyone to get a working container image without requiring any of the Rust toolchain installed locally.
 
 ```bash
 docker build \
 	--tag $OWNER/$IMAGE_NAME \
- --file ./docker/dockerfiles/polkadot-parachain/polkadot-parachain_builder.Dockerfile .
+ 	--file ./docker/dockerfiles/polkadot-parachain/polkadot-parachain_builder.Dockerfile .
 ```
 
 You may then run your new container:

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -501,7 +501,7 @@ where
 	/// Poll the active runtime API requests.
 	async fn poll_requests(&mut self) {
 		// If there are no active requests, this future should be pending forever.
-		if self.active_requests.len() == 0 {
+		if self.active_requests.is_empty() {
 			return futures::pending!();
 		}
 

--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -678,8 +678,7 @@ pub mod pallet {
 			let mut announcements = <Announcements<T, I>>::get();
 			let pos = announcements
 				.binary_search(&announcement)
-				.ok()
-				.ok_or(Error::<T, I>::MissingAnnouncement)?;
+				.map_err(|_| Error::<T, I>::MissingAnnouncement)?;
 			announcements.remove(pos);
 			<Announcements<T, I>>::put(announcements);
 
@@ -1064,8 +1063,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				for who in out_accounts.iter() {
 					let pos = accounts
 						.binary_search(who)
-						.ok()
-						.ok_or(Error::<T, I>::NotListedAsUnscrupulous)?;
+						.map_err(|_| Error::<T, I>::NotListedAsUnscrupulous)?;
 					accounts.remove(pos);
 				}
 				Ok(())
@@ -1076,8 +1074,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				for web in out_webs.iter() {
 					let pos = webs
 						.binary_search(web)
-						.ok()
-						.ok_or(Error::<T, I>::NotListedAsUnscrupulous)?;
+						.map_err(|_| Error::<T, I>::NotListedAsUnscrupulous)?;
 					webs.remove(pos);
 				}
 				Ok(())


### PR DESCRIPTION
## What does this PR do?

Replaces `len() == 0` with `is_empty()` when checking whether `active_requests` is empty.

## Why is this needed?

`is_empty()` is the more idiomatic and clearer Rust style for checking emptiness, while preserving the same behavior.

## What is the best way to test this PR?

Review the diff and confirm the empty check now uses `is_empty()` instead of `len() == 0`.

## Relevant issues

N/A