### PR TITLE
pallet-uniques: repatriate collection deposit in force_item_status on owner change

### DIFF
--- a/prdoc/pr_12325.prdoc
+++ b/prdoc/pr_12325.prdoc
@@ -1,0 +1,12 @@
+title: 'pallet-uniques: repatriate collection deposit in force_item_status on owner
+  change'
+doc:
+- audience: Runtime Dev
+  description: "Fixes #12193.\n\n`force_item_status` lets `ForceOrigin` reassign a\
+    \ collection's owner, but it only\nmoved `item.owner` and the `CollectionAccount`\
+    \ index to the new owner \u2014 it never\nmoved the reserved collection deposit.\
+    \ This left `total_deposit` reserved under the\n*old* owner while the collection\
+    \ was owned by the *new* account."
+crates:
+- name: pallet-uniques
+  bump: patch

--- a/substrate/frame/uniques/src/lib.rs
+++ b/substrate/frame/uniques/src/lib.rs
@@ -1081,15 +1081,30 @@ pub mod pallet {
 				let mut item = maybe_item.take().ok_or(Error::<T, I>::UnknownCollection)?;
 				let old_owner = item.owner;
 				let new_owner = T::Lookup::lookup(owner)?;
-				item.owner = new_owner.clone();
-				item.issuer = T::Lookup::lookup(issuer)?;
-				item.admin = T::Lookup::lookup(admin)?;
-				item.freezer = T::Lookup::lookup(freezer)?;
+				let issuer = T::Lookup::lookup(issuer)?;
+				let admin = T::Lookup::lookup(admin)?;
+				let freezer = T::Lookup::lookup(freezer)?;
+
+				if old_owner != new_owner {
+					// Move the deposit to the new owner so that deposit accounting stays
+					// consistent when the collection ownership changes.
+					T::Currency::repatriate_reserved(
+						&old_owner,
+						&new_owner,
+						item.total_deposit,
+						Reserved,
+					)?;
+					CollectionAccount::<T, I>::remove(&old_owner, &collection);
+					CollectionAccount::<T, I>::insert(&new_owner, &collection, ());
+				}
+
+				item.owner = new_owner;
+				item.issuer = issuer;
+				item.admin = admin;
+				item.freezer = freezer;
 				item.free_holding = free_holding;
 				item.is_frozen = is_frozen;
 				*maybe_item = Some(item);
-				CollectionAccount::<T, I>::remove(&old_owner, &collection);
-				CollectionAccount::<T, I>::insert(&new_owner, &collection, ());
 
 				Self::deposit_event(Event::ItemStatusChanged { collection });
 				Ok(())

--- a/substrate/frame/uniques/src/tests.rs
+++ b/substrate/frame/uniques/src/tests.rs
@@ -634,6 +634,47 @@ fn force_item_status_should_work() {
 }
 
 #[test]
+fn force_item_status_repatriates_deposit_on_owner_change() {
+	new_test_ext().execute_with(|| {
+		Balances::make_free_balance_be(&1, 100);
+		Balances::make_free_balance_be(&2, 100);
+
+		assert_ok!(Uniques::force_create(RuntimeOrigin::root(), 0, 1, false));
+		assert_ok!(Uniques::mint(RuntimeOrigin::signed(1), 0, 42, 1));
+		assert_ok!(Uniques::set_collection_metadata(
+			RuntimeOrigin::signed(1),
+			0,
+			bvec![0; 20],
+			false
+		));
+		assert_ok!(Uniques::set_metadata(RuntimeOrigin::signed(1), 0, 42, bvec![0; 20], false));
+
+		// The collection owner (account 1) holds the whole deposit.
+		let total_deposit = Balances::reserved_balance(1);
+		assert!(total_deposit > 0);
+		assert_eq!(Balances::reserved_balance(2), 0);
+		assert_eq!(CollectionAccount::<Test>::get(1, 0), Some(()));
+		assert_eq!(CollectionAccount::<Test>::get(2, 0), None);
+
+		// Force the collection ownership over to account 2.
+		assert_ok!(Uniques::force_item_status(RuntimeOrigin::root(), 0, 2, 2, 2, 2, false, false));
+
+		// The deposit moves with the ownership instead of being stranded on account 1.
+		assert_eq!(Balances::reserved_balance(1), 0);
+		assert_eq!(Balances::reserved_balance(2), total_deposit);
+		assert_eq!(CollectionAccount::<Test>::get(1, 0), None);
+		assert_eq!(CollectionAccount::<Test>::get(2, 0), Some(()));
+
+		// Destroying the collection unreserves the deposit from the current owner,
+		// leaving no funds stranded.
+		let w = Collection::<Test>::get(0).unwrap().destroy_witness();
+		assert_ok!(Uniques::destroy(RuntimeOrigin::signed(2), 0, w));
+		assert_eq!(Balances::reserved_balance(1), 0);
+		assert_eq!(Balances::reserved_balance(2), 0);
+	});
+}
+
+#[test]
 fn burn_works() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&1, 100);


### PR DESCRIPTION
Fixes #12193.

`force_item_status` lets `ForceOrigin` reassign a collection's owner, but it only
moved `item.owner` and the `CollectionAccount` index to the new owner — it never
moved the reserved collection deposit. This left `total_deposit` reserved under the
*old* owner while the collection was owned by the *new* account.