### PR TITLE
statement-store: index v2 peers by DHT key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21977,6 +21977,7 @@ dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "async-trait",
+ "bitvec",
  "criterion",
  "fastbloom",
  "futures",

--- a/substrate/client/network/statement/Cargo.toml
+++ b/substrate/client/network/statement/Cargo.toml
@@ -21,6 +21,7 @@ test-helpers = []
 [dependencies]
 array-bytes = { workspace = true, default-features = true }
 async-channel = { workspace = true }
+bitvec = { workspace = true }
 codec = { features = ["derive"], workspace = true, default-features = true }
 fastbloom = { workspace = true }
 futures = { workspace = true }

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -19,6 +19,7 @@
 //! DHT-targeted gossip path for the statement protocol.
 
 mod explicit_affinity;
+mod peers_index;
 pub mod peers_topology;
 
 use crate::{affinity::AffinityFilter, LOG_TARGET};

--- a/substrate/client/network/statement/src/v2dht/peers_index.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_index.rs
@@ -1,0 +1,238 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use bitvec::{order::Msb0, view::BitView};
+use sc_network_types::PeerId;
+use std::{collections::BTreeMap, ops::Bound};
+
+/// A point in the 32-byte key space shared by topics and hashed peer ids.
+pub(crate) type Key = [u8; 32];
+type KeyRange = (Bound<Key>, Bound<Key>);
+
+/// Peers keyed by their position in the 32-byte key space, queryable in increasing XOR distance to
+/// a target without sorting the full set.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PeersIndex {
+	/// Peers grouped by key; keys are ordered, and peers sharing a key are ordered by peer id.
+	peers_by_key: BTreeMap<Key, Vec<PeerId>>,
+}
+
+impl PeersIndex {
+	pub(crate) fn insert(&mut self, key: Key, peer: PeerId) {
+		let peers = self.peers_by_key.entry(key).or_default();
+		if let Err(position) = peers.binary_search(&peer) {
+			peers.insert(position, peer);
+		}
+	}
+
+	pub(crate) fn remove(&mut self, key: Key, peer: &PeerId) {
+		if let Some(peers) = self.peers_by_key.get_mut(&key) {
+			if let Ok(position) = peers.binary_search(peer) {
+				peers.remove(position);
+			}
+			if peers.is_empty() {
+				self.peers_by_key.remove(&key);
+			}
+		}
+	}
+
+	pub(crate) fn closest(&self, target: Key) -> Closest<'_> {
+		closest(&self.peers_by_key, target)
+	}
+}
+
+/// Peers of `index` in increasing `(xor_distance(target, key), peer)` order, without sorting the
+/// full set.
+///
+/// The keys are already sorted in the `BTreeMap`. Each pending key range is split at the most
+/// significant bit where its lowest and highest keys differ; the half whose bit matches the target
+/// holds the closer keys and is visited first. Peers sharing a key have equal distance, so the
+/// peer-id order within a key completes the `(distance, peer)` order.
+fn closest(index: &BTreeMap<Key, Vec<PeerId>>, target: Key) -> Closest<'_> {
+	Closest { index, target, stack: vec![(Bound::Unbounded, Bound::Unbounded)], current: None }
+}
+
+pub(crate) struct Closest<'a> {
+	index: &'a BTreeMap<Key, Vec<PeerId>>,
+	target: Key,
+	/// Pending key ranges, the range nearest to `target` on top.
+	stack: Vec<KeyRange>,
+	/// Key and remaining peers of the entry currently being yielded.
+	current: Option<(Key, std::slice::Iter<'a, PeerId>)>,
+}
+
+impl<'a> Iterator for Closest<'a> {
+	type Item = (PeerId, Key);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		loop {
+			if let Some((key, mut peers)) = self.current.take() {
+				if let Some(peer) = peers.next() {
+					self.current = Some((key, peers));
+					return Some((*peer, key));
+				}
+			}
+			let range = self.stack.pop()?;
+			match self.range_keys(range) {
+				RangeKeys::Empty => continue,
+				RangeKeys::Single { key, peers } => self.current = Some((key, peers)),
+				RangeKeys::Multiple { first, last } => {
+					let (lo, hi) = split_range(&first, &last, &self.target);
+					self.stack.push(hi);
+					self.stack.push(lo);
+				},
+			}
+		}
+	}
+}
+
+impl<'a> Closest<'a> {
+	fn range_keys(&self, range: KeyRange) -> RangeKeys<'a> {
+		let mut keys = self.index.range(range);
+		let Some((first, peers)) = keys.next() else { return RangeKeys::Empty };
+
+		match keys.next_back() {
+			None => RangeKeys::Single { key: *first, peers: peers.iter() },
+			Some((last, _)) => RangeKeys::Multiple { first: *first, last: *last },
+		}
+	}
+}
+
+enum RangeKeys<'a> {
+	Empty,
+	Single { key: Key, peers: std::slice::Iter<'a, PeerId> },
+	Multiple { first: Key, last: Key },
+}
+
+fn split_range(lo: &Key, hi: &Key, target: &Key) -> (KeyRange, KeyRange) {
+	let bit = divergence_bit(lo, hi);
+	let split = split_key(lo, bit);
+	let lower = (Bound::Included(*lo), Bound::Excluded(split));
+	let upper = (Bound::Included(split), Bound::Included(*hi));
+
+	if target.view_bits::<Msb0>()[usize::from(bit)] {
+		(upper, lower)
+	} else {
+		(lower, upper)
+	}
+}
+
+/// First bit where `a` and `b` differ; the keys must differ.
+fn divergence_bit(a: &Key, b: &Key) -> u16 {
+	a.iter()
+		.zip(b)
+		.enumerate()
+		.find_map(|(byte, (a, b))| {
+			let diff = a ^ b;
+			(diff != 0).then(|| byte as u16 * 8 + diff.leading_zeros() as u16)
+		})
+		.expect("the keys differ; qed")
+}
+
+/// `key` with bit `bit` set and every following bit cleared: the lower bound of the upper half of a
+/// key range splitting at `bit`.
+fn split_key(key: &Key, bit: u16) -> Key {
+	let bit = usize::from(bit);
+	let mut split = [0; 32];
+
+	let source = key.view_bits::<Msb0>();
+	let target = split.view_bits_mut::<Msb0>();
+	for prefix_bit in 0..bit {
+		target.set(prefix_bit, source[prefix_bit]);
+	}
+	target.set(bit, true);
+
+	split
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn peer(seed: u8) -> PeerId {
+		let mut bytes = [seed; 34];
+		bytes[0] = 0;
+		bytes[1] = 32;
+		PeerId::from_bytes(&bytes).expect("identity multihash peer id")
+	}
+
+	fn peer_key(peer: &PeerId) -> Key {
+		sp_crypto_hashing::blake2_256(&peer.to_bytes())
+	}
+
+	fn xor_distance(a: Key, b: Key) -> Key {
+		let mut distance = [0; 32];
+		for ((distance, a), b) in distance.iter_mut().zip(a).zip(b) {
+			*distance = a ^ b;
+		}
+		distance
+	}
+
+	#[test]
+	fn closest_yields_keys_in_xor_order_with_peer_tiebreak() {
+		let mut index = PeersIndex::default();
+		let mut records = Vec::new();
+
+		// Uniformly hashed keys.
+		for seed in 2..=120 {
+			let peer = peer(seed);
+			let key = peer_key(&peer);
+			index.insert(key, peer);
+			records.push((peer, key));
+		}
+		// Adversarial keys sharing a 248-bit prefix.
+		for seed in 0..8 {
+			let mut key = [0xAB; 32];
+			key[31] = seed;
+			let peer = peer(130 + seed);
+			index.insert(key, peer);
+			records.push((peer, key));
+		}
+		// One key shared by several peers, as after a hash collision.
+		let shared = [0xCD; 32];
+		for seed in [202, 200, 201] {
+			let peer = peer(seed);
+			index.insert(shared, peer);
+			records.push((peer, shared));
+		}
+
+		for target in [[0; 32], [0xAB; 32], [0xCD; 32], [0xFF; 32], peer_key(&peer(7))] {
+			let mut expected = records.clone();
+			expected.sort_by_key(|(peer, key)| (xor_distance(target, *key), *peer));
+			assert_eq!(index.closest(target).collect::<Vec<_>>(), expected);
+		}
+	}
+
+	#[test]
+	fn index_mutations_keep_peers_ordered_and_pruned() {
+		let mut index = PeersIndex::default();
+		let key = [7; 32];
+
+		index.insert(key, peer(3));
+		index.insert(key, peer(2));
+		index.insert(key, peer(2));
+		assert_eq!(index.peers_by_key[&key], vec![peer(2), peer(3)]);
+
+		index.remove(key, &peer(2));
+		index.remove(key, &peer(2));
+		assert_eq!(index.peers_by_key[&key], vec![peer(3)]);
+
+		index.remove(key, &peer(3));
+		assert!(index.peers_by_key.is_empty());
+	}
+}

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -16,19 +16,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use bitvec::{order::Msb0, view::BitView};
+use super::peers_index::{Key, PeersIndex};
 use sc_network_types::PeerId;
 pub use sp_statement_store::Topic;
 use std::{
 	cmp::Reverse,
-	collections::{BTreeMap, HashMap, HashSet},
+	collections::{HashMap, HashSet},
 	num::NonZeroUsize,
-	ops::Bound,
 };
-
-/// A point in the 32-byte key space shared by topics and hashed peer ids.
-type Key = [u8; 32];
-type KeyRange = (Bound<Key>, Bound<Key>);
 
 #[derive(Debug, Clone)]
 pub struct PeersTopologyConfig {
@@ -68,8 +63,8 @@ struct PeerInfo {
 /// statement notification connections. It computes XOR distances locally over that learned peer
 /// set; it does not issue topic-specific Kademlia lookups.
 ///
-/// Topic queries traverse the sorted key indexes as an implicit binary trie (see [`closest`]),
-/// so peers arrive in increasing XOR distance without sorting the full peer set.
+/// Topic queries walk the sorted key indexes in increasing XOR distance, without sorting the full
+/// peer set.
 #[derive(Debug, Clone)]
 pub struct PeersTopology {
 	local_peer: PeerId,
@@ -79,15 +74,10 @@ pub struct PeersTopology {
 	// A follow-up should evict peers that leave the network entirely or become unresponsive.
 	discovered: HashMap<PeerId, PeerInfo>,
 	/// XOR-ordered index of the statement-protocol peers: the candidates for DHT storage,
-	/// affinity and forwarding decisions. Buckets are ordered by peer id.
-	candidates: PeersIndex,
+	/// affinity and forwarding decisions.
+	discovered_index: PeersIndex,
 	/// XOR-ordered index of the connected peers, i.e. those with an open statement notification
 	/// substream.
-	///
-	/// Kept separately from `candidates` rather than as a flag: the implicit-trie descent prunes
-	/// by range emptiness and cannot see per-entry flags. Also not a subset of `candidates`: a
-	/// connected peer stays a forwarding candidate even after identify metadata withdraws
-	/// statement-protocol support.
 	connected: PeersIndex,
 }
 
@@ -99,7 +89,7 @@ impl PeersTopology {
 			local_key: peer_key(&local_peer),
 			config,
 			discovered: HashMap::new(),
-			candidates: PeersIndex::default(),
+			discovered_index: PeersIndex::default(),
 			connected: PeersIndex::default(),
 		}
 	}
@@ -121,12 +111,11 @@ impl PeersTopology {
 	pub fn on_peer_identified(&mut self, peer: PeerId, supports_statement_protocol: bool) {
 		let info = self.get_or_insert_peer(peer);
 		let key = info.key;
-		let was_supported = info.supports_protocol;
 		info.supports_protocol = supports_statement_protocol;
-		match (was_supported, supports_statement_protocol) {
-			(false, true) => self.candidates.insert(key, peer),
-			(true, false) => self.candidates.remove(key, &peer),
-			_ => (),
+		if supports_statement_protocol {
+			self.discovered_index.insert(key, peer);
+		} else {
+			self.discovered_index.remove(key, &peer);
 		}
 	}
 
@@ -136,27 +125,18 @@ impl PeersTopology {
 	pub fn on_substream_opened(&mut self, peer: PeerId) {
 		let info = self.get_or_insert_peer(peer);
 		let key = info.key;
-		let was_supported = info.supports_protocol;
-		let was_connected = info.connected;
 		info.supports_protocol = true;
 		info.connected = true;
-		if !was_supported {
-			self.candidates.insert(key, peer);
-		}
-		if !was_connected {
-			self.connected.insert(key, peer);
-		}
+		self.discovered_index.insert(key, peer);
+		self.connected.insert(key, peer);
 	}
 
 	/// Record that the statement notification substream closed.
 	pub fn on_substream_closed(&mut self, peer: PeerId) {
 		let Some(info) = self.discovered.get_mut(&peer) else { return };
 		let key = info.key;
-		let was_connected = info.connected;
 		info.connected = false;
-		if was_connected {
-			self.connected.remove(key, &peer);
-		}
+		self.connected.remove(key, &peer);
 	}
 
 	fn is_connected(&self, peer: &PeerId) -> bool {
@@ -190,7 +170,7 @@ impl PeersTopology {
 		// before the local node form a prefix; the local node is a replica when that prefix is
 		// shorter than the replication factor.
 		let closer_count = self
-			.candidates
+			.discovered_index
 			.closest(*topic)
 			.take_while(|(peer, key)| {
 				(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
@@ -267,145 +247,8 @@ impl PeersTopology {
 	/// `closest_known` paired with each peer's key, so callers that compute further distances
 	/// reuse the key instead of looking it up again.
 	fn closest_known_keyed(&self, topic: Topic, limit: usize) -> Vec<(PeerId, Key)> {
-		self.candidates.closest(*topic).take(limit).collect()
+		self.discovered_index.closest(*topic).take(limit).collect()
 	}
-}
-
-#[derive(Debug, Clone, Default)]
-struct PeersIndex {
-	/// Buckets are ordered by key; peers within each bucket are ordered by peer id.
-	buckets: BTreeMap<Key, Vec<PeerId>>,
-}
-
-impl PeersIndex {
-	fn insert(&mut self, key: Key, peer: PeerId) {
-		let bucket = self.buckets.entry(key).or_default();
-		if let Err(position) = bucket.binary_search(&peer) {
-			bucket.insert(position, peer);
-		}
-	}
-
-	fn remove(&mut self, key: Key, peer: &PeerId) {
-		if let Some(bucket) = self.buckets.get_mut(&key) {
-			if let Ok(position) = bucket.binary_search(peer) {
-				bucket.remove(position);
-			}
-			if bucket.is_empty() {
-				self.buckets.remove(&key);
-			}
-		}
-	}
-
-	fn closest(&self, target: Key) -> Closest<'_> {
-		closest(&self.buckets, target)
-	}
-}
-
-/// Peers of `index` in increasing `(xor_distance(target, key), peer)` order.
-///
-/// The sorted key set is traversed as an implicit binary trie: a trie node is a contiguous key
-/// range sharing a prefix, split at the first bit where the range's outermost keys differ, and
-/// the half whose bit matches the target is exhausted first. Equal distance means equal key, so
-/// the in-bucket peer-id order completes the `(distance, peer)` order. Visiting a node costs one
-/// range lookup; taking `k` peers costs `O((k + depth) · log n)` instead of an `O(n log n)` sort.
-fn closest(index: &BTreeMap<Key, Vec<PeerId>>, target: Key) -> Closest<'_> {
-	Closest { index, target, stack: vec![(Bound::Unbounded, Bound::Unbounded)], bucket: None }
-}
-
-/// See [`closest`].
-struct Closest<'a> {
-	index: &'a BTreeMap<Key, Vec<PeerId>>,
-	target: Key,
-	/// Pending key ranges, the range nearest to `target` on top.
-	stack: Vec<KeyRange>,
-	/// Key and remaining peers of the bucket currently being yielded.
-	bucket: Option<(Key, std::slice::Iter<'a, PeerId>)>,
-}
-
-impl<'a> Iterator for Closest<'a> {
-	type Item = (PeerId, Key);
-
-	fn next(&mut self) -> Option<Self::Item> {
-		loop {
-			if let Some((key, mut peers)) = self.bucket.take() {
-				if let Some(peer) = peers.next() {
-					self.bucket = Some((key, peers));
-					return Some((*peer, key));
-				}
-			}
-			let range = self.stack.pop()?;
-			match self.range_keys(range) {
-				RangeKeys::Empty => continue,
-				RangeKeys::Single { key, peers } => self.bucket = Some((key, peers)),
-				RangeKeys::Multiple { first, last } => {
-					let (lo, hi) = split_range(&first, &last, &self.target);
-					// Both halves hold a key (`first` and `last` respectively), so every
-					// pushed range is non-empty and strictly smaller: the descent terminates.
-					self.stack.push(hi);
-					self.stack.push(lo);
-				},
-			}
-		}
-	}
-}
-
-impl<'a> Closest<'a> {
-	fn range_keys(&self, range: KeyRange) -> RangeKeys<'a> {
-		let mut keys = self.index.range(range);
-		let Some((first, peers)) = keys.next() else { return RangeKeys::Empty };
-
-		match keys.next_back() {
-			None => RangeKeys::Single { key: *first, peers: peers.iter() },
-			Some((last, _)) => RangeKeys::Multiple { first: *first, last: *last },
-		}
-	}
-}
-
-enum RangeKeys<'a> {
-	Empty,
-	Single { key: Key, peers: std::slice::Iter<'a, PeerId> },
-	Multiple { first: Key, last: Key },
-}
-
-fn split_range(lo: &Key, hi: &Key, target: &Key) -> (KeyRange, KeyRange) {
-	let bit = divergence_bit(lo, hi);
-	let split = split_key(lo, bit);
-	let lower = (Bound::Included(*lo), Bound::Excluded(split));
-	let upper = (Bound::Included(split), Bound::Included(*hi));
-
-	if target.view_bits::<Msb0>()[usize::from(bit)] {
-		(upper, lower)
-	} else {
-		(lower, upper)
-	}
-}
-
-/// First bit where `a` and `b` differ; the keys must differ.
-fn divergence_bit(a: &Key, b: &Key) -> u16 {
-	a.iter()
-		.zip(b)
-		.enumerate()
-		.find_map(|(byte, (a, b))| {
-			let diff = a ^ b;
-			(diff != 0).then(|| byte as u16 * 8 + diff.leading_zeros() as u16)
-		})
-		.expect("the keys differ; qed")
-}
-
-/// `key` with bit `bit` set and every following bit cleared: the lower bound of the upper half
-/// of a key range splitting at `bit`.
-fn split_key(key: &Key, bit: u16) -> Key {
-	let bit = usize::from(bit);
-	let mut split = [0; 32];
-
-	let source = key.view_bits::<Msb0>();
-	let target = split.view_bits_mut::<Msb0>();
-	for prefix_bit in 0..bit {
-		target.set(prefix_bit, source[prefix_bit]);
-	}
-	target.set(bit, true);
-
-	split
 }
 
 /// The peer covering the most uncovered topics, breaking ties by the smallest distance to a
@@ -684,59 +527,6 @@ mod tests {
 			})
 			.collect::<Vec<u8>>();
 		assert_eq!(selected_seeds, vec![13]);
-	}
-
-	#[test]
-	fn closest_yields_keys_in_xor_order_with_peer_tiebreak() {
-		let mut index = PeersIndex::default();
-		let mut records = Vec::new();
-
-		// Uniformly hashed keys.
-		for seed in 2..=120 {
-			let peer = peer(seed);
-			let key = peer_key(&peer);
-			index.insert(key, peer);
-			records.push((peer, key));
-		}
-		// Adversarial keys sharing a 248-bit prefix.
-		for seed in 0..8 {
-			let mut key = [0xAB; 32];
-			key[31] = seed;
-			let peer = peer(130 + seed);
-			index.insert(key, peer);
-			records.push((peer, key));
-		}
-		// One key shared by several peers, as after a hash collision.
-		let shared = [0xCD; 32];
-		for seed in [202, 200, 201] {
-			let peer = peer(seed);
-			index.insert(shared, peer);
-			records.push((peer, shared));
-		}
-
-		for target in [[0; 32], [0xAB; 32], [0xCD; 32], [0xFF; 32], peer_key(&peer(7))] {
-			let mut expected = records.clone();
-			expected.sort_by_key(|(peer, key)| (xor_distance(target, *key), *peer));
-			assert_eq!(index.closest(target).collect::<Vec<_>>(), expected);
-		}
-	}
-
-	#[test]
-	fn index_mutations_keep_buckets_ordered_and_pruned() {
-		let mut index = PeersIndex::default();
-		let key = [7; 32];
-
-		index.insert(key, peer(3));
-		index.insert(key, peer(2));
-		index.insert(key, peer(2));
-		assert_eq!(index.buckets[&key], vec![peer(2), peer(3)]);
-
-		index.remove(key, &peer(2));
-		index.remove(key, &peer(2));
-		assert_eq!(index.buckets[&key], vec![peer(3)]);
-
-		index.remove(key, &peer(3));
-		assert!(index.buckets.is_empty());
 	}
 
 	#[test]

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -16,13 +16,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use bitvec::{order::Msb0, view::BitView};
 use sc_network_types::PeerId;
 pub use sp_statement_store::Topic;
 use std::{
 	cmp::Reverse,
-	collections::{HashMap, HashSet},
+	collections::{BTreeMap, HashMap, HashSet},
 	num::NonZeroUsize,
+	ops::Bound,
 };
+
+/// A point in the 32-byte key space shared by topics and hashed peer ids.
+type Key = [u8; 32];
+type KeyRange = (Bound<Key>, Bound<Key>);
 
 #[derive(Debug, Clone)]
 pub struct PeersTopologyConfig {
@@ -50,8 +56,10 @@ impl Default for PeersTopologyConfig {
 #[derive(Debug, Clone)]
 struct PeerInfo {
 	supports_protocol: bool,
+	/// The statement notification substream to the peer is open.
+	connected: bool,
 	/// Cached `peer_key`; the peer id never changes and hashing is costly.
-	key: [u8; 32],
+	key: Key,
 }
 
 /// Pure, event-fed local view of statement-store peers.
@@ -59,16 +67,28 @@ struct PeerInfo {
 /// The topology is built from peers learned through routing-table updates, identify metadata and
 /// statement notification connections. It computes XOR distances locally over that learned peer
 /// set; it does not issue topic-specific Kademlia lookups.
+///
+/// Topic queries traverse the sorted key indexes as an implicit binary trie (see [`closest`]),
+/// so peers arrive in increasing XOR distance without sorting the full peer set.
 #[derive(Debug, Clone)]
 pub struct PeersTopology {
 	local_peer: PeerId,
-	local_key: [u8; 32],
+	local_key: Key,
 	config: PeersTopologyConfig,
 	// TODO: add an eviction mechanism; this map grows unbounded as peers are discovered.
-	// This scaffold only records the event-fed view. A follow-up should evict peers that
-	// leave the network entirely or become unresponsive + optimize time complexity(Binary Trie).
+	// A follow-up should evict peers that leave the network entirely or become unresponsive.
 	discovered: HashMap<PeerId, PeerInfo>,
-	connected: HashSet<PeerId>,
+	/// XOR-ordered index of the statement-protocol peers: the candidates for DHT storage,
+	/// affinity and forwarding decisions. Buckets are ordered by peer id.
+	candidates: PeersIndex,
+	/// XOR-ordered index of the connected peers, i.e. those with an open statement notification
+	/// substream.
+	///
+	/// Kept separately from `candidates` rather than as a flag: the implicit-trie descent prunes
+	/// by range emptiness and cannot see per-entry flags. Also not a subset of `candidates`: a
+	/// connected peer stays a forwarding candidate even after identify metadata withdraws
+	/// statement-protocol support.
+	connected: PeersIndex,
 }
 
 #[allow(dead_code)]
@@ -79,7 +99,8 @@ impl PeersTopology {
 			local_key: peer_key(&local_peer),
 			config,
 			discovered: HashMap::new(),
-			connected: HashSet::new(),
+			candidates: PeersIndex::default(),
+			connected: PeersIndex::default(),
 		}
 	}
 
@@ -98,24 +119,48 @@ impl PeersTopology {
 	/// Peers that do not support the statement protocol remain known but are excluded from DHT
 	/// storage and forwarding decisions.
 	pub fn on_peer_identified(&mut self, peer: PeerId, supports_statement_protocol: bool) {
-		self.get_or_insert_peer(peer).supports_protocol = supports_statement_protocol;
+		let info = self.get_or_insert_peer(peer);
+		let key = info.key;
+		let was_supported = info.supports_protocol;
+		info.supports_protocol = supports_statement_protocol;
+		match (was_supported, supports_statement_protocol) {
+			(false, true) => self.candidates.insert(key, peer),
+			(true, false) => self.candidates.remove(key, &peer),
+			_ => (),
+		}
 	}
 
 	/// Record that the statement notification substream opened.
 	///
 	/// An open substream implies statement-protocol support.
 	pub fn on_substream_opened(&mut self, peer: PeerId) {
-		self.get_or_insert_peer(peer).supports_protocol = true;
-		self.connected.insert(peer);
+		let info = self.get_or_insert_peer(peer);
+		let key = info.key;
+		let was_supported = info.supports_protocol;
+		let was_connected = info.connected;
+		info.supports_protocol = true;
+		info.connected = true;
+		if !was_supported {
+			self.candidates.insert(key, peer);
+		}
+		if !was_connected {
+			self.connected.insert(key, peer);
+		}
 	}
 
 	/// Record that the statement notification substream closed.
 	pub fn on_substream_closed(&mut self, peer: PeerId) {
-		self.connected.remove(&peer);
+		let Some(info) = self.discovered.get_mut(&peer) else { return };
+		let key = info.key;
+		let was_connected = info.connected;
+		info.connected = false;
+		if was_connected {
+			self.connected.remove(key, &peer);
+		}
 	}
 
 	fn is_connected(&self, peer: &PeerId) -> bool {
-		self.connected.contains(peer)
+		self.discovered.get(peer).is_some_and(|info| info.connected)
 	}
 
 	/// Number of known remote peers, including peers without confirmed statement-protocol support.
@@ -138,16 +183,21 @@ impl PeersTopology {
 	///
 	/// This answers whether this node should store statements for `topic` according to DHT
 	/// affinity over the locally learned statement-store peers.
-	///
-	/// TODO: Performance is very bad, we should optimise this before any production deployment.
 	pub fn is_dht_affine(&self, topic: Topic) -> bool {
-		let mut candidates = self.dht_candidates().collect::<Vec<_>>();
-		candidates.push((self.local_peer, self.local_key));
-		candidates.sort_by_cached_key(|(peer, key)| (xor_distance(*topic, *key), *peer));
-		candidates
-			.into_iter()
-			.take(self.config.replication_factor.get())
-			.any(|(peer, _)| peer == self.local_peer)
+		let local_distance = xor_distance(*topic, self.local_key);
+		let replication_factor = self.config.replication_factor.get();
+		// The descent yields candidates in `(distance, peer)` order, so the candidates ranked
+		// before the local node form a prefix; the local node is a replica when that prefix is
+		// shorter than the replication factor.
+		let closer_count = self
+			.candidates
+			.closest(*topic)
+			.take_while(|(peer, key)| {
+				(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
+			})
+			.take(replication_factor)
+			.count();
+		closer_count < replication_factor
 	}
 
 	/// Connected peers closer to `topic` than the local node, capped at `gossip_target`.
@@ -156,19 +206,12 @@ impl PeersTopology {
 	/// responsible for storing it.
 	pub fn routing_targets(&self, topic: Topic) -> Vec<PeerId> {
 		let local_distance = xor_distance(*topic, self.local_key);
-		let mut peers = self
-			.connected
-			.iter()
-			.filter_map(|peer| {
-				let info = self.discovered.get(peer)?;
-				let distance = xor_distance(*topic, info.key);
-				(distance < local_distance).then_some((*peer, distance))
-			})
-			.collect::<Vec<_>>();
-
-		peers.sort_unstable_by_key(|&(peer, distance)| (distance, peer));
-		peers.truncate(self.config.gossip_target.get());
-		peers.into_iter().map(|(peer, _)| peer).collect()
+		self.connected
+			.closest(*topic)
+			.take_while(|(_, key)| xor_distance(*topic, *key) < local_distance)
+			.take(self.config.gossip_target.get())
+			.map(|(peer, _)| peer)
+			.collect()
 	}
 
 	/// Local-only explicit-affinity connection candidates for `topics`.
@@ -214,33 +257,162 @@ impl PeersTopology {
 
 	/// Insert `peer` into the discovered set if absent and return its record.
 	fn get_or_insert_peer(&mut self, peer: PeerId) -> &mut PeerInfo {
-		self.discovered
-			.entry(peer)
-			.or_insert_with(|| PeerInfo { supports_protocol: false, key: peer_key(&peer) })
+		self.discovered.entry(peer).or_insert_with(|| PeerInfo {
+			supports_protocol: false,
+			connected: false,
+			key: peer_key(&peer),
+		})
 	}
 
-	/// `closest_known` paired with each peer's cached key, so callers that compute further
-	/// distances reuse the key instead of looking it up again.
-	fn closest_known_keyed(&self, topic: Topic, limit: usize) -> Vec<(PeerId, [u8; 32])> {
-		let mut peers = self.dht_candidates().collect::<Vec<_>>();
-		peers.sort_by_cached_key(|(peer, key)| (xor_distance(*topic, *key), *peer));
-		peers.truncate(limit);
-		peers
+	/// `closest_known` paired with each peer's key, so callers that compute further distances
+	/// reuse the key instead of looking it up again.
+	fn closest_known_keyed(&self, topic: Topic, limit: usize) -> Vec<(PeerId, Key)> {
+		self.candidates.closest(*topic).take(limit).collect()
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+struct PeersIndex {
+	/// Buckets are ordered by key; peers within each bucket are ordered by peer id.
+	buckets: BTreeMap<Key, Vec<PeerId>>,
+}
+
+impl PeersIndex {
+	fn insert(&mut self, key: Key, peer: PeerId) {
+		let bucket = self.buckets.entry(key).or_default();
+		if let Err(position) = bucket.binary_search(&peer) {
+			bucket.insert(position, peer);
+		}
 	}
 
-	fn dht_candidates(&self) -> impl Iterator<Item = (PeerId, [u8; 32])> + '_ {
-		self.discovered
-			.iter()
-			.filter(|(_, peer_info)| peer_info.supports_protocol)
-			.map(|(peer, peer_info)| (*peer, peer_info.key))
+	fn remove(&mut self, key: Key, peer: &PeerId) {
+		if let Some(bucket) = self.buckets.get_mut(&key) {
+			if let Ok(position) = bucket.binary_search(peer) {
+				bucket.remove(position);
+			}
+			if bucket.is_empty() {
+				self.buckets.remove(&key);
+			}
+		}
 	}
+
+	fn closest(&self, target: Key) -> Closest<'_> {
+		closest(&self.buckets, target)
+	}
+}
+
+/// Peers of `index` in increasing `(xor_distance(target, key), peer)` order.
+///
+/// The sorted key set is traversed as an implicit binary trie: a trie node is a contiguous key
+/// range sharing a prefix, split at the first bit where the range's outermost keys differ, and
+/// the half whose bit matches the target is exhausted first. Equal distance means equal key, so
+/// the in-bucket peer-id order completes the `(distance, peer)` order. Visiting a node costs one
+/// range lookup; taking `k` peers costs `O((k + depth) · log n)` instead of an `O(n log n)` sort.
+fn closest(index: &BTreeMap<Key, Vec<PeerId>>, target: Key) -> Closest<'_> {
+	Closest { index, target, stack: vec![(Bound::Unbounded, Bound::Unbounded)], bucket: None }
+}
+
+/// See [`closest`].
+struct Closest<'a> {
+	index: &'a BTreeMap<Key, Vec<PeerId>>,
+	target: Key,
+	/// Pending key ranges, the range nearest to `target` on top.
+	stack: Vec<KeyRange>,
+	/// Key and remaining peers of the bucket currently being yielded.
+	bucket: Option<(Key, std::slice::Iter<'a, PeerId>)>,
+}
+
+impl<'a> Iterator for Closest<'a> {
+	type Item = (PeerId, Key);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		loop {
+			if let Some((key, mut peers)) = self.bucket.take() {
+				if let Some(peer) = peers.next() {
+					self.bucket = Some((key, peers));
+					return Some((*peer, key));
+				}
+			}
+			let range = self.stack.pop()?;
+			match self.range_keys(range) {
+				RangeKeys::Empty => continue,
+				RangeKeys::Single { key, peers } => self.bucket = Some((key, peers)),
+				RangeKeys::Multiple { first, last } => {
+					let (lo, hi) = split_range(&first, &last, &self.target);
+					// Both halves hold a key (`first` and `last` respectively), so every
+					// pushed range is non-empty and strictly smaller: the descent terminates.
+					self.stack.push(hi);
+					self.stack.push(lo);
+				},
+			}
+		}
+	}
+}
+
+impl<'a> Closest<'a> {
+	fn range_keys(&self, range: KeyRange) -> RangeKeys<'a> {
+		let mut keys = self.index.range(range);
+		let Some((first, peers)) = keys.next() else { return RangeKeys::Empty };
+
+		match keys.next_back() {
+			None => RangeKeys::Single { key: *first, peers: peers.iter() },
+			Some((last, _)) => RangeKeys::Multiple { first: *first, last: *last },
+		}
+	}
+}
+
+enum RangeKeys<'a> {
+	Empty,
+	Single { key: Key, peers: std::slice::Iter<'a, PeerId> },
+	Multiple { first: Key, last: Key },
+}
+
+fn split_range(lo: &Key, hi: &Key, target: &Key) -> (KeyRange, KeyRange) {
+	let bit = divergence_bit(lo, hi);
+	let split = split_key(lo, bit);
+	let lower = (Bound::Included(*lo), Bound::Excluded(split));
+	let upper = (Bound::Included(split), Bound::Included(*hi));
+
+	if target.view_bits::<Msb0>()[usize::from(bit)] {
+		(upper, lower)
+	} else {
+		(lower, upper)
+	}
+}
+
+/// First bit where `a` and `b` differ; the keys must differ.
+fn divergence_bit(a: &Key, b: &Key) -> u16 {
+	a.iter()
+		.zip(b)
+		.enumerate()
+		.find_map(|(byte, (a, b))| {
+			let diff = a ^ b;
+			(diff != 0).then(|| byte as u16 * 8 + diff.leading_zeros() as u16)
+		})
+		.expect("the keys differ; qed")
+}
+
+/// `key` with bit `bit` set and every following bit cleared: the lower bound of the upper half
+/// of a key range splitting at `bit`.
+fn split_key(key: &Key, bit: u16) -> Key {
+	let bit = usize::from(bit);
+	let mut split = [0; 32];
+
+	let source = key.view_bits::<Msb0>();
+	let target = split.view_bits_mut::<Msb0>();
+	for prefix_bit in 0..bit {
+		target.set(prefix_bit, source[prefix_bit]);
+	}
+	target.set(bit, true);
+
+	split
 }
 
 /// The peer covering the most uncovered topics, breaking ties by the smallest distance to a
 /// covered topic, then by the smallest peer id.
 fn best_candidate(
 	topics: &[Topic],
-	pools: &[Vec<(PeerId, [u8; 32])>],
+	pools: &[Vec<(PeerId, Key)>],
 	uncovered: &HashSet<usize>,
 	selected: &[PeerId],
 ) -> Option<PeerId> {
@@ -266,7 +438,7 @@ fn best_candidate(
 		.map(|(peer, ..)| peer)
 }
 
-fn pool_contains(pool: &[(PeerId, [u8; 32])], peer: &PeerId) -> bool {
+fn pool_contains(pool: &[(PeerId, Key)], peer: &PeerId) -> bool {
 	pool.iter().any(|(candidate, _)| candidate == peer)
 }
 
@@ -275,11 +447,11 @@ fn pool_contains(pool: &[(PeerId, [u8; 32])], peer: &PeerId) -> bool {
 /// Blake2b-256 spreads peer ids uniformly over the key space. The keys only need to be
 /// consistent across statement-store nodes, which all derive them here; they need not match
 /// litep2p's SHA-256 Kademlia keys because the topology never queries Kademlia by topic.
-fn peer_key(peer: &PeerId) -> [u8; 32] {
+fn peer_key(peer: &PeerId) -> Key {
 	sp_crypto_hashing::blake2_256(&peer.to_bytes())
 }
 
-fn xor_distance(a: [u8; 32], b: [u8; 32]) -> [u8; 32] {
+fn xor_distance(a: Key, b: Key) -> Key {
 	let mut distance = [0; 32];
 	for ((distance, a), b) in distance.iter_mut().zip(a).zip(b) {
 		*distance = a ^ b;
@@ -512,5 +684,111 @@ mod tests {
 			})
 			.collect::<Vec<u8>>();
 		assert_eq!(selected_seeds, vec![13]);
+	}
+
+	#[test]
+	fn closest_yields_keys_in_xor_order_with_peer_tiebreak() {
+		let mut index = PeersIndex::default();
+		let mut records = Vec::new();
+
+		// Uniformly hashed keys.
+		for seed in 2..=120 {
+			let peer = peer(seed);
+			let key = peer_key(&peer);
+			index.insert(key, peer);
+			records.push((peer, key));
+		}
+		// Adversarial keys sharing a 248-bit prefix.
+		for seed in 0..8 {
+			let mut key = [0xAB; 32];
+			key[31] = seed;
+			let peer = peer(130 + seed);
+			index.insert(key, peer);
+			records.push((peer, key));
+		}
+		// One key shared by several peers, as after a hash collision.
+		let shared = [0xCD; 32];
+		for seed in [202, 200, 201] {
+			let peer = peer(seed);
+			index.insert(shared, peer);
+			records.push((peer, shared));
+		}
+
+		for target in [[0; 32], [0xAB; 32], [0xCD; 32], [0xFF; 32], peer_key(&peer(7))] {
+			let mut expected = records.clone();
+			expected.sort_by_key(|(peer, key)| (xor_distance(target, *key), *peer));
+			assert_eq!(index.closest(target).collect::<Vec<_>>(), expected);
+		}
+	}
+
+	#[test]
+	fn index_mutations_keep_buckets_ordered_and_pruned() {
+		let mut index = PeersIndex::default();
+		let key = [7; 32];
+
+		index.insert(key, peer(3));
+		index.insert(key, peer(2));
+		index.insert(key, peer(2));
+		assert_eq!(index.buckets[&key], vec![peer(2), peer(3)]);
+
+		index.remove(key, &peer(2));
+		index.remove(key, &peer(2));
+		assert_eq!(index.buckets[&key], vec![peer(3)]);
+
+		index.remove(key, &peer(3));
+		assert!(index.buckets.is_empty());
+	}
+
+	#[test]
+	fn queries_match_naive_recomputation() {
+		let local = peer(1);
+		let mut topology = PeersTopology::new(local, config(5, 3));
+		let mut records = Vec::new();
+
+		for seed in 2..=220 {
+			let peer = peer(seed);
+			let supports = seed % 3 != 0;
+			let connected = seed % 4 == 0;
+			topology.on_peers_discovered([peer]);
+			if connected {
+				topology.on_substream_opened(peer);
+			}
+			// Identify after the substream opens: a connected peer may withdraw protocol
+			// support yet must remain a routing candidate.
+			topology.on_peer_identified(peer, supports);
+			records.push((peer, supports, connected));
+		}
+
+		for topic_seed in 0..32 {
+			let topic = topic(topic_seed);
+
+			let mut candidates = records
+				.iter()
+				.filter(|(_, supports, _)| *supports)
+				.map(|(peer, ..)| *peer)
+				.collect::<Vec<_>>();
+			candidates.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
+			assert_eq!(
+				topology.closest_known(topic, 7),
+				candidates.iter().copied().take(7).collect::<Vec<_>>()
+			);
+
+			let mut with_local = candidates.clone();
+			with_local.push(local);
+			with_local.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
+			let expected_affine = with_local.iter().take(5).any(|peer| *peer == local);
+			assert_eq!(topology.is_dht_affine(topic), expected_affine);
+
+			let local_distance = distance_to(topic, &local);
+			let mut connected = records
+				.iter()
+				.filter(|(_, _, connected)| *connected)
+				.map(|(peer, ..)| *peer)
+				.filter(|peer| distance_to(topic, peer) < local_distance)
+				.collect::<Vec<_>>();
+			connected.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
+			connected.truncate(3);
+			assert_eq!(topology.routing_targets(topic), connected);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Impl #12292 

This PR optimizes the statement-store v2 peer topology queries by replacing per-query full scans/sorts with key-ordered peer indexes.

What changed:

- Add a `PeersIndex` backed by `BTreeMap<Key, Vec<PeerId>>`, where `Key` is the 32-byte hashed peer id in the same keyspace as statement topics.
- Maintain separate indexes for:
  - `candidates`: known peers with statement-protocol support, used for DHT storage/affinity decisions.
  - `connected`: peers with an open statement notification substream, used for immediate forwarding/routing targets.
- Add a lazy `closest(topic)` traversal over the sorted key index. It walks the key ranges as an implicit binary trie and yields peers in `(xor_distance(topic, peer_key), peer_id)` order without sorting the full peer set.
- Preserve the previous `is_dht_affine` semantics by counting candidates ranked before the local peer instead of sorting `candidates + local` on every query.
- Use `bitvec::order::Msb0` for key-bit access so bit order matches lexicographic `[u8; 32]` / `BTreeMap` ordering without manual masks.

## Why

The old implementation recomputed query results from a flat `HashMap` by scanning candidates and sorting by XOR distance on every topic query. That is expensive for workloads with many topic lookups and relatively low peer-set churn.

The new index shifts work to peer lifecycle updates and makes topic queries lazy and bounded by the number of peers actually needed.

## Benchmarks

Before collecting timings, the benchmark asserts output equality between `naive` and `btree` for `closest_known`, `is_dht_affine`, `routing_targets`, and `peers_for_topics`. The latest run completed successfully, so those assertions passed.

Criterion mean estimates from the latest run:

| benchmark | n | old naive | new btree | old/new |
|---|---:|---:|---:|---:|
| `closest_known` | 10 | 336.85 ns | 539.73 ns | 0.6x |
| `closest_known` | 1,000 | 52.53 µs | 1.93 µs | 27.2x |
| `closest_known` | 10,000 | 682.83 µs | 2.71 µs | 252.2x |
| `closest_known` | 100,000 | 10.32 ms | 3.75 µs | 2749.1x |
| `closest_known` | 500,000 | 70.77 ms | 4.20 µs | 16861.2x |
| `closest_known` | 1,000,000 | 158.87 ms | 4.63 µs | 34323.0x |
| `is_dht_affine` | 10 | 352.68 ns | 262.70 ns | 1.3x |
| `is_dht_affine` | 1,000 | 54.16 µs | 1.67 µs | 32.4x |
| `is_dht_affine` | 10,000 | 682.70 µs | 2.43 µs | 281.5x |
| `is_dht_affine` | 100,000 | 10.22 ms | 3.60 µs | 2842.6x |
| `is_dht_affine` | 500,000 | 69.78 ms | 3.99 µs | 17485.3x |
| `is_dht_affine` | 1,000,000 | 155.59 ms | 4.39 µs | 35423.5x |
| `routing_targets` | 10 | 342.57 ns | 215.25 ns | 1.6x |
| `routing_targets` | 1,000 | 1.60 µs | 322.92 ns | 5.0x |
| `routing_targets` | 10,000 | 1.57 µs | 328.69 ns | 4.8x |
| `routing_targets` | 100,000 | 1.58 µs | 324.59 ns | 4.9x |
| `routing_targets` | 500,000 | 1.60 µs | 331.94 ns | 4.8x |
| `routing_targets` | 1,000,000 | 1.55 µs | 323.27 ns | 4.8x |
| `peers_for_topics` | 10 | 2.72 µs | 4.28 µs | 0.6x |
| `peers_for_topics` | 1,000 | 394.11 µs | 44.70 µs | 8.8x |
| `peers_for_topics` | 10,000 | 5.59 ms | 181.66 µs | 30.8x |
| `peers_for_topics` | 100,000 | 90.04 ms | 212.41 µs | 423.9x |
| `peers_for_topics` | 500,000 | 588.26 ms | 215.77 µs | 2726.4x |
| `peers_for_topics` | 1,000,000 | 1.25 s | 220.50 µs | 5680.2x |
| `build` | 10 | 2.72 µs | 3.18 µs | 0.9x |
| `build` | 1,000 | 207.50 µs | 281.88 µs | 0.7x |
| `build` | 10,000 | 1.94 ms | 3.15 ms | 0.6x |
| `build` | 100,000 | 21.22 ms | 47.05 ms | 0.5x |
| `build` | 500,000 | 140.53 ms | 315.26 ms | 0.4x |
| `build` | 1,000,000 | 289.14 ms | 727.33 ms | 0.4x |

Interpretation:

- Query paths are substantially faster, especially for larger learned peer sets.
- At very small peer sets, the index overhead can outweigh the query-path savings.
- Build/update path is slower because it maintains ordered indexes on peer lifecycle updates.

