### PR TITLE
[pallet-revive] fix double deposit charge to parent contractinfo

### DIFF
--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1601,6 +1601,10 @@ where
 					contract,
 				);
 				if let Some(f) = self.frames_mut().find(|f| f.account_id == *account_id) {
+					// Child persisted this frame's preview-applied `ContractInfo`; bank the diff
+					// before invalidating so finalize doesn't apply it twice.
+					// See: <https://github.com/paritytech/contract-issues/issues/213>
+					f.frame_meter.bank_pending_storage_changes(f.contract_info.as_contract());
 					f.contract_info.invalidate();
 				}
 			}

--- a/substrate/frame/revive/src/exec/tests.rs
+++ b/substrate/frame/revive/src/exec/tests.rs
@@ -29,7 +29,7 @@ use crate::{
 	test_utils::*,
 	tests::{
 		ExtBuilder, RuntimeEvent as MetaEvent, Test,
-		test_utils::{get_balance, place_contract, set_balance},
+		test_utils::{get_balance, get_contract, place_contract, set_balance},
 	},
 };
 use assert_matches::assert_matches;
@@ -1409,6 +1409,175 @@ fn in_memory_changes_not_discarded() {
 		);
 		assert_matches!(result, Ok(_));
 	});
+}
+
+#[test]
+fn same_contract_reentry_does_not_double_count_storage() {
+	// Without the bank-pending-changes fix the pre-call write is applied to the
+	// persisted `ContractInfo` twice (child's preview-persist + parent's finalize),
+	// inflating `storage_items` from 2 to 3. See contract-issues#213.
+	let code_bob = MockLoader::insert(Call, |ctx, _| {
+		if ctx.input_data[0] == 0 {
+			ctx.ext.set_storage(&Key::Fix([1; 32]), Some(vec![1, 2, 3]), false).unwrap();
+			assert_ok!(ctx.ext.call(
+				&Default::default(),
+				&BOB_ADDR,
+				U256::zero(),
+				vec![1],
+				ReentrancyProtection::AllowReentry,
+				false,
+			));
+			ctx.ext.set_storage(&Key::Fix([2; 32]), Some(vec![4, 5, 6]), false).unwrap();
+		}
+		exec_success()
+	});
+
+	ExtBuilder::default().build().execute_with(|| {
+		let min_balance = <Test as Config>::Currency::minimum_balance();
+		set_balance(&ALICE, min_balance * 1000);
+		place_contract(&BOB, code_bob);
+		let origin = Origin::from_account_id(ALICE);
+		let mut meter =
+			TransactionMeter::<Test>::new_from_limits(WEIGHT_LIMIT, deposit_limit::<Test>())
+				.unwrap();
+
+		assert_ok!(MockStack::run_call(
+			origin,
+			BOB_ADDR,
+			&mut meter,
+			U256::zero(),
+			vec![0],
+			&ExecConfig::new_substrate_tx(),
+		));
+
+		assert_eq!(
+			get_contract(&BOB_ADDR).storage_items,
+			2,
+			"storage_items inflated by double-applied pending diff under same-contract reentry",
+		);
+	});
+}
+
+#[test]
+fn transitive_reentry_does_not_double_count_storage() {
+	// Same bug reached transitively: BOB -> CHARLIE -> BOB'. The invalidation matcher
+	// keys on `account_id`, so any ancestor reentered through an intermediary is also
+	// affected.
+	let code_charlie = MockLoader::insert(Call, |ctx, _| {
+		assert_ok!(ctx.ext.call(
+			&Default::default(),
+			&BOB_ADDR,
+			U256::zero(),
+			vec![1],
+			ReentrancyProtection::AllowReentry,
+			false,
+		));
+		exec_success()
+	});
+	let code_bob = MockLoader::insert(Call, |ctx, _| {
+		if ctx.input_data[0] == 0 {
+			ctx.ext.set_storage(&Key::Fix([1; 32]), Some(vec![1, 2, 3]), false).unwrap();
+			assert_ok!(ctx.ext.call(
+				&Default::default(),
+				&CHARLIE_ADDR,
+				U256::zero(),
+				vec![],
+				ReentrancyProtection::AllowReentry,
+				false,
+			));
+			ctx.ext.set_storage(&Key::Fix([2; 32]), Some(vec![4, 5, 6]), false).unwrap();
+		}
+		exec_success()
+	});
+
+	ExtBuilder::default().build().execute_with(|| {
+		let min_balance = <Test as Config>::Currency::minimum_balance();
+		set_balance(&ALICE, min_balance * 1000);
+		place_contract(&BOB, code_bob);
+		place_contract(&CHARLIE, code_charlie);
+		let mut meter =
+			TransactionMeter::<Test>::new_from_limits(WEIGHT_LIMIT, deposit_limit::<Test>())
+				.unwrap();
+		assert_ok!(MockStack::run_call(
+			Origin::from_account_id(ALICE),
+			BOB_ADDR,
+			&mut meter,
+			U256::zero(),
+			vec![0],
+			&ExecConfig::new_substrate_tx(),
+		));
+		assert_eq!(
+			get_contract(&BOB_ADDR).storage_items,
+			2,
+			"storage_items inflated by double-applied diff under transitive reentry",
+		);
+	});
+}
+
+#[test]
+fn nested_clear_refund_matches_direct_clear() {
+	// Mock equivalent of `metering::tests::nested_call_storage_refund` (#213) — a fast
+	// regression guard. Direct (set, set, clear) and nested (set, set, call-self-clear)
+	// executions must produce identical `ContractInfo` accounting.
+	let code = MockLoader::insert(Call, |ctx, _| {
+		match ctx.input_data[0] {
+			0 => {
+				ctx.ext.set_storage(&Key::Fix([1; 32]), Some(vec![1, 2, 3]), false).unwrap();
+				ctx.ext.set_storage(&Key::Fix([2; 32]), Some(vec![4, 5, 6]), false).unwrap();
+				ctx.ext.set_storage(&Key::Fix([2; 32]), None, false).unwrap();
+			},
+			1 => {
+				ctx.ext.set_storage(&Key::Fix([1; 32]), Some(vec![1, 2, 3]), false).unwrap();
+				ctx.ext.set_storage(&Key::Fix([2; 32]), Some(vec![4, 5, 6]), false).unwrap();
+				assert_ok!(ctx.ext.call(
+					&Default::default(),
+					&BOB_ADDR,
+					U256::zero(),
+					vec![2],
+					ReentrancyProtection::AllowReentry,
+					false,
+				));
+			},
+			_ => {
+				ctx.ext.set_storage(&Key::Fix([2; 32]), None, false).unwrap();
+			},
+		}
+		exec_success()
+	});
+
+	let run = |input: u8| {
+		ExtBuilder::default().build().execute_with(|| {
+			let min_balance = <Test as Config>::Currency::minimum_balance();
+			set_balance(&ALICE, min_balance * 1000);
+			place_contract(&BOB, code);
+			let mut meter =
+				TransactionMeter::<Test>::new_from_limits(WEIGHT_LIMIT, deposit_limit::<Test>())
+					.unwrap();
+			assert_ok!(MockStack::run_call(
+				Origin::from_account_id(ALICE),
+				BOB_ADDR,
+				&mut meter,
+				U256::zero(),
+				vec![input],
+				&ExecConfig::new_substrate_tx(),
+			));
+			get_contract(&BOB_ADDR)
+		})
+	};
+
+	let direct = run(0);
+	let nested = run(1);
+
+	assert_eq!(direct.storage_items, nested.storage_items, "storage_items mismatch");
+	assert_eq!(direct.storage_bytes, nested.storage_bytes, "storage_bytes mismatch");
+	assert_eq!(
+		direct.storage_item_deposit, nested.storage_item_deposit,
+		"storage_item_deposit mismatch",
+	);
+	assert_eq!(
+		direct.storage_byte_deposit, nested.storage_byte_deposit,
+		"storage_byte_deposit mismatch",
+	);
 }
 
 #[test]

--- a/substrate/frame/revive/src/metering/mod.rs
+++ b/substrate/frame/revive/src/metering/mod.rs
@@ -673,6 +673,11 @@ impl<T: Config> FrameMeter<T> {
 	pub fn apply_pending_storage_changes(&self, info: &mut ContractInfo<T>) {
 		self.deposit.apply_pending_changes_to_contract(info);
 	}
+
+	/// See [`storage::RawMeter::bank_pending_changes`].
+	pub fn bank_pending_storage_changes(&mut self, info: Option<&mut ContractInfo<T>>) {
+		self.deposit.bank_pending_changes(info);
+	}
 }
 
 /// Ethereum transaction context for gas conversions.

--- a/substrate/frame/revive/src/metering/storage.rs
+++ b/substrate/frame/revive/src/metering/storage.rs
@@ -80,6 +80,10 @@ pub struct RawMeter<T: Config, E, S: State> {
 	/// The amount of storage changes that were recorded in this meter alone.
 	/// This has no meaning for Root meters and will always be Contribution::Checked(0)
 	own_contribution: Contribution<T>,
+	/// Deposit for a diff already applied to the persisted `ContractInfo` out of band
+	/// (see [`Self::bank_pending_changes`]). Counted toward the charge but not
+	/// re-applied to `info` on finalize.
+	applied_deposit: DepositOf<T>,
 	/// List of charges that should be applied at the end of a contract stack execution.
 	///
 	/// We only have one charge per contract hence the size of this vector is
@@ -292,7 +296,10 @@ where
 			.max_charged
 			.max(self.consumed().saturating_add(&absorbed.max_charged()).charge_or_zero());
 
-		let own_deposit = absorbed.own_contribution.update_contract(info);
+		let own_deposit = absorbed
+			.own_contribution
+			.update_contract(info)
+			.saturating_add(&absorbed.applied_deposit);
 		self.total_deposit = self
 			.total_deposit
 			.saturating_add(&absorbed.total_deposit)
@@ -336,7 +343,9 @@ where
 	/// This disregards any refunds pending in the current frame. This
 	/// is because we can calculate refunds only at the end of each frame.
 	pub fn consumed(&self) -> DepositOf<T> {
-		self.total_deposit.saturating_add(&self.own_contribution.update_contract(None))
+		self.total_deposit
+			.saturating_add(&self.own_contribution.update_contract(None))
+			.saturating_add(&self.applied_deposit)
 	}
 
 	/// Return the maximum consumed deposit at any point in the previous execution
@@ -506,6 +515,20 @@ impl<T: Config, E: Ext<T>> RawMeter<T, E, Nested> {
 			// We don't care about the return value (the deposit amount) here,
 			// we just want to update the ContractInfo so child frames can see it.
 			let _ = diff.update_contract::<T>(Some(info));
+		}
+	}
+
+	/// Apply the pending diff to `info` and record its deposit in
+	/// [`Self::applied_deposit`], then reset `own_contribution` so finalize does not
+	/// apply it a second time.
+	///
+	/// `info` must be the frame's pre-reload `ContractInfo` so refunds are pro-rated
+	/// against the storage state the diff was recorded against.
+	pub fn bank_pending_changes(&mut self, info: Option<&mut ContractInfo<T>>) {
+		if matches!(self.own_contribution, Contribution::Alive(_)) {
+			let deposit = self.own_contribution.update_contract(info);
+			self.applied_deposit = self.applied_deposit.saturating_add(&deposit);
+			self.own_contribution = Contribution::Alive(Default::default());
 		}
 	}
 }


### PR DESCRIPTION
## What

Fixes a regression from #10920 (the `contract-issues#213` fix). When a contract writes
storage, reenters **itself** (directly or transitively, e.g. `X→Y→X`), and then writes
storage **again after the nested call returns**, the diff recorded *before* the nested call
is applied to the contract's persisted `ContractInfo` twice — inflating `storage_items` /
`storage_bytes` / `storage_*_deposit`. The corruption is persisted and survives across
transactions.

## Root cause

#10920 makes a frame's pending diff visible to nested frames by preview-applying it into a
clone of the `ContractInfo`, **without consuming** the parent's `own_contribution`. Under
same-contract reentry the child persists that preview and invalidates the parent's cache;
the parent reloads the now-`K1`-inclusive info, and `finalize()` re-applies its still-pending
`own_contribution` on top → `base + 2·K1 + K2`.

The existing #213 test (`nested_call_storage_refund`) misses this: its parent does no write
after the nested call, so the parent's cache stays `Invalidated` and `finalize` never
re-applies.

## Fix

Bank the parent's pending diff the moment a same-contract descendant has persisted it, so
`finalize()` only applies writes recorded *afterwards*:

- New `RawMeter::applied_deposit` + `bank_pending_changes()` — applies the pending diff once,
  records its deposit, and resets `own_contribution`.
- `applied_deposit` is included in `consumed()` and `absorb()`, so the deposit is still
  **charged** (verified unchanged) but not re-applied to `ContractInfo`.
- Called at the cache-invalidation site in `pop_frame`, before `invalidate()`.

No behavior change outside same-contract reentry (no-op when there is no live same-account
frame or the pending diff is empty).

## Testing

- New `same_contract_reentry_does_not_double_count_storage` and
  `transitive_reentry_does_not_double_count_storage` — fail without the fix, pass with it.
- New `nested_clear_refund_matches_direct_clear` — fast #213 guard.
- Full `pallet-revive` lib suite (635 tests, incl. all solc/resolc `nested_call_storage_refund`
  and PVM storage-deposit fixtures) passes.

## Impact

Low. Refunds only ever under-pay; the `.min(1)` ratio clamp and `refund_all` reading
`balance_on_hold` rule out over-refund/theft, and residue is recoverable via `terminate`.
