### PR TITLE
staking-async / WAH: use div_ceil for VoterSnapshotPerBlock

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/staking.rs
@@ -37,8 +37,10 @@ parameter_types! {
 	/// Maximum number of validators that we may want to elect. 1000 is the end target.
 	pub const MaxValidatorSet: u32 = 1000;
 
-	/// Number of nominators per page of the snapshot, and consequently number of backers in the solution.
-	pub VoterSnapshotPerBlock: u32 = MaxElectingVoters::get() / Pages::get();
+	/// Number of nominators per page of the snapshot, and consequently number of backers in the
+	/// solution. Uses ceiling division so that `VoterSnapshotPerBlock * Pages >= MaxElectingVoters`
+	/// holds for any configured values.
+	pub VoterSnapshotPerBlock: u32 = MaxElectingVoters::get().div_ceil(Pages::get());
 
 	/// Number of validators per page of the snapshot.
 	pub TargetSnapshotPerBlock: u32 = MaxValidatorSet::get();

--- a/prdoc/pr_12100.prdoc
+++ b/prdoc/pr_12100.prdoc
@@ -1,12 +1,14 @@
 title: 'staking-async / WAH: use div_ceil for VoterSnapshotPerBlock'
 doc:
 - audience: Runtime Dev
-  description: "Floor division undersized the paged voter snapshot by 4 voters:\n\n\
-    * DOT preset: 22_500 / 32 = 703 \u2192 22_496 (-4)\n* KSM preset: 12_500 / 16\
-    \ = 781 \u2192 12_496 (-4)\n\nSwitch to `div_ceil` so `VoterSnapshotPerBlock *\
-    \ Pages >= MaxElectingVoters` holds for any configured values, and add invariant\
-    \ tests for both presets.\n\nAligns AH-Westend and the fake DOT/KSM presets with\
-    \ PAH and KAH in the runtimes repo, which already use `div_ceil`."
+  description: |
+    Floor division could undersize the paged voter snapshot relative to
+    `MaxElectingVoters`. Switch to `div_ceil` so
+    `VoterSnapshotPerBlock * Pages >= MaxElectingVoters` holds for any
+    configured values, and add invariant tests for both fake presets.
+
+    Aligns AH-Westend and the fake DOT/KSM presets with PAH and KAH in the
+    runtimes repo, which already use `div_ceil`.
 crates:
 - name: asset-hub-westend-runtime
   bump: patch

--- a/prdoc/pr_12100.prdoc
+++ b/prdoc/pr_12100.prdoc
@@ -1,0 +1,12 @@
+title: 'staking-async / WAH: use div_ceil for VoterSnapshotPerBlock'
+doc:
+- audience: Runtime Dev
+  description: "Floor division undersized the paged voter snapshot by 4 voters:\n\n\
+    * DOT preset: 22_500 / 32 = 703 \u2192 22_496 (-4)\n* KSM preset: 12_500 / 16\
+    \ = 781 \u2192 12_496 (-4)\n\nSwitch to `div_ceil` so `VoterSnapshotPerBlock *\
+    \ Pages >= MaxElectingVoters` holds for any configured values, and add invariant\
+    \ tests for both presets.\n\nAligns AH-Westend and the fake DOT/KSM presets with\
+    \ PAH and KAH in the runtimes repo, which already use `div_ceil`."
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch

--- a/substrate/frame/staking-async/runtimes/parachain/src/staking.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/staking.rs
@@ -160,8 +160,9 @@ parameter_types! {
 	/// Number of nominators per page of the snapshot, and consequently number of backers in the
 	/// solution.
 	///
-	/// 703 in both Polkadot and Kusama.
-	pub VoterSnapshotPerBlock: u32 = MaxElectingVoters::get() / Pages::get();
+	/// 704 in Polkadot (32 pages), 782 in Kusama (16 pages). Uses ceiling division so that
+	/// `VoterSnapshotPerBlock * Pages >= MaxElectingVoters` holds for any configured values.
+	pub VoterSnapshotPerBlock: u32 = MaxElectingVoters::get().div_ceil(Pages::get());
 
 	/// In each page, we may observe up to all of the validators.
 	pub const MaxWinnersPerPage: u32 = MaxValidatorSet::get();
@@ -781,6 +782,32 @@ mod tests {
 			op.proof_size() / WEIGHT_PROOF_SIZE_PER_KB,
 			op.proof_size() as f64 / block.proof_size() as f64
 		);
+	}
+
+	#[test]
+	fn fake_dot_preset_snapshot_capacity_covers_max_electing_voters() {
+		sp_io::TestExternalities::default().execute_with(|| {
+			super::enable_dot_preset(false);
+			assert!(
+				VoterSnapshotPerBlock::get() * Pages::get() >= MaxElectingVoters::get(),
+				"paged snapshot capacity {} < MaxElectingVoters {}",
+				VoterSnapshotPerBlock::get() * Pages::get(),
+				MaxElectingVoters::get(),
+			);
+		});
+	}
+
+	#[test]
+	fn fake_ksm_preset_snapshot_capacity_covers_max_electing_voters() {
+		sp_io::TestExternalities::default().execute_with(|| {
+			super::enable_ksm_preset(false);
+			assert!(
+				VoterSnapshotPerBlock::get() * Pages::get() >= MaxElectingVoters::get(),
+				"paged snapshot capacity {} < MaxElectingVoters {}",
+				VoterSnapshotPerBlock::get() * Pages::get(),
+				MaxElectingVoters::get(),
+			);
+		});
 	}
 
 	#[test]


### PR DESCRIPTION
Floor division could undersize the paged voter snapshot relative to `MaxElectingVoters`. Switched to `div_ceil` so `VoterSnapshotPerBlock * Pages >= MaxElectingVoters` holds for any configured values, and added invariant tests for both fake presets.

Aligned AH-Westend and the fake DOT/KSM presets with PAH and KAH in the runtimes repo, which already use `div_ceil`.


Example in staking-async testnet configuration: floor division undersized the paged voter snapshot by 4 voters:
* DOT: floor(22_500 / 32) = 703 → 703 * 32 = 22_496 (4 short)
* KSM: floor(12_500 / 16) = 781 → 781 * 16 = 12_496 (4 short)