### PR TITLE
affine safe failure results in invalid projective point

### DIFF
--- a/prdoc/pr_12239.prdoc
+++ b/prdoc/pr_12239.prdoc
@@ -1,0 +1,8 @@
+title: affine safe failure results in invalid projective point
+doc:
+- audience: Runtime Dev
+  description: This is more similar to arkworks behavoir when it hit the incompleteness
+    of the incomplete formula.
+crates:
+- name: sp-crypto-ec-utils
+  bump: major

--- a/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_381_bandersnatch.rs
+++ b/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_381_bandersnatch.rs
@@ -263,7 +263,14 @@ mod tests {
 			"all-zero projective must map to None via IntoAffineSafe",
 		);
 
-		// (3) The trait-level z=0 detection also catches other degenerate shapes.
+		// (3) Another degenerate z=0 shape: (X=0, Y!=0, Z=0).
+		// arkworks' `into_affine()` panics here because `is_zero()`
+		// requires `!y.is_zero()` AND `y == z`, so with Y!=0 and Z=0
+		// it returns false, falling through to `z.inverse().unwrap()`
+		// which panics. `into_affine_safe` returns `None` instead.
+		// Note: `msm_te` / `mul_te` can produce either this shape or
+		// the all-zero `(0,0,0,0)` shape — both have z=0 and both are
+		// caught by `into_affine_safe`.
 		let degenerate = TEProjective::<RawConfig>::new_unchecked(
 			Fq::ZERO,        // X = 0
 			Fq::from(7u64),  // Y != 0 (F-exception)

--- a/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_381_bandersnatch.rs
+++ b/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_381_bandersnatch.rs
@@ -43,7 +43,7 @@
 //! first place.
 
 use crate::utils::{
-	self, te_non_subgroup_fallback, Error, HostcallResult, IntoAffineSafe, FAIL_MSG,
+	self, invalid_projective_point_fallback, Error, HostcallResult, IntoAffineSafe, FAIL_MSG,
 };
 use alloc::vec::Vec;
 use ark_ec::{AffineRepr, CurveConfig};
@@ -73,12 +73,11 @@ pub type SWProjective = ark_ed_on_bls12_381_bandersnatch_ext::SWProjective<HostH
 /// Group scalar field (Fr).
 pub type ScalarField = <BandersnatchConfig as CurveConfig>::ScalarField;
 
-/// The unified `(0, -1)` non-subgroup fallback (lifted to projective). Used
-/// by the hooks to substitute a `z = 0` result that cannot ride the affine
-/// FFI channel.
+/// Invalid projective point fallback with all-zero coordinates. Used by the
+/// hooks to substitute a `z = 0` result that cannot ride the affine FFI channel.
 #[inline(always)]
 fn fallback_projective() -> EdwardsProjective {
-	te_non_subgroup_fallback::<EdwardsConfig>().into_group()
+	invalid_projective_point_fallback::<EdwardsConfig>()
 }
 
 /// Curve hooks jumping into [`host_calls`] host functions.
@@ -172,9 +171,12 @@ pub trait HostCalls {
 mod tests {
 	use super::*;
 	use crate::utils::testing::*;
-	use ark_ec::twisted_edwards::{Affine as TEAffine, Projective as TEProjective, TECurveConfig};
+	use ark_ec::{
+		twisted_edwards::{Affine as TEAffine, Projective as TEProjective, TECurveConfig},
+		CurveGroup,
+	};
 	use ark_ed_on_bls12_381_bandersnatch::{EdwardsConfig as RawConfig, Fq, Fr};
-	use ark_ff::{AdditiveGroup, PrimeField, Zero};
+	use ark_ff::{AdditiveGroup, MontFp, PrimeField, Zero};
 
 	#[test]
 	fn mul_works() {
@@ -223,10 +225,10 @@ mod tests {
 		assert_eq!(err, Error::DegeneratePoint);
 
 		// The runtime-side hook catches that error and substitutes the
-		// `(0, -1)` fallback (lifted to projective).
+		// all-zero invalid projective point.
 		let p_ext: EdwardsProjective = y2_non_subgroup::<EdwardsConfig>().into_group();
 		let r = <HostHooks as CurveHooks>::mul_projective_te(&p_ext, Fr::MODULUS.0.as_ref());
-		assert_eq!(r, fallback_projective(), "hook must return (0, -1) on degenerate");
+		assert_eq!(r, fallback_projective(), "hook must return all-zero projective on degenerate");
 	}
 
 	#[test]
@@ -237,26 +239,31 @@ mod tests {
 		let t = Fq::rand(&mut rng);
 		let p = EdwardsProjective::new_unchecked(Fq::ZERO, y, t, Fq::ZERO);
 		let r = <HostHooks as CurveHooks>::mul_projective_te(&p, &[7u64, 0, 0, 0]);
-		assert_eq!(r, fallback_projective(), "z=0 input must yield (0, -1) projective");
+		assert_eq!(r, fallback_projective(), "z=0 input must yield all-zero coordinate projective");
 	}
 
 	#[test]
-	fn fallback_is_non_subgroup_te_sentinel() {
-		use ark_ed_on_bls12_381_bandersnatch::EdwardsAffine as RawAffine;
+	fn fallback_is_invalid_projective_point() {
+		// (1) The fallback is the all-zero projective point.
+		let fallback = fallback_projective();
+		assert!(fallback.x.is_zero(), "fallback x must be zero");
+		assert!(fallback.y.is_zero(), "fallback y must be zero");
+		assert!(fallback.t.is_zero(), "fallback t must be zero");
+		assert!(fallback.z.is_zero(), "fallback z must be zero");
 
-		// (1) The fallback constant the helper hardcodes.
-		let fallback: RawAffine = te_non_subgroup_fallback::<RawConfig>();
-		assert!(fallback.is_on_curve(), "fallback (0, -1) must lie on the curve");
+		// (2) `z = 0` means `into_affine()` would hit `z.inverse().unwrap()`
+		// and panic, but only if arkworks' `is_zero()` doesn't short-circuit
+		// first. `is_zero()` for TE projective requires `!y.is_zero()`, so
+		// with `y = 0` the check returns `false` and the panic path is
+		// reached. This means `into_affine_safe()` returns `None` and
+		// `into_affine()` panics — both correctly rejecting this sentinel.
+		assert!(!fallback.is_zero(), "all-zero projective must NOT be considered identity");
 		assert!(
-			!fallback.is_in_correct_subgroup_assuming_on_curve(),
-			"fallback (0, -1) must NOT be in the prime-order subgroup",
+			fallback.into_affine_safe().is_none(),
+			"all-zero projective must map to None via IntoAffineSafe",
 		);
 
-		// (2) The trait-level z=0 detection. Use an F-exception shape
-		// (X=0, Y!=0, Z=0): arkworks' standard into_affine() panics here;
-		// into_affine_safe must return None instead, which is exactly the
-		// branch where `msm_te` / `mul_te` return Err(DegeneratePoint) and
-		// the hook substitutes the fallback.
+		// (3) The trait-level z=0 detection also catches other degenerate shapes.
 		let degenerate = TEProjective::<RawConfig>::new_unchecked(
 			Fq::ZERO,        // X = 0
 			Fq::from(7u64),  // Y != 0 (F-exception)
@@ -267,16 +274,113 @@ mod tests {
 			degenerate.into_affine_safe().is_none(),
 			"z=0 projective must map to None via IntoAffineSafe",
 		);
+	}
 
-		// (3) End-to-end: encode the fallback and decode it back, to
-		// confirm the wire bytes the hook would write on the degenerate
-		// path round-trip to the same point through the standard
-		// `ArkScale<TEAffine>` codec the runtime uses.
-		let mut buf = utils::buffer_for::<EdwardsAffine>();
-		utils::encode_into(fallback, &mut buf).unwrap();
-		let decoded: RawAffine = utils::decode(&buf).unwrap();
-		assert_eq!(decoded, fallback);
-		assert!(!decoded.is_in_correct_subgroup_assuming_on_curve());
+	/// F_q-rational pair found via Sage brute-force search. They satisfy
+	/// d * x_A * x_B * y_A * y_B = 1, which forces HWCD's Z_3 = F*G = 0
+	/// even though both inputs are valid affine curve points.
+	fn exceptional_pair() -> (EdwardsAffine, EdwardsAffine, EdwardsAffine) {
+		let xa: Fq = MontFp!(
+			"12611587488970178020234800979835231446181428428390492190317266241455236381927"
+		);
+		let ya: Fq = MontFp!(
+			"8625363597705895091270672088731506059935752500467284843225771956507605756711"
+		);
+		let xb: Fq = MontFp!(
+			"5253339395048946693631279295832797565125937378490576959411837397991361739535"
+		);
+		let yb: Fq = MontFp!(
+			"24752777243643877000069062635360441442644758493268974317933177186378585499408"
+		);
+		// True A+B as computed via SW form in Sage (the group-law answer).
+		let x_sum: Fq = MontFp!(
+			"30239213723729448420307207485613680945165091785466061697591732383921178212543"
+		);
+		let y_sum: Fq = MontFp!(
+			"48407687168732128978323921344344221491641898681064657528705691267288289221251"
+		);
+		(
+			EdwardsAffine::new_unchecked(xa, ya),
+			EdwardsAffine::new_unchecked(xb, yb),
+			EdwardsAffine::new_unchecked(x_sum, y_sum),
+		)
+	}
+
+	#[test]
+	fn hwcd_exceptional_pair_produces_all_zero_projective() {
+		let (a, b, _expected_sum) = exceptional_pair();
+		assert!(a.is_on_curve(), "point A must be on curve");
+		assert!(b.is_on_curve(), "point B must be on curve");
+
+		// HWCD addition of this exceptional pair produces (0, 0, 0, 0).
+		let a_proj: EdwardsProjective = a.into_group();
+		let b_proj: EdwardsProjective = b.into_group();
+		let sum = a_proj + b_proj;
+		assert!(sum.x.is_zero(), "exceptional sum x must be zero");
+		assert!(sum.y.is_zero(), "exceptional sum y must be zero");
+		assert!(sum.t.is_zero(), "exceptional sum t must be zero");
+		assert!(sum.z.is_zero(), "exceptional sum z must be zero");
+	}
+
+	#[test]
+	fn hwcd_exceptional_pair_recovers_via_sage_sum() {
+		let (a, b, sage_sum) = exceptional_pair();
+		let a_proj: EdwardsProjective = a.into_group();
+		let b_proj: EdwardsProjective = b.into_group();
+		let sage_sum_proj: EdwardsProjective = sage_sum.into_group();
+
+		// A + (A+B from arkworks) produces all-zero: the HWCD exception
+		// propagates through the (0,0,0,0) intermediate.
+		let ark_sum = a_proj + b_proj;
+		let a_plus_ark_sum = a_proj + ark_sum;
+		assert_eq!(
+			a_plus_ark_sum,
+			invalid_projective_point_fallback::<EdwardsConfig>(),
+			"A + (A+B from arkworks) must produce all-zero projective"
+		);
+
+		// A + (A+B from Sage) gives the correct 2*A + B because A and
+		// the Sage sum are not an exceptional pair.
+		let two_a = a_proj + a_proj;
+		let two_a_plus_b = two_a + b_proj;
+		let a_plus_sage_sum = a_proj + sage_sum_proj;
+		assert_eq!(
+			a_plus_sage_sum.into_affine(),
+			two_a_plus_b.into_affine(),
+			"A + (A+B from Sage) must equal 2*A + B"
+		);
+	}
+
+	#[test]
+	fn hwcd_exceptional_pair_msm_produces_all_zero() {
+		use ark_ec::VariableBaseMSM;
+
+		let (a, b, _expected_sum) = exceptional_pair();
+
+		// msm([A, B], [2, 1]) = 2*A + B, but internally pippenger will
+		// compute A+B which hits the exceptional case.
+		let bases = vec![a, b];
+		let scalars = vec![Fr::from(2u64), Fr::from(1u64)];
+		let result = EdwardsProjective::msm(&bases, &scalars).unwrap();
+
+		assert_eq!(
+			result,
+			fallback_projective(),
+			"msm([A, B], [2, 1]) must produce invalid projective fallback"
+		);
+	}
+
+	#[test]
+	fn hwcd_exceptional_pair_msm_te_returns_invalid_projective() {
+		let (a, b, _expected_sum) = exceptional_pair();
+
+		// msm_te via the host call should detect the degenerate z=0 result
+		// and return the invalid projective point fallback.
+		let bases = vec![a, b];
+		let scalars = vec![Fr::from(2u64), Fr::from(1u64)];
+		let result = <HostHooks as CurveHooks>::msm_te(&bases, &scalars);
+
+		assert_eq!(result, fallback_projective(), "msm_te must return invalid projective fallback");
 	}
 
 	#[test]

--- a/substrate/primitives/crypto/ec-utils/src/utils.rs
+++ b/substrate/primitives/crypto/ec-utils/src/utils.rs
@@ -233,6 +233,22 @@ pub fn mul_sw<T: SWCurveConfig>(base: &[u8], scalar: &[u8], out: &mut [u8]) -> R
 	encode_into::<SWAffine<T>>(res, out)
 }
 
+/// Invalid projective point with all-zero coordinates.
+///
+/// This is not a valid curve point — it represents an undefined/degenerate
+/// result in projective coordinates. Useful as a sentinel value when
+/// operations produce a `z = 0` projective that has no affine representative.
+/// Any downstream validity or subgroup check will reject it.
+#[inline(always)]
+pub fn invalid_projective_point_fallback<T: TECurveConfig>() -> TEProjective<T> {
+	TEProjective::<T>::new_unchecked(
+		T::BaseField::ZERO,
+		T::BaseField::ZERO,
+		T::BaseField::ZERO,
+		T::BaseField::ZERO,
+	)
+}
+
 /// Universal twisted Edwards "no affine representative" fallback.
 ///
 /// Returned by [`mul_te`] / [`msm_te`] when the projective result has


### PR DESCRIPTION
This is more similar to arkworks behavoir when it hit the incompleteness of the incomplete formula.