### PR TITLE
pallet-dap: re-export WeightInfo at crate root

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_dap.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_dap.rs
@@ -49,7 +49,7 @@ use core::marker::PhantomData;
 
 /// Weight functions for `pallet_dap`.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: frame_system::Config> pallet_dap::weights::WeightInfo for WeightInfo<T> {
+impl<T: frame_system::Config> pallet_dap::WeightInfo for WeightInfo<T> {
 	/// Storage: `Dap::BudgetAllocation` (r:0 w:1)
 	/// Proof: `Dap::BudgetAllocation` (`max_values`: Some(1), `max_size`: Some(593), added: 1088, mode: `MaxEncodedLen`)
 	fn set_budget_allocation() -> Weight {

--- a/prdoc/pr_12246.prdoc
+++ b/prdoc/pr_12246.prdoc
@@ -1,0 +1,10 @@
+title: 'pallet-dap: re-export WeightInfo at crate root'
+doc:
+- audience: Runtime Dev
+  description: |-
+    The trait was only reachable at `pallet_dap::weights::WeightInfo`, so the benchmark template's generated `pallet_dap::WeightInfo` path failed to resolve and required a manual fixup in every consumer. Add the standard FRAME re-export (`pub use weights::WeightInfo;`) and switch the Asset Hub Westend weights file and the staking-async integration test back to the canonical `pallet_dap::WeightInfo` path.
+crates:
+- name: asset-hub-westend-runtime
+  bump: patch
+- name: pallet-dap
+  bump: patch

--- a/prdoc/pr_12246.prdoc
+++ b/prdoc/pr_12246.prdoc
@@ -7,4 +7,4 @@ crates:
 - name: asset-hub-westend-runtime
   bump: patch
 - name: pallet-dap
-  bump: patch
+  bump: minor

--- a/substrate/frame/dap/src/lib.rs
+++ b/substrate/frame/dap/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub mod migrations;
 pub mod weights;
+pub use weights::WeightInfo;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;

--- a/substrate/frame/staking-async/integration-tests/src/ah/weights.rs
+++ b/substrate/frame/staking-async/integration-tests/src/ah/weights.rs
@@ -217,7 +217,7 @@ impl pallet_staking_async::WeightInfo for StakingAsyncWeightInfo {
 		let max_block =
 			<ah::mock::BlockWeights as Get<frame_system::limits::BlockWeights>>::get().max_block;
 		// Reserve headroom for DAP drip weight which also runs in on_initialize.
-		max_block.saturating_sub(<() as pallet_dap::weights::WeightInfo>::drip_issuance())
+		max_block.saturating_sub(<() as pallet_dap::WeightInfo>::drip_issuance())
 	}
 	fn rc_on_offence(_: u32) -> Weight {
 		Default::default()


### PR DESCRIPTION
The trait was only reachable at `pallet_dap::weights::WeightInfo`, so the benchmark template's generated `pallet_dap::WeightInfo` path failed to resolve and required a manual fixup in every consumer. Add the standard FRAME re-export (`pub use weights::WeightInfo;`) and switch the Asset Hub Westend weights file and the staking-async integration test back to the canonical `pallet_dap::WeightInfo` path.

