### PR TITLE
Use app token to create post crates release PR 

### DIFF
--- a/.github/workflows/release-60_post-crates-release-activities.yml
+++ b/.github/workflows/release-60_post-crates-release-activities.yml
@@ -185,9 +185,16 @@ jobs:
           git push
           echo "Changes pushed successfully"
 
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_BACKPORT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BACKPORT_AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Create Pull Request to base release branch
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           BRANCH_NAME: ${{ github.ref_name }}
           FULL_RELEASE: ${{ inputs.version }}
           GH_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
This PR replaces standard GH token with the one generated for the GH app so that CI checks will be triggered automatically when PR is created from the Post Crates Activities flow
Closes: https://github.com/paritytech/release-engineering/issues/296