### PR TITLE
xcm: add ERC-721 asset transactor for cross-chain NFT transfers via pallet-revive

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -214,6 +214,14 @@ parameter_types! {
 	pub const ERC20TransferGasLimit: Weight = Weight::from_parts(500_000_000_000, 10 * 1024 * 1024);
 	pub const ERC20TransferStorageDepositLimit: Balance = 10_200_000_000;
 	pub ERC20TransfersCheckingAccount: AccountId = PalletId(*b"py/revch").into_account_truncating();
+	/// Taken from the real gas and deposits of a standard ERC721 transferFrom call.
+	/// ERC-721 transfers cost slightly more gas than ERC-20 transfers due to storage writes
+	/// on the owner mapping, so we use the same conservative upper bound.
+	pub const ERC721TransferGasLimit: Weight = Weight::from_parts(500_000_000_000, 10 * 1024 * 1024);
+	pub const ERC721TransferStorageDepositLimit: Balance = 10_200_000_000;
+	/// Sovereign checking account for ERC-721 transfers. Distinct from the ERC-20 checking
+	/// account so NFT ownership is tracked separately and auditable on-chain.
+	pub ERC721TransfersCheckingAccount: AccountId = PalletId(*b"py/72ich").into_account_truncating();
 	pub DapBufferAccount: AccountId = pallet_dap::Pallet::<Runtime>::buffer_account();
 }
 
@@ -235,6 +243,25 @@ pub type ERC20Transactor = assets_common::ERC20Transactor<
 	ERC20TransfersCheckingAccount,
 >;
 
+/// Transactor for ERC-721 non-fungible tokens.
+pub type ERC721Transactor = assets_common::ERC721Transactor<
+	// We need this for accessing pallet-revive.
+	Runtime,
+	// The matcher for ERC-721 smart contracts: matches Location(0, [AccountKey20]) with
+	// NonFungible(AssetInstance::Index(token_id)).
+	assets_common::ERC721Matcher,
+	// How to convert from a location to an account id.
+	LocationToAccountId,
+	// The maximum gas that can be used by a standard ERC-721 transferFrom call.
+	ERC721TransferGasLimit,
+	// The maximum storage deposit that can be used by a standard ERC-721 transferFrom call.
+	ERC721TransferStorageDepositLimit,
+	// We're generic over this so we can't escape specifying it.
+	AccountId,
+	// Checking account for ERC-721 transfers.
+	ERC721TransfersCheckingAccount,
+>;
+
 /// Means for transacting assets on this chain.
 pub type AssetTransactors = (
 	FungibleTransactor,
@@ -242,6 +269,7 @@ pub type AssetTransactors = (
 	ForeignFungiblesTransactor,
 	UniquesTransactor,
 	ERC20Transactor,
+	ERC721Transactor,
 );
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -214,13 +214,8 @@ parameter_types! {
 	pub const ERC20TransferGasLimit: Weight = Weight::from_parts(500_000_000_000, 10 * 1024 * 1024);
 	pub const ERC20TransferStorageDepositLimit: Balance = 10_200_000_000;
 	pub ERC20TransfersCheckingAccount: AccountId = PalletId(*b"py/revch").into_account_truncating();
-	/// Taken from the real gas and deposits of a standard ERC721 transferFrom call.
-	/// ERC-721 transfers cost slightly more gas than ERC-20 transfers due to storage writes
-	/// on the owner mapping, so we use the same conservative upper bound.
 	pub const ERC721TransferGasLimit: Weight = Weight::from_parts(500_000_000_000, 10 * 1024 * 1024);
 	pub const ERC721TransferStorageDepositLimit: Balance = 10_200_000_000;
-	/// Sovereign checking account for ERC-721 transfers. Distinct from the ERC-20 checking
-	/// account so NFT ownership is tracked separately and auditable on-chain.
 	pub ERC721TransfersCheckingAccount: AccountId = PalletId(*b"py/72ich").into_account_truncating();
 	pub DapBufferAccount: AccountId = pallet_dap::Pallet::<Runtime>::buffer_account();
 }

--- a/cumulus/parachains/runtimes/assets/common/src/erc721_transactor.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/erc721_transactor.rs
@@ -71,17 +71,6 @@ type BalanceOf<T> = <<T as pallet_revive::Config>::Currency as Inspect<
 >>::Balance;
 
 /// An Asset Transactor that deals with ERC-721 non-fungible tokens.
-///
-/// Generic parameters:
-/// - `T`: The runtime type, must implement `pallet_revive::Config`.
-/// - `Matcher`: Matches an XCM `Asset` to an ERC-721 contract address (`H160`) and token ID
-///   (`u128`). Use [`ERC721Matcher`](crate::ERC721Matcher) for the standard case.
-/// - `AccountIdConverter`: Converts an XCM `Location` into an `AccountId`.
-/// - `WeightLimit`: The maximum weight (gas limit) allowed for a single ERC-721 contract call.
-/// - `StorageDepositLimit`: The maximum storage deposit allowed per contract call.
-/// - `AccountId`: The runtime account ID type.
-/// - `TransfersCheckingAccount`: A sovereign account used as an intermediate holder of NFTs during
-///   cross-chain transfers.
 pub struct ERC721Transactor<
 	T,
 	Matcher,
@@ -145,12 +134,6 @@ where
 	}
 
 	/// Withdraws an ERC-721 token from the sender by transferring it to the checking account.
-	///
-	/// Calls `transferFrom(owner, checking_account, tokenId)` on the ERC-721 contract.
-	/// Because `msg.sender` is the NFT owner (via `signed(who)` origin), the ERC-721
-	/// contract authorises the transfer without requiring a prior `approve` call.
-	///
-	/// Returns the asset in holding and any unused weight as a surplus.
 	fn withdraw_asset_with_surplus(
 		what: &Asset,
 		who: &Location,
@@ -234,15 +217,6 @@ where
 	}
 
 	/// Deposits an ERC-721 token to the beneficiary by transferring it from the checking account.
-	///
-	/// Calls `transferFrom(checking_account, beneficiary, tokenId)` on the ERC-721 contract,
-	/// signed by the checking account so that `msg.sender == from`, which the ERC-721 contract
-	/// permits.
-	///
-	/// Note: Only a single non-fungible asset is processed per call. `defensive_assert!` guards
-	/// against misuse during development.
-	///
-	/// Returns any unused weight as a surplus.
 	fn deposit_asset_with_surplus(
 		what: AssetsInHolding,
 		who: &Location,

--- a/cumulus/parachains/runtimes/assets/common/src/erc721_transactor.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/erc721_transactor.rs
@@ -1,0 +1,331 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The ERC721 Asset Transactor.
+//!
+//! Enables XCM reserve transfers of ERC-721 non-fungible tokens held in smart contracts
+//! deployed via `pallet-revive`. Teleportation is not supported.
+//!
+//! # Transfer Flow
+//!
+//! **Withdraw (source chain):** The XCM executor calls `withdraw_asset`, which calls
+//! `transferFrom(owner, checking_account, tokenId)` on the ERC-721 contract, moving the
+//! NFT to a sovereign checking account while the asset is in transit.
+//!
+//! **Deposit (destination chain):** The XCM executor calls `deposit_asset`, which calls
+//! `transferFrom(checking_account, beneficiary, tokenId)` on the ERC-721 contract,
+//! releasing the NFT from the checking account to the final recipient.
+//!
+//! # Asset Identification
+//!
+//! ERC-721 assets are identified in XCM using:
+//! - `AssetId`: A `Location` ending with `AccountKey20 { key: contract_address }`, which points to
+//!   the deployed ERC-721 contract.
+//! - `AssetInstance::Index(token_id)`: The unique token ID within the collection.
+//!
+//! Example XCM asset for an ERC-721 token on Asset Hub:
+//! ```text
+//! Asset {
+//!     id: Location(0, [AccountKey20 { key: 0xabcd...1234 }]),
+//!     fun: NonFungible(AssetInstance::Index(42)),
+//! }
+//! ```
+
+use core::marker::PhantomData;
+use ethereum_standards::IERC721;
+use frame_support::{
+	defensive_assert,
+	traits::{fungible::Inspect, OriginTrait},
+};
+use frame_system::pallet_prelude::OriginFor;
+use pallet_revive::{
+	precompiles::alloy::{
+		primitives::{Address, U256 as EU256},
+		sol_types::SolCall,
+	},
+	AddressMapper, ContractResult, ExecConfig, MomentOf, TransactionLimits,
+};
+use sp_core::{Get, H160, H256, U256};
+use sp_runtime::Weight;
+use xcm::latest::prelude::*;
+use xcm_executor::{
+	traits::{ConvertLocation, Error as MatchError, MatchesNonFungibles, TransactAsset},
+	AssetsInHolding,
+};
+
+type BalanceOf<T> = <<T as pallet_revive::Config>::Currency as Inspect<
+	<T as frame_system::Config>::AccountId,
+>>::Balance;
+
+/// An Asset Transactor that deals with ERC-721 non-fungible tokens.
+///
+/// Generic parameters:
+/// - `T`: The runtime type, must implement `pallet_revive::Config`.
+/// - `Matcher`: Matches an XCM `Asset` to an ERC-721 contract address (`H160`) and token ID
+///   (`u128`). Use [`ERC721Matcher`](crate::ERC721Matcher) for the standard case.
+/// - `AccountIdConverter`: Converts an XCM `Location` into an `AccountId`.
+/// - `WeightLimit`: The maximum weight (gas limit) allowed for a single ERC-721 contract call.
+/// - `StorageDepositLimit`: The maximum storage deposit allowed per contract call.
+/// - `AccountId`: The runtime account ID type.
+/// - `TransfersCheckingAccount`: A sovereign account used as an intermediate holder of NFTs during
+///   cross-chain transfers.
+pub struct ERC721Transactor<
+	T,
+	Matcher,
+	AccountIdConverter,
+	WeightLimit,
+	StorageDepositLimit,
+	AccountId,
+	TransfersCheckingAccount,
+>(
+	PhantomData<(
+		T,
+		Matcher,
+		AccountIdConverter,
+		WeightLimit,
+		StorageDepositLimit,
+		AccountId,
+		TransfersCheckingAccount,
+	)>,
+);
+
+impl<
+		AccountId: Eq + Clone,
+		T: pallet_revive::Config<AccountId = AccountId>,
+		AccountIdConverter: ConvertLocation<AccountId>,
+		Matcher: MatchesNonFungibles<H160, u128>,
+		WeightLimit: Get<Weight>,
+		StorageDepositLimit: Get<BalanceOf<T>>,
+		TransfersCheckingAccount: Get<AccountId>,
+	> TransactAsset
+	for ERC721Transactor<
+		T,
+		Matcher,
+		AccountIdConverter,
+		WeightLimit,
+		StorageDepositLimit,
+		AccountId,
+		TransfersCheckingAccount,
+	>
+where
+	BalanceOf<T>: Into<U256> + TryFrom<U256>,
+	MomentOf<T>: Into<U256>,
+	T::Hash: frame_support::traits::IsType<H256>,
+{
+	fn can_check_in(_origin: &Location, _what: &Asset, _context: &XcmContext) -> XcmResult {
+		// Teleportation is not supported for ERC-721 tokens: the contract state cannot be
+		// burned on the source chain and minted on the destination.
+		Err(XcmError::Unimplemented)
+	}
+
+	fn check_in(_origin: &Location, _what: &Asset, _context: &XcmContext) {
+		// No-op: teleportation not supported.
+	}
+
+	fn can_check_out(_destination: &Location, _what: &Asset, _context: &XcmContext) -> XcmResult {
+		// Teleportation is not supported for ERC-721 tokens.
+		Err(XcmError::Unimplemented)
+	}
+
+	fn check_out(_destination: &Location, _what: &Asset, _context: &XcmContext) {
+		// No-op: teleportation not supported.
+	}
+
+	/// Withdraws an ERC-721 token from the sender by transferring it to the checking account.
+	///
+	/// Calls `transferFrom(owner, checking_account, tokenId)` on the ERC-721 contract.
+	/// Because `msg.sender` is the NFT owner (via `signed(who)` origin), the ERC-721
+	/// contract authorises the transfer without requiring a prior `approve` call.
+	///
+	/// Returns the asset in holding and any unused weight as a surplus.
+	fn withdraw_asset_with_surplus(
+		what: &Asset,
+		who: &Location,
+		_context: Option<&XcmContext>,
+	) -> Result<(AssetsInHolding, Weight), XcmError> {
+		tracing::trace!(
+			target: "xcm::transactor::erc721::withdraw",
+			?what, ?who,
+		);
+		let (contract_id, token_id) = Matcher::matches_nonfungibles(what)?;
+		let who = AccountIdConverter::convert_location(who)
+			.ok_or(MatchError::AccountIdConversionFailed)?;
+		// Map the 32-byte owner account to a 20-byte Ethereum address (msg.sender of the call).
+		let owner_eth = T::AddressMapper::to_address(&who);
+		let from = Address::from(Into::<[u8; 20]>::into(owner_eth));
+		// Map the 32-byte checking account to a 20-byte Ethereum address (recipient of the NFT).
+		let checking_account_eth = T::AddressMapper::to_address(&TransfersCheckingAccount::get());
+		let to = Address::from(Into::<[u8; 20]>::into(checking_account_eth));
+		let weight_limit = WeightLimit::get();
+		// Call ERC-721 transferFrom(owner, checking_account, tokenId) from the owner's origin.
+		// Since msg.sender == from == owner, the ERC-721 contract permits this transfer.
+		let data =
+			IERC721::transferFromCall { from, to, tokenId: EU256::from(token_id) }.abi_encode();
+		let ContractResult { result, weight_consumed, storage_deposit, .. } =
+			pallet_revive::Pallet::<T>::bare_call(
+				OriginFor::<T>::signed(who.clone()),
+				contract_id,
+				U256::zero(),
+				TransactionLimits::WeightAndDeposit {
+					weight_limit,
+					deposit_limit: StorageDepositLimit::get(),
+				},
+				data,
+				&ExecConfig::new_substrate_tx(),
+			);
+		// Return unused weight so the XCM executor can refund it.
+		let surplus = weight_limit.saturating_sub(weight_consumed);
+		tracing::trace!(
+			target: "xcm::transactor::erc721::withdraw",
+			?weight_consumed, ?surplus, ?storage_deposit,
+		);
+		match result {
+			Ok(return_value) => {
+				tracing::trace!(
+					target: "xcm::transactor::erc721::withdraw",
+					?return_value,
+					"Return value by withdraw_asset",
+				);
+				if return_value.did_revert() {
+					tracing::debug!(
+						target: "xcm::transactor::erc721::withdraw",
+						"ERC721 contract reverted",
+					);
+					Err(XcmError::FailedToTransactAsset("ERC721 contract reverted"))
+				} else {
+					// transferFrom returns void; a non-reverting call means success.
+					tracing::trace!(
+						target: "xcm::transactor::erc721::withdraw",
+						"ERC721 transferFrom successful",
+					);
+					Ok((
+						AssetsInHolding::new_from_non_fungible(
+							what.id.clone(),
+							AssetInstance::Index(token_id),
+						),
+						surplus,
+					))
+				}
+			},
+			Err(error) => {
+				tracing::debug!(
+					target: "xcm::transactor::erc721::withdraw",
+					?error,
+					"ERC721 contract execution errored",
+				);
+				// Could be out-of-gas, duplicate contract call, etc.
+				// A hardcoded gas limit means the user cannot fix this by changing the XCM.
+				Err(XcmError::FailedToTransactAsset("ERC721 contract execution errored"))
+			},
+		}
+	}
+
+	/// Deposits an ERC-721 token to the beneficiary by transferring it from the checking account.
+	///
+	/// Calls `transferFrom(checking_account, beneficiary, tokenId)` on the ERC-721 contract,
+	/// signed by the checking account so that `msg.sender == from`, which the ERC-721 contract
+	/// permits.
+	///
+	/// Note: Only a single non-fungible asset is processed per call. `defensive_assert!` guards
+	/// against misuse during development.
+	///
+	/// Returns any unused weight as a surplus.
+	fn deposit_asset_with_surplus(
+		what: AssetsInHolding,
+		who: &Location,
+		_context: Option<&XcmContext>,
+	) -> Result<Weight, (AssetsInHolding, XcmError)> {
+		tracing::trace!(
+			target: "xcm::transactor::erc721::deposit",
+			?what, ?who,
+		);
+		defensive_assert!(what.len() == 1, "Trying to deposit more than one asset!");
+		// Retrieve the single non-fungible asset and match it.
+		let maybe = what
+			.non_fungible_assets_iter()
+			.next()
+			.and_then(|asset| Matcher::matches_nonfungibles(&asset).ok());
+		let (contract_id, token_id) = match maybe {
+			Some(inner) => inner,
+			None => return Err((what, MatchError::AssetNotHandled.into())),
+		};
+		let who = match AccountIdConverter::convert_location(who) {
+			Some(inner) => inner,
+			None => return Err((what, MatchError::AccountIdConversionFailed.into())),
+		};
+		// Map the 32-byte beneficiary account to a 20-byte Ethereum address.
+		let eth_address = T::AddressMapper::to_address(&who);
+		let to = Address::from(Into::<[u8; 20]>::into(eth_address));
+		// Map the 32-byte checking account to a 20-byte Ethereum address (current NFT holder).
+		let checking_account_eth = T::AddressMapper::to_address(&TransfersCheckingAccount::get());
+		let from = Address::from(Into::<[u8; 20]>::into(checking_account_eth));
+		let weight_limit = WeightLimit::get();
+		// Call ERC-721 transferFrom(checking_account, beneficiary, tokenId) from the checking
+		// account's origin. Since msg.sender == from == checking_account, the ERC-721 contract
+		// permits this transfer.
+		let data =
+			IERC721::transferFromCall { from, to, tokenId: EU256::from(token_id) }.abi_encode();
+		let ContractResult { result, weight_consumed, storage_deposit, .. } =
+			pallet_revive::Pallet::<T>::bare_call(
+				OriginFor::<T>::signed(TransfersCheckingAccount::get()),
+				contract_id,
+				U256::zero(),
+				TransactionLimits::WeightAndDeposit {
+					weight_limit,
+					deposit_limit: StorageDepositLimit::get(),
+				},
+				data,
+				&ExecConfig::new_substrate_tx(),
+			);
+		// Return unused weight so the XCM executor can refund it.
+		let surplus = weight_limit.saturating_sub(weight_consumed);
+		tracing::trace!(
+			target: "xcm::transactor::erc721::deposit",
+			?weight_consumed, ?surplus, ?storage_deposit,
+		);
+		match result {
+			Ok(return_value) => {
+				tracing::trace!(
+					target: "xcm::transactor::erc721::deposit",
+					?return_value,
+					"Return value",
+				);
+				if return_value.did_revert() {
+					tracing::debug!(
+						target: "xcm::transactor::erc721::deposit",
+						"ERC721 contract reverted",
+					);
+					Err((what, XcmError::FailedToTransactAsset("ERC721 contract reverted")))
+				} else {
+					// transferFrom returns void; a non-reverting call means success.
+					tracing::trace!(
+						target: "xcm::transactor::erc721::deposit",
+						"ERC721 transferFrom successful",
+					);
+					Ok(surplus)
+				}
+			},
+			Err(error) => {
+				tracing::debug!(
+					target: "xcm::transactor::erc721::deposit",
+					?error,
+					"ERC721 contract execution errored",
+				);
+				Err((what, XcmError::FailedToTransactAsset("ERC721 contract execution errored")))
+			},
+		}
+	}
+}

--- a/cumulus/parachains/runtimes/assets/common/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/lib.rs
@@ -18,6 +18,7 @@
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarks;
 mod erc20_transactor;
+mod erc721_transactor;
 pub mod foreign_creators;
 pub mod fungible_conversion;
 pub mod local_and_foreign_assets;
@@ -26,6 +27,7 @@ pub mod migrations;
 pub mod runtime_api;
 
 pub use erc20_transactor::ERC20Transactor;
+pub use erc721_transactor::ERC721Transactor;
 
 extern crate alloc;
 extern crate core;
@@ -159,6 +161,35 @@ impl MaybeEquivalence<Location, H160> for AccountKey20ToH160 {
 /// ERC20 tokens.
 pub type ERC20Matcher =
 	MatchedConvertedConcreteId<H160, u128, IsLocalAccountKey20, AccountKey20ToH160, JustTry>;
+
+/// Converts an [`AssetInstance::Index`] to a `u128` token ID.
+///
+/// Used by [`ERC721Matcher`] to extract the numeric token ID from a non-fungible XCM asset.
+/// Only `AssetInstance::Index` variants are accepted; all others are rejected.
+pub struct AssetInstanceIndexToU128;
+impl sp_runtime::traits::MaybeEquivalence<xcm::latest::AssetInstance, u128>
+	for AssetInstanceIndexToU128
+{
+	fn convert(instance: &xcm::latest::AssetInstance) -> Option<u128> {
+		match instance {
+			xcm::latest::AssetInstance::Index(id) => Some(*id),
+			_ => None,
+		}
+	}
+
+	fn convert_back(id: &u128) -> Option<xcm::latest::AssetInstance> {
+		Some(xcm::latest::AssetInstance::Index(*id))
+	}
+}
+
+/// [`xcm_executor::traits::MatchesNonFungibles`] implementation that matches ERC-721 tokens.
+pub type ERC721Matcher = MatchedConvertedConcreteId<
+	H160,
+	u128,
+	IsLocalAccountKey20,
+	AccountKey20ToH160,
+	AssetInstanceIndexToU128,
+>;
 
 pub type AssetIdForPoolAssets = u32;
 

--- a/cumulus/parachains/runtimes/assets/common/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/common/src/lib.rs
@@ -163,9 +163,6 @@ pub type ERC20Matcher =
 	MatchedConvertedConcreteId<H160, u128, IsLocalAccountKey20, AccountKey20ToH160, JustTry>;
 
 /// Converts an [`AssetInstance::Index`] to a `u128` token ID.
-///
-/// Used by [`ERC721Matcher`] to extract the numeric token ID from a non-fungible XCM asset.
-/// Only `AssetInstance::Index` variants are accepted; all others are rejected.
 pub struct AssetInstanceIndexToU128;
 impl sp_runtime::traits::MaybeEquivalence<xcm::latest::AssetInstance, u128>
 	for AssetInstanceIndexToU128

--- a/prdoc/pr_11878.prdoc
+++ b/prdoc/pr_11878.prdoc
@@ -1,0 +1,14 @@
+title: 'xcm: add ERC-721 asset transactor for cross-chain NFT transfers via pallet-revive'
+doc:
+- audience: Runtime Dev
+  description: |-
+    closes https://github.com/paritytech/polkadot-sdk/issues/7523
+
+    This PR Implements `ERC721Transactor`: a new XCM `TransactAsset` adapter for ERC-721 non-fungible tokens deployed via pallet-revive, along with `IERC721` Solidity interface, `ERC721Matcher`, and the corresponding Asset Hub Westend `xcm_config` wiring, enabling reserve transfers of smart-contract NFTs across parachains using `AccountKey20`-based XCM locations.
+crates:
+- name: asset-hub-westend-runtime
+  bump: minor
+- name: assets-common
+  bump: minor
+- name: ethereum-standards
+  bump: minor

--- a/substrate/primitives/ethereum-standards/src/IERC721.sol
+++ b/substrate/primitives/ethereum-standards/src/IERC721.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Based on OpenZeppelin's ERC-721 interfaces:
+//
+// IERC721.sol (base ERC-721 interface)
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/IERC721.sol
+//
+// IERC721Metadata.sol (ERC-721 metadata extension)
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/extensions/IERC721Metadata.sol
+//
+pragma solidity ^0.8.20;
+
+///
+/// @dev Interface combining the ERC-721 Non-Fungible Token Standard and its metadata extension.
+/// Note: Due to ABI generation constraints, all interfaces are merged into a single contract.
+/// The `safeTransferFrom` overloads are omitted; use `transferFrom` for programmatic transfers.
+///
+interface IERC721 {
+    // ============================================================
+    // IERC721 - Base ERC-721 Interface
+    // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/IERC721.sol
+    // ============================================================
+
+    /// @dev Emitted when `tokenId` token is transferred from `from` to `to`.
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /// @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /// @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /// @dev Returns the number of tokens in `owner`'s account.
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    /// @dev Returns the owner of the `tokenId` token.
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    /// @dev Transfers `tokenId` token from `from` to `to`.
+    ///
+    /// WARNING: Note that the caller is responsible to confirm that the recipient is capable of
+    /// receiving ERC-721 or else they may be permanently lost. Usage of {safeTransferFrom}
+    /// prevents loss, though the caller must understand this adds an external call which
+    /// potentially creates a reentrancy vulnerability.
+    ///
+    /// Requirements:
+    /// - `from` cannot be the zero address.
+    /// - `to` cannot be the zero address.
+    /// - `tokenId` token must be owned by `from`.
+    /// - If the caller is not `from`, it must be approved to move this token by either
+    ///   {approve} or {setApprovalForAll}.
+    ///
+    /// Emits a {Transfer} event.
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /// @dev Gives permission to `to` to transfer `tokenId` token to another account.
+    /// The approval is cleared when the token is transferred.
+    ///
+    /// Only a single account can be approved at a time, so approving the zero address clears
+    /// previous approvals.
+    function approve(address to, uint256 tokenId) external;
+
+    /// @dev Approve or remove `operator` as an operator for the caller.
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /// @dev Returns the account approved for `tokenId` token.
+    function getApproved(uint256 tokenId) external view returns (address operator);
+
+    /// @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+
+    // ============================================================
+    // IERC721Metadata - ERC-721 Metadata Extension
+    // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/extensions/IERC721Metadata.sol
+    // ============================================================
+
+    /// @dev Returns the token collection name.
+    function name() external view returns (string memory);
+
+    /// @dev Returns the token collection symbol.
+    function symbol() external view returns (string memory);
+
+    /// @dev Returns the Uniform Resource Identifier (URI) for `tokenId` token.
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/substrate/primitives/ethereum-standards/src/lib.rs
+++ b/substrate/primitives/ethereum-standards/src/lib.rs
@@ -20,3 +20,4 @@
 #![no_std]
 
 alloy_core::sol!("src/IERC20.sol");
+alloy_core::sol!("src/IERC721.sol");


### PR DESCRIPTION
closes https://github.com/paritytech/polkadot-sdk/issues/7523

This PR Implements `ERC721Transactor`: a new XCM `TransactAsset` adapter for ERC-721 non-fungible tokens deployed via pallet-revive, along with `IERC721` Solidity interface, `ERC721Matcher`, and the corresponding Asset Hub Westend `xcm_config` wiring, enabling reserve transfers of smart-contract NFTs across parachains using `AccountKey20`-based XCM locations.