### PR TITLE
statement-store: propagate v2 statements to their target peers

### DIFF
--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -1401,6 +1401,44 @@ where
 		self.send_statements_in_chunks(who, &to_send).await;
 	}
 
+	/// Send the `indices` of `statements` to `peer`, batched.
+	///
+	/// The v2 DHT path's [`V2DhtOrchestrator::propagate_statements`] already decided that `peer`
+	/// should receive these statements, so this skips the explicit-affinity bloom filter that
+	/// [`Self::send_statements_to_peer`] applies and only drops statements the peer already knows.
+	async fn send_targeted_statements_to_peer(
+		&mut self,
+		who: &PeerId,
+		statements: &[(Hash, Statement)],
+		indices: &[usize],
+	) {
+		let Some(peer) = self.peers.get_mut(who) else {
+			return;
+		};
+
+		if !peer.can_receive() {
+			return;
+		}
+
+		let to_send: Vec<_> = indices
+			.iter()
+			.filter_map(|&index| {
+				let (hash, stmt) = &statements[index];
+				if peer.known_statements.contains(hash) {
+					return None;
+				}
+				peer.known_statements.insert(*hash);
+				Some(stmt)
+			})
+			.collect();
+
+		if to_send.is_empty() {
+			return;
+		}
+
+		self.send_statements_in_chunks(who, &to_send).await;
+	}
+
 	/// Send statements to a peer in chunks, respecting the maximum notification size.
 	async fn send_statements_in_chunks(&mut self, who: &PeerId, statements: &[&Statement]) {
 		let mut offset = 0;
@@ -1435,10 +1473,15 @@ where
 		}
 
 		let Ok(statements) = self.statement_store.take_recent_statements() else { return };
-		if !statements.is_empty() {
-			if v2dht_enabled() {
-				self.v2dht.propagate_statements().await;
+		if statements.is_empty() {
+			return;
+		}
+
+		if v2dht_enabled() {
+			for (who, indices) in self.v2dht.propagate_statements(&statements) {
+				self.send_targeted_statements_to_peer(&who, &statements, &indices).await;
 			}
+		} else {
 			self.do_propagate_statements(&statements).await;
 		}
 	}
@@ -2197,6 +2240,50 @@ mod tests {
 			"Expected ANY_STATEMENT, ANY_STATEMENT_REFUND, DUPLICATE_STATEMENT reputation change, but got: {:?}",
 			reports
 		);
+	}
+
+	#[tokio::test]
+	async fn send_targeted_statements_skips_affinity_filter_then_dedups() {
+		let (mut handler, _store, _network, notification_service, _, _) = build_handler(0);
+
+		// A peer whose advertised filter matches no topic; the v2 send must ignore it because the
+		// orchestrator already chose this peer.
+		let peer_id = PeerId::random();
+		handler.peers.insert(
+			peer_id,
+			Peer {
+				known_statements: LruHashSet::new(NonZeroUsize::new(1000).unwrap()),
+				rate_limiter: PeerRateLimiter::new(
+					NonZeroU32::new(DEFAULT_STATEMENTS_PER_SECOND).expect("nonzero"),
+					NonZeroU32::new(
+						DEFAULT_STATEMENTS_PER_SECOND * config::STATEMENTS_BURST_COEFFICIENT,
+					)
+					.expect("nonzero"),
+				),
+				protocol_version: PeerProtocolVersion::V1,
+				topic_affinity: Some(AffinityFilter::new(BLOOM_SEED, 0.01, 10)),
+				is_light: false,
+				pending_topic_affinity: None,
+			},
+		);
+
+		let mut statement = Statement::new();
+		statement.set_plain_data(b"targeted".to_vec());
+		statement.set_topic(0, Topic([7u8; 32]));
+		let hash = statement.hash();
+		let statements = vec![(hash, statement)];
+
+		handler.send_targeted_statements_to_peer(&peer_id, &statements, &[0]).await;
+		assert_eq!(
+			get_peer_hashes(&notification_service.get_sent_notifications(), peer_id),
+			vec![hash],
+			"targeted send must deliver the statement despite the non-matching filter"
+		);
+
+		// The peer now knows the statement, so a second send delivers nothing.
+		notification_service.clear_sent_notifications();
+		handler.send_targeted_statements_to_peer(&peer_id, &statements, &[0]).await;
+		assert!(notification_service.get_sent_notifications().is_empty());
 	}
 
 	#[tokio::test]

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -1403,7 +1403,7 @@ where
 
 	/// Send the `indices` of `statements` to `peer`, batched.
 	///
-	/// The v2 DHT path's [`V2DhtOrchestrator::propagate_statements`] already decided that `peer`
+	/// The v2 DHT path's [`V2DhtOrchestrator::propagation_plan`] already decided that `peer`
 	/// should receive these statements, so this skips the explicit-affinity bloom filter that
 	/// [`Self::send_statements_to_peer`] applies and only drops statements the peer already knows.
 	async fn send_targeted_statements_to_peer(
@@ -1478,7 +1478,7 @@ where
 		}
 
 		if v2dht_enabled() {
-			for (who, indices) in self.v2dht.propagate_statements(&statements) {
+			for (who, indices) in self.v2dht.propagation_plan(&statements) {
 				self.send_targeted_statements_to_peer(&who, &statements, &indices).await;
 			}
 		} else {
@@ -2284,6 +2284,51 @@ mod tests {
 		notification_service.clear_sent_notifications();
 		handler.send_targeted_statements_to_peer(&peer_id, &statements, &[0]).await;
 		assert!(notification_service.get_sent_notifications().is_empty());
+	}
+
+	#[tokio::test]
+	async fn send_targeted_statements_ignores_a_disconnected_peer() {
+		let (mut handler, _store, _network, notification_service, _, _) = build_handler(0);
+
+		let mut statement = Statement::new();
+		statement.set_plain_data(b"orphan".to_vec());
+		let hash = statement.hash();
+		let statements = vec![(hash, statement)];
+
+		handler
+			.send_targeted_statements_to_peer(&PeerId::random(), &statements, &[0])
+			.await;
+		assert!(notification_service.get_sent_notifications().is_empty());
+	}
+
+	#[tokio::test]
+	async fn send_targeted_statements_delivers_only_indexed_unknown_statements() {
+		let (mut handler, _store, _network, notification_service, _, _) = build_handler(0);
+
+		let make = |seed: u8| {
+			let mut statement = Statement::new();
+			statement.set_plain_data(vec![seed]);
+			(statement.hash(), statement)
+		};
+		let statements = vec![make(1), make(2), make(3)];
+
+		let peer_id = PeerId::random();
+		let mut peer = Peer::new_for_testing(
+			LruHashSet::new(NonZeroUsize::new(1000).unwrap()),
+			NonZeroU32::new(DEFAULT_STATEMENTS_PER_SECOND).expect("nonzero"),
+			NonZeroU32::new(DEFAULT_STATEMENTS_PER_SECOND * config::STATEMENTS_BURST_COEFFICIENT)
+				.expect("nonzero"),
+		);
+		// The peer already holds the statement at index 1.
+		peer.known_statements.insert(statements[1].0);
+		handler.peers.insert(peer_id, peer);
+
+		// The plan names indices 0 and 1: index 1 drops as already known, index 2 is never offered.
+		handler.send_targeted_statements_to_peer(&peer_id, &statements, &[0, 1]).await;
+		assert_eq!(
+			get_peer_hashes(&notification_service.get_sent_notifications(), peer_id),
+			vec![statements[0].0]
+		);
 	}
 
 	#[tokio::test]

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -121,7 +121,7 @@ impl V2DhtOrchestrator {
 	/// A peer is a target for a statement when it is a DHT routing target for one of the
 	/// statement's topics ([`PeersTopology::routing_targets`]) or its advertised filter matches the
 	/// statement ([`ExplicitAffinity::peer_has_explicit_affinity`]).
-	pub(crate) fn propagate_statements(
+	pub(crate) fn propagation_plan(
 		&self,
 		statements: &[(Hash, Statement)],
 	) -> Vec<(PeerId, Vec<usize>)> {
@@ -201,7 +201,7 @@ mod tests {
 		(statement.hash(), statement)
 	}
 
-	/// Routing targets `propagate_statements` is expected to reach for `topics`, taken from the
+	/// Routing targets `propagation_plan` is expected to reach for `topics`, taken from the
 	/// already-tested [`PeersTopology::routing_targets`] rather than recomputed from XOR distances.
 	fn routing_targets(orchestrator: &V2DhtOrchestrator, topics: &[Topic]) -> Vec<PeerId> {
 		let mut targets: Vec<PeerId> = topics
@@ -223,7 +223,7 @@ mod tests {
 		let expected = routing_targets(&orchestrator, &topics);
 		assert!(!expected.is_empty(), "fixture must yield routing targets");
 
-		let plan = orchestrator.propagate_statements(&[statement(1, &topics)]);
+		let plan = orchestrator.propagation_plan(&[statement(1, &topics)]);
 
 		let mut planned: Vec<PeerId> = plan.iter().map(|(peer, _)| *peer).collect();
 		planned.sort();
@@ -246,7 +246,7 @@ mod tests {
 			.expect("fixture must yield a routing target");
 
 		let plan =
-			orchestrator.propagate_statements(&[statement(1, &[topic]), statement(2, &[topic])]);
+			orchestrator.propagation_plan(&[statement(1, &[topic]), statement(2, &[topic])]);
 
 		let batch = plan
 			.iter()

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -26,8 +26,8 @@ use crate::{affinity::AffinityFilter, LOG_TARGET};
 use explicit_affinity::{AffinitySource, ExplicitAffinity};
 use peers_topology::{PeersTopology, PeersTopologyConfig};
 use sc_network_types::PeerId;
-use sp_statement_store::{SubmitResult, Topic};
-use std::collections::HashSet;
+use sp_statement_store::{Hash, Statement, SubmitResult, Topic};
+use std::collections::{HashMap, HashSet};
 
 /// Coordinates the v2 DHT-affinity statement gossip path.
 #[allow(dead_code)]
@@ -116,9 +116,35 @@ impl V2DhtOrchestrator {
 
 	// === Periodic ticks & post-iteration hooks ===
 
-	pub(crate) async fn propagate_statements(&mut self) {
-		// TODO: We need to know where to propagate
-		log::trace!(target: LOG_TARGET, "v2dht: propagate_statements (stub)");
+	/// For each connected peer, the indices of `statements` it should receive.
+	///
+	/// A peer is a target for a statement when it is a DHT routing target for one of the
+	/// statement's topics ([`PeersTopology::routing_targets`]) or its advertised filter matches the
+	/// statement ([`ExplicitAffinity::peer_has_explicit_affinity`]).
+	pub(crate) fn propagate_statements(
+		&self,
+		statements: &[(Hash, Statement)],
+	) -> Vec<(PeerId, Vec<usize>)> {
+		let mut statements_by_peer: HashMap<PeerId, Vec<usize>> = HashMap::new();
+
+		for (index, (_hash, statement)) in statements.iter().enumerate() {
+			let mut targets: HashSet<PeerId> = HashSet::new();
+
+			for topic in statement.topics() {
+				targets.extend(self.peers_topology.routing_targets(*topic));
+			}
+			for peer in self.peers_topology.connected_peers() {
+				if self.explicit_affinity.peer_has_explicit_affinity(peer, statement) {
+					targets.insert(peer);
+				}
+			}
+
+			for peer_id in targets {
+				statements_by_peer.entry(peer_id).or_default().push(index);
+			}
+		}
+
+		statements_by_peer.into_iter().collect()
 	}
 
 	pub(crate) async fn on_initial_sync(&mut self) {
@@ -134,5 +160,99 @@ impl V2DhtOrchestrator {
 	pub(crate) fn on_major_sync_end(&mut self) {
 		// TODO: The major sync processing may be different
 		log::trace!(target: LOG_TARGET, "v2dht: on_major_sync_end (stub)");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::num::NonZeroUsize;
+
+	fn peer(seed: u8) -> PeerId {
+		let mut bytes = [seed; 34];
+		bytes[0] = 0;
+		bytes[1] = 32;
+		PeerId::from_bytes(&bytes).expect("identity multihash peer id")
+	}
+
+	fn config(replication_factor: usize, gossip_target: usize) -> PeersTopologyConfig {
+		PeersTopologyConfig {
+			replication_factor: NonZeroUsize::new(replication_factor).expect("non-zero"),
+			gossip_target: NonZeroUsize::new(gossip_target).expect("non-zero"),
+		}
+	}
+
+	fn orchestrator(local_seed: u8, config: PeersTopologyConfig) -> V2DhtOrchestrator {
+		V2DhtOrchestrator::new(&[], peer(local_seed), config)
+	}
+
+	fn connect(orchestrator: &mut V2DhtOrchestrator, peer: PeerId) {
+		orchestrator.on_peers_discovered([peer]);
+		orchestrator.on_peer_identified(peer, true);
+		orchestrator.on_substream_opened(peer);
+	}
+
+	fn statement(seed: u8, topics: &[Topic]) -> (Hash, Statement) {
+		let mut statement = Statement::new();
+		statement.set_plain_data(vec![seed]);
+		for (index, topic) in topics.iter().enumerate() {
+			statement.set_topic(index, *topic);
+		}
+		(statement.hash(), statement)
+	}
+
+	/// Routing targets `propagate_statements` is expected to reach for `topics`, taken from the
+	/// already-tested [`PeersTopology::routing_targets`] rather than recomputed from XOR distances.
+	fn routing_targets(orchestrator: &V2DhtOrchestrator, topics: &[Topic]) -> Vec<PeerId> {
+		let mut targets: Vec<PeerId> = topics
+			.iter()
+			.flat_map(|topic| orchestrator.peers_topology.routing_targets(*topic))
+			.collect();
+		targets.sort();
+		targets.dedup();
+		targets
+	}
+
+	#[test]
+	fn routes_a_statement_to_the_union_of_its_topics_routing_targets_once() {
+		let mut orchestrator = orchestrator(1, config(20, 3));
+		for seed in 2u8..=60 {
+			connect(&mut orchestrator, peer(seed));
+		}
+		let topics = [Topic([7; 32]), Topic([42; 32])];
+		let expected = routing_targets(&orchestrator, &topics);
+		assert!(!expected.is_empty(), "fixture must yield routing targets");
+
+		let plan = orchestrator.propagate_statements(&[statement(1, &topics)]);
+
+		let mut planned: Vec<PeerId> = plan.iter().map(|(peer, _)| *peer).collect();
+		planned.sort();
+		assert_eq!(planned, expected);
+		assert!(
+			plan.iter().all(|(_, indices)| indices == &[0]),
+			"a target receives the statement once however many of its topics route there"
+		);
+	}
+
+	#[test]
+	fn batches_statements_bound_for_the_same_peer() {
+		let mut orchestrator = orchestrator(1, config(20, 3));
+		for seed in 2u8..=60 {
+			connect(&mut orchestrator, peer(seed));
+		}
+		let topic = Topic([7; 32]);
+		let target = *routing_targets(&orchestrator, &[topic])
+			.first()
+			.expect("fixture must yield a routing target");
+
+		let plan =
+			orchestrator.propagate_statements(&[statement(1, &[topic]), statement(2, &[topic])]);
+
+		let batch = plan
+			.iter()
+			.find(|(peer, _)| *peer == target)
+			.map(|(_, indices)| indices.clone())
+			.expect("the shared target must be planned");
+		assert_eq!(batch, vec![0, 1]);
 	}
 }

--- a/substrate/client/network/statement/src/v2dht/peers_index.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_index.rs
@@ -54,6 +54,11 @@ impl PeersIndex {
 	pub(crate) fn closest(&self, target: Key) -> Closest<'_> {
 		closest(&self.peers_by_key, target)
 	}
+
+	/// All peers in the index, in `(key, peer)` order.
+	pub(crate) fn peers(&self) -> impl Iterator<Item = PeerId> + '_ {
+		self.peers_by_key.values().flatten().copied()
+	}
 }
 
 /// Peers of `index` in increasing `(xor_distance(target, key), peer)` order, without sorting the

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -143,6 +143,11 @@ impl PeersTopology {
 		self.discovered.get(peer).is_some_and(|info| info.connected)
 	}
 
+	/// The connected statement-protocol peers, those with an open notification substream.
+	pub fn connected_peers(&self) -> impl Iterator<Item = PeerId> + '_ {
+		self.connected.peers()
+	}
+
 	/// Number of known remote peers, including peers without confirmed statement-protocol support.
 	pub fn known_peers_count(&self) -> usize {
 		self.discovered.len()


### PR DESCRIPTION
## Summary

Implements the v2 DHT propagation step: instead of flooding every recent
statement to every peer, route each statement only to the peers that should
receive it, batched per peer. Part of #11932 


 ## What changed

- `V2DhtOrchestrator::propagate_statements(&[(Hash, Statement)]) -> Vec<(PeerId, Vec<usize>)>`
builds, for each connected peer, the indices of the statements it should
receive: the union of DHT routing targets across each statement's topics
(`PeersTopology::routing_targets`) and the connected peers whose advertised
filter matches (`ExplicitAffinity::peer_has_explicit_affinity`). Collecting a
statement's targets in a set sends it to a peer once however many of its
topics route there; grouping by peer lets the caller batch one send per peer.

- New `StatementHandler::send_targeted_statements_to_peer` sends a per-peer batch:
it dedups against the peer's `known_statements` and chunks like the flood path,
but skips the explicit-affinity bloom re-filter, since the plan already chose
the targets (a DHT-routed statement whose topic is absent from the peer's bloom
must still be sent).

- `PeersTopology::connected_peers()` (and `PeersIndex::peers()`) expose the
connected statement-protocol peers.