### PR TITLE
Wired pallet_dap weights on Asset Hub Westend

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -368,7 +368,7 @@ impl pallet_dap::Config for Runtime {
 	type IssuanceCadence = IssuanceCadence;
 	type MaxElapsedPerDrip = MaxElapsedPerDrip;
 	type BudgetOrigin = frame_system::EnsureRoot<AccountId>;
-	type WeightInfo = ();
+	type WeightInfo = weights::pallet_dap::WeightInfo<Runtime>;
 }
 
 #[derive(Encode, Decode)]

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/mod.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/mod.rs
@@ -34,6 +34,7 @@ pub mod pallet_bags_list;
 pub mod pallet_balances;
 pub mod pallet_collator_selection;
 pub mod pallet_conviction_voting;
+pub mod pallet_dap;
 pub mod pallet_election_provider_multi_block;
 pub mod pallet_election_provider_multi_block_signed;
 pub mod pallet_election_provider_multi_block_unsigned;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_dap.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_dap.rs
@@ -49,7 +49,7 @@ use core::marker::PhantomData;
 
 /// Weight functions for `pallet_dap`.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: frame_system::Config> pallet_dap::WeightInfo for WeightInfo<T> {
+impl<T: frame_system::Config> pallet_dap::weights::WeightInfo for WeightInfo<T> {
 	/// Storage: `Dap::BudgetAllocation` (r:0 w:1)
 	/// Proof: `Dap::BudgetAllocation` (`max_values`: Some(1), `max_size`: Some(593), added: 1088, mode: `MaxEncodedLen`)
 	fn set_budget_allocation() -> Weight {

--- a/prdoc/pr_11811.prdoc
+++ b/prdoc/pr_11811.prdoc
@@ -1,0 +1,8 @@
+title: Wired pallet_dap weights on Asset Hub Westend
+doc:
+  - audience: Runtime Dev
+    description: |-
+      Replaced type WeightInfo = () with the generated weights::pallet_dap::WeightInfo<Runtime>
+crates:
+  - name: asset-hub-westend-runtime
+    bump: patch


### PR DESCRIPTION
Replaced `type WeightInfo = ()` with the generated `weights::pallet_dap::WeightInfo<Runtime>`
