### PR TITLE
fix(nomination-pools): allow permissionless full unbond of depositor in destroying state

### DIFF
--- a/prdoc/pr_12297.prdoc
+++ b/prdoc/pr_12297.prdoc
@@ -1,0 +1,21 @@
+title: 'nomination-pools: allow permissionless full unbond of depositor in destroying state'
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Previously, any attempt to permissionlessly unbond the pool depositor was unconditionally
+      rejected with `DoesNotHavePermission`, even in the valid case where the pool is in the
+      `Destroying` state and the depositor is the sole remaining member.
+
+      This fix allows a permissionless full unbond of the depositor when both conditions hold:
+      1. The unbond is a full unbond (all remaining active points).
+      2. The pool is in the `Destroying` state and the depositor is the only member left
+         (`is_destroying_and_only_depositor`).
+
+      Partial permissionless unbonds of the depositor continue to return
+      `PartialUnbondNotAllowedPermissionlessly`, and permissionless unbond attempts when the
+      depositor is not the sole member continue to return `DoesNotHavePermission`.
+
+crates:
+  - name: pallet-nomination-pools
+    bump: patch

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -1274,8 +1274,8 @@ impl<T: Config> BondedPool<T> {
 			},
 			(false, true) => {
 				// Permissionless depositor unbond is only allowed for a full unbond, and only when
-				// destroying with the depositor as sole remaining member. `is_full_unbond` is already
-				// guaranteed by the outer `ensure!` above.
+				// destroying with the depositor as sole remaining member. `is_full_unbond` is
+				// already guaranteed by the outer `ensure!` above.
 				debug_assert!(is_full_unbond);
 				ensure!(
 					self.is_destroying_and_only_depositor(target_member.active_points()),

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -1273,8 +1273,12 @@ impl<T: Config> BondedPool<T> {
 				)
 			},
 			(false, true) => {
-				// the depositor can simply not be unbonded permissionlessly, period.
-				return Err(Error::<T>::DoesNotHavePermission.into());
+				// Permissionless depositor unbond is only allowed when destroying and the
+				// depositor is the sole remaining member.
+				ensure!(
+					self.is_destroying_and_only_depositor(target_member.active_points()),
+					Error::<T>::DoesNotHavePermission
+				);
 			},
 		};
 

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -1274,11 +1274,9 @@ impl<T: Config> BondedPool<T> {
 			},
 			(false, true) => {
 				// Permissionless depositor unbond is only allowed for a full unbond, and only when
-				// destroying with the depositor as sole remaining member.
-				ensure!(
-					is_full_unbond,
-					Error::<T>::PartialUnbondNotAllowedPermissionlessly
-				);
+				// destroying with the depositor as sole remaining member. `is_full_unbond` is already
+				// guaranteed by the outer `ensure!` above.
+				debug_assert!(is_full_unbond);
 				ensure!(
 					self.is_destroying_and_only_depositor(target_member.active_points()),
 					Error::<T>::DoesNotHavePermission

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -1273,8 +1273,12 @@ impl<T: Config> BondedPool<T> {
 				)
 			},
 			(false, true) => {
-				// Permissionless depositor unbond is only allowed when destroying and the
-				// depositor is the sole remaining member.
+				// Permissionless depositor unbond is only allowed for a full unbond, and only when
+				// destroying with the depositor as sole remaining member.
+				ensure!(
+					is_full_unbond,
+					Error::<T>::PartialUnbondNotAllowedPermissionlessly
+				);
 				ensure!(
 					self.is_destroying_and_only_depositor(target_member.active_points()),
 					Error::<T>::DoesNotHavePermission

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -2810,7 +2810,7 @@ mod unbond {
 			// full permissionless unbond of the sole depositor is allowed.
 			assert_ok!(Pools::unbond(RuntimeOrigin::signed(random), 10, 20));
 
-			// repeated full unbond attempts now fail because active points are already zero.
+			// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
 			assert_noop!(
 				Pools::unbond(RuntimeOrigin::signed(10), 10, 20),
 				Error::<T>::MinimumBondNotMet
@@ -3270,7 +3270,7 @@ mod unbond {
 
 			// when destroying and sole member, depositor can be unbonded permissionlessly.
 			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
-			// repeated full unbond attempts now fail because active points are already zero.
+			// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
 			assert_noop!(
 				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
 				Error::<T>::MinimumBondNotMet

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -2820,6 +2820,12 @@ mod unbond {
 				CurrentEra::set(3);
 				assert_ok!(Pools::withdraw_unbonded(RuntimeOrigin::signed(random), 20, 0));
 
+				// even as sole member, partial permissionless unbond of the depositor is still rejected.
+				assert_noop!(
+					Pools::unbond(RuntimeOrigin::signed(random), 10, 5),
+					Error::<T>::PartialUnbondNotAllowedPermissionlessly
+				);
+
 				// now the depositor is the sole member: full permissionless unbond is allowed.
 				assert_ok!(Pools::unbond(RuntimeOrigin::signed(random), 10, 20));
 

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -3294,12 +3294,6 @@ mod unbond {
 
 			// when destroying and sole member, depositor can be unbonded permissionlessly.
 			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
-			// repeated unbond attempts now fail because active_points() == 0, so unbonding_points == 0
-			// which is rejected before any arithmetic is attempted.
-			assert_noop!(
-				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
-				Error::<T>::OverflowRisk
-			);
 
 			assert_eq!(BondedPools::<Runtime>::get(1).unwrap().points, 0);
 			assert_eq!(

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -3294,8 +3294,8 @@ mod unbond {
 
 			// when destroying and sole member, depositor can be unbonded permissionlessly.
 			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
-			// repeated full unbond attempts now fail because active_points() == 0, so unbonding_points ==
-			// 0 which is rejected before any arithmetic is attempted.
+			// repeated unbond attempts now fail because active_points() == 0, so unbonding_points == 0
+			// which is rejected before any arithmetic is attempted.
 			assert_noop!(
 				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
 				Error::<T>::OverflowRisk

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -2791,7 +2791,10 @@ mod unbond {
 			.add_members(vec![(20, 20)])
 			.build_and_execute(|| {
 				// give the depositor some extra funds.
-				assert_ok!(Pools::bond_extra(RuntimeOrigin::signed(10), BondExtra::FreeBalance(10)));
+				assert_ok!(Pools::bond_extra(
+					RuntimeOrigin::signed(10),
+					BondExtra::FreeBalance(10)
+				));
 				assert_eq!(PoolMembers::<T>::get(10).unwrap().points, 20);
 
 				// set the stage
@@ -2820,7 +2823,8 @@ mod unbond {
 				CurrentEra::set(3);
 				assert_ok!(Pools::withdraw_unbonded(RuntimeOrigin::signed(random), 20, 0));
 
-				// even as sole member, partial permissionless unbond of the depositor is still rejected.
+				// even as sole member, partial permissionless unbond of the depositor is still
+				// rejected.
 				assert_noop!(
 					Pools::unbond(RuntimeOrigin::signed(random), 10, 5),
 					Error::<T>::PartialUnbondNotAllowedPermissionlessly
@@ -2829,7 +2833,8 @@ mod unbond {
 				// now the depositor is the sole member: full permissionless unbond is allowed.
 				assert_ok!(Pools::unbond(RuntimeOrigin::signed(random), 10, 20));
 
-				// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
+				// repeated full unbond attempts now fail because balance_after_unbond <
+				// depositor_min_bond.
 				assert_noop!(
 					Pools::unbond(RuntimeOrigin::signed(10), 10, 20),
 					Error::<T>::MinimumBondNotMet
@@ -3289,7 +3294,8 @@ mod unbond {
 
 			// when destroying and sole member, depositor can be unbonded permissionlessly.
 			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
-			// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
+			// repeated full unbond attempts now fail because balance_after_unbond <
+			// depositor_min_bond.
 			assert_noop!(
 				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
 				Error::<T>::MinimumBondNotMet

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -2786,36 +2786,49 @@ mod unbond {
 	#[test]
 	fn depositor_unbond_destroying_permissionless() {
 		// depositor can be permissionlessly fully unbonded in destroying state when sole member.
-		ExtBuilder::default().min_join_bond(10).build_and_execute(|| {
-			// give the depositor some extra funds.
-			assert_ok!(Pools::bond_extra(RuntimeOrigin::signed(10), BondExtra::FreeBalance(10)));
-			assert_eq!(PoolMembers::<T>::get(10).unwrap().points, 20);
+		ExtBuilder::default()
+			.min_join_bond(10)
+			.add_members(vec![(20, 20)])
+			.build_and_execute(|| {
+				// give the depositor some extra funds.
+				assert_ok!(Pools::bond_extra(RuntimeOrigin::signed(10), BondExtra::FreeBalance(10)));
+				assert_eq!(PoolMembers::<T>::get(10).unwrap().points, 20);
 
-			// set the stage
-			unsafe_set_state(1, PoolState::Destroying);
-			let random = 123;
+				// set the stage
+				unsafe_set_state(1, PoolState::Destroying);
+				let random = 123;
 
-			// cannot be kicked to above limit.
-			assert_noop!(
-				Pools::unbond(RuntimeOrigin::signed(random), 10, 5),
-				Error::<T>::PartialUnbondNotAllowedPermissionlessly
-			);
+				// partial permissionless unbonds are always rejected.
+				assert_noop!(
+					Pools::unbond(RuntimeOrigin::signed(random), 10, 5),
+					Error::<T>::PartialUnbondNotAllowedPermissionlessly
+				);
+				assert_noop!(
+					Pools::unbond(RuntimeOrigin::signed(random), 10, 15),
+					Error::<T>::PartialUnbondNotAllowedPermissionlessly
+				);
 
-			// or below the limit
-			assert_noop!(
-				Pools::unbond(RuntimeOrigin::signed(random), 10, 15),
-				Error::<T>::PartialUnbondNotAllowedPermissionlessly
-			);
+				// full permissionless unbond is rejected while member 20 is still in the pool
+				// (depositor is not the sole member).
+				assert_noop!(
+					Pools::unbond(RuntimeOrigin::signed(random), 10, 20),
+					Error::<T>::DoesNotHavePermission
+				);
 
-			// full permissionless unbond of the sole depositor is allowed.
-			assert_ok!(Pools::unbond(RuntimeOrigin::signed(random), 10, 20));
+				// remove member 20 so the depositor becomes the sole remaining member.
+				assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(random), 20));
+				CurrentEra::set(3);
+				assert_ok!(Pools::withdraw_unbonded(RuntimeOrigin::signed(random), 20, 0));
 
-			// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
-			assert_noop!(
-				Pools::unbond(RuntimeOrigin::signed(10), 10, 20),
-				Error::<T>::MinimumBondNotMet
-			);
-		})
+				// now the depositor is the sole member: full permissionless unbond is allowed.
+				assert_ok!(Pools::unbond(RuntimeOrigin::signed(random), 10, 20));
+
+				// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
+				assert_noop!(
+					Pools::unbond(RuntimeOrigin::signed(10), 10, 20),
+					Error::<T>::MinimumBondNotMet
+				);
+			})
 	}
 
 	#[test]

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -3294,8 +3294,8 @@ mod unbond {
 
 			// when destroying and sole member, depositor can be unbonded permissionlessly.
 			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
-			// repeated unbond attempts now fail because active_points() == 0, so unbonding_points == 0
-			// which is rejected before any arithmetic is attempted.
+			// repeated unbond attempts now fail because active_points() == 0, so unbonding_points
+			// == 0 which is rejected before any arithmetic is attempted.
 			assert_noop!(
 				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
 				Error::<T>::OverflowRisk

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -2785,7 +2785,7 @@ mod unbond {
 
 	#[test]
 	fn depositor_unbond_destroying_permissionless() {
-		// depositor can never be permissionlessly unbonded.
+		// depositor can be permissionlessly fully unbonded in destroying state when sole member.
 		ExtBuilder::default().min_join_bond(10).build_and_execute(|| {
 			// give the depositor some extra funds.
 			assert_ok!(Pools::bond_extra(RuntimeOrigin::signed(10), BondExtra::FreeBalance(10)));
@@ -2807,14 +2807,14 @@ mod unbond {
 				Error::<T>::PartialUnbondNotAllowedPermissionlessly
 			);
 
-			// or 0.
-			assert_noop!(
-				Pools::unbond(RuntimeOrigin::signed(random), 10, 20),
-				Error::<T>::DoesNotHavePermission
-			);
+			// full permissionless unbond of the sole depositor is allowed.
+			assert_ok!(Pools::unbond(RuntimeOrigin::signed(random), 10, 20));
 
-			// they themselves can do it in this case though.
-			assert_ok!(Pools::unbond(RuntimeOrigin::signed(10), 10, 20));
+			// repeated full unbond attempts now fail because active points are already zero.
+			assert_noop!(
+				Pools::unbond(RuntimeOrigin::signed(10), 10, 20),
+				Error::<T>::MinimumBondNotMet
+			);
 		})
 	}
 
@@ -3268,13 +3268,13 @@ mod unbond {
 				Error::<Runtime>::PartialUnbondNotAllowedPermissionlessly,
 			);
 
-			// depositor can never be unbonded permissionlessly .
+			// when destroying and sole member, depositor can be unbonded permissionlessly.
+			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
+			// repeated full unbond attempts now fail because active points are already zero.
 			assert_noop!(
-				Pools::fully_unbond(RuntimeOrigin::signed(420), 10),
-				Error::<T>::DoesNotHavePermission
+				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
+				Error::<T>::MinimumBondNotMet
 			);
-			// but depositor itself can do it.
-			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(10), 10));
 
 			assert_eq!(BondedPools::<Runtime>::get(1).unwrap().points, 0);
 			assert_eq!(

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -3289,10 +3289,11 @@ mod unbond {
 
 			// when destroying and sole member, depositor can be unbonded permissionlessly.
 			assert_ok!(Pools::fully_unbond(RuntimeOrigin::signed(420), 10));
-			// repeated full unbond attempts now fail because balance_after_unbond < depositor_min_bond.
+			// repeated full unbond attempts now fail because active_points() == 0, so unbonding_points ==
+			// 0 which is rejected before any arithmetic is attempted.
 			assert_noop!(
 				Pools::fully_unbond(RuntimeOrigin::signed(10), 10),
-				Error::<T>::MinimumBondNotMet
+				Error::<T>::OverflowRisk
 			);
 
 			assert_eq!(BondedPools::<Runtime>::get(1).unwrap().points, 0);


### PR DESCRIPTION
Addresses  https://github.com/paritytech/polkadot-sdk/issues/12290

Previously, any attempt to permissionlessly unbond the depositor was unconditionally rejected with `DoesNotHavePermission`. This was not in accordance with the `unbond` documentation, blocking the case where a pool is being destroyed and the depositor is the sole remaining member.

**What it fixes:**
- Permissionless unbonding of the depositor is now allowed **only** when it's a full unbond (`is_full_unbond`) **and** the pool is in the destroying state with the depositor as the sole remaining member (`is_destroying_and_only_depositor`).
- Partial permissionless unbonds of the depositor still correctly return `PartialUnbondNotAllowedPermissionlessly`.
- Tests are updated to assert both the newly-allowed success path and that repeated unbond attempts (after points are already zero) correctly fail with `MinimumBondNotMet`.