### PR TITLE
make polkadot/cumulus workflows required

### DIFF
--- a/.github/workflows/build-publish-images.yml
+++ b/.github/workflows/build-publish-images.yml
@@ -786,9 +786,8 @@ jobs:
     runs-on: ubuntu-latest
     name: All zombienet tests passed
     needs:
-      # Disabled until zombienet polkadot/cumulus flows are stable
-      # - trigger-zombienet-polkadot
-      # - trigger-zombienet-cumulus
+      - trigger-zombienet-polkadot
+      - trigger-zombienet-cumulus
       - trigger-zombienet-substrate
       - trigger-zombienet-parachain-template
     if: always() && !cancelled()


### PR DESCRIPTION
Make polkadot/cumulus zombienet test required again.

cc: @sandreim 