### PR TITLE
pallet-beefy-mmr: align ECDSA→ETH failure sentinel between converter and consumer

### DIFF
--- a/prdoc/pr_12214.prdoc
+++ b/prdoc/pr_12214.prdoc
@@ -1,0 +1,11 @@
+title: "pallet-beefy-mmr: align ECDSA\u2192ETH failure sentinel between converter\
+  \ and consumer"
+doc:
+- audience: Runtime Dev
+  description: |-
+    BeefyEcdsaToEthereum returned an empty Vec<u8> on conversion failure, while compute_authority_set counted failures by matching [0u8; 20].
+    Extract the sentinel into a shared FAILED_BEEFY_TO_ETH_ADDRESS constant referenced by both sites.
+    Fix mock_beefy_id to derive valid ECDSA keys so tests exercise the happy path as well as the failure branch.
+crates:
+- name: pallet-beefy-mmr
+  bump: patch

--- a/substrate/frame/beefy-mmr/src/lib.rs
+++ b/substrate/frame/beefy-mmr/src/lib.rs
@@ -83,6 +83,13 @@ where
 	}
 }
 
+/// Sentinel returned by [`BeefyEcdsaToEthereum`] when an ECDSA public key cannot be
+/// converted to an Ethereum address. Both producer and consumer must reference this
+/// constant so the two ends of the conversion can never drift to different sentinels
+/// (see `Pallet::compute_authority_set`, which counts failed conversions by matching
+/// against this value).
+pub const FAILED_BEEFY_TO_ETH_ADDRESS: [u8; 20] = [0u8; 20];
+
 /// Convert BEEFY secp256k1 public keys into Ethereum addresses
 pub struct BeefyEcdsaToEthereum;
 impl Convert<sp_consensus_beefy::ecdsa_crypto::AuthorityId, Vec<u8>> for BeefyEcdsaToEthereum {
@@ -90,10 +97,10 @@ impl Convert<sp_consensus_beefy::ecdsa_crypto::AuthorityId, Vec<u8>> for BeefyEc
 		sp_core::ecdsa::Public::from(beefy_id)
 			.to_eth_address()
 			.map(|v| v.to_vec())
-			.map_err(|_| {
+			.unwrap_or_else(|_| {
 				log::debug!(target: "runtime::beefy", "Failed to convert BEEFY PublicKey to ETH address!");
+				FAILED_BEEFY_TO_ETH_ADDRESS.to_vec()
 			})
-			.unwrap_or_default()
 	}
 }
 
@@ -336,11 +343,10 @@ impl<T: Config> Pallet<T> {
 			.cloned()
 			.map(T::BeefyAuthorityToMerkleLeaf::convert)
 			.collect::<Vec<_>>();
-		let default_eth_addr = [0u8; 20];
 		let len = beefy_addresses.len() as u32;
 		let uninitialized_addresses = beefy_addresses
 			.iter()
-			.filter(|&addr| addr.as_slice().eq(&default_eth_addr))
+			.filter(|&addr| addr.as_slice().eq(&FAILED_BEEFY_TO_ETH_ADDRESS))
 			.count();
 		if uninitialized_addresses > 0 {
 			log::error!(

--- a/substrate/frame/beefy-mmr/src/mock.rs
+++ b/substrate/frame/beefy-mmr/src/mock.rs
@@ -25,7 +25,6 @@ use frame_support::{
 use sp_consensus_beefy::mmr::MmrLeafVersion;
 use sp_io::TestExternalities;
 use sp_runtime::{
-	app_crypto::ecdsa::Public,
 	impl_opaque_keys,
 	traits::{ConvertInto, Keccak256, OpaqueKeys},
 	BuildStorage,
@@ -35,9 +34,14 @@ use sp_state_machine::BasicExternalities;
 use crate as pallet_beefy_mmr;
 
 pub use sp_consensus_beefy::{
-	ecdsa_crypto::AuthorityId as BeefyId, mmr::BeefyDataProvider, ConsensusLog, BEEFY_ENGINE_ID,
+	ecdsa_crypto::{AuthorityId as BeefyId, Pair as BeefyPair},
+	mmr::BeefyDataProvider,
+	ConsensusLog, BEEFY_ENGINE_ID,
 };
-use sp_core::offchain::{testing::TestOffchainExt, OffchainDbExt, OffchainWorkerExt};
+use sp_core::{
+	offchain::{testing::TestOffchainExt, OffchainDbExt, OffchainWorkerExt},
+	Pair,
+};
 
 impl_opaque_keys! {
 	pub struct MockSessionKeys {
@@ -167,12 +171,15 @@ impl pallet_session::SessionManager<u64> for MockSessionManager {
 // of `to_public_key()` assumes, that a public key is 32 bytes long. This is true for
 // ed25519 and sr25519 but *not* for ecdsa. A compressed ecdsa public key is 33 bytes,
 // with the first one containing information to reconstruct the uncompressed key.
+//
+// We derive deterministic *valid* ECDSA keys from a per-id seed so that
+// `BeefyEcdsaToEthereum` exercises its happy path (it errors on malformed keys and
+// falls back to the all-zeros sentinel; using fabricated bytes would silently hide
+// that behavior in tests).
 pub fn mock_beefy_id(id: u8) -> BeefyId {
-	let mut buf: [u8; 33] = [id; 33];
-	// Set to something valid.
-	buf[0] = 0x02;
-	let pk = Public::from_raw(buf);
-	BeefyId::from(pk)
+	let mut seed = [0u8; 32];
+	seed[0] = id;
+	BeefyPair::from_seed(&seed).public()
 }
 
 pub fn mock_authorities(vec: Vec<u8>) -> Vec<(u64, BeefyId)> {

--- a/substrate/frame/beefy-mmr/src/tests.rs
+++ b/substrate/frame/beefy-mmr/src/tests.rs
@@ -69,8 +69,8 @@ fn should_contain_mmr_digest() {
 					ValidatorSet::new(vec![mock_beefy_id(1), mock_beefy_id(2)], 1).unwrap()
 				)),
 				beefy_log(ConsensusLog::MmrRoot(H256::from_slice(&[
-					117, 0, 56, 25, 185, 195, 71, 232, 67, 213, 27, 178, 64, 168, 137, 220, 64,
-					184, 64, 240, 83, 245, 18, 93, 185, 202, 125, 205, 17, 254, 18, 143
+					173, 241, 162, 161, 65, 69, 21, 229, 31, 108, 53, 148, 216, 188, 0, 176, 115,
+					165, 143, 151, 91, 233, 129, 93, 235, 171, 5, 201, 206, 160, 27, 22
 				])))
 			]
 		);
@@ -84,8 +84,8 @@ fn should_contain_mmr_digest() {
 					ValidatorSet::new(vec![mock_beefy_id(3), mock_beefy_id(4)], 2).unwrap()
 				)),
 				beefy_log(ConsensusLog::MmrRoot(H256::from_slice(&[
-					193, 246, 48, 7, 89, 204, 186, 109, 167, 226, 188, 211, 8, 243, 203, 154, 234,
-					235, 136, 210, 245, 7, 209, 27, 241, 90, 156, 113, 137, 65, 191, 139
+					6, 76, 16, 37, 40, 27, 157, 217, 207, 77, 66, 97, 27, 167, 7, 210, 179, 3, 209,
+					245, 24, 108, 70, 169, 172, 67, 201, 117, 203, 0, 249, 138
 				]))),
 			]
 		);
@@ -114,7 +114,7 @@ fn should_contain_valid_leaf_data() {
 				id: 2,
 				len: 2,
 				keyset_commitment: array_bytes::hex_n_into_unchecked(
-					"9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5"
+					"d4eb50bacc74545046503f26b678fb8e71031a1b5fb6659576eab17521c64d34"
 				)
 			},
 			leaf_extra: array_bytes::hex2bytes_unchecked(
@@ -139,7 +139,7 @@ fn should_contain_valid_leaf_data() {
 				id: 3,
 				len: 2,
 				keyset_commitment: array_bytes::hex_n_into_unchecked(
-					"9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5"
+					"d4eb50bacc74545046503f26b678fb8e71031a1b5fb6659576eab17521c64d34"
 				)
 			},
 			leaf_extra: array_bytes::hex2bytes_unchecked(
@@ -159,7 +159,7 @@ fn should_update_authorities() {
 		assert_eq!(0, auth_set.id);
 		assert_eq!(2, auth_set.len);
 		let want = array_bytes::hex_n_into_unchecked::<_, H256, 32>(
-			"176e73f1bf656478b728e28dd1a7733c98621b8acf830bff585949763dca7a96",
+			"8db0d5104b090776e5812e995875ba50ff47886f4ba9b6a221596443f01cb258",
 		);
 		assert_eq!(want, auth_set.keyset_commitment);
 
@@ -179,7 +179,7 @@ fn should_update_authorities() {
 		// check next auth set
 		assert_eq!(2, next_auth_set.id);
 		let want = array_bytes::hex_n_into_unchecked::<_, H256, 32>(
-			"9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5",
+			"d4eb50bacc74545046503f26b678fb8e71031a1b5fb6659576eab17521c64d34",
 		);
 		assert_eq!(2, next_auth_set.len);
 		assert_eq!(want, next_auth_set.keyset_commitment);
@@ -195,7 +195,7 @@ fn should_update_authorities() {
 		// check next auth set
 		assert_eq!(3, next_auth_set.id);
 		let want = array_bytes::hex_n_into_unchecked::<_, H256, 32>(
-			"9c6b2c1b0d0b25a008e6c882cc7b415f309965c72ad2b944ac0931048ca31cd5",
+			"d4eb50bacc74545046503f26b678fb8e71031a1b5fb6659576eab17521c64d34",
 		);
 		assert_eq!(2, next_auth_set.len);
 		assert_eq!(want, next_auth_set.keyset_commitment);
@@ -218,7 +218,7 @@ fn extract_validation_context_should_work_correctly() {
 
 		// Check the MMR root log
 		let expected_mmr_root: [u8; 32] = array_bytes::hex_n_into_unchecked(
-			"322c6a46ac00d3455c87bd9af42ebafb388f589a1b562f5e39b1d0d71bcbe8e0",
+			"9c26423184ad4f1c978df3b60294ad63b67b52b8e3bb8d831cabac40d98f7fb7",
 		);
 
 		assert_eq!(
@@ -388,4 +388,22 @@ fn is_non_canonical_should_work_correctly() {
 			)
 		}
 	});
+}
+
+#[test]
+fn ecdsa_to_eth_falls_back_to_zero_address_on_invalid_key() {
+	use sp_runtime::traits::Convert;
+
+	// Malformed ECDSA public key — `to_eth_address` fails on this input.
+	let malformed = BeefyId::from(sp_core::ecdsa::Public::from_raw([0xFF; 33]));
+	assert_eq!(
+		crate::BeefyEcdsaToEthereum::convert(malformed),
+		crate::FAILED_BEEFY_TO_ETH_ADDRESS.to_vec(),
+	);
+
+	// Valid keys still convert to non-zero, distinct Ethereum addresses.
+	let addr1 = crate::BeefyEcdsaToEthereum::convert(mock_beefy_id(1));
+	let addr2 = crate::BeefyEcdsaToEthereum::convert(mock_beefy_id(2));
+	assert_ne!(addr1, crate::FAILED_BEEFY_TO_ETH_ADDRESS.to_vec());
+	assert_ne!(addr1, addr2);
 }


### PR DESCRIPTION
BeefyEcdsaToEthereum returned an empty Vec<u8> on conversion failure, while compute_authority_set counted failures by matching [0u8; 20].
Extract the sentinel into a shared FAILED_BEEFY_TO_ETH_ADDRESS constant referenced by both sites.
Fix mock_beefy_id to derive valid ECDSA keys so tests exercise the happy path as well as the failure branch.