### PR TITLE
fix(statement-network): split peer metric by kind

### DIFF
--- a/prdoc/pr_12080.prdoc
+++ b/prdoc/pr_12080.prdoc
@@ -1,0 +1,13 @@
+title: 'fix(statement-network): split peer metric by kind'
+doc:
+- audience: Node Dev
+  description: |-
+    Impl #12060
+
+    ## Summary
+
+    - Change `substrate_sync_statement_peers_connected` from a plain gauge to a `GaugeVec` labelled by `kind`
+    - Report statement protocol peers as `kind="full"` or `kind="light"`
+crates:
+- name: sc-network-statement
+  bump: patch

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -1027,9 +1027,9 @@ where
 				);
 				debug_assert!(_was_in.is_none());
 
-				if let Some(metrics) = &self.metrics {
+				self.metrics.as_ref().map(|metrics| {
 					metrics.peers_connected.with_label_values(&[peer_kind]).inc();
-				}
+				});
 
 				// Light V2 peers must set topic affinity before receiving statements.
 				// All other peers get initial sync immediately.
@@ -1042,12 +1042,12 @@ where
 				debug_assert!(removed_peer.is_some());
 
 				if let Some(removed_peer) = removed_peer {
-					if let Some(metrics) = &self.metrics {
+					self.metrics.as_ref().map(|metrics| {
 						metrics
 							.peers_connected
 							.with_label_values(&[Self::peer_kind_label(removed_peer.is_light)])
 							.dec();
-					}
+					});
 				}
 
 				if let Some(pending) = self.pending_initial_syncs.remove(&peer) {

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -44,8 +44,8 @@ use governor::{
 	Quota, RateLimiter,
 };
 use prometheus_endpoint::{
-	exponential_buckets, register, Counter, Gauge, Histogram, HistogramOpts, PrometheusError,
-	Registry, U64,
+	exponential_buckets, register, Counter, Gauge, GaugeVec, Histogram, HistogramOpts, Opts,
+	PrometheusError, Registry, U64,
 };
 use rand::seq::IteratorRandom;
 use sc_network::{
@@ -168,7 +168,7 @@ struct Metrics {
 	propagated_statements_chunks: Histogram,
 	pending_statements: Gauge<U64>,
 	ignored_statements: Counter<U64>,
-	peers_connected: Gauge<U64>,
+	peers_connected: GaugeVec<U64>,
 	statements_received: Counter<U64>,
 	bytes_sent_total: Counter<U64>,
 	bytes_received_total: Counter<U64>,
@@ -182,6 +182,19 @@ struct Metrics {
 
 impl Metrics {
 	fn register(r: &Registry) -> Result<Self, PrometheusError> {
+		let peers_connected = register(
+			GaugeVec::new(
+				Opts::new(
+					"substrate_sync_statement_peers_connected",
+					"Number of peers connected using the statement protocol by kind",
+				),
+				&["kind"],
+			)?,
+			r,
+		)?;
+		peers_connected.with_label_values(&["full"]).set(0);
+		peers_connected.with_label_values(&["light"]).set(0);
+
 		Ok(Self {
 			propagated_statements: register(
 				Counter::new(
@@ -228,13 +241,7 @@ impl Metrics {
 				)?,
 				r,
 			)?,
-			peers_connected: register(
-				Gauge::new(
-					"substrate_sync_statement_peers_connected",
-					"Number of peers connected using the statement protocol",
-				)?,
-				r,
-			)?,
+			peers_connected,
 			statements_received: register(
 				Counter::new(
 					"substrate_sync_statements_received",
@@ -674,6 +681,16 @@ where
 	N: NetworkPeers + NetworkEventStream,
 	S: SyncEventStream + sp_consensus::SyncOracle,
 {
+	fn update_peers_connected_metrics(&self) {
+		let light = self.peers.values().filter(|peer| peer.is_light).count() as u64;
+		let full = self.peers.len() as u64 - light;
+
+		if let Some(metrics) = &self.metrics {
+			metrics.peers_connected.with_label_values(&["full"]).set(full);
+			metrics.peers_connected.with_label_values(&["light"]).set(light);
+		}
+	}
+
 	/// Create a new `StatementHandler` for testing/benchmarking purposes.
 	#[cfg(any(test, feature = "test-helpers"))]
 	pub fn new_for_testing(
@@ -1011,9 +1028,7 @@ where
 				);
 				debug_assert!(_was_in.is_none());
 
-				self.metrics.as_ref().map(|metrics| {
-					metrics.peers_connected.set(self.peers.len() as u64);
-				});
+				self.update_peers_connected_metrics();
 
 				// Light V2 peers must set topic affinity before receiving statements.
 				// All other peers get initial sync immediately.
@@ -1033,9 +1048,7 @@ where
 					});
 				}
 				self.initial_sync_peer_queue.retain(|p| *p != peer);
-				self.metrics.as_ref().map(|metrics| {
-					metrics.peers_connected.set(self.peers.len() as u64);
-				});
+				self.update_peers_connected_metrics();
 			},
 			NotificationEvent::NotificationReceived { peer, notification } => {
 				let bytes_received = notification.len() as u64;

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -681,13 +681,11 @@ where
 	N: NetworkPeers + NetworkEventStream,
 	S: SyncEventStream + sp_consensus::SyncOracle,
 {
-	fn update_peers_connected_metrics(&self) {
-		let light = self.peers.values().filter(|peer| peer.is_light).count() as u64;
-		let full = self.peers.len() as u64 - light;
-
-		if let Some(metrics) = &self.metrics {
-			metrics.peers_connected.with_label_values(&["full"]).set(full);
-			metrics.peers_connected.with_label_values(&["light"]).set(light);
+	fn peer_kind_label(is_light: bool) -> &'static str {
+		if is_light {
+			"light"
+		} else {
+			"full"
 		}
 	}
 
@@ -1002,6 +1000,7 @@ where
 					return;
 				};
 				let is_light = peer_role.is_light();
+				let peer_kind = Self::peer_kind_label(is_light);
 				log::debug!(
 					target: LOG_TARGET,
 					"Peer {peer} connected with statement protocol {protocol_version:?}, role={peer_role:?}"
@@ -1028,7 +1027,9 @@ where
 				);
 				debug_assert!(_was_in.is_none());
 
-				self.update_peers_connected_metrics();
+				if let Some(metrics) = &self.metrics {
+					metrics.peers_connected.with_label_values(&[peer_kind]).inc();
+				}
 
 				// Light V2 peers must set topic affinity before receiving statements.
 				// All other peers get initial sync immediately.
@@ -1037,8 +1038,18 @@ where
 				}
 			},
 			NotificationEvent::NotificationStreamClosed { peer } => {
-				let _peer = self.peers.remove(&peer);
-				debug_assert!(_peer.is_some());
+				let removed_peer = self.peers.remove(&peer);
+				debug_assert!(removed_peer.is_some());
+
+				if let Some(removed_peer) = removed_peer {
+					if let Some(metrics) = &self.metrics {
+						metrics
+							.peers_connected
+							.with_label_values(&[Self::peer_kind_label(removed_peer.is_light)])
+							.dec();
+					}
+				}
+
 				if let Some(pending) = self.pending_initial_syncs.remove(&peer) {
 					self.metrics.as_ref().map(|metrics| {
 						metrics.initial_sync_peers_active.dec();
@@ -1048,7 +1059,6 @@ where
 					});
 				}
 				self.initial_sync_peer_queue.retain(|p| *p != peer);
-				self.update_peers_connected_metrics();
 			},
 			NotificationEvent::NotificationReceived { peer, notification } => {
 				let bytes_received = notification.len() as u64;

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -674,6 +674,14 @@ impl Peer {
 			self.protocol_version == PeerProtocolVersion::V2 &&
 			self.topic_affinity.is_none())
 	}
+
+	fn kind(&self) -> &'static str {
+		if self.is_light {
+			"light"
+		} else {
+			"full"
+		}
+	}
 }
 
 impl<N, S> StatementHandler<N, S>
@@ -681,14 +689,6 @@ where
 	N: NetworkPeers + NetworkEventStream,
 	S: SyncEventStream + sp_consensus::SyncOracle,
 {
-	fn peer_kind_label(is_light: bool) -> &'static str {
-		if is_light {
-			"light"
-		} else {
-			"full"
-		}
-	}
-
 	/// Create a new `StatementHandler` for testing/benchmarking purposes.
 	#[cfg(any(test, feature = "test-helpers"))]
 	pub fn new_for_testing(
@@ -1000,7 +1000,6 @@ where
 					return;
 				};
 				let is_light = peer_role.is_light();
-				let peer_kind = Self::peer_kind_label(is_light);
 				log::debug!(
 					target: LOG_TARGET,
 					"Peer {peer} connected with statement protocol {protocol_version:?}, role={peer_role:?}"
@@ -1028,7 +1027,9 @@ where
 				debug_assert!(_was_in.is_none());
 
 				self.metrics.as_ref().map(|metrics| {
-					metrics.peers_connected.with_label_values(&[peer_kind]).inc();
+					if let Some(peer) = self.peers.get(&peer) {
+						metrics.peers_connected.with_label_values(&[peer.kind()]).inc();
+					}
 				});
 
 				// Light V2 peers must set topic affinity before receiving statements.
@@ -1043,10 +1044,7 @@ where
 
 				if let Some(removed_peer) = removed_peer {
 					self.metrics.as_ref().map(|metrics| {
-						metrics
-							.peers_connected
-							.with_label_values(&[Self::peer_kind_label(removed_peer.is_light)])
-							.dec();
+						metrics.peers_connected.with_label_values(&[removed_peer.kind()]).dec();
 					});
 				}
 


### PR DESCRIPTION
Impl #12060 

## Summary

- Change `substrate_sync_statement_peers_connected` from a plain gauge to a `GaugeVec` labelled by `kind`
- Report statement protocol peers as `kind="full"` or `kind="light"`
