### PR TITLE
fix(child-bounties): fix curator assignment bugs in unassign and award (RWF)

### DIFF
--- a/substrate/frame/child-bounties/src/lib.rs
+++ b/substrate/frame/child-bounties/src/lib.rs
@@ -590,6 +590,9 @@ pub mod pallet {
 							// Continue to change child-bounty status below.
 						},
 					};
+					ChildrenCuratorFees::<T>::mutate(parent_bounty_id, |value| {
+						*value = value.saturating_sub(child_bounty.fee)
+					});
 					// Move the child-bounty state to Added.
 					child_bounty.status = ChildBountyStatus::Added;
 					Ok(())
@@ -643,7 +646,7 @@ pub mod pallet {
 						);
 						// Move the child-bounty state to pending payout.
 						child_bounty.status = ChildBountyStatus::PendingPayout {
-							curator: signer,
+							curator: curator.clone(),
 							beneficiary: beneficiary.clone(),
 							unlock_at: Self::treasury_block_number() +
 								T::BountyDepositPayoutDelay::get(),


### PR DESCRIPTION
Fixes #12192: `unassign_curator` can return a child bounty to `Added` status without subtracting the child curator fee from `ChildrenCuratorFees`.
This PR adds the missing mutation to ensure parent-bounty accounting is not inflated after the unassignment.

Fixes #12190: When a parent curator awards an active child bounty, the pallet incorrectly records the parent curator (the `signer`) as the `PendingPayout.curator` instead of preserving the child-bounty curator.
This PR fixes it by using `curator.clone()` instead of `signer`.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana)