### PR TITLE
In `glutton_westend_config` patch the genesis config with the passed para_id

### DIFF
--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/genesis_config_presets.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/genesis_config_presets.rs
@@ -23,9 +23,11 @@ use parachains_common::AuraId;
 use sp_genesis_builder::PresetId;
 use sp_keyring::Sr25519Keyring;
 
-/// Default value, unused in a testnet setup currently because
-/// we want to supply varying para-ids from the CLI for Glutton.
-/// However, the presets does not allow dynamic para-ids currently.
+/// Default para-id baked into the presets.
+///
+/// The preset API cannot take a dynamic para-id, so the presets are built with this fixed value.
+/// Callers that need a specific para-id (e.g. the `glutton-westend-*-<id>` CLI chain specs) patch
+/// `parachain_info.parachain_id` over the preset output instead of relying on this default.
 pub const DEFAULT_GLUTTON_PARA_ID: ParaId = ParaId::new(1300);
 
 pub fn glutton_westend_genesis(

--- a/cumulus/polkadot-parachain/src/chain_spec/glutton.rs
+++ b/cumulus/polkadot-parachain/src/chain_spec/glutton.rs
@@ -29,7 +29,7 @@ pub fn glutton_westend_config(
 
 	GenericChainSpec::builder(
 		glutton_westend_runtime::WASM_BINARY.expect("WASM binary was not built, please build it!"),
-		Extensions::new_with_relay_chain(relay_chain.into()),
+		Extensions::new(relay_chain.into(), para_id.into()),
 	)
 	.with_name(&chain_type_name(para_id, &chain_type))
 	.with_id(&chain_id(para_id, &chain_type))
@@ -39,6 +39,10 @@ pub fn glutton_westend_config(
 		ChainType::Local => sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET,
 		_ => panic!("chain_type: {chain_type:?} not supported here!"),
 	})
+	// The presets bake in a fixed (fallback) para-id, so patch the requested one on top.
+	.with_genesis_config_patch(serde_json::json!({
+		"parachainInfo": { "parachainId": u32::from(para_id) },
+	}))
 	.build()
 }
 

--- a/prdoc/pr_12275.prdoc
+++ b/prdoc/pr_12275.prdoc
@@ -1,0 +1,12 @@
+title: In `glutton_westend_config` patch the genesis config with the passed para_id
+doc:
+- audience: Runtime Dev
+  description: |-
+    While running tests on Versi I noticed that while generating chainspec for e.g. `glutton-westend-local-1301` I noticed that the para id in the spec id is ignored and always set to 1300.
+
+    Not sure if there is a good reason for this behaviour but it's misleading.
+crates:
+- name: glutton-westend-runtime
+  bump: patch
+- name: polkadot-parachain-bin
+  bump: patch


### PR DESCRIPTION
While running tests on Versi I noticed that while generating chainspec for e.g. `glutton-westend-local-1301` I noticed that the para id in the spec id is ignored and always set to 1300.

Not sure if there is a good reason for this behaviour but it's misleading.