### PR TITLE
Clock abstraction: Preparation for deterministic simulation testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16252,6 +16252,7 @@ dependencies = [
  "itertools 0.11.0",
  "kvdb-memorydb",
  "parity-scale-codec",
+ "polkadot-node-clock",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -16403,6 +16404,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-node-clock"
+version = "7.0.0"
+dependencies = [
+ "futures-timer",
+]
+
+[[package]]
 name = "polkadot-node-collation-generation"
 version = "7.0.0"
 dependencies = [
@@ -16507,8 +16515,8 @@ dependencies = [
  "futures-timer",
  "kvdb-memorydb",
  "parity-scale-codec",
- "parking_lot 0.12.3",
  "polkadot-erasure-coding",
+ "polkadot-node-clock",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
@@ -16627,6 +16635,7 @@ dependencies = [
  "kvdb-memorydb",
  "parity-scale-codec",
  "parking_lot 0.12.3",
+ "polkadot-node-clock",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
@@ -16647,6 +16656,7 @@ dependencies = [
  "futures-timer",
  "kvdb-memorydb",
  "parity-scale-codec",
+ "polkadot-node-clock",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18013,6 +18013,7 @@ dependencies = [
  "polkadot-dispute-distribution",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
+ "polkadot-node-clock",
  "polkadot-node-collation-generation",
  "polkadot-node-core-approval-voting",
  "polkadot-node-core-approval-voting-parallel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17646,6 +17646,7 @@ dependencies = [
  "polkadot-erasure-coding",
  "polkadot-gossip-support",
  "polkadot-network-bridge",
+ "polkadot-node-clock",
  "polkadot-node-collation-generation",
  "polkadot-node-core-approval-voting",
  "polkadot-node-core-approval-voting-parallel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ members = [
 	"polkadot/erasure-coding",
 	"polkadot/erasure-coding/fuzzer",
 	"polkadot/jemalloc-shim",
+	"polkadot/node/clock",
 	"polkadot/node/collation-generation",
 	"polkadot/node/core/approval-voting",
 	"polkadot/node/core/approval-voting-parallel",
@@ -1122,6 +1123,7 @@ polkadot-erasure-coding = { path = "polkadot/erasure-coding", default-features =
 polkadot-gossip-support = { path = "polkadot/node/network/gossip-support", default-features = false }
 polkadot-jemalloc-shim = { path = "polkadot/jemalloc-shim" }
 polkadot-network-bridge = { path = "polkadot/node/network/bridge", default-features = false }
+polkadot-node-clock = { path = "polkadot/node/clock", default-features = false }
 polkadot-node-collation-generation = { path = "polkadot/node/collation-generation", default-features = false }
 polkadot-node-core-approval-voting = { path = "polkadot/node/core/approval-voting", default-features = false }
 polkadot-node-core-approval-voting-parallel = { path = "polkadot/node/core/approval-voting-parallel", default-features = false }

--- a/polkadot/node/clock/Cargo.toml
+++ b/polkadot/node/clock/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "polkadot-node-clock"
+version = "7.0.0"
+description = "Clock abstraction shared by Polkadot node subsystems."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+futures-timer = { workspace = true }
+
+[features]
+default = []
+# Exposes test helpers: a deterministic `MockClock` implementation.
+test = []

--- a/polkadot/node/clock/src/lib.rs
+++ b/polkadot/node/clock/src/lib.rs
@@ -1,0 +1,89 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Clock abstraction shared by Polkadot node subsystems.
+//!
+//! Production code uses [`SystemClock`]. Tests inject a deterministic mock so subsystems'
+//! time-dependent behavior can be driven and observed without wall-clock dependence.
+//!
+//! Subsystems that need time should accept `Arc<dyn Clock>` rather than reading
+//! `Instant::now()`, `SystemTime::now()`, `futures_timer::Delay::new(..)`, or
+//! `tokio::time::sleep(..)` directly. Consider enforcing this via a crate-level
+//! `clippy.toml` (see `polkadot-collator-protocol` for an example).
+//!
+//! Note: not every subsystem currently routes all of its time reads through this
+//! trait. In particular, `polkadot-node-core-chain-selection`,
+//! `polkadot-node-core-av-store`, and `polkadot-node-core-dispute-coordinator`
+//! presently use this trait only for their wall-clock reads and continue to call
+//! `futures_timer::Delay::new` directly for their internal timers. Those call sites
+//! need to be migrated before those subsystems can run under a deterministic test
+//! harness.
+
+#![deny(missing_docs)]
+#![deny(unused_crate_dependencies)]
+
+use std::{
+	future::Future,
+	pin::Pin,
+	sync::Arc,
+	time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+/// Boxed future returned by [`Clock::delay`].
+pub type BoxedDelay = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Abstraction over wall-clock time. See module-level docs.
+pub trait Clock: Send + Sync {
+	/// Monotonic timestamp suitable for measuring durations between two reads.
+	fn now(&self) -> Instant;
+
+	/// Future that resolves after `dur` has elapsed in this clock's frame.
+	fn delay(&self, dur: Duration) -> BoxedDelay;
+
+	/// Wall-clock millisecond timestamp since the UNIX epoch. Used for slot math and persistence
+	/// timestamps; not monotonic.
+	fn timestamp_millis(&self) -> u128;
+}
+
+/// Production clock backed by `std::time` and `futures_timer`.
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+	fn now(&self) -> Instant {
+		Instant::now()
+	}
+
+	fn delay(&self, dur: Duration) -> BoxedDelay {
+		Box::pin(futures_timer::Delay::new(dur))
+	}
+
+	fn timestamp_millis(&self) -> u128 {
+		SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.map(|d| d.as_millis())
+			.unwrap_or(0)
+	}
+}
+
+/// Convenience constructor returning a thread-safe handle to a [`SystemClock`].
+pub fn system_clock() -> Arc<dyn Clock> {
+	Arc::new(SystemClock)
+}
+
+#[cfg(feature = "test")]
+pub mod mock;
+#[cfg(feature = "test")]
+pub use mock::MockClock;

--- a/polkadot/node/clock/src/lib.rs
+++ b/polkadot/node/clock/src/lib.rs
@@ -53,9 +53,10 @@ pub trait Clock: Send + Sync {
 	/// Future that resolves after `dur` has elapsed in this clock's frame.
 	fn delay(&self, dur: Duration) -> BoxedDelay;
 
-	/// Wall-clock millisecond timestamp since the UNIX epoch. Used for slot math and persistence
-	/// timestamps; not monotonic.
-	fn timestamp_millis(&self) -> u128;
+	/// Wall-clock duration since the UNIX epoch. Used for slot math and persistence
+	/// timestamps; not monotonic. Callers pick a granularity (`as_secs`, `as_millis`)
+	/// at the call site.
+	fn duration_since_epoch(&self) -> Duration;
 }
 
 /// Production clock backed by `std::time` and `futures_timer`.
@@ -70,11 +71,10 @@ impl Clock for SystemClock {
 		Box::pin(futures_timer::Delay::new(dur))
 	}
 
-	fn timestamp_millis(&self) -> u128 {
+	fn duration_since_epoch(&self) -> Duration {
 		SystemTime::now()
 			.duration_since(UNIX_EPOCH)
-			.map(|d| d.as_millis())
-			.unwrap_or(0)
+			.expect("system time is before the UNIX epoch; check the system clock;")
 	}
 }
 

--- a/polkadot/node/clock/src/mock.rs
+++ b/polkadot/node/clock/src/mock.rs
@@ -1,0 +1,94 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Deterministic [`Clock`] implementation for tests.
+//!
+//! Stores a single wall-clock instant (in milliseconds since the UNIX epoch) that tests can
+//! advance explicitly via [`MockClock::set_millis`] / [`MockClock::inc`] /
+//! [`MockClock::inc_secs`].
+//!
+//! Note: this mock only virtualises wall-clock reads. `now()` still returns a real
+//! `Instant::now()` and `delay()` still uses a real `futures_timer::Delay`. Those are
+//! sufficient for current subsystem tests, which only assert on wall-clock-derived state. A
+//! follow-up could add fully virtual time (driving `delay` by `inc(_)`) once subsystems route
+//! their internal timers through the shared trait too.
+
+use crate::{BoxedDelay, Clock};
+use std::{
+	sync::{
+		atomic::{AtomicU64, Ordering},
+		Arc,
+	},
+	time::{Duration, Instant},
+};
+
+/// Test clock storing wall-clock milliseconds since the UNIX epoch.
+#[derive(Clone, Default)]
+pub struct MockClock {
+	millis: Arc<AtomicU64>,
+}
+
+impl MockClock {
+	/// Create a new clock fixed at the given wall-clock time in milliseconds since the UNIX
+	/// epoch.
+	pub fn new_at_millis(millis: u64) -> Self {
+		Self { millis: Arc::new(AtomicU64::new(millis)) }
+	}
+
+	/// Create a new clock fixed at the given wall-clock time in seconds since the UNIX epoch.
+	pub fn new_at_secs(secs: u64) -> Self {
+		Self::new_at_millis(secs.saturating_mul(1_000))
+	}
+
+	/// Advance the clock by `dur`.
+	pub fn inc(&self, dur: Duration) {
+		self.millis.fetch_add(dur.as_millis() as u64, Ordering::SeqCst);
+	}
+
+	/// Advance the clock by `secs` seconds.
+	pub fn inc_secs(&self, secs: u64) {
+		self.millis.fetch_add(secs.saturating_mul(1_000), Ordering::SeqCst);
+	}
+
+	/// Set the clock to the given wall-clock time in milliseconds since the UNIX epoch.
+	pub fn set_millis(&self, millis: u64) {
+		self.millis.store(millis, Ordering::SeqCst);
+	}
+
+	/// Set the clock to the given wall-clock time in seconds since the UNIX epoch.
+	pub fn set_secs(&self, secs: u64) {
+		self.set_millis(secs.saturating_mul(1_000));
+	}
+
+	/// Read the current wall-clock time in seconds since the UNIX epoch.
+	pub fn now_secs(&self) -> u64 {
+		self.millis.load(Ordering::SeqCst) / 1_000
+	}
+}
+
+impl Clock for MockClock {
+	fn now(&self) -> Instant {
+		Instant::now()
+	}
+
+	fn delay(&self, dur: Duration) -> BoxedDelay {
+		Box::pin(futures_timer::Delay::new(dur))
+	}
+
+	fn timestamp_millis(&self) -> u128 {
+		self.millis.load(Ordering::SeqCst) as u128
+	}
+}

--- a/polkadot/node/clock/src/mock.rs
+++ b/polkadot/node/clock/src/mock.rs
@@ -72,11 +72,6 @@ impl MockClock {
 	pub fn set_secs(&self, secs: u64) {
 		self.set_millis(secs.saturating_mul(1_000));
 	}
-
-	/// Read the current wall-clock time in seconds since the UNIX epoch.
-	pub fn now_secs(&self) -> u64 {
-		self.millis.load(Ordering::SeqCst) / 1_000
-	}
 }
 
 impl Clock for MockClock {
@@ -88,7 +83,7 @@ impl Clock for MockClock {
 		Box::pin(futures_timer::Delay::new(dur))
 	}
 
-	fn timestamp_millis(&self) -> u128 {
-		self.millis.load(Ordering::SeqCst) as u128
+	fn duration_since_epoch(&self) -> Duration {
+		Duration::from_millis(self.millis.load(Ordering::SeqCst))
 	}
 }

--- a/polkadot/node/core/av-store/Cargo.toml
+++ b/polkadot/node/core/av-store/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 
 codec = { features = ["derive"], workspace = true, default-features = true }
 polkadot-erasure-coding = { workspace = true, default-features = true }
+polkadot-node-clock = { workspace = true, default-features = true }
 polkadot-node-primitives = { workspace = true, default-features = true }
 polkadot-node-subsystem = { workspace = true, default-features = true }
 polkadot-node-subsystem-util = { workspace = true, default-features = true }
@@ -31,7 +32,7 @@ assert_matches = { workspace = true }
 kvdb-memorydb = { workspace = true }
 sp-tracing = { workspace = true }
 
-parking_lot = { workspace = true, default-features = true }
+polkadot-node-clock = { workspace = true, default-features = true, features = ["test"] }
 polkadot-node-subsystem-test-helpers = { workspace = true }
 polkadot-primitives-test-helpers = { workspace = true }
 sp-core = { workspace = true, default-features = true }

--- a/polkadot/node/core/av-store/src/lib.rs
+++ b/polkadot/node/core/av-store/src/lib.rs
@@ -429,11 +429,6 @@ pub struct Config {
 	pub keep_finalized_for: u32,
 }
 
-/// Read the wall-clock duration since the UNIX epoch via the shared [`Clock`] abstraction.
-fn now_since_epoch(clock: &dyn Clock) -> Duration {
-	Duration::from_millis(clock.timestamp_millis() as u64)
-}
-
 /// An implementation of the Availability Store subsystem.
 pub struct AvailabilityStoreSubsystem {
 	pruning_config: PruningConfig,
@@ -647,7 +642,7 @@ async fn start_prune_all<Context>(
 	let metrics = subsystem.metrics.clone();
 	let db = subsystem.db.clone();
 	let config = subsystem.config;
-	let time_now = now_since_epoch(&*subsystem.clock);
+	let time_now = subsystem.clock.duration_since_epoch();
 
 	ctx.spawn_blocking(
 		"av-store-prunning",
@@ -672,7 +667,7 @@ async fn process_block_activated<Context>(
 	subsystem: &mut AvailabilityStoreSubsystem,
 	activated: Hash,
 ) -> Result<(), Error> {
-	let now = now_since_epoch(&*subsystem.clock);
+	let now = subsystem.clock.duration_since_epoch();
 
 	let block_header = {
 		let (tx, rx) = oneshot::channel();
@@ -874,7 +869,7 @@ async fn process_block_finalized<Context>(
 	finalized_hash: Hash,
 	finalized_number: BlockNumber,
 ) -> Result<(), Error> {
-	let now = now_since_epoch(&*subsystem.clock);
+	let now = subsystem.clock.duration_since_epoch();
 
 	let mut next_possible_batch = 0;
 	loop {
@@ -1285,7 +1280,7 @@ fn store_available_data(
 			m
 		},
 		None => {
-			let now = now_since_epoch(&*subsystem.clock);
+			let now = subsystem.clock.duration_since_epoch();
 
 			// Write a pruning record.
 			let prune_at = now + subsystem.pruning_config.keep_unavailable_for;

--- a/polkadot/node/core/av-store/src/lib.rs
+++ b/polkadot/node/core/av-store/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
 	collections::{BTreeSet, HashMap, HashSet},
 	io,
 	sync::Arc,
-	time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH},
+	time::Duration,
 };
 
 use codec::{Decode, Encode, Error as CodecError, Input};
@@ -35,6 +35,7 @@ use futures::{
 	future, select, FutureExt, SinkExt, StreamExt,
 };
 use futures_timer::Delay;
+use polkadot_node_clock::Clock;
 use polkadot_node_subsystem_util::database::{DBTransaction, Database};
 use sp_consensus::SyncOracle;
 
@@ -365,9 +366,6 @@ pub enum Error {
 	ContextChannelClosed,
 
 	#[error(transparent)]
-	Time(#[from] SystemTimeError),
-
-	#[error(transparent)]
 	Codec(#[from] CodecError),
 
 	#[error("Custom databases are not supported")]
@@ -431,17 +429,9 @@ pub struct Config {
 	pub keep_finalized_for: u32,
 }
 
-trait Clock: Send + Sync {
-	// Returns time since unix epoch.
-	fn now(&self) -> Result<Duration, Error>;
-}
-
-struct SystemClock;
-
-impl Clock for SystemClock {
-	fn now(&self) -> Result<Duration, Error> {
-		SystemTime::now().duration_since(UNIX_EPOCH).map_err(Into::into)
-	}
+/// Read the wall-clock duration since the UNIX epoch via the shared [`Clock`] abstraction.
+fn now_since_epoch(clock: &dyn Clock) -> Duration {
+	Duration::from_millis(clock.timestamp_millis() as u64)
 }
 
 /// An implementation of the Availability Store subsystem.
@@ -452,7 +442,7 @@ pub struct AvailabilityStoreSubsystem {
 	known_blocks: KnownUnfinalizedBlocks,
 	finalized_number: Option<BlockNumber>,
 	metrics: Metrics,
-	clock: Box<dyn Clock>,
+	clock: Arc<dyn Clock>,
 	sync_oracle: Box<dyn SyncOracle + Send + Sync>,
 }
 
@@ -474,7 +464,7 @@ impl AvailabilityStoreSubsystem {
 			db,
 			config,
 			pruning_config,
-			Box::new(SystemClock),
+			polkadot_node_clock::system_clock(),
 			sync_oracle,
 			metrics,
 		)
@@ -485,7 +475,7 @@ impl AvailabilityStoreSubsystem {
 		db: Arc<dyn Database>,
 		config: Config,
 		pruning_config: PruningConfig,
-		clock: Box<dyn Clock>,
+		clock: Arc<dyn Clock>,
 		sync_oracle: Box<dyn SyncOracle + Send + Sync>,
 		metrics: Metrics,
 	) -> Self {
@@ -657,7 +647,7 @@ async fn start_prune_all<Context>(
 	let metrics = subsystem.metrics.clone();
 	let db = subsystem.db.clone();
 	let config = subsystem.config;
-	let time_now = subsystem.clock.now()?;
+	let time_now = now_since_epoch(&*subsystem.clock);
 
 	ctx.spawn_blocking(
 		"av-store-prunning",
@@ -682,7 +672,7 @@ async fn process_block_activated<Context>(
 	subsystem: &mut AvailabilityStoreSubsystem,
 	activated: Hash,
 ) -> Result<(), Error> {
-	let now = subsystem.clock.now()?;
+	let now = now_since_epoch(&*subsystem.clock);
 
 	let block_header = {
 		let (tx, rx) = oneshot::channel();
@@ -884,7 +874,7 @@ async fn process_block_finalized<Context>(
 	finalized_hash: Hash,
 	finalized_number: BlockNumber,
 ) -> Result<(), Error> {
-	let now = subsystem.clock.now()?;
+	let now = now_since_epoch(&*subsystem.clock);
 
 	let mut next_possible_batch = 0;
 	loop {
@@ -1295,7 +1285,7 @@ fn store_available_data(
 			m
 		},
 		None => {
-			let now = subsystem.clock.now()?;
+			let now = now_since_epoch(&*subsystem.clock);
 
 			// Write a pruning record.
 			let prune_at = now + subsystem.pruning_config.keep_unavailable_for;

--- a/polkadot/node/core/av-store/src/tests.rs
+++ b/polkadot/node/core/av-store/src/tests.rs
@@ -21,7 +21,6 @@ use futures::{channel::oneshot, executor, future, Future};
 use util::availability_chunks::availability_chunk_index;
 
 use self::test_helpers::mock::new_leaf;
-use parking_lot::Mutex;
 use polkadot_node_primitives::{AvailableData, BlockData, PoV, Proof};
 use polkadot_node_subsystem::{
 	errors::RuntimeApiError,
@@ -49,32 +48,13 @@ const TEST_CONFIG: Config =
 type VirtualOverseer =
 	polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle<AvailabilityStoreMessage>;
 
-#[derive(Clone)]
-struct TestClock {
-	inner: Arc<Mutex<Duration>>,
-}
-
-impl TestClock {
-	fn now(&self) -> Duration {
-		*self.inner.lock()
-	}
-
-	fn inc(&self, by: Duration) {
-		*self.inner.lock() += by;
-	}
-}
-
-impl Clock for TestClock {
-	fn now(&self) -> Result<Duration, Error> {
-		Ok(TestClock::now(self))
-	}
-}
+use polkadot_node_clock::MockClock;
 
 #[derive(Clone)]
 struct TestState {
 	persisted_validation_data: PersistedValidationData,
 	pruning_config: PruningConfig,
-	clock: TestClock,
+	clock: MockClock,
 }
 
 impl TestState {
@@ -100,7 +80,7 @@ impl Default for TestState {
 			pruning_interval: Duration::from_millis(250),
 		};
 
-		let clock = TestClock { inner: Arc::new(Mutex::new(Duration::from_secs(0))) };
+		let clock = MockClock::default();
 
 		Self { persisted_validation_data, pruning_config, clock }
 	}
@@ -133,7 +113,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		store,
 		TEST_CONFIG,
 		state.pruning_config.clone(),
-		Box::new(state.clock),
+		Arc::new(state.clock),
 		Box::new(NoSyncOracle),
 		Metrics::default(),
 	);

--- a/polkadot/node/core/chain-selection/Cargo.toml
+++ b/polkadot/node/core/chain-selection/Cargo.toml
@@ -16,6 +16,7 @@ codec = { workspace = true, default-features = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 gum = { workspace = true, default-features = true }
+polkadot-node-clock = { workspace = true, default-features = true }
 polkadot-node-primitives = { workspace = true, default-features = true }
 polkadot-node-subsystem = { workspace = true, default-features = true }
 polkadot-node-subsystem-util = { workspace = true, default-features = true }
@@ -26,5 +27,6 @@ thiserror = { workspace = true }
 assert_matches = { workspace = true }
 kvdb-memorydb = { workspace = true }
 parking_lot = { workspace = true, default-features = true }
+polkadot-node-clock = { workspace = true, default-features = true, features = ["test"] }
 polkadot-node-subsystem-test-helpers = { workspace = true }
 sp-core = { workspace = true, default-features = true }

--- a/polkadot/node/core/chain-selection/src/lib.rs
+++ b/polkadot/node/core/chain-selection/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! Implements the Chain Selection Subsystem.
 
+use polkadot_node_clock::Clock;
 use polkadot_node_primitives::BlockWeight;
 use polkadot_node_subsystem::{
 	errors::ChainApiError,
@@ -29,10 +30,7 @@ use polkadot_primitives::{BlockNumber, ConsensusLog, Hash, Header};
 use codec::Error as CodecError;
 use futures::{channel::oneshot, future::Either, prelude::*};
 
-use std::{
-	sync::Arc,
-	time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{sync::Arc, time::Duration};
 
 use crate::backend::{Backend, BackendWriteOp, OverlayedBackend};
 
@@ -221,37 +219,18 @@ impl Error {
 	}
 }
 
-/// A clock used for fetching the current timestamp.
-pub trait Clock {
-	/// Get the current timestamp.
-	fn timestamp_now(&self) -> Timestamp;
-}
-
-struct SystemClock;
-
-impl Clock for SystemClock {
-	fn timestamp_now(&self) -> Timestamp {
-		// `SystemTime` is notoriously non-monotonic, so our timers might not work
-		// exactly as expected. Regardless, stagnation is detected on the order of minutes,
-		// and slippage of a few seconds in either direction won't cause any major harm.
-		//
-		// The exact time that a block becomes stagnant in the local node is always expected
-		// to differ from other nodes due to network asynchrony and delays in block propagation.
-		// Non-monotonicity exacerbates that somewhat, but not meaningfully.
-
-		match SystemTime::now().duration_since(UNIX_EPOCH) {
-			Ok(d) => d.as_secs(),
-			Err(e) => {
-				gum::warn!(
-					target: LOG_TARGET,
-					err = ?e,
-					"Current time is before unix epoch. Validation will not work correctly."
-				);
-
-				0
-			},
-		}
-	}
+/// Read the wall-clock timestamp in seconds since the UNIX epoch, going through the shared
+/// [`Clock`] abstraction.
+///
+/// `SystemTime` is notoriously non-monotonic, so our timers might not work exactly as
+/// expected. Regardless, stagnation is detected on the order of minutes, and slippage of a few
+/// seconds in either direction won't cause any major harm.
+///
+/// The exact time that a block becomes stagnant in the local node is always expected to differ
+/// from other nodes due to network asynchrony and delays in block propagation.
+/// Non-monotonicity exacerbates that somewhat, but not meaningfully.
+fn timestamp_now(clock: &dyn Clock) -> Timestamp {
+	(clock.timestamp_millis() / 1000) as Timestamp
 }
 
 /// The interval, in seconds to check for stagnant blocks.
@@ -364,7 +343,7 @@ impl<Context> ChainSelectionSubsystem {
 				backend,
 				self.config.stagnant_check_interval,
 				self.config.stagnant_check_mode,
-				Box::new(SystemClock),
+				polkadot_node_clock::system_clock(),
 			)
 			.map(Ok)
 			.boxed(),
@@ -379,7 +358,7 @@ async fn run<Context, B>(
 	mut backend: B,
 	stagnant_check_interval: StagnantCheckInterval,
 	stagnant_check_mode: StagnantCheckMode,
-	clock: Box<dyn Clock + Send + Sync>,
+	clock: Arc<dyn Clock>,
 ) where
 	B: Backend,
 {
@@ -418,7 +397,7 @@ async fn run_until_error<Context, B>(
 	backend: &mut B,
 	stagnant_check_interval: &StagnantCheckInterval,
 	stagnant_check_mode: &StagnantCheckMode,
-	clock: &(dyn Clock + Sync),
+	clock: &dyn Clock,
 ) -> Result<(), Error>
 where
 	B: Backend,
@@ -437,7 +416,7 @@ where
 							let write_ops = handle_active_leaf(
 								ctx.sender(),
 								&*backend,
-								clock.timestamp_now() + STAGNANT_TIMEOUT,
+								timestamp_now(clock) + STAGNANT_TIMEOUT,
 								leaf.hash,
 							).await?;
 
@@ -477,9 +456,9 @@ where
 			}
 			_ = stagnant_check_stream.next().fuse() => {
 				match stagnant_check_mode {
-					StagnantCheckMode::CheckAndPrune => detect_stagnant(backend, clock.timestamp_now(), MAX_STAGNANT_ENTRIES),
+					StagnantCheckMode::CheckAndPrune => detect_stagnant(backend, timestamp_now(clock), MAX_STAGNANT_ENTRIES),
 					StagnantCheckMode::PruneOnly => {
-						let now_timestamp = clock.timestamp_now();
+						let now_timestamp = timestamp_now(clock);
 						prune_only_stagnant(backend, now_timestamp - STAGNANT_PRUNE_DELAY, MAX_STAGNANT_ENTRIES)
 					},
 				}?;

--- a/polkadot/node/core/chain-selection/src/lib.rs
+++ b/polkadot/node/core/chain-selection/src/lib.rs
@@ -219,19 +219,6 @@ impl Error {
 	}
 }
 
-/// Read the wall-clock timestamp in seconds since the UNIX epoch, going through the shared
-/// [`Clock`] abstraction.
-///
-/// `SystemTime` is notoriously non-monotonic, so our timers might not work exactly as
-/// expected. Regardless, stagnation is detected on the order of minutes, and slippage of a few
-/// seconds in either direction won't cause any major harm.
-///
-/// The exact time that a block becomes stagnant in the local node is always expected to differ
-/// from other nodes due to network asynchrony and delays in block propagation.
-/// Non-monotonicity exacerbates that somewhat, but not meaningfully.
-fn timestamp_now(clock: &dyn Clock) -> Timestamp {
-	(clock.timestamp_millis() / 1000) as Timestamp
-}
 
 /// The interval, in seconds to check for stagnant blocks.
 #[derive(Debug, Clone)]
@@ -416,7 +403,7 @@ where
 							let write_ops = handle_active_leaf(
 								ctx.sender(),
 								&*backend,
-								timestamp_now(clock) + STAGNANT_TIMEOUT,
+								clock.duration_since_epoch().as_secs() + STAGNANT_TIMEOUT,
 								leaf.hash,
 							).await?;
 
@@ -456,9 +443,9 @@ where
 			}
 			_ = stagnant_check_stream.next().fuse() => {
 				match stagnant_check_mode {
-					StagnantCheckMode::CheckAndPrune => detect_stagnant(backend, timestamp_now(clock), MAX_STAGNANT_ENTRIES),
+					StagnantCheckMode::CheckAndPrune => detect_stagnant(backend, clock.duration_since_epoch().as_secs(), MAX_STAGNANT_ENTRIES),
 					StagnantCheckMode::PruneOnly => {
-						let now_timestamp = timestamp_now(clock);
+						let now_timestamp = clock.duration_since_epoch().as_secs();
 						prune_only_stagnant(backend, now_timestamp - STAGNANT_PRUNE_DELAY, MAX_STAGNANT_ENTRIES)
 					},
 				}?;

--- a/polkadot/node/core/chain-selection/src/lib.rs
+++ b/polkadot/node/core/chain-selection/src/lib.rs
@@ -219,7 +219,6 @@ impl Error {
 	}
 }
 
-
 /// The interval, in seconds to check for stagnant blocks.
 #[derive(Debug, Clone)]
 pub struct StagnantCheckInterval(Option<Duration>);

--- a/polkadot/node/core/chain-selection/src/tests.rs
+++ b/polkadot/node/core/chain-selection/src/tests.rs
@@ -23,15 +23,13 @@
 use super::*;
 use std::{
 	collections::{BTreeMap, HashMap, HashSet},
-	sync::{
-		atomic::{AtomicU64, Ordering as AtomicOrdering},
-		Arc,
-	},
+	sync::Arc,
 };
 
 use assert_matches::assert_matches;
 use codec::Encode;
 use futures::channel::oneshot;
+use polkadot_node_clock::MockClock;
 use parking_lot::Mutex;
 use sp_core::testing::TaskExecutor;
 
@@ -208,45 +206,26 @@ impl Backend for TestBackend {
 	}
 }
 
-#[derive(Clone)]
-pub struct TestClock(Arc<AtomicU64>);
-
-impl TestClock {
-	fn new(initial: u64) -> Self {
-		TestClock(Arc::new(AtomicU64::new(initial)))
-	}
-
-	fn inc_by(&self, duration: u64) {
-		self.0.fetch_add(duration, AtomicOrdering::Relaxed);
-	}
-}
-
-impl Clock for TestClock {
-	fn timestamp_now(&self) -> Timestamp {
-		self.0.load(AtomicOrdering::Relaxed)
-	}
-}
-
 const TEST_STAGNANT_INTERVAL: Duration = Duration::from_millis(20);
 
 type VirtualOverseer =
 	polkadot_node_subsystem_test_helpers::TestSubsystemContextHandle<ChainSelectionMessage>;
 
 fn test_harness<T: Future<Output = VirtualOverseer>>(
-	test: impl FnOnce(TestBackend, TestClock, VirtualOverseer) -> T,
+	test: impl FnOnce(TestBackend, MockClock, VirtualOverseer) -> T,
 ) {
 	let pool = TaskExecutor::new();
 	let (context, virtual_overseer) =
 		polkadot_node_subsystem_test_helpers::make_subsystem_context(pool);
 
 	let backend = TestBackend::default();
-	let clock = TestClock::new(0);
+	let clock = MockClock::default();
 	let subsystem = crate::run(
 		context,
 		backend.clone(),
 		StagnantCheckInterval::new(TEST_STAGNANT_INTERVAL),
 		StagnantCheckMode::CheckAndPrune,
-		Box::new(clock.clone()),
+		Arc::new(clock.clone()),
 	);
 
 	let test_fut = test(backend, clock, virtual_overseer);
@@ -1796,7 +1775,7 @@ fn block_has_correct_stagnant_at() {
 		)
 		.await;
 
-		clock.inc_by(1);
+		clock.inc_secs(1);
 
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_a_ext.clone()).await;
 
@@ -1833,7 +1812,7 @@ fn detects_stagnant() {
 
 		{
 			let (_, write_rx) = backend.await_next_write();
-			clock.inc_by(STAGNANT_TIMEOUT);
+			clock.inc_secs(STAGNANT_TIMEOUT);
 
 			write_rx.await.unwrap();
 		}
@@ -1877,13 +1856,13 @@ fn finalize_stagnant_unlocks_subtree() {
 		)
 		.await;
 
-		clock.inc_by(1);
+		clock.inc_secs(1);
 
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_a_ext.clone()).await;
 
 		{
 			let (_, write_rx) = backend.await_next_write();
-			clock.inc_by(STAGNANT_TIMEOUT - 1);
+			clock.inc_secs(STAGNANT_TIMEOUT - 1);
 
 			write_rx.await.unwrap();
 		}
@@ -1931,13 +1910,13 @@ fn approval_undoes_stagnant_unlocking_subtree() {
 		)
 		.await;
 
-		clock.inc_by(1);
+		clock.inc_secs(1);
 
 		import_blocks_into(&mut virtual_overseer, &backend, None, chain_a_ext.clone()).await;
 
 		{
 			let (_, write_rx) = backend.await_next_write();
-			clock.inc_by(STAGNANT_TIMEOUT - 1);
+			clock.inc_secs(STAGNANT_TIMEOUT - 1);
 
 			write_rx.await.unwrap();
 		}
@@ -1993,7 +1972,7 @@ fn stagnant_preserves_parents_children() {
 
 		{
 			let (_, write_rx) = backend.await_next_write();
-			clock.inc_by(STAGNANT_TIMEOUT);
+			clock.inc_secs(STAGNANT_TIMEOUT);
 
 			write_rx.await.unwrap();
 		}
@@ -2035,7 +2014,7 @@ fn stagnant_makes_childless_parent_leaf() {
 
 		{
 			let (_, write_rx) = backend.await_next_write();
-			clock.inc_by(STAGNANT_TIMEOUT);
+			clock.inc_secs(STAGNANT_TIMEOUT);
 
 			write_rx.await.unwrap();
 		}

--- a/polkadot/node/core/chain-selection/src/tests.rs
+++ b/polkadot/node/core/chain-selection/src/tests.rs
@@ -29,8 +29,8 @@ use std::{
 use assert_matches::assert_matches;
 use codec::Encode;
 use futures::channel::oneshot;
-use polkadot_node_clock::MockClock;
 use parking_lot::Mutex;
+use polkadot_node_clock::MockClock;
 use sp_core::testing::TaskExecutor;
 
 use polkadot_node_subsystem::{messages::AllMessages, ActiveLeavesUpdate};

--- a/polkadot/node/core/dispute-coordinator/Cargo.toml
+++ b/polkadot/node/core/dispute-coordinator/Cargo.toml
@@ -25,6 +25,7 @@ gum = { workspace = true, default-features = true }
 schnellru = { workspace = true }
 thiserror = { workspace = true }
 
+polkadot-node-clock = { workspace = true, default-features = true }
 polkadot-node-primitives = { workspace = true, default-features = true }
 polkadot-node-subsystem = { workspace = true, default-features = true }
 polkadot-node-subsystem-util = { workspace = true, default-features = true }
@@ -36,6 +37,7 @@ sc-keystore = { workspace = true, default-features = true }
 assert_matches = { workspace = true }
 futures-timer = { workspace = true }
 kvdb-memorydb = { workspace = true }
+polkadot-node-clock = { workspace = true, default-features = true, features = ["test"] }
 polkadot-node-subsystem-test-helpers = { workspace = true }
 polkadot-primitives = { workspace = true, features = ["test"] }
 polkadot-primitives-test-helpers = { workspace = true }

--- a/polkadot/node/core/dispute-coordinator/src/initialized.rs
+++ b/polkadot/node/core/dispute-coordinator/src/initialized.rs
@@ -317,7 +317,13 @@ impl Initialized {
 							default_confirm
 						},
 						FromOrchestra::Communication { msg } => {
-							self.handle_incoming(ctx, &mut overlay_db, msg, clock.duration_since_epoch().as_secs()).await?
+							self.handle_incoming(
+								ctx,
+								&mut overlay_db,
+								msg,
+								clock.duration_since_epoch().as_secs(),
+							)
+							.await?
 						},
 					},
 				};

--- a/polkadot/node/core/dispute-coordinator/src/initialized.rs
+++ b/polkadot/node/core/dispute-coordinator/src/initialized.rs
@@ -28,6 +28,7 @@ use futures::{
 
 use sc_keystore::LocalKeystore;
 
+use polkadot_node_clock::Clock;
 use polkadot_node_primitives::{
 	disputes::ValidCandidateVotes, CandidateVotes, DisputeStatus, SignedDisputeStatement,
 	Timestamp, DISPUTE_WINDOW,
@@ -58,7 +59,7 @@ use crate::{
 	is_potential_spam,
 	metrics::Metrics,
 	scraping::ScrapedUpdates,
-	status::{get_active_with_status, Clock},
+	status::{get_active_with_status, timestamp_now},
 	DisputeCoordinatorSubsystem, LOG_TARGET,
 };
 
@@ -172,7 +173,7 @@ impl Initialized {
 		mut ctx: Context,
 		mut backend: B,
 		mut initial_data: Option<InitialData>,
-		clock: Box<dyn Clock>,
+		clock: Arc<dyn Clock>,
 	) -> FatalResult<()>
 	where
 		B: Backend,
@@ -244,7 +245,7 @@ impl Initialized {
 				ctx,
 				&mut overlay_db,
 				on_chain_votes,
-				clock.now(),
+				timestamp_now(clock),
 				first_leaf.hash,
 			)
 			.await;
@@ -289,7 +290,7 @@ impl Initialized {
 								candidate_receipt,
 								session,
 								valid,
-								clock.now(),
+								timestamp_now(clock),
 							)
 							.await?;
 						} else {
@@ -305,7 +306,7 @@ impl Initialized {
 								ctx,
 								&mut overlay_db,
 								update,
-								clock.now(),
+								timestamp_now(clock),
 							)
 							.await?;
 							default_confirm
@@ -316,7 +317,7 @@ impl Initialized {
 							default_confirm
 						},
 						FromOrchestra::Communication { msg } => {
-							self.handle_incoming(ctx, &mut overlay_db, msg, clock.now()).await?
+							self.handle_incoming(ctx, &mut overlay_db, msg, timestamp_now(clock)).await?
 						},
 					},
 				};

--- a/polkadot/node/core/dispute-coordinator/src/initialized.rs
+++ b/polkadot/node/core/dispute-coordinator/src/initialized.rs
@@ -59,7 +59,7 @@ use crate::{
 	is_potential_spam,
 	metrics::Metrics,
 	scraping::ScrapedUpdates,
-	status::{get_active_with_status, timestamp_now},
+	status::get_active_with_status,
 	DisputeCoordinatorSubsystem, LOG_TARGET,
 };
 
@@ -245,7 +245,7 @@ impl Initialized {
 				ctx,
 				&mut overlay_db,
 				on_chain_votes,
-				timestamp_now(clock),
+				clock.duration_since_epoch().as_secs(),
 				first_leaf.hash,
 			)
 			.await;
@@ -290,7 +290,7 @@ impl Initialized {
 								candidate_receipt,
 								session,
 								valid,
-								timestamp_now(clock),
+								clock.duration_since_epoch().as_secs(),
 							)
 							.await?;
 						} else {
@@ -306,7 +306,7 @@ impl Initialized {
 								ctx,
 								&mut overlay_db,
 								update,
-								timestamp_now(clock),
+								clock.duration_since_epoch().as_secs(),
 							)
 							.await?;
 							default_confirm
@@ -317,7 +317,7 @@ impl Initialized {
 							default_confirm
 						},
 						FromOrchestra::Communication { msg } => {
-							self.handle_incoming(ctx, &mut overlay_db, msg, timestamp_now(clock)).await?
+							self.handle_incoming(ctx, &mut overlay_db, msg, clock.duration_since_epoch().as_secs()).await?
 						},
 					},
 				};

--- a/polkadot/node/core/dispute-coordinator/src/lib.rs
+++ b/polkadot/node/core/dispute-coordinator/src/lib.rs
@@ -53,7 +53,7 @@ use polkadot_primitives::{
 use crate::{
 	error::{FatalResult, Result},
 	metrics::Metrics,
-	status::{get_active_with_status, timestamp_now},
+	status::get_active_with_status,
 };
 use backend::{Backend, OverlayedBackend};
 use db::v1::DbBackend;
@@ -292,7 +292,7 @@ impl DisputeCoordinatorSubsystem {
 		initialized::OffchainDisabledValidators,
 		ControlledValidatorIndices,
 	)> {
-		let now = timestamp_now(clock);
+		let now = clock.duration_since_epoch().as_secs();
 
 		// We assume the highest session is the passed leaf. If we can't get the session index
 		// we can't initialize the subsystem so we'll wait for a new leaf

--- a/polkadot/node/core/dispute-coordinator/src/lib.rs
+++ b/polkadot/node/core/dispute-coordinator/src/lib.rs
@@ -53,7 +53,7 @@ use polkadot_primitives::{
 use crate::{
 	error::{FatalResult, Result},
 	metrics::Metrics,
-	status::{get_active_with_status, SystemClock},
+	status::{get_active_with_status, timestamp_now},
 };
 use backend::{Backend, OverlayedBackend};
 use db::v1::DbBackend;
@@ -110,7 +110,7 @@ mod metrics;
 /// Status tracking of disputes (`DisputeStatus`).
 mod status;
 
-use crate::status::Clock;
+use polkadot_node_clock::Clock;
 
 #[cfg(test)]
 mod tests;
@@ -147,7 +147,7 @@ impl<Context: Send> DisputeCoordinatorSubsystem {
 				self.config.column_config(),
 				self.metrics.clone(),
 			);
-			self.run(ctx, backend, Box::new(SystemClock))
+			self.run(ctx, backend, polkadot_node_clock::system_clock())
 				.await
 				.map_err(|e| SubsystemError::with_origin("dispute-coordinator", e))
 		}
@@ -174,7 +174,7 @@ impl DisputeCoordinatorSubsystem {
 		self,
 		mut ctx: Context,
 		backend: B,
-		clock: Box<dyn Clock>,
+		clock: Arc<dyn Clock>,
 	) -> FatalResult<()>
 	where
 		B: Backend + 'static,
@@ -292,7 +292,7 @@ impl DisputeCoordinatorSubsystem {
 		initialized::OffchainDisabledValidators,
 		ControlledValidatorIndices,
 	)> {
-		let now = clock.now();
+		let now = timestamp_now(clock);
 
 		// We assume the highest session is the passed leaf. If we can't get the session index
 		// we can't initialize the subsystem so we'll wait for a new leaf

--- a/polkadot/node/core/dispute-coordinator/src/status.rs
+++ b/polkadot/node/core/dispute-coordinator/src/status.rs
@@ -14,11 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
+use polkadot_node_clock::Clock;
 use polkadot_node_primitives::{dispute_is_inactive, DisputeStatus, Timestamp};
 use polkadot_primitives::{CandidateHash, SessionIndex};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use crate::LOG_TARGET;
 
 /// Get active disputes as iterator, preserving its `DisputeStatus`.
 pub fn get_active_with_status(
@@ -28,31 +26,12 @@ pub fn get_active_with_status(
 	recent_disputes.filter(move |(_, status)| !dispute_is_inactive(status, &now))
 }
 
-pub trait Clock: Send + Sync {
-	fn now(&self) -> Timestamp;
-}
-
-pub struct SystemClock;
-
-impl Clock for SystemClock {
-	fn now(&self) -> Timestamp {
-		// `SystemTime` is notoriously non-monotonic, so our timers might not work
-		// exactly as expected.
-		//
-		// Regardless, disputes are considered active based on an order of minutes,
-		// so a few seconds of slippage in either direction shouldn't affect the
-		// amount of work the node is doing significantly.
-		match SystemTime::now().duration_since(UNIX_EPOCH) {
-			Ok(d) => d.as_secs(),
-			Err(e) => {
-				gum::warn!(
-					target: LOG_TARGET,
-					err = ?e,
-					"Current time is before unix epoch. Validation will not work correctly."
-				);
-
-				0
-			},
-		}
-	}
+/// Read the wall-clock timestamp in seconds since the UNIX epoch via the shared [`Clock`].
+///
+/// `SystemTime` is notoriously non-monotonic, so our timers might not work exactly as
+/// expected. Regardless, disputes are considered active based on an order of minutes, so a few
+/// seconds of slippage in either direction shouldn't affect the amount of work the node is
+/// doing significantly.
+pub fn timestamp_now(clock: &dyn Clock) -> Timestamp {
+	(clock.timestamp_millis() / 1000) as Timestamp
 }

--- a/polkadot/node/core/dispute-coordinator/src/status.rs
+++ b/polkadot/node/core/dispute-coordinator/src/status.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use polkadot_node_clock::Clock;
 use polkadot_node_primitives::{dispute_is_inactive, DisputeStatus, Timestamp};
 use polkadot_primitives::{CandidateHash, SessionIndex};
 
@@ -24,14 +23,4 @@ pub fn get_active_with_status(
 	now: Timestamp,
 ) -> impl Iterator<Item = ((SessionIndex, CandidateHash), DisputeStatus)> {
 	recent_disputes.filter(move |(_, status)| !dispute_is_inactive(status, &now))
-}
-
-/// Read the wall-clock timestamp in seconds since the UNIX epoch via the shared [`Clock`].
-///
-/// `SystemTime` is notoriously non-monotonic, so our timers might not work exactly as
-/// expected. Regardless, disputes are considered active based on an order of minutes, so a few
-/// seconds of slippage in either direction shouldn't affect the amount of work the node is
-/// doing significantly.
-pub fn timestamp_now(clock: &dyn Clock) -> Timestamp {
-	(clock.timestamp_millis() / 1000) as Timestamp
 }

--- a/polkadot/node/core/dispute-coordinator/src/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/tests.rs
@@ -48,7 +48,7 @@ use sp_core::{sr25519::Pair, testing::TaskExecutor, Pair as PairT};
 use sp_keyring::Sr25519Keyring;
 use sp_keystore::{Keystore, KeystorePtr};
 
-use polkadot_node_primitives::{Timestamp, ACTIVE_DURATION_SECS};
+use polkadot_node_primitives::ACTIVE_DURATION_SECS;
 use polkadot_node_subsystem::{
 	messages::{AllMessages, BlockDescription, RuntimeApiMessage, RuntimeApiRequest},
 	ActiveLeavesUpdate,
@@ -73,7 +73,7 @@ use crate::{
 	participation::{participation_full_happy_path, participation_missing_availability},
 	Config, DisputeCoordinatorSubsystem,
 };
-use polkadot_node_clock::MockClock;
+use polkadot_node_clock::{Clock, MockClock};
 
 use super::db::v1::DbBackend;
 
@@ -2353,7 +2353,9 @@ fn resume_dispute_without_local_statement() {
 
 			// Advance the clock far enough so that the concluded dispute will be omitted from an
 			// ActiveDisputes query.
-			test_state.clock.set_secs(test_state.clock.now_secs() + ACTIVE_DURATION_SECS + 1);
+			test_state.clock.set_secs(
+				test_state.clock.duration_since_epoch().as_secs() + ACTIVE_DURATION_SECS + 1,
+			);
 
 			{
 				let (tx, rx) = oneshot::channel();

--- a/polkadot/node/core/dispute-coordinator/src/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/tests.rs
@@ -16,10 +16,7 @@
 
 use std::{
 	collections::{BTreeMap, HashMap},
-	sync::{
-		atomic::{AtomicU64, Ordering as AtomicOrdering},
-		Arc,
-	},
+	sync::Arc,
 	time::Duration,
 };
 
@@ -74,9 +71,9 @@ use crate::{
 	backend::Backend,
 	metrics::Metrics,
 	participation::{participation_full_happy_path, participation_missing_availability},
-	status::Clock,
 	Config, DisputeCoordinatorSubsystem,
 };
+use polkadot_node_clock::MockClock;
 
 use super::db::v1::DbBackend;
 
@@ -141,29 +138,6 @@ async fn generate_opposing_votes_pair(
 	);
 
 	(valid_vote, invalid_vote)
-}
-
-#[derive(Clone)]
-struct MockClock {
-	time: Arc<AtomicU64>,
-}
-
-impl Default for MockClock {
-	fn default() -> Self {
-		MockClock { time: Arc::new(AtomicU64::default()) }
-	}
-}
-
-impl Clock for MockClock {
-	fn now(&self) -> Timestamp {
-		self.time.load(AtomicOrdering::SeqCst)
-	}
-}
-
-impl MockClock {
-	fn set(&self, to: Timestamp) {
-		self.time.store(to, AtomicOrdering::SeqCst)
-	}
 }
 
 struct TestState {
@@ -582,7 +556,7 @@ impl TestState {
 		);
 		let backend =
 			DbBackend::new(self.db.clone(), self.config.column_config(), Metrics::default());
-		let subsystem_task = subsystem.run(ctx, backend, Box::new(self.clock.clone()));
+		let subsystem_task = subsystem.run(ctx, backend, Arc::new(self.clock.clone()));
 		let test_task = test(self, ctx_handle);
 
 		let (_, state) = futures::executor::block_on(future::join(subsystem_task, test_task));
@@ -2093,7 +2067,7 @@ fn concluded_supermajority_for_non_active_after_time() {
 			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash, HashMap::new())
 				.await;
 
-			test_state.clock.set(ACTIVE_DURATION_SECS + 1);
+			test_state.clock.set_secs(ACTIVE_DURATION_SECS + 1);
 
 			{
 				let (tx, rx) = oneshot::channel();
@@ -2215,7 +2189,7 @@ fn concluded_supermajority_against_non_active_after_time() {
 			handle_approval_vote_request(&mut virtual_overseer, &candidate_hash, HashMap::new())
 				.await;
 
-			test_state.clock.set(ACTIVE_DURATION_SECS + 1);
+			test_state.clock.set_secs(ACTIVE_DURATION_SECS + 1);
 
 			{
 				let (tx, rx) = oneshot::channel();
@@ -2379,7 +2353,7 @@ fn resume_dispute_without_local_statement() {
 
 			// Advance the clock far enough so that the concluded dispute will be omitted from an
 			// ActiveDisputes query.
-			test_state.clock.set(test_state.clock.now() + ACTIVE_DURATION_SECS + 1);
+			test_state.clock.set_secs(test_state.clock.now_secs() + ACTIVE_DURATION_SECS + 1);
 
 			{
 				let (tx, rx) = oneshot::channel();

--- a/polkadot/node/network/collator-protocol/Cargo.toml
+++ b/polkadot/node/network/collator-protocol/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 async-trait = { workspace = true }
 bitvec = { features = ["alloc"], workspace = true }
 futures = { workspace = true }
-futures-timer = { workspace = true }
 gum = { workspace = true, default-features = true }
 schnellru = { workspace = true }
 
@@ -28,6 +27,7 @@ sp-timestamp = { workspace = true, default-features = true }
 
 codec = { workspace = true }
 fatality = { workspace = true }
+polkadot-node-clock = { workspace = true, default-features = true }
 polkadot-node-network-protocol = { workspace = true, default-features = true }
 polkadot-node-primitives = { workspace = true, default-features = true }
 polkadot-node-subsystem = { workspace = true, default-features = true }
@@ -39,6 +39,7 @@ tokio-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+futures-timer = { workspace = true }
 kvdb-memorydb = { workspace = true }
 rstest = { workspace = true }
 sc-network-types = { workspace = true, default-features = true }

--- a/polkadot/node/network/collator-protocol/clippy.toml
+++ b/polkadot/node/network/collator-protocol/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "use Clock::now() — see src/clock.rs" },
+    { path = "std::time::SystemTime::now", reason = "use Clock::timestamp_millis() — see src/clock.rs" },
+    { path = "tokio::time::sleep", reason = "use Clock::delay() — see src/clock.rs" },
+    { path = "futures_timer::Delay::new", reason = "use Clock::delay() — see src/clock.rs" },
+    { path = "sp_timestamp::Timestamp::current", reason = "use Clock::timestamp_millis() — see src/clock.rs" },
+]

--- a/polkadot/node/network/collator-protocol/clippy.toml
+++ b/polkadot/node/network/collator-protocol/clippy.toml
@@ -1,7 +1,7 @@
 disallowed-methods = [
-    { path = "std::time::Instant::now", reason = "use Clock::now() — see polkadot-node-clock" },
-    { path = "std::time::SystemTime::now", reason = "use Clock::duration_since_epoch() — see polkadot-node-clock" },
-    { path = "tokio::time::sleep", reason = "use Clock::delay() — see polkadot-node-clock" },
-    { path = "futures_timer::Delay::new", reason = "use Clock::delay() — see polkadot-node-clock" },
-    { path = "sp_timestamp::Timestamp::current", reason = "use Clock::duration_since_epoch() — see polkadot-node-clock" },
+	{ path = "futures_timer::Delay::new", reason = "use Clock::delay() — see polkadot-node-clock" },
+	{ path = "sp_timestamp::Timestamp::current", reason = "use Clock::duration_since_epoch() — see polkadot-node-clock" },
+	{ path = "std::time::Instant::now", reason = "use Clock::now() — see polkadot-node-clock" },
+	{ path = "std::time::SystemTime::now", reason = "use Clock::duration_since_epoch() — see polkadot-node-clock" },
+	{ path = "tokio::time::sleep", reason = "use Clock::delay() — see polkadot-node-clock" },
 ]

--- a/polkadot/node/network/collator-protocol/clippy.toml
+++ b/polkadot/node/network/collator-protocol/clippy.toml
@@ -1,7 +1,7 @@
 disallowed-methods = [
-    { path = "std::time::Instant::now", reason = "use Clock::now() — see src/clock.rs" },
-    { path = "std::time::SystemTime::now", reason = "use Clock::timestamp_millis() — see src/clock.rs" },
-    { path = "tokio::time::sleep", reason = "use Clock::delay() — see src/clock.rs" },
-    { path = "futures_timer::Delay::new", reason = "use Clock::delay() — see src/clock.rs" },
-    { path = "sp_timestamp::Timestamp::current", reason = "use Clock::timestamp_millis() — see src/clock.rs" },
+    { path = "std::time::Instant::now", reason = "use Clock::now() — see polkadot-node-clock" },
+    { path = "std::time::SystemTime::now", reason = "use Clock::duration_since_epoch() — see polkadot-node-clock" },
+    { path = "tokio::time::sleep", reason = "use Clock::delay() — see polkadot-node-clock" },
+    { path = "futures_timer::Delay::new", reason = "use Clock::delay() — see polkadot-node-clock" },
+    { path = "sp_timestamp::Timestamp::current", reason = "use Clock::duration_since_epoch() — see polkadot-node-clock" },
 ]

--- a/polkadot/node/network/collator-protocol/src/collator_side/metrics.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/metrics.rs
@@ -434,7 +434,7 @@ pub(crate) struct CollationStats {
 impl CollationStats {
 	/// Create new empty instance.
 	pub fn new(
-		clock: &dyn crate::Clock,
+		clock: &dyn polkadot_node_clock::Clock,
 		head: Hash,
 		relay_parent_number: BlockNumber,
 		relay_parent: Hash,

--- a/polkadot/node/network/collator-protocol/src/collator_side/metrics.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/metrics.rs
@@ -434,6 +434,7 @@ pub(crate) struct CollationStats {
 impl CollationStats {
 	/// Create new empty instance.
 	pub fn new(
+		clock: &dyn crate::Clock,
 		head: Hash,
 		relay_parent_number: BlockNumber,
 		relay_parent: Hash,
@@ -446,7 +447,7 @@ impl CollationStats {
 			head,
 			relay_parent_number,
 			relay_parent,
-			advertised_at: std::time::Instant::now(),
+			advertised_at: clock.now(),
 			backed_at: None,
 			expired_at: None,
 			fetched_at: None,

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -60,7 +60,8 @@ use polkadot_primitives::{
 	SessionIndex,
 };
 
-use crate::{modify_reputation, Clock, LOG_TARGET, LOG_TARGET_STATS};
+use crate::{modify_reputation, LOG_TARGET, LOG_TARGET_STATS};
+use polkadot_node_clock::{BoxedDelay, Clock};
 
 mod collation;
 mod error;
@@ -113,7 +114,7 @@ const MAX_PARALLEL_CHAIN_API_REQUESTS: usize = 10;
 ///
 /// `Pending` variant never finishes and should be used when there're no peers
 /// connected.
-type ReconnectTimeout = Fuse<crate::BoxedDelay>;
+type ReconnectTimeout = Fuse<BoxedDelay>;
 
 /// A future that returns a candidate hash along with validator discovery
 /// keys once a timeout hit.
@@ -122,7 +123,7 @@ type ReconnectTimeout = Fuse<crate::BoxedDelay>;
 /// we should reset its interest in this advertisement in a buffer. For example,
 /// when the PoV was already requested from another peer.
 struct ResetInterestTimeout {
-	fut: crate::BoxedDelay,
+	fut: BoxedDelay,
 	candidate_hash: CandidateHash,
 	peer_id: PeerId,
 }
@@ -343,7 +344,7 @@ impl PerSchedulingParent {
 }
 
 struct State {
-	/// Clock used for all time reads. Production passes [`crate::SystemClock`]; tests inject a
+	/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a
 	/// mock.
 	clock: Arc<dyn Clock>,
 

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -16,6 +16,7 @@
 
 use std::{
 	collections::{hash_map::Entry, HashMap, HashSet},
+	sync::Arc,
 	time::Duration,
 };
 
@@ -59,7 +60,7 @@ use polkadot_primitives::{
 	SessionIndex,
 };
 
-use crate::{modify_reputation, LOG_TARGET, LOG_TARGET_STATS};
+use crate::{modify_reputation, Clock, LOG_TARGET, LOG_TARGET_STATS};
 
 mod collation;
 mod error;
@@ -112,7 +113,7 @@ const MAX_PARALLEL_CHAIN_API_REQUESTS: usize = 10;
 ///
 /// `Pending` variant never finishes and should be used when there're no peers
 /// connected.
-type ReconnectTimeout = Fuse<futures_timer::Delay>;
+type ReconnectTimeout = Fuse<crate::BoxedDelay>;
 
 /// A future that returns a candidate hash along with validator discovery
 /// keys once a timeout hit.
@@ -121,15 +122,20 @@ type ReconnectTimeout = Fuse<futures_timer::Delay>;
 /// we should reset its interest in this advertisement in a buffer. For example,
 /// when the PoV was already requested from another peer.
 struct ResetInterestTimeout {
-	fut: futures_timer::Delay,
+	fut: crate::BoxedDelay,
 	candidate_hash: CandidateHash,
 	peer_id: PeerId,
 }
 
 impl ResetInterestTimeout {
 	/// Returns new `ResetInterestTimeout` that resolves after given timeout.
-	fn new(candidate_hash: CandidateHash, peer_id: PeerId, delay: Duration) -> Self {
-		Self { fut: futures_timer::Delay::new(delay), candidate_hash, peer_id }
+	fn new(
+		clock: &dyn Clock,
+		candidate_hash: CandidateHash,
+		peer_id: PeerId,
+		delay: Duration,
+	) -> Self {
+		Self { fut: clock.delay(delay), candidate_hash, peer_id }
 	}
 }
 
@@ -140,7 +146,7 @@ impl std::future::Future for ResetInterestTimeout {
 		mut self: std::pin::Pin<&mut Self>,
 		cx: &mut std::task::Context<'_>,
 	) -> std::task::Poll<Self::Output> {
-		self.fut.poll_unpin(cx).map(|_| (self.candidate_hash, self.peer_id))
+		self.fut.as_mut().poll(cx).map(|_| (self.candidate_hash, self.peer_id))
 	}
 }
 
@@ -337,6 +343,10 @@ impl PerSchedulingParent {
 }
 
 struct State {
+	/// Clock used for all time reads. Production passes [`crate::SystemClock`]; tests inject a
+	/// mock.
+	clock: Arc<dyn Clock>,
+
 	/// Our network peer id.
 	local_peer_id: PeerId,
 
@@ -411,8 +421,10 @@ impl State {
 		collator_pair: CollatorPair,
 		metrics: Metrics,
 		reputation: ReputationAggregator,
+		clock: Arc<dyn Clock>,
 	) -> State {
 		State {
+			clock,
 			local_peer_id,
 			collator_pair,
 			metrics,
@@ -586,6 +598,7 @@ async fn distribute_collation<Context>(
 			session_index: per_scheduling_parent.session_index,
 			stats: per_scheduling_parent.block_number.map(|n| {
 				CollationStats::new(
+					&*state.clock,
 					para_head,
 					n,
 					scheduling_parent,
@@ -624,6 +637,7 @@ async fn distribute_collation<Context>(
 
 		advertise_collation(
 			ctx,
+			&*state.clock,
 			scheduling_parent,
 			per_scheduling_parent,
 			peer_id,
@@ -867,6 +881,7 @@ async fn update_validator_connections<Context>(
 #[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
 async fn advertise_collation<Context>(
 	ctx: &mut Context,
+	clock: &dyn Clock,
 	scheduling_parent: Hash,
 	per_scheduling_parent: &mut PerSchedulingParent,
 	peer: &PeerId,
@@ -951,6 +966,7 @@ async fn advertise_collation<Context>(
 		validator_group.advertised_to_peer(candidate_hash, &peer_ids, peer);
 
 		advertisement_timeouts.push(ResetInterestTimeout::new(
+			clock,
 			*candidate_hash,
 			*peer,
 			RESET_INTEREST_TIMEOUT,
@@ -1373,6 +1389,7 @@ async fn advertise_collations_for_scheduling_parents<Context>(
 		None => return unknown_scheduling_parents,
 	};
 
+	let clock = state.clock.clone();
 	for scheduling_parent in scheduling_parents {
 		let block_hashes = match state.per_scheduling_parent.contains_key(&scheduling_parent) {
 			true => state
@@ -1392,6 +1409,7 @@ async fn advertise_collations_for_scheduling_parents<Context>(
 			if let Some(per_scheduling_parent) = state.per_scheduling_parent.get_mut(block_hash) {
 				advertise_collation(
 					ctx,
+					&*clock,
 					*block_hash,
 					per_scheduling_parent,
 					peer_id,
@@ -1751,6 +1769,7 @@ async fn handle_our_view_change<Context>(
 
 				advertise_collation(
 					ctx,
+					&*state.clock,
 					*block_hash,
 					per_relay_parent,
 					peer_id,
@@ -1988,6 +2007,7 @@ pub(crate) async fn run<Context>(
 	collator_pair: CollatorPair,
 	req_v2_receiver: IncomingRequestReceiver<request_v2::CollationFetchingRequest>,
 	metrics: Metrics,
+	clock: Arc<dyn Clock>,
 ) -> std::result::Result<(), FatalError> {
 	run_inner(
 		ctx,
@@ -1997,6 +2017,7 @@ pub(crate) async fn run<Context>(
 		metrics,
 		ReputationAggregator::default(),
 		REPUTATION_CHANGE_INTERVAL,
+		clock,
 	)
 	.await
 }
@@ -2010,13 +2031,15 @@ async fn run_inner<Context>(
 	metrics: Metrics,
 	reputation: ReputationAggregator,
 	reputation_interval: Duration,
+	clock: Arc<dyn Clock>,
 ) -> std::result::Result<(), FatalError> {
 	use OverseerSignal::*;
 
-	let new_reputation_delay = || futures_timer::Delay::new(reputation_interval).fuse();
+	let new_reputation_delay = || clock.delay(reputation_interval).fuse();
 	let mut reputation_delay = new_reputation_delay();
 
-	let mut state = State::new(local_peer_id, collator_pair, metrics.clone(), reputation);
+	let mut state =
+		State::new(local_peer_id, collator_pair, metrics.clone(), reputation, clock.clone());
 	let mut runtime = RuntimeInfo::new(None);
 
 	loop {
@@ -2039,7 +2062,7 @@ async fn run_inner<Context>(
 				},
 				FromOrchestra::Signal(ActiveLeaves(update)) => {
 					if update.activated.is_some() {
-						*reconnect_timeout = futures_timer::Delay::new(RECONNECT_AFTER_LEAF_TIMEOUT).fuse();
+						*reconnect_timeout = clock.delay(RECONNECT_AFTER_LEAF_TIMEOUT).fuse();
 					}
 				}
 				FromOrchestra::Signal(BlockFinalized(hash, number)) => {
@@ -2075,7 +2098,7 @@ async fn run_inner<Context>(
 
 								if let Some(mut stats) = maybe_stats {
 									// Update the timestamp when collation has been sent (from subsystem perspective)
-									stats.set_fetched_at(std::time::Instant::now());
+									stats.set_fetched_at(clock.now());
 									gum::debug!(
 										target: LOG_TARGET_STATS,
 										para_head = ?stats.head(),

--- a/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/mod.rs
@@ -344,8 +344,8 @@ impl PerSchedulingParent {
 }
 
 struct State {
-	/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a
-	/// mock.
+	/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`];
+	/// tests inject a mock.
 	clock: Arc<dyn Clock>,
 
 	/// Our network peer id.

--- a/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
@@ -232,6 +232,7 @@ fn test_harness<T: Future<Output = TestHarness>>(
 			Default::default(),
 			reputation,
 			REPUTATION_CHANGE_TEST_INTERVAL,
+			crate::system_clock(),
 		)
 		.await
 		.unwrap();

--- a/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/collator_side/tests/mod.rs
@@ -232,7 +232,7 @@ fn test_harness<T: Future<Output = TestHarness>>(
 			Default::default(),
 			reputation,
 			REPUTATION_CHANGE_TEST_INTERVAL,
-			crate::system_clock(),
+			polkadot_node_clock::system_clock(),
 		)
 		.await
 		.unwrap();

--- a/polkadot/node/network/collator-protocol/src/lib.rs
+++ b/polkadot/node/network/collator-protocol/src/lib.rs
@@ -54,7 +54,7 @@ use polkadot_primitives::{CollatorPair, Hash, RELAY_CHAIN_SLOT_DURATION_MILLIS};
 use sp_consensus_slots::SlotDuration;
 pub use validator_side_experimental::ReputationConfig;
 
-pub use polkadot_node_clock::{system_clock, BoxedDelay, Clock, SystemClock};
+use polkadot_node_clock::Clock;
 
 mod collator_side;
 mod validator_side;
@@ -287,7 +287,7 @@ pub(crate) fn is_scheduling_parent_valid(
 ) -> bool {
 	let slot_duration = SlotDuration::from_millis(RELAY_CHAIN_SLOT_DURATION_MILLIS);
 	let current_slot = sp_consensus_slots::Slot::from_timestamp(
-		sp_timestamp::Timestamp::new(clock.timestamp_millis() as u64),
+		sp_timestamp::Timestamp::new(clock.duration_since_epoch().as_millis() as u64),
 		slot_duration,
 	);
 	if let Some(info) = leaf_scheduling_info.get(scheduling_parent) {

--- a/polkadot/node/network/collator-protocol/src/lib.rs
+++ b/polkadot/node/network/collator-protocol/src/lib.rs
@@ -19,6 +19,10 @@
 
 #![deny(missing_docs)]
 #![deny(unused_crate_dependencies)]
+#![deny(clippy::disallowed_methods)]
+// Tests still call `Instant::now`, `Delay::new`, etc directly. The deterministic-clock plumbing
+// is enforced for production code; legacy tests retain their original behavior.
+#![cfg_attr(test, allow(clippy::disallowed_methods))]
 #![recursion_limit = "256"]
 
 use std::{
@@ -49,6 +53,8 @@ use polkadot_node_subsystem::{
 use polkadot_primitives::{CollatorPair, Hash, RELAY_CHAIN_SLOT_DURATION_MILLIS};
 use sp_consensus_slots::SlotDuration;
 pub use validator_side_experimental::ReputationConfig;
+
+pub use polkadot_node_clock::{system_clock, BoxedDelay, Clock, SystemClock};
 
 mod collator_side;
 mod validator_side;
@@ -92,6 +98,8 @@ pub enum ProtocolSide {
 		invulnerables: HashSet<PeerId>,
 		/// Override for `HOLD_OFF_DURATION` constant .
 		collator_protocol_hold_off: Option<Duration>,
+		/// Clock used for all time reads. Production passes [`SystemClock`]; tests inject a mock.
+		clock: Arc<dyn Clock>,
 	},
 	/// Experimental variant of the validator side. Do not use in production.
 	ValidatorExperimental {
@@ -103,6 +111,8 @@ pub enum ProtocolSide {
 		db: Arc<dyn Database>,
 		/// Reputation configuration (column number).
 		reputation_config: validator_side_experimental::ReputationConfig,
+		/// Clock used for all time reads. Production passes [`SystemClock`]; tests inject a mock.
+		clock: Arc<dyn Clock>,
 	},
 	/// Collators operate on a parachain.
 	Collator {
@@ -114,6 +124,8 @@ pub enum ProtocolSide {
 		request_receiver_v2: IncomingRequestReceiver<protocol_v2::CollationFetchingRequest>,
 		/// Metrics.
 		metrics: collator_side::Metrics,
+		/// Clock used for all time reads. Production passes [`SystemClock`]; tests inject a mock.
+		clock: Arc<dyn Clock>,
 	},
 	/// No protocol side, just disable it.
 	None,
@@ -142,6 +154,7 @@ impl<Context> CollatorProtocolSubsystem {
 				metrics,
 				invulnerables,
 				collator_protocol_hold_off,
+				clock,
 			} => {
 				gum::trace!(
 					target: LOG_TARGET,
@@ -156,20 +169,43 @@ impl<Context> CollatorProtocolSubsystem {
 					metrics,
 					invulnerables,
 					collator_protocol_hold_off,
+					clock,
 				)
 				.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
 				.boxed()
 			},
-			ProtocolSide::ValidatorExperimental { keystore, metrics, db, reputation_config } => {
-				validator_side_experimental::run(ctx, keystore, metrics, db, reputation_config)
-					.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
-					.boxed()
-			},
-			ProtocolSide::Collator { peer_id, collator_pair, request_receiver_v2, metrics } => {
-				collator_side::run(ctx, peer_id, collator_pair, request_receiver_v2, metrics)
-					.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
-					.boxed()
-			},
+			ProtocolSide::ValidatorExperimental {
+				keystore,
+				metrics,
+				db,
+				reputation_config,
+				clock,
+			} => validator_side_experimental::run(
+				ctx,
+				keystore,
+				metrics,
+				db,
+				reputation_config,
+				clock,
+			)
+			.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
+			.boxed(),
+			ProtocolSide::Collator {
+				peer_id,
+				collator_pair,
+				request_receiver_v2,
+				metrics,
+				clock,
+			} => collator_side::run(
+				ctx,
+				peer_id,
+				collator_pair,
+				request_receiver_v2,
+				metrics,
+				clock,
+			)
+			.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
+			.boxed(),
 			ProtocolSide::None => return DummySubsystem.start(ctx),
 		};
 
@@ -195,21 +231,26 @@ async fn modify_reputation(
 }
 
 /// Wait until tick and return the timestamp for the following one.
-async fn wait_until_next_tick(last_poll: Instant, period: Duration) -> Instant {
-	let now = Instant::now();
+async fn wait_until_next_tick(
+	clock: &dyn Clock,
+	last_poll: Instant,
+	period: Duration,
+) -> Instant {
+	let now = clock.now();
 	let next_poll = last_poll + period;
 
 	if next_poll > now {
-		futures_timer::Delay::new(next_poll - now).await
+		clock.delay(next_poll - now).await
 	}
 
-	Instant::now()
+	clock.now()
 }
 
 /// Returns an infinite stream that yields with an interval of `period`.
-fn tick_stream(period: Duration) -> impl FusedStream<Item = ()> {
-	futures::stream::unfold(Instant::now(), move |next_check| async move {
-		Some(((), wait_until_next_tick(next_check, period).await))
+fn tick_stream(clock: Arc<dyn Clock>, period: Duration) -> impl FusedStream<Item = ()> {
+	futures::stream::unfold(clock.now(), move |next_check| {
+		let clock = clock.clone();
+		async move { Some(((), wait_until_next_tick(&*clock, next_check, period).await)) }
 	})
 	.fuse()
 }
@@ -240,12 +281,15 @@ pub(crate) async fn extract_leaf_scheduling_info<Sender: CollatorProtocolSenderT
 }
 
 pub(crate) fn is_scheduling_parent_valid(
+	clock: &dyn Clock,
 	scheduling_parent: &Hash,
 	leaf_scheduling_info: &HashMap<Hash, LeafSchedulingInfo>,
 ) -> bool {
 	let slot_duration = SlotDuration::from_millis(RELAY_CHAIN_SLOT_DURATION_MILLIS);
-	let current_slot =
-		sp_consensus_slots::Slot::from_timestamp(sp_timestamp::Timestamp::current(), slot_duration);
+	let current_slot = sp_consensus_slots::Slot::from_timestamp(
+		sp_timestamp::Timestamp::new(clock.timestamp_millis() as u64),
+		slot_duration,
+	);
 	if let Some(info) = leaf_scheduling_info.get(scheduling_parent) {
 		// scheduling_parent is a leaf. This is allowed only when the leaf's slot is
 		// the previous slot.

--- a/polkadot/node/network/collator-protocol/src/lib.rs
+++ b/polkadot/node/network/collator-protocol/src/lib.rs
@@ -196,16 +196,11 @@ impl<Context> CollatorProtocolSubsystem {
 				request_receiver_v2,
 				metrics,
 				clock,
-			} => collator_side::run(
-				ctx,
-				peer_id,
-				collator_pair,
-				request_receiver_v2,
-				metrics,
-				clock,
-			)
-			.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
-			.boxed(),
+			} => {
+				collator_side::run(ctx, peer_id, collator_pair, request_receiver_v2, metrics, clock)
+					.map_err(|e| SubsystemError::with_origin("collator-protocol", e))
+					.boxed()
+			},
 			ProtocolSide::None => return DummySubsystem.start(ctx),
 		};
 
@@ -231,11 +226,7 @@ async fn modify_reputation(
 }
 
 /// Wait until tick and return the timestamp for the following one.
-async fn wait_until_next_tick(
-	clock: &dyn Clock,
-	last_poll: Instant,
-	period: Duration,
-) -> Instant {
+async fn wait_until_next_tick(clock: &dyn Clock, last_poll: Instant, period: Duration) -> Instant {
 	let now = clock.now();
 	let next_poll = last_poll + period;
 

--- a/polkadot/node/network/collator-protocol/src/lib.rs
+++ b/polkadot/node/network/collator-protocol/src/lib.rs
@@ -98,7 +98,7 @@ pub enum ProtocolSide {
 		invulnerables: HashSet<PeerId>,
 		/// Override for `HOLD_OFF_DURATION` constant .
 		collator_protocol_hold_off: Option<Duration>,
-		/// Clock used for all time reads. Production passes [`SystemClock`]; tests inject a mock.
+		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a mock.
 		clock: Arc<dyn Clock>,
 	},
 	/// Experimental variant of the validator side. Do not use in production.
@@ -111,7 +111,7 @@ pub enum ProtocolSide {
 		db: Arc<dyn Database>,
 		/// Reputation configuration (column number).
 		reputation_config: validator_side_experimental::ReputationConfig,
-		/// Clock used for all time reads. Production passes [`SystemClock`]; tests inject a mock.
+		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a mock.
 		clock: Arc<dyn Clock>,
 	},
 	/// Collators operate on a parachain.
@@ -124,7 +124,7 @@ pub enum ProtocolSide {
 		request_receiver_v2: IncomingRequestReceiver<protocol_v2::CollationFetchingRequest>,
 		/// Metrics.
 		metrics: collator_side::Metrics,
-		/// Clock used for all time reads. Production passes [`SystemClock`]; tests inject a mock.
+		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a mock.
 		clock: Arc<dyn Clock>,
 	},
 	/// No protocol side, just disable it.

--- a/polkadot/node/network/collator-protocol/src/lib.rs
+++ b/polkadot/node/network/collator-protocol/src/lib.rs
@@ -98,7 +98,8 @@ pub enum ProtocolSide {
 		invulnerables: HashSet<PeerId>,
 		/// Override for `HOLD_OFF_DURATION` constant .
 		collator_protocol_hold_off: Option<Duration>,
-		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a mock.
+		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`];
+		/// tests inject a mock.
 		clock: Arc<dyn Clock>,
 	},
 	/// Experimental variant of the validator side. Do not use in production.
@@ -111,7 +112,8 @@ pub enum ProtocolSide {
 		db: Arc<dyn Database>,
 		/// Reputation configuration (column number).
 		reputation_config: validator_side_experimental::ReputationConfig,
-		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a mock.
+		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`];
+		/// tests inject a mock.
 		clock: Arc<dyn Clock>,
 	},
 	/// Collators operate on a parachain.
@@ -124,7 +126,8 @@ pub enum ProtocolSide {
 		request_receiver_v2: IncomingRequestReceiver<protocol_v2::CollationFetchingRequest>,
 		/// Metrics.
 		metrics: collator_side::Metrics,
-		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a mock.
+		/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`];
+		/// tests inject a mock.
 		clock: Arc<dyn Clock>,
 	},
 	/// No protocol side, just disable it.

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -133,17 +133,19 @@ use bitvec::vec::BitVec;
 use futures::{
 	channel::oneshot, future::BoxFuture, select, stream::FuturesUnordered, FutureExt, StreamExt,
 };
+#[cfg(test)]
 use futures_timer::Delay;
 use std::{
 	collections::{hash_map::Entry, BTreeMap, HashMap, HashSet, VecDeque},
 	future::Future,
+	sync::Arc,
 	time::{Duration, Instant},
 };
 use tokio_util::sync::CancellationToken;
 
 use sp_keystore::KeystorePtr;
 
-use crate::{extract_leaf_scheduling_info, is_scheduling_parent_valid, LeafSchedulingInfo};
+use crate::{extract_leaf_scheduling_info, is_scheduling_parent_valid, Clock, LeafSchedulingInfo};
 use polkadot_node_network_protocol::{
 	self as net_protocol,
 	peer_set::{CollationVersion, PeerSet, MAX_AUTHORITY_INCOMING_STREAMS},
@@ -346,6 +348,7 @@ impl PeerData {
 		implicit_view: &ImplicitView,
 		per_scheduling_parent: &PerSchedulingParent,
 		leaf_claim_queues: &HashMap<Hash, BTreeMap<CoreIndex, VecDeque<ParaId>>>,
+		clock: &dyn Clock,
 	) -> std::result::Result<(CollatorId, ParaId), InsertAdvertisementError> {
 		match self.state {
 			PeerState::Connected(_) => Err(InsertAdvertisementError::UndeclaredCollator),
@@ -410,7 +413,7 @@ impl PeerData {
 						.insert(on_scheduling_parent, HashSet::from_iter(candidate_hash));
 				};
 
-				state.last_active = Instant::now();
+				state.last_active = clock.now();
 				Ok((state.collator_id.clone(), state.para_id))
 			},
 		}
@@ -428,12 +431,12 @@ impl PeerData {
 	///
 	/// This will overwrite any previous call to `set_collating` and should only be called
 	/// if `is_collating` is false.
-	fn set_collating(&mut self, collator_id: CollatorId, para_id: ParaId) {
+	fn set_collating(&mut self, collator_id: CollatorId, para_id: ParaId, clock: &dyn Clock) {
 		self.state = PeerState::Collating(CollatingPeerState {
 			collator_id,
 			para_id,
 			advertisements: HashMap::new(),
-			last_active: Instant::now(),
+			last_active: clock.now(),
 		});
 	}
 
@@ -473,12 +476,13 @@ impl PeerData {
 	}
 
 	/// Whether the peer is now inactive according to the current instant and the eviction policy.
-	fn is_inactive(&self, policy: &crate::CollatorEvictionPolicy) -> bool {
+	fn is_inactive(&self, clock: &dyn crate::Clock, policy: &crate::CollatorEvictionPolicy) -> bool {
+		let now = clock.now();
 		match self.state {
-			PeerState::Connected(connected_at) => connected_at.elapsed() >= policy.undeclared,
-			PeerState::Collating(ref state) => {
-				state.last_active.elapsed() >= policy.inactive_collator
-			},
+			PeerState::Connected(connected_at) =>
+				now.saturating_duration_since(connected_at) >= policy.undeclared,
+			PeerState::Collating(ref state) =>
+				now.saturating_duration_since(state.last_active) >= policy.inactive_collator,
 		}
 	}
 }
@@ -584,8 +588,10 @@ struct HeldOffAdvertisement {
 }
 
 /// All state relevant for the validator side of the protocol lives here.
-#[derive(Default)]
 struct State {
+	/// Clock used for all time reads. Production passes [`crate::SystemClock`]; tests inject a
+	/// mock.
+	clock: Arc<dyn Clock>,
 	/// Leaves that do support asynchronous backing along with
 	/// implicit ancestry. Leaves from the implicit view are present in
 	/// `active_leaves`, the opposite doesn't hold true.
@@ -676,6 +682,34 @@ struct State {
 }
 
 impl State {
+	fn new(
+		clock: Arc<dyn Clock>,
+		metrics: Metrics,
+		reputation: ReputationAggregator,
+		ah_invulnerables: HashSet<PeerId>,
+		hold_off_duration: Duration,
+	) -> Self {
+		Self {
+			clock,
+			implicit_view: Default::default(),
+			leaf_claim_queues: Default::default(),
+			leaf_scheduling_info: Default::default(),
+			per_scheduling_parent: Default::default(),
+			peer_data: Default::default(),
+			assigned_cores: Default::default(),
+			collation_requests: Default::default(),
+			collation_requests_cancel_handles: Default::default(),
+			metrics,
+			collation_fetch_timeouts: Default::default(),
+			fetched_candidates: Default::default(),
+			blocked_from_seconding: Default::default(),
+			reputation,
+			ah_invulnerables,
+			ah_held_off_rp_timers: Default::default(),
+			hold_off_duration,
+		}
+	}
+
 	// Returns the number of seconded and pending collations for a specific `ParaId`. Pending
 	// collations are:
 	// 1. Collations being fetched from a collator.
@@ -855,8 +889,9 @@ async fn fetch_collation(
 
 	if peer_data.has_advertised(&relay_parent, candidate_hash) {
 		request_collation(sender, state, pc, id.clone(), peer_data.version).await?;
+		let clock = state.clock.clone();
 		let timeout = |collator_id, candidate_hash, relay_parent| async move {
-			Delay::new(MAX_UNSHARED_DOWNLOAD_TIME).await;
+			clock.delay(MAX_UNSHARED_DOWNLOAD_TIME).await;
 			(collator_id, candidate_hash, relay_parent)
 		};
 		state
@@ -1150,7 +1185,7 @@ async fn process_incoming_peer_message<Context>(
 					"Declared as collator for current para",
 				);
 
-				peer_data.set_collating(collator_id, para_id);
+				peer_data.set_collating(collator_id, para_id, &*state.clock);
 			} else {
 				gum::debug!(
 					target: LOG_TARGET,
@@ -1327,8 +1362,9 @@ fn hold_off_asset_hub_collation_if_needed(
 
 	match hold_off_outcome {
 		HoldOffOperationOutcome::FirstHoldOff => {
+			let clock = state.clock.clone();
 			state.ah_held_off_rp_timers.push(Box::pin(async move {
-				Delay::new(hold_off_duration).await;
+				clock.delay(hold_off_duration).await;
 				scheduling_parent
 			}));
 
@@ -1692,6 +1728,7 @@ where
 			&state.implicit_view,
 			&per_scheduling_parent,
 			&state.leaf_claim_queues,
+			&*state.clock,
 		)
 		.map_err(|error| {
 			gum::debug!(
@@ -1772,7 +1809,11 @@ where
 	// finished relay chain slot. We compare slot numbers rather than timestamps to keep
 	// the logic simple and aligned with how BABE/Aura reason about slots.
 	if candidate_descriptor_version == CandidateDescriptorVersion::V3 {
-		if !is_scheduling_parent_valid(&scheduling_parent, &state.leaf_scheduling_info) {
+		if !is_scheduling_parent_valid(
+			&*state.clock,
+			&scheduling_parent,
+			&state.leaf_scheduling_info,
+		) {
 			return Err(AdvertisementError::SchedulingParentNotValid);
 		}
 	}
@@ -1788,6 +1829,7 @@ where
 			&state.implicit_view,
 			&per_scheduling_parent,
 			&state.leaf_claim_queues,
+			&*state.clock,
 		)
 		.map_err(AdvertisementError::Invalid)?;
 
@@ -2193,9 +2235,10 @@ async fn handle_network_msg<Context>(
 				return Ok(());
 			}
 
+			let now = state.clock.now();
 			state.peer_data.entry(peer_id).or_insert_with(|| PeerData {
 				view: View::default(),
-				state: PeerState::Connected(Instant::now()),
+				state: PeerState::Connected(now),
 				version,
 			});
 			state.metrics.note_collator_peer_count(state.peer_data.len());
@@ -2397,6 +2440,7 @@ pub(crate) async fn run<Context>(
 	metrics: Metrics,
 	ah_invulnerables: HashSet<PeerId>,
 	hold_off_duration: Option<Duration>,
+	clock: Arc<dyn Clock>,
 ) -> std::result::Result<(), SubsystemError> {
 	gum::info!(target: LOG_TARGET, "Running legacy collator protocol");
 	run_inner(
@@ -2408,6 +2452,7 @@ pub(crate) async fn run<Context>(
 		REPUTATION_CHANGE_INTERVAL,
 		ah_invulnerables,
 		hold_off_duration.unwrap_or(HOLD_OFF_DURATION_DEFAULT_VALUE),
+		clock,
 	)
 	.await
 }
@@ -2422,14 +2467,15 @@ async fn run_inner<Context>(
 	reputation_interval: Duration,
 	ah_invulnerables: HashSet<PeerId>,
 	hold_off_duration: Duration,
+	clock: Arc<dyn Clock>,
 ) -> std::result::Result<(), SubsystemError> {
-	let new_reputation_delay = || futures_timer::Delay::new(reputation_interval).fuse();
+	let new_reputation_delay = || clock.delay(reputation_interval).fuse();
 	let mut reputation_delay = new_reputation_delay();
 
 	let mut state =
-		State { metrics, reputation, ah_invulnerables, hold_off_duration, ..Default::default() };
+		State::new(clock.clone(), metrics, reputation, ah_invulnerables, hold_off_duration);
 
-	let next_inactivity_stream = tick_stream(ACTIVITY_POLL);
+	let next_inactivity_stream = tick_stream(clock.clone(), ACTIVITY_POLL);
 	futures::pin_mut!(next_inactivity_stream);
 
 	let mut network_error_freq = gum::Freq::new();
@@ -2457,7 +2503,7 @@ async fn run_inner<Context>(
 				}
 			},
 			_ = next_inactivity_stream.next() => {
-				disconnect_inactive_peers(ctx.sender(), &eviction_policy, &state.peer_data).await;
+				disconnect_inactive_peers(ctx.sender(), &*clock, &eviction_policy, &state.peer_data).await;
 			},
 			resp = state.collation_requests.select_next_some() => {
 				let relay_parent = resp.0.pending_collation.scheduling_parent;
@@ -2849,11 +2895,12 @@ async fn kick_off_seconding<Context>(
 // receipt of the `PeerDisconnected` event.
 async fn disconnect_inactive_peers(
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
+	clock: &dyn crate::Clock,
 	eviction_policy: &crate::CollatorEvictionPolicy,
 	peers: &HashMap<PeerId, PeerData>,
 ) {
 	for (peer, peer_data) in peers {
-		if peer_data.is_inactive(&eviction_policy) {
+		if peer_data.is_inactive(clock, &eviction_policy) {
 			gum::trace!(target: LOG_TARGET, ?peer, "Disconnecting inactive peer");
 			disconnect_peer(sender, *peer).await;
 		}

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -480,10 +480,12 @@ impl PeerData {
 	fn is_inactive(&self, clock: &dyn Clock, policy: &crate::CollatorEvictionPolicy) -> bool {
 		let now = clock.now();
 		match self.state {
-			PeerState::Connected(connected_at) =>
-				now.saturating_duration_since(connected_at) >= policy.undeclared,
-			PeerState::Collating(ref state) =>
-				now.saturating_duration_since(state.last_active) >= policy.inactive_collator,
+			PeerState::Connected(connected_at) => {
+				now.saturating_duration_since(connected_at) >= policy.undeclared
+			},
+			PeerState::Collating(ref state) => {
+				now.saturating_duration_since(state.last_active) >= policy.inactive_collator
+			},
 		}
 	}
 }
@@ -590,8 +592,8 @@ struct HeldOffAdvertisement {
 
 /// All state relevant for the validator side of the protocol lives here.
 struct State {
-	/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a
-	/// mock.
+	/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`];
+	/// tests inject a mock.
 	clock: Arc<dyn Clock>,
 	/// Leaves that do support asynchronous backing along with
 	/// implicit ancestry. Leaves from the implicit view are present in

--- a/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/mod.rs
@@ -145,7 +145,8 @@ use tokio_util::sync::CancellationToken;
 
 use sp_keystore::KeystorePtr;
 
-use crate::{extract_leaf_scheduling_info, is_scheduling_parent_valid, Clock, LeafSchedulingInfo};
+use crate::{extract_leaf_scheduling_info, is_scheduling_parent_valid, LeafSchedulingInfo};
+use polkadot_node_clock::Clock;
 use polkadot_node_network_protocol::{
 	self as net_protocol,
 	peer_set::{CollationVersion, PeerSet, MAX_AUTHORITY_INCOMING_STREAMS},
@@ -476,7 +477,7 @@ impl PeerData {
 	}
 
 	/// Whether the peer is now inactive according to the current instant and the eviction policy.
-	fn is_inactive(&self, clock: &dyn crate::Clock, policy: &crate::CollatorEvictionPolicy) -> bool {
+	fn is_inactive(&self, clock: &dyn Clock, policy: &crate::CollatorEvictionPolicy) -> bool {
 		let now = clock.now();
 		match self.state {
 			PeerState::Connected(connected_at) =>
@@ -589,7 +590,7 @@ struct HeldOffAdvertisement {
 
 /// All state relevant for the validator side of the protocol lives here.
 struct State {
-	/// Clock used for all time reads. Production passes [`crate::SystemClock`]; tests inject a
+	/// Clock used for all time reads. Production passes [`polkadot_node_clock::SystemClock`]; tests inject a
 	/// mock.
 	clock: Arc<dyn Clock>,
 	/// Leaves that do support asynchronous backing along with
@@ -2895,7 +2896,7 @@ async fn kick_off_seconding<Context>(
 // receipt of the `PeerDisconnected` event.
 async fn disconnect_inactive_peers(
 	sender: &mut impl overseer::CollatorProtocolSenderTrait,
-	clock: &dyn crate::Clock,
+	clock: &dyn Clock,
 	eviction_policy: &crate::CollatorEvictionPolicy,
 	peers: &HashMap<PeerId, PeerData>,
 ) {

--- a/polkadot/node/network/collator-protocol/src/validator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/tests/mod.rs
@@ -228,6 +228,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		REPUTATION_CHANGE_TEST_INTERVAL,
 		ah_invulnerable_collators,
 		HOLD_OFF_DURATION_DEFAULT_VALUE,
+		crate::system_clock(),
 	);
 
 	let test_fut = test(TestHarness { virtual_overseer, keystore });

--- a/polkadot/node/network/collator-protocol/src/validator_side/tests/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side/tests/mod.rs
@@ -228,7 +228,7 @@ fn test_harness<T: Future<Output = VirtualOverseer>>(
 		REPUTATION_CHANGE_TEST_INTERVAL,
 		ah_invulnerable_collators,
 		HOLD_OFF_DURATION_DEFAULT_VALUE,
-		crate::system_clock(),
+		polkadot_node_clock::system_clock(),
 	);
 
 	let test_fut = test(TestHarness { virtual_overseer, keystore });

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/collation_manager/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/collation_manager/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 		},
 		error::{Error, FatalResult, Result},
 	},
-	LeafSchedulingInfo, LOG_TARGET,
+	Clock, LeafSchedulingInfo, LOG_TARGET,
 };
 use fatality::Split;
 use futures::{channel::oneshot, stream::FusedStream};
@@ -58,6 +58,7 @@ use sp_keystore::KeystorePtr;
 use sp_runtime::Either;
 use std::{
 	collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+	sync::Arc,
 	time::{Duration, Instant},
 };
 
@@ -110,6 +111,8 @@ pub struct CollationManager {
 	// Key store.
 	keystore: KeystorePtr,
 	leaf_scheduling_info: HashMap<Hash, LeafSchedulingInfo>,
+	// Clock for time reads (V3 scheduling-parent slot validation, advertisement timestamps).
+	clock: Arc<dyn Clock>,
 }
 
 impl CollationManager {
@@ -117,6 +120,7 @@ impl CollationManager {
 		sender: &mut Sender,
 		keystore: KeystorePtr,
 		active_leaf: ActivatedLeaf,
+		clock: Arc<dyn Clock>,
 	) -> FatalResult<Self> {
 		let mut instance = Self {
 			implicit_view: ImplicitView::new(),
@@ -127,6 +131,7 @@ impl CollationManager {
 			fetching: PendingRequests::default(),
 			keystore,
 			leaf_scheduling_info: HashMap::default(),
+			clock,
 		};
 
 		instance.update_view(sender, OurView::new([active_leaf.hash], 0)).await?;
@@ -246,8 +251,10 @@ impl CollationManager {
 						continue;
 					},
 				};
-				self.per_scheduling_parent
-					.insert(*ancestor, PerSchedulingParent::new(session_index, core));
+				self.per_scheduling_parent.insert(
+					*ancestor,
+					PerSchedulingParent::new(session_index, core, &*self.clock),
+				);
 			}
 
 			// Fetch and store the leaf's full per-core claim queue. Capacity at every
@@ -316,8 +323,11 @@ impl CollationManager {
 		// V3 candidate descriptors require scheduling_parent to be the block from the last
 		// finished relay chain slot.
 		if advertised_descriptor_version == Some(CandidateDescriptorVersion::V3) &&
-			!is_scheduling_parent_valid(&scheduling_parent, &self.leaf_scheduling_info)
-		{
+			!is_scheduling_parent_valid(
+				&*self.clock,
+				&scheduling_parent,
+				&self.leaf_scheduling_info,
+			) {
 			return Err(AdvertisementError::SchedulingParentNotValid);
 		}
 
@@ -343,7 +353,7 @@ impl CollationManager {
 			return Err(AdvertisementError::BlockedByBacking);
 		}
 
-		per_sp.add_advertisement(advertisement, Instant::now());
+		per_sp.add_advertisement(advertisement, self.clock.now());
 
 		Ok(())
 	}
@@ -407,7 +417,7 @@ impl CollationManager {
 		max_scores: HashMap<ParaId, Score>,
 		mut create_timer_fn: TimerFn,
 	) -> (Vec<Requests>, Option<Duration>) {
-		let now = Instant::now();
+		let now = self.clock.now();
 		let mut requests = vec![];
 		let mut maybe_min_delay = None;
 
@@ -1190,13 +1200,13 @@ struct PerSchedulingParent {
 }
 
 impl PerSchedulingParent {
-	fn new(session_index: SessionIndex, core_index: CoreIndex) -> Self {
+	fn new(session_index: SessionIndex, core_index: CoreIndex, clock: &dyn Clock) -> Self {
 		Self {
 			session_index,
 			core_index,
 			peer_advertisements: Default::default(),
 			fetched_collations: Default::default(),
-			activated_at: Instant::now(),
+			activated_at: clock.now(),
 		}
 	}
 
@@ -1674,13 +1684,14 @@ mod tests {
 			leaf_claim_queues: HashMap::new(),
 			per_scheduling_parent: HashMap::from([(
 				scheduling_parent,
-				PerSchedulingParent::new(0, CoreIndex(0)),
+				PerSchedulingParent::new(0, CoreIndex(0), &*crate::system_clock()),
 			)]),
 			blocked_from_seconding: HashMap::new(),
 			per_session: LruMap::new(ByLength::new(2)),
 			fetching: PendingRequests::default(),
 			keystore: Arc::new(sc_keystore::LocalKeystore::in_memory()),
 			leaf_scheduling_info: HashMap::default(),
+			clock: crate::system_clock(),
 		};
 
 		// No advertisements - returns Left(None).

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/collation_manager/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/collation_manager/mod.rs
@@ -28,9 +28,10 @@ use crate::{
 		},
 		error::{Error, FatalResult, Result},
 	},
-	Clock, LeafSchedulingInfo, LOG_TARGET,
+	LeafSchedulingInfo, LOG_TARGET,
 };
 use fatality::Split;
+use polkadot_node_clock::Clock;
 use futures::{channel::oneshot, stream::FusedStream};
 use polkadot_node_network_protocol::{
 	peer_set::CollationVersion,
@@ -1684,14 +1685,14 @@ mod tests {
 			leaf_claim_queues: HashMap::new(),
 			per_scheduling_parent: HashMap::from([(
 				scheduling_parent,
-				PerSchedulingParent::new(0, CoreIndex(0), &*crate::system_clock()),
+				PerSchedulingParent::new(0, CoreIndex(0), &*polkadot_node_clock::system_clock()),
 			)]),
 			blocked_from_seconding: HashMap::new(),
 			per_session: LruMap::new(ByLength::new(2)),
 			fetching: PendingRequests::default(),
 			keystore: Arc::new(sc_keystore::LocalKeystore::in_memory()),
 			leaf_scheduling_info: HashMap::default(),
-			clock: crate::system_clock(),
+			clock: polkadot_node_clock::system_clock(),
 		};
 
 		// No advertisements - returns Left(None).

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/collation_manager/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/collation_manager/mod.rs
@@ -31,8 +31,8 @@ use crate::{
 	LeafSchedulingInfo, LOG_TARGET,
 };
 use fatality::Split;
-use polkadot_node_clock::Clock;
 use futures::{channel::oneshot, stream::FusedStream};
+use polkadot_node_clock::Clock;
 use polkadot_node_network_protocol::{
 	peer_set::CollationVersion,
 	request_response::{outgoing::RequestError, v2 as request_v2, Requests},
@@ -252,10 +252,8 @@ impl CollationManager {
 						continue;
 					},
 				};
-				self.per_scheduling_parent.insert(
-					*ancestor,
-					PerSchedulingParent::new(session_index, core, &*self.clock),
-				);
+				self.per_scheduling_parent
+					.insert(*ancestor, PerSchedulingParent::new(session_index, core, &*self.clock));
 			}
 
 			// Fetch and store the leaf's full per-core claim queue. Capacity at every

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
@@ -24,13 +24,12 @@ mod tests;
 
 use crate::{
 	validator_side_experimental::{common::MIN_FETCH_TIMER_DELAY, peer_manager::PersistentDb},
-	LOG_TARGET,
+	Clock, LOG_TARGET,
 };
 use collation_manager::CollationManager;
 use common::{ProspectiveCandidate, MAX_STORED_SCORES_PER_PARA};
 use error::{log_error, FatalError, FatalResult, Result};
 use futures::{future::Fuse, select, FutureExt, StreamExt};
-use futures_timer::Delay;
 use polkadot_node_network_protocol::{
 	self as net_protocol, peer_set::PeerSet, v1 as protocol_v1, v2 as protocol_v2,
 	v3_collation as protocol_v3, CollationProtocols, PeerId,
@@ -72,6 +71,7 @@ pub(crate) async fn run<Context>(
 	metrics: Metrics,
 	db: Arc<dyn Database>,
 	reputation_config: ReputationConfig,
+	clock: Arc<dyn Clock>,
 ) -> FatalResult<()> {
 	let persist_interval = reputation_config
 		.persist_interval
@@ -81,8 +81,10 @@ pub(crate) async fn run<Context>(
 		persist_interval_secs = persist_interval.as_secs(),
 		"Running experimental collator protocol"
 	);
-	if let Some(state) = initialize(&mut ctx, keystore, metrics, db, reputation_config).await? {
-		run_inner(ctx, state, persist_interval).await?;
+	if let Some(state) =
+		initialize(&mut ctx, keystore, metrics, db, reputation_config, clock.clone()).await?
+	{
+		run_inner(ctx, state, persist_interval, clock).await?;
 	}
 
 	Ok(())
@@ -95,6 +97,7 @@ async fn initialize<Context>(
 	metrics: Metrics,
 	db: Arc<dyn Database>,
 	reputation_config: ReputationConfig,
+	clock: Arc<dyn Clock>,
 ) -> FatalResult<Option<State<PersistentDb>>> {
 	loop {
 		let first_leaf = match wait_for_first_leaf(ctx).await? {
@@ -111,7 +114,8 @@ async fn initialize<Context>(
 		};
 
 		let collation_manager =
-			CollationManager::new(ctx.sender(), keystore.clone(), first_leaf).await?;
+			CollationManager::new(ctx.sender(), keystore.clone(), first_leaf, clock.clone())
+				.await?;
 
 		let scheduled_paras = collation_manager.assignments();
 
@@ -140,8 +144,13 @@ async fn initialize<Context>(
 
 		gum::trace!(target: LOG_TARGET, "Spawned background reputation persistence task");
 
-		match PeerManager::startup(backend, ctx.sender(), scheduled_paras.into_iter().collect())
-			.await
+		match PeerManager::startup(
+			backend,
+			ctx.sender(),
+			scheduled_paras.into_iter().collect(),
+			clock.clone(),
+		)
+		.await
 		{
 			Ok(peer_manager) => {
 				return Ok(Some(State::new(peer_manager, collation_manager, metrics)))
@@ -211,9 +220,12 @@ async fn wait_for_first_leaf<Context>(ctx: &mut Context) -> FatalResult<Option<A
 	}
 }
 
-fn create_timer(maybe_delay: Option<Duration>) -> Fuse<Pin<Box<dyn Future<Output = ()> + Send>>> {
+fn create_timer(
+	clock: &dyn Clock,
+	maybe_delay: Option<Duration>,
+) -> Fuse<Pin<Box<dyn Future<Output = ()> + Send>>> {
 	let timer: Pin<Box<dyn Future<Output = ()> + Send>> = match maybe_delay {
-		Some(delay) => Box::pin(Delay::new(delay)),
+		Some(delay) => clock.delay(delay),
 		None => Box::pin(future::pending::<()>()),
 	};
 
@@ -221,9 +233,11 @@ fn create_timer(maybe_delay: Option<Duration>) -> Fuse<Pin<Box<dyn Future<Output
 }
 
 /// Create the persistence timer that fires after the given interval.
-fn create_persistence_timer(interval: Duration) -> Fuse<Pin<Box<dyn Future<Output = ()> + Send>>> {
-	let delay: Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(Delay::new(interval));
-	delay.fuse()
+fn create_persistence_timer(
+	clock: &dyn Clock,
+	interval: Duration,
+) -> Fuse<Pin<Box<dyn Future<Output = ()> + Send>>> {
+	clock.delay(interval).fuse()
 }
 
 #[overseer::contextbounds(CollatorProtocol, prefix = self::overseer)]
@@ -231,9 +245,10 @@ async fn run_inner<Context>(
 	mut ctx: Context,
 	mut state: State<PersistentDb>,
 	persist_interval: Duration,
+	clock: Arc<dyn Clock>,
 ) -> FatalResult<()> {
-	let mut timer = create_timer(None);
-	let mut persistence_timer = create_persistence_timer(persist_interval);
+	let mut timer = create_timer(&*clock, None);
+	let mut persistence_timer = create_persistence_timer(&*clock, persist_interval);
 
 	loop {
 		select! {
@@ -274,7 +289,7 @@ async fn run_inner<Context>(
 				// Periodic persistence - write reputation DB to disk
 				state.background_persist_reputations();
 				// Reset the timer for the next interval
-				persistence_timer = create_persistence_timer(persist_interval);
+				persistence_timer = create_persistence_timer(&*clock, persist_interval);
 			},
 		}
 
@@ -286,7 +301,10 @@ async fn run_inner<Context>(
 		// Also, it takes constant time to run because we only try launching new requests for
 		// unfulfilled claims. It's probably not worth optimising.
 		let maybe_delay = state.try_launch_new_fetch_requests(ctx.sender()).await;
-		timer = create_timer(maybe_delay.map(|delay| std::cmp::max(delay, MIN_FETCH_TIMER_DELAY)));
+		timer = create_timer(
+			&*clock,
+			maybe_delay.map(|delay| std::cmp::max(delay, MIN_FETCH_TIMER_DELAY)),
+		);
 	}
 
 	Ok(())

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
@@ -24,8 +24,9 @@ mod tests;
 
 use crate::{
 	validator_side_experimental::{common::MIN_FETCH_TIMER_DELAY, peer_manager::PersistentDb},
-	Clock, LOG_TARGET,
+	LOG_TARGET,
 };
+use polkadot_node_clock::Clock;
 use collation_manager::CollationManager;
 use common::{ProspectiveCandidate, MAX_STORED_SCORES_PER_PARA};
 use error::{log_error, FatalError, FatalResult, Result};

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/mod.rs
@@ -26,11 +26,11 @@ use crate::{
 	validator_side_experimental::{common::MIN_FETCH_TIMER_DELAY, peer_manager::PersistentDb},
 	LOG_TARGET,
 };
-use polkadot_node_clock::Clock;
 use collation_manager::CollationManager;
 use common::{ProspectiveCandidate, MAX_STORED_SCORES_PER_PARA};
 use error::{log_error, FatalError, FatalResult, Result};
 use futures::{future::Fuse, select, FutureExt, StreamExt};
+use polkadot_node_clock::Clock;
 use polkadot_node_network_protocol::{
 	self as net_protocol, peer_set::PeerSet, v1 as protocol_v1, v2 as protocol_v2,
 	v3_collation as protocol_v3, CollationProtocols, PeerId,

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/backend.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/backend.rs
@@ -36,15 +36,15 @@ pub trait Backend {
 	/// decay for the other collators of that para (if the `decay_value` param is present) and
 	/// because if the number of stored reputations go over the `stored_limit_per_para`, we'll 100%
 	/// slash the least recently bumped peers. `leaf_number` needs to be at least equal to the
-	/// `processed_finalized_block_number`. `now_ms` is the current wall-clock timestamp (millis
-	/// since UNIX epoch) used to stamp the bumped entries; passed in so tests can supply a
+	/// `processed_finalized_block_number`. `now` is the current wall-clock duration since the
+	/// UNIX epoch used to stamp the bumped entries; passed in so tests can supply a
 	/// deterministic clock.
 	async fn process_bumps(
 		&mut self,
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		decay_value: Option<Score>,
-		now_ms: u128,
+		now: std::time::Duration,
 	) -> Vec<ReputationUpdate>;
 	/// Get the maximum scores for the given paraids.
 	async fn max_scores_for_paras(&self, paras: BTreeSet<ParaId>) -> HashMap<ParaId, Score>;

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/backend.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/backend.rs
@@ -36,12 +36,15 @@ pub trait Backend {
 	/// decay for the other collators of that para (if the `decay_value` param is present) and
 	/// because if the number of stored reputations go over the `stored_limit_per_para`, we'll 100%
 	/// slash the least recently bumped peers. `leaf_number` needs to be at least equal to the
-	/// `processed_finalized_block_number`
+	/// `processed_finalized_block_number`. `now_ms` is the current wall-clock timestamp (millis
+	/// since UNIX epoch) used to stamp the bumped entries; passed in so tests can supply a
+	/// deterministic clock.
 	async fn process_bumps(
 		&mut self,
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		decay_value: Option<Score>,
+		now_ms: u128,
 	) -> Vec<ReputationUpdate>;
 	/// Get the maximum scores for the given paraids.
 	async fn max_scores_for_paras(&self, paras: BTreeSet<ParaId>) -> HashMap<ParaId, Score>;

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
@@ -87,14 +87,14 @@ impl Backend for Db {
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		decay_value: Option<Score>,
-		now_ms: u128,
+		now: std::time::Duration,
 	) -> Vec<ReputationUpdate> {
 		if self.last_finalized.unwrap_or(0) >= leaf_number {
 			return vec![];
 		}
 
 		self.last_finalized = Some(leaf_number);
-		self.bump_reputations(bumps, decay_value, now_ms)
+		self.bump_reputations(bumps, decay_value, now.as_millis())
 	}
 
 	async fn max_scores_for_paras(&self, paras: BTreeSet<ParaId>) -> HashMap<ParaId, Score> {
@@ -114,10 +114,9 @@ impl Db {
 		&mut self,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		maybe_decay_value: Option<Score>,
-		now_ms: u128,
+		now: u128,
 	) -> Vec<ReputationUpdate> {
 		let mut reported_updates = vec![];
-		let now = now_ms;
 
 		for (para, bumps_per_para) in bumps {
 			reported_updates.reserve(bumps_per_para.len());
@@ -289,7 +288,7 @@ mod tests {
 		assert_eq!(db.len(), 0);
 
 		// Test empty update with no decay.
-		assert!(db.process_bumps(10, Default::default(), None, 0).await.is_empty());
+		assert!(db.process_bumps(10, Default::default(), None, std::time::Duration::ZERO).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(10));
 		assert_eq!(db.len(), 0);
 
@@ -297,12 +296,12 @@ mod tests {
 		assert_eq!(db.query(&PeerId::random(), &ParaId::from(1000)).await, None);
 
 		// Test empty update with decay.
-		assert!(db.process_bumps(11, Default::default(), Some(Score::new(1)), 0).await.is_empty());
+		assert!(db.process_bumps(11, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(11));
 		assert_eq!(db.len(), 0);
 
 		// Test empty update with a leaf number smaller than the latest one.
-		assert!(db.process_bumps(5, Default::default(), Some(Score::new(1)), 0).await.is_empty());
+		assert!(db.process_bumps(5, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(11));
 		assert_eq!(db.len(), 0);
 
@@ -314,7 +313,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			, 0)
+			, std::time::Duration::ZERO)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(12));
@@ -330,7 +329,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			, 0)
+			, std::time::Duration::ZERO)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(12));
@@ -345,7 +344,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			, 0)
+			, std::time::Duration::ZERO)
 			.await,
 			vec![ReputationUpdate {
 				peer_id: first_peer_id,
@@ -370,7 +369,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			, 0)
+			, std::time::Duration::ZERO)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(13));
@@ -390,7 +389,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				None
-			, 0)
+			, std::time::Duration::ZERO)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -414,7 +413,7 @@ mod tests {
 		assert_eq!(db.query(&first_peer_id, &second_para_id).await.unwrap(), Score::new(5));
 
 		// Empty update with decay has no effect.
-		assert!(db.process_bumps(15, Default::default(), Some(Score::new(1)), 0).await.is_empty());
+		assert!(db.process_bumps(15, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(15));
 		assert_eq!(db.len(), 2);
 		assert_eq!(db.query(&first_peer_id, &first_para_id).await.unwrap(), Score::new(10));
@@ -432,7 +431,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(1))
-			, 0)
+			, std::time::Duration::ZERO)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -476,7 +475,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(5))
-			, 0)
+			, std::time::Duration::ZERO)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -516,7 +515,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				None,
-			0)
+			std::time::Duration::ZERO)
 			.await
 			.len(),
 			10
@@ -545,7 +544,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(5)),
-			0)
+			std::time::Duration::ZERO)
 			.await
 			.len(),
 			10
@@ -569,7 +568,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(5)),
-			0)
+			std::time::Duration::ZERO)
 			.await
 			.len(),
 			11
@@ -593,7 +592,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(10)),
-			0)
+			std::time::Duration::ZERO)
 			.await
 			.len(),
 			11
@@ -632,7 +631,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(10)),
-			0)
+			std::time::Duration::ZERO)
 			.await
 			.len(),
 			3
@@ -682,7 +681,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(10)),
-			0)
+			std::time::Duration::ZERO)
 			.await
 			.len(),
 			3
@@ -757,7 +756,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			now)
+			std::time::Duration::from_millis(now as u64))
 			.await;
 
 			// The oldest peer (smallest last_bumped) should have been evicted.
@@ -802,7 +801,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			now)
+			std::time::Duration::from_millis(now as u64))
 			.await;
 
 			assert!(db.query(&peer_high_score, &para_id).await.is_some(), "ratio≈0.328, survives");
@@ -858,7 +857,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			now)
+			std::time::Duration::from_millis(now as u64))
 			.await;
 
 			assert_eq!(db.query(&peer_old, &para_id).await, None, "ratio=1/30_000, evicted");
@@ -915,7 +914,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			now)
+			std::time::Duration::from_millis(now as u64))
 			.await;
 
 			assert_eq!(db.query(&peer_a, &para_id).await, None, "ratio=1/100_000, evicted");
@@ -956,7 +955,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			now)
+			std::time::Duration::from_millis(now as u64))
 			.await;
 
 			assert_eq!(db.query(&peer_zero, &para_id).await, None, "ratio=0, evicted");
@@ -997,7 +996,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			now)
+			std::time::Duration::from_millis(now as u64))
 			.await;
 
 			assert_eq!(db.query(&peer_a, &para_id).await, None, "lower score wins tie, evicted");

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
@@ -22,10 +22,7 @@ use async_trait::async_trait;
 use polkadot_node_network_protocol::PeerId;
 use polkadot_primitives::{BlockNumber, Id as ParaId};
 use sp_runtime::{traits::Bounded, FixedPointNumber, FixedU128};
-use std::{
-	collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap},
-	time::{SystemTime, UNIX_EPOCH},
-};
+use std::collections::{btree_map, hash_map, BTreeMap, BTreeSet, HashMap};
 
 /// This is an in-memory temporary implementation for the DB, to be used only for prototyping and
 /// testing purposes.
@@ -90,13 +87,14 @@ impl Backend for Db {
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		decay_value: Option<Score>,
+		now_ms: u128,
 	) -> Vec<ReputationUpdate> {
 		if self.last_finalized.unwrap_or(0) >= leaf_number {
 			return vec![];
 		}
 
 		self.last_finalized = Some(leaf_number);
-		self.bump_reputations(bumps, decay_value)
+		self.bump_reputations(bumps, decay_value, now_ms)
 	}
 
 	async fn max_scores_for_paras(&self, paras: BTreeSet<ParaId>) -> HashMap<ParaId, Score> {
@@ -116,9 +114,10 @@ impl Db {
 		&mut self,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		maybe_decay_value: Option<Score>,
+		now_ms: u128,
 	) -> Vec<ReputationUpdate> {
 		let mut reported_updates = vec![];
-		let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+		let now = now_ms;
 
 		for (para, bumps_per_para) in bumps {
 			reported_updates.reserve(bumps_per_para.len());
@@ -290,7 +289,7 @@ mod tests {
 		assert_eq!(db.len(), 0);
 
 		// Test empty update with no decay.
-		assert!(db.process_bumps(10, Default::default(), None).await.is_empty());
+		assert!(db.process_bumps(10, Default::default(), None, 0).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(10));
 		assert_eq!(db.len(), 0);
 
@@ -298,12 +297,12 @@ mod tests {
 		assert_eq!(db.query(&PeerId::random(), &ParaId::from(1000)).await, None);
 
 		// Test empty update with decay.
-		assert!(db.process_bumps(11, Default::default(), Some(Score::new(1))).await.is_empty());
+		assert!(db.process_bumps(11, Default::default(), Some(Score::new(1)), 0).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(11));
 		assert_eq!(db.len(), 0);
 
 		// Test empty update with a leaf number smaller than the latest one.
-		assert!(db.process_bumps(5, Default::default(), Some(Score::new(1))).await.is_empty());
+		assert!(db.process_bumps(5, Default::default(), Some(Score::new(1)), 0).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(11));
 		assert_eq!(db.len(), 0);
 
@@ -315,7 +314,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			)
+			, 0)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(12));
@@ -331,7 +330,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			)
+			, 0)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(12));
@@ -346,7 +345,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			)
+			, 0)
 			.await,
 			vec![ReputationUpdate {
 				peer_id: first_peer_id,
@@ -371,7 +370,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(1))
-			)
+			, 0)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(13));
@@ -391,7 +390,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				None
-			)
+			, 0)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -415,7 +414,7 @@ mod tests {
 		assert_eq!(db.query(&first_peer_id, &second_para_id).await.unwrap(), Score::new(5));
 
 		// Empty update with decay has no effect.
-		assert!(db.process_bumps(15, Default::default(), Some(Score::new(1))).await.is_empty());
+		assert!(db.process_bumps(15, Default::default(), Some(Score::new(1)), 0).await.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(15));
 		assert_eq!(db.len(), 2);
 		assert_eq!(db.query(&first_peer_id, &first_para_id).await.unwrap(), Score::new(10));
@@ -433,7 +432,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(1))
-			)
+			, 0)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -477,7 +476,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(5))
-			)
+			, 0)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -517,7 +516,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				None,
-			)
+			0)
 			.await
 			.len(),
 			10
@@ -546,7 +545,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(5)),
-			)
+			0)
 			.await
 			.len(),
 			10
@@ -570,7 +569,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(5)),
-			)
+			0)
 			.await
 			.len(),
 			11
@@ -594,7 +593,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(10)),
-			)
+			0)
 			.await
 			.len(),
 			11
@@ -633,7 +632,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(10)),
-			)
+			0)
 			.await
 			.len(),
 			3
@@ -683,7 +682,7 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(10)),
-			)
+			0)
 			.await
 			.len(),
 			3
@@ -758,7 +757,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			)
+			now)
 			.await;
 
 			// The oldest peer (smallest last_bumped) should have been evicted.
@@ -803,7 +802,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			)
+			now)
 			.await;
 
 			assert!(db.query(&peer_high_score, &para_id).await.is_some(), "ratio≈0.328, survives");
@@ -859,7 +858,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			)
+			now)
 			.await;
 
 			assert_eq!(db.query(&peer_old, &para_id).await, None, "ratio=1/30_000, evicted");
@@ -916,7 +915,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			)
+			now)
 			.await;
 
 			assert_eq!(db.query(&peer_a, &para_id).await, None, "ratio=1/100_000, evicted");
@@ -957,7 +956,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			)
+			now)
 			.await;
 
 			assert_eq!(db.query(&peer_zero, &para_id).await, None, "ratio=0, evicted");
@@ -998,7 +997,7 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			)
+			now)
 			.await;
 
 			assert_eq!(db.query(&peer_a, &para_id).await, None, "lower score wins tie, evicted");

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/db.rs
@@ -288,7 +288,10 @@ mod tests {
 		assert_eq!(db.len(), 0);
 
 		// Test empty update with no decay.
-		assert!(db.process_bumps(10, Default::default(), None, std::time::Duration::ZERO).await.is_empty());
+		assert!(db
+			.process_bumps(10, Default::default(), None, std::time::Duration::ZERO)
+			.await
+			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(10));
 		assert_eq!(db.len(), 0);
 
@@ -296,12 +299,18 @@ mod tests {
 		assert_eq!(db.query(&PeerId::random(), &ParaId::from(1000)).await, None);
 
 		// Test empty update with decay.
-		assert!(db.process_bumps(11, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO).await.is_empty());
+		assert!(db
+			.process_bumps(11, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO)
+			.await
+			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(11));
 		assert_eq!(db.len(), 0);
 
 		// Test empty update with a leaf number smaller than the latest one.
-		assert!(db.process_bumps(5, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO).await.is_empty());
+		assert!(db
+			.process_bumps(5, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO)
+			.await
+			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(11));
 		assert_eq!(db.len(), 0);
 
@@ -312,8 +321,9 @@ mod tests {
 				[(ParaId::from(100), [(PeerId::random(), Score::new(0))].into_iter().collect())]
 					.into_iter()
 					.collect(),
-				Some(Score::new(1))
-			, std::time::Duration::ZERO)
+				Some(Score::new(1)),
+				std::time::Duration::ZERO
+			)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(12));
@@ -328,8 +338,9 @@ mod tests {
 				[(first_para_id, [(first_peer_id, Score::new(10))].into_iter().collect())]
 					.into_iter()
 					.collect(),
-				Some(Score::new(1))
-			, std::time::Duration::ZERO)
+				Some(Score::new(1)),
+				std::time::Duration::ZERO
+			)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(12));
@@ -343,8 +354,9 @@ mod tests {
 				[(first_para_id, [(first_peer_id, Score::new(10))].into_iter().collect())]
 					.into_iter()
 					.collect(),
-				Some(Score::new(1))
-			, std::time::Duration::ZERO)
+				Some(Score::new(1)),
+				std::time::Duration::ZERO
+			)
 			.await,
 			vec![ReputationUpdate {
 				peer_id: first_peer_id,
@@ -368,8 +380,9 @@ mod tests {
 				[(first_para_id, [(first_peer_id, Score::new(10))].into_iter().collect())]
 					.into_iter()
 					.collect(),
-				Some(Score::new(1))
-			, std::time::Duration::ZERO)
+				Some(Score::new(1)),
+				std::time::Duration::ZERO
+			)
 			.await
 			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(13));
@@ -388,8 +401,9 @@ mod tests {
 				]
 				.into_iter()
 				.collect(),
-				None
-			, std::time::Duration::ZERO)
+				None,
+				std::time::Duration::ZERO
+			)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -413,7 +427,10 @@ mod tests {
 		assert_eq!(db.query(&first_peer_id, &second_para_id).await.unwrap(), Score::new(5));
 
 		// Empty update with decay has no effect.
-		assert!(db.process_bumps(15, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO).await.is_empty());
+		assert!(db
+			.process_bumps(15, Default::default(), Some(Score::new(1)), std::time::Duration::ZERO)
+			.await
+			.is_empty());
 		assert_eq!(db.processed_finalized_block_number().await, Some(15));
 		assert_eq!(db.len(), 2);
 		assert_eq!(db.query(&first_peer_id, &first_para_id).await.unwrap(), Score::new(10));
@@ -430,8 +447,9 @@ mod tests {
 				]
 				.into_iter()
 				.collect(),
-				Some(Score::new(1))
-			, std::time::Duration::ZERO)
+				Some(Score::new(1)),
+				std::time::Duration::ZERO
+			)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -474,8 +492,9 @@ mod tests {
 				[(second_para_id, [(second_peer_id, Score::new(10))].into_iter().collect()),]
 					.into_iter()
 					.collect(),
-				Some(Score::new(5))
-			, std::time::Duration::ZERO)
+				Some(Score::new(5)),
+				std::time::Duration::ZERO
+			)
 			.await,
 			vec![
 				ReputationUpdate {
@@ -515,7 +534,8 @@ mod tests {
 				.into_iter()
 				.collect(),
 				None,
-			std::time::Duration::ZERO)
+				std::time::Duration::ZERO
+			)
 			.await
 			.len(),
 			10
@@ -544,7 +564,8 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(5)),
-			std::time::Duration::ZERO)
+				std::time::Duration::ZERO
+			)
 			.await
 			.len(),
 			10
@@ -568,7 +589,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(5)),
-			std::time::Duration::ZERO)
+				std::time::Duration::ZERO
+			)
 			.await
 			.len(),
 			11
@@ -592,7 +614,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				Some(Score::new(10)),
-			std::time::Duration::ZERO)
+				std::time::Duration::ZERO
+			)
 			.await
 			.len(),
 			11
@@ -631,7 +654,8 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(10)),
-			std::time::Duration::ZERO)
+				std::time::Duration::ZERO
+			)
 			.await
 			.len(),
 			3
@@ -681,7 +705,8 @@ mod tests {
 				.into_iter()
 				.collect(),
 				Some(Score::new(10)),
-			std::time::Duration::ZERO)
+				std::time::Duration::ZERO
+			)
 			.await
 			.len(),
 			3
@@ -756,7 +781,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			std::time::Duration::from_millis(now as u64))
+				std::time::Duration::from_millis(now as u64),
+			)
 			.await;
 
 			// The oldest peer (smallest last_bumped) should have been evicted.
@@ -801,7 +827,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			std::time::Duration::from_millis(now as u64))
+				std::time::Duration::from_millis(now as u64),
+			)
 			.await;
 
 			assert!(db.query(&peer_high_score, &para_id).await.is_some(), "ratio≈0.328, survives");
@@ -857,7 +884,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			std::time::Duration::from_millis(now as u64))
+				std::time::Duration::from_millis(now as u64),
+			)
 			.await;
 
 			assert_eq!(db.query(&peer_old, &para_id).await, None, "ratio=1/30_000, evicted");
@@ -914,7 +942,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			std::time::Duration::from_millis(now as u64))
+				std::time::Duration::from_millis(now as u64),
+			)
 			.await;
 
 			assert_eq!(db.query(&peer_a, &para_id).await, None, "ratio=1/100_000, evicted");
@@ -955,7 +984,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			std::time::Duration::from_millis(now as u64))
+				std::time::Duration::from_millis(now as u64),
+			)
 			.await;
 
 			assert_eq!(db.query(&peer_zero, &para_id).await, None, "ratio=0, evicted");
@@ -996,7 +1026,8 @@ mod tests {
 					.into_iter()
 					.collect(),
 				None,
-			std::time::Duration::from_millis(now as u64))
+				std::time::Duration::from_millis(now as u64),
+			)
 			.await;
 
 			assert_eq!(db.query(&peer_a, &para_id).await, None, "lower score wins tie, evicted");

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/mod.rs
@@ -82,7 +82,7 @@ pub struct PeerManager<B> {
 	/// The `SessionIndex` of the last finalized block
 	latest_finalized_session: Option<SessionIndex>,
 	/// Clock used for reputation timestamps (passed to `Backend::process_bumps`).
-	clock: std::sync::Arc<dyn crate::Clock>,
+	clock: std::sync::Arc<dyn polkadot_node_clock::Clock>,
 }
 
 impl<B: Backend> PeerManager<B> {
@@ -92,7 +92,7 @@ impl<B: Backend> PeerManager<B> {
 		backend: B,
 		sender: &mut Sender,
 		scheduled_paras: BTreeSet<ParaId>,
-		clock: std::sync::Arc<dyn crate::Clock>,
+		clock: std::sync::Arc<dyn polkadot_node_clock::Clock>,
 	) -> Result<Self> {
 		let mut instance = Self {
 			db: backend,
@@ -129,7 +129,12 @@ impl<B: Backend> PeerManager<B> {
 
 		instance
 			.db
-			.process_bumps(latest_finalized_block_number, bumps, None, instance.clock.timestamp_millis())
+			.process_bumps(
+				latest_finalized_block_number,
+				bumps,
+				None,
+				instance.clock.duration_since_epoch(),
+			)
 			.await;
 
 		if latest_finalized_block_number != processed_finalized_block_number {
@@ -162,10 +167,10 @@ impl<B: Backend> PeerManager<B> {
 		)
 		.await?;
 
-		let now_ms = self.clock.timestamp_millis();
+		let now = self.clock.duration_since_epoch();
 		let updates = self
 			.db
-			.process_bumps(finalized_block_number, bumps, Some(Score::new(INACTIVITY_DECAY)), now_ms)
+			.process_bumps(finalized_block_number, bumps, Some(Score::new(INACTIVITY_DECAY)), now)
 			.await;
 		for update in updates {
 			self.connected.update_reputation(update);

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/mod.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/mod.rs
@@ -81,6 +81,8 @@ pub struct PeerManager<B> {
 	connected: ConnectedPeers,
 	/// The `SessionIndex` of the last finalized block
 	latest_finalized_session: Option<SessionIndex>,
+	/// Clock used for reputation timestamps (passed to `Backend::process_bumps`).
+	clock: std::sync::Arc<dyn crate::Clock>,
 }
 
 impl<B: Backend> PeerManager<B> {
@@ -90,6 +92,7 @@ impl<B: Backend> PeerManager<B> {
 		backend: B,
 		sender: &mut Sender,
 		scheduled_paras: BTreeSet<ParaId>,
+		clock: std::sync::Arc<dyn crate::Clock>,
 	) -> Result<Self> {
 		let mut instance = Self {
 			db: backend,
@@ -99,6 +102,7 @@ impl<B: Backend> PeerManager<B> {
 				CONNECTED_PEERS_PARA_LIMIT,
 			),
 			latest_finalized_session: None,
+			clock,
 		};
 
 		let (latest_finalized_block_number, latest_finalized_block_hash) =
@@ -123,7 +127,10 @@ impl<B: Backend> PeerManager<B> {
 		)
 		.await?;
 
-		instance.db.process_bumps(latest_finalized_block_number, bumps, None).await;
+		instance
+			.db
+			.process_bumps(latest_finalized_block_number, bumps, None, instance.clock.timestamp_millis())
+			.await;
 
 		if latest_finalized_block_number != processed_finalized_block_number {
 			gum::trace!(
@@ -155,9 +162,10 @@ impl<B: Backend> PeerManager<B> {
 		)
 		.await?;
 
+		let now_ms = self.clock.timestamp_millis();
 		let updates = self
 			.db
-			.process_bumps(finalized_block_number, bumps, Some(Score::new(INACTIVITY_DECAY)))
+			.process_bumps(finalized_block_number, bumps, Some(Score::new(INACTIVITY_DECAY)), now_ms)
 			.await;
 		for update in updates {
 			self.connected.update_reputation(update);

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/persistent_db.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/persistent_db.rs
@@ -429,6 +429,7 @@ impl Backend for PersistentDb {
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		decay_value: Option<Score>,
+		now_ms: u128,
 	) -> Vec<ReputationUpdate> {
 		// Mark all paras in bumps as dirty.
 		for para_id in bumps.keys() {
@@ -437,7 +438,7 @@ impl Backend for PersistentDb {
 
 		// Delegate to inner DB - NO PERSISTENCE HERE
 		// Persistence happens via the periodic timer calling persist()
-		self.inner.process_bumps(leaf_number, bumps, decay_value).await
+		self.inner.process_bumps(leaf_number, bumps, decay_value, now_ms).await
 	}
 
 	async fn max_scores_for_paras(&self, paras: BTreeSet<ParaId>) -> HashMap<ParaId, Score> {
@@ -513,7 +514,7 @@ mod tests {
 			.into_iter()
 			.collect();
 
-			db.process_bumps(10, bumps, None).await;
+			db.process_bumps(10, bumps, None, 0).await;
 
 			// Persist to disk
 			let _ = db.persist_and_wait().await;
@@ -550,7 +551,7 @@ mod tests {
 			let bumps = [(para_id, [(peer, Score::new(100))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(10, bumps, None).await;
+			db.process_bumps(10, bumps, None, 0).await;
 
 			// Persist initial state
 			let _ = db.persist_and_wait().await;
@@ -587,7 +588,7 @@ mod tests {
 			let bumps = [(para_id, [(peer, Score::new(50))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(10, bumps, None).await;
+			db.process_bumps(10, bumps, None, 0).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -634,7 +635,7 @@ mod tests {
 			]
 			.into_iter()
 			.collect();
-			db.process_bumps(10, bumps, None).await;
+			db.process_bumps(10, bumps, None, 0).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -682,7 +683,7 @@ mod tests {
 			]
 			.into_iter()
 			.collect();
-			db.process_bumps(15, bumps, None).await;
+			db.process_bumps(15, bumps, None, 0).await;
 
 			// Now call periodic persist
 			let _ = db.persist_and_wait().await;
@@ -724,7 +725,7 @@ mod tests {
 			]
 			.into_iter()
 			.collect();
-			db.process_bumps(20, bumps, None).await;
+			db.process_bumps(20, bumps, None, 0).await;
 
 			// Slash peer2 (also persists all dirty paras via background writer)
 			db.slash(&peer2, &para_id_100, Score::new(25)).await;
@@ -748,7 +749,7 @@ mod tests {
 			let bumps = [(para_id_100, [(peer1, Score::new(50))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(25, bumps, None).await;
+			db.process_bumps(25, bumps, None, 0).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -787,7 +788,7 @@ mod tests {
 				[(para_id, original_scores.iter().map(|(peer, score)| (*peer, *score)).collect())]
 					.into_iter()
 					.collect();
-			db.process_bumps(100, bumps, None).await;
+			db.process_bumps(100, bumps, None, 0).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -825,7 +826,7 @@ mod tests {
 			let bumps = [(para_id, [(peer, Score::new(100))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(10, bumps, None).await;
+			db.process_bumps(10, bumps, None, 0).await;
 
 			// Verify in-memory state
 			assert_eq!(db.query(&peer, &para_id).await, Some(Score::new(100)));
@@ -872,7 +873,7 @@ mod tests {
 				})
 				.collect();
 
-			db.process_bumps(50, bumps, None).await;
+			db.process_bumps(50, bumps, None, 0).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -912,7 +913,7 @@ mod tests {
 		let bumps_para_100 = [(para_id_100, [(peer1, Score::new(50))].into_iter().collect())]
 			.into_iter()
 			.collect();
-		db.process_bumps(10, bumps_para_100, None).await;
+		db.process_bumps(10, bumps_para_100, None, 0).await;
 
 		assert!(db.dirty_paras.contains(&para_id_100), "Para 100 should be dirty after bump");
 		assert!(!db.dirty_paras.contains(&para_id_200), "Para 200 should NOT be dirty");
@@ -960,7 +961,7 @@ mod tests {
 		]
 		.into_iter()
 		.collect();
-		db.process_bumps(10, bumps, None).await;
+		db.process_bumps(10, bumps, None, 0).await;
 
 		assert_eq!(db.dirty_paras.len(), 2);
 		assert!(db.dirty_paras.contains(&para_id_100));
@@ -1005,7 +1006,7 @@ mod tests {
 		]
 		.into_iter()
 		.collect();
-		db.process_bumps(10, bumps, None).await;
+		db.process_bumps(10, bumps, None, 0).await;
 
 		assert!(db.dirty_paras.contains(&para_id_100));
 		assert!(db.dirty_paras.contains(&para_id_200));
@@ -1043,7 +1044,7 @@ mod tests {
 		let bumps1 = [(para_id_100, [(peer1, Score::new(50))].into_iter().collect())]
 			.into_iter()
 			.collect();
-		db.process_bumps(10, bumps1, None).await;
+		db.process_bumps(10, bumps1, None, 0).await;
 		db.persist_async(None);
 		sleep(Duration::from_millis(50)).await;
 
@@ -1055,7 +1056,7 @@ mod tests {
 		let bumps2 = [(para_id_100, [(peer1, Score::new(15))].into_iter().collect())]
 			.into_iter()
 			.collect();
-		db.process_bumps(20, bumps2, None).await;
+		db.process_bumps(20, bumps2, None, 0).await;
 
 		// "Crash" (Abort handle, drop DB)
 		handle.abort();

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/persistent_db.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/peer_manager/persistent_db.rs
@@ -429,7 +429,7 @@ impl Backend for PersistentDb {
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		decay_value: Option<Score>,
-		now_ms: u128,
+		now: std::time::Duration,
 	) -> Vec<ReputationUpdate> {
 		// Mark all paras in bumps as dirty.
 		for para_id in bumps.keys() {
@@ -438,7 +438,7 @@ impl Backend for PersistentDb {
 
 		// Delegate to inner DB - NO PERSISTENCE HERE
 		// Persistence happens via the periodic timer calling persist()
-		self.inner.process_bumps(leaf_number, bumps, decay_value, now_ms).await
+		self.inner.process_bumps(leaf_number, bumps, decay_value, now).await
 	}
 
 	async fn max_scores_for_paras(&self, paras: BTreeSet<ParaId>) -> HashMap<ParaId, Score> {
@@ -514,7 +514,7 @@ mod tests {
 			.into_iter()
 			.collect();
 
-			db.process_bumps(10, bumps, None, 0).await;
+			db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 
 			// Persist to disk
 			let _ = db.persist_and_wait().await;
@@ -551,7 +551,7 @@ mod tests {
 			let bumps = [(para_id, [(peer, Score::new(100))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(10, bumps, None, 0).await;
+			db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 
 			// Persist initial state
 			let _ = db.persist_and_wait().await;
@@ -588,7 +588,7 @@ mod tests {
 			let bumps = [(para_id, [(peer, Score::new(50))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(10, bumps, None, 0).await;
+			db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -635,7 +635,7 @@ mod tests {
 			]
 			.into_iter()
 			.collect();
-			db.process_bumps(10, bumps, None, 0).await;
+			db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -683,7 +683,7 @@ mod tests {
 			]
 			.into_iter()
 			.collect();
-			db.process_bumps(15, bumps, None, 0).await;
+			db.process_bumps(15, bumps, None, std::time::Duration::ZERO).await;
 
 			// Now call periodic persist
 			let _ = db.persist_and_wait().await;
@@ -725,7 +725,7 @@ mod tests {
 			]
 			.into_iter()
 			.collect();
-			db.process_bumps(20, bumps, None, 0).await;
+			db.process_bumps(20, bumps, None, std::time::Duration::ZERO).await;
 
 			// Slash peer2 (also persists all dirty paras via background writer)
 			db.slash(&peer2, &para_id_100, Score::new(25)).await;
@@ -749,7 +749,7 @@ mod tests {
 			let bumps = [(para_id_100, [(peer1, Score::new(50))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(25, bumps, None, 0).await;
+			db.process_bumps(25, bumps, None, std::time::Duration::ZERO).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -788,7 +788,7 @@ mod tests {
 				[(para_id, original_scores.iter().map(|(peer, score)| (*peer, *score)).collect())]
 					.into_iter()
 					.collect();
-			db.process_bumps(100, bumps, None, 0).await;
+			db.process_bumps(100, bumps, None, std::time::Duration::ZERO).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -826,7 +826,7 @@ mod tests {
 			let bumps = [(para_id, [(peer, Score::new(100))].into_iter().collect())]
 				.into_iter()
 				.collect();
-			db.process_bumps(10, bumps, None, 0).await;
+			db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 
 			// Verify in-memory state
 			assert_eq!(db.query(&peer, &para_id).await, Some(Score::new(100)));
@@ -873,7 +873,7 @@ mod tests {
 				})
 				.collect();
 
-			db.process_bumps(50, bumps, None, 0).await;
+			db.process_bumps(50, bumps, None, std::time::Duration::ZERO).await;
 			let _ = db.persist_and_wait().await;
 			handle.abort();
 		}
@@ -913,7 +913,7 @@ mod tests {
 		let bumps_para_100 = [(para_id_100, [(peer1, Score::new(50))].into_iter().collect())]
 			.into_iter()
 			.collect();
-		db.process_bumps(10, bumps_para_100, None, 0).await;
+		db.process_bumps(10, bumps_para_100, None, std::time::Duration::ZERO).await;
 
 		assert!(db.dirty_paras.contains(&para_id_100), "Para 100 should be dirty after bump");
 		assert!(!db.dirty_paras.contains(&para_id_200), "Para 200 should NOT be dirty");
@@ -961,7 +961,7 @@ mod tests {
 		]
 		.into_iter()
 		.collect();
-		db.process_bumps(10, bumps, None, 0).await;
+		db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 
 		assert_eq!(db.dirty_paras.len(), 2);
 		assert!(db.dirty_paras.contains(&para_id_100));
@@ -1006,7 +1006,7 @@ mod tests {
 		]
 		.into_iter()
 		.collect();
-		db.process_bumps(10, bumps, None, 0).await;
+		db.process_bumps(10, bumps, None, std::time::Duration::ZERO).await;
 
 		assert!(db.dirty_paras.contains(&para_id_100));
 		assert!(db.dirty_paras.contains(&para_id_200));
@@ -1044,7 +1044,7 @@ mod tests {
 		let bumps1 = [(para_id_100, [(peer1, Score::new(50))].into_iter().collect())]
 			.into_iter()
 			.collect();
-		db.process_bumps(10, bumps1, None, 0).await;
+		db.process_bumps(10, bumps1, None, std::time::Duration::ZERO).await;
 		db.persist_async(None);
 		sleep(Duration::from_millis(50)).await;
 
@@ -1056,7 +1056,7 @@ mod tests {
 		let bumps2 = [(para_id_100, [(peer1, Score::new(15))].into_iter().collect())]
 			.into_iter()
 			.collect();
-		db.process_bumps(20, bumps2, None, 0).await;
+		db.process_bumps(20, bumps2, None, std::time::Duration::ZERO).await;
 
 		// "Crash" (Abort handle, drop DB)
 		handle.abort();

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/tests.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/tests.rs
@@ -1021,13 +1021,19 @@ async fn make_state<B: Backend>(
 			&mut sender,
 			keystore,
 			new_leaf(initial_leaf_hash, initial_leaf_number),
+			crate::system_clock(),
 		)
 		.await
 		.unwrap();
 
-		let peer_manager = PeerManager::startup(db, &mut sender, collation_manager.assignments())
-			.await
-			.unwrap();
+		let peer_manager = PeerManager::startup(
+			db,
+			&mut sender,
+			collation_manager.assignments(),
+			crate::system_clock(),
+		)
+		.await
+		.unwrap();
 
 		State::new(peer_manager, collation_manager, Metrics::default())
 	};
@@ -1101,6 +1107,7 @@ impl Backend for MockDb {
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		_decay_value: Option<Score>,
+		_now_ms: u128,
 	) -> Vec<ReputationUpdate> {
 		let old_bumps = std::mem::replace(
 			self.witnessed_bumps.lock().unwrap().deref_mut(),

--- a/polkadot/node/network/collator-protocol/src/validator_side_experimental/tests.rs
+++ b/polkadot/node/network/collator-protocol/src/validator_side_experimental/tests.rs
@@ -1021,7 +1021,7 @@ async fn make_state<B: Backend>(
 			&mut sender,
 			keystore,
 			new_leaf(initial_leaf_hash, initial_leaf_number),
-			crate::system_clock(),
+			polkadot_node_clock::system_clock(),
 		)
 		.await
 		.unwrap();
@@ -1030,7 +1030,7 @@ async fn make_state<B: Backend>(
 			db,
 			&mut sender,
 			collation_manager.assignments(),
-			crate::system_clock(),
+			polkadot_node_clock::system_clock(),
 		)
 		.await
 		.unwrap();
@@ -1107,7 +1107,7 @@ impl Backend for MockDb {
 		leaf_number: BlockNumber,
 		bumps: BTreeMap<ParaId, HashMap<PeerId, Score>>,
 		_decay_value: Option<Score>,
-		_now_ms: u128,
+		_now: std::time::Duration,
 	) -> Vec<ReputationUpdate> {
 		let old_bumps = std::mem::replace(
 			self.witnessed_bumps.lock().unwrap().deref_mut(),

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -113,6 +113,7 @@ polkadot-availability-bitfield-distribution = { optional = true, workspace = tru
 polkadot-availability-distribution = { optional = true, workspace = true, default-features = true }
 polkadot-availability-recovery = { optional = true, workspace = true, default-features = true }
 polkadot-collator-protocol = { optional = true, workspace = true, default-features = true }
+polkadot-node-clock = { optional = true, workspace = true, default-features = true }
 polkadot-dispute-distribution = { optional = true, workspace = true, default-features = true }
 polkadot-gossip-support = { optional = true, workspace = true, default-features = true }
 polkadot-network-bridge = { optional = true, workspace = true, default-features = true }
@@ -155,6 +156,7 @@ full-node = [
 	"polkadot-availability-distribution",
 	"polkadot-availability-recovery",
 	"polkadot-collator-protocol",
+	"polkadot-node-clock",
 	"polkadot-dispute-distribution",
 	"polkadot-gossip-support",
 	"polkadot-network-bridge",

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -113,10 +113,10 @@ polkadot-availability-bitfield-distribution = { optional = true, workspace = tru
 polkadot-availability-distribution = { optional = true, workspace = true, default-features = true }
 polkadot-availability-recovery = { optional = true, workspace = true, default-features = true }
 polkadot-collator-protocol = { optional = true, workspace = true, default-features = true }
-polkadot-node-clock = { optional = true, workspace = true, default-features = true }
 polkadot-dispute-distribution = { optional = true, workspace = true, default-features = true }
 polkadot-gossip-support = { optional = true, workspace = true, default-features = true }
 polkadot-network-bridge = { optional = true, workspace = true, default-features = true }
+polkadot-node-clock = { optional = true, workspace = true, default-features = true }
 polkadot-node-collation-generation = { optional = true, workspace = true, default-features = true }
 polkadot-node-core-approval-voting = { optional = true, workspace = true, default-features = true }
 polkadot-node-core-approval-voting-parallel = { optional = true, workspace = true, default-features = true }
@@ -156,10 +156,10 @@ full-node = [
 	"polkadot-availability-distribution",
 	"polkadot-availability-recovery",
 	"polkadot-collator-protocol",
-	"polkadot-node-clock",
 	"polkadot-dispute-distribution",
 	"polkadot-gossip-support",
 	"polkadot-network-bridge",
+	"polkadot-node-clock",
 	"polkadot-node-collation-generation",
 	"polkadot-node-core-approval-voting",
 	"polkadot-node-core-approval-voting-parallel",

--- a/polkadot/node/service/src/overseer.rs
+++ b/polkadot/node/service/src/overseer.rs
@@ -314,7 +314,7 @@ where
 							metrics: Metrics::register(registry)?,
 							db: parachains_db.clone(),
 							reputation_config,
-							clock: polkadot_collator_protocol::system_clock(),
+							clock: polkadot_node_clock::system_clock(),
 						}
 					} else {
 						ProtocolSide::Validator {
@@ -323,7 +323,7 @@ where
 							metrics: Metrics::register(registry)?,
 							invulnerables: invulnerable_ah_collators,
 							collator_protocol_hold_off,
-							clock: polkadot_collator_protocol::system_clock(),
+							clock: polkadot_node_clock::system_clock(),
 						}
 					}
 				},
@@ -497,7 +497,7 @@ where
 					collator_pair,
 					request_receiver_v2: collation_req_v2_receiver,
 					metrics: Metrics::register(registry)?,
-					clock: polkadot_collator_protocol::system_clock(),
+					clock: polkadot_node_clock::system_clock(),
 				},
 				IsParachainNode::FullNode => ProtocolSide::None,
 			};

--- a/polkadot/node/service/src/overseer.rs
+++ b/polkadot/node/service/src/overseer.rs
@@ -314,6 +314,7 @@ where
 							metrics: Metrics::register(registry)?,
 							db: parachains_db.clone(),
 							reputation_config,
+							clock: polkadot_collator_protocol::system_clock(),
 						}
 					} else {
 						ProtocolSide::Validator {
@@ -322,6 +323,7 @@ where
 							metrics: Metrics::register(registry)?,
 							invulnerables: invulnerable_ah_collators,
 							collator_protocol_hold_off,
+							clock: polkadot_collator_protocol::system_clock(),
 						}
 					}
 				},
@@ -495,6 +497,7 @@ where
 					collator_pair,
 					request_receiver_v2: collation_req_v2_receiver,
 					metrics: Metrics::register(registry)?,
+					clock: polkadot_collator_protocol::system_clock(),
 				},
 				IsParachainNode::FullNode => ProtocolSide::None,
 			};

--- a/prdoc/pr_12212.prdoc
+++ b/prdoc/pr_12212.prdoc
@@ -44,10 +44,12 @@ crates:
   - name: polkadot-collator-protocol
     bump: major
   - name: polkadot-node-core-chain-selection
-    bump: patch
+    bump: major
   - name: polkadot-node-core-av-store
-    bump: patch
+    bump: major
   - name: polkadot-node-core-dispute-coordinator
-    bump: patch
+    bump: minor
   - name: polkadot-service
-    bump: patch
+    bump: minor
+  - name: polkadot-sdk
+    bump: minor

--- a/prdoc/pr_12212.prdoc
+++ b/prdoc/pr_12212.prdoc
@@ -4,9 +4,10 @@ doc:
   - audience: Node Dev
     description: |
       Introduces a new `polkadot-node-clock` crate exporting a unified `Clock`
-      trait (`now/delay/timestamp_millis`) plus a production `SystemClock`
-      implementation. Migrates four subsystems off their ad-hoc per-crate
-      clock traits and onto the shared abstraction:
+      trait (`now` / `delay` / `duration_since_epoch`) plus a production
+      `SystemClock` implementation and a feature-gated `MockClock` for tests.
+      Migrates four subsystems off their ad-hoc per-crate clock traits and
+      onto the shared abstraction:
 
       - `polkadot-collator-protocol`: full migration of all time reads
         (production paths use the shared `SystemClock`; the crate-level
@@ -39,6 +40,7 @@ doc:
 crates:
   - name: polkadot-node-clock
     bump: major
+    validate: false
   - name: polkadot-collator-protocol
     bump: major
   - name: polkadot-node-core-chain-selection

--- a/prdoc/pr_node_clock_abstraction.prdoc
+++ b/prdoc/pr_node_clock_abstraction.prdoc
@@ -1,0 +1,51 @@
+title: "node: introduce shared `Clock` abstraction and apply to four subsystems"
+
+doc:
+  - audience: Node Dev
+    description: |
+      Introduces a new `polkadot-node-clock` crate exporting a unified `Clock`
+      trait (`now/delay/timestamp_millis`) plus a production `SystemClock`
+      implementation. Migrates four subsystems off their ad-hoc per-crate
+      clock traits and onto the shared abstraction:
+
+      - `polkadot-collator-protocol`: full migration of all time reads
+        (production paths use the shared `SystemClock`; the crate-level
+        `clippy.toml` forbids direct `Instant::now`, `SystemTime::now`,
+        `tokio::time::sleep`, `futures_timer::Delay::new`, and
+        `sp_timestamp::Timestamp::current`).
+      - `polkadot-node-core-chain-selection`: replaces the local `Clock` /
+        `SystemClock` with the shared crate.
+      - `polkadot-node-core-av-store`: replaces the local `Clock` /
+        `SystemClock` with the shared crate. Drops the `Error::Time`
+        variant; reads via the shared trait are infallible.
+      - `polkadot-node-core-dispute-coordinator`: replaces the local
+        `Clock` / `SystemClock` (in `status.rs`) with the shared crate.
+
+      Known gap (documented in `polkadot-node-clock`'s module docs): the
+      chain-selection, av-store, and dispute-coordinator subsystems still
+      call `futures_timer::Delay::new` directly for their internal timers
+      (their previous `Clock` traits did not cover delays either). Those
+      sites are not yet routed through the shared trait and must be
+      migrated before those subsystems can run under a deterministic test
+      harness. The collator-protocol subsystem routes all its time reads
+      through the shared `Clock`.
+
+      The approval-voting / approval-distribution stack has its own
+      tick-aligned clock layer; that migration is deferred to a follow-up
+      PR.
+
+      No production behaviour change.
+
+crates:
+  - name: polkadot-node-clock
+    bump: major
+  - name: polkadot-collator-protocol
+    bump: major
+  - name: polkadot-node-core-chain-selection
+    bump: patch
+  - name: polkadot-node-core-av-store
+    bump: patch
+  - name: polkadot-node-core-dispute-coordinator
+    bump: patch
+  - name: polkadot-service
+    bump: patch

--- a/umbrella/Cargo.toml
+++ b/umbrella/Cargo.toml
@@ -923,6 +923,7 @@ node = [
 	"polkadot-erasure-coding",
 	"polkadot-gossip-support",
 	"polkadot-network-bridge",
+	"polkadot-node-clock",
 	"polkadot-node-collation-generation",
 	"polkadot-node-core-approval-voting",
 	"polkadot-node-core-approval-voting-parallel",
@@ -2459,6 +2460,11 @@ path = "../polkadot/node/network/gossip-support"
 default-features = false
 optional = true
 path = "../polkadot/node/network/bridge"
+
+[dependencies.polkadot-node-clock]
+default-features = false
+optional = true
+path = "../polkadot/node/clock"
 
 [dependencies.polkadot-node-collation-generation]
 default-features = false

--- a/umbrella/src/lib.rs
+++ b/umbrella/src/lib.rs
@@ -890,6 +890,10 @@ pub use polkadot_gossip_support;
 #[cfg(feature = "polkadot-network-bridge")]
 pub use polkadot_network_bridge;
 
+/// Clock abstraction shared by Polkadot node subsystems.
+#[cfg(feature = "polkadot-node-clock")]
+pub use polkadot_node_clock;
+
 /// Collator-side subsystem that handles incoming candidate submissions from the parachain.
 #[cfg(feature = "polkadot-node-collation-generation")]
 pub use polkadot_node_collation_generation;


### PR DESCRIPTION
All prod changes needed for https://github.com/paritytech/polkadot-sdk/pull/12007 . With this merged, 12007 should be test code only. We skipped full determinism for now on subsystems we don't have deterministic tests yet anyways. Those will come later as needed.