### PR TITLE
[pallet-revive] 0-base transactionIndex on TransactionInfo/ReceiptInfo/Log

### DIFF
--- a/substrate/frame/revive/rpc/migrations/0005_zero_base_transaction_index.sql
+++ b/substrate/frame/revive/rpc/migrations/0005_zero_base_transaction_index.sql
@@ -1,0 +1,9 @@
+-- #6790 pt 3: `transaction_index` in `transaction_hashes` / `logs` used to hold the
+-- substrate extrinsic index; it now holds the 0-based EVM index. Hard cutoff: wipe receipt
+-- caches plus the block mapping and sync checkpoints that gate re-extraction
+-- (`insert_into_db` short-circuits on existing `eth_to_substrate_blocks` rows). One-time
+-- backfill on next start; downstream indexers should re-sync transaction-indexed data.
+DELETE FROM transaction_hashes;
+DELETE FROM logs;
+DELETE FROM eth_to_substrate_blocks;
+DELETE FROM sync_state;

--- a/substrate/frame/revive/rpc/src/client.rs
+++ b/substrate/frame/revive/rpc/src/client.rs
@@ -41,6 +41,7 @@ use runtime_api::RuntimeApi;
 use sp_runtime::traits::Block as BlockT;
 use sp_weights::Weight;
 use std::{
+	collections::BTreeMap,
 	sync::{
 		Arc,
 		atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -800,7 +801,15 @@ impl Client {
 		let ReceiptInfo { block_hash, transaction_index, .. } = self.receipt(tx_hash).await?;
 		let block_hash = self.resolve_substrate_hash(&block_hash).await?;
 		let block = self.block_provider.block_by_hash(&block_hash).await.ok()??;
-		let ext = block.extrinsics().await.ok()?.iter().nth(transaction_index.as_u32() as _)?;
+		// EVM index → substrate extrinsic index; the full extrinsic list includes inherents.
+		let extrinsic_index = self
+			.receipt_provider
+			.eth_transact_extrinsic_indices(&block)
+			.await
+			.ok()?
+			.get(transaction_index.as_u32() as usize)
+			.copied()?;
+		let ext = block.extrinsics().await.ok()?.iter().nth(extrinsic_index)?;
 		let event = ext.events().await.ok()?.find_first::<ExtrinsicSuccess>().ok()??;
 		Some(event.dispatch_info.weight.0)
 	}
@@ -1009,8 +1018,22 @@ impl Client {
 			.await
 			.ok_or(ClientError::EthExtrinsicNotFound)?;
 
+		// `trace_block` returns substrate-keyed traces; `hashes` is EVM-keyed. Translate at
+		// the eth-rpc boundary rather than changing the runtime API contract.
+		let substrate_block =
+			self.block_by_hash(&block_hash).await?.ok_or(ClientError::BlockNotFound)?;
+		let evm_index_by_extrinsic: BTreeMap<usize, usize> = self
+			.receipt_provider
+			.eth_transact_extrinsic_indices(&substrate_block)
+			.await?
+			.into_iter()
+			.enumerate()
+			.map(|(evm_index, extrinsic_index)| (extrinsic_index, evm_index))
+			.collect();
+
 		let traces = traces.into_iter().filter_map(|(index, trace)| {
-			Some(TransactionTrace { tx_hash: hashes.remove(&(index as usize))?, trace })
+			let evm_index = evm_index_by_extrinsic.get(&(index as usize))?;
+			Some(TransactionTrace { tx_hash: hashes.remove(evm_index)?, trace })
 		});
 
 		Ok(traces.collect())
@@ -1028,11 +1051,22 @@ impl Client {
 			.await
 			.ok_or(ClientError::EthExtrinsicNotFound)?;
 
+		// EVM index (from DB) → substrate extrinsic index, expected by `trace_tx`.
+		let substrate_block =
+			self.block_by_hash(&block_hash).await?.ok_or(ClientError::BlockNotFound)?;
+		let extrinsic_index = self
+			.receipt_provider
+			.eth_transact_extrinsic_indices(&substrate_block)
+			.await?
+			.get(transaction_index)
+			.copied()
+			.ok_or(ClientError::EthExtrinsicNotFound)?;
+
 		let block = self.tracing_block(block_hash).await?;
 		let parent_hash = block.header.parent_hash;
 		let runtime_api = self.runtime_api(parent_hash);
 
-		runtime_api.trace_tx(block, transaction_index as u32, config).await
+		runtime_api.trace_tx(block, extrinsic_index as u32, config).await
 	}
 
 	/// Get the transaction traces for the given block.

--- a/substrate/frame/revive/rpc/src/receipt_extractor.rs
+++ b/substrate/frame/revive/rpc/src/receipt_extractor.rs
@@ -93,24 +93,24 @@ fn decode_revive_event(
 	None
 }
 
-/// Iterate decoded block events and bucket revert flags and logs per extrinsic.
-/// Events for other extrinsics are skipped.
+/// Iterate decoded block events and bucket revert flags and logs per transaction.
+/// Decode errors are logged and skipped to avoid losing the entire receipt — events are
+/// stored sequentially without size markers, so a single undecodable event would corrupt
+/// the offset for everything after it.
 ///
-/// Events are stored sequentially without size markers, so a single
-/// undecodable event (e.g. from a runtime upgrade that shifted variant
-/// indices) corrupts the offset for all subsequent events.
-/// Decode errors are logged and skipped to avoid losing the entire receipt.
-///
-/// Returns `(reverted_extrinsics, logs_by_extrinsic)` keyed by extrinsic index.
+/// `eth_tx_for(extrinsic_index)` returns `(eth tx hash, 0-based EVM index)` for an
+/// `EthTransact` extrinsic, or `None`. Events are matched by substrate index; returned
+/// maps and the `Log.transaction_index` they carry are keyed by 0-based EVM index (#6790
+/// pt 3).
 fn extract_revive_events(
 	block_events: &subxt::events::Events<SrcChainConfig>,
 	substrate_block_number: SubstrateBlockNumber,
 	eth_block_number: U256,
 	eth_block_hash: H256,
-	eth_tx_hash_for: impl Fn(usize) -> Option<H256>,
+	eth_tx_for: impl Fn(usize) -> Option<(H256, usize)>,
 ) -> (HashSet<usize>, HashMap<usize, Vec<Log>>) {
-	let mut reverted_extrinsics: HashSet<usize> = HashSet::new();
-	let mut logs_by_extrinsic: HashMap<usize, Vec<Log>> = HashMap::new();
+	let mut reverted_transactions: HashSet<usize> = HashSet::new();
+	let mut logs_by_transaction: HashMap<usize, Vec<Log>> = HashMap::new();
 
 	for (event_index, event_result) in block_events.iter().enumerate() {
 		let event = match event_result {
@@ -129,26 +129,26 @@ fn extract_revive_events(
 			_ => continue,
 		};
 
-		let Some(eth_tx_hash) = eth_tx_hash_for(extrinsic_index) else { continue };
+		let Some((eth_tx_hash, transaction_index)) = eth_tx_for(extrinsic_index) else { continue };
 
 		match decode_revive_event(
 			&event,
 			eth_block_number,
 			eth_tx_hash,
-			extrinsic_index,
+			transaction_index,
 			eth_block_hash,
 		) {
 			Some(ReviveEvent::Revert) => {
-				reverted_extrinsics.insert(extrinsic_index);
+				reverted_transactions.insert(transaction_index);
 			},
 			Some(ReviveEvent::Log(log)) => {
-				logs_by_extrinsic.entry(extrinsic_index).or_default().push(log);
+				logs_by_transaction.entry(transaction_index).or_default().push(log);
 			},
 			None => {},
 		}
 	}
 
-	(reverted_extrinsics, logs_by_extrinsic)
+	(reverted_transactions, logs_by_transaction)
 }
 
 type FetchReceiptDataFn = Arc<
@@ -290,6 +290,8 @@ impl ReceiptExtractor {
 	}
 
 	/// Decode the raw call payload into a [`TransactionSigned`] and construct its [`ReceiptInfo`].
+	///
+	/// `transaction_index` is the 0-based EVM transaction index stamped onto the receipt.
 	fn decode_transaction_and_build_receipt(
 		&self,
 		eth_block_hash: H256,
@@ -366,7 +368,9 @@ impl ReceiptExtractor {
 			return Ok(vec![]);
 		}
 
-		let eth_tx_by_index: BTreeMap<usize, (EthTransact, H256, ReceiptGasInfo)> = self
+		// Substrate-keyed for event matching; the 0-based EVM index is each entry's rank
+		// in this ordered map (#6790 pt 3).
+		let eth_tx_by_extrinsic: BTreeMap<usize, (EthTransact, H256, ReceiptGasInfo)> = self
 			.get_block_extrinsics(block)
 			.await?
 			.map(|(call, receipt_gas_info, extrinsic_index)| {
@@ -375,28 +379,38 @@ impl ReceiptExtractor {
 			})
 			.collect();
 
-		if eth_tx_by_index.is_empty() {
+		if eth_tx_by_extrinsic.is_empty() {
 			return Ok(vec![]);
 		}
+
+		// substrate extrinsic index → (eth tx hash, 0-based EVM index), for event lookup.
+		let eth_tx_for_extrinsic: BTreeMap<usize, (H256, usize)> = eth_tx_by_extrinsic
+			.iter()
+			.enumerate()
+			.map(|(transaction_index, (&extrinsic_index, (_, hash, _)))| {
+				(extrinsic_index, (*hash, transaction_index))
+			})
+			.collect();
 
 		let substrate_block_number = block.number();
 		let eth_block_number: U256 = substrate_block_number.into();
 		let block_events = block.events().await.inspect_err(|err| {
 			log::debug!(target: LOG_TARGET, "Error fetching events for block #{substrate_block_number}: {err:?}");
 		})?;
-		let (reverted_extrinsics, mut logs_by_extrinsic) = extract_revive_events(
+		let (reverted_transactions, mut logs_by_transaction) = extract_revive_events(
 			&block_events,
 			substrate_block_number,
 			eth_block_number,
 			eth_block_hash,
-			|idx| eth_tx_by_index.get(&idx).map(|(_, hash, _)| *hash),
+			|extrinsic_index| eth_tx_for_extrinsic.get(&extrinsic_index).copied(),
 		);
 
-		eth_tx_by_index
-			.into_iter()
+		eth_tx_by_extrinsic
+			.into_values()
+			.enumerate()
 			.map(|(transaction_index, (call, transaction_hash, receipt_gas_info))| {
-				let reverted = reverted_extrinsics.contains(&transaction_index);
-				let logs = logs_by_extrinsic.remove(&transaction_index).unwrap_or_default();
+				let reverted = reverted_transactions.contains(&transaction_index);
+				let logs = logs_by_transaction.remove(&transaction_index).unwrap_or_default();
 				self.decode_transaction_and_build_receipt(
 					eth_block_hash,
 					eth_block_number,
@@ -457,25 +471,28 @@ impl ReceiptExtractor {
 		}
 	}
 
-	/// Extract a [`TransactionSigned`] and a [`ReceiptInfo`] for a specific transaction in a
-	/// [`SubstrateBlock`]
+	/// Extract a [`TransactionSigned`] and [`ReceiptInfo`] for the transaction at the given
+	/// 0-based EVM `transaction_index` — the index among the block's `EthTransact` calls,
+	/// not the substrate extrinsic index (#6790 pt 3).
 	pub async fn extract_from_transaction(
 		&self,
 		block: &SubstrateBlock,
 		transaction_index: usize,
 	) -> Result<(TransactionSigned, ReceiptInfo), ClientError> {
-		let (eth_call, receipt_gas_info, transaction_hash) = self
+		// EVM index → substrate extrinsic index, by enumerating filtered `EthTransact` calls.
+		let (eth_call, receipt_gas_info, extrinsic_index, transaction_hash) = self
 			.get_block_extrinsics(block)
 			.await?
-			.find_map(|(call, receipt_gas_info, extrinsic_index)| {
-				(extrinsic_index == transaction_index).then(|| {
+			.enumerate()
+			.find_map(|(evm_index, (call, receipt_gas_info, extrinsic_index))| {
+				(evm_index == transaction_index).then(|| {
 					let hash = H256(keccak_256(&call.payload));
-					(call, receipt_gas_info, hash)
+					(call, receipt_gas_info, extrinsic_index, hash)
 				})
 			})
 			.ok_or_else(|| {
 				log::trace!(target: LOG_TARGET,
-					"extract_from_transaction: no EVM extrinsic at tx_index {transaction_index} \
+					"extract_from_transaction: no EVM extrinsic at EVM index {transaction_index} \
 					 in block #{} ({:?})", block.number(), block.hash());
 				ClientError::EthExtrinsicNotFound
 			})?;
@@ -487,16 +504,16 @@ impl ReceiptExtractor {
 		let block_events = block.events().await.inspect_err(|err| {
 			log::debug!(target: LOG_TARGET, "Error fetching events for block #{substrate_block_number}: {err:?}");
 		})?;
-		let (reverted_extrinsics, mut logs_by_extrinsic) = extract_revive_events(
+		let (reverted_transactions, mut logs_by_transaction) = extract_revive_events(
 			&block_events,
 			substrate_block_number,
 			eth_block_number,
 			eth_block_hash,
-			|idx| (idx == transaction_index).then_some(transaction_hash),
+			|idx| (idx == extrinsic_index).then_some((transaction_hash, transaction_index)),
 		);
 
-		let reverted = reverted_extrinsics.contains(&transaction_index);
-		let logs = logs_by_extrinsic.remove(&transaction_index).unwrap_or_default();
+		let reverted = reverted_transactions.contains(&transaction_index);
+		let logs = logs_by_transaction.remove(&transaction_index).unwrap_or_default();
 		self.decode_transaction_and_build_receipt(
 			eth_block_hash,
 			eth_block_number,
@@ -507,6 +524,25 @@ impl ReceiptExtractor {
 			reverted,
 			logs,
 		)
+	}
+
+	/// `vec[evm_index] = substrate extrinsic index`. The single bridge between substrate
+	/// extrinsic-index space (used by `trace_block`/`trace_tx`) and the 0-based EVM index
+	/// exposed over JSON-RPC (#6790 pt 3).
+	pub async fn eth_transact_extrinsic_indices(
+		&self,
+		block: &SubstrateBlock,
+	) -> Result<Vec<usize>, ClientError> {
+		let extrinsics = block.extrinsics().await.inspect_err(|err| {
+			log::debug!(target: LOG_TARGET, "Error fetching extrinsics for #{:?}: {err:?}", block.number());
+		})?;
+		Ok(extrinsics
+			.iter()
+			.enumerate()
+			.filter_map(|(extrinsic_index, ext)| {
+				ext.as_extrinsic::<EthTransact>().ok().flatten().map(|_| extrinsic_index)
+			})
+			.collect())
 	}
 
 	/// Get the Ethereum block hash for the Substrate block with specific hash.
@@ -755,24 +791,26 @@ mod tests {
 		let substrate_block_number = 42u32;
 		let eth_block_number = U256::from(substrate_block_number);
 
+		// Substrate extrinsic index 5 maps to the 0-based EVM transaction index 0.
 		let (reverts, logs) = extract_revive_events(
 			&events,
 			substrate_block_number,
 			eth_block_number,
 			eth_block_hash,
-			|idx| (idx == 5).then_some(tx_hash),
+			|idx| (idx == 5).then_some((tx_hash, 0)),
 		);
 
 		assert!(reverts.is_empty());
 		assert_eq!(logs.len(), 1);
-		let log = &logs[&5][0];
+		let log = &logs[&0][0];
 		assert_eq!(log.address, contract);
 		assert_eq!(log.topics, topics);
 		assert_eq!(log.data.as_ref().unwrap().0, data);
 		assert_eq!(log.block_hash, eth_block_hash);
 		assert_eq!(log.block_number, eth_block_number);
 		assert_eq!(log.transaction_hash, tx_hash);
-		assert_eq!(log.transaction_index, U256::from(5));
+		// The log carries the 0-based EVM index, not the substrate extrinsic index (5).
+		assert_eq!(log.transaction_index, U256::from(0));
 	}
 
 	#[test]
@@ -794,10 +832,10 @@ mod tests {
 			.push_event(frame_system::Phase::ApplyExtrinsic(5), revert)
 			.build();
 
-		// The tx-hash closure returns `Some` only for extrinsic 7 (not present)
+		// The tx closure returns `Some` only for extrinsic 7 (not present)
 		let (reverts, logs) =
 			extract_revive_events(&events, 0, U256::zero(), H256::zero(), |idx| {
-				(idx == 7).then_some(H256::zero())
+				(idx == 7).then_some((H256::zero(), 0))
 			});
 
 		assert!(reverts.is_empty());
@@ -805,7 +843,7 @@ mod tests {
 	}
 
 	#[test]
-	fn extract_revive_events_accumulates_per_extrinsic() {
+	fn extract_revive_events_accumulates_per_transaction_with_leading_inherents() {
 		let tx0 = H256::from([0x01; 32]);
 		let tx1 = H256::from([0x02; 32]);
 		let tx2 = H256::from([0x03; 32]);
@@ -814,29 +852,35 @@ mod tests {
 			data: vec![],
 			topics: vec![],
 		};
+		// Simulate two leading inherents: the `EthTransact` calls sit at substrate extrinsic
+		// indices 2, 3, 4 and must map to 0-based EVM indices 0, 1, 2 (#6790 pt 3).
 		let events = EventsBuilder::new()
-			.push_event(frame_system::Phase::ApplyExtrinsic(0), emitted_by(H160::from([0xaa; 20])))
-			.push_event(frame_system::Phase::ApplyExtrinsic(0), emitted_by(H160::from([0xbb; 20])))
+			.push_event(frame_system::Phase::ApplyExtrinsic(2), emitted_by(H160::from([0xaa; 20])))
+			.push_event(frame_system::Phase::ApplyExtrinsic(2), emitted_by(H160::from([0xbb; 20])))
 			.push_event(
-				frame_system::Phase::ApplyExtrinsic(1),
+				frame_system::Phase::ApplyExtrinsic(3),
 				pallet_revive::Event::EthExtrinsicRevert {
 					dispatch_error: sp_runtime::DispatchError::Other("tx-1 revert"),
 				},
 			)
-			.push_event(frame_system::Phase::ApplyExtrinsic(2), emitted_by(H160::from([0xcc; 20])))
+			.push_event(frame_system::Phase::ApplyExtrinsic(4), emitted_by(H160::from([0xcc; 20])))
 			.build();
 
 		let (reverts, logs) =
 			extract_revive_events(&events, 0, U256::zero(), H256::zero(), |idx| match idx {
-				0 => Some(tx0),
-				1 => Some(tx1),
-				2 => Some(tx2),
+				2 => Some((tx0, 0)),
+				3 => Some((tx1, 1)),
+				4 => Some((tx2, 2)),
 				_ => None,
 			});
 
+		// Reverts and logs are keyed by the 0-based EVM index, not the substrate index.
 		assert_eq!(reverts, [1usize].into_iter().collect::<HashSet<_>>());
 		assert_eq!(logs[&0].len(), 2);
 		assert_eq!(logs[&2].len(), 1);
+		// Each log carries its transaction's 0-based EVM index.
+		assert_eq!(logs[&0][0].transaction_index, U256::from(0));
+		assert_eq!(logs[&2][0].transaction_index, U256::from(2));
 		// log_index is block-wide
 		assert_eq!(logs[&0][0].log_index, U256::from(0));
 		assert_eq!(logs[&0][1].log_index, U256::from(1));

--- a/substrate/frame/revive/rpc/src/receipt_provider.rs
+++ b/substrate/frame/revive/rpc/src/receipt_provider.rs
@@ -883,6 +883,15 @@ impl<B: BlockInfoProvider> ReceiptProvider<B> {
 		Some(rows.into_iter().collect())
 	}
 
+	/// See [`ReceiptExtractor::eth_transact_extrinsic_indices`]. Bridges the substrate
+	/// extrinsic-index space and the 0-based EVM index space (#6790 pt 3).
+	pub async fn eth_transact_extrinsic_indices(
+		&self,
+		block: &SubstrateBlock,
+	) -> Result<Vec<usize>, ClientError> {
+		self.receipt_extractor.eth_transact_extrinsic_indices(block).await
+	}
+
 	/// Get the receipt for the given block hash and transaction index.
 	pub async fn receipt_by_block_hash_and_index(
 		&self,

--- a/substrate/frame/revive/rpc/src/tests.rs
+++ b/substrate/frame/revive/rpc/src/tests.rs
@@ -351,6 +351,7 @@ async fn run_all_eth_rpc_tests_inner() -> anyhow::Result<()> {
 		test_invalid_transaction,
 		test_evm_blocks_should_match,
 		test_evm_blocks_hydrated_should_match,
+		test_transaction_index_is_zero_based,
 		test_block_hash_for_tag_with_proper_ethereum_block_hash_works,
 		test_block_hash_for_tag_with_invalid_ethereum_block_hash_fails,
 		test_block_hash_for_tag_with_block_number_works,
@@ -824,6 +825,54 @@ async fn test_evm_blocks_hydrated_should_match() -> anyhow::Result<()> {
 		panic!("Expected hydrated transactions");
 	};
 	assert_eq!(expected_tx_info, tx_info, "TransationInfos should match");
+
+	Ok(())
+}
+
+/// #6790 pt 3: `transactionIndex` must be 0-based EVM, not substrate extrinsic index. The
+/// dev runtime puts a `timestamp` inherent at substrate index 0, so the first EVM tx sits
+/// at substrate index ≥ 1 — the RPC must still report it as 0.
+async fn test_transaction_index_is_zero_based() -> anyhow::Result<()> {
+	let client = Arc::new(SharedResources::client().await);
+	let (bytes, _) = pallet_revive_fixtures::compile_module("dummy")?;
+	let tx = TransactionBuilder::new(client.clone())
+		.value(U256::from(5_000_000_000_000u128))
+		.input(bytes.to_vec())
+		.send()
+		.await?;
+	let receipt = tx.wait_for_receipt().await?;
+	let block_number: BlockNumberOrTag = receipt.block_number.try_into().unwrap();
+
+	let tx_count = client
+		.get_block_transaction_count_by_number(Some(block_number))
+		.await?
+		.expect("block should exist");
+	assert!(tx_count >= U256::one(), "block should contain at least our transaction");
+
+	// Before the fix, index 0 returned null (substrate index 0 is the timestamp inherent).
+	let first = client
+		.get_transaction_by_block_number_and_index(block_number, U256::zero())
+		.await?;
+	assert!(first.is_some(), "index 0 must return the first EVM transaction, not null");
+
+	// Dense 0-based: `tx_count` is one past the end.
+	let past_end = client
+		.get_transaction_by_block_number_and_index(block_number, tx_count)
+		.await?;
+	assert!(past_end.is_none(), "index == tx_count must return null");
+
+	// Receipt's index is 0-based (< count) and round-trips. Pre-fix it carried the
+	// substrate extrinsic index (≥ 1) and failed both checks.
+	assert!(
+		receipt.transaction_index < tx_count,
+		"transaction_index {} must be 0-based (< count {tx_count})",
+		receipt.transaction_index,
+	);
+	let ours = client
+		.get_transaction_by_block_number_and_index(block_number, receipt.transaction_index)
+		.await?
+		.expect("our transaction must be addressable by its receipt index");
+	assert_eq!(ours.hash, receipt.transaction_hash);
 
 	Ok(())
 }


### PR DESCRIPTION
## What

`transactionIndex` on `TransactionInfo` / `ReceiptInfo` / `Log` is now the 0-based
EVM index (the index among a block's `EthTransact` calls), not the substrate
extrinsic index.

## Why

Ethereum JSON-RPC requires `transactionIndex ∈ {0..n-1}` for the n ETH txs in a
block. We were leaking the substrate extrinsic index, which on a parachain
typically starts at 2 (after timestamp + parachain-system inherents). That made
`eth_getTransactionByBlockNumberAndIndex(block, 0)` return null on every block,
and every `transactionIndex` in receipts/logs/tx objects was off by the inherent
count.

## How

`extract_from_block_with_eth_hash` and `extract_from_transaction` filter
`EthTransact` calls then `enumerate()` the survivors; that 0-based rank becomes
`ReceiptInfo.transaction_index` and the key for log/revert maps. Substrate
indices are kept internally only to match block events.

The two trace endpoints (`debug_traceBlockByNumber`, `debug_traceTransaction`)
and the weight lookup translate at the eth-rpc boundary instead of changing the
runtime `trace_block` / `trace_tx` contract — they still receive substrate
indices.

## sqlite migration

`transaction_hashes.transaction_index` and `logs.transaction_index` change
meaning. Migration 0005 wipes the receipt caches plus `eth_to_substrate_blocks`
and `sync_state` so eth-rpc re-scans chain history with 0-based indices on the
next start. One-time cost per operator.

## Tests

- New integration test `test_transaction_index_is_zero_based` asserts the dev
  runtime's first EVM tx is addressable at index 0 (despite the timestamp
  inherent), that `(block, count)` returns null, and that the receipt's index
  round-trips through `eth_getTransactionByBlockNumberAndIndex`.
- Existing receipt extractor + integration tests pass.

## Caller impact

Downstream indexers / explorers that persisted `transactionIndex` should
re-sync transaction-indexed data after upgrade.
