### PR TITLE
fatxpool: histogram of transaction age at removal (#7791)

### DIFF
--- a/prdoc/pr_11907.prdoc
+++ b/prdoc/pr_11907.prdoc
@@ -1,0 +1,20 @@
+title: '`fatxpool`: histogram of transaction age at removal'
+doc:
+- audience: Node Operator
+  description: |-
+    Adds a new prometheus histogram `substrate_sub_txpool_tx_age_at_removal_seconds`
+    that records, for every transaction leaving the fork-aware transaction pool,
+    the time it spent in the pool, broken down by `reason` (one of `finalized`,
+    `invalid_revalidation_mempool`, `invalid_revalidation_view`, `invalid_reported`,
+    `dropped_usurped`, `dropped_limits`, `dropped_invalid`, `finality_timeout`)
+    and `source` (`local`, `external`, `in_block`).
+
+    This is the foundational observability tool requested in issue #7791 to
+    detect stuck transactions in the field. Operators can graph the high-age
+    buckets per `reason` to determine empirically whether stuck transactions
+    are happening, before any heuristic-based detection logic is introduced.
+
+    No breaking changes to existing metrics or APIs.
+crates:
+- name: sc-transaction-pool
+  bump: minor

--- a/prdoc/pr_11907.prdoc
+++ b/prdoc/pr_11907.prdoc
@@ -13,8 +13,6 @@ doc:
     detect stuck transactions in the field. Operators can graph the high-age
     buckets per `reason` to determine empirically whether stuck transactions
     are happening, before any heuristic-based detection logic is introduced.
-
-    No breaking changes to existing metrics or APIs.
 crates:
 - name: sc-transaction-pool
   bump: minor

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -285,6 +285,7 @@ where
 			mempool.clone(),
 			view_store.clone(),
 			import_notification_sink.clone(),
+			Default::default(),
 		);
 
 		let combined_tasks = async move {
@@ -342,6 +343,7 @@ where
 			Block::Hash,
 			ExtrinsicHash<ChainApi>,
 		>,
+		metrics: PrometheusMetrics,
 	) {
 		let dropped_stats = DurationSlidingStats::new(Duration::from_secs(STAT_SLIDING_WINDOW));
 		loop {
@@ -357,7 +359,7 @@ where
 				reason = ?dropped.reason,
 				"fatp::dropped notification, removing"
 			);
-			match dropped.reason {
+			let removal_reason = match dropped.reason {
 				DroppedReason::Usurped(new_tx_hash) => {
 					if let Some(new_tx) = mempool.get_by_hash(new_tx_hash).await {
 						view_store.replace_transaction(new_tx.source(), new_tx.tx(), tx_hash).await;
@@ -368,13 +370,29 @@ where
 							"error: dropped_monitor_task: no entry in mempool for new transaction"
 						);
 					};
+					RemovalReason::DroppedUsurped
 				},
-				DroppedReason::LimitsEnforced | DroppedReason::Invalid => {
+				DroppedReason::LimitsEnforced => {
 					view_store.remove_transaction_subtree(tx_hash, |_, _| {});
+					RemovalReason::DroppedLimits
+				},
+				DroppedReason::Invalid => {
+					view_store.remove_transaction_subtree(tx_hash, |_, _| {});
+					RemovalReason::DroppedInvalid
 				},
 			};
 
-			mempool.remove_transactions(&[tx_hash]).await;
+			let removed = mempool.remove_transactions(&[tx_hash]).await;
+			let removed_at = Instant::now();
+			for tx in &removed {
+				let tx_source = tx.source();
+				if let Some(submitted_at) = tx_source.timestamp {
+					let age = removed_at.saturating_duration_since(submitted_at);
+					metrics.report(|m| {
+						m.tx_age_at_removal.observe(removal_reason, tx_source.source, age)
+					});
+				}
+			}
 			import_notification_sink.clean_notified_items(&[tx_hash]);
 			view_store.listener.transaction_dropped(dropped);
 			insert_and_log_throttled!(
@@ -438,6 +456,7 @@ where
 			mempool.clone(),
 			view_store.clone(),
 			import_notification_sink.clone(),
+			metrics.clone(),
 		);
 
 		let combined_tasks = async move {

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -28,12 +28,11 @@ use super::{
 	view_store::ViewStore,
 };
 use crate::{
-	LOG_TARGET, LOG_TARGET_STAT, ReadyIteratorFor, ValidateTransactionPriority,
 	api::FullChainApi,
 	common::{
-		STAT_SLIDING_WINDOW,
 		sliding_stat::DurationSlidingStats,
 		tracing_log_xt::{log_xt_debug, log_xt_trace},
+		STAT_SLIDING_WINDOW,
 	},
 	enactment_state::{EnactmentAction, EnactmentState},
 	fork_aware_txpool::{
@@ -41,32 +40,34 @@ use crate::{
 		revalidation_worker,
 	},
 	graph::{
-		self, BlockHash, ExtrinsicFor, ExtrinsicHash, IsValidator, Options, RawExtrinsicFor,
+		self,
 		base_pool::{TimedTransactionSource, Transaction},
+		BlockHash, ExtrinsicFor, ExtrinsicHash, IsValidator, Options, RawExtrinsicFor,
 	},
-	insert_and_log_throttled,
+	insert_and_log_throttled, ReadyIteratorFor, ValidateTransactionPriority, LOG_TARGET,
+	LOG_TARGET_STAT,
 };
 use async_trait::async_trait;
 use futures::{
-	FutureExt,
 	channel::oneshot,
 	future::{self},
 	prelude::*,
+	FutureExt,
 };
 use parking_lot::Mutex;
 use prometheus_endpoint::Registry as PrometheusRegistry;
 use sc_transaction_pool_api::{
-	ChainEvent, ImportNotificationStream, MaintainedTransactionPool, PoolStatus, TransactionFor,
-	TransactionPool, TransactionSource, TransactionStatusStreamFor, TxHash, TxInvalidityReportMap,
-	error::Error as TxPoolApiError,
+	error::Error as TxPoolApiError, ChainEvent, ImportNotificationStream,
+	MaintainedTransactionPool, PoolStatus, TransactionFor, TransactionPool, TransactionSource,
+	TransactionStatusStreamFor, TxHash, TxInvalidityReportMap,
 };
 use sp_blockchain::{HashAndNumber, TreeRoute};
 use sp_core::traits::SpawnEssentialNamed;
 use sp_runtime::{
-	Saturating,
 	generic::BlockId,
 	traits::{Block as BlockT, NumberFor},
 	transaction_validity::{TransactionTag as Tag, TransactionValidityError, ValidTransaction},
+	Saturating,
 };
 use std::{
 	collections::{BTreeMap, HashMap, HashSet},
@@ -75,7 +76,7 @@ use std::{
 	time::{Duration, Instant},
 };
 use tokio::select;
-use tracing::{Level, debug, instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn, Level};
 
 /// The maximum block height difference before considering a view or transaction as timed-out
 /// due to a finality stall. When the difference exceeds this threshold, elements are treated

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -386,12 +386,10 @@ where
 			let removed_at = Instant::now();
 			for tx in &removed {
 				let tx_source = tx.source();
-				if let Some(submitted_at) = tx_source.timestamp {
-					let age = removed_at.saturating_duration_since(submitted_at);
-					metrics.report(|m| {
-						m.tx_age_at_removal.observe(removal_reason, tx_source.source, age)
-					});
-				}
+				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
+				metrics.report(|m| {
+					m.tx_age_at_removal.observe(removal_reason, tx_source.source, age)
+				});
 			}
 			import_notification_sink.clean_notified_items(&[tx_hash]);
 			view_store.listener.transaction_dropped(dropped);
@@ -1076,13 +1074,12 @@ where
 		self.metrics.report(|metrics| {
 			metrics.removed_invalid_txs.inc_by(removed_hashes.len() as _);
 			for tx in &removed {
-				if let Some(submitted_at) = tx.source.timestamp {
-					metrics.tx_age_at_removal.observe(
-						RemovalReason::InvalidReported,
-						tx.source.source,
-						removed_at.saturating_duration_since(submitted_at),
-					);
-				}
+				let age = tx.source.timestamp.map(|t| removed_at.saturating_duration_since(t));
+				metrics.tx_age_at_removal.observe(
+					RemovalReason::InvalidReported,
+					tx.source.source,
+					age,
+				);
 			}
 		});
 
@@ -1350,16 +1347,14 @@ where
 			let removed_at = Instant::now();
 			for tx in &removed {
 				let tx_source = tx.source();
-				if let Some(submitted_at) = tx_source.timestamp {
-					let age = removed_at.saturating_duration_since(submitted_at);
-					self.metrics.report(|m| {
-						m.tx_age_at_removal.observe(
-							RemovalReason::FinalityTimeout,
-							tx_source.source,
-							age,
-						)
-					});
-				}
+				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
+				self.metrics.report(|m| {
+					m.tx_age_at_removal.observe(
+						RemovalReason::FinalityTimeout,
+						tx_source.source,
+						age,
+					)
+				});
 			}
 			self.import_notification_sink.clean_notified_items(&tx_hashes);
 			self.view_store.dropped_stream_controller.remove_transactions(tx_hashes.clone());

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -28,11 +28,12 @@ use super::{
 	view_store::ViewStore,
 };
 use crate::{
+	LOG_TARGET, LOG_TARGET_STAT, ReadyIteratorFor, ValidateTransactionPriority,
 	api::FullChainApi,
 	common::{
+		STAT_SLIDING_WINDOW,
 		sliding_stat::DurationSlidingStats,
 		tracing_log_xt::{log_xt_debug, log_xt_trace},
-		STAT_SLIDING_WINDOW,
 	},
 	enactment_state::{EnactmentAction, EnactmentState},
 	fork_aware_txpool::{
@@ -40,34 +41,32 @@ use crate::{
 		revalidation_worker,
 	},
 	graph::{
-		self,
+		self, BlockHash, ExtrinsicFor, ExtrinsicHash, IsValidator, Options, RawExtrinsicFor,
 		base_pool::{TimedTransactionSource, Transaction},
-		BlockHash, ExtrinsicFor, ExtrinsicHash, IsValidator, Options, RawExtrinsicFor,
 	},
-	insert_and_log_throttled, ReadyIteratorFor, ValidateTransactionPriority, LOG_TARGET,
-	LOG_TARGET_STAT,
+	insert_and_log_throttled,
 };
 use async_trait::async_trait;
 use futures::{
+	FutureExt,
 	channel::oneshot,
 	future::{self},
 	prelude::*,
-	FutureExt,
 };
 use parking_lot::Mutex;
 use prometheus_endpoint::Registry as PrometheusRegistry;
 use sc_transaction_pool_api::{
-	error::Error as TxPoolApiError, ChainEvent, ImportNotificationStream,
-	MaintainedTransactionPool, PoolStatus, TransactionFor, TransactionPool, TransactionSource,
-	TransactionStatusStreamFor, TxHash, TxInvalidityReportMap,
+	ChainEvent, ImportNotificationStream, MaintainedTransactionPool, PoolStatus, TransactionFor,
+	TransactionPool, TransactionSource, TransactionStatusStreamFor, TxHash, TxInvalidityReportMap,
+	error::Error as TxPoolApiError,
 };
 use sp_blockchain::{HashAndNumber, TreeRoute};
 use sp_core::traits::SpawnEssentialNamed;
 use sp_runtime::{
+	Saturating,
 	generic::BlockId,
 	traits::{Block as BlockT, NumberFor},
 	transaction_validity::{TransactionTag as Tag, TransactionValidityError, ValidTransaction},
-	Saturating,
 };
 use std::{
 	collections::{BTreeMap, HashMap, HashSet},
@@ -76,7 +75,7 @@ use std::{
 	time::{Duration, Instant},
 };
 use tokio::select;
-use tracing::{debug, instrument, trace, warn, Level};
+use tracing::{Level, debug, instrument, trace, warn};
 
 /// The maximum block height difference before considering a view or transaction as timed-out
 /// due to a finality stall. When the difference exceeds this threshold, elements are treated
@@ -384,12 +383,9 @@ where
 
 			let removed = mempool.remove_transactions(&[tx_hash]).await;
 			let removed_at = Instant::now();
-			for tx in &removed {
-				let tx_source = tx.source();
-				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
-				metrics
-					.report(|m| m.tx_age_at_removal.observe(removal_reason, tx_source.source, age));
-			}
+			metrics.report(|m| {
+				m.tx_age_at_removal.observe_batch(removal_reason, removed_at, &removed)
+			});
 			import_notification_sink.clean_notified_items(&[tx_hash]);
 			view_store.listener.transaction_dropped(dropped);
 			insert_and_log_throttled!(
@@ -867,8 +863,7 @@ where
 		//
 		// Finally, it collects the hashes of updated transactions or submission errors (either
 		// from the mempool or view_store) into a returned vector (final_results).
-		const RESULTS_ASSUMPTION : &str =
-			"The number of Ok results in mempool is exactly the same as the size of view_store submission result. qed.";
+		const RESULTS_ASSUMPTION: &str = "The number of Ok results in mempool is exactly the same as the size of view_store submission result. qed.";
 		let merged_results = mempool_results.into_iter().map(|result| {
 			result.map_err(Into::into).and_then(|insertion| {
 				Ok((insertion.hash, submission_results.next().expect(RESULTS_ASSUMPTION)))
@@ -1072,14 +1067,11 @@ where
 
 		self.metrics.report(|metrics| {
 			metrics.removed_invalid_txs.inc_by(removed_hashes.len() as _);
-			for tx in &removed {
-				let age = tx.source.timestamp.map(|t| removed_at.saturating_duration_since(t));
-				metrics.tx_age_at_removal.observe(
-					RemovalReason::InvalidReported,
-					tx.source.source,
-					age,
-				);
-			}
+			metrics.tx_age_at_removal.observe_batch(
+				RemovalReason::InvalidReported,
+				removed_at,
+				&removed,
+			);
 		});
 
 		removed
@@ -1344,17 +1336,13 @@ where
 
 			let removed = self.mempool.remove_transactions(&tx_hashes).await;
 			let removed_at = Instant::now();
-			for tx in &removed {
-				let tx_source = tx.source();
-				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
-				self.metrics.report(|m| {
-					m.tx_age_at_removal.observe(
-						RemovalReason::FinalityTimeout,
-						tx_source.source,
-						age,
-					)
-				});
-			}
+			self.metrics.report(|m| {
+				m.tx_age_at_removal.observe_batch(
+					RemovalReason::FinalityTimeout,
+					removed_at,
+					&removed,
+				)
+			});
 			self.import_notification_sink.clean_notified_items(&tx_hashes);
 			self.view_store.dropped_stream_controller.remove_transactions(tx_hashes.clone());
 		}
@@ -2028,7 +2016,7 @@ where
 				Err(e) => {
 					return Err(format!(
 						"Error occurred while computing tree_route from {from:?} to {to:?}: {e}"
-					))
+					));
 				},
 			}
 		};

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -387,9 +387,8 @@ where
 			for tx in &removed {
 				let tx_source = tx.source();
 				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
-				metrics.report(|m| {
-					m.tx_age_at_removal.observe(removal_reason, tx_source.source, age)
-				});
+				metrics
+					.report(|m| m.tx_age_at_removal.observe(removal_reason, tx_source.source, age));
 			}
 			import_notification_sink.clean_notified_items(&[tx_hash]);
 			view_store.listener.transaction_dropped(dropped);

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -1346,7 +1346,21 @@ where
 		for (block_hash, tx_hashes) in finality_timedout_blocks {
 			self.view_store.listener.transactions_finality_timeout(&tx_hashes, block_hash);
 
-			self.mempool.remove_transactions(&tx_hashes).await;
+			let removed = self.mempool.remove_transactions(&tx_hashes).await;
+			let removed_at = Instant::now();
+			for tx in &removed {
+				let tx_source = tx.source();
+				if let Some(submitted_at) = tx_source.timestamp {
+					let age = removed_at.saturating_duration_since(submitted_at);
+					self.metrics.report(|m| {
+						m.tx_age_at_removal.observe(
+							RemovalReason::FinalityTimeout,
+							tx_source.source,
+							age,
+						)
+					});
+				}
+			}
 			self.import_notification_sink.clean_notified_items(&tx_hashes);
 			self.view_store.dropped_stream_controller.remove_transactions(tx_hashes.clone());
 		}

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/fork_aware_txpool.rs
@@ -21,7 +21,7 @@
 use super::{
 	dropped_watcher::{MultiViewDroppedWatcherController, StreamOfDropped},
 	import_notification_sink::MultiViewImportNotificationSink,
-	metrics::{EventsMetricsCollector, MetricsLink as PrometheusMetrics},
+	metrics::{EventsMetricsCollector, MetricsLink as PrometheusMetrics, RemovalReason},
 	multi_view_listener::MultiViewListener,
 	tx_mem_pool::{InsertionInfo, TxMemPool},
 	view::View,
@@ -1048,13 +1048,24 @@ where
 			.report(|metrics| metrics.reported_invalid_txs.inc_by(invalid_tx_errors.len() as _));
 
 		let removed = self.view_store.report_invalid(at, invalid_tx_errors);
+		let removed_at = Instant::now();
 
 		let removed_hashes = removed.iter().map(|tx| tx.hash).collect::<Vec<_>>();
 		self.mempool.remove_transactions(&removed_hashes).await;
 		self.import_notification_sink.clean_notified_items(&removed_hashes);
 
-		self.metrics
-			.report(|metrics| metrics.removed_invalid_txs.inc_by(removed_hashes.len() as _));
+		self.metrics.report(|metrics| {
+			metrics.removed_invalid_txs.inc_by(removed_hashes.len() as _);
+			for tx in &removed {
+				if let Some(submitted_at) = tx.source.timestamp {
+					metrics.tx_age_at_removal.observe(
+						RemovalReason::InvalidReported,
+						tx.source.source,
+						removed_at.saturating_duration_since(submitted_at),
+					);
+				}
+			}
+		});
 
 		removed
 	}

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -20,21 +20,21 @@
 
 use super::tx_mem_pool::{InsertionInfo, InvalidTxReason};
 use crate::{
+	LOG_TARGET,
 	common::metrics::{GenericMetricsLink, MetricsRegistrant},
 	graph::{self, BlockHash, ExtrinsicHash},
-	LOG_TARGET,
 };
 use futures::{FutureExt, StreamExt};
 use prometheus_endpoint::{
-	exponential_buckets, histogram_opts, linear_buckets, register, Counter, CounterVec, Gauge,
-	Histogram, HistogramOpts, HistogramVec, Opts, PrometheusError, Registry, U64,
+	Counter, CounterVec, Gauge, Histogram, HistogramOpts, HistogramVec, Opts, PrometheusError,
+	Registry, U64, exponential_buckets, histogram_opts, linear_buckets, register,
 };
 #[cfg(doc)]
 use sc_transaction_pool_api::TransactionPool;
 use sc_transaction_pool_api::TransactionStatus;
 use sc_utils::mpsc;
 use std::{
-	collections::{hash_map::Entry, HashMap},
+	collections::{HashMap, hash_map::Entry},
 	future::Future,
 	pin::Pin,
 	time::{Duration, Instant},
@@ -330,9 +330,10 @@ impl MempoolInvalidTxReasonCounter {
 
 /// Reason why a transaction was removed from the pool.
 ///
-/// Used as a Prometheus label on the [`TxAgeAtRemovalHistogram`] metric, so the
-/// variants are mapped to short snake_case strings via [`Self::as_str`].
-#[derive(Clone, Copy, Debug)]
+/// Used as a Prometheus label on the [`TxAgeAtRemovalHistogram`] metric. The
+/// variants are mapped to short snake_case strings via `strum::AsRefStr`.
+#[derive(Clone, Copy, Debug, strum::AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum RemovalReason {
 	/// Transaction was finalized in a block.
 	Finalized,
@@ -350,22 +351,6 @@ pub enum RemovalReason {
 	DroppedInvalid,
 	/// Transaction reached the configured finality timeout without being finalized.
 	FinalityTimeout,
-}
-
-impl RemovalReason {
-	/// Returns the snake_case label used as the Prometheus `reason` label value.
-	pub fn as_str(&self) -> &'static str {
-		match self {
-			Self::Finalized => "finalized",
-			Self::InvalidRevalidationMempool => "invalid_revalidation_mempool",
-			Self::InvalidRevalidationView => "invalid_revalidation_view",
-			Self::InvalidReported => "invalid_reported",
-			Self::DroppedUsurped => "dropped_usurped",
-			Self::DroppedLimits => "dropped_limits",
-			Self::DroppedInvalid => "dropped_invalid",
-			Self::FinalityTimeout => "finality_timeout",
-		}
-	}
 }
 
 /// Maps a [`sp_runtime::transaction_validity::TransactionSource`] to the
@@ -422,7 +407,7 @@ impl TxAgeAtRemovalHistogram {
 	) {
 		let value = age.map(|a| a.as_secs_f64()).unwrap_or(f64::INFINITY);
 		self.inner
-			.with_label_values(&[reason.as_str(), source_label(source)])
+			.with_label_values(&[reason.as_ref(), source_label(source)])
 			.observe(value)
 	}
 }
@@ -785,17 +770,17 @@ mod tests {
 		// The metric labels are part of the public observability surface
 		// and dashboards depend on them — keep this test in sync if you
 		// rename a variant.
-		assert_eq!(RemovalReason::Finalized.as_str(), "finalized");
+		assert_eq!(RemovalReason::Finalized.as_ref(), "finalized");
 		assert_eq!(
-			RemovalReason::InvalidRevalidationMempool.as_str(),
+			RemovalReason::InvalidRevalidationMempool.as_ref(),
 			"invalid_revalidation_mempool",
 		);
-		assert_eq!(RemovalReason::InvalidRevalidationView.as_str(), "invalid_revalidation_view",);
-		assert_eq!(RemovalReason::InvalidReported.as_str(), "invalid_reported");
-		assert_eq!(RemovalReason::DroppedUsurped.as_str(), "dropped_usurped");
-		assert_eq!(RemovalReason::DroppedLimits.as_str(), "dropped_limits");
-		assert_eq!(RemovalReason::DroppedInvalid.as_str(), "dropped_invalid");
-		assert_eq!(RemovalReason::FinalityTimeout.as_str(), "finality_timeout");
+		assert_eq!(RemovalReason::InvalidRevalidationView.as_ref(), "invalid_revalidation_view");
+		assert_eq!(RemovalReason::InvalidReported.as_ref(), "invalid_reported");
+		assert_eq!(RemovalReason::DroppedUsurped.as_ref(), "dropped_usurped");
+		assert_eq!(RemovalReason::DroppedLimits.as_ref(), "dropped_limits");
+		assert_eq!(RemovalReason::DroppedInvalid.as_ref(), "dropped_invalid");
+		assert_eq!(RemovalReason::FinalityTimeout.as_ref(), "finality_timeout");
 	}
 
 	#[test]

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -772,3 +772,98 @@ where
 		(Self { metrics_message_sink: Some(metrics_message_sink) }, task.boxed())
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_runtime::transaction_validity::TransactionSource;
+
+	#[test]
+	fn removal_reason_label_strings_are_stable() {
+		// The metric labels are part of the public observability surface
+		// and dashboards depend on them — keep this test in sync if you
+		// rename a variant.
+		assert_eq!(RemovalReason::Finalized.as_str(), "finalized");
+		assert_eq!(
+			RemovalReason::InvalidRevalidationMempool.as_str(),
+			"invalid_revalidation_mempool",
+		);
+		assert_eq!(
+			RemovalReason::InvalidRevalidationView.as_str(),
+			"invalid_revalidation_view",
+		);
+		assert_eq!(RemovalReason::InvalidReported.as_str(), "invalid_reported");
+		assert_eq!(RemovalReason::DroppedUsurped.as_str(), "dropped_usurped");
+		assert_eq!(RemovalReason::DroppedLimits.as_str(), "dropped_limits");
+		assert_eq!(RemovalReason::DroppedInvalid.as_str(), "dropped_invalid");
+		assert_eq!(RemovalReason::FinalityTimeout.as_str(), "finality_timeout");
+	}
+
+	#[test]
+	fn source_label_maps_each_variant() {
+		assert_eq!(source_label(TransactionSource::Local), "local");
+		assert_eq!(source_label(TransactionSource::External), "external");
+		assert_eq!(source_label(TransactionSource::InBlock), "in_block");
+	}
+
+	/// Returns the sample count of the histogram for the given (reason, source) pair,
+	/// or `None` if the metric family is not present yet.
+	fn sample_count(registry: &Registry, reason: &str, source: &str) -> Option<u64> {
+		registry
+			.gather()
+			.into_iter()
+			.find(|m| m.get_name() == "substrate_sub_txpool_tx_age_at_removal_seconds")?
+			.take_metric()
+			.into_iter()
+			.find(|m| {
+				let labels = m.get_label();
+				labels.iter().any(|l| l.get_name() == "reason" && l.get_value() == reason)
+					&& labels
+						.iter()
+						.any(|l| l.get_name() == "source" && l.get_value() == source)
+			})
+			.map(|m| m.get_histogram().get_sample_count())
+	}
+
+	#[test]
+	fn observe_records_one_sample_with_expected_labels() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+
+		histogram.observe(
+			RemovalReason::Finalized,
+			TransactionSource::External,
+			Duration::from_secs(42),
+		);
+
+		assert_eq!(sample_count(&registry, "finalized", "external"), Some(1));
+		// Other label combinations must not have been touched.
+		assert_eq!(sample_count(&registry, "finalized", "local"), None);
+		assert_eq!(sample_count(&registry, "dropped_usurped", "external"), None);
+	}
+
+	#[test]
+	fn observe_groups_samples_with_matching_labels() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+
+		histogram.observe(
+			RemovalReason::DroppedUsurped,
+			TransactionSource::Local,
+			Duration::from_millis(100),
+		);
+		histogram.observe(
+			RemovalReason::DroppedUsurped,
+			TransactionSource::Local,
+			Duration::from_secs(3600),
+		);
+		histogram.observe(
+			RemovalReason::DroppedUsurped,
+			TransactionSource::External,
+			Duration::from_secs(5),
+		);
+
+		assert_eq!(sample_count(&registry, "dropped_usurped", "local"), Some(2));
+		assert_eq!(sample_count(&registry, "dropped_usurped", "external"), Some(1));
+	}
+}

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -788,10 +788,7 @@ mod tests {
 			RemovalReason::InvalidRevalidationMempool.as_str(),
 			"invalid_revalidation_mempool",
 		);
-		assert_eq!(
-			RemovalReason::InvalidRevalidationView.as_str(),
-			"invalid_revalidation_view",
-		);
+		assert_eq!(RemovalReason::InvalidRevalidationView.as_str(), "invalid_revalidation_view",);
 		assert_eq!(RemovalReason::InvalidReported.as_str(), "invalid_reported");
 		assert_eq!(RemovalReason::DroppedUsurped.as_str(), "dropped_usurped");
 		assert_eq!(RemovalReason::DroppedLimits.as_str(), "dropped_limits");
@@ -817,10 +814,8 @@ mod tests {
 			.into_iter()
 			.find(|m| {
 				let labels = m.get_label();
-				labels.iter().any(|l| l.get_name() == "reason" && l.get_value() == reason)
-					&& labels
-						.iter()
-						.any(|l| l.get_name() == "source" && l.get_value() == source)
+				labels.iter().any(|l| l.get_name() == "reason" && l.get_value() == reason) &&
+					labels.iter().any(|l| l.get_name() == "source" && l.get_value() == source)
 			})
 			.map(|m| m.get_histogram().get_sample_count())
 	}

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -27,7 +27,7 @@ use crate::{
 use futures::{FutureExt, StreamExt};
 use prometheus_endpoint::{
 	exponential_buckets, histogram_opts, linear_buckets, register, Counter, CounterVec, Gauge,
-	Histogram, Opts, PrometheusError, Registry, U64,
+	Histogram, HistogramOpts, HistogramVec, Opts, PrometheusError, Registry, U64,
 };
 #[cfg(doc)]
 use sc_transaction_pool_api::TransactionPool;
@@ -85,6 +85,13 @@ pub struct Metrics {
 	pub non_cloned_views: Counter<U64>,
 	/// Histograms to track the timing distribution of individual transaction pool events.
 	pub events_histograms: EventsHistograms,
+	/// Histogram of transaction age (residence time in the pool) at the moment a
+	/// transaction is removed, broken down by `reason` and `source`.
+	///
+	/// This metric is the main observability tool for detecting stuck transactions
+	/// in the fork-aware pool: spikes in the high-age buckets per `reason` indicate
+	/// transactions that lingered in the pool before leaving (see issue #7791).
+	pub tx_age_at_removal: TxAgeAtRemovalHistogram,
 }
 
 /// Represents a collection of histogram timings for different transaction statuses.
@@ -325,6 +332,102 @@ impl MempoolInvalidTxReasonCounter {
 	}
 }
 
+/// Reason why a transaction was removed from the pool.
+///
+/// Used as a Prometheus label on the [`TxAgeAtRemovalHistogram`] metric, so the
+/// variants are mapped to short snake_case strings via [`Self::as_str`].
+#[derive(Clone, Copy, Debug)]
+pub enum RemovalReason {
+	/// Transaction was finalized in a block.
+	Finalized,
+	/// Transaction was found invalid during mempool revalidation.
+	InvalidRevalidationMempool,
+	/// Transaction was found invalid during view revalidation.
+	InvalidRevalidationView,
+	/// Transaction was reported as invalid via the `report_invalid` API.
+	InvalidReported,
+	/// Transaction was dropped because it was usurped by another (higher-priority) one.
+	DroppedUsurped,
+	/// Transaction was dropped because the pool's size limits were enforced.
+	DroppedLimits,
+	/// Transaction was dropped because the view marked it as invalid.
+	DroppedInvalid,
+	/// Transaction reached the configured finality timeout without being finalized.
+	FinalityTimeout,
+	/// Transaction came in via block import but was unknown to the pool.
+	BlockImportUnknown,
+}
+
+impl RemovalReason {
+	/// Returns the snake_case label used as the Prometheus `reason` label value.
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Self::Finalized => "finalized",
+			Self::InvalidRevalidationMempool => "invalid_revalidation_mempool",
+			Self::InvalidRevalidationView => "invalid_revalidation_view",
+			Self::InvalidReported => "invalid_reported",
+			Self::DroppedUsurped => "dropped_usurped",
+			Self::DroppedLimits => "dropped_limits",
+			Self::DroppedInvalid => "dropped_invalid",
+			Self::FinalityTimeout => "finality_timeout",
+			Self::BlockImportUnknown => "block_import_unknown",
+		}
+	}
+}
+
+/// Maps a [`sp_runtime::transaction_validity::TransactionSource`] to the
+/// snake_case label used as the Prometheus `source` label value.
+fn source_label(source: sp_runtime::transaction_validity::TransactionSource) -> &'static str {
+	use sp_runtime::transaction_validity::TransactionSource;
+	match source {
+		TransactionSource::InBlock => "in_block",
+		TransactionSource::Local => "local",
+		TransactionSource::External => "external",
+	}
+}
+
+/// Histogram of transaction age in the pool at the moment of removal,
+/// labeled by `reason` and `source`.
+pub struct TxAgeAtRemovalHistogram {
+	inner: HistogramVec,
+}
+
+impl TxAgeAtRemovalHistogram {
+	fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+		// Exponential buckets covering ~1s up to ~24h:
+		// 1s, 2.5s, 6.25s, 15.6s, 39s, 1.6m, 4m, 10.2m, 25.4m, 1.06h, 2.65h, 6.6h, 16.5h, 41.4h.
+		let buckets = exponential_buckets(1.0, 2.5, 14)
+			.expect("exponential_buckets parameters are valid; qed");
+		Ok(Self {
+			inner: register(
+				HistogramVec::new(
+					HistogramOpts::new(
+						"substrate_sub_txpool_tx_age_at_removal_seconds",
+						"Transaction age (in seconds) in the fork-aware pool at the moment of \
+						removal, labeled by `reason` and `source`. Used to detect stuck \
+						transactions (see issue #7791).",
+					)
+					.buckets(buckets),
+					&["reason", "source"],
+				)?,
+				registry,
+			)?,
+		})
+	}
+
+	/// Records the given residence `age` for a transaction leaving the pool.
+	pub fn observe(
+		&self,
+		reason: RemovalReason,
+		source: sp_runtime::transaction_validity::TransactionSource,
+		age: Duration,
+	) {
+		self.inner
+			.with_label_values(&[reason.as_str(), source_label(source)])
+			.observe(age.as_secs_f64())
+	}
+}
+
 impl MetricsRegistrant for Metrics {
 	fn register(registry: &Registry) -> Result<Box<Self>, PrometheusError> {
 		Ok(Box::from(Self {
@@ -444,6 +547,7 @@ impl MetricsRegistrant for Metrics {
 				registry,
 			)?,
 			events_histograms: EventsHistograms::register(registry)?,
+			tx_age_at_removal: TxAgeAtRemovalHistogram::register(registry)?,
 		}))
 	}
 }

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -20,17 +20,18 @@
 
 use super::tx_mem_pool::{InsertionInfo, InvalidTxReason, TxInMemPool};
 use crate::{
-	LOG_TARGET,
 	common::metrics::{GenericMetricsLink, MetricsRegistrant},
 	graph::{
-		self, BlockHash, ExtrinsicHash,
+		self,
 		base_pool::{TimedTransactionSource, Transaction},
+		BlockHash, ExtrinsicHash,
 	},
+	LOG_TARGET,
 };
 use futures::{FutureExt, StreamExt};
 use prometheus_endpoint::{
-	Counter, CounterVec, Gauge, Histogram, HistogramOpts, HistogramVec, Opts, PrometheusError,
-	Registry, U64, exponential_buckets, histogram_opts, linear_buckets, register,
+	exponential_buckets, histogram_opts, linear_buckets, register, Counter, CounterVec, Gauge,
+	Histogram, HistogramOpts, HistogramVec, Opts, PrometheusError, Registry, U64,
 };
 #[cfg(doc)]
 use sc_transaction_pool_api::TransactionPool;
@@ -38,7 +39,7 @@ use sc_transaction_pool_api::TransactionStatus;
 use sc_utils::mpsc;
 use sp_runtime::traits::Block as BlockT;
 use std::{
-	collections::{HashMap, hash_map::Entry},
+	collections::{hash_map::Entry, HashMap},
 	future::Future,
 	pin::Pin,
 	sync::Arc,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -353,17 +353,6 @@ pub enum RemovalReason {
 	FinalityTimeout,
 }
 
-/// Maps a [`sp_runtime::transaction_validity::TransactionSource`] to the
-/// snake_case label used as the Prometheus `source` label value.
-fn source_label(source: sp_runtime::transaction_validity::TransactionSource) -> &'static str {
-	use sp_runtime::transaction_validity::TransactionSource;
-	match source {
-		TransactionSource::InBlock => "in_block",
-		TransactionSource::Local => "local",
-		TransactionSource::External => "external",
-	}
-}
-
 /// Histogram of transaction age in the pool at the moment of removal,
 /// labeled by `reason` and `source`.
 pub struct TxAgeAtRemovalHistogram {
@@ -406,9 +395,7 @@ impl TxAgeAtRemovalHistogram {
 		age: Option<Duration>,
 	) {
 		let value = age.map(|a| a.as_secs_f64()).unwrap_or(f64::INFINITY);
-		self.inner
-			.with_label_values(&[reason.as_ref(), source_label(source)])
-			.observe(value)
+		self.inner.with_label_values(&[reason.as_ref(), source.as_ref()]).observe(value)
 	}
 }
 
@@ -785,9 +772,9 @@ mod tests {
 
 	#[test]
 	fn source_label_maps_each_variant() {
-		assert_eq!(source_label(TransactionSource::Local), "local");
-		assert_eq!(source_label(TransactionSource::External), "external");
-		assert_eq!(source_label(TransactionSource::InBlock), "in_block");
+		assert_eq!(TransactionSource::Local.as_ref(), "local");
+		assert_eq!(TransactionSource::External.as_ref(), "external");
+		assert_eq!(TransactionSource::InBlock.as_ref(), "in_block");
 	}
 
 	/// Returns the sample count of the histogram for the given (reason, source) pair,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -408,16 +408,22 @@ impl TxAgeAtRemovalHistogram {
 		})
 	}
 
-	/// Records the given residence `age` for a transaction leaving the pool.
+	/// Records the residence time of a transaction leaving the pool.
+	///
+	/// `age` is `None` when the original submission timestamp is unavailable, which
+	/// in production should never happen (timestamps are always set in the fork-aware
+	/// pool). Such observations are routed to the highest bucket so they remain
+	/// visible in dashboards rather than being silently dropped.
 	pub fn observe(
 		&self,
 		reason: RemovalReason,
 		source: sp_runtime::transaction_validity::TransactionSource,
-		age: Duration,
+		age: Option<Duration>,
 	) {
+		let value = age.map(|a| a.as_secs_f64()).unwrap_or(f64::INFINITY);
 		self.inner
 			.with_label_values(&[reason.as_str(), source_label(source)])
-			.observe(age.as_secs_f64())
+			.observe(value)
 	}
 }
 
@@ -824,7 +830,7 @@ mod tests {
 		histogram.observe(
 			RemovalReason::Finalized,
 			TransactionSource::External,
-			Duration::from_secs(42),
+			Some(Duration::from_secs(42)),
 		);
 
 		assert_eq!(sample_count(&registry, "finalized", "external"), Some(1));
@@ -841,20 +847,32 @@ mod tests {
 		histogram.observe(
 			RemovalReason::DroppedUsurped,
 			TransactionSource::Local,
-			Duration::from_millis(100),
+			Some(Duration::from_millis(100)),
 		);
 		histogram.observe(
 			RemovalReason::DroppedUsurped,
 			TransactionSource::Local,
-			Duration::from_secs(3600),
+			Some(Duration::from_secs(3600)),
 		);
 		histogram.observe(
 			RemovalReason::DroppedUsurped,
 			TransactionSource::External,
-			Duration::from_secs(5),
+			Some(Duration::from_secs(5)),
 		);
 
 		assert_eq!(sample_count(&registry, "dropped_usurped", "local"), Some(2));
 		assert_eq!(sample_count(&registry, "dropped_usurped", "external"), Some(1));
+	}
+
+	#[test]
+	fn observe_with_none_age_records_in_highest_bucket() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+
+		histogram.observe(RemovalReason::Finalized, TransactionSource::External, None);
+
+		// Sample is recorded (count = 1) but it lands above all finite buckets,
+		// so it's only counted in the implicit `+Inf` bucket.
+		assert_eq!(sample_count(&registry, "finalized", "external"), Some(1));
 	}
 }

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -85,12 +85,8 @@ pub struct Metrics {
 	pub non_cloned_views: Counter<U64>,
 	/// Histograms to track the timing distribution of individual transaction pool events.
 	pub events_histograms: EventsHistograms,
-	/// Histogram of transaction age (residence time in the pool) at the moment a
-	/// transaction is removed, broken down by `reason` and `source`.
-	///
-	/// This metric is the main observability tool for detecting stuck transactions
-	/// in the fork-aware pool: spikes in the high-age buckets per `reason` indicate
-	/// transactions that lingered in the pool before leaving (see issue #7791).
+	/// Histogram of transaction age in the pool at the moment of removal, labeled by
+	/// `reason` and `source`.
 	pub tx_age_at_removal: TxAgeAtRemovalHistogram,
 }
 

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -18,11 +18,14 @@
 
 //! Prometheus's metrics for a fork-aware transaction pool.
 
-use super::tx_mem_pool::{InsertionInfo, InvalidTxReason};
+use super::tx_mem_pool::{InsertionInfo, InvalidTxReason, TxInMemPool};
 use crate::{
 	LOG_TARGET,
 	common::metrics::{GenericMetricsLink, MetricsRegistrant},
-	graph::{self, BlockHash, ExtrinsicHash},
+	graph::{
+		self, BlockHash, ExtrinsicHash,
+		base_pool::{TimedTransactionSource, Transaction},
+	},
 };
 use futures::{FutureExt, StreamExt};
 use prometheus_endpoint::{
@@ -33,10 +36,12 @@ use prometheus_endpoint::{
 use sc_transaction_pool_api::TransactionPool;
 use sc_transaction_pool_api::TransactionStatus;
 use sc_utils::mpsc;
+use sp_runtime::traits::Block as BlockT;
 use std::{
 	collections::{HashMap, hash_map::Entry},
 	future::Future,
 	pin::Pin,
+	sync::Arc,
 	time::{Duration, Instant},
 };
 use tracing::trace;
@@ -353,6 +358,51 @@ pub enum RemovalReason {
 	FinalityTimeout,
 }
 
+/// Provides access to the [`TimedTransactionSource`] of an object held in the
+/// fork-aware transaction pool.
+///
+/// Used by [`TxAgeAtRemovalHistogram::observe_batch`] to record the residence
+/// time of a batch of removed transactions without forcing each call site to
+/// thread `source` and `timestamp` manually.
+// Call sites are wired in a follow-up commit; allow dead_code so the API can
+// land independently from its consumers.
+#[allow(dead_code)]
+pub(super) trait HasSource {
+	/// Returns a reference to the source of the transaction.
+	fn timed_source(&self) -> &TimedTransactionSource;
+}
+
+/// Auto-impl so any `Arc<T: HasSource>` works without boilerplate.
+impl<T: HasSource + ?Sized> HasSource for Arc<T> {
+	fn timed_source(&self) -> &TimedTransactionSource {
+		(**self).timed_source()
+	}
+}
+
+/// Auto-impl so iterators over references (`(&items).into_iter()`) work
+/// without forcing call sites to clone or move ownership.
+impl<T: HasSource + ?Sized> HasSource for &T {
+	fn timed_source(&self) -> &TimedTransactionSource {
+		(**self).timed_source()
+	}
+}
+
+impl<ChainApi, Block> HasSource for TxInMemPool<ChainApi, Block>
+where
+	Block: BlockT,
+	ChainApi: graph::ChainApi<Block = Block> + 'static,
+{
+	fn timed_source(&self) -> &TimedTransactionSource {
+		self.source_ref()
+	}
+}
+
+impl<Hash, Extrinsic> HasSource for Transaction<Hash, Extrinsic> {
+	fn timed_source(&self) -> &TimedTransactionSource {
+		&self.source
+	}
+}
+
 /// Histogram of transaction age in the pool at the moment of removal,
 /// labeled by `reason` and `source`.
 pub struct TxAgeAtRemovalHistogram {
@@ -396,6 +446,26 @@ impl TxAgeAtRemovalHistogram {
 	) {
 		let value = age.map(|a| a.as_secs_f64()).unwrap_or(f64::INFINITY);
 		self.inner.with_label_values(&[reason.as_ref(), source.as_ref()]).observe(value)
+	}
+
+	/// Records one observation per item, computing each transaction's age as
+	/// `removed_at - timestamp`.
+	///
+	/// `removed_at` is taken once at the call site so every item in the batch
+	/// is anchored against the same instant — this matches the existing manual
+	/// loops the helper replaces.
+	// Call sites are wired in a follow-up commit.
+	#[allow(dead_code)]
+	pub(super) fn observe_batch<I>(&self, reason: RemovalReason, removed_at: Instant, items: I)
+	where
+		I: IntoIterator,
+		I::Item: HasSource,
+	{
+		for item in items {
+			let ts = item.timed_source();
+			let age = ts.timestamp.map(|t| removed_at.saturating_duration_since(t));
+			self.observe(reason, ts.source, age);
+		}
 	}
 }
 
@@ -846,5 +916,87 @@ mod tests {
 		// Sample is recorded (count = 1) but it lands above all finite buckets,
 		// so it's only counted in the implicit `+Inf` bucket.
 		assert_eq!(sample_count(&registry, "finalized", "external"), Some(1));
+	}
+
+	/// Test fixture implementing [`HasSource`] without depending on the full
+	/// `TxInMemPool` / `Transaction` machinery.
+	struct MockTimedSource(TimedTransactionSource);
+
+	impl HasSource for MockTimedSource {
+		fn timed_source(&self) -> &TimedTransactionSource {
+			&self.0
+		}
+	}
+
+	fn mock_item(source: TransactionSource, timestamp: Option<Instant>) -> MockTimedSource {
+		MockTimedSource(TimedTransactionSource { source, timestamp })
+	}
+
+	#[test]
+	fn observe_batch_records_one_sample_per_item() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+		let removed_at = Instant::now();
+		let now = Some(removed_at);
+
+		let items = vec![
+			mock_item(TransactionSource::External, now),
+			mock_item(TransactionSource::External, now),
+			mock_item(TransactionSource::External, now),
+		];
+
+		histogram.observe_batch(RemovalReason::Finalized, removed_at, &items);
+
+		assert_eq!(sample_count(&registry, "finalized", "external"), Some(3));
+	}
+
+	#[test]
+	fn observe_batch_with_empty_iterator_is_noop() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+
+		let items: Vec<MockTimedSource> = Vec::new();
+		histogram.observe_batch(RemovalReason::Finalized, Instant::now(), &items);
+
+		assert_eq!(sample_count(&registry, "finalized", "external"), None);
+		assert_eq!(sample_count(&registry, "finalized", "local"), None);
+	}
+
+	#[test]
+	fn observe_batch_routes_per_source_label() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+		let removed_at = Instant::now();
+		let now = Some(removed_at);
+
+		let items = vec![
+			mock_item(TransactionSource::Local, now),
+			mock_item(TransactionSource::External, now),
+			mock_item(TransactionSource::External, now),
+			mock_item(TransactionSource::InBlock, now),
+		];
+
+		histogram.observe_batch(RemovalReason::DroppedUsurped, removed_at, &items);
+
+		assert_eq!(sample_count(&registry, "dropped_usurped", "local"), Some(1));
+		assert_eq!(sample_count(&registry, "dropped_usurped", "external"), Some(2));
+		assert_eq!(sample_count(&registry, "dropped_usurped", "in_block"), Some(1));
+	}
+
+	#[test]
+	fn observe_batch_routes_missing_timestamp_to_infinity_bucket() {
+		let registry = Registry::new();
+		let histogram = TxAgeAtRemovalHistogram::register(&registry).unwrap();
+
+		let items = vec![
+			mock_item(TransactionSource::External, None),
+			mock_item(TransactionSource::External, None),
+		];
+
+		histogram.observe_batch(RemovalReason::FinalityTimeout, Instant::now(), &items);
+
+		// Both samples are recorded; lacking a timestamp they land in the
+		// implicit `+Inf` bucket per the same contract as `observe`.
+		assert_eq!(sample_count(&registry, "finality_timeout", "external"), Some(2));
 	}
 }

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -354,8 +354,6 @@ pub enum RemovalReason {
 	DroppedInvalid,
 	/// Transaction reached the configured finality timeout without being finalized.
 	FinalityTimeout,
-	/// Transaction came in via block import but was unknown to the pool.
-	BlockImportUnknown,
 }
 
 impl RemovalReason {
@@ -370,7 +368,6 @@ impl RemovalReason {
 			Self::DroppedLimits => "dropped_limits",
 			Self::DroppedInvalid => "dropped_invalid",
 			Self::FinalityTimeout => "finality_timeout",
-			Self::BlockImportUnknown => "block_import_unknown",
 		}
 	}
 }

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/metrics.rs
@@ -364,9 +364,6 @@ pub enum RemovalReason {
 /// Used by [`TxAgeAtRemovalHistogram::observe_batch`] to record the residence
 /// time of a batch of removed transactions without forcing each call site to
 /// thread `source` and `timestamp` manually.
-// Call sites are wired in a follow-up commit; allow dead_code so the API can
-// land independently from its consumers.
-#[allow(dead_code)]
 pub(super) trait HasSource {
 	/// Returns a reference to the source of the transaction.
 	fn timed_source(&self) -> &TimedTransactionSource;
@@ -454,8 +451,6 @@ impl TxAgeAtRemovalHistogram {
 	/// `removed_at` is taken once at the call site so every item in the batch
 	/// is anchored against the same instant — this matches the existing manual
 	/// loops the helper replaces.
-	// Call sites are wired in a follow-up commit.
-	#[allow(dead_code)]
 	pub(super) fn observe_batch<I>(&self, reason: RemovalReason, removed_at: Instant, items: I)
 	where
 		I: IntoIterator,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -724,11 +724,11 @@ where
 
 		let mut invalid_hashes_subtrees = Vec::new();
 		// Include also subtree txs.
-		for (tx, _, reason) in &invalid_hashes {
+		for (tx, _, invalid_reason) in &invalid_hashes {
 			let txs_in_subtree =
 				view_store.remove_transaction_subtree(*tx, |_, _| {}).into_iter().map(|tx| {
 					let subtree_source = tx.source.clone();
-					(tx.hash, subtree_source, InvalidTxReason::Subtree(reason.to_string()))
+					(tx.hash, subtree_source, InvalidTxReason::Subtree(invalid_reason.to_string()))
 				});
 			invalid_hashes_subtrees.extend(txs_in_subtree);
 		}
@@ -742,10 +742,10 @@ where
 		let invalid_hashes = invalid_hashes
 			.into_iter()
 			.chain(invalid_hashes_subtrees)
-			.map(|(tx, tx_source, reason)| {
+			.map(|(tx, tx_source, invalid_reason)| {
 				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
 				self.metrics.report(|metrics| {
-					metrics.mempool_revalidation_invalid_txs.observe(&reason, 1);
+					metrics.mempool_revalidation_invalid_txs.observe(&invalid_reason, 1);
 					metrics.tx_age_at_removal.observe(
 						RemovalReason::InvalidRevalidationMempool,
 						tx_source.source,

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -225,8 +225,6 @@ where
 	///
 	/// Cheaper than [`Self::source`] when the caller only needs to read the
 	/// source (e.g. metric labels) without taking ownership.
-	// Used by `HasSource` impl in metrics.rs; call sites are wired in a follow-up commit.
-	#[allow(dead_code)]
 	pub(super) fn source_ref(&self) -> &TimedTransactionSource {
 		&self.source
 	}
@@ -737,6 +735,10 @@ where
 
 		let revalidated_invalid_hashes_len = invalid_hashes.len();
 		let removed_at = Instant::now();
+		// `observe_batch` doesn't fit here: each element carries a distinct
+		// `InvalidTxReason` that feeds a second metric
+		// (`mempool_revalidation_invalid_txs`), so the per-element observation
+		// can't be hoisted out of this fused iterator without a second pass.
 		let invalid_hashes = invalid_hashes
 			.into_iter()
 			.chain(invalid_hashes_subtrees)
@@ -780,16 +782,16 @@ where
 		);
 		log_xt_trace!(target: LOG_TARGET, finalized_xts, "purged finalized transactions");
 		let mut transactions = self.transactions.write().await;
+		let removed: Vec<_> = finalized_xts
+			.iter()
+			.filter_map(|tx_hash| transactions.remove(tx_hash))
+			.collect();
 		let removed_at = Instant::now();
-		for tx_hash in finalized_xts {
-			if let Some(tx) = transactions.remove(tx_hash) {
-				let age = tx.source.timestamp.map(|t| removed_at.saturating_duration_since(t));
-				let source = tx.source.source;
-				self.metrics.report(|metrics| {
-					metrics.tx_age_at_removal.observe(RemovalReason::Finalized, source, age);
-				});
-			}
-		}
+		self.metrics.report(|metrics| {
+			metrics
+				.tx_age_at_removal
+				.observe_batch(RemovalReason::Finalized, removed_at, &removed);
+		});
 	}
 
 	/// Revalidates transactions in the memory pool against a given finalized block and removes

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -31,10 +31,10 @@
 //! See <https://github.com/paritytech/polkadot-sdk/issues/8912> for some more information. The implementation of the
 //! bridging is based on passing messages from sync context to tokio thread.
 
-use futures::{FutureExt, future::join_all};
+use futures::{future::join_all, FutureExt};
 use itertools::Itertools;
 use parking_lot::RwLock;
-use sc_transaction_pool_api::{TransactionPriority, TransactionSource, error::IntoMetricsLabel};
+use sc_transaction_pool_api::{error::IntoMetricsLabel, TransactionPriority, TransactionSource};
 use sp_blockchain::HashAndNumber;
 use sp_runtime::{
 	traits::Block as BlockT,
@@ -45,21 +45,21 @@ use std::{
 	future::Future,
 	pin::Pin,
 	sync::{
-		Arc,
 		atomic::{self, AtomicU64},
 		mpsc::{
-			Receiver as SyncBridgeReceiver, Sender as SyncBridgeSender,
-			channel as sync_bridge_channel,
+			channel as sync_bridge_channel, Receiver as SyncBridgeReceiver,
+			Sender as SyncBridgeSender,
 		},
+		Arc,
 	},
 	time::Instant,
 };
 use tracing::{debug, trace};
 
 use crate::{
-	LOG_TARGET, ValidateTransactionPriority,
 	common::tracing_log_xt::log_xt_trace,
-	graph::{self, ExtrinsicFor, ExtrinsicHash, base_pool::TimedTransactionSource},
+	graph::{self, base_pool::TimedTransactionSource, ExtrinsicFor, ExtrinsicHash},
+	ValidateTransactionPriority, LOG_TARGET,
 };
 
 use super::{
@@ -1063,7 +1063,7 @@ where
 #[cfg(test)]
 mod tx_mem_pool_tests {
 	use futures::future::join_all;
-	use substrate_test_runtime::{AccountId, Extrinsic, ExtrinsicBuilder, H256, Transfer};
+	use substrate_test_runtime::{AccountId, Extrinsic, ExtrinsicBuilder, Transfer, H256};
 	use substrate_test_runtime_client::Sr25519Keyring::*;
 
 	use crate::{

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -703,11 +703,7 @@ where
 						?validation_result,
 						"mempool::revalidate_inner cannot determine transaction validity"
 					);
-					Some((
-						tx_hash,
-						tx_source,
-						InvalidTxReason::Unknown(error.as_ref().to_string()),
-					))
+					Some((tx_hash, tx_source, InvalidTxReason::Unknown(error.as_ref().to_string())))
 				},
 				Ok(Err(TransactionValidityError::Invalid(error))) => {
 					trace!(
@@ -716,11 +712,7 @@ where
 						?validation_result,
 						"mempool::revalidate_inner transaction is invalid"
 					);
-					Some((
-						tx_hash,
-						tx_source,
-						InvalidTxReason::Invalid(error.as_ref().to_string()),
-					))
+					Some((tx_hash, tx_source, InvalidTxReason::Invalid(error.as_ref().to_string())))
 				},
 			})
 			.collect::<Vec<_>>();
@@ -728,10 +720,8 @@ where
 		let mut invalid_hashes_subtrees = Vec::new();
 		// Include also subtree txs.
 		for (tx, _, reason) in &invalid_hashes {
-			let txs_in_subtree = view_store
-				.remove_transaction_subtree(*tx, |_, _| {})
-				.into_iter()
-				.map(|tx| {
+			let txs_in_subtree =
+				view_store.remove_transaction_subtree(*tx, |_, _| {}).into_iter().map(|tx| {
 					let subtree_source = tx.source.clone();
 					(tx.hash, subtree_source, InvalidTxReason::Subtree(reason.to_string()))
 				});
@@ -791,11 +781,7 @@ where
 					let age = removed_at.saturating_duration_since(submitted_at);
 					let source = tx.source.source;
 					self.metrics.report(|metrics| {
-						metrics.tx_age_at_removal.observe(
-							RemovalReason::Finalized,
-							source,
-							age,
-						);
+						metrics.tx_age_at_removal.observe(RemovalReason::Finalized, source, age);
 					});
 				}
 			}

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -771,9 +771,22 @@ where
 		);
 		log_xt_trace!(target: LOG_TARGET, finalized_xts, "purged finalized transactions");
 		let mut transactions = self.transactions.write().await;
-		finalized_xts.iter().for_each(|t| {
-			transactions.remove(t);
-		});
+		let removed_at = Instant::now();
+		for tx_hash in finalized_xts {
+			if let Some(tx) = transactions.remove(tx_hash) {
+				if let Some(submitted_at) = tx.source.timestamp {
+					let age = removed_at.saturating_duration_since(submitted_at);
+					let source = tx.source.source;
+					self.metrics.report(|metrics| {
+						metrics.tx_age_at_removal.observe(
+							RemovalReason::Finalized,
+							source,
+							age,
+						);
+					});
+				}
+			}
+		}
 	}
 
 	/// Revalidates transactions in the memory pool against a given finalized block and removes

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -619,7 +619,7 @@ where
 	) -> Vec<Arc<TxInMemPool<ChainApi, Block>>> {
 		log_xt_trace!(target: LOG_TARGET, tx_hashes, "mempool::remove_transaction");
 		let mut transactions = self.transactions.write().await;
-		let mut removed = Vec::with_capacity(tx_hashes.len());
+		let mut removed = Vec::new();
 		for tx_hash in tx_hashes {
 			if let Some(tx) = transactions.remove(tx_hash) {
 				removed.push(tx);

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -63,7 +63,8 @@ use crate::{
 };
 
 use super::{
-	metrics::MetricsLink as PrometheusMetrics, multi_view_listener::MultiViewListener,
+	metrics::{MetricsLink as PrometheusMetrics, RemovalReason},
+	multi_view_listener::MultiViewListener,
 	view_store::ViewStore,
 };
 
@@ -649,6 +650,7 @@ where
 		};
 
 		let validations_futures = to_be_validated.into_iter().map(|(xt_hash, xt)| {
+			let xt_source = xt.source.clone();
 			self.api
 				.validate_transaction(
 					finalized_block.hash,
@@ -659,7 +661,7 @@ where
 				.map(move |validation_result| {
 					xt.validated_at
 						.store(finalized_block.number.into().as_u64(), atomic::Ordering::Relaxed);
-					(xt_hash, validation_result)
+					(xt_hash, xt_source, validation_result)
 				})
 		});
 		let validation_results = futures::future::join_all(validations_futures).await;
@@ -668,7 +670,7 @@ where
 		let duration = start.elapsed();
 		let invalid_hashes = validation_results
 			.into_iter()
-			.filter_map(|(tx_hash, validation_result)| match validation_result {
+			.filter_map(|(tx_hash, tx_source, validation_result)| match validation_result {
 				Ok(Ok(_) | Err(TransactionValidityError::Invalid(InvalidTransaction::Future))) => {
 					None
 				},
@@ -679,7 +681,7 @@ where
 						?validation_result,
 						"mempool::revalidate_inner error during revalidation"
 					);
-					Some((tx_hash, InvalidTxReason::ValidationFailed(error.label())))
+					Some((tx_hash, tx_source, InvalidTxReason::ValidationFailed(error.label())))
 				},
 				Ok(Err(TransactionValidityError::Unknown(error))) => {
 					trace!(
@@ -688,7 +690,11 @@ where
 						?validation_result,
 						"mempool::revalidate_inner cannot determine transaction validity"
 					);
-					Some((tx_hash, InvalidTxReason::Unknown(error.as_ref().to_string())))
+					Some((
+						tx_hash,
+						tx_source,
+						InvalidTxReason::Unknown(error.as_ref().to_string()),
+					))
 				},
 				Ok(Err(TransactionValidityError::Invalid(error))) => {
 					trace!(
@@ -697,28 +703,44 @@ where
 						?validation_result,
 						"mempool::revalidate_inner transaction is invalid"
 					);
-					Some((tx_hash, InvalidTxReason::Invalid(error.as_ref().to_string())))
+					Some((
+						tx_hash,
+						tx_source,
+						InvalidTxReason::Invalid(error.as_ref().to_string()),
+					))
 				},
 			})
 			.collect::<Vec<_>>();
 
 		let mut invalid_hashes_subtrees = Vec::new();
 		// Include also subtree txs.
-		for (tx, reason) in &invalid_hashes {
+		for (tx, _, reason) in &invalid_hashes {
 			let txs_in_subtree = view_store
 				.remove_transaction_subtree(*tx, |_, _| {})
 				.into_iter()
-				.map(|tx| (tx.hash, InvalidTxReason::Subtree(reason.to_string())));
+				.map(|tx| {
+					let subtree_source = tx.source.clone();
+					(tx.hash, subtree_source, InvalidTxReason::Subtree(reason.to_string()))
+				});
 			invalid_hashes_subtrees.extend(txs_in_subtree);
 		}
 
 		let revalidated_invalid_hashes_len = invalid_hashes.len();
+		let now = Instant::now();
 		let invalid_hashes = invalid_hashes
 			.into_iter()
 			.chain(invalid_hashes_subtrees)
-			.map(|(tx, reason)| {
-				self.metrics
-					.report(|metrics| metrics.mempool_revalidation_invalid_txs.observe(&reason, 1));
+			.map(|(tx, tx_source, reason)| {
+				self.metrics.report(|metrics| {
+					metrics.mempool_revalidation_invalid_txs.observe(&reason, 1);
+					if let Some(submitted_at) = tx_source.timestamp {
+						metrics.tx_age_at_removal.observe(
+							RemovalReason::InvalidRevalidationMempool,
+							tx_source.source,
+							now.saturating_duration_since(submitted_at),
+						);
+					}
+				});
 				tx
 			})
 			.collect::<HashSet<_>>();

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -731,15 +731,14 @@ where
 			.into_iter()
 			.chain(invalid_hashes_subtrees)
 			.map(|(tx, tx_source, reason)| {
+				let age = tx_source.timestamp.map(|t| removed_at.saturating_duration_since(t));
 				self.metrics.report(|metrics| {
 					metrics.mempool_revalidation_invalid_txs.observe(&reason, 1);
-					if let Some(submitted_at) = tx_source.timestamp {
-						metrics.tx_age_at_removal.observe(
-							RemovalReason::InvalidRevalidationMempool,
-							tx_source.source,
-							removed_at.saturating_duration_since(submitted_at),
-						);
-					}
+					metrics.tx_age_at_removal.observe(
+						RemovalReason::InvalidRevalidationMempool,
+						tx_source.source,
+						age,
+					);
 				});
 				tx
 			})
@@ -774,13 +773,11 @@ where
 		let removed_at = Instant::now();
 		for tx_hash in finalized_xts {
 			if let Some(tx) = transactions.remove(tx_hash) {
-				if let Some(submitted_at) = tx.source.timestamp {
-					let age = removed_at.saturating_duration_since(submitted_at);
-					let source = tx.source.source;
-					self.metrics.report(|metrics| {
-						metrics.tx_age_at_removal.observe(RemovalReason::Finalized, source, age);
-					});
-				}
+				let age = tx.source.timestamp.map(|t| removed_at.saturating_duration_since(t));
+				let source = tx.source.source;
+				self.metrics.report(|metrics| {
+					metrics.tx_age_at_removal.observe(RemovalReason::Finalized, source, age);
+				});
 			}
 		}
 	}

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -31,10 +31,10 @@
 //! See <https://github.com/paritytech/polkadot-sdk/issues/8912> for some more information. The implementation of the
 //! bridging is based on passing messages from sync context to tokio thread.
 
-use futures::{future::join_all, FutureExt};
+use futures::{FutureExt, future::join_all};
 use itertools::Itertools;
 use parking_lot::RwLock;
-use sc_transaction_pool_api::{error::IntoMetricsLabel, TransactionPriority, TransactionSource};
+use sc_transaction_pool_api::{TransactionPriority, TransactionSource, error::IntoMetricsLabel};
 use sp_blockchain::HashAndNumber;
 use sp_runtime::{
 	traits::Block as BlockT,
@@ -45,21 +45,21 @@ use std::{
 	future::Future,
 	pin::Pin,
 	sync::{
+		Arc,
 		atomic::{self, AtomicU64},
 		mpsc::{
-			channel as sync_bridge_channel, Receiver as SyncBridgeReceiver,
-			Sender as SyncBridgeSender,
+			Receiver as SyncBridgeReceiver, Sender as SyncBridgeSender,
+			channel as sync_bridge_channel,
 		},
-		Arc,
 	},
 	time::Instant,
 };
 use tracing::{debug, trace};
 
 use crate::{
+	LOG_TARGET, ValidateTransactionPriority,
 	common::tracing_log_xt::log_xt_trace,
-	graph::{self, base_pool::TimedTransactionSource, ExtrinsicFor, ExtrinsicHash},
-	ValidateTransactionPriority, LOG_TARGET,
+	graph::{self, ExtrinsicFor, ExtrinsicHash, base_pool::TimedTransactionSource},
 };
 
 use super::{
@@ -219,6 +219,16 @@ where
 	/// Returns the source of the transaction.
 	pub(crate) fn source(&self) -> TimedTransactionSource {
 		self.source.clone()
+	}
+
+	/// Returns a reference to the source of the transaction.
+	///
+	/// Cheaper than [`Self::source`] when the caller only needs to read the
+	/// source (e.g. metric labels) without taking ownership.
+	// Used by `HasSource` impl in metrics.rs; call sites are wired in a follow-up commit.
+	#[allow(dead_code)]
+	pub(super) fn source_ref(&self) -> &TimedTransactionSource {
+		&self.source
 	}
 
 	/// Returns the priority of the transaction.
@@ -1051,7 +1061,7 @@ where
 #[cfg(test)]
 mod tx_mem_pool_tests {
 	use futures::future::join_all;
-	use substrate_test_runtime::{AccountId, Extrinsic, ExtrinsicBuilder, Transfer, H256};
+	use substrate_test_runtime::{AccountId, Extrinsic, ExtrinsicBuilder, H256, Transfer};
 	use substrate_test_runtime_client::Sr25519Keyring::*;
 
 	use crate::{

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -607,12 +607,25 @@ where
 	}
 
 	/// Removes transactions with given hashes from the memory pool.
-	pub(super) async fn remove_transactions(&self, tx_hashes: &[ExtrinsicHash<ChainApi>]) {
+	///
+	/// Returns the list of transactions that were actually removed (a hash that was not present
+	/// in the pool yields no entry in the returned vector). Callers that know the cause of the
+	/// removal should pass the returned slice to
+	/// [`TxAgeAtRemovalHistogram::observe_batch`] so the residence time of each removed
+	/// transaction is recorded on the `tx_age_at_removal_seconds` histogram.
+	pub(super) async fn remove_transactions(
+		&self,
+		tx_hashes: &[ExtrinsicHash<ChainApi>],
+	) -> Vec<Arc<TxInMemPool<ChainApi, Block>>> {
 		log_xt_trace!(target: LOG_TARGET, tx_hashes, "mempool::remove_transaction");
 		let mut transactions = self.transactions.write().await;
+		let mut removed = Vec::with_capacity(tx_hashes.len());
 		for tx_hash in tx_hashes {
-			transactions.remove(tx_hash);
+			if let Some(tx) = transactions.remove(tx_hash) {
+				removed.push(tx);
+			}
 		}
+		removed
 	}
 
 	/// Revalidates a batch of transactions against the provided finalized block.

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -740,7 +740,7 @@ where
 						metrics.tx_age_at_removal.observe(
 							RemovalReason::InvalidRevalidationMempool,
 							tx_source.source,
-							now.saturating_duration_since(submitted_at),
+							removed_at.saturating_duration_since(submitted_at),
 						);
 					}
 				});

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -609,10 +609,7 @@ where
 	/// Removes transactions with given hashes from the memory pool.
 	///
 	/// Returns the list of transactions that were actually removed (a hash that was not present
-	/// in the pool yields no entry in the returned vector). Callers that know the cause of the
-	/// removal should pass the returned slice to
-	/// [`TxAgeAtRemovalHistogram::observe_batch`] so the residence time of each removed
-	/// transaction is recorded on the `tx_age_at_removal_seconds` histogram.
+	/// in the pool yields no entry in the returned vector).
 	pub(super) async fn remove_transactions(
 		&self,
 		tx_hashes: &[ExtrinsicHash<ChainApi>],

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/tx_mem_pool.rs
@@ -729,7 +729,7 @@ where
 		}
 
 		let revalidated_invalid_hashes_len = invalid_hashes.len();
-		let now = Instant::now();
+		let removed_at = Instant::now();
 		let invalid_hashes = invalid_hashes
 			.into_iter()
 			.chain(invalid_hashes_subtrees)

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -25,25 +25,25 @@
 
 use super::metrics::{MetricsLink as PrometheusMetrics, RemovalReason};
 use crate::{
+	LOG_TARGET,
 	common::tracing_log_xt::log_xt_trace,
 	graph::{
-		self, base_pool::TimedTransactionSource, BlockHash, ExtrinsicFor, ExtrinsicHash,
-		IsValidator, TransactionFor, ValidateTransactionPriority, ValidatedPoolSubmitOutcome,
-		ValidatedTransaction, ValidatedTransactionFor,
+		self, BlockHash, ExtrinsicFor, ExtrinsicHash, IsValidator, TransactionFor,
+		ValidateTransactionPriority, ValidatedPoolSubmitOutcome, ValidatedTransaction,
+		ValidatedTransactionFor, base_pool::TimedTransactionSource,
 	},
-	LOG_TARGET,
 };
 use indexmap::IndexMap;
 use parking_lot::Mutex;
-use sc_transaction_pool_api::{error::Error as TxPoolError, PoolStatus, TransactionStatus};
-use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
+use sc_transaction_pool_api::{PoolStatus, TransactionStatus, error::Error as TxPoolError};
+use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender, tracing_unbounded};
 use sp_blockchain::HashAndNumber;
 use sp_runtime::{
-	generic::BlockId, traits::Block as BlockT, transaction_validity::TransactionValidityError,
-	SaturatedConversion,
+	SaturatedConversion, generic::BlockId, traits::Block as BlockT,
+	transaction_validity::TransactionValidityError,
 };
 use std::{sync::Arc, time::Instant};
-use tracing::{debug, instrument, trace, Level};
+use tracing::{Level, debug, instrument, trace};
 
 pub(super) struct RevalidationResult<ChainApi: graph::ChainApi> {
 	revalidated: IndexMap<ExtrinsicHash<ChainApi>, ValidatedTransactionFor<ChainApi>>,
@@ -652,14 +652,11 @@ where
 						.map(|v| metrics.view_revalidation_resubmitted_txs.inc_by(v)),
 				);
 
-				for tx in &removed_invalid {
-					let age = tx.source.timestamp.map(|t| removed_at.saturating_duration_since(t));
-					metrics.tx_age_at_removal.observe(
-						RemovalReason::InvalidRevalidationView,
-						tx.source.source,
-						age,
-					);
-				}
+				metrics.tx_age_at_removal.observe_batch(
+					RemovalReason::InvalidRevalidationView,
+					removed_at,
+					&removed_invalid,
+				);
 			});
 
 			debug!(

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -653,13 +653,12 @@ where
 				);
 
 				for tx in &removed_invalid {
-					if let Some(submitted_at) = tx.source.timestamp {
-						metrics.tx_age_at_removal.observe(
-							RemovalReason::InvalidRevalidationView,
-							tx.source.source,
-							removed_at.saturating_duration_since(submitted_at),
-						);
-					}
+					let age = tx.source.timestamp.map(|t| removed_at.saturating_duration_since(t));
+					metrics.tx_age_at_removal.observe(
+						RemovalReason::InvalidRevalidationView,
+						tx.source.source,
+						age,
+					);
 				}
 			});
 

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -633,7 +633,8 @@ where
 			let start = Instant::now();
 			let revalidated_len = revalidation_result.revalidated.len();
 			let validated_pool = self.pool.validated_pool();
-			let removed_invalid = validated_pool.remove_invalid(&revalidation_result.invalid_hashes);
+			let removed_invalid =
+				validated_pool.remove_invalid(&revalidation_result.invalid_hashes);
 			let removed_at = Instant::now();
 			if revalidated_len > 0 {
 				self.pool.resubmit(revalidation_result.revalidated);

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -23,7 +23,7 @@
 //!
 //! Refer to [*View*](../index.html#view) section for more details.
 
-use super::metrics::MetricsLink as PrometheusMetrics;
+use super::metrics::{MetricsLink as PrometheusMetrics, RemovalReason};
 use crate::{
 	common::tracing_log_xt::log_xt_trace,
 	graph::{
@@ -633,7 +633,8 @@ where
 			let start = Instant::now();
 			let revalidated_len = revalidation_result.revalidated.len();
 			let validated_pool = self.pool.validated_pool();
-			validated_pool.remove_invalid(&revalidation_result.invalid_hashes);
+			let removed_invalid = validated_pool.remove_invalid(&revalidation_result.invalid_hashes);
+			let removed_at = Instant::now();
 			if revalidated_len > 0 {
 				self.pool.resubmit(revalidation_result.revalidated);
 			}
@@ -649,6 +650,16 @@ where
 						.try_into()
 						.map(|v| metrics.view_revalidation_resubmitted_txs.inc_by(v)),
 				);
+
+				for tx in &removed_invalid {
+					if let Some(submitted_at) = tx.source.timestamp {
+						metrics.tx_age_at_removal.observe(
+							RemovalReason::InvalidRevalidationView,
+							tx.source.source,
+							removed_at.saturating_duration_since(submitted_at),
+						);
+					}
+				}
 			});
 
 			debug!(

--- a/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
+++ b/substrate/client/transaction-pool/src/fork_aware_txpool/view.rs
@@ -25,25 +25,25 @@
 
 use super::metrics::{MetricsLink as PrometheusMetrics, RemovalReason};
 use crate::{
-	LOG_TARGET,
 	common::tracing_log_xt::log_xt_trace,
 	graph::{
-		self, BlockHash, ExtrinsicFor, ExtrinsicHash, IsValidator, TransactionFor,
-		ValidateTransactionPriority, ValidatedPoolSubmitOutcome, ValidatedTransaction,
-		ValidatedTransactionFor, base_pool::TimedTransactionSource,
+		self, base_pool::TimedTransactionSource, BlockHash, ExtrinsicFor, ExtrinsicHash,
+		IsValidator, TransactionFor, ValidateTransactionPriority, ValidatedPoolSubmitOutcome,
+		ValidatedTransaction, ValidatedTransactionFor,
 	},
+	LOG_TARGET,
 };
 use indexmap::IndexMap;
 use parking_lot::Mutex;
-use sc_transaction_pool_api::{PoolStatus, TransactionStatus, error::Error as TxPoolError};
-use sc_utils::mpsc::{TracingUnboundedReceiver, TracingUnboundedSender, tracing_unbounded};
+use sc_transaction_pool_api::{error::Error as TxPoolError, PoolStatus, TransactionStatus};
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use sp_blockchain::HashAndNumber;
 use sp_runtime::{
-	SaturatedConversion, generic::BlockId, traits::Block as BlockT,
-	transaction_validity::TransactionValidityError,
+	generic::BlockId, traits::Block as BlockT, transaction_validity::TransactionValidityError,
+	SaturatedConversion,
 };
 use std::{sync::Arc, time::Instant};
-use tracing::{Level, debug, instrument, trace};
+use tracing::{debug, instrument, trace, Level};
 
 pub(super) struct RevalidationResult<ChainApi: graph::ChainApi> {
 	revalidated: IndexMap<ExtrinsicHash<ChainApi>, ValidatedTransactionFor<ChainApi>>,

--- a/substrate/primitives/runtime/src/transaction_validity.rs
+++ b/substrate/primitives/runtime/src/transaction_validity.rs
@@ -18,8 +18,8 @@
 //! Transaction validity interface.
 
 use crate::{
-	Debug,
 	codec::{Decode, Encode},
+	Debug,
 };
 use alloc::{vec, vec::Vec};
 use scale_info::TypeInfo;
@@ -64,7 +64,8 @@ pub enum InvalidTransaction {
 	/// # Possible causes
 	///
 	/// For `FRAME`-based runtimes this would be caused by `current block number
-	/// - Era::birth block number > BlockHashCount`. (e.g. in Polkadot `BlockHashCount` = 2400, so a
+	/// - Era::birth block number > BlockHashCount`. (e.g. in Polkadot `BlockHashCount` = 2400, so
+	///   a
 	/// transaction with birth block number 1337 would be valid up until block number 1337 + 2400,
 	/// after which point the transaction would be considered to have an ancient birth block.)
 	AncientBirthBlock,

--- a/substrate/primitives/runtime/src/transaction_validity.rs
+++ b/substrate/primitives/runtime/src/transaction_validity.rs
@@ -18,8 +18,8 @@
 //! Transaction validity interface.
 
 use crate::{
-	codec::{Decode, Encode},
 	Debug,
+	codec::{Decode, Encode},
 };
 use alloc::{vec, vec::Vec};
 use scale_info::TypeInfo;
@@ -64,8 +64,7 @@ pub enum InvalidTransaction {
 	/// # Possible causes
 	///
 	/// For `FRAME`-based runtimes this would be caused by `current block number
-	/// - Era::birth block number > BlockHashCount`. (e.g. in Polkadot `BlockHashCount` = 2400, so
-	///   a
+	/// - Era::birth block number > BlockHashCount`. (e.g. in Polkadot `BlockHashCount` = 2400, so a
 	/// transaction with birth block number 1337 would be valid up until block number 1337 + 2400,
 	/// after which point the transaction would be considered to have an ancient birth block.)
 	AncientBirthBlock,
@@ -252,6 +251,8 @@ impl From<UnknownTransaction> for TransactionValidity {
 /// For instance we can disallow specific kinds of transactions if they were not produced
 /// by our local node (for instance off-chain workers).
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, Debug, TypeInfo, Hash)]
+#[cfg_attr(feature = "std", derive(strum::AsRefStr))]
+#[cfg_attr(feature = "std", strum(serialize_all = "snake_case"))]
 pub enum TransactionSource {
 	/// Transaction is already included in block.
 	///


### PR DESCRIPTION
# Description

This PR adds a new prometheus histogram for the **age of transactions at the moment of removal** from the fork-aware transaction pool, fulfilling the first observability requirement of issue #7791.

The metric, `substrate_sub_txpool_tx_age_at_removal_seconds`, is labeled by:

- `reason`: one of `finalized | invalid_revalidation_mempool | invalid_revalidation_view | invalid_reported | dropped_usurped | dropped_limits | dropped_invalid | finality_timeout`.
- `source`: one of `local | external | in_block`.

Together with the existing `EventsHistograms` (which measure submission-to-event latency), this gives operators the data needed to empirically answer the question raised by @bkchr in #7783 (*"did we ever observe stuck transactions?"*) before any heuristic-based detection logic is introduced.

Closes part of #7791. Refs: #7783.

## Integration

Node operators querying Prometheus will see a new histogram metric. No breaking changes; existing metrics are untouched.

Dashboards can now graph high-age buckets per `reason` to visualise transactions that lingered in the pool before leaving:

```promql
rate(substrate_sub_txpool_tx_age_at_removal_seconds_bucket{le="3600", reason="finality_timeout"}[5m])
```

No runtime impact, no API changes for downstream pool consumers.

## Review Notes

The PR is split into 10 small, atomic commits to make review tractable:

1. `feat(fatxpool): add tx_age_at_removal_seconds histogram metric` — registers the histogram, defines the `RemovalReason` enum and `source_label` mapping. No call sites instrumented yet.
2. `feat(fatxpool): record tx age on mempool revalidation removal`
3. `feat(fatxpool): record tx age on view revalidation removal`
4. `feat(fatxpool): record tx age on report_invalid removal`
5. `feat(fatxpool): record tx age on finalized removal`
6. `feat(fatxpool): record tx age on dropped transactions` — also makes `remove_transactions` return the removed `Vec<Arc<TxInMemPool>>` and threads `PrometheusMetrics` through `dropped_monitor_task`.
7. `feat(fatxpool): record tx age on finality timeout removal`
8. `refactor(fatxpool): drop BlockImportUnknown from RemovalReason` — this case is not a pool removal (the tx was never in the pool), so it does not belong on the histogram. The existing `unknown_from_block_import_txs` counter already covers it.
9. `test(fatxpool): unit tests for tx_age_at_removal metric API`
10. `style(fatxpool): apply nightly rustfmt`

Key design decisions worth flagging for review:

- **Per-call-site instrumentation, not a wrapper method.** `remove_transactions` stays as a low-level pool operation; the domain-aware caller is responsible for measuring. This mirrors the pattern in `purge_finalized_transactions` and `revalidate_inner` (already in the file) and in `report_invalid`. We considered a `remove_transactions_observed(hashes, reason)` wrapper but rejected it because it would either force a `Cleanup`/`SubmitFailed` variant that pollutes the histogram with near-zero samples, or leave a foot-gun where forgetting `_observed` silently drops metrics.
- **`MetricsLink` injected into `dropped_monitor_task` explicitly.** This task is a free function (no `self`), so we pass it the metrics handle the same way it receives `mempool` and `view_store`.
- **Mortality is intentionally not a label.** Mortality lives in signed extensions and is runtime-specific; the pool layer does not know about it. Operators that need to correlate mortality with stuck txs can do so by joining metrics with on-chain state.
- **Buckets:** `exponential_buckets(1.0, 2.5, 14)` covers ~1s up to ~41h. This range is appropriate for residence-time analysis (tx that stay in the pool for hours are the real signal of interest).

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required) — see comment below.
* [x] I have made corresponding changes to the documentation (prdoc to be added in a follow-up commit once the PR number is assigned).
* [x] I have added tests that prove my feature works.