### PR TITLE
[CI] Fix parity-publish build failure on Bullseye (OpenSSL 1.1.1)

### DIFF
--- a/.github/workflows/release-80_publish-crates.yml
+++ b/.github/workflows/release-80_publish-crates.yml
@@ -189,6 +189,8 @@ jobs:
           cache-on-failure: true
 
       - name: Install parity-publish
+        env:
+          LIBCURL_SYS_USE_PKG_CONFIG: 1
         run: |
           sudo apt-get update && sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
           cargo install parity-publish@0.10.15 --locked -q


### PR DESCRIPTION
## Summary

- The `Install parity-publish` step in `release-80_publish-crates.yml` fails because `curl-sys` vendors a curl that requires OpenSSL >= 3.0.0, but the Bullseye container only has OpenSSL 1.1.1.
- Fix: set `LIBCURL_SYS_USE_PKG_CONFIG=1` so `curl-sys` uses the system libcurl (already linked against OpenSSL 1.1.1) instead of building vendored curl from source.

Failing run: https://github.com/paritytech-release/polkadot-sdk/actions/runs/24510892147

## Test plan

- [ ] Re-run the crates publish workflow and verify `Install parity-publish` succeeds