### PR TITLE
Block bundling Zombienet tests: Adapt to skipped blocks

### DIFF
--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/block_bundling/three_cores_glutton.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/block_bundling/three_cores_glutton.rs
@@ -58,7 +58,7 @@ async fn block_bundling_three_cores_glutton() -> Result<(), anyhow::Error> {
 		&relay_client,
 		6,
 		[(ParaId::from(PARA_ID), 12..19)],
-		[(ParaId::from(PARA_ID), (para_client.clone(), 48..73))],
+		[(ParaId::from(PARA_ID), (para_client.clone(), 44..73))],
 	)
 	.await?;
 


### PR DESCRIPTION
 Closes: https://github.com/paritytech/polkadot-sdk/issues/11825