### PR TITLE
[stable2512] Rve/stable2512 4 unblock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-standards"
-version = "0.1.4"
+version = "0.1.3"
 dependencies = [
  "alloy-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-standards"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "alloy-core",
 ]

--- a/prdoc/pr_12105.prdoc
+++ b/prdoc/pr_12105.prdoc
@@ -4,25 +4,22 @@ doc:
   description: |-
     Unblocks the `stable2512-4` crates release.
 
-    `ethereum-standards 0.1.3` (already on crates.io, published from master) widened the `IERC20`
-    interface with `IERC20Metadata` (`name`/`symbol`/`decimals`) and EIP-2612 permit
+    `ethereum-standards 0.1.3` (already on crates.io, published from `stable2603`) widened the
+    `IERC20` interface with `IERC20Metadata` (`name`/`symbol`/`decimals`) and EIP-2612 permit
     (`permit`/`nonces`/`DOMAIN_SEPARATOR`) variants. `parity-publish`'s verify step compiles
     `pallet-assets-precompiles` against registry-resolved dependencies, so it picks the wider
     `0.1.3` enum, and the existing 6-arm `match input` becomes non-exhaustive.
 
-    Two minimal changes:
-    - Append the metadata and permit signatures to `ethereum-standards`'s `IERC20.sol` so the
-      workspace enum aligns with what crates.io already exposes. Bump the crate to `0.1.4`
-      (skipping over the already-published `0.1.3`).
+    Fix on `stable2512`:
+    - Sync `ethereum-standards` (`Cargo.toml` and `IERC20.sol`) to the `stable2603` state, which
+      is the source of the already-published `0.1.3`. No new version of `ethereum-standards` is
+      published; the workspace just catches up to the registry.
     - Add named match arms in `pallet-assets-precompiles` for the six new variants, each
       reverting with "Unsupported function".
 
     The actual `IERC20Metadata` and EIP-2612 permit handlers are not backported. Runtimes on
-    `stable2512` never registered handlers for these functions in the first place, so reverting
-    on them preserves observable behaviour while making the match exhaustive against the wider
-    enum.
+    `stable2512` never registered handlers for these functions, so reverting on them preserves
+    observable behaviour while making the match exhaustive against the wider enum.
 crates:
-- name: ethereum-standards
-  bump: patch
 - name: pallet-assets-precompiles
   bump: patch

--- a/prdoc/pr_12105.prdoc
+++ b/prdoc/pr_12105.prdoc
@@ -1,0 +1,28 @@
+title: '[stable2512] Unblock pallet-assets-precompiles crates.io publish'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Unblocks the `stable2512-4` crates release.
+
+    `ethereum-standards 0.1.3` (already on crates.io, published from master) widened the `IERC20`
+    interface with `IERC20Metadata` (`name`/`symbol`/`decimals`) and EIP-2612 permit
+    (`permit`/`nonces`/`DOMAIN_SEPARATOR`) variants. `parity-publish`'s verify step compiles
+    `pallet-assets-precompiles` against registry-resolved dependencies, so it picks the wider
+    `0.1.3` enum, and the existing 6-arm `match input` becomes non-exhaustive.
+
+    Two minimal changes:
+    - Append the metadata and permit signatures to `ethereum-standards`'s `IERC20.sol` so the
+      workspace enum aligns with what crates.io already exposes. Bump the crate to `0.1.4`
+      (skipping over the already-published `0.1.3`).
+    - Add named match arms in `pallet-assets-precompiles` for the six new variants, each
+      reverting with "Unsupported function".
+
+    The actual `IERC20Metadata` and EIP-2612 permit handlers are not backported. Runtimes on
+    `stable2512` never registered handlers for these functions in the first place, so reverting
+    on them preserves observable behaviour while making the match exhaustive against the wider
+    enum.
+crates:
+- name: ethereum-standards
+  bump: patch
+- name: pallet-assets-precompiles
+  bump: patch

--- a/prdoc/pr_12105.prdoc
+++ b/prdoc/pr_12105.prdoc
@@ -24,5 +24,6 @@ doc:
 crates:
 - name: ethereum-standards
   bump: patch
+  validate: false
 - name: pallet-assets-precompiles
   bump: patch

--- a/prdoc/pr_12105.prdoc
+++ b/prdoc/pr_12105.prdoc
@@ -22,7 +22,7 @@ doc:
     observable behaviour while making the match exhaustive against the wider enum.
 crates:
 - name: ethereum-standards
-  bump: patch
+  bump: none
   validate: false
 - name: pallet-assets-precompiles
   bump: patch

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -118,6 +118,17 @@ where
 			IERC20Calls::allowance(call) => Self::allowance(asset_id, call, env),
 			IERC20Calls::approve(call) => Self::approve(asset_id, call, env),
 			IERC20Calls::transferFrom(call) => Self::transfer_from(asset_id, call, env),
+
+			// IERC20Metadata (`name`/`symbol`/`decimals`) and EIP-2612 permit
+			// (`permit`/`nonces`/`DOMAIN_SEPARATOR`) are exposed by `ethereum-standards`
+			// but their handlers are not backported to this stable branch.
+			IERC20Calls::name(_) |
+			IERC20Calls::symbol(_) |
+			IERC20Calls::decimals(_) |
+			IERC20Calls::permit(_) |
+			IERC20Calls::nonces(_) |
+			IERC20Calls::DOMAIN_SEPARATOR(_) =>
+				Err(Error::Revert(Revert { reason: "Unsupported function".into() })),
 		}
 	}
 }

--- a/substrate/primitives/ethereum-standards/Cargo.toml
+++ b/substrate/primitives/ethereum-standards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-standards"
-version = "0.1.2"
+version = "0.1.4"
 authors.workspace = true
 edition.workspace = true
 description = "Interfaces for Ethereum standards"

--- a/substrate/primitives/ethereum-standards/Cargo.toml
+++ b/substrate/primitives/ethereum-standards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-standards"
-version = "0.1.4"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 description = "Interfaces for Ethereum standards"

--- a/substrate/primitives/ethereum-standards/src/IERC20.sol
+++ b/substrate/primitives/ethereum-standards/src/IERC20.sol
@@ -60,4 +60,32 @@ interface IERC20 {
      ///
      /// Emits a {Transfer} event.
     function transferFrom(address from, address to, uint256 value) external returns (bool);
+
+     /// @dev Returns the name of the token. (IERC20Metadata extension)
+    function name() external view returns (string memory);
+
+     /// @dev Returns the symbol of the token. (IERC20Metadata extension)
+    function symbol() external view returns (string memory);
+
+     /// @dev Returns the decimals places of the token. (IERC20Metadata extension)
+    function decimals() external view returns (uint8);
+
+     /// @dev EIP-2612 permit. Sets `value` as the allowance of `spender` over `owner`'s
+     /// tokens, given `owner`'s signed approval.
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+     /// @dev Returns the current nonce for `owner`. (EIP-2612)
+    function nonces(address owner) external view returns (uint256);
+
+     /// @dev Returns the EIP-712 domain separator. (EIP-2612)
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
 }

--- a/substrate/primitives/ethereum-standards/src/IERC20.sol
+++ b/substrate/primitives/ethereum-standards/src/IERC20.sol
@@ -1,77 +1,118 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/IERC20.sol)
+// This interface combines methods from three OpenZeppelin contracts:
+//
+// IERC20.sol (base ERC-20 interface)
 // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol
+//
+// IERC20Metadata.sol (ERC-20 metadata extension)
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/IERC20Metadata.sol
+//
+// IERC20Permit.sol (EIP-2612 permit extension)
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/IERC20Permit.sol
+//
 pragma solidity ^0.8.20;
 
 ///
-/// @dev Interface of the ERC-20 standard as defined in the ERC.
+/// @dev Interface combining the ERC-20 standard, its metadata extension, and EIP-2612 permit.
+/// Note: Due to ABI generation constraints, all interfaces are merged into a single contract.
 ///
 interface IERC20 {
-     /// @dev Emitted when `value` tokens are moved from one account (`from`) to
-     /// another (`to`).
-     ///
-     /// Note that `value` may be zero.
+    // ============================================================
+    // IERC20 - Base ERC-20 Interface
+    // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol
+    // ============================================================
+
+    /// @dev Emitted when `value` tokens are moved from one account (`from`) to
+    /// another (`to`).
+    ///
+    /// Note that `value` may be zero.
     event Transfer(address indexed from, address indexed to, uint256 value);
 
-     /// @dev Emitted when the allowance of a `spender` for an `owner` is set by
-     /// a call to {approve}. `value` is the new allowance.
+    /// @dev Emitted when the allowance of a `spender` for an `owner` is set by
+    /// a call to {approve}. `value` is the new allowance.
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
-     /// @dev Returns the value of tokens in existence.
+    /// @dev Returns the value of tokens in existence.
     function totalSupply() external view returns (uint256);
 
-     /// @dev Returns the value of tokens owned by `account`.
+    /// @dev Returns the value of tokens owned by `account`.
     function balanceOf(address account) external view returns (uint256);
 
-     /// @dev Moves a `value` amount of tokens from the caller's account to `to`.
-     ///
-     /// Returns a boolean value indicating whether the operation succeeded.
-     ///
-     /// Emits a {Transfer} event.
+    /// @dev Moves a `value` amount of tokens from the caller's account to `to`.
+    ///
+    /// Returns a boolean value indicating whether the operation succeeded.
+    ///
+    /// Emits a {Transfer} event.
     function transfer(address to, uint256 value) external returns (bool);
 
-     /// @dev Returns the remaining number of tokens that `spender` will be
-     /// allowed to spend on behalf of `owner` through {transferFrom}. This is
-     /// zero by default.
-     ///
-     /// This value changes when {approve} or {transferFrom} are called.
+    /// @dev Returns the remaining number of tokens that `spender` will be
+    /// allowed to spend on behalf of `owner` through {transferFrom}. This is
+    /// zero by default.
+    ///
+    /// This value changes when {approve} or {transferFrom} are called.
     function allowance(address owner, address spender) external view returns (uint256);
 
-     /// @dev Sets a `value` amount of tokens as the allowance of `spender` over the
-     /// caller's tokens.
-     ///
-     /// Returns a boolean value indicating whether the operation succeeded.
-     ///
-     /// IMPORTANT: Beware that changing an allowance with this method brings the risk
-     /// that someone may use both the old and the new allowance by unfortunate
-     /// transaction ordering. One possible solution to mitigate this race
-     /// condition is to first reduce the spender's allowance to 0 and set the
-     /// desired value afterwards:
-     /// https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-     ///
-     /// Emits an {Approval} event.
+    /// @dev Sets a `value` amount of tokens as the allowance of `spender` over the
+    /// caller's tokens.
+    ///
+    /// Returns a boolean value indicating whether the operation succeeded.
+    ///
+    /// IMPORTANT: Beware that changing an allowance with this method brings the risk
+    /// that someone may use both the old and the new allowance by unfortunate
+    /// transaction ordering. One possible solution to mitigate this race
+    /// condition is to first reduce the spender's allowance to 0 and set the
+    /// desired value afterwards:
+    /// https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    ///
+    /// Emits an {Approval} event.
     function approve(address spender, uint256 value) external returns (bool);
 
-     /// @dev Moves a `value` amount of tokens from `from` to `to` using the
-     /// allowance mechanism. `value` is then deducted from the caller's
-     /// allowance.
-     ///
-     /// Returns a boolean value indicating whether the operation succeeded.
-     ///
-     /// Emits a {Transfer} event.
+    /// @dev Moves a `value` amount of tokens from `from` to `to` using the
+    /// allowance mechanism. `value` is then deducted from the caller's
+    /// allowance.
+    ///
+    /// Returns a boolean value indicating whether the operation succeeded.
+    ///
+    /// Emits a {Transfer} event.
     function transferFrom(address from, address to, uint256 value) external returns (bool);
 
-     /// @dev Returns the name of the token. (IERC20Metadata extension)
+    // ============================================================
+    // IERC20Metadata - ERC-20 Metadata Extension
+    // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/IERC20Metadata.sol
+    // ============================================================
+
+    /// @dev Returns the name of the token.
     function name() external view returns (string memory);
 
-     /// @dev Returns the symbol of the token. (IERC20Metadata extension)
+    /// @dev Returns the symbol of the token.
     function symbol() external view returns (string memory);
 
-     /// @dev Returns the decimals places of the token. (IERC20Metadata extension)
+    /// @dev Returns the decimals places of the token.
     function decimals() external view returns (uint8);
 
-     /// @dev EIP-2612 permit. Sets `value` as the allowance of `spender` over `owner`'s
-     /// tokens, given `owner`'s signed approval.
+    // ============================================================
+    // IERC20Permit - EIP-2612 Permit Extension
+    // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/IERC20Permit.sol
+    // ============================================================
+
+    /// @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,
+    /// given ``owner``'s signed approval.
+    ///
+    /// IMPORTANT: The same issues {IERC20-approve} has related to transaction
+    /// ordering also apply here.
+    ///
+    /// Emits an {Approval} event.
+    ///
+    /// Requirements:
+    ///
+    /// - `spender` cannot be the zero address.
+    /// - `deadline` must be a timestamp in the future.
+    /// - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
+    /// over the EIP712-formatted function arguments.
+    /// - the signature must use ``owner``'s current nonce (see {nonces}).
+    ///
+    /// For more information on the signature format, see the
+    /// https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section].
     function permit(
         address owner,
         address spender,
@@ -82,10 +123,15 @@ interface IERC20 {
         bytes32 s
     ) external;
 
-     /// @dev Returns the current nonce for `owner`. (EIP-2612)
+    /// @dev Returns the current nonce for `owner`. This value must be
+    /// included whenever a signature is generated for {permit}.
+    ///
+    /// Every successful call to {permit} increases ``owner``'s nonce by one. This
+    /// prevents a signature from being used multiple times.
     function nonces(address owner) external view returns (uint256);
 
-     /// @dev Returns the EIP-712 domain separator. (EIP-2612)
+    /// @dev Returns the domain separator used in the encoding of the signature for {permit},
+    /// as defined by {EIP712}.
     // solhint-disable-next-line func-name-mixedcase
     function DOMAIN_SEPARATOR() external view returns (bytes32);
 }


### PR DESCRIPTION
## Context

The `stable2512-4` crates release is blocked at the `pallet-assets-precompiles` verify step. The relevant failed run is [#24882536401, job #72854393703 step 21 line 54](https://github.com/paritytech-release/polkadot-sdk/actions/runs/24882536401/job/72854393703#step:21:54):

```
error[E0004]: non-exhaustive patterns: `&IERC20Calls::name(_)`, `&IERC20Calls::symbol(_)`,
              `&IERC20Calls::decimals(_)` and 3 more not covered
   --> src/lib.rs:110:9
note: `IERC20Calls` defined here
   --> /usr/local/cargo/registry/src/index.crates.io-.../ethereum-standards-0.1.3/src/lib.rs:22:1
```

`ethereum-standards 0.1.3` (already on crates.io, published from `master`) widened the `IERC20` interface with:

- `IERC20Metadata` — `name()`, `symbol()`, `decimals()` (from #10971)
- EIP-2612 permit — `permit()`, `nonces()`, `DOMAIN_SEPARATOR()` (from #11044)

`parity-publish`'s verify step compiles the `pallet-assets-precompiles` tarball against registry-resolved dependencies, so it resolves the wider `0.1.3` enum and the existing 6-arm `match input` becomes non-exhaustive.

`ethereum-standards` is *not* republished from this branch because the workspace version (`0.1.2`) is older than the registry's (`0.1.3`), so the path-dep workaround alone is not sufficient — the source on `stable2512` must align with what is already on crates.io.

## Fix

Two minimal changes:

1. **`substrate/primitives/ethereum-standards/`** — append the metadata + permit signatures to `IERC20.sol` so the workspace's `IERC20Calls` enum matches what crates.io already exposes. Bump the crate version `0.1.2 → 0.1.4` (skipping over the already-published `0.1.3`).
2. **`substrate/frame/assets/precompiles/src/lib.rs`** — add named match arms for the six new variants, each returning `Error::Revert { reason: "Unsupported function" }`. The actual `IERC20Metadata` / EIP-2612 permit handlers are *not* backported.

Runtimes on `stable2512` never registered handlers for these functions, so reverting on them preserves observable behaviour while making the match exhaustive against the wider enum at both workspace-build and publish-verify time.

## Why not backport #10971 / #11044?

The feature backports were considered and rejected:

- #10971 alone wouldn't unblock the publish — it only adds `name`/`symbol`/`decimals` handlers; `permit`/`nonces`/`DOMAIN_SEPARATOR` would still be unhandled.
- Backporting both #10971 and #11044 means pulling a new `permit` pallet, EIP-712 signature verification, four new dependencies (`const-crypto`, `pallet-timestamp`, `sp-keystore`, `frame-benchmarking`), a storage migration, and benchmarks into a stable patch release. The risk profile is wrong for a publish-unblock.
- #10869 (`ForeignAssetIdExtractor`) is unrelated to this error.

The runtime-side work to actually support the metadata / permit functions on stable releases can ship in a future stable cycle if needed.

## Test plan

- [x] `SKIP_WASM_BUILD=1 cargo check -p pallet-assets-precompiles -p ethereum-standards`
- [x] `SKIP_WASM_BUILD=1 RUSTFLAGS="-D warnings" cargo check -p pallet-assets-precompiles -p ethereum-standards` (matches `publish-check-compile.yml`)
- [ ] Re-run release publish-crates workflow against `stable2512` HEAD after merge.
