### PR TITLE
Backport: xcmp-queue: Store the bytes in the channel status (#12176)

### DIFF
--- a/cumulus/pallets/xcmp-queue/src/lib.rs
+++ b/cumulus/pallets/xcmp-queue/src/lib.rs
@@ -428,6 +428,8 @@ pub struct OutboundChannelDetails {
 	last_index: u16,
 	/// Flags
 	flags: OutboundChannelFlags,
+	/// Cached total byte size of the pages currently queued in this channel.
+	queued_bytes: u32,
 }
 
 impl OutboundChannelDetails {
@@ -439,6 +441,7 @@ impl OutboundChannelDetails {
 			first_index: 0,
 			last_index: 0,
 			flags: OutboundChannelFlags::empty(),
+			queued_bytes: 0,
 		}
 	}
 
@@ -608,29 +611,29 @@ impl<T: Config> Pallet<T> {
 		let mut current_page = existing_page.unwrap_or_else(|| {
 			// We need to add a new page.
 			channel_details.last_index += 1;
-			format.encode()
+			let new_page = format.encode();
+			channel_details.queued_bytes =
+				channel_details.queued_bytes.saturating_add(new_page.len() as u32);
+			new_page
 		});
 
 		current_page.append(&mut encoded_fragment);
+		channel_details.queued_bytes =
+			channel_details.queued_bytes.saturating_add(encoded_fragment_len as u32);
 		let current_page = WeakBoundedVec::try_from(current_page).map_err(|error| {
 			tracing::debug!(target: LOG_TARGET, ?error, "Failed to create bounded message page");
 			MessageSendError::TooBig
 		})?;
 		let page_count =
 			channel_details.last_index.saturating_sub(channel_details.first_index) as u32;
-		let last_page_size = current_page.len();
 		<OutboundXcmpMessages<T>>::insert(recipient, channel_details.last_index - 1, current_page);
-		<OutboundXcmpStatus<T>>::put(all_channels);
 
-		// We have to count the total size here since `channel_info.total_size` is not updated at
-		// this point in time. We assume all previous pages are filled, which, in practice, is not
-		// always the case.
-		let total_size =
-			page_count.saturating_sub(1) * max_message_size as u32 + last_page_size as u32;
 		let threshold = channel_info.max_total_size / delivery_fee_constants::THRESHOLD_FACTOR;
-		if total_size > threshold {
+		if channel_details.queued_bytes > threshold {
 			Self::increase_fee_factor(recipient, encoded_fragment_len as u128);
 		}
+
+		<OutboundXcmpStatus<T>>::put(all_channels);
 
 		Ok(page_count)
 	}
@@ -1099,6 +1102,7 @@ impl<T: Config> XcmpMessageSource for Pallet<T> {
 				first_index,
 				last_index,
 				flags,
+				queued_bytes,
 			} = status;
 
 			let (max_size_now, max_size_ever) = match T::ChannelInfo::get_channel_status(*para_id) {
@@ -1154,6 +1158,7 @@ impl<T: Config> XcmpMessageSource for Pallet<T> {
 					if page.len() < max_size_now {
 						<OutboundXcmpMessages<T>>::remove(*para_id, *first_index);
 						*first_index += 1;
+						*queued_bytes = queued_bytes.saturating_sub(page.len() as u32);
 						break 'page_fetch page;
 					}
 				}
@@ -1180,6 +1185,7 @@ impl<T: Config> XcmpMessageSource for Pallet<T> {
 			if first_index == last_index {
 				*first_index = 0;
 				*last_index = 0;
+				*queued_bytes = 0;
 			}
 
 			if page.len() > max_size_ever {
@@ -1195,14 +1201,12 @@ impl<T: Config> XcmpMessageSource for Pallet<T> {
 				Some(channel_info) => channel_info.max_total_size,
 				None => {
 					tracing::warn!(target: LOG_TARGET, "calling `get_channel_info` with no RelevantMessagingState?!");
-					MAX_POSSIBLE_ALLOCATION // We use this as a fallback in case the messaging state is not present
+					// We use this as a fallback in case the messaging state is not present
+					MAX_POSSIBLE_ALLOCATION
 				},
 			};
 			let threshold = max_total_size.saturating_div(delivery_fee_constants::THRESHOLD_FACTOR);
-			let remaining_total_size: usize = (*first_index..*last_index)
-				.map(|index| OutboundXcmpMessages::<T>::decode_len(*para_id, index).unwrap())
-				.sum();
-			if remaining_total_size <= threshold as usize {
+			if *queued_bytes <= threshold {
 				Self::decrease_fee_factor(*para_id);
 			}
 
@@ -1307,6 +1311,7 @@ impl<T: Config> InspectMessageQueues for Pallet<T> {
 			for details in details_vec {
 				details.first_index = 0;
 				details.last_index = 0;
+				details.queued_bytes = 0;
 			}
 		});
 	}

--- a/cumulus/pallets/xcmp-queue/src/migration/mod.rs
+++ b/cumulus/pallets/xcmp-queue/src/migration/mod.rs
@@ -18,6 +18,7 @@
 
 pub mod v5;
 pub mod v6;
+pub mod v7;
 
 use crate::{Config, OverweightIndex, Pallet, QueueConfig, QueueConfigData, DEFAULT_POV_SIZE};
 use alloc::vec::Vec;
@@ -29,7 +30,7 @@ use frame_support::{
 };
 
 /// The in-code storage version.
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
 
 pub const LOG: &str = "runtime::xcmp-queue-migration";
 

--- a/cumulus/pallets/xcmp-queue/src/migration/v7.rs
+++ b/cumulus/pallets/xcmp-queue/src/migration/v7.rs
@@ -14,37 +14,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Migrates the storage to version 6.
+//! Migrates the storage to version 7.
 
 use crate::*;
 use frame_support::{pallet_prelude::*, traits::UncheckedOnRuntimeUpgrade};
 
 /// [`VersionedMigration`](frame_support::migrations::VersionedMigration), that is performed only
-/// when the on-chain version is 5.
-pub type MigrateV5ToV6<T> = frame_support::migrations::VersionedMigration<
-	5,
+/// when the on-chain version is 6.
+pub type MigrateV6ToV7<T> = frame_support::migrations::VersionedMigration<
 	6,
-	unversioned::UncheckedMigrateV5ToV6<T>,
+	7,
+	unversioned::UncheckedMigrateV6ToV7<T>,
 	Pallet<T>,
 	<T as frame_system::Config>::DbWeight,
 >;
 
-// V5 storage aliases
-mod v5 {
+// V6 storage aliases
+mod v6 {
 	use super::*;
 
 	#[derive(Clone, Eq, PartialEq, Encode, Decode, TypeInfo, Debug, MaxEncodedLen)]
 	pub struct OutboundChannelDetails {
-		/// The `ParaId` of the parachain that this channel is connected with.
 		pub recipient: ParaId,
-		/// The state of the channel.
 		pub state: OutboundState,
-		/// Whether any signals exist in this channel.
 		pub signals_exist: bool,
-		/// The index of the first outbound message.
 		pub first_index: u16,
-		/// The index of the last outbound message.
 		pub last_index: u16,
+		pub flags: OutboundChannelFlags,
 	}
 
 	#[frame_support::storage_alias]
@@ -57,15 +53,15 @@ mod v5 {
 
 mod unversioned {
 	use super::*;
-	pub struct UncheckedMigrateV5ToV6<T: Config>(PhantomData<T>);
+	pub struct UncheckedMigrateV6ToV7<T: Config>(PhantomData<T>);
 }
 
-impl<T: Config> UncheckedOnRuntimeUpgrade for unversioned::UncheckedMigrateV5ToV6<T> {
+impl<T: Config> UncheckedOnRuntimeUpgrade for unversioned::UncheckedMigrateV6ToV7<T> {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		// We use `Vec` instead of `BoundedVec` for `pre` in order to avoid any decoding error
 		// in case `T::MaxActiveOutboundChannels` is decreased in the same runtime upgrade where
 		// the migration is executed.
-		let translate = |pre: Vec<v5::OutboundChannelDetails>|
+		let translate = |pre: Vec<v6::OutboundChannelDetails>|
 		 -> BoundedVec<OutboundChannelDetails, T::MaxActiveOutboundChannels> {
 			BoundedVec::defensive_truncate_from(
 				pre.iter()
@@ -75,8 +71,8 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for unversioned::UncheckedMigrateV5ToV
 						signals_exist: pre_channel_details.signals_exist,
 						first_index: pre_channel_details.first_index,
 						last_index: pre_channel_details.last_index,
-						// The new field added by the migration.
-						flags: OutboundChannelFlags::empty(),
+						flags: pre_channel_details.flags,
+						// Corrects itself over time.
 						queued_bytes: 0,
 					})
 					.collect(),
@@ -86,12 +82,10 @@ impl<T: Config> UncheckedOnRuntimeUpgrade for unversioned::UncheckedMigrateV5ToV
 		if OutboundXcmpStatus::<T>::translate(|pre| pre.map(translate)).is_err() {
 			defensive!(
 				"unexpected error when performing translation of the OutboundXcmpStatus type \
-				during storage upgrade to v6"
+				during storage upgrade to v7"
 			);
 		}
 
-		// We need to account for the proof size and ref time of reading and writing
-		// `OutboundChannelDetails` once.
 		let proof_size = 2 * BoundedVec::<
 			OutboundChannelDetails,
 			<T as Config>::MaxActiveOutboundChannels,

--- a/cumulus/pallets/xcmp-queue/src/tests.rs
+++ b/cumulus/pallets/xcmp-queue/src/tests.rs
@@ -1290,3 +1290,45 @@ fn page_not_modified_when_fragment_does_not_fit() {
 		}
 	});
 }
+
+fn actual_queued_bytes(para: ParaId, status: &OutboundChannelDetails) -> u32 {
+	(status.first_index..status.last_index)
+		.map(|i| OutboundXcmpMessages::<Test>::get(para, i).len() as u32)
+		.sum()
+}
+
+fn status_for(para: ParaId) -> OutboundChannelDetails {
+	OutboundXcmpStatus::<Test>::get()
+		.into_iter()
+		.find(|s| s.recipient == para)
+		.expect("channel exists")
+}
+
+#[test]
+fn queued_bytes_tracks_send_and_take() {
+	new_test_ext().execute_with(|| {
+		let sibling = ParaId::from(2001);
+		ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(sibling);
+		let destination: Location = (Parent, Parachain(sibling.into())).into();
+		let message = Xcm(vec![ClearOrigin]);
+
+		for _ in 0..5 {
+			assert_ok!(send_xcm::<XcmpQueue>(destination.clone(), message.clone()));
+			let status = status_for(sibling);
+			assert_eq!(status.queued_bytes, actual_queued_bytes(sibling, &status));
+		}
+
+		while !XcmpQueue::take_outbound_messages(1, &[]).is_empty() {
+			if let Some(status) =
+				OutboundXcmpStatus::<Test>::get().into_iter().find(|s| s.recipient == sibling)
+			{
+				assert_eq!(status.queued_bytes, actual_queued_bytes(sibling, &status));
+			}
+		}
+
+		let drained = status_for(sibling);
+		assert_eq!(drained.first_index, 0);
+		assert_eq!(drained.last_index, 0);
+		assert_eq!(drained.queued_bytes, 0);
+	});
+}

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1171,6 +1171,7 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	pallet_collator_selection::migration::v2::MigrationToV2<Runtime>,
 	frame_support::migrations::RemovePallet<StateTrieMigrationName, RocksDbWeight>,
 	// unreleased

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1959,6 +1959,7 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	// unreleased
 	pallet_assets::migration::next_asset_id::SetNextAssetId<
 		ConstU32<50_000_000>,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -155,6 +155,7 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	snowbridge_pallet_system::migration::v0::InitializeOnUpgrade<
 		Runtime,
 		ConstU32<BRIDGE_HUB_ID>,

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -154,6 +154,7 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	pallet_bridge_messages::migration::v1::MigrationToV1<
 		Runtime,
 		bridge_to_rococo_config::WithBridgeHubRococoMessagesInstance,

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -848,6 +848,7 @@ type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 	// unreleased

--- a/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -115,6 +115,7 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	// permanent
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
 );

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -131,6 +131,7 @@ pub type Migrations = (
 	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
 	cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
 	pallet_broker::migration::MigrateV0ToV1<Runtime>,
 	pallet_broker::migration::MigrateV1ToV2<Runtime>,
 	pallet_broker::migration::MigrateV2ToV3<Runtime>,

--- a/prdoc/pr_12176.prdoc
+++ b/prdoc/pr_12176.prdoc
@@ -1,0 +1,20 @@
+title: 'xcmp-queue: Store the bytes in the channel status'
+doc:
+- audience: Runtime Dev
+  description: |-
+    This improves the performance of xcmp-queue by not requiring to check all pages individually.
+crates:
+- name: cumulus-pallet-xcmp-queue
+  bump: major
+- name: asset-hub-rococo-runtime
+  bump: major
+- name: asset-hub-westend-runtime
+  bump: major
+- name: bridge-hub-rococo-runtime
+  bump: major
+- name: bridge-hub-westend-runtime
+  bump: major
+- name: collectives-westend-runtime
+  bump: major
+- name: coretime-westend-runtime
+  bump: major


### PR DESCRIPTION
try-runtime checks for unstable2604 are failing right now due to a missing migration. Eg https://github.com/paritytech/polkadot-sdk/actions/runs/27601009445/job/81602074568

Backport https://github.com/paritytech/polkadot-sdk/pull/12176 to fix the issue.