### PR TITLE
RPC: add runtime apis metrics

### DIFF
--- a/prdoc/pr_11850.prdoc
+++ b/prdoc/pr_11850.prdoc
@@ -1,0 +1,17 @@
+title: 'RPC: add runtime apis metrics'
+doc:
+- audience: Node Dev
+  description: "## Summary\nAdd a metics `substrate_rpc_runtime_api_calls_time` that\
+    \ tracks which runtime APIs are called via `state_call` / `state_callAt` / `chainHead_v1_call`,\
+    \ with per-call latency.\n\n### Metric labels:\n- `runtime_api` \u2014 the runtime\
+    \ API function name (e.g. `ReviveApi_eth_block`, `Metadata_metadata`)\n- `cached`\
+    \ \u2014 \"true\" / \"false\" indicating whether the response was served from\
+    \ the RPC response cache\n\nThe runtime API name is extracted from the JSON-RPC\
+    \ request params in the existing middleware layer.\n\nThis complements `substrate_rpc_calls_time{method=...}`\
+    \ which already tracks per-RPC-method latency but doesn't reveal which runtime\
+    \ API is being invoked when callers use the generic `state_call` (or other mentioned\
+    \ above) pass-through.\n\n## Motivation\n\nWhen debugging node performance issues,\
+    \ it's useful to know which runtime APIs are being called and how often."
+crates:
+- name: sc-rpc-server
+  bump: patch

--- a/substrate/client/rpc-servers/src/middleware/cache.rs
+++ b/substrate/client/rpc-servers/src/middleware/cache.rs
@@ -41,6 +41,7 @@ use std::{
 	collections::hash_map::DefaultHasher,
 	hash::{Hash, Hasher},
 	sync::Arc,
+	time::Instant,
 };
 
 use futures::future::{BoxFuture, FutureExt};
@@ -350,6 +351,7 @@ where
 	type Future = BoxFuture<'a, MethodResponse>;
 
 	fn call(&self, req: Request<'a>) -> Self::Future {
+		let now = Instant::now();
 		let method = req.method_name();
 
 		// Check if this method is cacheable.
@@ -378,6 +380,13 @@ where
 					let rp = response_from_cache(req.id(), &cached.result);
 					if let Some(ref metrics) = self.metrics {
 						metrics.on_hit(method);
+					}
+					// Record runtime API name for state_call / chainHead_v1_call cache hits.
+					if let Some(api_name) = super::metrics::extract_runtime_api_name(&req) {
+						let micros = now.elapsed().as_micros();
+						super::metrics::RUNTIME_API_CALLS_TIME
+							.with_label_values(&[&api_name, "true"])
+							.observe(micros as _);
 					}
 					log::trace!(
 						target: "rpc_cache",

--- a/substrate/client/rpc-servers/src/middleware/cache.rs
+++ b/substrate/client/rpc-servers/src/middleware/cache.rs
@@ -413,8 +413,7 @@ where
 			// Only cache successful responses.
 			if rp.is_success() {
 				if let Some(result) = extract_result(rp.as_result()) {
-					let cached =
-						CachedResponse::new(method_name.clone(), canonical_owned, result);
+					let cached = CachedResponse::new(method_name.clone(), canonical_owned, result);
 					let byte_size = cached.byte_size;
 					let mut cache_guard = cache.lock();
 					cache_guard.insert(key, cached);

--- a/substrate/client/rpc-servers/src/middleware/metrics.rs
+++ b/substrate/client/rpc-servers/src/middleware/metrics.rs
@@ -74,6 +74,8 @@ pub struct RpcMetrics {
 	ws_sessions_closed: Option<Counter<U64>>,
 	/// Histogram over RPC websocket sessions.
 	ws_sessions_time: HistogramVec,
+	/// Histogram over runtime API call times via `state_call` / `chainHead_v1_call`.
+	runtime_api_calls_time: HistogramVec,
 }
 
 impl RpcMetrics {
@@ -160,6 +162,17 @@ impl RpcMetrics {
 						)
 						.buckets(HISTOGRAM_BUCKETS.to_vec()),
 						&["protocol"],
+					)?,
+					metrics_registry,
+				)?,
+				runtime_api_calls_time: register(
+					HistogramVec::new(
+						HistogramOpts::new(
+							"substrate_rpc_runtime_api_calls_time",
+							"Total time [μs] of runtime API calls via state_call / chainHead_v1_call",
+						)
+						.buckets(HISTOGRAM_BUCKETS.to_vec()),
+						&["runtime_api"],
 					)?,
 					metrics_registry,
 				)?,
@@ -250,6 +263,13 @@ impl RpcMetrics {
 				if is_rate_limited { "true" } else { "false" },
 			])
 			.inc();
+
+		// Record per-runtime-API timing for state_call / chainHead_v1_call.
+		if rp.is_success() {
+			if let Some(api_name) = extract_runtime_api_name(req) {
+				self.runtime_api_calls_time.with_label_values(&[&api_name]).observe(micros as _);
+			}
+		}
 	}
 }
 
@@ -295,4 +315,23 @@ impl Metrics {
 	) {
 		self.inner.on_response(req, rp, is_rate_limited, self.transport_label, now)
 	}
+}
+
+/// Extract the runtime API function name from `state_call` or `chainHead_v1_call` params.
+///
+/// - `state_call` params: `["RuntimeApi_method", "0x...", ...]`
+/// - `chainHead_v1_call` params: `["follow_sub", "0xhash", "RuntimeApi_method", "0x..."]`
+fn extract_runtime_api_name(req: &Request) -> Option<String> {
+	let idx = match req.method_name() {
+		"state_call" | "state_callAt" => 0,
+		"chainHead_v1_call" => 2,
+		_ => return None,
+	};
+
+	let params_raw = req.params();
+	let params_str = params_raw.as_str()?;
+	let params: Vec<&serde_json::value::RawValue> = serde_json::from_str(params_str).ok()?;
+	let raw = params.get(idx)?;
+	let name: String = serde_json::from_str(raw.get()).ok()?;
+	Some(name)
 }

--- a/substrate/client/rpc-servers/src/middleware/metrics.rs
+++ b/substrate/client/rpc-servers/src/middleware/metrics.rs
@@ -39,6 +39,22 @@ pub(crate) static RPC_THREADS_ALIVE: LazyLock<GenericGauge<U64>> = LazyLock::new
 		.expect("Creating of statics doesn't fail. qed")
 });
 
+/// Histogram of runtime API call times via `state_call` / `chainHead_v1_call`.
+///
+/// Shared between the RPC metrics layer (non-cached) and the cache layer (cached hits).
+/// Registered with the prometheus registry in [`RpcMetrics::new`].
+pub(crate) static RUNTIME_API_CALLS_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+	HistogramVec::new(
+		HistogramOpts::new(
+			"substrate_rpc_runtime_api_calls_time",
+			"Total time [μs] of runtime API calls via state_call / chainHead_v1_call",
+		)
+		.buckets(HISTOGRAM_BUCKETS.to_vec()),
+		&["runtime_api", "cached"],
+	)
+	.expect("Creating of statics doesn't fail. qed")
+});
+
 /// Histogram time buckets in microseconds.
 const HISTOGRAM_BUCKETS: [f64; 11] = [
 	5.0,
@@ -74,8 +90,6 @@ pub struct RpcMetrics {
 	ws_sessions_closed: Option<Counter<U64>>,
 	/// Histogram over RPC websocket sessions.
 	ws_sessions_time: HistogramVec,
-	/// Histogram over runtime API call times via `state_call` / `chainHead_v1_call`.
-	runtime_api_calls_time: HistogramVec,
 }
 
 impl RpcMetrics {
@@ -86,7 +100,7 @@ impl RpcMetrics {
 			metrics_registry.register(Box::new(RPC_THREADS_TOTAL.clone()))?;
 			metrics_registry.register(Box::new(RPC_THREADS_ALIVE.clone()))?;
 
-			Ok(Some(Self {
+			let metrics = Self {
 				calls_time: register(
 					HistogramVec::new(
 						HistogramOpts::new(
@@ -165,18 +179,12 @@ impl RpcMetrics {
 					)?,
 					metrics_registry,
 				)?,
-				runtime_api_calls_time: register(
-					HistogramVec::new(
-						HistogramOpts::new(
-							"substrate_rpc_runtime_api_calls_time",
-							"Total time [μs] of runtime API calls via state_call / chainHead_v1_call",
-						)
-						.buckets(HISTOGRAM_BUCKETS.to_vec()),
-						&["runtime_api"],
-					)?,
-					metrics_registry,
-				)?,
-			}))
+			};
+
+			// Register shared static metric.
+			metrics_registry.register(Box::new(RUNTIME_API_CALLS_TIME.clone()))?;
+
+			Ok(Some(metrics))
 		} else {
 			Ok(None)
 		}
@@ -267,7 +275,9 @@ impl RpcMetrics {
 		// Record per-runtime-API timing for state_call / chainHead_v1_call.
 		if rp.is_success() {
 			if let Some(api_name) = extract_runtime_api_name(req) {
-				self.runtime_api_calls_time.with_label_values(&[&api_name]).observe(micros as _);
+				RUNTIME_API_CALLS_TIME
+					.with_label_values(&[&api_name, "false"])
+					.observe(micros as _);
 			}
 		}
 	}
@@ -321,7 +331,7 @@ impl Metrics {
 ///
 /// - `state_call` params: `["RuntimeApi_method", "0x...", ...]`
 /// - `chainHead_v1_call` params: `["follow_sub", "0xhash", "RuntimeApi_method", "0x..."]`
-fn extract_runtime_api_name(req: &Request) -> Option<String> {
+pub(crate) fn extract_runtime_api_name(req: &Request) -> Option<String> {
 	let idx = match req.method_name() {
 		"state_call" | "state_callAt" => 0,
 		"chainHead_v1_call" => 2,


### PR DESCRIPTION
## Summary
Add a metics `substrate_rpc_runtime_api_calls_time` that tracks which runtime APIs are called via `state_call` / `state_callAt` / `chainHead_v1_call`, with per-call latency.

### Metric labels:
- `runtime_api` — the runtime API function name (e.g. `ReviveApi_eth_block`, `Metadata_metadata`)
- `cached` — "true" / "false" indicating whether the response was served from the RPC response cache

The runtime API name is extracted from the JSON-RPC request params in the existing middleware layer.

This complements `substrate_rpc_calls_time{method=...}` which already tracks per-RPC-method latency but doesn't reveal which runtime API is being invoked when callers use the generic `state_call` (or other mentioned above) pass-through.

## Motivation

When debugging node performance issues, it's useful to know which runtime APIs are being called and how often. 
