### PR TITLE
Fix migrations for recovery & parachain-system pallets

### DIFF
--- a/cumulus/pallets/parachain-system/src/migration.rs
+++ b/cumulus/pallets/parachain-system/src/migration.rs
@@ -22,7 +22,7 @@ use frame_support::{
 };
 
 /// The in-code storage version.
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 /// Migrates the pallet storage to the most recent version.
 pub struct Migration<T: Config>(PhantomData<T>);
@@ -43,6 +43,13 @@ impl<T: Config> OnRuntimeUpgrade for Migration<T> {
 				.saturating_add(v2::migrate::<T>())
 				.saturating_add(T::DbWeight::get().writes(1));
 			StorageVersion::new(2).put::<Pallet<T>>();
+		}
+
+		if StorageVersion::get::<Pallet<T>>() == 2 {
+			// Runtime upgrades are in their own PoV so there is no issue with killing this.
+			crate::PoVMessagesTracker::<T>::kill();
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+			StorageVersion::new(3).put::<Pallet<T>>();
 		}
 
 		weight

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1990,6 +1990,7 @@ pub type Migrations = (
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
+	cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 	// unreleased
 
 	// start: PSM reset

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -191,6 +191,7 @@ pub type Migrations = (
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
+	cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 );
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -859,6 +859,7 @@ type Migrations = (
 		Runtime,
 		pallet_session::migrations::v1::InitOffenceSeverity<Runtime>,
 	>,
+	cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -142,6 +142,7 @@ pub type Migrations = (
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
+	cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/prdoc/pr_12123.prdoc
+++ b/prdoc/pr_12123.prdoc
@@ -10,3 +10,5 @@ crates:
   bump: patch
 - name: cumulus-pallet-parachain-system
   bump: patch
+- name: pallet-assets
+  bump: patch

--- a/prdoc/pr_12123.prdoc
+++ b/prdoc/pr_12123.prdoc
@@ -1,0 +1,12 @@
+title: Fix migrations for recovery & parachain-system pallets
+doc:
+- audience: Runtime Dev
+  description: |-
+    Changes:
+    - pallet-recovery: be more lenient towards broken accounts to keep their recovery config
+    - parachain-system: clear old storage value to prevent decoding error
+crates:
+- name: pallet-recovery
+  bump: patch
+- name: cumulus-pallet-parachain-system
+  bump: patch

--- a/prdoc/pr_12123.prdoc
+++ b/prdoc/pr_12123.prdoc
@@ -12,3 +12,11 @@ crates:
   bump: patch
 - name: pallet-assets
   bump: patch
+- name: asset-hub-westend-runtime
+  bump: patch
+- name: bridge-hub-westend-runtime
+  bump: patch
+- name: collectives-westend-runtime
+  bump: patch
+- name: coretime-westend-runtime
+  bump: patch

--- a/substrate/frame/assets/src/lib.rs
+++ b/substrate/frame/assets/src/lib.rs
@@ -2016,7 +2016,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			// contain overcounted supply from prior refunds.
 			// TODO: add a migration to recalculate supply, then tighten this to `==`.
 			ensure!(details.supply >= calculated_supply, "Asset supply mismatch");
-			if details.accounts == calculated_accounts {
+			if details.accounts != calculated_accounts {
 				// Legacy error in Kusama Asset Hub that needs to be cleaned up.
 				log::error!(
 					"Asset {asset_id:?} account count mismatch: calculated {calculated_accounts} vs expected {}",

--- a/substrate/frame/recovery/src/migrations/v1.rs
+++ b/substrate/frame/recovery/src/migrations/v1.rs
@@ -332,12 +332,28 @@ impl<T: v0::MigrationConfig> SteppedMigration for MigrateV0ToV1<T> {
 			inheritor_count,
 		);
 
-		// FriendGroups should have same count as Recoverable (unless some failed)
-		assert!(friend_groups_count == recoverable_count);
-		// Attempt should have same count as ActiveRecoveries (unless some failed)
-		assert!(attempt_count == active_recoveries_count);
-		// Inheritor should have same count as Proxy (unless some failed)
-		assert!(inheritor_count == proxy_count);
+		// These can fail for Kusama AH because of buggy accounts...
+		if friend_groups_count != recoverable_count {
+			log::error!(
+				"MigrateV0ToV1: FriendGroups count mismatch: {} != {}",
+				friend_groups_count,
+				recoverable_count
+			);
+		}
+		if attempt_count != active_recoveries_count {
+			log::error!(
+				"MigrateV0ToV1: Attempt count mismatch: {} != {}",
+				attempt_count,
+				active_recoveries_count
+			);
+		}
+		if inheritor_count != proxy_count {
+			log::error!(
+				"MigrateV0ToV1: Inheritor count mismatch: {} != {}",
+				inheritor_count,
+				proxy_count
+			);
+		}
 
 		Ok(())
 	}

--- a/substrate/frame/recovery/src/migrations/v1.rs
+++ b/substrate/frame/recovery/src/migrations/v1.rs
@@ -201,14 +201,24 @@ impl<T: v0::MigrationConfig> SteppedMigration for MigrateV0ToV1<T> {
 						approvals,
 					};
 
-					// Create attempt ticket and store
 					let security_deposit = T::SecurityDeposit::get();
-					let Ok(ticket) = crate::AttemptTicketOf::<T>::new(
+					let ticket = match crate::AttemptTicketOf::<T>::new(
 						&rescuer,
 						Pallet::<T>::attempt_footprint(),
-					) else {
-						frame_support::defensive!("MigrateV0ToV1: Failed to create Attempt ticket");
-						continue;
+					) {
+						Ok(ticket) => ticket,
+						Err(e) => {
+							log::error!(
+								"MigrateV0ToV1: Failed to create Attempt ticket for rescuer {:?}: {:?}",
+								rescuer,
+								e,
+							);
+							crate::IdentifiedConsideration {
+								depositor: rescuer.clone(),
+								ticket: None,
+								_phantom: Default::default(),
+							}
+						},
 					};
 
 					let held_deposit = if <T as pallet::Config>::Currency::hold(
@@ -255,16 +265,22 @@ impl<T: v0::MigrationConfig> SteppedMigration for MigrateV0ToV1<T> {
 					let inheritance_priority = 0u32;
 
 					// Create inheritor ticket
-					if let Ok(ticket) = Pallet::<T>::inheritor_ticket(&inheritor) {
-						pallet::Inheritor::<T>::insert(
-							&lost,
-							(inheritance_priority, inheritor, ticket),
-						);
-					} else {
-						frame_support::defensive!(
-							"MigrateV0ToV1: Failed to create Inheritor ticket"
-						);
-					}
+					let ticket = match Pallet::<T>::inheritor_ticket(&inheritor) {
+						Ok(ticket) => ticket,
+						Err(e) => {
+							log::error!("MigrateV0ToV1: Failed to create Inheritor ticket for rescuer {:?}: {:?}", inheritor, e);
+							crate::IdentifiedConsideration {
+								depositor: rescuer.clone(),
+								ticket: None,
+								_phantom: Default::default(),
+							}
+						},
+					};
+
+					pallet::Inheritor::<T>::insert(
+						&lost,
+						(inheritance_priority, inheritor, ticket),
+					);
 				},
 			}
 		}
@@ -680,10 +696,114 @@ mod tests {
 			assert_eq!(pallet::Pallet::<T>::on_chain_storage_version(), 1);
 
 			let _guard = frame_support::StorageNoopGuard::new();
-			run_migration();
-
 			let mut meter = WeightMeter::new();
 			assert!(matches!(MigrateV0ToV1::<T>::step(None, &mut meter), Ok(None)));
+		});
+	}
+
+	#[test]
+	fn migration_inserts_attempt_when_storage_ticket_fails() {
+		new_test_ext().execute_with(|| {
+			let config_deposit = 50u128;
+			let old_recovery_deposit = 10u128;
+			let rescuer: u64 = 99;
+			let lost = ALICE;
+
+			pallet_balances::Pallet::<Test>::force_set_balance(
+				frame_system::RawOrigin::Root.into(),
+				rescuer,
+				crate::mock::ExistentialDeposit::get() as u128 + old_recovery_deposit,
+			)
+			.unwrap();
+			Balances::reserve(&rescuer, old_recovery_deposit).unwrap();
+
+			v0::Recoverable::<T>::insert(
+				lost,
+				v0::RecoveryConfig {
+					delay_period: 10u64,
+					deposit: config_deposit,
+					friends: friends(&[BOB, CHARLIE]),
+					threshold: 2,
+				},
+			);
+			Balances::reserve(&lost, config_deposit).unwrap();
+
+			v0::ActiveRecoveries::<T>::insert(
+				lost,
+				rescuer,
+				v0::ActiveRecovery {
+					created: 1u64,
+					deposit: old_recovery_deposit,
+					friends: BoundedVec::default(),
+				},
+			);
+
+			run_migration();
+
+			assert_eq!(v0::ActiveRecoveries::<T>::iter().count(), 0);
+			assert_eq!(
+				pallet::Attempt::<T>::iter().count(),
+				1,
+				"Attempt entry must survive even when storage ticket creation fails",
+			);
+
+			let (attempt, ticket, held_deposit) = pallet::Attempt::<T>::get(lost, 0u32).unwrap();
+			assert_eq!(attempt.initiator, rescuer);
+			assert!(ticket.ticket.is_none(), "Inner ticket must be None when storage hold failed");
+			assert_eq!(ticket.depositor, rescuer);
+			assert_eq!(held_deposit, 0, "Security deposit must be zero when hold failed");
+
+			use frame::traits::fungible::InspectHold;
+			assert_eq!(
+				Balances::balance_on_hold(&crate::HoldReason::AttemptStorage.into(), &rescuer),
+				0,
+			);
+			assert_eq!(
+				Balances::balance_on_hold(&crate::HoldReason::SecurityDeposit.into(), &rescuer),
+				0,
+			);
+		});
+	}
+
+	#[test]
+	fn migration_inserts_inheritor_when_ticket_fails() {
+		use frame::traits::fungible::InspectHold;
+
+		new_test_ext().execute_with(|| {
+			let rescuer: u64 = 99;
+			let lost = ALICE;
+
+			pallet_balances::Pallet::<Test>::force_set_balance(
+				frame_system::RawOrigin::Root.into(),
+				rescuer,
+				crate::mock::ExistentialDeposit::get() as u128,
+			)
+			.unwrap();
+			frame_system::Pallet::<T>::inc_consumers(&rescuer).unwrap();
+
+			v0::Proxy::<T>::insert(rescuer, lost);
+			assert_eq!(frame_system::Pallet::<T>::consumers(&rescuer), 1);
+
+			run_migration();
+
+			assert_eq!(v0::Proxy::<T>::iter().count(), 0);
+			assert_eq!(frame_system::Pallet::<T>::consumers(&rescuer), 0);
+
+			assert_eq!(
+				pallet::Inheritor::<T>::iter().count(),
+				1,
+				"Inheritor entry must survive even when ticket creation fails",
+			);
+			let (priority, inheritor, ticket) = pallet::Inheritor::<T>::get(lost).unwrap();
+			assert_eq!(inheritor, rescuer);
+			assert_eq!(priority, 0);
+			assert!(ticket.ticket.is_none(), "Inner ticket must be None when hold failed");
+			assert_eq!(ticket.depositor, rescuer);
+
+			assert_eq!(
+				Balances::balance_on_hold(&crate::HoldReason::InheritorStorage.into(), &rescuer),
+				0,
+			);
 		});
 	}
 }

--- a/substrate/frame/recovery/src/migrations/v1.rs
+++ b/substrate/frame/recovery/src/migrations/v1.rs
@@ -27,7 +27,10 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
 	pallet_prelude::PhantomData,
-	traits::{fungible::MutateHold, Consideration, Get, ReservableCurrency},
+	traits::{
+		fungible::MutateHold, Consideration, Get, GetStorageVersion, ReservableCurrency,
+		StorageVersion,
+	},
 	weights::WeightMeter,
 	BoundedVec,
 };
@@ -69,6 +72,10 @@ impl<T: v0::MigrationConfig> SteppedMigration for MigrateV0ToV1<T> {
 		cursor: Option<Self::Cursor>,
 		meter: &mut WeightMeter,
 	) -> Result<Option<Self::Cursor>, SteppedMigrationError> {
+		if Pallet::<T>::on_chain_storage_version() != Self::id().version_from as u16 {
+			return Ok(None);
+		}
+
 		let required = T::DbWeight::get().reads_writes(2, 2);
 
 		if meter.remaining().any_lt(required) {
@@ -233,7 +240,11 @@ impl<T: v0::MigrationConfig> SteppedMigration for MigrateV0ToV1<T> {
 						v0::Proxy::<T>::iter()
 					};
 
-					let Some((rescuer, lost)) = iter.next() else { return Ok(None) };
+					let Some((rescuer, lost)) = iter.next() else {
+						// only exit return
+						StorageVersion::new(Self::id().version_to as u16).put::<Pallet<T>>();
+						return Ok(None);
+					};
 					cursor = MigrationCursor::Proxy(Some(rescuer.clone()));
 					v0::Proxy::<T>::remove(&rescuer);
 
@@ -324,7 +335,10 @@ mod tests {
 		pallet,
 	};
 	use frame_support::{
-		migrations::SteppedMigration, traits::ReservableCurrency, weights::WeightMeter, BoundedVec,
+		migrations::SteppedMigration,
+		traits::{GetStorageVersion, ReservableCurrency, StorageVersion},
+		weights::WeightMeter,
+		BoundedVec,
 	};
 
 	type T = Test;
@@ -620,6 +634,56 @@ mod tests {
 
 			// Attempt should be removed after finish
 			assert!(pallet::Attempt::<T>::get(ALICE, 0u32).is_none());
+		});
+	}
+
+	#[test]
+	fn migration_bumps_on_chain_storage_version() {
+		new_test_ext().execute_with(|| {
+			StorageVersion::new(0).put::<pallet::Pallet<T>>();
+			assert_eq!(pallet::Pallet::<T>::on_chain_storage_version(), 0);
+
+			v0::Recoverable::<T>::insert(
+				ALICE,
+				v0::RecoveryConfig {
+					delay_period: 10u64,
+					deposit: 50u128,
+					friends: friends(&[BOB, CHARLIE]),
+					threshold: 2,
+				},
+			);
+			Balances::reserve(&ALICE, 50u128).unwrap();
+
+			run_migration();
+
+			assert_eq!(pallet::Pallet::<T>::on_chain_storage_version(), 1);
+		});
+	}
+
+	#[test]
+	fn migration_is_idempotent_after_completion() {
+		new_test_ext().execute_with(|| {
+			StorageVersion::new(0).put::<pallet::Pallet<T>>();
+
+			v0::Recoverable::<T>::insert(
+				ALICE,
+				v0::RecoveryConfig {
+					delay_period: 10u64,
+					deposit: 50u128,
+					friends: friends(&[BOB, CHARLIE]),
+					threshold: 2,
+				},
+			);
+			Balances::reserve(&ALICE, 50u128).unwrap();
+
+			run_migration();
+			assert_eq!(pallet::Pallet::<T>::on_chain_storage_version(), 1);
+
+			let _guard = frame_support::StorageNoopGuard::new();
+			run_migration();
+
+			let mut meter = WeightMeter::new();
+			assert!(matches!(MigrateV0ToV1::<T>::step(None, &mut meter), Ok(None)));
 		});
 	}
 }


### PR DESCRIPTION
Changes:
- pallet-recovery: be more lenient towards broken accounts to keep their recovery config and write storage version 🤦 
- parachain-system: clear old storage value to prevent decoding error, see discussion [here](https://github.com/paritytech/polkadot-sdk/pull/10477#discussion_r3264157119)
- pallet-assets: fix logs in migration
