### PR TITLE
[unstable2604] Fix regex in Publish draft flow to parse unstable branch name

### DIFF
--- a/.github/workflows/release-30_publish_release_draft.yml
+++ b/.github/workflows/release-30_publish_release_draft.yml
@@ -152,10 +152,10 @@ jobs:
             echo "REF2: ${REF2}"
           fi
           echo "REL_TAG=$REF2" >> $GITHUB_ENV
-          export VERSION=$(echo "$REF2" | sed -E 's/.*((un)?stable[0-9]{4}(-[0-9]+)?).*$/\1/')
+          export VERSION=$(echo "$REF2" | sed -E 's/^(polkadot-)?((un)?stable[0-9]{4}(-[0-9]+)?).*$/\2/')
           echo "Version: $VERSION"
 
-          export STABLE_VERSION=$(sed -E 's/.*((un)?stable[0-9]{4}).*$/\1/' <<< "$VERSION")
+          export STABLE_VERSION=$(sed -E 's/^((un)?stable[0-9]{4}).*$/\1/' <<< "$VERSION")
           export NODE_VERSION=v$(get_polkadot_node_version_from_code)
 
           ./scripts/release/build-changelogs.sh


### PR DESCRIPTION
This PR fixes an issue with the regex in the Publish draft flow, so that the unstable branch name was properly parced and set as version for the chaneglog