### PR TITLE
pallet-revive: map account in prepare_dry_run

### DIFF
--- a/prdoc/pr_12225.prdoc
+++ b/prdoc/pr_12225.prdoc
@@ -1,0 +1,12 @@
+title: 'pallet-revive: map account in prepare_dry_run'
+doc:
+- audience: Runtime Dev
+  description: |-
+    ## Summary
+    - Map the origin account in `prepare_dry_run` when it is not already mapped, so dry-running contract calls/instantiations does not fail with `AccountUnmapped` for callers that never registered a mapping.
+
+    ## Test plan
+    - [ ] CI passes
+crates:
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -1821,6 +1821,12 @@ impl<T: Config> Pallet<T> {
 		// Bump the  nonce to simulate what would happen
 		// `pre-dispatch` if the transaction was executed.
 		frame_system::Pallet::<T>::inc_account_nonce(account);
+
+		// Map the account if it is not mapped already so we don't hit
+		// `AccountUnmapped` from the origin when dry-running.
+		if !T::AddressMapper::is_mapped(account) {
+			let _ = T::AddressMapper::map_no_deposit_unchecked(account);
+		}
 	}
 
 	/// A generalized version of [`Self::instantiate`] or [`Self::instantiate_with_code`].

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3949,7 +3949,6 @@ fn origin_must_be_mapped() {
 fn prepare_dry_run_maps_unmapped_account() {
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
 		// EVE is not eth-derived and has no balance, so the account does not exist.
-		assert!(!<Test as Config>::AddressMapper::is_mapped(&EVE));
 		assert!(!frame_system::Pallet::<Test>::account_exists(&EVE));
 
 		Pallet::<Test>::prepare_dry_run(&EVE);

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3946,6 +3946,19 @@ fn origin_must_be_mapped() {
 }
 
 #[test]
+fn prepare_dry_run_maps_unmapped_account() {
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		// EVE is not eth-derived and has no balance, so the account does not exist.
+		assert!(!<Test as Config>::AddressMapper::is_mapped(&EVE));
+		assert!(!frame_system::Pallet::<Test>::account_exists(&EVE));
+
+		Pallet::<Test>::prepare_dry_run(&EVE);
+
+		assert!(<Test as Config>::AddressMapper::is_mapped(&EVE));
+	});
+}
+
+#[test]
 fn mapped_address_works() {
 	let (code, _) = compile_module("terminate_and_send_to_argument").unwrap();
 

--- a/substrate/frame/revive/src/tests/pvm.rs
+++ b/substrate/frame/revive/src/tests/pvm.rs
@@ -3948,8 +3948,8 @@ fn origin_must_be_mapped() {
 #[test]
 fn prepare_dry_run_maps_unmapped_account() {
 	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
-		// EVE is not eth-derived and has no balance, so the account does not exist.
 		assert!(!frame_system::Pallet::<Test>::account_exists(&EVE));
+		assert!(!<Test as Config>::AddressMapper::is_mapped(&EVE));
 
 		Pallet::<Test>::prepare_dry_run(&EVE);
 


### PR DESCRIPTION
- Map the origin account in `prepare_dry_run` when it is not already mapped, so dry-running contract calls/instantiations does not fail with `AccountUnmapped` for  callers that never registered a mapping (e.g fresh product account that does not exist on chain yet)
