### PR TITLE
allow Root-originated nested CREATE

### DIFF
--- a/prdoc/pr_12144.prdoc
+++ b/prdoc/pr_12144.prdoc
@@ -5,28 +5,22 @@ doc:
     \n## Motivation\n\n`pallet-revive`'s exec stack rejects `Origin::Root` at any\
     \ constructor frame, which means `bare_call(RuntimeOrigin::root(), contract_addr,\
     \ ...)` errors with `RootNotAllowed` the moment the called contract reaches a\
-    \ `CREATE`/`CREATE2` opcode \u2014 even though the contract itself is the semantic\
+    \ `CREATE`/`CREATE2` opcode — even though the contract itself is the semantic\
     \ instantiator.\n\nThe historical reason for the block was that the origin had\
     \ to fund the new contract's ED. Since the PGAS rework, the ED is freshly minted\
     \ by `T::Deposit::init_contract` and immediately deactivated for issuance accounting,\
     \ so the origin no longer needs to pay it.\n\n## Change\n\n- Remove the explicit\
     \ `RootNotAllowed` check at the start of the constructor frame in `exec.rs`.\n\
-    - Move the `self.origin.account_id()?` extraction inside the `!is_pvm` branch\
-    \ where it's actually consumed (as the EVM runtime-code upload-deposit owner).\
-    \ PVM constructors no longer touch it.\n\nRoot is still **not** allowed to instantiate\
+    \nRoot is still **not** allowed to instantiate\
     \ directly: `instantiate`/`bare_instantiate` continue to gate on `T::InstantiateOrigin::ensure_origin`\
-    \ (default `EnsureSigned` \u2192 `BadOrigin`). The change only unblocks the case\
+    \ (default `EnsureSigned` → `BadOrigin`). The change only unblocks the case\
     \ where another contract sits between Root and the new contract and acts as the\
     \ instantiator. Giving Root its own contract-address attribution is intentionally\
-    \ out of scope.\n\nEVM CREATE under Root continues to error `RootNotAllowed` \u2014\
-    \ at the runtime-code owner extraction rather than at the constructor entry \u2014\
-    \ because there's no address to attribute the upload deposit to.\n\n## Test plan\n\
-    \n- New `root_call_can_nested_instantiate` covers `bare_call(Root, deployer, value=0)`\
-    \ where the deployer issues a `CREATE1`; asserts the child account exists with\
-    \ the freshly minted ED.\n- Existing `root_cannot_instantiate{,_with_code}` and\
-    \ `root_can_call` continue to pass \u2014 direct Root instantiation is still rejected\
+    \ out of scope.\n\n## Test plan\n\
+    \n- Existing `root_cannot_instantiate{,_with_code}` and\
+    \ `root_can_call` continue to pass — direct Root instantiation is still rejected\
     \ at the dispatchable layer, and Root-originated calls remain functional.\n- Full\
-    \ `pallet-revive` test suite (614 tests) is green."
+    \ `pallet-revive` test suite is green."
 crates:
 - name: pallet-revive
   bump: minor

--- a/prdoc/pr_12144.prdoc
+++ b/prdoc/pr_12144.prdoc
@@ -1,0 +1,32 @@
+title: allow Root-originated nested CREATE
+doc:
+- audience: Runtime Dev
+  description: "# Allow Root-originated nested CREATE in pallet-revive\n\nCloses paritytech/contract-issues#279.\n\
+    \n## Motivation\n\n`pallet-revive`'s exec stack rejects `Origin::Root` at any\
+    \ constructor frame, which means `bare_call(RuntimeOrigin::root(), contract_addr,\
+    \ ...)` errors with `RootNotAllowed` the moment the called contract reaches a\
+    \ `CREATE`/`CREATE2` opcode \u2014 even though the contract itself is the semantic\
+    \ instantiator.\n\nThe historical reason for the block was that the origin had\
+    \ to fund the new contract's ED. Since the PGAS rework, the ED is freshly minted\
+    \ by `T::Deposit::init_contract` and immediately deactivated for issuance accounting,\
+    \ so the origin no longer needs to pay it.\n\n## Change\n\n- Remove the explicit\
+    \ `RootNotAllowed` check at the start of the constructor frame in `exec.rs`.\n\
+    - Move the `self.origin.account_id()?` extraction inside the `!is_pvm` branch\
+    \ where it's actually consumed (as the EVM runtime-code upload-deposit owner).\
+    \ PVM constructors no longer touch it.\n\nRoot is still **not** allowed to instantiate\
+    \ directly: `instantiate`/`bare_instantiate` continue to gate on `T::InstantiateOrigin::ensure_origin`\
+    \ (default `EnsureSigned` \u2192 `BadOrigin`). The change only unblocks the case\
+    \ where another contract sits between Root and the new contract and acts as the\
+    \ instantiator. Giving Root its own contract-address attribution is intentionally\
+    \ out of scope.\n\nEVM CREATE under Root continues to error `RootNotAllowed` \u2014\
+    \ at the runtime-code owner extraction rather than at the constructor entry \u2014\
+    \ because there's no address to attribute the upload deposit to.\n\n## Test plan\n\
+    \n- New `root_call_can_nested_instantiate` covers `bare_call(Root, deployer, value=0)`\
+    \ where the deployer issues a `CREATE1`; asserts the child account exists with\
+    \ the freshly minted ED.\n- Existing `root_cannot_instantiate{,_with_code}` and\
+    \ `root_can_call` continue to pass \u2014 direct Root instantiation is still rejected\
+    \ at the dispatchable layer, and Root-originated calls remain functional.\n- Full\
+    \ `pallet-revive` test suite (614 tests) is green."
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
+++ b/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
@@ -1,16 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import "@revive/ISystem.sol";
+
 contract NestedDeployer {
     function deployChild() external returns (address) {
         return address(new NestedChild());
-    }
-
-    function deployAndDestroyChild(address payable beneficiary) external returns (address) {
-        NestedChild child = new NestedChild();
-        address childAddr = address(child);
-        child.destroy(beneficiary);
-        return childAddr;
     }
 }
 
@@ -21,7 +16,15 @@ contract NestedChild {
         state = 42;
     }
 
-    function destroy(address payable beneficiary) external {
-        selfdestruct(beneficiary);
+    /// Self-terminate via the system precompile (`only_if_same_tx: false`), so the
+    /// contract can be destroyed in a later tx than the one that created it.
+    function destroyViaPrecompile(address beneficiary) external {
+        bytes memory data = abi.encodeWithSelector(ISystem.terminate.selector, beneficiary);
+        (bool success, bytes memory returnData) = SYSTEM_ADDR.call(data);
+        if (!success) {
+            assembly {
+                revert(add(returnData, 0x20), mload(returnData))
+            }
+        }
     }
 }

--- a/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
+++ b/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
@@ -7,6 +7,15 @@ contract NestedDeployer {
     function deployChild() external returns (address) {
         return address(new NestedChild());
     }
+
+    /// Create and immediately destroy the child in the same tx — exercises the
+    /// SELFDESTRUCT path (`only_if_same_tx: true`, EIP-6780 compliant).
+    function deployAndDestroyChild(address payable beneficiary) external returns (address) {
+        NestedChild child = new NestedChild();
+        address childAddr = address(child);
+        child.destroy(beneficiary);
+        return childAddr;
+    }
 }
 
 contract NestedChild {
@@ -14,6 +23,13 @@ contract NestedChild {
 
     constructor() {
         state = 42;
+    }
+
+    /// Self-terminate via the SELFDESTRUCT opcode (`only_if_same_tx: true`,
+    /// EIP-6780): only actually destroys the contract if invoked in the same tx
+    /// that created it.
+    function destroy(address payable beneficiary) external {
+        selfdestruct(beneficiary);
     }
 
     /// Self-terminate via the system precompile (`only_if_same_tx: false`), so the

--- a/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
+++ b/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
@@ -5,6 +5,13 @@ contract NestedDeployer {
     function deployChild() external returns (address) {
         return address(new NestedChild());
     }
+
+    function deployAndDestroyChild(address payable beneficiary) external returns (address) {
+        NestedChild child = new NestedChild();
+        address childAddr = address(child);
+        child.destroy(beneficiary);
+        return childAddr;
+    }
 }
 
 contract NestedChild {
@@ -12,5 +19,9 @@ contract NestedChild {
 
     constructor() {
         state = 42;
+    }
+
+    function destroy(address payable beneficiary) external {
+        selfdestruct(beneficiary);
     }
 }

--- a/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
+++ b/substrate/frame/revive/fixtures/contracts/NestedDeployer.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+contract NestedDeployer {
+    function deployChild() external returns (address) {
+        return address(new NestedChild());
+    }
+}
+
+contract NestedChild {
+    uint256 public state;
+
+    constructor() {
+        state = 42;
+    }
+}

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1313,9 +1313,6 @@ where
 			// We need to make sure that the contract's account exists before calling its
 			// constructor.
 			if entry_point == ExportedFunction::Constructor {
-				// Root origin can't be used to instantiate a contract.
-				ensure!(matches!(self.origin, Origin::Signed(_)), DispatchError::RootNotAllowed);
-
 				if !frame_system::Pallet::<T>::account_exists(&account_id) {
 					T::Deposit::init_contract(account_id)?;
 				}
@@ -1409,11 +1406,12 @@ where
 			// The deposit we charge for a contract depends on the size of the immutable data.
 			// Hence we need to delay charging the base deposit after execution.
 			let frame = if entry_point == ExportedFunction::Constructor {
-				let origin = self.origin.account_id()?.clone();
 				let frame = top_frame_mut!(self);
 				// if we are dealing with EVM bytecode
 				// We upload the new runtime code, and update the code
 				if !is_pvm {
+					// Owns the runtime-code upload deposit, prevents EVM CREATE under Root.
+					let origin = self.origin.account_id()?.clone();
 					// Only keep return data for tracing and for dry runs.
 					// When a dry-run simulates contract deployment, keep the execution result's
 					// data.

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1731,10 +1731,18 @@ where
 	) -> Result<(), DispatchError> {
 		let contract_address = T::AddressMapper::to_address(contract_account);
 
+		// If root created this contract we need to use the pallet account_id because root no
+		// account.
+		let synthetic_origin: Origin<T> = Origin::from_account_id(crate::Pallet::<T>::account_id());
+		let effective_origin: &Origin<T> =
+			if matches!(origin, Origin::Root) { &synthetic_origin } else { origin };
+
 		let mut delete_contract = |trie_id: &TrieId, code_hash: &H256| {
 			// deposit needs to be removed as it adds a consumer
-			let refund =
-				T::Deposit::refund_all(&contract_account, exec_config.funds(origin.account_id()?))?;
+			let refund = T::Deposit::refund_all(
+				&contract_account,
+				exec_config.funds(effective_origin.account_id()?),
+			)?;
 
 			// we added this consumer manually when instantiating
 			System::<T>::dec_consumers(&contract_account);
@@ -1749,7 +1757,7 @@ where
 				contract_address.into(),
 			));
 			Self::transfer(
-				origin,
+				effective_origin,
 				contract_account,
 				&args.beneficiary,
 				balance,

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1740,10 +1740,8 @@ where
 
 		let mut delete_contract = |trie_id: &TrieId, code_hash: &H256| {
 			// deposit needs to be removed as it adds a consumer
-			let refund = T::Deposit::refund_all(
-				&contract_account,
-				exec_config.funds(origin.account_id()?),
-			)?;
+			let refund =
+				T::Deposit::refund_all(&contract_account, exec_config.funds(origin.account_id()?))?;
 
 			// we added this consumer manually when instantiating
 			System::<T>::dec_consumers(&contract_account);

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1410,8 +1410,10 @@ where
 				// if we are dealing with EVM bytecode
 				// We upload the new runtime code, and update the code
 				if !is_pvm {
-					// EVM CREATE requires an account to own the runtime-code upload
-					// deposit; Root has none, so it must be rejected here.
+					// EVM CREATE produces runtime bytecode inline and must charge the
+					// code-upload deposit synchronously against an account. Unlike the
+					// contract storage deposit, there is no Root waiver for
+					// CodeUploadDepositReserve, so we reject here.
 					let Origin::Signed(origin) = &self.origin else {
 						return Err(DispatchError::RootNotAllowed.into());
 					};

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1410,8 +1410,12 @@ where
 				// if we are dealing with EVM bytecode
 				// We upload the new runtime code, and update the code
 				if !is_pvm {
-					// Owns the runtime-code upload deposit, prevents EVM CREATE under Root.
-					let origin = self.origin.account_id()?.clone();
+					// EVM CREATE requires an account to own the runtime-code upload
+					// deposit; Root has none, so it must be rejected here.
+					let Origin::Signed(origin) = &self.origin else {
+						return Err(DispatchError::RootNotAllowed.into());
+					};
+					let origin = origin.clone();
 					// Only keep return data for tracing and for dry runs.
 					// When a dry-run simulates contract deployment, keep the execution result's
 					// data.

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1734,7 +1734,7 @@ where
 		// If root created this contract we need to use the pallet account_id because root has no
 		// account.
 		let origin: Origin<T> = match origin {
-			Origin::Signed(o) => Origin::Signed(o),
+			Origin::Signed(o) => Origin::Signed(o.clone()),
 			Origin::Root => Origin::from_account_id(crate::Pallet::<T>::account_id()),
 		};
 

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -61,7 +61,7 @@ use sp_core::{
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::blake2_256};
 use sp_runtime::{
 	DispatchError, SaturatedConversion,
-	traits::{BadOrigin, Saturating, TrailingZeroInput},
+	traits::{BadOrigin, Saturating, TrailingZeroInput, Zero},
 };
 
 #[cfg(test)]
@@ -1410,14 +1410,6 @@ where
 				// if we are dealing with EVM bytecode
 				// We upload the new runtime code, and update the code
 				if !is_pvm {
-					// EVM CREATE produces runtime bytecode inline and must charge the
-					// code-upload deposit synchronously against an account. Unlike the
-					// contract storage deposit, there is no Root waiver for
-					// CodeUploadDepositReserve, so we reject here.
-					let Origin::Signed(origin) = &self.origin else {
-						return Err(DispatchError::RootNotAllowed.into());
-					};
-					let origin = origin.clone();
 					// Only keep return data for tracing and for dry runs.
 					// When a dry-run simulates contract deployment, keep the execution result's
 					// data.
@@ -1429,7 +1421,21 @@ where
 						output.data.clone()
 					};
 
-					let mut module = crate::ContractBlob::<T>::from_evm_runtime_code(data, origin)?;
+					// Under Root there is no origin account to attribute the upload
+					// deposit to: use the pallet's own account as a sentinel owner
+					// with zero deposit so charge/refund are no-ops.
+					let mut module = match &self.origin {
+						Origin::Signed(o) => {
+							crate::ContractBlob::<T>::from_evm_runtime_code(data, o.clone())?
+						},
+						Origin::Root => {
+							crate::ContractBlob::<T>::from_evm_runtime_code_with_deposit(
+								data,
+								crate::Pallet::<T>::account_id(),
+								Zero::zero(),
+							)?
+						},
+					};
 					module.store_code(&self.exec_config, &mut frame.frame_meter)?;
 					code_deposit = module.code_info().deposit();
 

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1731,7 +1731,7 @@ where
 	) -> Result<(), DispatchError> {
 		let contract_address = T::AddressMapper::to_address(contract_account);
 
-		// If root created this contract we need to use the pallet account_id because root no
+		// If root created this contract we need to use the pallet account_id because root has no
 		// account.
 		let synthetic_origin: Origin<T> = Origin::from_account_id(crate::Pallet::<T>::account_id());
 		let effective_origin: &Origin<T> =

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1733,15 +1733,16 @@ where
 
 		// If root created this contract we need to use the pallet account_id because root has no
 		// account.
-		let synthetic_origin: Origin<T> = Origin::from_account_id(crate::Pallet::<T>::account_id());
-		let effective_origin: &Origin<T> =
-			if matches!(origin, Origin::Root) { &synthetic_origin } else { origin };
+		let origin: Origin<T> = match origin {
+			Origin::Signed(o) => Origin::Signed(o.clone()),
+			Origin::Root => Origin::from_account_id(crate::Pallet::<T>::account_id()),
+		};
 
 		let mut delete_contract = |trie_id: &TrieId, code_hash: &H256| {
 			// deposit needs to be removed as it adds a consumer
 			let refund = T::Deposit::refund_all(
 				&contract_account,
-				exec_config.funds(effective_origin.account_id()?),
+				exec_config.funds(origin.account_id()?),
 			)?;
 
 			// we added this consumer manually when instantiating
@@ -1757,7 +1758,7 @@ where
 				contract_address.into(),
 			));
 			Self::transfer(
-				effective_origin,
+				&origin,
 				contract_account,
 				&args.beneficiary,
 				balance,

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1734,7 +1734,7 @@ where
 		// If root created this contract we need to use the pallet account_id because root has no
 		// account.
 		let origin: Origin<T> = match origin {
-			Origin::Signed(o) => Origin::Signed(o.clone()),
+			Origin::Signed(o) => Origin::Signed(o),
 			Origin::Root => Origin::from_account_id(crate::Pallet::<T>::account_id()),
 		};
 

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3165,15 +3165,11 @@ fn root_call_can_nested_instantiate() {
 	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
 
-		// Deploy the deployer contract (signed). Its constructor does nothing.
 		let Contract { addr, account_id: deployer_id } =
 			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
 
-		// Top up the deployer so it can transfer ED to the new contract.
 		let _ = <Test as Config>::Currency::set_balance(&deployer_id, 1_000_000);
 
-		// Root invokes the deployer with zero value (Root cannot transfer value at the
-		// top frame); the deployer then issues a CREATE1 of its own code with no value.
 		assert_ok!(
 			builder::bare_call(addr)
 				.origin(RuntimeOrigin::root())

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3160,44 +3160,6 @@ fn root_cannot_instantiate() {
 }
 
 #[test]
-fn root_call_can_nested_instantiate() {
-	let (code, code_hash) = compile_module("create1_with_value").unwrap();
-	const ED: u64 = 200;
-	ExtBuilder::default().existential_deposit(ED.into()).build().execute_with(|| {
-		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
-
-		let Contract { addr, account_id: deployer_id } =
-			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
-
-		let _ = <Test as Config>::Currency::set_balance(&deployer_id, 1_000_000);
-		let hold = HoldReason::StorageDepositReserve.into();
-		let deployer_hold_before = get_balance_on_hold(&hold, &deployer_id);
-		let deployer_free_before = <Test as Config>::Currency::total_balance(&deployer_id);
-
-		assert_ok!(
-			builder::bare_call(addr)
-				.origin(RuntimeOrigin::root())
-				.data(code_hash.encode())
-				.build()
-				.result
-		);
-
-		// Verify the new contract was actually deployed.
-		let new_addr = crate::address::create1(&addr, 1);
-		let new_id = <Test as Config>::AddressMapper::to_account_id(&new_addr);
-		let info = <AccountInfo<Test>>::load_contract(&new_addr)
-			.expect("new contract should have ContractInfo");
-		assert_eq!(info.code_hash, code_hash);
-		assert_eq!(<Test as Config>::Currency::total_balance(&new_id), ED.into());
-
-		// Storage deposits are waived under Root.
-		assert_eq!(get_balance_on_hold(&hold, &new_id), 0);
-		assert_eq!(get_balance_on_hold(&hold, &deployer_id), deployer_hold_before);
-		assert_eq!(<Test as Config>::Currency::total_balance(&deployer_id), deployer_free_before);
-	});
-}
-
-#[test]
 fn only_upload_origin_can_upload() {
 	let (binary, _) = compile_module("dummy").unwrap();
 	UploadAccount::set(Some(ALICE));

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3162,7 +3162,8 @@ fn root_cannot_instantiate() {
 #[test]
 fn root_call_can_nested_instantiate() {
 	let (code, code_hash) = compile_module("create1_with_value").unwrap();
-	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
+	const ED: u64 = 200;
+	ExtBuilder::default().existential_deposit(ED.into()).build().execute_with(|| {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
 
 		let Contract { addr, account_id: deployer_id } =
@@ -3178,10 +3179,13 @@ fn root_call_can_nested_instantiate() {
 				.result
 		);
 
-		// New contract's account exists with the freshly minted ED.
+		// Verify the new contract was actually deployed.
 		let new_addr = crate::address::create1(&addr, 1);
 		let new_id = <Test as Config>::AddressMapper::to_account_id(&new_addr);
-		assert!(frame_system::Pallet::<Test>::account_exists(&new_id));
+		let info = <AccountInfo<Test>>::load_contract(&new_addr)
+			.expect("new contract should have ContractInfo");
+		assert_eq!(info.code_hash, code_hash);
+		assert_eq!(<Test as Config>::Currency::total_balance(&new_id), ED.into());
 	});
 }
 

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3170,6 +3170,9 @@ fn root_call_can_nested_instantiate() {
 			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
 
 		let _ = <Test as Config>::Currency::set_balance(&deployer_id, 1_000_000);
+		let hold = HoldReason::StorageDepositReserve.into();
+		let deployer_hold_before = get_balance_on_hold(&hold, &deployer_id);
+		let deployer_free_before = <Test as Config>::Currency::total_balance(&deployer_id);
 
 		assert_ok!(
 			builder::bare_call(addr)
@@ -3186,6 +3189,11 @@ fn root_call_can_nested_instantiate() {
 			.expect("new contract should have ContractInfo");
 		assert_eq!(info.code_hash, code_hash);
 		assert_eq!(<Test as Config>::Currency::total_balance(&new_id), ED.into());
+
+		// Storage deposits are waived under Root.
+		assert_eq!(get_balance_on_hold(&hold, &new_id), 0);
+		assert_eq!(get_balance_on_hold(&hold, &deployer_id), deployer_hold_before);
+		assert_eq!(<Test as Config>::Currency::total_balance(&deployer_id), deployer_free_before);
 	});
 }
 

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3160,6 +3160,36 @@ fn root_cannot_instantiate() {
 }
 
 #[test]
+fn root_call_can_nested_instantiate() {
+	let (code, code_hash) = compile_module("create1_with_value").unwrap();
+	ExtBuilder::default().existential_deposit(200).build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 1_000_000);
+
+		// Deploy the deployer contract (signed). Its constructor does nothing.
+		let Contract { addr, account_id: deployer_id } =
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
+
+		// Top up the deployer so it can transfer ED to the new contract.
+		let _ = <Test as Config>::Currency::set_balance(&deployer_id, 1_000_000);
+
+		// Root invokes the deployer with zero value (Root cannot transfer value at the
+		// top frame); the deployer then issues a CREATE1 of its own code with no value.
+		assert_ok!(
+			builder::bare_call(addr)
+				.origin(RuntimeOrigin::root())
+				.data(code_hash.encode())
+				.build()
+				.result
+		);
+
+		// New contract's account exists with the freshly minted ED.
+		let new_addr = crate::address::create1(&addr, 1);
+		let new_id = <Test as Config>::AddressMapper::to_account_id(&new_addr);
+		assert!(frame_system::Pallet::<Test>::account_exists(&new_id));
+	});
+}
+
+#[test]
 fn only_upload_origin_can_upload() {
 	let (binary, _) = compile_module("dummy").unwrap();
 	UploadAccount::set(Some(ALICE));

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -803,6 +803,86 @@ fn root_call_can_create_and_destroy_in_next_block(
 	});
 }
 
+/// Sibling of the cross-block test, but using the Solidity `selfdestruct` opcode
+/// (`only_if_same_tx: true`). To actually reach `do_terminate` past the EIP-6780
+/// gate at [exec.rs] `contracts_to_destroy`, creation and destruction must
+/// happen in the same tx — covers the `only_if_same_tx: true` branch.
+#[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
+#[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]
+#[test_case(FixtureType::Resolc, FixtureType::Resolc; "resolc->resolc")]
+fn root_call_can_create_and_destroy_in_same_tx(caller_type: FixtureType, callee_type: FixtureType) {
+	use crate::{
+		AccountInfo, HoldReason, Pallet, address::AddressMapper, test_utils::DJANGO_ADDR,
+		tests::test_utils::get_balance_on_hold,
+	};
+	use alloy_core::primitives::Address;
+	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployAndDestroyChildCall};
+
+	let (code, _) = compile_module_with_type("NestedDeployer", caller_type).unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000_000);
+
+		if caller_type == FixtureType::Resolc {
+			let (child_code, _) = compile_module_with_type("NestedChild", callee_type).unwrap();
+			Pallet::<Test>::upload_code(
+				RuntimeOrigin::signed(ALICE.clone()),
+				child_code,
+				<BalanceOf<Test>>::MAX,
+			)
+			.unwrap();
+		}
+
+		let Contract { addr, account_id } =
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
+		let _ = <Test as Config>::Currency::set_balance(&account_id, 100_000_000_000_000);
+
+		let storage_hold = HoldReason::StorageDepositReserve.into();
+		let upload_hold = HoldReason::CodeUploadDepositReserve.into();
+		let pallet_account = Pallet::<Test>::account_id();
+		let deployer_storage_hold_before = get_balance_on_hold(&storage_hold, &account_id);
+		let deployer_free_before = <<Test as Config>::Currency as Inspect<_>>::balance(&account_id);
+		let pallet_upload_hold_before = get_balance_on_hold(&upload_hold, &pallet_account);
+
+		let result = builder::bare_call(addr)
+			.origin(RuntimeOrigin::root())
+			.data(
+				NestedDeployerCalls::deployAndDestroyChild(deployAndDestroyChildCall {
+					beneficiary: DJANGO_ADDR.0.into(),
+				})
+				.abi_encode(),
+			)
+			.build_and_unwrap_result();
+		assert!(!result.did_revert(), "Root nested CREATE + SELFDESTRUCT should succeed");
+
+		let returned: Address =
+			deployAndDestroyChildCall::abi_decode_returns(&result.data).unwrap();
+		let child_addr = H160::from_slice(returned.as_slice());
+
+		// EIP-6780: created-and-destroyed in the same tx must actually remove the
+		// contract. Before the do_terminate fix this silently failed under Root and
+		// the ContractInfo stayed put.
+		assert!(
+			AccountInfo::<Test>::load_contract(&child_addr).is_none(),
+			"child contract must have been terminated, not silently left on-chain",
+		);
+
+		let child_id = <Test as crate::Config>::AddressMapper::to_account_id(&child_addr);
+		assert_eq!(get_balance_on_hold(&storage_hold, &child_id), 0);
+		assert_eq!(get_balance_on_hold(&storage_hold, &account_id), deployer_storage_hold_before);
+		assert_eq!(
+			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id),
+			deployer_free_before,
+		);
+		if caller_type == FixtureType::Solc {
+			assert_eq!(
+				get_balance_on_hold(&upload_hold, &pallet_account),
+				pallet_upload_hold_before
+			);
+		}
+	});
+}
+
 /// No resolc caller since the subcall limiting is not implemented on resolc, yet.
 #[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
 #[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -701,27 +701,25 @@ fn instantiate_from_constructor_works() {
 	});
 }
 
-/// `bare_call(Root, deployer, ...)` where the deployer issues a nested CREATE
-/// must succeed on both backends. The deposit (storage + code upload for EVM)
-/// is waived under Root; the new contract is otherwise fully formed.
+/// SELFDESTRUCT of a Root-instantiated contract in the same tx must terminate
+/// cleanly. `do_terminate` previously called `origin.account_id()?` and silently
+/// failed under Root (the error was swallowed by `.ok()` at the call site),
+/// leaving the contract on-chain after a "successful" call.
 #[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
 #[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]
-fn root_call_can_nested_instantiate(caller_type: FixtureType, callee_type: FixtureType) {
-	use crate::{
-		AccountInfo, HoldReason, Pallet,
-		address::{AddressMapper, create1},
-		tests::{System, test_utils::get_balance_on_hold},
-	};
+fn root_call_can_nested_instantiate_and_destroy(
+	caller_type: FixtureType,
+	callee_type: FixtureType,
+) {
+	use crate::{AccountInfo, Pallet, address::create1, test_utils::DJANGO_ADDR, tests::System};
 	use alloy_core::primitives::Address;
-	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployChildCall};
+	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployAndDestroyChildCall};
 
 	let (code, _) = compile_module_with_type("NestedDeployer", caller_type).unwrap();
 
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000_000);
 
-		// PVM requires the child's code to be pre-uploaded; EVM bytecode is uploaded
-		// inline by CREATE.
 		if caller_type == FixtureType::Resolc {
 			let (child_code, _) = compile_module_with_type("NestedChild", callee_type).unwrap();
 			Pallet::<Test>::upload_code(
@@ -736,17 +734,11 @@ fn root_call_can_nested_instantiate(caller_type: FixtureType, callee_type: Fixtu
 			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
 		let _ = <Test as Config>::Currency::set_balance(&account_id, 100_000_000_000_000);
 
-		let data = NestedDeployerCalls::deployChild(deployChildCall {}).abi_encode();
+		let data = NestedDeployerCalls::deployAndDestroyChild(deployAndDestroyChildCall {
+			beneficiary: DJANGO_ADDR.0.into(),
+		})
+		.abi_encode();
 
-		// Snapshot balances/holds the Root call must not touch.
-		let storage_hold = HoldReason::StorageDepositReserve.into();
-		let upload_hold = HoldReason::CodeUploadDepositReserve.into();
-		let pallet_account = Pallet::<Test>::account_id();
-		let deployer_storage_hold_before = get_balance_on_hold(&storage_hold, &account_id);
-		let deployer_free_before = <<Test as Config>::Currency as Inspect<_>>::balance(&account_id);
-		let pallet_upload_hold_before = get_balance_on_hold(&upload_hold, &pallet_account);
-
-		// Predict the address the next `new` will land at, then call under Root.
 		let deployer_nonce = System::account_nonce(&account_id);
 		let expected = create1(&addr, deployer_nonce.into());
 
@@ -754,31 +746,19 @@ fn root_call_can_nested_instantiate(caller_type: FixtureType, callee_type: Fixtu
 			.origin(RuntimeOrigin::root())
 			.data(data)
 			.build_and_unwrap_result();
-		assert!(!result.did_revert(), "Root nested CREATE should succeed");
+		assert!(!result.did_revert(), "Root nested CREATE + SELFDESTRUCT should succeed");
 
-		let returned: Address = deployChildCall::abi_decode_returns(&result.data).unwrap();
-		assert_ne!(returned, Address::ZERO, "CREATE should not return zero");
-		assert_eq!(
-			H160::from_slice(returned.as_slice()),
-			expected,
-			"returned address must match CREATE1 derivation",
-		);
+		let returned: Address =
+			deployAndDestroyChildCall::abi_decode_returns(&result.data).unwrap();
+		assert_eq!(H160::from_slice(returned.as_slice()), expected);
+
+		// EIP-6780: created-and-destroyed in the same tx must actually remove the
+		// contract. Before the do_terminate fix this silently failed under Root and
+		// the ContractInfo stayed put.
 		assert!(
-			AccountInfo::<Test>::load_contract(&expected).is_some(),
-			"new contract should have ContractInfo",
+			AccountInfo::<Test>::load_contract(&expected).is_none(),
+			"child contract must have been terminated, not silently left on-chain",
 		);
-
-		// Deposits are waived under Root: no storage-deposit hold on the new contract
-		// (or the deployer), and no code-upload hold on the pallet's sentinel-owner
-		// account (only relevant for EVM, where the runtime code is uploaded inline).
-		let new_id = <Test as crate::Config>::AddressMapper::to_account_id(&expected);
-		assert_eq!(get_balance_on_hold(&storage_hold, &new_id), 0);
-		assert_eq!(get_balance_on_hold(&storage_hold, &account_id), deployer_storage_hold_before);
-		assert_eq!(
-			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id),
-			deployer_free_before,
-		);
-		assert_eq!(get_balance_on_hold(&upload_hold, &pallet_account), pallet_upload_hold_before);
 	});
 }
 

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -34,7 +34,7 @@ use alloy_core::{
 };
 use frame_support::{
 	assert_err,
-	traits::fungible::{Balanced, Mutate},
+	traits::fungible::{Balanced, Inspect, Mutate},
 };
 use itertools::Itertools;
 use pallet_revive_fixtures::{Callee, Caller, FixtureType, Host, compile_module_with_type};
@@ -707,7 +707,12 @@ fn instantiate_from_constructor_works() {
 #[test_case(FixtureType::Solc;   "solc")]
 #[test_case(FixtureType::Resolc; "resolc")]
 fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
-	use crate::{AccountInfo, Pallet, address::create1, tests::System};
+	use crate::{
+		AccountInfo, HoldReason, Pallet,
+		address::AddressMapper,
+		address::create1,
+		tests::{System, test_utils::get_balance_on_hold},
+	};
 	use alloy_core::primitives::Address;
 	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployChildCall};
 
@@ -735,6 +740,15 @@ fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
 
 		let data = NestedDeployerCalls::deployChild(deployChildCall {}).abi_encode();
 
+		// Snapshot balances/holds the Root call must not touch.
+		let storage_hold = HoldReason::StorageDepositReserve.into();
+		let upload_hold = HoldReason::CodeUploadDepositReserve.into();
+		let pallet_account = Pallet::<Test>::account_id();
+		let deployer_storage_hold_before = get_balance_on_hold(&storage_hold, &account_id);
+		let deployer_free_before =
+			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id);
+		let pallet_upload_hold_before = get_balance_on_hold(&upload_hold, &pallet_account);
+
 		// Predict the address the next `new` will land at, then call under Root.
 		let deployer_nonce = System::account_nonce(&account_id);
 		let expected = create1(&addr, deployer_nonce.into());
@@ -756,6 +770,18 @@ fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
 			AccountInfo::<Test>::load_contract(&expected).is_some(),
 			"new contract should have ContractInfo",
 		);
+
+		// Deposits are waived under Root: no storage-deposit hold on the new contract
+		// (or the deployer), and no code-upload hold on the pallet's sentinel-owner
+		// account (only relevant for EVM, where the runtime code is uploaded inline).
+		let new_id = <Test as crate::Config>::AddressMapper::to_account_id(&expected);
+		assert_eq!(get_balance_on_hold(&storage_hold, &new_id), 0);
+		assert_eq!(get_balance_on_hold(&storage_hold, &account_id), deployer_storage_hold_before);
+		assert_eq!(
+			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id),
+			deployer_free_before,
+		);
+		assert_eq!(get_balance_on_hold(&upload_hold, &pallet_account), pallet_upload_hold_before);
 	});
 }
 

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -704,9 +704,9 @@ fn instantiate_from_constructor_works() {
 /// `bare_call(Root, deployer, ...)` where the deployer issues a nested CREATE
 /// must succeed on both backends. The deposit (storage + code upload for EVM)
 /// is waived under Root; the new contract is otherwise fully formed.
-#[test_case(FixtureType::Solc;   "solc")]
-#[test_case(FixtureType::Resolc; "resolc")]
-fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
+#[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
+#[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]
+fn root_call_can_nested_instantiate(caller_type: FixtureType, callee_type: FixtureType) {
 	use crate::{
 		AccountInfo, HoldReason, Pallet,
 		address::{AddressMapper, create1},
@@ -715,16 +715,15 @@ fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
 	use alloy_core::primitives::Address;
 	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployChildCall};
 
-	let (code, _) = compile_module_with_type("NestedDeployer", deployer_type).unwrap();
+	let (code, _) = compile_module_with_type("NestedDeployer", caller_type).unwrap();
 
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000_000);
 
 		// PVM requires the child's code to be pre-uploaded; EVM bytecode is uploaded
 		// inline by CREATE.
-		if deployer_type == FixtureType::Resolc {
-			let (child_code, _) =
-				compile_module_with_type("NestedChild", FixtureType::Resolc).unwrap();
+		if caller_type == FixtureType::Resolc {
+			let (child_code, _) = compile_module_with_type("NestedChild", callee_type).unwrap();
 			Pallet::<Test>::upload_code(
 				RuntimeOrigin::signed(ALICE.clone()),
 				child_code,

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -706,7 +706,10 @@ fn instantiate_from_constructor_works() {
 /// Root and confirms the deposit waiver holds across both calls.
 #[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
 #[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]
-fn root_call_can_create_and_destroy_in_next_block(caller_type: FixtureType, callee_type: FixtureType) {
+fn root_call_can_create_and_destroy_in_next_block(
+	caller_type: FixtureType,
+	callee_type: FixtureType,
+) {
 	use crate::{
 		AccountInfo, HoldReason, Pallet,
 		address::{AddressMapper, create1},

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -26,7 +26,7 @@ use crate::{
 	evm::{decode_revert_reason, fees::InfoT},
 	metering::TransactionLimits,
 	test_utils::{ALICE, ALICE_ADDR, BOB_ADDR, WEIGHT_LIMIT, builder::Contract, deposit_limit},
-	tests::{ExtBuilder, MOCK_CODE, MockHandlerImpl, Test, builder},
+	tests::{ExtBuilder, MOCK_CODE, MockHandlerImpl, RuntimeOrigin, Test, builder},
 };
 use alloy_core::{
 	primitives::{Bytes, FixedBytes},
@@ -698,6 +698,46 @@ fn instantiate_from_constructor_works() {
 		let result = builder::bare_call(addr).data(data).build_and_unwrap_result();
 		let result = callBarCall::abi_decode_returns(&result.data).unwrap();
 		assert_eq!(result, 42u64);
+	});
+}
+
+/// Root-originated EVM `CREATE` (via Solidity `new ContractName()`) must still be
+/// rejected: a non-PVM constructor frame can't be opened under Root because the
+/// runtime-code upload deposit has no origin address to attribute to. Acts as a
+/// regression guard against future refactors that pre-extract that owner from
+/// elsewhere (e.g. `caller`) and silently lift the restriction.
+#[test]
+fn root_call_cannot_nested_evm_create() {
+	use pallet_revive_fixtures::HostEvmOnlyFactory::{
+		HostEvmOnlyFactoryCalls, createAndSelfdestructCall,
+	};
+
+	let (factory_code, _) =
+		compile_module_with_type("HostEvmOnlyFactory", FixtureType::Solc).unwrap();
+
+	ExtBuilder::default().build().execute_with(|| {
+		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000_000);
+
+		let Contract { addr, account_id } =
+			builder::bare_instantiate(Code::Upload(factory_code)).build_and_unwrap_contract();
+		// Top up so the factory could fund the new contract if CREATE were allowed.
+		let _ = <Test as Config>::Currency::set_balance(&account_id, 100_000_000_000_000);
+
+		let data = HostEvmOnlyFactoryCalls::createAndSelfdestruct(createAndSelfdestructCall {
+			recipient: ALICE_ADDR.0.into(),
+		})
+		.abi_encode();
+
+		// Sanity check: Signed origin succeeds.
+		let signed = builder::bare_call(addr).data(data.clone()).build_and_unwrap_result();
+		assert!(!signed.did_revert(), "Signed nested CREATE should succeed");
+
+		// Root origin: Solidity's `new` reverts when the host rejects the CREATE.
+		let root = builder::bare_call(addr)
+			.origin(RuntimeOrigin::root())
+			.data(data)
+			.build_and_unwrap_result();
+		assert!(root.did_revert(), "Root nested EVM CREATE must be rejected");
 	});
 }
 

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -708,6 +708,7 @@ fn instantiate_from_constructor_works() {
 /// elsewhere (e.g. `caller`) and silently lift the restriction.
 #[test]
 fn root_call_cannot_nested_evm_create() {
+	use crate::{AccountInfo, address::create1, tests::System};
 	use pallet_revive_fixtures::HostEvmOnlyFactory::{
 		HostEvmOnlyFactoryCalls, createAndSelfdestructCall,
 	};
@@ -732,12 +733,26 @@ fn root_call_cannot_nested_evm_create() {
 		let signed = builder::bare_call(addr).data(data.clone()).build_and_unwrap_result();
 		assert!(!signed.did_revert(), "Signed nested CREATE should succeed");
 
-		// Root origin: Solidity's `new` reverts when the host rejects the CREATE.
+		// Predict the address the next `new` would land at (nonce snapshot) and assert
+		// the Root call leaves no contract there. This pins the failure to CREATE
+		// rejection itself, not some unrelated downstream revert.
+		let factory_nonce = System::account_nonce(&account_id);
+		let would_be_addr = create1(&addr, factory_nonce.into());
+
 		let root = builder::bare_call(addr)
 			.origin(RuntimeOrigin::root())
 			.data(data)
 			.build_and_unwrap_result();
 		assert!(root.did_revert(), "Root nested EVM CREATE must be rejected");
+		assert!(
+			AccountInfo::<Test>::load_contract(&would_be_addr).is_none(),
+			"no contract should have been created at the would-be CREATE1 address"
+		);
+		assert_eq!(
+			System::account_nonce(&account_id),
+			factory_nonce,
+			"factory nonce must not advance when CREATE is rejected"
+		);
 	});
 }
 

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -706,13 +706,14 @@ fn instantiate_from_constructor_works() {
 /// Root and confirms the deposit waiver holds across both calls.
 #[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
 #[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]
+#[test_case(FixtureType::Resolc, FixtureType::Resolc; "resolc->resolc")]
 fn root_call_can_create_and_destroy_in_next_block(
 	caller_type: FixtureType,
 	callee_type: FixtureType,
 ) {
 	use crate::{
 		AccountInfo, HoldReason, Pallet,
-		address::{AddressMapper, create1},
+		address::AddressMapper,
 		test_utils::DJANGO_ADDR,
 		tests::{System, initialize_block, test_utils::get_balance_on_hold},
 	};
@@ -750,16 +751,23 @@ fn root_call_can_create_and_destroy_in_next_block(
 		let pallet_upload_hold_before = get_balance_on_hold(&upload_hold, &pallet_account);
 
 		// Block 1: Root creates the child via nested CREATE.
-		let deployer_nonce = System::account_nonce(&account_id);
-		let child_addr = create1(&addr, deployer_nonce.into());
 		let create_result = builder::bare_call(addr)
 			.origin(RuntimeOrigin::root())
 			.data(NestedDeployerCalls::deployChild(deployChildCall {}).abi_encode())
 			.build_and_unwrap_result();
 		assert!(!create_result.did_revert());
 		let returned: Address = deployChildCall::abi_decode_returns(&create_result.data).unwrap();
-		assert_eq!(H160::from_slice(returned.as_slice()), child_addr);
+		let child_addr = H160::from_slice(returned.as_slice());
 		assert!(AccountInfo::<Test>::load_contract(&child_addr).is_some());
+
+		// Deposits stayed waived across the Root create.
+		let child_id = <Test as crate::Config>::AddressMapper::to_account_id(&child_addr);
+		assert_eq!(get_balance_on_hold(&storage_hold, &child_id), 0);
+		assert_eq!(get_balance_on_hold(&storage_hold, &account_id), deployer_storage_hold_before);
+		assert_eq!(
+			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id),
+			deployer_free_before,
+		);
 
 		// Block 2: Root tells the child to self-terminate via the system precompile.
 		initialize_block(System::block_number() + 1);
@@ -780,14 +788,18 @@ fn root_call_can_create_and_destroy_in_next_block(
 		);
 
 		// Deposits stayed waived across both Root calls.
-		let child_id = <Test as crate::Config>::AddressMapper::to_account_id(&child_addr);
 		assert_eq!(get_balance_on_hold(&storage_hold, &child_id), 0);
 		assert_eq!(get_balance_on_hold(&storage_hold, &account_id), deployer_storage_hold_before);
 		assert_eq!(
 			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id),
 			deployer_free_before,
 		);
-		assert_eq!(get_balance_on_hold(&upload_hold, &pallet_account), pallet_upload_hold_before);
+		if caller_type == FixtureType::Solc {
+			assert_eq!(
+				get_balance_on_hold(&upload_hold, &pallet_account),
+				pallet_upload_hold_before
+			);
+		}
 	});
 }
 

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -709,8 +709,7 @@ fn instantiate_from_constructor_works() {
 fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
 	use crate::{
 		AccountInfo, HoldReason, Pallet,
-		address::AddressMapper,
-		address::create1,
+		address::{AddressMapper, create1},
 		tests::{System, test_utils::get_balance_on_hold},
 	};
 	use alloy_core::primitives::Address;
@@ -745,8 +744,7 @@ fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
 		let upload_hold = HoldReason::CodeUploadDepositReserve.into();
 		let pallet_account = Pallet::<Test>::account_id();
 		let deployer_storage_hold_before = get_balance_on_hold(&storage_hold, &account_id);
-		let deployer_free_before =
-			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id);
+		let deployer_free_before = <<Test as Config>::Currency as Inspect<_>>::balance(&account_id);
 		let pallet_upload_hold_before = get_balance_on_hold(&upload_hold, &pallet_account);
 
 		// Predict the address the next `new` will land at, then call under Root.

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -701,57 +701,60 @@ fn instantiate_from_constructor_works() {
 	});
 }
 
-/// Root-originated EVM `CREATE` (via Solidity `new ContractName()`) must still be
-/// rejected: a non-PVM constructor frame can't be opened under Root because the
-/// runtime-code upload deposit has no origin address to attribute to. Acts as a
-/// regression guard against future refactors that pre-extract that owner from
-/// elsewhere (e.g. `caller`) and silently lift the restriction.
-#[test]
-fn root_call_cannot_nested_evm_create() {
-	use crate::{AccountInfo, address::create1, tests::System};
-	use pallet_revive_fixtures::HostEvmOnlyFactory::{
-		HostEvmOnlyFactoryCalls, createAndSelfdestructCall,
-	};
+/// `bare_call(Root, deployer, ...)` where the deployer issues a nested CREATE
+/// must succeed on both backends. The deposit (storage + code upload for EVM)
+/// is waived under Root; the new contract is otherwise fully formed.
+#[test_case(FixtureType::Solc;   "solc")]
+#[test_case(FixtureType::Resolc; "resolc")]
+fn root_call_can_nested_instantiate(deployer_type: FixtureType) {
+	use crate::{AccountInfo, Pallet, address::create1, tests::System};
+	use alloy_core::primitives::Address;
+	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployChildCall};
 
-	let (factory_code, _) =
-		compile_module_with_type("HostEvmOnlyFactory", FixtureType::Solc).unwrap();
+	let (code, _) = compile_module_with_type("NestedDeployer", deployer_type).unwrap();
 
 	ExtBuilder::default().build().execute_with(|| {
 		let _ = <Test as Config>::Currency::set_balance(&ALICE, 100_000_000_000_000);
 
+		// PVM requires the child's code to be pre-uploaded; EVM bytecode is uploaded
+		// inline by CREATE.
+		if deployer_type == FixtureType::Resolc {
+			let (child_code, _) =
+				compile_module_with_type("NestedChild", FixtureType::Resolc).unwrap();
+			Pallet::<Test>::upload_code(
+				RuntimeOrigin::signed(ALICE.clone()),
+				child_code,
+				<BalanceOf<Test>>::MAX,
+			)
+			.unwrap();
+		}
+
 		let Contract { addr, account_id } =
-			builder::bare_instantiate(Code::Upload(factory_code)).build_and_unwrap_contract();
-		// Top up so the factory could fund the new contract if CREATE were allowed.
+			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
 		let _ = <Test as Config>::Currency::set_balance(&account_id, 100_000_000_000_000);
 
-		let data = HostEvmOnlyFactoryCalls::createAndSelfdestruct(createAndSelfdestructCall {
-			recipient: ALICE_ADDR.0.into(),
-		})
-		.abi_encode();
+		let data = NestedDeployerCalls::deployChild(deployChildCall {}).abi_encode();
 
-		// Sanity check: Signed origin succeeds.
-		let signed = builder::bare_call(addr).data(data.clone()).build_and_unwrap_result();
-		assert!(!signed.did_revert(), "Signed nested CREATE should succeed");
+		// Predict the address the next `new` will land at, then call under Root.
+		let deployer_nonce = System::account_nonce(&account_id);
+		let expected = create1(&addr, deployer_nonce.into());
 
-		// Predict the address the next `new` would land at (nonce snapshot) and assert
-		// the Root call leaves no contract there. This pins the failure to CREATE
-		// rejection itself, not some unrelated downstream revert.
-		let factory_nonce = System::account_nonce(&account_id);
-		let would_be_addr = create1(&addr, factory_nonce.into());
-
-		let root = builder::bare_call(addr)
+		let result = builder::bare_call(addr)
 			.origin(RuntimeOrigin::root())
 			.data(data)
 			.build_and_unwrap_result();
-		assert!(root.did_revert(), "Root nested EVM CREATE must be rejected");
-		assert!(
-			AccountInfo::<Test>::load_contract(&would_be_addr).is_none(),
-			"no contract should have been created at the would-be CREATE1 address"
-		);
+		assert!(!result.did_revert(), "Root nested CREATE should succeed");
+
+		let returned: Address = deployChildCall::abi_decode_returns(&result.data).unwrap();
+		assert_ne!(returned, Address::ZERO, "CREATE should not return zero");
 		assert_eq!(
-			System::account_nonce(&account_id),
-			factory_nonce,
-			"factory nonce must not advance when CREATE is rejected"
+			H160::from_slice(returned.as_slice()),
+			expected,
+			"returned address must match CREATE1 derivation",
+		);
+		assert!(
+			AccountInfo::<Test>::load_contract(&expected).is_some(),
+			"new contract should have ContractInfo",
 		);
 	});
 }

--- a/substrate/frame/revive/src/tests/sol/contract.rs
+++ b/substrate/frame/revive/src/tests/sol/contract.rs
@@ -701,19 +701,23 @@ fn instantiate_from_constructor_works() {
 	});
 }
 
-/// SELFDESTRUCT of a Root-instantiated contract in the same tx must terminate
-/// cleanly. `do_terminate` previously called `origin.account_id()?` and silently
-/// failed under Root (the error was swallowed by `.ok()` at the call site),
-/// leaving the contract on-chain after a "successful" call.
+/// Root creates a contract via nested CREATE in block N and destroys it via the
+/// system precompile in block N+1. Exercises the full `do_terminate` path under
+/// Root and confirms the deposit waiver holds across both calls.
 #[test_case(FixtureType::Solc,   FixtureType::Solc;   "solc->solc")]
 #[test_case(FixtureType::Solc,   FixtureType::Resolc; "solc->resolc")]
-fn root_call_can_nested_instantiate_and_destroy(
-	caller_type: FixtureType,
-	callee_type: FixtureType,
-) {
-	use crate::{AccountInfo, Pallet, address::create1, test_utils::DJANGO_ADDR, tests::System};
+fn root_call_can_create_and_destroy_in_next_block(caller_type: FixtureType, callee_type: FixtureType) {
+	use crate::{
+		AccountInfo, HoldReason, Pallet,
+		address::{AddressMapper, create1},
+		test_utils::DJANGO_ADDR,
+		tests::{System, initialize_block, test_utils::get_balance_on_hold},
+	};
 	use alloy_core::primitives::Address;
-	use pallet_revive_fixtures::NestedDeployer::{NestedDeployerCalls, deployAndDestroyChildCall};
+	use pallet_revive_fixtures::{
+		NestedChild::{NestedChildCalls, destroyViaPrecompileCall},
+		NestedDeployer::{NestedDeployerCalls, deployChildCall},
+	};
 
 	let (code, _) = compile_module_with_type("NestedDeployer", caller_type).unwrap();
 
@@ -734,31 +738,53 @@ fn root_call_can_nested_instantiate_and_destroy(
 			builder::bare_instantiate(Code::Upload(code)).build_and_unwrap_contract();
 		let _ = <Test as Config>::Currency::set_balance(&account_id, 100_000_000_000_000);
 
-		let data = NestedDeployerCalls::deployAndDestroyChild(deployAndDestroyChildCall {
-			beneficiary: DJANGO_ADDR.0.into(),
-		})
-		.abi_encode();
+		// Snapshot balances/holds the two Root calls must not touch.
+		let storage_hold = HoldReason::StorageDepositReserve.into();
+		let upload_hold = HoldReason::CodeUploadDepositReserve.into();
+		let pallet_account = Pallet::<Test>::account_id();
+		let deployer_storage_hold_before = get_balance_on_hold(&storage_hold, &account_id);
+		let deployer_free_before = <<Test as Config>::Currency as Inspect<_>>::balance(&account_id);
+		let pallet_upload_hold_before = get_balance_on_hold(&upload_hold, &pallet_account);
 
+		// Block 1: Root creates the child via nested CREATE.
 		let deployer_nonce = System::account_nonce(&account_id);
-		let expected = create1(&addr, deployer_nonce.into());
-
-		let result = builder::bare_call(addr)
+		let child_addr = create1(&addr, deployer_nonce.into());
+		let create_result = builder::bare_call(addr)
 			.origin(RuntimeOrigin::root())
-			.data(data)
+			.data(NestedDeployerCalls::deployChild(deployChildCall {}).abi_encode())
 			.build_and_unwrap_result();
-		assert!(!result.did_revert(), "Root nested CREATE + SELFDESTRUCT should succeed");
+		assert!(!create_result.did_revert());
+		let returned: Address = deployChildCall::abi_decode_returns(&create_result.data).unwrap();
+		assert_eq!(H160::from_slice(returned.as_slice()), child_addr);
+		assert!(AccountInfo::<Test>::load_contract(&child_addr).is_some());
 
-		let returned: Address =
-			deployAndDestroyChildCall::abi_decode_returns(&result.data).unwrap();
-		assert_eq!(H160::from_slice(returned.as_slice()), expected);
+		// Block 2: Root tells the child to self-terminate via the system precompile.
+		initialize_block(System::block_number() + 1);
+		let destroy_result = builder::bare_call(child_addr)
+			.origin(RuntimeOrigin::root())
+			.data(
+				NestedChildCalls::destroyViaPrecompile(destroyViaPrecompileCall {
+					beneficiary: DJANGO_ADDR.0.into(),
+				})
+				.abi_encode(),
+			)
+			.build_and_unwrap_result();
+		assert!(!destroy_result.did_revert(), "Root cross-tx terminate should succeed");
 
-		// EIP-6780: created-and-destroyed in the same tx must actually remove the
-		// contract. Before the do_terminate fix this silently failed under Root and
-		// the ContractInfo stayed put.
 		assert!(
-			AccountInfo::<Test>::load_contract(&expected).is_none(),
-			"child contract must have been terminated, not silently left on-chain",
+			AccountInfo::<Test>::load_contract(&child_addr).is_none(),
+			"child must be destroyed by the cross-block terminate call",
 		);
+
+		// Deposits stayed waived across both Root calls.
+		let child_id = <Test as crate::Config>::AddressMapper::to_account_id(&child_addr);
+		assert_eq!(get_balance_on_hold(&storage_hold, &child_id), 0);
+		assert_eq!(get_balance_on_hold(&storage_hold, &account_id), deployer_storage_hold_before);
+		assert_eq!(
+			<<Test as Config>::Currency as Inspect<_>>::balance(&account_id),
+			deployer_free_before,
+		);
+		assert_eq!(get_balance_on_hold(&upload_hold, &pallet_account), pallet_upload_hold_before);
 	});
 }
 

--- a/substrate/frame/revive/src/vm/evm.rs
+++ b/substrate/frame/revive/src/vm/evm.rs
@@ -15,7 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::{
-	AccountIdOf, CodeInfo, Config, ContractBlob, DispatchError, Error, H256, LOG_TARGET, Weight,
+	AccountIdOf, BalanceOf, CodeInfo, Config, ContractBlob, DispatchError, Error, H256, LOG_TARGET,
+	Weight,
 	debug::DebugSettings,
 	precompiles::Token,
 	tracing,
@@ -99,6 +100,24 @@ impl<T: Config> ContractBlob<T> {
 		code: Vec<u8>,
 		owner: AccountIdOf<T>,
 	) -> Result<Self, DispatchError> {
+		let code_len = code.len() as u32;
+		let deposit = super::calculate_code_deposit::<T>(code_len);
+		Self::from_evm_runtime_code_with_deposit(code, owner, deposit)
+	}
+
+	/// Create a new contract from EVM runtime code with an explicit owner and
+	/// deposit amount.
+	///
+	/// Used for `Origin::Root` uploads: there is no origin account to attribute
+	/// the deposit to, so the caller passes the pallet's own account as a
+	/// sentinel owner (no user can sign as it, so the code can't be removed via
+	/// the owner-gated path) and a zero deposit (both `charge_deposit` and
+	/// `refund_deposit` short-circuit at amount 0).
+	pub fn from_evm_runtime_code_with_deposit(
+		code: Vec<u8>,
+		owner: AccountIdOf<T>,
+		deposit: BalanceOf<T>,
+	) -> Result<Self, DispatchError> {
 		if code.len() > revm::primitives::eip170::MAX_CODE_SIZE &&
 			!DebugSettings::is_unlimited_contract_size_allowed::<T>()
 		{
@@ -106,7 +125,6 @@ impl<T: Config> ContractBlob<T> {
 		}
 
 		let code_len = code.len() as u32;
-		let deposit = super::calculate_code_deposit::<T>(code_len);
 
 		let code_info = CodeInfo {
 			owner,

--- a/substrate/frame/revive/src/vm/evm.rs
+++ b/substrate/frame/revive/src/vm/evm.rs
@@ -113,7 +113,7 @@ impl<T: Config> ContractBlob<T> {
 	/// sentinel owner (no user can sign as it, so the code can't be removed via
 	/// the owner-gated path) and a zero deposit (both `charge_deposit` and
 	/// `refund_deposit` short-circuit at amount 0).
-	pub(crate) fn from_evm_runtime_code_with_deposit(
+	pub fn from_evm_runtime_code_with_deposit(
 		code: Vec<u8>,
 		owner: AccountIdOf<T>,
 		deposit: BalanceOf<T>,

--- a/substrate/frame/revive/src/vm/evm.rs
+++ b/substrate/frame/revive/src/vm/evm.rs
@@ -113,7 +113,7 @@ impl<T: Config> ContractBlob<T> {
 	/// sentinel owner (no user can sign as it, so the code can't be removed via
 	/// the owner-gated path) and a zero deposit (both `charge_deposit` and
 	/// `refund_deposit` short-circuit at amount 0).
-	pub fn from_evm_runtime_code_with_deposit(
+	pub(crate) fn from_evm_runtime_code_with_deposit(
 		code: Vec<u8>,
 		owner: AccountIdOf<T>,
 		deposit: BalanceOf<T>,


### PR DESCRIPTION
# Allow Root-originated nested CREATE in pallet-revive

Closes paritytech/contract-issues#279.

## Motivation

`pallet-revive`'s exec stack rejects `Origin::Root` at every constructor frame, so `bare_call(RuntimeOrigin::root(), contract_addr, ...)` errors `RootNotAllowed` the moment the called contract reaches a `CREATE`/`CREATE2` opcode — even though the contract itself is the semantic instantiator.

The historical reason for the block was that the origin had to fund the new contract's ED. Since the PGAS rework, the ED is freshly minted by `T::Deposit::init_contract` and immediately deactivated for issuance accounting, so the origin no longer needs to pay it.

## Changes

- **Remove the `RootNotAllowed` ensure** at the start of the constructor frame in [`exec.rs`](substrate/frame/revive/src/exec.rs).
- **EVM CREATE under Root**: when constructing the runtime code's `CodeInfo`, substitute the missing origin account with the pallet's own account as a sentinel owner and a zero deposit. Both `charge_deposit` and `refund_deposit` short-circuit at amount 0, and the sentinel can't be signed for, so the code can't be removed via the owner-gated path. A new `ContractBlob::from_evm_runtime_code_with_deposit` exposes the (owner, deposit) construction explicitly.
- **`do_terminate` under Root**: the function called `origin.account_id()?` and silently failed for Root (the result was swallowed by `.ok()` at the SELFDESTRUCT queue site), leaving the contract on-chain after a "successful" call. Substitute the missing origin with the pallet-account sentinel at the top of the function so refund destination and beneficiary-ED bootstrap don't need to special-case `Root`.

Root is still **not** allowed to instantiate directly: `instantiate`/`bare_instantiate` continue to gate on `T::InstantiateOrigin::ensure_origin` (default `EnsureSigned` → `BadOrigin`). The change only unblocks the case where another contract sits between Root and the new contract and acts as the instantiator. Giving Root its own contract-address attribution is intentionally out of scope.

## Test plan

Two parametrized Solidity tests (Solc and Resolc backends) using a new `NestedDeployer` fixture:

- **`root_call_can_create_and_destroy_in_same_tx`** — Root invokes a deployer that creates a child and immediately calls `selfdestruct` on it (`only_if_same_tx: true`, EIP-6780). Asserts the child is gone post-call.
- **`root_call_can_create_and_destroy_in_next_block`** — Root creates the child in block N, then in block N+1 calls the child's `destroyViaPrecompile` (`ISystem.terminate`, `only_if_same_tx: false`). Asserts the child is gone, and that no storage-deposit hold landed on the child or deployer and no EVM upload deposit hit the pallet sentinel.

The `resolc → solc` combination is omitted because PVM `new` references a baked-in PVM code hash; a Resolc parent cannot create an EVM child. The runtime has no Root-only path that could bypass this (Root only reaches CREATE via an intermediary contract, which is constrained by its compilation backend).

Existing `root_cannot_instantiate{,_with_code}` and `root_can_call` continue to pass. Full `pallet-revive` suite is green.
