### PR TITLE
Harden asset-conversion quote functions against zero amounts

### DIFF
--- a/prdoc/pr_11795.prdoc
+++ b/prdoc/pr_11795.prdoc
@@ -1,0 +1,11 @@
+title: "Harden asset-conversion quote functions against zero amounts"
+doc:
+- audience: Runtime Dev
+  description: |-
+    Hardens `quote_price_exact_tokens_for_tokens` and `quote_price_tokens_for_exact_tokens` in
+    `pallet-asset-conversion` to return `None` for zero input amounts and when integer rounding
+    produces a zero output. Previously, zero inputs could propagate through the AMM math and
+    zero outputs from small-input rounding were returned as `Some(0)`.
+crates:
+- name: pallet-asset-conversion
+  bump: patch

--- a/substrate/frame/asset-conversion/src/lib.rs
+++ b/substrate/frame/asset-conversion/src/lib.rs
@@ -1411,6 +1411,11 @@ pub mod pallet {
 			amount: T::Balance,
 			include_fee: bool,
 		) -> Option<T::Balance> {
+			// Swaps reject zero amounts, match that behavior.
+			if amount.is_zero() {
+				return None;
+			}
+
 			let pool_account = T::PoolLocator::pool_address(&asset1, &asset2).ok()?;
 
 			let balance1 = Self::get_balance(&pool_account, asset1);
@@ -1425,6 +1430,11 @@ pub mod pallet {
 			} else {
 				Self::quote(&amount, &balance1, &balance2).ok()?
 			};
+
+			// Small inputs can round output to zero due to integer division.
+			if amount_out.is_zero() {
+				return None;
+			}
 
 			// Swap withdrawals from pools use `keep_alive=true` (Preserve). Use the same
 			// preservation level to determine the actual withdrawable amount.
@@ -1449,6 +1459,10 @@ pub mod pallet {
 			amount: T::Balance,
 			include_fee: bool,
 		) -> Option<T::Balance> {
+			// Swaps reject zero amounts, match that behavior.
+			if amount.is_zero() {
+				return None;
+			}
 			let pool_account = T::PoolLocator::pool_address(&asset1, &asset2).ok()?;
 
 			let balance1 = Self::get_balance(&pool_account, asset1);

--- a/substrate/frame/asset-conversion/src/tests.rs
+++ b/substrate/frame/asset-conversion/src/tests.rs
@@ -644,6 +644,108 @@ fn can_not_redeem_more_lp_tokens_than_were_minted() {
 }
 
 #[test]
+fn quote_price_returns_none_for_zero_amount() {
+	new_test_ext().execute_with(|| {
+		let user = 1;
+		let token_1 = NativeOrWithId::Native;
+		let token_2 = NativeOrWithId::WithId(2);
+
+		create_tokens(user, vec![token_2.clone()]);
+		assert_ok!(AssetConversion::create_pool(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone())
+		));
+
+		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), user, 100000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), 2, user, 1000));
+
+		assert_ok!(AssetConversion::add_liquidity(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone()),
+			10000,
+			200,
+			1,
+			1,
+			user,
+		));
+
+		assert_eq!(
+			AssetConversion::quote_price_exact_tokens_for_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				0,
+				true,
+			),
+			None
+		);
+		assert_eq!(
+			AssetConversion::quote_price_tokens_for_exact_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				0,
+				true,
+			),
+			None
+		);
+	});
+}
+
+#[test]
+fn quote_price_returns_none_for_zero_output() {
+	new_test_ext().execute_with(|| {
+		let user = 1;
+		let token_1 = NativeOrWithId::Native;
+		let token_2 = NativeOrWithId::WithId(2);
+
+		create_tokens(user, vec![token_2.clone()]);
+		assert_ok!(AssetConversion::create_pool(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone())
+		));
+
+		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), user, 10_000_000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), 2, user, 1000));
+
+		// Create a heavily skewed pool: lots of asset1, very little asset2.
+		assert_ok!(AssetConversion::add_liquidity(
+			RuntimeOrigin::signed(user),
+			Box::new(token_1.clone()),
+			Box::new(token_2.clone()),
+			1_000_000,
+			200,
+			1,
+			1,
+			user,
+		));
+
+		// Tiny input into a skewed pool rounds output to zero.
+		// get_amount_out(1, 1_000_000, 200) = 1*997*200 / (1_000_000*1000 + 997) = 0
+		assert_eq!(
+			AssetConversion::quote_price_exact_tokens_for_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				1,
+				true,
+			),
+			None
+		);
+		// Without fees: quote(1, 1_000_000, 200) = 1*200/1_000_000 = 0
+		assert_eq!(
+			AssetConversion::quote_price_exact_tokens_for_tokens(
+				token_1.clone(),
+				token_2.clone(),
+				1,
+				false,
+			),
+			None
+		);
+	});
+}
+
+#[test]
 fn can_quote_price() {
 	new_test_ext().execute_with(|| {
 		let user = 1;


### PR DESCRIPTION
Hardens `quote_price_exact_tokens_for_tokens` and `quote_price_tokens_for_exact_tokens` in `pallet-asset-conversion` to return `None` for zero input amounts and when integer rounding produces a zero output. Previously, zero inputs could propagate through the AMM math and zero outputs from small-input rounding were returned as `Some(0)`.