### PR TITLE
UncheckedExtrinsic: Improve memory usage

### DIFF
--- a/prdoc/pr_11908.prdoc
+++ b/prdoc/pr_11908.prdoc
@@ -1,0 +1,10 @@
+title: 'UncheckedExtrinsic: Improve memory usage'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Improves the memory usage of the unchecked extrinsic by pre-allocating some buffers and preventing e.g. printing huge calls.
+crates:
+- name: frame-executive
+  bump: patch
+- name: sp-runtime
+  bump: patch

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -609,13 +609,14 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	(with_startup_data)(&block_import, &babe_link);
 
 	if let sc_service::config::Role::Authority { .. } = &role {
-		let proposer = sc_basic_authorship::ProposerFactory::new(
+		let mut proposer = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),
 			client.clone(),
 			transaction_pool.clone(),
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|x| x.handle()),
 		);
+		proposer.set_default_block_size_limit(15 * 1024 * 1024);
 
 		let client_clone = client.clone();
 		let slot_duration = babe_link.config().slot_duration();

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -205,9 +205,9 @@ type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 /// We assume that ~10% of the block weight is consumed by `on_initialize` handlers.
 /// This is used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
-/// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used
+/// We allow `Normal` extrinsics to fill up the block up to 95%, the rest can be used
 /// by  Operational  extrinsics.
-const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(95);
 /// We allow for 2 seconds of compute with a 6 second average block time, with maximum proof size.
 const MAXIMUM_BLOCK_WEIGHT: Weight =
 	Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2), u64::MAX);
@@ -216,7 +216,7 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	pub const Version: RuntimeVersion = VERSION;
 	pub RuntimeBlockLength: BlockLength = BlockLength::builder()
-		.max_length(5 * 1024 * 1024)
+		.max_length(15 * 1024 * 1024)
 		.modify_max_length_for_class(DispatchClass::Normal, |m| {
 			*m = NORMAL_DISPATCH_RATIO * *m
 		})

--- a/substrate/client/executor/runtime-test/build.rs
+++ b/substrate/client/executor/runtime-test/build.rs
@@ -27,17 +27,4 @@ fn main() {
 			.disable_runtime_version_section_check()
 			.build();
 	}
-
-	// and building with tracing activated
-	#[cfg(feature = "std")]
-	{
-		substrate_wasm_builder::WasmBuilder::new()
-			.with_current_project()
-			.export_heap_base()
-			.import_memory()
-			.set_file_name("wasm_binary_with_tracing.rs")
-			.append_to_rust_flags(r#"--cfg feature="with-tracing""#)
-			.disable_runtime_version_section_check()
-			.build();
-	}
 }

--- a/substrate/frame/executive/src/lib.rs
+++ b/substrate/frame/executive/src/lib.rs
@@ -865,8 +865,10 @@ where
 		sp_io::init_tracing();
 		let encoded = uxt.encode();
 		let encoded_len = encoded.len();
-		sp_tracing::enter_span!(sp_tracing::info_span!("apply_extrinsic",
-			ext=?sp_core::hexdisplay::HexDisplay::from(&encoded)));
+		sp_tracing::enter_span!(sp_tracing::info_span!(
+			"apply_extrinsic",
+			ext=?sp_core::hexdisplay::HexDisplay::from(&encoded)
+		));
 
 		let uxt = <Block::Extrinsic as codec::DecodeLimit>::decode_all_with_depth_limit(
 			MAX_EXTRINSIC_DEPTH,

--- a/substrate/frame/revive/src/evm/runtime.rs
+++ b/substrate/frame/revive/src/evm/runtime.rs
@@ -229,8 +229,8 @@ impl<Address: Encode, Signature: Encode, E: EthExtra> serde::Serialize
 	}
 }
 
-impl<'a, Address: Decode, Signature: Decode, E: EthExtra> serde::Deserialize<'a>
-	for UncheckedExtrinsic<Address, Signature, E>
+impl<'a, Address: DecodeWithMemTracking, Signature: DecodeWithMemTracking, E: EthExtra>
+	serde::Deserialize<'a> for UncheckedExtrinsic<Address, Signature, E>
 {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error>
 	where

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -512,7 +512,9 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 	{
 		let mut input = CountedInput::new(input);
 
-		let preamble = Decode::decode(&mut input)?;
+		// Decode the preamble using the same memory limit as we will use for the `call`.
+		// The preamble is not that big, but we play it safe.
+		let preamble = Call::decode_with_mem_limit(&mut input, MAX_CALL_SIZE.saturating_add(1))?;
 
 		struct CloneBytes<'a, I>(&'a mut I, Vec<u8>);
 		impl<I: Input> Input for CloneBytes<'_, I> {

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -514,7 +514,8 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 
 		// Decode the preamble using the same memory limit as we will use for the `call`.
 		// The preamble is not that big, but we play it safe.
-		let preamble = DecodeWithMemLimit::decode_with_mem_limit(&mut input, MAX_CALL_SIZE.saturating_add(1))?;
+		let preamble =
+			DecodeWithMemLimit::decode_with_mem_limit(&mut input, MAX_CALL_SIZE.saturating_add(1))?;
 
 		struct CloneBytes<'a, I>(&'a mut I, Vec<u8>);
 		impl<I: Input> Input for CloneBytes<'_, I> {

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -507,14 +507,14 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 
 	fn decode_with_len<I: Input>(input: &mut I, len: usize) -> Result<Self, codec::Error>
 	where
-		Preamble<Address, Signature, ExtensionV0, ExtensionOtherVersions>: Decode,
+		Preamble<Address, Signature, ExtensionV0, ExtensionOtherVersions>: DecodeWithMemTracking,
 		Call: DecodeWithMemTracking,
 	{
 		let mut input = CountedInput::new(input);
 
 		// Decode the preamble using the same memory limit as we will use for the `call`.
 		// The preamble is not that big, but we play it safe.
-		let preamble = Call::decode_with_mem_limit(&mut input, MAX_CALL_SIZE.saturating_add(1))?;
+		let preamble = DecodeWithMemLimit::decode_with_mem_limit(&mut input, MAX_CALL_SIZE.saturating_add(1))?;
 
 		struct CloneBytes<'a, I>(&'a mut I, Vec<u8>);
 		impl<I: Input> Input for CloneBytes<'_, I> {
@@ -761,11 +761,11 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 		MAX_CALL_SIZE,
 	>
 where
-	Address: Decode,
-	Signature: Decode,
+	Address: DecodeWithMemTracking,
+	Signature: DecodeWithMemTracking,
 	Call: DecodeWithMemTracking,
-	ExtensionV0: Decode,
-	ExtensionOtherVersions: DecodeWithVersion,
+	ExtensionV0: DecodeWithMemTracking,
+	ExtensionOtherVersions: DecodeWithVersionWithMemTracking,
 {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
 		// This is a little more complicated than usual since the binary format must be compatible
@@ -869,11 +869,11 @@ impl<
 		MAX_CALL_SIZE,
 	>
 where
-	Address: Decode,
-	Signature: Decode,
+	Address: DecodeWithMemTracking,
+	Signature: DecodeWithMemTracking,
 	Call: DecodeWithMemTracking,
-	ExtensionV0: Decode,
-	ExtensionOtherVersions: DecodeWithVersion,
+	ExtensionV0: DecodeWithMemTracking,
+	ExtensionOtherVersions: DecodeWithVersionWithMemTracking,
 {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error>
 	where
@@ -1027,10 +1027,10 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 		MAX_CALL_SIZE,
 	>
 where
-	Preamble<Address, Signature, ExtensionV0, ExtensionOtherVersions>: Decode,
+	Preamble<Address, Signature, ExtensionV0, ExtensionOtherVersions>: DecodeWithMemTracking,
 	Call: DecodeWithMemTracking,
-	ExtensionV0: Decode,
-	ExtensionOtherVersions: DecodeWithVersion + PipelineVersion,
+	ExtensionV0: DecodeWithMemTracking,
+	ExtensionOtherVersions: DecodeWithVersionWithMemTracking + PipelineVersion,
 {
 	fn decode_unprefixed(data: &[u8]) -> Result<Self, codec::Error> {
 		Self::decode_with_len(&mut &data[..], data.len())

--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -333,6 +333,11 @@ pub struct UncheckedExtrinsic<
 	/// are not bijective (encodes to the exact same bytes it was encoded from). If this `field`
 	/// is set, it is being used when re-encoding this transaction.
 	pub encoded_call: Option<Vec<u8>>,
+	/// The encoded length of this extrinsic.
+	///
+	/// Used internally to optimize some allocations, should be set to `None` if not known.
+	#[codec(skip)]
+	pub encoded_len: Option<usize>,
 }
 
 impl<
@@ -353,10 +358,18 @@ impl<
 	>
 {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.debug_struct("UncheckedExtrinsic")
-			.field("preamble", &self.preamble)
-			.field("function", &self.function)
-			.finish()
+		let mut debug_struct = f.debug_struct("UncheckedExtrinsic");
+
+		debug_struct.field("preamble", &self.preamble);
+
+		// Given our current allocator, we can at maximum allocate 32MiB and this is not enough for
+		// big transactions.
+		if self.encoded_len.unwrap_or_default() < 1024 * 1024 {
+			debug_struct.field("function", &self.function)
+		} else {
+			debug_struct.field("function", &"Too big to be printed from the runtime")
+		}
+		.finish()
 	}
 }
 
@@ -464,7 +477,7 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 		function: Call,
 		preamble: Preamble<Address, Signature, ExtensionV0, ExtensionOtherVersions>,
 	) -> Self {
-		Self { preamble, function, encoded_call: None }
+		Self { preamble, function, encoded_call: None, encoded_len: None }
 	}
 
 	/// New instance of a bare (ne unsigned) extrinsic.
@@ -527,7 +540,7 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 			}
 		}
 
-		let mut clone_bytes = CloneBytes(&mut input, Vec::new());
+		let mut clone_bytes = CloneBytes(&mut input, Vec::with_capacity(len));
 
 		// Adds 1 byte to the `MAX_CALL_SIZE` as the decoding fails exactly at the given value and
 		// the maximum should be allowed to fit in.
@@ -540,7 +553,7 @@ impl<Address, Call, Signature, ExtensionV0, ExtensionOtherVersions, const MAX_CA
 			return Err("Invalid length prefix".into());
 		}
 
-		Ok(Self { preamble, function, encoded_call })
+		Ok(Self { preamble, function, encoded_call, encoded_len: Some(len) })
 	}
 
 	fn encode_without_prefix(&self) -> Vec<u8>
@@ -647,9 +660,17 @@ where
 					CallAndMaybeEncoded { encoded: self.encoded_call, call: self.function },
 					tx_ext,
 				)?;
-				if !raw_payload.using_encoded(|payload| signature.verify(payload, &signed)) {
+
+				let mut payload = Vec::with_capacity(self.encoded_len.unwrap_or_default());
+				raw_payload.0.encode_to(&mut payload);
+
+				let payload =
+					if payload.len() > 256 { blake2_256(&payload).to_vec() } else { payload };
+
+				if !signature.verify(payload.as_ref(), &signed) {
 					return Err(InvalidTransaction::BadProof.into());
 				}
+
 				let (function, tx_ext, _) = raw_payload.deconstruct();
 				CheckedExtrinsic { format: ExtrinsicFormat::Signed(signed, tx_ext), function }
 			},
@@ -882,6 +903,13 @@ impl<T> From<T> for CallAndMaybeEncoded<T> {
 }
 
 impl<T: Encode> Encode for CallAndMaybeEncoded<T> {
+	fn encode_to<O: codec::Output + ?Sized>(&self, dest: &mut O) {
+		match &self.encoded {
+			Some(enc) => dest.write(enc),
+			None => self.call.encode_to(dest),
+		}
+	}
+
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
 		match &self.encoded {
 			Some(enc) => f(&enc),
@@ -1351,6 +1379,58 @@ mod tests {
 				format: ExtrinsicFormat::Signed(TEST_ACCOUNT, DummyExtension),
 				function: Call::Raw(vec![0u8; 0]).into()
 			}),
+		);
+	}
+
+	#[test]
+	fn large_signed_check_uses_blake2_256_hashed_payload() {
+		// A 257-byte call ensures the encoded `(call, ext, implicit)` tuple is > 256 bytes,
+		// triggering the blake2_256 hashing branch in both `SignedPayload::using_encoded`
+		// (used to build the signature here) and `check` (which re-derives the same
+		// payload). The two paths must produce the same bytes for `verify` to succeed.
+		let large_call_data = vec![0u8; 257];
+		let call: TestCall = large_call_data.clone().into();
+		let sig_payload = SignedPayload::from_raw(
+			call.clone(),
+			DummyExtension,
+			DummyExtension.implicit().unwrap(),
+		);
+
+		// Sanity-check the test setup: the *raw* encoded tuple is > 256 bytes, but
+		// `SignedPayload::encode()` returns the 32-byte blake2_256 hash.
+		let raw_payload = (call.clone(), DummyExtension, ()).encode();
+		assert!(raw_payload.len() > 256);
+		let signed_bytes = sig_payload.encode();
+		assert_eq!(signed_bytes.len(), 32);
+		assert_eq!(signed_bytes, blake2_256(&raw_payload).to_vec());
+
+		let ux =
+			Ex::new_signed(call, TEST_ACCOUNT, TestSig(TEST_ACCOUNT, signed_bytes), DummyExtension);
+		assert!(!ux.is_inherent());
+		assert_eq!(
+			<Ex as Checkable<TestContext>>::check(ux, &Default::default()),
+			Ok(CEx {
+				format: ExtrinsicFormat::Signed(TEST_ACCOUNT, DummyExtension),
+				function: Call::Raw(large_call_data).into(),
+			}),
+		);
+	}
+
+	#[test]
+	fn large_signed_check_fails_if_signed_over_unhashed_payload() {
+		// If the signer (incorrectly) signs the *raw* > 256 byte payload instead of the
+		// blake2_256 hash, `check` must reject it with `BadProof` because `check` always
+		// hashes payloads that exceed 256 bytes.
+		let large_call_data = vec![0u8; 257];
+		let call: TestCall = large_call_data.into();
+		let raw_payload = (call.clone(), DummyExtension, ()).encode();
+		assert!(raw_payload.len() > 256);
+
+		let ux =
+			Ex::new_signed(call, TEST_ACCOUNT, TestSig(TEST_ACCOUNT, raw_payload), DummyExtension);
+		assert_eq!(
+			<Ex as Checkable<TestContext>>::check(ux, &Default::default()),
+			Err(InvalidTransaction::BadProof.into()),
 		);
 	}
 

--- a/substrate/zombienet/zombienet-sdk/tests/zombie_ci/block_building.rs
+++ b/substrate/zombienet/zombienet-sdk/tests/zombie_ci/block_building.rs
@@ -187,9 +187,8 @@ async fn submit_large_remark_and_wait_finalization(node: &NetworkNode) -> Result
 
 	log::info!("Submitting {} MiB remark transaction", LARGE_REMARK_SIZE / (1024 * 1024));
 
-	let block_number = tokio::time::timeout(
-		Duration::from_secs(LARGE_REMARK_FINALIZATION_TIMEOUT_SECS),
-		async {
+	let block_number =
+		tokio::time::timeout(Duration::from_secs(LARGE_REMARK_FINALIZATION_TIMEOUT_SECS), async {
 			let in_block = client
 				.tx()
 				.sign_and_submit_then_watch_default(&remark_call, &signer)
@@ -200,10 +199,9 @@ async fn submit_large_remark_and_wait_finalization(node: &NetworkNode) -> Result
 			in_block.wait_for_success().await?;
 			let block = client.blocks().at(block_hash).await?;
 			Ok::<u32, subxt::Error>(block.number())
-		},
-	)
-	.await
-	.map_err(|_| anyhow!("large remark transaction timed out"))??;
+		})
+		.await
+		.map_err(|_| anyhow!("large remark transaction timed out"))??;
 
 	log::info!("Large remark transaction finalized in block #{block_number}");
 

--- a/substrate/zombienet/zombienet-sdk/tests/zombie_ci/block_building.rs
+++ b/substrate/zombienet/zombienet-sdk/tests/zombie_ci/block_building.rs
@@ -4,14 +4,13 @@
 use std::time::Duration;
 
 use crate::utils::{
-	env_or_default, initialize_network, log_line_absent, BEST_BLOCK_METRIC, CHAIN_SPEC_ENV,
-	DEFAULT_CHAIN_SPEC, DEFAULT_SUBSTRATE_IMAGE, INTEGRATION_IMAGE_ENV, NODE_ROLE_METRIC,
-	PEER_COUNT_METRIC,
+	env_or_default, initialize_network, log_line_absent, BEST_BLOCK_METRIC,
+	DEFAULT_SUBSTRATE_IMAGE, INTEGRATION_IMAGE_ENV, NODE_ROLE_METRIC, PEER_COUNT_METRIC,
 };
 use anyhow::{anyhow, Result};
 use subxt::{config::substrate::SubstrateConfig, dynamic::tx, OnlineClient};
 use subxt_signer::sr25519::dev;
-use zombienet_sdk::{NetworkConfig, NetworkConfigBuilder, NetworkNode};
+use zombienet_sdk::{Arg, NetworkConfig, NetworkConfigBuilder, NetworkNode};
 
 const NODE_NAMES: [&str; 2] = ["alice", "bob"];
 
@@ -19,12 +18,14 @@ const ROLE_VALIDATOR_VALUE: f64 = 4.0;
 const PEER_MIN_THRESHOLD: f64 = 1.0;
 const BLOCK_TARGET: f64 = 5.0;
 
-const NETWORK_READY_TIMEOUT_SECS: u64 = 60;
-const METRIC_TIMEOUT_SECS: u64 = 20;
+const NETWORK_READY_TIMEOUT_SECS: u64 = 180;
+const METRIC_TIMEOUT_SECS: u64 = 60;
 const LOG_TIMEOUT_SECS: u64 = 2;
 const TRANSACTION_TIMEOUT_SECS: u64 = 30;
 
 const REMARK_PAYLOAD: &[u8] = b"block-building-test";
+const LARGE_REMARK_SIZE: usize = 8 * 1024 * 1024;
+const LARGE_REMARK_FINALIZATION_TIMEOUT_SECS: u64 = 120;
 #[tokio::test(flavor = "multi_thread")]
 async fn block_building_test() -> Result<()> {
 	let _ = env_logger::try_init_from_env(
@@ -45,6 +46,18 @@ async fn block_building_test() -> Result<()> {
 	let alice = network.get_node("alice")?;
 	submit_transaction_and_wait_finalization(alice).await?;
 
+	let large_remark_block = submit_large_remark_and_wait_finalization(alice).await?;
+	let target_height = large_remark_block as f64;
+
+	let bob = network.get_node("bob")?;
+	bob.wait_metric_with_timeout(
+		BEST_BLOCK_METRIC,
+		|height| height >= target_height,
+		METRIC_TIMEOUT_SECS,
+	)
+	.await?;
+	log::info!("Bob imported block #{large_remark_block} containing the large remark");
+
 	network.destroy().await?;
 
 	Ok(())
@@ -52,7 +65,15 @@ async fn block_building_test() -> Result<()> {
 
 fn build_network_config() -> Result<NetworkConfig> {
 	let integration_image = env_or_default(INTEGRATION_IMAGE_ENV, DEFAULT_SUBSTRATE_IMAGE);
-	let chain_spec = env_or_default(CHAIN_SPEC_ENV, DEFAULT_CHAIN_SPEC);
+	let wasm_runtime_overrides = std::env::var("WASM_RUNTIME_OVERRIDES").ok();
+	let mut default_args = vec![
+		Arg::from("--rpc-max-request-size=100"),
+		Arg::from("--rpc-max-response-size=100"),
+		Arg::from("--log=wasm-heap=trace"),
+	];
+	if let Some(path) = wasm_runtime_overrides.as_ref() {
+		default_args.push(Arg::from(format!("--wasm-runtime-overrides={path}").as_str()));
+	}
 
 	let config = NetworkConfigBuilder::new()
 		.with_relaychain(|relaychain| {
@@ -60,7 +81,11 @@ fn build_network_config() -> Result<NetworkConfig> {
 				.with_chain("local")
 				.with_default_command("substrate")
 				.with_default_image(integration_image.as_str())
-				.with_chain_spec_path(chain_spec.as_str())
+				.with_chain_spec_command(
+					"substrate build-spec --chain {{chainName}} --disable-default-bootnode --raw",
+				)
+				.chain_spec_command_is_local(true)
+				.with_default_args(default_args)
 				.with_validator(|node| node.with_name("alice"))
 				.with_validator(|node| node.with_name("bob"))
 		})
@@ -127,4 +152,60 @@ async fn submit_transaction_and_wait_finalization(node: &NetworkNode) -> Result<
 	.map_err(|_| anyhow!("transaction timed out"))??;
 
 	Ok(())
+}
+
+async fn build_client_with_large_payload(url: &str) -> Result<OnlineClient<SubstrateConfig>> {
+	use subxt::ext::jsonrpsee::{
+		client_transport::ws::{Url, WsTransportClientBuilder},
+		core::client::Client,
+	};
+
+	let url = Url::parse(url).map_err(|e| anyhow!("invalid URL: {e}"))?;
+	let (sender, receiver) = WsTransportClientBuilder::default()
+		.max_request_size(100 * 1024 * 1024)
+		.max_response_size(100 * 1024 * 1024)
+		.build(url)
+		.await
+		.map_err(|e| anyhow!("WS transport failed: {e}"))?;
+
+	let rpc_client = Client::builder()
+		.max_buffer_capacity_per_subscription(4096)
+		.build_with_tokio(sender, receiver);
+
+	OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client)
+		.await
+		.map_err(|e| anyhow!("OnlineClient creation failed: {e}"))
+}
+
+async fn submit_large_remark_and_wait_finalization(node: &NetworkNode) -> Result<u32> {
+	let client = build_client_with_large_payload(node.ws_uri()).await?;
+	let signer = dev::alice();
+
+	let large_payload = vec![0u8; LARGE_REMARK_SIZE];
+	let remark_call =
+		tx("System", "remark", vec![subxt::dynamic::Value::from_bytes(&large_payload)]);
+
+	log::info!("Submitting {} MiB remark transaction", LARGE_REMARK_SIZE / (1024 * 1024));
+
+	let block_number = tokio::time::timeout(
+		Duration::from_secs(LARGE_REMARK_FINALIZATION_TIMEOUT_SECS),
+		async {
+			let in_block = client
+				.tx()
+				.sign_and_submit_then_watch_default(&remark_call, &signer)
+				.await?
+				.wait_for_finalized()
+				.await?;
+			let block_hash = in_block.block_hash();
+			in_block.wait_for_success().await?;
+			let block = client.blocks().at(block_hash).await?;
+			Ok::<u32, subxt::Error>(block.number())
+		},
+	)
+	.await
+	.map_err(|_| anyhow!("large remark transaction timed out"))??;
+
+	log::info!("Large remark transaction finalized in block #{block_number}");
+
+	Ok(block_number)
 }


### PR DESCRIPTION
Improves the memory usage of the unchecked extrinsic by pre-allocating some buffers and preventing e.g. printing huge calls.

