### PR TITLE
Test RCs: Enable max block len up to 10MiB + node support for larger code size

### DIFF
--- a/polkadot/node/network/protocol/src/request_response/mod.rs
+++ b/polkadot/node/network/protocol/src/request_response/mod.rs
@@ -51,7 +51,6 @@
 
 use std::{collections::HashMap, time::Duration, u64};
 
-use polkadot_primitives::MAX_CODE_SIZE;
 use sc_network::{NetworkBackend, MAX_RESPONSE_SIZE};
 use sp_runtime::traits::Block;
 use strum::{EnumIter, IntoEnumIterator};
@@ -153,9 +152,12 @@ const POV_RESPONSE_SIZE: u64 = MAX_RESPONSE_SIZE;
 
 /// Maximum response sizes for `AttestedCandidateV2`.
 ///
-/// This is `MAX_CODE_SIZE` plus some additional space for protocol overhead and
-/// additional backing statements.
-const ATTESTED_CANDIDATE_RESPONSE_SIZE: u64 = MAX_CODE_SIZE as u64 + 100_000;
+/// Chosen as a safe upper bound above the governance ceiling on validation code size
+/// (`polkadot_primitives::MAX_CODE_SIZE`), leaving headroom for backing statements and
+/// protocol overhead. This is a transport-level DoS cap only; the effective policy is
+/// enforced by the runtime and the node-side inclusion emulator against the on-chain
+/// `HostConfiguration.max_code_size`.
+const ATTESTED_CANDIDATE_RESPONSE_SIZE: u64 = 8 * 1024 * 1024;
 
 /// We can have relative large timeouts here, there is no value of hitting a
 /// timeout as we want to get statements through to each node in any case.
@@ -282,7 +284,7 @@ impl Protocol {
 				let available_bandwidth = 7 * MIN_BANDWIDTH_BYTES / 10;
 				let size = u64::saturating_sub(
 					ATTESTED_CANDIDATE_TIMEOUT.as_millis() as u64 * available_bandwidth /
-						(1000 * MAX_CODE_SIZE as u64),
+						(1000 * ATTESTED_CANDIDATE_RESPONSE_SIZE),
 					MAX_PARALLEL_ATTESTED_CANDIDATE_REQUESTS as u64,
 				);
 				debug_assert!(

--- a/polkadot/node/test/service/tests/block-length.rs
+++ b/polkadot/node/test/service/tests/block-length.rs
@@ -33,7 +33,6 @@ use std::time::Duration;
 
 const OVERSIZED_PAYLOAD: usize = 7 * 1024 * 1024 + 921 * 1024; // ≈ 7.9 MiB
 const ACCEPTED_PAYLOAD: usize = 7 * 1024 * 1024;
-const LEGACY_MAX_BLOCK_LENGTH: usize = 5 * 1024 * 1024;
 const SUBMIT_TIMEOUT: Duration = Duration::from_secs(60);
 const BLOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
 

--- a/polkadot/node/test/service/tests/block-length.rs
+++ b/polkadot/node/test/service/tests/block-length.rs
@@ -14,43 +14,100 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-//! End-to-end coverage for the relay-chain `BlockLength` parameter.
+//! End-to-end test for the relay-chain `BlockLength` parameter.
 //!
-//! `polkadot-test-runtime` overrides `BlockLength` to 10 MiB in the same way the production
-//! relay-chain runtimes (Westend, Rococo) do. The Normal-dispatch-class cap is therefore
-//! `NORMAL_DISPATCH_RATIO * 10 MiB = 7.5 MiB`. Under the previous 5 MiB default the Normal
-//! cap was 3.75 MiB, so a 7 MiB `System::remark_with_event` would have been rejected at
-//! pool validation with `InvalidTransaction::ExhaustsResources`. Accepting it here proves
-//! the new parameter is wired through `frame_system::CheckWeight` end-to-end.
+//! Test runtime overrides `BlockLength` to 10 MiB; with `NORMAL_DISPATCH_RATIO = 75 %`
+//! the Normal-class cap is 7.5 MiB.
+//!
+//! 1. Submit a ~7.9 MiB `System::remark_with_event` and assert it is rejected with
+//!    `InvalidTransaction::ExhaustsResources` (above the Normal-class cap).
+//! 2. Submit a 7 MiB `System::remark_with_event` and assert it is accepted, included in
+//!    a block, and that the block exceeds the legacy 5 MiB `BlockLength` cap.
 
 use polkadot_test_service::*;
+use sc_client_api::BlockBackend;
+use sp_blockchain::HeaderBackend;
 use sp_keyring::Sr25519Keyring;
+use sp_runtime::{codec::Encode, traits::Header as _};
 use std::time::Duration;
 
-const REMARK_PAYLOAD_SIZE: usize = 7 * 1024 * 1024;
-const TEST_TIMEOUT: Duration = Duration::from_secs(120);
+const OVERSIZED_PAYLOAD: usize = 7 * 1024 * 1024 + 921 * 1024; // ≈ 7.9 MiB
+const ACCEPTED_PAYLOAD: usize = 7 * 1024 * 1024;
+const LEGACY_MAX_BLOCK_LENGTH: usize = 5 * 1024 * 1024;
+const SUBMIT_TIMEOUT: Duration = Duration::from_secs(60);
+const BLOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
+
+fn remark_call(size: usize) -> polkadot_test_runtime::RuntimeCall {
+	polkadot_test_runtime::RuntimeCall::System(frame_system::Call::remark_with_event {
+		remark: vec![0u8; size],
+	})
+}
 
 #[tokio::test(flavor = "multi_thread")]
-async fn relay_chain_accepts_extrinsic_above_legacy_normal_cap() {
-	let alice_config = node_config(
+async fn make_big_block() {
+	let mut alice_config = node_config(
 		|| {},
 		tokio::runtime::Handle::current(),
 		Sr25519Keyring::Alice,
 		Vec::new(),
 		true,
 	);
+
+	alice_config.force_authoring = true;
 	let alice = run_validator_node(alice_config, None).await;
 
-	let remark = vec![0u8; REMARK_PAYLOAD_SIZE];
-	let call = polkadot_test_runtime::RuntimeCall::System(
-		frame_system::Call::remark_with_event { remark },
+	// 1. Above the 7.5 MiB Normal-class cap → must be rejected by `check_block_length`.
+	let oversized = tokio::time::timeout(
+		SUBMIT_TIMEOUT,
+		alice.send_extrinsic(remark_call(OVERSIZED_PAYLOAD), Sr25519Keyring::Bob),
+	)
+	.await
+	.expect("submission must complete within the timeout");
+	assert!(
+		oversized.is_err(),
+		"{OVERSIZED_PAYLOAD}-byte extrinsic must be rejected; got: {oversized:?}",
 	);
 
-	tokio::time::timeout(TEST_TIMEOUT, alice.send_extrinsic(call, Sr25519Keyring::Bob))
+	// 2. Under the 7.5 MiB Normal-class cap → must be accepted and included.
+	tokio::time::timeout(
+		SUBMIT_TIMEOUT,
+		alice.send_extrinsic(remark_call(ACCEPTED_PAYLOAD), Sr25519Keyring::Charlie),
+	)
+	.await
+	.expect("submission must complete within the timeout")
+	.expect("7 MiB extrinsic must be accepted under the 10 MiB BlockLength");
+
+	tokio::time::timeout(BLOCK_WAIT_TIMEOUT, alice.wait_for_blocks(2))
 		.await
-		.expect("RPC submission must complete within the timeout")
-		.expect(
-			"7 MiB Normal-class extrinsic must be accepted under the 10 MiB \
-			 BlockLength (would fail under the legacy 5 MiB cap)",
-		);
+		.expect("block production must continue after submitting the 7 MiB extrinsic");
+
+	// Walk the chain back from best and find the largest produced block.
+	let mut hash = alice.client.info().best_hash;
+	let mut max_block_size = 0usize;
+	loop {
+		let header = alice
+			.client
+			.header(hash)
+			.expect("header query must succeed")
+			.expect("header must exist");
+		let body =
+			alice.client.block_body(hash).expect("body query must succeed").unwrap_or_default();
+
+		let size = header.encoded_size() + body.iter().map(Encode::encoded_size).sum::<usize>();
+		if size > max_block_size {
+			max_block_size = size;
+		}
+
+		let parent = *header.parent_hash();
+		if parent == Default::default() {
+			break;
+		}
+		hash = parent;
+	}
+
+	assert!(
+		max_block_size > ACCEPTED_PAYLOAD,
+		"expected a block larger than the remark {ACCEPTED_PAYLOAD}-byte payload; \
+		 largest was {max_block_size}",
+	);
 }

--- a/polkadot/node/test/service/tests/block-length.rs
+++ b/polkadot/node/test/service/tests/block-length.rs
@@ -1,0 +1,56 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! End-to-end coverage for the relay-chain `BlockLength` parameter.
+//!
+//! `polkadot-test-runtime` overrides `BlockLength` to 10 MiB in the same way the production
+//! relay-chain runtimes (Westend, Rococo) do. The Normal-dispatch-class cap is therefore
+//! `NORMAL_DISPATCH_RATIO * 10 MiB = 7.5 MiB`. Under the previous 5 MiB default the Normal
+//! cap was 3.75 MiB, so a 7 MiB `System::remark_with_event` would have been rejected at
+//! pool validation with `InvalidTransaction::ExhaustsResources`. Accepting it here proves
+//! the new parameter is wired through `frame_system::CheckWeight` end-to-end.
+
+use polkadot_test_service::*;
+use sp_keyring::Sr25519Keyring;
+use std::time::Duration;
+
+const REMARK_PAYLOAD_SIZE: usize = 7 * 1024 * 1024;
+const TEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn relay_chain_accepts_extrinsic_above_legacy_normal_cap() {
+	let alice_config = node_config(
+		|| {},
+		tokio::runtime::Handle::current(),
+		Sr25519Keyring::Alice,
+		Vec::new(),
+		true,
+	);
+	let alice = run_validator_node(alice_config, None).await;
+
+	let remark = vec![0u8; REMARK_PAYLOAD_SIZE];
+	let call = polkadot_test_runtime::RuntimeCall::System(
+		frame_system::Call::remark_with_event { remark },
+	);
+
+	tokio::time::timeout(TEST_TIMEOUT, alice.send_extrinsic(call, Sr25519Keyring::Bob))
+		.await
+		.expect("RPC submission must complete within the timeout")
+		.expect(
+			"7 MiB Normal-class extrinsic must be accepted under the 10 MiB \
+			 BlockLength (would fail under the legacy 5 MiB cap)",
+		);
+}

--- a/polkadot/node/test/service/tests/block-length.rs
+++ b/polkadot/node/test/service/tests/block-length.rs
@@ -22,7 +22,7 @@
 //! 1. Submit a ~7.9 MiB `System::remark_with_event` and assert it is rejected with
 //!    `InvalidTransaction::ExhaustsResources` (above the Normal-class cap).
 //! 2. Submit a 7 MiB `System::remark_with_event` and assert it is accepted, included in
-//!    a block, and that the block exceeds the legacy 5 MiB `BlockLength` cap.
+//!    a block.
 
 use polkadot_test_service::*;
 use sc_client_api::BlockBackend;

--- a/polkadot/node/test/service/tests/block-length.rs
+++ b/polkadot/node/test/service/tests/block-length.rs
@@ -21,8 +21,7 @@
 //!
 //! 1. Submit a ~7.9 MiB `System::remark_with_event` and assert it is rejected with
 //!    `InvalidTransaction::ExhaustsResources` (above the Normal-class cap).
-//! 2. Submit a 7 MiB `System::remark_with_event` and assert it is accepted, included in
-//!    a block.
+//! 2. Submit a 7 MiB `System::remark_with_event` and assert it is accepted, included in a block.
 
 use polkadot_test_service::*;
 use sc_client_api::BlockBackend;
@@ -89,8 +88,11 @@ async fn make_big_block() {
 			.header(hash)
 			.expect("header query must succeed")
 			.expect("header must exist");
-		let body =
-			alice.client.block_body(hash).expect("body query must succeed").unwrap_or_default();
+		let body = alice
+			.client
+			.block_body(hash)
+			.expect("body query must succeed")
+			.unwrap_or_default();
 
 		let size = header.encoded_size() + body.iter().map(Encode::encoded_size).sum::<usize>();
 		if size > max_block_size {

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -63,7 +63,7 @@ use polkadot_runtime_common::{
 	},
 	paras_registrar, paras_sudo_wrapper, prod_or_fast, slots,
 	traits::OnSwap,
-	BlockHashCount, BlockLength, SlowAdjustingFeeUpdate,
+	BlockHashCount, SlowAdjustingFeeUpdate,
 };
 use polkadot_runtime_parachains::{
 	configuration as parachains_configuration,
@@ -216,6 +216,15 @@ impl Contains<RuntimeCall> for IsIdentityCall {
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const SS58Prefix: u8 = 42;
+	/// Maximum length of a relay-chain block is up to 10 MiB.
+	pub BlockLength: frame_system::limits::BlockLength =
+		frame_system::limits::BlockLength::builder()
+			.max_length(10 * 1024 * 1024)
+			.modify_max_length_for_class(
+				frame_support::dispatch::DispatchClass::Normal,
+				|m| { *m = polkadot_runtime_common::NORMAL_DISPATCH_RATIO * *m },
+			)
+			.build();
 }
 
 #[derive_impl(frame_system::config_preludes::RelayChainDefaultConfig)]

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -69,8 +69,7 @@ use polkadot_primitives::{
 	ValidatorIndex, PARACHAIN_KEY_TYPE_ID,
 };
 use polkadot_runtime_common::{
-	claims, impl_runtime_weights, paras_sudo_wrapper, BlockHashCount, BlockLength,
-	SlowAdjustingFeeUpdate,
+	claims, impl_runtime_weights, paras_sudo_wrapper, BlockHashCount, SlowAdjustingFeeUpdate,
 };
 use polkadot_runtime_parachains::reward_points::RewardValidatorsWithEraPoints;
 use sp_authority_discovery::AuthorityId as AuthorityDiscoveryId;
@@ -149,6 +148,15 @@ sp_api::decl_runtime_apis! {
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const SS58Prefix: u8 = 42;
+	/// Maximum length of a relay-chain block is up to 10 MiB.
+	pub BlockLength: frame_system::limits::BlockLength =
+		frame_system::limits::BlockLength::builder()
+			.max_length(10 * 1024 * 1024)
+			.modify_max_length_for_class(
+				frame_support::dispatch::DispatchClass::Normal,
+				|m| { *m = polkadot_runtime_common::NORMAL_DISPATCH_RATIO * *m },
+			)
+			.build();
 }
 
 #[derive_impl(frame_system::config_preludes::RelayChainDefaultConfig)]

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -70,7 +70,7 @@ use polkadot_runtime_common::{
 	impls::{ToAuthor, VersionedLocatableAsset},
 	paras_registrar, paras_sudo_wrapper, prod_or_fast, slots,
 	traits::OnSwap,
-	BalanceToU256, BlockHashCount, BlockLength, SlowAdjustingFeeUpdate, U256ToBalance,
+	BalanceToU256, BlockHashCount, SlowAdjustingFeeUpdate, U256ToBalance,
 };
 use polkadot_runtime_parachains::{
 	configuration as parachains_configuration,
@@ -198,6 +198,15 @@ impl Contains<RuntimeCall> for IsIdentityCall {
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const SS58Prefix: u8 = 42;
+	/// Maximum length of a relay-chain block is up to 10 MiB.
+	pub BlockLength: frame_system::limits::BlockLength =
+		frame_system::limits::BlockLength::builder()
+			.max_length(10 * 1024 * 1024)
+			.modify_max_length_for_class(
+				frame_support::dispatch::DispatchClass::Normal,
+				|m| { *m = polkadot_runtime_common::NORMAL_DISPATCH_RATIO * *m },
+			)
+			.build();
 }
 
 #[derive_impl(frame_system::config_preludes::RelayChainDefaultConfig)]

--- a/prdoc/pr_11893.prdoc
+++ b/prdoc/pr_11893.prdoc
@@ -1,0 +1,26 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: 'Raise relay-chain BlockLength to 10 MiB on test runtimes; decouple AttestedCandidate response cap'
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Raises the relay-chain block-length cap from 5 MiB to 10 MiB on `westend-runtime`,
+      `rococo-runtime`, and `polkadot-test-runtime`.
+
+  - audience: Node Dev
+    description: |
+      `polkadot-node-network-protocol` decouples the libp2p response-size cap for the
+      `AttestedCandidateV2` request-response protocol from `polkadot_primitives::MAX_CODE_SIZE`
+      and pins it at a flat 8 MiB. 
+
+      Adds an end-to-end test in `polkadot-test-service`. 
+
+crates:
+  - name: polkadot-node-network-protocol
+    bump: patch
+  - name: westend-runtime
+    bump: minor
+  - name: rococo-runtime
+    bump: minor


### PR DESCRIPTION
Part of fix for: https://github.com/paritytech/polkadot-sdk/issues/11880 

This PR does the following changes:
- decouples the node from the `MAX_CODE_SIZE` constant. We bump `ATTESTED_CANDIDATE_RESPONSE_SIZE` to 8MiB which gives enough room for overhead and further increases if needed.
- enables 10MiB blocks on all test RC runtimes
- test for 10MiB blocks

Prod runtimes: https://github.com/polkadot-fellows/runtimes/pull/1157 .

TODO:
- [x] finish test
