### PR TITLE
ci: build container image for statement-store-tools

### DIFF
--- a/.github/workflows/build-publish-images.yml
+++ b/.github/workflows/build-publish-images.yml
@@ -257,6 +257,47 @@ jobs:
   #
   #
   #
+  build-statement-store-tools:
+    needs: [preflight]
+    runs-on: ${{ needs.preflight.outputs.RUNNER }}
+    timeout-minutes: 60
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: build
+        id: required
+        run: |
+          forklift cargo build --locked --release -p statement-latency-bench --bin statement-latency-bench --bin setup-allowances
+      - name: pack artifacts
+        run: |
+          mkdir -p ./artifacts
+          mv ./target/release/statement-latency-bench ./artifacts/.
+          mv ./target/release/setup-allowances ./artifacts/.
+          echo -n "${{ needs.preflight.outputs.SOURCE_REF_SLUG }}" > ./artifacts/VERSION
+          echo -n "${{ needs.preflight.outputs.SOURCE_REF_SLUG }}-${COMMIT_SHA}" > ./artifacts/EXTRATAG
+          echo "statement-store-tools = $(cat ./artifacts/VERSION) (EXTRATAG = $(cat ./artifacts/EXTRATAG))"
+          cp -r ./docker/* ./artifacts
+
+      - name: tar
+        run: tar -cvf artifacts.tar artifacts
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ github.job }}-${{ needs.preflight.outputs.SOURCE_REF_SLUG }}
+          path: artifacts.tar
+          retention-days: 1
+      - name: Stop all workflows if failed
+        if: ${{ failure() && steps.required.conclusion == 'failure' && !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/workflow-stopper
+        with:
+          app-id: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_ID }}
+          app-key: ${{ secrets.WORKFLOW_STOPPER_RUNNER_APP_KEY }}
+  #
+  #
+  #
   build-linux-substrate:
     needs: [preflight]
     runs-on: ${{ needs.preflight.outputs.RUNNER }}
@@ -604,6 +645,32 @@ jobs:
   #
   #
   #
+  build-push-image-statement-store-tools:
+    needs: [preflight, build-statement-store-tools]
+    runs-on: ${{ needs.preflight.outputs.RUNNER_DEFAULT }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-statement-store-tools-${{ needs.preflight.outputs.SOURCE_REF_SLUG }}
+
+      - name: tar
+        run: tar -xvf artifacts.tar
+
+      - name: build and push image
+        uses: ./.github/actions/build-push-image
+        with:
+          image-name: "statement-store-tools"
+          dockerfile: "docker/dockerfiles/statement-store-tools_injected.Dockerfile"
+          username: ${{ secrets.PARITYPR_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.PARITYPR_DOCKERHUB_PASSWORD }}
+
+  #
+  #
+  #
   build-push-image-substrate-pr:
     needs: [preflight, build-linux-substrate]
     runs-on: ${{ needs.preflight.outputs.RUNNER_DEFAULT }}
@@ -714,6 +781,7 @@ jobs:
       - build-test-parachain
       - build-test-collators
       - build-malus
+      - build-statement-store-tools
       - build-linux-substrate
       - build-templates-node
       - prepare-cumulus-zombienet-artifacts

--- a/docker/dockerfiles/statement-store-tools_injected.Dockerfile
+++ b/docker/dockerfiles/statement-store-tools_injected.Dockerfile
@@ -1,0 +1,51 @@
+FROM debian:bullseye-slim
+
+# metadata
+ARG VCS_REF
+ARG BUILD_DATE
+ARG IMAGE_NAME
+
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="${IMAGE_NAME}" \
+	io.parity.image.description="Statement store benchmarking tools" \
+	io.parity.image.source="https://github.com/paritytech/polkadot-sdk/blob/${VCS_REF}/docker/dockerfiles/statement-store-tools_injected.Dockerfile" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}" \
+	io.parity.image.documentation="https://github.com/paritytech/polkadot-sdk/"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+# install tools and dependencies
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates \
+    curl \
+    libssl1.1 \
+    tini && \
+# apt cleanup
+	apt-get autoremove -y && \
+	apt-get clean && \
+	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
+# add user
+  groupadd --gid 10000 nonroot && \
+  useradd  --home-dir /home/nonroot \
+           --create-home \
+           --shell /bin/bash \
+           --gid nonroot \
+           --groups nonroot \
+           --uid 10000 nonroot
+
+
+# add statement-store-tools binaries to docker image
+COPY ./artifacts/statement-latency-bench ./artifacts/setup-allowances /usr/local/bin
+
+USER nonroot
+
+# check if executables work in this container
+RUN /usr/local/bin/statement-latency-bench --help >/dev/null && \
+	/usr/local/bin/setup-allowances --help >/dev/null
+
+# Tini allows us to avoid several Docker edge cases, see https://github.com/krallin/tini.
+ENTRYPOINT ["tini", "--", "/bin/bash"]

--- a/docker/scripts/statement-store-tools/build-injected.sh
+++ b/docker/scripts/statement-store-tools/build-injected.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Sample call:
+# $0 /path/to/folder_with_binary
+# This script replace the former dedicated Dockerfile
+# and shows how to use the generic binary_injected.dockerfile
+
+PROJECT_ROOT=`git rev-parse --show-toplevel`
+
+export BINARY=statement-latency-bench,setup-allowances
+export ARTIFACTS_FOLDER=$1
+export DOCKERFILE=docker/dockerfiles/statement-store-tools_injected.Dockerfile
+# export TAGS=...
+
+$PROJECT_ROOT/docker/scripts/build-injected.sh


### PR DESCRIPTION
Adds a `statement-store-tools` docker image bundling the two binaries shipped by the `statement-latency-bench` crate (`statement-latency-bench` and `setup-allowances`) so the bench tools can be run as a published image instead of building from source.
