### PR TITLE
Allow Emergency origin to set PSM max debt

### DIFF
--- a/prdoc/pr_12012.prdoc
+++ b/prdoc/pr_12012.prdoc
@@ -1,0 +1,20 @@
+title: 'Allow Emergency origin to set PSM max debt'
+doc:
+- audience: Runtime Dev
+  description: |-
+    - `PsmManagerLevel::can_set_max_psm_debt` now returns `true` for both `Full` and
+      `Emergency`.
+    - Updates the `ManagerOrigin` doc comment to reflect the expanded Emergency
+      capabilities.
+    - Flips the `emergency_origin_cannot_set_max_psm_debt` unit test to
+      `emergency_origin_can_set_max_psm_debt`.
+
+    When the max PSM debt is reached, minting is blocked and the internal stablecoin
+    can depeg to the upside. Arbitrageurs can no longer deposit external stablecoins
+    to mint and sell internal above peg, so demand pressure has nowhere to relieve.
+
+    Allowing the Emergency origin to raise the ratio restores the arbitrage path.
+
+crates:
+- name: pallet-psm
+  bump: minor

--- a/substrate/frame/psm/src/lib.rs
+++ b/substrate/frame/psm/src/lib.rs
@@ -210,19 +210,19 @@ pub mod pallet {
 		/// Whether this level allows modifying the circuit breaker status.
 		/// Both Full and Emergency levels can set circuit breaker.
 		pub const fn can_set_circuit_breaker(&self) -> bool {
-			true
+			matches!(self, PsmManagerLevel::Full | PsmManagerLevel::Emergency)
 		}
 
 		/// Whether this level allows modifying the global PSM debt ratio.
 		/// Both Full and Emergency levels can set the max PSM debt.
 		pub const fn can_set_max_psm_debt(&self) -> bool {
-			true
+			matches!(self, PsmManagerLevel::Full | PsmManagerLevel::Emergency)
 		}
 
 		/// Whether this level allows modifying per-asset ceiling weights.
 		/// Both Full and Emergency levels can set asset ceilings.
 		pub const fn can_set_asset_ceiling(&self) -> bool {
-			true
+			matches!(self, PsmManagerLevel::Full | PsmManagerLevel::Emergency)
 		}
 
 		/// Whether this level allows adding or removing external assets.

--- a/substrate/frame/psm/src/lib.rs
+++ b/substrate/frame/psm/src/lib.rs
@@ -214,8 +214,9 @@ pub mod pallet {
 		}
 
 		/// Whether this level allows modifying the global PSM debt ratio.
+		/// Both Full and Emergency levels can set the max PSM debt.
 		pub const fn can_set_max_psm_debt(&self) -> bool {
-			matches!(self, PsmManagerLevel::Full)
+			true
 		}
 
 		/// Whether this level allows modifying per-asset ceiling weights.
@@ -263,7 +264,8 @@ pub mod pallet {
 		///
 		/// Returns `PsmManagerLevel` to distinguish privilege levels:
 		/// - `Full` (via GeneralAdmin): Can modify all parameters
-		/// - `Emergency` (via EmergencyAction): Can only modify circuit breaker status
+		/// - `Emergency` (via EmergencyAction): Can modify circuit breaker status, per-asset
+		///   ceiling weights, and the global max PSM debt ratio.
 		type ManagerOrigin: EnsureOrigin<Self::RuntimeOrigin, Success = PsmManagerLevel>;
 
 		/// A type representing the weights required by the dispatchables of this pallet.

--- a/substrate/frame/psm/src/tests.rs
+++ b/substrate/frame/psm/src/tests.rs
@@ -980,19 +980,16 @@ mod governance {
 	}
 
 	#[test]
-	fn emergency_origin_cannot_set_max_psm_debt() {
+	fn emergency_origin_can_set_max_psm_debt() {
 		new_test_ext().execute_with(|| {
-			let old_ratio = MaxPsmDebtOfTotal::<Test>::get();
+			let new_ratio = Permill::from_percent(20);
 
-			assert_noop!(
-				Psm::set_max_psm_debt(
-					RuntimeOrigin::signed(EMERGENCY_ACCOUNT),
-					Permill::from_percent(20)
-				),
-				Error::<Test>::InsufficientPrivilege
-			);
+			assert_ok!(Psm::set_max_psm_debt(
+				RuntimeOrigin::signed(EMERGENCY_ACCOUNT),
+				new_ratio
+			));
 
-			assert_eq!(MaxPsmDebtOfTotal::<Test>::get(), old_ratio);
+			assert_eq!(MaxPsmDebtOfTotal::<Test>::get(), new_ratio);
 		});
 	}
 

--- a/substrate/frame/psm/src/tests.rs
+++ b/substrate/frame/psm/src/tests.rs
@@ -984,10 +984,7 @@ mod governance {
 		new_test_ext().execute_with(|| {
 			let new_ratio = Permill::from_percent(20);
 
-			assert_ok!(Psm::set_max_psm_debt(
-				RuntimeOrigin::signed(EMERGENCY_ACCOUNT),
-				new_ratio
-			));
+			assert_ok!(Psm::set_max_psm_debt(RuntimeOrigin::signed(EMERGENCY_ACCOUNT), new_ratio));
 
 			assert_eq!(MaxPsmDebtOfTotal::<Test>::get(), new_ratio);
 		});


### PR DESCRIPTION
## Summary

- `PsmManagerLevel::can_set_max_psm_debt` now returns `true` for both `Full` and `Emergency`
- Updates the `ManagerOrigin` doc comment to reflect the expanded Emergency capabilities.
- Flips the `emergency_origin_cannot_set_max_psm_debt` unit test to `emergency_origin_can_set_max_psm_debt`.

## Motivation

When the max PSM debt is reached, minting is blocked and the internal stablecoin can depeg to the upside. Arbitrageurs can no longer deposit external stablecoins to mint and sell internal above peg, so demand pressure has nowhere to relieve. 

Allowing the Emergency origin to raise the ratio restores the arbitrage path.