### PR TITLE
[pallet-assets-precompiles] Charge DepositEvent by data length, not topic count

### DIFF
--- a/prdoc/pr_11912.prdoc
+++ b/prdoc/pr_11912.prdoc
@@ -1,0 +1,22 @@
+title: '[pallet-assets-precompiles] Charge DepositEvent by data length, not topic
+  count'
+doc:
+- audience: Runtime Dev
+  description: "## Summary\n\n`deposit_event` in the assets ERC-20 precompile passed\
+    \ `topics.len()` for both the `num_topic` and `len` fields of `RuntimeCosts::DepositEvent`.\
+    \ The `len` field is the byte length of the event data payload, so the per-byte\
+    \ data cost was charged against the topic count (always 3 for the ERC-20 events\
+    \ emitted here) instead of the actual payload size \u2014 undercharging every\
+    \ `Transfer` and `Approval` emitted via this precompile by 7,640,746 ref_time\
+    \ and making its metering inconsistent with the EVM `LOG_n` path in `pallet-revive`,\
+    \ which correctly passes the data byte length.\n\n## Changes\n\n- `substrate/frame/assets/precompiles/src/lib.rs`:\
+    \ pass `data.len()` to `RuntimeCosts::DepositEvent { len }`.\n- `substrate/frame/assets/precompiles/src/tests.rs`:\
+    \ add `deposit_event_charges_data_byte_length` regression test that asserts a\
+    \ precompile `transfer`'s `weight_consumed` equals `WeightInfo::transfer() + DepositEvent{num_topic:\
+    \ 3, len: 32}.weight()`. Verified to pass with the fix and fail without it (off\
+    \ by exactly the per-byte event-charge delta).\n\n## Test plan\n- [x] Verified\
+    \ the new regression test fails when the bug is reintroduced and passes when the\
+    \ fix is in place"
+crates:
+- name: pallet-assets-precompiles
+  bump: patch

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -247,7 +247,7 @@ where
 		let topics = topics.into_iter().map(|v| H256(v.0)).collect::<Vec<_>>();
 		env.frame_meter_mut().charge_weight_token(RuntimeCosts::DepositEvent {
 			num_topic: topics.len() as u32,
-			len: topics.len() as u32,
+			len: data.len() as u32,
 		})?;
 		env.deposit_event(topics, data.to_vec());
 		Ok(())

--- a/substrate/frame/assets/precompiles/src/tests.rs
+++ b/substrate/frame/assets/precompiles/src/tests.rs
@@ -57,6 +57,62 @@ fn setup_asset_for_prefix(asset_id: u32, prefix: u16) {
 	}
 }
 
+// Regression test: `deposit_event` in lib.rs must pass `data.len()` (32 bytes for
+// every ERC-20 event emitted by this precompile) — not `topics.len()` (always 3) —
+// to the `len` field of `RuntimeCosts::DepositEvent`. The two are independent
+// arguments with different per-unit weights, so swapping them silently undercharges
+// the per-byte event cost on every Transfer/Approval.
+//
+// A bare-call `transfer` charges exactly `WeightInfo::transfer() + DepositEvent`,
+// so we can assert the consumed weight against that sum. With the bug, the actual
+// consumed weight is lower by `DepositEvent{len:32} - DepositEvent{len:3}` and the
+// equality fails.
+#[test]
+fn deposit_event_charges_data_byte_length() {
+	use pallet_revive::precompiles::Token;
+
+	new_test_ext().execute_with(|| {
+		let asset_id = 0u32;
+		let asset_addr = H160::from(set_prefix_in_address(PRECOMPILE_ADDRESS_PREFIX));
+		let from = 123456789;
+		let to = 987654321;
+		Balances::make_free_balance_be(&from, 100);
+		Balances::make_free_balance_be(&to, 100);
+		let to_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&to);
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, from, true, 1));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(from), asset_id, from, 100));
+
+		let data =
+			IERC20::transferCall { to: to_addr.0.into(), value: U256::from(10) }.abi_encode();
+
+		let result = pallet_revive::Pallet::<Test>::bare_call(
+			RuntimeOrigin::signed(from),
+			asset_addr,
+			0u32.into(),
+			TransactionLimits::WeightAndDeposit {
+				weight_limit: Weight::MAX,
+				deposit_limit: u64::MAX,
+			},
+			data,
+			&ExecConfig::new_substrate_tx(),
+		);
+		assert!(result.result.is_ok(), "transfer call failed: {:?}", result.result);
+
+		let expected =
+			<() as pallet_assets::WeightInfo>::transfer().saturating_add(<RuntimeCosts as Token<
+				Test,
+			>>::weight(
+				&RuntimeCosts::DepositEvent { num_topic: 3, len: 32 },
+			));
+		assert_eq!(
+			result.weight_consumed, expected,
+			"transfer weight does not match WeightInfo::transfer() + \
+			 DepositEvent{{num_topic: 3, len: 32}} — deposit_event has likely \
+			 regressed to charging len=topics.len() instead of len=data.len()",
+		);
+	});
+}
+
 #[test]
 fn asset_id_extractor_works() {
 	let address: [u8; 20] =


### PR DESCRIPTION

## Summary

`deposit_event` in the assets ERC-20 precompile passed `topics.len()` for both the `num_topic` and `len` fields of `RuntimeCosts::DepositEvent`. The `len` field is the byte length of the event data payload, so the per-byte data cost was charged against the topic count (always 3 for the ERC-20 events emitted here) instead of the actual payload size — undercharging every `Transfer` and `Approval` emitted via this precompile by 7,640,746 ref_time and making its metering inconsistent with the EVM `LOG_n` path in `pallet-revive`, which correctly passes the data byte length.

## Changes

- `substrate/frame/assets/precompiles/src/lib.rs`: pass `data.len()` to `RuntimeCosts::DepositEvent { len }`.
- `substrate/frame/assets/precompiles/src/tests.rs`: add `deposit_event_charges_data_byte_length` regression test that asserts a precompile `transfer`'s `weight_consumed` equals `WeightInfo::transfer() + DepositEvent{num_topic: 3, len: 32}.weight()`. Verified to pass with the fix and fail without it (off by exactly the per-byte event-charge delta).

## Test plan
- [x] Verified the new regression test fails when the bug is reintroduced and passes when the fix is in place
