### PR TITLE
pallet-transaction-storage: mark publish = false and drop from umbrella

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9820,6 +9820,7 @@ dependencies = [
  "node-primitives",
  "pallet-example-mbm",
  "pallet-example-tasks",
+ "pallet-transaction-storage",
  "parity-scale-codec",
  "polkadot-sdk",
  "primitive-types 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17506,7 +17506,6 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
- "pallet-transaction-storage",
  "pallet-treasury",
  "pallet-tx-pause",
  "pallet-uniques",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1078,6 +1078,7 @@ pallet-tips = { path = "substrate/frame/tips", default-features = false }
 pallet-transaction-payment = { path = "substrate/frame/transaction-payment", default-features = false }
 pallet-transaction-payment-rpc = { path = "substrate/frame/transaction-payment/rpc", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { path = "substrate/frame/transaction-payment/rpc/runtime-api", default-features = false }
+pallet-transaction-storage = { path = "substrate/frame/transaction-storage", default-features = false }
 pallet-treasury = { path = "substrate/frame/treasury", default-features = false }
 pallet-uniques = { path = "substrate/frame/uniques", default-features = false }
 pallet-utility = { path = "substrate/frame/utility", default-features = false }

--- a/prdoc/pr_12059.prdoc
+++ b/prdoc/pr_12059.prdoc
@@ -1,0 +1,13 @@
+title: 'pallet-transaction-storage: mark publish = false and drop from umbrella'
+doc:
+- audience: Runtime Dev
+  description: |-
+    ## Summary
+
+      - Set `publish = false` on `pallet-transaction-storage` so it is no longer published to crates.io as part of the SDK release.
+      - Remove all references to `pallet-transaction-storage` from the `polkadot-sdk` umbrella crate
+
+    The pallet remains a normal workspace member and can still be depended on directly via its path, but it is excluded from the umbrella crate and the published release set.
+crates:
+- name: polkadot-sdk
+  bump: patch

--- a/prdoc/pr_12059.prdoc
+++ b/prdoc/pr_12059.prdoc
@@ -3,10 +3,6 @@ doc:
 - audience: Runtime Dev
   description: |-
     ## Summary
-
-      - Set `publish = false` on `pallet-transaction-storage` so it is no longer published to crates.io as part of the SDK release.
-      - Remove all references to `pallet-transaction-storage` from the `polkadot-sdk` umbrella crate
-
     The pallet remains a normal workspace member and can still be depended on directly via its path, but it is excluded from the umbrella crate and the published release set.
 crates:
 - name: polkadot-sdk

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -39,6 +39,7 @@ node-primitives = { workspace = true }
 # Example pallets that are not published:
 pallet-example-mbm = { workspace = true }
 pallet-example-tasks = { workspace = true }
+pallet-transaction-storage = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }
@@ -52,6 +53,7 @@ std = [
 	"node-primitives/std",
 	"pallet-example-mbm/std",
 	"pallet-example-tasks/std",
+	"pallet-transaction-storage/std",
 	"polkadot-sdk/std",
 	"primitive-types/std",
 	"rand?/std",
@@ -63,6 +65,7 @@ std = [
 runtime-benchmarks = [
 	"pallet-example-mbm/runtime-benchmarks",
 	"pallet-example-tasks/runtime-benchmarks",
+	"pallet-transaction-storage/runtime-benchmarks",
 	"polkadot-sdk/runtime-benchmarks",
 	"rand",
 	"rand_pcg",
@@ -70,6 +73,7 @@ runtime-benchmarks = [
 try-runtime = [
 	"pallet-example-mbm/try-runtime",
 	"pallet-example-tasks/try-runtime",
+	"pallet-transaction-storage/try-runtime",
 	"polkadot-sdk/try-runtime",
 ]
 experimental = [

--- a/substrate/frame/transaction-storage/Cargo.toml
+++ b/substrate/frame/transaction-storage/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 description = "Storage chain pallet"
 readme = "README.md"
+publish = false
 
 [lints]
 workspace = true

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -162,7 +162,6 @@ std = [
 	"pallet-tips?/std",
 	"pallet-transaction-payment-rpc-runtime-api?/std",
 	"pallet-transaction-payment?/std",
-	"pallet-transaction-storage?/std",
 	"pallet-treasury?/std",
 	"pallet-tx-pause?/std",
 	"pallet-uniques?/std",
@@ -353,7 +352,6 @@ runtime-benchmarks = [
 	"pallet-timestamp?/runtime-benchmarks",
 	"pallet-tips?/runtime-benchmarks",
 	"pallet-transaction-payment?/runtime-benchmarks",
-	"pallet-transaction-storage?/runtime-benchmarks",
 	"pallet-treasury?/runtime-benchmarks",
 	"pallet-tx-pause?/runtime-benchmarks",
 	"pallet-uniques?/runtime-benchmarks",
@@ -503,7 +501,6 @@ try-runtime = [
 	"pallet-timestamp?/try-runtime",
 	"pallet-tips?/try-runtime",
 	"pallet-transaction-payment?/try-runtime",
-	"pallet-transaction-storage?/try-runtime",
 	"pallet-treasury?/try-runtime",
 	"pallet-tx-pause?/try-runtime",
 	"pallet-uniques?/try-runtime",
@@ -544,7 +541,6 @@ serde = [
 	"pallet-state-trie-migration?/serde",
 	"pallet-tips?/serde",
 	"pallet-transaction-payment?/serde",
-	"pallet-transaction-storage?/serde",
 	"pallet-treasury?/serde",
 	"pallet-xcm?/serde",
 	"sp-application-crypto?/serde",
@@ -736,7 +732,6 @@ runtime-full = [
 	"pallet-tips",
 	"pallet-transaction-payment",
 	"pallet-transaction-payment-rpc-runtime-api",
-	"pallet-transaction-storage",
 	"pallet-treasury",
 	"pallet-tx-pause",
 	"pallet-uniques",
@@ -1847,11 +1842,6 @@ path = "../substrate/frame/transaction-payment"
 default-features = false
 optional = true
 path = "../substrate/frame/transaction-payment/rpc/runtime-api"
-
-[dependencies.pallet-transaction-storage]
-default-features = false
-optional = true
-path = "../substrate/frame/transaction-storage"
 
 [dependencies.pallet-treasury]
 default-features = false

--- a/umbrella/src/lib.rs
+++ b/umbrella/src/lib.rs
@@ -775,10 +775,6 @@ pub use pallet_transaction_payment_rpc;
 #[cfg(feature = "pallet-transaction-payment-rpc-runtime-api")]
 pub use pallet_transaction_payment_rpc_runtime_api;
 
-/// Storage chain pallet.
-#[cfg(feature = "pallet-transaction-storage")]
-pub use pallet_transaction_storage;
-
 /// FRAME pallet to manage treasury.
 #[cfg(feature = "pallet-treasury")]
 pub use pallet_treasury;


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                           
  - Set `publish = false` on `pallet-transaction-storage` so it is no longer published to crates.io as part of the SDK release.
  - Remove all references to `pallet-transaction-storage` from the `polkadot-sdk` umbrella crate

The pallet remains a normal workspace member and can still be depended on directly via its path, but it is excluded from the umbrella crate and the published release set.