### PR TITLE
statement-store: add --seed flag for single-account latency probe

### DIFF
--- a/substrate/client/statement-store/statement-latency-bench/src/bench.rs
+++ b/substrate/client/statement-store/statement-latency-bench/src/bench.rs
@@ -41,7 +41,7 @@ use jsonrpsee::{
 use log::{debug, info, warn};
 use sc_statement_store::test_utils::get_keypair;
 use serde::{Deserialize, Serialize};
-use sp_core::{blake2_256, bounded_vec::BoundedVec, Bytes, ConstU32};
+use sp_core::{blake2_256, bounded_vec::BoundedVec, sr25519, Bytes, ConstU32, Pair};
 use sp_statement_store::{Statement, StatementEvent, SubmitResult, Topic, TopicFilter};
 use std::{
 	collections::{HashMap, HashSet},
@@ -89,6 +89,10 @@ struct Args {
 	/// Stop immediately on first round failure instead of continuing
 	#[arg(long, default_value = "false")]
 	fail_fast: bool,
+
+	/// Optional SURI / seed phrase for single-account mode
+	#[arg(long)]
+	seed: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -214,6 +218,7 @@ struct ClientConfig {
 	interval_ms: u64,
 	statement_expiry_ms: u64,
 	fail_fast: bool,
+	seed: Option<String>,
 }
 
 async fn execute_round(
@@ -383,7 +388,11 @@ async fn run_client(
 		..
 	} = &config;
 
-	let keyring = get_keypair(client_id);
+	let keyring = match &config.seed {
+		Some(suri) =>
+			sr25519::Pair::from_string(suri, None).expect("--seed validated at startup"),
+		None => get_keypair(client_id),
+	};
 
 	// Same cancel-safety caveat as the inter-round barrier: if any peer never reaches
 	// this point, the rest would block forever without a timeout.
@@ -493,6 +502,17 @@ async fn main() -> Result<(), anyhow::Error> {
 		));
 	}
 
+	if let Some(seed) = &args.seed {
+		if args.num_clients != 1 {
+			return Err(anyhow!(
+				"--seed requires --num-clients=1 (single-account quota model); got num_clients={}",
+				args.num_clients
+			));
+		}
+		sr25519::Pair::from_string(seed, None)
+			.map_err(|e| anyhow!("Invalid --seed SURI: {e:?}"))?;
+	}
+
 	log_configuration(&args, &messages_pattern);
 
 	let rpc_clients = connect_to_endpoints(&args.rpc_endpoints).await?;
@@ -515,6 +535,7 @@ async fn main() -> Result<(), anyhow::Error> {
 				interval_ms: args.interval_ms,
 				statement_expiry_ms: args.statement_expiry_ms,
 				fail_fast: args.fail_fast,
+				seed: args.seed.clone(),
 			};
 			let node_idx = (client_id as usize) % rpc_clients.len();
 			let rpc_client = Arc::clone(&rpc_clients[node_idx]);

--- a/substrate/client/statement-store/statement-latency-bench/src/bench.rs
+++ b/substrate/client/statement-store/statement-latency-bench/src/bench.rs
@@ -389,8 +389,7 @@ async fn run_client(
 	} = &config;
 
 	let keyring = match &config.seed {
-		Some(suri) =>
-			sr25519::Pair::from_string(suri, None).expect("--seed validated at startup"),
+		Some(suri) => sr25519::Pair::from_string(suri, None).expect("--seed validated at startup"),
 		None => get_keypair(client_id),
 	};
 


### PR DESCRIPTION
## Summary 

Adds an opt-in `--seed <SURI>` flag to `statement-latency-bench` so the                                                              
bench can run as a latency probe against networks where: 
- statement allowances can't be provisioned through Sudo, and                                                                        
- only a single, externally pre-allowanced account is available

## Motivation
Goal is a daily latency telemetry signal on Paseo People against a real                                                              
account with a fixed 50-statement / 50 KiB allowance, scheduled hourly                                                               
(1 statement × 1 KiB per run, 24 datapoints/day)