### PR TITLE
cumulus-test-runtime: move feature-gated params into flavor module

### DIFF
--- a/cumulus/test/runtime/src/flavor/aura.rs
+++ b/cumulus/test/runtime/src/flavor/aura.rs
@@ -1,0 +1,25 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Aura backing flavor: sync-backing disables multiple blocks per slot.
+
+use sp_core::ConstBool;
+
+#[cfg(feature = "sync-backing")]
+pub type AllowMultipleBlocksPerSlot = ConstBool<false>;
+
+#[cfg(not(feature = "sync-backing"))]
+pub type AllowMultipleBlocksPerSlot = ConstBool<true>;

--- a/cumulus/test/runtime/src/flavor/block_velocity.rs
+++ b/cumulus/test/runtime/src/flavor/block_velocity.rs
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Blocks processed per relay chain slot for this build flavor.
+
+#[cfg(any(feature = "elastic-scaling-500ms", feature = "block-bundling"))]
+pub const BLOCK_PROCESSING_VELOCITY: u32 = 12;
+
+#[cfg(all(feature = "elastic-scaling-multi-block-slot", not(feature = "elastic-scaling-500ms")))]
+pub const BLOCK_PROCESSING_VELOCITY: u32 = 6;
+
+#[cfg(all(
+	any(feature = "elastic-scaling", feature = "relay-parent-offset"),
+	not(feature = "elastic-scaling-500ms"),
+	not(feature = "elastic-scaling-multi-block-slot")
+))]
+pub const BLOCK_PROCESSING_VELOCITY: u32 = 3;
+
+#[cfg(not(any(
+	feature = "elastic-scaling",
+	feature = "elastic-scaling-500ms",
+	feature = "elastic-scaling-multi-block-slot",
+	feature = "relay-parent-offset",
+	feature = "block-bundling",
+)))]
+pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;

--- a/cumulus/test/runtime/src/flavor/mod.rs
+++ b/cumulus/test/runtime/src/flavor/mod.rs
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Feature-gated parameters for [`crate::Runtime`].
+//!
+//! This crate is built many times with different Cargo features (see `Cargo.toml` and
+//! `build.rs`). Each combination selects a **flavor** of the same runtime source: block
+//! processing velocity, slot duration, relay parent offset, unincluded segment capacity, and
+//! Aura backing behavior.
+//!
+//! Keep flavor-specific `#[cfg(...)]` ladders in the submodules here instead of in `lib.rs`, so
+//! adding a new flavor stays localized and reviewable.
+
+mod aura;
+mod block_velocity;
+mod relay_chain;
+mod relay_parent;
+mod slot;
+mod unincluded_segment;
+
+pub use aura::AllowMultipleBlocksPerSlot;
+pub use block_velocity::BLOCK_PROCESSING_VELOCITY;
+pub use relay_chain::RELAY_CHAIN_SLOT_DURATION_MILLIS;
+pub use relay_parent::RELAY_PARENT_OFFSET;
+pub use slot::SLOT_DURATION;
+pub use unincluded_segment::UNINCLUDED_SEGMENT_CAPACITY;

--- a/cumulus/test/runtime/src/flavor/relay_chain.rs
+++ b/cumulus/test/runtime/src/flavor/relay_chain.rs
@@ -1,0 +1,19 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Relay chain slot duration used by the consensus hook (milliseconds).
+
+pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;

--- a/cumulus/test/runtime/src/flavor/relay_parent.rs
+++ b/cumulus/test/runtime/src/flavor/relay_parent.rs
@@ -1,0 +1,23 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Relay parent offset when the `relay-parent-offset` flavor is enabled.
+
+#[cfg(feature = "relay-parent-offset")]
+pub const RELAY_PARENT_OFFSET: u32 = 2;
+
+#[cfg(not(feature = "relay-parent-offset"))]
+pub const RELAY_PARENT_OFFSET: u32 = 0;

--- a/cumulus/test/runtime/src/flavor/slot.rs
+++ b/cumulus/test/runtime/src/flavor/slot.rs
@@ -1,0 +1,33 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Aura / timestamp slot duration for this build flavor (milliseconds).
+
+#[cfg(feature = "slot-duration-18s")]
+pub const SLOT_DURATION: u64 = 18000;
+
+#[cfg(all(
+	any(feature = "sync-backing", feature = "elastic-scaling-12s-slot"),
+	not(feature = "slot-duration-18s")
+))]
+pub const SLOT_DURATION: u64 = 12000;
+
+#[cfg(not(any(
+	feature = "sync-backing",
+	feature = "elastic-scaling-12s-slot",
+	feature = "slot-duration-18s"
+)))]
+pub const SLOT_DURATION: u64 = 6000;

--- a/cumulus/test/runtime/src/flavor/unincluded_segment.rs
+++ b/cumulus/test/runtime/src/flavor/unincluded_segment.rs
@@ -35,5 +35,4 @@ pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 1;
 ///   parachain is also `RELAY_PARENT_OFFSET` relay blocks older (one relay block may contains
 ///   multiple parachain blocks).
 #[cfg(all(not(feature = "sync-backing"), not(feature = "async-backing")))]
-pub const UNINCLUDED_SEGMENT_CAPACITY: u32 =
-	BLOCK_PROCESSING_VELOCITY * (3 + RELAY_PARENT_OFFSET);
+pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = BLOCK_PROCESSING_VELOCITY * (3 + RELAY_PARENT_OFFSET);

--- a/cumulus/test/runtime/src/flavor/unincluded_segment.rs
+++ b/cumulus/test/runtime/src/flavor/unincluded_segment.rs
@@ -16,6 +16,7 @@
 
 //! Unincluded segment capacity for [`cumulus_pallet_aura_ext::FixedVelocityConsensusHook`].
 
+#[cfg(all(not(feature = "sync-backing"), not(feature = "async-backing")))]
 use super::{block_velocity::BLOCK_PROCESSING_VELOCITY, relay_parent::RELAY_PARENT_OFFSET};
 
 #[cfg(feature = "async-backing")]

--- a/cumulus/test/runtime/src/flavor/unincluded_segment.rs
+++ b/cumulus/test/runtime/src/flavor/unincluded_segment.rs
@@ -1,0 +1,39 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+//
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Unincluded segment capacity for [`cumulus_pallet_aura_ext::FixedVelocityConsensusHook`].
+
+use super::{block_velocity::BLOCK_PROCESSING_VELOCITY, relay_parent::RELAY_PARENT_OFFSET};
+
+#[cfg(feature = "async-backing")]
+pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
+
+#[cfg(all(feature = "sync-backing", not(feature = "async-backing")))]
+pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 1;
+
+/// We need `VELOCITY * 3`, because the block flow is the following:
+///
+/// - Collator produces the block(s) on relay chain block `X`
+/// - In the mean time the relay chain is building block `X + 1`
+/// - The collator sends the collation to the relay chain and it gets backed on chain in relay block
+///   `X + 2`
+/// - The collation then gets included on chain in relay block `X + 3`
+/// - As we are building on `RELAY_PARENT_OFFSET` old relay parents, the included block from the
+///   parachain is also `RELAY_PARENT_OFFSET` relay blocks older (one relay block may contains
+///   multiple parachain blocks).
+#[cfg(all(not(feature = "sync-backing"), not(feature = "async-backing")))]
+pub const UNINCLUDED_SEGMENT_CAPACITY: u32 =
+	BLOCK_PROCESSING_VELOCITY * (3 + RELAY_PARENT_OFFSET);

--- a/cumulus/test/runtime/src/lib.rs
+++ b/cumulus/test/runtime/src/lib.rs
@@ -71,6 +71,7 @@ pub mod slot_duration_18s {
 	include!(concat!(env!("OUT_DIR"), "/wasm_binary_slot_duration_18s.rs"));
 }
 
+mod flavor;
 mod genesis_config_presets;
 pub mod test_pallet;
 
@@ -80,7 +81,7 @@ use alloc::{vec, vec::Vec};
 use frame_support::{derive_impl, traits::OnRuntimeUpgrade, PalletId};
 use sp_api::{decl_runtime_apis, impl_runtime_apis};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{ConstBool, ConstU32, ConstU64, Get, OpaqueMetadata};
+use sp_core::{ConstU32, ConstU64, Get, OpaqueMetadata};
 
 use sp_runtime::{
 	generic, impl_opaque_keys,
@@ -134,62 +135,9 @@ impl_opaque_keys! {
 /// The para-id used in this runtime.
 pub const PARACHAIN_ID: u32 = 100;
 
-#[cfg(any(feature = "elastic-scaling-500ms", feature = "block-bundling"))]
-pub const BLOCK_PROCESSING_VELOCITY: u32 = 12;
+pub use flavor::{BLOCK_PROCESSING_VELOCITY, SLOT_DURATION};
 
-#[cfg(all(feature = "elastic-scaling-multi-block-slot", not(feature = "elastic-scaling-500ms")))]
-pub const BLOCK_PROCESSING_VELOCITY: u32 = 6;
-
-#[cfg(all(
-	any(feature = "elastic-scaling", feature = "relay-parent-offset"),
-	not(feature = "elastic-scaling-500ms"),
-	not(feature = "elastic-scaling-multi-block-slot")
-))]
-pub const BLOCK_PROCESSING_VELOCITY: u32 = 3;
-
-#[cfg(not(any(
-	feature = "elastic-scaling",
-	feature = "elastic-scaling-500ms",
-	feature = "elastic-scaling-multi-block-slot",
-	feature = "relay-parent-offset",
-	feature = "block-bundling",
-)))]
-pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
-
-#[cfg(feature = "async-backing")]
-const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
-
-#[cfg(all(feature = "sync-backing", not(feature = "async-backing")))]
-const UNINCLUDED_SEGMENT_CAPACITY: u32 = 1;
-
-/// We need `VELOCITY * 3`, because the block flow is the following:
-///
-/// - Collator produces the block(s) on relay chain block `X`
-/// - In the mean time the relay chain is building block `X + 1`
-/// - The collator sends the collation to the relay chain and it gets backed on chain in relay block
-///   `X + 2`
-/// - The collation then gets included on chain in relay block `X + 3`
-/// - As we are building on `RELAY_PARENT_OFFSET` old relay parents, the included block from the
-///   parachain is also `RELAY_PARENT_OFFSET` relay blocks older (one relay block may contains
-///   multiple parachain blocks).
-#[cfg(all(not(feature = "sync-backing"), not(feature = "async-backing")))]
-const UNINCLUDED_SEGMENT_CAPACITY: u32 = BLOCK_PROCESSING_VELOCITY * (3 + RELAY_PARENT_OFFSET);
-
-#[cfg(feature = "slot-duration-18s")]
-pub const SLOT_DURATION: u64 = 18000;
-#[cfg(all(
-	any(feature = "sync-backing", feature = "elastic-scaling-12s-slot"),
-	not(feature = "slot-duration-18s")
-))]
-pub const SLOT_DURATION: u64 = 12000;
-#[cfg(not(any(
-	feature = "sync-backing",
-	feature = "elastic-scaling-12s-slot",
-	feature = "slot-duration-18s"
-)))]
-pub const SLOT_DURATION: u64 = 6000;
-
-const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+use flavor::{RELAY_CHAIN_SLOT_DURATION_MILLIS, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY};
 
 // The only difference between the two declarations below is the `spec_version`. With the
 // `increment-spec-version` feature enabled `spec_version` should be greater than the one of without
@@ -394,12 +342,6 @@ impl pallet_glutton::Config for Runtime {
 	type WeightInfo = pallet_glutton::weights::SubstrateWeight<Runtime>;
 }
 
-#[cfg(feature = "relay-parent-offset")]
-const RELAY_PARENT_OFFSET: u32 = 2;
-
-#[cfg(not(feature = "relay-parent-offset"))]
-const RELAY_PARENT_OFFSET: u32 = 0;
-
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
 	Runtime,
 	RELAY_CHAIN_SLOT_DURATION_MILLIS,
@@ -429,10 +371,7 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<32>;
-	#[cfg(feature = "sync-backing")]
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	#[cfg(not(feature = "sync-backing"))]
-	type AllowMultipleBlocksPerSlot = ConstBool<true>;
+	type AllowMultipleBlocksPerSlot = flavor::AllowMultipleBlocksPerSlot;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
@@ -576,7 +515,7 @@ impl_runtime_apis! {
 
 	impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
 		fn relay_parent_offset() -> u32 {
-			RELAY_PARENT_OFFSET
+			flavor::RELAY_PARENT_OFFSET
 		}
 	}
 

--- a/prdoc/pr_12129.prdoc
+++ b/prdoc/pr_12129.prdoc
@@ -1,0 +1,18 @@
+title: 'cumulus-test-runtime: move feature-gated params into flavor module'
+doc:
+- audience: Node Dev
+  description: |-
+    ## Summary
+
+    Refactors `cumulus-test-runtime` so feature-gated parameters live in a dedicated `flavor/` module tree instead of scattered `#[cfg(...)]` blocks in `lib.rs`.
+
+    - Add `src/flavor/` with modules for block velocity, slot duration, relay parent offset, unincluded segment capacity, relay chain slot duration, and Aura backing behavior.
+    - Wire `lib.rs` to import from `flavor/`; keep `VERSION` in `lib.rs` (required by `#[sp_version::runtime_version]`).
+    - No behavior change same Cargo features, same values, same WASM build setup.
+
+    Closes #11991.
+
+    ## Motivation
+
+    The test runtime is built many times with different Cargo features (elastic scaling, sync/async backing, relay-parent offset, block-bundling, etc.). Constants that depend on those features were hard to follow and extend in `lib.rs`. Grouping them by concern makes it easier to see which feature enables which values and to add new flavors later.
+crates: []


### PR DESCRIPTION
## Summary

Refactors `cumulus-test-runtime` so feature-gated parameters live in a dedicated `flavor/` module tree instead of scattered `#[cfg(...)]` blocks in `lib.rs`.

- Add `src/flavor/` with modules for block velocity, slot duration, relay parent offset, unincluded segment capacity, relay chain slot duration, and Aura backing behavior.
- Wire `lib.rs` to import from `flavor/`; keep `VERSION` in `lib.rs` (required by `#[sp_version::runtime_version]`).
- No behavior change same Cargo features, same values, same WASM build setup.

Closes #11991.

## Motivation

The test runtime is built many times with different Cargo features (elastic scaling, sync/async backing, relay-parent offset, block-bundling, etc.). Constants that depend on those features were hard to follow and extend in `lib.rs`. Grouping them by concern makes it easier to see which feature enables which values and to add new flavors later.