### PR TITLE
[asset-hub-westend] Add pallet_revive v4 migration

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1445,6 +1445,7 @@ impl pallet_migrations::Config for Runtime {
 			pallet_assets_precompiles::weights::SubstrateWeight<Runtime>,
 		>,
 		pallet_revive::migrations::v3::Migration<Runtime>,
+		pallet_revive::migrations::v4::Migration<Runtime>,
 	);
 	// Benchmarks need mocked migrations to guarantee that they succeed.
 	#[cfg(feature = "runtime-benchmarks")]

--- a/prdoc/pr_11983.prdoc
+++ b/prdoc/pr_11983.prdoc
@@ -1,0 +1,10 @@
+title: '[asset-hub-westend] Add pallet_revive v4 migration'
+doc:
+- audience: Runtime Dev
+  description: |-
+    ## Summary
+    - Wire the missing `pallet_revive::migrations::v4::Migration` into the Asset Hub Westend `pallet_migrations::Config::Migrations` tuple, alongside `v3`.
+    - v4 is the multi-block migration that switches storage deposits from the native currency to PGAS (introduced in #11847); without this entry it would never run on WAH.
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch


### PR DESCRIPTION
## Summary
- Wire the missing `pallet_revive::migrations::v4::Migration` into the Asset Hub Westend `pallet_migrations::Config::Migrations` tuple, alongside `v3`.
- v4 is the multi-block migration that switches storage deposits from the native currency to PGAS (introduced in #11847); without this entry it would never run on WAH.
