### PR TITLE
pallet-alliance: migrate candidacy deposit from Currency reserves to fungible holds

### DIFF
--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -77,8 +77,8 @@ use frame_support::{
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
 	traits::{
-		fungible::HoldConsideration, ConstBool, ConstU32, ConstU64, ConstU8, EitherOfDiverse,
-		InstanceFilter, LinearStoragePrice, TransformOrigin,
+		fungible::HoldConsideration, ConstBool, ConstU128, ConstU32, ConstU64, ConstU8,
+		EitherOfDiverse, InstanceFilter, LinearStoragePrice, TransformOrigin,
 	},
 	weights::{ConstantMultiplier, Weight},
 	PalletId,
@@ -607,6 +607,8 @@ parameter_types! {
 	// The number of blocks a member must wait between giving a retirement notice and retiring.
 	// Supposed to be greater than time required to `kick_member` with alliance motion.
 	pub const AllianceRetirementPeriod: BlockNumber = (90 * DAYS) + ALLIANCE_MOTION_DURATION;
+	pub const AllianceHoldReason: RuntimeHoldReason =
+		RuntimeHoldReason::Alliance(pallet_alliance::HoldReason::AllianceDeposit);
 }
 
 impl pallet_alliance::Config for Runtime {
@@ -615,8 +617,15 @@ impl pallet_alliance::Config for Runtime {
 	type AdminOrigin = RootOrAllianceTwoThirdsMajority;
 	type MembershipManager = RootOrAllianceTwoThirdsMajority;
 	type AnnouncementOrigin = RootOrAllianceTwoThirdsMajority;
-	type Currency = Balances;
-	type Slashed = pallet_accumulate_and_forward::LegacyAdapter<Runtime, Balances>;
+	type OldCurrency = Balances;
+	// A flat `AllyDeposit` candidacy bond (zero per-byte slope), held under the alliance hold
+	// reason. Note: kicking a member now burns the deposit rather than forwarding it.
+	type Consideration = HoldConsideration<
+		AccountId,
+		Balances,
+		AllianceHoldReason,
+		LinearStoragePrice<AllyDeposit, ConstU128<0>, Balance>,
+	>;
 	type InitializeMembers = AllianceMotion;
 	type MembershipChanged = AllianceMotion;
 	type RetirementPeriod = AllianceRetirementPeriod;
@@ -629,7 +638,6 @@ impl pallet_alliance::Config for Runtime {
 	type MaxWebsiteUrlLength = ConstU32<255>;
 	type MaxAnnouncementsCount = ConstU32<100>;
 	type MaxMembersCount = ConstU32<ALLIANCE_MAX_MEMBERS>;
-	type AllyDeposit = AllyDeposit;
 	type WeightInfo = weights::pallet_alliance::WeightInfo<Runtime>;
 }
 
@@ -864,6 +872,8 @@ type Migrations = (
 		pallet_session::migrations::v1::InitOffenceSeverity<Runtime>,
 	>,
 	cumulus_pallet_parachain_system::migration::Migration<Runtime>,
+	// unreleased: migrate Alliance candidacy deposits from reserves to holds.
+	pallet_alliance::migration::Migration<Runtime>,
 );
 
 /// Executive: handles dispatch to the various modules.

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -618,8 +618,7 @@ impl pallet_alliance::Config for Runtime {
 	type MembershipManager = RootOrAllianceTwoThirdsMajority;
 	type AnnouncementOrigin = RootOrAllianceTwoThirdsMajority;
 	type OldCurrency = Balances;
-	// A flat `AllyDeposit` candidacy bond (zero per-byte slope), held under the alliance hold
-	// reason. Note: kicking a member now burns the deposit rather than forwarding it.
+	// Flat `AllyDeposit` candidacy bond, held under the alliance hold reason. Kicking now burns it.
 	type Consideration = HoldConsideration<
 		AccountId,
 		Balances,

--- a/prdoc/pr_12412.prdoc
+++ b/prdoc/pr_12412.prdoc
@@ -1,0 +1,13 @@
+title: 'pallet-alliance: migrate candidacy deposit from Currency reserves to fungible
+  holds'
+doc:
+- audience: Runtime Dev
+  description: "Part of #12399, which tracks #226\n\nMigrates `pallet-alliance` off\
+    \ the deprecated `ReservableCurrency` trait onto `fungible` holds via `Consideration`,\
+    \ with a reserve-to-hold storage migration, as part of the FRAME `Currency`\u2192\
+    `fungible`"
+crates:
+- name: collectives-westend-runtime
+  bump: major
+- name: pallet-alliance
+  bump: major

--- a/prdoc/pr_12412.prdoc
+++ b/prdoc/pr_12412.prdoc
@@ -2,10 +2,38 @@ title: 'pallet-alliance: migrate candidacy deposit from Currency reserves to fun
   holds'
 doc:
 - audience: Runtime Dev
-  description: "Part of #12399, which tracks #226\n\nMigrates `pallet-alliance` off\
-    \ the deprecated `ReservableCurrency` trait onto `fungible` holds via `Consideration`,\
-    \ with a reserve-to-hold storage migration, as part of the FRAME `Currency`\u2192\
-    `fungible`"
+  description: |
+    Part of #12399, which tracks #226.
+
+    Migrates `pallet-alliance` off the deprecated `ReservableCurrency` trait onto
+    `fungible` holds via `Consideration`, with a reserve-to-hold storage migration,
+    as part of the FRAME `Currency`→`fungible` effort.
+
+    Config changes (breaking):
+    - `Currency: ReservableCurrency` is replaced by `OldCurrency: ReservableCurrency`,
+      kept only so `migration::Migration` can convert pre-existing reserved deposits
+      to holds. It can be removed once the migration has run.
+    - The candidacy deposit is now taken via `Consideration: Consideration<AccountId, Footprint>`
+      (e.g. `fungible::HoldConsideration`). The `AllyDeposit` config item and the
+      `Slashed: OnUnbalanced` handler are removed; the deposit amount is now set by the
+      `Consideration` implementation.
+    - A new `HoldReason::AllianceDeposit` is added; runtimes must expose it through their
+      `RuntimeHoldReason` and run `pallet_alliance::migration::Migration`.
+
+    Behavior change — slashed deposits are now BURNED, not routed to `Slashed`/Treasury:
+    Previously `kick_member` slashed the reserved deposit and sent the proceeds to the
+    `type Slashed` handler (e.g. `Treasury` in the kitchensink node runtime). With holds,
+    `kick_member` calls `Consideration::burn`, which for `HoldConsideration` destroys the
+    held balance via `fungible::MutateHold::burn_held` rather than redirecting it anywhere.
+    Runtimes that relied on slash proceeds reaching the Treasury (or another destination)
+    will no longer receive them. If routing the proceeds is still required, provide a custom
+    `Consideration` implementation that burns the hold and mints an equivalent credit to the
+    desired destination instead of using the default `HoldConsideration`.
+
+    The deposit-bearing events lost their now-redundant balance fields: `NewAllyJoined` no
+    longer carries `reserved`, `MemberRetired` no longer carries `unreserved`, `MemberKicked`
+    no longer carries `slashed`, and `AllianceDisbanded`'s `unreserved` count is renamed to
+    `released`.
 crates:
 - name: collectives-westend-runtime
   bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2344,6 +2344,8 @@ parameter_types! {
 	pub const MaxAllies: u32 = 100;
 	pub const AllyDeposit: Balance = 10 * DOLLARS;
 	pub const RetirementPeriod: BlockNumber = ALLIANCE_MOTION_DURATION_IN_BLOCKS + (1 * DAYS);
+	pub const AllianceHoldReason: RuntimeHoldReason =
+		RuntimeHoldReason::Alliance(pallet_alliance::HoldReason::AllianceDeposit);
 }
 
 impl pallet_alliance::Config for Runtime {
@@ -2361,8 +2363,15 @@ impl pallet_alliance::Config for Runtime {
 		EnsureRoot<AccountId>,
 		pallet_collective::EnsureProportionMoreThan<AccountId, AllianceCollective, 2, 3>,
 	>;
-	type Currency = Balances;
-	type Slashed = Treasury;
+	type OldCurrency = Balances;
+	// A flat candidacy bond of `AllyDeposit` (zero per-byte slope), held under the alliance hold
+	// reason. Note: kicking a member now burns the deposit instead of routing it to the treasury.
+	type Consideration = HoldConsideration<
+		AccountId,
+		Balances,
+		AllianceHoldReason,
+		LinearStoragePrice<AllyDeposit, ConstU128<0>, Balance>,
+	>;
 	type InitializeMembers = AllianceMotion;
 	type MembershipChanged = AllianceMotion;
 	#[cfg(not(feature = "runtime-benchmarks"))]
@@ -2377,7 +2386,6 @@ impl pallet_alliance::Config for Runtime {
 	type MaxWebsiteUrlLength = ConstU32<255>;
 	type MaxAnnouncementsCount = ConstU32<100>;
 	type MaxMembersCount = AllianceMaxMembers;
-	type AllyDeposit = AllyDeposit;
 	type WeightInfo = pallet_alliance::weights::SubstrateWeight<Runtime>;
 	type RetirementPeriod = RetirementPeriod;
 }

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2364,8 +2364,7 @@ impl pallet_alliance::Config for Runtime {
 		pallet_collective::EnsureProportionMoreThan<AccountId, AllianceCollective, 2, 3>,
 	>;
 	type OldCurrency = Balances;
-	// A flat candidacy bond of `AllyDeposit` (zero per-byte slope), held under the alliance hold
-	// reason. Note: kicking a member now burns the deposit instead of routing it to the treasury.
+	// Flat `AllyDeposit` candidacy bond, held under the alliance hold reason. Kicking now burns it.
 	type Consideration = HoldConsideration<
 		AccountId,
 		Balances,

--- a/substrate/frame/alliance/src/benchmarking.rs
+++ b/substrate/frame/alliance/src/benchmarking.rs
@@ -23,7 +23,7 @@ use core::{cmp, mem::size_of};
 use sp_runtime::traits::{Bounded, Hash, StaticLookup};
 
 use frame_benchmarking::{account, v2::*, BenchmarkError};
-use frame_support::traits::{EnsureOrigin, Get, UnfilteredDispatchable};
+use frame_support::traits::{Consideration, EnsureOrigin, Get, UnfilteredDispatchable};
 use frame_system::{pallet_prelude::BlockNumberFor, Pallet as System, RawOrigin as SystemOrigin};
 
 use super::{Call as AllianceCall, Pallet as Alliance, *};
@@ -51,8 +51,16 @@ fn announcement(input: impl AsRef<[u8]>) -> Cid {
 
 fn funded_account<T: Config<I>, I: 'static>(name: &'static str, index: u32) -> T::AccountId {
 	let account: T::AccountId = account(name, index, SEED);
-	T::Currency::make_free_balance_be(&account, BalanceOf::<T, I>::max_value() / 100u8.into());
+	T::OldCurrency::make_free_balance_be(&account, BalanceOf::<T, I>::max_value() / 100u8.into());
 	account
+}
+
+/// Place a candidacy deposit hold for `who` and record the resulting ticket, mirroring what
+/// `join_alliance` does. The account must already be funded.
+fn give_deposit<T: Config<I>, I: 'static>(who: &T::AccountId) {
+	let ticket = T::Consideration::new(who, Alliance::<T, I>::deposit_footprint())
+		.expect("benchmark account is funded; qed");
+	<DepositOf<T, I>>::insert(who, ticket);
 }
 
 fn fellow<T: Config<I>, I: 'static>(index: u32) -> T::AccountId {
@@ -74,18 +82,12 @@ fn generate_unscrupulous_account<T: Config<I>, I: 'static>(index: u32) -> T::Acc
 fn set_members<T: Config<I>, I: 'static>() {
 	let fellows: BoundedVec<_, T::MaxMembersCount> =
 		BoundedVec::try_from(vec![fellow::<T, I>(1), fellow::<T, I>(2)]).unwrap();
-	fellows.iter().for_each(|who| {
-		T::Currency::reserve(&who, T::AllyDeposit::get()).unwrap();
-		<DepositOf<T, I>>::insert(&who, T::AllyDeposit::get());
-	});
+	fellows.iter().for_each(|who| give_deposit::<T, I>(who));
 	Members::<T, I>::insert(MemberRole::Fellow, fellows.clone());
 
 	let allies: BoundedVec<_, T::MaxMembersCount> =
 		BoundedVec::try_from(vec![ally::<T, I>(1)]).unwrap();
-	allies.iter().for_each(|who| {
-		T::Currency::reserve(&who, T::AllyDeposit::get()).unwrap();
-		<DepositOf<T, I>>::insert(&who, T::AllyDeposit::get());
-	});
+	allies.iter().for_each(|who| give_deposit::<T, I>(who));
 	Members::<T, I>::insert(MemberRole::Ally, allies);
 
 	T::InitializeMembers::initialize_members(&[fellows.as_slice()].concat());
@@ -519,11 +521,9 @@ mod benchmarks {
 		// setting the Alliance to disband on the benchmark call
 		Alliance::<T, I>::init_members(SystemOrigin::Root.into(), fellows.clone(), allies.clone())?;
 
-		// reserve deposits
-		let deposit = T::AllyDeposit::get();
+		// place candidacy deposit holds
 		for member in fellows.iter().chain(allies.iter()).take(z as usize) {
-			T::Currency::reserve(&member, deposit)?;
-			<DepositOf<T, I>>::insert(&member, deposit);
+			give_deposit::<T, I>(member);
 		}
 
 		assert_eq!(Alliance::<T, I>::voting_members_count(), x);
@@ -536,7 +536,7 @@ mod benchmarks {
 			Event::AllianceDisbanded {
 				fellow_members: x,
 				ally_members: y,
-				unreserved: cmp::min(z, x + y),
+				released: cmp::min(z, x + y),
 			}
 			.into(),
 		);
@@ -619,16 +619,9 @@ mod benchmarks {
 		_(SystemOrigin::Signed(outsider.clone()));
 
 		assert!(Alliance::<T, I>::is_member_of(&outsider, MemberRole::Ally)); // outsider is now an ally
-		assert_eq!(DepositOf::<T, I>::get(&outsider), Some(T::AllyDeposit::get())); // with a deposit
+		assert!(DepositOf::<T, I>::contains_key(&outsider)); // with a deposit
 		assert!(!Alliance::<T, I>::has_voting_rights(&outsider)); // allies don't have voting rights
-		assert_last_event::<T, I>(
-			Event::NewAllyJoined {
-				ally: outsider,
-				nominator: None,
-				reserved: Some(T::AllyDeposit::get()),
-			}
-			.into(),
-		);
+		assert_last_event::<T, I>(Event::NewAllyJoined { ally: outsider, nominator: None }.into());
 		Ok(())
 	}
 
@@ -652,8 +645,7 @@ mod benchmarks {
 		assert_eq!(DepositOf::<T, I>::get(&outsider), None); // without a deposit
 		assert!(!Alliance::<T, I>::has_voting_rights(&outsider)); // allies don't have voting rights
 		assert_last_event::<T, I>(
-			Event::NewAllyJoined { ally: outsider, nominator: Some(fellow1), reserved: None }
-				.into(),
+			Event::NewAllyJoined { ally: outsider, nominator: Some(fellow1) }.into(),
 		);
 
 		Ok(())
@@ -715,17 +707,14 @@ mod benchmarks {
 		);
 		System::<T>::set_block_number(System::<T>::block_number() + T::RetirementPeriod::get());
 
-		assert_eq!(DepositOf::<T, I>::get(&fellow2), Some(T::AllyDeposit::get()));
+		assert!(DepositOf::<T, I>::contains_key(&fellow2));
 
 		#[extrinsic_call]
 		_(SystemOrigin::Signed(fellow2.clone()));
 
 		assert!(!Alliance::<T, I>::is_member(&fellow2));
 		assert_eq!(DepositOf::<T, I>::get(&fellow2), None);
-		assert_last_event::<T, I>(
-			Event::MemberRetired { member: fellow2, unreserved: Some(T::AllyDeposit::get()) }
-				.into(),
-		);
+		assert_last_event::<T, I>(Event::MemberRetired { member: fellow2 }.into());
 		Ok(())
 	}
 
@@ -735,7 +724,7 @@ mod benchmarks {
 
 		let fellow2 = fellow::<T, I>(2);
 		assert!(Alliance::<T, I>::is_member_of(&fellow2, MemberRole::Fellow));
-		assert_eq!(DepositOf::<T, I>::get(&fellow2), Some(T::AllyDeposit::get()));
+		assert!(DepositOf::<T, I>::contains_key(&fellow2));
 
 		let fellow2_lookup = T::Lookup::unlookup(fellow2.clone());
 		let call = Call::<T, I>::kick_member { who: fellow2_lookup };
@@ -749,9 +738,7 @@ mod benchmarks {
 
 		assert!(!Alliance::<T, I>::is_member(&fellow2));
 		assert_eq!(DepositOf::<T, I>::get(&fellow2), None);
-		assert_last_event::<T, I>(
-			Event::MemberKicked { member: fellow2, slashed: Some(T::AllyDeposit::get()) }.into(),
-		);
+		assert_last_event::<T, I>(Event::MemberKicked { member: fellow2 }.into());
 		Ok(())
 	}
 

--- a/substrate/frame/alliance/src/benchmarking.rs
+++ b/substrate/frame/alliance/src/benchmarking.rs
@@ -55,8 +55,7 @@ fn funded_account<T: Config<I>, I: 'static>(name: &'static str, index: u32) -> T
 	account
 }
 
-/// Place a candidacy deposit hold for `who` and record the resulting ticket, mirroring what
-/// `join_alliance` does. The account must already be funded.
+/// Hold a candidacy deposit for `who` and record the ticket. `who` must already be funded.
 fn give_deposit<T: Config<I>, I: 'static>(who: &T::AccountId) {
 	let ticket = T::Consideration::new(who, Alliance::<T, I>::deposit_footprint())
 		.expect("benchmark account is funded; qed");

--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -101,7 +101,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::pallet_prelude::*;
 use frame_system::pallet_prelude::*;
 use sp_runtime::{
-	traits::{Dispatchable, Saturating, StaticLookup, Zero},
+	traits::{Dispatchable, Saturating, StaticLookup},
 	Debug, DispatchError,
 };
 
@@ -109,7 +109,7 @@ use frame_support::{
 	dispatch::{DispatchResult, DispatchResultWithPostInfo, GetDispatchInfo, PostDispatchInfo},
 	ensure,
 	traits::{
-		ChangeMembers, Currency, Get, InitializeMembers, IsSubType, OnUnbalanced,
+		ChangeMembers, Consideration, Currency, Footprint, Get, InitializeMembers, IsSubType,
 		ReservableCurrency,
 	},
 	weights::Weight,
@@ -128,11 +128,10 @@ pub type ProposalIndex = u32;
 
 type UrlOf<T, I> = BoundedVec<u8, <T as pallet::Config<I>>::MaxWebsiteUrlLength>;
 
+/// Balance type of the legacy [`pallet::Config::OldCurrency`]. Only used by the reserve-to-hold
+/// migration in [`crate::migration`].
 type BalanceOf<T, I> =
-	<<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-type NegativeImbalanceOf<T, I> = <<T as Config<I>>::Currency as Currency<
-	<T as frame_system::Config>::AccountId,
->>::NegativeImbalance;
+	<<T as Config<I>>::OldCurrency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
 /// Interface required for identity verification.
 pub trait IdentityVerifier<AccountId> {
@@ -250,11 +249,20 @@ pub mod pallet {
 		/// Origin for making announcements and adding/removing unscrupulous items.
 		type AnnouncementOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
-		/// The currency used for deposits.
-		type Currency: ReservableCurrency<Self::AccountId>;
+		/// The legacy reservable currency, retained only to migrate pre-existing reserved
+		/// candidacy deposits to held deposits in [`crate::migration`].
+		///
+		/// It is otherwise unused and can be removed once all reserves have been migrated to
+		/// holds via the `MigrateToV3` migration.
+		type OldCurrency: ReservableCurrency<Self::AccountId>;
 
-		/// What to do with slashed funds.
-		type Slashed: OnUnbalanced<NegativeImbalanceOf<Self, I>>;
+		/// The mechanism by which a candidacy deposit is taken and held.
+		///
+		/// The deposit is held for as long as an account is an Alliance member (`Ally`/`Fellow`)
+		/// or is retiring. It is released on retirement or when the Alliance is disbanded, and
+		/// burned when a member is kicked. The amount is determined by the runtime, which allows
+		/// the deposit pricing policy (e.g. a flat anti-spam bond) to be configured per-runtime.
+		type Consideration: Consideration<Self::AccountId, Footprint>;
 
 		/// What to do with initial voting members of the Alliance.
 		type InitializeMembers: InitializeMembers<Self::AccountId>;
@@ -293,10 +301,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxWebsiteUrlLength: Get<u32>;
 
-		/// The deposit required for submitting candidacy.
-		#[pallet::constant]
-		type AllyDeposit: Get<BalanceOf<Self, I>>;
-
 		/// The maximum number of announcements.
 		#[pallet::constant]
 		type MaxAnnouncementsCount: Get<u32>;
@@ -311,6 +315,14 @@ pub mod pallet {
 		/// The number of blocks a member must wait between giving a retirement notice and retiring.
 		/// Supposed to be greater than time required to `kick_member`.
 		type RetirementPeriod: Get<BlockNumberFor<Self>>;
+	}
+
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason<I: 'static = ()> {
+		/// The funds are held as a deposit for being or becoming an Alliance member.
+		#[codec(index = 0)]
+		AllianceDeposit,
 	}
 
 	#[pallet::error]
@@ -377,26 +389,22 @@ pub mod pallet {
 		AnnouncementRemoved { announcement: Cid },
 		/// Some accounts have been initialized as members (fellows/allies).
 		MembersInitialized { fellows: Vec<T::AccountId>, allies: Vec<T::AccountId> },
-		/// An account has been added as an Ally and reserved its deposit.
-		NewAllyJoined {
-			ally: T::AccountId,
-			nominator: Option<T::AccountId>,
-			reserved: Option<BalanceOf<T, I>>,
-		},
+		/// An account has been added as an Ally and held its deposit.
+		NewAllyJoined { ally: T::AccountId, nominator: Option<T::AccountId> },
 		/// An ally has been elevated to Fellow.
 		AllyElevated { ally: T::AccountId },
 		/// A member gave retirement notice and their retirement period started.
 		MemberRetirementPeriodStarted { member: T::AccountId },
-		/// A member has retired with its deposit unreserved.
-		MemberRetired { member: T::AccountId, unreserved: Option<BalanceOf<T, I>> },
-		/// A member has been kicked out with its deposit slashed.
-		MemberKicked { member: T::AccountId, slashed: Option<BalanceOf<T, I>> },
+		/// A member has retired and had its deposit released.
+		MemberRetired { member: T::AccountId },
+		/// A member has been kicked out and had its deposit burned.
+		MemberKicked { member: T::AccountId },
 		/// Accounts or websites have been added into the list of unscrupulous items.
 		UnscrupulousItemAdded { items: Vec<UnscrupulousItemOf<T, I>> },
 		/// Accounts or websites have been removed from the list of unscrupulous items.
 		UnscrupulousItemRemoved { items: Vec<UnscrupulousItemOf<T, I>> },
-		/// Alliance disbanded. Includes number deleted members and unreserved deposits.
-		AllianceDisbanded { fellow_members: u32, ally_members: u32, unreserved: u32 },
+		/// Alliance disbanded. Includes number of deleted members and released deposits.
+		AllianceDisbanded { fellow_members: u32, ally_members: u32, released: u32 },
 		/// A Fellow abdicated their voting rights. They are now an Ally.
 		FellowAbdicated { fellow: T::AccountId },
 	}
@@ -462,10 +470,10 @@ pub mod pallet {
 	pub type Announcements<T: Config<I>, I: 'static = ()> =
 		StorageValue<_, BoundedVec<Cid, T::MaxAnnouncementsCount>, ValueQuery>;
 
-	/// Maps members to their candidacy deposit.
+	/// Maps members to their candidacy deposit ticket.
 	#[pallet::storage]
 	pub type DepositOf<T: Config<I>, I: 'static = ()> =
-		StorageMap<_, Blake2_128Concat, T::AccountId, BalanceOf<T, I>, OptionQuery>;
+		StorageMap<_, Blake2_128Concat, T::AccountId, T::Consideration, OptionQuery>;
 
 	/// Maps member type to members of each type.
 	#[pallet::storage]
@@ -618,12 +626,12 @@ pub mod pallet {
 			T::MembershipChanged::change_members_sorted(&[], &voting_members, &[]);
 
 			let ally_members = Self::members_of(MemberRole::Ally);
-			let mut unreserve_count: u32 = 0;
+			let mut released_count: u32 = 0;
 			for member in voting_members.iter().chain(ally_members.iter()) {
 				if let Some(deposit) = DepositOf::<T, I>::take(&member) {
-					let err_amount = T::Currency::unreserve(&member, deposit);
-					debug_assert!(err_amount.is_zero());
-					unreserve_count += 1;
+					let res = deposit.drop(&member);
+					debug_assert!(res.is_ok());
+					released_count += 1;
 				}
 			}
 
@@ -633,13 +641,13 @@ pub mod pallet {
 			Self::deposit_event(Event::AllianceDisbanded {
 				fellow_members: voting_members.len() as u32,
 				ally_members: ally_members.len() as u32,
-				unreserved: unreserve_count,
+				released: released_count,
 			});
 
 			Ok(Some(T::WeightInfo::disband(
 				voting_members.len() as u32,
 				ally_members.len() as u32,
-				unreserve_count,
+				released_count,
 			))
 			.into())
 		}
@@ -708,17 +716,13 @@ pub mod pallet {
 			// website.
 			Self::has_identity(&who)?;
 
-			let deposit = T::AllyDeposit::get();
-			T::Currency::reserve(&who, deposit).map_err(|_| Error::<T, I>::InsufficientFunds)?;
+			let deposit = T::Consideration::new(&who, Self::deposit_footprint())
+				.map_err(|_| Error::<T, I>::InsufficientFunds)?;
 			<DepositOf<T, I>>::insert(&who, deposit);
 
 			Self::add_member(&who, MemberRole::Ally)?;
 
-			Self::deposit_event(Event::NewAllyJoined {
-				ally: who,
-				nominator: None,
-				reserved: Some(deposit),
-			});
+			Self::deposit_event(Event::NewAllyJoined { ally: who, nominator: None });
 			Ok(())
 		}
 
@@ -739,11 +743,7 @@ pub mod pallet {
 
 			Self::add_member(&who, MemberRole::Ally)?;
 
-			Self::deposit_event(Event::NewAllyJoined {
-				ally: who,
-				nominator: Some(nominator),
-				reserved: None,
-			});
+			Self::deposit_event(Event::NewAllyJoined { ally: who, nominator: Some(nominator) });
 			Ok(())
 		}
 
@@ -798,12 +798,11 @@ pub mod pallet {
 
 			Self::remove_member(&who, MemberRole::Retiring)?;
 			<RetiringMembers<T, I>>::remove(&who);
-			let deposit = DepositOf::<T, I>::take(&who);
-			if let Some(deposit) = deposit {
-				let err_amount = T::Currency::unreserve(&who, deposit);
-				debug_assert!(err_amount.is_zero());
+			if let Some(deposit) = DepositOf::<T, I>::take(&who) {
+				let res = deposit.drop(&who);
+				debug_assert!(res.is_ok());
 			}
-			Self::deposit_event(Event::MemberRetired { member: who, unreserved: deposit });
+			Self::deposit_event(Event::MemberRetired { member: who });
 			Ok(())
 		}
 
@@ -815,12 +814,11 @@ pub mod pallet {
 
 			let role = Self::member_role_of(&member).ok_or(Error::<T, I>::NotMember)?;
 			Self::remove_member(&member, role)?;
-			let deposit = DepositOf::<T, I>::take(member.clone());
-			if let Some(deposit) = deposit {
-				T::Slashed::on_unbalanced(T::Currency::slash_reserved(&member, deposit).0);
+			if let Some(deposit) = DepositOf::<T, I>::take(member.clone()) {
+				deposit.burn(&member);
 			}
 
-			Self::deposit_event(Event::MemberKicked { member, slashed: deposit });
+			Self::deposit_event(Event::MemberKicked { member });
 			Ok(())
 		}
 
@@ -926,6 +924,14 @@ pub mod pallet {
 }
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// The storage footprint of a single candidacy deposit.
+	///
+	/// The deposit is a flat anti-spam bond, so it accounts for a single item with no variable
+	/// size; the actual amount is determined by [`Config::Consideration`] in the runtime.
+	pub(crate) fn deposit_footprint() -> Footprint {
+		Footprint::from_parts(1, 0)
+	}
+
 	/// Check if the Alliance has been initialized.
 	fn is_initialized() -> bool {
 		Self::has_member(MemberRole::Fellow) || Self::has_member(MemberRole::Ally)

--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -128,8 +128,7 @@ pub type ProposalIndex = u32;
 
 type UrlOf<T, I> = BoundedVec<u8, <T as pallet::Config<I>>::MaxWebsiteUrlLength>;
 
-/// Balance type of the legacy [`pallet::Config::OldCurrency`]. Only used by the reserve-to-hold
-/// migration in [`crate::migration`].
+/// Balance type of the legacy [`Config::OldCurrency`], used only by [`crate::migration`].
 type BalanceOf<T, I> =
 	<<T as Config<I>>::OldCurrency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
@@ -249,19 +248,12 @@ pub mod pallet {
 		/// Origin for making announcements and adding/removing unscrupulous items.
 		type AnnouncementOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
-		/// The legacy reservable currency, retained only to migrate pre-existing reserved
-		/// candidacy deposits to held deposits in [`crate::migration`].
-		///
-		/// It is otherwise unused and can be removed once all reserves have been migrated to
-		/// holds via the `MigrateToV3` migration.
+		/// Legacy reservable currency, kept only so [`crate::migration`] can convert pre-existing
+		/// reserved deposits to holds. Removable once `MigrateToV3` has run.
 		type OldCurrency: ReservableCurrency<Self::AccountId>;
 
-		/// The mechanism by which a candidacy deposit is taken and held.
-		///
-		/// The deposit is held for as long as an account is an Alliance member (`Ally`/`Fellow`)
-		/// or is retiring. It is released on retirement or when the Alliance is disbanded, and
-		/// burned when a member is kicked. The amount is determined by the runtime, which allows
-		/// the deposit pricing policy (e.g. a flat anti-spam bond) to be configured per-runtime.
+		/// Takes and holds the candidacy deposit. Held while an account is a member or retiring;
+		/// released on retirement/disband and burned on kick. Amount is set by the runtime.
 		type Consideration: Consideration<Self::AccountId, Footprint>;
 
 		/// What to do with initial voting members of the Alliance.
@@ -924,10 +916,7 @@ pub mod pallet {
 }
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
-	/// The storage footprint of a single candidacy deposit.
-	///
-	/// The deposit is a flat anti-spam bond, so it accounts for a single item with no variable
-	/// size; the actual amount is determined by [`Config::Consideration`] in the runtime.
+	/// Footprint of a candidacy deposit: a single item, no variable size (a flat bond).
 	pub(crate) fn deposit_footprint() -> Footprint {
 		Footprint::from_parts(1, 0)
 	}

--- a/substrate/frame/alliance/src/migration.rs
+++ b/substrate/frame/alliance/src/migration.rs
@@ -173,14 +173,8 @@ pub(crate) mod v1_to_v2 {
 	}
 }
 
-/// v2_to_v3: migrate legacy reserved candidacy deposits to `Consideration`-based holds.
-///
-/// Before this migration, `DepositOf` stored the reserved candidacy balance directly and the
-/// deposit was tracked through `ReservableCurrency`. After it, `DepositOf` stores a
-/// [`frame_support::traits::Consideration`] ticket and the funds are held rather than reserved.
-///
-/// The set of accounts with a deposit is bounded by `MaxMembersCount`, so this single-block
-/// migration is safe to run in one go.
+/// v2_to_v3: convert legacy reserved candidacy deposits into `Consideration`-based holds, turning
+/// each `DepositOf` balance into a ticket. Bounded by `MaxMembersCount`, so safe in one block.
 pub mod v2_to_v3 {
 	use super::*;
 	use crate::{BalanceOf, DepositOf};
@@ -224,9 +218,8 @@ pub mod v2_to_v3 {
 			match T::Consideration::new(&who, footprint) {
 				Ok(ticket) => DepositOf::<T, I>::insert(&who, ticket),
 				Err(e) => {
-					// The account can no longer back the deposit (e.g. its free balance dropped
-					// below the new amount). Drop the tracking entry so state stays consistent; the
-					// now-unreserved funds simply remain free with the account.
+					// Account can no longer back the deposit; drop the entry so state stays
+					// consistent (the unreserved funds just remain free).
 					log::error!(
 						target: LOG_TARGET,
 						"Failed to hold a migrated alliance deposit: {:?}. Removing the entry.",
@@ -246,13 +239,12 @@ pub mod v2_to_v3 {
 	pub fn pre_upgrade<T: Config<I>, I: 'static>() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
 		use codec::Encode;
 
-		// Only snapshot when this migration is actually going to run.
+		// Only snapshot if the migration will run.
 		if Pallet::<T, I>::on_chain_storage_version() >= 3 {
 			return Ok(Vec::new());
 		}
 
-		// Record the accounts that currently have a deposit. They must all still have a deposit
-		// (now as a hold) afterwards.
+		// Record accounts with a deposit; all must still have one (as a hold) afterwards.
 		let accounts: Vec<T::AccountId> =
 			legacy_deposits::<T, I>().into_iter().map(|(who, _)| who).collect();
 		Ok(accounts.encode())
@@ -321,7 +313,7 @@ mod test {
 			let reason = RuntimeHoldReason::Alliance(HoldReason::AllianceDeposit);
 
 			// Simulate a legacy ally: reserve the deposit and store it in the old `DepositOf`
-			// format (a raw balance keyed by account).
+			// format.
 			assert_ok!(<Test as crate::Config>::OldCurrency::reserve(&who, amount));
 			let key = Blake2_128Concat::hash(&who.encode());
 			put_storage_value(Alliance::name().as_bytes(), b"DepositOf", &key, amount);

--- a/substrate/frame/alliance/src/migration.rs
+++ b/substrate/frame/alliance/src/migration.rs
@@ -20,7 +20,7 @@ use frame_support::{pallet_prelude::*, storage::migration, traits::OnRuntimeUpgr
 use log;
 
 /// The in-code storage version.
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 /// Wrapper for all migrations of this pallet.
 pub fn migrate<T: Config<I>, I: 'static>() -> Weight {
@@ -35,6 +35,10 @@ pub fn migrate<T: Config<I>, I: 'static>() -> Weight {
 		weight = weight.saturating_add(v1_to_v2::migrate::<T, I>());
 	}
 
+	if on_chain_version < 3 {
+		weight = weight.saturating_add(v2_to_v3::migrate::<T, I>());
+	}
+
 	STORAGE_VERSION.put::<Pallet<T, I>>();
 	weight = weight.saturating_add(T::DbWeight::get().writes(1));
 
@@ -47,6 +51,16 @@ pub struct Migration<T, I = ()>(PhantomData<(T, I)>);
 impl<T: Config<I>, I: 'static> OnRuntimeUpgrade for Migration<T, I> {
 	fn on_runtime_upgrade() -> Weight {
 		migrate::<T, I>()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		v2_to_v3::pre_upgrade::<T, I>()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		v2_to_v3::post_upgrade::<T, I>(state)
 	}
 }
 
@@ -159,6 +173,118 @@ pub(crate) mod v1_to_v2 {
 	}
 }
 
+/// v2_to_v3: migrate legacy reserved candidacy deposits to `Consideration`-based holds.
+///
+/// Before this migration, `DepositOf` stored the reserved candidacy balance directly and the
+/// deposit was tracked through `ReservableCurrency`. After it, `DepositOf` stores a
+/// [`frame_support::traits::Consideration`] ticket and the funds are held rather than reserved.
+///
+/// The set of accounts with a deposit is bounded by `MaxMembersCount`, so this single-block
+/// migration is safe to run in one go.
+pub mod v2_to_v3 {
+	use super::*;
+	use crate::{BalanceOf, DepositOf};
+	use alloc::vec::Vec;
+	use frame_support::traits::{Consideration, ReservableCurrency};
+	use sp_runtime::traits::Zero;
+
+	/// Read the legacy `(account, reserved balance)` pairs from the pre-migration `DepositOf` map.
+	pub(crate) fn legacy_deposits<T: Config<I>, I: 'static>() -> Vec<(T::AccountId, BalanceOf<T, I>)>
+	{
+		migration::storage_key_iter::<T::AccountId, BalanceOf<T, I>, Blake2_128Concat>(
+			<Pallet<T, I>>::name().as_bytes(),
+			b"DepositOf",
+		)
+		.collect()
+	}
+
+	pub fn migrate<T: Config<I>, I: 'static>() -> Weight {
+		let footprint = Pallet::<T, I>::deposit_footprint();
+		let old_deposits = legacy_deposits::<T, I>();
+
+		log::info!(
+			target: LOG_TARGET,
+			"Running migration v2_to_v3: converting {} reserved deposit(s) to holds.",
+			old_deposits.len(),
+		);
+
+		let mut weight = T::DbWeight::get().reads(old_deposits.len() as u64);
+
+		for (who, amount) in old_deposits {
+			// Release the legacy reserve.
+			let remaining = T::OldCurrency::unreserve(&who, amount);
+			if !remaining.is_zero() {
+				log::error!(
+					target: LOG_TARGET,
+					"Could not fully unreserve a legacy alliance deposit; some balance remained reserved.",
+				);
+			}
+
+			// Place the equivalent hold via the configured `Consideration`.
+			match T::Consideration::new(&who, footprint) {
+				Ok(ticket) => DepositOf::<T, I>::insert(&who, ticket),
+				Err(e) => {
+					// The account can no longer back the deposit (e.g. its free balance dropped
+					// below the new amount). Drop the tracking entry so state stays consistent; the
+					// now-unreserved funds simply remain free with the account.
+					log::error!(
+						target: LOG_TARGET,
+						"Failed to hold a migrated alliance deposit: {:?}. Removing the entry.",
+						e,
+					);
+					DepositOf::<T, I>::remove(&who);
+				},
+			}
+
+			weight = weight.saturating_add(T::DbWeight::get().reads_writes(2, 2));
+		}
+
+		weight
+	}
+
+	#[cfg(feature = "try-runtime")]
+	pub fn pre_upgrade<T: Config<I>, I: 'static>() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+		use codec::Encode;
+
+		// Only snapshot when this migration is actually going to run.
+		if Pallet::<T, I>::on_chain_storage_version() >= 3 {
+			return Ok(Vec::new());
+		}
+
+		// Record the accounts that currently have a deposit. They must all still have a deposit
+		// (now as a hold) afterwards.
+		let accounts: Vec<T::AccountId> =
+			legacy_deposits::<T, I>().into_iter().map(|(who, _)| who).collect();
+		Ok(accounts.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	pub fn post_upgrade<T: Config<I>, I: 'static>(
+		state: Vec<u8>,
+	) -> Result<(), sp_runtime::TryRuntimeError> {
+		use codec::Decode;
+
+		if state.is_empty() {
+			return Ok(());
+		}
+
+		let accounts = Vec::<T::AccountId>::decode(&mut &state[..])
+			.map_err(|_| "alliance::v2_to_v3: failed to decode pre-upgrade state")?;
+
+		ensure!(
+			Pallet::<T, I>::on_chain_storage_version() >= 3,
+			"alliance::v2_to_v3: storage version was not bumped"
+		);
+		for who in accounts {
+			ensure!(
+				DepositOf::<T, I>::contains_key(&who),
+				"alliance::v2_to_v3: a member's deposit was lost during migration"
+			);
+		}
+		Ok(())
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;
@@ -174,6 +300,47 @@ mod test {
 			assert_eq!(Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3, 4]);
 			assert_eq!(Members::<Test>::get(MemberRole::Ally), vec![]);
 			assert_eq!(Members::<Test>::get(MemberRole::Retiring), vec![]);
+		});
+	}
+
+	#[test]
+	fn migration_v2_to_v3_converts_reserve_to_hold() {
+		use crate::{DepositOf, HoldReason};
+		use frame_support::{
+			migration::put_storage_value,
+			traits::{fungible::InspectHold, Consideration, ReservableCurrency},
+			Blake2_128Concat, StorageHasher,
+		};
+
+		new_test_ext().execute_with(|| {
+			// Pretend the chain is still on storage version 2.
+			StorageVersion::new(2).put::<Alliance>();
+
+			let who = 4u64;
+			let amount = AllyDeposit::get();
+			let reason = RuntimeHoldReason::Alliance(HoldReason::AllianceDeposit);
+
+			// Simulate a legacy ally: reserve the deposit and store it in the old `DepositOf`
+			// format (a raw balance keyed by account).
+			assert_ok!(<Test as crate::Config>::OldCurrency::reserve(&who, amount));
+			let key = Blake2_128Concat::hash(&who.encode());
+			put_storage_value(Alliance::name().as_bytes(), b"DepositOf", &key, amount);
+
+			// Before the migration the funds are reserved, not held.
+			assert_eq!(Balances::balance_on_hold(&reason, &who), 0);
+
+			// Run the full migration wrapper.
+			Migration::<Test, ()>::on_runtime_upgrade();
+
+			// The legacy reserve is now a hold of the same amount, tracked by a `Consideration`.
+			assert_eq!(Balances::balance_on_hold(&reason, &who), amount);
+			assert!(DepositOf::<Test>::contains_key(who));
+			assert_eq!(Alliance::on_chain_storage_version(), 3);
+
+			// Releasing the ticket frees exactly the migrated amount.
+			let ticket = DepositOf::<Test>::take(who).unwrap();
+			assert_ok!(ticket.drop(&who));
+			assert_eq!(Balances::balance_on_hold(&reason, &who), 0);
 		});
 	}
 }

--- a/substrate/frame/alliance/src/mock.rs
+++ b/substrate/frame/alliance/src/mock.rs
@@ -26,7 +26,8 @@ pub use sp_runtime::{
 
 pub use frame_support::{
 	assert_noop, assert_ok, derive_impl, ord_parameter_types, parameter_types,
-	traits::EitherOfDiverse, BoundedVec,
+	traits::{tokens::fungible::HoldConsideration, ConstU64, EitherOfDiverse, LinearStoragePrice},
+	BoundedVec,
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
 use pallet_identity::{
@@ -55,6 +56,7 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 const MOTION_DURATION_IN_BLOCKS: BlockNumber = 3;
@@ -220,6 +222,8 @@ parameter_types! {
 	pub const MaxAllies: u32 = 100;
 	pub const AllyDeposit: u64 = 25;
 	pub const RetirementPeriod: BlockNumber = MOTION_DURATION_IN_BLOCKS + 1;
+	pub const AllianceHoldReason: RuntimeHoldReason =
+		RuntimeHoldReason::Alliance(pallet_alliance::HoldReason::AllianceDeposit);
 }
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
@@ -227,8 +231,14 @@ impl Config for Test {
 	type AdminOrigin = EnsureSignedBy<One, AccountId>;
 	type MembershipManager = EnsureSignedBy<Two, AccountId>;
 	type AnnouncementOrigin = EnsureSignedBy<Three, AccountId>;
-	type Currency = Balances;
-	type Slashed = ();
+	type OldCurrency = Balances;
+	// A flat anti-spam bond of `AllyDeposit` (slope `0`), held under the alliance hold reason.
+	type Consideration = HoldConsideration<
+		AccountId,
+		Balances,
+		AllianceHoldReason,
+		LinearStoragePrice<AllyDeposit, ConstU64<0>, u64>,
+	>;
 	type InitializeMembers = AllianceMotion;
 	type MembershipChanged = AllianceMotion;
 	#[cfg(not(feature = "runtime-benchmarks"))]
@@ -243,7 +253,6 @@ impl Config for Test {
 	type MaxWebsiteUrlLength = ConstU32<255>;
 	type MaxAnnouncementsCount = ConstU32<100>;
 	type MaxMembersCount = MaxMembers;
-	type AllyDeposit = AllyDeposit;
 	type WeightInfo = ();
 	type RetirementPeriod = RetirementPeriod;
 }

--- a/substrate/frame/alliance/src/mock.rs
+++ b/substrate/frame/alliance/src/mock.rs
@@ -232,7 +232,7 @@ impl Config for Test {
 	type MembershipManager = EnsureSignedBy<Two, AccountId>;
 	type AnnouncementOrigin = EnsureSignedBy<Three, AccountId>;
 	type OldCurrency = Balances;
-	// A flat anti-spam bond of `AllyDeposit` (slope `0`), held under the alliance hold reason.
+	// Flat `AllyDeposit` bond, held under the alliance hold reason.
 	type Consideration = HoldConsideration<
 		AccountId,
 		Balances,

--- a/substrate/frame/alliance/src/tests.rs
+++ b/substrate/frame/alliance/src/tests.rs
@@ -107,7 +107,7 @@ fn init_members_works() {
 fn disband_works() {
 	build_and_execute(|| {
 		let id_deposit = test_identity_info_deposit();
-		let expected_join_deposit = <Test as Config>::AllyDeposit::get();
+		let expected_join_deposit = AllyDeposit::get();
 		assert_eq!(Balances::free_balance(9), 1000 - id_deposit);
 		// ensure alliance is set
 		assert_eq!(Alliance::voting_members(), vec![1, 2, 3]);
@@ -119,7 +119,7 @@ fn disband_works() {
 		// join alliance and reserve funds
 		assert_eq!(Balances::free_balance(9), 1000 - id_deposit);
 		assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(9)));
-		assert_eq!(alliance::DepositOf::<Test>::get(9), Some(expected_join_deposit));
+		assert!(alliance::DepositOf::<Test>::contains_key(9));
 		assert_eq!(Balances::free_balance(9), 1000 - id_deposit - expected_join_deposit);
 		assert!(Alliance::is_member_of(&9, MemberRole::Ally));
 
@@ -155,7 +155,7 @@ fn disband_works() {
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::AllianceDisbanded {
 			fellow_members: 2,
 			ally_members: 1,
-			unreserved: 1,
+			released: 1,
 		}));
 
 		// the Alliance must be set first
@@ -363,7 +363,7 @@ fn remove_announcement_works() {
 fn join_alliance_works() {
 	build_and_execute(|| {
 		let id_deposit = test_identity_info_deposit();
-		let join_deposit = <Test as Config>::AllyDeposit::get();
+		let join_deposit = AllyDeposit::get();
 		assert_eq!(Balances::free_balance(9), 1000 - id_deposit);
 		// check already member
 		assert_noop!(
@@ -395,7 +395,7 @@ fn join_alliance_works() {
 		// success to submit
 		assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(4)));
 		assert_eq!(Balances::free_balance(4), 1000 - id_deposit - join_deposit);
-		assert_eq!(alliance::DepositOf::<Test>::get(4), Some(25));
+		assert!(alliance::DepositOf::<Test>::contains_key(4));
 		assert_eq!(alliance::Members::<Test>::get(MemberRole::Ally), vec![4]);
 
 		// check already member
@@ -539,7 +539,6 @@ fn retire_works() {
 		assert_eq!(alliance::Members::<Test>::get(MemberRole::Fellow), vec![1, 2]);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::MemberRetired {
 			member: (3),
-			unreserved: None,
 		}));
 
 		// Move time on:
@@ -573,14 +572,23 @@ fn kick_member_works() {
 			Error::<Test, ()>::NotMember
 		);
 
-		<DepositOf<Test, ()>>::insert(2, 25);
-		assert_eq!(alliance::Members::<Test>::get(MemberRole::Fellow), vec![1, 2, 3]);
-		assert_ok!(Alliance::kick_member(RuntimeOrigin::signed(2), 2));
-		assert_eq!(alliance::Members::<Test>::get(MemberRole::Fellow), vec![1, 3]);
-		assert_eq!(<DepositOf<Test, ()>>::get(2), None);
+		// An ally joins and places a real hold for its candidacy deposit.
+		let id_deposit = test_identity_info_deposit();
+		let deposit = AllyDeposit::get();
+		assert_ok!(Alliance::join_alliance(RuntimeOrigin::signed(4)));
+		assert!(Alliance::is_member_of(&4, MemberRole::Ally));
+		assert!(<DepositOf<Test, ()>>::contains_key(4));
+		assert_eq!(Balances::free_balance(4), 1000 - id_deposit - deposit);
+		let issuance_before = Balances::total_issuance();
+
+		// Kicking the member burns its deposit: it is not returned and total issuance drops.
+		assert_ok!(Alliance::kick_member(RuntimeOrigin::signed(2), 4));
+		assert!(!Alliance::is_member(&4));
+		assert_eq!(<DepositOf<Test, ()>>::get(4), None);
+		assert_eq!(Balances::free_balance(4), 1000 - id_deposit - deposit);
+		assert_eq!(Balances::total_issuance(), issuance_before - deposit);
 		System::assert_last_event(mock::RuntimeEvent::Alliance(crate::Event::MemberKicked {
-			member: (2),
-			slashed: Some(25),
+			member: (4),
 		}));
 	});
 }


### PR DESCRIPTION
Part of #12399, which tracks #226

Migrates `pallet-alliance` off the deprecated `ReservableCurrency` trait onto `fungible` holds via `Consideration`, with a reserve-to-hold storage migration, as part of the FRAME `Currency`→`fungible` effort.

### Behavior change: slashed deposits are now burned, not routed to Treasury

Previously, `kick_member` slashed the reserved candidacy deposit and forwarded the proceeds to the `type Slashed` handler (e.g. `Treasury` in the kitchensink node runtime, the accumulate-and-forward adapter in collectives-westend):

```rust
T::Slashed::on_unbalanced(T::Currency::slash_reserved(&member, deposit).0);
```

With holds, `kick_member` now calls `Consideration::burn`:

```rust
deposit.burn(&member);
```

For the default `HoldConsideration`, this destroys the held balance via `fungible::MutateHold::burn_held` rather than redirecting it anywhere. **Runtimes that relied on slash proceeds reaching the Treasury (or another destination) will no longer receive them.** The `type Slashed` config item is removed accordingly.

If routing the proceeds is still desired, a runtime can wire a custom `Consideration` implementation that burns the hold and mints an equivalent credit to the destination, instead of using the default `HoldConsideration`.

This is documented in the prdoc.
