### PR TITLE
changes to use zombie-bite

### DIFF
--- a/polkadot/node/core/dispute-coordinator/src/scraping/mod.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/mod.rs
@@ -315,7 +315,7 @@ impl ChainScraper {
 	pub fn process_finalized_block(&mut self, finalized_block_number: &BlockNumber) {
 		// `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION - 1` because
 		// `finalized_block_number`counts to the candidate lifetime.
-		match finalized_block_number.checked_sub(DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION - 1)
+		match finalized_block_number.checked_sub(*DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION - 1)
 		{
 			Some(key_to_prune) => {
 				self.backed_candidates.remove_up_to_height(&key_to_prune);
@@ -393,7 +393,7 @@ impl ChainScraper {
 	{
 		let target_ancestor = get_finalized_block_number(sender)
 			.await?
-			.saturating_sub(DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION);
+			.saturating_sub(*DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION);
 
 		let mut ancestors = Vec::new();
 

--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -428,7 +428,7 @@ fn scraper_requests_candidates_of_non_finalized_ancestors() {
 			&chain,
 			finalized_block_number,
 			BLOCKS_TO_SKIP -
-				(finalized_block_number - DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION) as usize, /* Expect the provider not to go past finalized block. */
+				(finalized_block_number - *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION) as usize, /* Expect the provider not to go past finalized block. */
 			get_backed_and_included_candidate_events,
 		);
 		join(process_active_leaves_update(ctx.sender(), &mut ordering, next_update), overseer_fut)
@@ -474,7 +474,7 @@ fn scraper_prunes_finalized_candidates() {
 		// After `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` blocks the candidate should be
 		// removed
 		finalized_block_number =
-			TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+			TEST_TARGET_BLOCK_NUMBER + *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		assert!(!scraper.is_candidate_backed(&candidate.hash()));
@@ -533,10 +533,10 @@ fn scraper_handles_backed_but_not_included_candidate() {
 		// The candidate should be removed.
 		assert!(
 			finalized_block_number <
-				TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION
+				TEST_TARGET_BLOCK_NUMBER + *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION
 		);
 		finalized_block_number +=
-			TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+			TEST_TARGET_BLOCK_NUMBER + *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		assert!(!scraper.is_candidate_included(&candidate.hash()));
@@ -584,7 +584,7 @@ fn scraper_handles_the_same_candidate_included_in_two_different_block_heights() 
 		// The magic candidate was added twice, so it shouldn't be removed if we finalize two more
 		// blocks.
 		finalized_block_number = test_targets.first().expect("there are two block nums") +
-			DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+			*DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		let magic_candidate = make_candidate_receipt(get_magic_candidate_hash());
@@ -650,7 +650,7 @@ fn inclusions_per_candidate_properly_adds_and_prunes() {
 		// After `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` blocks the earlier inclusion should
 		// be removed
 		finalized_block_number =
-			TEST_TARGET_BLOCK_NUMBER + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+			TEST_TARGET_BLOCK_NUMBER + *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		// The later inclusion should still be present, as we haven't exceeded its lifetime
@@ -663,7 +663,7 @@ fn inclusions_per_candidate_properly_adds_and_prunes() {
 		);
 
 		finalized_block_number =
-			TEST_TARGET_BLOCK_NUMBER_2 + DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
+			TEST_TARGET_BLOCK_NUMBER_2 + *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION;
 		process_finalized_block(&mut scraper, &finalized_block_number);
 
 		// Now both inclusions have exceeded their lifetimes after finalization and should be purged

--- a/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
+++ b/polkadot/node/core/dispute-coordinator/src/scraping/tests.rs
@@ -428,7 +428,8 @@ fn scraper_requests_candidates_of_non_finalized_ancestors() {
 			&chain,
 			finalized_block_number,
 			BLOCKS_TO_SKIP -
-				(finalized_block_number - *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION) as usize, /* Expect the provider not to go past finalized block. */
+				(finalized_block_number - *DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION)
+					as usize, // Expect the provider not to go past finalized block.
 			get_backed_and_included_candidate_events,
 		);
 		join(process_active_leaves_update(ctx.sender(), &mut ordering, next_update), overseer_fut)

--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -23,6 +23,8 @@
 #![deny(missing_docs)]
 
 use std::pin::Pin;
+use std::sync::LazyLock;
+use std::env::var;
 
 use bounded_vec::BoundedVec;
 use codec::{Decode, Encode, Error as CodecError, Input};
@@ -100,7 +102,16 @@ pub const POV_BOMB_LIMIT: usize = (MAX_POV_SIZE * 4u32) as usize;
 ///
 /// slot time * `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` > `APPROVAL_EXECUTION_TIMEOUT`
 /// + slot time
-pub const DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION: BlockNumber = 10;
+///
+/// NOTE: In order to use zombie-bite with the less possible changes in the client we need to set
+/// this value to `1` (checking iff the env var `ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` is set).
+pub static DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION: LazyLock<BlockNumber> = LazyLock::new(|| {
+	if var("ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION").is_ok() {
+		1
+	} else {
+		10
+	}
+});
 
 /// Linked to `MAX_FINALITY_LAG` in relay chain selection,
 /// `MAX_HEADS_LOOK_BACK` in `approval-voting` and

--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -22,9 +22,7 @@
 
 #![deny(missing_docs)]
 
-use std::pin::Pin;
-use std::sync::LazyLock;
-use std::env::var;
+use std::{env::var, pin::Pin, sync::LazyLock};
 
 use bounded_vec::BoundedVec;
 use codec::{Decode, Encode, Error as CodecError, Input};
@@ -104,14 +102,16 @@ pub const POV_BOMB_LIMIT: usize = (MAX_POV_SIZE * 4u32) as usize;
 /// + slot time
 ///
 /// NOTE: In order to use zombie-bite with the less possible changes in the client we need to set
-/// this value to `1` (checking iff the env var `ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` is set).
-pub static DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION: LazyLock<BlockNumber> = LazyLock::new(|| {
-	if var("ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION").is_ok() {
-		1
-	} else {
-		10
-	}
-});
+/// this value to `1` (checking iff the env var
+/// `ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` is set).
+pub static DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION: LazyLock<BlockNumber> =
+	LazyLock::new(|| {
+		if var("ZOMBIE_DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION").is_ok() {
+			1
+		} else {
+			10
+		}
+	});
 
 /// Linked to `MAX_FINALITY_LAG` in relay chain selection,
 /// `MAX_HEADS_LOOK_BACK` in `approval-voting` and

--- a/prdoc/pr_12247.prdoc
+++ b/prdoc/pr_12247.prdoc
@@ -1,0 +1,12 @@
+title: changes to use zombie-bite
+doc:
+- audience: Node Operator
+  description: |-
+    In order to use [zombie-bite](https://github.com/paritytech/zombie-bite) (to fork and spawn a live network with the _state_) with the same client binaries (for testing releases), we need to allow to set this value `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` to __1__. I think the best approach here is to use an _env var_, since we _only_ need it for our use case. Cc @eskimor wdyt?
+
+    Thx!
+crates:
+- name: polkadot-node-core-dispute-coordinator
+  bump: patch
+- name: polkadot-node-primitives
+  bump: patch

--- a/prdoc/pr_12247.prdoc
+++ b/prdoc/pr_12247.prdoc
@@ -2,7 +2,7 @@ title: changes to use zombie-bite
 doc:
 - audience: Node Operator
   description: |-
-    In order to use [zombie-bite](https://github.com/paritytech/zombie-bite) (to fork and spawn a live network with the _state_) with the same client binaries (for testing releases), we need to allow to set this value `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` to __1__. I think the best approach here is to use an _env var_, since we _only_ need it for our use case. Cc @eskimor wdyt?
+    In order to use [zombie-bite](https://github.com/paritytech/zombie-bite) (to fork and spawn a live network with the current _state_) with the same client binaries (for testing releases), we need to allow to set this value `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` to __1__.
 
     Thx!
 crates:


### PR DESCRIPTION
In order to use [zombie-bite](https://github.com/paritytech/zombie-bite) (to fork and spawn a live network with the _state_) with the same client binaries (for testing releases), we need to allow to set this value `DISPUTE_CANDIDATE_LIFETIME_AFTER_FINALIZATION` to __1__. I think the best approach here is to use an _env var_, since we _only_ need it for our use case. Cc @eskimor wdyt?

Thx!
