### PR TITLE
[CI] Fix parity-publish install in container (drop sudo)

### DIFF
--- a/.github/workflows/release-80_publish-crates.yml
+++ b/.github/workflows/release-80_publish-crates.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Install parity-publish
         run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
+          apt-get update && apt-get install -y --no-install-recommends libcurl4-openssl-dev pkg-config
           cargo install parity-publish@0.10.15 --locked -q
 
       - name: Run parity-publish plan


### PR DESCRIPTION
## Summary

- `Install parity-publish` step fails because `sudo` doesn't exist in the container, so `sudo apt-get install libcurl4-openssl-dev pkg-config` silently fails.
- Without `pkg-config` and `libcurl-dev`, `curl-sys` can't find system libcurl, falls back to vendored curl 8.18.0 which requires OpenSSL >= 3.0.0, and fails against Bullseye's OpenSSL 1.1.1.
- Fix: drop `sudo` — the container runs as root.

Failing run: https://github.com/paritytech-release/polkadot-sdk/actions/runs/24510892147

## Test plan

- [ ] Re-run the crates publish workflow and verify `Install parity-publish` succeeds