### PR TITLE
Allow calling `runtime_api` with supplied storage overlay

### DIFF
--- a/prdoc/pr_12084.prdoc
+++ b/prdoc/pr_12084.prdoc
@@ -1,0 +1,12 @@
+title: Allow calling `runtime_api` with supplied storage overlay
+doc:
+- audience: Node Dev
+  description: |-
+    This change allows users of `client.runtime_api()` to provide a custom overlay with changes before calling further runtime APIs.
+
+    Concrete use-case is a future PR where I receive changes from a block execution and want to call a runtime API on the post state of said block even before it hits the DB.
+crates:
+- name: sp-api-proc-macro
+  bump: patch
+- name: sp-api
+  bump: patch

--- a/prdoc/pr_12084.prdoc
+++ b/prdoc/pr_12084.prdoc
@@ -7,6 +7,6 @@ doc:
     Concrete use-case is a future PR where I receive changes from a block execution and want to call a runtime API on the post state of said block even before it hits the DB.
 crates:
 - name: sp-api-proc-macro
-  bump: patch
+  bump: major
 - name: sp-api
-  bump: patch
+  bump: major

--- a/prdoc/pr_12084.prdoc
+++ b/prdoc/pr_12084.prdoc
@@ -3,8 +3,6 @@ doc:
 - audience: Node Dev
   description: |-
     This change allows users of `client.runtime_api()` to provide a custom overlay with changes before calling further runtime APIs.
-
-    Concrete use-case is a future PR where I receive changes from a block execution and want to call a runtime API on the post state of said block even before it hits the DB.
 crates:
 - name: sp-api-proc-macro
   bump: major

--- a/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -367,6 +367,10 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 				fn register_extension<E: #crate_::Extension>(&mut self, extension: E) {
 					std::cell::RefCell::borrow_mut(&self.extensions).register(extension);
 				}
+
+				fn set_overlayed_changes(&mut self, changes: #crate_::OverlayedChanges<#crate_::HashingFor<Block>>) {
+					*self.changes.borrow_mut() = changes;
+				}
 			}
 
 			#[automatically_derived]

--- a/substrate/primitives/api/proc-macro/src/mock_impl_runtime_apis.rs
+++ b/substrate/primitives/api/proc-macro/src/mock_impl_runtime_apis.rs
@@ -131,6 +131,10 @@ fn implement_common_api_traits(block_type: TypePath, self_ty: Type) -> Result<To
 			fn register_extension<E: #crate_::Extension>(&mut self, _: E) {
 				unimplemented!("`register_extension` not implemented for runtime api mocks")
 			}
+
+			fn set_overlayed_changes(&mut self, _: #crate_::OverlayedChanges<#crate_::HashingFor<#block_type>>) {
+				unimplemented!("`set_overlayed_changes` not implemented for runtime api mocks")
+			}
 		}
 
 		impl #crate_::Core<#block_type> for #self_ty {

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -652,6 +652,17 @@ pub trait ApiExt<Block: BlockT> {
 
 	/// Register an [`Extension`] that will be accessible while executing a runtime api call.
 	fn register_extension<E: Extension>(&mut self, extension: E);
+
+	/// Replace the overlayed changes used by subsequent runtime API calls on this instance.
+	///
+	/// This replaces any previously set overlay — it does not merge with it. Callers should
+	/// construct the full `OverlayedChanges` value (including parent state and any pending
+	/// writes) before calling this method.
+	///
+	/// Should be called before entering a runtime API transaction. Calling it after
+	/// `register_extension` has run for a given block may leave extensions generated for
+	/// a different state.
+	fn set_overlayed_changes(&mut self, changes: OverlayedChanges<HashingFor<Block>>);
 }
 
 /// Parameters for [`CallApiAt::call_api_at`].

--- a/substrate/primitives/api/src/lib.rs
+++ b/substrate/primitives/api/src/lib.rs
@@ -654,14 +654,6 @@ pub trait ApiExt<Block: BlockT> {
 	fn register_extension<E: Extension>(&mut self, extension: E);
 
 	/// Replace the overlayed changes used by subsequent runtime API calls on this instance.
-	///
-	/// This replaces any previously set overlay — it does not merge with it. Callers should
-	/// construct the full `OverlayedChanges` value (including parent state and any pending
-	/// writes) before calling this method.
-	///
-	/// Should be called before entering a runtime API transaction. Calling it after
-	/// `register_extension` has run for a given block may leave extensions generated for
-	/// a different state.
 	fn set_overlayed_changes(&mut self, changes: OverlayedChanges<HashingFor<Block>>);
 }
 

--- a/substrate/primitives/api/test/tests/runtime_calls.rs
+++ b/substrate/primitives/api/test/tests/runtime_calls.rs
@@ -30,7 +30,9 @@ use sp_runtime::{
 	traits::{HashingFor, Header as HeaderT},
 	TransactionOutcome,
 };
-use sp_state_machine::{create_proof_check_backend, execution_proof_check_on_trie_backend};
+use sp_state_machine::{
+	create_proof_check_backend, execution_proof_check_on_trie_backend, OverlayedChanges,
+};
 
 use substrate_test_runtime_client::{
 	prelude::*,
@@ -275,4 +277,29 @@ fn ensure_transactional_works() {
 	assert_eq!(transaction_tester.started.load(Ordering::Relaxed), 4);
 	assert_eq!(transaction_tester.committed.load(Ordering::Relaxed), 3);
 	assert_eq!(transaction_tester.rolled_back.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn set_overlayed_changes_is_observed_by_typed_call() {
+	// `TestAPI::get_block_number` reads `frame_system::Number`, whose storage key is
+	// `twox_128("System") ++ twox_128("Number")` and whose value is SCALE-encoded `u64`.
+	// This is FRAME's standard `StorageValue` key derivation; spelled out here so the
+	// test does not need a frame-support dependency.
+	let system_number_key: Vec<u8> = sp_core::hashing::twox_128(b"System")
+		.iter()
+		.chain(sp_core::hashing::twox_128(b"Number").iter())
+		.copied()
+		.collect();
+
+	let client = TestClientBuilder::new().build();
+	let mut runtime_api = client.runtime_api();
+	let best_hash = client.chain_info().best_hash;
+
+	assert_eq!(runtime_api.get_block_number(best_hash).unwrap(), 0);
+
+	let mut overlayed: OverlayedChanges<HashingFor<Block>> = OverlayedChanges::default();
+	overlayed.set_storage(system_number_key, Some(42u64.encode()));
+	runtime_api.set_overlayed_changes(overlayed);
+
+	assert_eq!(runtime_api.get_block_number(best_hash).unwrap(), 42);
 }

--- a/substrate/primitives/api/test/tests/runtime_calls.rs
+++ b/substrate/primitives/api/test/tests/runtime_calls.rs
@@ -281,10 +281,6 @@ fn ensure_transactional_works() {
 
 #[test]
 fn set_overlayed_changes_is_observed_by_typed_call() {
-	// `TestAPI::get_block_number` reads `frame_system::Number`, whose storage key is
-	// `twox_128("System") ++ twox_128("Number")` and whose value is SCALE-encoded `u64`.
-	// This is FRAME's standard `StorageValue` key derivation; spelled out here so the
-	// test does not need a frame-support dependency.
 	let system_number_key: Vec<u8> = sp_core::hashing::twox_128(b"System")
 		.iter()
 		.chain(sp_core::hashing::twox_128(b"Number").iter())


### PR DESCRIPTION
This change allows users of `client.runtime_api()` to provide a custom overlay with changes before calling further runtime APIs.

Concrete use-case is a future PR where I receive changes from a block execution and want to call a runtime API on the post state of said block even before it hits the DB.