### PR TITLE
pallet-psm: switch Westend Asset Hub to Location AssetId backed by LocalAndForeignAssets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19680,6 +19680,7 @@ dependencies = [
  "pallet-psm-remote-tests",
  "sp-core 28.0.0",
  "sp-tracing 16.0.0",
+ "staging-xcm",
  "tokio",
 ]
 

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1346,6 +1346,7 @@ impl pallet_vesting_precompiles::pallet::Config for Runtime {
 parameter_types! {
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * RuntimeBlockWeights::get().max_block;
 	pub FastUnstakeName: &'static str = "FastUnstake";
+	pub PsmName: &'static str = "Psm";
 }
 
 impl pallet_migrations::Config for Runtime {
@@ -1570,19 +1571,28 @@ impl frame_support::traits::EnsureOrigin<RuntimeOrigin> for EnsurePsmManager {
 #[cfg(feature = "runtime-benchmarks")]
 pub struct PsmBenchmarkHelper;
 #[cfg(feature = "runtime-benchmarks")]
-impl pallet_psm::BenchmarkHelper<AssetIdForTrustBackedAssets, AccountId> for PsmBenchmarkHelper {
-	fn create_asset(asset_id: AssetIdForTrustBackedAssets, owner: &AccountId, decimals: u8) {
-		use frame_support::traits::fungibles::{metadata::Mutate as MetadataMutate, Create};
-		if !<Assets as frame_support::traits::fungibles::Inspect<AccountId>>::asset_exists(asset_id)
-		{
-			let _ = <Assets as Create<AccountId>>::create(asset_id, owner.clone(), true, 1);
+impl pallet_psm::BenchmarkHelper<xcm::v5::Location, AccountId> for PsmBenchmarkHelper {
+	fn get_asset_id(asset_index: u32) -> xcm::v5::Location {
+		Location::new(0, [PalletInstance(50), GeneralIndex(asset_index.into())])
+	}
+	fn create_asset(asset_id: xcm::v5::Location, owner: &AccountId, decimals: u8) {
+		use frame_support::traits::fungibles::{
+			metadata::Mutate as MetadataMutate, Create, Inspect,
+		};
+		if !<LocalAndForeignAssets as Inspect<AccountId>>::asset_exists(asset_id.clone()) {
+			let _ = <LocalAndForeignAssets as Create<AccountId>>::create(
+				asset_id.clone(),
+				owner.clone(),
+				true,
+				1,
+			);
 		}
 		let _ = Balances::force_set_balance(
 			RuntimeOrigin::root(),
 			owner.clone().into(),
 			10u128.pow(18),
 		);
-		let _ = <Assets as MetadataMutate<AccountId>>::set(
+		let _ = <LocalAndForeignAssets as MetadataMutate<AccountId>>::set(
 			asset_id,
 			owner,
 			b"Benchmark".to_vec(),
@@ -1593,8 +1603,8 @@ impl pallet_psm::BenchmarkHelper<AssetIdForTrustBackedAssets, AccountId> for Psm
 }
 
 impl pallet_psm::Config for Runtime {
-	type Fungibles = Assets;
-	type AssetId = AssetIdForTrustBackedAssets;
+	type Fungibles = LocalAndForeignAssets;
+	type AssetId = xcm::v5::Location;
 	type MaximumIssuance = dynamic_params::pusd::MaximumIssuance;
 	type ManagerOrigin = EnsurePsmManager;
 	type WeightInfo = weights::pallet_psm::WeightInfo<Runtime>;
@@ -1607,22 +1617,22 @@ impl pallet_psm::Config for Runtime {
 	type BenchmarkHelper = PsmBenchmarkHelper;
 }
 
-/// Initial PSM configuration applied via the V1 migration.
+/// Initial PSM configuration applied via the init migration.
 ///
-/// Sets up USDT (1984) as the first external asset.
+/// Sets up USDT (trust-backed asset `1984`, addressed by its `Location`) as the
+/// first external asset.
 pub struct PsmInitialConfig;
 impl pallet_psm::migrations::init::InitialPsmConfig<Runtime> for PsmInitialConfig {
 	fn max_psm_debt_of_total() -> Permill {
 		// USDT PSM cap is 5M out of 50M total issuance = 10%.
 		Permill::from_percent(10)
 	}
-
-	fn asset_configs() -> alloc::collections::btree_map::BTreeMap<
-		AssetIdForTrustBackedAssets,
-		(Permill, Permill, Permill),
-	> {
+	fn asset_configs(
+	) -> alloc::collections::btree_map::BTreeMap<xcm::v5::Location, (Permill, Permill, Permill)> {
+		use xcm::latest::prelude::*;
+		let usdt_location = xcm::v5::Location::new(0, [PalletInstance(50), GeneralIndex(1984)]);
 		[(
-			1984u32, // USDT
+			usdt_location,
 			(
 				Permill::zero(),                         // 0% minting fee
 				Permill::from_rational(1u32, 10_000u32), // 0.01% redemption fee
@@ -1890,10 +1900,11 @@ pub type Migrations = (
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
 	// unreleased
-	// PSM v1 -> v2: backfill ExternalDecimals/InternalDecimals snapshots for assets
-	// that were approved under v1 (no per-asset decimals). One-shot; only runs
-	// when the on-chain pallet storage version is 1, then bumps it to 2.
-	pallet_psm::migrations::decimals::PopulateDecimals<Runtime>,
+
+	// start: PSM reset
+	frame_support::migrations::RemovePallet<PsmName, <Runtime as frame_system::Config>::DbWeight>,
+	pallet_psm::migrations::init::InitializePsm<Runtime, PsmInitialConfig>,
+	// end: PSM reset
 	pallet_dap::migrations::MigrateV1ToV2<
 		Runtime,
 		DapLastIssuanceTimestamp,

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1348,12 +1348,30 @@ parameter_types! {
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * RuntimeBlockWeights::get().max_block;
 	pub FastUnstakeName: &'static str = "FastUnstake";
 	pub PsmName: &'static str = "Psm";
-	pub PsmDebtStorage: &'static str = "PsmDebt";
-	pub PsmMintingFeeStorage: &'static str = "MintingFee";
-	pub PsmRedemptionFeeStorage: &'static str = "RedemptionFee";
-	pub PsmMaxPsmDebtOfTotalStorage: &'static str = "MaxPsmDebtOfTotal";
-	pub PsmAssetCeilingWeightStorage: &'static str = "AssetCeilingWeight";
-	pub PsmExternalAssetsStorage: &'static str = "ExternalAssets";
+}
+
+/// One-shot migration: writes `pallet_psm`'s on-chain storage version to v2.
+/// Required because `RemovePallet<PsmName>` (above in the migration tuple)
+/// wipes the pallet's `:__STORAGE_VERSION__:` key, and `InitializePsm` doesn't
+/// re-seed it. Without this, try-runtime's post-upgrade check sees in-code = 2,
+/// on-chain = 0 and panics.
+pub struct SetPsmStorageVersionV2;
+impl frame_support::traits::OnRuntimeUpgrade for SetPsmStorageVersionV2 {
+	fn on_runtime_upgrade() -> Weight {
+		frame_support::traits::StorageVersion::new(2).put::<pallet_psm::Pallet<Runtime>>();
+		<Runtime as frame_system::Config>::DbWeight::get().writes(1)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(_: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		use frame_support::{ensure, traits::GetStorageVersion};
+		ensure!(
+			pallet_psm::Pallet::<Runtime>::on_chain_storage_version() ==
+				frame_support::traits::StorageVersion::new(2),
+			"PSM on-chain storage version was not set to 2"
+		);
+		Ok(())
+	}
 }
 
 impl pallet_migrations::Config for Runtime {
@@ -1909,38 +1927,14 @@ pub type Migrations = (
 	// unreleased
 
 	// start: PSM reset
-	frame_support::migrations::RemoveStorage<
-		PsmName,
-		PsmDebtStorage,
-		<Runtime as frame_system::Config>::DbWeight,
-	>,
-	frame_support::migrations::RemoveStorage<
-		PsmName,
-		PsmMintingFeeStorage,
-		<Runtime as frame_system::Config>::DbWeight,
-	>,
-	frame_support::migrations::RemoveStorage<
-		PsmName,
-		PsmRedemptionFeeStorage,
-		<Runtime as frame_system::Config>::DbWeight,
-	>,
-	frame_support::migrations::RemoveStorage<
-		PsmName,
-		PsmMaxPsmDebtOfTotalStorage,
-		<Runtime as frame_system::Config>::DbWeight,
-	>,
-	frame_support::migrations::RemoveStorage<
-		PsmName,
-		PsmAssetCeilingWeightStorage,
-		<Runtime as frame_system::Config>::DbWeight,
-	>,
-	frame_support::migrations::RemoveStorage<
-		PsmName,
-		PsmExternalAssetsStorage,
-		<Runtime as frame_system::Config>::DbWeight,
-	>,
+
+	// `RemovePallet` wipes ALL of PSM's storage (entries + CountedStorageMap
+	// counters + the storage version key). `InitializePsm` then re-seeds data
+	// under the new `Location` AssetId, and `SetPsmStorageVersionV2` writes
+	// the on-chain storage version that `RemovePallet` cleared.
+	frame_support::migrations::RemovePallet<PsmName, <Runtime as frame_system::Config>::DbWeight>,
 	pallet_psm::migrations::init::InitializePsm<Runtime, PsmInitialConfig>,
-	pallet_psm::migrations::PopulateDecimals<Runtime>,
+	SetPsmStorageVersionV2,
 	// end: PSM reset
 	pallet_dap::migrations::MigrateV1ToV2<
 		Runtime,

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1348,6 +1348,12 @@ parameter_types! {
 	pub MbmServiceWeight: Weight = Perbill::from_percent(80) * RuntimeBlockWeights::get().max_block;
 	pub FastUnstakeName: &'static str = "FastUnstake";
 	pub PsmName: &'static str = "Psm";
+	pub PsmDebtStorage: &'static str = "PsmDebt";
+	pub PsmMintingFeeStorage: &'static str = "MintingFee";
+	pub PsmRedemptionFeeStorage: &'static str = "RedemptionFee";
+	pub PsmMaxPsmDebtOfTotalStorage: &'static str = "MaxPsmDebtOfTotal";
+	pub PsmAssetCeilingWeightStorage: &'static str = "AssetCeilingWeight";
+	pub PsmExternalAssetsStorage: &'static str = "ExternalAssets";
 }
 
 impl pallet_migrations::Config for Runtime {
@@ -1903,7 +1909,36 @@ pub type Migrations = (
 	// unreleased
 
 	// start: PSM reset
-	frame_support::migrations::RemovePallet<PsmName, <Runtime as frame_system::Config>::DbWeight>,
+	frame_support::migrations::RemoveStorage<
+		PsmName,
+		PsmDebtStorage,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
+	frame_support::migrations::RemoveStorage<
+		PsmName,
+		PsmMintingFeeStorage,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
+	frame_support::migrations::RemoveStorage<
+		PsmName,
+		PsmRedemptionFeeStorage,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
+	frame_support::migrations::RemoveStorage<
+		PsmName,
+		PsmMaxPsmDebtOfTotalStorage,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
+	frame_support::migrations::RemoveStorage<
+		PsmName,
+		PsmAssetCeilingWeightStorage,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
+	frame_support::migrations::RemoveStorage<
+		PsmName,
+		PsmExternalAssetsStorage,
+		<Runtime as frame_system::Config>::DbWeight,
+	>,
 	pallet_psm::migrations::init::InitializePsm<Runtime, PsmInitialConfig>,
 	// end: PSM reset
 	pallet_dap::migrations::MigrateV1ToV2<

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1940,6 +1940,7 @@ pub type Migrations = (
 		<Runtime as frame_system::Config>::DbWeight,
 	>,
 	pallet_psm::migrations::init::InitializePsm<Runtime, PsmInitialConfig>,
+	pallet_psm::migrations::PopulateDecimals<Runtime>,
 	// end: PSM reset
 	pallet_dap::migrations::MigrateV1ToV2<
 		Runtime,

--- a/polkadot/utils/remote-ext-tests/psm/Cargo.toml
+++ b/polkadot/utils/remote-ext-tests/psm/Cargo.toml
@@ -20,6 +20,8 @@ pallet-psm-remote-tests = { workspace = true }
 sp-core = { workspace = true, default-features = true }
 sp-tracing = { workspace = true, default-features = true }
 
+xcm = { workspace = true }
+
 clap = { features = ["derive"], workspace = true }
 log = { workspace = true, default-features = true }
 tokio = { features = ["macros"], workspace = true, default-features = true }

--- a/polkadot/utils/remote-ext-tests/psm/src/main.rs
+++ b/polkadot/utils/remote-ext-tests/psm/src/main.rs
@@ -17,6 +17,7 @@
 //! Remote tests for pallet-psm against live Asset Hub state.
 
 use clap::{Parser, ValueEnum};
+use pallet_psm_remote_tests::PsmTestConfigOf;
 
 #[derive(Clone, Debug, ValueEnum)]
 #[value(rename_all = "PascalCase")]
@@ -35,11 +36,10 @@ struct Cli {
 	asset_id: u32,
 }
 
-fn asset_hub_westend_config(asset_id: u32) -> pallet_psm_remote_tests::PsmTestConfig {
-	let internal_asset_id = asset_hub_westend_runtime::PsmStablecoinAssetId::get();
-	pallet_psm_remote_tests::PsmTestConfig {
-		external_asset_id: asset_id,
-		internal_asset_id,
+fn asset_hub_westend_config(asset_id: u32) -> PsmTestConfigOf<asset_hub_westend_runtime::Runtime> {
+	use xcm::latest::prelude::*;
+	PsmTestConfigOf::<asset_hub_westend_runtime::Runtime> {
+		external_asset_id: Location::new(0, [PalletInstance(50), GeneralIndex(asset_id.into())]),
 		internal_asset_decimals: 6,
 		assets_pallet_name: "Assets".to_string(),
 		pre_create_hook: None,

--- a/prdoc/pr_11921.prdoc
+++ b/prdoc/pr_11921.prdoc
@@ -26,3 +26,9 @@ crates:
   bump: major
 - name: asset-hub-westend-runtime
   bump: major
+- name: kitchensink-runtime
+  bump: patch
+- name: pallet-psm-remote-tests
+  bump: major
+- name: remote-ext-tests-psm
+  bump: patch

--- a/prdoc/pr_11921.prdoc
+++ b/prdoc/pr_11921.prdoc
@@ -1,0 +1,28 @@
+title: 'pallet-psm: switch Westend Asset Hub to Location AssetId backed by LocalAndForeignAssets'
+
+doc:
+- audience: Runtime Dev
+  description: |-
+    On Asset Hub Westend, `pallet-psm` is switched from `u32` (trust-backed
+    asset id) to `xcm::v5::Location` as its `AssetId`, and from `Assets` to
+    `LocalAndForeignAssets` as its `Fungibles`. PSM can now mint and redeem
+    against both trust-backed and foreign-registered external stablecoins,
+    addressed uniformly by `Location`.
+
+    Storage migration: every `AssetId`-keyed PSM storage item is encoded under
+    the old `u32` key. The runtime wipes the existing PSM storage with
+    `frame_support::migrations::RemovePallet` and re-seeds the pallet from
+    `PsmInitialConfig` via `InitializePsm`. USDT (trust-backed asset `1984`)
+    is reseeded under its `Location` representation as the first external
+    asset.
+
+    `pallet-psm`'s `BenchmarkHelper` trait gains a `get_asset_id(index: u32)`
+    method so benchmark scenarios can derive a runtime-specific `AssetId`
+    (e.g. a `Location`) from a `u32` index. Existing impls need to add this
+    method.
+
+crates:
+- name: pallet-psm
+  bump: major
+- name: asset-hub-westend-runtime
+  bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3146,6 +3146,9 @@ impl frame_support::traits::EnsureOrigin<RuntimeOrigin> for EnsurePsmManager {
 pub struct PsmBenchmarkHelper;
 #[cfg(feature = "runtime-benchmarks")]
 impl pallet_psm::BenchmarkHelper<u32, AccountId> for PsmBenchmarkHelper {
+	fn get_asset_id(asset_index: u32) -> u32 {
+		asset_index
+	}
 	fn create_asset(asset_id: u32, owner: &AccountId, decimals: u8) {
 		use frame_support::traits::fungibles::{metadata::Mutate as MetadataMutate, Create};
 		if !<Assets as frame_support::traits::fungibles::Inspect<AccountId>>::asset_exists(asset_id)

--- a/substrate/frame/psm/remote-tests/src/lib.rs
+++ b/substrate/frame/psm/remote-tests/src/lib.rs
@@ -24,7 +24,10 @@
 use frame_support::{
 	assert_noop, assert_ok,
 	traits::{
-		fungible::{metadata::Inspect as FungibleMetadataInspect, Inspect as FungibleInspect},
+		fungible::{
+			metadata::{Inspect as FungibleMetadataInspect, Mutate as FungibleMetadataMutate},
+			Create as FungibleCreate, Inspect as FungibleInspect,
+		},
 		fungibles::{
 			metadata::{Inspect as FungiblesMetadataInspect, Mutate as FungiblesMetadataMutate},
 			Create as FungiblesCreate, Inspect as FungiblesInspect, Mutate as FungiblesMutate,
@@ -46,12 +49,16 @@ type BalanceOf<Runtime> =
 		<Runtime as frame_system::Config>::AccountId,
 	>>::Balance;
 
+/// Balance type used by the PSM pallet's fungibles.
+pub type AssetIdOf<Runtime> = <Runtime as pallet_psm::Config>::AssetId;
+
+/// [`PsmTestConfig`] for a given runtime.
+pub type PsmTestConfigOf<Runtime> = PsmTestConfig<AssetIdOf<Runtime>>;
+
 /// Configuration for which asset to use as the external stablecoin in tests.
-pub struct PsmTestConfig {
-	/// The external stablecoin asset ID (e.g., USDT = 1984).
-	pub external_asset_id: u32,
-	/// The internal asset ID. Will be created if it doesn't exist.
-	pub internal_asset_id: u32,
+pub struct PsmTestConfig<AssetId> {
+	/// The external stablecoin asset ID.
+	pub external_asset_id: AssetId,
 	/// The expected decimal precision for the internal asset (e.g., 6).
 	pub internal_asset_decimals: u8,
 	/// The pallet name for the assets pallet on the target chain (e.g., "Assets").
@@ -80,17 +87,17 @@ struct TestEnv<Runtime: pallet_psm::Config + frame_system::Config> {
 
 /// Create internal asset if needed, configure PSM, and fund test accounts.
 /// Must be called inside `execute_with`.
-fn setup<Runtime, InitialPsmConfig>(config: &PsmTestConfig) -> TestEnv<Runtime>
+fn setup<Runtime, InitialPsmConfig>(config: &PsmTestConfigOf<Runtime>) -> TestEnv<Runtime>
 where
 	Runtime: pallet_psm::Config + frame_system::Config,
-	Runtime::AssetId: From<u32>,
 	BalanceOf<Runtime>: TryFrom<u128> + core::fmt::Debug,
 	Runtime::Fungibles:
 		FungiblesCreate<Runtime::AccountId> + FungiblesMetadataMutate<Runtime::AccountId>,
+	Runtime::InternalAsset:
+		FungibleCreate<Runtime::AccountId> + FungibleMetadataMutate<Runtime::AccountId>,
 	InitialPsmConfig: pallet_psm::migrations::init::InitialPsmConfig<Runtime>,
 {
-	let asset_id: Runtime::AssetId = config.external_asset_id.into();
-	let internal_asset_id: Runtime::AssetId = config.internal_asset_id.into();
+	let asset_id = config.external_asset_id.clone();
 	let psm_account: Runtime::AccountId = Runtime::PalletId::get().into_account_truncating();
 
 	// Check that the external asset actually exists on-chain.
@@ -112,9 +119,8 @@ where
 	);
 
 	// Create the internal asset if it doesn't exist yet.
-	if !<Runtime::Fungibles as FungiblesInspect<Runtime::AccountId>>::asset_exists(
-		internal_asset_id.clone(),
-	) {
+	if <Runtime::InternalAsset as FungibleInspect<Runtime::AccountId>>::minimum_balance().is_zero()
+	{
 		// Run pre-create hook (e.g., set NextAssetId for AutoIncAssetId chains).
 		if let Some(hook) = &config.pre_create_hook {
 			hook();
@@ -122,16 +128,14 @@ where
 
 		let _ = frame_system::Pallet::<Runtime>::inc_providers(&psm_account);
 
-		assert_ok!(<Runtime::Fungibles as FungiblesCreate<Runtime::AccountId>>::create(
-			internal_asset_id.clone(),
+		assert_ok!(<Runtime::InternalAsset as FungibleCreate<Runtime::AccountId>>::create(
 			psm_account.clone(),
 			true,
 			10_000u128.try_into().unwrap_or_else(|_| panic!("balance conversion failed")),
 		));
 
 		// Set internal asset metadata using the configured decimals.
-		assert_ok!(<Runtime::Fungibles as FungiblesMetadataMutate<Runtime::AccountId>>::set(
-			internal_asset_id,
+		assert_ok!(<Runtime::InternalAsset as FungibleMetadataMutate<Runtime::AccountId>>::set(
 			&psm_account,
 			b"internal".to_vec(),
 			b"internal".to_vec(),
@@ -140,8 +144,7 @@ where
 
 		log::info!(
 			target: LOG_TARGET,
-			"Created internal asset (id={}) with {} decimals",
-			config.internal_asset_id,
+			"Created internal asset with {} decimals",
 			config.internal_asset_decimals,
 		);
 	}
@@ -232,14 +235,15 @@ pub fn clear_ext() {
 /// 4. Verifies balances, debt tracking, and fee accounting
 pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 	ext: &mut remote_externalities::RemoteExternalities<Block>,
-	config: &PsmTestConfig,
+	config: &PsmTestConfigOf<Runtime>,
 ) where
 	Runtime: pallet_psm::Config + frame_system::Config,
 	Block: BlockT,
-	Runtime::AssetId: From<u32>,
 	BalanceOf<Runtime>: TryFrom<u128> + core::fmt::Debug,
 	Runtime::Fungibles:
 		FungiblesCreate<Runtime::AccountId> + FungiblesMetadataMutate<Runtime::AccountId>,
+	Runtime::InternalAsset:
+		FungibleCreate<Runtime::AccountId> + FungibleMetadataMutate<Runtime::AccountId>,
 	InitialPsmConfig: pallet_psm::migrations::init::InitialPsmConfig<Runtime>,
 {
 	ext.execute_with(|| {
@@ -338,14 +342,15 @@ pub fn mint_and_redeem<Runtime, Block, InitialPsmConfig>(
 /// 4. Deactivates circuit breaker — verifies both operations resume
 pub fn circuit_breaker<Runtime, Block, InitialPsmConfig>(
 	ext: &mut remote_externalities::RemoteExternalities<Block>,
-	config: &PsmTestConfig,
+	config: &PsmTestConfigOf<Runtime>,
 ) where
 	Runtime: pallet_psm::Config + frame_system::Config,
 	Block: BlockT,
-	Runtime::AssetId: From<u32>,
 	BalanceOf<Runtime>: TryFrom<u128> + core::fmt::Debug,
 	Runtime::Fungibles:
 		FungiblesCreate<Runtime::AccountId> + FungiblesMetadataMutate<Runtime::AccountId>,
+	Runtime::InternalAsset:
+		FungibleCreate<Runtime::AccountId> + FungibleMetadataMutate<Runtime::AccountId>,
 	InitialPsmConfig: pallet_psm::migrations::init::InitialPsmConfig<Runtime>,
 {
 	ext.execute_with(|| {

--- a/substrate/frame/psm/src/benchmarking.rs
+++ b/substrate/frame/psm/src/benchmarking.rs
@@ -68,7 +68,6 @@ fn setup_assets<T: Config>(n: u32) -> T::AssetId
 where
 	T::Fungibles: FungiblesCreate<T::AccountId>,
 	T::InternalAsset: FungibleCreate<T::AccountId>,
-	T::AssetId: From<u32>,
 {
 	let admin: T::AccountId = whitelisted_caller();
 	let _ = frame_system::Pallet::<T>::inc_providers(&admin);
@@ -79,7 +78,7 @@ where
 	// helper. Setting metadata requires reserving a native deposit, which the
 	// helper handles by funding `admin` first — something the fungibles traits
 	// alone cannot express.
-	let target_id: T::AssetId = ASSET_ID_OFFSET.into();
+	let target_id: T::AssetId = T::BenchmarkHelper::get_asset_id(ASSET_ID_OFFSET);
 	if !T::Fungibles::asset_exists(target_id.clone()) {
 		T::BenchmarkHelper::create_asset(target_id.clone(), &admin, internal_decimals);
 	}
@@ -89,7 +88,7 @@ where
 	// entries. They are never swapped against, so their underlying fungibles
 	// asset does not need to exist and no ExternalDecimals snapshot is required.
 	for i in 0..n {
-		let id: T::AssetId = (ASSET_ID_OFFSET + i).into();
+		let id: T::AssetId = T::BenchmarkHelper::get_asset_id(ASSET_ID_OFFSET + i);
 		crate::ExternalAssets::<T>::insert(&id, CircuitBreakerLevel::AllEnabled);
 		crate::AssetCeilingWeight::<T>::insert(&id, Permill::from_percent(1));
 		crate::PsmDebt::<T>::insert(&id, BalanceOf::<T>::from(1u32));
@@ -102,7 +101,11 @@ where
 	target_id
 }
 
-#[benchmarks(where T::Fungibles: FungiblesCreate<T::AccountId>, T::InternalAsset: FungibleCreate<T::AccountId>, T::AssetId: From<u32>)]
+#[benchmarks(
+	where
+		T::Fungibles: FungiblesCreate<T::AccountId>,
+		T::InternalAsset: FungibleCreate<T::AccountId>,
+)]
 mod benchmarks {
 	use super::*;
 
@@ -218,7 +221,7 @@ mod benchmarks {
 		// reads the snapshot and compares it against live metadata.
 		let internal_decimals = ensure_internal_setup::<T>();
 		let caller: T::AccountId = whitelisted_caller();
-		let new_asset_id: T::AssetId = ASSET_ID_OFFSET.into();
+		let new_asset_id: T::AssetId = T::BenchmarkHelper::get_asset_id(ASSET_ID_OFFSET);
 
 		T::BenchmarkHelper::create_asset(new_asset_id.clone(), &caller, internal_decimals);
 

--- a/substrate/frame/psm/src/lib.rs
+++ b/substrate/frame/psm/src/lib.rs
@@ -103,6 +103,8 @@ pub use weights::WeightInfo;
 /// asset pallet.
 #[cfg(feature = "runtime-benchmarks")]
 pub trait BenchmarkHelper<AssetId, AccountId> {
+	/// Get the asset ID for a given asset index.
+	fn get_asset_id(asset_index: u32) -> AssetId;
 	/// Create an asset with metadata matching the internal asset's decimals.
 	fn create_asset(asset_id: AssetId, owner: &AccountId, decimals: u8);
 }

--- a/substrate/frame/psm/src/mock.rs
+++ b/substrate/frame/psm/src/mock.rs
@@ -147,6 +147,9 @@ impl EnsureOrigin<RuntimeOrigin> for MockManagerOrigin {
 pub struct PsmBenchmarkHelper;
 #[cfg(feature = "runtime-benchmarks")]
 impl crate::BenchmarkHelper<u32, u64> for PsmBenchmarkHelper {
+	fn get_asset_id(asset_index: u32) -> u32 {
+		asset_index
+	}
 	fn create_asset(asset_id: u32, owner: &u64, decimals: u8) {
 		use frame_support::traits::fungibles::{metadata::Mutate as MetadataMutate, Create};
 		if !<Assets as frame_support::traits::fungibles::Inspect<u64>>::asset_exists(asset_id) {


### PR DESCRIPTION
On Asset Hub Westend, `pallet-psm` is switched from `u32` (trust-backed asset id) to `xcm::v5::Location` as its `AssetId`, and from `Assets` to `LocalAndForeignAssets` as its `Fungibles`. PSM can now mint and redeem against both trust-backed and foreign-registered external stablecoins, addressed uniformly by `Location`.

Storage migration: every `AssetId`-keyed PSM storage item is encoded under the old `u32` key. The runtime wipes the existing PSM storage with `frame_support::migrations::RemovePallet` and re-seeds the pallet from `PsmInitialConfig` via `InitializePsm`. USDT (trust-backed asset `1984`) is reseeded under its `Location` representation as the first external asset.

`pallet-psm`'s `BenchmarkHelper` trait gains a `get_asset_id(index: u32)` method so benchmark scenarios can derive a runtime-specific `AssetId` (e.g. a `Location`) from a `u32` index. Existing impls need to add this method.