### PR TITLE
fix: duplicated "the" in development_environment_advice and runtime/common/elections doc-comments

### DIFF
--- a/docs/sdk/src/reference_docs/development_environment_advice.rs
+++ b/docs/sdk/src/reference_docs/development_environment_advice.rs
@@ -150,7 +150,7 @@
 //! [cargo-remote](https://github.com/sgeisler/cargo-remote) to execute cargo commands on it,
 //! freeing up local resources for other tasks like `rust-analyzer`.
 //!
-//! When using `cargo-remote`, you can configure your editor to perform the the typical
+//! When using `cargo-remote`, you can configure your editor to perform the typical
 //! "check-on-save" remotely as well. The configuration for VSCode (or any VSCode-based editor like
 //! Cursor) is as follows:
 //!

--- a/polkadot/runtime/common/src/elections.rs
+++ b/polkadot/runtime/common/src/elections.rs
@@ -45,7 +45,7 @@ macro_rules! impl_elections_weights {
 	};
 }
 
-/// The numbers configured here could always be more than the the maximum limits of staking pallet
+/// The numbers configured here could always be more than the maximum limits of staking pallet
 /// to ensure election snapshot will not run out of memory. For now, we set them to smaller values
 /// since the staking is bounded and the weight pipeline takes hours for this single pallet.
 pub struct BenchmarkConfig;


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in doc-comments:
- `docs/sdk/src/reference_docs/development_environment_advice.rs` — "//! When using `cargo-remote`, you can configure your editor to perform the the typical" → "...perform the typical"
- `polkadot/runtime/common/src/elections.rs` — "/// The numbers configured here could always be more than the the maximum limits of staking pallet" → "...more than the maximum limits of staking pallet"

No code/behavior change.