### PR TITLE
PSM init: skip assets with mismatched decimals instead of panicking

### DIFF
--- a/prdoc/pr_11807.prdoc
+++ b/prdoc/pr_11807.prdoc
@@ -1,0 +1,11 @@
+title: 'PSM init: skip assets with mismatched decimals instead of panicking'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Replaces the `assert!` in the PSM `InitializePsm` migration with a log and skip
+    when an asset's decimals don't match the stable asset. Panicking in a runtime
+    upgrade bricks the chain. Migrations must be infallible.
+
+crates:
+- name: pallet-psm
+  bump: patch

--- a/substrate/frame/psm/src/migrations/init.rs
+++ b/substrate/frame/psm/src/migrations/init.rs
@@ -121,11 +121,14 @@ impl<T: Config, I: InitialPsmConfig<T>> frame_support::traits::OnRuntimeUpgrade
 				continue;
 			}
 
-			assert!(
-				T::Fungibles::decimals(*asset_id) == stable_decimals,
-				"PSM migration: asset {:?} decimals do not match stable asset decimals",
-				asset_id,
-			);
+			if T::Fungibles::decimals(*asset_id) != stable_decimals {
+				log::error!(
+					target: LOG_TARGET,
+					"Asset {:?} decimals do not match stable asset decimals, skipping",
+					asset_id,
+				);
+				continue;
+			}
 			ExternalAssets::<T>::insert(asset_id, CircuitBreakerLevel::AllEnabled);
 			MintingFee::<T>::insert(asset_id, minting_fee);
 			RedemptionFee::<T>::insert(asset_id, redemption_fee);
@@ -195,7 +198,8 @@ impl<T: Config, I: InitialPsmConfig<T>> frame_support::traits::OnRuntimeUpgrade
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{new_test_ext, Test, USDC_ASSET_ID, USDT_ASSET_ID};
+	use crate::mock::{new_test_ext, Assets, Test, ALICE, USDC_ASSET_ID, USDT_ASSET_ID};
+	use frame_support::assert_ok;
 
 	struct TestPsmConfig;
 
@@ -298,6 +302,63 @@ mod tests {
 			assert_eq!(MintingFee::<Test>::get(USDT_ASSET_ID), minting_fee);
 			assert_eq!(RedemptionFee::<Test>::get(USDT_ASSET_ID), redemption_fee);
 			assert_eq!(AssetCeilingWeight::<Test>::get(USDT_ASSET_ID), ceiling_weight);
+		});
+	}
+
+	#[test]
+	fn initialize_psm_skips_assets_with_wrong_decimals() {
+		use frame_support::traits::{
+			fungibles::{Create as FungiblesCreate, metadata::Mutate as MetadataMutate},
+			OnRuntimeUpgrade,
+		};
+
+		const WRONG_DECIMALS_ID: u32 = 99;
+
+		new_test_ext().execute_with(|| {
+			// Create an asset with 8 decimals (stable asset has 6).
+			assert_ok!(<Assets as FungiblesCreate<u64>>::create(WRONG_DECIMALS_ID, ALICE, true, 1));
+			assert_ok!(<Assets as MetadataMutate<u64>>::set(
+				WRONG_DECIMALS_ID,
+				&ALICE,
+				b"Wrong".to_vec(),
+				b"WRG".to_vec(),
+				8, // mismatched decimals
+			));
+
+			struct MixedDecimalsConfig;
+			impl InitialPsmConfig<Test> for MixedDecimalsConfig {
+				fn max_psm_debt_of_total() -> Permill {
+					Permill::from_percent(50)
+				}
+				fn asset_configs() -> BTreeMap<u32, (Permill, Permill, Permill)> {
+					[
+						(
+							WRONG_DECIMALS_ID,
+							(Permill::zero(), Permill::zero(), Permill::from_percent(50)),
+						),
+						(
+							USDC_ASSET_ID, // 6 decimals — matches stable asset
+							(Permill::zero(), Permill::zero(), Permill::from_percent(50)),
+						),
+					]
+					.into_iter()
+					.collect()
+				}
+			}
+
+			ExternalAssets::<Test>::remove(WRONG_DECIMALS_ID);
+			ExternalAssets::<Test>::remove(USDC_ASSET_ID);
+
+			InitializePsm::<Test, MixedDecimalsConfig>::on_runtime_upgrade();
+
+			// Wrong decimals asset was skipped.
+			assert_eq!(ExternalAssets::<Test>::get(WRONG_DECIMALS_ID), None);
+
+			// Matching decimals asset was configured.
+			assert_eq!(
+				ExternalAssets::<Test>::get(USDC_ASSET_ID),
+				Some(CircuitBreakerLevel::AllEnabled)
+			);
 		});
 	}
 

--- a/substrate/frame/psm/src/migrations/init.rs
+++ b/substrate/frame/psm/src/migrations/init.rs
@@ -308,7 +308,7 @@ mod tests {
 	#[test]
 	fn initialize_psm_skips_assets_with_wrong_decimals() {
 		use frame_support::traits::{
-			fungibles::{Create as FungiblesCreate, metadata::Mutate as MetadataMutate},
+			fungibles::{metadata::Mutate as MetadataMutate, Create as FungiblesCreate},
 			OnRuntimeUpgrade,
 		};
 


### PR DESCRIPTION
Addresses issue @ggwpez raised in this comment: https://github.com/paritytech/polkadot-sdk/pull/11068#discussion_r3096189282

## Summary

Replaces the `assert!` in the PSM `InitializePsm` migration with a log + skip when an asset's decimals don't match the stable asset. Panicking in a runtime upgrade bricks the chain. Migrations must be infallible.

### Test

Adds `initialize_psm_skips_assets_with_wrong_decimals` which verifies that assets with mismatched decimals are skipped while correctly-configured assets in the same migration are still added.