### PR TITLE
wip/sync: Force peers into ancestry search when blocks are not locally known

### DIFF
--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -517,10 +517,15 @@ where
 			return None;
 		}
 
-		// The node is continuing a known fork if either the block itself is known, the
-		// parent is known or the block references the previously announced `best_hash`.
-		let continues_known_fork =
-			known || known_parent || announce.header.parent_hash() == &peer.best_hash;
+		// The node is continuing a known fork if either the block itself is know or the
+		// parent is known.
+		//
+		// We cannot follow the fork any longer when the parent of the announcement is
+		// the peer's current best, because the peer's current best is updated from the announcement
+		// itself and not from the block import. This means that if the parent is the peer's current
+		// best, the peer might be announcing a new fork that we haven't seen before, and we
+		// cannot be sure that it continues a known fork.
+		let continues_known_fork = known || known_parent;
 
 		let peer_info = is_best.then(|| {
 			// update their best block

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -520,11 +520,8 @@ where
 		// The node is continuing a known fork if either the block itself is know or the
 		// parent is known.
 		//
-		// We cannot follow the fork any longer when the parent of the announcement is
-		// the peer's current best, because the peer's current best is updated from the announcement
-		// itself and not from the block import. This means that if the parent is the peer's current
-		// best, the peer might be announcing a new fork that we haven't seen before, and we
-		// cannot be sure that it continues a known fork.
+		// We cannot follow the fork by simply looking at the peer best hash, since that
+		// can be re-announced by the peer from a different fork entirely.
 		let continues_known_fork = known || known_parent;
 
 		let peer_info = is_best.then(|| {


### PR DESCRIPTION
This PR ensures peers are forced into ancestry search regardless if the announcement is the peer's current best.
This is because peers can reannounce their current best and we might continue on a different fork entirely.
Eventually, this will catchup to importing a block with an unkown parent.

Part of: https://github.com/paritytech/polkadot-sdk/issues/11916
Prior work: https://github.com/paritytech/polkadot-sdk/pull/11085

## Next Steps

- [ ] Validate on version 