### PR TITLE
pallet-nfts: migrate deposits from Currency reserves to fungible holds

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -980,6 +980,8 @@ impl pallet_nfts::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = ItemId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type ForceOrigin = AssetsForceOrigin;
 	type Locker = ();

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1304,6 +1304,8 @@ impl pallet_nfts::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = ItemId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type ForceOrigin = AssetsForceOrigin;
 	type Locker = ();

--- a/prdoc/pr_12417.prdoc
+++ b/prdoc/pr_12417.prdoc
@@ -1,0 +1,15 @@
+title: 'pallet-nfts: migrate deposits from Currency reserves to fungible holds'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Migrates `pallet-nfts` off the deprecated `ReservableCurrency` trait. Collection, item, metadata and attribute deposits are now taken as `fungible` holds under `HoldReason::Deposit`, and price/royalty payments use `fungible::Mutate::transfer`.
+    Part of #12399 / #226.
+crates:
+- name: asset-hub-rococo-runtime
+  bump: major
+- name: asset-hub-westend-runtime
+  bump: major
+- name: pallet-nft-fractionalization
+  bump: major
+- name: pallet-nfts
+  bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2237,6 +2237,8 @@ impl pallet_nfts::Config for Runtime {
 	type CollectionId = u32;
 	type ItemId = u32;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type CollectionDeposit = CollectionDeposit;
 	type ItemDeposit = ItemDeposit;

--- a/substrate/frame/nft-fractionalization/src/mock.rs
+++ b/substrate/frame/nft-fractionalization/src/mock.rs
@@ -51,6 +51,7 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 impl pallet_assets::Config for Test {
@@ -88,6 +89,8 @@ impl pallet_nfts::Config for Test {
 	type CollectionId = u32;
 	type ItemId = u32;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<Self::AccountId>>;
 	type ForceOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type Locker = ();

--- a/substrate/frame/nfts/src/benchmarking.rs
+++ b/substrate/frame/nfts/src/benchmarking.rs
@@ -41,7 +41,10 @@ fn create_collection<T: Config<I>, I: 'static>(
 	let caller: T::AccountId = whitelisted_caller();
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
 	let collection = T::Helper::collection(0);
-	T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+	T::OldCurrency::make_free_balance_be(
+		&caller,
+		DepositBalanceOf::<T, I>::max_value() / 1000u32.into(),
+	);
 	assert_ok!(Nfts::<T, I>::force_create(
 		SystemOrigin::Root.into(),
 		caller_lookup.clone(),
@@ -231,7 +234,7 @@ benchmarks_instance_pallet! {
 		let caller = T::CreateOrigin::ensure_origin(origin.clone(), &collection).unwrap();
 		whitelist_account!(caller);
 		let admin = T::Lookup::unlookup(caller.clone());
-		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		let call = Call::<T, I>::create { admin, config: default_collection_config::<T, I>() };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
@@ -510,7 +513,7 @@ benchmarks_instance_pallet! {
 			item,
 			target_lookup.clone(),
 		)?;
-		T::OldCurrency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		let value: BoundedVec<_, _> = vec![0u8; T::ValueLimit::get() as usize].try_into().unwrap();
 		for i in 0..n {
 			let key = make_filled_vec(i as u16, T::KeyLimit::get() as usize);
@@ -611,7 +614,7 @@ benchmarks_instance_pallet! {
 
 	set_accept_ownership {
 		let caller: T::AccountId = whitelisted_caller();
-		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		let collection = T::Helper::collection(0);
 	}: _(SystemOrigin::Signed(caller.clone()), Some(collection))
 	verify {
@@ -669,7 +672,7 @@ benchmarks_instance_pallet! {
 		let price = ItemPrice::<T, I>::from(0u32);
 		let origin = SystemOrigin::Signed(seller.clone()).into();
 		Nfts::<T, I>::set_price(origin, collection, item, Some(price), Some(buyer_lookup))?;
-		T::OldCurrency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 	}: _(SystemOrigin::Signed(buyer.clone()), collection, item, price)
 	verify {
 		assert_last_event::<T, I>(Event::ItemBought {
@@ -685,6 +688,10 @@ benchmarks_instance_pallet! {
 		let n in 0 .. T::MaxTips::get() as u32;
 		let amount = BalanceOf::<T, I>::from(100u32);
 		let caller: T::AccountId = whitelisted_caller();
+		T::OldCurrency::make_free_balance_be(
+			&caller,
+			DepositBalanceOf::<T, I>::max_value() / 1000u32.into(),
+		);
 		let collection = T::Helper::collection(0);
 		let item = T::Helper::item(0);
 		let tips: BoundedVec<_, _> = vec![
@@ -790,7 +797,7 @@ benchmarks_instance_pallet! {
 	mint_pre_signed {
 		let n in 0 .. T::MaxAttributesPerCall::get() as u32;
 		let (caller_public, caller) = T::Helper::signer();
-		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 
 		let collection = T::Helper::collection(0);
@@ -821,7 +828,7 @@ benchmarks_instance_pallet! {
 		let signature = T::Helper::sign(&caller_public, &message);
 
 		let target: T::AccountId = account("target", 0, SEED);
-		T::OldCurrency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		T::BlockNumberProvider::set_block_number(One::one());
 	}: _(SystemOrigin::Signed(target.clone()), Box::new(mint_data), signature.into(), caller)
 	verify {
@@ -838,7 +845,7 @@ benchmarks_instance_pallet! {
 
 		let (signer_public, signer) = T::Helper::signer();
 
-		T::OldCurrency::make_free_balance_be(&item_owner, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&item_owner, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 
 		let item = T::Helper::item(0);
 		assert_ok!(Nfts::<T, I>::force_mint(

--- a/substrate/frame/nfts/src/benchmarking.rs
+++ b/substrate/frame/nfts/src/benchmarking.rs
@@ -41,7 +41,7 @@ fn create_collection<T: Config<I>, I: 'static>(
 	let caller: T::AccountId = whitelisted_caller();
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
 	let collection = T::Helper::collection(0);
-	T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+	T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 	assert_ok!(Nfts::<T, I>::force_create(
 		SystemOrigin::Root.into(),
 		caller_lookup.clone(),
@@ -231,7 +231,7 @@ benchmarks_instance_pallet! {
 		let caller = T::CreateOrigin::ensure_origin(origin.clone(), &collection).unwrap();
 		whitelist_account!(caller);
 		let admin = T::Lookup::unlookup(caller.clone());
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 		let call = Call::<T, I>::create { admin, config: default_collection_config::<T, I>() };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
@@ -303,7 +303,7 @@ benchmarks_instance_pallet! {
 
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
-		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
+		T::OldCurrency::make_free_balance_be(&target, T::OldCurrency::minimum_balance());
 	}: _(SystemOrigin::Signed(caller.clone()), collection, item, target_lookup)
 	verify {
 		assert_last_event::<T, I>(Event::Transferred { collection, item, from: caller, to: target }.into());
@@ -361,7 +361,7 @@ benchmarks_instance_pallet! {
 		let (collection, caller, _) = create_collection::<T, I>();
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
-		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
+		T::OldCurrency::make_free_balance_be(&target, T::OldCurrency::minimum_balance());
 		let origin = SystemOrigin::Signed(target.clone()).into();
 		Nfts::<T, I>::set_accept_ownership(origin, Some(collection))?;
 	}: _(SystemOrigin::Signed(caller), collection, target_lookup)
@@ -390,7 +390,7 @@ benchmarks_instance_pallet! {
 			T::ForceOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
-		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
+		T::OldCurrency::make_free_balance_be(&target, T::OldCurrency::minimum_balance());
 		let call = Call::<T, I>::force_collection_owner {
 			collection,
 			owner: target_lookup,
@@ -510,7 +510,7 @@ benchmarks_instance_pallet! {
 			item,
 			target_lookup.clone(),
 		)?;
-		T::Currency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value());
 		let value: BoundedVec<_, _> = vec![0u8; T::ValueLimit::get() as usize].try_into().unwrap();
 		for i in 0..n {
 			let key = make_filled_vec(i as u16, T::KeyLimit::get() as usize);
@@ -611,7 +611,7 @@ benchmarks_instance_pallet! {
 
 	set_accept_ownership {
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 		let collection = T::Helper::collection(0);
 	}: _(SystemOrigin::Signed(caller.clone()), Some(collection))
 	verify {
@@ -669,7 +669,7 @@ benchmarks_instance_pallet! {
 		let price = ItemPrice::<T, I>::from(0u32);
 		let origin = SystemOrigin::Signed(seller.clone()).into();
 		Nfts::<T, I>::set_price(origin, collection, item, Some(price), Some(buyer_lookup))?;
-		T::Currency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value());
 	}: _(SystemOrigin::Signed(buyer.clone()), collection, item, price)
 	verify {
 		assert_last_event::<T, I>(Event::ItemBought {
@@ -759,7 +759,7 @@ benchmarks_instance_pallet! {
 		let duration = T::MaxDeadlineDuration::get();
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
-		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
+		T::OldCurrency::make_free_balance_be(&target, T::OldCurrency::minimum_balance());
 		let origin = SystemOrigin::Signed(caller.clone());
 		T::BlockNumberProvider::set_block_number(One::one());
 		Nfts::<T, I>::transfer(origin.clone().into(), collection, item2, target_lookup)?;
@@ -790,7 +790,7 @@ benchmarks_instance_pallet! {
 	mint_pre_signed {
 		let n in 0 .. T::MaxAttributesPerCall::get() as u32;
 		let (caller_public, caller) = T::Helper::signer();
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 		let caller_lookup = T::Lookup::unlookup(caller.clone());
 
 		let collection = T::Helper::collection(0);
@@ -821,7 +821,7 @@ benchmarks_instance_pallet! {
 		let signature = T::Helper::sign(&caller_public, &message);
 
 		let target: T::AccountId = account("target", 0, SEED);
-		T::Currency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&target, DepositBalanceOf::<T, I>::max_value());
 		T::BlockNumberProvider::set_block_number(One::one());
 	}: _(SystemOrigin::Signed(target.clone()), Box::new(mint_data), signature.into(), caller)
 	verify {
@@ -838,7 +838,7 @@ benchmarks_instance_pallet! {
 
 		let (signer_public, signer) = T::Helper::signer();
 
-		T::Currency::make_free_balance_be(&item_owner, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&item_owner, DepositBalanceOf::<T, I>::max_value());
 
 		let item = T::Helper::item(0);
 		assert_ok!(Nfts::<T, I>::force_mint(

--- a/substrate/frame/nfts/src/common_functions.rs
+++ b/substrate/frame/nfts/src/common_functions.rs
@@ -19,9 +19,79 @@
 
 use crate::*;
 use alloc::vec::Vec;
-use frame_support::pallet_prelude::*;
+use frame_support::{
+	pallet_prelude::*,
+	traits::tokens::fungible::{InspectHold, MutateHold},
+};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// The hold reason used for all native-token deposits taken by this pallet.
+	pub(crate) fn deposit_reason() -> T::RuntimeHoldReason {
+		HoldReason::<I>::Deposit.into()
+	}
+
+	/// Take a native-token deposit of `amount` from `who` as a hold.
+	///
+	/// A zero amount is a no-op (mirrors `reserve`), so callers that may pass a zero deposit (e.g.
+	/// force-created collections) do not fail on provider-less accounts.
+	pub(crate) fn hold_deposit(
+		who: &T::AccountId,
+		amount: DepositBalanceOf<T, I>,
+	) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		T::Currency::hold(&Self::deposit_reason(), who, amount)
+	}
+
+	/// Release a native-token deposit of `amount` previously taken from `who`.
+	///
+	/// Drains the new hold first, then unreserves any remainder from a pre-migration legacy
+	/// reserve. This lazily migrates old reserves to holds: new deposits are taken as holds, and
+	/// pre-existing reserves are released here as the entities holding them are torn down.
+	pub(crate) fn release_deposit(who: &T::AccountId, amount: DepositBalanceOf<T, I>) {
+		let reason = Self::deposit_reason();
+		let from_hold = amount.min(T::Currency::balance_on_hold(&reason, who));
+		if !from_hold.is_zero() {
+			let r = T::Currency::release(&reason, who, from_hold, BestEffort);
+			debug_assert!(r.is_ok());
+		}
+		let from_reserve = amount.saturating_sub(from_hold);
+		if !from_reserve.is_zero() {
+			let remaining = T::OldCurrency::unreserve(who, from_reserve);
+			debug_assert!(remaining.is_zero());
+		}
+	}
+
+	/// Move a native-token deposit of `amount` from `from` to `to`, keeping it on deposit.
+	///
+	/// Mirrors [`Self::release_deposit`]'s lazy migration: the held portion is moved as a hold and
+	/// any legacy-reserved remainder is repatriated as a reserve on `to`.
+	pub(crate) fn repatriate_deposit(
+		from: &T::AccountId,
+		to: &T::AccountId,
+		amount: DepositBalanceOf<T, I>,
+	) -> DispatchResult {
+		let reason = Self::deposit_reason();
+		let from_hold = amount.min(T::Currency::balance_on_hold(&reason, from));
+		if !from_hold.is_zero() {
+			T::Currency::transfer_on_hold(
+				&reason,
+				from,
+				to,
+				from_hold,
+				Exact,
+				OnHold,
+				Fortitude::Polite,
+			)?;
+		}
+		let from_reserve = amount.saturating_sub(from_hold);
+		if !from_reserve.is_zero() {
+			T::OldCurrency::repatriate_reserved(from, to, from_reserve, Reserved)?;
+		}
+		Ok(())
+	}
+
 	/// Get the owner of the item, if the item exists.
 	pub fn owner(collection: T::CollectionId, item: T::ItemId) -> Option<T::AccountId> {
 		Item::<T, I>::get(collection, item).map(|i| i.owner)

--- a/substrate/frame/nfts/src/features/atomic_swap.rs
+++ b/substrate/frame/nfts/src/features/atomic_swap.rs
@@ -23,7 +23,7 @@
 use crate::*;
 use frame_support::{
 	pallet_prelude::*,
-	traits::{Currency, ExistenceRequirement::KeepAlive},
+	traits::tokens::{fungible::Mutate, Preservation},
 };
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
@@ -196,13 +196,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					&receive_item.owner,
 					&send_item.owner,
 					price.amount,
-					KeepAlive,
+					Preservation::Preserve,
 				)?,
 				PriceDirection::Receive => T::Currency::transfer(
 					&send_item.owner,
 					&receive_item.owner,
 					price.amount,
-					KeepAlive,
+					Preservation::Preserve,
 				)?,
 			};
 		}

--- a/substrate/frame/nfts/src/features/attributes.rs
+++ b/substrate/frame/nfts/src/features/attributes.rs
@@ -126,13 +126,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		// and return the deposit to the previous owner.
 		if depositor_has_changed {
 			if let Some(old_depositor) = old_depositor {
-				T::Currency::unreserve(&old_depositor, old_deposit.amount);
+				Self::release_deposit(&old_depositor, old_deposit.amount);
 			}
-			T::Currency::reserve(&depositor, deposit)?;
+			Self::hold_deposit(&depositor, deposit)?;
 		} else if deposit > old_deposit.amount {
-			T::Currency::reserve(&depositor, deposit - old_deposit.amount)?;
+			Self::hold_deposit(&depositor, deposit - old_deposit.amount)?;
 		} else if deposit < old_deposit.amount {
-			T::Currency::unreserve(&depositor, old_deposit.amount - deposit);
+			Self::release_deposit(&depositor, old_deposit.amount - deposit);
 		}
 
 		if is_depositor_collection_owner {
@@ -188,7 +188,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		if let Some((_, deposit)) = attribute {
 			if deposit.account != set_as && deposit.amount != Zero::zero() {
 				if let Some(deposit_account) = deposit.account {
-					T::Currency::unreserve(&deposit_account, deposit.amount);
+					Self::release_deposit(&deposit_account, deposit.amount);
 				}
 			}
 		} else {
@@ -343,11 +343,11 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		match deposit.account {
 			Some(deposit_account) => {
-				T::Currency::unreserve(&deposit_account, deposit.amount);
+				Self::release_deposit(&deposit_account, deposit.amount);
 			},
 			None if namespace == AttributeNamespace::CollectionOwner => {
 				collection_details.owner_deposit.saturating_reduce(deposit.amount);
-				T::Currency::unreserve(&collection_details.owner, deposit.amount);
+				Self::release_deposit(&collection_details.owner, deposit.amount);
 			},
 			_ => (),
 		}
@@ -440,7 +440,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			ensure!(attributes <= witness.account_attributes, Error::<T, I>::BadWitness);
 
 			if !deposited.is_zero() {
-				T::Currency::unreserve(&delegate, deposited);
+				Self::release_deposit(&delegate, deposited);
 			}
 
 			Self::deposit_event(Event::ItemAttributesApprovalRemoved {

--- a/substrate/frame/nfts/src/features/buy_sell.rs
+++ b/substrate/frame/nfts/src/features/buy_sell.rs
@@ -23,7 +23,7 @@
 use crate::*;
 use frame_support::{
 	pallet_prelude::*,
-	traits::{Currency, ExistenceRequirement, ExistenceRequirement::KeepAlive},
+	traits::tokens::{fungible::Mutate, Preservation},
 };
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
@@ -43,7 +43,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> DispatchResult {
 		for tip in tips {
 			let ItemTip { collection, item, receiver, amount } = tip;
-			T::Currency::transfer(&sender, &receiver, amount, KeepAlive)?;
+			T::Currency::transfer(&sender, &receiver, amount, Preservation::Preserve)?;
 			Self::deposit_event(Event::TipSent {
 				collection,
 				item,
@@ -148,12 +148,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			ensure!(only_buyer == buyer, Error::<T, I>::NoPermission);
 		}
 
-		T::Currency::transfer(
-			&buyer,
-			&details.owner,
-			price_info.0,
-			ExistenceRequirement::KeepAlive,
-		)?;
+		T::Currency::transfer(&buyer, &details.owner, price_info.0, Preservation::Preserve)?;
 
 		let old_owner = details.owner.clone();
 

--- a/substrate/frame/nfts/src/features/create_delete_collection.rs
+++ b/substrate/frame/nfts/src/features/create_delete_collection.rs
@@ -43,7 +43,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> DispatchResult {
 		ensure!(!Collection::<T, I>::contains_key(collection), Error::<T, I>::CollectionIdInUse);
 
-		T::Currency::reserve(&owner, deposit)?;
+		Self::hold_deposit(&owner, deposit)?;
 
 		Collection::<T, I>::insert(
 			collection,
@@ -121,7 +121,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 			for (_, metadata) in ItemMetadataOf::<T, I>::drain_prefix(&collection) {
 				if let Some(depositor) = metadata.deposit.account {
-					T::Currency::unreserve(&depositor, metadata.deposit.amount);
+					Self::release_deposit(&depositor, metadata.deposit.amount);
 				}
 			}
 
@@ -131,13 +131,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			for (_, (_, deposit)) in Attribute::<T, I>::drain_prefix((&collection,)) {
 				if !deposit.amount.is_zero() {
 					if let Some(account) = deposit.account {
-						T::Currency::unreserve(&account, deposit.amount);
+						Self::release_deposit(&account, deposit.amount);
 					}
 				}
 			}
 
 			CollectionAccount::<T, I>::remove(&collection_details.owner, &collection);
-			T::Currency::unreserve(&collection_details.owner, collection_details.owner_deposit);
+			Self::release_deposit(&collection_details.owner, collection_details.owner_deposit);
 			CollectionConfigOf::<T, I>::remove(&collection);
 			let _ = ItemConfigOf::<T, I>::clear_prefix(&collection, witness.item_configs, None);
 

--- a/substrate/frame/nfts/src/features/create_delete_item.rs
+++ b/substrate/frame/nfts/src/features/create_delete_item.rs
@@ -19,7 +19,10 @@
 //! items for the NFTs pallet.
 
 use crate::*;
-use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
+use frame_support::{
+	pallet_prelude::*,
+	traits::tokens::{fungible::Mutate, Preservation},
+};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// Mint a new unique item with the given `collection`, `item`, and other minting configuration
@@ -91,7 +94,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					collection_details.item_configs.saturating_inc();
 				}
 
-				T::Currency::reserve(&deposit_account, deposit_amount)?;
+				Self::hold_deposit(&deposit_account, deposit_amount)?;
 
 				let deposit = ItemDeposit { account: deposit_account, amount: deposit_amount };
 				let details = ItemDetails {
@@ -166,7 +169,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						&mint_to,
 						&collection_details.owner,
 						price,
-						ExistenceRequirement::KeepAlive,
+						Preservation::Preserve,
 					)?;
 				}
 				Ok(())
@@ -229,7 +232,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				with_details(&details)?;
 
 				// Return the deposit.
-				T::Currency::unreserve(&details.deposit.account, details.deposit.amount);
+				Self::release_deposit(&details.deposit.account, details.deposit.amount);
 				collection_details.items.saturating_dec();
 
 				if remove_config {
@@ -242,7 +245,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 						let depositor_account =
 							metadata.deposit.account.unwrap_or(collection_details.owner.clone());
 
-						T::Currency::unreserve(&depositor_account, metadata.deposit.amount);
+						Self::release_deposit(&depositor_account, metadata.deposit.amount);
 						collection_details.item_metadatas.saturating_dec();
 
 						if depositor_account == collection_details.owner {

--- a/substrate/frame/nfts/src/features/metadata.rs
+++ b/substrate/frame/nfts/src/features/metadata.rs
@@ -86,12 +86,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			let old_depositor = old_deposit.account.unwrap_or(collection_details.owner.clone());
 
 			if depositor != old_depositor {
-				T::Currency::unreserve(&old_depositor, old_deposit.amount);
-				T::Currency::reserve(&depositor, deposit)?;
+				Self::release_deposit(&old_depositor, old_deposit.amount);
+				Self::hold_deposit(&depositor, deposit)?;
 			} else if deposit > old_deposit.amount {
-				T::Currency::reserve(&depositor, deposit - old_deposit.amount)?;
+				Self::hold_deposit(&depositor, deposit - old_deposit.amount)?;
 			} else if deposit < old_deposit.amount {
-				T::Currency::unreserve(&depositor, old_deposit.amount - deposit);
+				Self::release_deposit(&depositor, old_deposit.amount - deposit);
 			}
 
 			if maybe_depositor.is_none() {
@@ -151,7 +151,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		ensure!(is_root || !is_locked, Error::<T, I>::LockedItemMetadata);
 
 		collection_details.item_metadatas.saturating_dec();
-		T::Currency::unreserve(&depositor_account, metadata.deposit.amount);
+		Self::release_deposit(&depositor_account, metadata.deposit.amount);
 
 		if depositor_account == collection_details.owner {
 			collection_details.owner_deposit.saturating_reduce(metadata.deposit.amount);
@@ -209,9 +209,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					.saturating_add(T::MetadataDepositBase::get());
 			}
 			if deposit > old_deposit {
-				T::Currency::reserve(&details.owner, deposit - old_deposit)?;
+				Self::hold_deposit(&details.owner, deposit - old_deposit)?;
 			} else if deposit < old_deposit {
-				T::Currency::unreserve(&details.owner, old_deposit - deposit);
+				Self::release_deposit(&details.owner, old_deposit - deposit);
 			}
 			details.owner_deposit.saturating_accrue(deposit);
 
@@ -260,7 +260,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		CollectionMetadataOf::<T, I>::try_mutate_exists(collection, |metadata| {
 			let deposit = metadata.take().ok_or(Error::<T, I>::UnknownCollection)?.deposit;
-			T::Currency::unreserve(&details.owner, deposit);
+			Self::release_deposit(&details.owner, deposit);
 			details.owner_deposit.saturating_reduce(deposit);
 			Collection::<T, I>::insert(&collection, details);
 			Self::deposit_event(Event::CollectionMetadataCleared { collection });

--- a/substrate/frame/nfts/src/features/transfer.rs
+++ b/substrate/frame/nfts/src/features/transfer.rs
@@ -140,12 +140,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}
 
 			// Move the deposit to the new owner.
-			T::Currency::repatriate_reserved(
-				&details.owner,
-				&new_owner,
-				details.owner_deposit,
-				Reserved,
-			)?;
+			Self::repatriate_deposit(&details.owner, &new_owner, details.owner_deposit)?;
 
 			// Update account ownership information.
 			CollectionAccount::<T, I>::remove(&details.owner, &collection);
@@ -214,12 +209,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			}
 
 			// Move the deposit to the new owner.
-			T::Currency::repatriate_reserved(
-				&details.owner,
-				&owner,
-				details.owner_deposit,
-				Reserved,
-			)?;
+			Self::repatriate_deposit(&details.owner, &owner, details.owner_deposit)?;
 
 			// Update collection accounts and set the new owner.
 			CollectionAccount::<T, I>::remove(&details.owner, &collection);

--- a/substrate/frame/nfts/src/lib.rs
+++ b/substrate/frame/nfts/src/lib.rs
@@ -53,8 +53,14 @@ extern crate alloc;
 use alloc::{boxed::Box, vec, vec::Vec};
 use codec::{Decode, Encode};
 use frame_support::traits::{
-	tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, Incrementable,
-	ReservableCurrency,
+	tokens::{
+		fungible, Fortitude, Locker,
+		Precision::{BestEffort, Exact},
+		Preservation,
+		Restriction::OnHold,
+	},
+	BalanceStatus::Reserved,
+	Currency, EnsureOriginWithArg, Incrementable, ReservableCurrency,
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{
@@ -75,7 +81,7 @@ type AccountIdLookupOf<T> = <<T as SystemConfig>::Lookup as StaticLookup>::Sourc
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{pallet_prelude::*, traits::ExistenceRequirement};
+	use frame_support::pallet_prelude::*;
 	use frame_system::{ensure_signed, pallet_prelude::OriginFor};
 
 	/// The in-code storage version.
@@ -84,6 +90,14 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason<I: 'static = ()> {
+		/// Funds are held as a deposit for a collection, item, metadata or attribute.
+		#[codec(index = 0)]
+		Deposit,
+	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	pub trait BenchmarkHelper<CollectionId, ItemId, Public, AccountId, Signature> {
@@ -146,8 +160,20 @@ pub mod pallet {
 		/// The type used to identify a unique item within a collection.
 		type ItemId: Member + Parameter + MaxEncodedLen + Copy;
 
-		/// The currency mechanism, used for paying for reserves.
-		type Currency: ReservableCurrency<Self::AccountId>;
+		/// The currency mechanism, used for deposits (taken as holds under [`HoldReason`]) and for
+		/// price/royalty transfers.
+		type Currency: fungible::Inspect<Self::AccountId>
+			+ fungible::Mutate<Self::AccountId>
+			+ fungible::MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>;
+
+		/// The overarching hold reason.
+		type RuntimeHoldReason: From<HoldReason<I>>;
+
+		/// The legacy reservable currency. Retained only to drain pre-existing reserved deposits as
+		/// the entities holding them are released (lazy migration); new deposits are taken as
+		/// holds. Otherwise unused.
+		type OldCurrency: Currency<Self::AccountId, Balance = DepositBalanceOf<Self, I>>
+			+ ReservableCurrency<Self::AccountId>;
 
 		/// The origin which may forcibly create or destroy an item or otherwise alter privileged
 		/// attributes.
@@ -924,11 +950,11 @@ pub mod pallet {
 							witness_data.clone().ok_or(Error::<T, I>::WitnessRequired)?;
 						let mint_price = mint_price.ok_or(Error::<T, I>::BadWitness)?;
 						ensure!(mint_price >= price, Error::<T, I>::BadWitness);
-						T::Currency::transfer(
+						<T::Currency as fungible::Mutate<_>>::transfer(
 							&caller,
 							&collection_details.owner,
 							price,
-							ExistenceRequirement::KeepAlive,
+							Preservation::Preserve,
 						)?;
 					}
 
@@ -1085,9 +1111,9 @@ pub mod pallet {
 				};
 				let old = details.deposit.amount;
 				if old > deposit {
-					T::Currency::unreserve(&details.deposit.account, old - deposit);
+					Self::release_deposit(&details.deposit.account, old - deposit);
 				} else if deposit > old {
-					if T::Currency::reserve(&details.deposit.account, deposit - old).is_err() {
+					if Self::hold_deposit(&details.deposit.account, deposit - old).is_err() {
 						// NOTE: No alterations made to collection_details in this iteration so far,
 						// so this is OK to do.
 						continue;

--- a/substrate/frame/nfts/src/mock.rs
+++ b/substrate/frame/nfts/src/mock.rs
@@ -56,6 +56,7 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 parameter_types! {
@@ -67,6 +68,8 @@ impl Config for Test {
 	type CollectionId = u32;
 	type ItemId = u32;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<Self::AccountId>>;
 	type ForceOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type Locker = ();

--- a/substrate/frame/nfts/src/tests.rs
+++ b/substrate/frame/nfts/src/tests.rs
@@ -26,11 +26,10 @@ use frame_support::{
 		Currency, Get,
 	},
 };
-use pallet_balances::Error as BalancesError;
 use sp_core::{bounded::BoundedVec, Pair};
 use sp_runtime::{
 	traits::{Dispatchable, IdentifyAccount},
-	MultiSignature, MultiSigner,
+	MultiSignature, MultiSigner, TokenError,
 };
 
 type AccountIdOf<Test> = <Test as frame_system::Config>::AccountId;
@@ -789,7 +788,7 @@ fn set_collection_metadata_should_work() {
 		// Cannot over-reserve
 		assert_noop!(
 			Nfts::set_collection_metadata(RuntimeOrigin::signed(account(1)), 0, bvec![0u8; 40]),
-			BalancesError::<Test, _>::InsufficientBalance,
+			TokenError::FundsUnavailable,
 		);
 
 		// Can't set or clear metadata once frozen
@@ -866,7 +865,7 @@ fn set_item_metadata_should_work() {
 		// Cannot over-reserve
 		assert_noop!(
 			Nfts::set_metadata(RuntimeOrigin::signed(account(1)), 0, 42, bvec![0u8; 40]),
-			BalancesError::<Test, _>::InsufficientBalance,
+			TokenError::FundsUnavailable,
 		);
 
 		// Can't set or clear metadata once frozen

--- a/substrate/frame/nfts/src/types.rs
+++ b/substrate/frame/nfts/src/types.rs
@@ -34,7 +34,9 @@ pub type BlockNumberFor<T, I = ()> =
 
 /// A type alias for handling balance deposits.
 pub type DepositBalanceOf<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
+	<<T as Config<I>>::Currency as frame_support::traits::fungible::Inspect<
+		<T as SystemConfig>::AccountId,
+	>>::Balance;
 /// A type alias representing the details of a collection.
 pub type CollectionDetailsFor<T, I> =
 	CollectionDetails<<T as SystemConfig>::AccountId, DepositBalanceOf<T, I>>;
@@ -60,7 +62,9 @@ pub type ItemDetailsFor<T, I> =
 	ItemDetails<<T as SystemConfig>::AccountId, ItemDepositOf<T, I>, ApprovalsOf<T, I>>;
 /// A type alias for an accounts balance.
 pub type BalanceOf<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
+	<<T as Config<I>>::Currency as frame_support::traits::fungible::Inspect<
+		<T as SystemConfig>::AccountId,
+	>>::Balance;
 /// A type alias to represent the price of an item.
 pub type ItemPrice<T, I = ()> = BalanceOf<T, I>;
 /// A type alias for the tips held by a single item.

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -1045,6 +1045,8 @@ impl pallet_nfts::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = ItemId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type ForceOrigin = AssetsForceOrigin;
 	type Locker = ();


### PR DESCRIPTION
Migrates `pallet-nfts` off the deprecated `ReservableCurrency` trait. Collection, item, metadata and attribute deposits are now taken as `fungible` holds under `HoldReason::Deposit`, and price/royalty payments use `fungible::Mutate::transfer`. 
Part of #12399 / #226.
