### PR TITLE
ParityDB: Value should still be stored after transaction with store + reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21007,6 +21007,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
+ "rstest",
  "sc-client-api 28.0.0",
  "sc-state-db",
  "schnellru",

--- a/prdoc/pr_12082.prdoc
+++ b/prdoc/pr_12082.prdoc
@@ -1,0 +1,19 @@
+# Schema: Polkadot SDK PRDoc Schema (prdoc) v1.0.0
+# See doc at https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/prdoc/schema_user.json
+
+title: 'ParityDB: Do not skip storing on store + ref in same tx'
+
+doc:
+  - audience: ['Node Operator', 'Node Dev']
+    description: |
+      Fixes a bug in the ParityDB adapter where a `store` + `reference` on the same
+      unknown key within a single transaction would skip storing the value entirely.
+
+      ParityDB internally transformed the reference into a dereference, making the value
+      disappear from the database after commit. The fix maps changes directly to
+      `parity_db::Operation` variants so the `Set` is always emitted regardless of other
+      operations in the same transaction.
+
+crates:
+  - name: sc-client-db
+    bump: patch

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -51,6 +51,7 @@ criterion = { workspace = true, default-features = true }
 kitchensink-runtime = { workspace = true }
 kvdb-rocksdb = { workspace = true }
 rand = { workspace = true, default-features = true }
+rstest = { workspace = true }
 sp-database = { workspace = true, default-features = true, features = ["rocksdb"] }
 sp-tracing = { workspace = true, default-features = true }
 substrate-test-runtime-client = { workspace = true }

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -6480,9 +6480,10 @@ pub(crate) mod tests {
 			fn open(&self) -> Arc<dyn Database<DbHash>> {
 				match self {
 					Self::Persistent(arc) => arc.clone(),
-					Self::OnDisk { path, kind: BackendKind::ParityDb, .. } =>
+					Self::OnDisk { path, kind: BackendKind::ParityDb, .. } => {
 						crate::parity_db::open::<DbHash>(path, DatabaseType::Full, true, false)
-							.expect("parity-db open succeeds in test"),
+							.expect("parity-db open succeeds in test")
+					},
 					Self::OnDisk { path, kind: BackendKind::RocksDb, .. } => {
 						let mut cfg = kvdb_rocksdb::DatabaseConfig::with_columns(NUM_COLUMNS);
 						cfg.create_if_missing = true;

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -6442,4 +6442,207 @@ pub(crate) mod tests {
 		assert_eq!(gap.start, 1);
 		assert_eq!(gap.end, 2);
 	}
+
+	mod database_adapter_tests {
+		use super::*;
+		use crate::utils::NUM_COLUMNS;
+		use rstest::rstest;
+		use sp_database::Transaction as DbTransaction;
+		use std::{path::PathBuf, sync::Arc};
+		use tempfile::TempDir;
+
+		#[derive(Debug, Clone, Copy)]
+		enum BackendKind {
+			KvdbMemdb,
+			ParityDb,
+			RocksDb,
+		}
+
+		enum DbFactory {
+			Persistent(Arc<dyn Database<DbHash>>),
+			OnDisk { path: PathBuf, kind: BackendKind, _tmp: TempDir },
+		}
+
+		impl DbFactory {
+			fn new(kind: BackendKind) -> Self {
+				match kind {
+					BackendKind::KvdbMemdb => Self::Persistent(sp_database::as_database(
+						kvdb_memorydb::create(NUM_COLUMNS),
+					)),
+					BackendKind::ParityDb | BackendKind::RocksDb => {
+						let tmp = TempDir::new().unwrap();
+						let path = tmp.path().to_path_buf();
+						Self::OnDisk { path, kind, _tmp: tmp }
+					},
+				}
+			}
+
+			fn open(&self) -> Arc<dyn Database<DbHash>> {
+				match self {
+					Self::Persistent(arc) => arc.clone(),
+					Self::OnDisk { path, kind: BackendKind::ParityDb, .. } =>
+						crate::parity_db::open::<DbHash>(path, DatabaseType::Full, true, false)
+							.expect("parity-db open succeeds in test"),
+					Self::OnDisk { path, kind: BackendKind::RocksDb, .. } => {
+						let mut cfg = kvdb_rocksdb::DatabaseConfig::with_columns(NUM_COLUMNS);
+						cfg.create_if_missing = true;
+						let db = kvdb_rocksdb::Database::open(&cfg, path)
+							.expect("kvdb-rocksdb open succeeds in test");
+						sp_database::as_database(db)
+					},
+					Self::OnDisk { kind: BackendKind::KvdbMemdb, .. } => unreachable!(),
+				}
+			}
+		}
+
+		const TEST_COL: u32 = columns::TRANSACTION;
+
+		fn hash(seed: u8) -> DbHash {
+			DbHash::repeat_byte(seed)
+		}
+
+		fn commit_store(factory: &DbFactory, h: DbHash, bytes: Vec<u8>) {
+			let db = factory.open();
+			let mut tx = DbTransaction::new();
+			tx.store(TEST_COL, h, bytes);
+			db.commit(tx).unwrap();
+		}
+
+		fn commit_reference(factory: &DbFactory, h: DbHash) {
+			let db = factory.open();
+			let mut tx = DbTransaction::new();
+			tx.reference(TEST_COL, h);
+			db.commit(tx).unwrap();
+		}
+
+		fn commit_release(factory: &DbFactory, h: DbHash) {
+			let db = factory.open();
+			let mut tx = DbTransaction::new();
+			tx.release(TEST_COL, h);
+			db.commit(tx).unwrap();
+		}
+
+		fn get_value(factory: &DbFactory, h: DbHash) -> Option<Vec<u8>> {
+			factory.open().get(TEST_COL, h.as_ref())
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn store_then_get(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA1);
+			let bytes = b"a1-bytes".to_vec();
+			commit_store(&factory, h, bytes.clone());
+			assert_eq!(get_value(&factory, h).as_deref(), Some(bytes.as_slice()));
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn store_release_separate_commits(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA2);
+			let bytes = b"a2-bytes".to_vec();
+			commit_store(&factory, h, bytes);
+			assert!(get_value(&factory, h).is_some(), "present after store");
+			commit_release(&factory, h);
+			assert!(get_value(&factory, h).is_none(), "gone after release");
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn store_reference_release_release_separate_commits(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA3);
+			let bytes = b"a3-bytes".to_vec();
+			commit_store(&factory, h, bytes);
+			commit_reference(&factory, h);
+			assert!(get_value(&factory, h).is_some(), "rc=2 after reference");
+			commit_release(&factory, h);
+			assert!(get_value(&factory, h).is_some(), "rc=1 still present");
+			commit_release(&factory, h);
+			assert!(get_value(&factory, h).is_none(), "rc=0 removed");
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn store_then_reference_same_commit_keeps_value(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA4);
+			let bytes = b"a4-bytes".to_vec();
+			{
+				let db = factory.open();
+				let mut tx = DbTransaction::new();
+				tx.store(TEST_COL, h, bytes.clone());
+				tx.reference(TEST_COL, h);
+				db.commit(tx).unwrap();
+			}
+			assert_eq!(
+				get_value(&factory, h).as_deref(),
+				Some(bytes.as_slice()),
+				"Store + Reference on fresh hash in a single commit must keep the value \
+				 (observed via fresh DB handle so overlay caching is bypassed)",
+			);
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn store_then_two_references_same_commit_keeps_value(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA5);
+			let bytes = b"a5-bytes".to_vec();
+			{
+				let db = factory.open();
+				let mut tx = DbTransaction::new();
+				tx.store(TEST_COL, h, bytes.clone());
+				tx.reference(TEST_COL, h);
+				tx.reference(TEST_COL, h);
+				db.commit(tx).unwrap();
+			}
+			assert_eq!(
+				get_value(&factory, h).as_deref(),
+				Some(bytes.as_slice()),
+				"Store + 2x Reference on fresh hash must keep the value (post-sync observation)",
+			);
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn reference_on_missing_hash_is_noop(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA6);
+			commit_reference(&factory, h);
+			assert!(get_value(&factory, h).is_none(), "reference on missing key is a no-op");
+			let bytes = b"a6-bytes".to_vec();
+			commit_store(&factory, h, bytes.clone());
+			assert_eq!(get_value(&factory, h).as_deref(), Some(bytes.as_slice()));
+			commit_release(&factory, h);
+			assert!(get_value(&factory, h).is_none(), "single release balances the store");
+		}
+
+		#[rstest]
+		#[case::kvdb_memdb(BackendKind::KvdbMemdb)]
+		#[case::paritydb(BackendKind::ParityDb)]
+		#[case::rocksdb(BackendKind::RocksDb)]
+		fn release_on_missing_hash_is_noop(#[case] kind: BackendKind) {
+			let factory = DbFactory::new(kind);
+			let h = hash(0xA7);
+			commit_release(&factory, h);
+			assert!(get_value(&factory, h).is_none(), "release on missing key is a no-op");
+			let bytes = b"a7-bytes".to_vec();
+			commit_store(&factory, h, bytes.clone());
+			assert_eq!(get_value(&factory, h).as_deref(), Some(bytes.as_slice()));
+		}
+	}
 }

--- a/substrate/client/db/src/parity_db.rs
+++ b/substrate/client/db/src/parity_db.rs
@@ -92,14 +92,16 @@ fn ref_counted_column(col: u32) -> bool {
 
 impl<H: Clone + AsRef<[u8]>> Database<H> for DbAdapter {
 	fn commit(&self, transaction: Transaction<H>) -> Result<(), DatabaseError> {
+		use parity_db::Operation;
+
 		let mut not_ref_counted_column = Vec::new();
-		let result = self.0.commit(transaction.0.into_iter().filter_map(|change| {
+		let result = self.0.commit_changes(transaction.0.into_iter().filter_map(|change| {
 			Some(match change {
-				Change::Set(col, key, value) => (col as u8, key, Some(value)),
-				Change::Remove(col, key) => (col as u8, key, None),
+				Change::Set(col, key, value) => (col as u8, Operation::Set(key, value)),
+				Change::Remove(col, key) => (col as u8, Operation::Dereference(key)),
 				Change::Store(col, key, value) => {
 					if ref_counted_column(col) {
-						(col as u8, key.as_ref().to_vec(), Some(value))
+						(col as u8, Operation::Set(key.as_ref().to_vec(), value))
 					} else {
 						if !not_ref_counted_column.contains(&col) {
 							not_ref_counted_column.push(col);
@@ -109,9 +111,7 @@ impl<H: Clone + AsRef<[u8]>> Database<H> for DbAdapter {
 				},
 				Change::Reference(col, key) => {
 					if ref_counted_column(col) {
-						// FIXME accessing value is not strictly needed, optimize this in parity-db.
-						let value = <Self as Database<H>>::get(self, col, key.as_ref());
-						(col as u8, key.as_ref().to_vec(), value)
+						(col as u8, Operation::Reference(key.as_ref().to_vec()))
 					} else {
 						if !not_ref_counted_column.contains(&col) {
 							not_ref_counted_column.push(col);
@@ -121,7 +121,7 @@ impl<H: Clone + AsRef<[u8]>> Database<H> for DbAdapter {
 				},
 				Change::Release(col, key) => {
 					if ref_counted_column(col) {
-						(col as u8, key.as_ref().to_vec(), None)
+						(col as u8, Operation::Dereference(key.as_ref().to_vec()))
 					} else {
 						if !not_ref_counted_column.contains(&col) {
 							not_ref_counted_column.push(col);


### PR DESCRIPTION
Whenever we would see a store + reference within the same database transaction on a yet unknown value, parityDB would transform the reference into a dereference, which would give us invalid DB state. Intuitively, the value should be stored in the DB but was actually not present. 

In this PR we fix this by introducing a direct mapping to operations and adding test cases for this.

Note: In chains with pallet-transaction-storage, the runtime would prevent this because you can not renew a transaction that was not already present in a prior block. But at the low level this should still work.