### PR TITLE
try state hook for pallet derivatives

### DIFF
--- a/prdoc/pr_12421.prdoc
+++ b/prdoc/pr_12421.prdoc
@@ -1,0 +1,10 @@
+title: try state hook for pallet derivatives
+doc:
+- audience: Todo
+  description: |-
+    This PR introduces try state hook into the Derivatives Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-derivatives
+  bump: major

--- a/prdoc/pr_12421.prdoc
+++ b/prdoc/pr_12421.prdoc
@@ -1,6 +1,6 @@
 title: try state hook for pallet derivatives
 doc:
-- audience: Todo
+- audience: Runtime Dev
   description: |-
     This PR introduces try state hook into the Derivatives Pallet. It also defines the invariants that holds for the pallet.
 

--- a/substrate/frame/derivatives/src/lib.rs
+++ b/substrate/frame/derivatives/src/lib.rs
@@ -229,6 +229,14 @@ pub mod pallet {
 		InvalidAsset,
 	}
 
+	#[pallet::hooks]
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
+	}
+
 	#[pallet::call(weight(T::WeightInfo))]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		#[pallet::call_index(0)]
@@ -265,6 +273,67 @@ pub mod pallet {
 
 			Ok(())
 		}
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_mappings_are_consistent()?;
+		Self::try_state_derivative_extra_consistent()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every entry in `OriginalToDerivative` must have a corresponding reverse entry in
+	///   `DerivativeToOriginal` pointing back to the same original.
+	/// * Every entry in `DerivativeToOriginal` must have a corresponding forward entry in
+	///   `OriginalToDerivative` pointing back to the same derivative.
+	/// * The number of entries in `OriginalToDerivative` must equal the number of entries in
+	///   `DerivativeToOriginal`.
+	fn try_state_mappings_are_consistent() -> Result<(), sp_runtime::TryRuntimeError> {
+		for (original, derivative) in OriginalToDerivative::<T, I>::iter() {
+			ensure!(
+				DerivativeToOriginal::<T, I>::get(&derivative).as_ref() == Some(&original),
+				"`OriginalToDerivative` entry has no matching reverse in `DerivativeToOriginal`"
+			);
+		}
+
+		for (derivative, original) in DerivativeToOriginal::<T, I>::iter() {
+			ensure!(
+				OriginalToDerivative::<T, I>::get(&original).as_ref() == Some(&derivative),
+				"`DerivativeToOriginal` entry has no matching forward in `OriginalToDerivative`"
+			);
+		}
+
+		let forward_count = OriginalToDerivative::<T, I>::iter().count();
+		let reverse_count = DerivativeToOriginal::<T, I>::iter().count();
+		ensure!(
+			forward_count == reverse_count,
+			"Number of entries in `OriginalToDerivative` must equal `DerivativeToOriginal`"
+		);
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every key in `DerivativeExtra` must correspond to a registered derivative in
+	///   `DerivativeToOriginal`.
+	fn try_state_derivative_extra_consistent() -> Result<(), sp_runtime::TryRuntimeError> {
+		for derivative in DerivativeExtra::<T, I>::iter_keys() {
+			ensure!(
+				DerivativeToOriginal::<T, I>::contains_key(&derivative),
+				"`DerivativeExtra` has an entry for an unregistered derivative"
+			);
+		}
+
+		Ok(())
 	}
 }
 

--- a/substrate/frame/derivatives/src/mock/mod.rs
+++ b/substrate/frame/derivatives/src/mock/mod.rs
@@ -446,3 +446,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	sp_io::TestExternalities::new(t)
 }
+
+pub fn build_and_execute(test: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		test();
+		PredefinedIdDerivativeCollections::do_try_state()
+			.expect("All invariants must hold after a test");
+		AutoIdDerivativeCollections::do_try_state().expect("All invariants must hold after a test");
+		DerivativeNfts::do_try_state().expect("All invariants must hold after a test");
+	});
+}

--- a/substrate/frame/derivatives/src/tests.rs
+++ b/substrate/frame/derivatives/src/tests.rs
@@ -25,7 +25,7 @@ use xcm_executor::XcmExecutor;
 
 #[test]
 fn predefined_id_collection() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let id = AssetId(Location::new(1, [Parachain(1111), PalletInstance(42), GeneralIndex(1)]));
 
 		// An invalid origin is rejected.
@@ -84,7 +84,7 @@ fn predefined_id_collection() {
 
 #[test]
 fn auto_id_collection() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let id_a =
 			AssetId(Location::new(1, [Parachain(2222), PalletInstance(42), GeneralIndex(1)]));
 		let id_b =
@@ -172,7 +172,7 @@ fn auto_id_collection() {
 
 #[test]
 fn local_nfts() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let collection_owner = 1;
 		let nft_initial_owner = 2;
 		let nft_beneficiary = 3;
@@ -242,7 +242,7 @@ fn local_nfts() {
 #[test]
 fn derivative_nfts() {
 	sp_tracing::try_init_simple();
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let foreign_para_id = 2222;
 
 		// Create derivative NFT collection


### PR DESCRIPTION
This PR introduces try state hook into the Derivatives Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239