### PR TITLE
pallet-psm: relax `AssetId` from `Copy` to `Clone`

### DIFF
--- a/prdoc/pr_11905.prdoc
+++ b/prdoc/pr_11905.prdoc
@@ -1,0 +1,14 @@
+title: "pallet-psm: relax AssetId from Copy to Clone"
+doc:
+- audience: Runtime Dev
+  description: |
+    Relaxes the `T::AssetId` bound on `pallet-psm`'s `Config` from `Copy` to
+    `Clone`. Lets runtimes wire `pallet-psm` with a non-`Copy` `AssetId` —
+    the most relevant example is using XCM `Location` as `AssetId`.
+
+    No semantic changes; only the `Config` bound and ownership at use sites.
+    For `AssetId`s that are `Copy` (e.g. `u32`), the added `.clone()` calls
+    are free since `Copy` types implement `Clone` trivially.
+crates:
+- name: pallet-psm
+  bump: minor

--- a/prdoc/pr_11905.prdoc
+++ b/prdoc/pr_11905.prdoc
@@ -3,8 +3,8 @@ doc:
 - audience: Runtime Dev
   description: |
     Relaxes the `T::AssetId` bound on `pallet-psm`'s `Config` from `Copy` to
-    `Clone`. Lets runtimes wire `pallet-psm` with a non-`Copy` `AssetId` —
-    the most relevant example is using XCM `Location` as `AssetId`.
+    `Clone`. Lets runtimes wire `pallet-psm` with a non-`Copy` `AssetId`.
+    The most relevant example is using XCM `Location` as `AssetId`.
 
     No semantic changes; only the `Config` bound and ownership at use sites.
     For `AssetId`s that are `Copy` (e.g. `u32`), the added `.clone()` calls
@@ -12,3 +12,4 @@ doc:
 crates:
 - name: pallet-psm
   bump: minor
+ 

--- a/substrate/frame/psm/remote-tests/src/lib.rs
+++ b/substrate/frame/psm/remote-tests/src/lib.rs
@@ -95,13 +95,13 @@ where
 
 	// Check that the external asset actually exists on-chain.
 	assert!(
-		<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(asset_id),
+		<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(asset_id.clone()),
 		"External asset does not exist on the live chain. \
 		 Make sure the asset ID is correct."
 	);
 
 	let decimals =
-		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(asset_id);
+		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(asset_id.clone());
 	log::info!(
 		target: LOG_TARGET,
 		"External asset found with {} decimals",
@@ -109,7 +109,7 @@ where
 	);
 
 	// Create the pUSD stable asset if it doesn't exist yet.
-	if !<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(stable_asset_id)
+	if !<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(stable_asset_id.clone())
 	{
 		// Run pre-create hook (e.g., set NextAssetId for AutoIncAssetId chains).
 		if let Some(hook) = &config.pre_create_hook {
@@ -119,7 +119,7 @@ where
 		let _ = frame_system::Pallet::<Runtime>::inc_providers(&psm_account);
 
 		assert_ok!(<Runtime::Fungibles as FungiblesCreate<Runtime::AccountId>>::create(
-			stable_asset_id,
+			stable_asset_id.clone(),
 			psm_account.clone(),
 			true,
 			10_000u128.try_into().unwrap_or_else(|_| panic!("balance conversion failed")),
@@ -146,7 +146,7 @@ where
 	let stable_decimals =
 		<Runtime::StableAsset as FungibleMetadataInspect<Runtime::AccountId>>::decimals();
 	let external_decimals =
-		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(asset_id);
+		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(asset_id.clone());
 	assert_eq!(
 		stable_decimals, external_decimals,
 		"Decimals mismatch: stable={} vs external={}",
@@ -168,7 +168,7 @@ where
 		.try_into()
 		.unwrap_or_else(|_| panic!("balance conversion failed"));
 	assert_ok!(<Runtime::Fungibles as FungiblesMutate<Runtime::AccountId>>::mint_into(
-		asset_id,
+		asset_id.clone(),
 		&caller,
 		fund_amount,
 	));
@@ -241,7 +241,7 @@ pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 			setup::<Runtime, InitialPsmConfig>(config);
 
 		let balance_before = <Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::balance(
-			asset_id, &caller,
+			asset_id.clone(), &caller,
 		);
 
 		log::info!(
@@ -253,13 +253,13 @@ pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 		// Test mint
 		assert_ok!(pallet_psm::Pallet::<Runtime>::mint(
 			frame_system::RawOrigin::Signed(caller.clone()).into(),
-			asset_id,
+			asset_id.clone(),
 			swap_amount,
 		));
 
 		let balance_after_mint =
 			<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::balance(
-				asset_id, &caller,
+				asset_id.clone(), &caller,
 			);
 		assert_eq!(
 			balance_after_mint,
@@ -273,7 +273,7 @@ pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 
 		// The PSM account should hold the external stablecoin.
 		let psm_external = <Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::balance(
-			asset_id,
+			asset_id.clone(),
 			&psm_account,
 		);
 		assert_eq!(psm_external, swap_amount, "PSM should hold the external stablecoin");
@@ -347,7 +347,7 @@ pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 		// Mint some pUSD first so we have something to redeem later.
 		assert_ok!(pallet_psm::Pallet::<Runtime>::mint(
 			frame_system::RawOrigin::Signed(caller.clone()).into(),
-			asset_id,
+			asset_id.clone(),
 			swap_amount,
 		));
 
@@ -359,14 +359,14 @@ pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 		// Test: MintingDisabled. Mint fails, redeem still works
 		assert_ok!(pallet_psm::Pallet::<Runtime>::set_asset_status(
 			frame_system::RawOrigin::Root.into(),
-			asset_id,
+			asset_id.clone(),
 			pallet_psm::CircuitBreakerLevel::MintingDisabled,
 		));
 
 		assert_noop!(
 			pallet_psm::Pallet::<Runtime>::mint(
 				frame_system::RawOrigin::Signed(caller.clone()).into(),
-				asset_id,
+				asset_id.clone(),
 				swap_amount,
 			),
 			pallet_psm::Error::<Runtime>::MintingStopped
@@ -374,7 +374,7 @@ pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 
 		assert_ok!(pallet_psm::Pallet::<Runtime>::redeem(
 			frame_system::RawOrigin::Signed(caller.clone()).into(),
-			asset_id,
+			asset_id.clone(),
 			small_redeem,
 		));
 
@@ -383,14 +383,14 @@ pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 		// Test: AllDisabled. Both mint and redeem fail
 		assert_ok!(pallet_psm::Pallet::<Runtime>::set_asset_status(
 			frame_system::RawOrigin::Root.into(),
-			asset_id,
+			asset_id.clone(),
 			pallet_psm::CircuitBreakerLevel::AllDisabled,
 		));
 
 		assert_noop!(
 			pallet_psm::Pallet::<Runtime>::mint(
 				frame_system::RawOrigin::Signed(caller.clone()).into(),
-				asset_id,
+				asset_id.clone(),
 				swap_amount,
 			),
 			pallet_psm::Error::<Runtime>::MintingStopped
@@ -399,7 +399,7 @@ pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 		assert_noop!(
 			pallet_psm::Pallet::<Runtime>::redeem(
 				frame_system::RawOrigin::Signed(caller.clone()).into(),
-				asset_id,
+				asset_id.clone(),
 				small_redeem,
 			),
 			pallet_psm::Error::<Runtime>::AllSwapsStopped
@@ -410,13 +410,13 @@ pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 		// Test: Re-enable. Both operations resume
 		assert_ok!(pallet_psm::Pallet::<Runtime>::set_asset_status(
 			frame_system::RawOrigin::Root.into(),
-			asset_id,
+			asset_id.clone(),
 			pallet_psm::CircuitBreakerLevel::AllEnabled,
 		));
 
 		assert_ok!(pallet_psm::Pallet::<Runtime>::mint(
 			frame_system::RawOrigin::Signed(caller.clone()).into(),
-			asset_id,
+			asset_id.clone(),
 			swap_amount,
 		));
 

--- a/substrate/frame/psm/remote-tests/src/lib.rs
+++ b/substrate/frame/psm/remote-tests/src/lib.rs
@@ -95,13 +95,16 @@ where
 
 	// Check that the external asset actually exists on-chain.
 	assert!(
-		<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(asset_id.clone()),
+		<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(
+			asset_id.clone()
+		),
 		"External asset does not exist on the live chain. \
 		 Make sure the asset ID is correct."
 	);
 
-	let decimals =
-		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(asset_id.clone());
+	let decimals = <Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(
+		asset_id.clone(),
+	);
 	log::info!(
 		target: LOG_TARGET,
 		"External asset found with {} decimals",
@@ -109,8 +112,9 @@ where
 	);
 
 	// Create the pUSD stable asset if it doesn't exist yet.
-	if !<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(stable_asset_id.clone())
-	{
+	if !<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(
+		stable_asset_id.clone(),
+	) {
 		// Run pre-create hook (e.g., set NextAssetId for AutoIncAssetId chains).
 		if let Some(hook) = &config.pre_create_hook {
 			hook();
@@ -146,7 +150,9 @@ where
 	let stable_decimals =
 		<Runtime::StableAsset as FungibleMetadataInspect<Runtime::AccountId>>::decimals();
 	let external_decimals =
-		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(asset_id.clone());
+		<Runtime::Fungibles as FungiblesMetadataInspect<Runtime::AccountId>>::decimals(
+			asset_id.clone(),
+		);
 	assert_eq!(
 		stable_decimals, external_decimals,
 		"Decimals mismatch: stable={} vs external={}",
@@ -241,7 +247,8 @@ pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 			setup::<Runtime, InitialPsmConfig>(config);
 
 		let balance_before = <Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::balance(
-			asset_id.clone(), &caller,
+			asset_id.clone(),
+			&caller,
 		);
 
 		log::info!(
@@ -259,7 +266,8 @@ pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 
 		let balance_after_mint =
 			<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::balance(
-				asset_id.clone(), &caller,
+				asset_id.clone(),
+				&caller,
 			);
 		assert_eq!(
 			balance_after_mint,

--- a/substrate/frame/psm/src/benchmarking.rs
+++ b/substrate/frame/psm/src/benchmarking.rs
@@ -135,8 +135,12 @@ mod benchmarks {
 		let setup_amount = T::MinSwapAmount::get().saturating_mul(10u32.into());
 		let redeem_amount = T::MinSwapAmount::get();
 
-		T::Fungibles::mint_into(asset_id.clone(), &caller, setup_amount.saturating_mul(2u32.into()))
-			.map_err(|_| BenchmarkError::Stop("Failed to fund caller"))?;
+		T::Fungibles::mint_into(
+			asset_id.clone(),
+			&caller,
+			setup_amount.saturating_mul(2u32.into()),
+		)
+		.map_err(|_| BenchmarkError::Stop("Failed to fund caller"))?;
 		Psm::<T>::mint(RawOrigin::Signed(caller.clone()).into(), asset_id.clone(), setup_amount)
 			.map_err(|_| BenchmarkError::Stop("Failed to setup reserve via mint"))?;
 

--- a/substrate/frame/psm/src/benchmarking.rs
+++ b/substrate/frame/psm/src/benchmarking.rs
@@ -80,8 +80,8 @@ where
 	// helper handles by funding `admin` first — something the fungibles traits
 	// alone cannot express.
 	let target_id: T::AssetId = ASSET_ID_OFFSET.into();
-	if !T::Fungibles::asset_exists(target_id) {
-		T::BenchmarkHelper::create_asset(target_id, &admin, stable_decimals);
+	if !T::Fungibles::asset_exists(target_id.clone()) {
+		T::BenchmarkHelper::create_asset(target_id.clone(), &admin, stable_decimals);
 	}
 
 	crate::MaxPsmDebtOfTotal::<T>::put(Permill::from_percent(100));
@@ -90,14 +90,14 @@ where
 	// asset does not need to exist and no AssetDecimals snapshot is required.
 	for i in 0..n {
 		let id: T::AssetId = (ASSET_ID_OFFSET + i).into();
-		crate::ExternalAssets::<T>::insert(id, CircuitBreakerLevel::AllEnabled);
-		crate::AssetCeilingWeight::<T>::insert(id, Permill::from_percent(1));
-		crate::PsmDebt::<T>::insert(id, BalanceOf::<T>::from(1u32));
+		crate::ExternalAssets::<T>::insert(&id, CircuitBreakerLevel::AllEnabled);
+		crate::AssetCeilingWeight::<T>::insert(&id, Permill::from_percent(1));
+		crate::PsmDebt::<T>::insert(&id, BalanceOf::<T>::from(1u32));
 	}
 	// Target-specific: dominant weight so it can absorb the full mint amount,
 	// and a decimals snapshot so `ensure_decimals_match` passes.
-	crate::AssetCeilingWeight::<T>::insert(target_id, Permill::from_percent(100));
-	crate::AssetDecimals::<T>::insert(target_id, stable_decimals);
+	crate::AssetCeilingWeight::<T>::insert(&target_id, Permill::from_percent(100));
+	crate::AssetDecimals::<T>::insert(&target_id, stable_decimals);
 
 	target_id
 }
@@ -115,14 +115,14 @@ mod benchmarks {
 		let asset_id = setup_assets::<T>(n);
 		let mint_amount = T::MinSwapAmount::get().saturating_mul(10u32.into());
 
-		T::Fungibles::mint_into(asset_id, &caller, mint_amount.saturating_mul(2u32.into()))
+		T::Fungibles::mint_into(asset_id.clone(), &caller, mint_amount.saturating_mul(2u32.into()))
 			.map_err(|_| BenchmarkError::Stop("Failed to fund caller"))?;
 
 		let psm_account = Psm::<T>::account_id();
-		let reserve_before = T::Fungibles::balance(asset_id, &psm_account);
+		let reserve_before = T::Fungibles::balance(asset_id.clone(), &psm_account);
 
 		#[extrinsic_call]
-		_(RawOrigin::Signed(caller.clone()), asset_id, mint_amount);
+		_(RawOrigin::Signed(caller.clone()), asset_id.clone(), mint_amount);
 
 		assert!(T::Fungibles::balance(asset_id, &psm_account) > reserve_before);
 		Ok(())
@@ -135,16 +135,16 @@ mod benchmarks {
 		let setup_amount = T::MinSwapAmount::get().saturating_mul(10u32.into());
 		let redeem_amount = T::MinSwapAmount::get();
 
-		T::Fungibles::mint_into(asset_id, &caller, setup_amount.saturating_mul(2u32.into()))
+		T::Fungibles::mint_into(asset_id.clone(), &caller, setup_amount.saturating_mul(2u32.into()))
 			.map_err(|_| BenchmarkError::Stop("Failed to fund caller"))?;
-		Psm::<T>::mint(RawOrigin::Signed(caller.clone()).into(), asset_id, setup_amount)
+		Psm::<T>::mint(RawOrigin::Signed(caller.clone()).into(), asset_id.clone(), setup_amount)
 			.map_err(|_| BenchmarkError::Stop("Failed to setup reserve via mint"))?;
 
 		let psm_account = Psm::<T>::account_id();
-		let reserve_before = T::Fungibles::balance(asset_id, &psm_account);
+		let reserve_before = T::Fungibles::balance(asset_id.clone(), &psm_account);
 
 		#[extrinsic_call]
-		_(RawOrigin::Signed(caller.clone()), asset_id, redeem_amount);
+		_(RawOrigin::Signed(caller.clone()), asset_id.clone(), redeem_amount);
 
 		assert!(T::Fungibles::balance(asset_id, &psm_account) < reserve_before);
 		Ok(())
@@ -156,9 +156,9 @@ mod benchmarks {
 		let new_fee = Permill::from_percent(2);
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, asset_id, new_fee);
+		_(RawOrigin::Root, asset_id.clone(), new_fee);
 
-		assert_eq!(crate::MintingFee::<T>::get(asset_id), new_fee);
+		assert_eq!(crate::MintingFee::<T>::get(&asset_id), new_fee);
 		Ok(())
 	}
 
@@ -168,9 +168,9 @@ mod benchmarks {
 		let new_fee = Permill::from_percent(2);
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, asset_id, new_fee);
+		_(RawOrigin::Root, asset_id.clone(), new_fee);
 
-		assert_eq!(crate::RedemptionFee::<T>::get(asset_id), new_fee);
+		assert_eq!(crate::RedemptionFee::<T>::get(&asset_id), new_fee);
 		Ok(())
 	}
 
@@ -191,9 +191,9 @@ mod benchmarks {
 		let new_status = CircuitBreakerLevel::MintingDisabled;
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, asset_id, new_status);
+		_(RawOrigin::Root, asset_id.clone(), new_status);
 
-		assert_eq!(crate::ExternalAssets::<T>::get(asset_id), Some(new_status));
+		assert_eq!(crate::ExternalAssets::<T>::get(&asset_id), Some(new_status));
 		Ok(())
 	}
 
@@ -203,9 +203,9 @@ mod benchmarks {
 		let new_weight = Permill::from_percent(50);
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, asset_id, new_weight);
+		_(RawOrigin::Root, asset_id.clone(), new_weight);
 
-		assert_eq!(crate::AssetCeilingWeight::<T>::get(asset_id), new_weight);
+		assert_eq!(crate::AssetCeilingWeight::<T>::get(&asset_id), new_weight);
 		Ok(())
 	}
 	#[benchmark]
@@ -216,24 +216,24 @@ mod benchmarks {
 		let caller: T::AccountId = whitelisted_caller();
 		let new_asset_id: T::AssetId = ASSET_ID_OFFSET.into();
 
-		T::BenchmarkHelper::create_asset(new_asset_id, &caller, stable_decimals);
+		T::BenchmarkHelper::create_asset(new_asset_id.clone(), &caller, stable_decimals);
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, new_asset_id);
+		_(RawOrigin::Root, new_asset_id.clone());
 
-		assert!(crate::ExternalAssets::<T>::contains_key(new_asset_id));
+		assert!(crate::ExternalAssets::<T>::contains_key(&new_asset_id));
 		Ok(())
 	}
 
 	#[benchmark]
 	fn remove_external_asset() -> Result<(), BenchmarkError> {
 		let asset_id = setup_assets::<T>(1);
-		crate::PsmDebt::<T>::remove(asset_id);
+		crate::PsmDebt::<T>::remove(&asset_id);
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, asset_id);
+		_(RawOrigin::Root, asset_id.clone());
 
-		assert!(!crate::ExternalAssets::<T>::contains_key(asset_id));
+		assert!(!crate::ExternalAssets::<T>::contains_key(&asset_id));
 		Ok(())
 	}
 

--- a/substrate/frame/psm/src/lib.rs
+++ b/substrate/frame/psm/src/lib.rs
@@ -236,7 +236,7 @@ pub mod pallet {
 			+ FungiblesMetadataInspect<Self::AccountId>;
 
 		/// Asset identifier type.
-		type AssetId: Parameter + Member + Copy + MaybeSerializeDeserialize + MaxEncodedLen + Ord;
+		type AssetId: Parameter + Member + Clone + MaybeSerializeDeserialize + MaxEncodedLen + Ord;
 
 		/// Maximum allowed pUSD issuance across the entire system.
 		type MaximumIssuance: Get<BalanceOf<Self>>;
@@ -368,7 +368,7 @@ pub mod pallet {
 			let stable_decimals = T::StableAsset::decimals();
 			StableDecimals::<T>::put(stable_decimals);
 			for (asset_id, (minting_fee, redemption_fee, ceiling_weight)) in &self.asset_configs {
-				let asset_decimals = T::Fungibles::decimals(*asset_id);
+				let asset_decimals = T::Fungibles::decimals(asset_id.clone());
 				let diff = asset_decimals.abs_diff(stable_decimals) as u32;
 				assert!(
 					diff <= MAX_DECIMALS_DIFF,
@@ -510,11 +510,11 @@ pub mod pallet {
 
 			// Check asset is approved and minting is enabled
 			let asset_status =
-				ExternalAssets::<T>::get(asset_id).ok_or(Error::<T>::UnsupportedAsset)?;
+				ExternalAssets::<T>::get(&asset_id).ok_or(Error::<T>::UnsupportedAsset)?;
 			ensure!(asset_status.allows_minting(), Error::<T>::MintingStopped);
 
 			// Guard against runtime drift in live decimals.
-			let (ext_decimals, pusd_decimals) = Self::ensure_decimals_match(asset_id)?;
+			let (ext_decimals, pusd_decimals) = Self::ensure_decimals_match(asset_id.clone())?;
 
 			// Normalize to pUSD units for all internal accounting.
 			let pusd_equivalent =
@@ -527,7 +527,7 @@ pub mod pallet {
 			let effective_external =
 				Self::pusd_to_external(pusd_equivalent, ext_decimals, pusd_decimals)?;
 
-			let fee = MintingFee::<T>::get(asset_id).mul_ceil(pusd_equivalent);
+			let fee = MintingFee::<T>::get(&asset_id).mul_ceil(pusd_equivalent);
 			let pusd_to_user = pusd_equivalent.saturating_sub(fee);
 
 			// Total new issuance = pusd_to_user + fee = pusd_equivalent.
@@ -547,15 +547,15 @@ pub mod pallet {
 			);
 
 			// Check per-asset ceiling (redistributes from disabled assets).
-			let current_debt = PsmDebt::<T>::get(asset_id);
-			let max_debt = Self::max_asset_debt(asset_id);
+			let current_debt = PsmDebt::<T>::get(&asset_id);
+			let max_debt = Self::max_asset_debt(asset_id.clone());
 			let new_debt = current_debt.saturating_add(pusd_equivalent);
 			ensure!(new_debt <= max_debt, Error::<T>::ExceedsMaxPsmDebt);
 
 			let psm_account = Self::account_id();
 
 			T::Fungibles::transfer(
-				asset_id,
+				asset_id.clone(),
 				&who,
 				&psm_account,
 				effective_external,
@@ -566,7 +566,7 @@ pub mod pallet {
 				T::StableAsset::mint_into(&T::FeeDestination::get(), fee)?;
 			}
 
-			PsmDebt::<T>::insert(asset_id, new_debt);
+			PsmDebt::<T>::insert(&asset_id, new_debt);
 
 			Self::deposit_event(Event::Minted {
 				who,
@@ -622,15 +622,15 @@ pub mod pallet {
 
 			// Check asset is approved and redemption is enabled
 			let asset_status =
-				ExternalAssets::<T>::get(asset_id).ok_or(Error::<T>::UnsupportedAsset)?;
+				ExternalAssets::<T>::get(&asset_id).ok_or(Error::<T>::UnsupportedAsset)?;
 			ensure!(asset_status.allows_redemption(), Error::<T>::AllSwapsStopped);
 
 			// Guard against runtime drift in live decimals.
-			let (ext_decimals, pusd_decimals) = Self::ensure_decimals_match(asset_id)?;
+			let (ext_decimals, pusd_decimals) = Self::ensure_decimals_match(asset_id.clone())?;
 
 			ensure!(pusd_amount >= T::MinSwapAmount::get(), Error::<T>::BelowMinimumSwap);
 
-			let fee = RedemptionFee::<T>::get(asset_id).mul_ceil(pusd_amount);
+			let fee = RedemptionFee::<T>::get(&asset_id).mul_ceil(pusd_amount);
 			let pusd_net = pusd_amount.saturating_sub(fee);
 
 			// Convert pUSD-net to external units (floor) and round-trip back. The round-tripped
@@ -650,10 +650,10 @@ pub mod pallet {
 
 			// Check debt first - redemptions are limited by tracked debt, not raw reserve.
 			// This prevents redemption of "donated" reserves that aren't backed by debt.
-			let current_debt = PsmDebt::<T>::get(asset_id);
+			let current_debt = PsmDebt::<T>::get(&asset_id);
 			ensure!(current_debt >= effective_pusd_net, Error::<T>::InsufficientReserve);
 
-			let reserve = Self::get_reserve(asset_id);
+			let reserve = Self::get_reserve(asset_id.clone());
 			if reserve < external_out {
 				defensive!("PSM reserve is less than expected output amount");
 				return Err(Error::<T>::Unexpected.into());
@@ -683,7 +683,7 @@ pub mod pallet {
 			let psm_account = Self::account_id();
 			if !external_out.is_zero() {
 				T::Fungibles::transfer(
-					asset_id,
+					asset_id.clone(),
 					&psm_account,
 					&who,
 					external_out,
@@ -691,7 +691,7 @@ pub mod pallet {
 				)?;
 			}
 
-			PsmDebt::<T>::mutate(asset_id, |debt| {
+			PsmDebt::<T>::mutate(&asset_id, |debt| {
 				*debt = debt.saturating_sub(effective_pusd_net);
 			});
 
@@ -729,9 +729,9 @@ pub mod pallet {
 		) -> DispatchResult {
 			let level = T::ManagerOrigin::ensure_origin(origin)?;
 			ensure!(level.can_set_fees(), Error::<T>::InsufficientPrivilege);
-			ensure!(ExternalAssets::<T>::contains_key(asset_id), Error::<T>::AssetNotApproved);
-			let old_value = MintingFee::<T>::get(asset_id);
-			MintingFee::<T>::insert(asset_id, fee);
+			ensure!(ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetNotApproved);
+			let old_value = MintingFee::<T>::get(&asset_id);
+			MintingFee::<T>::insert(&asset_id, fee);
 			Self::deposit_event(Event::MintingFeeUpdated { asset_id, old_value, new_value: fee });
 			Ok(())
 		}
@@ -759,9 +759,9 @@ pub mod pallet {
 		) -> DispatchResult {
 			let level = T::ManagerOrigin::ensure_origin(origin)?;
 			ensure!(level.can_set_fees(), Error::<T>::InsufficientPrivilege);
-			ensure!(ExternalAssets::<T>::contains_key(asset_id), Error::<T>::AssetNotApproved);
-			let old_value = RedemptionFee::<T>::get(asset_id);
-			RedemptionFee::<T>::insert(asset_id, fee);
+			ensure!(ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetNotApproved);
+			let old_value = RedemptionFee::<T>::get(&asset_id);
+			RedemptionFee::<T>::insert(&asset_id, fee);
 			Self::deposit_event(Event::RedemptionFeeUpdated {
 				asset_id,
 				old_value,
@@ -824,8 +824,8 @@ pub mod pallet {
 			status: CircuitBreakerLevel,
 		) -> DispatchResult {
 			T::ManagerOrigin::ensure_origin(origin)?;
-			ensure!(ExternalAssets::<T>::contains_key(asset_id), Error::<T>::AssetNotApproved);
-			ExternalAssets::<T>::insert(asset_id, status);
+			ensure!(ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetNotApproved);
+			ExternalAssets::<T>::insert(&asset_id, status);
 			Self::deposit_event(Event::AssetStatusUpdated { asset_id, status });
 			Ok(())
 		}
@@ -861,9 +861,9 @@ pub mod pallet {
 		) -> DispatchResult {
 			let level = T::ManagerOrigin::ensure_origin(origin)?;
 			ensure!(level.can_set_asset_ceiling(), Error::<T>::InsufficientPrivilege);
-			ensure!(ExternalAssets::<T>::contains_key(asset_id), Error::<T>::AssetNotApproved);
-			let old_value = AssetCeilingWeight::<T>::get(asset_id);
-			AssetCeilingWeight::<T>::insert(asset_id, weight);
+			ensure!(ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetNotApproved);
+			let old_value = AssetCeilingWeight::<T>::get(&asset_id);
+			AssetCeilingWeight::<T>::insert(&asset_id, weight);
 			Self::deposit_event(Event::AssetCeilingWeightUpdated {
 				asset_id,
 				old_value,
@@ -894,12 +894,12 @@ pub mod pallet {
 		pub fn add_external_asset(origin: OriginFor<T>, asset_id: T::AssetId) -> DispatchResult {
 			let level = T::ManagerOrigin::ensure_origin(origin)?;
 			ensure!(level.can_manage_assets(), Error::<T>::InsufficientPrivilege);
-			ensure!(!ExternalAssets::<T>::contains_key(asset_id), Error::<T>::AssetAlreadyApproved);
-			ensure!(T::Fungibles::asset_exists(asset_id), Error::<T>::AssetDoesNotExist);
+			ensure!(!ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetAlreadyApproved);
+			ensure!(T::Fungibles::asset_exists(asset_id.clone()), Error::<T>::AssetDoesNotExist);
 			let count = ExternalAssets::<T>::count();
 			ensure!(count < T::MaxExternalAssets::get(), Error::<T>::TooManyAssets);
 
-			let asset_decimals = T::Fungibles::decimals(asset_id);
+			let asset_decimals = T::Fungibles::decimals(asset_id.clone());
 			let stable_decimals = StableDecimals::<T>::get().ok_or(Error::<T>::Unexpected)?;
 			ensure!(T::StableAsset::decimals() == stable_decimals, Error::<T>::DecimalsMismatch);
 			ensure!(
@@ -907,8 +907,8 @@ pub mod pallet {
 				Error::<T>::DecimalsRangeExceeded
 			);
 
-			ExternalAssets::<T>::insert(asset_id, CircuitBreakerLevel::AllEnabled);
-			AssetDecimals::<T>::insert(asset_id, asset_decimals);
+			ExternalAssets::<T>::insert(&asset_id, CircuitBreakerLevel::AllEnabled);
+			AssetDecimals::<T>::insert(&asset_id, asset_decimals);
 			Self::deposit_event(Event::ExternalAssetAdded { asset_id });
 			Ok(())
 		}
@@ -946,16 +946,16 @@ pub mod pallet {
 		pub fn remove_external_asset(origin: OriginFor<T>, asset_id: T::AssetId) -> DispatchResult {
 			let level = T::ManagerOrigin::ensure_origin(origin)?;
 			ensure!(level.can_manage_assets(), Error::<T>::InsufficientPrivilege);
-			ensure!(ExternalAssets::<T>::contains_key(asset_id), Error::<T>::AssetNotApproved);
-			ensure!(PsmDebt::<T>::get(asset_id).is_zero(), Error::<T>::AssetHasDebt);
-			ExternalAssets::<T>::remove(asset_id);
+			ensure!(ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetNotApproved);
+			ensure!(PsmDebt::<T>::get(&asset_id).is_zero(), Error::<T>::AssetHasDebt);
+			ExternalAssets::<T>::remove(&asset_id);
 
 			// Clean up associated configuration
-			MintingFee::<T>::remove(asset_id);
-			RedemptionFee::<T>::remove(asset_id);
-			AssetCeilingWeight::<T>::remove(asset_id);
-			AssetDecimals::<T>::remove(asset_id);
-			PsmDebt::<T>::remove(asset_id);
+			MintingFee::<T>::remove(&asset_id);
+			RedemptionFee::<T>::remove(&asset_id);
+			AssetCeilingWeight::<T>::remove(&asset_id);
+			AssetDecimals::<T>::remove(&asset_id);
+			PsmDebt::<T>::remove(&asset_id);
 			Self::deposit_event(Event::ExternalAssetRemoved { asset_id });
 			Ok(())
 		}
@@ -1083,7 +1083,7 @@ pub mod pallet {
 			asset_id: T::AssetId,
 		) -> Result<(u8, u8), DispatchError> {
 			let ext_decimals =
-				AssetDecimals::<T>::get(asset_id).ok_or(Error::<T>::UnsupportedAsset)?;
+				AssetDecimals::<T>::get(&asset_id).ok_or(Error::<T>::UnsupportedAsset)?;
 			ensure!(T::Fungibles::decimals(asset_id) == ext_decimals, Error::<T>::DecimalsMismatch);
 
 			let pusd_decimals = StableDecimals::<T>::get().ok_or(Error::<T>::Unexpected)?;
@@ -1112,7 +1112,7 @@ pub mod pallet {
 				"Stable asset live decimals differ from the genesis snapshot"
 			);
 			for (asset_id, _) in ExternalAssets::<T>::iter() {
-				let snapshot = AssetDecimals::<T>::get(asset_id)
+				let snapshot = AssetDecimals::<T>::get(&asset_id)
 					.ok_or("Approved external asset missing decimals snapshot")?;
 				ensure!(
 					T::Fungibles::decimals(asset_id) == snapshot,
@@ -1123,9 +1123,9 @@ pub mod pallet {
 			// Check 2: Per-asset reserve (in external units) must be >= the external equivalent of
 			// the tracked pUSD debt. Donated reserves may make it strictly greater.
 			for (asset_id, _) in ExternalAssets::<T>::iter() {
-				let debt = PsmDebt::<T>::get(asset_id);
-				let reserve = Self::get_reserve(asset_id);
-				let ext_decimals = AssetDecimals::<T>::get(asset_id)
+				let debt = PsmDebt::<T>::get(&asset_id);
+				let reserve = Self::get_reserve(asset_id.clone());
+				let ext_decimals = AssetDecimals::<T>::get(&asset_id)
 					.ok_or("Approved external asset missing decimals snapshot")?;
 				let debt_as_external =
 					Self::pusd_to_external(debt, ext_decimals, stable_decimals_snapshot)
@@ -1140,7 +1140,7 @@ pub mod pallet {
 			let mut sum = BalanceOf::<T>::zero();
 			for (asset_id, _) in ExternalAssets::<T>::iter() {
 				sum = sum
-					.checked_add(&PsmDebt::<T>::get(asset_id))
+					.checked_add(&PsmDebt::<T>::get(&asset_id))
 					.ok_or("PSM debt overflow when summing per-asset debts")?;
 			}
 			ensure!(
@@ -1153,7 +1153,7 @@ pub mod pallet {
 			// should hold under normal operation.)
 			for (asset_id, status) in ExternalAssets::<T>::iter() {
 				if status.allows_minting() {
-					let debt = PsmDebt::<T>::get(asset_id);
+					let debt = PsmDebt::<T>::get(&asset_id);
 					let ceiling = Self::max_asset_debt(asset_id);
 					ensure!(debt <= ceiling, "Per-asset PSM debt exceeds its ceiling");
 				}

--- a/substrate/frame/psm/src/lib.rs
+++ b/substrate/frame/psm/src/lib.rs
@@ -894,7 +894,10 @@ pub mod pallet {
 		pub fn add_external_asset(origin: OriginFor<T>, asset_id: T::AssetId) -> DispatchResult {
 			let level = T::ManagerOrigin::ensure_origin(origin)?;
 			ensure!(level.can_manage_assets(), Error::<T>::InsufficientPrivilege);
-			ensure!(!ExternalAssets::<T>::contains_key(&asset_id), Error::<T>::AssetAlreadyApproved);
+			ensure!(
+				!ExternalAssets::<T>::contains_key(&asset_id),
+				Error::<T>::AssetAlreadyApproved
+			);
 			ensure!(T::Fungibles::asset_exists(asset_id.clone()), Error::<T>::AssetDoesNotExist);
 			let count = ExternalAssets::<T>::count();
 			ensure!(count < T::MaxExternalAssets::get(), Error::<T>::TooManyAssets);

--- a/substrate/frame/psm/src/migrations/decimals.rs
+++ b/substrate/frame/psm/src/migrations/decimals.rs
@@ -107,7 +107,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for InnerPopulateDecimals<T> {
 		// Per-asset snapshots. Walk every approved external asset.
 		for (asset_id, status) in ExternalAssets::<T>::iter() {
 			reads += 3; // ExternalAssets iter item + AssetDecimals + Fungibles::decimals reads below
-			if AssetDecimals::<T>::contains_key(asset_id) {
+			if AssetDecimals::<T>::contains_key(&asset_id) {
 				log::info!(
 					target: LOG_TARGET,
 					"Asset {:?} already has a decimals snapshot, skipping",
@@ -116,8 +116,8 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for InnerPopulateDecimals<T> {
 				continue;
 			}
 
-			let asset_decimals = T::Fungibles::decimals(asset_id);
-			AssetDecimals::<T>::insert(asset_id, asset_decimals);
+			let asset_decimals = T::Fungibles::decimals(asset_id.clone());
+			AssetDecimals::<T>::insert(&asset_id, asset_decimals);
 			writes += 1;
 
 			let diff = asset_decimals.abs_diff(stable_decimals) as u32;
@@ -127,7 +127,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for InnerPopulateDecimals<T> {
 				// snapshot is still written — it preserves the observed state
 				// and lets the runtime guard surface the divergence clearly.
 				if status != CircuitBreakerLevel::AllDisabled {
-					ExternalAssets::<T>::insert(asset_id, CircuitBreakerLevel::AllDisabled);
+					ExternalAssets::<T>::insert(&asset_id, CircuitBreakerLevel::AllDisabled);
 					writes += 1;
 				}
 				log::warn!(
@@ -170,7 +170,7 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for InnerPopulateDecimals<T> {
 
 		let stable_decimals = T::StableAsset::decimals();
 		for (asset_id, status) in ExternalAssets::<T>::iter() {
-			let snapshot = AssetDecimals::<T>::get(asset_id)
+			let snapshot = AssetDecimals::<T>::get(&asset_id)
 				.ok_or("Approved external asset missing decimals snapshot after migration")?;
 			ensure!(
 				snapshot == T::Fungibles::decimals(asset_id),

--- a/substrate/frame/psm/src/migrations/init.rs
+++ b/substrate/frame/psm/src/migrations/init.rs
@@ -130,7 +130,7 @@ impl<T: Config, I: InitialPsmConfig<T>> frame_support::traits::OnRuntimeUpgrade
 				continue;
 			}
 
-			let asset_decimals = T::Fungibles::decimals(*asset_id);
+			let asset_decimals = T::Fungibles::decimals(asset_id.clone());
 			let diff = asset_decimals.abs_diff(stable_decimals) as u32;
 			if diff > MAX_DECIMALS_DIFF {
 				log::error!(
@@ -183,19 +183,19 @@ impl<T: Config, I: InitialPsmConfig<T>> frame_support::traits::OnRuntimeUpgrade
 
 		for (asset_id, (minting_fee, redemption_fee, ceiling_weight)) in I::asset_configs() {
 			ensure!(
-				ExternalAssets::<T>::get(asset_id) == Some(CircuitBreakerLevel::AllEnabled),
+				ExternalAssets::<T>::get(&asset_id) == Some(CircuitBreakerLevel::AllEnabled),
 				"External asset missing or not AllEnabled after migration"
 			);
 			ensure!(
-				MintingFee::<T>::get(asset_id) == minting_fee,
+				MintingFee::<T>::get(&asset_id) == minting_fee,
 				"MintingFee mismatch after migration"
 			);
 			ensure!(
-				RedemptionFee::<T>::get(asset_id) == redemption_fee,
+				RedemptionFee::<T>::get(&asset_id) == redemption_fee,
 				"RedemptionFee mismatch after migration"
 			);
 			ensure!(
-				AssetCeilingWeight::<T>::get(asset_id) == ceiling_weight,
+				AssetCeilingWeight::<T>::get(&asset_id) == ceiling_weight,
 				"AssetCeilingWeight mismatch after migration"
 			);
 		}


### PR DESCRIPTION
## Summary

Relax the `T::AssetId` bound on `pallet-psm`'s `Config` from `Copy` to `Clone`. 

### Why

`pallet-psm` currently can't be wired with an `AssetId` that isn't `Copy`. The most relevant example is using XCM `Location` as `AssetId`. 

### Implementation

No semantic changes. Only the `Config` bound and ownership at use sites.

For `AssetId`s that are `Copy` (e.g., `u32`), the `.clone()` calls are free. `Copy` types implement `Clone` trivially. No runtime cost.