### PR TITLE
pallet-society: migrate from Currency to fungible (holds, transfers, pot reads)

### DIFF
--- a/polkadot/runtime/rococo/src/lib.rs
+++ b/polkadot/runtime/rococo/src/lib.rs
@@ -850,6 +850,8 @@ parameter_types! {
 impl pallet_society::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Randomness = pallet_babe::RandomnessFromOneEpochAgo<Runtime>;
 	type GraceStrikes = ConstU32<1>;
 	type PeriodSpend = ConstU128<{ 50_000 * CENTS }>;
@@ -1736,6 +1738,8 @@ pub mod migrations {
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = (
         pallet_society::migrations::MigrateToV2<Runtime, (), ()>,
+        // Migrate society bid deposits from reserves to holds.
+        pallet_society::migrations::MigrateToV3<Runtime, ()>,
         parachains_configuration::migration::v7::MigrateToV7<Runtime>,
         assigned_slots::migration::v1::MigrateToV1<Runtime>,
         parachains_configuration::migration::v8::MigrateToV8<Runtime>,

--- a/prdoc/pr_12413.prdoc
+++ b/prdoc/pr_12413.prdoc
@@ -1,0 +1,13 @@
+title: 'pallet-society: migrate from Currency to fungible (holds, transfers, pot reads)'
+doc:
+- audience: Runtime Dev
+  description: "Migrates `pallet-society` off the deprecated `Currency`/`ReservableCurrency`\
+    \ traits onto the `fungible` trait family. Bid/candidacy deposits become `fungible`\
+    \ holds, internal payout/pot movements use `fungible::Mutate::transfer,` and pot\
+    \ reads use `fungible::Inspect`, with a versioned reserve-to-hold storage migration.\
+    \ Part of #12399 / #226.\r\n"
+crates:
+- name: rococo-runtime
+  bump: major
+- name: pallet-society
+  bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1831,6 +1831,8 @@ impl pallet_society::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type PalletId = SocietyPalletId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Randomness = RandomnessCollectiveFlip;
 	type GraceStrikes = GraceStrikes;
 	type PeriodSpend = PeriodSpend;
@@ -3019,6 +3021,8 @@ type Migrations = (
 	pallet_alliance::migration::Migration<Runtime>,
 	pallet_contracts::Migration<Runtime>,
 	pallet_identity::migration::versioned::V0ToV1<Runtime, IDENTITY_MIGRATION_KEY_LIMIT>,
+	// Migrate society bid deposits from reserves to holds.
+	pallet_society::migrations::MigrateToV3<Runtime, ()>,
 );
 
 type EventRecord = frame_system::EventRecord<

--- a/substrate/frame/society/src/benchmarking.rs
+++ b/substrate/frame/society/src/benchmarking.rs
@@ -22,6 +22,7 @@
 use super::*;
 
 use frame_benchmarking::v2::*;
+use frame_support::traits::fungible::{InspectHold, Mutate, MutateHold};
 use frame_system::RawOrigin;
 
 use alloc::vec;
@@ -40,10 +41,11 @@ fn mock_balance_deposit<T: Config<I>, I: 'static>() -> BalanceOf<T, I> {
 fn make_deposit<T: Config<I>, I: 'static>(who: &T::AccountId) -> BalanceOf<T, I> {
 	let amount = mock_balance_deposit::<T, I>();
 	let required = amount.saturating_add(T::Currency::minimum_balance());
-	if T::Currency::free_balance(who) < required {
-		T::Currency::make_free_balance_be(who, required);
+	if T::Currency::balance(who) < required {
+		let _ = T::Currency::set_balance(who, required);
 	}
-	T::Currency::reserve(who, amount).expect("Pre-funded account; qed");
+	T::Currency::hold(&Society::<T, I>::deposit_reason(), who, amount)
+		.expect("Pre-funded account; qed");
 	amount
 }
 
@@ -54,10 +56,8 @@ fn make_bid<T: Config<I>, I: 'static>(
 }
 
 fn fund_society<T: Config<I>, I: 'static>() {
-	T::Currency::make_free_balance_be(
-		&Society::<T, I>::account_id(),
-		BalanceOf::<T, I>::max_value(),
-	);
+	let _ =
+		T::Currency::set_balance(&Society::<T, I>::account_id(), BalanceOf::<T, I>::max_value());
 	Pot::<T, I>::put(&BalanceOf::<T, I>::max_value());
 }
 
@@ -78,11 +78,9 @@ fn setup_society<T: Config<I>, I: 'static>() -> Result<T::AccountId, &'static st
 		mock_balance_deposit::<T, I>(),
 		b"benchmarking-society".to_vec(),
 	)?;
-	T::Currency::make_free_balance_be(
-		&Society::<T, I>::account_id(),
-		T::Currency::minimum_balance(),
-	);
-	T::Currency::make_free_balance_be(&Society::<T, I>::payouts(), T::Currency::minimum_balance());
+	let _ =
+		T::Currency::set_balance(&Society::<T, I>::account_id(), T::Currency::minimum_balance());
+	let _ = T::Currency::set_balance(&Society::<T, I>::payouts(), T::Currency::minimum_balance());
 	Ok(founder)
 }
 
@@ -123,7 +121,7 @@ mod benchmarks {
 	fn bid() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), 10u32.into());
@@ -141,7 +139,7 @@ mod benchmarks {
 	fn unbid() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 		let mut bids = Bids::<T, I>::get();
 		Society::<T, I>::insert_bid(&mut bids, &caller, 10u32.into(), make_bid::<T, I>(&caller));
 		Bids::<T, I>::put(bids);
@@ -158,7 +156,7 @@ mod benchmarks {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
 		let vouched: T::AccountId = account("vouched", 0, 0);
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 		let _ = Society::<T, I>::insert_member(&caller, 1u32.into());
 		let vouched_lookup: <T::Lookup as StaticLookup>::Source =
 			T::Lookup::unlookup(vouched.clone());
@@ -180,7 +178,7 @@ mod benchmarks {
 	fn unvouch() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 		let mut bids = Bids::<T, I>::get();
 		Society::<T, I>::insert_bid(
 			&mut bids,
@@ -201,7 +199,7 @@ mod benchmarks {
 	fn vote() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 		let _ = Society::<T, I>::insert_member(&caller, 1u32.into());
 		let candidate = add_candidate::<T, I>("candidate", Default::default(), false);
 		let candidate_lookup: <T::Lookup as StaticLookup>::Source =
@@ -219,7 +217,7 @@ mod benchmarks {
 	fn defender_vote() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 		let _ = Society::<T, I>::insert_member(&caller, 1u32.into());
 		let defender: T::AccountId = account("defender", 0, 0);
 		Defending::<T, I>::put((defender, caller.clone(), Tally::default()));
@@ -238,7 +236,7 @@ mod benchmarks {
 		setup_funded_society::<T, I>()?;
 		// Payee's account already exists and is a member.
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, mock_balance_deposit::<T, I>());
+		let _ = T::Currency::set_balance(&caller, mock_balance_deposit::<T, I>());
 		let _ = Society::<T, I>::insert_member(&caller, 0u32.into());
 		// Introduce payout.
 		Society::<T, I>::bump_payout(&caller, 0u32.into(), 1u32.into());
@@ -255,7 +253,7 @@ mod benchmarks {
 	fn waive_repay() -> Result<(), BenchmarkError> {
 		setup_funded_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
 		let _ = Society::<T, I>::insert_member(&caller, 0u32.into());
 		Society::<T, I>::bump_payout(&caller, 0u32.into(), 1u32.into());
 
@@ -515,19 +513,20 @@ mod benchmarks {
 		// Set up society
 		setup_society::<T, I>()?;
 		let bidder: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&bidder, BalanceOf::<T, I>::max_value());
+		let _ = T::Currency::set_balance(&bidder, BalanceOf::<T, I>::max_value());
 
 		// Make initial bid
 		let initial_deposit = mock_balance_deposit::<T, I>();
 		Society::<T, I>::bid(RawOrigin::Signed(bidder.clone()).into(), 0u32.into())?;
 
 		// Verify initial state
-		assert_eq!(T::Currency::reserved_balance(&bidder), initial_deposit);
+		let reason = Society::<T, I>::deposit_reason();
+		assert_eq!(T::Currency::balance_on_hold(&reason, &bidder), initial_deposit);
 		let bids = Bids::<T, I>::get();
 		let existing_bid = bids.iter().find(|b| b.who == bidder).expect("Bid should exist");
 		assert_eq!(existing_bid.kind, BidKind::Deposit(initial_deposit));
 
-		// Artificially increase deposit in storage and reserve extra balance
+		// Artificially increase deposit in storage and hold extra balance
 		let extra_amount = 2u32.into();
 		let increased_deposit = initial_deposit.saturating_add(extra_amount);
 		Bids::<T, I>::try_mutate(|bids| -> Result<(), BenchmarkError> {
@@ -538,10 +537,10 @@ mod benchmarks {
 				Err(BenchmarkError::Stop("Bid not found"))
 			}
 		})?;
-		T::Currency::reserve(&bidder, extra_amount)?;
+		T::Currency::hold(&reason, &bidder, extra_amount)?;
 
 		// Verify increased state
-		assert_eq!(T::Currency::reserved_balance(&bidder), increased_deposit);
+		assert_eq!(T::Currency::balance_on_hold(&reason, &bidder), increased_deposit);
 		let bids = Bids::<T, I>::get();
 		let existing_bid = bids.iter().find(|b| b.who == bidder).expect("Bid should exist");
 		assert_eq!(existing_bid.kind, BidKind::Deposit(increased_deposit));
@@ -550,7 +549,7 @@ mod benchmarks {
 		_(RawOrigin::Signed(bidder.clone()));
 
 		// Verify final state returned to initial deposit
-		assert_eq!(T::Currency::reserved_balance(&bidder), initial_deposit);
+		assert_eq!(T::Currency::balance_on_hold(&reason, &bidder), initial_deposit);
 		let bids = Bids::<T, I>::get();
 		let existing_bid = bids.iter().find(|b| b.who == bidder).expect("Bid should exist");
 		assert_eq!(existing_bid.kind, BidKind::Deposit(initial_deposit));

--- a/substrate/frame/society/src/benchmarking.rs
+++ b/substrate/frame/society/src/benchmarking.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use frame_benchmarking::v2::*;
-use frame_support::traits::fungible::{InspectHold, Mutate, MutateHold};
+use frame_support::traits::fungible::{InspectHold, MutateHold};
 use frame_system::RawOrigin;
 
 use alloc::vec;

--- a/substrate/frame/society/src/benchmarking.rs
+++ b/substrate/frame/society/src/benchmarking.rs
@@ -42,7 +42,7 @@ fn make_deposit<T: Config<I>, I: 'static>(who: &T::AccountId) -> BalanceOf<T, I>
 	let amount = mock_balance_deposit::<T, I>();
 	let required = amount.saturating_add(T::Currency::minimum_balance());
 	if T::Currency::balance(who) < required {
-		let _ = T::Currency::set_balance(who, required);
+		let _ = T::OldCurrency::make_free_balance_be(who, required);
 	}
 	T::Currency::hold(&Society::<T, I>::deposit_reason(), who, amount)
 		.expect("Pre-funded account; qed");
@@ -56,9 +56,11 @@ fn make_bid<T: Config<I>, I: 'static>(
 }
 
 fn fund_society<T: Config<I>, I: 'static>() {
-	let _ =
-		T::Currency::set_balance(&Society::<T, I>::account_id(), BalanceOf::<T, I>::max_value());
-	Pot::<T, I>::put(&BalanceOf::<T, I>::max_value());
+	let _ = T::OldCurrency::make_free_balance_be(
+		&Society::<T, I>::account_id(),
+		BalanceOf::<T, I>::max_value() / 1000u32.into(),
+	);
+	Pot::<T, I>::put(BalanceOf::<T, I>::max_value() / 1000u32.into());
 }
 
 // Set up Society
@@ -78,9 +80,14 @@ fn setup_society<T: Config<I>, I: 'static>() -> Result<T::AccountId, &'static st
 		mock_balance_deposit::<T, I>(),
 		b"benchmarking-society".to_vec(),
 	)?;
-	let _ =
-		T::Currency::set_balance(&Society::<T, I>::account_id(), T::Currency::minimum_balance());
-	let _ = T::Currency::set_balance(&Society::<T, I>::payouts(), T::Currency::minimum_balance());
+	let _ = T::OldCurrency::make_free_balance_be(
+		&Society::<T, I>::account_id(),
+		T::Currency::minimum_balance(),
+	);
+	let _ = T::OldCurrency::make_free_balance_be(
+		&Society::<T, I>::payouts(),
+		T::Currency::minimum_balance(),
+	);
 	Ok(founder)
 }
 
@@ -121,7 +128,10 @@ mod benchmarks {
 	fn bid() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), 10u32.into());
@@ -139,7 +149,10 @@ mod benchmarks {
 	fn unbid() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let mut bids = Bids::<T, I>::get();
 		Society::<T, I>::insert_bid(&mut bids, &caller, 10u32.into(), make_bid::<T, I>(&caller));
 		Bids::<T, I>::put(bids);
@@ -156,7 +169,10 @@ mod benchmarks {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
 		let vouched: T::AccountId = account("vouched", 0, 0);
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let _ = Society::<T, I>::insert_member(&caller, 1u32.into());
 		let vouched_lookup: <T::Lookup as StaticLookup>::Source =
 			T::Lookup::unlookup(vouched.clone());
@@ -178,7 +194,10 @@ mod benchmarks {
 	fn unvouch() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let mut bids = Bids::<T, I>::get();
 		Society::<T, I>::insert_bid(
 			&mut bids,
@@ -199,7 +218,10 @@ mod benchmarks {
 	fn vote() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let _ = Society::<T, I>::insert_member(&caller, 1u32.into());
 		let candidate = add_candidate::<T, I>("candidate", Default::default(), false);
 		let candidate_lookup: <T::Lookup as StaticLookup>::Source =
@@ -217,7 +239,10 @@ mod benchmarks {
 	fn defender_vote() -> Result<(), BenchmarkError> {
 		setup_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let _ = Society::<T, I>::insert_member(&caller, 1u32.into());
 		let defender: T::AccountId = account("defender", 0, 0);
 		Defending::<T, I>::put((defender, caller.clone(), Tally::default()));
@@ -236,7 +261,7 @@ mod benchmarks {
 		setup_funded_society::<T, I>()?;
 		// Payee's account already exists and is a member.
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, mock_balance_deposit::<T, I>());
+		let _ = T::OldCurrency::make_free_balance_be(&caller, mock_balance_deposit::<T, I>());
 		let _ = Society::<T, I>::insert_member(&caller, 0u32.into());
 		// Introduce payout.
 		Society::<T, I>::bump_payout(&caller, 0u32.into(), 1u32.into());
@@ -253,7 +278,10 @@ mod benchmarks {
 	fn waive_repay() -> Result<(), BenchmarkError> {
 		setup_funded_society::<T, I>()?;
 		let caller: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&caller, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&caller,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let _ = Society::<T, I>::insert_member(&caller, 0u32.into());
 		Society::<T, I>::bump_payout(&caller, 0u32.into(), 1u32.into());
 
@@ -513,7 +541,10 @@ mod benchmarks {
 		// Set up society
 		setup_society::<T, I>()?;
 		let bidder: T::AccountId = whitelisted_caller();
-		let _ = T::Currency::set_balance(&bidder, BalanceOf::<T, I>::max_value());
+		let _ = T::OldCurrency::make_free_balance_be(
+			&bidder,
+			BalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 
 		// Make initial bid
 		let initial_deposit = mock_balance_deposit::<T, I>();

--- a/substrate/frame/society/src/lib.rs
+++ b/substrate/frame/society/src/lib.rs
@@ -265,9 +265,10 @@ use frame_support::{
 	pallet_prelude::*,
 	storage::KeyLenOf,
 	traits::{
-		BalanceStatus, Currency, EnsureOrigin, EnsureOriginWithArg,
-		ExistenceRequirement::AllowDeath, Imbalance, OnUnbalanced, Randomness, ReservableCurrency,
-		StorageVersion,
+		fungible::{Inspect, Mutate, MutateHold},
+		tokens::{Fortitude, Precision, Preservation, Restriction},
+		Currency, EnsureOrigin, EnsureOriginWithArg, Imbalance, OnUnbalanced, Randomness,
+		ReservableCurrency, StorageVersion,
 	},
 	PalletId,
 };
@@ -297,8 +298,11 @@ pub type BlockNumberFor<T, I> =
 	<<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
 pub type BalanceOf<T, I> =
-	<<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-pub type NegativeImbalanceOf<T, I> = <<T as Config<I>>::Currency as Currency<
+	<<T as Config<I>>::Currency as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
+/// Legacy negative imbalance of [`Config::OldCurrency`]. Retained so the society pot can still be
+/// funded by `Currency`-based [`OnUnbalanced`] callers (e.g. `pallet-treasury`'s burn destination)
+/// until those callers are migrated to `fungible`.
+pub type NegativeImbalanceOf<T, I> = <<T as Config<I>>::OldCurrency as Currency<
 	<T as frame_system::Config>::AccountId,
 >>::NegativeImbalance;
 pub type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
@@ -480,7 +484,7 @@ pub struct GroupParams<Balance> {
 
 pub type GroupParamsFor<T, I> = GroupParams<BalanceOf<T, I>>;
 
-pub(crate) const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+pub(crate) const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -501,8 +505,18 @@ pub mod pallet {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 
-		/// The currency type used for bidding.
-		type Currency: ReservableCurrency<Self::AccountId>;
+		/// The overarching hold reason type.
+		type RuntimeHoldReason: From<HoldReason<I>>;
+
+		/// The currency type used for bidding, deposits, payouts and the society pot.
+		type Currency: Inspect<Self::AccountId>
+			+ Mutate<Self::AccountId>
+			+ MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>;
+
+		/// The legacy reservable currency. Retained only to migrate pre-existing reserved bid
+		/// deposits to holds in [`crate::migrations`]; it is otherwise unused and can be removed
+		/// once all reserves have been migrated.
+		type OldCurrency: ReservableCurrency<Self::AccountId, Balance = BalanceOf<Self, I>>;
 
 		/// Something that provides randomness in the runtime.
 		type Randomness: Randomness<Self::Hash, BlockNumberFor<Self, I>>;
@@ -791,6 +805,14 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type NextChallengeAt<T: Config<I>, I: 'static = ()> = StorageValue<_, BlockNumberFor<T, I>>;
 
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason<I: 'static = ()> {
+		/// Funds are held as a deposit for a society membership bid.
+		#[codec(index = 0)]
+		BidDeposit,
+	}
+
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<SystemBlockNumberFor<T>> for Pallet<T, I> {
 		fn on_initialize(_n: SystemBlockNumberFor<T>) -> Weight {
@@ -867,8 +889,8 @@ pub mod pallet {
 
 			let params = Parameters::<T, I>::get().ok_or(Error::<T, I>::NotGroup)?;
 			let deposit = params.candidate_deposit;
-			// NOTE: Reserve must happen before `insert_bid` since that could end up unreserving.
-			T::Currency::reserve(&who, deposit)?;
+			// NOTE: The hold must happen before `insert_bid` since that could end up releasing.
+			T::Currency::hold(&Self::deposit_reason(), &who, deposit)?;
 			Self::insert_bid(&mut bids, &who, value, BidKind::Deposit(deposit));
 
 			Bids::<T, I>::put(bids);
@@ -1061,7 +1083,12 @@ pub mod pallet {
 			if let Some((when, amount)) = record.payouts.first() {
 				if when <= &block_number {
 					record.paid = record.paid.checked_add(amount).ok_or(Overflow)?;
-					T::Currency::transfer(&Self::payouts(), &who, *amount, AllowDeath)?;
+					T::Currency::transfer(
+						&Self::payouts(),
+						&who,
+						*amount,
+						Preservation::Expendable,
+					)?;
 					record.payouts.remove(0);
 					Payouts::<T, I>::insert(&who, record);
 					return Ok(());
@@ -1081,7 +1108,12 @@ pub mod pallet {
 			ensure!(record.rank == 0, Error::<T, I>::AlreadyElevated);
 			ensure!(amount >= payout_record.paid, Error::<T, I>::InsufficientFunds);
 
-			T::Currency::transfer(&who, &Self::account_id(), payout_record.paid, AllowDeath)?;
+			T::Currency::transfer(
+				&who,
+				&Self::account_id(),
+				payout_record.paid,
+				Preservation::Expendable,
+			)?;
 			payout_record.paid = Zero::zero();
 			payout_record.payouts.clear();
 			record.rank = 1;
@@ -1432,18 +1464,19 @@ pub mod pallet {
 				return Ok(Pays::Yes.into());
 			}
 
+			let reason = Self::deposit_reason();
 			if new_deposit > old_deposit {
-				// Need to reserve more
+				// Need to hold more
 				let extra = new_deposit.saturating_sub(old_deposit);
-				T::Currency::reserve(&who, extra)?;
+				T::Currency::hold(&reason, &who, extra)?;
 			} else {
-				// Need to unreserve some
+				// Need to release some
 				let excess = old_deposit.saturating_sub(new_deposit);
-				let remaining_unreserved = T::Currency::unreserve(&who, excess);
-				if !remaining_unreserved.is_zero() {
+				let released = T::Currency::release(&reason, &who, excess, Precision::BestEffort)?;
+				if released != excess {
 					defensive!(
-						"Failed to unreserve for full amount for bid (Requested, Actual)",
-						(excess, excess.saturating_sub(remaining_unreserved))
+						"Failed to release for full amount for bid (Requested, Actual)",
+						(excess, released)
 					);
 				}
 			}
@@ -1719,7 +1752,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		// Bump the pot by at most `PeriodSpend`, but less if there's not very much left in our
 		// account.
 		let mut pot = Pot::<T, I>::get();
-		let unaccounted = T::Currency::free_balance(&Self::account_id()).saturating_sub(pot);
+		let unaccounted = T::Currency::balance(&Self::account_id()).saturating_sub(pot);
 		pot.saturating_accrue(T::PeriodSpend::get().min(unaccounted / 2u8.into()));
 		Pot::<T, I>::put(&pot);
 
@@ -1817,8 +1850,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	fn clean_bid(bid: &Bid<T::AccountId, BalanceOf<T, I>>) {
 		match &bid.kind {
 			BidKind::Deposit(deposit) => {
-				let err_amount = T::Currency::unreserve(&bid.who, *deposit);
-				debug_assert!(err_amount.is_zero());
+				let res = T::Currency::release(
+					&Self::deposit_reason(),
+					&bid.who,
+					*deposit,
+					Precision::BestEffort,
+				);
+				debug_assert!(res.is_ok());
 			},
 			BidKind::Vouch(voucher, _) => {
 				Members::<T, I>::mutate_extant(voucher, |record| record.vouching = None);
@@ -1837,8 +1875,17 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		match kind {
 			BidKind::Deposit(deposit) => {
 				let pot = Self::account_id();
-				let free = BalanceStatus::Free;
-				let r = T::Currency::repatriate_reserved(&who, &pot, *deposit, free);
+				// Move the held deposit to the society pot as free balance (the equivalent of the
+				// former `repatriate_reserved` to `BalanceStatus::Free`).
+				let r = T::Currency::transfer_on_hold(
+					&Self::deposit_reason(),
+					who,
+					&pot,
+					*deposit,
+					Precision::BestEffort,
+					Restriction::Free,
+					Fortitude::Polite,
+				);
 				debug_assert!(r.is_ok());
 			},
 			BidKind::Vouch(voucher, _) => {
@@ -2080,10 +2127,14 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) {
 		let value = match kind {
 			BidKind::Deposit(deposit) => {
-				// In the case that a normal deposit bid is accepted we unreserve
-				// the deposit.
-				let err_amount = T::Currency::unreserve(candidate, deposit);
-				debug_assert!(err_amount.is_zero());
+				// In the case that a normal deposit bid is accepted we release the deposit.
+				let res = T::Currency::release(
+					&Self::deposit_reason(),
+					candidate,
+					deposit,
+					Precision::BestEffort,
+				);
+				debug_assert!(res.is_ok());
 				value
 			},
 			BidKind::Vouch(voucher, tip) => {
@@ -2160,7 +2211,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		// this should never fail since we ensure we can afford the payouts in a previous
 		// block, but there's not much we can do to recover if it fails anyway.
-		let res = T::Currency::transfer(&Self::account_id(), &Self::payouts(), amount, AllowDeath);
+		let res = T::Currency::transfer(
+			&Self::account_id(),
+			&Self::payouts(),
+			amount,
+			Preservation::Expendable,
+		);
 		debug_assert!(res.is_ok());
 	}
 
@@ -2172,8 +2228,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		// this should never fail since we ensure we can afford the payouts in a previous
 		// block, but there's not much we can do to recover if it fails anyway.
-		let res = T::Currency::transfer(&Self::payouts(), &Self::account_id(), amount, AllowDeath);
+		let res = T::Currency::transfer(
+			&Self::payouts(),
+			&Self::account_id(),
+			amount,
+			Preservation::Expendable,
+		);
 		debug_assert!(res.is_ok());
+	}
+
+	/// The hold reason used for membership bid deposits.
+	pub(crate) fn deposit_reason() -> T::RuntimeHoldReason {
+		HoldReason::<I>::BidDeposit.into()
 	}
 
 	/// The account ID of the treasury pot.
@@ -2202,12 +2268,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 }
 
+/// Funding path for the society pot.
+///
+/// The pot is currently funded through the legacy `Currency` imbalance interface (e.g.
+/// `pallet-treasury`'s `BurnDestination`). This still routes through [`Config::OldCurrency`] until
+/// those callers are migrated to `fungible`, at which point this can move to
+/// `fungible::Balanced::resolve` over a `Credit`.
 impl<T: Config<I>, I: 'static> OnUnbalanced<NegativeImbalanceOf<T, I>> for Pallet<T, I> {
 	fn on_nonzero_unbalanced(amount: NegativeImbalanceOf<T, I>) {
 		let numeric_amount = amount.peek();
 
 		// Must resolve into existing but better to be safe.
-		let _ = T::Currency::resolve_creating(&Self::account_id(), amount);
+		let _ = T::OldCurrency::resolve_creating(&Self::account_id(), amount);
 
 		Self::deposit_event(Event::<T, I>::Deposit { value: numeric_amount });
 	}

--- a/substrate/frame/society/src/migrations.rs
+++ b/substrate/frame/society/src/migrations.rs
@@ -104,6 +104,104 @@ pub type MigrateToV2<T, I, PastPayouts> = frame_support::migrations::VersionedMi
 	<T as frame_system::Config>::DbWeight,
 >;
 
+/// Migrate bid deposits from `Currency` reserves to `fungible` holds.
+///
+/// Every `BidKind::Deposit` in [`Bids`] and [`Candidates`] has a reserved balance under the
+/// legacy [`Config::OldCurrency`]. This migration unreserves it and places an equivalent hold
+/// under [`HoldReason::BidDeposit`]. Vouched bids have no deposit and are left untouched.
+///
+/// The number of accounts touched is bounded by `MaxBids + max_members`, so this is safe to run
+/// as a single-block migration.
+pub struct VersionUncheckedMigrateToV3<T, I = ()>(core::marker::PhantomData<(T, I)>);
+
+impl<T: Config<I>, I: 'static> VersionUncheckedMigrateToV3<T, I> {
+	/// Unreserve the legacy deposit of `who` and re-apply it as a hold.
+	fn migrate_deposit(reason: &T::RuntimeHoldReason, who: &T::AccountId, amount: BalanceOf<T, I>) {
+		let leftover = T::OldCurrency::unreserve(who, amount);
+		if !leftover.is_zero() {
+			log::warn!(
+				target: TARGET,
+				"v3: could not fully unreserve a legacy bid deposit; some balance remained reserved",
+			);
+		}
+		if let Err(e) = <T::Currency as frame_support::traits::fungible::MutateHold<_>>::hold(
+			reason, who, amount,
+		) {
+			log::error!(target: TARGET, "v3: failed to hold a migrated bid deposit: {:?}", e);
+		}
+	}
+}
+
+impl<T: Config<I>, I: 'static> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateToV3<T, I> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+		// Collect (account, amount) for every deposit-backed bid and candidacy.
+		let mut deposits: Vec<(<T as frame_system::Config>::AccountId, BalanceOf<T, I>)> =
+			Vec::new();
+		for bid in Bids::<T, I>::get().into_iter() {
+			if let BidKind::Deposit(amount) = bid.kind {
+				deposits.push((bid.who, amount));
+			}
+		}
+		for (who, candidacy) in Candidates::<T, I>::iter() {
+			if let BidKind::Deposit(amount) = candidacy.kind {
+				deposits.push((who, amount));
+			}
+		}
+		Ok(deposits.encode())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		let reason = Pallet::<T, I>::deposit_reason();
+		let mut reads: u64 = 1;
+		let mut writes: u64 = 0;
+
+		for bid in Bids::<T, I>::get().into_iter() {
+			if let BidKind::Deposit(amount) = bid.kind {
+				Self::migrate_deposit(&reason, &bid.who, amount);
+				reads = reads.saturating_add(2);
+				writes = writes.saturating_add(2);
+			}
+		}
+		for (who, candidacy) in Candidates::<T, I>::iter() {
+			reads = reads.saturating_add(1);
+			if let BidKind::Deposit(amount) = candidacy.kind {
+				Self::migrate_deposit(&reason, &who, amount);
+				reads = reads.saturating_add(2);
+				writes = writes.saturating_add(2);
+			}
+		}
+
+		T::DbWeight::get().reads_writes(reads, writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(data: Vec<u8>) -> Result<(), TryRuntimeError> {
+		use frame_support::traits::fungible::InspectHold;
+
+		let deposits: Vec<(<T as frame_system::Config>::AccountId, BalanceOf<T, I>)> =
+			Decode::decode(&mut &data[..]).expect("Bad data");
+		let reason = Pallet::<T, I>::deposit_reason();
+		for (who, amount) in deposits {
+			ensure!(
+				<T::Currency as InspectHold<_>>::balance_on_hold(&reason, &who) >= amount,
+				"society::v3: bid deposit was not migrated to a hold"
+			);
+		}
+		Ok(())
+	}
+}
+
+/// [`VersionUncheckedMigrateToV3`] wrapped in a [`frame_support::migrations::VersionedMigration`],
+/// converting reserved bid deposits to holds when the on-chain version is 2.
+pub type MigrateToV3<T, I = ()> = frame_support::migrations::VersionedMigration<
+	2,
+	3,
+	VersionUncheckedMigrateToV3<T, I>,
+	crate::pallet::Pallet<T, I>,
+	<T as frame_system::Config>::DbWeight,
+>;
+
 pub(crate) mod v0 {
 	use super::*;
 	use frame_support::storage_alias;

--- a/substrate/frame/society/src/mock.rs
+++ b/substrate/frame/society/src/mock.rs
@@ -67,12 +67,15 @@ impl frame_system::Config for Test {
 impl pallet_balances::Config for Test {
 	type ReserveIdentifier = [u8; 8];
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type PalletId = SocietyPalletId;
 	type Currency = pallet_balances::Pallet<Self>;
+	type OldCurrency = pallet_balances::Pallet<Self>;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type Randomness = TestRandomness<Self>;
 	type GraceStrikes = ConstU32<1>;
 	type PeriodSpend = ConstU64<1000>;

--- a/substrate/frame/society/src/tests.rs
+++ b/substrate/frame/society/src/tests.rs
@@ -21,7 +21,7 @@ use super::*;
 use migrations::v0;
 use mock::*;
 
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::Currency};
 use sp_crypto_hashing::blake2_256;
 use sp_runtime::traits::BadOrigin;
 use BidKind::*;
@@ -1462,11 +1462,58 @@ fn poke_deposit_handles_insufficient_balance() {
 		// Change parameters to require higher deposit
 		assert_ok!(Society::set_parameters(Origin::signed(10), 10, 8, 3, initial_deposit + 50,));
 
-		// Should fail due to insufficient balance
+		// Should fail due to insufficient balance to extend the hold.
 		assert_noop!(
 			Society::poke_deposit(Origin::signed(20)),
-			pallet_balances::Error::<Test>::InsufficientBalance
+			sp_runtime::TokenError::FundsUnavailable
 		);
+	});
+}
+
+#[test]
+fn migrate_to_v3_converts_reserves_to_holds() {
+	use crate::migrations::MigrateToV3;
+	use frame_support::traits::{
+		fungible::InspectHold, OnRuntimeUpgrade, ReservableCurrency, StorageVersion,
+	};
+
+	EnvBuilder::new().execute(|| {
+		// Pretend we are on storage version 2.
+		StorageVersion::new(2).put::<Society>();
+
+		let reason = RuntimeHoldReason::Society(crate::HoldReason::BidDeposit);
+		let deposit = 25u64;
+
+		// A legacy deposit-backed bid (account 60) and candidacy (account 70): funds are
+		// *reserved* (the v2 representation) and recorded with `BidKind::Deposit`.
+		assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&60, deposit));
+		Bids::<Test>::put(
+			BoundedVec::try_from(vec![Bid { who: 60, kind: BidKind::Deposit(deposit), value: 0 }])
+				.unwrap(),
+		);
+
+		assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&70, deposit));
+		Candidates::<Test>::insert(
+			70,
+			Candidacy {
+				round: 0,
+				kind: BidKind::Deposit(deposit),
+				bid: 0,
+				tally: Default::default(),
+				skeptic_struck: false,
+			},
+		);
+
+		// Before: reserved, nothing held.
+		assert_eq!(Balances::balance_on_hold(&reason, &60), 0);
+		assert_eq!(Balances::balance_on_hold(&reason, &70), 0);
+
+		MigrateToV3::<Test, ()>::on_runtime_upgrade();
+
+		// After: the reserves became holds of the same amount.
+		assert_eq!(Balances::balance_on_hold(&reason, &60), deposit);
+		assert_eq!(Balances::balance_on_hold(&reason, &70), deposit);
+		assert_eq!(Society::on_chain_storage_version(), 3);
 	});
 }
 


### PR DESCRIPTION
Migrates `pallet-society` off the deprecated `Currency`/`ReservableCurrency` traits onto the `fungible` trait family. Bid/candidacy deposits become `fungible` holds, internal payout/pot movements use `fungible::Mutate::transfer,` and pot reads use `fungible::Inspect`, with a versioned reserve-to-hold storage migration. Part of #12399 / #226.
