### PR TITLE
fix(alliance): maintain sorted announcements and clean up retiring members on kick

### DIFF
--- a/prdoc/pr_12124.prdoc
+++ b/prdoc/pr_12124.prdoc
@@ -1,0 +1,15 @@
+title: 'fix(alliance): maintain sorted announcements and clean up retiring members
+  on kick'
+doc:
+- audience: Runtime Dev
+  description: |-
+    This PR fixes two issues in the alliance pallet related to announcement management and retiring member cleanup.
+
+    ### Changes
+    - **Announcements now inserted in sorted order**: The `announce` call previously used `try_push`, which appends to the end of the list. However, `remove_announcement` relies on binary search, which requires the list to be sorted. This fix uses `binary_search` to find the correct insertion position and `try_insert` to maintain sorted order, preserving the invariant needed for removal.
+    - **Retiring members cleaned up on kick**: When a retiring member was kicked via `kick_member`, the `RetiringMembers` storage entry was not removed, leaving stale data. The fix explicitly removes the `RetiringMembers` entry for retiring members before calling `remove_member`.
+    - Added test `announce_maintains_sorted_order` to verify announcements remain sorted regardless of insertion order.
+    - Added test `kick_retiring_member_removes_from_retiring_members` to verify full cleanup when a retiring member is kicked.
+crates:
+- name: pallet-alliance
+  bump: patch

--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -663,7 +663,10 @@ pub mod pallet {
 			<Announcements<T, I>>::try_mutate(|announcements| -> DispatchResult {
 				// Insert in sorted order to maintain the invariant required by
 				// `remove_announcement` which uses binary search.
-				let pos = announcements.binary_search(&announcement).err().ok_or(Error::<T, I>::TooManyAnnouncements)?;
+				let pos = announcements
+					.binary_search(&announcement)
+					.err()
+					.ok_or(Error::<T, I>::TooManyAnnouncements)?;
 				announcements
 					.try_insert(pos, announcement.clone())
 					.map_err(|_| Error::<T, I>::TooManyAnnouncements)?;

--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -660,11 +660,15 @@ pub mod pallet {
 		pub fn announce(origin: OriginFor<T>, announcement: Cid) -> DispatchResult {
 			T::AnnouncementOrigin::ensure_origin(origin)?;
 
-			let mut announcements = <Announcements<T, I>>::get();
-			announcements
-				.try_push(announcement.clone())
-				.map_err(|_| Error::<T, I>::TooManyAnnouncements)?;
-			<Announcements<T, I>>::put(announcements);
+			<Announcements<T, I>>::try_mutate(|announcements| -> DispatchResult {
+				// Insert in sorted order to maintain the invariant required by
+				// `remove_announcement` which uses binary search.
+				let pos = announcements.binary_search(&announcement).err().ok_or(Error::<T, I>::TooManyAnnouncements)?;
+				announcements
+					.try_insert(pos, announcement.clone())
+					.map_err(|_| Error::<T, I>::TooManyAnnouncements)?;
+				Ok(())
+			})?;
 
 			Self::deposit_event(Event::Announced { announcement });
 			Ok(())
@@ -814,6 +818,12 @@ pub mod pallet {
 			let member = T::Lookup::lookup(who)?;
 
 			let role = Self::member_role_of(&member).ok_or(Error::<T, I>::NotMember)?;
+
+			// If the member is retiring, clean up the RetiringMembers entry.
+			if role == MemberRole::Retiring {
+				<RetiringMembers<T, I>>::remove(&member);
+			}
+
 			Self::remove_member(&member, role)?;
 			let deposit = DepositOf::<T, I>::take(member.clone());
 			if let Some(deposit) = deposit {

--- a/substrate/frame/alliance/src/tests.rs
+++ b/substrate/frame/alliance/src/tests.rs
@@ -643,6 +643,65 @@ fn remove_unscrupulous_items_works() {
 }
 
 #[test]
+fn announce_maintains_sorted_order() {
+	build_and_execute(|| {
+		// Create CIDs that would be out of order if appended
+		let cid_alpha = {
+			let result = sp_crypto_hashing::sha2_256(b"announcement_alpha");
+			Cid::new_v0(result)
+		};
+		let cid_beta = {
+			let result = sp_crypto_hashing::sha2_256(b"announcement_beta");
+			Cid::new_v0(result)
+		};
+		let cid_gamma = {
+			let result = sp_crypto_hashing::sha2_256(b"announcement_gamma");
+			Cid::new_v0(result)
+		};
+
+		// Add announcements in non-sorted order
+		assert_ok!(Alliance::announce(RuntimeOrigin::signed(3), cid_beta.clone()));
+		assert_ok!(Alliance::announce(RuntimeOrigin::signed(3), cid_alpha.clone()));
+		assert_ok!(Alliance::announce(RuntimeOrigin::signed(3), cid_gamma.clone()));
+
+		let announcements = alliance::Announcements::<Test>::get();
+		// Verify they are sorted
+		let mut sorted_announcements = announcements.clone();
+		sorted_announcements.sort();
+		assert_eq!(announcements, sorted_announcements);
+
+		// Verify we can remove any announcement
+		assert_ok!(Alliance::remove_announcement(RuntimeOrigin::signed(3), cid_beta.clone()));
+		assert_eq!(alliance::Announcements::<Test>::get().len(), 2);
+		assert!(!alliance::Announcements::<Test>::get().contains(&cid_beta));
+	});
+}
+
+#[test]
+fn kick_retiring_member_removes_from_retiring_members() {
+	build_and_execute(|| {
+		// Manually add account 3 as a fellow (since we're in test mode)
+		let members: frame_support::BoundedVec<u64, MaxMembers> = vec![1, 2, 3].try_into().unwrap();
+		alliance::Members::<Test>::insert(MemberRole::Fellow, members);
+		<DepositOf<Test, ()>>::insert(3, 25);
+		assert!(Alliance::is_member_of(&3, MemberRole::Fellow));
+
+		// Give retirement notice
+		assert_ok!(Alliance::give_retirement_notice(RuntimeOrigin::signed(3)));
+		assert!(Alliance::is_member_of(&3, MemberRole::Retiring));
+		assert!(alliance::RetiringMembers::<Test>::get(&3).is_some());
+
+		// Kick the retiring member
+		assert_ok!(Alliance::kick_member(RuntimeOrigin::signed(2), 3));
+
+		// Verify the member is completely removed
+		assert!(!Alliance::is_member(&3));
+		assert!(!alliance::RetiringMembers::<Test>::contains_key(&3));
+		assert_eq!(<DepositOf<Test, ()>>::get(3), None);
+	});
+}
+
+#[test]
 fn weights_sane() {
 	let info = crate::Call::<Test>::join_alliance {}.get_dispatch_info();
 	assert_eq!(<() as crate::WeightInfo>::join_alliance(), info.call_weight);


### PR DESCRIPTION
This PR fixes two issues in the alliance pallet related to announcement management and retiring member cleanup.

### Changes
- **Announcements now inserted in sorted order**: The `announce` call previously used `try_push`, which appends to the end of the list. However, `remove_announcement` relies on binary search, which requires the list to be sorted. This fix uses `binary_search` to find the correct insertion position and `try_insert` to maintain sorted order, preserving the invariant needed for removal.
- **Retiring members cleaned up on kick**: When a retiring member was kicked via `kick_member`, the `RetiringMembers` storage entry was not removed, leaving stale data. The fix explicitly removes the `RetiringMembers` entry for retiring members before calling `remove_member`.
- Added test `announce_maintains_sorted_order` to verify announcements remain sorted regardless of insertion order.
- Added test `kick_retiring_member_removes_from_retiring_members` to verify full cleanup when a retiring member is kicked.

Closes #12189
Closes #12191
