### PR TITLE
Update RELEASE.md

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -84,8 +84,7 @@ Inductively, the public API of our library crates is declared as all public item
 
 The versioning of the Polkadot node is done most of the time by only incrementing the `minor` version. The `major`
 version is only bumped for special releases and the `patch` is used for a patch release that happens every month and
-fixes found issues. The node version is not following SemVer. This means that the version doesn't express if there are
-any breaking changes in the CLI interface or similar. The node version is declared
+fixes found issues. The node version also follows SemVer. The node version is declared
 in the [`NODE_VERSION`](https://paritytech.github.io/polkadot-sdk/master/polkadot_node_primitives/constant.NODE_VERSION.html)
 variable.
 


### PR DESCRIPTION
# Description

Trivial fix to documentation: Node DOESS follow SemVer according to https://paritytech.github.io/polkadot-sdk/master/polkadot_node_primitives/constant.NODE_VERSION.html
