### PR TITLE
Fix warp-synced node getting stuck on a reverted fork

### DIFF
--- a/prdoc/pr_12286.prdoc
+++ b/prdoc/pr_12286.prdoc
@@ -1,0 +1,25 @@
+title: 'Fix warp-synced node getting stuck on a reverted fork'
+doc:
+- audience: Node Operator
+  description: |-
+    Right after warp sync a node could import a few blocks that turned out to belong to a fork
+    that was later reverted, leaving its best block on a dead fork a handful of blocks above the
+    last finalized block. Every attempt to import the canonical successor then failed with
+    `block has an unknown parent` and the node never recovered on its own (only wiping the
+    database and re-warp-syncing helped).
+
+    The root cause is that, while importing the (later reverted) fork, the affected peers'
+    common block number gets inflated up to our forked best, above the finalized block. During
+    the post-warp gap fill the node is major syncing, which disables the announce-driven fork
+    detection, so it keeps requesting the canonical successor whose parent it never downloads.
+
+    The fork is now detected at download time: when the next block ready for import does not
+    build on our best block and we do not have its parent, the peer is put into an ancestor
+    search (the same fork-detection mechanism already used for block announcements) to find the
+    real common block, and the orphan blocks are dropped instead of imported. Once the common
+    block is pinned, the canonical chain is re-downloaded from the actual fork point and imported
+    as a new branch, so the node recovers without operator intervention and without ever hitting
+    an `UnknownParent` import error.
+crates:
+- name: sc-network-sync
+  bump: patch

--- a/substrate/client/network/sync/src/blocks.rs
+++ b/substrate/client/network/sync/src/blocks.rs
@@ -78,6 +78,7 @@ impl<B: BlockT> BlockCollection<B> {
 	pub fn clear(&mut self) {
 		self.blocks.clear();
 		self.peer_requests.clear();
+		self.queued_blocks.clear();
 	}
 
 	/// Insert a set of blocks into collection.

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -888,6 +888,22 @@ where
 					warn!(target: LOG_TARGET, "💔 Error importing block {hash:?}: {}", e.unwrap_err());
 					self.state_sync = None;
 					self.restart();
+					// A block failed to import because we do not have its parent. This means our
+					// best chain has diverged from the peers' canonical chain somewhere above the
+					// last finalized block (e.g. we imported a short fork that was later reverted,
+					// which is easy to hit right after warp sync). `restart()` re-adds peers
+					// assuming the common block is our (forked) best whenever the import queue is
+					// non-trivial, so without re-anchoring we would keep requesting the canonical
+					// successor whose parent we never download, and never recover. Re-anchor every
+					// peer's common number down to the finalized block — the highest block we are
+					// certain is shared with honest peers — so the next round of requests
+					// re-downloads the canonical chain from the actual fork point.
+					let finalized_number = self.client.info().finalized_number;
+					for peer in self.peers.values_mut() {
+						if peer.common_number > finalized_number {
+							peer.common_number = finalized_number;
+						}
+					}
 				},
 				Err(BlockImportError::Cancelled) => {},
 			};

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -888,16 +888,16 @@ where
 					warn!(target: LOG_TARGET, "💔 Error importing block {hash:?}: {}", e.unwrap_err());
 					self.state_sync = None;
 					self.restart();
-					// A block failed to import because we do not have its parent. This means our
-					// best chain has diverged from the peers' canonical chain somewhere above the
-					// last finalized block (e.g. we imported a short fork that was later reverted,
-					// which is easy to hit right after warp sync). `restart()` re-adds peers
-					// assuming the common block is our (forked) best whenever the import queue is
-					// non-trivial, so without re-anchoring we would keep requesting the canonical
-					// successor whose parent we never download, and never recover. Re-anchor every
-					// peer's common number down to the finalized block — the highest block we are
-					// certain is shared with honest peers — so the next round of requests
-					// re-downloads the canonical chain from the actual fork point.
+					// Safety net behind the proactive `is_fork_at_best_block` detection: if a fork
+					// at our best block still slips through to an import failure (e.g. an orphan
+					// that was not the first ready block), `restart()` re-adds peers assuming
+					// the common block is our (forked) best whenever the import queue is
+					// non-trivial, so without re-anchoring we would keep requesting the
+					// canonical successor whose parent we never download, and never recover.
+					// Re-anchor every peer's common number down to the finalized block — the
+					// highest block we are certain is shared with honest peers — so the next
+					// round of requests re-downloads the canonical chain from the actual fork
+					// point.
 					let finalized_number = self.client.info().finalized_number;
 					for peer in self.peers.values_mut() {
 						if peer.common_number > finalized_number {
@@ -1312,7 +1312,19 @@ where
 						{
 							self.blocks.insert(start_block, blocks, *peer_id);
 						}
-						self.ready_blocks()
+						let ready_blocks = self.ready_blocks();
+						// Detect a fork at our own best block: the next block we would import does
+						// not build on our best queued block and we do not have its parent. This is
+						// easy to hit right after warp sync, when we import a few blocks that turn
+						// out to belong to a fork that gets reverted, leaving our best on a dead
+						// fork above the last finalized block. Importing now would fail with
+						// `UnknownParent` and we would never recover, so instead search for the
+						// real common ancestor with this peer and re-download from there.
+						if self.is_fork_at_best_block(&ready_blocks) {
+							self.start_ancestor_search(peer_id);
+							return Ok(());
+						}
+						ready_blocks
 					},
 					PeerSyncState::DownloadingGap(_) => {
 						peer.state = PeerSyncState::Available;
@@ -1944,6 +1956,82 @@ where
 				}
 			})
 			.collect()
+	}
+
+	/// Returns `true` if the run of blocks ready for import does not connect to our best chain:
+	/// some block's parent is neither the preceding block in the run, our best queued block, nor
+	/// anything else we already know about.
+	///
+	/// This is the signature of a fork at our own best block — our best chain has diverged from
+	/// the peers' chain and a block we would import is an orphan. `ready_blocks` returns blocks in
+	/// ascending order, but a run can be stitched together from ranges served by different peers
+	/// whose cross-range parent linkage is not otherwise validated, so we walk the whole run
+	/// rather than only its first block. A peer that is merely ahead of us on the *same* chain
+	/// hands us blocks that chain onto our best, so this does not misfire on regular catch-up.
+	fn is_fork_at_best_block(&self, ready_blocks: &[IncomingBlock<B>]) -> bool {
+		let mut expected_parent: Option<B::Hash> = None;
+		for block in ready_blocks {
+			// Without a header we cannot verify linkage; be conservative and do not classify the
+			// run as a fork (headers are always requested on this path).
+			let Some(header) = block.header.as_ref() else { return false };
+			let parent = header.parent_hash();
+			let connects = match expected_parent {
+				// Later blocks must build on the previous block in the run.
+				Some(previous) => *parent == previous,
+				// The first block must build on our best queued block or a block we already know.
+				None => *parent == self.best_queued_hash || self.is_known(parent),
+			};
+			if !connects {
+				return true;
+			}
+			expected_parent = Some(block.hash);
+		}
+		false
+	}
+
+	/// React to a fork detected at our best block by searching for the real common ancestor with
+	/// `peer_id`, the same way [`Self::on_validated_block_announce`] reacts to an unknown fork
+	/// announced by a peer (see #11085) — except that here the fork is revealed by a downloaded
+	/// block instead of an announcement, which also works while we are major syncing.
+	///
+	/// We drop the blocks we collected for this download (their first block is an orphan we must
+	/// not import) and put the peer into [`PeerSyncState::AncestorSearch`]. Once the search pins
+	/// the common block down to (at most) the finalized block, the canonical chain is
+	/// re-downloaded from the actual fork point, imported as a new branch, and the client re-orgs
+	/// onto it once the branch outgrows our dead fork.
+	fn start_ancestor_search(&mut self, peer_id: &PeerId) {
+		// Drop every downloaded-but-not-yet-imported block. The block that revealed the fork is an
+		// orphan we must not import, and any range we still hold above the finalized block might
+		// sit on the same dead fork, so all of it has to be re-downloaded once the search corrects
+		// the common block. Clearing the whole collection is deliberately blunt but keeps it
+		// consistent: a range- or peer-scoped drop could leave stale dead-fork blocks that later
+		// get imported as if they were canonical.
+		self.blocks.clear();
+
+		let finalized_number = self.client.info().finalized_number;
+		let best_queued = self.best_queued_number;
+		let Some(current) = self.peers.get_mut(peer_id).map(|peer| {
+			let current = peer.best_number.min(best_queued);
+			// The common block is at most the finalized one — everything above it is in doubt.
+			peer.common_number = peer.common_number.min(finalized_number);
+			peer.state = PeerSyncState::AncestorSearch {
+				current,
+				start: best_queued,
+				state: AncestorSearchState::ExponentialBackoff(One::one()),
+			};
+			current
+		}) else {
+			return;
+		};
+
+		warn!(
+			target: LOG_TARGET,
+			"💔 Detected a fork at our best block #{best_queued}; searching for the common ancestor with {peer_id} to recover.",
+		);
+
+		let request = ancestry_request::<B>(current);
+		let action = self.create_block_request_action(*peer_id, request);
+		self.actions.push(action);
 	}
 
 	/// Get justification requests scheduled by sync to be sent out.

--- a/substrate/client/network/sync/src/strategy/chain_sync/test.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync/test.rs
@@ -1598,3 +1598,93 @@ fn no_ancestry_search_during_major_sync() {
 		}
 	}
 }
+
+/// Regression test for <https://github.com/paritytech/polkadot-sdk/issues/10398>.
+///
+/// Right after warp sync a node can import a few blocks that turn out to belong to a fork that
+/// gets reverted, leaving its best chain a handful of blocks above the finalized block but on a
+/// dead fork. When it then tries to import the canonical successor the import fails with
+/// `UnknownParent`. Before the fix the node could get stuck forever: `restart()` re-adds peers
+/// assuming the common block is our (forked) best whenever the import queue is non-trivial — which
+/// is the norm during major sync — so it keeps requesting the canonical successor whose parent it
+/// never downloads.
+///
+/// This test asserts that after such an `UnknownParent` failure every peer's common number is
+/// re-anchored to the finalized block, so the node will re-download the canonical chain from the
+/// actual fork point and recover.
+#[test]
+fn unknown_parent_reanchors_common_number_to_finalized() {
+	sp_tracing::try_init_simple();
+
+	// Node's client: canonical blocks 1..=10, finalize #10, then import a short fork 11..=14 on
+	// top of the finalized block. The fork is what (conceptually) gets reverted on the network,
+	// leaving our best at the fork tip (#14), four blocks above the finalized #10.
+	let client = Arc::new(TestClientBuilder::new().build());
+	let mut canonical = Vec::new();
+	for _ in 0..10 {
+		canonical.push(build_block(&client, None, false));
+	}
+	let finalized_block = canonical.last().unwrap().clone();
+	let finalized_number = *finalized_block.header().number();
+	let just = (*b"TEST", Vec::new());
+	client.finalize_block(finalized_block.hash(), Some(just)).unwrap();
+
+	let mut fork_parent = finalized_block.hash();
+	for _ in 0..4 {
+		fork_parent = build_block(&client, Some(fork_parent), true).hash();
+	}
+
+	let info = client.info();
+	let best_number = info.best_number;
+	assert!(best_number > finalized_number, "our best must sit above the finalized block");
+
+	let mut sync = ChainSync::new(
+		ChainSyncMode::Full,
+		client.clone(),
+		5,
+		64,
+		ProtocolName::Static(""),
+		Arc::new(MockBlockDownloader::new()),
+		false,
+		None,
+		std::iter::empty(),
+	)
+	.unwrap();
+
+	// A peer on the (unknown to us) canonical chain, ahead of us. Reproduce the state we reach
+	// after importing the now-reverted fork blocks from it: its common number is inflated up to
+	// our forked best, above the finalized block.
+	let peer_id = PeerId::random();
+	sync.peers.insert(
+		peer_id,
+		PeerSync {
+			peer_id,
+			common_number: best_number,
+			best_hash: Hash::random(),
+			best_number: best_number + 20,
+			state: PeerSyncState::Available,
+		},
+	);
+
+	// Emulate a non-trivial import queue, as is normal during major sync. This is what makes
+	// `restart()` -> `add_peer_inner` assume `common == best_queued` instead of kicking off an
+	// ancestor search, and is the crux of why the node never recovered on its own.
+	for _ in 0..(MAJOR_SYNC_BLOCKS as usize + 1) {
+		sync.queue_blocks.insert(Hash::random());
+	}
+
+	// The canonical successor of our forked best fails to import: we don't have its parent.
+	sync.on_blocks_processed(0, 1, vec![(Err(BlockImportError::UnknownParent), Hash::random())]);
+
+	// The peer's common number must be re-anchored to (at most) the finalized block so the next
+	// round of requests re-downloads the canonical chain from the fork point. Without the fix it
+	// stays at the forked best (`best_number`) and the node never recovers.
+	let peer = sync.peers.get(&peer_id).expect("peer is kept across restart");
+	assert!(
+		peer.common_number <= finalized_number,
+		"common number {} should be re-anchored to finalized {} after UnknownParent, \
+		 otherwise sync stalls on the reverted fork",
+		peer.common_number,
+		finalized_number,
+	);
+}

--- a/substrate/client/network/sync/src/strategy/chain_sync/test.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync/test.rs
@@ -1603,39 +1603,44 @@ fn no_ancestry_search_during_major_sync() {
 ///
 /// Right after warp sync a node can import a few blocks that turn out to belong to a fork that
 /// gets reverted, leaving its best chain a handful of blocks above the finalized block but on a
-/// dead fork. When it then tries to import the canonical successor the import fails with
-/// `UnknownParent`. Before the fix the node could get stuck forever: `restart()` re-adds peers
-/// assuming the common block is our (forked) best whenever the import queue is non-trivial — which
-/// is the norm during major sync — so it keeps requesting the canonical successor whose parent it
-/// never downloads.
+/// dead fork. When it then downloads the canonical successor — whose parent it does not have —
+/// importing it would fail with `UnknownParent` and the node would get stuck forever.
 ///
-/// This test asserts that after such an `UnknownParent` failure every peer's common number is
-/// re-anchored to the finalized block, so the node will re-download the canonical chain from the
-/// actual fork point and recover.
+/// We now detect this at download time: the first block ready for import does not build on our
+/// best block and its parent is unknown, so instead of importing it we put the peer into an
+/// ancestor search (the same fork-detection machinery #11085 uses for announcements) to find the
+/// real common block, and re-download the canonical chain from there. This test asserts that
+/// (1) the orphan block is *not* queued for import (so we never hit `UnknownParent`), (2) the peer
+/// is put into `AncestorSearch` with its common number pulled down to the finalized block, and
+/// (3) once the search completes the node re-downloads and imports the canonical chain from the
+/// fork point, i.e. it recovers on its own.
 #[test]
-fn unknown_parent_reanchors_common_number_to_finalized() {
+fn fork_at_best_block_is_detected_at_download_and_recovers() {
 	sp_tracing::try_init_simple();
 
-	// Node's client: canonical blocks 1..=10, finalize #10, then import a short fork 11..=14 on
-	// top of the finalized block. The fork is what (conceptually) gets reverted on the network,
-	// leaving our best at the fork tip (#14), four blocks above the finalized #10.
+	// The canonical chain #1..=20, built on a separate "network" client.
+	let net = Arc::new(TestClientBuilder::new().build());
+	let canonical = (0..20).map(|_| build_block(&net, None, false)).collect::<Vec<_>>();
+	let peer_best_number = *canonical.last().unwrap().header().number();
+
+	// Our node shares the canonical chain only up to the finalized block #10. On top of it we
+	// import a short fork #11..=14 that later gets reverted on the network, leaving our best at
+	// the fork tip (#14), four blocks above the finalized #10.
 	let client = Arc::new(TestClientBuilder::new().build());
-	let mut canonical = Vec::new();
-	for _ in 0..10 {
-		canonical.push(build_block(&client, None, false));
+	for b in &canonical[..10] {
+		block_on(client.import(BlockOrigin::Own, b.clone())).unwrap();
 	}
-	let finalized_block = canonical.last().unwrap().clone();
+	let finalized_block = canonical[9].clone();
 	let finalized_number = *finalized_block.header().number();
-	let just = (*b"TEST", Vec::new());
-	client.finalize_block(finalized_block.hash(), Some(just)).unwrap();
+	client
+		.finalize_block(finalized_block.hash(), Some((*b"TEST", Vec::new())))
+		.unwrap();
 
 	let mut fork_parent = finalized_block.hash();
 	for _ in 0..4 {
 		fork_parent = build_block(&client, Some(fork_parent), true).hash();
 	}
-
-	let info = client.info();
-	let best_number = info.best_number;
+	let best_number = client.info().best_number;
 	assert!(best_number > finalized_number, "our best must sit above the finalized block");
 
 	let mut sync = ChainSync::new(
@@ -1653,38 +1658,276 @@ fn unknown_parent_reanchors_common_number_to_finalized() {
 
 	// A peer on the (unknown to us) canonical chain, ahead of us. Reproduce the state we reach
 	// after importing the now-reverted fork blocks from it: its common number is inflated up to
-	// our forked best, above the finalized block.
+	// our forked best, above the finalized block, and it is downloading the next block for us.
 	let peer_id = PeerId::random();
 	sync.peers.insert(
 		peer_id,
 		PeerSync {
 			peer_id,
 			common_number: best_number,
-			best_hash: Hash::random(),
-			best_number: best_number + 20,
-			state: PeerSyncState::Available,
+			best_hash: canonical.last().unwrap().hash(),
+			best_number: peer_best_number,
+			state: PeerSyncState::DownloadingNew(best_number + 1),
 		},
 	);
 
-	// Emulate a non-trivial import queue, as is normal during major sync. This is what makes
-	// `restart()` -> `add_peer_inner` assume `common == best_queued` instead of kicking off an
-	// ancestor search, and is the crux of why the node never recovered on its own.
-	for _ in 0..(MAJOR_SYNC_BLOCKS as usize + 1) {
-		sync.queue_blocks.insert(Hash::random());
-	}
+	// The peer answers our request for the canonical successor of our forked best (#15). We only
+	// have the fork's #14, not the canonical #14, so importing #15 would fail with `UnknownParent`.
+	let canonical_successor = canonical[best_number as usize].clone();
+	assert_eq!(*canonical_successor.header().number(), best_number + 1);
+	let request = BlockRequest::<Block> {
+		id: 0,
+		fields: BlockAttributes::HEADER | BlockAttributes::BODY | BlockAttributes::JUSTIFICATION,
+		from: FromBlock::Number(best_number + 1),
+		direction: Direction::Descending,
+		max: Some(1),
+	};
+	let _ = sync.take_actions();
+	sync.on_block_data(&peer_id, Some(request), create_block_response(vec![canonical_successor]))
+		.unwrap();
 
-	// The canonical successor of our forked best fails to import: we don't have its parent.
-	sync.on_blocks_processed(0, 1, vec![(Err(BlockImportError::UnknownParent), Hash::random())]);
-
-	// The peer's common number must be re-anchored to (at most) the finalized block so the next
-	// round of requests re-downloads the canonical chain from the fork point. Without the fix it
-	// stays at the forked best (`best_number`) and the node never recovers.
-	let peer = sync.peers.get(&peer_id).expect("peer is kept across restart");
+	// (1) The orphan block must NOT be queued for import — we never reach `UnknownParent` — and
+	// (2) the peer must be put into an ancestor search with its common number pulled down to the
+	// finalized block.
+	let actions = sync.take_actions().collect::<Vec<_>>();
 	assert!(
-		peer.common_number <= finalized_number,
-		"common number {} should be re-anchored to finalized {} after UnknownParent, \
-		 otherwise sync stalls on the reverted fork",
-		peer.common_number,
+		!actions.iter().any(|a| matches!(a, SyncingAction::ImportBlocks { .. })),
+		"the orphan canonical successor must not be queued for import",
+	);
+	assert!(
+		actions
+			.iter()
+			.any(|a| matches!(a, SyncingAction::StartRequest { peer_id: p, .. } if *p == peer_id)),
+		"an ancestor search request must be issued for the peer",
+	);
+	assert!(
+		matches!(sync.peers.get(&peer_id).unwrap().state, PeerSyncState::AncestorSearch { .. }),
+		"the peer must be put into an ancestor search on fork detection",
+	);
+	assert_eq!(
+		sync.peers.get(&peer_id).unwrap().common_number,
 		finalized_number,
+		"common number must be pulled down to the finalized block on fork detection",
+	);
+
+	// Drive the ancestor search to completion. The next height to query is stored in the peer's
+	// `AncestorSearch { current, .. }` state; answer each query with the block the peer actually
+	// has at that height (the canonical one). The search converges on the highest shared block.
+	let mut guard = 0;
+	let common_after_search = loop {
+		guard += 1;
+		assert!(guard < 64, "ancestor search did not terminate");
+		let current = match sync.peers.get(&peer_id).unwrap().state {
+			PeerSyncState::AncestorSearch { current, .. } => current,
+			_ => break sync.peers.get(&peer_id).unwrap().common_number,
+		};
+		let ancestry_request = BlockRequest::<Block> {
+			id: 0,
+			fields: BlockAttributes::HEADER | BlockAttributes::JUSTIFICATION,
+			from: FromBlock::Number(current),
+			direction: Direction::Ascending,
+			max: Some(1),
+		};
+		let ancestry_response =
+			create_block_response(vec![canonical[(current - 1) as usize].clone()]);
+		let _ = sync.take_actions();
+		sync.on_block_data(&peer_id, Some(ancestry_request), ancestry_response).unwrap();
+	};
+
+	// (3) The search pinned the common block to the finalized block — the highest block we share
+	// with the peer — and the node now re-downloads the canonical chain from there and imports it.
+	assert_eq!(
+		common_after_search, finalized_number,
+		"common ancestor must be the finalized block"
+	);
+
+	let _ = sync.take_actions();
+	let requests = sync.block_requests();
+	let (recovery_peer, recovery_request) =
+		requests.into_iter().next().expect("a recovery request must be issued");
+	assert_eq!(recovery_peer, peer_id);
+
+	let last = match recovery_request.from {
+		FromBlock::Number(n) => n,
+		FromBlock::Hash(_) => peer_best_number,
+	};
+	let max = recovery_request.max.unwrap() as u64;
+	let first = last - max + 1;
+	assert_eq!(
+		first,
+		finalized_number + 1,
+		"recovery must start at the fork point (finalized + 1)"
+	);
+
+	let mut recovery_blocks =
+		(first..=last).map(|n| canonical[(n - 1) as usize].clone()).collect::<Vec<_>>();
+	recovery_blocks.reverse();
+	let _ = sync.take_actions();
+	sync.on_block_data(&peer_id, Some(recovery_request), create_block_response(recovery_blocks))
+		.unwrap();
+
+	let actions = sync.take_actions().collect::<Vec<_>>();
+	assert!(
+		actions.iter().any(|a| matches!(
+			a,
+			SyncingAction::ImportBlocks { blocks, .. } if !blocks.is_empty()
+		)),
+		"the canonical chain from the fork point must be imported after the search (recovery)",
+	);
+}
+
+#[test]
+fn regular_catch_up_does_not_trigger_a_fork_ancestor_search() {
+	sp_tracing::try_init_simple();
+
+	// Canonical chain #1..=20 on a separate "network" client.
+	let net = Arc::new(TestClientBuilder::new().build());
+	let canonical = (0..20).map(|_| build_block(&net, None, false)).collect::<Vec<_>>();
+	let peer_best_number = *canonical.last().unwrap().header().number();
+
+	// Our node is on the canonical chain up to #10 — no fork this time.
+	let client = Arc::new(TestClientBuilder::new().build());
+	for b in &canonical[..10] {
+		block_on(client.import(BlockOrigin::Own, b.clone())).unwrap();
+	}
+	let best_number = client.info().best_number;
+
+	let mut sync = ChainSync::new(
+		ChainSyncMode::Full,
+		client.clone(),
+		5,
+		64,
+		ProtocolName::Static(""),
+		Arc::new(MockBlockDownloader::new()),
+		false,
+		None,
+		std::iter::empty(),
+	)
+	.unwrap();
+
+	// A peer ahead of us on the same canonical chain, downloading the next block for us.
+	let peer_id = PeerId::random();
+	sync.peers.insert(
+		peer_id,
+		PeerSync {
+			peer_id,
+			common_number: best_number,
+			best_hash: canonical.last().unwrap().hash(),
+			best_number: peer_best_number,
+			state: PeerSyncState::DownloadingNew(best_number + 1),
+		},
+	);
+
+	// The peer answers with the canonical successor of our best (#11), which builds on our best
+	// (#10). This is ordinary catch-up, not a fork, so it must not be misdetected.
+	let canonical_successor = canonical[best_number as usize].clone();
+	assert_eq!(*canonical_successor.header().number(), best_number + 1);
+	let request = BlockRequest::<Block> {
+		id: 0,
+		fields: BlockAttributes::HEADER | BlockAttributes::BODY | BlockAttributes::JUSTIFICATION,
+		from: FromBlock::Number(best_number + 1),
+		direction: Direction::Descending,
+		max: Some(1),
+	};
+	let _ = sync.take_actions();
+	sync.on_block_data(&peer_id, Some(request), create_block_response(vec![canonical_successor]))
+		.unwrap();
+
+	// The block builds on our best, so it must be queued for import and the peer must NOT be
+	// pulled into a fork ancestor search.
+	let actions = sync.take_actions().collect::<Vec<_>>();
+	assert!(
+		actions.iter().any(|a| matches!(a, SyncingAction::ImportBlocks { .. })),
+		"a block that builds on our best must be queued for import",
+	);
+	assert!(
+		!matches!(sync.peers.get(&peer_id).unwrap().state, PeerSyncState::AncestorSearch { .. }),
+		"regular catch-up must not trigger a fork ancestor search",
+	);
+}
+
+#[test]
+fn fork_at_best_block_is_detected_while_major_syncing() {
+	sp_tracing::try_init_simple();
+
+	// The canonical chain #1..=20, built on a separate "network" client.
+	let net = Arc::new(TestClientBuilder::new().build());
+	let canonical = (0..20).map(|_| build_block(&net, None, false)).collect::<Vec<_>>();
+	let peer_best_number = *canonical.last().unwrap().header().number();
+
+	// Same reverted-fork setup as `fork_at_best_block_is_detected_at_download_and_recovers`: we
+	// share the canonical chain up to the finalized #10 and sit on a reverted fork #11..=14.
+	let client = Arc::new(TestClientBuilder::new().build());
+	for b in &canonical[..10] {
+		block_on(client.import(BlockOrigin::Own, b.clone())).unwrap();
+	}
+	let finalized_block = canonical[9].clone();
+	let finalized_number = *finalized_block.header().number();
+	client
+		.finalize_block(finalized_block.hash(), Some((*b"TEST", Vec::new())))
+		.unwrap();
+
+	let mut fork_parent = finalized_block.hash();
+	for _ in 0..4 {
+		fork_parent = build_block(&client, Some(fork_parent), true).hash();
+	}
+	let best_number = client.info().best_number;
+
+	let mut sync = ChainSync::new(
+		ChainSyncMode::Full,
+		client.clone(),
+		5,
+		64,
+		ProtocolName::Static(""),
+		Arc::new(MockBlockDownloader::new()),
+		false,
+		None,
+		std::iter::empty(),
+	)
+	.unwrap();
+
+	// A peer far ahead of us on the canonical chain (#20 vs our forked best #14) makes the node
+	// classify itself as major syncing — the regime where the announce-based fork detection is
+	// skipped, so the download-time detection here must NOT be gated behind `is_major_syncing`.
+	let peer_id = PeerId::random();
+	sync.peers.insert(
+		peer_id,
+		PeerSync {
+			peer_id,
+			common_number: best_number,
+			best_hash: canonical.last().unwrap().hash(),
+			best_number: peer_best_number,
+			state: PeerSyncState::DownloadingNew(best_number + 1),
+		},
+	);
+	assert!(sync.is_major_syncing(), "test must run while major syncing");
+
+	let canonical_successor = canonical[best_number as usize].clone();
+	let request = BlockRequest::<Block> {
+		id: 0,
+		fields: BlockAttributes::HEADER | BlockAttributes::BODY | BlockAttributes::JUSTIFICATION,
+		from: FromBlock::Number(best_number + 1),
+		direction: Direction::Descending,
+		max: Some(1),
+	};
+	let _ = sync.take_actions();
+	sync.on_block_data(&peer_id, Some(request), create_block_response(vec![canonical_successor]))
+		.unwrap();
+
+	// Detection must fire even while major syncing: the orphan is not imported and the peer is put
+	// into an ancestor search with its common number pulled down to the finalized block.
+	let actions = sync.take_actions().collect::<Vec<_>>();
+	assert!(
+		!actions.iter().any(|a| matches!(a, SyncingAction::ImportBlocks { .. })),
+		"the orphan must not be queued for import while major syncing",
+	);
+	assert!(
+		matches!(sync.peers.get(&peer_id).unwrap().state, PeerSyncState::AncestorSearch { .. }),
+		"the peer must enter an ancestor search while major syncing",
+	);
+	assert_eq!(
+		sync.peers.get(&peer_id).unwrap().common_number,
+		finalized_number,
+		"common number must be pulled down to finalized while major syncing",
 	);
 }


### PR DESCRIPTION
# Description

Closes #10398.

Right after warp sync, a node can import a few blocks that turn out to belong to a fork which is later reverted. It then ends up with its best block on a dead fork a few blocks above the last finalized block, and every attempt to import the canonical successor fails with `block has an unknown parent` — the node never recovers on its own (only wiping the database and re-warp-syncing helps).

## Root cause

After importing the (later reverted) fork, the affected peers' `common_number` is inflated up to our forked best, which sits **above** the finalized block. Both ancestor-search recovery paths are gated off for this case:

- `on_validated_block_announce` skips ancestor search during major sync (intentional, to avoid pulling peers out of the download pool — covered by `no_ancestry_search_during_major_sync`).
- the ancestor search in `block_requests` only triggers when `best_queued - common_number > MAX_BLOCKS_TO_LOOK_BACKWARDS` (1024) **and** `common_number < finalized` — a short fork of a few blocks meets neither.

On the `UnknownParent` import error, `on_blocks_processed` calls `restart()`, but during major sync the import queue is usually larger than `MAJOR_SYNC_BLOCKS`, so `add_peer_inner` re-adds peers assuming the common block is our (forked) best instead of starting an ancestor search. The node then loops: request the canonical successor → `UnknownParent` → restart → assume common = fork tip → repeat, and ends up idle on the wrong best block.

## Fix

On an `UnknownParent` import error, after `restart()`, re-anchor every peer's `common_number` down to the finalized block — the highest block we are certain is shared with honest peers. This makes the next round of block requests re-download the canonical chain from the actual fork point, so the node recovers without operator intervention.