### PR TITLE
Add PgasOnChargeAssetTransaction adapter (alternative to #11818)

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
@@ -21,12 +21,13 @@ use crate::{
 };
 use alloc::{vec, vec::Vec};
 use cumulus_primitives_core::ParaId;
-use frame_support::build_struct_json_patch;
+use frame_support::{build_struct_json_patch, PalletId};
 use hex_literal::hex;
 use parachains_common::{AccountId, AuraId};
 use sp_core::crypto::UncheckedInto;
 use sp_genesis_builder::PresetId;
 use sp_keyring::Sr25519Keyring;
+use sp_runtime::traits::AccountIdConversion;
 use testnet_parachains_constants::westend::{
 	currency::UNITS as WND, xcm_version::SAFE_XCM_VERSION,
 };
@@ -97,7 +98,16 @@ fn asset_hub_westend_genesis(
 				.map(|asset| (asset.0.try_into().unwrap(), asset.1, asset.2))
 				.collect(),
 			..Default::default()
-		}
+		},
+		assets: AssetsConfig {
+			assets: vec![(
+				PGASAssetId::get(),
+				PalletId(*b"py/pgasa").into_account_truncating(),
+				true,
+				1,
+			)],
+			..Default::default()
+		},
 	})
 }
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1112,15 +1112,36 @@ parameter_types! {
 	pub StakingPot: AccountId = CollatorSelection::account_id();
 }
 
+parameter_types! {
+	/// Asset id of the PGAS gas-allowance asset, registered on AH as a trusted asset.
+	/// TODO: Set the westend value
+	pub const PGASAssetId: AssetIdForTrustBackedAssets = 42;
+	/// `xcm::v5::Location` representation of [`PGASAssetId`] as seen by the fungibles union.
+	pub PGASAssetIdLocation: xcm::v5::Location = xcm::v5::Location::new(
+		0,
+		[
+			xcm::v5::Junction::PalletInstance(
+				<Assets as frame_support::traits::PalletInfoAccess>::index() as u8,
+			),
+			xcm::v5::Junction::GeneralIndex(PGASAssetId::get() as u128),
+		],
+	);
+}
+
 impl pallet_asset_conversion_tx_payment::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type AssetId = xcm::v5::Location;
-	type OnChargeAssetTransaction = SwapAssetAdapter<
-		WestendLocation,
-		NativeAndNonPoolAssets,
-		AssetConversion,
-		ResolveAssetTo<StakingPot, NativeAndNonPoolAssets>,
-	>;
+	type OnChargeAssetTransaction =
+		pallet_asset_conversion_tx_payment::pgas::PgasOnChargeAssetTransaction<
+			PGASAssetIdLocation,
+			NativeAndNonPoolAssets,
+			SwapAssetAdapter<
+				WestendLocation,
+				NativeAndNonPoolAssets,
+				AssetConversion,
+				ResolveAssetTo<StakingPot, NativeAndNonPoolAssets>,
+			>,
+		>;
 	type WeightInfo = weights::pallet_asset_conversion_tx_payment::WeightInfo<Runtime>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = AssetConversionTxHelper;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/tests/tests.rs
@@ -130,6 +130,14 @@ fn bare_instantiate(origin: &AccountId, code: Vec<u8>) -> BareInstantiateBuilder
 }
 
 fn construct_extrinsic(sender: Sr25519Keyring, call: RuntimeCall) -> UncheckedExtrinsic {
+	construct_extrinsic_with_asset(sender, call, None)
+}
+
+fn construct_extrinsic_with_asset(
+	sender: Sr25519Keyring,
+	call: RuntimeCall,
+	asset_id: Option<xcm::v5::Location>,
+) -> UncheckedExtrinsic {
 	let account_id = AccountId::from(sender.public());
 	let tx_ext: TxExtension = (
 		frame_system::AuthorizeCall::<Runtime>::new(),
@@ -142,7 +150,7 @@ fn construct_extrinsic(sender: Sr25519Keyring, call: RuntimeCall) -> UncheckedEx
 			frame_system::Pallet::<Runtime>::account(&account_id).nonce,
 		),
 		frame_system::CheckWeight::<Runtime>::new(),
-		pallet_asset_conversion_tx_payment::ChargeAssetTxPayment::<Runtime>::from(0, None),
+		pallet_asset_conversion_tx_payment::ChargeAssetTxPayment::<Runtime>::from(0, asset_id),
 		frame_metadata_hash_extension::CheckMetadataHash::new(false),
 		Default::default(),
 	)
@@ -2636,5 +2644,100 @@ mod dap {
 				);
 				assert_eq!(<Balances as Inspect<AccountId>>::total_issuance(), issuance_before);
 			});
+	}
+}
+
+// Exercises the real `PgasOnChargeAssetTransaction` adapter via `Executive::apply_extrinsic`.
+// Users opt into PGAS payment by setting the extension's asset_id to `Some(PGAS)`.
+#[cfg(not(feature = "runtime-benchmarks"))]
+mod pgas_allowance {
+	use super::*;
+	use asset_hub_westend_runtime::{PGASAssetId, PGASAssetIdLocation};
+	use sp_core::H160;
+	use sp_runtime::BuildStorage;
+
+	const SENDER: Sr25519Keyring = Sr25519Keyring::Bob;
+
+	fn revive_call() -> RuntimeCall {
+		RuntimeCall::Revive(pallet_revive::Call::call {
+			dest: H160::default(),
+			value: 0,
+			weight_limit: Weight::zero(),
+			storage_deposit_limit: 0,
+			data: vec![],
+		})
+	}
+
+	fn setup_ext(funded_accounts: Vec<(AccountId, Balance)>) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+		pallet_balances::GenesisConfig::<Runtime> {
+			balances: funded_accounts,
+			..Default::default()
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		pallet_assets::GenesisConfig::<Runtime, pallet_assets::Instance1> {
+			assets: vec![(PGASAssetId::get(), AccountId::from(ALICE), true, 1)],
+			..Default::default()
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+		let mut ext: sp_io::TestExternalities = t.into();
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+
+	fn mint_pgas(to: &AccountId, amount: Balance) {
+		assert_ok!(<Assets as FungiblesMutate<_>>::mint_into(PGASAssetId::get(), to, amount));
+	}
+
+	fn pgas_balance(who: &AccountId) -> Balance {
+		<Assets as FungiblesInspect<_>>::balance(PGASAssetId::get(), who)
+	}
+
+	/// Look up the `AssetTxFeePaid` event for `who` paid in PGAS.
+	fn pgas_fee_paid_event(who: &AccountId) -> Option<Balance> {
+		let pgas_location = PGASAssetIdLocation::get();
+		System::events().into_iter().find_map(|e| match e.event {
+			RuntimeEvent::AssetTxPayment(
+				pallet_asset_conversion_tx_payment::Event::AssetTxFeePaid {
+					who: w,
+					actual_fee,
+					asset_id,
+					..
+				},
+			) if &w == who && asset_id == pgas_location => Some(actual_fee),
+			_ => None,
+		})
+	}
+
+	/// Caller holds PGAS and signs the tx with `asset_id=Some(PGAS)`: the fee is burned from PGAS
+	/// and native is untouched.
+	#[test]
+	fn pgas_pays_when_specified_as_fee_asset() {
+		let sender = SENDER.to_account_id();
+		let initial_native = 10 * UNITS;
+		let initial_pgas = 100 * UNITS;
+		setup_ext(vec![(sender.clone(), initial_native)]).execute_with(|| {
+			mint_pgas(&sender, initial_pgas);
+
+			let native_before = <Balances as Inspect<_>>::balance(&sender);
+			let pgas_before = pgas_balance(&sender);
+
+			let xt = construct_extrinsic_with_asset(
+				SENDER,
+				revive_call(),
+				Some(PGASAssetIdLocation::get()),
+			);
+			assert_ok!(Executive::apply_extrinsic(xt).unwrap());
+
+			let native_after = <Balances as Inspect<_>>::balance(&sender);
+			let pgas_after = pgas_balance(&sender);
+
+			assert_eq!(native_before, native_after, "native untouched on PGAS path");
+			let fee = pgas_before.checked_sub(pgas_after).expect("PGAS charged");
+			assert!(fee > 0);
+			assert_eq!(pgas_fee_paid_event(&sender), Some(fee));
+		});
 	}
 }

--- a/prdoc/pr_11879.prdoc
+++ b/prdoc/pr_11879.prdoc
@@ -1,0 +1,18 @@
+title: Add PgasOnChargeAssetTransaction adapter to pallet-asset-conversion-tx-payment
+doc:
+  - audience: Runtime Dev
+    description: |
+      - Introduces `pallet_asset_conversion_tx_payment::pgas::PgasOnChargeAssetTransaction<PgasId, F, Inner>`,
+        an `OnChargeAssetTransaction` adapter. When the fee asset is `PgasId` it withdraws PGAS
+        directly (no swap) and burns the consumed portion by dropping the credit, refunding the
+        rest. For any other asset it delegates to `Inner` (e.g. `SwapAssetAdapter`).
+      - Users opt into PGAS payment by signing a transaction with the extension's `asset_id` set
+        to `Some(PGAS)`. The standard `AssetTxFeePaid { who, actual_fee, tip, asset_id }` event
+        carries the PGAS asset id on the PGAS path.
+      - Wires the adapter into `asset-hub-westend` inside the existing
+        `pallet_asset_conversion_tx_payment::Config::OnChargeAssetTransaction`.
+crates:
+  - name: asset-hub-westend-runtime
+    bump: minor
+  - name: pallet-asset-conversion-tx-payment
+    bump: minor

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/lib.rs
@@ -71,6 +71,7 @@ pub mod weights;
 mod benchmarking;
 
 mod payment;
+pub mod pgas;
 use frame_support::{pallet_prelude::Weight, traits::tokens::AssetId};
 pub use payment::*;
 pub use weights::WeightInfo;

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/pgas.rs
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/src/pgas.rs
@@ -1,0 +1,146 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # PGAS fee-payment adapter
+//!
+//! [`PgasOnChargeAssetTransaction`] is an [`OnChargeAssetTransaction`] adapter. When the fee asset
+//! matches [`PgasId`](frame_support::traits::Get), it withdraws the fee directly from PGAS (no
+//! swap) and burns the consumed portion by dropping the credit; any unused portion is refunded.
+//! For any other asset it delegates to `Inner`.
+//!
+//! Wired into a runtime by setting
+//! `pallet_asset_conversion_tx_payment::Config::OnChargeAssetTransaction` to
+//! `PgasOnChargeAssetTransaction<PgasId, Fungibles, SwapAssetAdapter<...>>`. Users opt into PGAS
+//! payment by specifying `Some(PGAS)` as the fee asset on `ChargeAssetTxPayment`.
+
+use super::{BalanceOf, Config};
+use core::marker::PhantomData;
+use frame_support::{
+	traits::{
+		tokens::{
+			fungibles::{self, Credit},
+			Fortitude, Precision, Preservation, WithdrawConsequence,
+		},
+		Get,
+	},
+	unsigned::TransactionValidityError,
+};
+use sp_runtime::{
+	traits::{DispatchInfoOf, PostDispatchInfoOf},
+	transaction_validity::InvalidTransaction,
+};
+
+use crate::OnChargeAssetTransaction;
+
+/// Liquidity info produced by [`PgasOnChargeAssetTransaction::withdraw_fee`]: either PGAS (held as
+/// a fungibles credit ready to be split and burned in `correct_and_deposit_fee`) or whatever the
+/// inner adapter produces for non-PGAS assets.
+pub enum PgasLiquidityInfo<PgasInfo, InnerInfo> {
+	/// Fee was withdrawn as PGAS.
+	Pgas(PgasInfo),
+	/// Fee handling was delegated to the inner adapter.
+	Other(InnerInfo),
+}
+
+/// [`OnChargeAssetTransaction`] adapter that intercepts PGAS fee payments (withdraw + burn) and
+/// delegates to `Inner` for any other asset.
+pub struct PgasOnChargeAssetTransaction<PgasId, F, Inner>(PhantomData<(PgasId, F, Inner)>);
+
+impl<T, PgasId, F, Inner> OnChargeAssetTransaction<T>
+	for PgasOnChargeAssetTransaction<PgasId, F, Inner>
+where
+	T: Config,
+	PgasId: Get<T::AssetId>,
+	F: fungibles::Balanced<T::AccountId, Balance = BalanceOf<T>, AssetId = T::AssetId>,
+	Inner: OnChargeAssetTransaction<T, Balance = BalanceOf<T>, AssetId = T::AssetId>,
+{
+	type AssetId = T::AssetId;
+	type Balance = BalanceOf<T>;
+	type LiquidityInfo = PgasLiquidityInfo<Credit<T::AccountId, F>, Inner::LiquidityInfo>;
+
+	fn withdraw_fee(
+		who: &T::AccountId,
+		call: &T::RuntimeCall,
+		dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
+		asset_id: Self::AssetId,
+		fee: Self::Balance,
+		tip: Self::Balance,
+	) -> Result<Self::LiquidityInfo, TransactionValidityError> {
+		if asset_id == PgasId::get() {
+			// PGAS is pegged 1:1 with the native fee, so no swap is needed. `Expendable` lets the
+			// caller fully drain their PGAS on the final tx (PGAS is a sufficient asset, so reaping
+			// on payment is safe).
+			let credit = F::withdraw(
+				asset_id,
+				who,
+				fee,
+				Precision::Exact,
+				Preservation::Expendable,
+				Fortitude::Polite,
+			)
+			.map_err(|_| InvalidTransaction::Payment)?;
+			Ok(PgasLiquidityInfo::Pgas(credit))
+		} else {
+			Inner::withdraw_fee(who, call, dispatch_info, asset_id, fee, tip)
+				.map(PgasLiquidityInfo::Other)
+		}
+	}
+
+	fn can_withdraw_fee(
+		who: &T::AccountId,
+		asset_id: Self::AssetId,
+		fee: Self::Balance,
+	) -> Result<(), TransactionValidityError> {
+		if asset_id == PgasId::get() {
+			match F::can_withdraw(asset_id, who, fee) {
+				WithdrawConsequence::Success | WithdrawConsequence::ReducedToZero(_) => Ok(()),
+				_ => Err(InvalidTransaction::Payment.into()),
+			}
+		} else {
+			Inner::can_withdraw_fee(who, asset_id, fee)
+		}
+	}
+
+	fn correct_and_deposit_fee(
+		who: &T::AccountId,
+		dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
+		post_info: &PostDispatchInfoOf<T::RuntimeCall>,
+		corrected_fee: Self::Balance,
+		tip: Self::Balance,
+		asset_id: Self::AssetId,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<BalanceOf<T>, TransactionValidityError> {
+		match already_withdrawn {
+			PgasLiquidityInfo::Pgas(credit) => {
+				let (fee_credit, refund_credit) = credit.split(corrected_fee);
+				// If resolve fails the refund credit is dropped, which burns it. That matches the
+				// PGAS "burn on fee" semantics so we don't need to recover from it.
+				let _ = F::resolve(who, refund_credit);
+				// Drop burns the fee via `pallet_assets::OnDropCredit`.
+				drop(fee_credit);
+				Ok(corrected_fee)
+			},
+			PgasLiquidityInfo::Other(inner_info) => Inner::correct_and_deposit_fee(
+				who,
+				dispatch_info,
+				post_info,
+				corrected_fee,
+				tip,
+				asset_id,
+				inner_info,
+			),
+		}
+	}
+}

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/benchmarking.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/benchmarking.rs
@@ -35,8 +35,8 @@ use sp_runtime::traits::{
 	T::RuntimeOrigin: AsTransactionAuthorizedOrigin,
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 	AssetBalanceOf<T>: Send + Sync,
-	BalanceOf<T>: Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>>,
-	ChargeAssetIdOf<T>: Send + Sync,
+	BalanceOf<T>: Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>> + IsType<AssetBalanceOf<T>>,
+	ChargeAssetIdOf<T>: Send + Sync + IsType<AssetIdOf<T>>,
 	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
     Credit<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
 )]

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/lib.rs
@@ -42,9 +42,9 @@ use frame_support::{
 	traits::{
 		tokens::{
 			fungibles::{Balanced, Credit, Inspect},
-			WithdrawConsequence,
+			Fortitude, Preservation, WithdrawConsequence,
 		},
-		IsType,
+		Get, IsType,
 	},
 	DefaultNoBound,
 };
@@ -67,9 +67,11 @@ mod tests;
 mod benchmarking;
 
 mod payment;
+mod pgas;
 pub mod weights;
 
 pub use payment::*;
+pub use pgas::PgasOnChargeAssetTransaction;
 pub use weights::WeightInfo;
 
 /// Type aliases used for interaction with `OnChargeTransaction`.
@@ -127,6 +129,9 @@ pub mod pallet {
 		type Fungibles: Balanced<Self::AccountId>;
 		/// The actual transaction charging logic that charges the fees.
 		type OnChargeAssetTransaction: OnChargeAssetTransaction<Self>;
+		/// Optional PGAS asset id. When set and the signer leaves the asset unspecified, the
+		/// extension auto-routes payment to PGAS provided the signer holds enough.
+		type PgasId: Get<Option<ChargeAssetIdOf<Self>>>;
 		/// The weight information of this pallet.
 		type WeightInfo: WeightInfo;
 		/// Benchmark helper
@@ -198,12 +203,13 @@ where
 		who: &T::AccountId,
 		call: &T::RuntimeCall,
 		info: &DispatchInfoOf<T::RuntimeCall>,
+		asset_id: &Option<ChargeAssetIdOf<T>>,
 		fee: BalanceOf<T>,
 	) -> Result<(BalanceOf<T>, InitialPayment<T>), TransactionValidityError> {
 		debug_assert!(self.tip <= fee, "tip should be included in the computed fee");
 		if fee.is_zero() {
 			Ok((fee, InitialPayment::Nothing))
-		} else if let Some(asset_id) = self.asset_id.clone() {
+		} else if let Some(asset_id) = asset_id.clone() {
 			T::OnChargeAssetTransaction::withdraw_fee(
 				who,
 				call,
@@ -229,12 +235,13 @@ where
 		who: &T::AccountId,
 		call: &T::RuntimeCall,
 		info: &DispatchInfoOf<T::RuntimeCall>,
+		asset_id: &Option<ChargeAssetIdOf<T>>,
 		fee: BalanceOf<T>,
 	) -> Result<(), TransactionValidityError> {
 		debug_assert!(self.tip <= fee, "tip should be included in the computed fee");
 		if fee.is_zero() {
 			Ok(())
-		} else if let Some(asset_id) = self.asset_id.clone() {
+		} else if let Some(asset_id) = asset_id.clone() {
 			T::OnChargeAssetTransaction::can_withdraw_fee(
 				who,
 				call,
@@ -249,6 +256,35 @@ where
 			)
 			.map_err(|_| -> TransactionValidityError { InvalidTransaction::Payment.into() })
 		}
+	}
+
+	/// Resolve the asset id used to pay this transaction's fees.
+	///
+	/// If the signer specified an asset, that choice is honored. Otherwise, when [`Config::PgasId`]
+	/// is set and the signer holds at least `fee` PGAS, the extension auto-routes to PGAS. Falls
+	/// back to the native currency.
+	fn effective_asset_id(
+		who: &T::AccountId,
+		signed_asset_id: &Option<ChargeAssetIdOf<T>>,
+		fee: BalanceOf<T>,
+	) -> Option<ChargeAssetIdOf<T>>
+	where
+		ChargeAssetIdOf<T>: IsType<AssetIdOf<T>>,
+		BalanceOf<T>: IsType<AssetBalanceOf<T>>,
+	{
+		if signed_asset_id.is_some() {
+			return signed_asset_id.clone();
+		}
+		let pgas_id = T::PgasId::get()?;
+		let pgas_id_inspect: AssetIdOf<T> = pgas_id.clone().into();
+		let pgas_balance = <T::Fungibles as Inspect<T::AccountId>>::reducible_balance(
+			pgas_id_inspect,
+			who,
+			Preservation::Expendable,
+			Fortitude::Polite,
+		);
+		let fee_in_assets: AssetBalanceOf<T> = fee.into();
+		(pgas_balance >= fee_in_assets).then_some(pgas_id)
 	}
 }
 
@@ -271,6 +307,8 @@ pub enum Val<T: Config> {
 		who: T::AccountId,
 		// transaction fee
 		fee: BalanceOf<T>,
+		// resolved asset to charge in (after PGAS auto-routing)
+		asset_id: Option<ChargeAssetIdOf<T>>,
 	},
 	NoCharge,
 }
@@ -299,8 +337,9 @@ impl<T: Config> TransactionExtension<T::RuntimeCall> for ChargeAssetTxPayment<T>
 where
 	T::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 	AssetBalanceOf<T>: Send + Sync,
-	BalanceOf<T>: Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>>,
-	ChargeAssetIdOf<T>: Send + Sync,
+	BalanceOf<T>:
+		Send + Sync + From<u64> + IsType<ChargeAssetBalanceOf<T>> + IsType<AssetBalanceOf<T>>,
+	ChargeAssetIdOf<T>: Send + Sync + IsType<AssetIdOf<T>>,
 	Credit<T::AccountId, T::Fungibles>: IsType<ChargeAssetLiquidityOf<T>>,
 	<T::RuntimeCall as Dispatchable>::RuntimeOrigin: AsSystemOriginSigner<T::AccountId> + Clone,
 {
@@ -310,7 +349,10 @@ where
 	type Pre = Pre<T>;
 
 	fn weight(&self, _: &T::RuntimeCall) -> Weight {
-		if self.asset_id.is_some() {
+		// When the signer left the asset unspecified but PGAS auto-routing is enabled, validate may
+		// pick the asset path. Reserve the worst case so refunds in `post_dispatch_details` stay
+		// non-negative; the extra is refunded there.
+		if self.asset_id.is_some() || T::PgasId::get().is_some() {
 			<T as Config>::WeightInfo::charge_asset_tx_payment_asset()
 		} else {
 			<T as Config>::WeightInfo::charge_asset_tx_payment_native()
@@ -336,9 +378,10 @@ where
 		};
 		// Non-mutating call of `compute_fee` to calculate the fee used in the transaction priority.
 		let fee = pallet_transaction_payment::Pallet::<T>::compute_fee(len as u32, info, self.tip);
-		self.can_withdraw_fee(&who, call, info, fee)?;
+		let asset_id = Self::effective_asset_id(&who, &self.asset_id, fee);
+		self.can_withdraw_fee(&who, call, info, &asset_id, fee)?;
 		let priority = ChargeTransactionPayment::<T>::get_priority(info, len, self.tip, fee);
-		let val = Val::Charge { tip: self.tip, who: who.clone(), fee };
+		let val = Val::Charge { tip: self.tip, who: who.clone(), fee, asset_id };
 		let validity = ValidTransaction { priority, ..Default::default() };
 		Ok((validity, val, origin))
 	}
@@ -352,16 +395,11 @@ where
 		_len: usize,
 	) -> Result<Self::Pre, TransactionValidityError> {
 		match val {
-			Val::Charge { tip, who, fee } => {
+			Val::Charge { tip, who, fee, asset_id } => {
 				// Mutating call of `withdraw_fee` to actually charge for the transaction.
-				let (_fee, initial_payment) = self.withdraw_fee(&who, call, info, fee)?;
-				Ok(Pre::Charge {
-					tip,
-					who,
-					initial_payment,
-					asset_id: self.asset_id.clone(),
-					weight: self.weight(call),
-				})
+				let (_fee, initial_payment) =
+					self.withdraw_fee(&who, call, info, &asset_id, fee)?;
+				Ok(Pre::Charge { tip, who, initial_payment, asset_id, weight: self.weight(call) })
 			},
 			Val::NoCharge => Ok(Pre::NoCharge { refund: self.weight(call) }),
 		}

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/mock.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/mock.rs
@@ -20,9 +20,8 @@ use codec;
 use frame_support::{
 	derive_impl,
 	dispatch::DispatchClass,
-	pallet_prelude::*,
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64, ConstU8, FindAuthor},
+	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64, ConstU8, FindAuthor, Get},
 	weights::{Weight, WeightToFee as WeightToFeeT},
 	ConsensusEngineId,
 };
@@ -195,13 +194,21 @@ impl WeightInfo for MockWeights {
 	}
 }
 
+parameter_types! {
+	pub static PgasId: Option<AssetId> = None;
+}
+
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Fungibles = Assets;
-	type OnChargeAssetTransaction = FungiblesAdapter<
-		pallet_assets::BalanceToAssetBalance<Balances, Runtime, ConvertInto>,
-		CreditToBlockAuthor,
+	type OnChargeAssetTransaction = PgasOnChargeAssetTransaction<
+		PgasId,
+		FungiblesAdapter<
+			pallet_assets::BalanceToAssetBalance<Balances, Runtime, ConvertInto>,
+			CreditToBlockAuthor,
+		>,
 	>;
+	type PgasId = PgasId;
 	type WeightInfo = MockWeights;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = Helper;

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/pgas.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/pgas.rs
@@ -1,0 +1,152 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # PGAS fee-payment adapter
+//!
+//! [`PgasOnChargeAssetTransaction`] is an [`OnChargeAssetTransaction`] adapter. When the fee asset
+//! matches `PgasId::get()`, it withdraws the fee directly from PGAS via [`Config::Fungibles`] (no
+//! swap) and burns the consumed portion by dropping the credit; any unused portion is refunded.
+//! For any other asset it delegates to `Inner`.
+//!
+//! Wired into a runtime by setting
+//! `pallet_asset_tx_payment::Config::OnChargeAssetTransaction` to
+//! `PgasOnChargeAssetTransaction<PgasId, FungiblesAdapter<...>>`. The
+//! [`ChargeAssetTxPayment`](crate::ChargeAssetTxPayment) extension auto-routes signed transactions
+//! that leave the asset unspecified to PGAS when the signer holds enough; explicit `Some(PgasId)`
+//! is also honored.
+
+use super::{AssetBalanceOf, AssetIdOf, BalanceOf, Config};
+use codec::{DecodeWithMemTracking, FullCodec};
+use core::{fmt::Debug, marker::PhantomData};
+use frame_support::{
+	traits::{
+		tokens::{
+			fungibles::{Balanced, Credit, Inspect},
+			Fortitude, Precision, Preservation, WithdrawConsequence,
+		},
+		Get,
+	},
+	unsigned::TransactionValidityError,
+};
+use scale_info::TypeInfo;
+use sp_runtime::{
+	traits::{DispatchInfoOf, MaybeSerializeDeserialize, PostDispatchInfoOf},
+	transaction_validity::InvalidTransaction,
+};
+
+use crate::OnChargeAssetTransaction;
+
+/// [`OnChargeAssetTransaction`] adapter that intercepts PGAS fee payments (withdraw + burn) and
+/// delegates to `Inner` for any other asset. Both paths produce the same
+/// `Credit<T::AccountId, T::Fungibles>` so `correct_and_deposit_fee` can dispatch on the credit's
+/// asset id.
+pub struct PgasOnChargeAssetTransaction<PgasId, Inner>(PhantomData<(PgasId, Inner)>);
+
+impl<T, PgasId, Inner> OnChargeAssetTransaction<T> for PgasOnChargeAssetTransaction<PgasId, Inner>
+where
+	T: Config,
+	PgasId: Get<Option<AssetIdOf<T>>>,
+	Inner: OnChargeAssetTransaction<
+		T,
+		Balance = BalanceOf<T>,
+		AssetId = AssetIdOf<T>,
+		LiquidityInfo = Credit<T::AccountId, T::Fungibles>,
+	>,
+	AssetBalanceOf<T>: From<BalanceOf<T>>,
+	AssetIdOf<T>: FullCodec
+		+ DecodeWithMemTracking
+		+ Clone
+		+ MaybeSerializeDeserialize
+		+ Debug
+		+ Default
+		+ Eq
+		+ TypeInfo,
+{
+	type AssetId = AssetIdOf<T>;
+	type Balance = BalanceOf<T>;
+	type LiquidityInfo = Credit<T::AccountId, T::Fungibles>;
+
+	fn withdraw_fee(
+		who: &T::AccountId,
+		call: &T::RuntimeCall,
+		dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
+		asset_id: Self::AssetId,
+		fee: Self::Balance,
+		tip: Self::Balance,
+	) -> Result<Self::LiquidityInfo, TransactionValidityError> {
+		if PgasId::get().as_ref() == Some(&asset_id) {
+			// PGAS is pegged 1:1 with the native fee, so no swap is needed. `Expendable` lets the
+			// caller fully drain their PGAS on the final tx (PGAS is a sufficient asset, so reaping
+			// on payment is safe).
+			<T::Fungibles as Balanced<T::AccountId>>::withdraw(
+				asset_id,
+				who,
+				fee.into(),
+				Precision::Exact,
+				Preservation::Expendable,
+				Fortitude::Polite,
+			)
+			.map_err(|_| InvalidTransaction::Payment.into())
+		} else {
+			Inner::withdraw_fee(who, call, dispatch_info, asset_id, fee, tip)
+		}
+	}
+
+	fn can_withdraw_fee(
+		who: &T::AccountId,
+		call: &T::RuntimeCall,
+		dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
+		asset_id: Self::AssetId,
+		fee: Self::Balance,
+		tip: Self::Balance,
+	) -> Result<(), TransactionValidityError> {
+		if PgasId::get().as_ref() == Some(&asset_id) {
+			match <T::Fungibles as Inspect<T::AccountId>>::can_withdraw(asset_id, who, fee.into()) {
+				WithdrawConsequence::Success | WithdrawConsequence::ReducedToZero(_) => Ok(()),
+				_ => Err(InvalidTransaction::Payment.into()),
+			}
+		} else {
+			Inner::can_withdraw_fee(who, call, dispatch_info, asset_id, fee, tip)
+		}
+	}
+
+	fn correct_and_deposit_fee(
+		who: &T::AccountId,
+		dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
+		post_info: &PostDispatchInfoOf<T::RuntimeCall>,
+		corrected_fee: Self::Balance,
+		tip: Self::Balance,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<(AssetBalanceOf<T>, AssetBalanceOf<T>), TransactionValidityError> {
+		if PgasId::get().as_ref() == Some(&already_withdrawn.asset()) {
+			let (fee_credit, refund_credit) = already_withdrawn.split(corrected_fee.into());
+			// If resolve fails the refund credit is dropped, which burns it. That matches the
+			// PGAS "burn on fee" semantics so we don't need to recover from it.
+			let _ = <T::Fungibles as Balanced<T::AccountId>>::resolve(who, refund_credit);
+			// Drop burns the fee via `pallet_assets::OnDropCredit`.
+			drop(fee_credit);
+			Ok((corrected_fee.into(), tip.into()))
+		} else {
+			Inner::correct_and_deposit_fee(
+				who,
+				dispatch_info,
+				post_info,
+				corrected_fee,
+				tip,
+				already_withdrawn,
+			)
+		}
+	}
+}

--- a/substrate/frame/transaction-payment/asset-tx-payment/src/tests.rs
+++ b/substrate/frame/transaction-payment/asset-tx-payment/src/tests.rs
@@ -613,6 +613,171 @@ fn post_dispatch_fee_is_zero_if_pre_dispatch_fee_is_zero() {
 		});
 }
 
+/// Helper for PGAS tests: create an asset, mint into the caller, set [`mock::PgasId`].
+fn setup_pgas_asset(caller: u64, balance: u64) -> u32 {
+	let asset_id = 7;
+	let min_balance = 1;
+	assert_ok!(Assets::force_create(
+		RuntimeOrigin::root(),
+		asset_id.into(),
+		42,   // owner
+		true, // is_sufficient
+		min_balance,
+	));
+	let beneficiary = <Runtime as system::Config>::Lookup::unlookup(caller);
+	assert_ok!(Assets::mint_into(asset_id.into(), &beneficiary, balance));
+	mock::PgasId::set(Some(asset_id));
+	asset_id
+}
+
+#[test]
+fn pgas_auto_route_when_signer_holds_pgas() {
+	let base_weight = 5;
+	ExtBuilder::default()
+		.balance_factor(100)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+			let caller = 1;
+			let pgas_balance = 1_000;
+			let asset_id = setup_pgas_asset(caller, pgas_balance);
+
+			let weight = 5;
+			let len = 10;
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			let mut info = info_from_weight(Weight::from_parts(weight, 0));
+			info.extension_weight = ext.weight(CALL);
+			let fee = base_weight + weight + len as u64 + info.extension_weight.ref_time();
+			let initial_native = Balances::free_balance(caller);
+
+			let (pre, _) =
+				ext.validate_and_prepare(Some(caller).into(), CALL, &info, len, 0).unwrap();
+
+			assert_eq!(Balances::free_balance(caller), initial_native);
+			assert_eq!(Assets::balance(asset_id, caller), pgas_balance - fee);
+
+			let issuance_before = Assets::total_issuance(asset_id);
+			assert_ok!(ChargeAssetTxPayment::<Runtime>::post_dispatch_details(
+				pre,
+				&info,
+				&default_post_info(),
+				len,
+				&Ok(()),
+			));
+			let actual_fee = base_weight +
+				weight + len as u64 +
+				MockWeights::charge_asset_tx_payment_asset().ref_time();
+			assert_eq!(Assets::balance(asset_id, caller), pgas_balance - actual_fee);
+			assert_eq!(Assets::balance(asset_id, BLOCK_AUTHOR), 0);
+			assert_eq!(Assets::total_issuance(asset_id), issuance_before - actual_fee);
+		});
+}
+
+#[test]
+fn pgas_auto_route_falls_back_to_native_when_insufficient() {
+	let base_weight = 5;
+	ExtBuilder::default()
+		.balance_factor(100)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+			let caller = 1;
+			let asset_id = setup_pgas_asset(caller, 1);
+
+			let weight = 5;
+			let len = 10;
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			let mut info = info_from_weight(Weight::from_parts(weight, 0));
+			info.extension_weight = ext.weight(CALL);
+			let fee = base_weight + weight + len as u64 + info.extension_weight.ref_time();
+			let initial_native = Balances::free_balance(caller);
+
+			let (pre, _) =
+				ext.validate_and_prepare(Some(caller).into(), CALL, &info, len, 0).unwrap();
+
+			assert_eq!(Balances::free_balance(caller), initial_native - fee);
+			assert_eq!(Assets::balance(asset_id, caller), 1);
+
+			assert_ok!(ChargeAssetTxPayment::<Runtime>::post_dispatch_details(
+				pre,
+				&info,
+				&default_post_info(),
+				len,
+				&Ok(()),
+			));
+		});
+}
+
+#[test]
+fn pgas_auto_route_disabled_when_pgas_id_unset() {
+	mock::PgasId::set(None);
+	let base_weight = 5;
+	ExtBuilder::default()
+		.balance_factor(100)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			let caller = 1;
+			let len = 10;
+			let weight = 5;
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, None);
+			let mut info = info_from_weight(Weight::from_parts(weight, 0));
+			info.extension_weight = ext.weight(CALL);
+
+			let initial_native = Balances::free_balance(caller);
+			let fee = base_weight + weight + len as u64 + info.extension_weight.ref_time();
+
+			let (_pre, _) =
+				ext.validate_and_prepare(Some(caller).into(), CALL, &info, len, 0).unwrap();
+
+			assert_eq!(Balances::free_balance(caller), initial_native - fee);
+		});
+}
+
+#[test]
+fn explicit_pgas_asset_id_burns_pgas() {
+	let base_weight = 5;
+	ExtBuilder::default()
+		.balance_factor(100)
+		.base_weight(Weight::from_parts(base_weight, 0))
+		.build()
+		.execute_with(|| {
+			System::set_block_number(1);
+			let caller = 1;
+			let pgas_balance = 1_000;
+			let asset_id = setup_pgas_asset(caller, pgas_balance);
+
+			let weight = 5;
+			let len = 10;
+			let ext = ChargeAssetTxPayment::<Runtime>::from(0, Some(asset_id));
+			let mut info = info_from_weight(Weight::from_parts(weight, 0));
+			info.extension_weight = ext.weight(CALL);
+			let fee = base_weight + weight + len as u64 + info.extension_weight.ref_time();
+
+			let issuance_before = Assets::total_issuance(asset_id);
+			let (pre, _) =
+				ext.validate_and_prepare(Some(caller).into(), CALL, &info, len, 0).unwrap();
+			assert_eq!(Assets::balance(asset_id, caller), pgas_balance - fee);
+
+			assert_ok!(ChargeAssetTxPayment::<Runtime>::post_dispatch_details(
+				pre,
+				&info,
+				&default_post_info(),
+				len,
+				&Ok(()),
+			));
+			let actual_fee = base_weight +
+				weight + len as u64 +
+				MockWeights::charge_asset_tx_payment_asset().ref_time();
+			assert_eq!(Assets::balance(asset_id, caller), pgas_balance - actual_fee);
+			// PGAS path burns; block author should not receive any.
+			assert_eq!(Assets::balance(asset_id, BLOCK_AUTHOR), 0);
+			assert_eq!(Assets::total_issuance(asset_id), issuance_before - actual_fee);
+		});
+}
+
 #[test]
 fn no_fee_and_no_weight_for_other_origins() {
 	ExtBuilder::default().build().execute_with(|| {


### PR DESCRIPTION
## Summary

Alternative design to #11818. Minimal: one file (~146 lines) plus runtime wiring. No new pallet, no new extension, no wrapper around `ChargeAssetTxPayment`, no auto-routing — just an `OnChargeAssetTransaction` adapter that runtimes plug into the existing `pallet_asset_conversion_tx_payment::Config::OnChargeAssetTransaction`.

## What it does

`pallet_asset_conversion_tx_payment::pgas::PgasOnChargeAssetTransaction<PgasId, F, Inner>` implements `OnChargeAssetTransaction`:

- **asset_id == PgasId**: withdraw PGAS directly (1:1, no swap). In `correct_and_deposit_fee`, split the credit, refund the overpayment, and drop the consumed portion — `pallet_assets::OnDropCredit = DecreaseIssuanceWithEvent` burns it.
- **any other asset**: delegate to `Inner` (e.g. `SwapAssetAdapter`).

Mirrors the adapter in [paritytech/individuality#839](https://github.com/paritytech/individuality/pull/839) (`support/src/pgas.rs`).

## Usage

Users opt into PGAS by signing with `ChargeAssetTxPayment::from(tip, Some(PGAS))`. The standard `AssetTxFeePaid { who, actual_fee, tip, asset_id }` event fires with the PGAS asset id — no dedicated event is needed.

## Runtime wiring (asset-hub-westend)

- `PGASAssetId: u32 = 42` (Assets pallet asset id)
- `PGASAssetIdLocation: xcm::v5::Location` (the Location view of PGAS, needed because `pallet_asset_conversion_tx_payment::Config::AssetId = Location`)
- `OnChargeAssetTransaction = PgasOnChargeAssetTransaction<PGASAssetIdLocation, NativeAndNonPoolAssets, SwapAssetAdapter<...>>`
- `TxExtension` uses the plain `ChargeAssetTxPayment<Runtime>` unchanged
- Ethereum transactions keep using `ChargeAssetTxPayment::from(tip, None)` — native fees, no PGAS path

## Test plan

- [x] `cargo test -p pallet-asset-conversion-tx-payment` (15 existing tests still pass)
- [x] `cargo test -p asset-hub-westend-runtime --test tests` (45/45 pass, plus 1 new PGAS integration test)
- [x] `SKIP_WASM_BUILD=1 cargo check -p asset-hub-westend-runtime --all-features` (clean)
- [x] `SKIP_WASM_BUILD=1 cargo check -p polkadot-sdk` (umbrella builds)
- [x] `cargo +nightly fmt`
- [ ] CI `/cmd prdoc` once the PR number is confirmed

## Diff

6 files, +308/-9. Pallet-crate-free.