### PR TITLE
nomination-pools: snapshot rewards before set_commission_max lowers current commission

### DIFF
--- a/prdoc/pr_12397.prdoc
+++ b/prdoc/pr_12397.prdoc
@@ -1,0 +1,15 @@
+title: 'nomination-pools: snapshot rewards before `set_commission_max` lowers current commission'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `set_commission_max` force-lowers `commission.current` (via `try_update_max`) when the new max
+    is below the active rate, but did not first call `update_records`. Rewards accrued at the higher
+    rate since the last snapshot were therefore re-rated at the new lower rate on the next
+    `update_records`, crediting the differential `(old_current - new_max) * accrued` to members
+    instead of the commission payee.
+
+    The fix snapshots the reward pool at the current commission before the cut, mirroring the
+    ordering already used in `set_commission`.
+crates:
+- name: pallet-nomination-pools
+  bump: patch

--- a/substrate/frame/nomination-pools/src/lib.rs
+++ b/substrate/frame/nomination-pools/src/lib.rs
@@ -3024,6 +3024,19 @@ pub mod pallet {
 
 			ensure!(bonded_pool.can_manage_commission(&who), Error::<T>::DoesNotHavePermission);
 
+			let mut reward_pool = RewardPools::<T>::get(pool_id)
+				.defensive_ok_or::<Error<T>>(DefensiveError::RewardPoolNotFound.into())?;
+			// IMPORTANT: snapshot rewards accrued at the current commission before `try_update_max`
+			// can force-lower it. Otherwise rewards accrued since the last snapshot would be
+			// re-rated at the new (lower) rate and the differential credited to members instead
+			// of the commission payee. Mirrors the ordering in `set_commission`.
+			reward_pool.update_records(
+				pool_id,
+				bonded_pool.points,
+				bonded_pool.commission.current(),
+			)?;
+			RewardPools::insert(pool_id, reward_pool);
+
 			bonded_pool.commission.try_update_max(pool_id, max_commission)?;
 			bonded_pool.put();
 

--- a/substrate/frame/nomination-pools/src/tests.rs
+++ b/substrate/frame/nomination-pools/src/tests.rs
@@ -6913,6 +6913,50 @@ mod commission {
 	}
 
 	#[test]
+	fn set_commission_max_snapshots_rewards_before_lowering_current() {
+		// `set_commission_max` force-lowers `current` when the new max is below it. Rewards that
+		// accrued at the higher rate since the last snapshot must stay owed to the payee at that
+		// higher rate, not be re-rated at the new lower rate and leaked to members.
+		ExtBuilder::default().build_and_execute(|| {
+			let pool_id = 1;
+			let payee = 900;
+			let _ = Currency::set_balance(&payee, 5);
+
+			// GIVEN: commission is 50% (this snapshots the still-empty reward pool)...
+			assert_ok!(Pools::set_commission(
+				RuntimeOrigin::signed(900),
+				pool_id,
+				Some((Perbill::from_percent(50), payee))
+			));
+			// ...and 100 of rewards accrue with no intervening snapshot (no claim/bond happens).
+			deposit_rewards(100);
+			assert_eq!(RewardPool::<Runtime>::current_balance(pool_id), 100);
+			assert_eq!(RewardPools::<Runtime>::get(pool_id).unwrap().total_commission_pending, 0);
+
+			// WHEN: root force-lowers max commission to 20%, cutting `current` from 50% to 20%.
+			assert_ok!(Pools::set_commission_max(
+				RuntimeOrigin::signed(900),
+				pool_id,
+				Perbill::from_percent(20)
+			));
+
+			// THEN: the 100 that accrued at 50% was snapshotted before the cut, so 50 is owed to
+			// the payee. Without the pre-cut snapshot this would be 20% * 100 = 20.
+			assert_eq!(RewardPools::<Runtime>::get(pool_id).unwrap().total_commission_pending, 50);
+
+			// AND: claiming commission pays the payee the pre-cut 50, not the post-cut 20.
+			let _ = pool_events_since_last_call();
+			assert_ok!(Pools::claim_commission(RuntimeOrigin::signed(payee), pool_id));
+			assert_eq!(
+				pool_events_since_last_call(),
+				vec![Event::PoolCommissionClaimed { pool_id, commission: 50 }]
+			);
+			assert_eq!(Currency::free_balance(&payee), 5 + 50);
+			assert_eq!(RewardPools::<Runtime>::get(pool_id).unwrap().total_commission_claimed, 50);
+		})
+	}
+
+	#[test]
 	fn set_commission_change_rate_zero_max_increase_works() {
 		ExtBuilder::default().build_and_execute(|| {
 			// set commission change rate to 0% per 10 blocks


### PR DESCRIPTION
`set_commission_max` force-lowers `commission.current` (via `try_update_max`) when the new max is below the active rate, but did not first call `update_records`. Rewards accrued at the higher rate since the last snapshot were therefore re-rated at the new lower rate on the next `update_records`, crediting the differential `(old_current - new_max) * accrued` to members instead of the commission payee.

The fix snapshots the reward pool at the current commission before the cut, mirroring the ordering already used in `set_commission`.
