### PR TITLE
pallet-asset-conversion: distinguish `PoolEmpty` from `PoolNotFound`

### DIFF
--- a/prdoc/pr_11798.prdoc
+++ b/prdoc/pr_11798.prdoc
@@ -1,0 +1,14 @@
+title: 'pallet-asset-conversion: distinguish `PoolEmpty` from `PoolNotFound`'
+doc:
+- audience: Runtime Dev
+  description: "## Summary\n\n- Adds a new `PoolEmpty` error variant to `pallet-asset-conversion`\n\
+    - `PoolNotFound` now only means the pool does not exist in storage\n- `PoolEmpty`\
+    \ is returned when the pool exists but has zero reserves\n\n## Motivation\n\n\
+    When a pool exists but has no liquidity, `get_reserves()` returned `PoolNotFound`.\
+    \ This is misleading \u2014 the pool is in storage, it just has empty reserves.\
+    \ Users and frontends cannot distinguish between \"you need to create a pool\"\
+    \ and \"you need to add liquidity.\"\n\n## Changes\n\n- `substrate/frame/asset-conversion/src/lib.rs`:\
+    \ Added `PoolEmpty` error variant, changed the zero-reserves check in `get_reserves()`\
+    \ to use it\n- `substrate/frame/asset-conversion/src/tests.rs`: Updated `can_not_swap_in_pool_with_no_liquidity_added_yet`\
+    \ to expect `PoolEmpty`"
+crates: []

--- a/substrate/frame/asset-conversion/src/lib.rs
+++ b/substrate/frame/asset-conversion/src/lib.rs
@@ -379,6 +379,8 @@ pub mod pallet {
 		IncorrectPoolAssetId,
 		/// The destination account cannot exist with the swapped funds.
 		BelowMinimum,
+		/// The pool exists but has no liquidity (both reserves are zero).
+		PoolEmpty,
 	}
 
 	#[pallet::hooks]
@@ -1392,7 +1394,7 @@ pub mod pallet {
 			let balance2 = Self::get_balance(&pool_account, asset2);
 
 			if balance1.is_zero() || balance2.is_zero() {
-				Err(Error::<T>::PoolNotFound)?;
+				Err(Error::<T>::PoolEmpty)?;
 			}
 
 			Ok((balance1, balance2))

--- a/substrate/frame/asset-conversion/src/lib.rs
+++ b/substrate/frame/asset-conversion/src/lib.rs
@@ -379,7 +379,7 @@ pub mod pallet {
 		IncorrectPoolAssetId,
 		/// The destination account cannot exist with the swapped funds.
 		BelowMinimum,
-		/// The pool exists but has no liquidity (both reserves are zero).
+		/// The pool exists but has no liquidity (at least one of the reserves is zero).
 		PoolEmpty,
 	}
 

--- a/substrate/frame/asset-conversion/src/tests.rs
+++ b/substrate/frame/asset-conversion/src/tests.rs
@@ -1271,7 +1271,7 @@ fn can_not_swap_in_pool_with_no_liquidity_added_yet() {
 				user,
 				false,
 			),
-			Error::<Test>::PoolNotFound
+			Error::<Test>::PoolEmpty
 		);
 	});
 }


### PR DESCRIPTION
## Summary

- Adds a new `PoolEmpty` error variant to `pallet-asset-conversion`
- `PoolNotFound` now only means the pool does not exist in storage
- `PoolEmpty` is returned when the pool exists but has zero reserves

## Motivation

When a pool exists but has no liquidity, `get_reserves()` returned `PoolNotFound`. This is misleading — the pool is in storage, it just has empty reserves. Users and frontends cannot distinguish between "you need to create a pool" and "you need to add liquidity."

## Changes

- `substrate/frame/asset-conversion/src/lib.rs`: Added `PoolEmpty` error variant, changed the zero-reserves check in `get_reserves()` to use it
- `substrate/frame/asset-conversion/src/tests.rs`: Updated `can_not_swap_in_pool_with_no_liquidity_added_yet` to expect `PoolEmpty`