### PR TITLE
[xcm-emulator] Make block producer overridable for non-Aura chains

### DIFF
--- a/cumulus/xcm/xcm-emulator/src/lib.rs
+++ b/cumulus/xcm/xcm-emulator/src/lib.rs
@@ -161,6 +161,44 @@ pub trait AdditionalInherentCode {
 
 impl AdditionalInherentCode for () {}
 
+/// Customizes block production inside the emulator.
+///
+/// The default impl ([`AuraBlockProducer`]) covers Aura-based parachains.
+/// Parachains using a different consensus (e.g. Nimbus) can supply a custom
+/// implementation via the `BlockProducer:` field of `decl_test_parachains!`.
+pub trait BlockProducer {
+	/// Slot duration in milliseconds, used to compute the relay-to-para block
+	/// ratio when advancing the network.
+	fn slot_duration() -> u64;
+
+	/// Pre-runtime digest prepended when initialising a new parachain block.
+	fn pre_runtime_digest(relay_block_number: u32) -> Digest;
+}
+
+/// Default `BlockProducer` implementation for Aura-based parachains.
+pub struct AuraBlockProducer<T>(PhantomData<T>);
+
+impl<T> BlockProducer for AuraBlockProducer<T>
+where
+	T: pallet_aura::Config,
+	u64: From<<T as pallet_timestamp::Config>::Moment>,
+{
+	fn slot_duration() -> u64 {
+		pallet_aura::Pallet::<T>::slot_duration().into()
+	}
+
+	fn pre_runtime_digest(relay_block_number: u32) -> Digest {
+		let slot_duration = Self::slot_duration();
+		let aura_slot: Slot =
+			(relay_block_number as u64 * RELAY_CHAIN_SLOT_DURATION_MILLIS / slot_duration).into();
+		let mut digest = Digest::default();
+		digest
+			.logs
+			.push(DigestItem::PreRuntime(AURA_ENGINE_ID, Encode::encode(&aura_slot)));
+		digest
+	}
+}
+
 pub trait TestExt {
 	fn build_new_ext(storage: Storage) -> TestExternalities;
 	fn new_ext() -> TestExternalities;
@@ -292,6 +330,7 @@ pub trait Parachain: Chain {
 	type ParachainSystem;
 	type MessageProcessor: ProcessMessage + ServiceQueues;
 	type AdditionalInherentCode: AdditionalInherentCode;
+	type BlockProducer: BlockProducer;
 
 	fn init();
 
@@ -633,6 +672,7 @@ macro_rules! decl_test_parachains {
 					MessageOrigin: $message_origin:path,
 					$( AdditionalInherentCode: $additional_inherent_code:ty,)?
 					$( native_total_supply_tracker: $total_supply_tracker:expr,)?
+					$( BlockProducer: $block_producer:ty,)?
 				},
 				pallets = {
 					$($pallet_name:ident: $pallet_path:path,)*
@@ -678,6 +718,7 @@ macro_rules! decl_test_parachains {
 				type ParachainInfo = $parachain_info;
 				type MessageProcessor = $crate::DefaultParaMessageProcessor<$name<N>, $message_origin>;
 				$crate::decl_test_parachains!(@inner_additional_inherent_code $($additional_inherent_code)?);
+				$crate::decl_test_parachains!(@inner_block_producer $runtime, $($block_producer)?);
 
 				// We run an empty block during initialisation to open HRMP channels
 				// and have them ready for the next block
@@ -698,14 +739,15 @@ macro_rules! decl_test_parachains {
 
 				fn new_block() {
 					use $crate::{
-						Dispatchable, Chain, TestExt, Zero, AdditionalInherentCode,
-						RELAY_CHAIN_SLOT_DURATION_MILLIS
+						Dispatchable, Chain, TestExt, Zero, AdditionalInherentCode, BlockProducer,
+						Parachain, RELAY_CHAIN_SLOT_DURATION_MILLIS
 					};
 
 					let para_id = Self::para_id().into();
 
 					Self::ext_wrapper(|| {
-						let slot_duration = $crate::pallet_aura::Pallet::<$runtime::Runtime>::slot_duration();
+						let slot_duration =
+							<<Self as Parachain>::BlockProducer as BlockProducer>::slot_duration();
 
 						let relay_blocks_per_para_block =
 							(slot_duration / RELAY_CHAIN_SLOT_DURATION_MILLIS).max(1) as u32;
@@ -726,16 +768,9 @@ macro_rules! decl_test_parachains {
 							.clone()
 						);
 
-						// Build aura digest: derive para slot from relay block number and slot durations.
-						let aura_slot: $crate::Slot = (relay_block_number as u64
-							* RELAY_CHAIN_SLOT_DURATION_MILLIS
-							/ slot_duration)
-							.into();
-						let mut digest = $crate::Digest::default();
-						digest.logs.push($crate::DigestItem::PreRuntime(
-							$crate::AURA_ENGINE_ID,
-							$crate::Encode::encode(&aura_slot),
-						));
+						// Pre-runtime digest comes from the configured `BlockProducer`
+						// (Aura by default; Nimbus and friends can plug in).
+						let digest = <<Self as Parachain>::BlockProducer as BlockProducer>::pre_runtime_digest(relay_block_number);
 						<Self as Chain>::System::initialize(&block_number, &parent_head_data.hash(), &digest);
 
 						// Process `on_initialize` for all pallets except `System`.
@@ -839,6 +874,8 @@ macro_rules! decl_test_parachains {
 	( @inner_additional_inherent_code /* none */ ) => { type AdditionalInherentCode = (); };
 	( @inner_total_supply_tracker $total_supply_tracker:expr ) => { $total_supply_tracker };
 	( @inner_total_supply_tracker /* none */ ) => { false };
+	( @inner_block_producer $runtime:ident, $block_producer:ty ) => { type BlockProducer = $block_producer; };
+	( @inner_block_producer $runtime:ident, /* none */ ) => { type BlockProducer = $crate::AuraBlockProducer<$runtime::Runtime>; };
 }
 
 #[macro_export]

--- a/prdoc/pr_11791.prdoc
+++ b/prdoc/pr_11791.prdoc
@@ -1,0 +1,39 @@
+title: 'Make block producer overridable for non-Aura chains'
+doc:
+  - audience: Runtime Dev
+    description: |
+      Introduces a `BlockProducer` trait used by `xcm-emulator` to drive slot duration
+      and pre-runtime digest construction when emulating a parachain block. The default
+      `AuraBlockProducer<T>` impl preserves the previous behaviour (slot derived from
+      `pallet_aura::Pallet::<T>::slot_duration()` and an Aura `PreRuntime` digest under
+      `AURA_ENGINE_ID`), so existing Aura-based `decl_test_parachains!` invocations are
+      unaffected.
+
+      The `decl_test_parachains!` macro gains an optional `BlockProducer:` field. Nimbus-based
+      parachains (e.g. Moonbeam) can now plug in a custom producer that emits a Nimbus
+      pre-runtime digest and a bespoke slot duration instead of being forced to implement
+      `pallet_aura::Config` just to participate in xcm-emulator integration tests.
+
+      Example:
+
+      ```rust
+      decl_test_parachains! {
+          pub struct MyPara {
+              // ...
+              core = {
+                  XcmpMessageHandler: my_runtime::XcmpQueue,
+                  LocationToAccountId: my_runtime::LocationToAccountId,
+                  ParachainInfo: my_runtime::ParachainInfo,
+                  MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
+                  BlockProducer: MyNimbusBlockProducer,
+              },
+              // ...
+          }
+      }
+      ```
+
+      Downstream crates that implement `Parachain` directly (rather than via the macro)
+      must now also provide a `type BlockProducer: BlockProducer` associated type.
+crates:
+  - name: xcm-emulator
+    bump: major


### PR DESCRIPTION
# Description

Makes the slot/digest producer used by `xcm-emulator`'s `decl_test_parachains!` macro overridable so parachains that don't run Aura (e.g. Nimbus-based chains like Moonbeam) can be wired into xcm-emulator-based integration tests.

Previously, `new_block()` was hard-coded to call `pallet_aura::Pallet::<Runtime>::slot_duration()` and to build an Aura `PreRuntime` digest. This forced every emulated parachain to implement `pallet_aura::Config`, which is not viable for Nimbus-based runtimes.

  ## Integration

Fully backwards-compatible — existing `decl_test_parachains!` invocations need no changes. Aura-based parachains keep the same behaviour through a default `AuraBlockProducer<T>` impl.

Non-Aura parachains can now plug in a custom producer via a new optional `BlockProducer:` field:

  ```diff
   decl_test_parachains! {
       pub struct MyPara {
           genesis = genesis(),
           on_init = (),
           runtime = my_runtime,
           core = {
               XcmpMessageHandler: my_runtime::XcmpQueue,
               LocationToAccountId: my_runtime::LocationToAccountId,
               ParachainInfo: my_runtime::ParachainInfo,
               MessageOrigin: cumulus_primitives_core::AggregateMessageOrigin,
  +            BlockProducer: MyNimbusBlockProducer,
           },
           pallets = { /* ... */ }
       }
   }
  ```

  Where `MyNimbusBlockProducer` implements the new trait:

  ```rust
  pub trait BlockProducer {
      fn slot_duration() -> u64;
      fn pre_runtime_digest(relay_block_number: u32) -> Digest;
  }
  ```

If the field is omitted, `AuraBlockProducer<Runtime>` is used, reproducing the previous behaviour exactly.

## Review Notes

- Adds a public `BlockProducer` trait in `cumulus/xcm/xcm-emulator/src/lib.rs` with two methods (`slot_duration`, `pre_runtime_digest`) — the two call sites in `new_block()` that previously depended on
  `pallet_aura`.
- Provides `AuraBlockProducer<T>` as the default impl, gated on `T: pallet_aura::Config` with `u64: From<T::Moment>`. Its `pre_runtime_digest` reproduces the previous inline digest construction verbatim (same
  slot derivation, same `AURA_ENGINE_ID`).
- Adds `type BlockProducer: BlockProducer` to the `Parachain` trait.
- Extends `decl_test_parachains!` with an optional `BlockProducer:` field and an `@inner_block_producer` helper arm that falls back to `$crate::AuraBlockProducer<$runtime::Runtime>` when unspecified.
- In `new_block()`, `slot_duration` and the pre-runtime digest are now obtained through `<Self as Parachain>::BlockProducer`; all other inherent/timestamp logic is unchanged.

No new tests. Behaviour for Aura-based parachains is unchanged and already covered by existing emulator tests; the new extension point is exercised by downstream (Moonbeam) integration tests.