### PR TITLE
cumulus: add segment submission primitive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5147,6 +5147,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-client-unincluded-segment-store"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sc-client-api 28.0.0",
+ "sp-blockchain 28.0.0",
+ "sp-runtime 31.0.1",
+ "sp-trie 29.0.0",
+ "substrate-test-runtime",
+]
+
+[[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,11 +5157,9 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api 28.0.0",
  "sp-blockchain 28.0.0",
- "sp-consensus 0.32.0",
  "sp-runtime 31.0.1",
  "sp-trie 29.0.0",
  "substrate-test-runtime",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5151,13 +5151,16 @@ dependencies = [
 name = "cumulus-client-unincluded-segment-store"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "parity-scale-codec",
- "polkadot-primitives",
  "sc-client-api 28.0.0",
  "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
  "sp-runtime 31.0.1",
+ "sp-staking",
  "sp-trie 29.0.0",
  "substrate-test-runtime",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,10 +5156,12 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "sc-client-api 28.0.0",
+ "sc-client-db",
  "sp-blockchain 28.0.0",
  "sp-runtime 31.0.1",
  "sp-trie 29.0.0",
  "substrate-test-runtime",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,7 +5157,6 @@ dependencies = [
  "sp-blockchain 28.0.0",
  "sp-consensus 0.32.0",
  "sp-runtime 31.0.1",
- "sp-staking",
  "sp-trie 29.0.0",
  "substrate-test-runtime",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,6 +4897,7 @@ dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-parachain-inherent",
  "cumulus-client-proof-size-recording",
+ "cumulus-client-unincluded-segment-store",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,6 +4975,7 @@ dependencies = [
  "sp-trie 29.0.0",
  "sp-version 29.0.0",
  "substrate-prometheus-endpoint 0.17.0",
+ "substrate-test-runtime",
  "tokio",
  "tracing",
 ]
@@ -5151,6 +5152,7 @@ dependencies = [
 name = "cumulus-client-unincluded-segment-store"
 version = "0.1.0"
 dependencies = [
+ "cumulus-client-consensus-common",
  "hex",
  "parity-scale-codec",
  "sc-client-api 28.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
 	"cumulus/client/parachain-inherent",
 	"cumulus/client/pov-recovery",
 	"cumulus/client/proof-size-recording",
+	"cumulus/client/unincluded-segment-store",
 	"cumulus/client/relay-chain-inprocess-interface",
 	"cumulus/client/relay-chain-interface",
 	"cumulus/client/relay-chain-minimal-node",
@@ -771,6 +772,7 @@ cumulus-client-network = { path = "cumulus/client/network", default-features = f
 cumulus-client-parachain-inherent = { path = "cumulus/client/parachain-inherent", default-features = false }
 cumulus-client-pov-recovery = { path = "cumulus/client/pov-recovery", default-features = false }
 cumulus-client-proof-size-recording = { path = "cumulus/client/proof-size-recording", default-features = false }
+cumulus-client-unincluded-segment-store = { path = "cumulus/client/unincluded-segment-store", default-features = false }
 cumulus-client-service = { path = "cumulus/client/service", default-features = false }
 cumulus-pallet-aura-ext = { path = "cumulus/pallets/aura-ext", default-features = false }
 cumulus-pallet-parachain-system = { path = "cumulus/pallets/parachain-system", default-features = false }

--- a/cumulus/client/consensus/aura/Cargo.toml
+++ b/cumulus/client/consensus/aura/Cargo.toml
@@ -50,6 +50,7 @@ cumulus-client-collator = { workspace = true, default-features = true }
 cumulus-client-consensus-common = { workspace = true, default-features = true }
 cumulus-client-parachain-inherent = { workspace = true, default-features = true }
 cumulus-client-proof-size-recording = { workspace = true, default-features = true }
+cumulus-client-unincluded-segment-store = { workspace = true }
 cumulus-primitives-aura = { workspace = true, default-features = true }
 cumulus-primitives-core = { workspace = true, default-features = true }
 cumulus-relay-chain-interface = { workspace = true, default-features = true }

--- a/cumulus/client/consensus/aura/Cargo.toml
+++ b/cumulus/client/consensus/aura/Cargo.toml
@@ -50,7 +50,7 @@ cumulus-client-collator = { workspace = true, default-features = true }
 cumulus-client-consensus-common = { workspace = true, default-features = true }
 cumulus-client-parachain-inherent = { workspace = true, default-features = true }
 cumulus-client-proof-size-recording = { workspace = true, default-features = true }
-cumulus-client-unincluded-segment-store = { workspace = true }
+cumulus-client-unincluded-segment-store = { workspace = true, default-features = true }
 cumulus-primitives-aura = { workspace = true, default-features = true }
 cumulus-primitives-core = { workspace = true, default-features = true }
 cumulus-relay-chain-interface = { workspace = true, default-features = true }

--- a/cumulus/client/consensus/aura/src/collators/lookahead.rs
+++ b/cumulus/client/consensus/aura/src/collators/lookahead.rs
@@ -334,10 +334,10 @@ where
 				};
 
 			let parent_search_result = match crate::collators::find_parent(
-				relay_parent,
-				params.para_id,
-				&*params.para_backend,
 				&params.relay_client,
+				&*params.para_backend,
+				params.para_id,
+				relay_parent,
 				|_| true,
 			)
 			.await

--- a/cumulus/client/consensus/aura/src/collators/lookahead.rs
+++ b/cumulus/client/consensus/aura/src/collators/lookahead.rs
@@ -34,7 +34,9 @@
 
 use codec::{Codec, Encode};
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
-use cumulus_client_consensus_common::{self as consensus_common, ParachainBlockImportMarker};
+use cumulus_client_consensus_common::{
+	self as consensus_common, ParachainBlockImportMarker, ParentSearchParams,
+};
 use cumulus_primitives_aura::AuraUnincludedSegmentApi;
 use cumulus_primitives_core::{
 	CollectCollationInfo, KeyToIncludeInRelayProof, PersistedValidationData,
@@ -337,7 +339,7 @@ where
 				&params.relay_client,
 				&*params.para_backend,
 				params.para_id,
-				relay_parent,
+				ParentSearchParams::V2 { scheduling_parent: relay_parent },
 				|_| true,
 			)
 			.await

--- a/cumulus/client/consensus/aura/src/collators/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/mod.rs
@@ -23,7 +23,7 @@
 
 use crate::collator::SlotClaim;
 use codec::Codec;
-use cumulus_client_consensus_common::{self as consensus_common, ParentSearchParams};
+use cumulus_client_consensus_common::{self as consensus_common};
 use cumulus_primitives_aura::{AuraUnincludedSegmentApi, Slot};
 use cumulus_primitives_core::{
 	relay_chain::Header as RelayHeader, BlockT, KeyToIncludeInRelayProof, RelayProofRequest,
@@ -33,7 +33,6 @@ use polkadot_node_subsystem::messages::CollatorProtocolMessage;
 use polkadot_node_subsystem_util::runtime::ClaimQueueSnapshot;
 use polkadot_primitives::{
 	Hash as RelayHash, Id as ParaId, OccupiedCoreAssumption, ValidationCodeHash,
-	DEFAULT_SCHEDULING_LOOKAHEAD,
 };
 use sc_client_api::HeaderBackend;
 use sc_consensus_aura::{standalone as aura_internal, AuraApi};
@@ -238,26 +237,20 @@ where
 /// If the best parent does not pass `filter_parent`, walks backwards through ancestors
 /// until finding one that does, or reaching the included block.
 async fn find_parent<Block>(
-	relay_parent: RelayHash,
-	para_id: ParaId,
-	para_backend: &impl sc_client_api::Backend<Block>,
 	relay_client: &impl RelayChainInterface,
+	para_backend: &impl sc_client_api::Backend<Block>,
+	para_id: ParaId,
+	relay_parent: RelayHash,
 	filter_parent: impl Fn(&Block::Header) -> bool,
 ) -> Option<consensus_common::ParentSearchResult<Block>>
 where
 	Block: BlockT,
 {
-	let ancestry_lookback = relay_client
-		.scheduling_lookahead(relay_parent)
-		.await
-		.unwrap_or(DEFAULT_SCHEDULING_LOOKAHEAD)
-		.saturating_sub(1) as usize;
-	let parent_search_params = ParentSearchParams { relay_parent, para_id, ancestry_lookback };
-
 	let mut result = match cumulus_client_consensus_common::find_parent_for_building::<Block>(
-		parent_search_params,
-		para_backend,
 		relay_client,
+		para_backend,
+		para_id,
+		relay_parent,
 	)
 	.await
 	{

--- a/cumulus/client/consensus/aura/src/collators/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/mod.rs
@@ -23,7 +23,7 @@
 
 use crate::collator::SlotClaim;
 use codec::Codec;
-use cumulus_client_consensus_common::{self as consensus_common};
+use cumulus_client_consensus_common::{self as consensus_common, ParentSearchParams};
 use cumulus_primitives_aura::{AuraUnincludedSegmentApi, Slot};
 use cumulus_primitives_core::{
 	relay_chain::Header as RelayHeader, BlockT, KeyToIncludeInRelayProof, RelayProofRequest,
@@ -240,7 +240,7 @@ async fn find_parent<Block>(
 	relay_client: &impl RelayChainInterface,
 	para_backend: &impl sc_client_api::Backend<Block>,
 	para_id: ParaId,
-	relay_parent: RelayHash,
+	params: ParentSearchParams<Block>,
 	filter_parent: impl Fn(&Block::Header) -> bool,
 ) -> Option<consensus_common::ParentSearchResult<Block>>
 where
@@ -250,7 +250,7 @@ where
 		relay_client,
 		para_backend,
 		para_id,
-		relay_parent,
+		params.clone(),
 	)
 	.await
 	{
@@ -258,7 +258,7 @@ where
 		Ok(None) => {
 			tracing::warn!(
 				target: crate::LOG_TARGET,
-				?relay_parent,
+				?params,
 				"Could not find parent to build upon.",
 			);
 			return None;
@@ -266,7 +266,7 @@ where
 		Err(e) => {
 			tracing::error!(
 				target: crate::LOG_TARGET,
-				?relay_parent,
+				?params,
 				err = ?e,
 				"Could not find parent to build upon"
 			);

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -288,10 +288,10 @@ where
 			let relay_parent_hash = relay_parent_header.hash();
 
 			let Some(parent_search_result) = crate::collators::find_parent(
-				relay_parent_hash,
-				para_id,
-				&*para_backend,
 				&relay_client,
+				&*para_backend,
+				para_id,
+				relay_parent_hash,
 				|parent| {
 					// We never want to build on any "middle block" that isn't the last block in a
 					// core.

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -32,7 +32,8 @@ use crate::{
 use codec::{Codec, Encode};
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
 use cumulus_client_consensus_common::{
-	self as consensus_common, get_relay_slot, ParachainBlockImportMarker,
+	self as consensus_common, fetch_included_from_relay_chain, get_relay_slot,
+	ParachainBlockImportMarker, ParentSearchParams,
 };
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
 use cumulus_primitives_aura::{AuraUnincludedSegmentApi, Slot};
@@ -287,11 +288,18 @@ where
 			let relay_parent_header = relay_parent_data.relay_parent().clone();
 			let relay_parent_hash = relay_parent_header.hash();
 
+			let parent_search_params = match v3_enabled {
+				false => ParentSearchParams::V2 { scheduling_parent: relay_parent_hash },
+				true => ParentSearchParams::V3 {
+					scheduling_parent: scheduling_parent_hash,
+					para_best_hash,
+				},
+			};
 			let Some(parent_search_result) = crate::collators::find_parent(
 				&relay_client,
 				&*para_backend,
 				para_id,
-				relay_parent_hash,
+				parent_search_params,
 				|parent| {
 					// We never want to build on any "middle block" that isn't the last block in a
 					// core.
@@ -305,7 +313,22 @@ where
 				continue;
 			};
 
-			let included_header = parent_search_result.included_header;
+			let included_header = match v3_enabled {
+				false => parent_search_result.included_header,
+				true => {
+					let Ok(Some((_, included_header))) = fetch_included_from_relay_chain(
+						&relay_client,
+						&*para_backend,
+						para_id,
+						relay_parent_hash,
+					)
+					.await
+					else {
+						continue;
+					};
+					included_header
+				},
+			};
 			let initial_parent_hash = parent_search_result.best_parent_header.hash();
 			let initial_parent_header = parent_search_result.best_parent_header;
 			let unincluded_segment_len =

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -859,17 +859,10 @@ where
 		}
 
 		let time_ms = now_unix_ms();
-		prepare_unincluded_segment_aux_data(
-			parent_hash,
-			time_ms,
-			// TODO(paritytech/polkadot-sdk#11624): populate with the relay parent's session
-			// once it is available from RelayChainDataCache.
-			None,
-			built_block.proof.clone(),
-		)
-		.for_each(|(k, v)| {
-			import_block.auxiliary.push((k, Some(v)));
-		});
+		prepare_unincluded_segment_aux_data(parent_hash, time_ms, built_block.proof.clone())
+			.for_each(|(k, v)| {
+				import_block.auxiliary.push((k, Some(v)));
+			});
 
 		if let Err(error) = collator.import_block(import_block).await {
 			tracing::error!(target: LOG_TARGET, ?error, "Failed to import built block.");

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{CollatorMessage, CollatorSegmentEntry, CollatorSegmentMessage};
+use super::{CollatorMessage, CollatorSegmentMessage, SegmentKind};
 use crate::{
 	collator::{self as collator_util, BuildBlockAndImportParams, Collator, SlotClaim},
 	collators::{
@@ -940,25 +940,29 @@ where
 		"Sending out PoV"
 	);
 
-	let send_ok = if v3_enabled {
+	// `scheduling_proof` is `Some` iff `v3_enabled`; routes V3 bundles to `segment_sender`,
+	// V2 bundles (no proof) to `collator_sender`.
+	let send_ok = if let Some(scheduling_proof) = scheduling_proof {
 		segment_sender
 			.unbounded_send(CollatorSegmentMessage {
 				scheduling_proof,
 				core_index,
-				entries: vec![CollatorSegmentEntry {
-					relay_parent: relay_parent_hash,
-					parent_header: pov_parent_header.clone(),
-					blocks,
-					proof,
-					validation_code_hash,
-					validation_data,
-				}],
+				kind: SegmentKind::WithBundle {
+					bundle: CollatorMessage {
+						relay_parent: relay_parent_hash,
+						parent_header: pov_parent_header.clone(),
+						blocks,
+						proof,
+						validation_code_hash,
+						validation_data,
+						core_index,
+					},
+				},
 			})
 			.is_ok()
 	} else {
 		collator_sender
 			.unbounded_send(CollatorMessage {
-				scheduling_proof,
 				core_index,
 				relay_parent: relay_parent_hash,
 				parent_header: pov_parent_header.clone(),

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{CollatorSegmentEntry, CollatorSegmentMessage};
+use super::{CollatorMessage, CollatorSegmentEntry, CollatorSegmentMessage};
 use crate::{
 	collator::{self as collator_util, BuildBlockAndImportParams, Collator, SlotClaim},
 	collators::{
@@ -112,8 +112,10 @@ pub struct BuilderTaskParams<
 	pub proposer: Proposer,
 	/// The generic collator service used to plug into this consensus engine.
 	pub collator_service: CS,
-	/// Channel to send built blocks to the collation task.
-	pub collator_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
+	/// Channel for V2 single-bundle collations.
+	pub collator_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorMessage<Block>>,
+	/// Channel for V3 segment collations.
+	pub segment_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
 	/// Slot duration of the relay chain.
 	pub relay_chain_slot_duration: Duration,
 	/// Offset all time operations by this duration.
@@ -189,6 +191,7 @@ where
 			proposer,
 			collator_service,
 			collator_sender,
+			segment_sender,
 			code_hash_provider,
 			relay_chain_slot_duration,
 			para_backend,
@@ -528,6 +531,7 @@ where
 					code_hash_provider: &code_hash_provider,
 					slot_claim: &slot_claim,
 					collator_sender: &collator_sender,
+					segment_sender: &segment_sender,
 					collator: &mut collator,
 					allowed_pov_size,
 					core_info: cores.core_info(),
@@ -587,7 +591,8 @@ struct BuildCollationParams<
 	relay_client: &'a RelayClient,
 	code_hash_provider: &'a CHP,
 	slot_claim: &'a SlotClaim<P::Public>,
-	collator_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
+	collator_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorMessage<Block>>,
+	segment_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
 	collator: &'a mut Collator<Block, P, BI, CIDP, RelayClient, Proposer, CS>,
 	allowed_pov_size: usize,
 	core_info: CoreInfo,
@@ -632,6 +637,7 @@ async fn build_collation_for_core<
 		code_hash_provider,
 		slot_claim,
 		collator_sender,
+		segment_sender,
 		collator,
 		allowed_pov_size,
 		core_info,
@@ -934,19 +940,38 @@ where
 		"Sending out PoV"
 	);
 
-	if let Err(err) = collator_sender.unbounded_send(CollatorSegmentMessage {
-		scheduling_proof,
-		core_index,
-		entries: vec![CollatorSegmentEntry {
-			relay_parent: relay_parent_hash,
-			parent_header: pov_parent_header.clone(),
-			blocks,
-			proof,
-			validation_code_hash,
-			validation_data,
-		}],
-	}) {
-		tracing::error!(target: LOG_TARGET, ?err, "Unable to send block to collation task.");
+	let send_ok = if v3_enabled {
+		segment_sender
+			.unbounded_send(CollatorSegmentMessage {
+				scheduling_proof,
+				core_index,
+				entries: vec![CollatorSegmentEntry {
+					relay_parent: relay_parent_hash,
+					parent_header: pov_parent_header.clone(),
+					blocks,
+					proof,
+					validation_code_hash,
+					validation_data,
+				}],
+			})
+			.is_ok()
+	} else {
+		collator_sender
+			.unbounded_send(CollatorMessage {
+				scheduling_proof,
+				core_index,
+				relay_parent: relay_parent_hash,
+				parent_header: pov_parent_header.clone(),
+				blocks,
+				proof,
+				validation_code_hash,
+				validation_data,
+			})
+			.is_ok()
+	};
+
+	if !send_ok {
+		tracing::error!(target: LOG_TARGET, "Unable to send block to collation task.");
 		Err(())
 	} else {
 		// Now let's sleep for the rest of the core.

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -859,10 +859,11 @@ where
 		}
 
 		let time_ms = now_unix_ms();
-		prepare_unincluded_segment_aux_data(parent_hash, time_ms, built_block.proof.clone())
-			.for_each(|(k, v)| {
+		prepare_unincluded_segment_aux_data(parent_hash, time_ms, &built_block.proof).for_each(
+			|(k, v)| {
 				import_block.auxiliary.push((k, Some(v)));
-			});
+			},
+		);
 
 		if let Err(error) = collator.import_block(import_block).await {
 			tracing::error!(target: LOG_TARGET, ?error, "Failed to import built block.");

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
 
-use super::{CollatorMessage, CollatorSegmentMessage, SegmentKind};
+use super::{CollatorMessage, CollatorResubmitSegment, SegmentKind};
 use crate::{
 	collator::{self as collator_util, BuildBlockAndImportParams, Collator, SlotClaim},
 	collators::{
@@ -115,7 +115,7 @@ pub struct BuilderTaskParams<
 	/// Channel for V2 single-bundle collations.
 	pub collator_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorMessage<Block>>,
 	/// Channel for V3 segment collations.
-	pub segment_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
+	pub resubmit_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorResubmitSegment<Block>>,
 	/// Slot duration of the relay chain.
 	pub relay_chain_slot_duration: Duration,
 	/// Offset all time operations by this duration.
@@ -191,7 +191,7 @@ where
 			proposer,
 			collator_service,
 			collator_sender,
-			segment_sender,
+			resubmit_sender,
 			code_hash_provider,
 			relay_chain_slot_duration,
 			para_backend,
@@ -281,7 +281,7 @@ where
 					.await
 					.unwrap_or(0);
 			}
-			let Ok(Some(relay_parent_data)) = offset_relay_parent_find_descendants(
+			let Ok(Some(mut relay_parent_data)) = offset_relay_parent_find_descendants(
 				&mut relay_chain_data_cache,
 				scheduling_parent_header.clone(),
 				relay_parent_offset,
@@ -513,12 +513,43 @@ where
 				"Core configuration",
 			);
 
+			// Build the V3 scheduling proof once per slot — it's shared by every candidate in the
+			// segment. Consumes `relay_parent_data.descendants`, so the inherent created later
+			// downstream sees an empty list (which V3 verification expects).
+			let scheduling_proof = if v3_enabled {
+				let descendants = relay_parent_data.take_descendants();
+				let header_chain: Vec<_> = descendants.into_iter().rev().collect();
+				let scheduling_parent =
+					header_chain.first().map(|header| header.hash()).unwrap_or(relay_parent_hash);
+
+				tracing::debug!(
+					target: LOG_TARGET,
+					relay_parent = ?relay_parent_hash,
+					?scheduling_parent,
+					header_chain_len = header_chain.len(),
+					"Building V3 collation with scheduling proof",
+				);
+
+				Some(SchedulingProof {
+					header_chain,
+					internal_scheduling_parent_header: relay_parent_header.clone(),
+					// TODO: sign and populate when resubmission lands. The relay-chain verifier
+					// rejects `ResubmitOnly` / mixed segments whose proof lacks
+					// `signed_scheduling_info`.
+					signed_scheduling_info: None,
+				})
+			} else {
+				None
+			};
+
 			let mut pov_parent_header = initial_parent_header;
 			let mut pov_parent_hash = initial_parent_hash;
 			let block_time = relay_chain_slot_duration / number_of_blocks;
 
-			for blocks_per_core in blocks_per_cores {
+			for (core_iter_index, blocks_per_core) in blocks_per_cores.into_iter().enumerate() {
 				let time_for_core = slot_time.time_left() / cores.cores_left();
+				let is_first_core = core_iter_index == 0;
+				let this_core_index = cores.core_index();
 
 				match build_collation_for_core(BuildCollationParams {
 					pov_parent_header,
@@ -531,11 +562,11 @@ where
 					code_hash_provider: &code_hash_provider,
 					slot_claim: &slot_claim,
 					collator_sender: &collator_sender,
-					segment_sender: &segment_sender,
+					resubmit_sender: &resubmit_sender,
 					collator: &mut collator,
 					allowed_pov_size,
 					core_info: cores.core_info(),
-					core_index: cores.core_index(),
+					core_index: this_core_index,
 					block_time,
 					blocks_per_core,
 					time_for_core,
@@ -548,7 +579,7 @@ where
 					relay_slot,
 					para_slot: para_slot.slot,
 					para_client: &*para_client,
-					v3_enabled,
+					scheduling_proof: scheduling_proof.clone(),
 				})
 				.await
 				{
@@ -556,8 +587,19 @@ where
 						pov_parent_header = header;
 						pov_parent_hash = pov_parent_header.hash();
 					},
-					// Let's wait for the next slot
-					Ok(None) => break,
+					Ok(None) => {
+						// First-core failed to build a fresh bundle: still ship the held prior
+						// unincluded segment via `ResubmitOnly`.
+						if is_first_core {
+							if let Some(proof) = scheduling_proof.clone() {
+								let _ = resubmit_sender.unbounded_send(CollatorResubmitSegment {
+									scheduling_proof: proof,
+									kind: SegmentKind::ResubmitOnly { core_index: this_core_index },
+								});
+							}
+						}
+						break;
+					},
 					Err(()) => return,
 				}
 
@@ -592,7 +634,7 @@ struct BuildCollationParams<
 	code_hash_provider: &'a CHP,
 	slot_claim: &'a SlotClaim<P::Public>,
 	collator_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorMessage<Block>>,
-	segment_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
+	resubmit_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorResubmitSegment<Block>>,
 	collator: &'a mut Collator<Block, P, BI, CIDP, RelayClient, Proposer, CS>,
 	allowed_pov_size: usize,
 	core_info: CoreInfo,
@@ -609,7 +651,8 @@ struct BuildCollationParams<
 	relay_slot: cumulus_primitives_aura::Slot,
 	para_slot: cumulus_primitives_aura::Slot,
 	para_client: &'a Client,
-	v3_enabled: bool,
+	/// V3 scheduling proof, built once per slot. `Some` iff V3 is enabled.
+	scheduling_proof: Option<SchedulingProof>,
 }
 
 /// Build a collation for one core.
@@ -637,7 +680,7 @@ async fn build_collation_for_core<
 		code_hash_provider,
 		slot_claim,
 		collator_sender,
-		segment_sender,
+		resubmit_sender,
 		collator,
 		allowed_pov_size,
 		core_info,
@@ -647,13 +690,13 @@ async fn build_collation_for_core<
 		time_for_core: slot_time_for_core,
 		is_last_core_in_parachain_slot,
 		collator_peer_id,
-		mut relay_parent_data,
+		relay_parent_data,
 		total_number_of_blocks,
 		included_header_hash,
 		relay_slot,
 		para_slot,
 		para_client,
-		v3_enabled,
+		scheduling_proof,
 	}: BuildCollationParams<'_, Block, P, RelayClient, BI, CIDP, Proposer, CS, CHP, Client>,
 ) -> Result<Option<Block::Header>, ()>
 where
@@ -680,34 +723,6 @@ where
 		relay_parent_storage_root: *relay_parent_header.state_root(),
 		max_pov_size,
 	};
-
-	// Check if V3 scheduling is enabled and build scheduling proof if so.
-	let mut scheduling_proof = None;
-	if v3_enabled {
-		// The relay parent descendants are only needed for v2.
-		let descendants = relay_parent_data.take_descendants();
-		// The descendants are ordered from oldest to newest, so we need to reverse them.
-		let header_chain: Vec<_> = descendants.into_iter().rev().collect();
-		let scheduling_parent =
-			header_chain.first().map(|header| header.hash()).unwrap_or(relay_parent_hash);
-
-		tracing::debug!(
-			target: LOG_TARGET,
-			relay_parent = ?relay_parent_hash,
-			?scheduling_parent,
-			header_chain_len = header_chain.len(),
-			"Building V3 collation with scheduling proof",
-		);
-
-		scheduling_proof = Some(SchedulingProof {
-			header_chain,
-			// Initial submission: internal_scheduling_parent == relay_parent, so the
-			// internal scheduling parent header is the relay parent's header itself.
-			internal_scheduling_parent_header: relay_parent_header.clone(),
-			// Initial submission: no signature needed, core selection from UMP signals
-			signed_scheduling_info: None,
-		});
-	}
 
 	let Some(validation_code_hash) = code_hash_provider.code_hash_at(pov_parent_hash) else {
 		tracing::error!(
@@ -940,13 +955,12 @@ where
 		"Sending out PoV"
 	);
 
-	// `scheduling_proof` is `Some` iff `v3_enabled`; routes V3 bundles to `segment_sender`,
+	// `scheduling_proof` is `Some` iff `v3_enabled`; routes V3 bundles to `resubmit_sender`,
 	// V2 bundles (no proof) to `collator_sender`.
 	let send_ok = if let Some(scheduling_proof) = scheduling_proof {
-		segment_sender
-			.unbounded_send(CollatorSegmentMessage {
+		resubmit_sender
+			.unbounded_send(CollatorResubmitSegment {
 				scheduling_proof,
-				core_index,
 				kind: SegmentKind::WithBundle {
 					bundle: CollatorMessage {
 						relay_parent: relay_parent_hash,

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -36,7 +36,7 @@ use cumulus_client_consensus_common::{
 	ParachainBlockImportMarker, ParentSearchParams,
 };
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
-use cumulus_client_unincluded_segment_store::prepare_unincluded_segment_aux_data;
+use cumulus_client_unincluded_segment_store::{now_unix_ms, prepare_unincluded_segment_aux_data};
 use cumulus_primitives_aura::{AuraUnincludedSegmentApi, Slot};
 use cumulus_primitives_core::{
 	BlockBundleInfo, ClaimQueueOffset, CoreInfo, CoreSelector, CumulusDigestItem,
@@ -71,7 +71,7 @@ use sp_trie::{
 use std::{
 	collections::VecDeque,
 	sync::Arc,
-	time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+	time::{Duration, Instant},
 };
 
 /// Parameters for [`run_block_builder`].
@@ -858,11 +858,7 @@ where
 			);
 		}
 
-		let time_ms = SystemTime::now()
-			.duration_since(UNIX_EPOCH)
-			.map(|d| d.as_millis() as u64)
-			.unwrap_or(0);
-
+		let time_ms = now_unix_ms();
 		prepare_unincluded_segment_aux_data(
 			parent_hash,
 			time_ms,

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -601,6 +601,7 @@ where
 								let _ = resubmit_sender.unbounded_send(CollatorResubmitSegment {
 									scheduling_proof: proof,
 									kind: SegmentKind::ResubmitOnly { core_index: this_core_index },
+									unincluded_segment: Vec::new(),
 								});
 							}
 						}
@@ -978,6 +979,7 @@ where
 						core_index,
 					},
 				},
+				unincluded_segment: Vec::new(),
 			})
 			.is_ok()
 	} else {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
 
-use super::CollatorMessage;
+use super::{CollatorSegmentEntry, CollatorSegmentMessage};
 use crate::{
 	collator::{self as collator_util, BuildBlockAndImportParams, Collator, SlotClaim},
 	collators::{
@@ -113,7 +113,7 @@ pub struct BuilderTaskParams<
 	/// The generic collator service used to plug into this consensus engine.
 	pub collator_service: CS,
 	/// Channel to send built blocks to the collation task.
-	pub collator_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorMessage<Block>>,
+	pub collator_sender: sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
 	/// Slot duration of the relay chain.
 	pub relay_chain_slot_duration: Duration,
 	/// Offset all time operations by this duration.
@@ -587,7 +587,7 @@ struct BuildCollationParams<
 	relay_client: &'a RelayClient,
 	code_hash_provider: &'a CHP,
 	slot_claim: &'a SlotClaim<P::Public>,
-	collator_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorMessage<Block>>,
+	collator_sender: &'a sc_utils::mpsc::TracingUnboundedSender<CollatorSegmentMessage<Block>>,
 	collator: &'a mut Collator<Block, P, BI, CIDP, RelayClient, Proposer, CS>,
 	allowed_pov_size: usize,
 	core_info: CoreInfo,
@@ -934,15 +934,17 @@ where
 		"Sending out PoV"
 	);
 
-	if let Err(err) = collator_sender.unbounded_send(CollatorMessage {
-		relay_parent: relay_parent_hash,
+	if let Err(err) = collator_sender.unbounded_send(CollatorSegmentMessage {
 		scheduling_proof,
-		parent_header: pov_parent_header.clone(),
-		blocks,
-		proof,
-		validation_code_hash,
 		core_index,
-		validation_data,
+		entries: vec![CollatorSegmentEntry {
+			relay_parent: relay_parent_hash,
+			parent_header: pov_parent_header.clone(),
+			blocks,
+			proof,
+			validation_code_hash,
+			validation_data,
+		}],
 	}) {
 		tracing::error!(target: LOG_TARGET, ?err, "Unable to send block to collation task.");
 		Err(())

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -36,7 +36,9 @@ use cumulus_client_consensus_common::{
 	ParachainBlockImportMarker, ParentSearchParams,
 };
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
-use cumulus_client_unincluded_segment_store::{now_unix_ms, prepare_unincluded_segment_aux_data};
+use cumulus_client_unincluded_segment_store::{
+	now_unix_ms, prepare_aux_data as prepare_unincluded_segment_aux_data,
+};
 use cumulus_primitives_aura::{AuraUnincludedSegmentApi, Slot};
 use cumulus_primitives_core::{
 	BlockBundleInfo, ClaimQueueOffset, CoreInfo, CoreSelector, CumulusDigestItem,
@@ -859,11 +861,10 @@ where
 		}
 
 		let time_ms = now_unix_ms();
-		prepare_unincluded_segment_aux_data(parent_hash, time_ms, &built_block.proof).for_each(
-			|(k, v)| {
+		prepare_unincluded_segment_aux_data::<Block>(parent_hash, time_ms, &built_block.proof)
+			.for_each(|(k, v)| {
 				import_block.auxiliary.push((k, Some(v)));
-			},
-		);
+			});
 
 		if let Err(error) = collator.import_block(import_block).await {
 			tracing::error!(target: LOG_TARGET, ?error, "Failed to import built block.");

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -36,6 +36,7 @@ use cumulus_client_consensus_common::{
 	ParachainBlockImportMarker, ParentSearchParams,
 };
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
+use cumulus_client_unincluded_segment_store::prepare_unincluded_segment_aux_data;
 use cumulus_primitives_aura::{AuraUnincludedSegmentApi, Slot};
 use cumulus_primitives_core::{
 	BlockBundleInfo, ClaimQueueOffset, CoreInfo, CoreSelector, CumulusDigestItem,
@@ -70,7 +71,7 @@ use sp_trie::{
 use std::{
 	collections::VecDeque,
 	sync::Arc,
-	time::{Duration, Instant},
+	time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 /// Parameters for [`run_block_builder`].
@@ -856,6 +857,23 @@ where
 				},
 			);
 		}
+
+		let time_ms = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.map(|d| d.as_millis() as u64)
+			.unwrap_or(0);
+
+		prepare_unincluded_segment_aux_data(
+			parent_hash,
+			time_ms,
+			// TODO(paritytech/polkadot-sdk#11624): populate with the relay parent's session
+			// once it is available from RelayChainDataCache.
+			None,
+			built_block.proof.clone(),
+		)
+		.for_each(|(k, v)| {
+			import_block.auxiliary.push((k, Some(v)));
+		});
 
 		if let Err(error) = collator.import_block(import_block).await {
 			tracing::error!(target: LOG_TARGET, ?error, "Failed to import built block.");

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_builder_task.rs
@@ -590,6 +590,12 @@ where
 					Ok(None) => {
 						// First-core failed to build a fresh bundle: still ship the held prior
 						// unincluded segment via `ResubmitOnly`.
+						//
+						// TODO: seding to a certain core can apply in a custom way too, and
+						// other strategies for resubmitting a segment should be available - e.g.
+						// split segment between cores equally, or attempt grouping unincluded
+						// blocks based on the core index resulting from their `core_selector`
+						// and `claim_queue_offset` combination, at the `scheduling_parent`).
 						if is_first_core {
 							if let Some(proof) = scheduling_proof.clone() {
 								let _ = resubmit_sender.unbounded_send(CollatorResubmitSegment {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
@@ -18,6 +18,7 @@
 use crate::LOG_TARGET;
 use codec::{Decode, Encode};
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
+use cumulus_client_unincluded_segment_store::prepare_unincluded_segment_aux_data;
 use cumulus_primitives_core::{BlockBundleInfo, CoreInfo, CumulusDigestItem, RelayBlockIdentifier};
 use futures::{stream::FusedStream, StreamExt};
 use sc_client_api::{
@@ -35,7 +36,10 @@ use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_consensus::BlockOrigin;
 use sp_runtime::traits::{Block as BlockT, HashingFor, Header as _};
 use sp_trie::proof_size_extension::{ProofSizeExt, RecordingProofSizeProvider};
-use std::sync::Arc;
+use std::{
+	sync::Arc,
+	time::{SystemTime, UNIX_EPOCH},
+};
 
 /// The aux storage key used to store the ignored nodes for the given block hash.
 fn ignored_nodes_key<H: Encode>(block_hash: H) -> Vec<u8> {
@@ -212,6 +216,7 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 	fn execute_block_and_collect_storage_proof(
 		&self,
 		params: &mut sc_consensus::BlockImportParams<Block>,
+		time_ms: u64,
 	) -> Result<(), sp_consensus::Error>
 	where
 		Client: ProvideRuntimeApi<Block>
@@ -315,6 +320,18 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 			});
 		}
 
+		prepare_unincluded_segment_aux_data(
+			block_hash,
+			time_ms,
+			// TODO(paritytech/polkadot-sdk#11624): populate with the relay parent's session
+			// once it is available from RelayChainDataCache.
+			None,
+			storage_proof.clone(),
+		)
+		.for_each(|(k, v)| {
+			params.auxiliary.push((k, Some(v)));
+		});
+
 		params.state_action =
 			StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(gen_storage_changes));
 
@@ -352,11 +369,16 @@ where
 		&self,
 		mut params: sc_consensus::BlockImportParams<Block>,
 	) -> Result<sc_consensus::ImportResult, Self::Error> {
+		let time_ms = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.map(|d| d.as_millis() as u64)
+			.unwrap_or(0);
+
 		if !(params.origin == BlockOrigin::Own ||
 			params.with_state() ||
 			params.state_action.skip_execution_checks())
 		{
-			self.execute_block_and_collect_storage_proof(&mut params)?;
+			self.execute_block_and_collect_storage_proof(&mut params, time_ms)?;
 		}
 
 		self.inner.import_block(params).await.map_err(Into::into)

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
@@ -210,6 +210,7 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 	fn execute_block_and_collect_storage_proof(
 		&self,
 		params: &mut sc_consensus::BlockImportParams<Block>,
+		time_ms: u64,
 	) -> Result<(), sp_consensus::Error>
 	where
 		Client: ProvideRuntimeApi<Block>
@@ -313,16 +314,7 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 			});
 		}
 
-		let time_ms = now_unix_ms();
-		prepare_unincluded_segment_aux_data(
-			block_hash,
-			time_ms,
-			// TODO(paritytech/polkadot-sdk#11624): populate with the relay parent's session
-			// once it is available from RelayChainDataCache.
-			None,
-			storage_proof,
-		)
-		.for_each(|(k, v)| {
+		prepare_unincluded_segment_aux_data(block_hash, time_ms, storage_proof).for_each(|(k, v)| {
 			params.auxiliary.push((k, Some(v)));
 		});
 
@@ -363,11 +355,13 @@ where
 		&self,
 		mut params: sc_consensus::BlockImportParams<Block>,
 	) -> Result<sc_consensus::ImportResult, Self::Error> {
+		let time_ms = now_unix_ms();
+
 		if !(params.origin == BlockOrigin::Own ||
 			params.with_state() ||
 			params.state_action.skip_execution_checks())
 		{
-			self.execute_block_and_collect_storage_proof(&mut params)?;
+			self.execute_block_and_collect_storage_proof(&mut params, time_ms)?;
 		}
 
 		self.inner.import_block(params).await.map_err(Into::into)

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
@@ -17,8 +17,8 @@
 
 use crate::LOG_TARGET;
 use codec::{Decode, Encode};
-use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
 use cumulus_client_consensus_common::old_finalized_hash;
+use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
 use cumulus_client_unincluded_segment_store::{now_unix_ms, prepare_unincluded_segment_aux_data};
 use cumulus_primitives_core::{BlockBundleInfo, CoreInfo, CumulusDigestItem, RelayBlockIdentifier};
 use futures::{stream::FusedStream, StreamExt};
@@ -315,9 +315,11 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 			});
 		}
 
-		prepare_unincluded_segment_aux_data(block_hash, time_ms, storage_proof).for_each(|(k, v)| {
-			params.auxiliary.push((k, Some(v)));
-		});
+		prepare_unincluded_segment_aux_data(block_hash, time_ms, &storage_proof).for_each(
+			|(k, v)| {
+				params.auxiliary.push((k, Some(v)));
+			},
+		);
 
 		params.state_action =
 			StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(gen_storage_changes));

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
@@ -19,7 +19,9 @@ use crate::LOG_TARGET;
 use codec::{Decode, Encode};
 use cumulus_client_consensus_common::old_finalized_hash;
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
-use cumulus_client_unincluded_segment_store::{now_unix_ms, prepare_unincluded_segment_aux_data};
+use cumulus_client_unincluded_segment_store::{
+	now_unix_ms, prepare_aux_data as prepare_unincluded_segment_aux_data,
+};
 use cumulus_primitives_core::{BlockBundleInfo, CoreInfo, CumulusDigestItem, RelayBlockIdentifier};
 use futures::{stream::FusedStream, StreamExt};
 use sc_client_api::{
@@ -315,7 +317,7 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 			});
 		}
 
-		prepare_unincluded_segment_aux_data(block_hash, time_ms, &storage_proof).for_each(
+		prepare_unincluded_segment_aux_data::<Block>(block_hash, time_ms, &storage_proof).for_each(
 			|(k, v)| {
 				params.auxiliary.push((k, Some(v)));
 			},

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
@@ -18,7 +18,7 @@
 use crate::LOG_TARGET;
 use codec::{Decode, Encode};
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
-use cumulus_client_unincluded_segment_store::prepare_unincluded_segment_aux_data;
+use cumulus_client_unincluded_segment_store::{now_unix_ms, old_finalized_hash, prepare_unincluded_segment_aux_data};
 use cumulus_primitives_core::{BlockBundleInfo, CoreInfo, CumulusDigestItem, RelayBlockIdentifier};
 use futures::{stream::FusedStream, StreamExt};
 use sc_client_api::{
@@ -36,10 +36,7 @@ use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_consensus::BlockOrigin;
 use sp_runtime::traits::{Block as BlockT, HashingFor, Header as _};
 use sp_trie::proof_size_extension::{ProofSizeExt, RecordingProofSizeProvider};
-use std::{
-	sync::Arc,
-	time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::Arc;
 
 /// The aux storage key used to store the ignored nodes for the given block hash.
 fn ignored_nodes_key<H: Encode>(block_hash: H) -> Vec<u8> {
@@ -104,14 +101,11 @@ where
 {
 	let client_for_closure = client.clone();
 	let on_finality = move |notification: &FinalityNotification<Block>| -> AuxDataOperations {
-		// The old finalized block is the parent of the first block in the tree route,
-		// or the parent of the finalized block if the tree route is empty.
-		let old_finalized_hash = notification
-			.tree_route
-			.first()
-			.and_then(|hash| client_for_closure.header(*hash).ok().flatten())
-			.map(|h| *h.parent_hash())
-			.unwrap_or_else(|| *notification.header.parent_hash());
+		let old_finalized = old_finalized_hash::<_, Block>(
+			&*client_for_closure,
+			&notification.tree_route,
+			*notification.header.parent_hash(),
+		);
 
 		notification
 			.stale_blocks
@@ -129,7 +123,7 @@ where
 					.copied()
 					.map(|hash| (ignored_nodes_key(hash), None)),
 			)
-			.chain(std::iter::once((ignored_nodes_key(old_finalized_hash), None)))
+			.chain(std::iter::once((ignored_nodes_key(old_finalized), None)))
 			.collect()
 	};
 
@@ -216,7 +210,6 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 	fn execute_block_and_collect_storage_proof(
 		&self,
 		params: &mut sc_consensus::BlockImportParams<Block>,
-		time_ms: u64,
 	) -> Result<(), sp_consensus::Error>
 	where
 		Client: ProvideRuntimeApi<Block>
@@ -320,13 +313,14 @@ impl<Block: BlockT, BI, Client> SlotBasedBlockImport<Block, BI, Client> {
 			});
 		}
 
+		let time_ms = now_unix_ms();
 		prepare_unincluded_segment_aux_data(
 			block_hash,
 			time_ms,
 			// TODO(paritytech/polkadot-sdk#11624): populate with the relay parent's session
 			// once it is available from RelayChainDataCache.
 			None,
-			storage_proof.clone(),
+			storage_proof,
 		)
 		.for_each(|(k, v)| {
 			params.auxiliary.push((k, Some(v)));
@@ -369,16 +363,11 @@ where
 		&self,
 		mut params: sc_consensus::BlockImportParams<Block>,
 	) -> Result<sc_consensus::ImportResult, Self::Error> {
-		let time_ms = SystemTime::now()
-			.duration_since(UNIX_EPOCH)
-			.map(|d| d.as_millis() as u64)
-			.unwrap_or(0);
-
 		if !(params.origin == BlockOrigin::Own ||
 			params.with_state() ||
 			params.state_action.skip_execution_checks())
 		{
-			self.execute_block_and_collect_storage_proof(&mut params, time_ms)?;
+			self.execute_block_and_collect_storage_proof(&mut params)?;
 		}
 
 		self.inner.import_block(params).await.map_err(Into::into)

--- a/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/block_import.rs
@@ -18,7 +18,8 @@
 use crate::LOG_TARGET;
 use codec::{Decode, Encode};
 use cumulus_client_proof_size_recording::prepare_proof_size_recording_aux_data;
-use cumulus_client_unincluded_segment_store::{now_unix_ms, old_finalized_hash, prepare_unincluded_segment_aux_data};
+use cumulus_client_consensus_common::old_finalized_hash;
+use cumulus_client_unincluded_segment_store::{now_unix_ms, prepare_unincluded_segment_aux_data};
 use cumulus_primitives_core::{BlockBundleInfo, CoreInfo, CumulusDigestItem, RelayBlockIdentifier};
 use futures::{stream::FusedStream, StreamExt};
 use sc_client_api::{

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -140,18 +140,14 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 		validation_data,
 	} = message;
 
-	let (collation, block_data) = match collator_service.build_multi_block_collation(
-		&parent_header,
-		blocks,
-		proof,
-		None,
-	) {
-		Some(collation) => collation,
-		None => {
-			tracing::warn!(target: LOG_TARGET, ?core_index, "Unable to build collation.");
-			return;
-		},
-	};
+	let (collation, block_data) =
+		match collator_service.build_multi_block_collation(&parent_header, blocks, proof, None) {
+			Some(collation) => collation,
+			None => {
+				tracing::warn!(target: LOG_TARGET, ?core_index, "Unable to build collation.");
+				return;
+			},
+		};
 
 	block_data.log_size_info();
 
@@ -326,13 +322,10 @@ async fn handle_segment_message<Block: BlockT, RClient: RelayChainInterface + Cl
 			});
 		},
 		SegmentKind::ResubmitOnly => {
-			// TODO: merge with held unincluded segment. For now this branch produces an empty
-			// submission and is a no-op downstream.
+			if collations.is_empty() {
+				return;
+			}
 		},
-	}
-
-	if collations.is_empty() {
-		return;
 	}
 
 	overseer_handle

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
 use cumulus_relay_chain_interface::RelayChainInterface;
 
-use polkadot_node_primitives::{MaybeCompressedPoV, SubmitCollationParams};
+use polkadot_node_primitives::{MaybeCompressedPoV, SegmentCollation, SubmitSegmentParams};
 use polkadot_node_subsystem::messages::CollationGenerationMessage;
 use polkadot_overseer::Handle as OverseerHandle;
 use polkadot_primitives::{CollatorPair, Id as ParaId};
@@ -32,7 +32,7 @@ use crate::export_pov_to_path;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_runtime::traits::{Block as BlockT, Header};
 
-use super::CollatorMessage;
+use super::CollatorSegmentMessage;
 
 const LOG_TARGET: &str = "aura::cumulus::collation_task";
 
@@ -49,7 +49,7 @@ pub struct Params<Block: BlockT, RClient, CS> {
 	/// Collator service interface
 	pub collator_service: CS,
 	/// Receiver channel for communication with the block builder task.
-	pub collator_receiver: TracingUnboundedReceiver<CollatorMessage<Block>>,
+	pub collator_receiver: TracingUnboundedReceiver<CollatorSegmentMessage<Block>>,
 	/// The handle from the special slot based block import.
 	pub block_import_handle: super::SlotBasedBlockImportHandle<Block>,
 	/// When set, the collator will export every produced `POV` to this folder.
@@ -98,7 +98,7 @@ pub async fn run_collation_task<Block, RClient, CS>(
 					return;
 				};
 
-				handle_collation_message(message, &collator_service, &mut overseer_handle,relay_client.clone(),export_pov.clone()).await;
+				handle_segment_message(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
 			},
 			block_import_msg = block_import_handle.next().fuse() => {
 				// TODO: Implement me.
@@ -109,108 +109,119 @@ pub async fn run_collation_task<Block, RClient, CS>(
 	}
 }
 
-/// Handle an incoming collation message from the block builder task.
-/// This builds the collation from the [`CollatorMessage`] and submits it to
-/// the collation-generation subsystem of the relay chain.
-async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
-	message: CollatorMessage<Block>,
+/// Handle an incoming segment message from the block builder task. Each entry is built into a
+/// [`SegmentCollation`] (one PoV / one candidate on the relay chain); the whole segment is
+/// forwarded to the collation-generation subsystem as a single
+/// [`CollationGenerationMessage::SubmitSegment`]. Entries that fail to build or whose session
+/// lookup fails are skipped — they do not abort the whole segment.
+async fn handle_segment_message<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
+	message: CollatorSegmentMessage<Block>,
 	collator_service: &impl CollatorServiceInterface<Block>,
 	overseer_handle: &mut OverseerHandle,
 	relay_client: RClient,
 	export_pov: Option<PathBuf>,
 ) {
-	let CollatorMessage {
-		scheduling_proof,
-		parent_header,
-		blocks,
-		proof,
-		validation_code_hash,
-		relay_parent,
-		core_index,
-		validation_data,
-	} = message;
+	let CollatorSegmentMessage { scheduling_proof, core_index, entries } = message;
 
-	// Derive scheduling_parent from the proof (the ISP header's hash is used when the
-	// header chain is empty — that's the case with `relay_parent_offset = 0`).
+	// Unlike the single-collation path, we cannot fall back to "the" relay_parent here — entries
+	// may have different relay parents. `None` means V2 descriptors for the whole segment.
 	let scheduling_parent = scheduling_proof.as_ref().map(|p| p.scheduling_parent());
-	let (collation, block_data) = match collator_service.build_multi_block_collation(
-		&parent_header,
-		blocks,
-		proof,
-		scheduling_proof,
-	) {
-		Some(collation) => collation,
-		None => {
-			tracing::warn!(target: LOG_TARGET, ?core_index, "Unable to build collation.");
-			return;
-		},
-	};
 
-	block_data.log_size_info();
+	let mut collations = Vec::with_capacity(entries.len());
+	for entry in entries {
+		let relay_parent = entry.relay_parent;
+		let validation_code_hash = entry.validation_code_hash;
+		let validation_data = entry.validation_data;
+		let parent_header = entry.parent_header;
 
-	if let MaybeCompressedPoV::Compressed(ref pov) = collation.proof_of_validity {
-		if let Some(pov_path) = export_pov {
-			if let Ok(Some(relay_parent_header)) =
-				relay_client.header(BlockId::Hash(relay_parent)).await
-			{
-				if let Some(header) = block_data.blocks().first().map(|b| b.header()) {
-					export_pov_to_path::<Block>(
-						pov_path.clone(),
-						pov.clone(),
-						header.hash(),
-						*header.number(),
-						parent_header.clone(),
-						relay_parent_header.state_root,
-						relay_parent_header.number,
-						validation_data.max_pov_size,
-					);
+		let (collation, block_data) = match collator_service.build_multi_block_collation(
+			&parent_header,
+			entry.blocks,
+			entry.proof,
+			scheduling_proof.clone(),
+		) {
+			Some(collation) => collation,
+			None => {
+				tracing::warn!(target: LOG_TARGET, ?core_index, ?relay_parent, "Unable to build collation for segment entry.");
+				continue;
+			},
+		};
+
+		block_data.log_size_info();
+
+		if let MaybeCompressedPoV::Compressed(ref pov) = collation.proof_of_validity {
+			if let Some(pov_path) = export_pov.clone() {
+				if let Ok(Some(relay_parent_header)) =
+					relay_client.header(BlockId::Hash(relay_parent)).await
+				{
+					if let Some(header) = block_data.blocks().first().map(|b| b.header()) {
+						export_pov_to_path::<Block>(
+							pov_path,
+							pov.clone(),
+							header.hash(),
+							*header.number(),
+							parent_header.clone(),
+							relay_parent_header.state_root,
+							relay_parent_header.number,
+							validation_data.max_pov_size,
+						);
+					}
+				} else {
+					tracing::error!(target: LOG_TARGET, "Failed to get relay parent header from hash: {relay_parent:?}");
 				}
-			} else {
-				tracing::error!(target: LOG_TARGET, "Failed to get relay parent header from hash: {relay_parent:?}");
 			}
+
+			tracing::info!(
+				target: LOG_TARGET,
+				block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
+				"Compressed PoV size: {}kb",
+				pov.block_data.0.len() as f64 / 1024f64,
+			);
 		}
 
-		tracing::info!(
+		let session_index = match relay_client.session_index_for_child(relay_parent).await {
+			Ok(session_index) => session_index,
+			Err(err) => {
+				tracing::error!(
+					target: LOG_TARGET,
+					?err,
+					?relay_parent,
+					"Failed to fetch session index for segment entry.",
+				);
+				continue;
+			},
+		};
+
+		tracing::debug!(
 			target: LOG_TARGET,
+			?core_index,
+			?relay_parent,
 			block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
-			"Compressed PoV size: {}kb",
-			pov.block_data.0.len() as f64 / 1024f64,
+			"Adding entry to segment for core.",
 		);
+
+		collations.push(SegmentCollation {
+			relay_parent,
+			collation,
+			validation_code_hash,
+			result_sender: None,
+			session_index,
+			validation_data,
+		});
 	}
 
-	let session_index = match relay_client.session_index_for_child(relay_parent).await {
-		Ok(session_index) => session_index,
-		Err(err) => {
-			tracing::error!(
-				target: LOG_TARGET,
-				?err,
-				?relay_parent,
-				"Failed to fetch session index."
-			);
-			return;
-		},
-	};
-
-	tracing::debug!(
-		target: LOG_TARGET,
-		?core_index,
-		block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
-		"Submitting collation for core.",
-	);
+	if collations.is_empty() {
+		return;
+	}
 
 	overseer_handle
 		.send_msg(
-			CollationGenerationMessage::SubmitCollation(SubmitCollationParams {
-				relay_parent,
-				collation,
-				validation_code_hash,
-				core_index,
-				result_sender: None,
+			CollationGenerationMessage::SubmitSegment(SubmitSegmentParams {
 				scheduling_parent,
-				session_index,
-				validation_data,
+				core_index,
+				collations,
 			}),
-			"SubmitCollation",
+			"SubmitSegment",
 		)
 		.await;
 }

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -34,7 +34,7 @@ use crate::export_pov_to_path;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_runtime::traits::{Block as BlockT, Header};
 
-use super::{CollatorMessage, CollatorSegmentMessage, SegmentKind};
+use super::{CollatorMessage, CollatorResubmitSegment, SegmentKind};
 
 const LOG_TARGET: &str = "aura::cumulus::collation_task";
 
@@ -53,7 +53,7 @@ pub struct Params<Block: BlockT, RClient, CS> {
 	/// Receiver channel for V2 single-bundle collations from the block builder task.
 	pub collator_receiver: TracingUnboundedReceiver<CollatorMessage<Block>>,
 	/// Receiver channel for V3 segment collations from the block builder task.
-	pub segment_receiver: TracingUnboundedReceiver<CollatorSegmentMessage<Block>>,
+	pub resubmit_receiver: TracingUnboundedReceiver<CollatorResubmitSegment<Block>>,
 	/// The handle from the special slot based block import.
 	pub block_import_handle: super::SlotBasedBlockImportHandle<Block>,
 	/// When set, the collator will export every produced `POV` to this folder.
@@ -74,7 +74,7 @@ pub async fn run_collation_task<Block, RClient, CS>(
 		reinitialize,
 		collator_service,
 		mut collator_receiver,
-		mut segment_receiver,
+		mut resubmit_receiver,
 		mut block_import_handle,
 		export_pov,
 	}: Params<Block, RClient, CS>,
@@ -105,12 +105,12 @@ pub async fn run_collation_task<Block, RClient, CS>(
 
 				handle_collation_message(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
 			},
-			segment_message = segment_receiver.next() => {
-				let Some(message) = segment_message else {
+			resubmit_message = resubmit_receiver.next() => {
+				let Some(message) = resubmit_message else {
 					return;
 				};
 
-				handle_segment_message(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
+				handle_resubmit_segment(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
 			},
 			block_import_msg = block_import_handle.next().fuse() => {
 				// TODO: Implement me.
@@ -223,18 +223,18 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 /// forwarded to the collation-generation subsystem as a single
 /// [`CollationGenerationMessage::SubmitSegment`]. Entries that fail to build or whose session
 /// lookup fails are skipped — they do not abort the whole segment.
-async fn handle_segment_message<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
-	message: CollatorSegmentMessage<Block>,
+async fn handle_resubmit_segment<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
+	message: CollatorResubmitSegment<Block>,
 	collator_service: &impl CollatorServiceInterface<Block>,
 	overseer_handle: &mut OverseerHandle,
 	relay_client: RClient,
 	export_pov: Option<PathBuf>,
 ) {
-	let CollatorSegmentMessage { scheduling_proof, core_index, kind } = message;
+	let CollatorResubmitSegment { scheduling_proof, kind } = message;
 	let scheduling_parent = scheduling_proof.scheduling_parent();
 
 	let mut collations = Vec::new();
-	match kind {
+	let core_index = match kind {
 		SegmentKind::WithBundle { bundle } => {
 			let CollatorMessage {
 				relay_parent,
@@ -242,7 +242,7 @@ async fn handle_segment_message<Block: BlockT, RClient: RelayChainInterface + Cl
 				blocks,
 				proof,
 				validation_code_hash,
-				core_index: _bundle_core_index,
+				core_index,
 				validation_data,
 			} = bundle;
 
@@ -320,13 +320,16 @@ async fn handle_segment_message<Block: BlockT, RClient: RelayChainInterface + Cl
 				session_index,
 				validation_data,
 			});
+
+			core_index
 		},
-		SegmentKind::ResubmitOnly => {
+		SegmentKind::ResubmitOnly { core_index } => {
 			if collations.is_empty() {
 				return;
 			}
+			core_index
 		},
-	}
+	};
 
 	overseer_handle
 		.send_msg(

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -34,7 +34,7 @@ use crate::export_pov_to_path;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_runtime::traits::{Block as BlockT, Header};
 
-use super::{CollatorMessage, CollatorSegmentMessage};
+use super::{CollatorMessage, CollatorSegmentMessage, SegmentKind};
 
 const LOG_TARGET: &str = "aura::cumulus::collation_task";
 
@@ -131,7 +131,6 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 	export_pov: Option<PathBuf>,
 ) {
 	let CollatorMessage {
-		scheduling_proof,
 		parent_header,
 		blocks,
 		proof,
@@ -141,12 +140,11 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 		validation_data,
 	} = message;
 
-	let scheduling_parent = scheduling_proof.as_ref().map(|p| p.scheduling_parent());
 	let (collation, block_data) = match collator_service.build_multi_block_collation(
 		&parent_header,
 		blocks,
 		proof,
-		scheduling_proof,
+		None,
 	) {
 		Some(collation) => collation,
 		None => {
@@ -215,7 +213,7 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 				validation_code_hash,
 				core_index,
 				result_sender: None,
-				scheduling_parent,
+				scheduling_parent: None,
 				session_index,
 				validation_data,
 			}),
@@ -236,93 +234,101 @@ async fn handle_segment_message<Block: BlockT, RClient: RelayChainInterface + Cl
 	relay_client: RClient,
 	export_pov: Option<PathBuf>,
 ) {
-	let CollatorSegmentMessage { scheduling_proof, core_index, entries } = message;
+	let CollatorSegmentMessage { scheduling_proof, core_index, kind } = message;
+	let scheduling_parent = scheduling_proof.scheduling_parent();
 
-	// Unlike the single-collation path, we cannot fall back to "the" relay_parent here — entries
-	// may have different relay parents. `None` means V2 descriptors for the whole segment.
-	let scheduling_parent = scheduling_proof.as_ref().map(|p| p.scheduling_parent());
+	let mut collations = Vec::new();
+	match kind {
+		SegmentKind::WithBundle { bundle } => {
+			let CollatorMessage {
+				relay_parent,
+				parent_header,
+				blocks,
+				proof,
+				validation_code_hash,
+				core_index: _bundle_core_index,
+				validation_data,
+			} = bundle;
 
-	let mut collations = Vec::with_capacity(entries.len());
-	for entry in entries {
-		let relay_parent = entry.relay_parent;
-		let validation_code_hash = entry.validation_code_hash;
-		let validation_data = entry.validation_data;
-		let parent_header = entry.parent_header;
+			let (collation, block_data) = match collator_service.build_multi_block_collation(
+				&parent_header,
+				blocks,
+				proof,
+				Some(scheduling_proof.clone()),
+			) {
+				Some(collation) => collation,
+				None => {
+					tracing::warn!(target: LOG_TARGET, ?core_index, ?relay_parent, "Unable to build collation for segment entry.");
+					return;
+				},
+			};
 
-		let (collation, block_data) = match collator_service.build_multi_block_collation(
-			&parent_header,
-			entry.blocks,
-			entry.proof,
-			scheduling_proof.clone(),
-		) {
-			Some(collation) => collation,
-			None => {
-				tracing::warn!(target: LOG_TARGET, ?core_index, ?relay_parent, "Unable to build collation for segment entry.");
-				continue;
-			},
-		};
+			block_data.log_size_info();
 
-		block_data.log_size_info();
-
-		if let MaybeCompressedPoV::Compressed(ref pov) = collation.proof_of_validity {
-			if let Some(pov_path) = export_pov.clone() {
-				if let Ok(Some(relay_parent_header)) =
-					relay_client.header(BlockId::Hash(relay_parent)).await
-				{
-					if let Some(header) = block_data.blocks().first().map(|b| b.header()) {
-						export_pov_to_path::<Block>(
-							pov_path,
-							pov.clone(),
-							header.hash(),
-							*header.number(),
-							parent_header.clone(),
-							relay_parent_header.state_root,
-							relay_parent_header.number,
-							validation_data.max_pov_size,
-						);
+			if let MaybeCompressedPoV::Compressed(ref pov) = collation.proof_of_validity {
+				if let Some(pov_path) = export_pov.clone() {
+					if let Ok(Some(relay_parent_header)) =
+						relay_client.header(BlockId::Hash(relay_parent)).await
+					{
+						if let Some(header) = block_data.blocks().first().map(|b| b.header()) {
+							export_pov_to_path::<Block>(
+								pov_path,
+								pov.clone(),
+								header.hash(),
+								*header.number(),
+								parent_header.clone(),
+								relay_parent_header.state_root,
+								relay_parent_header.number,
+								validation_data.max_pov_size,
+							);
+						}
+					} else {
+						tracing::error!(target: LOG_TARGET, "Failed to get relay parent header from hash: {relay_parent:?}");
 					}
-				} else {
-					tracing::error!(target: LOG_TARGET, "Failed to get relay parent header from hash: {relay_parent:?}");
 				}
+
+				tracing::info!(
+					target: LOG_TARGET,
+					block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
+					"Compressed PoV size: {}kb",
+					pov.block_data.0.len() as f64 / 1024f64,
+				);
 			}
 
-			tracing::info!(
+			let session_index = match relay_client.session_index_for_child(relay_parent).await {
+				Ok(session_index) => session_index,
+				Err(err) => {
+					tracing::error!(
+						target: LOG_TARGET,
+						?err,
+						?relay_parent,
+						"Failed to fetch session index for segment entry.",
+					);
+					return;
+				},
+			};
+
+			tracing::debug!(
 				target: LOG_TARGET,
+				?core_index,
+				?relay_parent,
 				block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
-				"Compressed PoV size: {}kb",
-				pov.block_data.0.len() as f64 / 1024f64,
+				"Adding entry to segment for core.",
 			);
-		}
 
-		let session_index = match relay_client.session_index_for_child(relay_parent).await {
-			Ok(session_index) => session_index,
-			Err(err) => {
-				tracing::error!(
-					target: LOG_TARGET,
-					?err,
-					?relay_parent,
-					"Failed to fetch session index for segment entry.",
-				);
-				continue;
-			},
-		};
-
-		tracing::debug!(
-			target: LOG_TARGET,
-			?core_index,
-			?relay_parent,
-			block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
-			"Adding entry to segment for core.",
-		);
-
-		collations.push(SegmentCollation {
-			relay_parent,
-			collation,
-			validation_code_hash,
-			result_sender: None,
-			session_index,
-			validation_data,
-		});
+			collations.push(SegmentCollation {
+				relay_parent,
+				collation,
+				validation_code_hash,
+				result_sender: None,
+				session_index,
+				validation_data,
+			});
+		},
+		SegmentKind::ResubmitOnly => {
+			// TODO: merge with held unincluded segment. For now this branch produces an empty
+			// submission and is a no-op downstream.
+		},
 	}
 
 	if collations.is_empty() {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -235,7 +235,9 @@ async fn handle_resubmit_segment<Block: BlockT, RClient: RelayChainInterface + C
 	relay_client: RClient,
 	export_pov: Option<PathBuf>,
 ) {
-	let CollatorResubmitSegment { scheduling_proof, kind } = message;
+	// TODO: thread `unincluded_segment` into `SubmitSegmentParams::collations` once the
+	// hydration infrastructure (storage-proof store, code-hash provider) is wired in.
+	let CollatorResubmitSegment { scheduling_proof, kind, unincluded_segment: _ } = message;
 	let scheduling_parent = scheduling_proof.scheduling_parent();
 	let core_index = match kind {
 		SegmentKind::WithBundle { bundle } => {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -20,7 +20,9 @@ use std::path::PathBuf;
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
 use cumulus_relay_chain_interface::RelayChainInterface;
 
-use polkadot_node_primitives::{MaybeCompressedPoV, SegmentCollation, SubmitSegmentParams};
+use polkadot_node_primitives::{
+	MaybeCompressedPoV, SegmentCollation, SubmitCollationParams, SubmitSegmentParams,
+};
 use polkadot_node_subsystem::messages::CollationGenerationMessage;
 use polkadot_overseer::Handle as OverseerHandle;
 use polkadot_primitives::{CollatorPair, Id as ParaId};
@@ -32,7 +34,7 @@ use crate::export_pov_to_path;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_runtime::traits::{Block as BlockT, Header};
 
-use super::CollatorSegmentMessage;
+use super::{CollatorMessage, CollatorSegmentMessage};
 
 const LOG_TARGET: &str = "aura::cumulus::collation_task";
 
@@ -48,8 +50,10 @@ pub struct Params<Block: BlockT, RClient, CS> {
 	pub reinitialize: bool,
 	/// Collator service interface
 	pub collator_service: CS,
-	/// Receiver channel for communication with the block builder task.
-	pub collator_receiver: TracingUnboundedReceiver<CollatorSegmentMessage<Block>>,
+	/// Receiver channel for V2 single-bundle collations from the block builder task.
+	pub collator_receiver: TracingUnboundedReceiver<CollatorMessage<Block>>,
+	/// Receiver channel for V3 segment collations from the block builder task.
+	pub segment_receiver: TracingUnboundedReceiver<CollatorSegmentMessage<Block>>,
 	/// The handle from the special slot based block import.
 	pub block_import_handle: super::SlotBasedBlockImportHandle<Block>,
 	/// When set, the collator will export every produced `POV` to this folder.
@@ -70,6 +74,7 @@ pub async fn run_collation_task<Block, RClient, CS>(
 		reinitialize,
 		collator_service,
 		mut collator_receiver,
+		mut segment_receiver,
 		mut block_import_handle,
 		export_pov,
 	}: Params<Block, RClient, CS>,
@@ -98,6 +103,13 @@ pub async fn run_collation_task<Block, RClient, CS>(
 					return;
 				};
 
+				handle_collation_message(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
+			},
+			segment_message = segment_receiver.next() => {
+				let Some(message) = segment_message else {
+					return;
+				};
+
 				handle_segment_message(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
 			},
 			block_import_msg = block_import_handle.next().fuse() => {
@@ -107,6 +119,109 @@ pub async fn run_collation_task<Block, RClient, CS>(
 			}
 		}
 	}
+}
+
+/// Handle an incoming single-bundle V2 [`CollatorMessage`] and forward it to the collation
+/// generation subsystem as a [`CollationGenerationMessage::SubmitCollation`].
+async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
+	message: CollatorMessage<Block>,
+	collator_service: &impl CollatorServiceInterface<Block>,
+	overseer_handle: &mut OverseerHandle,
+	relay_client: RClient,
+	export_pov: Option<PathBuf>,
+) {
+	let CollatorMessage {
+		scheduling_proof,
+		parent_header,
+		blocks,
+		proof,
+		validation_code_hash,
+		relay_parent,
+		core_index,
+		validation_data,
+	} = message;
+
+	let scheduling_parent = scheduling_proof.as_ref().map(|p| p.scheduling_parent());
+	let (collation, block_data) = match collator_service.build_multi_block_collation(
+		&parent_header,
+		blocks,
+		proof,
+		scheduling_proof,
+	) {
+		Some(collation) => collation,
+		None => {
+			tracing::warn!(target: LOG_TARGET, ?core_index, "Unable to build collation.");
+			return;
+		},
+	};
+
+	block_data.log_size_info();
+
+	if let MaybeCompressedPoV::Compressed(ref pov) = collation.proof_of_validity {
+		if let Some(pov_path) = export_pov {
+			if let Ok(Some(relay_parent_header)) =
+				relay_client.header(BlockId::Hash(relay_parent)).await
+			{
+				if let Some(header) = block_data.blocks().first().map(|b| b.header()) {
+					export_pov_to_path::<Block>(
+						pov_path.clone(),
+						pov.clone(),
+						header.hash(),
+						*header.number(),
+						parent_header.clone(),
+						relay_parent_header.state_root,
+						relay_parent_header.number,
+						validation_data.max_pov_size,
+					);
+				}
+			} else {
+				tracing::error!(target: LOG_TARGET, "Failed to get relay parent header from hash: {relay_parent:?}");
+			}
+		}
+
+		tracing::info!(
+			target: LOG_TARGET,
+			block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
+			"Compressed PoV size: {}kb",
+			pov.block_data.0.len() as f64 / 1024f64,
+		);
+	}
+
+	let session_index = match relay_client.session_index_for_child(relay_parent).await {
+		Ok(session_index) => session_index,
+		Err(err) => {
+			tracing::error!(
+				target: LOG_TARGET,
+				?err,
+				?relay_parent,
+				"Failed to fetch session index."
+			);
+			return;
+		},
+	};
+
+	tracing::debug!(
+		target: LOG_TARGET,
+		?core_index,
+		block_numbers = ?block_data.blocks().iter().map(|b| *b.header().number()).collect::<Vec<_>>(),
+		"Submitting collation for core.",
+	);
+
+	overseer_handle
+		.send_msg(
+			CollationGenerationMessage::SubmitCollation(SubmitCollationParams {
+				relay_parent,
+				collation,
+				validation_code_hash,
+				core_index,
+				result_sender: None,
+				scheduling_parent,
+				session_index,
+				validation_data,
+			}),
+			"SubmitCollation",
+		)
+		.await;
 }
 
 /// Handle an incoming segment message from the block builder task. Each entry is built into a

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -110,7 +110,11 @@ pub async fn run_collation_task<Block, RClient, CS>(
 					return;
 				};
 
-				handle_resubmit_segment(message, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
+				// Seed the segment with the current unincluded-segment collations. Empty for now;
+				// future resubmission machinery — the layer that computes and keeps the unincluded
+				// segment up to date across parachain slots — will populate this before dispatch.
+				let collations = Vec::new();
+				handle_resubmit_segment(message, collations, &collator_service, &mut overseer_handle, relay_client.clone(), export_pov.clone()).await;
 			},
 			block_import_msg = block_import_handle.next().fuse() => {
 				// TODO: Implement me.
@@ -225,6 +229,7 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 /// lookup fails are skipped — they do not abort the whole segment.
 async fn handle_resubmit_segment<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
 	message: CollatorResubmitSegment<Block>,
+	mut collations: Vec<SegmentCollation<Block>>,
 	collator_service: &impl CollatorServiceInterface<Block>,
 	overseer_handle: &mut OverseerHandle,
 	relay_client: RClient,
@@ -232,8 +237,6 @@ async fn handle_resubmit_segment<Block: BlockT, RClient: RelayChainInterface + C
 ) {
 	let CollatorResubmitSegment { scheduling_proof, kind } = message;
 	let scheduling_parent = scheduling_proof.scheduling_parent();
-
-	let mut collations = Vec::new();
 	let core_index = match kind {
 		SegmentKind::WithBundle { bundle } => {
 			let CollatorMessage {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/collation_task.rs
@@ -229,7 +229,7 @@ async fn handle_collation_message<Block: BlockT, RClient: RelayChainInterface + 
 /// lookup fails are skipped — they do not abort the whole segment.
 async fn handle_resubmit_segment<Block: BlockT, RClient: RelayChainInterface + Clone + 'static>(
 	message: CollatorResubmitSegment<Block>,
-	mut collations: Vec<SegmentCollation<Block>>,
+	mut collations: Vec<SegmentCollation>,
 	collator_service: &impl CollatorServiceInterface<Block>,
 	overseer_handle: &mut OverseerHandle,
 	relay_client: RClient,

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -297,6 +297,10 @@ struct CollatorResubmitSegment<Block: BlockT> {
 	pub scheduling_proof: SchedulingProof,
 	/// Whether this message carries a freshly-built block or signals resubmit-only.
 	pub kind: SegmentKind<Block>,
+	/// Local view of the unincluded segment at the time the bundle was built. Empty when the
+	/// producer has not computed it yet (no consumer in this branch — the collation task
+	/// destructures and ignores it).
+	pub unincluded_segment: Vec<Block::Header>,
 }
 
 /// Kind of resubmit-segment message. The target `CoreIndex` is read from `bundle.core_index` in

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -222,7 +222,7 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 	UnincludedSegmentStore::<Block, _>::new(para_client.clone()).register_cleanup();
 
 	let (collation_tx, collation_rx) = tracing_unbounded("mpsc_builder_to_collator", 100);
-	let (segment_tx, segment_rx) = tracing_unbounded("mpsc_builder_to_collator_segment", 100);
+	let (resubmit_tx, resubmit_rx) = tracing_unbounded("mpsc_builder_to_collator_resubmit", 100);
 	let collator_task_params = collation_task::Params {
 		relay_client: relay_client.clone(),
 		collator_key,
@@ -230,7 +230,7 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 		reinitialize,
 		collator_service: collator_service.clone(),
 		collator_receiver: collation_rx,
-		segment_receiver: segment_rx,
+		resubmit_receiver: resubmit_rx,
 		block_import_handle,
 		export_pov,
 	};
@@ -250,7 +250,7 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 		proposer,
 		collator_service,
 		collator_sender: collation_tx,
-		segment_sender: segment_tx,
+		resubmit_sender: resubmit_tx,
 		relay_chain_slot_duration,
 		slot_offset,
 		max_pov_percentage,
@@ -290,25 +290,20 @@ struct CollatorMessage<Block: BlockT> {
 	pub validation_data: PersistedValidationData,
 }
 
-/// Segment message sent from the block builder for V3/V4 candidates. Routed to
-/// [`CollationGenerationMessage::SubmitSegment`] by the collation task. The collation task
-/// resubmits the held unincluded segment alongside the new bundle (if any) under the shared
-/// `scheduling_proof` and to the `core_index` specified here.
-struct CollatorSegmentMessage<Block: BlockT> {
-	/// Scheduling proof shared by every entry in the segment. `signed_scheduling_info` is
-	/// `Some` whenever any prior unincluded entry is being resubmitted.
+/// V3/V4 resubmit-segment message sent by the block builder. Routed to
+/// [`CollationGenerationMessage::SubmitSegment`] by the collation task.
+struct CollatorResubmitSegment<Block: BlockT> {
+	/// Scheduling proof shared by every entry in the submitted segment.
 	pub scheduling_proof: SchedulingProof,
-	/// Target core for the whole segment submission.
-	pub core_index: CoreIndex,
-	/// Whether this message carries a freshly-built bundle or signals "resubmit the held prior
-	/// alone, the builder produced nothing this slot".
+	/// Whether this message carries a freshly-built block or signals resubmit-only.
 	pub kind: SegmentKind<Block>,
 }
 
-/// Kind of segment message: with a fresh bundle to merge, or resubmit-only.
+/// Kind of resubmit-segment message. The target `CoreIndex` is read from `bundle.core_index` in
+/// the `WithBundle` case and carried explicitly in the `ResubmitOnly` case.
 enum SegmentKind<Block: BlockT> {
-	/// New bundle to merge with the held prior unincluded segment.
+	/// A freshly-built block to submit.
 	WithBundle { bundle: CollatorMessage<Block> },
-	/// No new bundle this slot — collation task should resubmit the held prior alone.
-	ResubmitOnly,
+	/// Resubmit only — no freshly-built block this slot.
+	ResubmitOnly { core_index: CoreIndex },
 }

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -268,24 +268,39 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 	);
 }
 
-/// Message to be sent from the block builder to the collation task.
+/// Message sent from the block builder to the collation task.
 ///
-/// Contains all data necessary to submit a collation to the relay chain.
-struct CollatorMessage<Block: BlockT> {
-	/// The hash of the relay chain block that provides the context for the parachain block.
-	pub relay_parent: RelayHash,
-	/// V3 scheduling proof. None for V1/V2 candidates.
+/// Represents a segment of collations targeted at a single core. The block builder produces one
+/// message per assigned core per wake-up; each entry in `entries` becomes one `SegmentCollation`
+/// (one PoV / candidate on the relay chain) and the whole vec is submitted as one
+/// `CollationGenerationMessage::SubmitSegment`.
+///
+/// At the moment the builder always emits length-1 segments — resubmission of the unincluded
+/// segment will extend this to multi-entry segments later.
+struct CollatorSegmentMessage<Block: BlockT> {
+	/// Shared V3 scheduling proof. `scheduling_parent` for the whole segment is derived from
+	/// `scheduling_proof.scheduling_parent()`. `None` → V2 descriptors for every entry.
 	pub scheduling_proof: Option<SchedulingProof>,
-	/// The header of the parent block.
+	/// Target core for every entry in the segment.
+	pub core_index: CoreIndex,
+	/// Per-entry payloads, in submission order.
+	pub entries: Vec<CollatorSegmentEntry<Block>>,
+}
+
+/// One entry of a [`CollatorSegmentMessage`]. Each entry produces one `SegmentCollation`
+/// (one PoV / one candidate on the relay chain), and may still bundle multiple parablocks
+/// inside its PoV via `build_multi_block_collation`.
+struct CollatorSegmentEntry<Block: BlockT> {
+	/// The hash of the relay chain block that provides the context for the parachain block(s).
+	pub relay_parent: RelayHash,
+	/// The header of the parent of the first block in this entry.
 	pub parent_header: Block::Header,
-	/// The built blocks.
+	/// The built blocks bundled into this entry.
 	pub blocks: Vec<Block>,
-	/// The storage proof that was collected while building all the blocks.
+	/// The storage proof collected while building all of `blocks`.
 	pub proof: StorageProof,
 	/// The validation code hash at the parent block.
 	pub validation_code_hash: ValidationCodeHash,
-	/// Core index that this block should be submitted on
-	pub core_index: CoreIndex,
-	/// The persisted validation data for this collation.
+	/// The persisted validation data for this entry.
 	pub validation_data: PersistedValidationData,
 }

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -74,7 +74,7 @@ use codec::Codec;
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
 use cumulus_client_consensus_common::{self as consensus_common, ParachainBlockImportMarker};
 use cumulus_client_proof_size_recording::register_proof_size_recording_cleanup;
-use cumulus_client_unincluded_segment_store::register_unincluded_segment_cleanup;
+use cumulus_client_unincluded_segment_store::UnincludedSegmentStore;
 use cumulus_primitives_aura::AuraUnincludedSegmentApi;
 use cumulus_primitives_core::{
 	KeyToIncludeInRelayProof, RelayParentOffsetApi, SchedulingProof, SchedulingV3EnabledApi,
@@ -219,7 +219,7 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 
 	// Initialize proof size recording cleanup
 	register_proof_size_recording_cleanup(para_client.clone());
-	register_unincluded_segment_cleanup(para_client.clone());
+	UnincludedSegmentStore::<Block, _>::new(para_client.clone()).register_cleanup();
 
 	let (tx, rx) = tracing_unbounded("mpsc_builder_to_collator", 100);
 	let collator_task_params = collation_task::Params {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -221,14 +221,16 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 	register_proof_size_recording_cleanup(para_client.clone());
 	UnincludedSegmentStore::<Block, _>::new(para_client.clone()).register_cleanup();
 
-	let (tx, rx) = tracing_unbounded("mpsc_builder_to_collator", 100);
+	let (collation_tx, collation_rx) = tracing_unbounded("mpsc_builder_to_collator", 100);
+	let (segment_tx, segment_rx) = tracing_unbounded("mpsc_builder_to_collator_segment", 100);
 	let collator_task_params = collation_task::Params {
 		relay_client: relay_client.clone(),
 		collator_key,
 		para_id,
 		reinitialize,
 		collator_service: collator_service.clone(),
-		collator_receiver: rx,
+		collator_receiver: collation_rx,
+		segment_receiver: segment_rx,
 		block_import_handle,
 		export_pov,
 	};
@@ -247,7 +249,8 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 		para_id,
 		proposer,
 		collator_service,
-		collator_sender: tx,
+		collator_sender: collation_tx,
+		segment_sender: segment_tx,
 		relay_chain_slot_duration,
 		slot_offset,
 		max_pov_percentage,
@@ -268,15 +271,31 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 	);
 }
 
-/// Message sent from the block builder to the collation task.
-///
-/// Represents a segment of collations targeted at a single core. The block builder produces one
-/// message per assigned core per wake-up; each entry in `entries` becomes one `SegmentCollation`
-/// (one PoV / candidate on the relay chain) and the whole vec is submitted as one
-/// `CollationGenerationMessage::SubmitSegment`.
-///
-/// At the moment the builder always emits length-1 segments — resubmission of the unincluded
-/// segment will extend this to multi-entry segments later.
+/// Single-bundle message sent from the block builder for V2 candidates. Routed to
+/// [`CollationGenerationMessage::SubmitCollation`] by the collation task.
+struct CollatorMessage<Block: BlockT> {
+	/// The hash of the relay chain block that provides the context for the parachain block.
+	pub relay_parent: RelayHash,
+	/// V3 scheduling proof. `None` for V2 candidates emitted on this channel.
+	pub scheduling_proof: Option<SchedulingProof>,
+	/// The header of the parent block.
+	pub parent_header: Block::Header,
+	/// The built blocks.
+	pub blocks: Vec<Block>,
+	/// The storage proof that was collected while building all the blocks.
+	pub proof: StorageProof,
+	/// The validation code hash at the parent block.
+	pub validation_code_hash: ValidationCodeHash,
+	/// Core index that this block should be submitted on.
+	pub core_index: CoreIndex,
+	/// The persisted validation data for this collation.
+	pub validation_data: PersistedValidationData,
+}
+
+/// Segment message sent from the block builder for V3 candidates. Routed to
+/// [`CollationGenerationMessage::SubmitSegment`] by the collation task. The builder always
+/// emits length-1 segments.
+// TODO: support multi-entry segments to enable unincluded-segment resubmission.
 struct CollatorSegmentMessage<Block: BlockT> {
 	/// Shared V3 scheduling proof. `scheduling_parent` for the whole segment is derived from
 	/// `scheduling_proof.scheduling_parent()`. `None` → V2 descriptors for every entry.

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -276,8 +276,6 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 struct CollatorMessage<Block: BlockT> {
 	/// The hash of the relay chain block that provides the context for the parachain block.
 	pub relay_parent: RelayHash,
-	/// V3 scheduling proof. `None` for V2 candidates emitted on this channel.
-	pub scheduling_proof: Option<SchedulingProof>,
 	/// The header of the parent block.
 	pub parent_header: Block::Header,
 	/// The built blocks.
@@ -292,34 +290,25 @@ struct CollatorMessage<Block: BlockT> {
 	pub validation_data: PersistedValidationData,
 }
 
-/// Segment message sent from the block builder for V3 candidates. Routed to
-/// [`CollationGenerationMessage::SubmitSegment`] by the collation task. The builder always
-/// emits length-1 segments.
-// TODO: support multi-entry segments to enable unincluded-segment resubmission.
+/// Segment message sent from the block builder for V3/V4 candidates. Routed to
+/// [`CollationGenerationMessage::SubmitSegment`] by the collation task. The collation task
+/// resubmits the held unincluded segment alongside the new bundle (if any) under the shared
+/// `scheduling_proof` and to the `core_index` specified here.
 struct CollatorSegmentMessage<Block: BlockT> {
-	/// Shared V3 scheduling proof. `scheduling_parent` for the whole segment is derived from
-	/// `scheduling_proof.scheduling_parent()`. `None` → V2 descriptors for every entry.
-	pub scheduling_proof: Option<SchedulingProof>,
-	/// Target core for every entry in the segment.
+	/// Scheduling proof shared by every entry in the segment. `signed_scheduling_info` is
+	/// `Some` whenever any prior unincluded entry is being resubmitted.
+	pub scheduling_proof: SchedulingProof,
+	/// Target core for the whole segment submission.
 	pub core_index: CoreIndex,
-	/// Per-entry payloads, in submission order.
-	pub entries: Vec<CollatorSegmentEntry<Block>>,
+	/// Whether this message carries a freshly-built bundle or signals "resubmit the held prior
+	/// alone, the builder produced nothing this slot".
+	pub kind: SegmentKind<Block>,
 }
 
-/// One entry of a [`CollatorSegmentMessage`]. Each entry produces one `SegmentCollation`
-/// (one PoV / one candidate on the relay chain), and may still bundle multiple parablocks
-/// inside its PoV via `build_multi_block_collation`.
-struct CollatorSegmentEntry<Block: BlockT> {
-	/// The hash of the relay chain block that provides the context for the parachain block(s).
-	pub relay_parent: RelayHash,
-	/// The header of the parent of the first block in this entry.
-	pub parent_header: Block::Header,
-	/// The built blocks bundled into this entry.
-	pub blocks: Vec<Block>,
-	/// The storage proof collected while building all of `blocks`.
-	pub proof: StorageProof,
-	/// The validation code hash at the parent block.
-	pub validation_code_hash: ValidationCodeHash,
-	/// The persisted validation data for this entry.
-	pub validation_data: PersistedValidationData,
+/// Kind of segment message: with a fresh bundle to merge, or resubmit-only.
+enum SegmentKind<Block: BlockT> {
+	/// New bundle to merge with the held prior unincluded segment.
+	WithBundle { bundle: CollatorMessage<Block> },
+	/// No new bundle this slot — collation task should resubmit the held prior alone.
+	ResubmitOnly,
 }

--- a/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/mod.rs
@@ -74,6 +74,7 @@ use codec::Codec;
 use cumulus_client_collator::service::ServiceInterface as CollatorServiceInterface;
 use cumulus_client_consensus_common::{self as consensus_common, ParachainBlockImportMarker};
 use cumulus_client_proof_size_recording::register_proof_size_recording_cleanup;
+use cumulus_client_unincluded_segment_store::register_unincluded_segment_cleanup;
 use cumulus_primitives_aura::AuraUnincludedSegmentApi;
 use cumulus_primitives_core::{
 	KeyToIncludeInRelayProof, RelayParentOffsetApi, SchedulingProof, SchedulingV3EnabledApi,
@@ -218,6 +219,7 @@ pub fn run<Block, P, BI, CIDP, Client, Backend, RClient, CHP, Proposer, CS, Spaw
 
 	// Initialize proof size recording cleanup
 	register_proof_size_recording_cleanup(para_client.clone());
+	register_unincluded_segment_cleanup(para_client.clone());
 
 	let (tx, rx) = tracing_unbounded("mpsc_builder_to_collator", 100);
 	let collator_task_params = collation_task::Params {

--- a/cumulus/client/consensus/aura/src/collators/slot_based/tests.rs
+++ b/cumulus/client/consensus/aura/src/collators/slot_based/tests.rs
@@ -26,8 +26,8 @@ use cumulus_relay_chain_interface::*;
 use futures::Stream;
 use polkadot_node_subsystem_util::runtime::ClaimQueueSnapshot;
 use polkadot_primitives::{
-	CandidateEvent, CommittedCandidateReceiptV2, CoreIndex, Hash as RelayHash,
-	Header as RelayHeader, Id as ParaId, NodeFeatures,
+	vstaging::RelayParentInfo, CandidateEvent, CommittedCandidateReceiptV2, CoreIndex,
+	Hash as RelayHash, Header as RelayHeader, Id as ParaId, NodeFeatures,
 };
 use sc_consensus_babe::{
 	AuthorityId, ConsensusLog as BabeConsensusLog, NextEpochDescriptor, BABE_ENGINE_ID,
@@ -508,6 +508,15 @@ impl RelayChainInterface for TestRelayClient {
 
 	async fn node_features(&self, _at: RelayHash) -> RelayChainResult<NodeFeatures> {
 		Ok(NodeFeatures::default())
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		_at: RelayHash,
+		_session_index: SessionIndex,
+		_relay_parent: RelayHash,
+	) -> RelayChainResult<Option<RelayParentInfo<RelayHash, BlockNumber>>> {
+		unimplemented!("Not needed for test")
 	}
 }
 

--- a/cumulus/client/consensus/common/Cargo.toml
+++ b/cumulus/client/consensus/common/Cargo.toml
@@ -54,3 +54,4 @@ sp-tracing = { workspace = true, default-features = true }
 # Cumulus
 cumulus-test-client = { workspace = true }
 cumulus-test-relay-sproof-builder = { workspace = true, default-features = true }
+substrate-test-runtime = { workspace = true }

--- a/cumulus/client/consensus/common/src/finality.rs
+++ b/cumulus/client/consensus/common/src/finality.rs
@@ -1,0 +1,138 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
+
+//! Shared helpers for finality-driven aux-storage cleanup.
+
+use sc_client_api::HeaderBackend;
+use sp_runtime::traits::{Block as BlockT, Header as _};
+
+/// Compute the previously-finalized block hash from a tree route and a fallback parent hash.
+///
+/// This is the parent of the first block in the tree route, or the supplied `fallback_parent`
+/// (typically the parent hash of the just-finalized header) when the tree route is empty or its
+/// first block's header can't be loaded.
+///
+/// Taking the inputs directly rather than a `FinalityNotification` keeps this function unit-
+/// testable from outside `sc-client-api` (which has a private `unpin_handle` field).
+pub fn old_finalized_hash<C, Block>(
+	client: &C,
+	tree_route: &[Block::Hash],
+	fallback_parent: Block::Hash,
+) -> Block::Hash
+where
+	C: HeaderBackend<Block>,
+	Block: BlockT,
+{
+	tree_route
+		.first()
+		.and_then(|hash| client.header(*hash).ok().flatten())
+		.map(|h| *h.parent_hash())
+		.unwrap_or(fallback_parent)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sp_blockchain::Result as ClientResult;
+
+	type Block = substrate_test_runtime::Block;
+	type Hash = <Block as BlockT>::Hash;
+
+	// Minimal `HeaderBackend` mock for the `old_finalized_hash_*` tests.
+	//
+	// `lookup` is `None` ⇒ `header()` returns `Ok(None)` (simulates a missing header).
+	struct MockHeaderBackend {
+		lookup: Option<(Hash, substrate_test_runtime::Header)>,
+	}
+
+	impl HeaderBackend<Block> for MockHeaderBackend {
+		fn header(
+			&self,
+			hash: <Block as BlockT>::Hash,
+		) -> ClientResult<Option<<Block as BlockT>::Header>> {
+			Ok(self.lookup.as_ref().and_then(|(h, hdr)| (*h == hash).then(|| hdr.clone())))
+		}
+
+		fn info(&self) -> sc_client_api::blockchain::Info<Block> {
+			unimplemented!()
+		}
+
+		fn status(
+			&self,
+			_hash: <Block as BlockT>::Hash,
+		) -> ClientResult<sc_client_api::blockchain::BlockStatus> {
+			unimplemented!()
+		}
+
+		fn number(
+			&self,
+			_hash: <Block as BlockT>::Hash,
+		) -> ClientResult<Option<sp_runtime::traits::NumberFor<Block>>> {
+			unimplemented!()
+		}
+
+		fn hash(
+			&self,
+			_number: sp_runtime::traits::NumberFor<Block>,
+		) -> ClientResult<Option<<Block as BlockT>::Hash>> {
+			unimplemented!()
+		}
+	}
+
+	#[test]
+	fn old_finalized_hash_with_empty_tree_route() {
+		let client = MockHeaderBackend { lookup: None };
+		let fallback = Hash::repeat_byte(0x01);
+
+		let old_hash = old_finalized_hash::<_, Block>(&client, &[], fallback);
+		assert_eq!(old_hash, fallback, "empty tree_route should fall through to the supplied parent");
+	}
+
+	#[test]
+	fn old_finalized_hash_with_tree_route() {
+		use substrate_test_runtime::Header as TestHeader;
+
+		let expected_old = Hash::repeat_byte(0x01);
+		let tree_block = Hash::repeat_byte(0x02);
+
+		let header = TestHeader {
+			parent_hash: expected_old,
+			number: 2,
+			state_root: Default::default(),
+			extrinsics_root: Default::default(),
+			digest: Default::default(),
+		};
+
+		let client = MockHeaderBackend { lookup: Some((tree_block, header)) };
+		let fallback = Hash::repeat_byte(0xFF);
+
+		let old_hash = old_finalized_hash::<_, Block>(&client, &[tree_block], fallback);
+		assert_eq!(old_hash, expected_old, "should resolve to parent of first tree_route block");
+	}
+
+	#[test]
+	fn old_finalized_hash_falls_back_when_header_missing() {
+		// Non-empty tree_route, but the header lookup returns None — the function should fall back
+		// to `fallback_parent` rather than panicking or returning a wrong hash.
+		let client = MockHeaderBackend { lookup: None };
+		let tree_block = Hash::repeat_byte(0x02);
+		let fallback = Hash::repeat_byte(0xAA);
+
+		let old_hash = old_finalized_hash::<_, Block>(&client, &[tree_block], fallback);
+		assert_eq!(old_hash, fallback, "missing header should fall back to the supplied parent");
+	}
+}

--- a/cumulus/client/consensus/common/src/finality.rs
+++ b/cumulus/client/consensus/common/src/finality.rs
@@ -20,6 +20,8 @@
 use sc_client_api::HeaderBackend;
 use sp_runtime::traits::{Block as BlockT, Header as _};
 
+const LOG_TARGET: &str = "consensus::common::finality";
+
 /// Compute the previously-finalized block hash from a tree route and a fallback parent hash.
 ///
 /// This is the parent of the first block in the tree route, or the supplied `fallback_parent`
@@ -37,11 +39,30 @@ where
 	C: HeaderBackend<Block>,
 	Block: BlockT,
 {
-	tree_route
-		.first()
-		.and_then(|hash| client.header(*hash).ok().flatten())
-		.map(|h| *h.parent_hash())
-		.unwrap_or(fallback_parent)
+	let Some(first) = tree_route.first() else {
+		return fallback_parent;
+	};
+
+	match client.header(*first) {
+		Ok(Some(header)) => *header.parent_hash(),
+		Ok(None) => {
+			tracing::warn!(
+				target: LOG_TARGET,
+				?first,
+				"tree_route head header missing; falling back to notification parent hash",
+			);
+			fallback_parent
+		},
+		Err(error) => {
+			tracing::warn!(
+				target: LOG_TARGET,
+				?first,
+				?error,
+				"tree_route head header lookup failed; falling back to notification parent hash",
+			);
+			fallback_parent
+		},
+	}
 }
 
 #[cfg(test)]
@@ -99,7 +120,10 @@ mod tests {
 		let fallback = Hash::repeat_byte(0x01);
 
 		let old_hash = old_finalized_hash::<_, Block>(&client, &[], fallback);
-		assert_eq!(old_hash, fallback, "empty tree_route should fall through to the supplied parent");
+		assert_eq!(
+			old_hash, fallback,
+			"empty tree_route should fall through to the supplied parent"
+		);
 	}
 
 	#[test]

--- a/cumulus/client/consensus/common/src/lib.rs
+++ b/cumulus/client/consensus/common/src/lib.rs
@@ -30,12 +30,14 @@ use sp_timestamp::Timestamp;
 
 use std::{sync::Arc, time::Duration};
 
+mod finality;
 mod level_monitor;
 mod parachain_consensus;
 mod parent_search;
 #[cfg(test)]
 mod tests;
 
+pub use finality::old_finalized_hash;
 pub use parent_search::*;
 
 pub use cumulus_relay_chain_streams::finalized_heads;

--- a/cumulus/client/consensus/common/src/parent_search.rs
+++ b/cumulus/client/consensus/common/src/parent_search.rs
@@ -16,33 +16,20 @@
 // along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
 
 use codec::Decode;
-use polkadot_primitives::Hash as RelayHash;
+use polkadot_primitives::{Block as RelayBlock, Hash as RelayHash, DEFAULT_SCHEDULING_LOOKAHEAD};
 
 use cumulus_primitives_core::{
 	relay_chain::{BlockId as RBlockId, OccupiedCoreAssumption},
 	ParaId,
 };
-use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface};
+use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
 
 use sc_client_api::{Backend, HeaderBackend};
-
+use sc_consensus_babe::contains_epoch_change;
 use sp_blockchain::Backend as BlockchainBackend;
-
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 const LOG_TARGET: &str = "consensus::common::parent_search";
-
-/// Parameters when searching for suitable parents to build on top of.
-#[derive(Debug)]
-pub struct ParentSearchParams {
-	/// The relay-parent that is intended to be used.
-	pub relay_parent: RelayHash,
-	/// The ID of the parachain.
-	pub para_id: ParaId,
-	/// A limitation on the age of relay parents for parachain blocks that are being
-	/// considered. This is relative to the `relay_parent` number.
-	pub ancestry_lookback: usize,
-}
 
 /// A potential parent block returned from [`find_parent_for_building`]
 #[derive(PartialEq, Clone)]
@@ -73,16 +60,21 @@ impl<B: BlockT> std::fmt::Debug for ParentSearchResult<B> {
 ///
 /// Returns `None` if no suitable parent can be found (e.g., included block unknown locally).
 pub async fn find_parent_for_building<B: BlockT>(
-	params: ParentSearchParams,
-	backend: &impl Backend<B>,
 	relay_client: &impl RelayChainInterface,
-) -> Result<Option<ParentSearchResult<B>>, RelayChainError> {
-	tracing::trace!(target: LOG_TARGET, "Parent search parameters: {params:?}");
+	backend: &impl Backend<B>,
+	para_id: ParaId,
+	relay_parent: RelayHash,
+) -> RelayChainResult<Option<ParentSearchResult<B>>> {
+	tracing::trace!(
+		target: LOG_TARGET,
+		?para_id,
+		?relay_parent,
+		"Parent search"
+	);
 
 	// Get the included block.
 	let Some((included_header, included_hash)) =
-		fetch_included_from_relay_chain(relay_client, backend, params.para_id, params.relay_parent)
-			.await?
+		fetch_included_from_relay_chain(relay_client, backend, para_id, relay_parent).await?
 	else {
 		return Ok(None);
 	};
@@ -93,11 +85,7 @@ pub async fn find_parent_for_building<B: BlockT>(
 		// `OccupiedCoreAssumption::Included` so the candidate pending availability gets enacted
 		// before being returned to us.
 		let pending_header = relay_client
-			.persisted_validation_data(
-				params.relay_parent,
-				params.para_id,
-				OccupiedCoreAssumption::Included,
-			)
+			.persisted_validation_data(relay_parent, para_id, OccupiedCoreAssumption::Included)
 			.await?
 			.and_then(|p| B::Header::decode(&mut &p.parent_head.0[..]).ok())
 			.filter(|x| x.hash() != included_hash);
@@ -137,14 +125,18 @@ pub async fn find_parent_for_building<B: BlockT>(
 		None => (included_hash, included_header.clone()),
 	};
 
+	let ancestry_lookback = relay_client
+		.scheduling_lookahead(relay_parent)
+		.await
+		.unwrap_or(DEFAULT_SCHEDULING_LOOKAHEAD)
+		.saturating_sub(1) as usize;
 	// Build up the ancestry record of the relay chain to compare against.
 	let rp_ancestry =
-		build_relay_parent_ancestry(params.ancestry_lookback, params.relay_parent, relay_client)
-			.await?;
+		build_relay_parent_ancestry(relay_client, relay_parent, ancestry_lookback).await?;
 
 	// Search for the deepest valid parent starting from the pending/included block.
 	let best_parent_header =
-		find_deepest_valid_parent(start_hash, start_header, backend, &rp_ancestry);
+		find_deepest_valid_parent(backend, start_header, start_hash, &rp_ancestry);
 
 	Ok(Some(ParentSearchResult { included_header, best_parent_header }))
 }
@@ -157,7 +149,7 @@ async fn fetch_included_from_relay_chain<B: BlockT>(
 	relay_parent: RelayHash,
 ) -> Result<Option<(B::Header, B::Hash)>, RelayChainError> {
 	// Fetch the pending header from the relay chain. We use `OccupiedCoreAssumption::TimedOut`
-	// so that even if there is a pending candidate, we assume it is timed out and we get the
+	// so that even if there is a pending candidate, we assume it is timed out, and we get the
 	// included head.
 	let included_header = relay_client
 		.persisted_validation_data(relay_parent, para_id, OccupiedCoreAssumption::TimedOut)
@@ -199,24 +191,22 @@ async fn fetch_included_from_relay_chain<B: BlockT>(
 /// On success, returns a vector of `(header_hash, state_root)` of the relevant relay chain
 /// ancestry blocks.
 async fn build_relay_parent_ancestry(
-	ancestry_lookback: usize,
-	relay_parent: RelayHash,
 	relay_client: &impl RelayChainInterface,
+	relay_parent: RelayHash,
+	ancestry_lookback: usize,
 ) -> Result<Vec<(RelayHash, RelayHash)>, RelayChainError> {
 	let mut ancestry = Vec::with_capacity(ancestry_lookback + 1);
 	let mut current_rp = relay_parent;
-	let mut required_session = None;
 	while ancestry.len() <= ancestry_lookback {
 		let Some(header) = relay_client.header(RBlockId::hash(current_rp)).await? else { break };
 
-		let session = relay_client.session_index_for_child(current_rp).await?;
-		if required_session.get_or_insert(session) != &session {
-			// Respect the relay-chain rule not to cross session boundaries.
-			break;
-		}
-
 		ancestry.push((current_rp, *header.state_root()));
 		current_rp = *header.parent_hash();
+
+		// Respect the relay-chain rule not to cross session boundaries.
+		if contains_epoch_change::<RelayBlock>(&header) {
+			break;
+		}
 
 		// don't iterate back into the genesis block.
 		if header.number == 1 {
@@ -232,9 +222,9 @@ async fn build_relay_parent_ancestry(
 /// This function explores its descendants via DFS, returning the deepest block
 /// whose relay-parent is within the allowed ancestry.
 fn find_deepest_valid_parent<Block: BlockT>(
-	start_hash: Block::Hash,
-	start_header: Block::Header,
 	backend: &impl Backend<Block>,
+	start_header: Block::Header,
+	start_hash: Block::Hash,
 	rp_ancestry: &[(RelayHash, RelayHash)],
 ) -> Block::Header {
 	let mut best = start_header;

--- a/cumulus/client/consensus/common/src/parent_search.rs
+++ b/cumulus/client/consensus/common/src/parent_search.rs
@@ -17,9 +17,10 @@
 
 use codec::Decode;
 use polkadot_primitives::{Block as RelayBlock, Hash as RelayHash, DEFAULT_SCHEDULING_LOOKAHEAD};
+use std::ops::Add;
 
 use cumulus_primitives_core::{
-	relay_chain::{BlockId as RBlockId, OccupiedCoreAssumption},
+	relay_chain::{BlockId as RelayBlockId, OccupiedCoreAssumption},
 	ParaId,
 };
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
@@ -27,54 +28,68 @@ use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayC
 use sc_client_api::{Backend, HeaderBackend};
 use sc_consensus_babe::contains_epoch_change;
 use sp_blockchain::Backend as BlockchainBackend;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, One};
 
 const LOG_TARGET: &str = "consensus::common::parent_search";
 
-/// A potential parent block returned from [`find_parent_for_building`]
-#[derive(PartialEq, Clone)]
-pub struct ParentSearchResult<B: BlockT> {
-	/// The header of the included block (confirmed on relay chain).
-	pub included_header: B::Header,
-	/// The header of the best parent block to build on.
-	pub best_parent_header: B::Header,
+fn get_para_header<Block: BlockT>(
+	backend: &impl Backend<Block>,
+	hash: Block::Hash,
+) -> Option<Block::Header> {
+	let Ok(Some(header)) = backend.blockchain().header(hash) else {
+		tracing::warn!(
+			target: LOG_TARGET,
+			%hash,
+			"Failed to get header for para block.",
+		);
+		return None;
+	};
+
+	Some(header)
 }
 
-impl<B: BlockT> std::fmt::Debug for ParentSearchResult<B> {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("ParentSearchResult")
-			.field("included_number", &self.included_header.number())
-			.field("best_parent_hash", &self.best_parent_header.hash())
-			.field("best_parent_number", &self.best_parent_header.number())
-			.finish()
-	}
-}
-
-/// Find the best parent block to build on.
-///
-/// This accepts a relay-chain block to be used as an anchor and searches for the best
-/// parachain block to use as a parent for a new block.
-///
-/// The search starts from either the pending block (if one exists) or the included block,
-/// and finds the deepest descendant whose relay-parent is within the allowed ancestry.
-///
-/// Returns `None` if no suitable parent can be found (e.g., included block unknown locally).
-pub async fn find_parent_for_building<B: BlockT>(
+/// Fetch the included block from the relay chain.
+pub async fn fetch_included_from_relay_chain<B: BlockT>(
 	relay_client: &impl RelayChainInterface,
 	backend: &impl Backend<B>,
 	para_id: ParaId,
 	relay_parent: RelayHash,
-) -> RelayChainResult<Option<ParentSearchResult<B>>> {
-	tracing::trace!(
-		target: LOG_TARGET,
-		?para_id,
-		?relay_parent,
-		"Parent search"
-	);
+) -> Result<Option<(B::Hash, B::Header)>, RelayChainError> {
+	// Fetch the pending header from the relay chain. We use `OccupiedCoreAssumption::TimedOut`
+	// so that even if there is a pending candidate, we assume it is timed out, and we get the
+	// included head.
+	let maybe_included_header = relay_client
+		.persisted_validation_data(relay_parent, para_id, OccupiedCoreAssumption::TimedOut)
+		.await?
+		.and_then(|pvd| B::Header::decode(&mut &pvd.parent_head.0[..]).ok());
+	let Some(included_header) = maybe_included_header else {
+		return Ok(None);
+	};
 
-	// Get the included block.
-	let Some((included_header, included_hash)) =
-		fetch_included_from_relay_chain(relay_client, backend, para_id, relay_parent).await?
+	let included_hash = included_header.hash();
+	// If the included block is not locally known, we can't do anything.
+	let Some(_) = get_para_header(backend, included_hash) else {
+		return Ok(None);
+	};
+
+	Ok(Some((included_hash, included_header)))
+}
+
+struct ParentSearchStart<Block: BlockT> {
+	/// The header of the included block (confirmed on relay chain) at the scheduling context.
+	included: Block::Header,
+	/// The hash and header of the block where the parent search can start.
+	start: (Block::Hash, Block::Header),
+}
+
+async fn get_parent_search_start<Block: BlockT>(
+	relay_client: &impl RelayChainInterface,
+	backend: &impl Backend<Block>,
+	para_id: ParaId,
+	scheduling_parent: RelayHash,
+) -> RelayChainResult<Option<ParentSearchStart<Block>>> {
+	let Some((included_hash, included_header)) =
+		fetch_included_from_relay_chain(relay_client, backend, para_id, scheduling_parent).await?
 	else {
 		return Ok(None);
 	};
@@ -85,31 +100,27 @@ pub async fn find_parent_for_building<B: BlockT>(
 		// `OccupiedCoreAssumption::Included` so the candidate pending availability gets enacted
 		// before being returned to us.
 		let pending_header = relay_client
-			.persisted_validation_data(relay_parent, para_id, OccupiedCoreAssumption::Included)
+			.persisted_validation_data(scheduling_parent, para_id, OccupiedCoreAssumption::Included)
 			.await?
-			.and_then(|p| B::Header::decode(&mut &p.parent_head.0[..]).ok())
+			.and_then(|p| Block::Header::decode(&mut &p.parent_head.0[..]).ok())
 			.filter(|x| x.hash() != included_hash);
 
 		// If the pending block is not locally known, we can't proceed.
-		if let Some(header) = pending_header {
-			let pending_hash = header.hash();
-			let Ok(Some(header)) = backend.blockchain().header(pending_hash) else {
-				tracing::warn!(
-					target: LOG_TARGET,
-					%pending_hash,
-					"Failed to get header for pending block.",
-				);
-				return Ok(None);
-			};
-			Some((header, pending_hash))
-		} else {
-			None
+		match pending_header {
+			Some(header) => {
+				let pending_hash = header.hash();
+				let Some(_) = get_para_header(backend, pending_hash) else {
+					return Ok(None);
+				};
+				Some((pending_hash, header))
+			},
+			None => None,
 		}
 	};
 
 	// Determine the starting point for the search.
 	let (start_hash, start_header) = match &maybe_pending {
-		Some((pending_header, pending_hash)) => {
+		Some((pending_hash, pending_header)) => {
 			// Verify pending is a descendant of included.
 			let route =
 				sp_blockchain::tree_route(backend.blockchain(), included_hash, *pending_hash)?;
@@ -125,60 +136,7 @@ pub async fn find_parent_for_building<B: BlockT>(
 		None => (included_hash, included_header.clone()),
 	};
 
-	let ancestry_lookback = relay_client
-		.scheduling_lookahead(relay_parent)
-		.await
-		.unwrap_or(DEFAULT_SCHEDULING_LOOKAHEAD)
-		.saturating_sub(1) as usize;
-	// Build up the ancestry record of the relay chain to compare against.
-	let rp_ancestry =
-		build_relay_parent_ancestry(relay_client, relay_parent, ancestry_lookback).await?;
-
-	// Search for the deepest valid parent starting from the pending/included block.
-	let best_parent_header =
-		find_deepest_valid_parent(backend, start_header, start_hash, &rp_ancestry);
-
-	Ok(Some(ParentSearchResult { included_header, best_parent_header }))
-}
-
-/// Fetch the included block from the relay chain.
-async fn fetch_included_from_relay_chain<B: BlockT>(
-	relay_client: &impl RelayChainInterface,
-	backend: &impl Backend<B>,
-	para_id: ParaId,
-	relay_parent: RelayHash,
-) -> Result<Option<(B::Header, B::Hash)>, RelayChainError> {
-	// Fetch the pending header from the relay chain. We use `OccupiedCoreAssumption::TimedOut`
-	// so that even if there is a pending candidate, we assume it is timed out, and we get the
-	// included head.
-	let included_header = relay_client
-		.persisted_validation_data(relay_parent, para_id, OccupiedCoreAssumption::TimedOut)
-		.await?;
-	let included_header = match included_header {
-		Some(pvd) => pvd.parent_head,
-		None => return Ok(None), // this implies the para doesn't exist.
-	};
-
-	let included_header = match B::Header::decode(&mut &included_header.0[..]).ok() {
-		None => return Ok(None),
-		Some(x) => x,
-	};
-
-	let included_hash = included_header.hash();
-	// If the included block is not locally known, we can't do anything.
-	match backend.blockchain().header(included_hash) {
-		Ok(None) | Err(_) => {
-			tracing::warn!(
-				target: LOG_TARGET,
-				%included_hash,
-				"Failed to get header for included block.",
-			);
-			return Ok(None);
-		},
-		_ => {},
-	};
-
-	Ok(Some((included_header, included_hash)))
+	Ok(Some(ParentSearchStart { included: included_header, start: (start_hash, start_header) }))
 }
 
 /// Build an ancestry of relay parents that are acceptable.
@@ -198,7 +156,9 @@ async fn build_relay_parent_ancestry(
 	let mut ancestry = Vec::with_capacity(ancestry_lookback + 1);
 	let mut current_rp = relay_parent;
 	while ancestry.len() <= ancestry_lookback {
-		let Some(header) = relay_client.header(RBlockId::hash(current_rp)).await? else { break };
+		let Some(header) = relay_client.header(RelayBlockId::hash(current_rp)).await? else {
+			break;
+		};
 
 		ancestry.push((current_rp, *header.state_root()));
 		current_rp = *header.parent_hash();
@@ -214,6 +174,25 @@ async fn build_relay_parent_ancestry(
 		}
 	}
 	Ok(ancestry)
+}
+
+/// Check if a block's relay parent is within the allowed ancestry.
+fn is_relay_parent_in_ancestry<Block: BlockT>(
+	header: &Block::Header,
+	rp_ancestry: &[(RelayHash, RelayHash)],
+) -> bool {
+	let digest = header.digest();
+	let relay_parent = cumulus_primitives_core::extract_relay_parent(digest);
+	let storage_root =
+		cumulus_primitives_core::rpsr_digest::extract_relay_parent_storage_root(digest)
+			.map(|(storage_root, _)| storage_root);
+	if relay_parent.is_none() && storage_root.is_none() {
+		return false;
+	}
+
+	rp_ancestry.iter().any(|(rp_hash, rp_storage_root)| {
+		Some(*rp_hash) == relay_parent || Some(*rp_storage_root) == storage_root
+	})
 }
 
 /// Find the deepest valid parent block starting from `start`.
@@ -257,21 +236,179 @@ fn find_deepest_valid_parent<Block: BlockT>(
 	best
 }
 
-/// Check if a block's relay parent is within the allowed ancestry.
-fn is_relay_parent_in_ancestry<Block: BlockT>(
+async fn has_ancestor_relay_parent_info<Block: BlockT>(
+	relay_client: &impl RelayChainInterface,
+	scheduling_parent: RelayHash,
 	header: &Block::Header,
-	rp_ancestry: &[(RelayHash, RelayHash)],
-) -> bool {
-	let digest = header.digest();
-	let relay_parent = cumulus_primitives_core::extract_relay_parent(digest);
-	let storage_root =
-		cumulus_primitives_core::rpsr_digest::extract_relay_parent_storage_root(digest)
-			.map(|(storage_root, _)| storage_root);
-	if relay_parent.is_none() && storage_root.is_none() {
-		return false;
+) -> RelayChainResult<bool> {
+	let relay_parent = 'get_relay_parent: {
+		let digest = header.digest();
+
+		if let Some(relay_parent) = cumulus_primitives_core::extract_relay_parent(digest) {
+			break 'get_relay_parent relay_parent;
+		}
+
+		if let Some((storage_root, number)) =
+			cumulus_primitives_core::rpsr_digest::extract_relay_parent_storage_root(digest)
+		{
+			let Some(relay_parent_header) =
+				relay_client.header(RelayBlockId::Number(number)).await?
+			else {
+				return Ok(false);
+			};
+			if relay_parent_header.state_root != storage_root {
+				return Ok(false);
+			}
+			break 'get_relay_parent relay_parent_header.hash();
+		}
+
+		return Ok(false);
+	};
+
+	if relay_parent == scheduling_parent {
+		return Ok(true);
 	}
 
-	rp_ancestry.iter().any(|(rp_hash, rp_storage_root)| {
-		Some(*rp_hash) == relay_parent || Some(*rp_storage_root) == storage_root
-	})
+	let relay_parent_session = relay_client.session_index_for_child(relay_parent).await?;
+	let Some(_info) = relay_client
+		.ancestor_relay_parent_info(scheduling_parent, relay_parent_session, relay_parent)
+		.await?
+	else {
+		return Ok(false);
+	};
+
+	Ok(true)
+}
+
+#[derive(Clone, Debug)]
+pub enum ParentSearchParams<Block: BlockT> {
+	V2 {
+		/// The scheduling-parent that is intended to be used.
+		/// For V2, the scheduling parent is equal to the relay parent.
+		scheduling_parent: RelayHash,
+	},
+	V3 {
+		/// The scheduling-parent that is intended to be used.
+		scheduling_parent: RelayHash,
+		para_best_hash: Block::Hash,
+	},
+}
+
+impl<Block: BlockT> ParentSearchParams<Block> {
+	fn scheduling_parent(&self) -> &RelayHash {
+		match self {
+			ParentSearchParams::V2 { scheduling_parent } => scheduling_parent,
+			ParentSearchParams::V3 { scheduling_parent, .. } => scheduling_parent,
+		}
+	}
+}
+
+/// A potential parent block returned from [`find_parent_for_building`]
+#[derive(PartialEq, Clone)]
+pub struct ParentSearchResult<Block: BlockT> {
+	/// The header of the included block (confirmed on relay chain).
+	pub included_header: Block::Header,
+	/// The header of the best parent block to build on.
+	pub best_parent_header: Block::Header,
+}
+
+impl<B: BlockT> std::fmt::Debug for ParentSearchResult<B> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ParentSearchResult")
+			.field("included_number", &self.included_header.number())
+			.field("best_parent_hash", &self.best_parent_header.hash())
+			.field("best_parent_number", &self.best_parent_header.number())
+			.finish()
+	}
+}
+
+/// Find the best parent block to build on.
+///
+/// This accepts a relay-chain block to be used as an anchor and searches for the best
+/// parachain block to use as a parent for a new block.
+///
+/// The search starts from either the pending block (if one exists) or the included block,
+/// and finds the deepest descendant whose relay-parent is within the allowed ancestry.
+///
+/// Returns `None` if no suitable parent can be found (e.g., included block unknown locally).
+pub async fn find_parent_for_building<Block: BlockT>(
+	relay_client: &impl RelayChainInterface,
+	backend: &impl Backend<Block>,
+	para_id: ParaId,
+	params: ParentSearchParams<Block>,
+) -> RelayChainResult<Option<ParentSearchResult<Block>>> {
+	tracing::trace!(
+		target: LOG_TARGET,
+		?para_id,
+		?params,
+		"Parent search"
+	);
+
+	let scheduling_parent = *params.scheduling_parent();
+
+	let Some(ParentSearchStart { included: included_header, start: (start_hash, start_header) }) =
+		get_parent_search_start(relay_client, backend, para_id, scheduling_parent).await?
+	else {
+		return Ok(None);
+	};
+
+	match params {
+		ParentSearchParams::V2 { scheduling_parent: relay_parent } => {
+			let ancestry_lookback = relay_client
+				.scheduling_lookahead(relay_parent)
+				.await
+				.unwrap_or(DEFAULT_SCHEDULING_LOOKAHEAD)
+				.saturating_sub(1) as usize;
+			// Build up the ancestry record of the relay chain to compare against.
+			let rp_ancestry =
+				build_relay_parent_ancestry(relay_client, relay_parent, ancestry_lookback).await?;
+
+			// Search for the deepest valid parent starting from the pending/included block.
+			let best_parent_header =
+				find_deepest_valid_parent(backend, start_header, start_hash, &rp_ancestry);
+
+			Ok(Some(ParentSearchResult { included_header, best_parent_header }))
+		},
+		ParentSearchParams::V3 { scheduling_parent, para_best_hash } => {
+			let mut para_best_header = None;
+			let mut current_hash = para_best_hash;
+			let best_parent_header = loop {
+				let Some(current_header) = get_para_header(backend, current_hash) else {
+					break None;
+				};
+				if current_hash == para_best_hash {
+					para_best_header = Some(current_header.clone());
+				}
+
+				if current_hash == para_best_hash ||
+					*current_header.number() == start_header.number().add(One::one())
+				{
+					if !has_ancestor_relay_parent_info::<Block>(
+						relay_client,
+						scheduling_parent,
+						&current_header,
+					)
+					.await?
+					{
+						break None;
+					}
+				}
+
+				if current_hash == start_hash {
+					break para_best_header;
+				}
+
+				if current_header.number() <= start_header.number() {
+					break None;
+				}
+
+				current_hash = *current_header.parent_hash();
+			};
+
+			Ok(Some(ParentSearchResult {
+				included_header,
+				best_parent_header: best_parent_header.unwrap_or(start_header),
+			}))
+		},
+	}
 }

--- a/cumulus/client/consensus/common/src/tests.rs
+++ b/cumulus/client/consensus/common/src/tests.rs
@@ -1033,7 +1033,7 @@ fn find_best_parent_in_allowed_ancestry() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: relay_parent },
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1065,7 +1065,7 @@ fn find_best_parent_in_allowed_ancestry() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1080,7 +1080,7 @@ fn find_best_parent_in_allowed_ancestry() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1135,7 +1135,7 @@ fn find_best_parent_with_pending() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1172,7 +1172,7 @@ fn find_best_parent_unknown_included_returns_none() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap();
 
@@ -1225,7 +1225,7 @@ fn find_best_parent_unknown_pending_returns_none() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap();
 
@@ -1345,7 +1345,7 @@ fn find_best_parent_with_forks_returns_deepest() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1420,7 +1420,7 @@ fn find_best_parent_returns_deepest_block() {
 		&relay_chain,
 		&*backend,
 		ParaId::from(100),
-		search_relay_parent,
+		ParentSearchParams::V2 { scheduling_parent: search_relay_parent },
 	))
 	.unwrap()
 	.expect("Should find a parent");

--- a/cumulus/client/consensus/common/src/tests.rs
+++ b/cumulus/client/consensus/common/src/tests.rs
@@ -86,11 +86,12 @@ impl RelaychainInner {
 #[derive(Clone)]
 struct Relaychain {
 	inner: Arc<Mutex<RelaychainInner>>,
+	scheduling_lookahead: Option<u32>,
 }
 
 impl Relaychain {
 	fn new() -> Self {
-		Self { inner: Arc::new(Mutex::new(RelaychainInner::new())) }
+		Self { inner: Arc::new(Mutex::new(RelaychainInner::new())), scheduling_lookahead: None }
 	}
 }
 
@@ -298,6 +299,10 @@ impl RelayChainInterface for Relaychain {
 	}
 
 	async fn scheduling_lookahead(&self, _: PHash) -> RelayChainResult<u32> {
+		if let Some(scheduling_lookahead) = self.scheduling_lookahead {
+			return Ok(scheduling_lookahead);
+		}
+
 		unimplemented!("Not needed for test")
 	}
 
@@ -1016,17 +1021,19 @@ fn find_best_parent_in_allowed_ancestry() {
 		Some(relay_parent),
 	);
 
-	let relay_chain = Relaychain::new();
+	let mut relay_chain = Relaychain::new();
 	{
 		let included_map = &mut relay_chain.inner.lock().unwrap().relay_chain_hash_to_header;
 		included_map.insert(relay_parent, included_block.header().clone());
 	}
 
 	// When there's only the included block, it should be the best parent.
+	relay_chain.scheduling_lookahead = Some(1);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams { relay_parent, para_id: ParaId::from(100), ancestry_lookback: 0 },
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		relay_parent,
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1053,14 +1060,12 @@ fn find_best_parent_in_allowed_ancestry() {
 	);
 
 	// With ancestry_lookback: 2, the child block should be the best parent.
+	relay_chain.scheduling_lookahead = Some(3);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 2,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1070,14 +1075,12 @@ fn find_best_parent_in_allowed_ancestry() {
 
 	// With ancestry_lookback: 0, child block's relay parent is too old,
 	// so included block should be the best parent.
+	relay_chain.scheduling_lookahead = Some(1);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 0,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1115,7 +1118,7 @@ fn find_best_parent_with_pending() {
 		Some(relay_parent),
 	);
 
-	let relay_chain = Relaychain::new();
+	let mut relay_chain = Relaychain::new();
 	let search_relay_parent = relay_hash_from_block_num(15);
 	{
 		let relay_inner = &mut relay_chain.inner.lock().unwrap();
@@ -1127,14 +1130,12 @@ fn find_best_parent_with_pending() {
 			.insert(search_relay_parent, pending_block.header().clone());
 	}
 
+	relay_chain.scheduling_lookahead = Some(1);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 0,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1158,7 +1159,7 @@ fn find_best_parent_unknown_included_returns_none() {
 	let sproof = sproof_with_best_parent(&client);
 	let included_but_unknown = build_block(&*client, sproof, None, None, Some(relay_parent));
 
-	let relay_chain = Relaychain::new();
+	let mut relay_chain = Relaychain::new();
 	{
 		let relay_inner = &mut relay_chain.inner.lock().unwrap();
 		relay_inner
@@ -1166,14 +1167,12 @@ fn find_best_parent_unknown_included_returns_none() {
 			.insert(search_relay_parent, included_but_unknown.header().clone());
 	}
 
+	relay_chain.scheduling_lookahead = Some(2);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 1,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap();
 
@@ -1210,7 +1209,7 @@ fn find_best_parent_unknown_pending_returns_none() {
 		Some(relay_parent),
 	);
 
-	let relay_chain = Relaychain::new();
+	let mut relay_chain = Relaychain::new();
 	{
 		let relay_inner = &mut relay_chain.inner.lock().unwrap();
 		relay_inner
@@ -1221,14 +1220,12 @@ fn find_best_parent_unknown_pending_returns_none() {
 			.insert(search_relay_parent, pending_but_unknown.header().clone());
 	}
 
+	relay_chain.scheduling_lookahead = Some(2);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 1,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap();
 
@@ -1266,7 +1263,7 @@ fn find_best_parent_with_forks_returns_deepest() {
 		Some(relay_hash_from_block_num(11)),
 	);
 
-	let relay_chain = Relaychain::new();
+	let mut relay_chain = Relaychain::new();
 	{
 		let relay_inner = &mut relay_chain.inner.lock().unwrap();
 		relay_inner
@@ -1343,14 +1340,12 @@ fn find_best_parent_with_forks_returns_deepest() {
 		Some(relay_hash_from_block_num(17)),
 	);
 
+	relay_chain.scheduling_lookahead = Some(11);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 10,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap()
 	.expect("Should find a parent");
@@ -1394,7 +1389,7 @@ fn find_best_parent_returns_deepest_block() {
 		Some(relay_parent),
 	);
 
-	let relay_chain = Relaychain::new();
+	let mut relay_chain = Relaychain::new();
 	{
 		let relay_inner = &mut relay_chain.inner.lock().unwrap();
 		relay_inner
@@ -1420,14 +1415,12 @@ fn find_best_parent_returns_deepest_block() {
 		last_block = block;
 	}
 
+	relay_chain.scheduling_lookahead = Some(2);
 	let result = block_on(find_parent_for_building(
-		ParentSearchParams {
-			relay_parent: search_relay_parent,
-			para_id: ParaId::from(100),
-			ancestry_lookback: 1,
-		},
-		&*backend,
 		&relay_chain,
+		&*backend,
+		ParaId::from(100),
+		search_relay_parent,
 	))
 	.unwrap()
 	.expect("Should find a parent");

--- a/cumulus/client/consensus/common/src/tests.rs
+++ b/cumulus/client/consensus/common/src/tests.rs
@@ -37,7 +37,7 @@ use cumulus_test_client::{
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 use futures::{channel::mpsc, executor::block_on, select, FutureExt, Stream, StreamExt};
 use futures_timer::Delay;
-use polkadot_primitives::{CandidateEvent, HeadData, NodeFeatures};
+use polkadot_primitives::{vstaging::RelayParentInfo, CandidateEvent, HeadData, NodeFeatures};
 use sc_client_api::{Backend as _, UsageProvider};
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy};
 use sp_blockchain::Backend as BlockchainBackend;
@@ -309,8 +309,17 @@ impl RelayChainInterface for Relaychain {
 		unimplemented!("Not needed for test")
 	}
 
-	async fn node_features(&self, _at: Hash) -> RelayChainResult<NodeFeatures> {
+	async fn node_features(&self, _at: PHash) -> RelayChainResult<NodeFeatures> {
 		unimplemented!("Not needed for test")
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		_at: PHash,
+		_session_index: SessionIndex,
+		_relay_parent: PHash,
+	) -> RelayChainResult<Option<RelayParentInfo<PHash, BlockNumber>>> {
+		todo!()
 	}
 }
 

--- a/cumulus/client/network/src/tests.rs
+++ b/cumulus/client/network/src/tests.rs
@@ -27,10 +27,10 @@ use futures::{executor::block_on, poll, task::Poll, FutureExt, Stream, StreamExt
 use parking_lot::Mutex;
 use polkadot_node_primitives::{SignedFullStatement, Statement};
 use polkadot_primitives::{
-	BlockNumber, CandidateCommitments, CandidateDescriptorV2, CandidateEvent, CollatorPair,
-	CommittedCandidateReceiptV2, CoreState, Hash as PHash, HeadData, InboundDownwardMessage,
-	InboundHrmpMessage, NodeFeatures, OccupiedCoreAssumption, PersistedValidationData,
-	SessionIndex, SigningContext, ValidationCodeHash, ValidatorId,
+	vstaging::RelayParentInfo, BlockNumber, CandidateCommitments, CandidateDescriptorV2,
+	CandidateEvent, CollatorPair, CommittedCandidateReceiptV2, CoreState, Hash as PHash, HeadData,
+	InboundDownwardMessage, InboundHrmpMessage, NodeFeatures, OccupiedCoreAssumption,
+	PersistedValidationData, SessionIndex, SigningContext, ValidationCodeHash, ValidatorId,
 };
 use polkadot_primitives_test_helpers::{CandidateDescriptor, CommittedCandidateReceipt};
 use polkadot_test_client::{
@@ -369,6 +369,15 @@ impl RelayChainInterface for DummyRelayChainInterface {
 	}
 
 	async fn node_features(&self, _at: PHash) -> RelayChainResult<NodeFeatures> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		_at: PHash,
+		_session_index: SessionIndex,
+		_relay_parent: PHash,
+	) -> RelayChainResult<Option<RelayParentInfo<PHash, BlockNumber>>> {
 		unimplemented!("Not needed for test")
 	}
 }

--- a/cumulus/client/pov-recovery/src/tests.rs
+++ b/cumulus/client/pov-recovery/src/tests.rs
@@ -19,7 +19,7 @@ use super::*;
 use assert_matches::assert_matches;
 use codec::{Decode, Encode};
 use cumulus_primitives_core::relay_chain::{
-	BlockId, CandidateCommitments, CandidateDescriptorV2, CoreIndex, CoreState,
+	BlockId, BlockNumber, CandidateCommitments, CandidateDescriptorV2, CoreIndex, CoreState,
 };
 use cumulus_relay_chain_interface::{
 	ChildInfo, InboundDownwardMessage, InboundHrmpMessage, OccupiedCoreAssumption, PHash, PHeader,
@@ -32,7 +32,7 @@ use polkadot_node_subsystem::{
 	messages::{AvailabilityRecoveryMessage, RuntimeApiRequest},
 	RecoveryError, TimeoutExt,
 };
-use polkadot_primitives::{CandidateEvent, NodeFeatures};
+use polkadot_primitives::{vstaging::RelayParentInfo, CandidateEvent, NodeFeatures};
 use rstest::rstest;
 use sc_client_api::{
 	BlockImportNotification, ClientInfo, CompactProof, FinalityNotification, FinalityNotifications,
@@ -534,6 +534,15 @@ impl RelayChainInterface for Relaychain {
 	}
 
 	async fn node_features(&self, _at: PHash) -> RelayChainResult<NodeFeatures> {
+		unimplemented!("Not needed for test");
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		_at: PHash,
+		_session_index: SessionIndex,
+		_relay_parent: PHash,
+	) -> RelayChainResult<Option<RelayParentInfo<PHash, BlockNumber>>> {
 		unimplemented!("Not needed for test");
 	}
 }

--- a/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-inprocess-interface/src/lib.rs
@@ -37,7 +37,7 @@ use cumulus_relay_chain_interface::{
 	ChildInfo, RelayChainError, RelayChainInterface, RelayChainResult,
 };
 use futures::{FutureExt, Stream, StreamExt};
-use polkadot_primitives::{CandidateEvent, NodeFeatures};
+use polkadot_primitives::{vstaging::RelayParentInfo, CandidateEvent, NodeFeatures};
 use polkadot_service::{
 	builder::PolkadotServiceBuilder, CollatorOverseerGen, CollatorPair, Configuration, FullBackend,
 	FullClient, Handle, NewFull, NewFullParams, TaskManager,
@@ -355,6 +355,19 @@ impl RelayChainInterface for RelayChainInProcessInterface {
 
 	async fn node_features(&self, at: PHash) -> RelayChainResult<NodeFeatures> {
 		Ok(self.full_client.runtime_api().node_features(at)?)
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		at: PHash,
+		session_index: SessionIndex,
+		relay_parent: PHash,
+	) -> RelayChainResult<Option<RelayParentInfo<PHash, BlockNumber>>> {
+		Ok(self.full_client.runtime_api().ancestor_relay_parent_info(
+			at,
+			session_index,
+			relay_parent,
+		)?)
 	}
 }
 

--- a/cumulus/client/relay-chain-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-interface/src/lib.rs
@@ -32,7 +32,7 @@ use jsonrpsee_core::ClientError as JsonRpcError;
 use sp_api::ApiError;
 
 use cumulus_primitives_core::relay_chain::{
-	BlockId, CandidateEvent, Hash as RelayHash, NodeFeatures,
+	vstaging::RelayParentInfo, BlockId, CandidateEvent, Hash as RelayHash, NodeFeatures,
 };
 pub use cumulus_primitives_core::{
 	relay_chain::{
@@ -265,6 +265,13 @@ pub trait RelayChainInterface: Send + Sync {
 	async fn max_relay_parent_session_age(&self, at: RelayHash) -> RelayChainResult<u32>;
 
 	async fn node_features(&self, at: RelayHash) -> RelayChainResult<NodeFeatures>;
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		at: RelayHash,
+		session_index: SessionIndex,
+		relay_parent: RelayHash,
+	) -> RelayChainResult<Option<RelayParentInfo<RelayHash, BlockNumber>>>;
 }
 
 #[async_trait]
@@ -443,6 +450,15 @@ where
 
 	async fn node_features(&self, at: RelayHash) -> RelayChainResult<NodeFeatures> {
 		(**self).node_features(at).await
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		at: RelayHash,
+		session_index: SessionIndex,
+		relay_parent: RelayHash,
+	) -> RelayChainResult<Option<RelayParentInfo<RelayHash, BlockNumber>>> {
+		(**self).ancestor_relay_parent_info(at, session_index, relay_parent).await
 	}
 }
 

--- a/cumulus/client/relay-chain-rpc-interface/src/lib.rs
+++ b/cumulus/client/relay-chain-rpc-interface/src/lib.rs
@@ -38,7 +38,7 @@ use sp_storage::StorageKey;
 use sp_version::RuntimeVersion;
 use std::{collections::btree_map::BTreeMap, pin::Pin};
 
-use cumulus_primitives_core::relay_chain::{BlockId, NodeFeatures};
+use cumulus_primitives_core::relay_chain::{vstaging::RelayParentInfo, BlockId, NodeFeatures};
 pub use url::Url;
 
 mod metrics;
@@ -313,5 +313,16 @@ impl RelayChainInterface for RelayChainRpcInterface {
 
 	async fn node_features(&self, at: RelayHash) -> RelayChainResult<NodeFeatures> {
 		self.rpc_client.parachain_host_node_features(at).await
+	}
+
+	async fn ancestor_relay_parent_info(
+		&self,
+		at: RelayHash,
+		session_index: SessionIndex,
+		relay_parent: RelayHash,
+	) -> RelayChainResult<Option<RelayParentInfo<RelayHash, BlockNumber>>> {
+		self.rpc_client
+			.parachain_host_ancestor_relay_parent_info(at, session_index, relay_parent)
+			.await
 	}
 }

--- a/cumulus/client/unincluded-segment-store/Cargo.toml
+++ b/cumulus/client/unincluded-segment-store/Cargo.toml
@@ -13,11 +13,14 @@ workspace = true
 
 [dependencies]
 codec = { workspace = true, default-features = true }
-polkadot-primitives = { workspace = true, default-features = true }
 sc-client-api = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
+sp-staking = { workspace = true, default-features = true }
 sp-trie = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
+hex = { workspace = true, default-features = true }
+sp-consensus = { workspace = true, default-features = true }
 substrate-test-runtime = { workspace = true }

--- a/cumulus/client/unincluded-segment-store/Cargo.toml
+++ b/cumulus/client/unincluded-segment-store/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors.workspace = true
+name = "cumulus-client-unincluded-segment-store"
+version = "0.1.0"
+edition.workspace = true
+description = "Per-block proof store for unincluded segment resubmission."
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+codec = { workspace = true, default-features = true }
+polkadot-primitives = { workspace = true, default-features = true }
+sc-client-api = { workspace = true, default-features = true }
+sp-blockchain = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+sp-trie = { workspace = true, default-features = true }
+
+[dev-dependencies]
+substrate-test-runtime = { workspace = true }

--- a/cumulus/client/unincluded-segment-store/Cargo.toml
+++ b/cumulus/client/unincluded-segment-store/Cargo.toml
@@ -18,9 +18,7 @@ sc-client-api = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-trie = { workspace = true, default-features = true }
-tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
 hex = { workspace = true, default-features = true }
-sp-consensus = { workspace = true, default-features = true }
 substrate-test-runtime = { workspace = true }

--- a/cumulus/client/unincluded-segment-store/Cargo.toml
+++ b/cumulus/client/unincluded-segment-store/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 codec = { workspace = true, default-features = true }
+cumulus-client-consensus-common = { workspace = true, default-features = true }
 sc-client-api = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }

--- a/cumulus/client/unincluded-segment-store/Cargo.toml
+++ b/cumulus/client/unincluded-segment-store/Cargo.toml
@@ -16,7 +16,6 @@ codec = { workspace = true, default-features = true }
 sc-client-api = { workspace = true, default-features = true }
 sp-blockchain = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
-sp-staking = { workspace = true, default-features = true }
 sp-trie = { workspace = true, default-features = true }
 tracing = { workspace = true, default-features = true }
 

--- a/cumulus/client/unincluded-segment-store/Cargo.toml
+++ b/cumulus/client/unincluded-segment-store/Cargo.toml
@@ -21,4 +21,6 @@ sp-trie = { workspace = true, default-features = true }
 
 [dev-dependencies]
 hex = { workspace = true, default-features = true }
+sc-client-db = { workspace = true, default-features = true }
 substrate-test-runtime = { workspace = true }
+tempfile = { workspace = true }

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -21,6 +21,7 @@
 //! pruned on parachain finality.
 
 use codec::{Decode, Encode};
+use cumulus_client_consensus_common::old_finalized_hash;
 use sc_client_api::{
 	backend::AuxStore,
 	client::{AuxDataOperations, FinalityNotification, PreCommitActions},
@@ -115,30 +116,6 @@ pub fn load_entry<H: Encode, B: AuxStore>(
 			other
 		))),
 	}
-}
-
-/// Compute the old finalized hash from a tree route and a fallback parent hash.
-///
-/// This is the parent of the first block in the tree route, or the supplied `fallback_parent`
-/// (typically the parent hash of the just-finalized header) when the tree route is empty or its
-/// first block's header can't be loaded.
-///
-/// Taking the inputs directly rather than a `FinalityNotification` keeps this function unit-
-/// testable from outside `sc-client-api` (which has a private `unpin_handle` field).
-pub fn old_finalized_hash<C, Block>(
-	client: &C,
-	tree_route: &[Block::Hash],
-	fallback_parent: Block::Hash,
-) -> Block::Hash
-where
-	C: HeaderBackend<Block>,
-	Block: BlockT,
-{
-	tree_route
-		.first()
-		.and_then(|hash| client.header(*hash).ok().flatten())
-		.map(|h| *h.parent_hash())
-		.unwrap_or(fallback_parent)
 }
 
 /// Compute aux storage cleanup operations.
@@ -242,107 +219,12 @@ mod tests {
 	}
 
 	#[test]
-	fn round_trip_write_and_load() {
-		let backend = TestBackend::new();
-		let hash = Hash::repeat_byte(0xCD);
-		let entry = create_test_entry(999888777);
-
-		// Write via prepare + manual insert
-		let aux_data =
-			prepare_unincluded_segment_aux_data(hash, entry.time_ms, entry.proof.clone());
-		write_aux_data(&backend, aux_data);
-
-		// Load back
-		let loaded = load_entry(&backend, hash).expect("load should succeed");
-		assert_eq!(loaded, Some(entry));
-	}
-
-	#[test]
 	fn load_returns_none_when_no_entry_exists() {
 		let backend = TestBackend::new();
 		let hash = Hash::repeat_byte(0xEF);
 
 		let loaded = load_entry(&backend, hash).expect("load should succeed");
 		assert_eq!(loaded, None);
-	}
-
-	#[test]
-	fn load_returns_error_on_version_mismatch() {
-		let backend = TestBackend::new();
-		let hash = Hash::repeat_byte(0x12);
-
-		// Write a bogus version
-		let bogus_version = 999u32.encode();
-		AuxStore::insert_aux(
-			&backend,
-			&[(UNINCLUDED_SEGMENT_STORE_VERSION, bogus_version.as_slice())],
-			&[],
-		)
-		.expect("aux insert should succeed");
-
-		// Also write an entry so it's not just missing
-		let entry = create_test_entry(12345);
-		let key = unincluded_segment_key(hash);
-		AuxStore::insert_aux(&backend, &[(&key[..], entry.encode().as_slice())], &[])
-			.expect("aux insert should succeed");
-
-		// Load should fail with version error
-		let result = load_entry(&backend, hash);
-		assert!(result.is_err());
-		let err_msg = result.unwrap_err().to_string();
-		assert!(
-			err_msg.contains("Unsupported unincluded segment store DB version"),
-			"unexpected error: {}",
-			err_msg
-		);
-	}
-
-	#[test]
-	fn cleanup_deletes_stale_blocks() {
-		let stale_1 = Hash::repeat_byte(0xAA);
-		let stale_2 = Hash::repeat_byte(0xBB);
-		let just_finalized = Hash::repeat_byte(0xFF);
-		let old_finalized = Hash::repeat_byte(0xF0);
-
-		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[], &[stale_1, stale_2]);
-
-		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
-		assert!(keys.contains(&unincluded_segment_key(stale_1)));
-		assert!(keys.contains(&unincluded_segment_key(stale_2)));
-
-		// Verify all values are None (deletes)
-		assert!(ops.iter().all(|(_, v)| v.is_none()));
-	}
-
-	#[test]
-	fn cleanup_deletes_tree_route() {
-		let route_1 = Hash::repeat_byte(0xC1);
-		let route_2 = Hash::repeat_byte(0xC2);
-		let just_finalized = Hash::repeat_byte(0xFF);
-		let old_finalized = Hash::repeat_byte(0xF0);
-
-		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[route_1, route_2], &[]);
-
-		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
-		assert!(keys.contains(&unincluded_segment_key(route_1)));
-		assert!(keys.contains(&unincluded_segment_key(route_2)));
-
-		// Verify all values are None (deletes)
-		assert!(ops.iter().all(|(_, v)| v.is_none()));
-	}
-
-	#[test]
-	fn cleanup_deletes_old_and_just_finalized() {
-		let just_finalized = Hash::repeat_byte(0xFF);
-		let old_finalized = Hash::repeat_byte(0xF0);
-
-		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[], &[]);
-
-		assert_eq!(ops.len(), 2);
-		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
-		assert!(keys.contains(&unincluded_segment_key(old_finalized)));
-		assert!(keys.contains(&unincluded_segment_key(just_finalized)));
-		assert!(ops.iter().all(|(_, v)| v.is_none()));
 	}
 
 	#[test]
@@ -442,90 +324,6 @@ mod tests {
 		);
 	}
 
-	// Minimal `HeaderBackend` mock for the `old_finalized_hash_*` tests.
-	//
-	// `lookup` is `None` ⇒ `header()` returns `Ok(None)` (simulates a missing header).
-	struct MockHeaderBackend {
-		lookup: Option<(Hash, substrate_test_runtime::Header)>,
-	}
-
-	impl HeaderBackend<Block> for MockHeaderBackend {
-		fn header(
-			&self,
-			hash: <Block as BlockT>::Hash,
-		) -> ClientResult<Option<<Block as BlockT>::Header>> {
-			Ok(self.lookup.as_ref().and_then(|(h, hdr)| (*h == hash).then(|| hdr.clone())))
-		}
-
-		fn info(&self) -> sc_client_api::blockchain::Info<Block> {
-			unimplemented!()
-		}
-
-		fn status(
-			&self,
-			_hash: <Block as BlockT>::Hash,
-		) -> ClientResult<sc_client_api::blockchain::BlockStatus> {
-			unimplemented!()
-		}
-
-		fn number(
-			&self,
-			_hash: <Block as BlockT>::Hash,
-		) -> ClientResult<Option<sp_runtime::traits::NumberFor<Block>>> {
-			unimplemented!()
-		}
-
-		fn hash(
-			&self,
-			_number: sp_runtime::traits::NumberFor<Block>,
-		) -> ClientResult<Option<<Block as BlockT>::Hash>> {
-			unimplemented!()
-		}
-	}
-
-	#[test]
-	fn old_finalized_hash_with_empty_tree_route() {
-		let client = MockHeaderBackend { lookup: None };
-		let fallback = Hash::repeat_byte(0x01);
-
-		let old_hash = old_finalized_hash::<_, Block>(&client, &[], fallback);
-		assert_eq!(old_hash, fallback, "empty tree_route should fall through to the supplied parent");
-	}
-
-	#[test]
-	fn old_finalized_hash_with_tree_route() {
-		use substrate_test_runtime::Header as TestHeader;
-
-		let expected_old = Hash::repeat_byte(0x01);
-		let tree_block = Hash::repeat_byte(0x02);
-
-		let header = TestHeader {
-			parent_hash: expected_old,
-			number: 2,
-			state_root: Default::default(),
-			extrinsics_root: Default::default(),
-			digest: Default::default(),
-		};
-
-		let client = MockHeaderBackend { lookup: Some((tree_block, header)) };
-		let fallback = Hash::repeat_byte(0xFF);
-
-		let old_hash = old_finalized_hash::<_, Block>(&client, &[tree_block], fallback);
-		assert_eq!(old_hash, expected_old, "should resolve to parent of first tree_route block");
-	}
-
-	#[test]
-	fn old_finalized_hash_falls_back_when_header_missing() {
-		// Non-empty tree_route, but the header lookup returns None — the function should fall back
-		// to `fallback_parent` rather than panicking or returning a wrong hash.
-		let client = MockHeaderBackend { lookup: None };
-		let tree_block = Hash::repeat_byte(0x02);
-		let fallback = Hash::repeat_byte(0xAA);
-
-		let old_hash = old_finalized_hash::<_, Block>(&client, &[tree_block], fallback);
-		assert_eq!(old_hash, fallback, "missing header should fall back to the supplied parent");
-	}
-
 	#[test]
 	fn end_to_end_write_cleanup_load() {
 		let backend = TestBackend::new();
@@ -552,10 +350,10 @@ mod tests {
 			prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, entry3.proof.clone()),
 		);
 
-		// Verify all three exist
-		assert!(load_entry(&backend, hash1).expect("load").is_some());
-		assert!(load_entry(&backend, hash2).expect("load").is_some());
-		assert!(load_entry(&backend, hash3).expect("load").is_some());
+		// Verify all three round-trip with value equality.
+		assert_eq!(load_entry(&backend, hash1).expect("load"), Some(entry1));
+		assert_eq!(load_entry(&backend, hash2).expect("load"), Some(entry2));
+		assert_eq!(load_entry(&backend, hash3).expect("load"), Some(entry3.clone()));
 
 		// Generate cleanup that deletes hash1 (just-finalized) and hash2 (in tree route).
 		let ops = aux_storage_cleanup(hash1, Hash::repeat_byte(0xF0), &[hash2], &[]);
@@ -565,9 +363,9 @@ mod tests {
 		// Apply deletes
 		AuxStore::insert_aux(&backend, &[], &delete_keys).expect("delete should succeed");
 
-		// Verify hash1 and hash2 deleted, hash3 survives
-		assert!(load_entry(&backend, hash1).expect("load").is_none(), "hash1 should be deleted");
-		assert!(load_entry(&backend, hash2).expect("load").is_none(), "hash2 should be deleted");
-		assert!(load_entry(&backend, hash3).expect("load").is_some(), "hash3 should survive");
+		// Verify hash1 and hash2 deleted, hash3 survives with original value intact.
+		assert_eq!(load_entry(&backend, hash1).expect("load"), None, "hash1 should be deleted");
+		assert_eq!(load_entry(&backend, hash2).expect("load"), None, "hash2 should be deleted");
+		assert_eq!(load_entry(&backend, hash3).expect("load"), Some(entry3), "hash3 should survive");
 	}
 }

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -35,21 +35,15 @@ use std::{
 	time::{SystemTime, UNIX_EPOCH},
 };
 
-const LOG_TARGET: &str = "cumulus-unincluded-segment-store";
 const UNINCLUDED_SEGMENT_STORE_VERSION: &[u8] = b"cumulus_unincluded_segment_store_version";
 const UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION: u32 = 1;
 
 /// Return the current Unix milliseconds timestamp.
-///
-/// Falls back to 0 if the system clock is before the Unix epoch.
 pub fn now_unix_ms() -> u64 {
-	match SystemTime::now().duration_since(UNIX_EPOCH) {
-		Ok(d) => d.as_millis() as u64,
-		Err(e) => {
-			tracing::warn!(target: LOG_TARGET, error = ?e, "system clock is before UNIX epoch; storing time_ms=0");
-			0
-		},
-	}
+	SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.expect("system clock is before UNIX epoch; qed")
+		.as_millis() as u64
 }
 
 /// Entry stored in aux storage for each unincluded parablock.
@@ -92,8 +86,7 @@ pub fn prepare_unincluded_segment_aux_data<H: Encode>(
 	proof: &StorageProof,
 ) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
 	let key = unincluded_segment_key(block_hash);
-	let mut encoded_entry = time_ms.encode();
-	proof.encode_to(&mut encoded_entry);
+	let encoded_entry = (time_ms, proof).encode();
 	let current_version = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
 
 	[(key, encoded_entry), (UNINCLUDED_SEGMENT_STORE_VERSION.to_vec(), current_version)].into_iter()
@@ -131,16 +124,19 @@ fn aux_storage_cleanup<H>(
 	just_finalized_hash: H,
 	old_finalized_hash: H,
 	tree_route: &[H],
-	stale_block_hashes: &[H],
+	stale_block_hashes: impl IntoIterator<Item = H>,
 ) -> AuxDataOperations
 where
 	H: Encode,
 {
-	let mut ops = Vec::with_capacity(stale_block_hashes.len() + tree_route.len() + 2);
-	ops.extend(stale_block_hashes.iter().map(|hash| (unincluded_segment_key(hash), None)));
+	let stale_iter = stale_block_hashes.into_iter();
+
+	let mut ops = Vec::with_capacity(stale_iter.size_hint().0 + tree_route.len() + 2);
+	ops.extend(stale_iter.map(|hash| (unincluded_segment_key(hash), None)));
 	ops.extend(tree_route.iter().map(|hash| (unincluded_segment_key(hash), None)));
 	ops.push((unincluded_segment_key(old_finalized_hash), None));
 	ops.push((unincluded_segment_key(just_finalized_hash), None));
+
 	ops
 }
 
@@ -161,10 +157,12 @@ where
 			*notification.header.parent_hash(),
 		);
 
-		let stale_block_hashes: Vec<_> = notification.stale_blocks.iter().map(|b| b.hash).collect();
-		let tree_route: Vec<_> = notification.tree_route.iter().copied().collect();
-
-		aux_storage_cleanup(notification.hash, old_finalized, &tree_route, &stale_block_hashes)
+		aux_storage_cleanup(
+			notification.hash,
+			old_finalized,
+			&notification.tree_route,
+			notification.stale_blocks.iter().map(|b| b.hash),
+		)
 	};
 
 	client.register_finality_action(Box::new(on_finality));
@@ -239,7 +237,7 @@ mod tests {
 			just_finalized,
 			old_finalized,
 			&[route_1, route_2],
-			&[stale_1, stale_2],
+			[stale_1, stale_2],
 		);
 
 		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
@@ -261,7 +259,8 @@ mod tests {
 		let just_finalized = Hash::repeat_byte(0xFF);
 		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[], &[]);
+		let ops =
+			aux_storage_cleanup(just_finalized, old_finalized, &[], std::iter::empty::<Hash>());
 
 		assert_eq!(ops.len(), 2);
 		assert!(ops.iter().all(|(_, v)| v.is_none()));
@@ -353,7 +352,12 @@ mod tests {
 		assert_eq!(load_entry(&backend, hash3).expect("load"), Some(entry3.clone()));
 
 		// Generate cleanup that deletes hash1 (just-finalized) and hash2 (in tree route).
-		let ops = aux_storage_cleanup(hash1, Hash::repeat_byte(0xF0), &[hash2], &[]);
+		let ops = aux_storage_cleanup(
+			hash1,
+			Hash::repeat_byte(0xF0),
+			&[hash2],
+			std::iter::empty::<Hash>(),
+		);
 		let delete_keys: Vec<_> =
 			ops.iter().filter_map(|(k, v)| v.is_none().then(|| k.as_slice())).collect();
 

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -89,11 +89,11 @@ where
 pub fn prepare_unincluded_segment_aux_data<H: Encode>(
 	block_hash: H,
 	time_ms: u64,
-	proof: StorageProof,
+	proof: &StorageProof,
 ) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
-	let entry = StoredEntry { time_ms, proof };
 	let key = unincluded_segment_key(block_hash);
-	let encoded_entry = entry.encode();
+	let mut encoded_entry = time_ms.encode();
+	proof.encode_to(&mut encoded_entry);
 	let current_version = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
 
 	[(key, encoded_entry), (UNINCLUDED_SEGMENT_STORE_VERSION.to_vec(), current_version)].into_iter()
@@ -196,8 +196,7 @@ mod tests {
 		let time_ms = 1234567890u64;
 		let proof = StorageProof::new(vec![vec![10, 20, 30]]);
 
-		let pairs: Vec<_> =
-			prepare_unincluded_segment_aux_data(hash, time_ms, proof.clone()).collect();
+		let pairs: Vec<_> = prepare_unincluded_segment_aux_data(hash, time_ms, &proof).collect();
 
 		assert_eq!(pairs.len(), 2);
 
@@ -271,10 +270,8 @@ mod tests {
 	#[test]
 	fn stored_entry_encoding_hex_snapshot() {
 		// Canonical entry for hex snapshot
-		let entry = StoredEntry {
-			time_ms: 1234567890u64,
-			proof: StorageProof::new(vec![vec![1, 2, 3]]),
-		};
+		let entry =
+			StoredEntry { time_ms: 1234567890u64, proof: StorageProof::new(vec![vec![1, 2, 3]]) };
 
 		let encoded = entry.encode();
 		// Snapshot of the SCALE encoding. If this assertion fires, the on-disk format of
@@ -339,15 +336,15 @@ mod tests {
 
 		write_aux_data(
 			&backend,
-			prepare_unincluded_segment_aux_data(hash1, entry1.time_ms, entry1.proof.clone()),
+			prepare_unincluded_segment_aux_data(hash1, entry1.time_ms, &entry1.proof),
 		);
 		write_aux_data(
 			&backend,
-			prepare_unincluded_segment_aux_data(hash2, entry2.time_ms, entry2.proof.clone()),
+			prepare_unincluded_segment_aux_data(hash2, entry2.time_ms, &entry2.proof),
 		);
 		write_aux_data(
 			&backend,
-			prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, entry3.proof.clone()),
+			prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, &entry3.proof),
 		);
 
 		// Verify all three round-trip with value equality.
@@ -366,6 +363,10 @@ mod tests {
 		// Verify hash1 and hash2 deleted, hash3 survives with original value intact.
 		assert_eq!(load_entry(&backend, hash1).expect("load"), None, "hash1 should be deleted");
 		assert_eq!(load_entry(&backend, hash2).expect("load"), None, "hash2 should be deleted");
-		assert_eq!(load_entry(&backend, hash3).expect("load"), Some(entry3), "hash3 should survive");
+		assert_eq!(
+			load_entry(&backend, hash3).expect("load"),
+			Some(entry3),
+			"hash3 should survive"
+		);
 	}
 }

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -17,8 +17,8 @@
 
 //! Per-block proof store for unincluded segment resubmission.
 //!
-//! Persists `(time, session, StorageProof)` per parablock built by a slot-based collator,
-//! keyed by parablock hash. Data is pruned on parachain finality.
+//! Persists `(time, StorageProof)` per imported parablock, keyed by parablock hash. Data is
+//! pruned on parachain finality.
 
 use codec::{Decode, Encode};
 use sc_client_api::{
@@ -28,7 +28,6 @@ use sc_client_api::{
 };
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_runtime::traits::{Block as BlockT, Header as _};
-use sp_staking::SessionIndex;
 use sp_trie::StorageProof;
 use std::{
 	sync::Arc,
@@ -57,9 +56,6 @@ pub fn now_unix_ms() -> u64 {
 pub struct StoredEntry {
 	/// Unix millis at the moment block_import started.
 	pub time_ms: u64,
-	/// SessionIndex of the relay parent.
-	/// TODO: Will be populated once paritytech/polkadot-sdk#11624 lands.
-	pub session: Option<SessionIndex>,
 	/// The storage proof captured at block_import.
 	pub proof: StorageProof,
 }
@@ -92,10 +88,9 @@ where
 pub fn prepare_unincluded_segment_aux_data<H: Encode>(
 	block_hash: H,
 	time_ms: u64,
-	session: Option<SessionIndex>,
 	proof: StorageProof,
 ) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
-	let entry = StoredEntry { time_ms, session, proof };
+	let entry = StoredEntry { time_ms, proof };
 	let key = unincluded_segment_key(block_hash);
 	let encoded_entry = entry.encode();
 	let current_version = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
@@ -148,13 +143,15 @@ where
 
 /// Compute aux storage cleanup operations.
 ///
-/// Emits deletes for stale blocks, intermediate tree-route blocks, and the pre-finality head.
-/// The just-finalized block is NOT deleted; it will be deleted by the next finality round via
-/// `old_finalized_hash`, kept for one round for parity with the ignored-nodes cleanup pattern.
+/// Emits deletes for stale-fork blocks, intermediate tree-route blocks, the pre-finality head,
+/// and the just-finalized block itself. Once a block is finalized it is no longer in any
+/// unincluded segment, so its proof entry is dead weight.
 ///
-/// TODO(#12034): once SessionIndex is populated (waiting on #11624), also prune entries whose
-/// stored `session` is older than `max_relay_parent_session_age` relative to the current session.
+/// TODO(#12034): also prune entries whose relay-parent session is older than
+/// `max_relay_parent_session_age` relative to the current session. Session info will be sourced
+/// from a separate session-data cache (see #11624), not from per-entry storage.
 fn aux_storage_cleanup<H>(
+	just_finalized_hash: H,
 	old_finalized_hash: H,
 	tree_route: &[H],
 	stale_block_hashes: &[H],
@@ -162,10 +159,11 @@ fn aux_storage_cleanup<H>(
 where
 	H: Encode,
 {
-	let mut ops = Vec::with_capacity(stale_block_hashes.len() + tree_route.len() + 1);
+	let mut ops = Vec::with_capacity(stale_block_hashes.len() + tree_route.len() + 2);
 	ops.extend(stale_block_hashes.iter().map(|hash| (unincluded_segment_key(hash), None)));
 	ops.extend(tree_route.iter().map(|hash| (unincluded_segment_key(hash), None)));
 	ops.push((unincluded_segment_key(old_finalized_hash), None));
+	ops.push((unincluded_segment_key(just_finalized_hash), None));
 	ops
 }
 
@@ -189,7 +187,7 @@ where
 		let stale_block_hashes: Vec<_> = notification.stale_blocks.iter().map(|b| b.hash).collect();
 		let tree_route: Vec<_> = notification.tree_route.iter().copied().collect();
 
-		aux_storage_cleanup(old_finalized, &tree_route, &stale_block_hashes)
+		aux_storage_cleanup(notification.hash, old_finalized, &tree_route, &stale_block_hashes)
 	};
 
 	client.register_finality_action(Box::new(on_finality));
@@ -205,11 +203,7 @@ mod tests {
 	type TestBackend = sc_client_api::in_mem::Backend<Block>;
 
 	fn create_test_entry(time_ms: u64) -> StoredEntry {
-		StoredEntry {
-			time_ms,
-			session: Some(42),
-			proof: StorageProof::new(vec![vec![1, 2, 3], vec![4, 5, 6]]),
-		}
+		StoredEntry { time_ms, proof: StorageProof::new(vec![vec![1, 2, 3], vec![4, 5, 6]]) }
 	}
 
 	fn write_aux_data(backend: &TestBackend, data: impl Iterator<Item = (Vec<u8>, Vec<u8>)>) {
@@ -223,11 +217,10 @@ mod tests {
 	fn prepare_produces_expected_key_value_pairs() {
 		let hash = Hash::repeat_byte(0xAB);
 		let time_ms = 1234567890u64;
-		let session = Some(5u32);
 		let proof = StorageProof::new(vec![vec![10, 20, 30]]);
 
 		let pairs: Vec<_> =
-			prepare_unincluded_segment_aux_data(hash, time_ms, session, proof.clone()).collect();
+			prepare_unincluded_segment_aux_data(hash, time_ms, proof.clone()).collect();
 
 		assert_eq!(pairs.len(), 2);
 
@@ -239,7 +232,6 @@ mod tests {
 		let decoded_entry =
 			StoredEntry::decode(&mut pairs[0].1.as_slice()).expect("entry should decode");
 		assert_eq!(decoded_entry.time_ms, time_ms);
-		assert_eq!(decoded_entry.session, session);
 		assert_eq!(decoded_entry.proof, proof);
 
 		// Second pair is the version
@@ -256,12 +248,8 @@ mod tests {
 		let entry = create_test_entry(999888777);
 
 		// Write via prepare + manual insert
-		let aux_data = prepare_unincluded_segment_aux_data(
-			hash,
-			entry.time_ms,
-			entry.session,
-			entry.proof.clone(),
-		);
+		let aux_data =
+			prepare_unincluded_segment_aux_data(hash, entry.time_ms, entry.proof.clone());
 		write_aux_data(&backend, aux_data);
 
 		// Load back
@@ -310,12 +298,13 @@ mod tests {
 	}
 
 	#[test]
-	fn aux_storage_cleanup_includes_stale_blocks() {
+	fn cleanup_deletes_stale_blocks() {
 		let stale_1 = Hash::repeat_byte(0xAA);
 		let stale_2 = Hash::repeat_byte(0xBB);
+		let just_finalized = Hash::repeat_byte(0xFF);
 		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let ops = aux_storage_cleanup(old_finalized, &[], &[stale_1, stale_2]);
+		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[], &[stale_1, stale_2]);
 
 		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
 		assert!(keys.contains(&unincluded_segment_key(stale_1)));
@@ -326,12 +315,13 @@ mod tests {
 	}
 
 	#[test]
-	fn aux_storage_cleanup_includes_tree_route() {
+	fn cleanup_deletes_tree_route() {
 		let route_1 = Hash::repeat_byte(0xC1);
 		let route_2 = Hash::repeat_byte(0xC2);
+		let just_finalized = Hash::repeat_byte(0xFF);
 		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let ops = aux_storage_cleanup(old_finalized, &[route_1, route_2], &[]);
+		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[route_1, route_2], &[]);
 
 		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
 		assert!(keys.contains(&unincluded_segment_key(route_1)));
@@ -342,18 +332,21 @@ mod tests {
 	}
 
 	#[test]
-	fn aux_storage_cleanup_includes_old_finalized() {
+	fn cleanup_deletes_old_and_just_finalized() {
+		let just_finalized = Hash::repeat_byte(0xFF);
 		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let ops = aux_storage_cleanup(old_finalized, &[], &[]);
+		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[], &[]);
 
-		assert_eq!(ops.len(), 1);
-		assert_eq!(ops[0].0, unincluded_segment_key(old_finalized));
-		assert!(ops[0].1.is_none());
+		assert_eq!(ops.len(), 2);
+		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
+		assert!(keys.contains(&unincluded_segment_key(old_finalized)));
+		assert!(keys.contains(&unincluded_segment_key(just_finalized)));
+		assert!(ops.iter().all(|(_, v)| v.is_none()));
 	}
 
 	#[test]
-	fn aux_storage_cleanup_combines_all_three() {
+	fn cleanup_combines_all_categories() {
 		let stale_1 = Hash::repeat_byte(0xAA);
 		let stale_2 = Hash::repeat_byte(0xBB);
 		let route_1 = Hash::repeat_byte(0xC1);
@@ -361,33 +354,36 @@ mod tests {
 		let old_finalized = Hash::repeat_byte(0xF0);
 		let just_finalized = Hash::repeat_byte(0xFF);
 
-		let ops = aux_storage_cleanup(old_finalized, &[route_1, route_2], &[stale_1, stale_2]);
+		let ops = aux_storage_cleanup(
+			just_finalized,
+			old_finalized,
+			&[route_1, route_2],
+			&[stale_1, stale_2],
+		);
 
 		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
 
-		// Verify all expected keys are present
+		// Verify all expected keys are present (including the just-finalized block).
 		assert!(keys.contains(&unincluded_segment_key(stale_1)));
 		assert!(keys.contains(&unincluded_segment_key(stale_2)));
 		assert!(keys.contains(&unincluded_segment_key(route_1)));
 		assert!(keys.contains(&unincluded_segment_key(route_2)));
 		assert!(keys.contains(&unincluded_segment_key(old_finalized)));
-
-		// Verify the just-finalized block is NOT in the output
-		assert!(!keys.contains(&unincluded_segment_key(just_finalized)));
+		assert!(keys.contains(&unincluded_segment_key(just_finalized)));
 
 		// Verify all values are None (deletes)
 		assert!(ops.iter().all(|(_, v)| v.is_none()));
 	}
 
 	#[test]
-	fn aux_storage_cleanup_handles_empty_inputs() {
+	fn cleanup_handles_empty_inputs() {
+		let just_finalized = Hash::repeat_byte(0xFF);
 		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let ops = aux_storage_cleanup(old_finalized, &[], &[]);
+		let ops = aux_storage_cleanup(just_finalized, old_finalized, &[], &[]);
 
-		assert_eq!(ops.len(), 1);
-		assert_eq!(ops[0].0, unincluded_segment_key(old_finalized));
-		assert!(ops[0].1.is_none());
+		assert_eq!(ops.len(), 2);
+		assert!(ops.iter().all(|(_, v)| v.is_none()));
 	}
 
 	#[test]
@@ -395,7 +391,6 @@ mod tests {
 		// Canonical entry for hex snapshot
 		let entry = StoredEntry {
 			time_ms: 1234567890u64,
-			session: Some(42u32),
 			proof: StorageProof::new(vec![vec![1, 2, 3]]),
 		};
 
@@ -404,8 +399,12 @@ mod tests {
 		// `StoredEntry` has changed and existing aux entries written by older builds will fail to
 		// decode — bump `UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION` and add a migration before
 		// updating this snapshot.
-		let expected_hex = "d202964900000000012a000000040c010203";
-		assert_eq!(hex::encode(&encoded), expected_hex, "StoredEntry encoding changed!");
+		let encoded_hex = hex::encode(&encoded);
+		// time_ms = 1234567890 little-endian u64 = d2 02 96 49 00 00 00 00
+		// proof   = Vec<Vec<u8>> with one element [1,2,3]: outer len 1 (SCALE compact = 04),
+		//           inner len 3 (compact = 0c), bytes 01 02 03
+		let expected_hex = "d20296490000000004 0c 010203".replace(' ', "");
+		assert_eq!(encoded_hex, expected_hex, "StoredEntry encoding changed!");
 
 		// Verify it decodes back correctly
 		let decoded = StoredEntry::decode(&mut encoded.as_slice()).expect("decode should succeed");
@@ -540,18 +539,28 @@ mod tests {
 		let entry2 = create_test_entry(2000);
 		let entry3 = create_test_entry(3000);
 
-		write_aux_data(&backend, prepare_unincluded_segment_aux_data(hash1, entry1.time_ms, entry1.session, entry1.proof.clone()));
-		write_aux_data(&backend, prepare_unincluded_segment_aux_data(hash2, entry2.time_ms, entry2.session, entry2.proof.clone()));
-		write_aux_data(&backend, prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, entry3.session, entry3.proof.clone()));
+		write_aux_data(
+			&backend,
+			prepare_unincluded_segment_aux_data(hash1, entry1.time_ms, entry1.proof.clone()),
+		);
+		write_aux_data(
+			&backend,
+			prepare_unincluded_segment_aux_data(hash2, entry2.time_ms, entry2.proof.clone()),
+		);
+		write_aux_data(
+			&backend,
+			prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, entry3.proof.clone()),
+		);
 
 		// Verify all three exist
 		assert!(load_entry(&backend, hash1).expect("load").is_some());
 		assert!(load_entry(&backend, hash2).expect("load").is_some());
 		assert!(load_entry(&backend, hash3).expect("load").is_some());
 
-		// Generate cleanup for hash1 and hash2
-		let ops = aux_storage_cleanup(hash1, &[hash2], &[]);
-		let delete_keys: Vec<_> = ops.iter().filter_map(|(k, v)| v.is_none().then(|| k.as_slice())).collect();
+		// Generate cleanup that deletes hash1 (just-finalized) and hash2 (in tree route).
+		let ops = aux_storage_cleanup(hash1, Hash::repeat_byte(0xF0), &[hash2], &[]);
+		let delete_keys: Vec<_> =
+			ops.iter().filter_map(|(k, v)| v.is_none().then(|| k.as_slice())).collect();
 
 		// Apply deletes
 		AuxStore::insert_aux(&backend, &[], &delete_keys).expect("delete should succeed");

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -107,46 +107,22 @@ pub fn load_proof<H: Encode, B: AuxStore>(
 	}
 }
 
-/// Compute aux storage cleanup operations for a finality notification.
+/// Compute aux storage cleanup operations.
 ///
-/// Deletes entries for:
-/// - All stale blocks (loser forks)
-/// - All blocks on the tree route to the finalized head (intermediate finalized blocks)
-/// - The old finalized block (parent of the first tree route block, or parent of finalized)
-///
-/// Does NOT delete the just-finalized block, since new blocks can still be imported on top of it.
-fn aux_storage_cleanup<Block, C>(
-	notification: &FinalityNotification<Block>,
-	client: &C,
+/// Emits deletes for stale blocks, intermediate tree-route blocks, and the pre-finality head;
+/// does NOT delete the just-finalized block since it can still receive children.
+fn aux_storage_cleanup<H>(
+	old_finalized_hash: H,
+	tree_route: &[H],
+	stale_block_hashes: &[H],
 ) -> AuxDataOperations
 where
-	Block: BlockT,
-	C: HeaderBackend<Block>,
+	H: Encode + Copy,
 {
-	// The old finalized block is the parent of the first block in the tree route,
-	// or the parent of the finalized block if the tree route is empty.
-	let old_finalized_hash = notification
-		.tree_route
-		.first()
-		.and_then(|hash| client.header(*hash).ok().flatten())
-		.map(|h| *h.parent_hash())
-		.unwrap_or_else(|| *notification.header.parent_hash());
-
-	notification
-		.stale_blocks
+	stale_block_hashes
 		.iter()
-		// Delete entries for all stale blocks.
-		.map(|b| (unincluded_segment_key(b.hash), None))
-		// Delete entries for blocks on the route to the finalized parent.
-		// These can no longer become parents for new blocks.
-		.chain(
-			notification
-				.tree_route
-				.iter()
-				.copied()
-				.map(|hash| (unincluded_segment_key(hash), None)),
-		)
-		// Delete the old finalized block's entry.
+		.map(|hash| (unincluded_segment_key(*hash), None))
+		.chain(tree_route.iter().map(|hash| (unincluded_segment_key(*hash), None)))
 		.chain(std::iter::once((unincluded_segment_key(old_finalized_hash), None)))
 		.collect()
 }
@@ -162,7 +138,19 @@ where
 {
 	let client_for_closure = client.clone();
 	let on_finality = move |notification: &FinalityNotification<Block>| -> AuxDataOperations {
-		aux_storage_cleanup(notification, &*client_for_closure)
+		// The old finalized block is the parent of the first block in the tree route,
+		// or the parent of the finalized block if the tree route is empty.
+		let old_finalized_hash = notification
+			.tree_route
+			.first()
+			.and_then(|hash| client_for_closure.header(*hash).ok().flatten())
+			.map(|h| *h.parent_hash())
+			.unwrap_or_else(|| *notification.header.parent_hash());
+
+		let stale_block_hashes: Vec<_> = notification.stale_blocks.iter().map(|b| b.hash).collect();
+		let tree_route: Vec<_> = notification.tree_route.iter().copied().collect();
+
+		aux_storage_cleanup(old_finalized_hash, &tree_route, &stale_block_hashes)
 	};
 
 	client.register_finality_action(Box::new(on_finality));
@@ -283,65 +271,84 @@ mod tests {
 	}
 
 	#[test]
-	fn cleanup_computes_correct_deletions() {
-		let backend = TestBackend::new();
+	fn aux_storage_cleanup_includes_stale_blocks() {
+		let stale_1 = Hash::repeat_byte(0xAA);
+		let stale_2 = Hash::repeat_byte(0xBB);
+		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let hash_c = Hash::repeat_byte(0xCC);
-		let hash_genesis = Hash::repeat_byte(0x00);
+		let ops = aux_storage_cleanup(old_finalized, &[], &[stale_1, stale_2]);
 
-		// Expected keys to delete:
-		let expected_stale_key = unincluded_segment_key(hash_c);
-		let expected_old_finalized_key = unincluded_segment_key(hash_genesis);
+		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
+		assert!(keys.contains(&unincluded_segment_key(stale_1)));
+		assert!(keys.contains(&unincluded_segment_key(stale_2)));
 
-		// Verify key format
-		assert_eq!(expected_stale_key, (b"cumulus_unincluded_segment_store", hash_c).encode());
-		assert_eq!(
-			expected_old_finalized_key,
-			(b"cumulus_unincluded_segment_store", hash_genesis).encode()
-		);
-
-		// Test that entries can be written and then "deleted" (set to None)
-		let entry = create_test_entry(111);
-		let key_c = unincluded_segment_key(hash_c);
-		AuxStore::insert_aux(&backend, &[(&key_c[..], entry.encode().as_slice())], &[])
-			.expect("insert should succeed");
-
-		// Verify entry exists
-		assert!(AuxStore::get_aux(&backend, &key_c).expect("get should succeed").is_some());
-
-		// Simulate deletion via AuxDataOperations
-		let delete_ops: AuxDataOperations = vec![(key_c.clone(), None)];
-		let deletes: Vec<&[u8]> = delete_ops
-			.iter()
-			.filter_map(|(k, v)| if v.is_none() { Some(k.as_slice()) } else { None })
-			.collect();
-		AuxStore::insert_aux(&backend, &[], &deletes).expect("delete should succeed");
-
-		// Verify entry is gone
-		assert!(AuxStore::get_aux(&backend, &key_c).expect("get should succeed").is_none());
+		// Verify all values are None (deletes)
+		assert!(ops.iter().all(|(_, v)| v.is_none()));
 	}
 
 	#[test]
-	fn cleanup_with_tree_route() {
-		// Test that cleanup includes tree_route blocks in deletions.
-		// This tests the logic without needing a real FinalityNotification.
+	fn aux_storage_cleanup_includes_tree_route() {
+		let route_1 = Hash::repeat_byte(0xC1);
+		let route_2 = Hash::repeat_byte(0xC2);
+		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let hash_a = Hash::repeat_byte(0xAA);
-		let hash_b = Hash::repeat_byte(0xBB);
-		let hash_c = Hash::repeat_byte(0xCC);
+		let ops = aux_storage_cleanup(old_finalized, &[route_1, route_2], &[]);
 
-		// Generate keys for tree_route blocks
-		let key_a = unincluded_segment_key(hash_a);
-		let key_b = unincluded_segment_key(hash_b);
-		let key_c = unincluded_segment_key(hash_c);
+		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
+		assert!(keys.contains(&unincluded_segment_key(route_1)));
+		assert!(keys.contains(&unincluded_segment_key(route_2)));
 
-		// All keys should be distinct
-		assert_ne!(key_a, key_b);
-		assert_ne!(key_b, key_c);
-		assert_ne!(key_a, key_c);
+		// Verify all values are None (deletes)
+		assert!(ops.iter().all(|(_, v)| v.is_none()));
+	}
 
-		// Keys should be deterministic
-		assert_eq!(key_a, unincluded_segment_key(hash_a));
+	#[test]
+	fn aux_storage_cleanup_includes_old_finalized() {
+		let old_finalized = Hash::repeat_byte(0xF0);
+
+		let ops = aux_storage_cleanup(old_finalized, &[], &[]);
+
+		assert_eq!(ops.len(), 1);
+		assert_eq!(ops[0].0, unincluded_segment_key(old_finalized));
+		assert!(ops[0].1.is_none());
+	}
+
+	#[test]
+	fn aux_storage_cleanup_combines_all_three() {
+		let stale_1 = Hash::repeat_byte(0xAA);
+		let stale_2 = Hash::repeat_byte(0xBB);
+		let route_1 = Hash::repeat_byte(0xC1);
+		let route_2 = Hash::repeat_byte(0xC2);
+		let old_finalized = Hash::repeat_byte(0xF0);
+		let just_finalized = Hash::repeat_byte(0xFF);
+
+		let ops = aux_storage_cleanup(old_finalized, &[route_1, route_2], &[stale_1, stale_2]);
+
+		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
+
+		// Verify all expected keys are present
+		assert!(keys.contains(&unincluded_segment_key(stale_1)));
+		assert!(keys.contains(&unincluded_segment_key(stale_2)));
+		assert!(keys.contains(&unincluded_segment_key(route_1)));
+		assert!(keys.contains(&unincluded_segment_key(route_2)));
+		assert!(keys.contains(&unincluded_segment_key(old_finalized)));
+
+		// Verify the just-finalized block is NOT in the output
+		assert!(!keys.contains(&unincluded_segment_key(just_finalized)));
+
+		// Verify all values are None (deletes)
+		assert!(ops.iter().all(|(_, v)| v.is_none()));
+	}
+
+	#[test]
+	fn aux_storage_cleanup_handles_empty_inputs() {
+		let old_finalized = Hash::repeat_byte(0xF0);
+
+		let ops = aux_storage_cleanup(old_finalized, &[], &[]);
+
+		assert_eq!(ops.len(), 1);
+		assert_eq!(ops[0].0, unincluded_segment_key(old_finalized));
+		assert!(ops[0].1.is_none());
 	}
 
 	#[test]

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -31,12 +31,14 @@ use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_runtime::traits::{Block as BlockT, Header as _};
 use sp_trie::StorageProof;
 use std::{
+	marker::PhantomData,
 	sync::Arc,
 	time::{SystemTime, UNIX_EPOCH},
 };
 
-const UNINCLUDED_SEGMENT_STORE_VERSION: &[u8] = b"cumulus_unincluded_segment_store_version";
-const UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION: u32 = 1;
+const STORE_VERSION_KEY: &[u8] = b"cumulus_unincluded_segment_store_version";
+const STORE_CURRENT_VERSION: u32 = 1;
+const STORE_ENTRY_PREFIX: &[u8] = b"cumulus_unincluded_segment_store";
 
 /// Return the current Unix milliseconds timestamp.
 pub fn now_unix_ms() -> u64 {
@@ -55,59 +57,102 @@ pub struct StoredEntry {
 	pub proof: StorageProof,
 }
 
-/// The aux storage key used to store the unincluded segment data for the given block hash.
-fn unincluded_segment_key<H: Encode>(block_hash: H) -> Vec<u8> {
-	(b"cumulus_unincluded_segment_store", block_hash).encode()
+fn entry_key<H: Encode>(block_hash: H) -> Vec<u8> {
+	(STORE_ENTRY_PREFIX, block_hash).encode()
 }
 
-fn load_decode<B, T>(backend: &B, key: &[u8]) -> ClientResult<Option<T>>
-where
-	B: AuxStore,
-	T: Decode,
-{
-	match backend.get_aux(key)? {
-		None => Ok(None),
-		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(|e| {
-			ClientError::Backend(format!(
-				"Unincluded segment store DB is corrupted. Decode error: {}",
-				e
-			))
-		}),
+/// Per-block proof store backed by `AuxStore`.
+pub struct UnincludedSegmentStore<Block: BlockT, B> {
+	backend: Arc<B>,
+	_marker: PhantomData<fn() -> Block>,
+}
+
+impl<Block: BlockT, B> Clone for UnincludedSegmentStore<Block, B> {
+	fn clone(&self) -> Self {
+		Self { backend: self.backend.clone(), _marker: PhantomData }
 	}
 }
 
-/// Prepare aux storage key-value pairs for persisting unincluded segment data.
+impl<Block: BlockT, B> UnincludedSegmentStore<Block, B> {
+	/// Create a new store over `backend`.
+	pub fn new(backend: Arc<B>) -> Self {
+		Self { backend, _marker: PhantomData }
+	}
+}
+
+/// Build the aux-data key/value pairs to commit alongside a block.
 ///
-/// The caller should push these into `BlockImportParams::auxiliary` so they commit
-/// in the same DB transaction as the block.
-pub fn prepare_unincluded_segment_aux_data<H: Encode>(
-	block_hash: H,
+/// The caller should push these into `BlockImportParams::auxiliary` so they commit in the
+/// same DB transaction as the block. Stateless — no backend access required.
+pub fn prepare_aux_data<Block: BlockT>(
+	block_hash: Block::Hash,
 	time_ms: u64,
 	proof: &StorageProof,
 ) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
-	let key = unincluded_segment_key(block_hash);
 	let encoded_entry = (time_ms, proof).encode();
-	let current_version = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
+	let encoded_version = STORE_CURRENT_VERSION.encode();
 
-	[(key, encoded_entry), (UNINCLUDED_SEGMENT_STORE_VERSION.to_vec(), current_version)].into_iter()
+	[(entry_key(block_hash), encoded_entry), (STORE_VERSION_KEY.to_vec(), encoded_version)]
+		.into_iter()
 }
 
-/// Load the unincluded segment entry associated with a block.
-pub fn load_entry<H: Encode, B: AuxStore>(
-	backend: &B,
-	block_hash: H,
-) -> ClientResult<Option<StoredEntry>> {
-	let version = load_decode::<_, u32>(backend, UNINCLUDED_SEGMENT_STORE_VERSION)?;
+impl<Block: BlockT, B: AuxStore> UnincludedSegmentStore<Block, B> {
+	/// Load the entry stored for `block_hash`, if any.
+	pub fn load(&self, block_hash: Block::Hash) -> ClientResult<Option<StoredEntry>> {
+		let version = self.decode_aux::<u32>(STORE_VERSION_KEY)?;
 
-	match version {
-		None => Ok(None),
-		Some(UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION) => {
-			load_decode(backend, unincluded_segment_key(block_hash).as_slice())
-		},
-		Some(other) => Err(ClientError::Backend(format!(
-			"Unsupported unincluded segment store DB version: {:?}",
-			other
-		))),
+		match version {
+			None => Ok(None),
+			Some(STORE_CURRENT_VERSION) => self.decode_aux(entry_key(block_hash).as_slice()),
+			Some(other) => Err(ClientError::Backend(format!(
+				"Unsupported unincluded segment store DB version: {:?}",
+				other
+			))),
+		}
+	}
+
+	fn decode_aux<T: Decode>(&self, key: &[u8]) -> ClientResult<Option<T>> {
+		match self.backend.get_aux(key)? {
+			None => Ok(None),
+			Some(t) => T::decode(&mut &t[..]).map(Some).map_err(|e| {
+				ClientError::Backend(format!(
+					"Unincluded segment store DB is corrupted. Decode error: {}",
+					e
+				))
+			}),
+		}
+	}
+}
+
+impl<Block, B> UnincludedSegmentStore<Block, B>
+where
+	Block: BlockT,
+	B: PreCommitActions<Block> + HeaderBackend<Block> + 'static,
+{
+	/// Register a finality hook that prunes entries for the just-finalized chain, the
+	/// intermediate tree route, the prior finalized head, and any stale forks.
+	///
+	/// TODO(#12034): also prune entries whose relay-parent session is older than
+	/// `max_relay_parent_session_age` relative to the current session. Session info will be
+	/// sourced from a separate session-data cache (see #11624), not from per-entry storage.
+	pub fn register_cleanup(&self) {
+		let client = self.backend.clone();
+		let on_finality = move |notification: &FinalityNotification<Block>| -> AuxDataOperations {
+			let old_finalized = old_finalized_hash::<_, Block>(
+				&*client,
+				&notification.tree_route,
+				*notification.header.parent_hash(),
+			);
+
+			finality_cleanup_ops::<Block>(
+				notification.hash,
+				old_finalized,
+				&notification.tree_route,
+				notification.stale_blocks.iter().map(|b| b.hash),
+			)
+		};
+
+		self.backend.register_finality_action(Box::new(on_finality));
 	}
 }
 
@@ -116,56 +161,21 @@ pub fn load_entry<H: Encode, B: AuxStore>(
 /// Emits deletes for stale-fork blocks, intermediate tree-route blocks, the pre-finality head,
 /// and the just-finalized block itself. Once a block is finalized it is no longer in any
 /// unincluded segment, so its proof entry is dead weight.
-///
-/// TODO(#12034): also prune entries whose relay-parent session is older than
-/// `max_relay_parent_session_age` relative to the current session. Session info will be sourced
-/// from a separate session-data cache (see #11624), not from per-entry storage.
-fn aux_storage_cleanup<H>(
-	just_finalized_hash: H,
-	old_finalized_hash: H,
-	tree_route: &[H],
-	stale_block_hashes: impl IntoIterator<Item = H>,
-) -> AuxDataOperations
-where
-	H: Encode,
-{
+fn finality_cleanup_ops<Block: BlockT>(
+	just_finalized_hash: Block::Hash,
+	old_finalized_hash: Block::Hash,
+	tree_route: &[Block::Hash],
+	stale_block_hashes: impl IntoIterator<Item = Block::Hash>,
+) -> AuxDataOperations {
 	let stale_iter = stale_block_hashes.into_iter();
 
 	let mut ops = Vec::with_capacity(stale_iter.size_hint().0 + tree_route.len() + 2);
-	ops.extend(stale_iter.map(|hash| (unincluded_segment_key(hash), None)));
-	ops.extend(tree_route.iter().map(|hash| (unincluded_segment_key(hash), None)));
-	ops.push((unincluded_segment_key(old_finalized_hash), None));
-	ops.push((unincluded_segment_key(just_finalized_hash), None));
+	ops.extend(stale_iter.map(|hash| (entry_key(hash), None)));
+	ops.extend(tree_route.iter().map(|hash| (entry_key(hash), None)));
+	ops.push((entry_key(old_finalized_hash), None));
+	ops.push((entry_key(just_finalized_hash), None));
 
 	ops
-}
-
-/// Register a finality action for cleaning up unincluded segment data.
-///
-/// This should be called during consensus initialization to automatically clean up
-/// unincluded segment data when blocks are finalized.
-pub fn register_unincluded_segment_cleanup<C, Block>(client: Arc<C>)
-where
-	C: PreCommitActions<Block> + HeaderBackend<Block> + 'static,
-	Block: BlockT,
-{
-	let client_for_closure = client.clone();
-	let on_finality = move |notification: &FinalityNotification<Block>| -> AuxDataOperations {
-		let old_finalized = old_finalized_hash::<_, Block>(
-			&*client_for_closure,
-			&notification.tree_route,
-			*notification.header.parent_hash(),
-		);
-
-		aux_storage_cleanup(
-			notification.hash,
-			old_finalized,
-			&notification.tree_route,
-			notification.stale_blocks.iter().map(|b| b.hash),
-		)
-	};
-
-	client.register_finality_action(Box::new(on_finality));
 }
 
 #[cfg(test)]
@@ -176,16 +186,23 @@ mod tests {
 	type Block = substrate_test_runtime::Block;
 	type Hash = <Block as BlockT>::Hash;
 	type TestBackend = sc_client_api::in_mem::Backend<Block>;
+	type Store = UnincludedSegmentStore<Block, TestBackend>;
 
 	fn create_test_entry(time_ms: u64) -> StoredEntry {
 		StoredEntry { time_ms, proof: StorageProof::new(vec![vec![1, 2, 3], vec![4, 5, 6]]) }
 	}
 
-	fn write_aux_data(backend: &TestBackend, data: impl Iterator<Item = (Vec<u8>, Vec<u8>)>) {
-		let pairs: Vec<_> = data.collect();
+	fn new_store() -> (Arc<TestBackend>, Store) {
+		let backend = Arc::new(TestBackend::new());
+		let store = Store::new(backend.clone());
+		(backend, store)
+	}
+
+	fn write_via_store(backend: &Arc<TestBackend>, hash: Hash, entry: &StoredEntry) {
+		let pairs: Vec<_> = prepare_aux_data::<Block>(hash, entry.time_ms, &entry.proof).collect();
 		let insert_pairs: Vec<_> =
 			pairs.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect();
-		AuxStore::insert_aux(backend, &insert_pairs, &[]).expect("aux insert should succeed");
+		AuxStore::insert_aux(&**backend, &insert_pairs, &[]).expect("aux insert should succeed");
 	}
 
 	#[test]
@@ -194,34 +211,30 @@ mod tests {
 		let time_ms = 1234567890u64;
 		let proof = StorageProof::new(vec![vec![10, 20, 30]]);
 
-		let pairs: Vec<_> = prepare_unincluded_segment_aux_data(hash, time_ms, &proof).collect();
+		let pairs: Vec<_> = prepare_aux_data::<Block>(hash, time_ms, &proof).collect();
 
 		assert_eq!(pairs.len(), 2);
 
-		// First pair is the entry
-		let expected_key = (b"cumulus_unincluded_segment_store", hash).encode();
+		let expected_key = (STORE_ENTRY_PREFIX, hash).encode();
 		assert_eq!(pairs[0].0, expected_key);
 
-		// Verify entry decodes correctly
 		let decoded_entry =
 			StoredEntry::decode(&mut pairs[0].1.as_slice()).expect("entry should decode");
 		assert_eq!(decoded_entry.time_ms, time_ms);
 		assert_eq!(decoded_entry.proof, proof);
 
-		// Second pair is the version
-		assert_eq!(pairs[1].0, UNINCLUDED_SEGMENT_STORE_VERSION.to_vec());
+		assert_eq!(pairs[1].0, STORE_VERSION_KEY.to_vec());
 		let decoded_version =
 			u32::decode(&mut pairs[1].1.as_slice()).expect("version should decode");
-		assert_eq!(decoded_version, UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION);
+		assert_eq!(decoded_version, STORE_CURRENT_VERSION);
 	}
 
 	#[test]
 	fn load_returns_none_when_no_entry_exists() {
-		let backend = TestBackend::new();
+		let (_backend, store) = new_store();
 		let hash = Hash::repeat_byte(0xEF);
 
-		let loaded = load_entry(&backend, hash).expect("load should succeed");
-		assert_eq!(loaded, None);
+		assert_eq!(store.load(hash).expect("load should succeed"), None);
 	}
 
 	#[test]
@@ -233,7 +246,7 @@ mod tests {
 		let old_finalized = Hash::repeat_byte(0xF0);
 		let just_finalized = Hash::repeat_byte(0xFF);
 
-		let ops = aux_storage_cleanup(
+		let ops = finality_cleanup_ops::<Block>(
 			just_finalized,
 			old_finalized,
 			&[route_1, route_2],
@@ -242,15 +255,13 @@ mod tests {
 
 		let keys: Vec<_> = ops.iter().map(|(k, _)| k.clone()).collect();
 
-		// Verify all expected keys are present (including the just-finalized block).
-		assert!(keys.contains(&unincluded_segment_key(stale_1)));
-		assert!(keys.contains(&unincluded_segment_key(stale_2)));
-		assert!(keys.contains(&unincluded_segment_key(route_1)));
-		assert!(keys.contains(&unincluded_segment_key(route_2)));
-		assert!(keys.contains(&unincluded_segment_key(old_finalized)));
-		assert!(keys.contains(&unincluded_segment_key(just_finalized)));
+		assert!(keys.contains(&entry_key(stale_1)));
+		assert!(keys.contains(&entry_key(stale_2)));
+		assert!(keys.contains(&entry_key(route_1)));
+		assert!(keys.contains(&entry_key(route_2)));
+		assert!(keys.contains(&entry_key(old_finalized)));
+		assert!(keys.contains(&entry_key(just_finalized)));
 
-		// Verify all values are None (deletes)
 		assert!(ops.iter().all(|(_, v)| v.is_none()));
 	}
 
@@ -259,8 +270,12 @@ mod tests {
 		let just_finalized = Hash::repeat_byte(0xFF);
 		let old_finalized = Hash::repeat_byte(0xF0);
 
-		let ops =
-			aux_storage_cleanup(just_finalized, old_finalized, &[], std::iter::empty::<Hash>());
+		let ops = finality_cleanup_ops::<Block>(
+			just_finalized,
+			old_finalized,
+			&[],
+			std::iter::empty::<Hash>(),
+		);
 
 		assert_eq!(ops.len(), 2);
 		assert!(ops.iter().all(|(_, v)| v.is_none()));
@@ -268,15 +283,14 @@ mod tests {
 
 	#[test]
 	fn stored_entry_encoding_hex_snapshot() {
-		// Canonical entry for hex snapshot
 		let entry =
 			StoredEntry { time_ms: 1234567890u64, proof: StorageProof::new(vec![vec![1, 2, 3]]) };
 
 		let encoded = entry.encode();
 		// Snapshot of the SCALE encoding. If this assertion fires, the on-disk format of
-		// `StoredEntry` has changed and existing aux entries written by older builds will fail to
-		// decode — bump `UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION` and add a migration before
-		// updating this snapshot.
+		// `StoredEntry` has changed and existing aux entries written by older builds will fail
+		// to decode — bump `STORE_CURRENT_VERSION` and add a migration before updating this
+		// snapshot.
 		let encoded_hex = hex::encode(&encoded);
 		// time_ms = 1234567890 little-endian u64 = d2 02 96 49 00 00 00 00
 		// proof   = Vec<Vec<u8>> with one element [1,2,3]: outer len 1 (SCALE compact = 04),
@@ -284,33 +298,27 @@ mod tests {
 		let expected_hex = "d20296490000000004 0c 010203".replace(' ', "");
 		assert_eq!(encoded_hex, expected_hex, "StoredEntry encoding changed!");
 
-		// Verify it decodes back correctly
 		let decoded = StoredEntry::decode(&mut encoded.as_slice()).expect("decode should succeed");
 		assert_eq!(entry, decoded);
 	}
 
 	#[test]
 	fn decode_corrupted_entry_body() {
-		let backend = TestBackend::new();
+		let (backend, store) = new_store();
 		let hash = Hash::repeat_byte(0xAB);
 
-		// Write correct version
-		let version_encoded = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
-		AuxStore::insert_aux(
-			&backend,
-			&[(UNINCLUDED_SEGMENT_STORE_VERSION, version_encoded.as_slice())],
-			&[],
-		)
-		.expect("aux insert should succeed");
-
-		// Write bogus entry body
-		let key = unincluded_segment_key(hash);
-		let bogus_data = vec![0xFF, 0xAA, 0xBB]; // Invalid SCALE encoding
-		AuxStore::insert_aux(&backend, &[(&key[..], bogus_data.as_slice())], &[])
+		// Write correct version.
+		let version_encoded = STORE_CURRENT_VERSION.encode();
+		AuxStore::insert_aux(&*backend, &[(STORE_VERSION_KEY, version_encoded.as_slice())], &[])
 			.expect("aux insert should succeed");
 
-		// Load should fail with decode error
-		let result = load_entry(&backend, hash);
+		// Write bogus entry body.
+		let key = entry_key(hash);
+		let bogus_data = vec![0xFF, 0xAA, 0xBB];
+		AuxStore::insert_aux(&*backend, &[(&key[..], bogus_data.as_slice())], &[])
+			.expect("aux insert should succeed");
+
+		let result = store.load(hash);
 		assert!(result.is_err());
 		let err_msg = result.unwrap_err().to_string();
 		assert!(
@@ -322,9 +330,8 @@ mod tests {
 
 	#[test]
 	fn end_to_end_write_cleanup_load() {
-		let backend = TestBackend::new();
+		let (backend, store) = new_store();
 
-		// Write three entries
 		let hash1 = Hash::repeat_byte(0x01);
 		let hash2 = Hash::repeat_byte(0x02);
 		let hash3 = Hash::repeat_byte(0x03);
@@ -333,26 +340,16 @@ mod tests {
 		let entry2 = create_test_entry(2000);
 		let entry3 = create_test_entry(3000);
 
-		write_aux_data(
-			&backend,
-			prepare_unincluded_segment_aux_data(hash1, entry1.time_ms, &entry1.proof),
-		);
-		write_aux_data(
-			&backend,
-			prepare_unincluded_segment_aux_data(hash2, entry2.time_ms, &entry2.proof),
-		);
-		write_aux_data(
-			&backend,
-			prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, &entry3.proof),
-		);
+		write_via_store(&backend, hash1, &entry1);
+		write_via_store(&backend, hash2, &entry2);
+		write_via_store(&backend, hash3, &entry3);
 
-		// Verify all three round-trip with value equality.
-		assert_eq!(load_entry(&backend, hash1).expect("load"), Some(entry1));
-		assert_eq!(load_entry(&backend, hash2).expect("load"), Some(entry2));
-		assert_eq!(load_entry(&backend, hash3).expect("load"), Some(entry3.clone()));
+		assert_eq!(store.load(hash1).expect("load"), Some(entry1));
+		assert_eq!(store.load(hash2).expect("load"), Some(entry2));
+		assert_eq!(store.load(hash3).expect("load"), Some(entry3.clone()));
 
 		// Generate cleanup that deletes hash1 (just-finalized) and hash2 (in tree route).
-		let ops = aux_storage_cleanup(
+		let ops = finality_cleanup_ops::<Block>(
 			hash1,
 			Hash::repeat_byte(0xF0),
 			&[hash2],
@@ -361,16 +358,83 @@ mod tests {
 		let delete_keys: Vec<_> =
 			ops.iter().filter_map(|(k, v)| v.is_none().then(|| k.as_slice())).collect();
 
-		// Apply deletes
-		AuxStore::insert_aux(&backend, &[], &delete_keys).expect("delete should succeed");
+		AuxStore::insert_aux(&*backend, &[], &delete_keys).expect("delete should succeed");
 
-		// Verify hash1 and hash2 deleted, hash3 survives with original value intact.
-		assert_eq!(load_entry(&backend, hash1).expect("load"), None, "hash1 should be deleted");
-		assert_eq!(load_entry(&backend, hash2).expect("load"), None, "hash2 should be deleted");
-		assert_eq!(
-			load_entry(&backend, hash3).expect("load"),
-			Some(entry3),
-			"hash3 should survive"
-		);
+		assert_eq!(store.load(hash1).expect("load"), None, "hash1 should be deleted");
+		assert_eq!(store.load(hash2).expect("load"), None, "hash2 should be deleted");
+		assert_eq!(store.load(hash3).expect("load"), Some(entry3), "hash3 should survive");
+	}
+
+	#[test]
+	fn entries_survive_disk_restart() {
+		use sc_client_db::{
+			Backend as DbBackend, BlocksPruning, DatabaseSettings, DatabaseSource, PruningMode,
+		};
+
+		fn with_backend<R>(
+			path: &std::path::Path,
+			f: impl FnOnce(&Arc<DbBackend<Block>>) -> R,
+		) -> R {
+			let backend = Arc::new(
+				DbBackend::<Block>::new(
+					DatabaseSettings {
+						trie_cache_maximum_size: Some(16 * 1024 * 1024),
+						state_pruning: Some(PruningMode::ArchiveAll),
+						blocks_pruning: BlocksPruning::KeepAll,
+						pruning_filters: Default::default(),
+						source: DatabaseSource::ParityDb { path: path.to_path_buf() },
+						metrics_registry: None,
+					},
+					0,
+				)
+				.expect("open backend"),
+			);
+			let result = f(&backend);
+			// `backend` (and any clones held by the closure) drop here, closing parity-db.
+			result
+		}
+
+		let tmp = tempfile::tempdir().expect("tempdir");
+		let path = tmp.path();
+
+		let hash_a = Hash::repeat_byte(0x10);
+		let hash_b = Hash::repeat_byte(0x20);
+		let entry_a = create_test_entry(10_000);
+		let entry_b = create_test_entry(20_000);
+
+		// Write `a` and `b` via the same path block-import uses, then close.
+		with_backend(path, |backend| {
+			let pairs: Vec<_> = prepare_aux_data::<Block>(hash_a, entry_a.time_ms, &entry_a.proof)
+				.chain(prepare_aux_data::<Block>(hash_b, entry_b.time_ms, &entry_b.proof))
+				.collect();
+			let refs: Vec<_> = pairs.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect();
+			AuxStore::insert_aux(&**backend, &refs, &[]).expect("aux insert");
+		});
+
+		// Restart: confirm both entries survived, then apply a finality-style delete of `a`.
+		with_backend(path, |backend| {
+			let store = UnincludedSegmentStore::<Block, _>::new(backend.clone());
+			assert_eq!(store.load(hash_a).expect("load a"), Some(entry_a.clone()));
+			assert_eq!(store.load(hash_b).expect("load b"), Some(entry_b.clone()));
+
+			let ops = finality_cleanup_ops::<Block>(
+				hash_a,
+				Hash::repeat_byte(0xF0),
+				&[],
+				std::iter::empty::<Hash>(),
+			);
+			let delete_keys: Vec<_> =
+				ops.iter().filter_map(|(k, v)| v.is_none().then(|| k.as_slice())).collect();
+			AuxStore::insert_aux(&**backend, &[], &delete_keys).expect("delete");
+		});
+
+		// Restart: the delete must have persisted; `b` must still be there.
+		with_backend(path, |backend| {
+			let store = UnincludedSegmentStore::<Block, _>::new(backend.clone());
+			assert_eq!(store.load(hash_a).expect("load a"), None, "hash_a delete must persist");
+			assert_eq!(store.load(hash_b).expect("load b"), Some(entry_b));
+		});
+
+		// `tmp` drops here, recursively removing the parity-db directory.
 	}
 }

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -1,0 +1,367 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
+
+//! Per-block proof store for unincluded segment resubmission.
+//!
+//! Persists `(time, session, StorageProof)` per parablock built by a slot-based collator,
+//! keyed by parablock hash. Data is pruned on parachain finality.
+
+use codec::{Decode, Encode};
+use polkadot_primitives::SessionIndex;
+use sc_client_api::{
+	backend::AuxStore,
+	client::{AuxDataOperations, FinalityNotification, PreCommitActions},
+	HeaderBackend,
+};
+use sp_blockchain::{Error as ClientError, Result as ClientResult};
+use sp_runtime::traits::{Block as BlockT, Header as _};
+use sp_trie::StorageProof;
+use std::sync::Arc;
+
+const UNINCLUDED_SEGMENT_STORE_VERSION: &[u8] = b"cumulus_unincluded_segment_store_version";
+const UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION: u32 = 1;
+
+/// Entry stored in aux storage for each unincluded parablock.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct StoredEntry {
+	/// Unix millis at the moment block_import started.
+	pub time_ms: u64,
+	/// SessionIndex of the relay parent.
+	/// TODO: Will be populated once paritytech/polkadot-sdk#11624 lands.
+	pub session: Option<SessionIndex>,
+	/// The storage proof captured at block_import.
+	pub proof: StorageProof,
+}
+
+/// The aux storage key used to store the unincluded segment data for the given block hash.
+fn unincluded_segment_key<H: Encode>(block_hash: H) -> Vec<u8> {
+	(b"cumulus_unincluded_segment_store", block_hash).encode()
+}
+
+fn load_decode<B, T>(backend: &B, key: &[u8]) -> ClientResult<Option<T>>
+where
+	B: AuxStore,
+	T: Decode,
+{
+	let corrupt = |e: codec::Error| {
+		ClientError::Backend(format!(
+			"Unincluded segment store DB is corrupted. Decode error: {}",
+			e
+		))
+	};
+
+	match backend.get_aux(key)? {
+		None => Ok(None),
+		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(corrupt),
+	}
+}
+
+/// Prepare aux storage key-value pairs for persisting unincluded segment data.
+///
+/// The caller should push these into `BlockImportParams::auxiliary` so they commit
+/// in the same DB transaction as the block.
+pub fn prepare_unincluded_segment_aux_data<H: Encode>(
+	block_hash: H,
+	time_ms: u64,
+	session: Option<SessionIndex>,
+	proof: StorageProof,
+) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> {
+	let entry = StoredEntry { time_ms, session, proof };
+	let key = unincluded_segment_key(block_hash);
+	let encoded_entry = entry.encode();
+	let current_version = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
+
+	[(key, encoded_entry), (UNINCLUDED_SEGMENT_STORE_VERSION.to_vec(), current_version)].into_iter()
+}
+
+/// Load the unincluded segment entry associated with a block.
+pub fn load_proof<H: Encode, B: AuxStore>(
+	backend: &B,
+	block_hash: H,
+) -> ClientResult<Option<StoredEntry>> {
+	let version = load_decode::<_, u32>(backend, UNINCLUDED_SEGMENT_STORE_VERSION)?;
+
+	match version {
+		None => Ok(None),
+		Some(UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION) => {
+			load_decode(backend, unincluded_segment_key(block_hash).as_slice())
+		},
+		Some(other) => Err(ClientError::Backend(format!(
+			"Unsupported unincluded segment store DB version: {:?}",
+			other
+		))),
+	}
+}
+
+/// Compute aux storage cleanup operations for a finality notification.
+///
+/// Deletes entries for:
+/// - All stale blocks (loser forks)
+/// - All blocks on the tree route to the finalized head (intermediate finalized blocks)
+/// - The old finalized block (parent of the first tree route block, or parent of finalized)
+///
+/// Does NOT delete the just-finalized block, since new blocks can still be imported on top of it.
+fn aux_storage_cleanup<Block, C>(
+	notification: &FinalityNotification<Block>,
+	client: &C,
+) -> AuxDataOperations
+where
+	Block: BlockT,
+	C: HeaderBackend<Block>,
+{
+	// The old finalized block is the parent of the first block in the tree route,
+	// or the parent of the finalized block if the tree route is empty.
+	let old_finalized_hash = notification
+		.tree_route
+		.first()
+		.and_then(|hash| client.header(*hash).ok().flatten())
+		.map(|h| *h.parent_hash())
+		.unwrap_or_else(|| *notification.header.parent_hash());
+
+	notification
+		.stale_blocks
+		.iter()
+		// Delete entries for all stale blocks.
+		.map(|b| (unincluded_segment_key(b.hash), None))
+		// Delete entries for blocks on the route to the finalized parent.
+		// These can no longer become parents for new blocks.
+		.chain(
+			notification
+				.tree_route
+				.iter()
+				.copied()
+				.map(|hash| (unincluded_segment_key(hash), None)),
+		)
+		// Delete the old finalized block's entry.
+		.chain(std::iter::once((unincluded_segment_key(old_finalized_hash), None)))
+		.collect()
+}
+
+/// Register a finality action for cleaning up unincluded segment data.
+///
+/// This should be called during consensus initialization to automatically clean up
+/// unincluded segment data when blocks are finalized.
+pub fn register_unincluded_segment_cleanup<C, Block>(client: Arc<C>)
+where
+	C: PreCommitActions<Block> + HeaderBackend<Block> + 'static,
+	Block: BlockT,
+{
+	let client_for_closure = client.clone();
+	let on_finality = move |notification: &FinalityNotification<Block>| -> AuxDataOperations {
+		aux_storage_cleanup(notification, &*client_for_closure)
+	};
+
+	client.register_finality_action(Box::new(on_finality));
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use sc_client_api::backend::AuxStore;
+
+	type Block = substrate_test_runtime::Block;
+	type Hash = <Block as BlockT>::Hash;
+	type TestBackend = sc_client_api::in_mem::Backend<Block>;
+
+	fn create_test_entry(time_ms: u64) -> StoredEntry {
+		StoredEntry {
+			time_ms,
+			session: Some(42),
+			proof: StorageProof::new(vec![vec![1, 2, 3], vec![4, 5, 6]]),
+		}
+	}
+
+	fn write_aux_data(backend: &TestBackend, data: impl Iterator<Item = (Vec<u8>, Vec<u8>)>) {
+		let pairs: Vec<_> = data.collect();
+		let insert_pairs: Vec<_> =
+			pairs.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect();
+		AuxStore::insert_aux(backend, &insert_pairs, &[]).expect("aux insert should succeed");
+	}
+
+	#[test]
+	fn prepare_produces_expected_key_value_pairs() {
+		let hash = Hash::repeat_byte(0xAB);
+		let time_ms = 1234567890u64;
+		let session = Some(5u32);
+		let proof = StorageProof::new(vec![vec![10, 20, 30]]);
+
+		let pairs: Vec<_> =
+			prepare_unincluded_segment_aux_data(hash, time_ms, session, proof.clone()).collect();
+
+		assert_eq!(pairs.len(), 2);
+
+		// First pair is the entry
+		let expected_key = (b"cumulus_unincluded_segment_store", hash).encode();
+		assert_eq!(pairs[0].0, expected_key);
+
+		// Verify entry decodes correctly
+		let decoded_entry =
+			StoredEntry::decode(&mut pairs[0].1.as_slice()).expect("entry should decode");
+		assert_eq!(decoded_entry.time_ms, time_ms);
+		assert_eq!(decoded_entry.session, session);
+		assert_eq!(decoded_entry.proof, proof);
+
+		// Second pair is the version
+		assert_eq!(pairs[1].0, UNINCLUDED_SEGMENT_STORE_VERSION.to_vec());
+		let decoded_version =
+			u32::decode(&mut pairs[1].1.as_slice()).expect("version should decode");
+		assert_eq!(decoded_version, UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION);
+	}
+
+	#[test]
+	fn round_trip_write_and_load() {
+		let backend = TestBackend::new();
+		let hash = Hash::repeat_byte(0xCD);
+		let entry = create_test_entry(999888777);
+
+		// Write via prepare + manual insert
+		let aux_data = prepare_unincluded_segment_aux_data(
+			hash,
+			entry.time_ms,
+			entry.session,
+			entry.proof.clone(),
+		);
+		write_aux_data(&backend, aux_data);
+
+		// Load back
+		let loaded = load_proof(&backend, hash).expect("load should succeed");
+		assert_eq!(loaded, Some(entry));
+	}
+
+	#[test]
+	fn load_returns_none_when_no_entry_exists() {
+		let backend = TestBackend::new();
+		let hash = Hash::repeat_byte(0xEF);
+
+		let loaded = load_proof(&backend, hash).expect("load should succeed");
+		assert_eq!(loaded, None);
+	}
+
+	#[test]
+	fn load_returns_error_on_version_mismatch() {
+		let backend = TestBackend::new();
+		let hash = Hash::repeat_byte(0x12);
+
+		// Write a bogus version
+		let bogus_version = 999u32.encode();
+		AuxStore::insert_aux(
+			&backend,
+			&[(UNINCLUDED_SEGMENT_STORE_VERSION, bogus_version.as_slice())],
+			&[],
+		)
+		.expect("aux insert should succeed");
+
+		// Also write an entry so it's not just missing
+		let entry = create_test_entry(12345);
+		let key = unincluded_segment_key(hash);
+		AuxStore::insert_aux(&backend, &[(&key[..], entry.encode().as_slice())], &[])
+			.expect("aux insert should succeed");
+
+		// Load should fail with version error
+		let result = load_proof(&backend, hash);
+		assert!(result.is_err());
+		let err_msg = result.unwrap_err().to_string();
+		assert!(
+			err_msg.contains("Unsupported unincluded segment store DB version"),
+			"unexpected error: {}",
+			err_msg
+		);
+	}
+
+	#[test]
+	fn cleanup_computes_correct_deletions() {
+		let backend = TestBackend::new();
+
+		let hash_c = Hash::repeat_byte(0xCC);
+		let hash_genesis = Hash::repeat_byte(0x00);
+
+		// Expected keys to delete:
+		let expected_stale_key = unincluded_segment_key(hash_c);
+		let expected_old_finalized_key = unincluded_segment_key(hash_genesis);
+
+		// Verify key format
+		assert_eq!(expected_stale_key, (b"cumulus_unincluded_segment_store", hash_c).encode());
+		assert_eq!(
+			expected_old_finalized_key,
+			(b"cumulus_unincluded_segment_store", hash_genesis).encode()
+		);
+
+		// Test that entries can be written and then "deleted" (set to None)
+		let entry = create_test_entry(111);
+		let key_c = unincluded_segment_key(hash_c);
+		AuxStore::insert_aux(&backend, &[(&key_c[..], entry.encode().as_slice())], &[])
+			.expect("insert should succeed");
+
+		// Verify entry exists
+		assert!(AuxStore::get_aux(&backend, &key_c).expect("get should succeed").is_some());
+
+		// Simulate deletion via AuxDataOperations
+		let delete_ops: AuxDataOperations = vec![(key_c.clone(), None)];
+		let deletes: Vec<&[u8]> = delete_ops
+			.iter()
+			.filter_map(|(k, v)| if v.is_none() { Some(k.as_slice()) } else { None })
+			.collect();
+		AuxStore::insert_aux(&backend, &[], &deletes).expect("delete should succeed");
+
+		// Verify entry is gone
+		assert!(AuxStore::get_aux(&backend, &key_c).expect("get should succeed").is_none());
+	}
+
+	#[test]
+	fn cleanup_with_tree_route() {
+		// Test that cleanup includes tree_route blocks in deletions.
+		// This tests the logic without needing a real FinalityNotification.
+
+		let hash_a = Hash::repeat_byte(0xAA);
+		let hash_b = Hash::repeat_byte(0xBB);
+		let hash_c = Hash::repeat_byte(0xCC);
+
+		// Generate keys for tree_route blocks
+		let key_a = unincluded_segment_key(hash_a);
+		let key_b = unincluded_segment_key(hash_b);
+		let key_c = unincluded_segment_key(hash_c);
+
+		// All keys should be distinct
+		assert_ne!(key_a, key_b);
+		assert_ne!(key_b, key_c);
+		assert_ne!(key_a, key_c);
+
+		// Keys should be deterministic
+		assert_eq!(key_a, unincluded_segment_key(hash_a));
+	}
+
+	#[test]
+	fn stored_entry_encoding_is_stable() {
+		// Verify that encoding/decoding is symmetric
+		let entry = StoredEntry { time_ms: u64::MAX, session: None, proof: StorageProof::empty() };
+
+		let encoded = entry.encode();
+		let decoded = StoredEntry::decode(&mut encoded.as_slice()).expect("decode should succeed");
+		assert_eq!(entry, decoded);
+
+		// With session
+		let entry_with_session = StoredEntry {
+			time_ms: 0,
+			session: Some(u32::MAX),
+			proof: StorageProof::new(vec![vec![255; 100]]),
+		};
+
+		let encoded = entry_with_session.encode();
+		let decoded = StoredEntry::decode(&mut encoded.as_slice()).expect("decode should succeed");
+		assert_eq!(entry_with_session, decoded);
+	}
+}

--- a/cumulus/client/unincluded-segment-store/src/lib.rs
+++ b/cumulus/client/unincluded-segment-store/src/lib.rs
@@ -21,7 +21,6 @@
 //! keyed by parablock hash. Data is pruned on parachain finality.
 
 use codec::{Decode, Encode};
-use polkadot_primitives::SessionIndex;
 use sc_client_api::{
 	backend::AuxStore,
 	client::{AuxDataOperations, FinalityNotification, PreCommitActions},
@@ -29,11 +28,29 @@ use sc_client_api::{
 };
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_runtime::traits::{Block as BlockT, Header as _};
+use sp_staking::SessionIndex;
 use sp_trie::StorageProof;
-use std::sync::Arc;
+use std::{
+	sync::Arc,
+	time::{SystemTime, UNIX_EPOCH},
+};
 
+const LOG_TARGET: &str = "cumulus-unincluded-segment-store";
 const UNINCLUDED_SEGMENT_STORE_VERSION: &[u8] = b"cumulus_unincluded_segment_store_version";
 const UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION: u32 = 1;
+
+/// Return the current Unix milliseconds timestamp.
+///
+/// Falls back to 0 if the system clock is before the Unix epoch.
+pub fn now_unix_ms() -> u64 {
+	match SystemTime::now().duration_since(UNIX_EPOCH) {
+		Ok(d) => d.as_millis() as u64,
+		Err(e) => {
+			tracing::warn!(target: LOG_TARGET, error = ?e, "system clock is before UNIX epoch; storing time_ms=0");
+			0
+		},
+	}
+}
 
 /// Entry stored in aux storage for each unincluded parablock.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
@@ -57,16 +74,14 @@ where
 	B: AuxStore,
 	T: Decode,
 {
-	let corrupt = |e: codec::Error| {
-		ClientError::Backend(format!(
-			"Unincluded segment store DB is corrupted. Decode error: {}",
-			e
-		))
-	};
-
 	match backend.get_aux(key)? {
 		None => Ok(None),
-		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(corrupt),
+		Some(t) => T::decode(&mut &t[..]).map(Some).map_err(|e| {
+			ClientError::Backend(format!(
+				"Unincluded segment store DB is corrupted. Decode error: {}",
+				e
+			))
+		}),
 	}
 }
 
@@ -89,7 +104,7 @@ pub fn prepare_unincluded_segment_aux_data<H: Encode>(
 }
 
 /// Load the unincluded segment entry associated with a block.
-pub fn load_proof<H: Encode, B: AuxStore>(
+pub fn load_entry<H: Encode, B: AuxStore>(
 	backend: &B,
 	block_hash: H,
 ) -> ClientResult<Option<StoredEntry>> {
@@ -107,24 +122,51 @@ pub fn load_proof<H: Encode, B: AuxStore>(
 	}
 }
 
+/// Compute the old finalized hash from a tree route and a fallback parent hash.
+///
+/// This is the parent of the first block in the tree route, or the supplied `fallback_parent`
+/// (typically the parent hash of the just-finalized header) when the tree route is empty or its
+/// first block's header can't be loaded.
+///
+/// Taking the inputs directly rather than a `FinalityNotification` keeps this function unit-
+/// testable from outside `sc-client-api` (which has a private `unpin_handle` field).
+pub fn old_finalized_hash<C, Block>(
+	client: &C,
+	tree_route: &[Block::Hash],
+	fallback_parent: Block::Hash,
+) -> Block::Hash
+where
+	C: HeaderBackend<Block>,
+	Block: BlockT,
+{
+	tree_route
+		.first()
+		.and_then(|hash| client.header(*hash).ok().flatten())
+		.map(|h| *h.parent_hash())
+		.unwrap_or(fallback_parent)
+}
+
 /// Compute aux storage cleanup operations.
 ///
-/// Emits deletes for stale blocks, intermediate tree-route blocks, and the pre-finality head;
-/// does NOT delete the just-finalized block since it can still receive children.
+/// Emits deletes for stale blocks, intermediate tree-route blocks, and the pre-finality head.
+/// The just-finalized block is NOT deleted; it will be deleted by the next finality round via
+/// `old_finalized_hash`, kept for one round for parity with the ignored-nodes cleanup pattern.
+///
+/// TODO(#12034): once SessionIndex is populated (waiting on #11624), also prune entries whose
+/// stored `session` is older than `max_relay_parent_session_age` relative to the current session.
 fn aux_storage_cleanup<H>(
 	old_finalized_hash: H,
 	tree_route: &[H],
 	stale_block_hashes: &[H],
 ) -> AuxDataOperations
 where
-	H: Encode + Copy,
+	H: Encode,
 {
-	stale_block_hashes
-		.iter()
-		.map(|hash| (unincluded_segment_key(*hash), None))
-		.chain(tree_route.iter().map(|hash| (unincluded_segment_key(*hash), None)))
-		.chain(std::iter::once((unincluded_segment_key(old_finalized_hash), None)))
-		.collect()
+	let mut ops = Vec::with_capacity(stale_block_hashes.len() + tree_route.len() + 1);
+	ops.extend(stale_block_hashes.iter().map(|hash| (unincluded_segment_key(hash), None)));
+	ops.extend(tree_route.iter().map(|hash| (unincluded_segment_key(hash), None)));
+	ops.push((unincluded_segment_key(old_finalized_hash), None));
+	ops
 }
 
 /// Register a finality action for cleaning up unincluded segment data.
@@ -138,19 +180,16 @@ where
 {
 	let client_for_closure = client.clone();
 	let on_finality = move |notification: &FinalityNotification<Block>| -> AuxDataOperations {
-		// The old finalized block is the parent of the first block in the tree route,
-		// or the parent of the finalized block if the tree route is empty.
-		let old_finalized_hash = notification
-			.tree_route
-			.first()
-			.and_then(|hash| client_for_closure.header(*hash).ok().flatten())
-			.map(|h| *h.parent_hash())
-			.unwrap_or_else(|| *notification.header.parent_hash());
+		let old_finalized = old_finalized_hash::<_, Block>(
+			&*client_for_closure,
+			&notification.tree_route,
+			*notification.header.parent_hash(),
+		);
 
 		let stale_block_hashes: Vec<_> = notification.stale_blocks.iter().map(|b| b.hash).collect();
 		let tree_route: Vec<_> = notification.tree_route.iter().copied().collect();
 
-		aux_storage_cleanup(old_finalized_hash, &tree_route, &stale_block_hashes)
+		aux_storage_cleanup(old_finalized, &tree_route, &stale_block_hashes)
 	};
 
 	client.register_finality_action(Box::new(on_finality));
@@ -226,7 +265,7 @@ mod tests {
 		write_aux_data(&backend, aux_data);
 
 		// Load back
-		let loaded = load_proof(&backend, hash).expect("load should succeed");
+		let loaded = load_entry(&backend, hash).expect("load should succeed");
 		assert_eq!(loaded, Some(entry));
 	}
 
@@ -235,7 +274,7 @@ mod tests {
 		let backend = TestBackend::new();
 		let hash = Hash::repeat_byte(0xEF);
 
-		let loaded = load_proof(&backend, hash).expect("load should succeed");
+		let loaded = load_entry(&backend, hash).expect("load should succeed");
 		assert_eq!(loaded, None);
 	}
 
@@ -260,7 +299,7 @@ mod tests {
 			.expect("aux insert should succeed");
 
 		// Load should fail with version error
-		let result = load_proof(&backend, hash);
+		let result = load_entry(&backend, hash);
 		assert!(result.is_err());
 		let err_msg = result.unwrap_err().to_string();
 		assert!(
@@ -352,23 +391,174 @@ mod tests {
 	}
 
 	#[test]
-	fn stored_entry_encoding_is_stable() {
-		// Verify that encoding/decoding is symmetric
-		let entry = StoredEntry { time_ms: u64::MAX, session: None, proof: StorageProof::empty() };
-
-		let encoded = entry.encode();
-		let decoded = StoredEntry::decode(&mut encoded.as_slice()).expect("decode should succeed");
-		assert_eq!(entry, decoded);
-
-		// With session
-		let entry_with_session = StoredEntry {
-			time_ms: 0,
-			session: Some(u32::MAX),
-			proof: StorageProof::new(vec![vec![255; 100]]),
+	fn stored_entry_encoding_hex_snapshot() {
+		// Canonical entry for hex snapshot
+		let entry = StoredEntry {
+			time_ms: 1234567890u64,
+			session: Some(42u32),
+			proof: StorageProof::new(vec![vec![1, 2, 3]]),
 		};
 
-		let encoded = entry_with_session.encode();
+		let encoded = entry.encode();
+		// Snapshot of the SCALE encoding. If this assertion fires, the on-disk format of
+		// `StoredEntry` has changed and existing aux entries written by older builds will fail to
+		// decode — bump `UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION` and add a migration before
+		// updating this snapshot.
+		let expected_hex = "d202964900000000012a000000040c010203";
+		assert_eq!(hex::encode(&encoded), expected_hex, "StoredEntry encoding changed!");
+
+		// Verify it decodes back correctly
 		let decoded = StoredEntry::decode(&mut encoded.as_slice()).expect("decode should succeed");
-		assert_eq!(entry_with_session, decoded);
+		assert_eq!(entry, decoded);
+	}
+
+	#[test]
+	fn decode_corrupted_entry_body() {
+		let backend = TestBackend::new();
+		let hash = Hash::repeat_byte(0xAB);
+
+		// Write correct version
+		let version_encoded = UNINCLUDED_SEGMENT_STORE_CURRENT_VERSION.encode();
+		AuxStore::insert_aux(
+			&backend,
+			&[(UNINCLUDED_SEGMENT_STORE_VERSION, version_encoded.as_slice())],
+			&[],
+		)
+		.expect("aux insert should succeed");
+
+		// Write bogus entry body
+		let key = unincluded_segment_key(hash);
+		let bogus_data = vec![0xFF, 0xAA, 0xBB]; // Invalid SCALE encoding
+		AuxStore::insert_aux(&backend, &[(&key[..], bogus_data.as_slice())], &[])
+			.expect("aux insert should succeed");
+
+		// Load should fail with decode error
+		let result = load_entry(&backend, hash);
+		assert!(result.is_err());
+		let err_msg = result.unwrap_err().to_string();
+		assert!(
+			err_msg.contains("DB is corrupted") && err_msg.contains("Decode error"),
+			"unexpected error: {}",
+			err_msg
+		);
+	}
+
+	// Minimal `HeaderBackend` mock for the `old_finalized_hash_*` tests.
+	//
+	// `lookup` is `None` ⇒ `header()` returns `Ok(None)` (simulates a missing header).
+	struct MockHeaderBackend {
+		lookup: Option<(Hash, substrate_test_runtime::Header)>,
+	}
+
+	impl HeaderBackend<Block> for MockHeaderBackend {
+		fn header(
+			&self,
+			hash: <Block as BlockT>::Hash,
+		) -> ClientResult<Option<<Block as BlockT>::Header>> {
+			Ok(self.lookup.as_ref().and_then(|(h, hdr)| (*h == hash).then(|| hdr.clone())))
+		}
+
+		fn info(&self) -> sc_client_api::blockchain::Info<Block> {
+			unimplemented!()
+		}
+
+		fn status(
+			&self,
+			_hash: <Block as BlockT>::Hash,
+		) -> ClientResult<sc_client_api::blockchain::BlockStatus> {
+			unimplemented!()
+		}
+
+		fn number(
+			&self,
+			_hash: <Block as BlockT>::Hash,
+		) -> ClientResult<Option<sp_runtime::traits::NumberFor<Block>>> {
+			unimplemented!()
+		}
+
+		fn hash(
+			&self,
+			_number: sp_runtime::traits::NumberFor<Block>,
+		) -> ClientResult<Option<<Block as BlockT>::Hash>> {
+			unimplemented!()
+		}
+	}
+
+	#[test]
+	fn old_finalized_hash_with_empty_tree_route() {
+		let client = MockHeaderBackend { lookup: None };
+		let fallback = Hash::repeat_byte(0x01);
+
+		let old_hash = old_finalized_hash::<_, Block>(&client, &[], fallback);
+		assert_eq!(old_hash, fallback, "empty tree_route should fall through to the supplied parent");
+	}
+
+	#[test]
+	fn old_finalized_hash_with_tree_route() {
+		use substrate_test_runtime::Header as TestHeader;
+
+		let expected_old = Hash::repeat_byte(0x01);
+		let tree_block = Hash::repeat_byte(0x02);
+
+		let header = TestHeader {
+			parent_hash: expected_old,
+			number: 2,
+			state_root: Default::default(),
+			extrinsics_root: Default::default(),
+			digest: Default::default(),
+		};
+
+		let client = MockHeaderBackend { lookup: Some((tree_block, header)) };
+		let fallback = Hash::repeat_byte(0xFF);
+
+		let old_hash = old_finalized_hash::<_, Block>(&client, &[tree_block], fallback);
+		assert_eq!(old_hash, expected_old, "should resolve to parent of first tree_route block");
+	}
+
+	#[test]
+	fn old_finalized_hash_falls_back_when_header_missing() {
+		// Non-empty tree_route, but the header lookup returns None — the function should fall back
+		// to `fallback_parent` rather than panicking or returning a wrong hash.
+		let client = MockHeaderBackend { lookup: None };
+		let tree_block = Hash::repeat_byte(0x02);
+		let fallback = Hash::repeat_byte(0xAA);
+
+		let old_hash = old_finalized_hash::<_, Block>(&client, &[tree_block], fallback);
+		assert_eq!(old_hash, fallback, "missing header should fall back to the supplied parent");
+	}
+
+	#[test]
+	fn end_to_end_write_cleanup_load() {
+		let backend = TestBackend::new();
+
+		// Write three entries
+		let hash1 = Hash::repeat_byte(0x01);
+		let hash2 = Hash::repeat_byte(0x02);
+		let hash3 = Hash::repeat_byte(0x03);
+
+		let entry1 = create_test_entry(1000);
+		let entry2 = create_test_entry(2000);
+		let entry3 = create_test_entry(3000);
+
+		write_aux_data(&backend, prepare_unincluded_segment_aux_data(hash1, entry1.time_ms, entry1.session, entry1.proof.clone()));
+		write_aux_data(&backend, prepare_unincluded_segment_aux_data(hash2, entry2.time_ms, entry2.session, entry2.proof.clone()));
+		write_aux_data(&backend, prepare_unincluded_segment_aux_data(hash3, entry3.time_ms, entry3.session, entry3.proof.clone()));
+
+		// Verify all three exist
+		assert!(load_entry(&backend, hash1).expect("load").is_some());
+		assert!(load_entry(&backend, hash2).expect("load").is_some());
+		assert!(load_entry(&backend, hash3).expect("load").is_some());
+
+		// Generate cleanup for hash1 and hash2
+		let ops = aux_storage_cleanup(hash1, &[hash2], &[]);
+		let delete_keys: Vec<_> = ops.iter().filter_map(|(k, v)| v.is_none().then(|| k.as_slice())).collect();
+
+		// Apply deletes
+		AuxStore::insert_aux(&backend, &[], &delete_keys).expect("delete should succeed");
+
+		// Verify hash1 and hash2 deleted, hash3 survives
+		assert!(load_entry(&backend, hash1).expect("load").is_none(), "hash1 should be deleted");
+		assert!(load_entry(&backend, hash2).expect("load").is_none(), "hash2 should be deleted");
+		assert!(load_entry(&backend, hash3).expect("load").is_some(), "hash3 should survive");
 	}
 }

--- a/cumulus/primitives/core/src/scheduling.rs
+++ b/cumulus/primitives/core/src/scheduling.rs
@@ -23,7 +23,8 @@ use codec::{Decode, Encode};
 use polkadot_primitives::{ApprovedPeerId, CoreSelector, Header as RelayChainHeader, Slot};
 use sp_runtime::traits::{BlakeTwo256, Hash as HashT};
 
-/// Payload signed by a collator for resubmission.
+/// Payload signed by a collator to authorize core selection — required on resubmission,
+/// optional on initial submission.
 ///
 /// This binds the core selection and reputation-credit peer to a specific internal
 /// scheduling parent, preventing replay attacks across different scheduling contexts.
@@ -78,22 +79,21 @@ impl SchedulingInfoPayload {
 
 /// V3 scheduling proof included in the POV.
 ///
-/// Provides the ancestry from scheduling_parent back to the internal scheduling
-/// parent. The PVF validates this against the relay_parent and scheduling_parent
-/// from the candidate descriptor extension.
+/// Carries the relay-chain ancestry starting at `scheduling_parent` and ending one step
+/// before `internal_scheduling_parent` (whose header is supplied separately). The PVF
+/// validates this against the `relay_parent` and `scheduling_parent` from the candidate
+/// descriptor extension.
 #[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
 pub struct SchedulingProof {
-	/// Relay chain headers proving ancestry from scheduling_parent backward.
-	///
 	/// Forms a chain where each header's parent_hash equals the next header's hash.
 	/// The first header's hash must equal the candidate's scheduling_parent.
 	/// The last header's parent_hash is the internal scheduling parent.
 	/// Length is defined by the parachain runtime config (`RelayParentOffset`); when that is
 	/// `0` the chain is empty and `scheduling_parent == internal_scheduling_parent`.
 	pub header_chain: Vec<RelayChainHeader>,
-	/// The relay chain header at `internal_scheduling_parent`. Its hash must equal the
-	/// `internal_scheduling_parent` derived from `header_chain` (the parent of the chain's
-	/// last header, or `scheduling_parent` if the chain is empty).
+	/// The relay chain header at `internal_scheduling_parent` (the parent of the chain's last
+	/// header, or `scheduling_parent` if the chain is empty). Carries the BABE pre-digest used
+	/// to look up the eligible block author when verifying `signed_scheduling_info`.
 	pub internal_scheduling_parent_header: RelayChainHeader,
 	/// Signed scheduling info. Required on resubmission, optional on initial submission.
 	///
@@ -101,14 +101,10 @@ pub struct SchedulingProof {
 	///   selection comes from the parachain block's UMP signals.
 	///
 	/// - `Some` with `relay_parent == internal_scheduling_parent`: Initial submission with
-	///   explicit signed core selection. Legal but not required; collators should refuse to
-	///   acknowledge blocks with invalid scheduling info, so the signature isn't load-bearing on
-	///   initial submission.
+	///   explicit signed core selection. Legal but not required.
 	///
 	/// - `Some` with `relay_parent != internal_scheduling_parent`: Resubmission (required). The
 	///   resubmitting collator signs the core selection, overriding the block's UMP signals.
-	///   Signature is verified against the eligible author for the slot at
-	///   `internal_scheduling_parent`.
 	///
 	/// - `None` with `relay_parent != internal_scheduling_parent`: invalid; rejected by the
 	///   verifier.

--- a/cumulus/primitives/core/src/scheduling.rs
+++ b/cumulus/primitives/core/src/scheduling.rs
@@ -10,9 +10,9 @@
 //!
 //! # Resubmission
 //!
-//! When a candidate fails to get backed in time, a different collator can resubmit
-//! it with a new `scheduling_parent` (fresh relay tip) without re-executing the blocks.
-//! The `relay_parent` stays the same since the execution context hasn't changed.
+//! When a candidate fails to get backed in time, a collator can resubmit it with a new
+//! `scheduling_parent` (fresh relay tip) without re-executing the blocks. The `relay_parent`
+//! stays the same since the execution context hasn't changed.
 //!
 //! For resubmission, `signed_scheduling_info` must be provided. The resubmitting
 //! collator signs the core selection, proving they are the eligible author for the
@@ -29,26 +29,29 @@ use sp_runtime::traits::{BlakeTwo256, Hash as HashT};
 /// scheduling parent, preventing replay attacks across different scheduling contexts.
 #[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
 pub struct SchedulingInfoPayload {
-	/// Which core to use (indexes into the parachain's assigned cores).
+	/// Index into the parachain's cores scheduled at depth `claim_queue_offset` of the relay
+	/// chain's claim queue. The relay chain resolves it to a `CoreIndex` at verification time.
 	pub core_selector: CoreSelector,
-	/// The claim queue offset.
+	/// Depth in the relay chain's claim queue (at `scheduling_parent`) used together with
+	/// `core_selector` to resolve the target `CoreIndex`.
 	pub claim_queue_offset: u8,
 	/// Peer ID to receive reputation credit for successful collation delivery.
 	pub peer_id: ApprovedPeerId,
-	/// The internal scheduling parent whom's slot decides the
-	/// eligible block author that must sign the payload.
+	/// The internal scheduling parent whose slot decides the eligible block author that must
+	/// sign the payload.
 	pub internal_scheduling_parent: polkadot_primitives::Hash,
 }
 
-/// Signed scheduling information for candidate resubmission.
+/// Signed scheduling information attached to a [`SchedulingProof`].
 ///
-/// When a collator resubmits a candidate (with a newer `scheduling_parent` but same
-/// `relay_parent`), they must sign the core selection to prove eligibility for the
-/// slot at `internal_scheduling_parent`.
+/// On **resubmission** (when the candidate is submitted once more under a newer
+/// `scheduling_parent` than the one used for its initial submission), this signature is
+/// required: the resubmitting collator signs the core selection to prove eligibility for the
+/// slot at the `internal_scheduling_parent`.
 ///
-/// The `claim_queue_offset` is derived from the runtime's `relay_parent_offset`
-/// configuration and is not part of this struct - it cannot be overridden by the
-/// collator.
+/// On **initial submission**, this is optional. When present, it provides an explicit signed
+/// core selection that overrides the parachain block's UMP signals; when absent, the relay
+/// chain falls back to those UMP signals.
 #[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
 pub struct SignedSchedulingInfo {
 	/// The scheduling information.
@@ -85,26 +88,30 @@ pub struct SchedulingProof {
 	/// Forms a chain where each header's parent_hash equals the next header's hash.
 	/// The first header's hash must equal the candidate's scheduling_parent.
 	/// The last header's parent_hash is the internal scheduling parent.
-	/// Length is defined by the parachain runtime config (RelayParentOffset).
+	/// Length is defined by the parachain runtime config (`RelayParentOffset`); when that is
+	/// `0` the chain is empty and `scheduling_parent == internal_scheduling_parent`.
 	pub header_chain: Vec<RelayChainHeader>,
 	/// The relay chain header at `internal_scheduling_parent`. Its hash must equal the
 	/// `internal_scheduling_parent` derived from `header_chain` (the parent of the chain's
 	/// last header, or `scheduling_parent` if the chain is empty).
 	pub internal_scheduling_parent_header: RelayChainHeader,
-	/// Signed scheduling info for core selection override.
+	/// Signed scheduling info. Required on resubmission, optional on initial submission.
 	///
 	/// - `None` with `relay_parent == internal_scheduling_parent`: Initial submission. Core
 	///   selection comes from the parachain block's UMP signals.
 	///
 	/// - `Some` with `relay_parent == internal_scheduling_parent`: Initial submission with
-	///   explicit core selection. This is optional but legal. Collators should refuse to
-	///   acknowledge blocks with invalid scheduling info, so providing a signature is not required
-	///   for initial submissions.
+	///   explicit signed core selection. Legal but not required; collators should refuse to
+	///   acknowledge blocks with invalid scheduling info, so the signature isn't load-bearing on
+	///   initial submission.
 	///
 	/// - `Some` with `relay_parent != internal_scheduling_parent`: Resubmission (required). The
 	///   resubmitting collator signs the core selection, overriding the block's UMP signals.
 	///   Signature is verified against the eligible author for the slot at
 	///   `internal_scheduling_parent`.
+	///
+	/// - `None` with `relay_parent != internal_scheduling_parent`: invalid; rejected by the
+	///   verifier.
 	pub signed_scheduling_info: Option<SignedSchedulingInfo>,
 }
 

--- a/cumulus/test/runtime/src/flavors.rs
+++ b/cumulus/test/runtime/src/flavors.rs
@@ -124,5 +124,8 @@ pub(crate) const fn unincluded_segment_capacity() -> u32 {
 	// - The collator sends the collation to the relay chain, and it gets backed on chain in relay
 	//   block `X + 2`
 	// - The collation then gets included on chain in relay block `X + 3`
-	block_processing_velocity() * 3
+	// - As we are building on `RELAY_PARENT_OFFSET` old relay parents, the included block from the
+	//   parachain is also `RELAY_PARENT_OFFSET` relay blocks older (one relay block may contains
+	//   multiple parachain blocks).
+	block_processing_velocity() * (3 + relay_parent_offset())
 }

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -324,7 +324,7 @@ impl CollationGenerationSubsystem {
 				validation_code_hash,
 				result_sender,
 				core_index,
-				scheduling_parent,
+				scheduling_parent: Some(scheduling_parent),
 				session_index,
 				validation_data,
 			},

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -90,7 +90,7 @@ use error::{Error, Result};
 use futures::{channel::oneshot, future::FutureExt, select};
 use polkadot_node_primitives::{
 	AvailableData, Collation, CollationGenerationConfig, CollationSecondedSignal, PoV,
-	SubmitCollationParams,
+	SegmentCollation, SubmitCollationParams, SubmitSegmentParams,
 };
 use polkadot_node_subsystem::{
 	messages::{CollationGenerationMessage, CollatorProtocolMessage, RuntimeApiMessage},
@@ -204,9 +204,12 @@ impl CollationGenerationSubsystem {
 				false
 			},
 			Ok(FromOrchestra::Communication {
-				msg: CollationGenerationMessage::SubmitSegment(_params),
+				msg: CollationGenerationMessage::SubmitSegment(params),
 			}) => {
-				// TODO: handle segment submission.
+				if let Err(err) = self.handle_submit_segment(params, ctx).await {
+					gum::error!(target: LOG_TARGET, ?err, "Failed to submit segment");
+				}
+
 				false
 			},
 			Ok(FromOrchestra::Signal(OverseerSignal::BlockFinalized(..))) => false,
@@ -280,6 +283,54 @@ impl CollationGenerationSubsystem {
 		.await?;
 
 		Ok(())
+	}
+
+	// TODO: once the V4 collator-protocol lands, distribute the receipts for the whole segment as
+	// a single unit instead of one collation at a time, and drop the length-1 restriction.
+	async fn handle_submit_segment<Context>(
+		&mut self,
+		params: SubmitSegmentParams,
+		ctx: &mut Context,
+	) -> Result<()> {
+		let SubmitSegmentParams { scheduling_parent, core_index, mut collations } = params;
+
+		if collations.is_empty() {
+			gum::warn!(target: LOG_TARGET, "received empty segment submission");
+			return Ok(());
+		}
+
+		if collations.len() > 1 {
+			gum::warn!(
+				target: LOG_TARGET,
+				len = collations.len(),
+				"multi-collation segment submission not yet supported; ignoring",
+			);
+			return Ok(());
+		}
+
+		let SegmentCollation {
+			relay_parent,
+			collation,
+			validation_code_hash,
+			result_sender,
+			session_index,
+			validation_data,
+		} = collations.pop().expect("len == 1; qed");
+
+		self.handle_submit_collation(
+			SubmitCollationParams {
+				relay_parent,
+				collation,
+				validation_code_hash,
+				result_sender,
+				core_index,
+				scheduling_parent,
+				session_index,
+				validation_data,
+			},
+			ctx,
+		)
+		.await
 	}
 
 	async fn handle_new_activation<Context>(

--- a/polkadot/node/collation-generation/src/lib.rs
+++ b/polkadot/node/collation-generation/src/lib.rs
@@ -203,6 +203,12 @@ impl CollationGenerationSubsystem {
 
 				false
 			},
+			Ok(FromOrchestra::Communication {
+				msg: CollationGenerationMessage::SubmitSegment(_params),
+			}) => {
+				// TODO: handle segment submission.
+				false
+			},
 			Ok(FromOrchestra::Signal(OverseerSignal::BlockFinalized(..))) => false,
 			Err(err) => {
 				gum::error!(

--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -553,6 +553,47 @@ pub struct SubmitCollationParams {
 	pub validation_data: PersistedValidationData,
 }
 
+/// A single collation in a segment submitted via `CollationGenerationMessage::SubmitSegment`.
+#[derive(Debug)]
+pub struct SegmentCollation {
+	/// The relay-parent the collation is built against.
+	pub relay_parent: Hash,
+	/// The collation itself (PoV and commitments).
+	pub collation: Collation,
+	/// The hash of the validation code the collation was created against.
+	pub validation_code_hash: ValidationCodeHash,
+	/// An optional result sender that should be informed about a successfully seconded collation.
+	///
+	/// See [`SubmitCollationParams::result_sender`] for the same caveats.
+	pub result_sender: Option<futures::channel::oneshot::Sender<CollationSecondedSignal>>,
+	/// The session index of the relay parent. Goes into the candidate descriptor.
+	/// Must be provided by the caller because the relay parent's state may be pruned.
+	pub session_index: SessionIndex,
+	/// The persisted validation data for this collation. The `parent_head` field must be set
+	/// to the correct parent head-data for the parablock being submitted.
+	pub validation_data: PersistedValidationData,
+}
+
+/// Parameters for `CollationGenerationMessage::SubmitSegment`.
+///
+/// Submits multiple collations that share a common scheduling parent and target core. Each
+/// [`SegmentCollation`] in `collations` carries the fields that may differ between blocks of the
+/// segment (relay parent, collation payload, validation data, etc.).
+#[derive(Debug)]
+pub struct SubmitSegmentParams {
+	/// The scheduling parent for V3 candidate descriptors, shared by all collations in the
+	/// segment. If set, every candidate descriptor will use this as the scheduling parent
+	/// (creating V3 descriptors). If `None`, each collation's `relay_parent` is used (V2
+	/// descriptors).
+	///
+	/// WARNING: Should only be set if the `CandidateReceiptV3` node feature is set.
+	pub scheduling_parent: Option<Hash>,
+	/// The core index on which the resulting candidates should be backed.
+	pub core_index: CoreIndex,
+	/// The collations in this segment, in the order they should be submitted.
+	pub collations: Vec<SegmentCollation>,
+}
+
 /// This is the data we keep available for each candidate included in the relay chain.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, Debug)]
 pub struct AvailableData {

--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -581,13 +581,11 @@ pub struct SegmentCollation {
 /// segment (relay parent, collation payload, validation data, etc.).
 #[derive(Debug)]
 pub struct SubmitSegmentParams {
-	/// The scheduling parent for V3 candidate descriptors, shared by all collations in the
-	/// segment. If set, every candidate descriptor will use this as the scheduling parent
-	/// (creating V3 descriptors). If `None`, each collation's `relay_parent` is used (V2
-	/// descriptors).
+	/// The scheduling parent shared by every collation in the segment. Segments are V3/V4-only,
+	/// so this is always present and produces V3 candidate descriptors.
 	///
-	/// WARNING: Should only be set if the `CandidateReceiptV3` node feature is set.
-	pub scheduling_parent: Option<Hash>,
+	/// WARNING: only valid when the `CandidateReceiptV3` node feature is set.
+	pub scheduling_parent: Hash,
 	/// The core index on which the resulting candidates should be backed.
 	pub core_index: CoreIndex,
 	/// The collations in this segment, in the order they should be submitted.

--- a/polkadot/node/primitives/src/lib.rs
+++ b/polkadot/node/primitives/src/lib.rs
@@ -576,9 +576,13 @@ pub struct SegmentCollation {
 
 /// Parameters for `CollationGenerationMessage::SubmitSegment`.
 ///
-/// Submits multiple collations that share a common scheduling parent and target core. Each
+/// Submits a segment of collations that share a common scheduling parent and target core. Each
 /// [`SegmentCollation`] in `collations` carries the fields that may differ between blocks of the
 /// segment (relay parent, collation payload, validation data, etc.).
+///
+/// **Currently restricted to `collations.len() == 1`.** The collation-generation subsystem drops
+/// submissions with more than one entry (the V4 collator-protocol work will lift this and
+/// distribute the whole segment as a single unit).
 #[derive(Debug)]
 pub struct SubmitSegmentParams {
 	/// The scheduling parent shared by every collation in the segment. Segments are V3/V4-only,
@@ -588,7 +592,8 @@ pub struct SubmitSegmentParams {
 	pub scheduling_parent: Hash,
 	/// The core index on which the resulting candidates should be backed.
 	pub core_index: CoreIndex,
-	/// The collations in this segment, in the order they should be submitted.
+	/// The collations in this segment, in the order they should be submitted. Must currently
+	/// contain exactly one entry; see the type-level note above.
 	pub collations: Vec<SegmentCollation>,
 }
 

--- a/polkadot/node/subsystem-types/src/messages.rs
+++ b/polkadot/node/subsystem-types/src/messages.rs
@@ -39,7 +39,7 @@ use polkadot_node_primitives::{
 	AvailableData, BabeEpoch, BlockWeight, CandidateVotes, CollationGenerationConfig,
 	CollationSecondedSignal, DisputeMessage, DisputeStatus, ErasureChunk, PoV,
 	SignedDisputeStatement, SignedFullStatement, SignedFullStatementWithPVD, SubmitCollationParams,
-	ValidationResult,
+	SubmitSegmentParams, ValidationResult,
 };
 use polkadot_primitives::{
 	self,
@@ -989,6 +989,12 @@ pub enum CollationGenerationMessage {
 	///
 	/// If sent before `Initialize`, this will be ignored.
 	SubmitCollation(SubmitCollationParams),
+	/// Submit a segment of collations that share a scheduling parent and target core. Each
+	/// collation is packaged into a signed [`CommittedCandidateReceipt`] and distributed to
+	/// validators, in the order they appear in [`SubmitSegmentParams::collations`].
+	///
+	/// If sent before `Initialize`, this will be ignored.
+	SubmitSegment(SubmitSegmentParams),
 }
 
 /// The result type of [`ApprovalVotingMessage::ImportAssignment`] request.


### PR DESCRIPTION
# Description

Adds collation-generation subsystem types that are used by the collators to submit segments. Currently the new types have corresponding types in cumulus, to enable the support for segment submission from the block_builder/collation_task levels.

We clearly separate now between V2 and V3/V4 messages - V2 submits `CollatorMessage` (named as before, although I would've changed it, and without the `scheduling_proof`, which was set to `None` either way), while V3 submits `CollatorResubmitSegment`, with various info that's used by the collation-task to craft the correct `SubmitSegment` collation-generation message.

The current block building/collation-task changes keep the existing submission contract for V2/V3. We attempt to build bundles for each core (for both V2/V3), but for V3, depending on whether it builds a bundle for the first core or not, it either sends across to the collation-task a `CollatorResubmitSegment` with a `SegmentKind::WithBundle` (appending a newly built bundle to an existing list of unincluded blocks, computed in a future resubmission manager, and submitting that - for now, the list contains just the newly built bundle) or a `SegmentKind::ResubmitOnly` (that's concerned just with resubmitting an existing unincluded segment as is, again computed by a future resubmission manager, and at the moment being handled as a no-op).

Closes https://github.com/paritytech/polkadot-sdk/issues/12310.

## Integration

N/A - segment submission primitive types usage is gated by the `CandidateReceiptV3` node feature on the relay chain side, by the `VerifySignedSchedulingInfo` parachain runtime config type (for which we do not have yet an implementation, pending on #12097), but it also lacks the requried collator resubmissions machinery (wip here: #12228, depending on this PR) or the V4 collator-protocol (wip here: #12172 for the collator-side, and a validator-side PR that's not yet up).

## Review Notes

Foundation for the resubmission machinery, and for the V4 collator-protocol's collator-side concerns, of distributing a whole segment.

TODO:
- [ ] I am in the process of rebasing #12228 on top of this work, some rough edges came up, and will mark this as ready to review once those are polished.