### PR TITLE
Remove deprecated WeightMeter::defensive_saturating_accrue

### DIFF
--- a/prdoc/pr_12146.prdoc
+++ b/prdoc/pr_12146.prdoc
@@ -1,0 +1,27 @@
+title: Remove deprecated WeightMeter::defensive_saturating_accrue
+doc:
+- audience: Runtime Dev
+  description: |-
+    # Description
+
+    Removes deprecated `WeightMeter::defensive_saturating_accrue` as part of #11561.
+
+    Deprecated in December 2023 in favor of `consume`. No remaining in-repo usage.
+
+    Does not close #11561.
+
+    ## Integration
+
+    Replace calls with `consume`:
+
+    ```diff
+    - meter.defensive_saturating_accrue(weight);
+    + meter.consume(weight);
+    ```
+    Review Notes
+
+    - Single-file change in sp-weights
+    - Other` defensive_saturating_accrue i`n the repo are unrelated traits `(frame_support::traits::misc)`
+crates:
+- name: sp-weights
+  bump: major

--- a/prdoc/pr_12146.prdoc
+++ b/prdoc/pr_12146.prdoc
@@ -2,26 +2,16 @@ title: Remove deprecated WeightMeter::defensive_saturating_accrue
 doc:
 - audience: Runtime Dev
   description: |-
-    # Description
-
-    Removes deprecated `WeightMeter::defensive_saturating_accrue` as part of #11561.
-
-    Deprecated in December 2023 in favor of `consume`. No remaining in-repo usage.
-
-    Does not close #11561.
-
-    ## Integration
-
-    Replace calls with `consume`:
+    Removes `WeightMeter::defensive_saturating_accrue`, deprecated in December 2023 in favor
+    of `consume`. No remaining in-repo usage.
 
     ```diff
     - meter.defensive_saturating_accrue(weight);
     + meter.consume(weight);
     ```
-    Review Notes
 
-    - Single-file change in sp-weights
-    - Other` defensive_saturating_accrue i`n the repo are unrelated traits `(frame_support::traits::misc)`
+    Other `defensive_saturating_accrue` in the repo are on unrelated traits in
+    `frame_support::traits::misc`, not `WeightMeter`.
 crates:
 - name: sp-weights
   bump: major

--- a/substrate/primitives/weights/src/weight_meter.rs
+++ b/substrate/primitives/weights/src/weight_meter.rs
@@ -119,12 +119,6 @@ impl WeightMeter {
 	}
 
 	/// Consume some weight and defensively fail if it is over the limit. Saturate in any case.
-	#[deprecated(note = "Use `consume` instead. Will be removed after December 2023.")]
-	pub fn defensive_saturating_accrue(&mut self, w: Weight) {
-		self.consume(w);
-	}
-
-	/// Consume some weight and defensively fail if it is over the limit. Saturate in any case.
 	pub fn consume(&mut self, w: Weight) {
 		self.consumed.saturating_accrue(w);
 		debug_assert!(self.consumed.all_lte(self.limit), "Weight counter overflow");


### PR DESCRIPTION
# Description

Removes deprecated `WeightMeter::defensive_saturating_accrue` as part of #11561.

Deprecated in December 2023 in favor of `consume`. No remaining in-repo usage.

Does not close #11561.

## Integration

Replace calls with `consume`:

```diff
- meter.defensive_saturating_accrue(weight);
+ meter.consume(weight);
```
Review Notes

- Single-file change in sp-weights
- Other` defensive_saturating_accrue i`n the repo are unrelated traits `(frame_support::traits::misc)`