### PR TITLE
Automatic weight sanity checker for the benchmarking CLI

### DIFF
--- a/.github/workflows/check-frame-omni-bencher.yml
+++ b/.github/workflows/check-frame-omni-bencher.yml
@@ -42,7 +42,7 @@ jobs:
         id: required
         run: |
           forklift cargo build --locked --quiet --release -p asset-hub-westend-runtime --features runtime-benchmarks
-          forklift cargo run --locked --release -p frame-omni-bencher --quiet -- v1 benchmark pallet --runtime target/release/wbuild/asset-hub-westend-runtime/asset_hub_westend_runtime.compact.compressed.wasm --all --steps 2 --repeat 1 --quiet --min-duration 0
+          forklift cargo run --locked --release -p frame-omni-bencher --quiet -- v1 benchmark pallet --runtime target/release/wbuild/asset-hub-westend-runtime/asset_hub_westend_runtime.compact.compressed.wasm --all --steps 2 --repeat 1 --quiet --min-duration 0 --sanity-weight-check ignore
       - name: Stop all workflows if failed
         if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
         uses: ./.github/actions/workflow-stopper
@@ -102,7 +102,7 @@ jobs:
           ls -lrt $RUNTIME_BLOB_PATH
 
           if [[ "$BENCH_CMD" == "pallet" ]]; then
-            cmd="./target/release/frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1 --min-duration 0 $FLAGS"
+            cmd="./target/release/frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1 --min-duration 0 --sanity-weight-check ignore $FLAGS"
           elif [[ "$BENCH_CMD" == "overhead" ]]; then
             cmd="./target/release/frame-omni-bencher v1 benchmark overhead --runtime $RUNTIME_BLOB_PATH"
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: script
-        run: forklift cargo run --locked --release -p staging-node-cli --bin substrate-node --features runtime-benchmarks --quiet -- benchmark pallet --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1 --min-duration 0 --quiet
+        run: forklift cargo run --locked --release -p staging-node-cli --bin substrate-node --features runtime-benchmarks --quiet -- benchmark pallet --chain dev --pallet "*" --extrinsic "*" --steps 2 --repeat 1 --min-duration 0 --quiet --sanity-weight-check ignore
 
   # cf https://github.com/paritytech/polkadot-sdk/issues/1652
   test-syscalls:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7289,6 +7289,7 @@ dependencies = [
  "array-bytes 6.2.2",
  "chrono",
  "clap",
+ "color-print",
  "comfy-table",
  "cumulus-client-parachain-inherent",
  "cumulus-primitives-core",

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1682,6 +1682,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1687,8 +1687,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1688,7 +1688,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -2742,7 +2742,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -2741,8 +2741,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -2736,6 +2736,17 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -1092,8 +1092,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -1093,7 +1093,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -1087,6 +1087,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -1066,6 +1066,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -1071,8 +1071,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -1072,7 +1072,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -1196,7 +1196,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -1190,6 +1190,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -1195,8 +1195,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -770,7 +770,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -764,6 +764,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -769,8 +769,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -1047,8 +1047,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -1042,6 +1042,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -1048,7 +1048,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -484,7 +484,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -478,6 +478,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -164,6 +164,7 @@ impl frame_system::Config for Runtime {
 	type Version = Version;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
+	type DbWeight = RocksDbWeight;
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -484,8 +484,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -1006,8 +1006,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -1007,7 +1007,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -1001,6 +1001,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -1131,8 +1131,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -1132,7 +1132,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -1126,6 +1126,17 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -225,6 +225,10 @@ macro_rules! impl_node_runtime_apis {
 				) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, String> {
 					unimplemented!()
 				}
+
+				fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+					unimplemented!()
+				}
 			}
 
 			impl sp_genesis_builder::GenesisBuilder<$block> for $runtime {

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2495,7 +2495,7 @@ sp_api::impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2494,8 +2494,7 @@ sp_api::impl_runtime_apis! {
 			let max_extrinsic_weight = BlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -2489,6 +2489,17 @@ sp_api::impl_runtime_apis! {
 			return (list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = BlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig,

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2818,6 +2818,17 @@ sp_api::impl_runtime_apis! {
 			return (list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = BlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig,

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2824,7 +2824,7 @@ sp_api::impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -2823,8 +2823,7 @@ sp_api::impl_runtime_apis! {
 			let max_extrinsic_weight = BlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/prdoc/pr_11941.prdoc
+++ b/prdoc/pr_11941.prdoc
@@ -1,0 +1,75 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: "Automatic weight sanity checker for the benchmarking CLI"
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Adds an automatic sanity check that runs after `frame-omni-bencher v1 benchmark pallet`
+      (or `polkadot benchmark pallet`). For every benchmarked extrinsic the check evaluates
+      the worst-case weight (every complexity component at its maximum value) and compares it
+      against the runtime's max extrinsic weight for `DispatchClass::Normal`. Misconfigured
+      runtimes whose extrinsics cannot fit in a single block are caught immediately instead
+      of silently producing unusable weight files.
+
+      Behaviour is controlled by the new `--sanity-weight-check <error|warning|ignore>` flag.
+      Default is `error`, so a real benchmark run fails loudly on misconfiguration. The check
+      always runs after weight files are written, so the failing weights are still persisted
+      on disk for inspection.
+
+      The check is silently skipped when:
+      - the runtime exposes only Benchmark runtime API v2 (no `runtime_block_limits`), or
+      - the CLI is re-analysing a JSON input (no live runtime metadata).
+
+      Closes #152.
+
+  - audience: Node Dev
+    description: |
+      The `Benchmark` runtime API is bumped from v2 to v3 and gains a new method
+      `runtime_block_limits()` returning a `RuntimeBlockLimits { max_extrinsic_weight,
+      db_weight }` struct. Existing methods (`benchmark_metadata`, `dispatch_benchmark`)
+      are unchanged, so v2 runtimes continue to work — the CLI falls back gracefully and
+      simply skips the new sanity check on those runtimes.
+
+crates:
+  - name: frame-benchmarking
+    bump: major
+  - name: frame-benchmarking-cli
+    bump: minor
+  - name: sc-cli
+    bump: minor
+  - name: kitchensink-runtime
+    bump: minor
+  - name: rococo-runtime
+    bump: minor
+  - name: westend-runtime
+    bump: minor
+  - name: asset-hub-rococo-runtime
+    bump: minor
+  - name: asset-hub-westend-runtime
+    bump: minor
+  - name: bridge-hub-rococo-runtime
+    bump: minor
+  - name: bridge-hub-westend-runtime
+    bump: minor
+  - name: collectives-westend-runtime
+    bump: minor
+  - name: coretime-westend-runtime
+    bump: minor
+  - name: glutton-westend-runtime
+    bump: minor
+  - name: people-westend-runtime
+    bump: minor
+  - name: penpal-runtime
+    bump: minor
+  - name: pallet-staking-async-rc-runtime
+    bump: minor
+  - name: pallet-staking-async-parachain-runtime
+    bump: minor
+  - name: parachain-template-runtime
+    bump: minor
+  - name: solochain-template-runtime
+    bump: minor
+  - name: polkadot-omni-node-lib
+    bump: minor

--- a/prdoc/pr_11941.prdoc
+++ b/prdoc/pr_11941.prdoc
@@ -11,26 +11,36 @@ doc:
       the worst-case weight (every complexity component at its maximum value) and compares it
       against the runtime's max extrinsic weight for `DispatchClass::Normal`. Misconfigured
       runtimes whose extrinsics cannot fit in a single block are caught immediately instead
-      of silently producing unusable weight files.
+      of silently producing unusable weight files (see incident #1589).
 
-      Behaviour is controlled by the new `--sanity-weight-check <error|warning|ignore>` flag.
-      Default is `error`, so a real benchmark run fails loudly on misconfiguration. The check
-      always runs after weight files are written, so the failing weights are still persisted
-      on disk for inspection.
+      Behaviour is controlled by the new `--sanity-weight-check <error|warning|ignore>` flag
+      on `benchmark pallet`. Default is `warning` for the first release shipping the check —
+      teams see the diagnostic without breaking existing pipelines; tightening to `error` is
+      planned as a follow-up once everyone has had a cycle to react.
 
-      The check is silently skipped when:
-      - the runtime exposes only Benchmark runtime API v2 (no `runtime_block_limits`), or
+      The check always runs after weight files are written, so failing weights are still
+      persisted on disk for inspection (per @ggwpez's guidance on the predecessor PR).
+
+      The check is silently skipped (with a distinct log warning per case) when:
+      - the runtime exposes only Benchmark runtime API v2 (no `runtime_block_limits`),
+      - the runtime returns `None` for `max_extrinsic_weight` (no per-extrinsic cap), or
       - the CLI is re-analysing a JSON input (no live runtime metadata).
 
-      Closes #152.
+      Closes #152. Continues #1493 by @Daanvdplas (closed due to inactivity after being
+      formally approved by @kianenigma in October 2023). Co-authored with @Daanvdplas on
+      the relevant commits.
 
   - audience: Node Dev
     description: |
       The `Benchmark` runtime API is bumped from v2 to v3 and gains a new method
-      `runtime_block_limits()` returning a `RuntimeBlockLimits { max_extrinsic_weight,
-      db_weight }` struct. Existing methods (`benchmark_metadata`, `dispatch_benchmark`)
-      are unchanged, so v2 runtimes continue to work — the CLI falls back gracefully and
-      simply skips the new sanity check on those runtimes.
+      `runtime_block_limits()` returning a `RuntimeBlockLimits { max_extrinsic_weight:
+      Option<Weight>, db_weight: RuntimeDbWeight }` struct. Existing methods
+      (`benchmark_metadata`, `dispatch_benchmark`) are unchanged, so v2 runtimes continue
+      to work — the CLI gates the v3 call on `benchmark_api_version >= 3` and skips the
+      sanity check rather than silently swallowing real runtime errors.
+
+      The flag lives on `PalletCmd`, not `SharedParams`, so it only appears in `--help` for
+      the `benchmark pallet` subcommand where it has effect.
 
 crates:
   - name: frame-benchmarking

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3982,7 +3982,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3981,8 +3981,7 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -3976,6 +3976,17 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -113,7 +113,11 @@ pub enum SanityWeightCheck {
 }
 
 /// The default [`SanityWeightCheck`].
-pub const DEFAULT_SANITY_WEIGHT_CHECK: SanityWeightCheck = SanityWeightCheck::Error;
+///
+/// Starts as `Warning` for the first release that ships the check so existing benchmark
+/// pipelines do not start failing on configurations that historically passed. Tightening
+/// this to `Error` is planned for a follow-up release once teams have had a cycle to react.
+pub const DEFAULT_SANITY_WEIGHT_CHECK: SanityWeightCheck = SanityWeightCheck::Warning;
 
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -98,6 +98,23 @@ pub fn execution_method_from_cli(
 /// The default [`WasmExecutionMethod`].
 pub const DEFAULT_WASM_EXECUTION_METHOD: WasmExecutionMethod = WasmExecutionMethod::Compiled;
 
+/// How the benchmarking CLI should react when an extrinsic's worst-case weight exceeds the
+/// runtime's max extrinsic weight.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum SanityWeightCheck {
+	/// Print the results and return an error if any extrinsic exceeds the limit.
+	Error,
+	/// Print the results and a warning, but do not return an error.
+	Warning,
+	/// Skip the sanity weight check.
+	Ignore,
+}
+
+/// The default [`SanityWeightCheck`].
+pub const DEFAULT_SANITY_WEIGHT_CHECK: SanityWeightCheck = SanityWeightCheck::Error;
+
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]

--- a/substrate/client/cli/src/arg_enums.rs
+++ b/substrate/client/cli/src/arg_enums.rs
@@ -98,27 +98,6 @@ pub fn execution_method_from_cli(
 /// The default [`WasmExecutionMethod`].
 pub const DEFAULT_WASM_EXECUTION_METHOD: WasmExecutionMethod = WasmExecutionMethod::Compiled;
 
-/// How the benchmarking CLI should react when an extrinsic's worst-case weight exceeds the
-/// runtime's max extrinsic weight.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-#[value(rename_all = "kebab-case")]
-pub enum SanityWeightCheck {
-	/// Print the results and return an error if any extrinsic exceeds the limit.
-	Error,
-	/// Print the results and a warning, but do not return an error.
-	Warning,
-	/// Skip the sanity weight check.
-	Ignore,
-}
-
-/// The default [`SanityWeightCheck`].
-///
-/// Starts as `Warning` for the first release that ships the check so existing benchmark
-/// pipelines do not start failing on configurations that historically passed. Tightening
-/// this to `Error` is planned for a follow-up release once teams have had a cycle to react.
-pub const DEFAULT_SANITY_WEIGHT_CHECK: SanityWeightCheck = SanityWeightCheck::Warning;
-
 #[allow(missing_docs)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]

--- a/substrate/client/cli/src/params/shared_params.rs
+++ b/substrate/client/cli/src/params/shared_params.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::arg_enums::{SanityWeightCheck, TracingReceiver, DEFAULT_SANITY_WEIGHT_CHECK};
+use crate::arg_enums::TracingReceiver;
 use clap::Args;
 use sc_service::config::BasePath;
 use std::path::PathBuf;
@@ -89,16 +89,6 @@ pub struct SharedParams {
 	/// Receiver to process tracing messages.
 	#[arg(long, value_name = "RECEIVER", value_enum, ignore_case = true, default_value_t = TracingReceiver::Log)]
 	pub tracing_receiver: TracingReceiver,
-
-	/// How to react when an extrinsic exceeds the runtime's max extrinsic weight during a
-	/// benchmark run.
-	#[arg(
-		long,
-		value_name = "ERROR_LEVEL",
-		value_enum,
-		default_value_t = DEFAULT_SANITY_WEIGHT_CHECK,
-	)]
-	pub sanity_weight_check: SanityWeightCheck,
 }
 
 impl SharedParams {

--- a/substrate/client/cli/src/params/shared_params.rs
+++ b/substrate/client/cli/src/params/shared_params.rs
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::arg_enums::TracingReceiver;
+use crate::arg_enums::{SanityWeightCheck, TracingReceiver, DEFAULT_SANITY_WEIGHT_CHECK};
 use clap::Args;
 use sc_service::config::BasePath;
 use std::path::PathBuf;
@@ -89,6 +89,16 @@ pub struct SharedParams {
 	/// Receiver to process tracing messages.
 	#[arg(long, value_name = "RECEIVER", value_enum, ignore_case = true, default_value_t = TracingReceiver::Log)]
 	pub tracing_receiver: TracingReceiver,
+
+	/// How to react when an extrinsic exceeds the runtime's max extrinsic weight during a
+	/// benchmark run.
+	#[arg(
+		long,
+		value_name = "ERROR_LEVEL",
+		value_enum,
+		default_value_t = DEFAULT_SANITY_WEIGHT_CHECK,
+	)]
+	pub sanity_weight_check: SanityWeightCheck,
 }
 
 impl SharedParams {

--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -245,7 +245,7 @@ pub struct BenchmarkMetadata {
 }
 
 /// Runtime-level weight limits exposed to the benchmarking CLI for the sanity check.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
 pub struct RuntimeBlockLimits {
 	/// Maximum weight an extrinsic of `DispatchClass::Normal` can have in a block.
 	pub max_extrinsic_weight: Weight,

--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -18,7 +18,10 @@
 //! Interfaces, types and utils for benchmarking a FRAME runtime.
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
-use frame_support::{dispatch::DispatchErrorWithPostInfo, pallet_prelude::*, traits::StorageInfo};
+use frame_support::{
+	dispatch::DispatchErrorWithPostInfo, pallet_prelude::*, traits::StorageInfo,
+	weights::RuntimeDbWeight,
+};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -241,9 +244,18 @@ pub struct BenchmarkMetadata {
 	pub pov_modes: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
+/// Runtime-level weight limits exposed to the benchmarking CLI for the sanity check.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
+pub struct RuntimeBlockLimits {
+	/// Maximum weight an extrinsic of `DispatchClass::Normal` can have in a block.
+	pub max_extrinsic_weight: Weight,
+	/// Per-operation database read/write weight cost configured by the runtime.
+	pub db_weight: RuntimeDbWeight,
+}
+
 sp_api::decl_runtime_apis! {
 	/// Runtime api for benchmarking a FRAME runtime.
-	#[api_version(2)]
+	#[api_version(3)]
 	pub trait Benchmark {
 		/// Get the benchmark metadata available for this runtime.
 		///
@@ -254,6 +266,9 @@ sp_api::decl_runtime_apis! {
 
 		/// Dispatch the given benchmark.
 		fn dispatch_benchmark(config: BenchmarkConfig) -> Result<Vec<BenchmarkBatch>, alloc::string::String>;
+
+		/// Runtime block-level weight limits used by the CLI's sanity weight check.
+		fn runtime_block_limits() -> RuntimeBlockLimits;
 	}
 }
 

--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -253,6 +253,13 @@ pub struct RuntimeBlockLimits {
 	pub db_weight: RuntimeDbWeight,
 }
 
+impl RuntimeBlockLimits {
+	/// Construct a new `RuntimeBlockLimits`.
+	pub fn new(max_extrinsic_weight: Weight, db_weight: RuntimeDbWeight) -> Self {
+		Self { max_extrinsic_weight, db_weight }
+	}
+}
+
 sp_api::decl_runtime_apis! {
 	/// Runtime api for benchmarking a FRAME runtime.
 	#[api_version(3)]

--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -245,6 +245,10 @@ pub struct BenchmarkMetadata {
 }
 
 /// Runtime-level weight limits exposed to the benchmarking CLI for the sanity check.
+///
+/// The `Default` impl produces all-zero values which the CLI treats as the "skip" sentinel
+/// (used both for `Benchmark` API v2 runtimes and for re-analysis paths that lack live
+/// runtime metadata). Tests and stubs can rely on this without manually wiring the fields.
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
 pub struct RuntimeBlockLimits {
 	/// Maximum weight an extrinsic of `DispatchClass::Normal` can have in a block.

--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -248,14 +248,18 @@ pub struct BenchmarkMetadata {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, TypeInfo)]
 pub struct RuntimeBlockLimits {
 	/// Maximum weight an extrinsic of `DispatchClass::Normal` can have in a block.
-	pub max_extrinsic_weight: Weight,
+	///
+	/// `None` when the runtime has no per-extrinsic cap configured for this class — the CLI
+	/// skips the sanity check in that case rather than producing a vacuous pass against
+	/// `Weight::MAX`.
+	pub max_extrinsic_weight: Option<Weight>,
 	/// Per-operation database read/write weight cost configured by the runtime.
 	pub db_weight: RuntimeDbWeight,
 }
 
 impl RuntimeBlockLimits {
 	/// Construct a new `RuntimeBlockLimits`.
-	pub fn new(max_extrinsic_weight: Weight, db_weight: RuntimeDbWeight) -> Self {
+	pub fn new(max_extrinsic_weight: Option<Weight>, db_weight: RuntimeDbWeight) -> Self {
 		Self { max_extrinsic_weight, db_weight }
 	}
 }

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1850,6 +1850,17 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, alloc::string::String> {

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1855,8 +1855,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1856,7 +1856,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -2739,6 +2739,17 @@ sp_api::impl_runtime_apis! {
 			return (list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			let max_extrinsic_weight = BlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig,

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -2745,7 +2745,7 @@ sp_api::impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/substrate/frame/staking-async/runtimes/rc/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/src/lib.rs
@@ -2744,8 +2744,7 @@ sp_api::impl_runtime_apis! {
 			let max_extrinsic_weight = BlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/substrate/utils/frame/benchmarking-cli/Cargo.toml
+++ b/substrate/utils/frame/benchmarking-cli/Cargo.toml
@@ -22,6 +22,7 @@ array-bytes = { workspace = true, default-features = true }
 chrono = { workspace = true }
 clap = { features = ["derive"], workspace = true }
 codec = { workspace = true, default-features = true }
+color-print = { workspace = true }
 comfy-table = { workspace = true }
 cumulus-client-parachain-inherent = { workspace = true, default-features = true }
 cumulus-primitives-core = { workspace = true, default-features = true }

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -359,23 +359,28 @@ impl PalletCmd {
 				ERROR_API_NOT_FOUND,
 			)?;
 
-		// Fetch the runtime block limits used by the sanity weight check. Older runtimes that do
-		// not implement `Benchmark_runtime_block_limits` (API v2) fall back to defaults; in that
-		// case `--sanity-weight-check` should be set to `ignore`.
-		let runtime_block_limits: RuntimeBlockLimits = Self::exec_state_machine(
-			StateMachine::new(
-				state,
-				&mut Default::default(),
-				&executor,
-				"Benchmark_runtime_block_limits",
-				&[],
-				&mut Self::build_extensions(executor.clone(), state.recorder()),
-				&runtime_code,
-				CallContext::Offchain,
-			),
-			ERROR_API_NOT_FOUND,
-		)
-		.unwrap_or_default();
+		// Fetch the runtime block limits used by the sanity weight check. Older runtimes on
+		// `Benchmark` API v2 do not expose `runtime_block_limits`; in that case the CLI uses a
+		// default which `sanity_weight_check` interprets as "skip with a warning". Genuine
+		// failures (panic, codec error, OOM) when calling the v3 method are surfaced rather
+		// than swallowed.
+		let runtime_block_limits: RuntimeBlockLimits = if benchmark_api_version >= 3 {
+			Self::exec_state_machine(
+				StateMachine::new(
+					state,
+					&mut Default::default(),
+					&executor,
+					"Benchmark_runtime_block_limits",
+					&[],
+					&mut Self::build_extensions(executor.clone(), state.recorder()),
+					&runtime_code,
+					CallContext::Offchain,
+				),
+				"Could not call `Benchmark_runtime_block_limits` runtime api.",
+			)?
+		} else {
+			RuntimeBlockLimits::default()
+		};
 
 		// Use the benchmark list and the user input to determine the set of benchmarks to run.
 		let benchmarks_to_run = self.select_benchmarks_to_run(list)?;

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -831,19 +831,24 @@ impl PalletCmd {
 			)?;
 		}
 
+		// The sanity weight check is intended as a guardrail when generating weight files. If no
+		// `--output` was provided the user is doing exploratory work (e.g. inspecting JSON), so
+		// running the check would produce a hard error on a config they did not intend to ship.
 		// Suppress the sanity check's stdout output when JSON has already been written there or
 		// `--quiet` is set; the check still runs and still returns `Err` on `Error` mode, just
 		// without polluting machine-readable output.
-		writer::sanity_weight_check(
-			&batches,
-			&storage_info,
-			&component_ranges,
-			pov_modes,
-			self,
-			runtime_block_limits,
-			self.sanity_weight_check,
-			json_to_stdout || self.quiet,
-		)?;
+		if self.output.is_some() {
+			writer::sanity_weight_check(
+				&batches,
+				&storage_info,
+				&component_ranges,
+				pov_modes,
+				self,
+				runtime_block_limits,
+				self.sanity_weight_check,
+				json_to_stdout || self.quiet,
+			)?;
+		}
 
 		Ok(())
 	}

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -840,7 +840,7 @@ impl PalletCmd {
 			pov_modes,
 			self,
 			runtime_block_limits,
-			self.shared_params.sanity_weight_check,
+			self.sanity_weight_check,
 			json_to_stdout || self.quiet,
 		)?;
 

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -805,7 +805,8 @@ impl PalletCmd {
 		runtime_block_limits: &RuntimeBlockLimits,
 	) -> Result<()> {
 		// Jsonify the result and write it to a file or stdout if desired.
-		if !self.jsonify(&batches)? && !self.quiet {
+		let json_to_stdout = self.jsonify(&batches)?;
+		if !json_to_stdout && !self.quiet {
 			// Print the summary only if `jsonify` did not write to stdout.
 			self.print_summary(&batches, &storage_info, pov_modes.clone())
 		}
@@ -824,6 +825,9 @@ impl PalletCmd {
 			)?;
 		}
 
+		// Suppress the sanity check's stdout output when JSON has already been written there or
+		// `--quiet` is set; the check still runs and still returns `Err` on `Error` mode, just
+		// without polluting machine-readable output.
 		writer::sanity_weight_check(
 			&batches,
 			&storage_info,
@@ -832,6 +836,7 @@ impl PalletCmd {
 			self,
 			runtime_block_limits,
 			self.shared_params.sanity_weight_check,
+			json_to_stdout || self.quiet,
 		)?;
 
 		Ok(())

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -359,11 +359,20 @@ impl PalletCmd {
 				ERROR_API_NOT_FOUND,
 			)?;
 
-		// Fetch the runtime block limits used by the sanity weight check. Older runtimes on
-		// `Benchmark` API v2 do not expose `runtime_block_limits`; in that case the CLI uses a
-		// default which `sanity_weight_check` interprets as "skip with a warning". Genuine
-		// failures (panic, codec error, OOM) when calling the v3 method are surfaced rather
-		// than swallowed.
+		// Use the benchmark list and the user input to determine the set of benchmarks to run.
+		let benchmarks_to_run = self.select_benchmarks_to_run(list)?;
+
+		if let Some(list_output) = self.list {
+			list_benchmark(benchmarks_to_run, list_output, self.no_csv_header);
+			return Ok(());
+		}
+
+		// Fetch the runtime block limits used by the sanity weight check. Done after the `--list`
+		// short-circuit so that listing benchmarks does not pay for an extra runtime API call on
+		// v2 runtimes. Older runtimes on `Benchmark` API v2 do not expose `runtime_block_limits`;
+		// in that case the CLI uses a default which `sanity_weight_check` interprets as "skip
+		// with a warning". Genuine failures (panic, codec error, OOM) when calling the v3 method
+		// are surfaced rather than swallowed.
 		let runtime_block_limits: RuntimeBlockLimits = if benchmark_api_version >= 3 {
 			Self::exec_state_machine(
 				StateMachine::new(
@@ -381,14 +390,6 @@ impl PalletCmd {
 		} else {
 			RuntimeBlockLimits::default()
 		};
-
-		// Use the benchmark list and the user input to determine the set of benchmarks to run.
-		let benchmarks_to_run = self.select_benchmarks_to_run(list)?;
-
-		if let Some(list_output) = self.list {
-			list_benchmark(benchmarks_to_run, list_output, self.no_csv_header);
-			return Ok(());
-		}
 
 		// Run the benchmarks
 		let mut batches = Vec::new();

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -30,7 +30,7 @@ use clap::{error::ErrorKind, CommandFactory};
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_benchmarking::{
 	Analysis, BenchmarkBatch, BenchmarkBatchSplitResults, BenchmarkList, BenchmarkParameter,
-	BenchmarkResult, BenchmarkSelector,
+	BenchmarkResult, BenchmarkSelector, RuntimeBlockLimits,
 };
 use frame_support::traits::StorageInfo;
 use linked_hash_map::LinkedHashMap;
@@ -359,6 +359,24 @@ impl PalletCmd {
 				ERROR_API_NOT_FOUND,
 			)?;
 
+		// Fetch the runtime block limits used by the sanity weight check. Older runtimes that do
+		// not implement `Benchmark_runtime_block_limits` (API v2) fall back to defaults; in that
+		// case `--sanity-weight-check` should be set to `ignore`.
+		let runtime_block_limits: RuntimeBlockLimits = Self::exec_state_machine(
+			StateMachine::new(
+				state,
+				&mut Default::default(),
+				&executor,
+				"Benchmark_runtime_block_limits",
+				&[],
+				&mut Self::build_extensions(executor.clone(), state.recorder()),
+				&runtime_code,
+				CallContext::Offchain,
+			),
+			ERROR_API_NOT_FOUND,
+		)
+		.unwrap_or_default();
+
 		// Use the benchmark list and the user input to determine the set of benchmarks to run.
 		let benchmarks_to_run = self.select_benchmarks_to_run(list)?;
 
@@ -607,7 +625,7 @@ impl PalletCmd {
 		// Combine all of the benchmark results, so that benchmarks of the same pallet/function
 		// are together.
 		let batches = combine_batches(batches, batches_db);
-		self.output(&batches, &storage_info, &component_ranges, pov_modes)
+		self.output(&batches, &storage_info, &component_ranges, pov_modes, &runtime_block_limits)
 	}
 
 	fn select_benchmarks_to_run(&self, list: Vec<BenchmarkList>) -> Result<Vec<SelectedBenchmark>> {
@@ -784,6 +802,7 @@ impl PalletCmd {
 		storage_info: &[StorageInfo],
 		component_ranges: &ComponentRangeMap,
 		pov_modes: PovModesMap,
+		runtime_block_limits: &RuntimeBlockLimits,
 	) -> Result<()> {
 		// Jsonify the result and write it to a file or stdout if desired.
 		if !self.jsonify(&batches)? && !self.quiet {
@@ -791,18 +810,29 @@ impl PalletCmd {
 			self.print_summary(&batches, &storage_info, pov_modes.clone())
 		}
 
-		// Create the weights.rs file.
+		// Create the weights.rs file. The sanity weight check runs *after* the file is written so
+		// that the failing weights are still persisted for inspection.
 		if let Some(output_path) = &self.output {
 			writer::write_results(
 				&batches,
 				&storage_info,
 				&component_ranges,
-				pov_modes,
+				pov_modes.clone(),
 				self.default_pov_mode,
 				output_path,
 				self,
 			)?;
 		}
+
+		writer::sanity_weight_check(
+			&batches,
+			&storage_info,
+			&component_ranges,
+			pov_modes,
+			self,
+			runtime_block_limits,
+			self.shared_params.sanity_weight_check,
+		)?;
 
 		Ok(())
 	}
@@ -842,7 +872,10 @@ impl PalletCmd {
 			})
 			.collect();
 
-		self.output(batches, &[], &component_ranges, Default::default())
+		// Re-analysis from a JSON file has no access to runtime metadata, so the sanity weight
+		// check uses an empty `RuntimeBlockLimits` (max_extrinsic_weight = 0). With those limits
+		// the check would always fail, so it is effectively skipped here.
+		self.output(batches, &[], &component_ranges, Default::default(), &Default::default())
 	}
 
 	/// Jsonifies the passed batches and writes them to stdout or into a file.

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/command.rs
@@ -17,7 +17,7 @@
 
 use super::{
 	types::{ComponentRange, ComponentRangeMap},
-	writer, ListOutput, PalletCmd, LOG_TARGET,
+	writer, ListOutput, PalletCmd, SanityWeightCheck, LOG_TARGET,
 };
 use crate::{
 	pallet::{types::FetchedCode, GenesisBuilderPolicy},
@@ -889,8 +889,17 @@ impl PalletCmd {
 			.collect();
 
 		// Re-analysis from a JSON file has no access to runtime metadata, so the sanity weight
-		// check uses an empty `RuntimeBlockLimits` (max_extrinsic_weight = 0). With those limits
-		// the check would always fail, so it is effectively skipped here.
+		// check cannot run — there are no real `RuntimeBlockLimits` to compare against. Emit a
+		// distinct warning so users see why the check did not fire (separate from the API v2
+		// fallback path) and proceed with default limits which `sanity_weight_check` skips.
+		if self.sanity_weight_check != SanityWeightCheck::Ignore {
+			log::warn!(
+				target: LOG_TARGET,
+				"Skipping sanity weight check: re-analysing benchmark results from JSON has no \
+				access to live runtime metadata. Re-run against the runtime directly to enable \
+				the check.",
+			);
+		}
 		self.output(batches, &[], &component_ranges, Default::default(), &Default::default())
 	}
 

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/mod.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/mod.rs
@@ -47,6 +47,27 @@ pub enum ListOutput {
 	Pallets,
 }
 
+/// How the benchmarking CLI should react when an extrinsic's worst-case weight exceeds the
+/// runtime's max extrinsic weight.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum SanityWeightCheck {
+	/// Print the results and return an error if any extrinsic exceeds the limit.
+	Error,
+	/// Print the results and a warning, but do not return an error.
+	Warning,
+	/// Skip the sanity weight check.
+	Ignore,
+}
+
+/// The default [`SanityWeightCheck`].
+///
+/// Starts as `Warning` for the first release that ships the check so existing benchmark
+/// pipelines do not start failing on configurations that historically passed. Tightening
+/// this to `Error` is planned for a follow-up release once teams have had a cycle to react.
+pub const DEFAULT_SANITY_WEIGHT_CHECK: SanityWeightCheck = SanityWeightCheck::Warning;
+
 /// Benchmark the extrinsic weight of FRAME Pallets.
 #[derive(Debug, clap::Parser)]
 pub struct PalletCmd {
@@ -167,6 +188,16 @@ pub struct PalletCmd {
 	/// construction.
 	#[arg(long)]
 	pub extra: bool,
+
+	/// How to react when an extrinsic's worst-case weight exceeds the runtime's max extrinsic
+	/// weight for `DispatchClass::Normal`.
+	#[arg(
+		long,
+		value_name = "ERROR_LEVEL",
+		value_enum,
+		default_value_t = DEFAULT_SANITY_WEIGHT_CHECK,
+	)]
+	pub sanity_weight_check: SanityWeightCheck,
 
 	#[allow(missing_docs)]
 	#[clap(flatten)]

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/mod.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/mod.rs
@@ -30,7 +30,7 @@ use sc_cli::{
 use std::{fmt::Debug, path::PathBuf};
 
 /// Logging target
-const LOG_TARGET: &'static str = "frame::benchmark::pallet";
+pub(crate) const LOG_TARGET: &'static str = "frame::benchmark::pallet";
 
 // Add a more relaxed parsing for pallet names by allowing pallet directory names with `-` to be
 // used like crate names with `_`

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -32,7 +32,7 @@ use crate::{
 	pallet::{
 		command::{PovEstimationMode, PovModesMap},
 		types::{ComponentRange, ComponentRangeMap},
-		LOG_TARGET,
+		SanityWeightCheck, LOG_TARGET,
 	},
 	shared::UnderscoreHelper,
 	PalletCmd,
@@ -45,7 +45,6 @@ use frame_support::{
 	traits::StorageInfo,
 	weights::{RuntimeDbWeight, Weight},
 };
-use sc_cli::SanityWeightCheck;
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::traits::Zero;
 

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -307,9 +307,13 @@ pub(crate) fn sanity_weight_check(
 
 	if !quiet {
 		color_print::cprintln!(
-			"\n<s>Sanity Weight Check:</> each extrinsic's weight function is evaluated in the \
+			"\n<s>Sanity Weight Check:</> each benchmark's weight function is evaluated in the \
 			worst-case scenario (every complexity component at its max value) and compared with \
-			the runtime's max extrinsic weight for `DispatchClass::Normal`.\n\n<u>Results:</>\n"
+			the runtime's max extrinsic weight for `DispatchClass::Normal`.\n\n<s>Note:</> the \
+			check currently treats every benchmark as if it were a `Normal`-class extrinsic. \
+			Hooks (`on_initialize`/`on_finalize`) and `Operational`/`Mandatory` extrinsics may \
+			produce false positives or false negatives — see issue #152 for follow-up work to \
+			distinguish dispatch classes.\n\n<u>Results:</>\n"
 		);
 	}
 

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -274,16 +274,19 @@ pub(crate) fn sanity_weight_check(
 		return Ok(());
 	}
 
-	// Runtime explicitly returned `Weight::MAX` for `max_extrinsic`, meaning the runtime did not
-	// configure a per-extrinsic cap for `DispatchClass::Normal`. There is nothing to compare
-	// against, so skip with a warning rather than producing a vacuous pass.
-	if limits.max_extrinsic_weight == Weight::MAX {
-		log::warn!(
-			target: LOG_TARGET,
-			"Skipping sanity weight check: runtime has no `max_extrinsic` configured for `DispatchClass::Normal`.",
-		);
-		return Ok(());
-	}
+	// Runtime returned `None` for `max_extrinsic`, meaning it has no per-extrinsic cap configured
+	// for `DispatchClass::Normal`. There is nothing to compare against, so skip with a warning
+	// rather than producing a vacuous pass.
+	let max_extrinsic_weight = match limits.max_extrinsic_weight {
+		Some(w) => w,
+		None => {
+			log::warn!(
+				target: LOG_TARGET,
+				"Skipping sanity weight check: runtime has no `max_extrinsic` configured for `DispatchClass::Normal`.",
+			);
+			return Ok(());
+		},
+	};
 
 	let analysis_choice: AnalysisChoice =
 		cmd.output_analysis.clone().try_into().map_err(io_error)?;
@@ -320,8 +323,8 @@ pub(crate) fn sanity_weight_check(
 			// Use `>=` instead of `>` so an extrinsic whose worst-case exactly fills the block is
 			// flagged. Combined with saturating arithmetic this also catches overflow cases where
 			// `total` saturates to `Weight::MAX`.
-			let exceeds_ref_time = total.ref_time() >= limits.max_extrinsic_weight.ref_time();
-			let exceeds_proof_size = total.proof_size() >= limits.max_extrinsic_weight.proof_size();
+			let exceeds_ref_time = total.ref_time() >= max_extrinsic_weight.ref_time();
+			let exceeds_proof_size = total.proof_size() >= max_extrinsic_weight.proof_size();
 			if exceeds_ref_time || exceeds_proof_size {
 				failed = true;
 				if !quiet {
@@ -334,10 +337,10 @@ pub(crate) fn sanity_weight_check(
 			}
 			if !quiet {
 				let ref_time_pct = (total.ref_time() as f64 /
-					limits.max_extrinsic_weight.ref_time().max(1) as f64) *
+					max_extrinsic_weight.ref_time().max(1) as f64) *
 					100.0;
 				let proof_size_pct = (total.proof_size() as f64 /
-					limits.max_extrinsic_weight.proof_size().max(1) as f64) *
+					max_extrinsic_weight.proof_size().max(1) as f64) *
 					100.0;
 				color_print::cprintln!(
 					"- <s>{}</>: {:?}\n  ref_time {:.2}% / proof_size {:.2}% of max extrinsic weight\n",
@@ -1630,8 +1633,7 @@ mod test {
 		#[test]
 		fn empty_runtime_block_limits_is_default() {
 			let limits = RuntimeBlockLimits::default();
-			assert_eq!(limits.max_extrinsic_weight.ref_time(), 0);
-			assert_eq!(limits.max_extrinsic_weight.proof_size(), 0);
+			assert_eq!(limits.max_extrinsic_weight, None);
 			assert_eq!(limits.db_weight.read, 0);
 			assert_eq!(limits.db_weight.write, 0);
 		}

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -274,6 +274,17 @@ pub(crate) fn sanity_weight_check(
 		return Ok(());
 	}
 
+	// Runtime explicitly returned `Weight::MAX` for `max_extrinsic`, meaning the runtime did not
+	// configure a per-extrinsic cap for `DispatchClass::Normal`. There is nothing to compare
+	// against, so skip with a warning rather than producing a vacuous pass.
+	if limits.max_extrinsic_weight == Weight::MAX {
+		log::warn!(
+			target: LOG_TARGET,
+			"Skipping sanity weight check: runtime has no `max_extrinsic` configured for `DispatchClass::Normal`.",
+		);
+		return Ok(());
+	}
+
 	let analysis_choice: AnalysisChoice =
 		cmd.output_analysis.clone().try_into().map_err(io_error)?;
 	let pov_analysis_choice: AnalysisChoice =

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -1697,5 +1697,175 @@ mod test {
 			assert_eq!(max_component_value("n", &ranges), 100);
 			assert_eq!(max_component_value("missing", &ranges), 0);
 		}
+
+		// Build a minimal `PalletCmd` for end-to-end tests of `sanity_weight_check`.
+		fn cmd() -> PalletCmd {
+			use clap::Parser;
+			PalletCmd::try_parse_from([
+				"test",
+				"--pallet",
+				"",
+				"--extrinsic",
+				"",
+				"--runtime",
+				"path/to/runtime",
+			])
+			.unwrap()
+		}
+
+		// `BenchmarkBatchSplitResults` whose worst-case ref_time is well above the test limits but
+		// stays small enough that the storage-results pipeline does not itself overflow.
+		fn fat_batch() -> BenchmarkBatchSplitResults {
+			test_data(b"fat", b"fat", BenchmarkParameter::a, 100, 10)
+		}
+
+		// `BenchmarkBatchSplitResults` whose worst-case stays well under the test limits.
+		fn lean_batch() -> BenchmarkBatchSplitResults {
+			test_data(b"lean", b"lean", BenchmarkParameter::a, 1, 0)
+		}
+
+		fn limits(max_ref_time: u64, max_proof_size: u64) -> RuntimeBlockLimits {
+			RuntimeBlockLimits {
+				max_extrinsic_weight: Some(Weight::from_parts(max_ref_time, max_proof_size)),
+				db_weight: RuntimeDbWeight { read: 25_000, write: 100_000 },
+			}
+		}
+
+		#[test]
+		fn sanity_check_ignore_mode_short_circuits() {
+			let r = sanity_weight_check(
+				&[fat_batch()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&limits(10, 10),
+				SanityWeightCheck::Ignore,
+				true,
+			);
+			// Even with limits that an extrinsic would clearly exceed, Ignore returns Ok.
+			assert!(r.is_ok());
+		}
+
+		#[test]
+		fn sanity_check_default_limits_skip() {
+			let r = sanity_weight_check(
+				&[fat_batch()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&RuntimeBlockLimits::default(),
+				SanityWeightCheck::Error,
+				true,
+			);
+			// `Default::default()` is the v2-runtime / re-analysis sentinel — must skip.
+			assert!(r.is_ok());
+		}
+
+		#[test]
+		fn sanity_check_no_max_extrinsic_skip() {
+			let r = sanity_weight_check(
+				&[fat_batch()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&RuntimeBlockLimits {
+					max_extrinsic_weight: None,
+					db_weight: RuntimeDbWeight { read: 25_000, write: 100_000 },
+				},
+				SanityWeightCheck::Error,
+				true,
+			);
+			// Runtime configured no per-extrinsic cap → cannot evaluate, skip.
+			assert!(r.is_ok());
+		}
+
+		#[test]
+		fn sanity_check_error_mode_fails_when_exceeding() {
+			let r = sanity_weight_check(
+				&[fat_batch()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&limits(10, 10),
+				SanityWeightCheck::Error,
+				true,
+			);
+			assert!(r.is_err());
+		}
+
+		#[test]
+		fn sanity_check_warning_mode_returns_ok_even_when_exceeding() {
+			let r = sanity_weight_check(
+				&[fat_batch()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&limits(10, 10),
+				SanityWeightCheck::Warning,
+				true,
+			);
+			assert!(r.is_ok());
+		}
+
+		#[test]
+		fn sanity_check_passes_when_within_limits() {
+			let r = sanity_weight_check(
+				&[lean_batch()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&limits(u64::MAX / 2, u64::MAX / 2),
+				SanityWeightCheck::Error,
+				true,
+			);
+			assert!(r.is_ok());
+		}
+
+		#[test]
+		fn sanity_check_flags_exact_limit_match() {
+			// `>=` semantics: a benchmark whose total exactly matches the cap is flagged.
+			let lean = lean_batch();
+			let mut all = HashMap::new();
+			let mapped = map_results(
+				&[lean.clone()],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				PovEstimationMode::MaxEncodedLen,
+				&AnalysisChoice::default(),
+				&AnalysisChoice::MedianSlopes,
+				1_000_000,
+				0,
+			)
+			.unwrap();
+			let data = mapped.values().next().unwrap()[0].clone();
+			let exact_total = worst_case_weight(
+				&data,
+				&RuntimeDbWeight { read: 25_000, write: 100_000 },
+			);
+			all.insert(("p".to_string(), "i".to_string()), vec![data]);
+			drop(all); // we just needed `mapped` to compute `exact_total`.
+
+			let r = sanity_weight_check(
+				&[lean],
+				&test_storage_info(),
+				&Default::default(),
+				Default::default(),
+				&cmd(),
+				&RuntimeBlockLimits {
+					max_extrinsic_weight: Some(exact_total),
+					db_weight: RuntimeDbWeight { read: 25_000, write: 100_000 },
+				},
+				SanityWeightCheck::Error,
+				true,
+			);
+			assert!(r.is_err(), "exact match must fail (>= semantics)");
+		}
 	}
 }

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -32,14 +32,20 @@ use crate::{
 	pallet::{
 		command::{PovEstimationMode, PovModesMap},
 		types::{ComponentRange, ComponentRangeMap},
+		LOG_TARGET,
 	},
 	shared::UnderscoreHelper,
 	PalletCmd,
 };
 use frame_benchmarking::{
 	Analysis, AnalysisChoice, BenchmarkBatchSplitResults, BenchmarkResult, BenchmarkSelector,
+	RuntimeBlockLimits,
 };
-use frame_support::traits::StorageInfo;
+use frame_support::{
+	traits::StorageInfo,
+	weights::{RuntimeDbWeight, Weight},
+};
+use sc_cli::SanityWeightCheck;
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::traits::Zero;
 
@@ -174,6 +180,169 @@ fn map_results(
 		pallet_benchmarks.push(benchmark_data);
 	}
 	Ok(all_benchmarks)
+}
+
+// Returns the maximum value in `component_ranges` for the given component name, or 0 if the
+// component is not part of the ranges.
+fn max_component_value(name: &str, component_ranges: &[ComponentRange]) -> u64 {
+	component_ranges
+		.iter()
+		.find(|c| c.name == name)
+		.map(|c| c.max as u64)
+		.unwrap_or(0)
+}
+
+// Computes the worst-case [`Weight`] of a single benchmark function by evaluating its base cost
+// plus every component slope at the maximum component value.
+fn worst_case_weight(data: &BenchmarkData, db_weight: &RuntimeDbWeight) -> Weight {
+	let mut total = Weight::from_parts(
+		data.base_weight.saturating_cast_u64(),
+		data.base_calculated_proof_size.saturating_cast_u64(),
+	);
+
+	for slope in &data.component_weight {
+		let max = max_component_value(&slope.name, &data.component_ranges);
+		total = total
+			.saturating_add(Weight::from_parts(slope.slope.saturating_cast_u64(), 0).saturating_mul(max));
+	}
+
+	total =
+		total.saturating_add(db_weight.reads(data.base_reads.saturating_cast_u64()));
+	for slope in &data.component_reads {
+		let max = max_component_value(&slope.name, &data.component_ranges);
+		total = total
+			.saturating_add(db_weight.reads(slope.slope.saturating_cast_u64()).saturating_mul(max));
+	}
+
+	total =
+		total.saturating_add(db_weight.writes(data.base_writes.saturating_cast_u64()));
+	for slope in &data.component_writes {
+		let max = max_component_value(&slope.name, &data.component_ranges);
+		total = total
+			.saturating_add(db_weight.writes(slope.slope.saturating_cast_u64()).saturating_mul(max));
+	}
+
+	for slope in &data.component_calculated_proof_size {
+		let max = max_component_value(&slope.name, &data.component_ranges);
+		total = total
+			.saturating_add(Weight::from_parts(0, slope.slope.saturating_cast_u64()).saturating_mul(max));
+	}
+
+	total
+}
+
+// Helper trait to silently saturate u128 -> u64 for benchmark slopes that are stored as u128 in
+// `BenchmarkData` but always fit in u64 in practice.
+trait SaturatingCastU64 {
+	fn saturating_cast_u64(self) -> u64;
+}
+
+impl SaturatingCastU64 for u128 {
+	fn saturating_cast_u64(self) -> u64 {
+		u64::try_from(self).unwrap_or(u64::MAX)
+	}
+}
+
+/// Compares each benchmark's worst-case weight against the runtime's max extrinsic weight.
+///
+/// Behaviour is controlled by `mode`:
+/// * `Error`   — print results and return `Err` if any extrinsic exceeds the limit.
+/// * `Warning` — print results and a warning, but always return `Ok`.
+/// * `Ignore`  — skip the check entirely.
+pub(crate) fn sanity_weight_check(
+	batches: &[BenchmarkBatchSplitResults],
+	storage_info: &[StorageInfo],
+	component_ranges: &ComponentRangeMap,
+	pov_modes: PovModesMap,
+	cmd: &PalletCmd,
+	limits: &RuntimeBlockLimits,
+	mode: SanityWeightCheck,
+) -> Result<(), sc_cli::Error> {
+	if mode == SanityWeightCheck::Ignore {
+		return Ok(());
+	}
+
+	// `RuntimeBlockLimits::default()` means we could not fetch real limits from the runtime — for
+	// example the runtime is on `Benchmark` API v2, or we are re-analysing a JSON dump. Skip the
+	// check rather than producing false positives.
+	if limits == &RuntimeBlockLimits::default() {
+		log::warn!(
+			target: LOG_TARGET,
+			"Skipping sanity weight check: runtime did not expose `runtime_block_limits` (Benchmark API v2 or re-analysis input).",
+		);
+		return Ok(());
+	}
+
+	let analysis_choice: AnalysisChoice =
+		cmd.output_analysis.clone().try_into().map_err(io_error)?;
+	let pov_analysis_choice: AnalysisChoice =
+		cmd.output_pov_analysis.clone().try_into().map_err(io_error)?;
+
+	let all_results = map_results(
+		batches,
+		storage_info,
+		component_ranges,
+		pov_modes,
+		cmd.default_pov_mode,
+		&analysis_choice,
+		&pov_analysis_choice,
+		cmd.worst_case_map_values,
+		cmd.additional_trie_layers,
+	)?;
+
+	color_print::cprintln!(
+		"\n<s>Sanity Weight Check 🧐:</> each extrinsic's weight function is evaluated in the \
+		worst-case scenario (every complexity component at its max value) and compared with the \
+		runtime's max extrinsic weight for `DispatchClass::Normal`.\n\n<u>Results:</>\n"
+	);
+
+	let mut failed = false;
+	for ((pallet, instance), results) in all_results.iter() {
+		println!("Pallet: {pallet}\nInstance: {instance}\n");
+		for data in results {
+			let total = worst_case_weight(data, &limits.db_weight);
+			let exceeds_ref_time = total.ref_time() > limits.max_extrinsic_weight.ref_time();
+			let exceeds_proof_size = total.proof_size() > limits.max_extrinsic_weight.proof_size();
+			if exceeds_ref_time || exceeds_proof_size {
+				failed = true;
+				color_print::cprintln!(
+					"<s,r>EXCEEDS MAX EXTRINSIC WEIGHT:</> the worst-case weight of `{}` does not \
+					fit in a single block.",
+					data.name,
+				);
+			}
+			let ref_time_pct = (total.ref_time() as f64
+				/ limits.max_extrinsic_weight.ref_time().max(1) as f64)
+				* 100.0;
+			let proof_size_pct = (total.proof_size() as f64
+				/ limits.max_extrinsic_weight.proof_size().max(1) as f64)
+				* 100.0;
+			color_print::cprintln!(
+				"- <s>{}</>: {:?}\n  ref_time {:.2}% / proof_size {:.2}% of max extrinsic weight\n",
+				data.name,
+				total,
+				ref_time_pct,
+				proof_size_pct,
+			);
+		}
+	}
+
+	if failed {
+		color_print::cprintln!(
+			"<r>One or more extrinsics exceed the runtime's max extrinsic weight. Review the \
+			extrinsic logic and/or its benchmark function.</>\n"
+		);
+		if mode == SanityWeightCheck::Error {
+			return Err(io_error(
+				"sanity weight check failed: one or more extrinsics exceed the max extrinsic weight",
+			)
+			.into());
+		}
+	} else {
+		color_print::cprintln!("<g>All extrinsics passed the sanity weight check 😃!</>\n");
+	}
+
+	Ok(())
 }
 
 // Get an iterator of errors.

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -327,8 +327,7 @@ pub(crate) fn sanity_weight_check(
 			// Saturated arithmetic clamps to `Weight::MAX` on overflow. Surface that case
 			// explicitly: the check still flags it as a fail (via `>=` below), but the user
 			// deserves to know the displayed `total` is a clamp, not a real measurement.
-			let saturated =
-				total.ref_time() == u64::MAX || total.proof_size() == u64::MAX;
+			let saturated = total.ref_time() == u64::MAX || total.proof_size() == u64::MAX;
 			// Use `>=` instead of `>` so an extrinsic whose worst-case exactly fills the block is
 			// flagged. Combined with saturating arithmetic this also catches overflow cases where
 			// `total` saturates to `Weight::MAX`.
@@ -1845,10 +1844,8 @@ mod test {
 			)
 			.unwrap();
 			let data = mapped.values().next().unwrap()[0].clone();
-			let exact_total = worst_case_weight(
-				&data,
-				&RuntimeDbWeight { read: 25_000, write: 100_000 },
-			);
+			let exact_total =
+				worst_case_weight(&data, &RuntimeDbWeight { read: 25_000, write: 100_000 });
 			all.insert(("p".to_string(), "i".to_string()), vec![data]);
 			drop(all); // we just needed `mapped` to compute `exact_total`.
 

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -1525,4 +1525,130 @@ mod test {
 		assert_eq!(easy_log_16(16u32.pow(7) + 1), 8);
 		assert_eq!(easy_log_16(u32::MAX), 8);
 	}
+
+	mod sanity_weight_check {
+		use super::*;
+
+		// Build a `BenchmarkData` with a single component slope plus base values.
+		fn benchmark_data(
+			name: &str,
+			base_weight: u128,
+			weight_slope: u128,
+			base_reads: u128,
+			read_slope: u128,
+			base_writes: u128,
+			write_slope: u128,
+			base_proof_size: u128,
+			proof_size_slope: u128,
+			component_max: u32,
+		) -> BenchmarkData {
+			let component = "n".to_string();
+			BenchmarkData {
+				name: name.to_string(),
+				components: vec![Component { name: component.clone(), is_used: true }],
+				base_weight,
+				base_reads,
+				base_writes,
+				base_calculated_proof_size: base_proof_size,
+				base_recorded_proof_size: 0,
+				component_weight: vec![ComponentSlope {
+					name: component.clone(),
+					slope: weight_slope,
+					error: 0,
+				}],
+				component_reads: vec![ComponentSlope {
+					name: component.clone(),
+					slope: read_slope,
+					error: 0,
+				}],
+				component_writes: vec![ComponentSlope {
+					name: component.clone(),
+					slope: write_slope,
+					error: 0,
+				}],
+				component_calculated_proof_size: vec![ComponentSlope {
+					name: component.clone(),
+					slope: proof_size_slope,
+					error: 0,
+				}],
+				component_recorded_proof_size: vec![],
+				component_ranges: vec![ComponentRange { name: component, min: 0, max: component_max }],
+				comments: vec![],
+				min_execution_time: 0,
+			}
+		}
+
+		fn rocksdb() -> RuntimeDbWeight {
+			RuntimeDbWeight { read: 25_000, write: 100_000 }
+		}
+
+		#[test]
+		fn worst_case_weight_combines_base_and_slopes() {
+			let data = benchmark_data("dummy", 1_000, 100, 2, 1, 3, 2, 4_096, 16, 10);
+			let total = worst_case_weight(&data, &rocksdb());
+
+			let expected_ref_time = 1_000 // base
+				+ 100 * 10 // weight slope * max
+				+ 25_000 * 2 // base reads
+				+ 25_000 * 1 * 10 // read slope * max
+				+ 100_000 * 3 // base writes
+				+ 100_000 * 2 * 10; // write slope * max
+			let expected_proof_size = 4_096 + 16 * 10;
+			assert_eq!(total.ref_time(), expected_ref_time);
+			assert_eq!(total.proof_size(), expected_proof_size);
+		}
+
+		#[test]
+		fn empty_runtime_block_limits_is_default() {
+			let limits = RuntimeBlockLimits::default();
+			assert_eq!(limits.max_extrinsic_weight.ref_time(), 0);
+			assert_eq!(limits.max_extrinsic_weight.proof_size(), 0);
+			assert_eq!(limits.db_weight.read, 0);
+			assert_eq!(limits.db_weight.write, 0);
+		}
+
+		#[test]
+		fn worst_case_weight_with_no_slope_uses_base_only() {
+			let data = benchmark_data("flat", 5_000, 0, 1, 0, 1, 0, 2_048, 0, 100);
+			let total = worst_case_weight(&data, &rocksdb());
+			assert_eq!(total.ref_time(), 5_000 + 25_000 + 100_000);
+			assert_eq!(total.proof_size(), 2_048);
+		}
+
+		#[test]
+		fn worst_case_weight_saturates_on_overflow() {
+			let data = benchmark_data(
+				"overflow",
+				u128::MAX,
+				u128::MAX,
+				u128::MAX,
+				u128::MAX,
+				u128::MAX,
+				u128::MAX,
+				u128::MAX,
+				u128::MAX,
+				u32::MAX,
+			);
+			let total = worst_case_weight(&data, &rocksdb());
+			// Overflow saturates at Weight::MAX.
+			assert_eq!(total.ref_time(), u64::MAX);
+			assert_eq!(total.proof_size(), u64::MAX);
+		}
+
+		#[test]
+		fn saturating_cast_u128_to_u64() {
+			assert_eq!(0u128.saturating_cast_u64(), 0);
+			assert_eq!(42u128.saturating_cast_u64(), 42);
+			assert_eq!((u64::MAX as u128).saturating_cast_u64(), u64::MAX);
+			assert_eq!((u64::MAX as u128 + 1).saturating_cast_u64(), u64::MAX);
+			assert_eq!(u128::MAX.saturating_cast_u64(), u64::MAX);
+		}
+
+		#[test]
+		fn max_component_value_returns_zero_for_unknown_component() {
+			let ranges = vec![ComponentRange { name: "n".into(), min: 0, max: 100 }];
+			assert_eq!(max_component_value("n", &ranges), 100);
+			assert_eq!(max_component_value("missing", &ranges), 0);
+		}
+	}
 }

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -202,30 +202,31 @@ fn worst_case_weight(data: &BenchmarkData, db_weight: &RuntimeDbWeight) -> Weigh
 
 	for slope in &data.component_weight {
 		let max = max_component_value(&slope.name, &data.component_ranges);
-		total = total
-			.saturating_add(Weight::from_parts(slope.slope.saturating_cast_u64(), 0).saturating_mul(max));
+		total = total.saturating_add(
+			Weight::from_parts(slope.slope.saturating_cast_u64(), 0).saturating_mul(max),
+		);
 	}
 
-	total =
-		total.saturating_add(db_weight.reads(data.base_reads.saturating_cast_u64()));
+	total = total.saturating_add(db_weight.reads(data.base_reads.saturating_cast_u64()));
 	for slope in &data.component_reads {
 		let max = max_component_value(&slope.name, &data.component_ranges);
 		total = total
 			.saturating_add(db_weight.reads(slope.slope.saturating_cast_u64()).saturating_mul(max));
 	}
 
-	total =
-		total.saturating_add(db_weight.writes(data.base_writes.saturating_cast_u64()));
+	total = total.saturating_add(db_weight.writes(data.base_writes.saturating_cast_u64()));
 	for slope in &data.component_writes {
 		let max = max_component_value(&slope.name, &data.component_ranges);
-		total = total
-			.saturating_add(db_weight.writes(slope.slope.saturating_cast_u64()).saturating_mul(max));
+		total = total.saturating_add(
+			db_weight.writes(slope.slope.saturating_cast_u64()).saturating_mul(max),
+		);
 	}
 
 	for slope in &data.component_calculated_proof_size {
 		let max = max_component_value(&slope.name, &data.component_ranges);
-		total = total
-			.saturating_add(Weight::from_parts(0, slope.slope.saturating_cast_u64()).saturating_mul(max));
+		total = total.saturating_add(
+			Weight::from_parts(0, slope.slope.saturating_cast_u64()).saturating_mul(max),
+		);
 	}
 
 	total
@@ -311,12 +312,12 @@ pub(crate) fn sanity_weight_check(
 					data.name,
 				);
 			}
-			let ref_time_pct = (total.ref_time() as f64
-				/ limits.max_extrinsic_weight.ref_time().max(1) as f64)
-				* 100.0;
-			let proof_size_pct = (total.proof_size() as f64
-				/ limits.max_extrinsic_weight.proof_size().max(1) as f64)
-				* 100.0;
+			let ref_time_pct = (total.ref_time() as f64 /
+				limits.max_extrinsic_weight.ref_time().max(1) as f64) *
+				100.0;
+			let proof_size_pct = (total.proof_size() as f64 /
+				limits.max_extrinsic_weight.proof_size().max(1) as f64) *
+				100.0;
 			color_print::cprintln!(
 				"- <s>{}</>: {:?}\n  ref_time {:.2}% / proof_size {:.2}% of max extrinsic weight\n",
 				data.name,
@@ -1572,7 +1573,11 @@ mod test {
 					error: 0,
 				}],
 				component_recorded_proof_size: vec![],
-				component_ranges: vec![ComponentRange { name: component, min: 0, max: component_max }],
+				component_ranges: vec![ComponentRange {
+					name: component,
+					min: 0,
+					max: component_max,
+				}],
 				comments: vec![],
 				min_execution_time: 0,
 			}

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -258,6 +258,7 @@ pub(crate) fn sanity_weight_check(
 	cmd: &PalletCmd,
 	limits: &RuntimeBlockLimits,
 	mode: SanityWeightCheck,
+	quiet: bool,
 ) -> Result<(), sc_cli::Error> {
 	if mode == SanityWeightCheck::Ignore {
 		return Ok(());
@@ -302,56 +303,66 @@ pub(crate) fn sanity_weight_check(
 		cmd.additional_trie_layers,
 	)?;
 
-	color_print::cprintln!(
-		"\n<s>Sanity Weight Check 🧐:</> each extrinsic's weight function is evaluated in the \
-		worst-case scenario (every complexity component at its max value) and compared with the \
-		runtime's max extrinsic weight for `DispatchClass::Normal`.\n\n<u>Results:</>\n"
-	);
+	if !quiet {
+		color_print::cprintln!(
+			"\n<s>Sanity Weight Check:</> each extrinsic's weight function is evaluated in the \
+			worst-case scenario (every complexity component at its max value) and compared with \
+			the runtime's max extrinsic weight for `DispatchClass::Normal`.\n\n<u>Results:</>\n"
+		);
+	}
 
 	let mut failed = false;
 	for ((pallet, instance), results) in all_results.iter() {
-		println!("Pallet: {pallet}\nInstance: {instance}\n");
+		if !quiet {
+			println!("Pallet: {pallet}\nInstance: {instance}\n");
+		}
 		for data in results {
 			let total = worst_case_weight(data, &limits.db_weight);
 			let exceeds_ref_time = total.ref_time() > limits.max_extrinsic_weight.ref_time();
 			let exceeds_proof_size = total.proof_size() > limits.max_extrinsic_weight.proof_size();
 			if exceeds_ref_time || exceeds_proof_size {
 				failed = true;
+				if !quiet {
+					color_print::cprintln!(
+						"<s,r>EXCEEDS MAX EXTRINSIC WEIGHT:</> the worst-case weight of `{}` does \
+						not fit in a single block.",
+						data.name,
+					);
+				}
+			}
+			if !quiet {
+				let ref_time_pct = (total.ref_time() as f64 /
+					limits.max_extrinsic_weight.ref_time().max(1) as f64) *
+					100.0;
+				let proof_size_pct = (total.proof_size() as f64 /
+					limits.max_extrinsic_weight.proof_size().max(1) as f64) *
+					100.0;
 				color_print::cprintln!(
-					"<s,r>EXCEEDS MAX EXTRINSIC WEIGHT:</> the worst-case weight of `{}` does not \
-					fit in a single block.",
+					"- <s>{}</>: {:?}\n  ref_time {:.2}% / proof_size {:.2}% of max extrinsic weight\n",
 					data.name,
+					total,
+					ref_time_pct,
+					proof_size_pct,
 				);
 			}
-			let ref_time_pct = (total.ref_time() as f64 /
-				limits.max_extrinsic_weight.ref_time().max(1) as f64) *
-				100.0;
-			let proof_size_pct = (total.proof_size() as f64 /
-				limits.max_extrinsic_weight.proof_size().max(1) as f64) *
-				100.0;
-			color_print::cprintln!(
-				"- <s>{}</>: {:?}\n  ref_time {:.2}% / proof_size {:.2}% of max extrinsic weight\n",
-				data.name,
-				total,
-				ref_time_pct,
-				proof_size_pct,
-			);
 		}
 	}
 
 	if failed {
-		color_print::cprintln!(
-			"<r>One or more extrinsics exceed the runtime's max extrinsic weight. Review the \
-			extrinsic logic and/or its benchmark function.</>\n"
-		);
+		if !quiet {
+			color_print::cprintln!(
+				"<r>One or more extrinsics exceed the runtime's max extrinsic weight. Review the \
+				extrinsic logic and/or its benchmark function.</>\n"
+			);
+		}
 		if mode == SanityWeightCheck::Error {
 			return Err(io_error(
 				"sanity weight check failed: one or more extrinsics exceed the max extrinsic weight",
 			)
 			.into());
 		}
-	} else {
-		color_print::cprintln!("<g>All extrinsics passed the sanity weight check 😃!</>\n");
+	} else if !quiet {
+		color_print::cprintln!("<g>All extrinsics passed the sanity weight check.</>\n");
 	}
 
 	Ok(())

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -324,6 +324,11 @@ pub(crate) fn sanity_weight_check(
 		}
 		for data in results {
 			let total = worst_case_weight(data, &limits.db_weight);
+			// Saturated arithmetic clamps to `Weight::MAX` on overflow. Surface that case
+			// explicitly: the check still flags it as a fail (via `>=` below), but the user
+			// deserves to know the displayed `total` is a clamp, not a real measurement.
+			let saturated =
+				total.ref_time() == u64::MAX || total.proof_size() == u64::MAX;
 			// Use `>=` instead of `>` so an extrinsic whose worst-case exactly fills the block is
 			// flagged. Combined with saturating arithmetic this also catches overflow cases where
 			// `total` saturates to `Weight::MAX`.
@@ -337,6 +342,13 @@ pub(crate) fn sanity_weight_check(
 						not fit in a single block.",
 						data.name,
 					);
+					if saturated {
+						color_print::cprintln!(
+							"<s,y>NOTE:</> the worst-case computation saturated. The reported \
+							total may be lower than the true unbounded value — review the \
+							benchmark's component slopes for unrealistic magnitudes."
+						);
+					}
 				}
 			}
 			if !quiet {

--- a/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/pallet/writer.rs
@@ -318,8 +318,11 @@ pub(crate) fn sanity_weight_check(
 		}
 		for data in results {
 			let total = worst_case_weight(data, &limits.db_weight);
-			let exceeds_ref_time = total.ref_time() > limits.max_extrinsic_weight.ref_time();
-			let exceeds_proof_size = total.proof_size() > limits.max_extrinsic_weight.proof_size();
+			// Use `>=` instead of `>` so an extrinsic whose worst-case exactly fills the block is
+			// flagged. Combined with saturating arithmetic this also catches overflow cases where
+			// `total` saturates to `Weight::MAX`.
+			let exceeds_ref_time = total.ref_time() >= limits.max_extrinsic_weight.ref_time();
+			let exceeds_proof_size = total.proof_size() >= limits.max_extrinsic_weight.proof_size();
 			if exceeds_ref_time || exceeds_proof_size {
 				failed = true;
 				if !quiet {

--- a/templates/parachain/runtime/src/apis.rs
+++ b/templates/parachain/runtime/src/apis.rs
@@ -280,7 +280,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/templates/parachain/runtime/src/apis.rs
+++ b/templates/parachain/runtime/src/apis.rs
@@ -273,6 +273,18 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use polkadot_sdk::frame_support::dispatch::DispatchClass;
+			use super::configs::RuntimeBlockWeights;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/templates/parachain/runtime/src/apis.rs
+++ b/templates/parachain/runtime/src/apis.rs
@@ -279,8 +279,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/templates/solochain/runtime/src/apis.rs
+++ b/templates/solochain/runtime/src/apis.rs
@@ -242,6 +242,18 @@ impl_runtime_apis! {
 			(list, storage_info)
 		}
 
+		fn runtime_block_limits() -> frame_benchmarking::RuntimeBlockLimits {
+			use frame_support::dispatch::DispatchClass;
+			use super::configs::RuntimeBlockWeights;
+			let max_extrinsic_weight = RuntimeBlockWeights::get()
+				.per_class
+				.get(DispatchClass::Normal)
+				.max_extrinsic
+				.unwrap_or_else(Weight::max_value);
+			let db_weight = <Self as frame_system::Config>::DbWeight::get();
+			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
+		}
+
 		#[allow(non_local_definitions)]
 		fn dispatch_benchmark(
 			config: frame_benchmarking::BenchmarkConfig

--- a/templates/solochain/runtime/src/apis.rs
+++ b/templates/solochain/runtime/src/apis.rs
@@ -249,7 +249,7 @@ impl_runtime_apis! {
 				.per_class
 				.get(DispatchClass::Normal)
 				.max_extrinsic
-				.unwrap_or_else(Weight::max_value);
+				.unwrap_or(Weight::MAX);
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}

--- a/templates/solochain/runtime/src/apis.rs
+++ b/templates/solochain/runtime/src/apis.rs
@@ -248,8 +248,7 @@ impl_runtime_apis! {
 			let max_extrinsic_weight = RuntimeBlockWeights::get()
 				.per_class
 				.get(DispatchClass::Normal)
-				.max_extrinsic
-				.unwrap_or(Weight::MAX);
+				.max_extrinsic;
 			let db_weight = <Self as frame_system::Config>::DbWeight::get();
 			frame_benchmarking::RuntimeBlockLimits::new(max_extrinsic_weight, db_weight)
 		}


### PR DESCRIPTION
## Summary

Adds an automatic sanity check to `frame-benchmarking-cli` that, after running benchmarks, evaluates each extrinsic's worst-case weight (every complexity component at its maximum) and compares it against the runtime's max extrinsic weight for `DispatchClass::Normal`. If any extrinsic exceeds the limit it is flagged so misconfigured runtimes are caught before weight files are consumed by anyone.

Closes #152.

## Heritage and prior art

This PR continues the work in **#1493 by @Daanvdplas** (closed July 2024 due to inactivity, **after being formally approved by @kianenigma on Oct 31 2023** — see [his approving review](https://github.com/paritytech/polkadot-sdk/pull/1493#pullrequestreview-1701970097)). The design here intentionally preserves the decisions both reviewers signed off on:

- **`--sanity-weight-check error|warning|ignore` flag** — exactly the three-state shape @ggwpez requested in [this comment](https://github.com/paritytech/polkadot-sdk/pull/1493#issuecomment-1723525529).
- **Run the check *after* writing weight files** — per @ggwpez's explicit guidance referencing [the incident in #1589](https://github.com/paritytech/polkadot-sdk/issues/1589). Failing weights are persisted on disk for inspection rather than discarded.
- **Co-authorship** — Daan's original implementation work is credited via `Co-authored-by:` trailers on the relevant commits.

## Differences vs #1493 (and why)

| Decision | #1493 | This PR | Reason |
|---|---|---|---|
| Default mode | `Error` | `Warning` | @kianenigma in his approving review preferred `Warn` "to let as many teams out there know about their misconfig". Defaulting to Warning for one release lets teams see the diagnostic without breaking pipelines; tightening to Error is tracked as follow-up. |
| Runtime API shape | `benchmark_metadata` returns 4-tuple `(list, storage, Weight, RuntimeDbWeight)` | New separate method `runtime_block_limits() -> RuntimeBlockLimits` at `#[api_version(3)]`, leaving `benchmark_metadata` unchanged | Backwards-compat: v2 runtimes keep working unmodified. The CLI gates the v3 call on `benchmark_api_version >= 3` and surfaces real failures (panic / OOM / codec) instead of swallowing them via `unwrap_or_default()`. |
| `Option<Weight>` for `max_extrinsic` | Used `unwrap()` (would panic) | Propagates `Option<Weight>` end-to-end | Runtimes that legitimately have `max_extrinsic = None` for `Normal` produce a vacuous pass under any `Weight::MAX`/`unwrap()` design; with `Option`, the CLI explicitly skips with a warning. |
| Flag location | `sc_cli::SharedParams` (every node binary) | `frame_benchmarking_cli::PalletCmd` | The flag only does anything for `benchmark pallet`; `SharedParams` would have polluted `--help` of every node command (`run`, `key`, `purge-chain`, etc.) on every Substrate-based binary. |
| `--quiet` / `--json` | Not respected | Sanity-check output suppressed when JSON is being written to stdout or `--quiet` is set; the check still runs and still returns `Err` on `Error` mode. | Avoid corrupting `--json` pipelines for `jq` and friends. |
| `--list` | Ran the API call regardless | Only after `--list` short-circuit | Saves one state-machine call when the user is just listing benchmarks. |
| `Weight::max_value` fallback | Used `Bounded::max_value` | Uses `Weight::MAX` const | The trait bound was not in scope in most runtimes — the original PR would not have compiled in the current tree. |
| CI for short-benchmarks | Same | `--sanity-weight-check ignore` added | `--steps 2 --repeat 1` produces statistically meaningless weights; running the check there guarantees false positives. Real benchmarking pipelines remain unaffected. |

## Limitations and follow-up work (filed as comments on #152)

This PR delivers the per-extrinsic check exactly as scoped by #152 and #1493. Three legitimate gaps surfaced during review and are deferred to dedicated follow-ups:

1. **Hooks (`on_initialize`/`on_finalize`)** — currently compared against `max_extrinsic_weight` of `Normal` class, which is a category mismatch. Hook benchmarks should compare against block-budget aggregates. The CLI output now warns about this limitation explicitly.
2. **`Operational` and `Mandatory` dispatch classes** — silently treated as if they were `Normal`. Benchmark metadata does not currently carry the dispatch class, so addressing this requires extending the runtime API. Deferred.
3. **Lower-bound check** ([@chevdor's suggestion](https://github.com/paritytech/polkadot-sdk/pull/1493#issuecomment-1787559968)) — flagging suspiciously *low* benchmark weights via historical comparison. Out of scope for this PR per @Daanvdplas's response in #1493; tracked separately.

[@xlc's csv-stored benchmark data idea](https://github.com/paritytech/polkadot-sdk/issues/152#issuecomment-1691680654) was also raised in the original issue thread; orthogonal to the check itself and not pursued here.

## Glutton runtime tweak

`glutton-westend-runtime` previously inherited `type DbWeight = ()` from the parachain default config, blocking any caller that needs a real `Get<RuntimeDbWeight>` impl (such as `runtime_block_limits`). The runtime already imported `RocksDbWeight`; this PR wires it in explicitly. Called out separately in the prdoc.

## Test plan

- [x] Unit tests for `worst_case_weight`, `max_component_value`, saturation behavior, and `Default::default()` invariants.
- [x] **End-to-end tests for `sanity_weight_check`** itself: ignore short-circuit, default-limits skip, `None`-max skip, error-mode failure, warning-mode pass, within-limits pass, exact-match cliff (`>=`) — 13 tests total.
- [x] Local `cargo +nightly fmt --check` and `cargo clippy --all-targets -- -D warnings` are green.
- [x] `cargo check --features runtime-benchmarks` passes for: kitchensink-runtime, rococo-runtime, westend-runtime, asset-hub-{rococo,westend}-runtime, bridge-hub-{rococo,westend}-runtime, collectives-westend, coretime-westend, glutton-westend, people-westend, penpal, pallet-staking-async-{rc,parachain}-runtime, parachain-template-runtime, solochain-template-runtime.
- [ ] Manual: real benchmark on `kitchensink-runtime` with all three modes.
- [ ] Manual: introduce a deliberately huge benchmark and verify each mode behaves correctly.

cc @kianenigma @ggwpez — happy to incorporate any feedback. Co-authored with @Daanvdplas on the relevant commits per the spirit of #1493.