### PR TITLE
try state check for pallet conviction voting

### DIFF
--- a/prdoc/pr_12418.prdoc
+++ b/prdoc/pr_12418.prdoc
@@ -1,6 +1,6 @@
 title: try state check for pallet conviction voting
 doc:
-- audience: Todo
+- audience: Runtime Dev
   description: |-
     This PR introduces try state hook into the Conviction Voting Pallet. It also defines the invariants that holds for the pallet.
 

--- a/prdoc/pr_12418.prdoc
+++ b/prdoc/pr_12418.prdoc
@@ -1,0 +1,10 @@
+title: try state check for pallet conviction voting
+doc:
+- audience: Todo
+  description: |-
+    This PR introduces try state hook into the Conviction Voting Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-conviction-voting
+  bump: major

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -448,14 +448,19 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	/// # Invariants
 	///
 	/// * Each class in [`ClassLocksFor`] must appear at most once per account.
-	/// * Each lock amount in [`ClassLocksFor`] must be non-zero.
+	///
+	/// Note: zero lock amounts are intentionally tolerated. Empty `ClassLocksFor` entries
+	/// (zero locks) currently exist in live state, see
+	/// <https://github.com/paritytech/polkadot-sdk/issues/7458>. Their prevention and cleanup is
+	/// handled separately in <https://github.com/paritytech/polkadot-sdk/pull/7631>, so this check
+	/// is not asserting non-zero amounts until that lands.
 	fn try_state_class_locks() -> Result<(), sp_runtime::TryRuntimeError> {
 		ClassLocksFor::<T, I>::iter().try_for_each(
 			|(_, locks)| -> Result<(), sp_runtime::TryRuntimeError> {
 				let mut seen = alloc::collections::BTreeSet::new();
-				for (class, amount) in locks.iter() {
+				// TODO(#7631): re-assert `!amount.is_zero()` once empty-entry cleanup lands.
+				for (class, _amount) in locks.iter() {
 					ensure!(seen.insert(class), "Duplicate class found in `ClassLocksFor`");
-					ensure!(!amount.is_zero(), "Zero lock amount found in `ClassLocksFor`");
 				}
 				Ok(())
 			},

--- a/substrate/frame/conviction-voting/src/lib.rs
+++ b/substrate/frame/conviction-voting/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
 	use super::*;
 	use frame_support::{
 		pallet_prelude::{
-			DispatchResultWithPostInfo, IsType, StorageDoubleMap, StorageMap, ValueQuery,
+			DispatchResultWithPostInfo, Hooks, IsType, StorageDoubleMap, StorageMap, ValueQuery,
 		},
 		traits::ClassCountOf,
 		Twox64Concat,
@@ -419,6 +419,74 @@ pub mod pallet {
 			Self::try_remove_vote(&target, index, Some(class), scope)?;
 			Ok(())
 		}
+	}
+
+	#[pallet::hooks]
+	impl<T: Config<I>, I: 'static> Hooks<frame_system::pallet_prelude::BlockNumberFor<T>>
+		for Pallet<T, I>
+	{
+		#[cfg(feature = "try-runtime")]
+		fn try_state(
+			_n: frame_system::pallet_prelude::BlockNumberFor<T>,
+		) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub(crate) fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_class_locks()?;
+		Self::try_state_voting()?;
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Each class in [`ClassLocksFor`] must appear at most once per account.
+	/// * Each lock amount in [`ClassLocksFor`] must be non-zero.
+	fn try_state_class_locks() -> Result<(), sp_runtime::TryRuntimeError> {
+		ClassLocksFor::<T, I>::iter().try_for_each(
+			|(_, locks)| -> Result<(), sp_runtime::TryRuntimeError> {
+				let mut seen = alloc::collections::BTreeSet::new();
+				for (class, amount) in locks.iter() {
+					ensure!(seen.insert(class), "Duplicate class found in `ClassLocksFor`");
+					ensure!(!amount.is_zero(), "Zero lock amount found in `ClassLocksFor`");
+				}
+				Ok(())
+			},
+		)
+	}
+
+	/// # Invariants
+	///
+	/// * For accounts in [`Voting::Casting`] state: votes must be sorted by poll index with no
+	///   duplicates (invariant required for the binary search used during vote insertion).
+	/// * For accounts in [`Voting::Delegating`] state: an account may not delegate to itself.
+	fn try_state_voting() -> Result<(), sp_runtime::TryRuntimeError> {
+		VotingFor::<T, I>::iter().try_for_each(
+			|(who, _, voting)| -> Result<(), sp_runtime::TryRuntimeError> {
+				match voting {
+					Voting::Casting(casting) => {
+						ensure!(
+							casting.votes.windows(2).all(|w| w[0].0 < w[1].0),
+							"Votes in `VotingFor` must be sorted by poll index with no duplicates"
+						);
+					},
+					Voting::Delegating(delegating) => {
+						ensure!(
+							delegating.target != who,
+							"Account in `VotingFor` may not delegate to itself"
+						);
+					},
+				}
+				Ok(())
+			},
+		)
 	}
 }
 

--- a/substrate/frame/conviction-voting/src/tests.rs
+++ b/substrate/frame/conviction-voting/src/tests.rs
@@ -173,9 +173,16 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
+pub fn build_and_execute(test: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		test();
+		Voting::do_try_state().expect("All invariants must hold after a test");
+	});
+}
+
 #[test]
 fn params_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_eq!(Balances::free_balance(42), 0);
 		assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), 210);
 	});
@@ -234,14 +241,14 @@ fn completed_poll_should_panic() {
 
 #[test]
 fn basic_stuff() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_eq!(tally(3), Tally::from_parts(0, 0, 0));
 	});
 }
 
 #[test]
 fn basic_voting_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(2, 5)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
@@ -300,7 +307,7 @@ fn basic_voting_works() {
 
 #[test]
 fn split_voting_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split(10, 0)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
@@ -337,7 +344,7 @@ fn split_voting_works() {
 
 #[test]
 fn abstain_voting_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, split_abstain(0, 0, 10)));
 		System::assert_last_event(tests::RuntimeEvent::Voting(Event::Voted {
 			who: 1,
@@ -391,7 +398,7 @@ fn abstain_voting_works() {
 
 #[test]
 fn voting_balance_gets_locked() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(2, 5)));
 		assert_eq!(tally(3), Tally::from_parts(10, 0, 2));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, nay(2, 5)));
@@ -420,7 +427,7 @@ fn voting_balance_gets_locked() {
 
 #[test]
 fn successful_but_zero_conviction_vote_balance_can_be_unlocked() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(1, 1)));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(2), 3, nay(20, 0)));
 		let c = class(3);
@@ -433,7 +440,7 @@ fn successful_but_zero_conviction_vote_balance_can_be_unlocked() {
 
 #[test]
 fn unsuccessful_conviction_vote_balance_can_be_unlocked() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 3, aye(1, 1)));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(2), 3, nay(20, 0)));
 		let c = class(3);
@@ -446,7 +453,7 @@ fn unsuccessful_conviction_vote_balance_can_be_unlocked() {
 
 #[test]
 fn successful_conviction_vote_balance_stays_locked_for_correct_time() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		for i in 1..=5 {
 			assert_ok!(Voting::vote(RuntimeOrigin::signed(i), 3, aye(10, i as u8)));
 		}
@@ -468,7 +475,7 @@ fn successful_conviction_vote_balance_stays_locked_for_correct_time() {
 
 #[test]
 fn classwise_delegation_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		Polls::set(
 			vec![
 				(0, Ongoing(Tally::new(0), 0)),
@@ -591,7 +598,7 @@ fn classwise_delegation_works() {
 
 #[test]
 fn redelegation_after_vote_ending_should_keep_lock() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		Polls::set(vec![(0, Ongoing(Tally::new(0), 0))].into_iter().collect());
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 0, 2, Conviction::Locked1x, 5));
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(2), 0, aye(10, 1)));
@@ -607,7 +614,7 @@ fn redelegation_after_vote_ending_should_keep_lock() {
 
 #[test]
 fn lock_amalgamation_valid_with_multiple_removed_votes() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		Polls::set(
 			vec![
 				(0, Ongoing(Tally::new(0), 0)),
@@ -655,7 +662,7 @@ fn lock_amalgamation_valid_with_multiple_removed_votes() {
 
 #[test]
 fn lock_amalgamation_valid_with_multiple_delegations() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 0, 2, Conviction::Locked1x, 5));
 		assert_ok!(Voting::undelegate(RuntimeOrigin::signed(1), 0));
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 0, 2, Conviction::Locked1x, 10));
@@ -681,7 +688,7 @@ fn lock_amalgamation_valid_with_multiple_delegations() {
 
 #[test]
 fn lock_amalgamation_valid_with_move_roundtrip_to_delegation() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		Polls::set(vec![(0, Ongoing(Tally::new(0), 0))].into_iter().collect());
 		assert_ok!(Voting::vote(RuntimeOrigin::signed(1), 0, aye(5, 1)));
 		Polls::set(vec![(0, Completed(1, true))].into_iter().collect());
@@ -715,7 +722,7 @@ fn lock_amalgamation_valid_with_move_roundtrip_to_delegation() {
 
 #[test]
 fn lock_amalgamation_valid_with_move_roundtrip_to_casting() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 0, 2, Conviction::Locked1x, 5));
 		assert_ok!(Voting::undelegate(RuntimeOrigin::signed(1), 0));
 
@@ -749,7 +756,7 @@ fn lock_amalgamation_valid_with_move_roundtrip_to_casting() {
 
 #[test]
 fn lock_aggregation_over_different_classes_with_delegation_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 0, 2, Conviction::Locked1x, 5));
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 1, 2, Conviction::Locked2x, 5));
 		assert_ok!(Voting::delegate(RuntimeOrigin::signed(1), 2, 2, Conviction::Locked1x, 10));
@@ -780,7 +787,7 @@ fn lock_aggregation_over_different_classes_with_delegation_works() {
 
 #[test]
 fn lock_aggregation_over_different_classes_with_casting_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		Polls::set(
 			vec![
 				(0, Ongoing(Tally::new(0), 0)),
@@ -824,7 +831,7 @@ fn lock_aggregation_over_different_classes_with_casting_works() {
 
 #[test]
 fn errors_with_vote_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			Voting::vote(RuntimeOrigin::signed(1), 0, aye(10, 0)),
 			Error::<Test>::NotOngoing
@@ -871,7 +878,7 @@ fn errors_with_vote_work() {
 
 #[test]
 fn errors_with_delegating_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			Voting::delegate(RuntimeOrigin::signed(1), 0, 2, Conviction::None, 11),
 			Error::<Test>::InsufficientFunds
@@ -893,7 +900,7 @@ fn errors_with_delegating_work() {
 
 #[test]
 fn remove_other_vote_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			Voting::remove_other_vote(RuntimeOrigin::signed(2), 1, 0, 3),
 			Error::<Test>::NotVoter
@@ -916,7 +923,7 @@ fn remove_other_vote_works() {
 
 #[test]
 fn errors_with_remove_vote_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			Voting::remove_vote(RuntimeOrigin::signed(1), Some(0), 3),
 			Error::<Test>::NotVoter
@@ -995,7 +1002,7 @@ impl VotingHooks<u64, u8, u64> for HooksHandler {
 
 #[test]
 fn voting_hooks_are_called_correctly() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let c = class(3);
 
 		let usable_balance_1 = Balances::usable_balance(1);
@@ -1069,7 +1076,7 @@ fn voting_hooks_are_called_correctly() {
 
 #[test]
 fn empty_tally_approval_is_zero() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let empty_tally = Tally::<u64, <Test as Config>::MaxTurnout>::from_parts(0, 0, 0);
 		assert_eq!(
 			<TallyOf<Test> as VoteTally<u64, u8>>::approval(&empty_tally, 0),


### PR DESCRIPTION
This PR introduces try state hook into the Conviction Voting Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239