### PR TITLE
Polkadot: Increase block size limit on the node side

### DIFF
--- a/polkadot/node/service/src/builder/mod.rs
+++ b/polkadot/node/service/src/builder/mod.rs
@@ -685,13 +685,16 @@ where
 		};
 
 		if role.is_authority() {
-			let proposer = sc_basic_authorship::ProposerFactory::new(
+			let mut proposer = sc_basic_authorship::ProposerFactory::new(
 				task_manager.spawn_handle(),
 				client.clone(),
 				transaction_pool.clone(),
 				prometheus_registry.as_ref(),
 				telemetry.as_ref().map(|x| x.handle()),
 			);
+			// We allow `15MiB` on the node side, but the actual block size limit is defined by the
+			// runtime.
+			proposer.set_default_block_size_limit(15 * 1024 * 1024);
 
 			let client_clone = client.clone();
 			let overseer_handle =

--- a/prdoc/pr_11900.prdoc
+++ b/prdoc/pr_11900.prdoc
@@ -1,0 +1,8 @@
+title: 'Polkadot: Increase block size limit on the node side'
+doc:
+- audience: Node Dev
+  description: |-
+    This pull request increases the block size limit allowed while building a block. This block size limit is checked on the node side. The ultimate authority about the actual block size limit is the runtime.
+crates:
+- name: polkadot-service
+  bump: patch


### PR DESCRIPTION
This pull request increases the block size limit allowed while building a block. This block size limit is checked on the node side. The ultimate authority about the actual block size limit is the runtime.


