### PR TITLE
[pallet-node-authorization] Validate MaxPeerIdLength for connection PeerIds

### DIFF
--- a/substrate/frame/node-authorization/src/lib.rs
+++ b/substrate/frame/node-authorization/src/lib.rs
@@ -399,6 +399,10 @@ pub mod pallet {
 			let mut nodes = AdditionalConnections::<T>::get(&node);
 
 			for add_node in connections.iter() {
+				ensure!(
+					add_node.0.len() < T::MaxPeerIdLength::get() as usize,
+					Error::<T>::PeerIdTooLong
+				);
 				if *add_node == node {
 					continue;
 				}
@@ -434,6 +438,10 @@ pub mod pallet {
 			let mut nodes = AdditionalConnections::<T>::get(&node);
 
 			for remove_node in connections.iter() {
+				ensure!(
+					remove_node.0.len() < T::MaxPeerIdLength::get() as usize,
+					Error::<T>::PeerIdTooLong
+				);
 				nodes.remove(remove_node);
 			}
 

--- a/substrate/frame/node-authorization/src/tests.rs
+++ b/substrate/frame/node-authorization/src/tests.rs
@@ -316,6 +316,18 @@ fn add_connections_works() {
 			Error::<Test>::NotOwner
 		);
 
+		// A connection `PeerId` exceeding `MaxPeerIdLength` is rejected, even when the `node`
+		// itself is valid, and no connection is stored.
+		assert_noop!(
+			NodeAuthorization::add_connections(
+				RuntimeOrigin::signed(20),
+				test_node(20),
+				vec![test_node(5), PeerId(vec![1, 2, 3])]
+			),
+			Error::<Test>::PeerIdTooLong
+		);
+		assert!(!AdditionalConnections::<Test>::contains_key(test_node(20)));
+
 		assert_ok!(NodeAuthorization::add_connections(
 			RuntimeOrigin::signed(20),
 			test_node(20),
@@ -361,6 +373,22 @@ fn remove_connections_works() {
 			test_node(20),
 			BTreeSet::from_iter(vec![test_node(5), test_node(15), test_node(25)]),
 		);
+
+		// A connection `PeerId` exceeding `MaxPeerIdLength` is rejected, and the stored
+		// connections are left untouched.
+		assert_noop!(
+			NodeAuthorization::remove_connections(
+				RuntimeOrigin::signed(20),
+				test_node(20),
+				vec![test_node(5), PeerId(vec![1, 2, 3])]
+			),
+			Error::<Test>::PeerIdTooLong
+		);
+		assert_eq!(
+			AdditionalConnections::<Test>::get(test_node(20)),
+			BTreeSet::from_iter(vec![test_node(5), test_node(15), test_node(25)])
+		);
+
 		assert_ok!(NodeAuthorization::remove_connections(
 			RuntimeOrigin::signed(20),
 			test_node(20),


### PR DESCRIPTION
Fixes #12258

`pallet-node-authorization`'s `add_connections` and `remove_connections` extrinsics
validated only the primary `node` parameter against `MaxPeerIdLength`, while every
`PeerId` passed in the `connections: Vec<PeerId>` parameter skipped validation. As a
result, oversized peer IDs could be written into the `AdditionalConnections` storage map,
bypassing the length bound enforced everywhere else in the pallet.