### PR TITLE
Fix `AllowedRelayParentInfo` off by one error

### DIFF
--- a/polkadot/runtime/parachains/src/paras_inherent/mod.rs
+++ b/polkadot/runtime/parachains/src/paras_inherent/mod.rs
@@ -323,7 +323,6 @@ impl<T: Config> Pallet<T> {
 				config.scheduler_params.lookahead,
 				parent_storage_root,
 				current_session,
-				config.max_relay_parent_session_age,
 			);
 		}
 

--- a/polkadot/runtime/parachains/src/shared.rs
+++ b/polkadot/runtime/parachains/src/shared.rs
@@ -214,6 +214,24 @@ impl<T: Config> Pallet<T> {
 		// to be in the current session.
 		AllowedSchedulingParents::<T>::mutate(|tracker| tracker.buffer.clear());
 
+		// Prune relay parents from sessions that are now too old.
+		let oldest_allowed_session =
+			session_index.saturating_sub(new_config.max_relay_parent_session_age);
+		let oldest_stored = OldestRelayParentSession::<T>::get();
+
+		// Only prune and advance the pointer if the allowed oldest session has moved
+		// forward. If max_relay_parent_session_age was increased at runtime,
+		// oldest_allowed_session may be less than oldest_stored; in that case, entries
+		// for those older sessions were already pruned in prior blocks and we must not
+		// move the pointer backward.
+		if oldest_allowed_session > oldest_stored {
+			for expired in oldest_stored..oldest_allowed_session {
+				let _ = AllowedRelayParents::<T>::clear_prefix(expired, u32::MAX, None);
+				MinimumRelayParentNumber::<T>::remove(expired);
+			}
+			OldestRelayParentSession::<T>::set(oldest_allowed_session);
+		}
+
 		CurrentSessionIndex::<T>::set(session_index);
 		let mut rng: ChaCha20Rng = SeedableRng::from_seed(random_seed);
 
@@ -264,7 +282,6 @@ impl<T: Config> Pallet<T> {
 	/// Called at the beginning of each block to update the allowed scheduling and relay parents.
 	///
 	/// Adds the parent block as an allowed scheduling parent and relay parent.
-	/// Prunes relay parents from sessions that are older than `max_relay_parent_session_age`.
 	pub fn new_block(
 		hash: T::Hash,
 		cq: BTreeMap<CoreIndex, VecDeque<ParaId>>,
@@ -272,7 +289,6 @@ impl<T: Config> Pallet<T> {
 		max_ancestry_len: u32,
 		storage_root: T::Hash,
 		session_index: SessionIndex,
-		max_relay_parent_session_age: u32,
 	) {
 		// Update the allowed scheduling parents.
 		AllowedSchedulingParents::<T>::mutate(|tracker| {
@@ -292,23 +308,6 @@ impl<T: Config> Pallet<T> {
 		if !MinimumRelayParentNumber::<T>::contains_key(session_index) {
 			MinimumRelayParentNumber::<T>::insert(session_index, block_number);
 		}
-
-		// Prune relay parents from sessions that are now too old.
-		let oldest_allowed_session = session_index.saturating_sub(max_relay_parent_session_age);
-		let oldest_stored = OldestRelayParentSession::<T>::get();
-
-		// Only prune and advance the pointer if the allowed oldest session has moved
-		// forward. If max_relay_parent_session_age was increased at runtime,
-		// oldest_allowed_session may be less than oldest_stored; in that case, entries
-		// for those older sessions were already pruned in prior blocks and we must not
-		// move the pointer backward.
-		if oldest_allowed_session > oldest_stored {
-			for expired in oldest_stored..oldest_allowed_session {
-				let _ = AllowedRelayParents::<T>::clear_prefix(expired, u32::MAX, None);
-				MinimumRelayParentNumber::<T>::remove(expired);
-			}
-			OldestRelayParentSession::<T>::set(oldest_allowed_session);
-		}
 	}
 
 	/// Retrieve relay parent info by session index and relay parent hash.
@@ -316,6 +315,11 @@ impl<T: Config> Pallet<T> {
 		session_index: SessionIndex,
 		relay_parent: T::Hash,
 	) -> Option<RelayParentInfo<T::Hash, BlockNumberFor<T>>> {
+		let oldest_stored = OldestRelayParentSession::<T>::get();
+		if session_index < oldest_stored {
+			return None;
+		}
+
 		AllowedRelayParents::<T>::get(session_index, relay_parent)
 	}
 

--- a/polkadot/runtime/parachains/src/shared.rs
+++ b/polkadot/runtime/parachains/src/shared.rs
@@ -315,11 +315,6 @@ impl<T: Config> Pallet<T> {
 		session_index: SessionIndex,
 		relay_parent: T::Hash,
 	) -> Option<RelayParentInfo<T::Hash, BlockNumberFor<T>>> {
-		let oldest_stored = OldestRelayParentSession::<T>::get();
-		if session_index < oldest_stored {
-			return None;
-		}
-
 		AllowedRelayParents::<T>::get(session_index, relay_parent)
 	}
 

--- a/polkadot/runtime/parachains/src/shared/tests.rs
+++ b/polkadot/runtime/parachains/src/shared/tests.rs
@@ -246,6 +246,14 @@ fn session_change_prunes_old_relay_parents() {
 		// Now move to session 3 with max_age=2. oldest_allowed = 3 - 2 = 1.
 		// All entries from session 0 should be pruned.
 		Pallet::<Test>::initializer_on_new_session(3, [0; 32], &config, vec![]);
+		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(0).count(), 0);
+		for i in 1..=3u32 {
+			assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte((10 + i) as u8))
+				.is_some());
+			assert!(Pallet::<Test>::get_relay_parent_info(2, Hash::repeat_byte((20 + i) as u8))
+				.is_some());
+		}
+
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(31),
 			Default::default(),
@@ -254,31 +262,15 @@ fn session_change_prunes_old_relay_parents() {
 			Default::default(),
 			3,
 		);
-		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(0).count(), 0);
-		for i in 1..=3u32 {
-			assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte((10 + i) as u8))
-				.is_some());
-			assert!(Pallet::<Test>::get_relay_parent_info(2, Hash::repeat_byte((20 + i) as u8))
-				.is_some());
-		}
 		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(31)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 1);
 
 		// Session 5 with max_age=2. oldest_allowed = 5 - 2 = 3.
 		// All entries from sessions 1 and 2 should be pruned.
 		Pallet::<Test>::initializer_on_new_session(5, [0; 32], &config, vec![]);
-		Pallet::<Test>::new_block(
-			Hash::repeat_byte(51),
-			Default::default(),
-			51,
-			10,
-			Default::default(),
-			5,
-		);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(1).count(), 0);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(2).count(), 0);
 		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(31)).is_some());
-		assert!(Pallet::<Test>::get_relay_parent_info(5, Hash::repeat_byte(51)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 3);
 	});
 }
@@ -289,7 +281,6 @@ fn max_age_zero_keeps_only_current_session() {
 		let config = HostConfiguration::default();
 
 		// Insert into session 0.
-		Pallet::<Test>::initializer_on_new_session(0, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(0),
 			Default::default(),
@@ -302,16 +293,7 @@ fn max_age_zero_keeps_only_current_session() {
 
 		// Move to session 1 with max_age=0. Session 0 should be pruned.
 		Pallet::<Test>::initializer_on_new_session(1, [0; 32], &config, vec![]);
-		Pallet::<Test>::new_block(
-			Hash::repeat_byte(1),
-			Default::default(),
-			10,
-			10,
-			Default::default(),
-			1,
-		);
 		assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(0)).is_none());
-		assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte(1)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 1);
 	});
 }
@@ -346,26 +328,14 @@ fn increasing_max_age() {
 		// are already gone.
 		config.max_relay_parent_session_age = 10;
 		Pallet::<Test>::initializer_on_new_session(4, [0; 32], &config, vec![]);
-		Pallet::<Test>::new_block(
-			Hash::repeat_byte(5),
-			Default::default(),
-			50,
-			10,
-			Default::default(),
-			4,
-		);
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 3);
-
 		// Sessions 0, 1, 2 are still gone.
 		assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(0)).is_none());
 		assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte(1)).is_none());
 		assert!(Pallet::<Test>::get_relay_parent_info(2, Hash::repeat_byte(2)).is_none());
-
 		// But sessions 3 and 4 are still there.
 		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(3)).is_some());
-		// The original session 4 entry (Hash::repeat_byte(4)) and the new one both survive.
 		assert!(Pallet::<Test>::get_relay_parent_info(4, Hash::repeat_byte(4)).is_some());
-		assert!(Pallet::<Test>::get_relay_parent_info(4, Hash::repeat_byte(5)).is_some());
 	});
 }
 
@@ -402,14 +372,6 @@ fn decreasing_max_age_prunes_multiple_sessions() {
 		// Sessions 0, 1, 2, 3 should all be pruned in one go.
 		config.max_relay_parent_session_age = 1;
 		ParasShared::initializer_on_new_session(5, [0; 32], &config, vec![]);
-		Pallet::<Test>::new_block(
-			Hash::repeat_byte(5),
-			Default::default(),
-			51,
-			10,
-			Default::default(),
-			5,
-		);
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 4);
 
 		for session in 0..4u32 {
@@ -420,7 +382,6 @@ fn decreasing_max_age_prunes_multiple_sessions() {
 			.is_none());
 		}
 		assert!(Pallet::<Test>::get_relay_parent_info(4, Hash::repeat_byte(4)).is_some());
-		assert!(Pallet::<Test>::get_relay_parent_info(5, Hash::repeat_byte(5)).is_some());
 	});
 }
 

--- a/polkadot/runtime/parachains/src/shared/tests.rs
+++ b/polkadot/runtime/parachains/src/shared/tests.rs
@@ -28,6 +28,8 @@ use sp_keyring::Sr25519Keyring;
 #[test]
 fn minimum_relay_parent_number() {
 	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+		let mut config = HostConfiguration::default();
+
 		// No entries yet — returns None.
 		assert!(Pallet::<Test>::get_minimum_relay_parent_number().is_none());
 
@@ -42,7 +44,6 @@ fn minimum_relay_parent_number() {
 			5,
 			Default::default(),
 			session,
-			0,
 		);
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(10));
 
@@ -54,12 +55,12 @@ fn minimum_relay_parent_number() {
 			5,
 			Default::default(),
 			session,
-			0,
 		);
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(10));
 
 		// New session 1 with max_relay_parent_session_age=1 (keep both sessions).
 		let session = 1;
+		config.max_relay_parent_session_age = 1;
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(3),
 			Default::default(),
@@ -67,13 +68,14 @@ fn minimum_relay_parent_number() {
 			5,
 			Default::default(),
 			session,
-			1,
 		);
+		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		// Minimum is still 10 from session 0 (oldest session).
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(10));
 
 		// New session 2 with max_relay_parent_session_age=1. Session 0 gets pruned.
 		let session = 2;
+		config.max_relay_parent_session_age = 1;
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(4),
 			Default::default(),
@@ -81,13 +83,14 @@ fn minimum_relay_parent_number() {
 			5,
 			Default::default(),
 			session,
-			1,
 		);
+		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		// Session 0 pruned, oldest is now session 1 with min block 20.
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(20));
 
 		// New session 3 with max_relay_parent_session_age=0. Sessions 1 and 2 get pruned.
 		let session = 3;
+		config.max_relay_parent_session_age = 0;
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(5),
 			Default::default(),
@@ -95,8 +98,8 @@ fn minimum_relay_parent_number() {
 			5,
 			Default::default(),
 			session,
-			0,
 		);
+		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		// Only session 3 remains, min is 40.
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(40));
 	});
@@ -190,15 +193,7 @@ fn new_block_inserts_relay_parent_and_scheduling_parent() {
 		let session = 0u32;
 		let state_root = Hash::repeat_byte(0xBB);
 
-		Pallet::<Test>::new_block(
-			hash,
-			Default::default(),
-			block_number,
-			10,
-			state_root,
-			session,
-			0,
-		);
+		Pallet::<Test>::new_block(hash, Default::default(), block_number, 10, state_root, session);
 
 		// Relay parent should be in the DoubleMap.
 		let info = Pallet::<Test>::get_relay_parent_info(session, hash)
@@ -214,12 +209,15 @@ fn new_block_inserts_relay_parent_and_scheduling_parent() {
 }
 
 #[test]
-fn new_block_prunes_old_sessions_relay_parents() {
+fn session_change_prunes_old_relay_parents() {
 	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+		let mut config = HostConfiguration::default();
+
 		// At genesis, OldestRelayParentSession starts at 0.
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 0);
 
 		// Insert multiple entries per session in sessions 0, 1, 2.
+		config.max_relay_parent_session_age = 2;
 		for session in 0..3u32 {
 			for i in 0..3u32 {
 				let hash = Hash::repeat_byte((session * 10 + i) as u8);
@@ -230,9 +228,9 @@ fn new_block_prunes_old_sessions_relay_parents() {
 					10,
 					Default::default(),
 					session,
-					2,
 				);
 			}
+			Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		}
 
 		// With max_relay_parent_session_age=2 at session 2,
@@ -255,8 +253,8 @@ fn new_block_prunes_old_sessions_relay_parents() {
 			10,
 			Default::default(),
 			3,
-			2,
 		);
+		Pallet::<Test>::initializer_on_new_session(3, [0; 32], &config, vec![]);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(0).count(), 0);
 		for i in 0..3u32 {
 			assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte((10 + i) as u8))
@@ -276,8 +274,8 @@ fn new_block_prunes_old_sessions_relay_parents() {
 			10,
 			Default::default(),
 			5,
-			2,
 		);
+		Pallet::<Test>::initializer_on_new_session(5, [0; 32], &config, vec![]);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(1).count(), 0);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(2).count(), 0);
 		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(30)).is_some());
@@ -287,8 +285,10 @@ fn new_block_prunes_old_sessions_relay_parents() {
 }
 
 #[test]
-fn new_block_max_age_zero_keeps_only_current_session() {
+fn max_age_zero_keeps_only_current_session() {
 	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+		let config = HostConfiguration::default();
+
 		// Insert into session 0.
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(0),
@@ -297,8 +297,8 @@ fn new_block_max_age_zero_keeps_only_current_session() {
 			10,
 			Default::default(),
 			0,
-			0,
 		);
+		Pallet::<Test>::initializer_on_new_session(0, [0; 32], &config, vec![]);
 		assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(0)).is_some());
 
 		// Move to session 1 with max_age=0. Session 0 should be pruned.
@@ -309,8 +309,8 @@ fn new_block_max_age_zero_keeps_only_current_session() {
 			10,
 			Default::default(),
 			1,
-			0,
 		);
+		Pallet::<Test>::initializer_on_new_session(1, [0; 32], &config, vec![]);
 		assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(0)).is_none());
 		assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte(1)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 1);
@@ -318,9 +318,12 @@ fn new_block_max_age_zero_keeps_only_current_session() {
 }
 
 #[test]
-fn new_block_increasing_max_age() {
+fn increasing_max_age() {
 	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+		let mut config = HostConfiguration::default();
+
 		// Build up sessions 0..5 with max_age=1.
+		config.max_relay_parent_session_age = 1;
 		for session in 0..5u32 {
 			Pallet::<Test>::new_block(
 				Hash::repeat_byte(session as u8),
@@ -329,8 +332,8 @@ fn new_block_increasing_max_age() {
 				10,
 				Default::default(),
 				session,
-				1,
 			);
+			Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		}
 
 		// After session 4 with max_age=1, oldest_allowed = 3.
@@ -349,8 +352,9 @@ fn new_block_increasing_max_age() {
 			10,
 			Default::default(),
 			4,
-			10,
 		);
+		config.max_relay_parent_session_age = 10;
+		Pallet::<Test>::initializer_on_new_session(4, [0; 32], &config, vec![]);
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 3);
 
 		// Sessions 0, 1, 2 are still gone.
@@ -367,9 +371,12 @@ fn new_block_increasing_max_age() {
 }
 
 #[test]
-fn new_block_decreasing_max_age_prunes_multiple_sessions() {
+fn decreasing_max_age_prunes_multiple_sessions() {
 	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
+		let mut config = HostConfiguration::default();
+
 		// Build up sessions 0..5 with max_age=5 (no pruning at all).
+		config.max_relay_parent_session_age = 5;
 		for session in 0..5u32 {
 			Pallet::<Test>::new_block(
 				Hash::repeat_byte(session as u8),
@@ -378,8 +385,8 @@ fn new_block_decreasing_max_age_prunes_multiple_sessions() {
 				10,
 				Default::default(),
 				session,
-				5,
 			);
+			ParasShared::initializer_on_new_session(1, [0; 32], &config, vec![]);
 		}
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 0);
 
@@ -401,8 +408,9 @@ fn new_block_decreasing_max_age_prunes_multiple_sessions() {
 			10,
 			Default::default(),
 			5,
-			1,
 		);
+		config.max_relay_parent_session_age = 1;
+		ParasShared::initializer_on_new_session(5, [0; 32], &config, vec![]);
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 4);
 
 		for session in 0..4u32 {
@@ -423,9 +431,9 @@ fn cross_session_relay_parents_are_accessible() {
 		// Insert relay parents across 3 sessions.
 		let hashes: Vec<Hash> = (0..3u8).map(|i| Hash::repeat_byte(i + 1)).collect();
 
-		Pallet::<Test>::new_block(hashes[0], Default::default(), 10, 10, Default::default(), 0, 5);
-		Pallet::<Test>::new_block(hashes[1], Default::default(), 20, 10, Default::default(), 1, 5);
-		Pallet::<Test>::new_block(hashes[2], Default::default(), 30, 10, Default::default(), 2, 5);
+		Pallet::<Test>::new_block(hashes[0], Default::default(), 10, 10, Default::default(), 0);
+		Pallet::<Test>::new_block(hashes[1], Default::default(), 20, 10, Default::default(), 1);
+		Pallet::<Test>::new_block(hashes[2], Default::default(), 30, 10, Default::default(), 2);
 
 		// All relay parents from all sessions should be accessible.
 		for (session, hash) in hashes.iter().enumerate() {
@@ -444,7 +452,7 @@ fn cross_session_relay_parents_are_accessible() {
 #[test]
 fn session_change_clears_scheduling_parents_but_not_relay_parents() {
 	new_test_ext(MockGenesisConfig::default()).execute_with(|| {
-		let config = HostConfiguration::default();
+		let mut config = HostConfiguration::default();
 
 		// Session 0: insert some relay parents.
 		Pallet::<Test>::new_block(
@@ -454,7 +462,6 @@ fn session_change_clears_scheduling_parents_but_not_relay_parents() {
 			10,
 			Default::default(),
 			0,
-			5,
 		);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(2),
@@ -463,15 +470,14 @@ fn session_change_clears_scheduling_parents_but_not_relay_parents() {
 			10,
 			Default::default(),
 			0,
-			5,
 		);
 
 		let tracker = AllowedSchedulingParents::<Test>::get();
 		assert_eq!(tracker.buffer.len(), 2);
 
 		// Simulate session change — this clears the scheduling parents buffer.
-		let pubkeys = validator_pubkeys(&[Sr25519Keyring::Alice]);
-		ParasShared::initializer_on_new_session(1, [0; 32], &config, pubkeys);
+		config.max_relay_parent_session_age = 1;
+		ParasShared::initializer_on_new_session(1, [0; 32], &config, vec![]);
 
 		// Scheduling parents buffer should be empty.
 		let tracker = AllowedSchedulingParents::<Test>::get();

--- a/polkadot/runtime/parachains/src/shared/tests.rs
+++ b/polkadot/runtime/parachains/src/shared/tests.rs
@@ -34,33 +34,33 @@ fn minimum_relay_parent_number() {
 		assert!(Pallet::<Test>::get_minimum_relay_parent_number().is_none());
 
 		let session = 0;
-
-		// Add a relay parent at block 10. This is the first entry for session 0,
-		// so MinimumRelayParentNumber is set to 10.
+		// Add a relay parent at block 9. This is the first entry for session 0,
+		// so MinimumRelayParentNumber is set to 9.
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(1),
+			Default::default(),
+			9,
+			5,
+			Default::default(),
+			session,
+		);
+		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(9));
+
+		// Add another relay parent at block 10. Minimum stays at 9.
+		Pallet::<Test>::new_block(
+			Hash::repeat_byte(2),
 			Default::default(),
 			10,
 			5,
 			Default::default(),
 			session,
 		);
-		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(10));
-
-		// Add another relay parent at block 11. Minimum stays at 10.
-		Pallet::<Test>::new_block(
-			Hash::repeat_byte(2),
-			Default::default(),
-			11,
-			5,
-			Default::default(),
-			session,
-		);
-		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(10));
+		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(9));
 
 		// New session 1 with max_relay_parent_session_age=1 (keep both sessions).
 		let session = 1;
 		config.max_relay_parent_session_age = 1;
+		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(3),
 			Default::default(),
@@ -69,13 +69,13 @@ fn minimum_relay_parent_number() {
 			Default::default(),
 			session,
 		);
-		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
-		// Minimum is still 10 from session 0 (oldest session).
-		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(10));
+		// Minimum is still 9 from session 0 (oldest session).
+		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(9));
 
 		// New session 2 with max_relay_parent_session_age=1. Session 0 gets pruned.
 		let session = 2;
 		config.max_relay_parent_session_age = 1;
+		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(4),
 			Default::default(),
@@ -84,13 +84,13 @@ fn minimum_relay_parent_number() {
 			Default::default(),
 			session,
 		);
-		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		// Session 0 pruned, oldest is now session 1 with min block 20.
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(20));
 
 		// New session 3 with max_relay_parent_session_age=0. Sessions 1 and 2 get pruned.
 		let session = 3;
 		config.max_relay_parent_session_age = 0;
+		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(5),
 			Default::default(),
@@ -99,7 +99,6 @@ fn minimum_relay_parent_number() {
 			Default::default(),
 			session,
 		);
-		Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		// Only session 3 remains, min is 40.
 		assert_eq!(Pallet::<Test>::get_minimum_relay_parent_number(), Some(40));
 	});
@@ -219,7 +218,8 @@ fn session_change_prunes_old_relay_parents() {
 		// Insert multiple entries per session in sessions 0, 1, 2.
 		config.max_relay_parent_session_age = 2;
 		for session in 0..3u32 {
-			for i in 0..3u32 {
+			Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
+			for i in 1..=3u32 {
 				let hash = Hash::repeat_byte((session * 10 + i) as u8);
 				Pallet::<Test>::new_block(
 					hash,
@@ -230,12 +230,11 @@ fn session_change_prunes_old_relay_parents() {
 					session,
 				);
 			}
-			Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		}
 
 		// With max_relay_parent_session_age=2 at session 2,
 		// oldest_allowed = 2 - 2 = 0. All sessions should still exist.
-		for i in 0..3u32 {
+		for i in 1..=3u32 {
 			assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(i as u8)).is_some());
 			assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte((10 + i) as u8))
 				.is_some());
@@ -246,40 +245,40 @@ fn session_change_prunes_old_relay_parents() {
 
 		// Now move to session 3 with max_age=2. oldest_allowed = 3 - 2 = 1.
 		// All entries from session 0 should be pruned.
+		Pallet::<Test>::initializer_on_new_session(3, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
-			Hash::repeat_byte(30),
+			Hash::repeat_byte(31),
 			Default::default(),
-			30,
+			31,
 			10,
 			Default::default(),
 			3,
 		);
-		Pallet::<Test>::initializer_on_new_session(3, [0; 32], &config, vec![]);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(0).count(), 0);
-		for i in 0..3u32 {
+		for i in 1..=3u32 {
 			assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte((10 + i) as u8))
 				.is_some());
 			assert!(Pallet::<Test>::get_relay_parent_info(2, Hash::repeat_byte((20 + i) as u8))
 				.is_some());
 		}
-		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(30)).is_some());
+		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(31)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 1);
 
 		// Session 5 with max_age=2. oldest_allowed = 5 - 2 = 3.
 		// All entries from sessions 1 and 2 should be pruned.
+		Pallet::<Test>::initializer_on_new_session(5, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
-			Hash::repeat_byte(50),
+			Hash::repeat_byte(51),
 			Default::default(),
-			50,
+			51,
 			10,
 			Default::default(),
 			5,
 		);
-		Pallet::<Test>::initializer_on_new_session(5, [0; 32], &config, vec![]);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(1).count(), 0);
 		assert_eq!(AllowedRelayParents::<Test>::iter_prefix(2).count(), 0);
-		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(30)).is_some());
-		assert!(Pallet::<Test>::get_relay_parent_info(5, Hash::repeat_byte(50)).is_some());
+		assert!(Pallet::<Test>::get_relay_parent_info(3, Hash::repeat_byte(31)).is_some());
+		assert!(Pallet::<Test>::get_relay_parent_info(5, Hash::repeat_byte(51)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 3);
 	});
 }
@@ -290,6 +289,7 @@ fn max_age_zero_keeps_only_current_session() {
 		let config = HostConfiguration::default();
 
 		// Insert into session 0.
+		Pallet::<Test>::initializer_on_new_session(0, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(0),
 			Default::default(),
@@ -298,10 +298,10 @@ fn max_age_zero_keeps_only_current_session() {
 			Default::default(),
 			0,
 		);
-		Pallet::<Test>::initializer_on_new_session(0, [0; 32], &config, vec![]);
 		assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(0)).is_some());
 
 		// Move to session 1 with max_age=0. Session 0 should be pruned.
+		Pallet::<Test>::initializer_on_new_session(1, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(1),
 			Default::default(),
@@ -310,7 +310,6 @@ fn max_age_zero_keeps_only_current_session() {
 			Default::default(),
 			1,
 		);
-		Pallet::<Test>::initializer_on_new_session(1, [0; 32], &config, vec![]);
 		assert!(Pallet::<Test>::get_relay_parent_info(0, Hash::repeat_byte(0)).is_none());
 		assert!(Pallet::<Test>::get_relay_parent_info(1, Hash::repeat_byte(1)).is_some());
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 1);
@@ -325,15 +324,15 @@ fn increasing_max_age() {
 		// Build up sessions 0..5 with max_age=1.
 		config.max_relay_parent_session_age = 1;
 		for session in 0..5u32 {
+			Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 			Pallet::<Test>::new_block(
 				Hash::repeat_byte(session as u8),
 				Default::default(),
-				session * 10,
+				session * 10 + 1,
 				10,
 				Default::default(),
 				session,
 			);
-			Pallet::<Test>::initializer_on_new_session(session, [0; 32], &config, vec![]);
 		}
 
 		// After session 4 with max_age=1, oldest_allowed = 3.
@@ -345,6 +344,8 @@ fn increasing_max_age() {
 		// Now increase max_age to 10. oldest_allowed = 4 - 10 = 0 (saturating).
 		// OldestRelayParentSession must NOT move backward to 0 — sessions 0, 1, 2
 		// are already gone.
+		config.max_relay_parent_session_age = 10;
+		Pallet::<Test>::initializer_on_new_session(4, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(5),
 			Default::default(),
@@ -353,8 +354,6 @@ fn increasing_max_age() {
 			Default::default(),
 			4,
 		);
-		config.max_relay_parent_session_age = 10;
-		Pallet::<Test>::initializer_on_new_session(4, [0; 32], &config, vec![]);
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 3);
 
 		// Sessions 0, 1, 2 are still gone.
@@ -378,15 +377,15 @@ fn decreasing_max_age_prunes_multiple_sessions() {
 		// Build up sessions 0..5 with max_age=5 (no pruning at all).
 		config.max_relay_parent_session_age = 5;
 		for session in 0..5u32 {
+			ParasShared::initializer_on_new_session(session, [0; 32], &config, vec![]);
 			Pallet::<Test>::new_block(
 				Hash::repeat_byte(session as u8),
 				Default::default(),
-				session * 10,
+				session * 10 + 1,
 				10,
 				Default::default(),
 				session,
 			);
-			ParasShared::initializer_on_new_session(1, [0; 32], &config, vec![]);
 		}
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 0);
 
@@ -401,16 +400,16 @@ fn decreasing_max_age_prunes_multiple_sessions() {
 
 		// Now decrease max_age to 1 at session 5. oldest_allowed = 5 - 1 = 4.
 		// Sessions 0, 1, 2, 3 should all be pruned in one go.
+		config.max_relay_parent_session_age = 1;
+		ParasShared::initializer_on_new_session(5, [0; 32], &config, vec![]);
 		Pallet::<Test>::new_block(
 			Hash::repeat_byte(5),
 			Default::default(),
-			50,
+			51,
 			10,
 			Default::default(),
 			5,
 		);
-		config.max_relay_parent_session_age = 1;
-		ParasShared::initializer_on_new_session(5, [0; 32], &config, vec![]);
 		assert_eq!(OldestRelayParentSession::<Test>::get(), 4);
 
 		for session in 0..4u32 {

--- a/prdoc/pr_12391.prdoc
+++ b/prdoc/pr_12391.prdoc
@@ -9,4 +9,4 @@ doc:
     Therefore I moved the prunning inside `initializer_on_new_session()`
 crates:
 - name: polkadot-runtime-parachains
-  bump: patch
+  bump: major

--- a/prdoc/pr_12391.prdoc
+++ b/prdoc/pr_12391.prdoc
@@ -1,0 +1,12 @@
+title: Fix `AllowedSchedulingParents` off by one error
+doc:
+- audience: Runtime Dev
+  description: |-
+    Related to https://github.com/paritytech/polkadot-sdk/issues/11624
+
+    As far as i understand `initializer_on_new_session()` is called after `new_block()`. So for the first block in each session, the pruning wasn't happening.
+
+    Therefore I moved the prunning inside `initializer_on_new_session()`
+crates:
+- name: polkadot-runtime-parachains
+  bump: patch

--- a/prdoc/pr_12391.prdoc
+++ b/prdoc/pr_12391.prdoc
@@ -1,12 +1,11 @@
-title: Fix `AllowedSchedulingParents` off by one error
+title: Fix `AllowedRelayParentInfo` off by one error
 doc:
 - audience: Runtime Dev
   description: |-
     Related to https://github.com/paritytech/polkadot-sdk/issues/11624
 
-    As far as i understand `initializer_on_new_session()` is called after `new_block()`. So for the first block in each session, the pruning wasn't happening.
-
-    Therefore I moved the prunning inside `initializer_on_new_session()`
+    Moved the pruning logic for `AllowedRelayParentInfo` from `new_block` to `initializer_on_new_session()`,
+    in order to avoid an off-by-one error.
 crates:
 - name: polkadot-runtime-parachains
   bump: major

--- a/prdoc/pr_12391.prdoc
+++ b/prdoc/pr_12391.prdoc
@@ -4,8 +4,15 @@ doc:
   description: |-
     Related to https://github.com/paritytech/polkadot-sdk/issues/11624
 
-    Moved the pruning logic for `AllowedRelayParentInfo` from `new_block` to `initializer_on_new_session()`,
-    in order to avoid an off-by-one error.
+    The pruning for AllowedRelayParentInfo was performed in new_block. But new_block is called at the beginning of
+    each block, receiving the parent block number and parent block session as arguments.
+    So when a new session starts, for example at block 31, new_block will be called for block 30, session 2,
+    and only at block 32, it will be called for block 31, session 3, performing the required pruning.
+    So at block 31, even if max_relay_parent_session_age, the blocks from session 1 were still considered valid
+    relay parents. Which is wrong.
+
+    Moved the pruning logic from new_block() to initializer_on_new_session(), which is actually called correctly
+    at the first block of the session for the current session (for example at block 31 for session 3).
 crates:
 - name: polkadot-runtime-parachains
-  bump: major
+  bump: patch

--- a/prdoc/pr_12391.prdoc
+++ b/prdoc/pr_12391.prdoc
@@ -15,4 +15,4 @@ doc:
     at the first block of the session for the current session (for example at block 31 for session 3).
 crates:
 - name: polkadot-runtime-parachains
-  bump: patch
+  bump: major


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-sdk/issues/11624

## The issue

This issue was found while working on https://github.com/paritytech/polkadot-sdk/pull/12296 . Added some debug logs in the function that was calling `ancestor_relay_parent_info` and sometimes there were situations like the following: 

```
max_relay_parent_session_age = 1

tokio-runtime-worker consensus::common::parent_search: [Parachain] ancestor_relay_parent_info call succeeded scheduling_parent=0x56fa4fbab20eb77b995d18c4a9b638a35422afaeb4138d2a89f6f73ee826055d scheduling_parent_session=3 relay_parent=0x8bcf87dc4c00e5394e046bca6e53fa7d9c3737dd22c72911e162a2847f22751d relay_parent_session=1
```

So a relay parent from session 1 is still valid at a scheduling parent from session 3. This shouldn't happen when max_relay_parent_session_age is 1.

## The cause

The pruning for `AllowedRelayParentInfo` was performed in `new_block`. But `new_block` is called at the beginning of each block, [receiving the parent block number and parent block session as arguments](https://github.com/paritytech/polkadot-sdk/blob/bcafdb3d87eb3756f64bd1e830b0785d17a86812/polkadot/runtime/parachains/src/paras_inherent/mod.rs#L319-L327). So when a new session starts, for example at block 31,  `new_block` will be called for block 30, session 2, and only at block 32, it will be called for block 31, session 3, performing the required pruning. So at block 31, even if `max_relay_parent_session_age`, the blocks from session 1 were still considered valid relay parents. Which is wrong.

## The fix

So moved the pruning logic from `new_block` to `initializer_on_new_session()`, which is actually called correctly at the first block of the session for the current session (for example at block 31 for session 3).