### PR TITLE
[pallet-assets-precompiles] saturate permit/approval allowance

### DIFF
--- a/prdoc/pr_12196.prdoc
+++ b/prdoc/pr_12196.prdoc
@@ -1,0 +1,19 @@
+title: '[pallet-assets-precompiles] saturate permit/approval allowance'
+doc:
+- audience: Runtime Dev
+  description: "## Summary\n\n`approve()` / `permit()` previously reverted with `\"\
+    Balance conversion failed\"` on `call.value > Balance::MAX` \u2014 including `type(uint256).max`,\
+    \ the universal \"infinite allowance\" idiom hard-coded by MetaMask, Uniswap,\
+    \ and every mainstream DEX router. The U256 \u2192 Balance conversion now saturates\
+    \ at `Balance::MAX`. `transfer` / `transferFrom` keep the existing revert-on-overflow\
+    \ behavior \u2014 they move exact amounts, so silently clamping would produce\
+    \ partial transfers the caller never asked for. The emitted `Approval` event still\
+    \ carries the raw `call.value`, matching the ERC-20 / OpenZeppelin convention.\n\
+    \n## Non-goals\n\nNo `transferFrom` sentinel branch \u2014 saturated allowances\
+    \ decrement on every spend; on a `u128` runtime `Balance::MAX` is large enough\
+    \ to be operationally indistinguishable from infinite. No `allowance()` readback\
+    \ lift \u2014 returns the stored value as-is.\n\n## Test plan\n\n- [x] `cargo\
+    \ test -p pallet-assets-precompiles`"
+crates:
+- name: pallet-assets-precompiles
+  bump: minor

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -28,6 +28,7 @@ use ethereum_standards::{
 };
 use frame_support::traits::fungibles::metadata::Inspect as MetadataInspect;
 use pallet_assets::{weights::WeightInfo as _, Call, Config, TransferFlags};
+use sp_runtime::traits::{UniqueSaturatedInto, Zero};
 use pallet_revive::precompiles::{
 	alloy::{
 		self,
@@ -344,13 +345,16 @@ where
 	/// Implements ERC-20 set semantics: `approve(spender, N)` sets the allowance to exactly `N`
 	/// rather than adding to it. When overwriting a non-zero allowance, the existing approval is
 	/// cancelled first so the new value replaces (not accumulates with) the old one.
+	///
+	/// `call.value > Balance::MAX` (the `type(uint256).max` "infinite allowance" idiom)
+	/// saturates the stored allowance at `Balance::MAX`. The `Approval` event carries the
+	/// raw `call.value`.
 	fn approve(
 		asset_id: <Runtime as Config<Instance>>::AssetId,
 		call: &IERC20::approveCall,
 		env: &mut impl Ext<T = Runtime>,
 	) -> Result<Vec<u8>, Error> {
 		use frame_support::traits::fungibles::approvals::Inspect as ApprovalsInspect;
-		use sp_runtime::traits::Zero;
 
 		// Reserve worst-case gas upfront, then refund the unused portion.
 		let worst_case = <Runtime as Config<Instance>>::WeightInfo::allowance()
@@ -363,7 +367,9 @@ where
 			<Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&owner);
 		let spender: H160 = call.spender.into_array().into();
 		let spender_account = env.to_account_id(&spender);
-		let new_amount = Self::to_balance(call.value)?;
+		// Saturate: `type(uint256).max` is the standard "infinite allowance" idiom and must
+		// not revert at the conversion boundary.
+		let new_amount: <Runtime as Config<Instance>>::Balance = call.value.unique_saturated_into();
 
 		let current = pallet_assets::Pallet::<Runtime, Instance>::allowance(
 			asset_id.clone(),
@@ -467,7 +473,8 @@ where
 	/// Execute the permit call (EIP-2612).
 	///
 	/// This verifies the signature, consumes the permit (increments nonce),
-	/// and sets the approval.
+	/// and sets the approval. Saturation policy and event payload match `approve` —
+	/// see its doc-comment.
 	pub(crate) fn permit(
 		asset_id: <Runtime as Config<Instance>>::AssetId,
 		verifying_contract: H160,
@@ -531,14 +538,15 @@ where
 				let spender_account =
 					<Runtime as pallet_revive::Config>::AddressMapper::to_account_id(&spender_h160);
 
-				let new_amount = Self::to_balance(call.value)?;
+				// Saturate: see `approve` for the rationale (infinite-allowance idiom).
+				let new_amount: <Runtime as Config<Instance>>::Balance =
+					call.value.unique_saturated_into();
 				let current = pallet_assets::Pallet::<Runtime, Instance>::allowance(
 					asset_id.clone(),
 					&owner_account,
 					&spender_account,
 				);
 
-				use sp_runtime::traits::Zero;
 				let actual_weight;
 				if new_amount.is_zero() {
 					if !current.is_zero() {

--- a/substrate/frame/assets/precompiles/src/lib.rs
+++ b/substrate/frame/assets/precompiles/src/lib.rs
@@ -28,7 +28,6 @@ use ethereum_standards::{
 };
 use frame_support::traits::fungibles::metadata::Inspect as MetadataInspect;
 use pallet_assets::{weights::WeightInfo as _, Call, Config, TransferFlags};
-use sp_runtime::traits::{UniqueSaturatedInto, Zero};
 use pallet_revive::precompiles::{
 	alloy::{
 		self,
@@ -37,6 +36,7 @@ use pallet_revive::precompiles::{
 	},
 	AddressMapper, AddressMatcher, Error, Ext, Precompile, RuntimeCosts, H160, H256,
 };
+use sp_runtime::traits::{UniqueSaturatedInto, Zero};
 use weights::WeightInfo as _;
 
 pub mod foreign_assets;

--- a/substrate/frame/assets/precompiles/src/permit_precompile_tests.rs
+++ b/substrate/frame/assets/precompiles/src/permit_precompile_tests.rs
@@ -743,6 +743,58 @@ fn permit_saturates_on_uint256_max() {
 	});
 }
 
+/// Mirrors `approve_saturates_above_balance_max`: pins the invariant that
+/// saturation applies to *any* `U256` exceeding `Balance::MAX`, not only the
+/// `U256::MAX` sentinel. Both `approve` and `permit` go through the same
+/// `unique_saturated_into()` conversion, so a regression that scopes the
+/// saturation to the sentinel would break this path identically.
+#[test]
+fn permit_saturates_just_above_balance_max() {
+	use frame_support::traits::fungibles::approvals::Inspect;
+
+	new_test_ext().execute_with(|| {
+		let setup = permit_setup(PRECOMPILE_ADDRESS_PREFIX);
+
+		// Smallest `U256` that doesn't fit in the mock's `Balance` (u128).
+		let just_over = AlloyU256::from(u128::MAX) + AlloyU256::from(1u64);
+		let (v, r, s) =
+			sign_permit(setup.asset_addr, setup.spender_addr, just_over, setup.deadline);
+		let result = raw_permit(
+			setup.submitter,
+			setup.asset_addr,
+			HARDHAT_ACCOUNT_0,
+			setup.spender_addr,
+			just_over,
+			setup.deadline,
+			v,
+			r,
+			s,
+		);
+		let exec = result.result.expect("permit must not trap");
+		assert!(!exec.did_revert(), "permit(u128::MAX + 1) must not revert: {:?}", exec);
+
+		// Stored allowance is saturated to `Balance::MAX`; nonce advanced.
+		assert_eq!(
+			Assets::allowance(setup.asset_id, &setup.owner_account, &setup.spender_account),
+			u128::MAX,
+		);
+		assert_eq!(
+			permit::Pallet::<Test>::nonce(&setup.asset_addr, &HARDHAT_ACCOUNT_0),
+			U256::one(),
+		);
+
+		// Event carries the raw signed value, not the saturated stored amount.
+		assert_contract_event(
+			setup.asset_addr,
+			IERC20Events::Approval(IERC20::Approval {
+				owner: HARDHAT_ACCOUNT_0.0.into(),
+				spender: setup.spender_addr.0.into(),
+				value: just_over,
+			}),
+		);
+	});
+}
+
 /// If the owner can't afford the `ApprovalDeposit`, `do_approve_transfer`
 /// returns a `DispatchError` (Error::Error → trap). Distinct failure
 /// path from the revert-based `to_balance` test.

--- a/substrate/frame/assets/precompiles/src/permit_precompile_tests.rs
+++ b/substrate/frame/assets/precompiles/src/permit_precompile_tests.rs
@@ -693,13 +693,13 @@ fn permit_rollback_preserves_prior_allowance() {
 	});
 }
 
-/// `to_balance` failure (value > runtime Balance capacity) returns
-/// `Error::Revert("Balance conversion failed")` *after* `use_permit`
-/// has incremented the nonce. The `with_transaction` wrapper must roll
-/// the nonce back. Distinct failure surface from the frozen-asset test
-/// (revert vs DispatchError trap).
+/// `permit(value = uint256.max)` is the gasless infinite-allowance idiom
+/// (EIP-2612). `U256::MAX` doesn't fit in the runtime `Balance`, so the
+/// precompile saturates the *stored* allowance at `Balance::MAX` rather
+/// than reverting at the conversion. Nonce advances normally and the
+/// `Approval` event carries the raw signed value.
 #[test]
-fn permit_value_overflow_rolls_back() {
+fn permit_saturates_on_uint256_max() {
 	use frame_support::traits::fungibles::approvals::Inspect;
 
 	new_test_ext().execute_with(|| {
@@ -718,17 +718,28 @@ fn permit_value_overflow_rolls_back() {
 			r,
 			s,
 		);
-		assert_permit_reverted_with(result, "Balance conversion failed");
-		assert_eq!(
-			permit::Pallet::<Test>::nonce(&setup.asset_addr, &HARDHAT_ACCOUNT_0),
-			U256::zero(),
-			"nonce must roll back when to_balance fails after use_permit"
-		);
+		let exec = result.result.expect("permit must not trap");
+		assert!(!exec.did_revert(), "permit(uint256.max) must not revert: {:?}", exec);
+
+		// Stored allowance is saturated to `Balance::MAX`; nonce advanced.
 		assert_eq!(
 			Assets::allowance(setup.asset_id, &setup.owner_account, &setup.spender_account),
-			0
+			u128::MAX,
 		);
-		assert_no_contract_event_from(setup.asset_addr);
+		assert_eq!(
+			permit::Pallet::<Test>::nonce(&setup.asset_addr, &HARDHAT_ACCOUNT_0),
+			U256::one(),
+		);
+
+		// Event carries the raw signed value, not the saturated stored amount.
+		assert_contract_event(
+			setup.asset_addr,
+			IERC20Events::Approval(IERC20::Approval {
+				owner: HARDHAT_ACCOUNT_0.0.into(),
+				spender: setup.spender_addr.0.into(),
+				value: huge,
+			}),
+		);
 	});
 }
 

--- a/substrate/frame/assets/precompiles/src/tests.rs
+++ b/substrate/frame/assets/precompiles/src/tests.rs
@@ -870,8 +870,7 @@ fn transfer_from_decrements_normally_after_max_approve(asset_index: u16) {
 
 		let owner_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&owner);
 		let spender_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&spender);
-		let recipient_addr =
-			<Test as pallet_revive::Config>::AddressMapper::to_address(&recipient);
+		let recipient_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&recipient);
 
 		setup_asset_for_prefix(asset_id, asset_index);
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, true, 1));

--- a/substrate/frame/assets/precompiles/src/tests.rs
+++ b/substrate/frame/assets/precompiles/src/tests.rs
@@ -713,3 +713,193 @@ fn delegatecall_is_rejected() {
 		assert!(!ret.success, "DELEGATECALL to asset precompile must be rejected");
 	});
 }
+
+/// `approve(spender, type(uint256).max)` is the universal "infinite allowance" idiom in EVM
+/// tooling (MetaMask, Uniswap, every DEX router). `U256::MAX` doesn't fit in the runtime
+/// `Balance`, so the precompile must saturate the *stored* allowance at `Balance::MAX`
+/// rather than revert at the conversion. The `Approval` event still carries the raw
+/// `call.value` (`U256::MAX`) so EVM wallets and indexers recognise the canonical
+/// "Unlimited approval" sentinel.
+#[test_case(PRECOMPILE_ADDRESS_PREFIX)]
+#[test_case(PRECOMPILE_ADDRESS_PREFIX_FOREIGN)]
+fn approve_saturates_on_uint256_max(asset_index: u16) {
+	use frame_support::traits::fungibles::approvals::Inspect;
+
+	new_test_ext().execute_with(|| {
+		let asset_id = 0u32;
+		let asset_addr = H160::from(set_prefix_in_address(asset_index));
+		let owner = 123456789u64;
+		let spender = 987654321u64;
+		Balances::make_free_balance_be(&owner, 100);
+
+		let owner_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&owner);
+		let spender_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&spender);
+
+		setup_asset_for_prefix(asset_id, asset_index);
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, true, 1));
+
+		call_approve(owner, asset_addr, spender_addr, U256::MAX);
+
+		// Stored allowance is saturated to `Balance::MAX`.
+		assert_eq!(Assets::allowance(asset_id, &owner, &spender), u128::MAX);
+
+		// Event carries the raw `call.value`, not the saturated stored amount.
+		assert_contract_event(
+			asset_addr,
+			IERC20Events::Approval(IERC20::Approval {
+				owner: owner_addr.0.into(),
+				spender: spender_addr.0.into(),
+				value: U256::MAX,
+			}),
+		);
+	});
+}
+
+/// Boundary: saturation must trigger for *any* `U256 > Balance::MAX`, not only the exact
+/// `U256::MAX` sentinel. Guards against a regression that would scope saturation to the
+/// `call.value == U256::MAX` literal — routers that compute "infinite allowance" as
+/// `U256::MAX - k` for small `k` would still need to work.
+#[test_case(PRECOMPILE_ADDRESS_PREFIX)]
+#[test_case(PRECOMPILE_ADDRESS_PREFIX_FOREIGN)]
+fn approve_saturates_above_balance_max(asset_index: u16) {
+	use frame_support::traits::fungibles::approvals::Inspect;
+
+	new_test_ext().execute_with(|| {
+		let asset_id = 0u32;
+		let asset_addr = H160::from(set_prefix_in_address(asset_index));
+		let owner = 123456789u64;
+		let spender = 987654321u64;
+		Balances::make_free_balance_be(&owner, 100);
+
+		let spender_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&spender);
+
+		setup_asset_for_prefix(asset_id, asset_index);
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, true, 1));
+
+		// Smallest `U256` that doesn't fit in the mock's `Balance` (u128).
+		let just_over = U256::from(u128::MAX) + U256::from(1u64);
+		call_approve(owner, asset_addr, spender_addr, just_over);
+		assert_eq!(Assets::allowance(asset_id, &owner, &spender), u128::MAX);
+	});
+}
+
+/// Asymmetry pin: `transfer` and `transferFrom` move exact amounts, so an overflowing
+/// `value` must revert at the `U256 → Balance` boundary rather than silently
+/// transferring `Balance::MAX`. Only allowance writes (`approve` / `permit`) saturate.
+#[test]
+fn transfer_and_transfer_from_revert_on_overflow() {
+	use alloy::sol_types::{Revert, SolError};
+
+	new_test_ext().execute_with(|| {
+		let asset_id = 0u32;
+		let asset_addr = H160::from(set_prefix_in_address(PRECOMPILE_ADDRESS_PREFIX));
+		let from = 123456789u64;
+		let to = 987654321u64;
+		Balances::make_free_balance_be(&from, 100);
+		Balances::make_free_balance_be(&to, 100);
+		let from_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&from);
+		let to_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&to);
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, from, true, 1));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(from), asset_id, from, 100));
+
+		// Authorise the spender with a small finite allowance so the `transferFrom`
+		// path reaches the value conversion before any approval check.
+		call_approve(from, asset_addr, to_addr, U256::from(50u64));
+
+		let assert_reverts_with = |caller: u64, data: Vec<u8>, label: &str| {
+			let exec = pallet_revive::Pallet::<Test>::bare_call(
+				RuntimeOrigin::signed(caller),
+				asset_addr,
+				0u32.into(),
+				TransactionLimits::WeightAndDeposit {
+					weight_limit: Weight::MAX,
+					deposit_limit: u128::MAX,
+				},
+				data,
+				&ExecConfig::new_substrate_tx(),
+			)
+			.result
+			.expect("must not trap");
+			assert!(exec.did_revert(), "{label} must revert on overflow");
+			let decoded = Revert::abi_decode(&exec.data).expect("Error(string) revert");
+			assert_eq!(
+				decoded.reason, "Balance conversion failed",
+				"{label} must revert at the U256 -> Balance boundary",
+			);
+		};
+
+		let transfer_data =
+			IERC20::transferCall { to: to_addr.0.into(), value: U256::MAX }.abi_encode();
+		assert_reverts_with(from, transfer_data, "transfer(uint256.max)");
+
+		let transfer_from_data = IERC20::transferFromCall {
+			from: from_addr.0.into(),
+			to: to_addr.0.into(),
+			value: U256::MAX,
+		}
+		.abi_encode();
+		assert_reverts_with(to, transfer_from_data, "transferFrom(_, _, uint256.max)");
+
+		// Nothing moved.
+		assert_eq!(Assets::balance(asset_id, from), 100);
+		assert_eq!(Assets::balance(asset_id, to), 0);
+	});
+}
+
+/// No on-chain sentinel: after `approve(uint256.max)` (which saturates to `Balance::MAX`),
+/// each `transferFrom` still decrements the stored allowance. This pins the deliberate
+/// departure from OpenZeppelin's `_spendAllowance` skip-on-`type(uint256).max` rule — on
+/// this chain there is no allowance-state inspection that can distinguish a saturated
+/// `uint256.max` approval from a finite `Balance::MAX` approval, so we don't try.
+/// `Balance::MAX` is large enough that this is operationally indistinguishable from
+/// infinite for any realistic transfer cadence.
+#[test_case(PRECOMPILE_ADDRESS_PREFIX)]
+#[test_case(PRECOMPILE_ADDRESS_PREFIX_FOREIGN)]
+fn transfer_from_decrements_normally_after_max_approve(asset_index: u16) {
+	use frame_support::traits::fungibles::approvals::Inspect;
+
+	new_test_ext().execute_with(|| {
+		let asset_id = 0u32;
+		let asset_addr = H160::from(set_prefix_in_address(asset_index));
+		let owner = 123456789u64;
+		let spender = 987654321u64;
+		let recipient = 111222333u64;
+		Balances::make_free_balance_be(&owner, 100);
+		Balances::make_free_balance_be(&spender, 100);
+		Balances::make_free_balance_be(&recipient, 100);
+
+		let owner_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&owner);
+		let spender_addr = <Test as pallet_revive::Config>::AddressMapper::to_address(&spender);
+		let recipient_addr =
+			<Test as pallet_revive::Config>::AddressMapper::to_address(&recipient);
+
+		setup_asset_for_prefix(asset_id, asset_index);
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, true, 1));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(owner), asset_id, owner, 100));
+
+		call_approve(owner, asset_addr, spender_addr, U256::MAX);
+		assert_eq!(Assets::allowance(asset_id, &owner, &spender), u128::MAX);
+
+		// Each `transferFrom` decrements the saturated allowance by the spent amount.
+		let data = IERC20::transferFromCall {
+			from: owner_addr.0.into(),
+			to: recipient_addr.0.into(),
+			value: U256::from(10u64),
+		}
+		.abi_encode();
+		let result = pallet_revive::Pallet::<Test>::bare_call(
+			RuntimeOrigin::signed(spender),
+			asset_addr,
+			0u32.into(),
+			TransactionLimits::WeightAndDeposit {
+				weight_limit: Weight::MAX,
+				deposit_limit: u128::MAX,
+			},
+			data,
+			&ExecConfig::new_substrate_tx(),
+		);
+		assert!(!result.result.unwrap().did_revert(), "transferFrom must succeed");
+		assert_eq!(Assets::allowance(asset_id, &owner, &spender), u128::MAX - 10);
+		assert_eq!(Assets::balance(asset_id, &recipient), 10);
+	});
+}


### PR DESCRIPTION
## Summary

`approve()` / `permit()` previously reverted with `"Balance conversion failed"` on `call.value > Balance::MAX` — including `type(uint256).max`, the universal "infinite allowance" idiom hard-coded by MetaMask, Uniswap, and every mainstream DEX router. The U256 → Balance conversion now saturates at `Balance::MAX`. `transfer` / `transferFrom` keep the existing revert-on-overflow behavior — they move exact amounts, so silently clamping would produce partial transfers the caller never asked for. The emitted `Approval` event still carries the raw `call.value`, matching the ERC-20 / OpenZeppelin convention.

## Non-goals

No `transferFrom` sentinel branch — saturated allowances decrement on every spend; on a `u128` runtime `Balance::MAX` is large enough to be operationally indistinguishable from infinite. No `allowance()` readback lift — returns the stored value as-is.

## Test plan

- [x] `cargo test -p pallet-assets-precompiles`
