### PR TITLE
make prepare-* jobs required to trigger zombienet workflows

### DIFF
--- a/.github/workflows/build-publish-images.yml
+++ b/.github/workflows/build-publish-images.yml
@@ -716,6 +716,10 @@ jobs:
       - build-malus
       - build-linux-substrate
       - build-templates-node
+      - prepare-cumulus-zombienet-artifacts
+      - prepare-parachain-templates-zombienet-artifacts
+      - prepare-polkadot-zombienet-artifacts
+      - prepare-substrate-zombienet-artifacts
     if: always() && !cancelled()
     outputs:
       build_success: ${{ steps.check_success.outputs.build_success }}


### PR DESCRIPTION
Make `prepare-*` jobs required to prevent race conditions like https://github.com/paritytech/polkadot-sdk/actions/runs/24575289788/job/71864462979?pr=11815.

cc: @alvicsam / @bkchr 