### PR TITLE
bug(revive): callerIsRoot doesnt survive proxy delegatecalls

### DIFF
--- a/substrate/frame/revive/fixtures/contracts/delegate_call_caller_is_root.rs
+++ b/substrate/frame/revive/fixtures/contracts/delegate_call_caller_is_root.rs
@@ -1,0 +1,54 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This fixture delegate-calls another contract and returns its output.
+
+#![no_std]
+#![no_main]
+include!("../panic_handler.rs");
+
+use uapi::{input, HostFn, HostFnImpl as api};
+
+#[no_mangle]
+#[polkavm_derive::polkavm_export]
+pub extern "C" fn deploy() {}
+
+#[no_mangle]
+#[polkavm_derive::polkavm_export]
+pub extern "C" fn call() {
+	input!(
+		512,
+		callee: &[u8; 20],
+		callee_input: [u8],
+	);
+
+	let mut output = [0u8; 32];
+	let output = &mut &mut output[..];
+
+	api::delegate_call(
+		uapi::CallFlags::empty(),
+		callee,
+		u64::MAX,
+		u64::MAX,
+		&[u8::MAX; 32],
+		callee_input,
+		Some(output),
+	)
+	.unwrap();
+
+	api::return_value(uapi::ReturnFlags::empty(), output);
+}

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -2313,8 +2313,45 @@ where
 	}
 
 	fn caller_is_root(&self, use_caller_of_caller: bool) -> bool {
-		// if the caller isn't origin, then it can't be root.
-		self.caller_is_origin(use_caller_of_caller) && self.origin == Origin::Root
+		if self.origin != Origin::Root {
+			return false;
+		}
+
+		if !use_caller_of_caller {
+			return self.caller_is_origin(false);
+		}
+
+		if self.caller_is_origin(true) {
+			return true;
+		}
+
+		// System::callerIsRoot() asks whether the contract that called the System precompile is
+		// ultimately executing on behalf of the root origin. Upgradeable proxy patterns reach the
+		// implementation with delegate calls:
+		//
+		// 1. Root calls the proxy.
+		// 2. The proxy delegate-calls the implementation.
+		// 3. The implementation calls System::callerIsRoot().
+		//
+		// `frames()` starts at the System precompile frame, so skip it and then allow root
+		// authority to cross only delegate-call frames. A regular contract-to-contract call
+		// remains a hard boundary and must not inherit root authority.
+		let mut frames = self.frames().skip(1).peekable();
+
+		while let Some(frame) = frames.next() {
+			// The last remaining frame is the contract originally called by Root; reaching it means
+			// every frame between that contract and the System precompile was a delegate call.
+			// The frame stack is bounded or determined by CALL_STACK_DEPTH, so this walk is SAFE.
+			if frames.peek().is_none() {
+				return true;
+			}
+
+			if frame.delegate.is_none() {
+				return false;
+			}
+		}
+
+		true
 	}
 
 	fn balance(&self) -> U256 {

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3630,6 +3630,176 @@ fn call_caller_is_root_from_non_root() {
 }
 
 #[test]
+fn call_caller_is_root_through_delegate_call() {
+	let (caller_code, _) = compile_module("delegate_call_caller_is_root").unwrap();
+	let (callee_code, _) = compile_module("call_caller_is_root").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		let Contract { addr: caller, .. } =
+			builder::bare_instantiate(Code::Upload(caller_code)).build_and_unwrap_contract();
+		let Contract { addr: callee, .. } =
+			builder::bare_instantiate(Code::Upload(callee_code)).build_and_unwrap_contract();
+
+		// Mirrors upgradeable proxy dispatch:
+		// 1. Root calls the proxy.
+		// 2. The proxy delegate-calls the implementation.
+		// 3. The implementation calls System::callerIsRoot().
+		let ret = builder::bare_call(caller)
+			.origin(RuntimeOrigin::root())
+			.data(callee.encode())
+			.build_and_unwrap_result();
+		let is_root = Bool::abi_decode(&ret.data).expect("decoding failed");
+		assert!(is_root);
+	});
+}
+
+#[test]
+fn call_caller_is_root_through_nested_delegate_calls() {
+	let (proxy_code, _) = compile_module("delegate_call_caller_is_root").unwrap();
+	let (implementation_code, _) = compile_module("call_caller_is_root").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+		let salt1 = [1; 32];
+		let salt2 = [2; 32];
+		let Contract { addr: first_proxy, .. } =
+			builder::bare_instantiate(Code::Upload(proxy_code.clone()))
+				.salt(Some(salt1))
+				.build_and_unwrap_contract();
+		let Contract { addr: second_proxy, .. } =
+			builder::bare_instantiate(Code::Upload(proxy_code))
+				.salt(Some(salt2))
+				.build_and_unwrap_contract();
+		let Contract { addr: implementation, .. } =
+			builder::bare_instantiate(Code::Upload(implementation_code))
+				.build_and_unwrap_contract();
+
+		// Covers delegate-heavy proxy layouts such as diamond/facet dispatch or proxy-to-proxy
+		// upgrade dispatch:
+		// 1. Root calls the first proxy.
+		// 2. The first proxy delegate-calls a second proxy or facet.
+		// 3. The second proxy or facet delegate-calls the implementation.
+		// 4. The implementation calls System::callerIsRoot().
+		let ret = builder::bare_call(first_proxy)
+			.origin(RuntimeOrigin::root())
+			.data(second_proxy.encode().into_iter().chain(implementation.encode()).collect())
+			.build_and_unwrap_result();
+		let is_root = Bool::abi_decode(&ret.data).expect("decoding failed");
+		assert!(is_root);
+	});
+}
+
+#[test]
+fn call_caller_is_root_through_delegate_call_from_non_root() {
+	let (caller_code, _) = compile_module("delegate_call_caller_is_root").unwrap();
+	let (callee_code, _) = compile_module("call_caller_is_root").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		let Contract { addr: caller, .. } =
+			builder::bare_instantiate(Code::Upload(caller_code)).build_and_unwrap_contract();
+		let Contract { addr: callee, .. } =
+			builder::bare_instantiate(Code::Upload(callee_code)).build_and_unwrap_contract();
+
+		// Delegatecall alone is not enough. The call-stack origin must still be Root.
+		let ret = builder::bare_call(caller).data(callee.encode()).build_and_unwrap_result();
+		let is_root = Bool::abi_decode(&ret.data).expect("decoding failed");
+		assert!(!is_root);
+	});
+}
+
+#[test]
+fn call_caller_is_root_through_nested_delegate_calls_from_non_root() {
+	let (proxy_code, _) = compile_module("delegate_call_caller_is_root").unwrap();
+	let (implementation_code, _) = compile_module("call_caller_is_root").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		let salt1 = [1; 32];
+		let salt2 = [2; 32];
+
+		let Contract { addr: first_proxy, .. } =
+			builder::bare_instantiate(Code::Upload(proxy_code.clone()))
+				.salt(Some(salt1))
+				.build_and_unwrap_contract();
+		let Contract { addr: second_proxy, .. } =
+			builder::bare_instantiate(Code::Upload(proxy_code))
+				.salt(Some(salt2))
+				.build_and_unwrap_contract();
+		let Contract { addr: implementation, .. } =
+			builder::bare_instantiate(Code::Upload(implementation_code))
+				.build_and_unwrap_contract();
+
+		// Delegatecall chains preserve execution context, but they do not turn a signed origin into
+		// root.
+		let ret = builder::bare_call(first_proxy)
+			.data(second_proxy.encode().into_iter().chain(implementation.encode()).collect())
+			.build_and_unwrap_result();
+		let is_root = Bool::abi_decode(&ret.data).expect("decoding failed");
+		assert!(!is_root);
+	});
+}
+
+#[test]
+fn call_caller_is_root_does_not_cross_regular_call_frame() {
+	let (caller_code, _) = compile_module("call_and_return").unwrap();
+	let (callee_code, _) = compile_module("call_caller_is_root").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		let Contract { addr: caller, .. } =
+			builder::bare_instantiate(Code::Upload(caller_code)).build_and_unwrap_contract();
+		let Contract { addr: callee, .. } =
+			builder::bare_instantiate(Code::Upload(callee_code)).build_and_unwrap_contract();
+
+		// Root authority can cross proxy delegatecall frames, but not ordinary contract calls.
+		let ret = builder::bare_call(caller)
+			.origin(RuntimeOrigin::root())
+			.data((&callee, 0u64).encode())
+			.build_and_unwrap_result();
+		let is_root = Bool::abi_decode(&ret.data).expect("decoding failed");
+		assert!(!is_root);
+	});
+}
+
+#[test]
+fn call_caller_is_root_does_not_cross_regular_call_before_proxy() {
+	let (caller_code, _) = compile_module("call_and_return").unwrap();
+	let (proxy_code, _) = compile_module("delegate_call_caller_is_root").unwrap();
+	let (implementation_code, _) = compile_module("call_caller_is_root").unwrap();
+
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		let Contract { addr: caller, .. } =
+			builder::bare_instantiate(Code::Upload(caller_code)).build_and_unwrap_contract();
+		let Contract { addr: proxy, .. } =
+			builder::bare_instantiate(Code::Upload(proxy_code)).build_and_unwrap_contract();
+		let Contract { addr: implementation, .. } =
+			builder::bare_instantiate(Code::Upload(implementation_code))
+				.build_and_unwrap_contract();
+
+		// A root-authenticated regular call into another contract must not leak root authority,
+		// even if the callee then enters an implementation through a UUPS/transparent-style proxy:
+		// 1. Root calls a contract.
+		// 2. That contract makes a regular call to a proxy.
+		// 3. The proxy delegate-calls the implementation.
+		// 4. The implementation calls System::callerIsRoot().
+		let ret = builder::bare_call(caller)
+			.origin(RuntimeOrigin::root())
+			.data((&proxy, 0u64).encode().into_iter().chain(implementation.encode()).collect())
+			.build_and_unwrap_result();
+		let is_root = Bool::abi_decode(&ret.data).expect("decoding failed");
+		assert!(!is_root);
+	});
+}
+
+#[test]
 fn call_caller_is_origin() {
 	let (code, _) = compile_module("call_caller_is_origin").unwrap();
 

--- a/substrate/frame/revive/uapi/sol/ISystem.sol
+++ b/substrate/frame/revive/uapi/sol/ISystem.sol
@@ -28,7 +28,9 @@ interface ISystem {
 	/// Checks whether the caller of the contract calling this function is root.
 	///
 	/// Note that only the origin of the call stack can be root. Hence this
-	/// function returning `true` implies that the contract is being called by the origin.
+	/// function returning `true` implies that the contract is being called by the origin,
+	/// either directly or through delegate-call frames such as upgradeable proxy dispatch.
+	/// Regular contract-to-contract call frames do not propagate root authority.
 	///
 	/// A return value of `true` indicates that this contract is being called by a root origin,
 	/// and `false` indicates that the caller is a signed origin.


### PR DESCRIPTION
# Description
`System.callerIsRoot()` currently assumes a direct root-origin call shape. This breaks upgradeable contract patterns where a runtime root call enters a proxy and the proxy reaches the implementation through `delegatecall`. This PR allows root authority to propagate through `delegate-call-only frames`, while preserving the existing safety boundary that ordinary `contract-to-contract calls` do not inherit root authority.

This fixes proxy shapes such as:

1. Root calls proxy.
2. Proxy delegate-calls implementation.
3. Implementation calls `System.callerIsRoot()`.
4. 
## Review Notes
The implementation keeps `callerIsRoot()` strict about the actual call-stack origin: it only returns `true` when the origin is `Root`.When checking the caller through the System precompile frame, it now permits intermediate frames only if they are delegate-call frames. Reaching a regular call frame returns `false`.

Covered cases:
1. Direct root call returns `true`.
2. Signed origin returns `false`.
3. Root through one delegatecall proxy returns `true`.
5. Root through nested delegatecall proxy/facet dispatch returns `true`.
6. Signed origin through delegatecall proxy dispatch returns `false`.
7. Root through a regular call returns `false`.
8. Root through a regular call into a proxy still returns `false`.
The frame walk is bounded by `CALL_STACK_DEPTH`, so this does not introduce unbounded work. I did leave a comment in  `caller_is_root`.
