### PR TITLE
[pallet-revive] Fail upload_code when code is already uploaded

### DIFF
--- a/prdoc/pr_11882.prdoc
+++ b/prdoc/pr_11882.prdoc
@@ -1,0 +1,10 @@
+title: '[pallet-revive] Fail upload_code when code is already uploaded'
+doc:
+- audience: Runtime Dev
+  description: |-
+    resolves https://github.com/paritytech/polkadot-sdk/issues/9248
+
+    Make `pallet_revive::Pallet::upload_code` fail with a new `CodeAlreadyExists` error when the same code hash is already stored, so callers can dry-run the extrinsic to learn whether the upload is required, while leaving `instantiate_with_code` and EVM constructor deploy paths unchanged (they still treat an existing blob as a no-op).
+crates:
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -1073,7 +1073,7 @@ async fn test_runtime_pallets_address_upload_code() -> anyhow::Result<()> {
 	let node_client = SharedResources::node_client().await;
 	let node_rpc_client = RpcClient::from_url(SharedResources::node_rpc_url()).await?;
 
-	let (bytecode, _) = pallet_revive_fixtures::compile_module("dummy")?;
+	let (bytecode, _) = pallet_revive_fixtures::compile_module("noop")?;
 	let signer = Account::default();
 
 	// Helper function to get substrate block hash from EVM block number

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -2431,7 +2431,7 @@ impl<T: Config> Pallet<T> {
 			deposit_limit: storage_deposit_limit,
 		})?;
 
-		let exec_config = ExecConfig::new_substrate_tx();
+		let exec_config = ExecConfig::<T>::new_substrate_tx();
 		let mut module = match bytecode_type {
 			BytecodeType::Pvm => ContractBlob::from_pvm_code(code, origin)?,
 			BytecodeType::Evm => ContractBlob::from_evm_runtime_code(code, origin)?,

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -639,6 +639,12 @@ pub mod pallet {
 		EcdsaRecoveryFailed = 0x41,
 		/// Manual mapping is disabled when auto-mapping is enabled.
 		AutoMappingEnabled = 0x42,
+		/// The supplied code is already uploaded under the same code hash.
+		///
+		/// Returned by [`Pallet::upload_code`] so that a dry-run reveals whether an upload
+		/// is required. Contract deployment paths treat an existing blob as a no-op and
+		/// therefore never surface this error.
+		CodeAlreadyExists = 0x43,
 		/// Benchmarking only error.
 		#[cfg(feature = "runtime-benchmarks")]
 		BenchmarkingError = 0xFF,
@@ -1476,8 +1482,13 @@ pub mod pallet {
 
 		/// Upload new `code` without instantiating a contract from it.
 		///
-		/// If the code does not already exist a deposit is reserved from the caller
-		/// The size of the reserve depends on the size of the supplied `code`.
+		/// A deposit proportional to the size of `code` is reserved from the caller.
+		///
+		/// Fails with [`Error::CodeAlreadyExists`] if a blob with the same code hash is
+		/// already stored. This makes a dry-run of the extrinsic a reliable way to check
+		/// whether an upload is required before submitting it on-chain. Callers that only
+		/// want to ensure the code is available should dry-run first and skip the upload
+		/// on that error.
 		///
 		/// # Note
 		///
@@ -2420,13 +2431,17 @@ impl<T: Config> Pallet<T> {
 			deposit_limit: storage_deposit_limit,
 		})?;
 
-		let module = Self::try_upload_code(
-			origin,
-			code,
-			bytecode_type,
-			&mut meter,
-			&ExecConfig::new_substrate_tx(),
-		)?;
+		let exec_config = ExecConfig::new_substrate_tx();
+		let mut module = match bytecode_type {
+			BytecodeType::Pvm => ContractBlob::from_pvm_code(code, origin)?,
+			BytecodeType::Evm => ContractBlob::from_evm_runtime_code(code, origin)?,
+		};
+
+		// Reject duplicate uploads so that a dry-run lets the caller discover whether the
+		// upload is needed. The deploy-time path keeps its no-op semantics via `store_code`.
+		ensure!(!<CodeInfoOf<T>>::contains_key(module.code_hash()), <Error<T>>::CodeAlreadyExists,);
+
+		module.store_code(&exec_config, &mut meter)?;
 		Ok(CodeUploadReturnValue {
 			code_hash: *module.code_hash(),
 			deposit: meter.deposit_consumed().charge_or_zero(),

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -5015,6 +5015,11 @@ fn eip3607_reject_tx_from_contract_or_precompile() {
 #[test]
 fn eip3607_allow_tx_from_contract_or_precompile_if_debug_setting_configured() {
 	let (binary, code_hash) = compile_module("dummy").unwrap();
+	let upload_binaries = [
+		compile_module("noop").unwrap().0,
+		compile_module("drain").unwrap().0,
+		compile_module("basic_block").unwrap().0,
+	];
 
 	let genesis_config = GenesisConfig::<Test> {
 		debug_settings: Some(DebugSettings::default().set_bypass_eip_3607(true)),
@@ -5040,7 +5045,8 @@ fn eip3607_allow_tx_from_contract_or_precompile_if_debug_setting_configured() {
 			let system_addr = H160::from_low_u64_be(0x900);
 			let addresses = [contract_addr, blake2_addr, system_addr];
 
-			for address in addresses {
+			for (i, address) in addresses.iter().enumerate() {
+				let address = *address;
 				let origin = <Test as Config>::AddressMapper::to_fallback_account_id(&address);
 
 				let _ = <Test as Config>::Currency::set_balance(&origin, 10_000_000_000_000);
@@ -5075,7 +5081,7 @@ fn eip3607_allow_tx_from_contract_or_precompile_if_debug_setting_configured() {
 
 				let result = <Pallet<Test>>::upload_code(
 					RuntimeOrigin::signed(origin.clone()),
-					binary.clone(),
+					upload_binaries[i].clone(),
 					<BalanceOf<Test>>::MAX,
 				);
 				assert_ok!(result);

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -5018,7 +5018,7 @@ fn eip3607_allow_tx_from_contract_or_precompile_if_debug_setting_configured() {
 	let upload_binaries = [
 		compile_module("noop").unwrap().0,
 		compile_module("drain").unwrap().0,
-		compile_module("basic_block").unwrap().0,
+		compile_module("balance").unwrap().0,
 	];
 
 	let genesis_config = GenesisConfig::<Test> {

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -5070,19 +5070,19 @@ fn eip3607_allow_tx_from_contract_or_precompile_if_debug_setting_configured() {
 					.build();
 				assert_ok!(result);
 
+				let result = <Pallet<Test>>::upload_code(
+					RuntimeOrigin::signed(origin.clone()),
+					upload_binaries[i].clone(),
+					<BalanceOf<Test>>::MAX,
+				);
+				assert_ok!(result);
+
 				let result = <Pallet<Test>>::dispatch_as_fallback_account(
 					RuntimeOrigin::signed(origin.clone()),
 					Box::new(RuntimeCall::Balances(pallet_balances::Call::transfer_all {
 						dest: EVE,
 						keep_alive: false,
 					})),
-				);
-				assert_ok!(result);
-
-				let result = <Pallet<Test>>::upload_code(
-					RuntimeOrigin::signed(origin.clone()),
-					upload_binaries[i].clone(),
-					<BalanceOf<Test>>::MAX,
 				);
 				assert_ok!(result);
 

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -1950,6 +1950,47 @@ fn upload_code_works() {
 }
 
 #[test]
+fn upload_code_fails_when_already_uploaded() {
+	let (binary, code_hash) = compile_module("dummy").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+		let _ = <Test as Config>::Currency::set_balance(&BOB, 1_000_000);
+
+		assert_ok!(Contracts::upload_code(
+			RuntimeOrigin::signed(ALICE),
+			binary.clone(),
+			deposit_limit::<Test>(),
+		));
+		let alice_deposit_after_first = expected_deposit(ensure_stored(code_hash));
+
+		// Drop previous events so we can assert nothing further happens on the failed upload.
+		initialize_block(2);
+
+		// Re-uploading by the same origin must fail so that a dry-run reveals the upload
+		// is unnecessary, instead of silently succeeding as a no-op.
+		assert_noop!(
+			Contracts::upload_code(
+				RuntimeOrigin::signed(ALICE),
+				binary.clone(),
+				deposit_limit::<Test>(),
+			),
+			<Error<Test>>::CodeAlreadyExists,
+		);
+
+		// A different origin must not be able to "take over" or duplicate the upload either.
+		assert_noop!(
+			Contracts::upload_code(RuntimeOrigin::signed(BOB), binary, deposit_limit::<Test>(),),
+			<Error<Test>>::CodeAlreadyExists,
+		);
+
+		// Storage and the reserved deposit are unchanged.
+		assert_eq!(expected_deposit(ensure_stored(code_hash)), alice_deposit_after_first);
+		assert_eq!(System::events(), vec![]);
+	});
+}
+
+#[test]
 fn upload_code_limit_too_low() {
 	let (binary, _code_hash) = compile_module("dummy").unwrap();
 	let deposit_expected = expected_deposit(binary.len());


### PR DESCRIPTION
resolves https://github.com/paritytech/polkadot-sdk/issues/9248

Make `pallet_revive::Pallet::upload_code` fail with a new `CodeAlreadyExists` error when the same code hash is already stored, so callers can dry-run the extrinsic to learn whether the upload is required, while leaving `instantiate_with_code` and EVM constructor deploy paths unchanged (they still treat an existing blob as a no-op).