### PR TITLE
pallet-democracy: migrate from Currency to fungible holds and freezes

### DIFF
--- a/prdoc/pr_12415.prdoc
+++ b/prdoc/pr_12415.prdoc
@@ -1,0 +1,9 @@
+title: 'pallet-democracy: migrate from Currency to fungible holds and freezes'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Migrates `pallet-democracy` off the deprecated `Currency`/`ReservableCurrency`/`LockableCurrency` traits onto the fungible trait family. Public-proposal deposits are now taken as holds under `HoldReason::Proposal`, conviction vote locks as freezes under `FreezeReason::Vote`, and balance queries use `fungible::Inspect`.
+    Part of #12399 / #226.
+crates:
+- name: pallet-democracy
+  bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1150,6 +1150,9 @@ parameter_types! {
 impl pallet_democracy::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type EnactmentPeriod = EnactmentPeriod;
 	type LaunchPeriod = LaunchPeriod;
 	type VotingPeriod = VotingPeriod;
@@ -1188,7 +1191,6 @@ impl pallet_democracy::Config for Runtime {
 	// only do it once and it lasts only for the cool-off period.
 	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCollective>;
 	type CooloffPeriod = CooloffPeriod;
-	type Slash = Treasury;
 	type Scheduler = Scheduler;
 	type PalletsOrigin = OriginCaller;
 	type MaxVotes = ConstU32<100>;
@@ -3019,6 +3021,8 @@ type Migrations = (
 	pallet_alliance::migration::Migration<Runtime>,
 	pallet_contracts::Migration<Runtime>,
 	pallet_identity::migration::versioned::V0ToV1<Runtime, IDENTITY_MIGRATION_KEY_LIMIT>,
+	// Migrate democracy public-proposal deposits from reserves to holds.
+	pallet_democracy::migrations::v2::MigrateToV2<Runtime>,
 );
 
 type EventRecord = frame_system::EventRecord<

--- a/substrate/frame/democracy/src/benchmarking.rs
+++ b/substrate/frame/democracy/src/benchmarking.rs
@@ -38,7 +38,7 @@ fn funded_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {
 	let caller: T::AccountId = account(name, index, SEED);
 	// Give the account half of the maximum value of the `Balance` type.
 	// Otherwise some transfers will fail with an overflow error.
-	T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value() / 2u32.into());
+	T::OldCurrency::make_free_balance_be(&caller, BalanceOf::<T>::max_value() / 2u32.into());
 	caller
 }
 

--- a/substrate/frame/democracy/src/lib.rs
+++ b/substrate/frame/democracy/src/lib.rs
@@ -160,9 +160,11 @@ use frame_support::{
 	ensure,
 	traits::{
 		defensive_prelude::*,
+		fungible::{Inspect, InspectFreeze, MutateFreeze, MutateHold},
 		schedule::{v3::Named as ScheduleNamed, DispatchTime},
-		Bounded, Currency, EnsureOrigin, Get, LockIdentifier, LockableCurrency, OnUnbalanced,
-		QueryPreimage, ReservableCurrency, StorePreimage, WithdrawReasons,
+		tokens::{Fortitude, Precision},
+		Bounded, Currency, EnsureOrigin, Get, LockIdentifier, LockableCurrency, QueryPreimage,
+		ReservableCurrency, StorePreimage,
 	},
 	weights::Weight,
 };
@@ -198,10 +200,7 @@ pub mod migrations;
 pub(crate) const DEMOCRACY_ID: LockIdentifier = *b"democrac";
 
 type BalanceOf<T> =
-	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
-type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<
-	<T as frame_system::Config>::AccountId,
->>::NegativeImbalance;
+	<<T as Config>::Currency as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 pub type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
 pub type BoundedCallOf<T> = Bounded<CallOf<T>, <T as frame_system::Config>::Hashing>;
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
@@ -213,7 +212,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 
 	/// The in-code storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
@@ -236,8 +235,24 @@ pub mod pallet {
 		/// The Preimage provider.
 		type Preimages: QueryPreimage<H = Self::Hashing> + StorePreimage;
 
-		/// Currency type for this pallet.
-		type Currency: ReservableCurrency<Self::AccountId>
+		/// Currency type for this pallet: proposal/second deposits are taken as holds and
+		/// conviction vote locks as freezes.
+		type Currency: Inspect<Self::AccountId>
+			+ MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>
+			+ MutateFreeze<Self::AccountId, Id = Self::RuntimeFreezeReason>
+			+ InspectFreeze<Self::AccountId>;
+
+		/// The overarching hold reason.
+		type RuntimeHoldReason: From<HoldReason>;
+
+		/// The overarching freeze reason.
+		type RuntimeFreezeReason: From<FreezeReason>;
+
+		/// The legacy reservable & lockable currency. Retained only to migrate pre-existing
+		/// reserved deposits to holds and locked conviction votes to freezes; otherwise unused and
+		/// can be removed once all accounts/proposals have migrated.
+		type OldCurrency: Currency<Self::AccountId, Balance = BalanceOf<Self>>
+			+ ReservableCurrency<Self::AccountId>
 			+ LockableCurrency<Self::AccountId, Moment = BlockNumberFor<Self>>;
 
 		/// The period between a proposal being approved and enacted.
@@ -341,9 +356,22 @@ pub mod pallet {
 
 		/// Overarching type of all pallets origins.
 		type PalletsOrigin: From<frame_system::RawOrigin<Self::AccountId>>;
+	}
 
-		/// Handler for the unbalanced reduction when slashing a preimage deposit.
-		type Slash: OnUnbalanced<NegativeImbalanceOf<Self>>;
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason {
+		/// Funds are held as a deposit for a public proposal (by the proposer or a seconder).
+		#[codec(index = 0)]
+		Proposal,
+	}
+
+	/// A reason for the pallet placing a freeze on funds.
+	#[pallet::composite_enum]
+	pub enum FreezeReason {
+		/// Funds are frozen for an active conviction vote (or delegation).
+		#[codec(index = 0)]
+		Vote,
 	}
 
 	/// The number of (public) proposals that have been made so far.
@@ -604,7 +632,7 @@ pub mod pallet {
 				);
 			}
 
-			T::Currency::reserve(&who, value)?;
+			T::Currency::hold(&Self::hold_reason(), &who, value)?;
 
 			let depositors = BoundedVec::<_, T::MaxDeposits>::truncate_from(vec![who.clone()]);
 			DepositOf::<T>::insert(index, (depositors, value));
@@ -635,7 +663,7 @@ pub mod pallet {
 			let seconds = Self::len_of_deposit_of(proposal).ok_or(Error::<T>::ProposalMissing)?;
 			ensure!(seconds < T::MaxDeposits::get(), Error::<T>::TooMany);
 			let mut deposit = DepositOf::<T>::get(proposal).ok_or(Error::<T>::ProposalMissing)?;
-			T::Currency::reserve(&who, deposit.1)?;
+			T::Currency::hold(&Self::hold_reason(), &who, deposit.1)?;
 			let ok = deposit.0.try_push(who.clone()).is_ok();
 			debug_assert!(ok, "`seconds` is below static limit; `try_insert` should succeed; qed");
 			DepositOf::<T>::insert(proposal, deposit);
@@ -1055,7 +1083,13 @@ pub mod pallet {
 					let (prop_index, ..) = props.remove(index);
 					if let Some((whos, amount)) = DepositOf::<T>::take(prop_index) {
 						for who in whos.into_iter() {
-							T::Slash::on_unbalanced(T::Currency::slash_reserved(&who, amount).0);
+							let _ = T::Currency::burn_held(
+								&Self::hold_reason(),
+								&who,
+								amount,
+								Precision::BestEffort,
+								Fortitude::Force,
+							);
 						}
 					}
 					Self::clear_metadata(MetadataOwner::Proposal(prop_index));
@@ -1099,7 +1133,13 @@ pub mod pallet {
 			PublicProps::<T>::mutate(|props| props.retain(|p| p.0 != prop_index));
 			if let Some((whos, amount)) = DepositOf::<T>::take(prop_index) {
 				for who in whos.into_iter() {
-					T::Slash::on_unbalanced(T::Currency::slash_reserved(&who, amount).0);
+					let _ = T::Currency::burn_held(
+						&Self::hold_reason(),
+						&who,
+						amount,
+						Precision::BestEffort,
+						Fortitude::Force,
+					);
 				}
 			}
 			Self::deposit_event(Event::<T>::ProposalCanceled { prop_index });
@@ -1275,7 +1315,7 @@ impl<T: Config> Pallet<T> {
 		vote: AccountVote<BalanceOf<T>>,
 	) -> DispatchResult {
 		let mut status = Self::referendum_status(ref_index)?;
-		ensure!(vote.balance() <= T::Currency::free_balance(who), Error::<T>::InsufficientFunds);
+		ensure!(vote.balance() <= T::Currency::balance(who), Error::<T>::InsufficientFunds);
 		VotingOf::<T>::try_mutate(who, |voting| -> DispatchResult {
 			if let Voting::Direct { ref mut votes, delegations, .. } = voting {
 				match votes.binary_search_by_key(&ref_index, |i| i.0) {
@@ -1304,14 +1344,9 @@ impl<T: Config> Pallet<T> {
 				Err(Error::<T>::AlreadyDelegating.into())
 			}
 		})?;
-		// Extend the lock to `balance` (rather than setting it) since we don't know what other
+		// Extend the freeze to `balance` (rather than setting it) since we don't know what other
 		// votes are in place.
-		T::Currency::extend_lock(
-			DEMOCRACY_ID,
-			who,
-			vote.balance(),
-			WithdrawReasons::except(WithdrawReasons::RESERVE),
-		);
+		let _ = T::Currency::extend_freeze(&Self::freeze_reason(), who, vote.balance()).defensive();
 		ReferendumInfoOf::<T>::insert(ref_index, ReferendumInfo::Ongoing(status));
 		Ok(())
 	}
@@ -1425,7 +1460,7 @@ impl<T: Config> Pallet<T> {
 		balance: BalanceOf<T>,
 	) -> Result<u32, DispatchError> {
 		ensure!(who != target, Error::<T>::Nonsense);
-		ensure!(balance <= T::Currency::free_balance(&who), Error::<T>::InsufficientFunds);
+		ensure!(balance <= T::Currency::balance(&who), Error::<T>::InsufficientFunds);
 		let votes = VotingOf::<T>::try_mutate(&who, |voting| -> Result<u32, DispatchError> {
 			let mut old = Voting::Delegating {
 				balance,
@@ -1455,14 +1490,9 @@ impl<T: Config> Pallet<T> {
 				},
 			}
 			let votes = Self::increase_upstream_delegation(&target, conviction.votes(balance));
-			// Extend the lock to `balance` (rather than setting it) since we don't know what other
-			// votes are in place.
-			T::Currency::extend_lock(
-				DEMOCRACY_ID,
-				&who,
-				balance,
-				WithdrawReasons::except(WithdrawReasons::RESERVE),
-			);
+			// Extend the freeze to `balance` (rather than setting it) since we don't know what
+			// other votes are in place.
+			let _ = T::Currency::extend_freeze(&Self::freeze_reason(), &who, balance).defensive();
 			Ok(votes)
 		})?;
 		Self::deposit_event(Event::<T>::Delegated { who, target });
@@ -1497,22 +1527,29 @@ impl<T: Config> Pallet<T> {
 		Ok(votes)
 	}
 
-	/// Rejig the lock on an account. It will never get more stringent (since that would indicate
+	/// The hold reason for public-proposal deposits.
+	fn hold_reason() -> T::RuntimeHoldReason {
+		HoldReason::Proposal.into()
+	}
+
+	/// The freeze reason for conviction vote locks.
+	fn freeze_reason() -> T::RuntimeFreezeReason {
+		FreezeReason::Vote.into()
+	}
+
+	/// Rejig the freeze on an account. It will never get more stringent (since that would indicate
 	/// a security hole) but may be reduced from what they are currently.
 	fn update_lock(who: &T::AccountId) {
 		let lock_needed = VotingOf::<T>::mutate(who, |voting| {
 			voting.rejig(frame_system::Pallet::<T>::block_number());
 			voting.locked_balance()
 		});
+		// Lazily migrate any legacy conviction lock to the freeze model. No-op if absent.
+		T::OldCurrency::remove_lock(DEMOCRACY_ID, who);
 		if lock_needed.is_zero() {
-			T::Currency::remove_lock(DEMOCRACY_ID, who);
+			let _ = T::Currency::thaw(&Self::freeze_reason(), who).defensive();
 		} else {
-			T::Currency::set_lock(
-				DEMOCRACY_ID,
-				who,
-				lock_needed,
-				WithdrawReasons::except(WithdrawReasons::RESERVE),
-			);
+			let _ = T::Currency::set_freeze(&Self::freeze_reason(), who, lock_needed).defensive();
 		}
 	}
 
@@ -1574,7 +1611,12 @@ impl<T: Config> Pallet<T> {
 			if let Some((depositors, deposit)) = DepositOf::<T>::take(prop_index) {
 				// refund depositors
 				for d in depositors.iter() {
-					T::Currency::unreserve(d, deposit);
+					let _ = T::Currency::release(
+						&Self::hold_reason(),
+						d,
+						deposit,
+						Precision::BestEffort,
+					);
 				}
 				Self::deposit_event(Event::<T>::Tabled { proposal_index: prop_index, deposit });
 				let ref_index = Self::inject_referendum(

--- a/substrate/frame/democracy/src/migrations/mod.rs
+++ b/substrate/frame/democracy/src/migrations/mod.rs
@@ -20,3 +20,6 @@ pub mod unlock_and_unreserve_all_funds;
 
 /// V1 storage migrations for the preimage pallet.
 pub mod v1;
+
+/// V2: migrate public-proposal deposits from `Currency` reserves to `fungible` holds.
+pub mod v2;

--- a/substrate/frame/democracy/src/migrations/v2.rs
+++ b/substrate/frame/democracy/src/migrations/v2.rs
@@ -1,0 +1,107 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Migration to convert public-proposal deposits from `Currency` reserves to `fungible` holds.
+
+use crate::*;
+use frame_support::traits::{fungible::MutateHold, ReservableCurrency, UncheckedOnRuntimeUpgrade};
+
+#[cfg(feature = "try-runtime")]
+use alloc::vec::Vec;
+
+/// The log target.
+const TARGET: &str = "runtime::democracy::migration::v2";
+
+/// Converts every reserved public-proposal deposit (proposer + seconders, tracked in
+/// [`DepositOf`]) into an equivalent hold under [`HoldReason::Proposal`].
+///
+/// The set of deposits is bounded by `MaxProposals * MaxDeposits`, so this is a single-block
+/// migration.
+pub struct VersionUncheckedMigrateToV2<T>(core::marker::PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for VersionUncheckedMigrateToV2<T> {
+	fn on_runtime_upgrade() -> Weight {
+		let reason: T::RuntimeHoldReason = HoldReason::Proposal.into();
+		let mut reads: u64 = 1;
+		let mut writes: u64 = 0;
+
+		for (_prop_index, (depositors, amount)) in DepositOf::<T>::iter() {
+			reads = reads.saturating_add(1);
+			for who in depositors.iter() {
+				let leftover = T::OldCurrency::unreserve(who, amount);
+				if !leftover.is_zero() {
+					log::warn!(
+						target: TARGET,
+						"could not fully unreserve a legacy proposal deposit; some balance remained reserved",
+					);
+				}
+				if let Err(e) = T::Currency::hold(&reason, who, amount) {
+					log::error!(
+						target: TARGET,
+						"failed to hold a migrated proposal deposit: {:?}",
+						e,
+					);
+				}
+				reads = reads.saturating_add(2);
+				writes = writes.saturating_add(2);
+			}
+		}
+
+		T::DbWeight::get().reads_writes(reads, writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+		// Record the total expected hold per account across all of their proposal deposits.
+		let mut expected: Vec<(T::AccountId, BalanceOf<T>)> = Vec::new();
+		for (_prop_index, (depositors, amount)) in DepositOf::<T>::iter() {
+			for who in depositors.into_iter() {
+				match expected.iter_mut().find(|(a, _)| a == &who) {
+					Some((_, total)) => *total = total.saturating_add(amount),
+					None => expected.push((who, amount)),
+				}
+			}
+		}
+		Ok(expected.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		use frame_support::traits::fungible::InspectHold;
+
+		let expected = Vec::<(T::AccountId, BalanceOf<T>)>::decode(&mut &state[..])
+			.expect("pre_upgrade provides a valid state; qed");
+		let reason: T::RuntimeHoldReason = HoldReason::Proposal.into();
+		for (who, total) in expected {
+			ensure!(
+				T::Currency::balance_on_hold(&reason, &who) >= total,
+				"democracy::v2: a proposal deposit was not migrated to a hold"
+			);
+		}
+		Ok(())
+	}
+}
+
+/// [`VersionUncheckedMigrateToV2`] wrapped in a [`frame_support::migrations::VersionedMigration`],
+/// ensuring it only runs when the on-chain storage version is 1.
+pub type MigrateToV2<T> = frame_support::migrations::VersionedMigration<
+	1,
+	2,
+	VersionUncheckedMigrateToV2<T>,
+	crate::pallet::Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;

--- a/substrate/frame/democracy/src/tests.rs
+++ b/substrate/frame/democracy/src/tests.rs
@@ -28,7 +28,6 @@ use frame_support::{
 	weights::Weight,
 };
 use frame_system::{EnsureRoot, EnsureSigned, EnsureSignedBy};
-use pallet_balances::{BalanceLock, Error as BalancesError};
 use sp_runtime::{
 	traits::{BadOrigin, BlakeTwo256, Hash},
 	BuildStorage, Perbill,
@@ -112,6 +111,10 @@ impl pallet_scheduler::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
+	type FreezeIdentifier = RuntimeFreezeReason;
+	type MaxFreezes = frame_support::traits::VariantCountOf<RuntimeFreezeReason>;
 }
 parameter_types! {
 	pub static PreimageByteDeposit: u64 = 0;
@@ -137,6 +140,9 @@ impl SortedMembers<u64> for OneToFive {
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = pallet_balances::Pallet<Self>;
+	type OldCurrency = pallet_balances::Pallet<Self>;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type EnactmentPeriod = ConstU64<2>;
 	type LaunchPeriod = ConstU64<2>;
 	type VotingPeriod = ConstU64<2>;
@@ -155,7 +161,6 @@ impl Config for Test {
 	type CancelProposalOrigin = EnsureRoot<u64>;
 	type VetoOrigin = EnsureSignedBy<OneToFive, u64>;
 	type CooloffPeriod = ConstU64<2>;
-	type Slash = ();
 	type InstantOrigin = EnsureSignedBy<Six, u64>;
 	type InstantAllowed = InstantAllowed;
 	type Scheduler = Scheduler;

--- a/substrate/frame/democracy/src/tests/lock_voting.rs
+++ b/substrate/frame/democracy/src/tests/lock_voting.rs
@@ -33,8 +33,10 @@ fn nay(x: u8, balance: u64) -> AccountVote<u64> {
 	}
 }
 
-fn the_lock(amount: u64) -> BalanceLock<u64> {
-	BalanceLock { id: DEMOCRACY_ID, amount, reasons: pallet_balances::Reasons::All }
+/// The amount currently frozen for conviction voting on `who`.
+fn frozen(who: u64) -> u64 {
+	use frame_support::traits::fungible::InspectFreeze;
+	Balances::balance_frozen(&RuntimeFreezeReason::Democracy(crate::FreezeReason::Vote), &who)
 }
 
 #[test]
@@ -56,7 +58,7 @@ fn lock_voting_should_work() {
 
 		// All balances are currently locked.
 		for i in 1..=5 {
-			assert_eq!(pallet_balances::Locks::<Test>::get(&i), vec![the_lock(i * 10)]);
+			assert_eq!(frozen(i), i * 10);
 		}
 
 		fast_forward_to(3);
@@ -77,11 +79,11 @@ fn lock_voting_should_work() {
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(2), r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(2), 2));
 
-		assert_eq!(pallet_balances::Locks::<Test>::get(&1), vec![]);
-		assert_eq!(pallet_balances::Locks::<Test>::get(&2), vec![the_lock(20)]);
-		assert_eq!(pallet_balances::Locks::<Test>::get(&3), vec![the_lock(30)]);
-		assert_eq!(pallet_balances::Locks::<Test>::get(&4), vec![the_lock(40)]);
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![]);
+		assert_eq!(frozen(1), 0);
+		assert_eq!(frozen(2), 20);
+		assert_eq!(frozen(3), 30);
+		assert_eq!(frozen(4), 40);
+		assert_eq!(frozen(5), 0);
 		assert_eq!(Balances::free_balance(42), 2);
 
 		fast_forward_to(7);
@@ -91,12 +93,12 @@ fn lock_voting_should_work() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 4));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&4), vec![the_lock(40)]);
+		assert_eq!(frozen(4), 40);
 		fast_forward_to(8);
 		// 4 should now be able to reap and unlock
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 4, r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 4));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&4), vec![]);
+		assert_eq!(frozen(4), 0);
 
 		fast_forward_to(13);
 		assert_noop!(
@@ -104,19 +106,19 @@ fn lock_voting_should_work() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 3));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&3), vec![the_lock(30)]);
+		assert_eq!(frozen(3), 30);
 		fast_forward_to(14);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 3, r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 3));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&3), vec![]);
+		assert_eq!(frozen(3), 0);
 
 		// 2 doesn't need to reap_vote here because it was already done before.
 		fast_forward_to(25);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 2));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&2), vec![the_lock(20)]);
+		assert_eq!(frozen(2), 20);
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(1), 2));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&2), vec![]);
+		assert_eq!(frozen(2), 0);
 	});
 }
 
@@ -137,7 +139,7 @@ fn no_locks_without_conviction_should_work() {
 		assert_eq!(Balances::free_balance(42), 2);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(2), 1, r));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(2), 1));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&1), vec![]);
+		assert_eq!(frozen(1), 0);
 	});
 }
 
@@ -198,33 +200,33 @@ fn prior_lockvotes_should_be_enforced() {
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(50)]);
+		assert_eq!(frozen(5), 50);
 		fast_forward_to(8);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.2));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(20)]);
+		assert_eq!(frozen(5), 20);
 		fast_forward_to(13);
 		assert_noop!(
 			Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.1),
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(20)]);
+		assert_eq!(frozen(5), 20);
 		fast_forward_to(14);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.1));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(10)]);
+		assert_eq!(frozen(5), 10);
 		fast_forward_to(25);
 		assert_noop!(
 			Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.0),
 			Error::<Test>::NoPermission
 		);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(10)]);
+		assert_eq!(frozen(5), 10);
 		fast_forward_to(26);
 		assert_ok!(Democracy::remove_other_vote(RuntimeOrigin::signed(1), 5, r.0));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![]);
+		assert_eq!(frozen(5), 0);
 	});
 }
 
@@ -239,26 +241,26 @@ fn single_consolidation_of_lockvotes_should_work_as_before() {
 		fast_forward_to(7);
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r.2));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(50)]);
+		assert_eq!(frozen(5), 50);
 		fast_forward_to(8);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(20)]);
+		assert_eq!(frozen(5), 20);
 
 		fast_forward_to(13);
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r.1));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(20)]);
+		assert_eq!(frozen(5), 20);
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(10)]);
+		assert_eq!(frozen(5), 10);
 
 		fast_forward_to(25);
 		assert_ok!(Democracy::remove_vote(RuntimeOrigin::signed(5), r.0));
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![the_lock(10)]);
+		assert_eq!(frozen(5), 10);
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![]);
+		assert_eq!(frozen(5), 0);
 	});
 }
 
@@ -276,15 +278,15 @@ fn multi_consolidation_of_lockvotes_should_be_conservative() {
 
 		fast_forward_to(8);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 20);
+		assert!(frozen(5) >= 20);
 
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 10);
+		assert!(frozen(5) >= 10);
 
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![]);
+		assert_eq!(frozen(5), 0);
 	});
 }
 
@@ -305,26 +307,26 @@ fn locks_should_persist_from_voting_to_delegation() {
 
 		assert_ok!(Democracy::delegate(RuntimeOrigin::signed(5), 1, Conviction::Locked3x, 20));
 		// locked 20.
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount == 20);
+		assert!(frozen(5) == 20);
 
 		assert_ok!(Democracy::undelegate(RuntimeOrigin::signed(5)));
 		// locked 20 until #14
 
 		fast_forward_to(13);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount == 20);
+		assert!(frozen(5) == 20);
 
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 10);
+		assert!(frozen(5) >= 10);
 
 		fast_forward_to(25);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 10);
+		assert!(frozen(5) >= 10);
 
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![]);
+		assert_eq!(frozen(5), 0);
 	});
 }
 
@@ -347,18 +349,18 @@ fn locks_should_persist_from_delegation_to_voting() {
 
 		fast_forward_to(8);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 20);
+		assert!(frozen(5) >= 20);
 
 		fast_forward_to(14);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 10);
+		assert!(frozen(5) >= 10);
 
 		fast_forward_to(26);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert!(pallet_balances::Locks::<Test>::get(&5)[0].amount >= 5);
+		assert!(frozen(5) >= 5);
 
 		fast_forward_to(48);
 		assert_ok!(Democracy::unlock(RuntimeOrigin::signed(5), 5));
-		assert_eq!(pallet_balances::Locks::<Test>::get(&5), vec![]);
+		assert_eq!(frozen(5), 0);
 	});
 }

--- a/substrate/frame/democracy/src/tests/public_proposals.rs
+++ b/substrate/frame/democracy/src/tests/public_proposals.rs
@@ -18,6 +18,7 @@
 //! The tests for the public proposal queue.
 
 use super::*;
+use sp_runtime::TokenError;
 
 #[test]
 fn backing_for_should_work() {
@@ -68,9 +69,40 @@ fn proposal_with_deposit_below_minimum_should_not_work() {
 }
 
 #[test]
+fn migrate_v2_converts_proposal_reserves_to_holds() {
+	use frame_support::{
+		traits::{fungible::InspectHold, OnRuntimeUpgrade, ReservableCurrency, StorageVersion},
+		BoundedVec,
+	};
+	new_test_ext().execute_with(|| {
+		// Pretend we are on storage version 1.
+		StorageVersion::new(1).put::<Democracy>();
+
+		let reason = RuntimeHoldReason::Democracy(crate::HoldReason::Proposal);
+		let amount = 5u64;
+
+		// Emulate a pre-v2 proposal: proposer (1) + seconder (2) with *reserved* deposits and a
+		// `DepositOf` entry in the legacy (balance) shape.
+		assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&1, amount));
+		assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&2, amount));
+		let depositors = BoundedVec::truncate_from(vec![1u64, 2u64]);
+		DepositOf::<Test>::insert(0, (depositors, amount));
+
+		assert_eq!(Balances::balance_on_hold(&reason, &1), 0);
+
+		crate::migrations::v2::MigrateToV2::<Test>::on_runtime_upgrade();
+
+		// Reserves became holds of the same amount.
+		assert_eq!(Balances::balance_on_hold(&reason, &1), amount);
+		assert_eq!(Balances::balance_on_hold(&reason, &2), amount);
+		assert_eq!(StorageVersion::get::<Democracy>(), 2);
+	});
+}
+
+#[test]
 fn poor_proposer_should_not_work() {
 	new_test_ext().execute_with(|| {
-		assert_noop!(propose_set_balance(1, 2, 11), BalancesError::<Test, _>::InsufficientBalance);
+		assert_noop!(propose_set_balance(1, 2, 11), TokenError::FundsUnavailable);
 	});
 }
 
@@ -78,10 +110,7 @@ fn poor_proposer_should_not_work() {
 fn poor_seconder_should_not_work() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(propose_set_balance(2, 2, 11));
-		assert_noop!(
-			Democracy::second(RuntimeOrigin::signed(1), 0),
-			BalancesError::<Test, _>::InsufficientBalance
-		);
+		assert_noop!(Democracy::second(RuntimeOrigin::signed(1), 0), TokenError::FundsUnavailable);
 	});
 }
 


### PR DESCRIPTION
Migrates `pallet-democracy` off the deprecated `Currency`/`ReservableCurrency`/`LockableCurrency` traits onto the fungible trait family. Public-proposal deposits are now taken as holds under `HoldReason::Proposal`, conviction vote locks as freezes under `FreezeReason::Vote`, and balance queries use `fungible::Inspect`. 
Part of #12399 / #226.
