### PR TITLE
ci: fix resolc download

### DIFF
--- a/.github/workflows/tests-linux-stable.yml
+++ b/.github/workflows/tests-linux-stable.yml
@@ -101,11 +101,18 @@ jobs:
       - name: Install resolc
         run: |
           VERSION="1.0.0"
-          ASSET_URL="https://github.com/paritytech/revive/releases/download/v$VERSION/resolc-x86_64-unknown-linux-musl"
-          echo "Downloading resolc v$VERSION from $ASSET_URL"
-          curl -Lsf --show-error -o /usr/local/bin/resolc "$ASSET_URL"
-          chmod +x /usr/local/bin/resolc
-          resolc --version
+          if command -v resolc >/dev/null 2>&1 && resolc --version 2>/dev/null | grep -q "$VERSION"; then
+            echo "resolc v$VERSION already present in image at $(command -v resolc)"
+            resolc --version
+          else
+            ASSET_URL="https://github.com/paritytech/revive/releases/download/v$VERSION/resolc-x86_64-unknown-linux-musl"
+            echo "Downloading resolc v$VERSION from $ASSET_URL"
+            curl -Lsf --show-error \
+              --retry 5 --retry-delay 5 --retry-connrefused \
+              -o /usr/local/bin/resolc "$ASSET_URL"
+            chmod +x /usr/local/bin/resolc
+            resolc --version
+          fi
       - name: script
         id: required
         run: |
@@ -155,11 +162,18 @@ jobs:
       - name: Install resolc
         run: |
           VERSION="1.0.0"
-          ASSET_URL="https://github.com/paritytech/revive/releases/download/v$VERSION/resolc-x86_64-unknown-linux-musl"
-          echo "Downloading resolc v$VERSION from $ASSET_URL"
-          curl -Lsf --show-error -o /usr/local/bin/resolc "$ASSET_URL"
-          chmod +x /usr/local/bin/resolc
-          resolc --version
+          if command -v resolc >/dev/null 2>&1 && resolc --version 2>/dev/null | grep -q "$VERSION"; then
+            echo "resolc v$VERSION already present in image at $(command -v resolc)"
+            resolc --version
+          else
+            ASSET_URL="https://github.com/paritytech/revive/releases/download/v$VERSION/resolc-x86_64-unknown-linux-musl"
+            echo "Downloading resolc v$VERSION from $ASSET_URL"
+            curl -Lsf --show-error \
+              --retry 5 --retry-delay 5 --retry-connrefused \
+              -o /usr/local/bin/resolc "$ASSET_URL"
+            chmod +x /usr/local/bin/resolc
+            resolc --version
+          fi
       - name: script
         id: required
         run: |


### PR DESCRIPTION
PR adds some logic to retry download resolc to avoid [such](https://github.com/paritytech/polkadot-sdk/actions/runs/25483886193/job/74774666969) problems 

cc https://github.com/paritytech/devops/issues/5285