### PR TITLE
candidate-validation: precompile PVFs with next-session executor params (fixes #5505)

### DIFF
--- a/cumulus/client/relay-chain-minimal-node/src/blockchain_rpc_client.rs
+++ b/cumulus/client/relay-chain-minimal-node/src/blockchain_rpc_client.rs
@@ -501,6 +501,16 @@ impl RuntimeApiSubsystemClient for BlockChainRpcClient {
 			.parachain_host_ancestor_relay_parent_info(at, session_index, relay_parent)
 			.await?)
 	}
+
+	async fn session_executor_params_for_next_session(
+		&self,
+		at: Hash,
+	) -> Result<Option<polkadot_primitives::ExecutorParams>, sp_api::ApiError> {
+		Ok(self
+			.rpc_client
+			.parachain_host_session_executor_params_for_next_session(at)
+			.await?)
+	}
 }
 
 #[async_trait::async_trait]

--- a/cumulus/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -812,6 +812,18 @@ impl RelayChainRpcClient {
 		)
 		.await
 	}
+
+	pub async fn parachain_host_session_executor_params_for_next_session(
+		&self,
+		at: RelayHash,
+	) -> Result<Option<ExecutorParams>, RelayChainError> {
+		self.call_remote_runtime_function(
+			"ParachainHost_session_executor_params_for_next_session",
+			at,
+			None::<()>,
+		)
+		.await
+	}
 }
 
 /// Send `header` through all channels contained in `senders`.

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/rococo/src/lib.rs
@@ -25,7 +25,7 @@ use emulated_integration_tests_common::{
 
 // Rococo declaration
 decl_test_relay_chains! {
-	#[api_version(16)]
+	#[api_version(17)]
 	pub struct Rococo {
 		genesis = genesis::genesis(),
 		on_init = (),

--- a/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/lib.rs
+++ b/cumulus/parachains/integration-tests/emulated/chains/relays/westend/src/lib.rs
@@ -25,7 +25,7 @@ use emulated_integration_tests_common::{
 
 // Westend declaration
 decl_test_relay_chains! {
-	#[api_version(16)]
+	#[api_version(17)]
 	pub struct Westend {
 		genesis = genesis::genesis(),
 		on_init = (),

--- a/polkadot/node/core/candidate-validation/src/lib.rs
+++ b/polkadot/node/core/candidate-validation/src/lib.rs
@@ -900,6 +900,11 @@ where
 		.take(per_block_limit)
 		.collect::<Vec<_>>();
 
+	// Precompilation prepares artifacts for use *after* the next session change,
+	// so we ask for the params that will be in effect then, not the current
+	// ones. The validation path (see `validate_candidate`) keeps using the
+	// current-session params resolved by the orchestrator, since that's what
+	// applies to candidates being validated *now*.
 	let Ok(executor_params) = util::executor_params_for_next_session(relay_parent, sender).await
 	else {
 		gum::warn!(
@@ -930,6 +935,11 @@ where
 
 		let Some(session_index) = get_session_index(sender, relay_parent).await else { continue };
 
+		// The bomb limit is read from the current session — it gates code
+		// decompression at preparation time, which happens *now* against the
+		// `validation_code` we just fetched at this relay parent. Reading the
+		// next-session value here would be wrong: the limit must match the
+		// data flowing through this code path.
 		let validation_code_bomb_limit = match util::runtime::fetch_validation_code_bomb_limit(
 			relay_parent,
 			session_index,

--- a/polkadot/node/core/candidate-validation/src/lib.rs
+++ b/polkadot/node/core/candidate-validation/src/lib.rs
@@ -900,12 +900,12 @@ where
 		.take(per_block_limit)
 		.collect::<Vec<_>>();
 
-	let Ok(executor_params) = util::executor_params_at_relay_parent(relay_parent, sender).await
+	let Ok(executor_params) = util::executor_params_for_next_session(relay_parent, sender).await
 	else {
 		gum::warn!(
 			target: LOG_TARGET,
 			?relay_parent,
-			"cannot fetch executor params for the session",
+			"cannot fetch executor params for the next session",
 		);
 		return None;
 	};

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -2021,6 +2021,120 @@ fn maybe_prepare_validation_falls_back_when_runtime_does_not_support_v17() {
 	assert_eq!(*pvf.executor_params(), expected_params);
 }
 
+// Defensive fallback: even though the runtime impl always returns `Some`, a
+// future runtime regression could break that contract. The helper must treat
+// an unexpected `Ok(None)` the same as `NotSupported` and fall through to the
+// v13 path, otherwise the whole precompilation would silently be skipped.
+#[test]
+fn maybe_prepare_validation_falls_back_when_runtime_returns_none_for_next_session() {
+	let pool = TaskExecutor::new();
+	let (mut ctx, mut ctx_handle) = make_subsystem_context::<AllMessages, _>(pool);
+
+	let keystore = alice_keystore();
+	let mut backend = MockHeadsUp::default();
+	let activated_hash = Hash::random();
+	let update = dummy_active_leaves_update(activated_hash);
+	let mut state = State::default();
+
+	let fallback_params = ExecutorParams::from(&[ExecutorParam::MaxMemoryPages(512)][..]);
+	let expected_params = fallback_params.clone();
+
+	let check_fut =
+		handle_active_leaves_update(ctx.sender(), keystore, &mut backend, update, &mut state);
+
+	let test_fut = async move {
+		assert_new_active_leaf_messages(&mut ctx_handle, 1).await;
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::NodeFeatures(_, tx))) => {
+				let _ = tx.send(Ok(NodeFeatures::new()));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::Authorities(tx))) => {
+				let _ = tx.send(Ok(vec![Sr25519Keyring::Alice.public().into()]));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionInfo(index, tx))) => {
+				assert_eq!(index, 1);
+				let _ = tx.send(Ok(Some(dummy_session_info(vec![Sr25519Keyring::Bob.public()]))));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::CandidateEvents(tx))) => {
+				let _ = tx.send(Ok(vec![dummy_candidate_backed(activated_hash, dummy_hash().into())]));
+			}
+		);
+
+		// Runtime answers `Ok(None)` against its own contract — the helper
+		// must still fall through to the v13 path instead of bailing.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
+				let _ = tx.send(Ok(None));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(1));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(index, tx))) => {
+				assert_eq!(index, 1);
+				let _ = tx.send(Ok(Some(fallback_params)));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::ValidationCodeByHash(hash, tx))) => {
+				assert_eq!(hash, dummy_hash().into());
+				let _ = tx.send(Ok(Some(ValidationCode(Vec::new()))));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(1));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::ValidationCodeBombLimit(session, tx))) => {
+				assert_eq!(session, 1);
+				let _ = tx.send(Ok(VALIDATION_CODE_BOMB_LIMIT));
+			}
+		);
+	};
+
+	let test_fut = future::join(test_fut, check_fut);
+	executor::block_on(test_fut);
+
+	assert_eq!(backend.heads_up_call_count.load(Ordering::SeqCst), 1);
+	assert!(state.session_index.is_some());
+	assert!(state.pvf_prep.is_next_session_authority);
+
+	let calls = backend.heads_up_calls.lock().unwrap();
+	let prepared = calls.first().expect("heads_up was invoked once");
+	let pvf = prepared.first().expect("one PVF was queued for preparation");
+	assert_eq!(*pvf.executor_params(), expected_params);
+}
+
 #[test]
 fn maybe_prepare_validation_checkes_authority_once_per_session() {
 	let pool = TaskExecutor::new();
@@ -2143,6 +2257,11 @@ fn maybe_prepare_validation_does_not_prepare_pvfs_if_no_new_session_but_a_valida
 		..Default::default()
 	};
 
+	// Distinguishable params so we also assert here that the next-session API
+	// value flows into the resulting PvfPrepData.
+	let next_session_params = ExecutorParams::from(&[ExecutorParam::MaxMemoryPages(4096)][..]);
+	let expected_params = next_session_params.clone();
+
 	let check_fut =
 		handle_active_leaves_update(ctx.sender(), keystore, &mut backend, update, &mut state);
 
@@ -2159,7 +2278,7 @@ fn maybe_prepare_validation_does_not_prepare_pvfs_if_no_new_session_but_a_valida
 		assert_matches!(
 			ctx_handle.recv().await,
 			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
-				let _ = tx.send(Ok(Some(ExecutorParams::default())));
+				let _ = tx.send(Ok(Some(next_session_params)));
 			}
 		);
 
@@ -2193,6 +2312,11 @@ fn maybe_prepare_validation_does_not_prepare_pvfs_if_no_new_session_but_a_valida
 	assert_eq!(backend.heads_up_call_count.load(Ordering::SeqCst), 1);
 	assert!(state.session_index.is_some());
 	assert!(state.pvf_prep.is_next_session_authority);
+
+	let calls = backend.heads_up_calls.lock().unwrap();
+	let prepared = calls.first().expect("heads_up was invoked once");
+	let pvf = prepared.first().expect("one PVF was queued for preparation");
+	assert_eq!(*pvf.executor_params(), expected_params);
 }
 
 #[test]

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -34,8 +34,8 @@ use polkadot_node_subsystem_util::reexports::SubsystemContext;
 use polkadot_overseer::ActivatedLeaf;
 use polkadot_primitives::{
 	CandidateDescriptorV2, CandidateDescriptorVersion, ClaimQueueOffset,
-	CommittedCandidateReceiptError, CoreIndex, CoreSelector, GroupIndex, HeadData, Id as ParaId,
-	MutateDescriptorV2, NodeFeatures, OccupiedCoreAssumption, SessionInfo, UMPSignal,
+	CommittedCandidateReceiptError, CoreIndex, CoreSelector, ExecutorParam, GroupIndex, HeadData,
+	Id as ParaId, MutateDescriptorV2, NodeFeatures, OccupiedCoreAssumption, SessionInfo, UMPSignal,
 	UpwardMessage, ValidatorId, DEFAULT_SCHEDULING_LOOKAHEAD, UMP_SEPARATOR,
 };
 use polkadot_primitives_test_helpers::{
@@ -1659,6 +1659,7 @@ fn precheck_properly_classifies_outcomes() {
 #[derive(Default, Clone)]
 struct MockHeadsUp {
 	heads_up_call_count: Arc<AtomicUsize>,
+	heads_up_calls: Arc<std::sync::Mutex<Vec<Vec<PvfPrepData>>>>,
 }
 
 #[async_trait]
@@ -1676,8 +1677,9 @@ impl ValidationBackend for MockHeadsUp {
 		unreachable!()
 	}
 
-	async fn heads_up(&mut self, _active_pvfs: Vec<PvfPrepData>) -> Result<(), String> {
+	async fn heads_up(&mut self, active_pvfs: Vec<PvfPrepData>) -> Result<(), String> {
 		let _ = self.heads_up_call_count.fetch_add(1, Ordering::SeqCst);
+		self.heads_up_calls.lock().unwrap().push(active_pvfs);
 		Ok(())
 	}
 
@@ -1812,6 +1814,11 @@ fn maybe_prepare_validation_golden_path() {
 	let update = dummy_active_leaves_update(activated_hash);
 	let mut state = State::default();
 
+	// Distinguishable executor params so we can verify they reach `PvfPrepData`,
+	// and not the default ones that the fallback path would surface.
+	let next_session_params = ExecutorParams::from(&[ExecutorParam::MaxMemoryPages(2048)][..]);
+	let expected_params = next_session_params.clone();
+
 	let check_fut =
 		handle_active_leaves_update(ctx.sender(), keystore, &mut backend, update, &mut state);
 
@@ -1850,7 +1857,7 @@ fn maybe_prepare_validation_golden_path() {
 		assert_matches!(
 			ctx_handle.recv().await,
 			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
-				let _ = tx.send(Ok(Some(ExecutorParams::default())));
+				let _ = tx.send(Ok(Some(next_session_params)));
 			}
 		);
 
@@ -1884,6 +1891,13 @@ fn maybe_prepare_validation_golden_path() {
 	assert_eq!(backend.heads_up_call_count.load(Ordering::SeqCst), 1);
 	assert!(state.session_index.is_some());
 	assert!(state.pvf_prep.is_next_session_authority);
+
+	// Regression check for #5505: the precompiled PVF must be built with the
+	// next-session executor params returned by the runtime, not the defaults.
+	let calls = backend.heads_up_calls.lock().unwrap();
+	let prepared = calls.first().expect("heads_up was invoked once");
+	let pvf = prepared.first().expect("one PVF was queued for preparation");
+	assert_eq!(*pvf.executor_params(), expected_params);
 }
 
 #[test]

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -1849,15 +1849,7 @@ fn maybe_prepare_validation_golden_path() {
 
 		assert_matches!(
 			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
-				let _ = tx.send(Ok(1));
-			}
-		);
-
-		assert_matches!(
-			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(index, tx))) => {
-				assert_eq!(index, 1);
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
 				let _ = tx.send(Ok(Some(ExecutorParams::default())));
 			}
 		);
@@ -2031,15 +2023,7 @@ fn maybe_prepare_validation_does_not_prepare_pvfs_if_no_new_session_but_a_valida
 
 		assert_matches!(
 			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
-				let _ = tx.send(Ok(1));
-			}
-		);
-
-		assert_matches!(
-			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(index, tx))) => {
-				assert_eq!(index, 1);
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
 				let _ = tx.send(Ok(Some(ExecutorParams::default())));
 			}
 		);
@@ -2228,15 +2212,7 @@ fn maybe_prepare_validation_prepares_a_limited_number_of_pvfs() {
 
 		assert_matches!(
 			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
-				let _ = tx.send(Ok(1));
-			}
-		);
-
-		assert_matches!(
-			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(index, tx))) => {
-				assert_eq!(index, 1);
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
 				let _ = tx.send(Ok(Some(ExecutorParams::default())));
 			}
 		);
@@ -2318,15 +2294,7 @@ fn maybe_prepare_validation_does_not_prepare_already_prepared_pvfs() {
 
 		assert_matches!(
 			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
-				let _ = tx.send(Ok(1));
-			}
-		);
-
-		assert_matches!(
-			ctx_handle.recv().await,
-			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(index, tx))) => {
-				assert_eq!(index, 1);
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
 				let _ = tx.send(Ok(Some(ExecutorParams::default())));
 			}
 		);

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -1900,6 +1900,127 @@ fn maybe_prepare_validation_golden_path() {
 	assert_eq!(*pvf.executor_params(), expected_params);
 }
 
+// Verifies the graceful fallback for nodes running against a runtime that does not
+// yet implement v17: when `SessionExecutorParamsForNextSession` returns
+// `NotSupported`, the helper falls back to the v13 `SessionExecutorParams` path
+// and the PVF is still queued for preparation with the params returned there.
+#[test]
+fn maybe_prepare_validation_falls_back_when_runtime_does_not_support_v17() {
+	let pool = TaskExecutor::new();
+	let (mut ctx, mut ctx_handle) = make_subsystem_context::<AllMessages, _>(pool);
+
+	let keystore = alice_keystore();
+	let mut backend = MockHeadsUp::default();
+	let activated_hash = Hash::random();
+	let update = dummy_active_leaves_update(activated_hash);
+	let mut state = State::default();
+
+	// Distinguishable params returned by the v13 fallback path; we'll assert
+	// they reach `PvfPrepData` exactly.
+	let fallback_params = ExecutorParams::from(&[ExecutorParam::MaxMemoryPages(1024)][..]);
+	let expected_params = fallback_params.clone();
+
+	let check_fut =
+		handle_active_leaves_update(ctx.sender(), keystore, &mut backend, update, &mut state);
+
+	let test_fut = async move {
+		assert_new_active_leaf_messages(&mut ctx_handle, 1).await;
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::NodeFeatures(_, tx))) => {
+				let _ = tx.send(Ok(NodeFeatures::new()));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::Authorities(tx))) => {
+				let _ = tx.send(Ok(vec![Sr25519Keyring::Alice.public().into()]));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionInfo(index, tx))) => {
+				assert_eq!(index, 1);
+				let _ = tx.send(Ok(Some(dummy_session_info(vec![Sr25519Keyring::Bob.public()]))));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::CandidateEvents(tx))) => {
+				let _ = tx.send(Ok(vec![dummy_candidate_backed(activated_hash, dummy_hash().into())]));
+			}
+		);
+
+		// New v17 API: pretend the runtime does not implement it.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParamsForNextSession(tx))) => {
+				let _ = tx.send(Err(RuntimeApiError::NotSupported {
+					runtime_api_name: "session_executor_params_for_next_session",
+				}));
+			}
+		);
+
+		// Helper falls back through executor_params_at_relay_parent: first
+		// SessionIndexForChild, then SessionExecutorParams keyed by that session.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(1));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionExecutorParams(index, tx))) => {
+				assert_eq!(index, 1);
+				let _ = tx.send(Ok(Some(fallback_params)));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::ValidationCodeByHash(hash, tx))) => {
+				assert_eq!(hash, dummy_hash().into());
+				let _ = tx.send(Ok(Some(ValidationCode(Vec::new()))));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(1));
+			}
+		);
+
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::ValidationCodeBombLimit(session, tx))) => {
+				assert_eq!(session, 1);
+				let _ = tx.send(Ok(VALIDATION_CODE_BOMB_LIMIT));
+			}
+		);
+	};
+
+	let test_fut = future::join(test_fut, check_fut);
+	executor::block_on(test_fut);
+
+	assert_eq!(backend.heads_up_call_count.load(Ordering::SeqCst), 1);
+	assert!(state.session_index.is_some());
+	assert!(state.pvf_prep.is_next_session_authority);
+
+	// The fallback path must still feed the precompiled PVF with the params it
+	// received from the v13 API — not defaults, not nothing.
+	let calls = backend.heads_up_calls.lock().unwrap();
+	let prepared = calls.first().expect("heads_up was invoked once");
+	let pvf = prepared.first().expect("one PVF was queued for preparation");
+	assert_eq!(*pvf.executor_params(), expected_params);
+}
+
 #[test]
 fn maybe_prepare_validation_checkes_authority_once_per_session() {
 	let pool = TaskExecutor::new();

--- a/polkadot/node/core/runtime-api/src/cache.rs
+++ b/polkadot/node/core/runtime-api/src/cache.rs
@@ -84,6 +84,7 @@ pub(crate) struct RequestResultCache {
 	max_relay_parent_session_age: LruMap<SessionIndex, u32>,
 	ancestor_relay_parent_info:
 		LruMap<(Hash, SessionIndex, Hash), Option<RelayParentInfo<Hash, BlockNumber>>>,
+	session_executor_params_for_next_session: LruMap<Hash, Option<ExecutorParams>>,
 }
 
 impl Default for RequestResultCache {
@@ -128,6 +129,7 @@ impl Default for RequestResultCache {
 			para_ids: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			max_relay_parent_session_age: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 			ancestor_relay_parent_info: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
+			session_executor_params_for_next_session: LruMap::new(ByLength::new(DEFAULT_CACHE_CAP)),
 		}
 	}
 }
@@ -677,6 +679,21 @@ impl RequestResultCache {
 		self.ancestor_relay_parent_info
 			.insert((relay_parent, session_index, queried_relay_parent), value);
 	}
+
+	pub(crate) fn session_executor_params_for_next_session(
+		&mut self,
+		relay_parent: &Hash,
+	) -> Option<&Option<ExecutorParams>> {
+		self.session_executor_params_for_next_session.get(relay_parent).map(|v| &*v)
+	}
+
+	pub(crate) fn cache_session_executor_params_for_next_session(
+		&mut self,
+		relay_parent: Hash,
+		value: Option<ExecutorParams>,
+	) {
+		self.session_executor_params_for_next_session.insert(relay_parent, value);
+	}
 }
 
 pub(crate) enum RequestResult {
@@ -734,6 +751,7 @@ pub(crate) enum RequestResult {
 	MaxRelayParentSessionAge(SessionIndex, u32),
 	AncestorRelayParentInfo(Hash, SessionIndex, Hash, Option<RelayParentInfo<Hash, BlockNumber>>),
 	UnappliedSlashesV2(Hash, Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>),
+	SessionExecutorParamsForNextSession(Hash, Option<ExecutorParams>),
 }
 
 #[cfg(test)]

--- a/polkadot/node/core/runtime-api/src/lib.rs
+++ b/polkadot/node/core/runtime-api/src/lib.rs
@@ -229,6 +229,9 @@ where
 					info,
 				)
 			},
+			SessionExecutorParamsForNextSession(relay_parent, executor_params) => self
+				.requests_cache
+				.cache_session_executor_params_for_next_session(relay_parent, executor_params),
 		}
 	}
 
@@ -470,6 +473,17 @@ where
 						queried_relay_parent,
 						sender,
 					))
+				}
+			},
+			Request::SessionExecutorParamsForNextSession(sender) => {
+				if let Some(value) =
+					self.requests_cache.session_executor_params_for_next_session(&relay_parent)
+				{
+					self.metrics.on_cached_request();
+					let _ = sender.send(Ok(value.clone()));
+					None
+				} else {
+					Some(Request::SessionExecutorParamsForNextSession(sender))
 				}
 			},
 		}
@@ -831,6 +845,12 @@ where
 			UnappliedSlashesV2,
 			unapplied_slashes_v2(),
 			ver = Request::UNAPPLIED_SLASHES_V2_RUNTIME_REQUIREMENT,
+			sender
+		),
+		Request::SessionExecutorParamsForNextSession(sender) => query!(
+			SessionExecutorParamsForNextSession,
+			session_executor_params_for_next_session(),
+			ver = Request::SESSION_EXECUTOR_PARAMS_FOR_NEXT_SESSION_RUNTIME_REQUIREMENT,
 			sender
 		),
 	}

--- a/polkadot/node/core/runtime-api/src/tests.rs
+++ b/polkadot/node/core/runtime-api/src/tests.rs
@@ -261,6 +261,13 @@ impl RuntimeApiSubsystemClient for MockSubsystemClient {
 		todo!("Not required for tests")
 	}
 
+	async fn session_executor_params_for_next_session(
+		&self,
+		_: Hash,
+	) -> Result<Option<ExecutorParams>, ApiError> {
+		todo!("Not required for tests")
+	}
+
 	/// Approval voting configuration parameters
 	async fn approval_voting_params(
 		&self,

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -850,6 +850,9 @@ pub enum RuntimeApiRequest {
 		Hash,
 		RuntimeApiSender<Option<RelayParentInfo<Hash, BlockNumber>>>,
 	),
+	/// Get the executor parameters that will be in effect at the next session.
+	/// `V17`
+	SessionExecutorParamsForNextSession(RuntimeApiSender<Option<ExecutorParams>>),
 }
 
 impl RuntimeApiRequest {
@@ -911,6 +914,9 @@ impl RuntimeApiRequest {
 
 	/// `AncestorRelayParentInfo`
 	pub const ANCESTOR_RELAY_PARENT_INFO_RUNTIME_REQUIREMENT: u32 = 16;
+
+	/// `SessionExecutorParamsForNextSession`
+	pub const SESSION_EXECUTOR_PARAMS_FOR_NEXT_SESSION_RUNTIME_REQUIREMENT: u32 = 17;
 }
 
 /// A message to the Runtime API subsystem.

--- a/polkadot/node/subsystem-types/src/runtime_client.rs
+++ b/polkadot/node/subsystem-types/src/runtime_client.rs
@@ -379,6 +379,13 @@ pub trait RuntimeApiSubsystemClient {
 		session_index: SessionIndex,
 		relay_parent: Hash,
 	) -> Result<Option<RelayParentInfo<Hash, BlockNumber>>, ApiError>;
+
+	// == v17 ==
+	/// Fetch the executor parameters that will be in effect at the next session.
+	async fn session_executor_params_for_next_session(
+		&self,
+		at: Hash,
+	) -> Result<Option<ExecutorParams>, ApiError>;
 }
 
 /// Default implementation of [`RuntimeApiSubsystemClient`] using the client.
@@ -697,6 +704,13 @@ where
 		self.client
 			.runtime_api()
 			.ancestor_relay_parent_info(at, session_index, relay_parent)
+	}
+
+	async fn session_executor_params_for_next_session(
+		&self,
+		at: Hash,
+	) -> Result<Option<ExecutorParams>, ApiError> {
+		self.client.runtime_api().session_executor_params_for_next_session(at)
 	}
 }
 

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -508,10 +508,17 @@ pub async fn executor_params_at_relay_parent(
 /// scheduled an executor parameter change.
 ///
 /// Falls back to [`executor_params_at_relay_parent`] (current-session params)
-/// when the runtime does not yet implement the v17 API. In that case the
-/// caller still gets useful executor params; the worst-case is one extra
-/// preparation pass at the next session change, which is strictly better
-/// than skipping precompilation altogether.
+/// in two cases:
+///
+/// - the runtime does not yet implement the v17 API (`NotSupported`);
+/// - the runtime returned `Ok(None)`. The runtime impl is contracted to
+///   always return `Some` (it falls back to `ActiveConfig` itself), so this
+///   is a defensive guard: a future runtime regression must not silently
+///   disable precompilation.
+///
+/// In both cases the caller still gets useful executor params; the worst
+/// case is one extra preparation pass at the next session change, which is
+/// strictly better than skipping precompilation altogether.
 pub async fn executor_params_for_next_session(
 	relay_parent: Hash,
 	sender: &mut impl overseer::SubsystemSender<RuntimeApiMessage>,

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -308,6 +308,7 @@ specialize_requests! {
 		-> Option<ValidationCodeHash>; ValidationCodeHash;
 	fn request_on_chain_votes() -> Option<ScrapedOnChainVotes>; FetchOnChainVotes;
 	fn request_session_executor_params(session_index: SessionIndex) -> Option<ExecutorParams>;SessionExecutorParams;
+	fn request_session_executor_params_for_next_session() -> Option<ExecutorParams>; SessionExecutorParamsForNextSession;
 	fn request_unapplied_slashes() -> Vec<(SessionIndex, CandidateHash, slashing::LegacyPendingSlashes)>; UnappliedSlashes;
 	fn request_unapplied_slashes_v2() -> Vec<(SessionIndex, CandidateHash, slashing::PendingSlashes)>; UnappliedSlashesV2;
 	fn request_key_ownership_proof(validator_id: ValidatorId) -> Option<slashing::OpaqueKeyOwnershipProof>; KeyOwnershipProof;
@@ -496,6 +497,44 @@ pub async fn executor_params_at_relay_parent(
 				Ok(Ok(Some(executor_params))) => Ok(executor_params),
 			}
 		},
+	}
+}
+
+/// Requests the executor parameters that will be in effect at the next session.
+///
+/// Used by the candidate-validation subsystem to precompile PVFs with the
+/// parameters that will actually be active when the node becomes a validator
+/// next session, avoiding wasted preparation work when governance has
+/// scheduled an executor parameter change.
+///
+/// Falls back to [`executor_params_at_relay_parent`] (current-session params)
+/// when the runtime does not yet implement the v17 API. In that case the
+/// caller still gets useful executor params; the worst-case is one extra
+/// preparation pass at the next session change, which is strictly better
+/// than skipping precompilation altogether.
+pub async fn executor_params_for_next_session(
+	relay_parent: Hash,
+	sender: &mut impl overseer::SubsystemSender<RuntimeApiMessage>,
+) -> Result<ExecutorParams, Error> {
+	match request_session_executor_params_for_next_session(relay_parent, sender).await.await {
+		Err(err) => {
+			// Failed to communicate with the runtime
+			Err(Error::Oneshot(err))
+		},
+		Ok(Err(RuntimeApiError::NotSupported { .. })) => {
+			// Older runtime: fall back to the current-session params.
+			executor_params_at_relay_parent(relay_parent, sender).await
+		},
+		Ok(Err(err)) => {
+			// Runtime failed to execute the request
+			Err(Error::RuntimeApi(err))
+		},
+		Ok(Ok(None)) => {
+			// The runtime impl always returns Some (fallback to ActiveConfig);
+			// reaching None would indicate a runtime bug.
+			Err(Error::DataNotAvailable)
+		},
+		Ok(Ok(Some(executor_params))) => Ok(executor_params),
 	}
 }
 

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -533,9 +533,13 @@ pub async fn executor_params_for_next_session(
 			Err(Error::RuntimeApi(err))
 		},
 		Ok(Ok(None)) => {
-			// The runtime impl always returns Some (fallback to ActiveConfig);
-			// reaching None would indicate a runtime bug.
-			Err(Error::DataNotAvailable)
+			// The runtime impl always returns Some (fallback to ActiveConfig).
+			// Treating an unexpected None as a fallback rather than an error
+			// keeps the precompilation path useful if a future runtime
+			// regression broke that contract: one extra preparation pass at
+			// the next session change is strictly better than skipping
+			// precompilation altogether.
+			executor_params_at_relay_parent(relay_parent, sender).await
 		},
 		Ok(Ok(Some(executor_params))) => Ok(executor_params),
 	}

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -511,10 +511,9 @@ pub async fn executor_params_at_relay_parent(
 /// in two cases:
 ///
 /// - the runtime does not yet implement the v17 API (`NotSupported`);
-/// - the runtime returned `Ok(None)`. The runtime impl is contracted to
-///   always return `Some` (it falls back to `ActiveConfig` itself), so this
-///   is a defensive guard: a future runtime regression must not silently
-///   disable precompilation.
+/// - the runtime returned `Ok(None)`. The runtime impl is contracted to always return `Some` (it
+///   falls back to `ActiveConfig` itself), so this is a defensive guard: a future runtime
+///   regression must not silently disable precompilation.
 ///
 /// In both cases the caller still gets useful executor params; the worst
 /// case is one extra preparation pass at the next session change, which is

--- a/polkadot/node/subsystem-util/src/lib.rs
+++ b/polkadot/node/subsystem-util/src/lib.rs
@@ -516,7 +516,10 @@ pub async fn executor_params_for_next_session(
 	relay_parent: Hash,
 	sender: &mut impl overseer::SubsystemSender<RuntimeApiMessage>,
 ) -> Result<ExecutorParams, Error> {
-	match request_session_executor_params_for_next_session(relay_parent, sender).await.await {
+	match request_session_executor_params_for_next_session(relay_parent, sender)
+		.await
+		.await
+	{
 		Err(err) => {
 			// Failed to communicate with the runtime
 			Err(Error::Oneshot(err))

--- a/polkadot/primitives/src/runtime_api.rs
+++ b/polkadot/primitives/src/runtime_api.rs
@@ -343,5 +343,20 @@ sp_api::decl_runtime_apis! {
 			session_index: SessionIndex,
 			relay_parent: Hash,
 		) -> Option<RelayParentInfo<Hash, BlockNumber>>;
+
+		/***** Added in v17 *****/
+
+		/// Returns the executor parameters that will be in effect at the next session.
+		///
+		/// Reads `PendingConfigs` and returns the `executor_params` of the entry
+		/// scheduled to apply at `current_session + 1`, falling back to
+		/// `ActiveConfig.executor_params` when no such pending entry exists.
+		///
+		/// Used by the candidate-validation subsystem to precompile PVFs with the
+		/// parameters that will actually be in force when the node becomes a
+		/// validator next session, avoiding wasted preparation work when governance
+		/// has scheduled an executor parameter change.
+		#[api_version(17)]
+		fn session_executor_params_for_next_session() -> Option<ExecutorParams>;
 	}
 }

--- a/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -69,3 +69,93 @@ pub fn session_executor_params_for_next_session<T: configuration::Config + share
 		.unwrap_or_else(|| configuration::ActiveConfig::<T>::get().executor_params);
 	Some(params)
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		configuration::HostConfiguration,
+		mock::{new_test_ext, MockGenesisConfig, ParasShared, Test},
+	};
+	use polkadot_primitives::ExecutorParam;
+
+	fn params_with_max_memory_pages(pages: u32) -> ExecutorParams {
+		ExecutorParams::from(&[ExecutorParam::MaxMemoryPages(pages)][..])
+	}
+
+	#[test]
+	fn returns_pending_executor_params_when_scheduled_for_next_session() {
+		new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+			ParasShared::set_session_index(10);
+
+			let next_session_params = params_with_max_memory_pages(2048);
+			let mut pending_config = configuration::ActiveConfig::<Test>::get();
+			pending_config.executor_params = next_session_params.clone();
+			configuration::PendingConfigs::<Test>::put(vec![(11, pending_config)]);
+
+			assert_eq!(
+				session_executor_params_for_next_session::<Test>(),
+				Some(next_session_params)
+			);
+		});
+	}
+
+	#[test]
+	fn falls_back_to_active_config_when_no_pending_for_next_session() {
+		new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+			ParasShared::set_session_index(10);
+
+			// `PendingConfigs` defaults to empty; no need to put anything.
+			let active_params = params_with_max_memory_pages(1024);
+			let mut active = configuration::ActiveConfig::<Test>::get();
+			active.executor_params = active_params.clone();
+			configuration::ActiveConfig::<Test>::put(active);
+
+			assert_eq!(session_executor_params_for_next_session::<Test>(), Some(active_params));
+		});
+	}
+
+	#[test]
+	fn ignores_pending_scheduled_two_sessions_ahead() {
+		new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+			ParasShared::set_session_index(10);
+
+			let active_params = params_with_max_memory_pages(1024);
+			let scheduled_only_params = params_with_max_memory_pages(4096);
+
+			let mut active = HostConfiguration::default();
+			active.executor_params = active_params.clone();
+			configuration::ActiveConfig::<Test>::put(active);
+
+			let mut scheduled_config = configuration::ActiveConfig::<Test>::get();
+			scheduled_config.executor_params = scheduled_only_params;
+			// Pending only at current + 2 (scheduled_session); next session
+			// (current + 1) inherits ActiveConfig.
+			configuration::PendingConfigs::<Test>::put(vec![(12, scheduled_config)]);
+
+			assert_eq!(session_executor_params_for_next_session::<Test>(), Some(active_params));
+		});
+	}
+
+	#[test]
+	fn picks_next_session_entry_when_both_next_and_scheduled_pending() {
+		new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+			ParasShared::set_session_index(10);
+
+			let next_params = params_with_max_memory_pages(2048);
+			let scheduled_params = params_with_max_memory_pages(4096);
+
+			let mut next_config = configuration::ActiveConfig::<Test>::get();
+			next_config.executor_params = next_params.clone();
+			let mut scheduled_config = configuration::ActiveConfig::<Test>::get();
+			scheduled_config.executor_params = scheduled_params;
+
+			configuration::PendingConfigs::<Test>::put(vec![
+				(11, next_config),
+				(12, scheduled_config),
+			]);
+
+			assert_eq!(session_executor_params_for_next_session::<Test>(), Some(next_params));
+		});
+	}
+}

--- a/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -21,7 +21,7 @@ use alloc::vec::Vec;
 use frame_system::pallet_prelude::BlockNumberFor;
 
 use polkadot_primitives::{
-	slashing, vstaging::RelayParentInfo, CandidateHash, Id as ParaId, SessionIndex,
+	slashing, vstaging::RelayParentInfo, CandidateHash, ExecutorParams, Id as ParaId, SessionIndex,
 };
 
 /// Implementation of `para_ids` runtime API
@@ -49,4 +49,23 @@ pub fn ancestor_relay_parent_info<T: shared::Config>(
 	relay_parent: T::Hash,
 ) -> Option<RelayParentInfo<T::Hash, BlockNumberFor<T>>> {
 	shared::Pallet::<T>::get_relay_parent_info(session_index, relay_parent)
+}
+
+/// Implementation of `session_executor_params_for_next_session` runtime API.
+///
+/// Returns the executor params that will be in effect at `current_session + 1`.
+/// `PendingConfigs` may hold entries for `current + 1` and/or `current + 2`
+/// (the `scheduled_session`); only an entry matching `current + 1` exactly
+/// will be applied at the next session change. When no such entry exists
+/// the next session inherits the active configuration.
+pub fn session_executor_params_for_next_session<T: configuration::Config + shared::Config>(
+) -> Option<ExecutorParams> {
+	let next_session = shared::CurrentSessionIndex::<T>::get().saturating_add(1);
+	let pending = configuration::PendingConfigs::<T>::get();
+	let params = pending
+		.into_iter()
+		.find(|(apply_at_session, _)| *apply_at_session == next_session)
+		.map(|(_, config)| config.executor_params)
+		.unwrap_or_else(|| configuration::ActiveConfig::<T>::get().executor_params);
+	Some(params)
 }

--- a/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
+++ b/polkadot/runtime/parachains/src/runtime_api_impl/vstaging.rs
@@ -61,6 +61,8 @@ pub fn ancestor_relay_parent_info<T: shared::Config>(
 pub fn session_executor_params_for_next_session<T: configuration::Config + shared::Config>(
 ) -> Option<ExecutorParams> {
 	let next_session = shared::CurrentSessionIndex::<T>::get().saturating_add(1);
+	// `PendingConfigs` is bounded to at most two entries, sorted ascending by
+	// `apply_at_session`, so a linear scan is fine.
 	let pending = configuration::PendingConfigs::<T>::get();
 	let params = pending
 		.into_iter()

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -1990,7 +1990,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(16)]
+	#[api_version(17)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -2187,6 +2187,10 @@ sp_api::impl_runtime_apis! {
 			relay_parent: Hash,
 		) -> Option<polkadot_primitives::vstaging::RelayParentInfo<Hash, BlockNumber>> {
 			parachains_staging_runtime_api_impl::ancestor_relay_parent_info::<Runtime>(session_index, relay_parent)
+		}
+
+		fn session_executor_params_for_next_session() -> Option<ExecutorParams> {
+			parachains_staging_runtime_api_impl::session_executor_params_for_next_session::<Runtime>()
 		}
 	}
 

--- a/polkadot/runtime/test-runtime/src/lib.rs
+++ b/polkadot/runtime/test-runtime/src/lib.rs
@@ -965,7 +965,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(16)]
+	#[api_version(17)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			runtime_impl::validators::<Runtime>()
@@ -1159,6 +1159,10 @@ sp_api::impl_runtime_apis! {
 			relay_parent: Hash,
 		) -> Option<polkadot_primitives::vstaging::RelayParentInfo<Hash, BlockNumber>> {
 			staging_runtime_impl::ancestor_relay_parent_info::<Runtime>(session_index, relay_parent)
+		}
+
+		fn session_executor_params_for_next_session() -> Option<ExecutorParams> {
+			staging_runtime_impl::session_executor_params_for_next_session::<Runtime>()
 		}
 	}
 

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2186,7 +2186,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-	#[api_version(16)]
+	#[api_version(17)]
 	impl polkadot_primitives::runtime_api::ParachainHost<Block> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -2383,6 +2383,10 @@ sp_api::impl_runtime_apis! {
 			relay_parent: Hash,
 		) -> Option<polkadot_primitives::vstaging::RelayParentInfo<Hash, BlockNumber>> {
 			parachains_staging_runtime_api_impl::ancestor_relay_parent_info::<Runtime>(session_index, relay_parent)
+		}
+
+		fn session_executor_params_for_next_session() -> Option<ExecutorParams> {
+			parachains_staging_runtime_api_impl::session_executor_params_for_next_session::<Runtime>()
 		}
 	}
 

--- a/prdoc/pr_11920.prdoc
+++ b/prdoc/pr_11920.prdoc
@@ -46,3 +46,7 @@ crates:
     bump: minor
   - name: cumulus-relay-chain-minimal-node
     bump: minor
+  - name: westend-emulated-chain
+    bump: patch
+  - name: rococo-emulated-chain
+    bump: patch

--- a/prdoc/pr_11920.prdoc
+++ b/prdoc/pr_11920.prdoc
@@ -1,0 +1,44 @@
+title: 'candidate-validation: precompile PVFs with next-session executor params'
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      Fixes the PVF precompilation path in the candidate-validation subsystem
+      so it prepares artifacts using the executor params that will be in
+      effect at the next session, rather than the current-session ones.
+
+      Adds a new ParachainHost runtime API (v17)
+      `session_executor_params_for_next_session()` that reads `PendingConfigs`
+      and returns the `executor_params` of the entry scheduled to apply at
+      `current_session + 1`, with fallback to `ActiveConfig.executor_params`.
+      The candidate-validation subsystem uses this API while precompiling
+      PVFs as a future validator, so when governance has scheduled an
+      executor parameter change the precompiled artifacts are indexed under
+      the params that will actually be active and remain valid past the
+      session rollover.
+
+      Older runtimes that do not yet implement v17 are handled gracefully:
+      the node falls back to the current-session params, matching the
+      previous behavior.
+
+      Closes #5505.
+
+crates:
+  - name: polkadot-primitives
+    bump: minor
+  - name: polkadot-runtime-parachains
+    bump: minor
+  - name: rococo-runtime
+    bump: patch
+  - name: westend-runtime
+    bump: patch
+  - name: polkadot-test-runtime
+    bump: patch
+  - name: polkadot-node-subsystem-types
+    bump: major
+  - name: polkadot-node-core-runtime-api
+    bump: minor
+  - name: polkadot-node-subsystem-util
+    bump: minor
+  - name: polkadot-node-core-candidate-validation
+    bump: patch

--- a/prdoc/pr_11920.prdoc
+++ b/prdoc/pr_11920.prdoc
@@ -42,3 +42,7 @@ crates:
     bump: minor
   - name: polkadot-node-core-candidate-validation
     bump: patch
+  - name: cumulus-relay-chain-rpc-interface
+    bump: minor
+  - name: cumulus-relay-chain-minimal-node
+    bump: minor


### PR DESCRIPTION
## Summary

- Adds a new ParachainHost runtime API `session_executor_params_for_next_session()` (v17) that returns the executor params that will be active at `current_session + 1`, reading `PendingConfigs` with fallback to `ActiveConfig`.
- Wires the new API end-to-end (runtime impl, runtime-api subsystem routing/cache, subsystem-util helper).
- Switches `prepare_pvfs_for_backed_candidates` in `candidate-validation` to use the next-session params instead of the current-session ones, fixing the actual issue.

## Why

Closes #5505.

The PVF precompilation path runs while the node is *about to become* a validator next session. Today it reads `executor_params_at_relay_parent`, which resolves to `SessionExecutorParams[current_session]` — the params of the session that has not rolled over yet. If governance has scheduled an `executor_params` change for the next session (via `set_executor_params(...)`, queued in `PendingConfigs`), the prepared artifact is indexed under the wrong params and the PVF host re-prepares it on the first candidate after the session change — exactly the latency the precompilation was meant to avoid.

The new API exposes the next-session params by reading `PendingConfigs` and matching `apply_at_session == current + 1` (entries at `current + 2` are the `scheduled_session` and won't apply yet, so they're ignored), with fallback to `ActiveConfig.executor_params` when no pending entry matches.

## Design notes

**Cache key choice — node side**: the new `session_executor_params_for_next_session` cache in `polkadot-node-core-runtime-api` is keyed by `relay_parent: Hash` rather than by `SessionIndex = current + 1`. The value is conceptually session-scoped, so a `SessionIndex` key would have a higher hit rate; however, the API is parameterless (the runtime computes `current + 1` internally), so keying by `SessionIndex` would require the runtime-api subsystem to first resolve `session_index_for_child(relay_parent)` and use a custom dispatch path bypassing the `query!` macro. The current pattern keeps the wiring uniform with peers like `candidate_events` and `authorities` that key on `relay_parent` even when their values are session-stable. Marked as a follow-up; an issue should be opened to migrate B → A as a pure caching optimization without changing public API.

**Defensive fallback in `executor_params_for_next_session`**: the helper falls back to `executor_params_at_relay_parent` (current-session params) in two cases:

1. The runtime does not implement v17 (`RuntimeApiError::NotSupported`) — older runtimes.
2. The runtime returned `Ok(None)`. The runtime impl is contracted to always return `Some` (it falls back to `ActiveConfig.executor_params`), so this is purely defensive: a future runtime regression must not silently disable precompilation.

In both cases the worst case is one extra preparation pass at the next session change, strictly better than skipping precompilation altogether.

**v17 collision**: another in-flight branch in this repo also reserves `#[api_version(17)]`. Whoever lands second will need to bump to v18 at rebase time.

## Test plan

- [x] `cargo test -p polkadot-runtime-parachains 'runtime_api_impl::vstaging'` — 4 unit tests on `session_executor_params_for_next_session`: pending at `current+1`, no pending (fallback to `ActiveConfig`), pending only at `current+2` (must be ignored), both pending (picks `current+1`).
- [x] `cargo test -p polkadot-node-core-candidate-validation` — 40 tests pass. Two `maybe_prepare_validation_*` tests (`golden_path` and `_no_new_session_but_a_validator`) now use distinguishable executor params (`MaxMemoryPages(2048)` and `MaxMemoryPages(4096)`) and assert the values reach `PvfPrepData` — regression coverage for #5505. Three other `maybe_prepare_validation_*` tests updated to mock the new API variant.
- [x] **`NotSupported` fallback covered**: `maybe_prepare_validation_falls_back_when_runtime_does_not_support_v17` mocks the v17 API returning `NotSupported`, asserts the helper falls through to the v13 `SessionIndexForChild` + `SessionExecutorParams` pair, and verifies the fallback params actually reach `PvfPrepData`.
- [x] **`Ok(None)` fallback covered**: `maybe_prepare_validation_falls_back_when_runtime_returns_none_for_next_session` exercises the defensive guard against an unexpected `Ok(None)` from the runtime — same fall-through behavior as `NotSupported`, asserted end-to-end.
- [x] `SKIP_WASM_BUILD=1 cargo check -p rococo-runtime -p westend-runtime -p polkadot-test-runtime` — clean.

## Follow-ups

- **Cache key migration (tracked separately):** the new entry in the runtime-api subsystem cache is keyed by `relay_parent`. The value is session-stable, so keying by `SessionIndex = current + 1` would give a higher hit rate. Not done here to keep the wiring uniform with `query!`-based peers; will open a follow-up issue for the migration (no public-API impact).
