### PR TITLE
statement-store: reduce sync burst interval

### DIFF
--- a/prdoc/pr_11892.prdoc
+++ b/prdoc/pr_11892.prdoc
@@ -1,0 +1,8 @@
+title: 'statement-store: reduce sync burst interval'
+doc:
+- audience: Node Dev
+  description: |-
+    Reduces `INITIAL_SYNC_BURST_INTERVAL` from 100 ms to 10 ms. With many light clients connected, this interval determines how quickly a light client syncs and observes statements of interest. Other flows are unaffected because the polling branch is already at the end of a `select!` biased toward higher-priority work.
+crates:
+- name: sc-network-statement
+  bump: patch

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -155,7 +155,7 @@ const STATEMENT_PROTOCOL_V1: &str = "statement/1";
 /// Maximum time we wait for sending a notification to a peer.
 const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// Interval for sending statement batches during initial sync to new peers.
-const INITIAL_SYNC_BURST_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+const INITIAL_SYNC_BURST_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
 /// Interval for processing pending topic affinity changes from peers.
 const PENDING_AFFINITIES_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 /// Delay before re-adding a peer to the reserved set after a forced disconnect for sync recovery.


### PR DESCRIPTION
... with a lot of light clients connected the sync interval impacts how fast a light client syncs and see the statements of interest, so let's reduce the period we check to 10 ms, this shouldn't be affecting other flows because the polling is already in a select biased at the end.