### PR TITLE
SpecMsg: Design Parachain Communication

### DIFF
--- a/docs/speculative-messaging-design.md
+++ b/docs/speculative-messaging-design.md
@@ -211,109 +211,34 @@ Instead of routing messages through relay chain state, we:
 
 ## Detailed Design
 
-## Parachain Communication
+## Parachain Discoverability
 
-Parachain collators operating on different peer-to-peer (P2P) networks need a way to exchange messages off-chain.
-The relay chain only processes message commitments, not the messages themselves. Direct communication between
-collators of different parachains is not possible due to different genesis hashes and sync protocols.
+Parachain nodes operating on different peer-to-peer (P2P) networks need a mechanism to exchange messages off-chain.
+The relay chain only processes message commitments, not the messages themselves. Parachains must rely on an
+alternative discovery method, since different geensis hashes and sync protocols prevent direct communication.
 
-To enable off-chain communicaiton between collators, a dedicated P2P network is created.
-This **Speculative Messaging Network** includes collators from al parachains that opt into
-speculative messaging.
+The discoverability of parachains leverages the existing bootnodes on DHT mechanism on the relay chain side,
+as specified at: [RFC 08](https://github.com/polkadot-fellows/RFCs/blob/main/text/0008-parachain-bootnodes-dht.md).
+The relay chain peers of parachains advertise themselves as providers in the relay chain DHT using the key `para ID || epoch randomness`.
+Only the 20 closest peer IDs to this key are kept as providers, and the provider set is updated on every epoch change.
 
-Alternative architectures were considered:
-- Routing through relay chain peers: Adds unnecessary laod and stress on the relay chain,
-  as well as new protocols for message exchange between collators.
-- Spawning a dedicated network backend for each parachain: Highly resource-intensive and doesn't scale
-  well with the number of parachains.
+To translate these peer IDs into actual bootnode addresses, the `/paranode` request-response protocol is used.
+This protocol accepts a SCALE-compact-encoded `para ID` as input and returns a list of bootnode multiaddresses for that parachain.
 
-By deploying a single network backend for the entire speculative messaging work, we keep the relay chain side
-changes to a minimum (needed for JAM compatibility) and we can leverage the existing bootnodes on DHT
-mechanism for collator discovery.
+## Parachain Communcation
 
-The **Speculative Messaging Network** exposes the following protocols:
-- Kademlia DHT: `/spec-msg/kad` for peer discovery.
-- Identify and Ping: `/spec-msg/identify` and `/spec-msg/ping` for obtaining peer addresses and keeping connections alive.
-- Speculative Messaging Protocol: `/spec-msg/exchange` for exchanging messages between collators.
-- Light Client Request-Response: `/spec-msg/light/2` for fetching authority discovery keys of other collators.
+Instead of spawning a dedicated global network for speculative messaging, a parachain node reutilizes its existing
+parachain-side litep2p network backend. After obtaining the bootnode list of the destination parachain from the relay chain,
+the genesis hash and fork ID are extracted directly from the bootnode list.
 
-Parachains outside a trust domain, or those that don't wish to participate can simply ignore the Speculative Messaging
-Network and not register themselves in the DHT.
+Using this information, the node registers dynamically and spawns a new Kademlia instance specifically for the destination parachain.
+The Kademlia instance is configured with the same genesis hash and fork ID, ensuring it only discovers and connects to nodes of the
+destination parachain. To conserve resources, this initialization happens lazily, meaning the Kademlia isntance is created at the very
+first time a parachain needs to establish communication with a given destination.
 
-### Bootnodes for the Speculative Messaging Network
-
-The architecture leverages the existing bootnodes on DHT mechanism on the relay chain side. 
-For more info, see [RFC 08](https://github.com/polkadot-fellows/RFCs/blob/main/text/0008-parachain-bootnodes-dht.md).
-
-Typically, relay chain peers of parachains advertise themselves as providers under the key `para ID || epoch randomness`
-in the relay chain DHT. Only the 20 closest peer IDs to this key are kept as providers, and the provider set is updated on every epoch change.
-
-Similarly, relay chain peers of collators advertise themselves as providers in the relay chain DHT.
-This utilizes the `ADD_PROVIDER` mechanism of the Kademlia DHT.
-The routing key is defined as `sha256(concat("spec-msg", epoch randomness))`, where the epoch randomness has the
-same semantics of the RFC 08, and can be obtained by calling `BabeApi_currentEpoch`.
-
-This extracts the relay chain side peer IDs of the 20 closest peers to the speculative messaging key.
-To obtain the actual bootnode addresses, the `/paranode` request-response is extended in a backwards compatible way.
-Originally, this request accepted a SCALE-compact-encoded `para ID` and returned a list of bootnode multiaddresses
-for that parchain. The protocol is extended to support the SCALE-compact-encoded `spec-msg` key as input,
-and the response is a list of multiaddresses of the collators that are bootnodes for the Speculative Messaging Network.
-
-To obtain the bootnodes of the Speculative Messaging Network, a relay chain side peer:
-- Queries the DHT for providers under the key `sha256(concat("spec-msg", epoch randomness))`, obtaining 20 peer IDs
-- For each peerID, it sends a request-response over `/paranode` with the `spec-msg` key, and obtains a list of multiaddresses
-for the collators that are bootnodes for the Speculative Messaging Network.
-
-### Speculative Messaging Network
-
-Once a collator obtains the bootnode list from the relay chain, it spawns a dedicated network backend for the 
-Speculative Messaging Network and connects to the bootnodes. Because the network connects collators from
-*all* parachains, collators from Parachain A must establish communication with collators from Parachain B.
-
-Peers register themself in the Speculative Messaging DHT as providers under the key `para ID || randomness`,
-exactly as bootnodes on the relay chain DHT do using the `ADD_PROVIDER` mechanism.
-This allows collators to quickly discover 20 closest peers. These peers serve as explicit entry points to
-validate collators and fetch their authority discovery keys.
-
-Separately to the `ADD_PROVIDER` mechanism, collators publish their `SignedCollatorAuthorityRecord` records into the DHT,
-using the `PUT_VALUE` kademlia mechanism. This ensures collators can discover the addresses of other collators and verify their integrity, strengthening the trust model for collators.
-This mechanism mirrors the authority discovery on the relay chain for validators.
-
-The `SignedCollatorAuthorityRecord` record has the following format:
-
-```rust
-/// Collator record to provide public reachable addresses for the collator,
-/// and the time of creation of the record.
-pub struct CollatorAuthority {
-    /// Parachain ID scale encoded.
-    pub parachain_id: Vec<u8>,
-    /// A vector of multiaddresses scale encoded.
-    pub addresses: Vec<Vec<u8>>,
-    /// The time since UNIX_EPOCH in nanoseconds, scale encoded.
-    /// Similar to authority-discovery this is used to update peers that have
-    /// stale records with newly discovered ones.
-    pub creation_time: Vec<u8>,
-}
-
-/// The speculative messaging peer signs the `CollatorAuthority` record with their private key,
-/// and includes the public key in the signature.
-pub struct PeerSignature {
-    /// The signature of the peer, scale encoded.
-    pub signature: Vec<u8>,
-    /// The public key of the peer, scale encoded.
-    pub public_key: Vec<u8>,
-}
-
-/// Record published in the DHT.
-pub struct SignedCollatorAuthorityRecord {
-    /// The actual record containing the multiaddresses and creation time.
-    pub record: CollatorAuthority,
-    /// The signature of the peer over the record.
-    pub peer_signature: PeerSignature,
-    /// The record signed by the authority discovery key of the collator, scale encoded.
-    pub auth_signature: Vec<u8>,
-}
-```
+Finally, the Kademlia protocol for the desitnation parachain is defined as `/{genesis_B}/{fork_B}/kad`.
+To prevent any potential intertwining of DHTs between different parachains, the dedicated Kademlia instance operates strictly in
+client-only mode, ensuring it only participates in the DHT of the destination parachain without contributing to its routing table.
 
 ### Trust Model for Collators
 

--- a/docs/speculative-messaging-design.md
+++ b/docs/speculative-messaging-design.md
@@ -213,9 +213,9 @@ Instead of routing messages through relay chain state, we:
 
 Parachain nodes operating on different peer-to-peer (P2P) networks need a mechanism to exchange messages off-chain.
 The relay chain only processes message commitments, not the messages themselves. Parachains must rely on an
-alternative discovery method, since different geensis hashes and sync protocols prevent direct communication.
+alternative discovery method: differing genesis hashes and sync protocols prevent direct communication.
 
-The design solves the following parts:
+The design covers the following parts:
 
 1. **Discoverability**: Parachain A finds the nodes of parachain B.
 2. **Communication**: Nodes from A connect to B in a resource efficient manner.
@@ -228,25 +228,25 @@ as specified in [RFC-0008](https://github.com/polkadot-fellows/RFCs/blob/main/te
 The relay chain peers of parachains advertise themselves as providers in the relay chain DHT under the key `para ID || epoch randomness`.
 Only the 20 closest peer IDs to this key are kept as providers, and the provider set is updated on every epoch change.
 
-To translate these peer IDs into actual bootnode addresses, the `/paranode` request-response protocol is used.
-This protocol accepts a SCALE-compact-encoded `para ID` as input and returns a list of bootnode multiaddresses for that parachain.
+To resolve these peer IDs into actual bootnode addresses, the node uses the /paranode request-response protocol.
+It accepts a SCALE-compact-encoded para ID and returns a list of bootnode multiaddresses for that parachain.
 
-## 2. Parachain Communcation
+## 2. Parachain Communication
 
-Instead of spawning a dedicated global network for speculative messaging, a parachain node reutilizes its existing
+Rather than spawning a dedicated global network for speculative messaging, a parachain node reuses its existing
 parachain-side litep2p network backend.
 
-Using the genesis hash and fork ID from the `/paranode` response, the node registers dynamically and spawns a new Kademlia
-instance dedicated to the destination parachain, named `/{genesis_B}/{fork_B}/kad`.
+Using the genesis hash and fork ID from the /paranode response, the node dynamically registers and spawns a new
+Kademlia instance dedicated to the destination parachain, named `/{genesis_B}/{fork_B}/kad`.
 
-The instance is initialized lazily at the first time when parachain A needs to communicate with parachain B.
+The instance is initialized lazily, the first time when parachain A needs to communicate with parachain B.
 
-To prevent any potential intertwining of DHTs between different parachains, the dedicated Kademlia instance operates strictly in
+To prevent intertwining of DHTs between different parachains, the dedicated Kademlia instance operates strictly in
 client-only mode, ensuring it only participates in the DHT of the destination parachain without contributing to its routing table.
 
-The dedicated Kademlia instance performs a low intensity DHT scrawling by submitting periodically `FIND_NODE` queries to the destination
-parachain. The discovered peers are kept in memory keyed by the parachain id. This information is used to send speculative messages only
-to the peers of the destination parachain.
+The instance performs a low intensity DHT crawling by periodically submitting `FIND_NODE` queries to the destination
+parachain. The discovered peers are kept in memory keyed by the parachain id. This information is used to send
+speculative messages only to the peers of the destination parachain.
 
 ## 3. Speculative Messaging P2P Protocol
 
@@ -260,8 +260,8 @@ genesis. Isolation is already provided by the dedicated Kademlia instance, which
 Without a block-announcement protocol to keep connections alive, an idle connection is subject to termination.
 To avoid re-dialing the peers for every message, the `/spec-msg/exchange/1` keeps a long lived substream active
 for the entire duration of the exchange and reutilizes it for subsequent requests.
-This reduces latency and removes repeated connection setup, and diverges slightly from
-Substrate's usual request-response protocols, where the substream is short-lived.
+This reduces latency and removes repeated connection setup. The protocol diverges slightly from
+Substrate's request-response protocols, where the substream is short-lived per request.
 
 All messages are SCALE-encoded.
 
@@ -271,8 +271,7 @@ All messages are SCALE-encoded.
 - `/spec-msg/exchange/1` — maximum over-the-wire payload of **16 MiB**.
 
 Payloads exceeding these limits are fragmented into multiple speculative messages and
-chunking is implementation-specific. Implementers must account for the
-messaging-format overhead when sizing chunks.
+chunking is implementation-specific. Implementers must account for the messaging-format overhead when sizing chunks.
 
 The trust does not come from the connection. Every message is verified against a root the
 sender signed. Therefore, any peer may deliver a batch message. Malformed messages, either
@@ -280,8 +279,8 @@ forged or substituted simply fail the verification against the MMR root.
 
 ### Handshake
 
-The handhsake only identifies the peer, it does not make the data trustworthy.
-The first message exchanged over the wire by both peers, on either protocol:
+The handshake only identifies the peer, it does not make the data trustworthy.
+It is the first message exchanged over the wire by both peers, on either protocol:
 
 ```rust
 pub struct Handshake {
@@ -300,10 +299,10 @@ This notification protocol informs the parachain B that A has included new messa
 
 Speculation happens under different modes:
 - HRMP replacement (phase 1): Parachain B builds blocks after A's block is backed on the relay chain.
-  B discoveres that A has propagated messages by reading the `provides` root from the relay chain state.
+  B discovers that A has propagated messages by reading the `provides` root from the relay chain state.
   In this mode, the notification protocol is entirely optional.
-- Best block: B aims to back its block roughtly at the same time as A, before A's block is on the relay chain.
-  In this mode, B has no on-chain anchor and the notification protoocl is mandatory.
+- Best block: B aims to back its block roughly at the same time as A, before A's block is on the relay chain.
+  In this mode, B has no on-chain anchor and the notification protocol is mandatory.
   The signature of the provided message anchors the trust author of the block.
 
 
@@ -406,13 +405,12 @@ pub struct MessageBatch {
 1. Append: Each message received is checked against `position == cursor`
   ensuring FIFO ordering, it is appended as a leaf and the cursor is advanced.
 2. Bag: Once all messages have been received, the peeks are transformed into a single root.
-3. Compare: The  SignedProvidesMessages::payload::provides` must each with the root. In case of
+3. Compare: The `SignedProvidesMessages::payload::provides` must each with the root. In case of
   a mismatch, the peer is banned and disconnected, data is discarded and repulled from a different source.
 
-The final check ensures: data has arrived in the appropriate order, messages are not altered or skipped, 
-all messages have been delivered.
+Together these checks ensure that data arrived in order, that messages were neither altered nor skipped, and that every message was delivered.
 
-**Chuncking**: Since the communication happens off-chain, parachains can choose to communicate large messages.
+**Chunking**: Since the communication happens off-chain, parachains can choose to communicate large messages.
 In these situations, a single p2p message is limited to 16 MiB. Parachain B chunks the requests as follows:
 - B reads the `SignedProvidesMessages::payload::message_count` from the signed announcement.
 - B sends `BatchRequest { source, provides, from_index }` using its own cursor
@@ -422,8 +420,8 @@ In these situations, a single p2p message is limited to 16 MiB. Parachain B chun
 
 ### Request-Response: Late Block Proof `/spec-msg/exchange/1`
 
-When B bound its `requires` to an older `provides` root that has since aged out of
-the relay chain's bounded provides window (A advanced to a newer root), B must prove
+When B binds its `requires` to an older `provides` root that has since aged out of
+the relay chain's provides window (A advanced to a newer root), B must prove
 that the new root extends the old one. This is out of the scope of the MVP.
 
 ```rust

--- a/docs/speculative-messaging-design.md
+++ b/docs/speculative-messaging-design.md
@@ -209,36 +209,245 @@ Instead of routing messages through relay chain state, we:
 
 ---
 
-## Detailed Design
-
-## Parachain Discoverability
+# Detailed Design - MVP focus
 
 Parachain nodes operating on different peer-to-peer (P2P) networks need a mechanism to exchange messages off-chain.
 The relay chain only processes message commitments, not the messages themselves. Parachains must rely on an
 alternative discovery method, since different geensis hashes and sync protocols prevent direct communication.
 
+The design solves the following parts:
+
+1. **Discoverability**: Parachain A finds the nodes of parachain B.
+2. **Communication**: Nodes from A connect to B in a resource efficient manner.
+3. **P2P messaging protocol**: Announcement and exchange of messages offchain.
+
+## 1. Parachain Discoverability
+
 The discoverability of parachains leverages the existing bootnodes on DHT mechanism on the relay chain side,
-as specified at: [RFC 08](https://github.com/polkadot-fellows/RFCs/blob/main/text/0008-parachain-bootnodes-dht.md).
-The relay chain peers of parachains advertise themselves as providers in the relay chain DHT using the key `para ID || epoch randomness`.
+as specified in [RFC-0008](https://github.com/polkadot-fellows/RFCs/blob/main/text/0008-parachain-bootnodes-dht.md).
+The relay chain peers of parachains advertise themselves as providers in the relay chain DHT under the key `para ID || epoch randomness`.
 Only the 20 closest peer IDs to this key are kept as providers, and the provider set is updated on every epoch change.
 
 To translate these peer IDs into actual bootnode addresses, the `/paranode` request-response protocol is used.
 This protocol accepts a SCALE-compact-encoded `para ID` as input and returns a list of bootnode multiaddresses for that parachain.
 
-## Parachain Communcation
+## 2. Parachain Communcation
 
 Instead of spawning a dedicated global network for speculative messaging, a parachain node reutilizes its existing
-parachain-side litep2p network backend. After obtaining the bootnode list of the destination parachain from the relay chain,
-the genesis hash and fork ID are extracted directly from the bootnode list.
+parachain-side litep2p network backend.
 
-Using this information, the node registers dynamically and spawns a new Kademlia instance specifically for the destination parachain.
-The Kademlia instance is configured with the same genesis hash and fork ID, ensuring it only discovers and connects to nodes of the
-destination parachain. To conserve resources, this initialization happens lazily, meaning the Kademlia isntance is created at the very
-first time a parachain needs to establish communication with a given destination.
+Using the genesis hash and fork ID from the `/paranode` response, the node registers dynamically and spawns a new Kademlia
+instance dedicated to the destination parachain, named `/{genesis_B}/{fork_B}/kad`.
 
-Finally, the Kademlia protocol for the desitnation parachain is defined as `/{genesis_B}/{fork_B}/kad`.
+The instance is initialized lazily at the first time when parachain A needs to communicate with parachain B.
+
 To prevent any potential intertwining of DHTs between different parachains, the dedicated Kademlia instance operates strictly in
 client-only mode, ensuring it only participates in the DHT of the destination parachain without contributing to its routing table.
+
+The dedicated Kademlia instance performs a low intensity DHT scrawling by submitting periodically `FIND_NODE` queries to the destination
+parachain. The discovered peers are kept in memory keyed by the parachain id. This information is used to send speculative messages only
+to the peers of the destination parachain.
+
+## 3. Speculative Messaging P2P Protocol
+
+The messages are exchanged over two new dedicated protocols:
+ - `/spec-msg/announce/1`: notification protocol required for speculating below backed-block tier.
+ - `/spec-msg/exchange/1`: request response protocol for fetching messages off-chain.
+
+The protocols intentionally omit the genesis hash and fork ID, so nodes can communicate regardless of
+genesis. Isolation is already provided by the dedicated Kademlia instance, which maps each parachain's peers.
+
+Without a block-announcement protocol to keep connections alive, an idle connection is subject to termination.
+To avoid re-dialing the peers for every message, the `/spec-msg/exchange/1` keeps a long lived substream active
+for the entire duration of the exchange and reutilizes it for subsequent requests.
+This reduces latency and removes repeated connection setup, and diverges slightly from
+Substrate's usual request-response protocols, where the substream is short-lived.
+
+All messages are SCALE-encoded.
+
+### Payload Limits
+
+- `/spec-msg/announce/1` — maximum over-the-wire payload of **2 MiB**.
+- `/spec-msg/exchange/1` — maximum over-the-wire payload of **16 MiB**.
+
+Payloads exceeding these limits are fragmented into multiple speculative messages and
+chunking is implementation-specific. Implementers must account for the
+messaging-format overhead when sizing chunks.
+
+The trust does not come from the connection. Every message is verified against a root the
+sender signed. Therefore, any peer may deliver a batch message. Malformed messages, either
+forged or substituted simply fail the verification against the MMR root.
+
+### Handshake
+
+The handhsake only identifies the peer, it does not make the data trustworthy.
+The first message exchanged over the wire by both peers, on either protocol:
+
+```rust
+pub struct Handshake {
+    /// The role of the node (light / full / authority).
+    pub node_role: NodeRole,
+    /// The parachain ID of the peer.
+    pub para_id: ParaId,
+}
+```
+
+The examples below assume parachain A sends to destination parachain B.
+
+### Notification: Message Announcement `/spec-msg/announce/1`
+
+This notification protocol informs the parachain B that A has included new messages for it in a block.
+
+Speculation happens under different modes:
+- HRMP replacement (phase 1): Parachain B builds blocks after A's block is backed on the relay chain.
+  B discoveres that A has propagated messages by reading the `provides` root from the relay chain state.
+  In this mode, the notification protocol is entirely optional.
+- Best block: B aims to back its block roughtly at the same time as A, before A's block is on the relay chain.
+  In this mode, B has no on-chain anchor and the notification protoocl is mandatory.
+  The signature of the provided message anchors the trust author of the block.
+
+
+```rust
+/// Per destination message.
+///
+/// When A communicates with multiple parachains in a single block,
+/// each destination receives its own individually signed announcement.
+/// In this model, B never learns A's other counterparties.
+pub struct ProvidesMessages {
+    /// The parachain A that authored the block.
+    pub source: ParaId,
+    /// The relay parent block the parachain block is built on (pins production slot).
+    pub relay_parent: Hash,
+    /// A's parachain block number.
+    pub source_number: BlockNumber,
+
+    /// Destination parachain B that receives the messages.
+    pub destination: ParaId,
+    /// A's parachain block that includes the messages.
+    pub source_block: Hash,
+
+    /// Root of A's cumulative per-destination MMR for B (the "provides" root).
+    pub provides: Hash,
+    /// Cumulative number of messages A has sent B through this block.
+    /// Doubles as the pagination target.
+    pub message_count: u64,
+
+    /// Session in which the collator key is valid (anti cross-session replay).
+    pub session_index: u32,
+}
+
+pub struct SignedProvidesMessages {
+    /// The signed payload.
+    pub payload: ProvidesMessages,
+    /// Signature by `collator` over the SCALE-encoded payload.
+    pub signature: Vec<u8>,
+}
+```
+
+The purpose of the message is to announce to B that A has included new messages
+for it in a block.
+
+**Equivocation**: A collator's block production slot is pinned by `(source, relay_parent, source_number)`
+as one checkpoint. If A signs this announcement for a slot, but the relay chain later includes a different
+`provides` root for the same `(source, relay_parent, source_number)`, the two conflicting signed
+messages are proof that A double produced. This is submittable on-chain to slash A's bond and makes
+the pre-backing speculation safe. Any node observing the double produced behavior can submit the proof on chain.
+
+Relay chain forks use a different `relay_parent` and parachain segment heights use different `source_number`.
+Therefore, neither is a slashable fault.
+
+In cases where A's block may fail to get backed, B's `requires` won't match at inclusion. Therefore, B
+drops the blocks and the rollback is the cost of speculation, without causing a penalty to A.
+
+### Request-Response: Batch Request `/spec-msg/exchange/1`
+
+The destination parachain pulls the messages from any peer that announced `SignedProvidesMessages`.
+The data is addressed by the `provides` field.
+
+```rust
+pub struct BatchRequest {
+    /// The para ID of A.
+    pub source: ParaId,
+    /// The provides from the `SignedProvidesMessages` per destination B only.
+    pub provides: Hash,
+    /// B's resume cursor: the first MMR leaf index B still needs.
+    pub from_index: u64,
+}
+```
+
+A message as it sits in the cumulative MMR:
+
+```rust
+pub struct OutgoingMessage {
+    /// Destination parachain
+    pub destination: ParaId,
+    /// Leaf position in the edge's cumulative MMR (assigned monotonically).
+    pub position: u64,
+    /// Opaque payload (ie XCM blob)
+    pub payload: Vec<u8>,
+
+}
+```
+
+The response carries the signed commitment plus the raw messages and no
+inclusion proof. B reconstructs and checks the root itself:
+
+```rust
+pub struct MessageBatch {
+    /// A's signed commitment (carries `provides` and `message_count`).
+    /// Lets B authenticate the batch even when a third-party peer served it.
+    pub signed_provides: SignedProvidesMessages,
+    /// The raw messages for this chunk, contiguous from `BatchRequest::from_index`.
+    pub messages: Vec<OutgoingMessage>,
+}
+```
+
+**Verification**: Because the batch carries no inclusion proof, verification relies on:
+1. Append: Each message received is checked against `position == cursor`
+  ensuring FIFO ordering, it is appended as a leaf and the cursor is advanced.
+2. Bag: Once all messages have been received, the peeks are transformed into a single root.
+3. Compare: The  SignedProvidesMessages::payload::provides` must each with the root. In case of
+  a mismatch, the peer is banned and disconnected, data is discarded and repulled from a different source.
+
+The final check ensures: data has arrived in the appropriate order, messages are not altered or skipped, 
+all messages have been delivered.
+
+**Chuncking**: Since the communication happens off-chain, parachains can choose to communicate large messages.
+In these situations, a single p2p message is limited to 16 MiB. Parachain B chunks the requests as follows:
+- B reads the `SignedProvidesMessages::payload::message_count` from the signed announcement.
+- B sends `BatchRequest { source, provides, from_index }` using its own cursor
+- A responds with as many `OutgoingMessage` that fit the message limit
+- B appends them and advances `from_index = last_received_position + 1`.
+- B repeats `BatchRequest` until all messages are delivered.
+
+### Request-Response: Late Block Proof `/spec-msg/exchange/1`
+
+When B bound its `requires` to an older `provides` root that has since aged out of
+the relay chain's bounded provides window (A advanced to a newer root), B must prove
+that the new root extends the old one. This is out of the scope of the MVP.
+
+```rust
+/// Request
+pub struct LateBlockRequest {
+    /// The para ID of A.
+    pub source: ParaId,
+    /// B's old root (its committed `requires`).
+    pub old_root: Hash,
+    /// The latest root, from observed announcements or backed on-chain.
+    pub new_root: Hash,
+}
+
+/// Response
+pub struct LateBlockProof {
+    pub old_root: Hash,
+    pub old_leaf_count: u64,
+    pub new_root: Hash,
+    pub new_leaf_count: u64,
+    /// Minimal MMR nodes that bag to `old_root` under `old_leaf_count`, and
+    /// combine with the extension nodes to bag to `new_root`. O(log n).
+    pub nodes: Vec<Hash>,
+}
+```
 
 ### Trust Model for Collators
 

--- a/docs/speculative-messaging-design.md
+++ b/docs/speculative-messaging-design.md
@@ -211,6 +211,131 @@ Instead of routing messages through relay chain state, we:
 
 ## Detailed Design
 
+## Parachain Communication
+
+Parachain collators operating on different peer-to-peer (P2P) networks need a way to exchange messages off-chain.
+The relay chain only processes message commitments, not the messages themselves. Direct communication between
+collators of different parachains is not possible due to different genesis hashes and sync protocols.
+
+To enable off-chain communicaiton between collators, a dedicated P2P network is created.
+This **Speculative Messaging Network** includes collators from al parachains that opt into
+speculative messaging.
+
+Alternative architectures were considered:
+- Routing through relay chain peers: Adds unnecessary laod and stress on the relay chain,
+  as well as new protocols for message exchange between collators.
+- Spawning a dedicated network backend for each parachain: Highly resource-intensive and doesn't scale
+  well with the number of parachains.
+
+By deploying a single network backend for the entire speculative messaging work, we keep the relay chain side
+changes to a minimum (needed for JAM compatibility) and we can leverage the existing bootnodes on DHT
+mechanism for collator discovery.
+
+The **Speculative Messaging Network** exposes the following protocols:
+- Kademlia DHT: `/spec-msg/kad` for peer discovery.
+- Identify and Ping: `/spec-msg/identify` and `/spec-msg/ping` for obtaining peer addresses and keeping connections alive.
+- Speculative Messaging Protocol: `/spec-msg/exchange` for exchanging messages between collators.
+- Light Client Request-Response: `/spec-msg/light/2` for fetching authority discovery keys of other collators.
+
+Parachains outside a trust domain, or those that don't wish to participate can simply ignore the Speculative Messaging
+Network and not register themselves in the DHT.
+
+### Bootnodes for the Speculative Messaging Network
+
+The architecture leverages the existing bootnodes on DHT mechanism on the relay chain side. 
+For more info, see [RFC 08](https://github.com/polkadot-fellows/RFCs/blob/main/text/0008-parachain-bootnodes-dht.md).
+
+Typically, relay chain peers of parachains advertise themselves as providers under the key `para ID || epoch randomness`
+in the relay chain DHT. Only the 20 closest peer IDs to this key are kept as providers, and the provider set is updated on every epoch change.
+
+Similarly, relay chain peers of collators advertise themselves as providers in the relay chain DHT.
+This utilizes the `ADD_PROVIDER` mechanism of the Kademlia DHT.
+The routing key is defined as `sha256(concat("spec-msg", epoch randomness))`, where the epoch randomness has the
+same semantics of the RFC 08, and can be obtained by calling `BabeApi_currentEpoch`.
+
+This extracts the relay chain side peer IDs of the 20 closest peers to the speculative messaging key.
+To obtain the actual bootnode addresses, the `/paranode` request-response is extended in a backwards compatible way.
+Originally, this request accepted a SCALE-compact-encoded `para ID` and returned a list of bootnode multiaddresses
+for that parchain. The protocol is extended to support the SCALE-compact-encoded `spec-msg` key as input,
+and the response is a list of multiaddresses of the collators that are bootnodes for the Speculative Messaging Network.
+
+To obtain the bootnodes of the Speculative Messaging Network, a relay chain side peer:
+- Queries the DHT for providers under the key `sha256(concat("spec-msg", epoch randomness))`, obtaining 20 peer IDs
+- For each peerID, it sends a request-response over `/paranode` with the `spec-msg` key, and obtains a list of multiaddresses
+for the collators that are bootnodes for the Speculative Messaging Network.
+
+### Speculative Messaging Network
+
+Once a collator obtains the bootnode list from the relay chain, it spawns a dedicated network backend for the 
+Speculative Messaging Network and connects to the bootnodes. Because the network connects collators from
+*all* parachains, collators from Parachain A must establish communication with collators from Parachain B.
+
+Peers register themself in the Speculative Messaging DHT as providers under the key `para ID || randomness`,
+exactly as bootnodes on the relay chain DHT do using the `ADD_PROVIDER` mechanism.
+This allows collators to quickly discover 20 closest peers. These peers serve as explicit entry points to
+validate collators and fetch their authority discovery keys.
+
+Separately to the `ADD_PROVIDER` mechanism, collators publish their `SignedCollatorAuthorityRecord` records into the DHT,
+using the `PUT_VALUE` kademlia mechanism. This ensures collators can discover the addresses of other collators and verify their integrity, strengthening the trust model for collators.
+This mechanism mirrors the authority discovery on the relay chain for validators.
+
+The `SignedCollatorAuthorityRecord` record has the following format:
+
+```rust
+/// Collator record to provide public reachable addresses for the collator,
+/// and the time of creation of the record.
+pub struct CollatorAuthority {
+    /// Parachain ID scale encoded.
+    pub parachain_id: Vec<u8>,
+    /// A vector of multiaddresses scale encoded.
+    pub addresses: Vec<Vec<u8>>,
+    /// The time since UNIX_EPOCH in nanoseconds, scale encoded.
+    /// Similar to authority-discovery this is used to update peers that have
+    /// stale records with newly discovered ones.
+    pub creation_time: Vec<u8>,
+}
+
+/// The speculative messaging peer signs the `CollatorAuthority` record with their private key,
+/// and includes the public key in the signature.
+pub struct PeerSignature {
+    /// The signature of the peer, scale encoded.
+    pub signature: Vec<u8>,
+    /// The public key of the peer, scale encoded.
+    pub public_key: Vec<u8>,
+}
+
+/// Record published in the DHT.
+pub struct SignedCollatorAuthorityRecord {
+    /// The actual record containing the multiaddresses and creation time.
+    pub record: CollatorAuthority,
+    /// The signature of the peer over the record.
+    pub peer_signature: PeerSignature,
+    /// The record signed by the authority discovery key of the collator, scale encoded.
+    pub auth_signature: Vec<u8>,
+}
+```
+
+### Trust Model for Collators
+
+For Parachain A to securely exchange messages with Parachain B, it must first obtain Parachain B's discovery keys.
+These keys allow Parachain A to map out collator addresses and verify peer integrity.
+
+The `SignedCollatorAuthorityRecord` guarantees that communication stirctly happens with legitimate collators
+of Parachain B, preventing eclipse attacks where malicious peers impersonate collators to drop or manipulate
+messages.
+
+Parachain A relies on light-client similar approach to fetch the discovery key from Parachain B:
+- 1. Read relay header: Parachain A reads Parachain B's header from the relay chain via `paras::Heads::get(Para B)`. This storage entry is located at [relay_well_known_keys::para_head(Para B)](https://github.com/paritytech/polkadot-sdk/blob/acf45cfbb1080f123aab1f2001967073977798c2/substrate/primitives/state-machine/src/lib.rs#L828-L833).
+- 2. Extract state root: The header is decoded to obtain the `state_root` of the block.
+- 3. Craft storage key: We craft the key for the storage read `twox_128("AuthorityDiscovery") ++ twox_128("Keys")`.
+- 4. Query peers: A request is made to the 20 closest peers that registered as providers under `para ID || randomness` key.
+- 5. Submit request: The request is submitted over `/spec-msg/light/2` which includes `RemoteReadRequest { block, keys }` protobuf encoded.
+- 6. Receive proof: The response contains `RemoteReadResponse` containing a storage proof.
+- 7. Verify proof: Parachain A verified via [read_proof_check()](https://github.com/paritytech/polkadot-sdk/blob/acf45cfbb1080f123aab1f2001967073977798c2/substrate/primitives/state-machine/src/lib.rs#L828-L833), passing in the `state_root` (step 2), crafted key (step 3), and the provided storage proof (step 6).
+
+Once verified, parachain A knows the authority keys of parachain B and starts `GET_VALUE` kademlia requests to fetch the multiaddresses of the collators on the Speculative Messaging Network. With the multiaddresses, parachain A can establish direct communication with parachain B's collators over the `/spec-msg/exchange` protocol.
+
+
 ### Message Accumulators
 
 Each parachain maintains a Merkle Mountain Range (MMR) accumulating all outgoing


### PR DESCRIPTION
Parachain nodes operating on different peer-to-peer (P2P) networks need a mechanism to exchange messages off-chain.
The relay chain only processes message commitments, not the messages themselves. Parachains must rely on an
alternative discovery method, since different geensis hashes and sync protocols prevent direct communication.

The design solves the following parts:

1. **Discoverability**: Parachain A finds the nodes of parachain B.
2. **Communication**: Nodes from A connect to B in a resource efficient manner.
3. **P2P messaging protocol**: Announcement and exchange of messages offchain.


Builds on top of: https://github.com/paritytech/polkadot-sdk/pull/10449