### PR TITLE
litep2p: bitswap metrics added

### DIFF
--- a/prdoc/pr_12232.prdoc
+++ b/prdoc/pr_12232.prdoc
@@ -1,0 +1,21 @@
+title: 'litep2p: bitswap metrics added'
+doc:
+- audience: Node Dev
+  description: "Related to: paritytech/polkadot-sdk#12083 (bitswap section).\n\nAdds\
+    \ four Prometheus metrics to the litep2p bitswap inbound handler so we can observe\
+    \ bitswap-driven load from network clients:\n\n| Metric | Type | Labels |\n|---|---|---|\n\
+    | `substrate_sub_libp2p_bitswap_entries_total` | counter | `outcome` \u2208 `block_served`,\
+    \ `have`, `dont_have`, `unsupported_cid` |\n| `substrate_sub_libp2p_bitswap_request_errors_total`\
+    \ | counter | `reason` \u2208 `too_many_entries`, `client` |\n| `substrate_sub_libp2p_bitswap_inbound_request_duration_seconds`\
+    \ | histogram | \u2014 |\n| `substrate_sub_libp2p_bitswap_response_bytes_total`\
+    \ | counter | \u2014 |\n\n`NetworkBackend::bitswap_server` gains an `Option<Registry>`\
+    \ parameter (mirroring `peer_store`). The libp2p backend impl accepts and ignores\
+    \ it \u2014 bitswap isn't wired into its request-response framework. Bitswap remains\
+    \ gated by `--ipfs-server`.\n\nLabels are pruned vs paritytech/polkadot-sdk#12083:\
+    \ `missing`/`bad_cid` outcomes and `decode`/`encode`/`invalid_wantlist` errors\
+    \ are absorbed by litep2p before reaching the shim."
+crates:
+- name: sc-network
+  bump: minor
+- name: sc-service
+  bump: minor

--- a/prdoc/pr_12232.prdoc
+++ b/prdoc/pr_12232.prdoc
@@ -2,8 +2,6 @@ title: 'litep2p: bitswap metrics added'
 doc:
   - audience: Node Dev
     description: |
-      Related to paritytech/polkadot-sdk#12083 (bitswap section).
-
       Adds four Prometheus metrics to the litep2p bitswap inbound handler so we can observe bitswap-driven load:
 
       - `substrate_sub_libp2p_bitswap_entries_total` — counter, label `outcome` one of: `block_served`, `have`, `dont_have`, `unsupported_cid`.

--- a/prdoc/pr_12232.prdoc
+++ b/prdoc/pr_12232.prdoc
@@ -1,21 +1,21 @@
 title: 'litep2p: bitswap metrics added'
 doc:
-- audience: Node Dev
-  description: "Related to: paritytech/polkadot-sdk#12083 (bitswap section).\n\nAdds\
-    \ four Prometheus metrics to the litep2p bitswap inbound handler so we can observe\
-    \ bitswap-driven load from network clients:\n\n| Metric | Type | Labels |\n|---|---|---|\n\
-    | `substrate_sub_libp2p_bitswap_entries_total` | counter | `outcome` \u2208 `block_served`,\
-    \ `have`, `dont_have`, `unsupported_cid` |\n| `substrate_sub_libp2p_bitswap_request_errors_total`\
-    \ | counter | `reason` \u2208 `too_many_entries`, `client` |\n| `substrate_sub_libp2p_bitswap_inbound_request_duration_seconds`\
-    \ | histogram | \u2014 |\n| `substrate_sub_libp2p_bitswap_response_bytes_total`\
-    \ | counter | \u2014 |\n\n`NetworkBackend::bitswap_server` gains an `Option<Registry>`\
-    \ parameter (mirroring `peer_store`). The libp2p backend impl accepts and ignores\
-    \ it \u2014 bitswap isn't wired into its request-response framework. Bitswap remains\
-    \ gated by `--ipfs-server`.\n\nLabels are pruned vs paritytech/polkadot-sdk#12083:\
-    \ `missing`/`bad_cid` outcomes and `decode`/`encode`/`invalid_wantlist` errors\
-    \ are absorbed by litep2p before reaching the shim."
+  - audience: Node Dev
+    description: |
+      Related to paritytech/polkadot-sdk#12083 (bitswap section).
+
+      Adds four Prometheus metrics to the litep2p bitswap inbound handler so we can observe bitswap-driven load:
+
+      - `substrate_sub_libp2p_bitswap_entries_total` — counter, label `outcome` one of: `block_served`, `have`, `dont_have`, `unsupported_cid`.
+      - `substrate_sub_libp2p_bitswap_request_errors_total` — counter, label `reason` one of: `too_many_entries`, `client`.
+      - `substrate_sub_libp2p_bitswap_inbound_request_duration_seconds` — histogram.
+      - `substrate_sub_libp2p_bitswap_response_bytes_total` — counter.
+
+      `NetworkBackend::bitswap_server` gains an `Option<Registry>` parameter (mirroring `peer_store`). The libp2p backend impl accepts and ignores it — bitswap isn't wired into its request-response framework. Bitswap remains gated by `--ipfs-server`.
+
+      Labels are pruned vs paritytech/polkadot-sdk#12083: `missing`/`bad_cid` outcomes and `decode`/`encode`/`invalid_wantlist` errors are absorbed by litep2p before reaching the shim.
 crates:
-- name: sc-network
-  bump: minor
-- name: sc-service
-  bump: minor
+  - name: sc-network
+    bump: major
+  - name: sc-service
+    bump: minor

--- a/substrate/client/network/src/litep2p/bitswap.rs
+++ b/substrate/client/network/src/litep2p/bitswap.rs
@@ -29,6 +29,7 @@ use crate::{
 		},
 		BitswapProtoMessage, Cid, Prefix, LOG_TARGET, MAX_WANTED_BLOCKS, PROTOCOL_NAME,
 	},
+	litep2p::bitswap_metrics::{errors, outcomes, BitswapMetrics},
 	request_responses::RequestFailure,
 	OutboundFailure, ProtocolName, MAX_RESPONSE_SIZE,
 };
@@ -36,6 +37,7 @@ use futures::{channel::oneshot, StreamExt};
 use litep2p::protocol::libp2p::bitswap::{
 	BitswapEvent, BitswapHandle, BlockPresenceType, Config, ResponseType, WantType,
 };
+use prometheus_endpoint::Registry;
 use prost::Message as ProstMessage;
 use sc_client_api::BlockBackend;
 use sp_core::H256;
@@ -232,6 +234,7 @@ pub(crate) struct BitswapService<Block: BlockT> {
 	client: Arc<dyn BlockBackend<Block> + Send + Sync>,
 	cmd_rx: mpsc::Receiver<BitswapOutboundCmd>,
 	pending: PendingBatches,
+	metrics: BitswapMetrics,
 }
 
 impl<Block: BlockT> BitswapService<Block> {
@@ -239,12 +242,21 @@ impl<Block: BlockT> BitswapService<Block> {
 	///
 	/// Returns the boxed task future (to be spawned on the executor) and the
 	/// [`BitswapConfig`] to be passed into the litep2p config builder.
+	///
+	/// If `metrics_registry` is `Some`, Prometheus metrics are registered with
+	/// it. A registration failure is logged and falls back to disabled metrics
+	/// (the service still runs).
 	pub(crate) fn new(
 		client: Arc<dyn BlockBackend<Block> + Send + Sync>,
+		metrics_registry: Option<&Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, BitswapConfig) {
+		let metrics = BitswapMetrics::new(metrics_registry).unwrap_or_else(|err| {
+			log::debug!(target: LOG_TARGET, "failed to register bitswap metrics: {err}");
+			BitswapMetrics::new(None).expect("registering with None registry never fails; qed")
+		});
 		let (litep2p_config, handle) = Config::new();
 		let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHANNEL_CAPACITY);
-		let service = Self { handle, client, cmd_rx, pending: PendingBatches::default() };
+		let service = Self { handle, client, cmd_rx, pending: PendingBatches::default(), metrics };
 		let future = Box::pin(async move { service.run().await });
 		let config = BitswapConfig { litep2p_config, cmd_tx };
 		(future, config)
@@ -286,37 +298,55 @@ impl<Block: BlockT> BitswapService<Block> {
 
 	/// Handle an inbound bitswap WANT request from `peer`.
 	async fn handle_inbound_request(&mut self, peer: litep2p::PeerId, cids: Vec<(Cid, WantType)>) {
+		let started = Instant::now();
 		let want_count = cids.len();
 		if inbound_wantlist_exceeds_limit(want_count) {
+			self.metrics.record_error(errors::TOO_MANY_ENTRIES);
 			log::trace!(target: LOG_TARGET, "bitswap: ignored inbound request with {want_count} entries");
 			return;
 		}
 
 		log::debug!(target: LOG_TARGET, "bitswap: handle inbound request from {peer:?} for {cids:?}");
 
+		let metrics = &self.metrics;
 		let response: Vec<ResponseType> = cids
 			.into_iter()
-			.filter(|(cid, _)| is_cid_supported(&cid))
+			.filter(|(cid, _)| {
+				let supported = is_cid_supported(cid);
+				if !supported {
+					metrics.record_entry(outcomes::UNSUPPORTED_CID);
+				}
+				supported
+			})
 			.map(|(cid, want_type)| {
 				let hash = H256::from_slice(&cid.hash().digest()[0..32]);
 				let transaction = match self.client.indexed_transaction(hash) {
 					Ok(ex) => ex,
 					Err(error) => {
+						metrics.record_error(errors::CLIENT);
 						log::error!(target: LOG_TARGET, "error retrieving transaction {hash}: {error}");
 						None
 					},
 				};
-				match transaction {
+				let response = match transaction {
 					Some(transaction) => match want_type {
 						WantType::Block => ResponseType::Block { cid, block: transaction },
 						_ => ResponseType::Presence { cid, presence: BlockPresenceType::Have },
 					},
 					None => ResponseType::Presence { cid, presence: BlockPresenceType::DontHave },
-				}
+				};
+				metrics.record_response(&response);
+				response
 			})
 			.collect();
 
+		// note: we assume the duplicate encode (litep2p re-serialises internally inside
+		// `send_response`) is cheap.
+		let response_bytes = encode_responses_as_bitswap_message(&response).len();
+		self.metrics.add_response_bytes(response_bytes as u64);
+
 		self.handle.send_response(peer, response).await;
+		self.metrics.record_duration(started.elapsed());
 	}
 
 	/// Handle an outbound bitswap command from the network service.
@@ -404,6 +434,8 @@ fn encode_responses_as_bitswap_message(responses: &[ResponseType]) -> Vec<u8> {
 mod tests {
 	use super::*;
 	use cid::multihash::Multihash as CidMultihash;
+	use prometheus_endpoint::Registry;
+	use substrate_test_runtime_client;
 
 	fn make_peer() -> litep2p::PeerId {
 		litep2p::PeerId::random()
@@ -419,6 +451,24 @@ mod tests {
 	fn inbound_wantlist_limit_rejects_only_over_cap_requests() {
 		assert!(!inbound_wantlist_exceeds_limit(MAX_WANTED_BLOCKS));
 		assert!(inbound_wantlist_exceeds_limit(MAX_WANTED_BLOCKS + 1));
+	}
+
+	#[test]
+	fn bitswap_service_constructs_without_registry() {
+		let client = Arc::new(substrate_test_runtime_client::new());
+		let (_future, _config) = BitswapService::new(client, None);
+	}
+
+	#[test]
+	fn bitswap_service_constructs_with_registry() {
+		let registry = Registry::new();
+		let client = Arc::new(substrate_test_runtime_client::new());
+		let (_future, _config) = BitswapService::new(client, Some(&registry));
+
+		// Sanity check: registering the same metric names a second time on the same
+		// registry must fail — proves the first registration actually went through.
+		let second = crate::litep2p::bitswap_metrics::BitswapMetrics::new(Some(&registry));
+		assert!(second.is_err(), "double registration should fail");
 	}
 
 	fn pending_batch(

--- a/substrate/client/network/src/litep2p/bitswap_metrics.rs
+++ b/substrate/client/network/src/litep2p/bitswap_metrics.rs
@@ -116,8 +116,9 @@ impl BitswapMetrics {
 		let outcome = match response {
 			ResponseType::Block { .. } => outcomes::BLOCK_SERVED,
 			ResponseType::Presence { presence: BlockPresenceType::Have, .. } => outcomes::HAVE,
-			ResponseType::Presence { presence: BlockPresenceType::DontHave, .. } =>
-				outcomes::DONT_HAVE,
+			ResponseType::Presence { presence: BlockPresenceType::DontHave, .. } => {
+				outcomes::DONT_HAVE
+			},
 		};
 		self.record_entry(outcome);
 	}
@@ -171,8 +172,7 @@ mod tests {
 
 		metrics.record_response(&ResponseType::Block { cid, block: vec![1, 2, 3] });
 		metrics.record_response(&ResponseType::Block { cid, block: vec![4] });
-		metrics
-			.record_response(&ResponseType::Presence { cid, presence: BlockPresenceType::Have });
+		metrics.record_response(&ResponseType::Presence { cid, presence: BlockPresenceType::Have });
 		metrics.record_response(&ResponseType::Presence {
 			cid,
 			presence: BlockPresenceType::DontHave,

--- a/substrate/client/network/src/litep2p/bitswap_metrics.rs
+++ b/substrate/client/network/src/litep2p/bitswap_metrics.rs
@@ -1,0 +1,219 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Prometheus metrics for the litep2p bitswap server.
+
+use litep2p::protocol::libp2p::bitswap::{BlockPresenceType, ResponseType};
+use prometheus_endpoint::{
+	exponential_buckets, register, Counter, CounterVec, Histogram, HistogramOpts, Opts,
+	PrometheusError, Registry, U64,
+};
+use std::time::Duration;
+
+/// `outcome` label values for `substrate_sub_libp2p_bitswap_entries_total`.
+pub mod outcomes {
+	pub const BLOCK_SERVED: &str = "block_served";
+	pub const HAVE: &str = "have";
+	pub const DONT_HAVE: &str = "dont_have";
+	pub const UNSUPPORTED_CID: &str = "unsupported_cid";
+}
+
+/// `reason` label values for `substrate_sub_libp2p_bitswap_request_errors_total`.
+pub mod errors {
+	pub const TOO_MANY_ENTRIES: &str = "too_many_entries";
+	pub const CLIENT: &str = "client";
+}
+
+struct Inner {
+	entries_total: CounterVec<U64>,
+	request_errors_total: CounterVec<U64>,
+	inbound_request_duration_seconds: Histogram,
+	response_bytes_total: Counter<U64>,
+}
+
+impl Inner {
+	fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			entries_total: register(
+				CounterVec::new(
+					Opts::new(
+						"substrate_sub_libp2p_bitswap_entries_total",
+						"Total number of bitswap wantlist entries processed, by outcome",
+					),
+					&["outcome"],
+				)?,
+				registry,
+			)?,
+			request_errors_total: register(
+				CounterVec::new(
+					Opts::new(
+						"substrate_sub_libp2p_bitswap_request_errors_total",
+						"Total number of bitswap inbound requests rejected, by reason",
+					),
+					&["reason"],
+				)?,
+				registry,
+			)?,
+			inbound_request_duration_seconds: register(
+				Histogram::with_opts(HistogramOpts {
+					common_opts: Opts::new(
+						"substrate_sub_libp2p_bitswap_inbound_request_duration_seconds",
+						"Duration of handling an inbound bitswap wantlist, in seconds",
+					),
+					buckets: exponential_buckets(0.001, 2.0, 16)
+						.expect("parameters are always valid values; qed"),
+				})?,
+				registry,
+			)?,
+			response_bytes_total: register(
+				Counter::new(
+					"substrate_sub_libp2p_bitswap_response_bytes_total",
+					"Total bytes sent in bitswap responses to inbound wantlists",
+				)?,
+				registry,
+			)?,
+		})
+	}
+}
+
+/// Helper wrapper around the bitswap server metrics.
+///
+/// When constructed without a `Registry`, all recording methods become no-ops.
+pub struct BitswapMetrics {
+	inner: Option<Inner>,
+}
+
+impl BitswapMetrics {
+	/// Register the metrics with the given Prometheus registry, if any.
+	pub fn new(registry: Option<&Registry>) -> Result<Self, PrometheusError> {
+		Ok(Self { inner: registry.map(Inner::register).transpose()? })
+	}
+
+	/// Record one wantlist entry processed with the given outcome.
+	pub fn record_entry(&self, outcome: &str) {
+		if let Some(inner) = &self.inner {
+			inner.entries_total.with_label_values(&[outcome]).inc();
+		}
+	}
+
+	/// Record one outbound response variant under the matching outcome label.
+	pub fn record_response(&self, response: &ResponseType) {
+		let outcome = match response {
+			ResponseType::Block { .. } => outcomes::BLOCK_SERVED,
+			ResponseType::Presence { presence: BlockPresenceType::Have, .. } => outcomes::HAVE,
+			ResponseType::Presence { presence: BlockPresenceType::DontHave, .. } =>
+				outcomes::DONT_HAVE,
+		};
+		self.record_entry(outcome);
+	}
+
+	/// Record one request-level error with the given reason.
+	pub fn record_error(&self, reason: &str) {
+		if let Some(inner) = &self.inner {
+			inner.request_errors_total.with_label_values(&[reason]).inc();
+		}
+	}
+
+	/// Observe the duration of an inbound wantlist handling.
+	pub fn record_duration(&self, duration: Duration) {
+		if let Some(inner) = &self.inner {
+			inner.inbound_request_duration_seconds.observe(duration.as_secs_f64());
+		}
+	}
+
+	/// Add to the running total of bitswap response bytes sent.
+	pub fn add_response_bytes(&self, bytes: u64) {
+		if let Some(inner) = &self.inner {
+			inner.response_bytes_total.inc_by(bytes);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use cid::{multihash::Multihash as CidMultihash, Cid};
+
+	fn make_cid() -> Cid {
+		let mh = CidMultihash::<64>::wrap(0xb220, &[0u8; 32]).unwrap();
+		Cid::new_v1(0x55, mh)
+	}
+
+	#[test]
+	fn disabled_metrics_are_no_ops() {
+		let metrics = BitswapMetrics::new(None).unwrap();
+		metrics.record_entry(outcomes::BLOCK_SERVED);
+		metrics.record_error(errors::CLIENT);
+		metrics.record_duration(Duration::from_millis(1));
+		metrics.add_response_bytes(42);
+	}
+
+	#[test]
+	fn record_response_maps_variants_to_outcomes() {
+		let registry = Registry::new();
+		let metrics = BitswapMetrics::new(Some(&registry)).unwrap();
+		let cid = make_cid();
+
+		metrics.record_response(&ResponseType::Block { cid, block: vec![1, 2, 3] });
+		metrics.record_response(&ResponseType::Block { cid, block: vec![4] });
+		metrics
+			.record_response(&ResponseType::Presence { cid, presence: BlockPresenceType::Have });
+		metrics.record_response(&ResponseType::Presence {
+			cid,
+			presence: BlockPresenceType::DontHave,
+		});
+		metrics.record_response(&ResponseType::Presence {
+			cid,
+			presence: BlockPresenceType::DontHave,
+		});
+		metrics.record_response(&ResponseType::Presence {
+			cid,
+			presence: BlockPresenceType::DontHave,
+		});
+
+		let inner = metrics.inner.as_ref().expect("inner should be present");
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::BLOCK_SERVED]).get(), 2);
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::HAVE]).get(), 1);
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::DONT_HAVE]).get(), 3);
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::UNSUPPORTED_CID]).get(), 0);
+	}
+
+	#[test]
+	fn enabled_metrics_register_and_increment() {
+		let registry = Registry::new();
+		let metrics = BitswapMetrics::new(Some(&registry)).unwrap();
+
+		metrics.record_entry(outcomes::BLOCK_SERVED);
+		metrics.record_entry(outcomes::BLOCK_SERVED);
+		metrics.record_entry(outcomes::HAVE);
+		metrics.record_error(errors::TOO_MANY_ENTRIES);
+		metrics.record_duration(Duration::from_millis(5));
+		metrics.add_response_bytes(1024);
+
+		let inner = metrics.inner.as_ref().expect("inner should be present when registry given");
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::BLOCK_SERVED]).get(), 2);
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::HAVE]).get(), 1);
+		assert_eq!(inner.entries_total.with_label_values(&[outcomes::DONT_HAVE]).get(), 0);
+		assert_eq!(
+			inner.request_errors_total.with_label_values(&[errors::TOO_MANY_ENTRIES]).get(),
+			1
+		);
+		assert_eq!(inner.response_bytes_total.get(), 1024);
+		assert_eq!(inner.inbound_request_duration_seconds.get_sample_count(), 1);
+	}
+}

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -93,6 +93,7 @@ use std::{
 };
 
 mod bitswap;
+mod bitswap_metrics;
 mod discovery;
 mod ipfs_dht;
 mod peerstore;
@@ -623,8 +624,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 	/// Create Bitswap server.
 	fn bitswap_server(
 		client: Arc<dyn BlockBackend<B> + Send + Sync>,
+		metrics_registry: Option<Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Self::BitswapConfig) {
-		BitswapService::new(client)
+		BitswapService::new(client, metrics_registry.as_ref())
 	}
 
 	/// Create notification protocol configuration for `protocol`.

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -199,6 +199,7 @@ where
 
 	fn bitswap_server(
 		client: Arc<dyn BlockBackend<B> + Send + Sync>,
+		_metrics_registry: Option<Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Self::BitswapConfig) {
 		let (handler, protocol_config) = BitswapRequestHandler::new(client.clone());
 

--- a/substrate/client/network/src/service/traits.rs
+++ b/substrate/client/network/src/service/traits.rs
@@ -146,6 +146,7 @@ pub trait NetworkBackend<B: BlockT + 'static, H: ExHashT>: Send + 'static {
 	/// Create Bitswap server.
 	fn bitswap_server(
 		client: Arc<dyn BlockBackend<B> + Send + Sync>,
+		metrics_registry: Option<Registry>,
 	) -> (Pin<Box<dyn Future<Output = ()> + Send>>, Self::BitswapConfig);
 
 	/// Create notification protocol configuration and an associated `NotificationService`

--- a/substrate/client/service/src/builder.rs
+++ b/substrate/client/service/src/builder.rs
@@ -1243,7 +1243,8 @@ where
 
 	// Initialize IPFS server.
 	let ipfs_config = net_config.network_config.ipfs_server.then(|| {
-		let (handler, bitswap_config) = Net::bitswap_server(client.clone());
+		let (handler, bitswap_config) =
+			Net::bitswap_server(client.clone(), metrics_registry.cloned());
 		spawn_handle.spawn("bitswap-request-handler", Some("networking"), handler);
 
 		let ipfs_num_blocks = match blocks_pruning {


### PR DESCRIPTION
Related to: paritytech/polkadot-sdk#12083 (bitswap section).

Adds four Prometheus metrics to the litep2p bitswap inbound handler so we can observe bitswap-driven load from network clients:

| Metric | Type | Labels |
|---|---|---|
| `substrate_sub_libp2p_bitswap_entries_total` | counter | `outcome` ∈ `block_served`, `have`, `dont_have`, `unsupported_cid` |
| `substrate_sub_libp2p_bitswap_request_errors_total` | counter | `reason` ∈ `too_many_entries`, `client` |
| `substrate_sub_libp2p_bitswap_inbound_request_duration_seconds` | histogram | — |
| `substrate_sub_libp2p_bitswap_response_bytes_total` | counter | — |

`NetworkBackend::bitswap_server` gains an `Option<Registry>` parameter (mirroring `peer_store`). The libp2p backend impl accepts and ignores it — bitswap isn't wired into its request-response framework. Bitswap remains gated by `--ipfs-server`.

Labels are pruned vs paritytech/polkadot-sdk#12083: `missing`/`bad_cid` outcomes and `decode`/`encode`/`invalid_wantlist` errors are absorbed by litep2p before reaching the shim.
