### PR TITLE
Add TransactionStorageApi v2 with `indexed_transactions` function

### DIFF
--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -251,6 +251,12 @@ macro_rules! impl_node_runtime_apis {
 				fn retention_period() -> sp_runtime::traits::NumberFor<$block> {
 					unimplemented!()
 				}
+
+				fn indexed_transactions(
+					_block: u32,
+				) -> Option<Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo>> {
+					unimplemented!()
+				}
 			}
 		}
 	};

--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -253,8 +253,8 @@ macro_rules! impl_node_runtime_apis {
 				}
 
 				fn indexed_transactions(
-					_block: u32,
-				) -> Option<Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo>> {
+					_block: sp_runtime::traits::NumberFor<$block>,
+				) -> Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo> {
 					unimplemented!()
 				}
 			}

--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -254,7 +254,7 @@ macro_rules! impl_node_runtime_apis {
 
 				fn indexed_transactions(
 					_block: sp_runtime::traits::NumberFor<$block>,
-				) -> Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo> {
+				) -> Vec<sp_transaction_storage_proof::IndexedTransactionInfo> {
 					unimplemented!()
 				}
 			}

--- a/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
+++ b/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
@@ -708,7 +708,7 @@ where
 				async move {
 					let has_tx_storage_api = client_clone
 						.runtime_api()
-						.has_api::<dyn TransactionStorageApi<Block>>(parent)
+						.has_api_with::<dyn TransactionStorageApi<Block>, _>(parent, |v| v >= 1)
 						.unwrap_or(false);
 					if has_tx_storage_api {
 						let storage_proof =
@@ -858,7 +858,7 @@ where
 					async move {
 						let has_tx_storage_api = client_clone
 							.runtime_api()
-							.has_api::<dyn TransactionStorageApi<Block>>(parent)
+							.has_api_with::<dyn TransactionStorageApi<Block>, _>(parent, |v| v >= 1)
 							.unwrap_or(false);
 						if has_tx_storage_api {
 							let storage_proof =

--- a/prdoc/pr_11939.prdoc
+++ b/prdoc/pr_11939.prdoc
@@ -11,6 +11,6 @@ crates:
 - name: polkadot-omni-node-lib
   bump: patch
 - name: pallet-transaction-storage
-  bump: patch
+  bump: minor
 - name: sp-transaction-storage-proof
-  bump: patch
+  bump: minor

--- a/prdoc/pr_11939.prdoc
+++ b/prdoc/pr_11939.prdoc
@@ -2,9 +2,7 @@ title: Add TransactionStorageApi v2 with `indexed_transactions` function
 doc:
 - audience: Runtime Dev
   description: |-
-    As discussed yesterday, this bumps TransactionStorageApi to v2 and offers the option to query data referenced in the blocks.
-
-    In an ideal world we would have extrinsic index to return per item too, but this is currently not stored in the runtime and I think we can get away without it.
+    This bumps `TransactionStorageApi` to v2 and offers the option to query data referenced in the blocks via `indexed_transactions`.
 crates:
 - name: polkadot-omni-node-lib
   bump: patch

--- a/prdoc/pr_11939.prdoc
+++ b/prdoc/pr_11939.prdoc
@@ -1,0 +1,16 @@
+title: Add TransactionStorageApi v2 with `indexed_transactions` function
+doc:
+- audience: Runtime Dev
+  description: |-
+    As discussed yesterday, this bumps TransactionStorageApi to v2 and offers the option to query data referenced in the blocks.
+
+    In an ideal world we would have extrinsic index to return per item too, but this is currently not stored in the runtime and I think we can get away without it.
+
+    cc @bkontur @karolk91
+crates:
+- name: polkadot-omni-node-lib
+  bump: patch
+- name: pallet-transaction-storage
+  bump: patch
+- name: sp-transaction-storage-proof
+  bump: patch

--- a/prdoc/pr_11939.prdoc
+++ b/prdoc/pr_11939.prdoc
@@ -5,8 +5,6 @@ doc:
     As discussed yesterday, this bumps TransactionStorageApi to v2 and offers the option to query data referenced in the blocks.
 
     In an ideal world we would have extrinsic index to return per item too, but this is currently not stored in the runtime and I think we can get away without it.
-
-    cc @bkontur @karolk91
 crates:
 - name: polkadot-omni-node-lib
   bump: patch

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3920,9 +3920,9 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 		}
 
 		fn indexed_transactions(
-			block: u32,
-		) -> Option<Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo>> {
-			TransactionStorage::indexed_transactions(block.into())
+			block: NumberFor<Block>,
+		) -> Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo> {
+			TransactionStorage::indexed_transactions(block)
 		}
 	}
 

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3921,7 +3921,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 
 		fn indexed_transactions(
 			block: NumberFor<Block>,
-		) -> Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo> {
+		) -> Vec<sp_transaction_storage_proof::IndexedTransactionInfo> {
 			TransactionStorage::indexed_transactions(block)
 		}
 	}

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3918,6 +3918,12 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 		fn retention_period() -> NumberFor<Block> {
 			TransactionStorage::retention_period()
 		}
+
+		fn indexed_transactions(
+			block: u32,
+		) -> Option<Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo>> {
+			TransactionStorage::indexed_transactions(block.into())
+		}
 	}
 
 	#[cfg(feature = "try-runtime")]

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -535,6 +535,9 @@ pub mod pallet {
 		pub fn indexed_transactions(
 			block: BlockNumberFor<T>,
 		) -> alloc::vec::Vec<sp_transaction_storage_proof::IndexedTransactionInfo> {
+
+			const RAW_CID_CODEC: sp_transaction_storage_proof::CidCodec = 0x55;
+
 			Transactions::<T>::get(block)
 				.map(|txs| {
 					txs.into_iter()
@@ -542,7 +545,7 @@ pub mod pallet {
 							content_hash: tx.content_hash.into(),
 							size: tx.size,
 							hashing: sp_transaction_storage_proof::HashingAlgorithm::Blake2b256,
-							cid_codec: sp_transaction_storage_proof::RAW_CID_CODEC,
+							cid_codec: RAW_CID_CODEC,
 							extrinsic_index: u32::MAX,
 						})
 						.collect()

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -534,18 +534,20 @@ pub mod pallet {
 
 		pub fn indexed_transactions(
 			block: BlockNumberFor<T>,
-		) -> Option<alloc::vec::Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo>> {
-			Transactions::<T>::get(block).map(|txs| {
-				txs.into_iter()
-					.map(|tx| sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo {
-						content_hash: tx.content_hash.into(),
-						size: tx.size,
-						hashing: sp_transaction_storage_proof::runtime_api::HashingAlgorithm::Blake2b256,
-						cid_codec: sp_transaction_storage_proof::runtime_api::RAW_CID_CODEC,
-						extrinsic_index: u32::MAX,
-					})
-					.collect()
-			})
+		) -> alloc::vec::Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo> {
+			Transactions::<T>::get(block)
+				.map(|txs| {
+					txs.into_iter()
+						.map(|tx| sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo {
+							content_hash: tx.content_hash.into(),
+							size: tx.size,
+							hashing: sp_transaction_storage_proof::runtime_api::HashingAlgorithm::Blake2b256,
+							cid_codec: sp_transaction_storage_proof::runtime_api::RAW_CID_CODEC,
+							extrinsic_index: u32::MAX,
+						})
+						.collect()
+				})
+				.unwrap_or_default()
 		}
 
 		/// Get ByteFee storage information from the outside of this pallet.

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -531,6 +531,22 @@ pub mod pallet {
 		) -> Option<BoundedVec<TransactionInfo, T::MaxBlockTransactions>> {
 			Transactions::<T>::get(block)
 		}
+
+		pub fn indexed_transactions(
+			block: BlockNumberFor<T>,
+		) -> Option<alloc::vec::Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo>> {
+			Transactions::<T>::get(block).map(|txs| {
+				txs.into_iter()
+					.map(|tx| sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo {
+						content_hash: tx.content_hash.into(),
+						size: tx.size,
+						hashing: sp_transaction_storage_proof::runtime_api::HashingAlgorithm::Blake2b256,
+						cid_codec: sp_transaction_storage_proof::runtime_api::RAW_CID_CODEC,
+					})
+					.collect()
+			})
+		}
+
 		/// Get ByteFee storage information from the outside of this pallet.
 		pub fn byte_fee() -> Option<BalanceOf<T>> {
 			ByteFee::<T>::get()

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -542,6 +542,7 @@ pub mod pallet {
 						size: tx.size,
 						hashing: sp_transaction_storage_proof::runtime_api::HashingAlgorithm::Blake2b256,
 						cid_codec: sp_transaction_storage_proof::runtime_api::RAW_CID_CODEC,
+						extrinsic_index: u32::MAX,
 					})
 					.collect()
 			})

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -534,18 +534,16 @@ pub mod pallet {
 
 		pub fn indexed_transactions(
 			block: BlockNumberFor<T>,
-		) -> alloc::vec::Vec<sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo> {
+		) -> alloc::vec::Vec<sp_transaction_storage_proof::IndexedTransactionInfo> {
 			Transactions::<T>::get(block)
 				.map(|txs| {
 					txs.into_iter()
-						.map(|tx| {
-							sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo {
+						.map(|tx| sp_transaction_storage_proof::IndexedTransactionInfo {
 							content_hash: tx.content_hash.into(),
 							size: tx.size,
-							hashing: sp_transaction_storage_proof::runtime_api::HashingAlgorithm::Blake2b256,
-							cid_codec: sp_transaction_storage_proof::runtime_api::RAW_CID_CODEC,
+							hashing: sp_transaction_storage_proof::HashingAlgorithm::Blake2b256,
+							cid_codec: sp_transaction_storage_proof::RAW_CID_CODEC,
 							extrinsic_index: u32::MAX,
-						}
 						})
 						.collect()
 				})

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -535,7 +535,6 @@ pub mod pallet {
 		pub fn indexed_transactions(
 			block: BlockNumberFor<T>,
 		) -> alloc::vec::Vec<sp_transaction_storage_proof::IndexedTransactionInfo> {
-
 			const RAW_CID_CODEC: sp_transaction_storage_proof::CidCodec = 0x55;
 
 			Transactions::<T>::get(block)

--- a/substrate/frame/transaction-storage/src/lib.rs
+++ b/substrate/frame/transaction-storage/src/lib.rs
@@ -538,12 +538,14 @@ pub mod pallet {
 			Transactions::<T>::get(block)
 				.map(|txs| {
 					txs.into_iter()
-						.map(|tx| sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo {
+						.map(|tx| {
+							sp_transaction_storage_proof::runtime_api::IndexedTransactionInfo {
 							content_hash: tx.content_hash.into(),
 							size: tx.size,
 							hashing: sp_transaction_storage_proof::runtime_api::HashingAlgorithm::Blake2b256,
 							cid_codec: sp_transaction_storage_proof::runtime_api::RAW_CID_CODEC,
 							extrinsic_index: u32::MAX,
+						}
 						})
 						.collect()
 				})

--- a/substrate/primitives/transaction-storage-proof/src/lib.rs
+++ b/substrate/primitives/transaction-storage-proof/src/lib.rs
@@ -28,6 +28,7 @@ use core::result::Result;
 
 use alloc::vec::Vec;
 use codec::{Decode, DecodeWithMemTracking, Encode};
+use scale_info::TypeInfo;
 use sp_inherents::{InherentData, InherentIdentifier, IsFatalError};
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 
@@ -40,6 +41,45 @@ pub const CHUNK_SIZE: usize = 256;
 
 /// Type used for counting/tracking chunks.
 pub type ChunkIndex = u32;
+
+/// Hash of indexed data; the algorithm is reported in [`HashingAlgorithm`].
+pub type ContentHash = [u8; 32];
+
+/// IPFS [multicodec](https://github.com/multiformats/multicodec) content-type
+/// identifier for an indexed payload.
+pub type CidCodec = u64;
+
+/// Multicodec identifier for opaque, raw bytes.
+pub const RAW_CID_CODEC: CidCodec = 0x55;
+
+/// Hashing algorithm used to compute a [`ContentHash`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+#[non_exhaustive]
+pub enum HashingAlgorithm {
+	/// BLAKE2b-256.
+	Blake2b256,
+	/// SHA2-256.
+	Sha2_256,
+	/// Keccak-256.
+	Keccak256,
+}
+
+/// Metadata for a single indexed transaction.
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+pub struct IndexedTransactionInfo {
+	/// Hash of the indexed data.
+	pub content_hash: ContentHash,
+	/// Size of the indexed data, in bytes.
+	pub size: u32,
+	/// Algorithm used to compute `content_hash`.
+	pub hashing: HashingAlgorithm,
+	/// CID codec for constructing the IPFS CID for the indexed data.
+	pub cid_codec: CidCodec,
+	/// Extrinsic index that produced this entry via `store` or `renew`.
+	///
+	/// `u32::MAX` when the producing pallet does not record it.
+	pub extrinsic_index: u32,
+}
 
 /// Errors that can occur while checking the storage proof.
 #[derive(Encode, Debug)]

--- a/substrate/primitives/transaction-storage-proof/src/lib.rs
+++ b/substrate/primitives/transaction-storage-proof/src/lib.rs
@@ -51,7 +51,6 @@ pub type CidCodec = u64;
 
 /// Hashing algorithm used to compute a [`ContentHash`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
-#[non_exhaustive]
 pub enum HashingAlgorithm {
 	/// BLAKE2b-256.
 	Blake2b256,

--- a/substrate/primitives/transaction-storage-proof/src/lib.rs
+++ b/substrate/primitives/transaction-storage-proof/src/lib.rs
@@ -49,9 +49,6 @@ pub type ContentHash = [u8; 32];
 /// identifier for an indexed payload.
 pub type CidCodec = u64;
 
-/// Multicodec identifier for opaque, raw bytes.
-pub const RAW_CID_CODEC: CidCodec = 0x55;
-
 /// Hashing algorithm used to compute a [`ContentHash`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
 #[non_exhaustive]

--- a/substrate/primitives/transaction-storage-proof/src/lib.rs
+++ b/substrate/primitives/transaction-storage-proof/src/lib.rs
@@ -46,7 +46,7 @@ pub type ChunkIndex = u32;
 pub type ContentHash = [u8; 32];
 
 /// IPFS [multicodec](https://github.com/multiformats/multicodec) content-type
-/// identifier for an indexed payload.
+/// identifier for an indexed payload. Full list of values [here](https://github.com/multiformats/multicodec/blob/master/table.csv).
 pub type CidCodec = u64;
 
 /// Hashing algorithm used to compute a [`ContentHash`].

--- a/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
+++ b/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
@@ -57,7 +57,10 @@ sp_api::decl_runtime_apis! {
 		/// Get the actual value of a retention period in blocks.
 		fn retention_period() -> NumberFor<Block>;
 
-		/// Get indexed-transaction metadata for a block.
-		fn indexed_transactions(block: u32) -> Option<Vec<IndexedTransactionInfo>>;
+		/// Get indexed-transaction metadata for `block`.
+		///
+		/// Returns an empty vector if the block has no indexed transactions or
+		/// is outside the retention window.
+		fn indexed_transactions(block: NumberFor<Block>) -> Vec<IndexedTransactionInfo>;
 	}
 }

--- a/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
+++ b/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
@@ -18,49 +18,19 @@
 //! Runtime API definition for the transaction storage proof processing.
 
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
-use scale_info::TypeInfo;
 use sp_runtime::traits::NumberFor;
-
-pub type ContentHash = [u8; 32];
-
-pub type CidCodec = u64;
-
-pub const RAW_CID_CODEC: CidCodec = 0x55;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
-#[non_exhaustive]
-pub enum HashingAlgorithm {
-	Blake2b256,
-	Sha2_256,
-	Keccak256,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
-pub struct IndexedTransactionInfo {
-	pub content_hash: ContentHash,
-	pub size: u32,
-	pub hashing: HashingAlgorithm,
-	pub cid_codec: CidCodec,
-	/// Extrinsic index within the block that originally indexed this data
-	/// (via `sp_io::transaction_index::index` / `renew`). For renewed entries
-	/// this holds the renewer's extrinsic index, not the original. Downstream
-	/// pallets that did not previously persist this value may emit `u32::MAX`
-	/// as a sentinel for entries that pre-date the field.
-	pub extrinsic_index: u32,
-}
 
 sp_api::decl_runtime_apis! {
 	/// Runtime API trait for transaction storage support.
 	#[api_version(2)]
 	pub trait TransactionStorageApi {
-		/// Get the actual value of a retention period in blocks.
+		/// Retention period for indexed data, in blocks.
 		fn retention_period() -> NumberFor<Block>;
 
-		/// Get indexed-transaction metadata for `block`.
+		/// Indexed-transaction metadata for `block`.
 		///
 		/// Returns an empty vector if the block has no indexed transactions or
 		/// is outside the retention window.
-		fn indexed_transactions(block: NumberFor<Block>) -> Vec<IndexedTransactionInfo>;
+		fn indexed_transactions(block: NumberFor<Block>) -> Vec<crate::IndexedTransactionInfo>;
 	}
 }

--- a/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
+++ b/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
@@ -42,6 +42,12 @@ pub struct IndexedTransactionInfo {
 	pub size: u32,
 	pub hashing: HashingAlgorithm,
 	pub cid_codec: CidCodec,
+	/// Extrinsic index within the block that originally indexed this data
+	/// (via `sp_io::transaction_index::index` / `renew`). For renewed entries
+	/// this holds the renewer's extrinsic index, not the original. Downstream
+	/// pallets that did not previously persist this value may emit `u32::MAX`
+	/// as a sentinel for entries that pre-date the field.
+	pub extrinsic_index: u32,
 }
 
 sp_api::decl_runtime_apis! {

--- a/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
+++ b/substrate/primitives/transaction-storage-proof/src/runtime_api.rs
@@ -17,12 +17,41 @@
 
 //! Runtime API definition for the transaction storage proof processing.
 
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use sp_runtime::traits::NumberFor;
+
+pub type ContentHash = [u8; 32];
+
+pub type CidCodec = u64;
+
+pub const RAW_CID_CODEC: CidCodec = 0x55;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+#[non_exhaustive]
+pub enum HashingAlgorithm {
+	Blake2b256,
+	Sha2_256,
+	Keccak256,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo)]
+pub struct IndexedTransactionInfo {
+	pub content_hash: ContentHash,
+	pub size: u32,
+	pub hashing: HashingAlgorithm,
+	pub cid_codec: CidCodec,
+}
 
 sp_api::decl_runtime_apis! {
 	/// Runtime API trait for transaction storage support.
+	#[api_version(2)]
 	pub trait TransactionStorageApi {
 		/// Get the actual value of a retention period in blocks.
 		fn retention_period() -> NumberFor<Block>;
+
+		/// Get indexed-transaction metadata for a block.
+		fn indexed_transactions(block: u32) -> Option<Vec<IndexedTransactionInfo>>;
 	}
 }


### PR DESCRIPTION
As discussed yesterday, this bumps TransactionStorageApi to v2 and offers the option to query data referenced in the blocks.

In an ideal world we would have extrinsic index to return per item too, but this is currently not stored in the runtime and I think we can get away without it.

cc @bkontur @karolk91