### PR TITLE
[pallet-revive] Implement versioned runtime API infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17483,6 +17483,7 @@ dependencies = [
  "pallet-remark",
  "pallet-revive",
  "pallet-revive-proc-macro",
+ "pallet-revive-types",
  "pallet-revive-uapi",
  "pallet-root-offences",
  "pallet-root-testing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14139,6 +14139,7 @@ dependencies = [
  "pallet-proxy",
  "pallet-revive-fixtures",
  "pallet-revive-proc-macro",
+ "pallet-revive-types",
  "pallet-revive-uapi",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -14249,6 +14250,20 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "pallet-revive-types"
+version = "0.1.0"
+dependencies = [
+ "pallet-revive-proc-macro",
+ "pallet-revive-uapi",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-weights 27.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,6 +429,7 @@ members = [
 	"substrate/frame/revive/fixtures",
 	"substrate/frame/revive/proc-macro",
 	"substrate/frame/revive/rpc",
+	"substrate/frame/revive/types",
 	"substrate/frame/revive/uapi",
 	"substrate/frame/revive/ui-tests",
 	"substrate/frame/root-offences",
@@ -1049,6 +1050,7 @@ pallet-referenda = { path = "substrate/frame/referenda", default-features = fals
 pallet-revive = { path = "substrate/frame/revive", default-features = false }
 pallet-revive-fixtures = { path = "substrate/frame/revive/fixtures", default-features = false }
 pallet-revive-proc-macro = { path = "substrate/frame/revive/proc-macro", default-features = false }
+pallet-revive-types = { path = "substrate/frame/revive/types", default-features = false }
 pallet-revive-uapi = { path = "substrate/frame/revive/uapi", default-features = false }
 pallet-root-offences = { default-features = false, path = "substrate/frame/root-offences" }
 pallet-root-testing = { path = "substrate/frame/root-testing", default-features = false }

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -51,6 +51,7 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-revive-fixtures = { workspace = true, optional = true }
 pallet-revive-proc-macro = { workspace = true }
+pallet-revive-types = { workspace = true }
 pallet-revive-uapi = { workspace = true, features = ["precompiles-sol-interfaces", "scale"] }
 pallet-transaction-payment = { workspace = true }
 ripemd = { workspace = true }
@@ -107,6 +108,7 @@ std = [
 	"num-traits/std",
 	"pallet-proxy/std",
 	"pallet-revive-fixtures?/std",
+	"pallet-revive-types/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment/std",
 	"pallet-utility/std",

--- a/substrate/frame/revive/proc-macro/src/lib.rs
+++ b/substrate/frame/revive/proc-macro/src/lib.rs
@@ -19,11 +19,17 @@
 //!
 //! Most likely you should use the [`#[define_env]`][`macro@define_env`] attribute macro which hides
 //! boilerplate of defining external environment for a polkavm module.
+//!
+//! Also exposes [`#[versioned_type]`][`macro@versioned_type`] for defining versioned wire types
+//! used at the `ReviveApi` runtime API boundary.
 
 use proc_macro::TokenStream;
 use proc_macro2::{Literal, Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens};
-use syn::{parse_quote, punctuated::Punctuated, spanned::Spanned, token::Comma, FnArg, Ident};
+use quote::{format_ident, quote, ToTokens};
+use syn::{
+	parse_macro_input, parse_quote, punctuated::Punctuated, spanned::Spanned, token::Comma,
+	DeriveInput, FnArg, GenericParam, Ident, LitInt,
+};
 
 /// Defines a host functions set that can be imported by contract polkavm code.
 ///
@@ -616,4 +622,86 @@ fn expand_trace_op_lookup(def: &EnvDef) -> TokenStream2 {
 			_ => None,
 		}
 	}
+}
+
+/// Attribute macro for defining a versioned wire type used at the `ReviveApi` boundary.
+#[proc_macro_attribute]
+pub fn versioned_type(attr: TokenStream, item: TokenStream) -> TokenStream {
+	let version: LitInt = match syn::parse(attr) {
+		Ok(v) => v,
+		Err(e) => return e.to_compile_error().into(),
+	};
+	let ver_value: u32 = match version.base10_parse() {
+		Ok(v) => v,
+		Err(e) => return e.to_compile_error().into(),
+	};
+
+	let input = parse_macro_input!(item as DeriveInput);
+	let original_ident = &input.ident;
+	let attrs = &input.attrs;
+	let vis = &input.vis;
+	let generics = &input.generics;
+
+	// Build `StructVN` identifier
+	let versioned_ident = format_ident!("{}V{}", original_ident, ver_value);
+
+	// Extract struct fields; only supports named-field structs.
+	let fields = match &input.data {
+		syn::Data::Struct(s) => &s.fields,
+		_ => {
+			return syn::Error::new_spanned(
+				&input.ident,
+				"`#[versioned_type]` can only be applied to `struct` items",
+			)
+			.to_compile_error()
+			.into()
+		},
+	};
+
+	// Collect generic parameter *names only* for the type alias (no bounds).
+	let generic_params_for_alias: Vec<TokenStream2> = generics
+		.params
+		.iter()
+		.map(|p| match p {
+			GenericParam::Type(t) => {
+				let id = &t.ident;
+				quote! { #id }
+			},
+			GenericParam::Lifetime(l) => {
+				let lt = &l.lifetime;
+				quote! { #lt }
+			},
+			GenericParam::Const(c) => {
+				let id = &c.ident;
+				quote! { #id }
+			},
+		})
+		.collect();
+
+	let where_clause = &generics.where_clause;
+
+	let output = if generic_params_for_alias.is_empty() {
+		quote! {
+			#( #attrs )*
+			#vis struct #versioned_ident #generics
+			#where_clause
+			#fields
+
+			/// Type alias pointing to the latest version of this wire type.
+			#vis type #original_ident = #versioned_ident;
+		}
+	} else {
+		quote! {
+			#( #attrs )*
+			#vis struct #versioned_ident #generics
+			#where_clause
+			#fields
+
+			/// Type alias pointing to the latest version of this wire type.
+			#vis type #original_ident<#(#generic_params_for_alias),*> =
+				#versioned_ident<#(#generic_params_for_alias),*>;
+		}
+	};
+
+	output.into()
 }

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -2795,27 +2795,6 @@ environmental!(executing_contract: bool);
 
 sp_api::decl_runtime_apis! {
 	/// The API used to dry-run contract interactions.
-	///
-	/// # Versioning
-	///
-	/// This trait follows Substrate's runtime API versioning convention:
-	///
-	/// * The `#[api_version(N)]` attribute declares the **current** version of the
-	///   entire trait.
-	/// * Methods whose signatures changed between versions carry a `#[changed_in(N)]`
-	///   annotation on the *old* overload. The *new* (current) overload has no such
-	///   annotation.
-	/// * Wire types used as parameters or return values are defined in
-	///   [`pallet_revive_types`] and follow the `TypeVN` naming convention. The
-	///   unversioned alias (e.g. `ContractResult`) always refers to the latest version.
-	///
-	/// ## Version history
-	///
-	/// | Version | Summary of changes |
-	/// |---------|-------------------|
-	/// | 1       | Initial API. |
-	/// | 2       | `eth_transact` replaced by `eth_transact_with_config` (added `DryRunConfig` |
-	/// |         | parameter). Wire types extracted to `pallet-revive-types`. |
 	#[api_version(2)]
 	pub trait ReviveApi<AccountId, Balance, Nonce, BlockNumber, Moment> where
 		AccountId: Codec,
@@ -3085,7 +3064,7 @@ macro_rules! impl_runtime_apis_plus_revive_traits {
 					<Self as $crate::Config>::AddressMapper::to_address(&account_id)
 				}
 
-				// ── eth_transact (deprecated, retained for API v1 compatibility) ──────
+				// eth_transact (deprecated, retained for API v1 compatibility)
 				// Clients built against API v1 call this method. We forward it to
 				// `dry_run_eth_transact` with a default config, matching v1 behaviour.
 				fn eth_transact(

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -2795,7 +2795,28 @@ environmental!(executing_contract: bool);
 
 sp_api::decl_runtime_apis! {
 	/// The API used to dry-run contract interactions.
-	#[api_version(1)]
+	///
+	/// # Versioning
+	///
+	/// This trait follows Substrate's runtime API versioning convention:
+	///
+	/// * The `#[api_version(N)]` attribute declares the **current** version of the
+	///   entire trait.
+	/// * Methods whose signatures changed between versions carry a `#[changed_in(N)]`
+	///   annotation on the *old* overload. The *new* (current) overload has no such
+	///   annotation.
+	/// * Wire types used as parameters or return values are defined in
+	///   [`pallet_revive_types`] and follow the `TypeVN` naming convention. The
+	///   unversioned alias (e.g. `ContractResult`) always refers to the latest version.
+	///
+	/// ## Version history
+	///
+	/// | Version | Summary of changes |
+	/// |---------|-------------------|
+	/// | 1       | Initial API. |
+	/// | 2       | `eth_transact` replaced by `eth_transact_with_config` (added `DryRunConfig` |
+	/// |         | parameter). Wire types extracted to `pallet-revive-types`. |
+	#[api_version(2)]
 	pub trait ReviveApi<AccountId, Balance, Nonce, BlockNumber, Moment> where
 		AccountId: Codec,
 		Balance: Codec,
@@ -2858,26 +2879,33 @@ sp_api::decl_runtime_apis! {
 			salt: Option<[u8; 32]>,
 		) -> ContractResult<InstantiateReturnValue, Balance>;
 
-
 		/// Perform an Ethereum call.
 		///
-		/// Deprecated use `v2` version instead.
-		/// See [`crate::Pallet::dry_run_eth_transact`]
+		/// **Deprecated** — use [`Self::eth_transact_with_config`] instead, which accepts
+		/// an explicit [`DryRunConfig`] and is the preferred interface from API version 2
+		/// onwards. This method is retained so that clients built against API version 1
+		/// continue to function; it internally delegates to
+		/// `dry_run_eth_transact` with a default config.
+		///
+		/// See [`crate::Pallet::dry_run_eth_transact`].
 		fn eth_transact(tx: GenericTransaction) -> Result<EthTransactInfo<Balance>, EthTransactError>;
 
-		/// Perform an Ethereum call.
+		/// Perform an Ethereum call with additional dry-run configuration.
 		///
-		/// See [`crate::Pallet::dry_run_eth_transact`]
+		/// This is the v2 replacement for the deprecated `eth_transact` method.  It accepts
+		/// an explicit [`DryRunConfig`] that controls simulation parameters such as the block
+		/// timestamp used during the dry-run.
+		///
+		/// See [`crate::Pallet::dry_run_eth_transact`].
 		fn eth_transact_with_config(
 			tx: GenericTransaction,
 			config: DryRunConfig<Moment>,
 		) -> Result<EthTransactInfo<Balance>, EthTransactError>;
 
-		/// Estimates the amount of gas that a transactions requires.
+		/// Estimates the amount of gas that a transaction requires.
 		///
-		/// This function estimates the gas of the transaction according to the same binary search
-		/// algorithm that's implemented in Geth. It stops when with an acceptable error ratio of
-		/// 1.5% so that the algorithm terminates early.
+		/// Uses the same binary-search algorithm as Geth with an acceptable error ratio of
+		/// 1.5% to terminate early.
 		fn eth_estimate_gas(
 			tx: GenericTransaction,
 			config: DryRunConfig<Moment>
@@ -2895,11 +2923,10 @@ sp_api::decl_runtime_apis! {
 			storage_deposit_limit: Option<Balance>,
 		) -> CodeUploadResult<Balance>;
 
-		/// Query a given storage key in a given contract.
+		/// Query a given fixed-size (32-byte) storage key in a given contract.
 		///
-		/// Returns `Ok(Some(Vec<u8>))` if the storage value exists under the given key in the
-		/// specified account and `Ok(None)` if it doesn't. If the account specified by the address
-		/// doesn't exist, or doesn't have a contract then `Err` is returned.
+		/// Returns `Ok(Some(Vec<u8>))` if the value exists, `Ok(None)` if not.
+		/// Returns `Err` if the address does not point to a contract.
 		fn get_storage(
 			address: H160,
 			key: [u8; 32],
@@ -2907,9 +2934,8 @@ sp_api::decl_runtime_apis! {
 
 		/// Query a given variable-sized storage key in a given contract.
 		///
-		/// Returns `Ok(Some(Vec<u8>))` if the storage value exists under the given key in the
-		/// specified account and `Ok(None)` if it doesn't. If the account specified by the address
-		/// doesn't exist, or doesn't have a contract then `Err` is returned.
+		/// Returns `Ok(Some(Vec<u8>))` if the value exists, `Ok(None)` if not.
+		/// Returns `Err` if the address does not point to a contract.
 		fn get_storage_var_key(
 			address: H160,
 			key: Vec<u8>,
@@ -2917,8 +2943,7 @@ sp_api::decl_runtime_apis! {
 
 		/// Traces the execution of an entire block and returns call traces.
 		///
-		/// This is intended to be called through `state_call` to replay the block from the
-		/// parent block.
+		/// Intended to be called via `state_call` to replay the block from its parent.
 		///
 		/// See eth-rpc `debug_traceBlockByNumber` for usage.
 		fn trace_block(
@@ -2928,8 +2953,8 @@ sp_api::decl_runtime_apis! {
 
 		/// Traces the execution of a specific transaction within a block.
 		///
-		/// This is intended to be called through `state_call` to replay the block from the
-		/// parent hash up to the transaction.
+		/// Intended to be called via `state_call` to replay the block from the
+		/// parent hash up to and including the indexed transaction.
 		///
 		/// See eth-rpc `debug_traceTransaction` for usage.
 		fn trace_tx(
@@ -2938,16 +2963,17 @@ sp_api::decl_runtime_apis! {
 			config: TracerType
 		) -> Option<Trace>;
 
-		/// Dry run and return the trace of the given call.
+		/// Dry-run and return the execution trace of the given call.
 		///
 		/// See eth-rpc `debug_traceCall` for usage.
 		fn trace_call(tx: GenericTransaction, config: TracerType) -> Result<Trace, EthTransactError>;
 
-		/// Dry run and return the trace of the given call with additional configuration.
+		/// Dry-run and return the execution trace of the given call with additional
+		/// configuration.
 		///
-		/// Like [`Self::trace_call`], but accepts a [`TracingConfig`] that can carry state
-		/// overrides and future extensibility. The config must be the **last argument** for
-		/// backwards compatibility — see [`TracingConfig`] documentation.
+		/// Like [`Self::trace_call`] but accepts a [`TracingConfig`] that carries state
+		/// overrides and provides a forward-compatible extension point.  The config **must**
+		/// remain the last argument to preserve backward compatibility.
 		fn trace_call_with_config(
 			tx: GenericTransaction,
 			tracer_type: TracerType,
@@ -2957,19 +2983,19 @@ sp_api::decl_runtime_apis! {
 		/// The address of the validator that produced the current block.
 		fn block_author() -> H160;
 
-		/// Get the H160 address associated to this account id
+		/// Get the H160 address associated with this `AccountId`.
 		fn address(account_id: AccountId) -> H160;
 
-		/// Get the account id associated to this H160 address.
+		/// Get the `AccountId` associated with this H160 address.
 		fn account_id(address: H160) -> AccountId;
 
-		/// The address used to call the runtime's pallets dispatchables
+		/// The address used to dispatch calls to runtime pallets from contracts.
 		fn runtime_pallets_address() -> H160;
 
-		/// The code at the specified address taking pre-compiles into account.
+		/// The bytecode at the specified address, taking precompiles into account.
 		fn code(address: H160) -> Vec<u8>;
 
-		/// Construct the new balance and dust components of this EVM balance.
+		/// Decompose an EVM `U256` balance into its native `Balance` and dust components.
 		fn new_balance_with_dust(balance: U256) -> Result<(Balance, u32), BalanceConversionError>;
 	}
 }
@@ -3059,14 +3085,12 @@ macro_rules! impl_runtime_apis_plus_revive_traits {
 					<Self as $crate::Config>::AddressMapper::to_address(&account_id)
 				}
 
+				// ── eth_transact (deprecated, retained for API v1 compatibility) ──────
+				// Clients built against API v1 call this method. We forward it to
+				// `dry_run_eth_transact` with a default config, matching v1 behaviour.
 				fn eth_transact(
 					tx: $crate::evm::GenericTransaction,
 				) -> Result<$crate::EthTransactInfo<Balance>, $crate::EthTransactError> {
-					use $crate::{
-						codec::Encode, evm::runtime::EthExtra, frame_support::traits::Get,
-						sp_runtime::traits::TransactionExtension,
-						sp_runtime::traits::Block as BlockT
-					};
 					$crate::Pallet::<Self>::dry_run_eth_transact(tx, Default::default())
 				}
 

--- a/substrate/frame/revive/src/primitives.rs
+++ b/substrate/frame/revive/src/primitives.rs
@@ -50,8 +50,8 @@
 //! * [`SetStorageResult`]
 
 use crate::{
-	BalanceOf, Config, Time, U256, evm::DryRunConfig, mock::MockHandler,
-	storage::WriteOutcome, transient_storage::TransientStorage,
+	BalanceOf, Config, Time, U256, evm::DryRunConfig, mock::MockHandler, storage::WriteOutcome,
+	transient_storage::TransientStorage,
 };
 use alloc::{boxed::Box, fmt::Debug};
 use core::cell::RefCell;
@@ -59,29 +59,25 @@ use frame_support::{DefaultNoBound, weights::Weight};
 use sp_core::Get;
 use sp_runtime::traits::{One, Saturating, Zero};
 
-// ─── Wire types (re-exported from pallet-revive-types) ───────────────────────
-
 pub use pallet_revive_types::{
-	// versioned concrete types
-	CodeUploadReturnValueV1,
-	ContractResultV1,
-	EthTransactInfoV1,
-	ExecReturnValueV1,
-	InstantiateReturnValueV1,
 	// unversioned aliases (always point to the latest version)
 	CodeUploadResult,
 	CodeUploadReturnValue,
+	// versioned concrete types
+	CodeUploadReturnValueV1,
 	ContractAccessError,
 	ContractResult,
+	ContractResultV1,
 	EthTransactError,
 	EthTransactInfo,
+	EthTransactInfoV1,
 	ExecReturnValue,
+	ExecReturnValueV1,
 	GetStorageResult,
 	InstantiateReturnValue,
+	InstantiateReturnValueV1,
 	StorageDeposit,
 };
-
-// ─── Execution types (pallet-internal) ───────────────────────────────────────
 
 /// Result type of a `set_storage` call.
 pub type SetStorageResult = Result<WriteOutcome, ContractAccessError>;

--- a/substrate/frame/revive/src/primitives.rs
+++ b/substrate/frame/revive/src/primitives.rs
@@ -15,118 +15,93 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A crate that hosts a common definitions that are relevant for the pallet-revive.
+//! Types used inside `pallet-revive`.
+//!
+//! # Wire types vs execution types
+//!
+//! This module maintains a clear distinction between two categories of types:
+//!
+//! ## Wire types (re-exported from `pallet-revive-types`)
+//!
+//! Stable, SCALE-encoded types exchanged at the `ReviveApi` runtime API boundary.
+//! They are defined in the lightweight [`pallet_revive_types`] crate so that
+//! off-chain tooling, light clients, and indexers can depend on them without
+//! pulling in the full `pallet-revive` crate.
+//!
+//! * [`ContractResult`] / [`ContractResultV1`]
+//! * [`ExecReturnValue`] / [`ExecReturnValueV1`]
+//! * [`InstantiateReturnValue`] / [`InstantiateReturnValueV1`]
+//! * [`CodeUploadReturnValue`] / [`CodeUploadReturnValueV1`]
+//! * [`EthTransactInfo`] / [`EthTransactInfoV1`]
+//! * [`EthTransactError`]
+//! * [`StorageDeposit`]
+//! * [`ContractAccessError`]
+//! * [`CodeUploadResult`] / [`GetStorageResult`]
+//!
+//! ## Execution types (defined here, pallet-internal)
+//!
+//! Runtime-internal types used during contract execution that may carry additional
+//! context unsuitable for SCALE serialisation or that need to evolve independently.
+//!
+//! * [`ExecConfig`]
+//! * [`BalanceWithDust`] / [`BalanceConversionError`]
+//! * [`Code`]
+//! * [`CodeRemoved`]
+//! * [`SetStorageResult`]
 
 use crate::{
-	BalanceOf, Config, H160, Time, U256, evm::DryRunConfig, mock::MockHandler,
+	BalanceOf, Config, Time, U256, evm::DryRunConfig, mock::MockHandler,
 	storage::WriteOutcome, transient_storage::TransientStorage,
 };
-use alloc::{boxed::Box, fmt::Debug, string::String, vec::Vec};
-use codec::{Decode, Encode, MaxEncodedLen};
+use alloc::{boxed::Box, fmt::Debug};
 use core::cell::RefCell;
-use frame_support::{DefaultNoBound, traits::tokens::Balance, weights::Weight};
-use pallet_revive_uapi::ReturnFlags;
-use scale_info::TypeInfo;
+use frame_support::{DefaultNoBound, weights::Weight};
 use sp_core::Get;
-use sp_runtime::{
-	DispatchError,
-	traits::{One, Saturating, Zero},
+use sp_runtime::traits::{One, Saturating, Zero};
+
+// ─── Wire types (re-exported from pallet-revive-types) ───────────────────────
+
+pub use pallet_revive_types::{
+	// versioned concrete types
+	CodeUploadReturnValueV1,
+	ContractResultV1,
+	EthTransactInfoV1,
+	ExecReturnValueV1,
+	InstantiateReturnValueV1,
+	// unversioned aliases (always point to the latest version)
+	CodeUploadResult,
+	CodeUploadReturnValue,
+	ContractAccessError,
+	ContractResult,
+	EthTransactError,
+	EthTransactInfo,
+	ExecReturnValue,
+	GetStorageResult,
+	InstantiateReturnValue,
+	StorageDeposit,
 };
 
-/// Result type of a `bare_call` or `bare_instantiate` call as well as `ContractsApi::call` and
-/// `ContractsApi::instantiate`.
-///
-/// It contains the execution result together with some auxiliary information.
-///
-/// #Note
-///
-/// It has been extended to include `events` at the end of the struct while not bumping the
-/// `ContractsApi` version. Therefore when SCALE decoding a `ContractResult` its trailing data
-/// should be ignored to avoid any potential compatibility issues.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
-pub struct ContractResult<R, Balance> {
-	/// How much weight was consumed during execution.
-	pub weight_consumed: Weight,
-	/// How much weight is required as weight limit in order to execute this call.
-	///
-	/// This value should be used to determine the weight limit for on-chain execution.
-	///
-	/// # Note
-	///
-	/// This can only be different from [`Self::weight_consumed`] when weight pre charging
-	/// is used. Currently, only `seal_call_runtime` makes use of pre charging.
-	/// Additionally, any `seal_call` or `seal_instantiate` makes use of pre-charging
-	/// when a non-zero `weight_limit` argument is supplied.
-	pub weight_required: Weight,
-	/// How much balance was paid by the origin into the contract's deposit account in order to
-	/// pay for storage.
-	///
-	/// The storage deposit is never actually charged from the origin in case of [`Self::result`]
-	/// is `Err`. This is because on error all storage changes are rolled back including the
-	/// payment of the deposit.
-	pub storage_deposit: StorageDeposit<Balance>,
-	/// The maximal storage deposit amount that occured at any time during the execution.
-	/// This can be higher than the final storage_deposit due to refunds
-	/// This is always a StorageDeposit::Charge(..)
-	pub max_storage_deposit: StorageDeposit<Balance>,
-	/// The amount of Ethereum gas that has been consumed during execution.
-	pub gas_consumed: Balance,
-	/// The execution result of the vm binary code.
-	pub result: Result<R, DispatchError>,
-}
+// ─── Execution types (pallet-internal) ───────────────────────────────────────
 
-impl<R: Default, B: Balance> Default for ContractResult<R, B> {
-	fn default() -> Self {
-		Self {
-			weight_consumed: Default::default(),
-			weight_required: Default::default(),
-			storage_deposit: Default::default(),
-			max_storage_deposit: Default::default(),
-			gas_consumed: Default::default(),
-			result: Ok(Default::default()),
-		}
-	}
-}
+/// Result type of a `set_storage` call.
+pub type SetStorageResult = Result<WriteOutcome, ContractAccessError>;
 
-/// The result of the execution of a `eth_transact` call.
-#[derive(Clone, Eq, PartialEq, Default, Encode, Decode, Debug, TypeInfo)]
-pub struct EthTransactInfo<Balance> {
-	/// The amount of weight that was necessary to execute the transaction.
-	pub weight_required: Weight,
-	/// Final storage deposit charged.
-	pub storage_deposit: Balance,
-	/// Maximal storage deposit charged at any time during execution.
-	pub max_storage_deposit: Balance,
-	/// The weight and deposit equivalent in EVM Gas.
-	pub eth_gas: U256,
-	/// The execution return value.
-	pub data: Vec<u8>,
-}
-
-/// Error type of a `eth_transact` call.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
-pub enum EthTransactError {
-	Data(Vec<u8>),
-	Message(String),
-}
-
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
-/// Error encountered while creating a BalanceWithDust from a U256 balance.
+/// Error encountered while creating a [`BalanceWithDust`] from a `U256` balance.
+#[derive(Clone, Eq, PartialEq, codec::Encode, codec::Decode, Debug, scale_info::TypeInfo)]
 pub enum BalanceConversionError {
-	/// Error encountered while creating the main balance value.
+	/// Error converting the main balance value.
 	Value,
-	/// Error encountered while creating the dust value.
+	/// Error converting the dust component.
 	Dust,
 }
 
-/// A Balance amount along with some "dust" to represent the lowest decimals that can't be expressed
-/// in the native currency
+/// A balance amount together with "dust" — the sub-unit remainder that cannot be
+/// expressed in the native currency denomination.
 #[derive(Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug)]
 pub struct BalanceWithDust<Balance> {
-	/// The value expressed in the native currency
+	/// The value expressed in the native currency.
 	value: Balance,
-	/// The dust, representing up to 1 unit of the native currency.
-	/// The dust is bounded between 0 and `crate::Config::NativeToEthRatio`
+	/// Fractional part bounded between `0` and `crate::Config::NativeToEthRatio`.
 	dust: u32,
 }
 
@@ -137,18 +112,18 @@ impl<Balance> From<Balance> for BalanceWithDust<Balance> {
 }
 
 impl<Balance> BalanceWithDust<Balance> {
-	/// Deconstructs the `BalanceWithDust` into its components.
+	/// Deconstructs into `(value, dust)`.
 	pub fn deconstruct(self) -> (Balance, u32) {
 		(self.value, self.dust)
 	}
 
-	/// Creates a new `BalanceWithDust` with the given value and dust.
+	/// Creates a `BalanceWithDust` without checking the dust bound.
 	pub fn new_unchecked<T: Config>(value: Balance, dust: u32) -> Self {
 		debug_assert!(dust < T::NativeToEthRatio::get());
 		Self { value, dust }
 	}
 
-	/// Creates a new `BalanceWithDust` from the given EVM value.
+	/// Creates a `BalanceWithDust` from the given EVM `U256` value.
 	pub fn from_value<T: Config>(
 		value: U256,
 	) -> Result<BalanceWithDust<BalanceOf<T>>, BalanceConversionError> {
@@ -165,241 +140,54 @@ impl<Balance> BalanceWithDust<Balance> {
 }
 
 impl<Balance: Zero + One + Saturating> BalanceWithDust<Balance> {
-	/// Returns true if both the value and dust are zero.
+	/// Returns `true` if both the value and dust are zero.
 	pub fn is_zero(&self) -> bool {
 		self.value.is_zero() && self.dust == 0
 	}
 
-	/// Returns the Balance rounded to the nearest whole unit if the dust is non-zero.
+	/// Returns the balance rounded up to the nearest whole unit when dust is non-zero.
 	pub fn into_rounded_balance(self) -> Balance {
 		if self.dust == 0 { self.value } else { self.value.saturating_add(Balance::one()) }
 	}
 }
 
-/// Result type of a `bare_code_upload` call.
-pub type CodeUploadResult<Balance> = Result<CodeUploadReturnValue<Balance>, DispatchError>;
-
-/// Result type of a `get_storage` call.
-pub type GetStorageResult = Result<Option<Vec<u8>>, ContractAccessError>;
-
-/// Result type of a `set_storage` call.
-pub type SetStorageResult = Result<WriteOutcome, ContractAccessError>;
-
-/// The possible errors that can happen querying the storage of a contract.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, MaxEncodedLen, Debug, TypeInfo)]
-pub enum ContractAccessError {
-	/// The given address doesn't point to a contract.
-	DoesntExist,
-	/// Storage key cannot be decoded from the provided input data.
-	KeyDecodingFailed,
-	/// Writing to storage failed.
-	StorageWriteFailed(DispatchError),
-}
-
-/// Output of a contract call or instantiation which ran to completion.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug, TypeInfo, Default)]
-pub struct ExecReturnValue {
-	/// Flags passed along by `seal_return`. Empty when `seal_return` was never called.
-	pub flags: ReturnFlags,
-	/// Buffer passed along by `seal_return`. Empty when `seal_return` was never called.
-	pub data: Vec<u8>,
-}
-
-impl ExecReturnValue {
-	/// The contract did revert all storage changes.
-	pub fn did_revert(&self) -> bool {
-		self.flags.contains(ReturnFlags::REVERT)
-	}
-}
-
-/// The result of a successful contract instantiation.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug, TypeInfo, Default)]
-pub struct InstantiateReturnValue {
-	/// The output of the called constructor.
-	pub result: ExecReturnValue,
-	/// The address of the new contract.
-	pub addr: H160,
-}
-
-/// The result of successfully uploading a contract.
-#[derive(Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen, Debug, TypeInfo)]
-pub struct CodeUploadReturnValue<Balance> {
-	/// The key under which the new code is stored.
-	pub code_hash: sp_core::H256,
-	/// The deposit that was reserved at the caller. Is zero when the code already existed.
-	pub deposit: Balance,
-}
-
-/// Reference to an existing code hash or a new vm module.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+/// Reference to existing on-chain code or a new bytecode upload.
+#[derive(Clone, Eq, PartialEq, codec::Encode, codec::Decode, Debug, scale_info::TypeInfo)]
 pub enum Code {
-	/// A vm module as raw bytes.
-	Upload(Vec<u8>),
-	/// The code hash of an on-chain vm binary blob.
+	/// Raw bytecode to be uploaded and stored.
+	Upload(alloc::vec::Vec<u8>),
+	/// The hash of code that is already stored on-chain.
 	Existing(sp_core::H256),
 }
 
-/// The amount of balance that was either charged or refunded in order to pay for storage.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo)]
-pub enum StorageDeposit<Balance> {
-	/// The transaction reduced storage consumption.
-	///
-	/// This means that the specified amount of balance was transferred from the involved
-	/// deposit accounts to the origin.
-	Refund(Balance),
-	/// The transaction increased storage consumption.
-	///
-	/// This means that the specified amount of balance was transferred from the origin
-	/// to the involved deposit accounts.
-	Charge(Balance),
-}
-
-impl<T, Balance> ContractResult<T, Balance> {
-	pub fn map_result<V>(self, map_fn: impl FnOnce(T) -> V) -> ContractResult<V, Balance> {
-		ContractResult {
-			weight_consumed: self.weight_consumed,
-			weight_required: self.weight_required,
-			storage_deposit: self.storage_deposit,
-			max_storage_deposit: self.max_storage_deposit,
-			gas_consumed: self.gas_consumed,
-			result: self.result.map(map_fn),
-		}
-	}
-}
-
-impl<Balance: Zero> Default for StorageDeposit<Balance> {
-	fn default() -> Self {
-		Self::Charge(Zero::zero())
-	}
-}
-
-impl<Balance: Zero + Copy> StorageDeposit<Balance> {
-	/// Returns how much balance is charged or `0` in case of a refund.
-	pub fn charge_or_zero(&self) -> Balance {
-		match self {
-			Self::Charge(amount) => *amount,
-			Self::Refund(_) => Zero::zero(),
-		}
-	}
-
-	pub fn is_zero(&self) -> bool {
-		match self {
-			Self::Charge(amount) => amount.is_zero(),
-			Self::Refund(amount) => amount.is_zero(),
-		}
-	}
-}
-
-impl<Balance> StorageDeposit<Balance>
-where
-	Balance: frame_support::traits::tokens::Balance + Saturating + Ord + Copy,
-{
-	/// This is essentially a saturating signed add.
-	pub fn saturating_add(&self, rhs: &Self) -> Self {
-		use StorageDeposit::*;
-		match (self, rhs) {
-			(Charge(lhs), Charge(rhs)) => Charge(lhs.saturating_add(*rhs)),
-			(Refund(lhs), Refund(rhs)) => Refund(lhs.saturating_add(*rhs)),
-			(Charge(lhs), Refund(rhs)) => {
-				if lhs >= rhs {
-					Charge(lhs.saturating_sub(*rhs))
-				} else {
-					Refund(rhs.saturating_sub(*lhs))
-				}
-			},
-			(Refund(lhs), Charge(rhs)) => {
-				if lhs > rhs {
-					Refund(lhs.saturating_sub(*rhs))
-				} else {
-					Charge(rhs.saturating_sub(*lhs))
-				}
-			},
-		}
-	}
-
-	/// This is essentially a saturating signed sub.
-	pub fn saturating_sub(&self, rhs: &Self) -> Self {
-		use StorageDeposit::*;
-		match (self, rhs) {
-			(Charge(lhs), Refund(rhs)) => Charge(lhs.saturating_add(*rhs)),
-			(Refund(lhs), Charge(rhs)) => Refund(lhs.saturating_add(*rhs)),
-			(Charge(lhs), Charge(rhs)) => {
-				if lhs >= rhs {
-					Charge(lhs.saturating_sub(*rhs))
-				} else {
-					Refund(rhs.saturating_sub(*lhs))
-				}
-			},
-			(Refund(lhs), Refund(rhs)) => {
-				if lhs > rhs {
-					Refund(lhs.saturating_sub(*rhs))
-				} else {
-					Charge(rhs.saturating_sub(*lhs))
-				}
-			},
-		}
-	}
-
-	/// If the amount of deposit (this type) is constrained by a `limit` this calculates how
-	/// much balance (if any) is still available from this limit.
-	///
-	/// # Note
-	///
-	/// In case of a refund the return value can be larger than `limit`.
-	pub fn available(&self, limit: &Balance) -> Option<Balance> {
-		use StorageDeposit::*;
-		match self {
-			Charge(amount) => limit.checked_sub(amount),
-			Refund(amount) => Some(limit.saturating_add(*amount)),
-		}
-	}
-}
-
-/// `Stack` wide configuration options.
+/// `Stack`-wide configuration options that govern a single execution.
 #[derive(DefaultNoBound)]
 pub struct ExecConfig<T: Config> {
-	/// Indicates whether the account nonce should be incremented after instantiating a new
-	/// contract.
+	/// Whether the account nonce should be incremented after a contract instantiation.
 	///
-	/// In Substrate, where transactions can be batched, the account's nonce should be incremented
-	/// after each instantiation, ensuring that each instantiation uses a unique nonce.
-	///
-	/// For transactions sent from Ethereum wallets, which cannot be batched, the nonce should only
-	/// be incremented once. In these cases, set this to `false` to suppress an extra nonce
-	/// increment.
-	///
-	/// Note:
-	/// The origin's nonce is already incremented pre-dispatch by the `CheckNonce` transaction
-	/// extension.
-	///
-	/// This does not apply to contract initiated instantatiations. Those will always bump the
-	/// instantiating contract's nonce.
+	/// Set to `true` for Substrate transactions (which can be batched) and `false` for
+	/// Ethereum transactions (which cannot be batched; the nonce is already bumped by
+	/// `CheckNonce` pre-dispatch).
 	pub bump_nonce: bool,
-	/// Whether deposits will be withdrawn from the pallet_transaction_payment credit (`Some`)
-	/// free balance (`None`).
+	/// Whether deposits should be collected from a `pallet-transaction-payment` credit
+	/// hold rather than free balance.
 	///
-	/// Contains the encoded_len + base weight.
+	/// `Some((encoded_len, base_weight))` when collecting from hold; `None` otherwise.
 	pub collect_deposit_from_hold: Option<(u32, Weight)>,
-	/// The gas price that was chosen for this transaction.
+	/// The effective gas price used for this transaction.
 	///
-	/// It is determined when transforming `eth_transact` into a proper extrinsic.
+	/// Populated when the execution originates from an Ethereum transaction.
 	pub effective_gas_price: Option<U256>,
-	/// Whether this configuration was created for a dry-run execution.
-	/// Use to enable logic that should only run in dry-run mode.
+	/// When set the execution runs as a dry-run.
 	pub is_dry_run: Option<DryRunConfig<<<T as Config>::Time as Time>::Moment>>,
-	/// An optional mock handler that can be used to override certain behaviors.
-	/// This is primarily used for testing purposes and should be `None` in production
-	/// environments.
+	/// An optional mock handler for testing purposes (`None` in production).
 	pub mock_handler: Option<Box<dyn MockHandler<T>>>,
-	/// Externally supplied transient storage.
-	///
-	/// This is only used for testing purposes and should be `None` in production
-	/// environments.
+	/// Optional externally-supplied transient storage for test environments.
 	pub test_env_transient_storage: Option<RefCell<TransientStorage<T>>>,
 }
 
 impl<T: Config> ExecConfig<T> {
-	/// Create a default config appropriate when the call originated from a substrate tx.
+	/// Default config for calls originating from a Substrate extrinsic.
 	pub fn new_substrate_tx() -> Self {
 		Self {
 			bump_nonce: true,
@@ -411,6 +199,7 @@ impl<T: Config> ExecConfig<T> {
 		}
 	}
 
+	/// Like [`Self::new_substrate_tx`] but suppresses the extra nonce bump.
 	pub fn new_substrate_tx_without_bump() -> Self {
 		Self {
 			bump_nonce: false,
@@ -422,7 +211,7 @@ impl<T: Config> ExecConfig<T> {
 		}
 	}
 
-	/// Create a default config appropriate when the call originated from a ethereum tx.
+	/// Default config for calls originating from an Ethereum transaction.
 	pub fn new_eth_tx(effective_gas_price: U256, encoded_len: u32, base_weight: Weight) -> Self {
 		Self {
 			bump_nonce: false,
@@ -434,7 +223,7 @@ impl<T: Config> ExecConfig<T> {
 		}
 	}
 
-	/// Set this config to be a dry-run.
+	/// Mark this config as a dry-run.
 	pub fn with_dry_run(
 		mut self,
 		dry_run_config: DryRunConfig<<<T as Config>::Time as Time>::Moment>,
@@ -443,7 +232,7 @@ impl<T: Config> ExecConfig<T> {
 		self
 	}
 
-	/// Almost clone for testing (does not clone mock_handler)
+	/// Shallow clone for testing (does not clone `mock_handler`).
 	#[cfg(test)]
 	pub fn clone(&self) -> Self {
 		Self {
@@ -457,11 +246,11 @@ impl<T: Config> ExecConfig<T> {
 	}
 }
 
-/// Indicates whether the code was removed after the last refcount was decremented.
+/// Indicates whether code was removed after the last reference was dropped.
 #[must_use = "You must handle whether the code was removed or not."]
 pub enum CodeRemoved {
-	/// The code was not removed. (refcount > 0)
+	/// Code was not removed (refcount > 0).
 	No,
-	/// The code was removed. (refcount == 0)
+	/// Code was removed (refcount reached 0).
 	Yes,
 }

--- a/substrate/frame/revive/src/vm/pvm.rs
+++ b/substrate/frame/revive/src/vm/pvm.rs
@@ -213,10 +213,6 @@ impl<T: Config> PolkaVmInstance<T> for polkavm::RawInstance {
 	}
 }
 
-// `From<&ExecReturnValue> for ReturnErrorCode` is defined in `pallet-revive-types`
-// (the crate that owns both types) and re-exported here via the `pallet_revive_types`
-// import in `primitives.rs`.
-
 /// The data passed through when a contract uses `seal_return`.
 #[derive(Debug)]
 pub struct ReturnData {

--- a/substrate/frame/revive/src/vm/pvm.rs
+++ b/substrate/frame/revive/src/vm/pvm.rs
@@ -25,7 +25,6 @@ use crate::{
 	limits,
 	metering::ChargedAmount,
 	precompiles::{All as AllPrecompiles, Precompiles},
-	primitives::ExecReturnValue,
 	tracing::FrameTraceInfo,
 };
 use alloc::{vec, vec::Vec};
@@ -214,11 +213,9 @@ impl<T: Config> PolkaVmInstance<T> for polkavm::RawInstance {
 	}
 }
 
-impl From<&ExecReturnValue> for ReturnErrorCode {
-	fn from(from: &ExecReturnValue) -> Self {
-		if from.flags.contains(ReturnFlags::REVERT) { Self::CalleeReverted } else { Self::Success }
-	}
-}
+// `From<&ExecReturnValue> for ReturnErrorCode` is defined in `pallet-revive-types`
+// (the crate that owns both types) and re-exported here via the `pallet_revive_types`
+// import in `primitives.rs`.
 
 /// The data passed through when a contract uses `seal_return`.
 #[derive(Debug)]

--- a/substrate/frame/revive/types/Cargo.toml
+++ b/substrate/frame/revive/types/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "pallet-revive-types"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "Versioned wire types for the pallet-revive runtime API boundary."
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { features = ["derive", "max-encoded-len"], workspace = true }
+paste = { workspace = true }
+pallet-revive-proc-macro = { workspace = true }
+pallet-revive-uapi = { workspace = true, features = ["scale"] }
+scale-info = { features = ["derive"], workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-weights = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-weights/std",
+]

--- a/substrate/frame/revive/types/Cargo.toml
+++ b/substrate/frame/revive/types/Cargo.toml
@@ -17,9 +17,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
-paste = { workspace = true }
 pallet-revive-proc-macro = { workspace = true }
 pallet-revive-uapi = { workspace = true, features = ["scale"] }
+paste = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }

--- a/substrate/frame/revive/types/src/lib.rs
+++ b/substrate/frame/revive/types/src/lib.rs
@@ -1,0 +1,410 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Versioned wire types for the `pallet-revive` runtime API boundary.
+//!
+//! # Purpose
+//!
+//! This crate provides the stable, versioned types exchanged across the runtime/client
+//! boundary (the "wire format"). It is intentionally kept lightweight so that off-chain
+//! tools, light clients, and indexers can depend on it without pulling in the entire
+//! `pallet-revive` crate.
+//!
+//! # Design principles
+//!
+//! ## Separate wire types from execution types
+//!
+//! `pallet-revive` maintains two distinct sets of types:
+//!
+//! * **Wire types** (this crate): stable, SCALE-encoded types exposed through the
+//!   `ReviveApi` runtime API. They must remain backward-compatible across API versions.
+//! * **Execution types** (inside `pallet-revive`): runtime-internal types used during
+//!   contract execution. These may carry additional context not suitable for serialisation
+//!   and are free to evolve independently.
+//!
+//! ## Versioning convention
+//!
+//! * Concrete versioned structs are named with a `VN` suffix: `ContractResultV1`,
+//!   `ContractResultV2`, etc.
+//! * The un-suffixed name (e.g. `ContractResult`) is always a type alias for the
+//!   **latest** version.
+//! * When a breaking change is needed, a new versioned struct is introduced and the
+//!   alias is updated. The old version is kept so it can be referenced with
+//!   `#[changed_in(N)]` in the `ReviveApi` runtime API trait.
+//!
+//! ## `define_versioned_type!` macro
+//!
+//! Use the [`define_versioned_type!`] macro to define a new versioned struct. The macro
+//! automatically generates the `VN`-suffixed concrete type and the un-suffixed alias.
+//! When upgrading to a new version, provide a `From` implementation to convert the
+//! previous version into the new one; this enables backwards-compatible decoding on the
+//! client side.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_core::{H160, H256, U256};
+use sp_runtime::{
+	DispatchError,
+	traits::{CheckedSub, One, Saturating, Zero},
+};
+use sp_weights::Weight;
+
+pub use pallet_revive_uapi::ReturnFlags;
+
+/// Define a versioned wire type.
+///
+/// This macro generates:
+///
+/// 1. A concrete struct named `<Name>V<N>` (e.g. `ContractResultV1`) that carries all
+///    of the specified fields together with the requested `#[derive(…)]` attributes.
+/// 2. A public type alias `<Name> = <Name>V<N>` that always points to the *latest*
+///    defined version. When you introduce `V2`, re-run the macro with `version = 2` and
+///    the alias will update automatically.
+///
+/// # Syntax
+///
+/// The `version = N,` clause **must come first**, before any doc comments or derive
+/// attributes:
+///
+/// ```ignore
+/// define_versioned_type! {
+///     version = 1,
+///     /// Optional doc comment.
+///     #[derive(Clone, Encode, Decode, TypeInfo)]
+///     pub struct MyType<A, B> {
+///         pub field_a: A,
+///         pub field_b: B,
+///     }
+/// }
+/// ```
+///
+/// # Upgrading to a new version
+///
+/// ```ignore
+/// // v2 — add a new field; provide a From conversion from v1.
+/// define_versioned_type! {
+///     version = 2,
+///     #[derive(Clone, Encode, Decode, TypeInfo)]
+///     pub struct MyType<A, B> {
+///         pub field_a: A,
+///         pub field_b: B,
+///         pub new_field: u32,
+///     }
+/// }
+///
+/// impl<A, B> From<MyTypeV1<A, B>> for MyTypeV2<A, B> {
+///     fn from(v1: MyTypeV1<A, B>) -> Self {
+///         MyTypeV2 { field_a: v1.field_a, field_b: v1.field_b, new_field: 0 }
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! define_versioned_type {
+	// The `version = N,` clause must appear first so the parser can unambiguously
+	// distinguish it from the outer attribute list that follows.
+	(
+		version = $ver:literal,
+		$(#[$outer:meta])*
+		pub struct $name:ident $(<$($gen:tt),+>)? {
+			$(
+				$(#[$fattrs:meta])*
+				pub $fname:ident: $fty:ty
+			),* $(,)?
+		}
+	) => {
+		::paste::paste! {
+			$(#[$outer])*
+			pub struct [<$name V $ver>] $(<$($gen),+>)? {
+				$(
+					$(#[$fattrs])*
+					pub $fname: $fty,
+				)*
+			}
+
+			/// Type alias pointing to the current (latest) version of this wire type.
+			pub type $name $(<$($gen),+>)? = [<$name V $ver>] $(<$($gen),+>)?;
+		}
+	};
+}
+
+/// The amount of balance that was either charged or refunded in order to pay for storage.
+#[derive(
+	Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo,
+)]
+pub enum StorageDeposit<Balance> {
+	/// The transaction reduced storage consumption.
+	///
+	/// The specified amount of balance was transferred *from* the involved deposit accounts
+	/// back to the origin.
+	Refund(Balance),
+	/// The transaction increased storage consumption.
+	///
+	/// The specified amount of balance was transferred *from* the origin to the involved
+	/// deposit accounts.
+	Charge(Balance),
+}
+
+/// The possible errors when querying or writing a contract's storage.
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, MaxEncodedLen, Debug, TypeInfo)]
+pub enum ContractAccessError {
+	/// The given address does not point to a contract.
+	DoesntExist,
+	/// The storage key could not be decoded from the provided input data.
+	KeyDecodingFailed,
+	/// Writing to storage failed.
+	StorageWriteFailed(DispatchError),
+}
+
+define_versioned_type! {
+	version = 1,
+	/// Result type returned across the runtime API boundary for `call` and `instantiate`.
+	///
+	/// Contains the execution result together with auxiliary information such as weight
+	/// consumed and storage deposit charged.
+	#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+	pub struct ContractResult<R, Balance> {
+		/// How much weight was consumed during execution.
+		pub weight_consumed: Weight,
+		/// How much weight is required as the weight limit for on-chain execution.
+		///
+		/// This value should be used as the `weight_limit` argument when submitting the
+		/// corresponding extrinsic. It can differ from `weight_consumed` when weight
+		/// pre-charging is applied.
+		pub weight_required: Weight,
+		/// How much balance was paid by the origin for storage.
+		///
+		/// Not charged when `result` is `Err`; all storage changes roll back on error.
+		pub storage_deposit: StorageDeposit<Balance>,
+		/// Maximal storage deposit at any point during execution.
+		///
+		/// Can exceed `storage_deposit` because intermediate allocations may be freed
+		/// before the transaction completes. Always encoded as `StorageDeposit::Charge`.
+		pub max_storage_deposit: StorageDeposit<Balance>,
+		/// The amount of Ethereum gas consumed during execution.
+		pub gas_consumed: Balance,
+		/// The execution result of the contract.
+		pub result: Result<R, DispatchError>
+	}
+}
+
+define_versioned_type! {
+	version = 1,
+	/// Return value produced by a contract execution that ran to completion.
+	#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug, TypeInfo, Default)]
+	pub struct ExecReturnValue {
+		/// Flags passed along by `seal_return`. Empty when `seal_return` was never called.
+		pub flags: ReturnFlags,
+		/// Buffer passed along by `seal_return`. Empty when `seal_return` was never called.
+		pub data: Vec<u8>
+	}
+}
+
+define_versioned_type! {
+	version = 1,
+	/// Result of a successful contract instantiation.
+	#[derive(Clone, PartialEq, Eq, Encode, Decode, Debug, TypeInfo, Default)]
+	pub struct InstantiateReturnValue {
+		/// The output of the called constructor.
+		pub result: ExecReturnValueV1,
+		/// The address of the newly deployed contract.
+		pub addr: H160
+	}
+}
+
+define_versioned_type! {
+	version = 1,
+	/// Result of a successful code upload via `bare_upload_code`.
+	#[derive(Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen, Debug, TypeInfo)]
+	pub struct CodeUploadReturnValue<Balance> {
+		/// The hash under which the uploaded code is stored on-chain.
+		pub code_hash: H256,
+		/// The storage deposit reserved at the caller.
+		///
+		/// Zero when the code already existed on-chain (de-duplicated upload).
+		pub deposit: Balance
+	}
+}
+
+define_versioned_type! {
+	version = 1,
+	/// Information returned by a successful `eth_transact` dry-run.
+	#[derive(Clone, Eq, PartialEq, Default, Encode, Decode, Debug, TypeInfo)]
+	pub struct EthTransactInfo<Balance> {
+		/// The weight required to execute the transaction on-chain.
+		pub weight_required: Weight,
+		/// Final storage deposit charged.
+		pub storage_deposit: Balance,
+		/// Maximal storage deposit charged at any point during execution.
+		pub max_storage_deposit: Balance,
+		/// The weight and deposit equivalent expressed in EVM gas units.
+		pub eth_gas: U256,
+		/// The execution return data.
+		pub data: Vec<u8>
+	}
+}
+
+/// Error returned by a failed `eth_transact` dry-run.
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, TypeInfo)]
+pub enum EthTransactError {
+	/// Execution reverted and returned ABI-encoded revert data.
+	Data(Vec<u8>),
+	/// Execution failed with a human-readable error message.
+	Message(String),
+}
+
+pub type CodeUploadResult<Balance> = Result<CodeUploadReturnValue<Balance>, DispatchError>;
+
+pub type GetStorageResult = Result<Option<Vec<u8>>, ContractAccessError>;
+
+pub use pallet_revive_uapi::ReturnErrorCode;
+
+impl ExecReturnValueV1 {
+	/// Returns `true` if the contract reverted all storage changes.
+	pub fn did_revert(&self) -> bool {
+		self.flags.contains(ReturnFlags::REVERT)
+	}
+}
+
+impl From<&ExecReturnValueV1> for ReturnErrorCode {
+	fn from(from: &ExecReturnValueV1) -> Self {
+		if from.flags.contains(ReturnFlags::REVERT) {
+			Self::CalleeReverted
+		} else {
+			Self::Success
+		}
+	}
+}
+
+impl<T, Balance> ContractResultV1<T, Balance> {
+	/// Map the inner `result` value while keeping all other fields unchanged.
+	pub fn map_result<V>(self, map_fn: impl FnOnce(T) -> V) -> ContractResultV1<V, Balance> {
+		ContractResultV1 {
+			weight_consumed: self.weight_consumed,
+			weight_required: self.weight_required,
+			storage_deposit: self.storage_deposit,
+			max_storage_deposit: self.max_storage_deposit,
+			gas_consumed: self.gas_consumed,
+			result: self.result.map(map_fn),
+		}
+	}
+}
+
+impl<R: Default, B: Zero + Default> Default for ContractResultV1<R, B> {
+	fn default() -> Self {
+		Self {
+			weight_consumed: Default::default(),
+			weight_required: Default::default(),
+			storage_deposit: Default::default(),
+			max_storage_deposit: Default::default(),
+			gas_consumed: Default::default(),
+			result: Ok(Default::default()),
+		}
+	}
+}
+
+impl<Balance: Zero> Default for StorageDeposit<Balance> {
+	fn default() -> Self {
+		Self::Charge(Zero::zero())
+	}
+}
+
+impl<Balance: Zero + Copy> StorageDeposit<Balance> {
+	/// Returns how much balance is charged, or `0` when this is a refund.
+	pub fn charge_or_zero(&self) -> Balance {
+		match self {
+			Self::Charge(amount) => *amount,
+			Self::Refund(_) => Zero::zero(),
+		}
+	}
+
+	/// Returns `true` if the deposit amount is zero.
+	pub fn is_zero(&self) -> bool {
+		match self {
+			Self::Charge(amount) => amount.is_zero(),
+			Self::Refund(amount) => amount.is_zero(),
+		}
+	}
+}
+
+impl<Balance> StorageDeposit<Balance>
+where
+	Balance: Saturating + Ord + Copy + Zero + One + CheckedSub,
+{
+	/// Saturating signed addition of two `StorageDeposit` values.
+	pub fn saturating_add(&self, rhs: &Self) -> Self {
+		use StorageDeposit::*;
+		match (self, rhs) {
+			(Charge(lhs), Charge(rhs)) => Charge(lhs.saturating_add(*rhs)),
+			(Refund(lhs), Refund(rhs)) => Refund(lhs.saturating_add(*rhs)),
+			(Charge(lhs), Refund(rhs)) => {
+				if lhs >= rhs {
+					Charge(lhs.saturating_sub(*rhs))
+				} else {
+					Refund(rhs.saturating_sub(*lhs))
+				}
+			},
+			(Refund(lhs), Charge(rhs)) => {
+				if lhs > rhs {
+					Refund(lhs.saturating_sub(*rhs))
+				} else {
+					Charge(rhs.saturating_sub(*lhs))
+				}
+			},
+		}
+	}
+
+	/// Saturating signed subtraction of two `StorageDeposit` values.
+	pub fn saturating_sub(&self, rhs: &Self) -> Self {
+		use StorageDeposit::*;
+		match (self, rhs) {
+			(Charge(lhs), Refund(rhs)) => Charge(lhs.saturating_add(*rhs)),
+			(Refund(lhs), Charge(rhs)) => Refund(lhs.saturating_add(*rhs)),
+			(Charge(lhs), Charge(rhs)) => {
+				if lhs >= rhs {
+					Charge(lhs.saturating_sub(*rhs))
+				} else {
+					Refund(rhs.saturating_sub(*lhs))
+				}
+			},
+			(Refund(lhs), Refund(rhs)) => {
+				if lhs > rhs {
+					Refund(lhs.saturating_sub(*rhs))
+				} else {
+					Charge(rhs.saturating_sub(*lhs))
+				}
+			},
+		}
+	}
+
+	/// How much balance remains available from `limit` after applying this deposit.
+	///
+	/// Returns `None` if a charge exceeds the limit.
+	/// Returns a value larger than `limit` in the case of a refund.
+	pub fn available(&self, limit: &Balance) -> Option<Balance> {
+		use StorageDeposit::*;
+		match self {
+			Charge(amount) => limit.checked_sub(amount),
+			Refund(amount) => Some(limit.saturating_add(*amount)),
+		}
+	}
+}

--- a/substrate/frame/revive/types/src/lib.rs
+++ b/substrate/frame/revive/types/src/lib.rs
@@ -30,21 +30,21 @@
 //!
 //! `pallet-revive` maintains two distinct sets of types:
 //!
-//! * **Wire types** (this crate): stable, SCALE-encoded types exposed through the
-//!   `ReviveApi` runtime API. They must remain backward-compatible across API versions.
-//! * **Execution types** (inside `pallet-revive`): runtime-internal types used during
-//!   contract execution. These may carry additional context not suitable for serialisation
-//!   and are free to evolve independently.
+//! * **Wire types** (this crate): stable, SCALE-encoded types exposed through the `ReviveApi`
+//!   runtime API. They must remain backward-compatible across API versions.
+//! * **Execution types** (inside `pallet-revive`): runtime-internal types used during contract
+//!   execution. These may carry additional context not suitable for serialisation and are free to
+//!   evolve independently.
 //!
 //! ## Versioning convention
 //!
 //! * Concrete versioned structs are named with a `VN` suffix: `ContractResultV1`,
 //!   `ContractResultV2`, etc.
-//! * The un-suffixed name (e.g. `ContractResult`) is always a type alias for the
-//!   **latest** version.
-//! * When a breaking change is needed, a new versioned struct is introduced and the
-//!   alias is updated. The old version is kept so it can be referenced with
-//!   `#[changed_in(N)]` in the `ReviveApi` runtime API trait.
+//! * The un-suffixed name (e.g. `ContractResult`) is always a type alias for the **latest**
+//!   version.
+//! * When a breaking change is needed, a new versioned struct is introduced and the alias is
+//!   updated. The old version is kept so it can be referenced with `#[changed_in(N)]` in the
+//!   `ReviveApi` runtime API trait.
 //!
 //! ## `define_versioned_type!` macro
 //!
@@ -64,8 +64,8 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::{H160, H256, U256};
 use sp_runtime::{
-	DispatchError,
 	traits::{CheckedSub, One, Saturating, Zero},
+	DispatchError,
 };
 use sp_weights::Weight;
 
@@ -75,11 +75,11 @@ pub use pallet_revive_uapi::ReturnFlags;
 ///
 /// This macro generates:
 ///
-/// 1. A concrete struct named `<Name>V<N>` (e.g. `ContractResultV1`) that carries all
-///    of the specified fields together with the requested `#[derive(…)]` attributes.
-/// 2. A public type alias `<Name> = <Name>V<N>` that always points to the *latest*
-///    defined version. When you introduce `V2`, re-run the macro with `version = 2` and
-///    the alias will update automatically.
+/// 1. A concrete struct named `<Name>V<N>` (e.g. `ContractResultV1`) that carries all of the
+///    specified fields together with the requested `#[derive(…)]` attributes.
+/// 2. A public type alias `<Name> = <Name>V<N>` that always points to the *latest* defined version.
+///    When you introduce `V2`, re-run the macro with `version = 2` and the alias will update
+///    automatically.
 ///
 /// # Syntax
 ///
@@ -148,9 +148,7 @@ macro_rules! define_versioned_type {
 }
 
 /// The amount of balance that was either charged or refunded in order to pay for storage.
-#[derive(
-	Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo,
-)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, Debug, TypeInfo)]
 pub enum StorageDeposit<Balance> {
 	/// The transaction reduced storage consumption.
 	///

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -137,6 +137,7 @@ std = [
 	"pallet-recovery?/std",
 	"pallet-referenda?/std",
 	"pallet-remark?/std",
+	"pallet-revive-types?/std",
 	"pallet-revive?/std",
 	"pallet-root-offences?/std",
 	"pallet-root-testing?/std",
@@ -709,6 +710,7 @@ runtime-full = [
 	"pallet-remark",
 	"pallet-revive",
 	"pallet-revive-proc-macro",
+	"pallet-revive-types",
 	"pallet-revive-uapi",
 	"pallet-root-offences",
 	"pallet-root-testing",
@@ -1714,6 +1716,11 @@ path = "../substrate/frame/revive"
 default-features = false
 optional = true
 path = "../substrate/frame/revive/proc-macro"
+
+[dependencies.pallet-revive-types]
+default-features = false
+optional = true
+path = "../substrate/frame/revive/types"
 
 [dependencies.pallet-revive-uapi]
 default-features = false

--- a/umbrella/src/lib.rs
+++ b/umbrella/src/lib.rs
@@ -664,6 +664,10 @@ pub use pallet_revive;
 #[cfg(feature = "pallet-revive-proc-macro")]
 pub use pallet_revive_proc_macro;
 
+/// Versioned wire types for the pallet-revive runtime API boundary.
+#[cfg(feature = "pallet-revive-types")]
+pub use pallet_revive_types;
+
 /// Exposes all the host functions that a contract can import.
 #[cfg(feature = "pallet-revive-uapi")]
 pub use pallet_revive_uapi;


### PR DESCRIPTION
fixes https://github.com/paritytech/polkadot-sdk/issues/11924

Extracts all `ReviveApi` wire types into a new lightweight `pallet-revive-types` crate and introduces `define_versioned_type!` / `#[versioned_type]` macros so the runtime API can evolve with full backward compatibility.
