### PR TITLE
[Staking] Stop being over defensive

### DIFF
--- a/substrate/frame/staking-async/src/pallet/impls.rs
+++ b/substrate/frame/staking-async/src/pallet/impls.rs
@@ -579,7 +579,6 @@ impl<T: Config> Pallet<T> {
 		let dest = match Self::payee(Stash(stash.clone())) {
 			Some(d) => d,
 			None => {
-				defensive!("Staker missing payee");
 				Self::deposit_event(Event::<T>::Unexpected(UnexpectedKind::MissingPayee {
 					era,
 					stash: stash.clone(),
@@ -634,7 +633,6 @@ impl<T: Config> Pallet<T> {
 		let dest = match Self::payee(StakingAccount::Stash(stash.clone())) {
 			Some(d) => d,
 			None => {
-				defensive!("Staker missing payee");
 				Self::deposit_event(Event::<T>::Unexpected(UnexpectedKind::MissingPayee {
 					era,
 					stash: stash.clone(),
@@ -729,7 +727,6 @@ impl<T: Config> Pallet<T> {
 				era,
 				stash: stash.clone(),
 			}));
-			defensive!("Validator missing payee");
 			return;
 		};
 		let Some(payout_account) = Self::payout_account_for_dest(stash, &dest) else {

--- a/substrate/frame/staking-async/src/reward.rs
+++ b/substrate/frame/staking-async/src/reward.rs
@@ -185,8 +185,8 @@ impl<T: Config> EraRewardManager<T> {
 			}
 		}
 
-		let _ = frame_system::Pallet::<T>::dec_providers(&pot_account)
-			.defensive_proof("Provider was added in Self::create; qed");
+		// try decrementing the provider we added at create.
+		let _ = frame_system::Pallet::<T>::dec_providers(&pot_account);
 	}
 
 	/// Checks if the pot account for an era's staker rewards exists.

--- a/substrate/frame/staking-async/src/reward.rs
+++ b/substrate/frame/staking-async/src/reward.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	traits::{
 		fungible::{Balanced, Inspect, Mutate},
 		tokens::{Fortitude, Precision, Preservation},
-		Defensive, OnUnbalanced,
+		OnUnbalanced,
 	},
 };
 use sp_runtime::{

--- a/substrate/frame/staking-async/src/tests/validator_incentive.rs
+++ b/substrate/frame/staking-async/src/tests/validator_incentive.rs
@@ -596,10 +596,8 @@ fn missing_payee_emits_unexpected_and_skips_payout() {
 
 		// THEN: alice's incentive is skipped with an Unexpected event; other validators still paid.
 		let events = staking_events_since_last_call();
-		assert!(events.contains(&Event::Unexpected(UnexpectedKind::MissingPayee {
-			era: 2,
-			stash: alice,
-		})));
+		assert!(events
+			.contains(&Event::Unexpected(UnexpectedKind::MissingPayee { era: 2, stash: alice })));
 		assert!(incentive_paid_for(alice, &events).is_none());
 		assert!(incentive_paid_for(21, &events).is_some());
 	});

--- a/substrate/frame/staking-async/src/tests/validator_incentive.rs
+++ b/substrate/frame/staking-async/src/tests/validator_incentive.rs
@@ -600,6 +600,9 @@ fn missing_payee_emits_unexpected_and_skips_payout() {
 			.contains(&Event::Unexpected(UnexpectedKind::MissingPayee { era: 2, stash: alice })));
 		assert!(incentive_paid_for(alice, &events).is_none());
 		assert!(incentive_paid_for(21, &events).is_some());
+
+		// Restore payee so post-test try_state passes.
+		Payee::<Test>::insert(alice, RewardDestination::Staked);
 	});
 }
 

--- a/substrate/frame/staking-async/src/tests/validator_incentive.rs
+++ b/substrate/frame/staking-async/src/tests/validator_incentive.rs
@@ -578,11 +578,8 @@ fn all_validators_zero_points_no_incentive_paid() {
 	});
 }
 
-// ===== Defensive path tests =====
-
 #[test]
-#[should_panic(expected = "Validator missing payee")]
-fn defensive_panic_on_missing_payee() {
+fn missing_payee_emits_unexpected_and_skips_payout() {
 	ExtBuilder::default().build_and_execute(|| {
 		let alice = 11; // validator
 
@@ -592,13 +589,23 @@ fn defensive_panic_on_missing_payee() {
 		Eras::<Test>::reward_active_era(vec![(alice, 1), (21, 1)]);
 		Session::roll_until_active_era(3);
 
-		// WHEN: missing payee for alice.
+		// WHEN: alice's payee is missing at payout time.
 		Payee::<Test>::remove(&alice);
-
-		// THEN: payout panics on defensive.
+		let _ = staking_events_since_last_call();
 		make_all_reward_payment(2);
+
+		// THEN: alice's incentive is skipped with an Unexpected event; other validators still paid.
+		let events = staking_events_since_last_call();
+		assert!(events.contains(&Event::Unexpected(UnexpectedKind::MissingPayee {
+			era: 2,
+			stash: alice,
+		})));
+		assert!(incentive_paid_for(alice, &events).is_none());
+		assert!(incentive_paid_for(21, &events).is_some());
 	});
 }
+
+// ===== Defensive path tests =====
 
 #[test]
 #[should_panic(expected = "Validator incentive liquid transfer failed")]


### PR DESCRIPTION
Fuzz testing causes false positives with these defensive panics that are triggerable by a user.