### PR TITLE
Remove deprecated NegativeImbalance from polkadot-runtime-common

### DIFF
--- a/polkadot/runtime/common/src/lib.rs
+++ b/polkadot/runtime/common/src/lib.rs
@@ -45,7 +45,7 @@ extern crate alloc;
 
 use frame_support::{
 	parameter_types,
-	traits::{ConstU32, Currency, OneSessionHandler},
+	traits::{ConstU32, OneSessionHandler},
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 };
 use frame_system::limits;
@@ -64,13 +64,6 @@ pub use sp_runtime::BuildStorage;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub use impls::ToAuthor;
-
-#[deprecated(
-	note = "Please use fungible::Credit instead. This type will be removed some time after March 2024."
-)]
-pub type NegativeImbalance<T> = <pallet_balances::Pallet<T> as Currency<
-	<T as frame_system::Config>::AccountId,
->>::NegativeImbalance;
 
 /// We assume that an on-initialize consumes 1% of the weight on average, hence a single extrinsic
 /// will not be allowed to consume more than `AvailableBlockRatio - 1%`.

--- a/prdoc/pr_12145.prdoc
+++ b/prdoc/pr_12145.prdoc
@@ -1,19 +1,11 @@
 title: Remove deprecated NegativeImbalance from polkadot-runtime-common
 doc:
 - audience: Runtime Dev
-  description: "# Description\n\nRemoves deprecated `polkadot_runtime_common::NegativeImbalance`\
-    \ as part of #11561.\n\nThe type alias was deprecated in March 2024 in favor of\
-    \ `fungible::Credit`. It has no remaining usage in this repository.\n\nDoes not\
-    \ close #11561.\n\n## Integration\n\nDownstream code using `polkadot_runtime_common::NegativeImbalance`\
-    \ must switch before upgrading:\n\nUse `fungible::Credit` from `frame_support::traits`\
-    \ instead.\n\n## Review Notes\n\n- Single-file change: `polkadot/runtime/common/src/lib.rs`\n\
-    - Verified no in-repo references before removal\n- Removed unused `Currency` import\
-    \ from `lib.rs`\n\n# Checklist\n\n* [x] My PR includes a detailed description\
-    \ as outlined in the \"Description\" and its two subsections above.\n* [ ] My\
-    \ PR follows the labeling requirements of this project (at minimum one label for\
-    \ `T` required)\n* [ ] I have made corresponding changes to the documentation\
-    \ (if applicable) \u2014 N/A\n* [ ] I have added tests that prove my fix is effective\
-    \ or that my feature works (if applicable) \u2014 N/A"
+  description: |-
+    Removes `polkadot_runtime_common::NegativeImbalance`, deprecated in March 2024
+    in favor of `fungible::Credit`. No remaining in-repo usage.
+
+    Downstream: use `fungible::Credit` from `frame_support::traits` instead.
 crates:
 - name: polkadot-runtime-common
   bump: major

--- a/prdoc/pr_12145.prdoc
+++ b/prdoc/pr_12145.prdoc
@@ -1,0 +1,19 @@
+title: Remove deprecated NegativeImbalance from polkadot-runtime-common
+doc:
+- audience: Runtime Dev
+  description: "# Description\n\nRemoves deprecated `polkadot_runtime_common::NegativeImbalance`\
+    \ as part of #11561.\n\nThe type alias was deprecated in March 2024 in favor of\
+    \ `fungible::Credit`. It has no remaining usage in this repository.\n\nDoes not\
+    \ close #11561.\n\n## Integration\n\nDownstream code using `polkadot_runtime_common::NegativeImbalance`\
+    \ must switch before upgrading:\n\nUse `fungible::Credit` from `frame_support::traits`\
+    \ instead.\n\n## Review Notes\n\n- Single-file change: `polkadot/runtime/common/src/lib.rs`\n\
+    - Verified no in-repo references before removal\n- Removed unused `Currency` import\
+    \ from `lib.rs`\n\n# Checklist\n\n* [x] My PR includes a detailed description\
+    \ as outlined in the \"Description\" and its two subsections above.\n* [ ] My\
+    \ PR follows the labeling requirements of this project (at minimum one label for\
+    \ `T` required)\n* [ ] I have made corresponding changes to the documentation\
+    \ (if applicable) \u2014 N/A\n* [ ] I have added tests that prove my fix is effective\
+    \ or that my feature works (if applicable) \u2014 N/A"
+crates:
+- name: polkadot-runtime-common
+  bump: major


### PR DESCRIPTION
# Description

Removes deprecated `polkadot_runtime_common::NegativeImbalance` as part of #11561.

The type alias was deprecated in March 2024 in favor of `fungible::Credit`. It has no remaining usage in this repository.

Does not close #11561.

## Integration

Downstream code using `polkadot_runtime_common::NegativeImbalance` must switch before upgrading:

Use `fungible::Credit` from `frame_support::traits` instead.

## Review Notes

- Single-file change: `polkadot/runtime/common/src/lib.rs`
- Verified no in-repo references before removal
- Removed unused `Currency` import from `lib.rs`

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the labeling requirements of this project (at minimum one label for `T` required)
* [ ] I have made corresponding changes to the documentation (if applicable) — N/A
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — N/A