### PR TITLE
pallet-uniques: migrate deposits from Currency reserves to fungible holds

### DIFF
--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -922,6 +922,8 @@ impl pallet_uniques::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = ItemId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type ForceOrigin = AssetsForceOrigin;
 	type CollectionDeposit = UniquesCollectionDeposit;
 	type ItemDeposit = UniquesItemDeposit;

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1246,6 +1246,8 @@ impl pallet_uniques::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = ItemId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type ForceOrigin = AssetsForceOrigin;
 	type CollectionDeposit = UniquesCollectionDeposit;
 	type ItemDeposit = UniquesItemDeposit;

--- a/polkadot/xcm/xcm-simulator/example/src/parachain/mod.rs
+++ b/polkadot/xcm/xcm-simulator/example/src/parachain/mod.rs
@@ -58,6 +58,7 @@ impl pallet_balances::Config for Runtime {
 	type Balance = Balance;
 	type ExistentialDeposit = ConstU128<1>;
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -77,6 +78,8 @@ impl pallet_uniques::Config for Runtime {
 	type CollectionId = Location;
 	type ItemId = AssetInstance;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = ForeignCreators;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type CollectionDeposit = frame_support::traits::ConstU128<1_000>;

--- a/polkadot/xcm/xcm-simulator/example/src/relay_chain/mod.rs
+++ b/polkadot/xcm/xcm-simulator/example/src/relay_chain/mod.rs
@@ -61,6 +61,7 @@ impl pallet_balances::Config for Runtime {
 	type Balance = Balance;
 	type ExistentialDeposit = ConstU128<1>;
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 impl pallet_uniques::Config for Runtime {
@@ -68,6 +69,8 @@ impl pallet_uniques::Config for Runtime {
 	type CollectionId = u32;
 	type ItemId = u32;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type CollectionDeposit = frame_support::traits::ConstU128<1_000>;

--- a/prdoc/pr_12420.prdoc
+++ b/prdoc/pr_12420.prdoc
@@ -1,0 +1,15 @@
+title: 'pallet-uniques: migrate deposits from Currency reserves to fungible holds'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Migrates `pallet-uniques` off the deprecated `ReservableCurrency` trait. Collection, item, metadata and attribute deposits are now taken as `fungible` holds under `HoldReason::Deposit`, and item-price payments use `fungible::Mutate::transfer`.
+    Part of #12399 / #226.
+crates:
+- name: asset-hub-rococo-runtime
+  bump: major
+- name: asset-hub-westend-runtime
+  bump: major
+- name: xcm-simulator-example
+  bump: major
+- name: pallet-uniques
+  bump: major

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -2148,6 +2148,8 @@ impl pallet_uniques::Config for Runtime {
 	type CollectionId = u32;
 	type ItemId = u32;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type CollectionDeposit = CollectionDeposit;
 	type ItemDeposit = ItemDeposit;

--- a/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/parachain/src/lib.rs
@@ -987,6 +987,8 @@ impl pallet_uniques::Config for Runtime {
 	type CollectionId = CollectionId;
 	type ItemId = ItemId;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type ForceOrigin = AssetsForceOrigin;
 	type CollectionDeposit = UniquesCollectionDeposit;
 	type ItemDeposit = UniquesItemDeposit;

--- a/substrate/frame/uniques/src/benchmarking.rs
+++ b/substrate/frame/uniques/src/benchmarking.rs
@@ -40,7 +40,10 @@ fn create_collection<T: Config<I>, I: 'static>(
 	let caller: T::AccountId = whitelisted_caller();
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
 	let collection = T::Helper::collection(0);
-	T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+	T::OldCurrency::make_free_balance_be(
+		&caller,
+		DepositBalanceOf::<T, I>::max_value() / 1000u32.into(),
+	);
 	assert!(Uniques::<T, I>::force_create(
 		SystemOrigin::Root.into(),
 		collection.clone(),
@@ -141,7 +144,7 @@ benchmarks_instance_pallet! {
 		let caller = T::CreateOrigin::ensure_origin(origin.clone(), &collection).unwrap();
 		whitelist_account!(caller);
 		let admin = T::Lookup::unlookup(caller.clone());
-		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		let call = Call::<T, I>::create { collection, admin };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
@@ -388,7 +391,7 @@ benchmarks_instance_pallet! {
 
 	set_accept_ownership {
 		let caller: T::AccountId = whitelisted_caller();
-		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 		let collection = T::Helper::collection(0);
 	}: _(SystemOrigin::Signed(caller.clone()), Some(collection.clone()))
 	verify {
@@ -432,7 +435,7 @@ benchmarks_instance_pallet! {
 		let price = ItemPrice::<T, I>::from(0u32);
 		let origin = SystemOrigin::Signed(seller.clone()).into();
 		Uniques::<T, I>::set_price(origin, collection.clone(), item, Some(price), Some(buyer_lookup))?;
-		T::OldCurrency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value() / 1000u32.into());
 	}: _(SystemOrigin::Signed(buyer.clone()), collection.clone(), item, price)
 	verify {
 		assert_last_event::<T, I>(Event::ItemBought {

--- a/substrate/frame/uniques/src/benchmarking.rs
+++ b/substrate/frame/uniques/src/benchmarking.rs
@@ -40,7 +40,7 @@ fn create_collection<T: Config<I>, I: 'static>(
 	let caller: T::AccountId = whitelisted_caller();
 	let caller_lookup = T::Lookup::unlookup(caller.clone());
 	let collection = T::Helper::collection(0);
-	T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+	T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 	assert!(Uniques::<T, I>::force_create(
 		SystemOrigin::Root.into(),
 		collection.clone(),
@@ -141,7 +141,7 @@ benchmarks_instance_pallet! {
 		let caller = T::CreateOrigin::ensure_origin(origin.clone(), &collection).unwrap();
 		whitelist_account!(caller);
 		let admin = T::Lookup::unlookup(caller.clone());
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 		let call = Call::<T, I>::create { collection, admin };
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
@@ -265,7 +265,7 @@ benchmarks_instance_pallet! {
 		let (collection, caller, _) = create_collection::<T, I>();
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup = T::Lookup::unlookup(target.clone());
-		T::Currency::make_free_balance_be(&target, T::Currency::minimum_balance());
+		T::OldCurrency::make_free_balance_be(&target, T::OldCurrency::minimum_balance());
 		let origin = SystemOrigin::Signed(target.clone()).into();
 		Uniques::<T, I>::set_accept_ownership(origin, Some(collection.clone()))?;
 	}: _(SystemOrigin::Signed(caller), collection.clone(), target_lookup)
@@ -388,7 +388,7 @@ benchmarks_instance_pallet! {
 
 	set_accept_ownership {
 		let caller: T::AccountId = whitelisted_caller();
-		T::Currency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&caller, DepositBalanceOf::<T, I>::max_value());
 		let collection = T::Helper::collection(0);
 	}: _(SystemOrigin::Signed(caller.clone()), Some(collection.clone()))
 	verify {
@@ -432,7 +432,7 @@ benchmarks_instance_pallet! {
 		let price = ItemPrice::<T, I>::from(0u32);
 		let origin = SystemOrigin::Signed(seller.clone()).into();
 		Uniques::<T, I>::set_price(origin, collection.clone(), item, Some(price), Some(buyer_lookup))?;
-		T::Currency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value());
+		T::OldCurrency::make_free_balance_be(&buyer, DepositBalanceOf::<T, I>::max_value());
 	}: _(SystemOrigin::Signed(buyer.clone()), collection.clone(), item, price)
 	verify {
 		assert_last_event::<T, I>(Event::ItemBought {

--- a/substrate/frame/uniques/src/functions.rs
+++ b/substrate/frame/uniques/src/functions.rs
@@ -20,11 +20,81 @@
 use super::*;
 use frame_support::{
 	ensure,
-	traits::{ExistenceRequirement, Get},
+	traits::{
+		tokens::fungible::{InspectHold, Mutate, MutateHold},
+		Get,
+	},
 };
-use sp_runtime::{DispatchError, DispatchResult};
+use sp_runtime::{traits::Zero, DispatchError, DispatchResult};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// The hold reason used for all native-token deposits taken by this pallet.
+	pub(crate) fn deposit_reason() -> T::RuntimeHoldReason {
+		HoldReason::<I>::Deposit.into()
+	}
+
+	/// Take a native-token deposit of `amount` from `who` as a hold.
+	///
+	/// A zero amount is a no-op (mirrors `reserve`), so callers that may pass a zero deposit (e.g.
+	/// force-created collections) do not fail on provider-less accounts.
+	pub(crate) fn hold_deposit(
+		who: &T::AccountId,
+		amount: DepositBalanceOf<T, I>,
+	) -> DispatchResult {
+		if amount.is_zero() {
+			return Ok(());
+		}
+		T::Currency::hold(&Self::deposit_reason(), who, amount)
+	}
+
+	/// Release a native-token deposit of `amount` previously taken from `who`.
+	///
+	/// Drains the new hold first, then unreserves any remainder from a pre-migration legacy
+	/// reserve. This lazily migrates old reserves to holds: new deposits are taken as holds, and
+	/// pre-existing reserves are released here as the entities holding them are torn down.
+	pub(crate) fn release_deposit(who: &T::AccountId, amount: DepositBalanceOf<T, I>) {
+		let reason = Self::deposit_reason();
+		let from_hold = amount.min(T::Currency::balance_on_hold(&reason, who));
+		if !from_hold.is_zero() {
+			let r = T::Currency::release(&reason, who, from_hold, BestEffort);
+			debug_assert!(r.is_ok());
+		}
+		let from_reserve = amount.saturating_sub(from_hold);
+		if !from_reserve.is_zero() {
+			let remaining = T::OldCurrency::unreserve(who, from_reserve);
+			debug_assert!(remaining.is_zero());
+		}
+	}
+
+	/// Move a native-token deposit of `amount` from `from` to `to`, keeping it on deposit.
+	///
+	/// Mirrors [`Self::release_deposit`]'s lazy migration: the held portion is moved as a hold and
+	/// any legacy-reserved remainder is repatriated as a reserve on `to`.
+	pub(crate) fn repatriate_deposit(
+		from: &T::AccountId,
+		to: &T::AccountId,
+		amount: DepositBalanceOf<T, I>,
+	) -> DispatchResult {
+		let reason = Self::deposit_reason();
+		let from_hold = amount.min(T::Currency::balance_on_hold(&reason, from));
+		if !from_hold.is_zero() {
+			T::Currency::transfer_on_hold(
+				&reason,
+				from,
+				to,
+				from_hold,
+				Exact,
+				OnHold,
+				Fortitude::Polite,
+			)?;
+		}
+		let from_reserve = amount.saturating_sub(from_hold);
+		if !from_reserve.is_zero() {
+			T::OldCurrency::repatriate_reserved(from, to, from_reserve, Reserved)?;
+		}
+		Ok(())
+	}
+
 	/// Perform a transfer of an item from one account to another within a collection.
 	///
 	/// # Errors
@@ -91,7 +161,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> DispatchResult {
 		ensure!(!Collection::<T, I>::contains_key(collection.clone()), Error::<T, I>::InUse);
 
-		T::Currency::reserve(&owner, deposit)?;
+		Self::hold_deposit(&owner, deposit)?;
 
 		Collection::<T, I>::insert(
 			collection.clone(),
@@ -152,7 +222,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			#[allow(deprecated)]
 			Attribute::<T, I>::remove_prefix((&collection,), None);
 			CollectionAccount::<T, I>::remove(&collection_details.owner, &collection);
-			T::Currency::unreserve(&collection_details.owner, collection_details.total_deposit);
+			Self::release_deposit(&collection_details.owner, collection_details.total_deposit);
 			CollectionMaxSupply::<T, I>::remove(&collection);
 
 			Self::deposit_event(Event::Destroyed { collection });
@@ -208,7 +278,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 					true => Zero::zero(),
 					false => T::ItemDeposit::get(),
 				};
-				T::Currency::reserve(&collection_details.owner, deposit)?;
+				Self::hold_deposit(&collection_details.owner, deposit)?;
 				collection_details.total_deposit += deposit;
 
 				let owner = owner.clone();
@@ -249,7 +319,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				with_details(collection_details, &details)?;
 
 				// Return the deposit.
-				T::Currency::unreserve(&collection_details.owner, details.deposit);
+				Self::release_deposit(&collection_details.owner, details.deposit);
 				collection_details.total_deposit.saturating_reduce(details.deposit);
 				collection_details.items.saturating_dec();
 				Ok(details.owner)
@@ -328,12 +398,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			ensure!(only_buyer == buyer, Error::<T, I>::NoPermission);
 		}
 
-		T::Currency::transfer(
-			&buyer,
-			&details.owner,
-			price_info.0,
-			ExistenceRequirement::KeepAlive,
-		)?;
+		T::Currency::transfer(&buyer, &details.owner, price_info.0, Preservation::Preserve)?;
 
 		let old_owner = details.owner.clone();
 

--- a/substrate/frame/uniques/src/lib.rs
+++ b/substrate/frame/uniques/src/lib.rs
@@ -48,7 +48,14 @@ extern crate alloc;
 use alloc::vec::Vec;
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::traits::{
-	tokens::Locker, BalanceStatus::Reserved, Currency, EnsureOriginWithArg, ReservableCurrency,
+	tokens::{
+		fungible, Fortitude, Locker,
+		Precision::{BestEffort, Exact},
+		Preservation,
+		Restriction::OnHold,
+	},
+	BalanceStatus::Reserved,
+	Currency, EnsureOriginWithArg, ReservableCurrency,
 };
 use frame_system::Config as SystemConfig;
 use sp_runtime::{
@@ -77,6 +84,14 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T, I = ()>(_);
+
+	/// A reason for the pallet placing a hold on funds.
+	#[pallet::composite_enum]
+	pub enum HoldReason<I: 'static = ()> {
+		/// Funds are held as a deposit for a collection, item, metadata or attribute.
+		#[codec(index = 0)]
+		Deposit,
+	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	pub trait BenchmarkHelper<CollectionId, ItemId> {
@@ -107,8 +122,20 @@ pub mod pallet {
 		/// The type used to identify a unique item within a collection.
 		type ItemId: Member + Parameter + MaxEncodedLen + Copy;
 
-		/// The currency mechanism, used for paying for reserves.
-		type Currency: ReservableCurrency<Self::AccountId>;
+		/// The currency mechanism, used for deposits (taken as holds under [`HoldReason`]) and for
+		/// item-price transfers.
+		type Currency: fungible::Inspect<Self::AccountId>
+			+ fungible::Mutate<Self::AccountId>
+			+ fungible::MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>;
+
+		/// The overarching hold reason.
+		type RuntimeHoldReason: From<HoldReason<I>>;
+
+		/// The legacy reservable currency. Retained only to drain pre-existing reserved deposits as
+		/// the entities holding them are released (lazy migration); new deposits are taken as
+		/// holds. Otherwise unused.
+		type OldCurrency: Currency<Self::AccountId, Balance = DepositBalanceOf<Self, I>>
+			+ ReservableCurrency<Self::AccountId>;
 
 		/// The origin which may forcibly create or destroy an item or otherwise alter privileged
 		/// attributes.
@@ -706,9 +733,9 @@ pub mod pallet {
 				};
 				let old = details.deposit;
 				if old > deposit {
-					T::Currency::unreserve(&collection_details.owner, old - deposit);
+					Self::release_deposit(&collection_details.owner, old - deposit);
 				} else if deposit > old {
-					if T::Currency::reserve(&collection_details.owner, deposit - old).is_err() {
+					if Self::hold_deposit(&collection_details.owner, deposit - old).is_err() {
 						// NOTE: No alterations made to collection_details in this iteration so far,
 						// so this is OK to do.
 						continue;
@@ -884,12 +911,7 @@ pub mod pallet {
 				}
 
 				// Move the deposit to the new owner.
-				T::Currency::repatriate_reserved(
-					&details.owner,
-					&new_owner,
-					details.total_deposit,
-					Reserved,
-				)?;
+				Self::repatriate_deposit(&details.owner, &new_owner, details.total_deposit)?;
 
 				CollectionAccount::<T, I>::remove(&details.owner, &collection);
 				CollectionAccount::<T, I>::insert(&new_owner, &collection, ());
@@ -1153,9 +1175,9 @@ pub mod pallet {
 			}
 			collection_details.total_deposit.saturating_accrue(deposit);
 			if deposit > old_deposit {
-				T::Currency::reserve(&collection_details.owner, deposit - old_deposit)?;
+				Self::hold_deposit(&collection_details.owner, deposit - old_deposit)?;
 			} else if deposit < old_deposit {
-				T::Currency::unreserve(&collection_details.owner, old_deposit - deposit);
+				Self::release_deposit(&collection_details.owner, old_deposit - deposit);
 			}
 
 			Attribute::<T, I>::insert((&collection, maybe_item, &key), (&value, deposit));
@@ -1208,7 +1230,7 @@ pub mod pallet {
 			{
 				collection_details.attributes.saturating_dec();
 				collection_details.total_deposit.saturating_reduce(deposit);
-				T::Currency::unreserve(&collection_details.owner, deposit);
+				Self::release_deposit(&collection_details.owner, deposit);
 				Collection::<T, I>::insert(collection.clone(), &collection_details);
 				Self::deposit_event(Event::AttributeCleared { collection, maybe_item, key });
 			}
@@ -1268,9 +1290,9 @@ pub mod pallet {
 						.saturating_add(T::MetadataDepositBase::get());
 				}
 				if deposit > old_deposit {
-					T::Currency::reserve(&collection_details.owner, deposit - old_deposit)?;
+					Self::hold_deposit(&collection_details.owner, deposit - old_deposit)?;
 				} else if deposit < old_deposit {
-					T::Currency::unreserve(&collection_details.owner, old_deposit - deposit);
+					Self::release_deposit(&collection_details.owner, old_deposit - deposit);
 				}
 				collection_details.total_deposit.saturating_accrue(deposit);
 
@@ -1320,7 +1342,7 @@ pub mod pallet {
 					collection_details.item_metadatas.saturating_dec();
 				}
 				let deposit = metadata.take().ok_or(Error::<T, I>::UnknownCollection)?.deposit;
-				T::Currency::unreserve(&collection_details.owner, deposit);
+				Self::release_deposit(&collection_details.owner, deposit);
 				collection_details.total_deposit.saturating_reduce(deposit);
 
 				Collection::<T, I>::insert(&collection, &collection_details);
@@ -1376,9 +1398,9 @@ pub mod pallet {
 						.saturating_add(T::MetadataDepositBase::get());
 				}
 				if deposit > old_deposit {
-					T::Currency::reserve(&details.owner, deposit - old_deposit)?;
+					Self::hold_deposit(&details.owner, deposit - old_deposit)?;
 				} else if deposit < old_deposit {
-					T::Currency::unreserve(&details.owner, old_deposit - deposit);
+					Self::release_deposit(&details.owner, old_deposit - deposit);
 				}
 				details.total_deposit.saturating_accrue(deposit);
 
@@ -1424,7 +1446,7 @@ pub mod pallet {
 				ensure!(maybe_check_owner.is_none() || !was_frozen, Error::<T, I>::Frozen);
 
 				let deposit = metadata.take().ok_or(Error::<T, I>::UnknownCollection)?.deposit;
-				T::Currency::unreserve(&details.owner, deposit);
+				Self::release_deposit(&details.owner, deposit);
 				details.total_deposit.saturating_reduce(deposit);
 				Collection::<T, I>::insert(&collection, details);
 				Self::deposit_event(Event::CollectionMetadataCleared { collection });

--- a/substrate/frame/uniques/src/mock.rs
+++ b/substrate/frame/uniques/src/mock.rs
@@ -46,6 +46,7 @@ impl frame_system::Config for Test {
 #[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
 impl pallet_balances::Config for Test {
 	type AccountStore = System;
+	type RuntimeHoldReason = RuntimeHoldReason;
 }
 
 impl Config for Test {
@@ -53,6 +54,8 @@ impl Config for Test {
 	type CollectionId = u32;
 	type ItemId = u32;
 	type Currency = Balances;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<u64>>;
 	type ForceOrigin = frame_system::EnsureRoot<u64>;
 	type Locker = ();

--- a/substrate/frame/uniques/src/tests.rs
+++ b/substrate/frame/uniques/src/tests.rs
@@ -19,8 +19,7 @@
 
 use crate::{mock::*, Event, *};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
-use pallet_balances::Error as BalancesError;
-use sp_runtime::{traits::Dispatchable, DispatchError};
+use sp_runtime::{traits::Dispatchable, DispatchError, TokenError};
 
 fn items() -> Vec<(u64, u32, u32)> {
 	let mut r: Vec<_> = Account::<Test>::iter().map(|x| x.0).collect();
@@ -364,7 +363,7 @@ fn set_collection_metadata_should_work() {
 		// Cannot over-reserve
 		assert_noop!(
 			Uniques::set_collection_metadata(RuntimeOrigin::signed(1), 0, bvec![0u8; 40], false),
-			BalancesError::<Test, _>::InsufficientBalance,
+			TokenError::FundsUnavailable,
 		);
 
 		// Can't set or clear metadata once frozen
@@ -434,7 +433,7 @@ fn set_item_metadata_should_work() {
 		// Cannot over-reserve
 		assert_noop!(
 			Uniques::set_metadata(RuntimeOrigin::signed(1), 0, 42, bvec![0u8; 40], false),
-			BalancesError::<Test, _>::InsufficientBalance,
+			TokenError::FundsUnavailable,
 		);
 
 		// Can't set or clear metadata once frozen

--- a/substrate/frame/uniques/src/types.rs
+++ b/substrate/frame/uniques/src/types.rs
@@ -26,7 +26,9 @@ use scale_info::TypeInfo;
 
 /// A type alias for handling balance deposits.
 pub type DepositBalanceOf<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
+	<<T as Config<I>>::Currency as frame_support::traits::fungible::Inspect<
+		<T as SystemConfig>::AccountId,
+	>>::Balance;
 /// A type alias representing the details of a collection.
 pub type CollectionDetailsFor<T, I> =
 	CollectionDetails<<T as SystemConfig>::AccountId, DepositBalanceOf<T, I>>;
@@ -34,7 +36,9 @@ pub type CollectionDetailsFor<T, I> =
 pub type ItemDetailsFor<T, I> = ItemDetails<<T as SystemConfig>::AccountId, DepositBalanceOf<T, I>>;
 /// A type alias to represent the price of an item.
 pub type ItemPrice<T, I = ()> =
-	<<T as Config<I>>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
+	<<T as Config<I>>::Currency as frame_support::traits::fungible::Inspect<
+		<T as SystemConfig>::AccountId,
+	>>::Balance;
 
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo, MaxEncodedLen)]
 pub struct CollectionDetails<AccountId, DepositBalance> {


### PR DESCRIPTION
Migrates `pallet-uniques` off the deprecated `ReservableCurrency` trait. Collection, item, metadata and attribute deposits are now taken as `fungible` holds under `HoldReason::Deposit`, and item-price payments use `fungible::Mutate::transfer`. 
Part of #12399 / #226.
