### PR TITLE
Add try_state hook to pallet-core-fellowship

### DIFF
--- a/substrate/frame/core-fellowship/src/lib.rs
+++ b/substrate/frame/core-fellowship/src/lib.rs
@@ -754,6 +754,86 @@ pub mod pallet {
 			salary[index]
 		}
 	}
+
+	#[pallet::hooks]
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
+	}
+
+	#[cfg(any(feature = "try-runtime", test))]
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		/// Ensure the correctness of the state of this pallet, used by the `try_state` hook and the
+		/// tests.
+		pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::try_state_params()?;
+			Self::try_state_members()?;
+			Self::try_state_evidence()?;
+			Ok(())
+		}
+
+		/// The four rank arrays are parallel tables, so they must share one length, and that length
+		/// must not exceed [`Config::MaxRank`] (arrays are only ever indexed by `rank - 1`).
+		fn try_state_params() -> Result<(), sp_runtime::TryRuntimeError> {
+			let params = Params::<T, I>::get();
+			let len = params.active_salary.len();
+			ensure!(
+				params.passive_salary.len() == len &&
+					params.demotion_period.len() == len &&
+					params.min_promotion_period.len() == len,
+				"All `Params` rank arrays must have the same length."
+			);
+			ensure!(
+				len <= T::MaxRank::get() as usize,
+				"`Params` rank arrays must not be longer than `MaxRank`."
+			);
+			Ok(())
+		}
+
+		/// Every tracked member with a non-zero rank must hold a rank the [`Params`] arrays can
+		/// price, so `get_salary`/`bump`/`promote` can never panic on indexing; and no member's
+		/// `last_proof`/`last_promotion` may be in the future. Rank-zero candidates and
+		/// externally-unranked members awaiting `offboard` don't index the arrays and are skipped.
+		fn try_state_members() -> Result<(), sp_runtime::TryRuntimeError> {
+			let params = Params::<T, I>::get();
+			let now = frame_system::Pallet::<T>::block_number();
+			Member::<T, I>::iter().try_for_each(|(who, status)| -> DispatchResult {
+				ensure!(status.last_proof <= now, "Member `last_proof` may not be in the future.");
+				ensure!(
+					status.last_promotion <= now,
+					"Member `last_promotion` may not be in the future."
+				);
+
+				if let Some(rank) = T::Members::rank_of(&who) {
+					if rank != 0 {
+						let index = Self::rank_to_index(rank)
+							.ok_or("Tracked member holds a rank above `MaxRank`.")?;
+						ensure!(
+							index < params.active_salary.len(),
+							"Tracked member holds a rank that the `Params` arrays cannot price."
+						);
+					}
+				}
+				Ok(())
+			})?;
+			Ok(())
+		}
+
+		/// Evidence is only ever submitted by a tracked member and cleared with the member record,
+		/// so every [`MemberEvidence`] key must also be a [`Member`].
+		fn try_state_evidence() -> Result<(), sp_runtime::TryRuntimeError> {
+			MemberEvidence::<T, I>::iter_keys().try_for_each(|who| -> DispatchResult {
+				ensure!(
+					Member::<T, I>::contains_key(&who),
+					"Every account with submitted evidence must be a tracked member."
+				);
+				Ok(())
+			})?;
+			Ok(())
+		}
+	}
 }
 
 /// Guard to ensure that the given origin is inducted into this pallet with a given minimum rank.

--- a/substrate/frame/core-fellowship/src/tests/integration.rs
+++ b/substrate/frame/core-fellowship/src/tests/integration.rs
@@ -145,6 +145,15 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
+/// Run the given closure in a fresh test externality and assert that all of the pallet's
+/// invariants hold afterwards.
+fn test(f: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		f();
+		CoreFellowship::do_try_state().expect("All invariants must hold after a test");
+	});
+}
+
 fn promote_n_times(acc: u64, r: u16) {
 	for _ in 0..r {
 		assert_ok!(Club::promote_member(RuntimeOrigin::root(), acc));
@@ -174,7 +183,7 @@ fn evidence(e: u32) -> Evidence<Test, ()> {
 
 #[test]
 fn import_simple_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		for i in 0u16..9 {
 			let acc = i as u64;
 
@@ -205,7 +214,7 @@ fn import_simple_works() {
 
 #[test]
 fn swap_simple_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		for i in 0u16..9 {
 			let acc = i as u64;
 
@@ -226,7 +235,7 @@ fn swap_simple_works() {
 /// The member also submits evidence before the swap.
 #[test]
 fn swap_exhaustive_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		let root_add = hypothetically!({
 			assert_ok!(Club::add_member(RuntimeOrigin::root(), 1));
 			promote_n_times(1, 4);
@@ -259,7 +268,7 @@ fn swap_exhaustive_works() {
 
 #[test]
 fn swap_bad_noops() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		assert_ok!(Club::add_member(RuntimeOrigin::root(), 0));
 		promote_n_times(0, 0);
 		assert_ok!(CoreFellowship::import(signed(0)));

--- a/substrate/frame/core-fellowship/src/tests/unit.rs
+++ b/substrate/frame/core-fellowship/src/tests/unit.rs
@@ -141,6 +141,15 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
+/// Run the given closure in a fresh test externality and assert that all of the pallet's
+/// invariants hold afterwards.
+fn test(f: impl FnOnce()) {
+	new_test_ext().execute_with(|| {
+		f();
+		CoreFellowship::do_try_state().expect("All invariants must hold after a test");
+	});
+}
+
 fn next_block() {
 	System::set_block_number(System::block_number() + 1);
 }
@@ -163,7 +172,7 @@ fn next_demotion(who: u64) -> u64 {
 
 #[test]
 fn basic_stuff() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		assert_eq!(CoreFellowship::rank_to_index(0), None);
 		assert_eq!(CoreFellowship::rank_to_index(1), Some(0));
 		assert_eq!(CoreFellowship::rank_to_index(9), Some(8));
@@ -174,7 +183,7 @@ fn basic_stuff() {
 
 #[test]
 fn set_params_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		let params = ParamsType {
 			active_salary: bounded_vec![10, 20, 30, 40, 50, 60, 70, 80, 90],
 			passive_salary: bounded_vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
@@ -192,7 +201,7 @@ fn set_params_works() {
 
 #[test]
 fn set_partial_params_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		let params = ParamsType {
 			active_salary: bounded_vec![None; 9],
 			passive_salary: bounded_vec![None; 9],
@@ -226,7 +235,7 @@ fn set_partial_params_works() {
 
 #[test]
 fn import_member_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		assert_noop!(CoreFellowship::import_member(signed(0), 0), Error::<Test>::Unranked);
 		assert_noop!(CoreFellowship::import(signed(0)), Error::<Test>::Unranked);
 
@@ -264,7 +273,7 @@ fn import_member_works() {
 
 #[test]
 fn import_member_same_as_import() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		for rank in 0..=9 {
 			set_rank(0, rank);
 
@@ -286,7 +295,7 @@ fn import_member_same_as_import() {
 
 #[test]
 fn induct_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(0, 0);
 		assert_ok!(CoreFellowship::import(signed(0)));
 		set_rank(1, 1);
@@ -301,7 +310,7 @@ fn induct_works() {
 
 #[test]
 fn promote_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(1, 1);
 		assert_ok!(CoreFellowship::import(signed(1)));
 		assert_noop!(CoreFellowship::promote(signed(1), 10, 1), Error::<Test>::Unranked);
@@ -323,7 +332,7 @@ fn promote_works() {
 fn promote_fast_works() {
 	let alice = 1;
 
-	new_test_ext().execute_with(|| {
+	test(|| {
 		assert_noop!(
 			CoreFellowship::promote_fast(signed(alice), alice, 1),
 			Error::<Test>::Unranked
@@ -379,7 +388,7 @@ fn promote_fast_works() {
 fn promote_fast_identical_to_promote() {
 	let alice = 1;
 
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(alice, 0);
 		assert_eq!(TestClub::rank_of(&alice), Some(0));
 		assert_ok!(CoreFellowship::import(signed(alice)));
@@ -414,7 +423,7 @@ fn promote_fast_identical_to_promote() {
 
 #[test]
 fn sync_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(10, 5);
 		assert_noop!(CoreFellowship::approve(signed(4), 10, 5), Error::<Test>::NoPermission);
 		assert_noop!(CoreFellowship::approve(signed(6), 10, 6), Error::<Test>::UnexpectedRank);
@@ -426,7 +435,7 @@ fn sync_works() {
 
 #[test]
 fn auto_demote_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(10, 5);
 		assert_ok!(CoreFellowship::import(signed(10)));
 
@@ -442,7 +451,7 @@ fn auto_demote_works() {
 
 #[test]
 fn auto_demote_offboard_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(10, 1);
 		assert_ok!(CoreFellowship::import(signed(10)));
 
@@ -458,7 +467,7 @@ fn auto_demote_offboard_works() {
 
 #[test]
 fn offboard_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		assert_noop!(CoreFellowship::offboard(signed(0), 10), Error::<Test>::NotTracked);
 		set_rank(10, 0);
 		assert_noop!(CoreFellowship::offboard(signed(0), 10), Error::<Test>::Ranked);
@@ -475,7 +484,7 @@ fn offboard_works() {
 
 #[test]
 fn infinite_demotion_period_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		let params = ParamsType {
 			active_salary: bounded_vec![10, 10, 10, 10, 10, 10, 10, 10, 10],
 			passive_salary: bounded_vec![10, 10, 10, 10, 10, 10, 10, 10, 10],
@@ -497,7 +506,7 @@ fn infinite_demotion_period_works() {
 
 #[test]
 fn proof_postpones_auto_demote() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(10, 5);
 		assert_ok!(CoreFellowship::import(signed(10)));
 
@@ -510,7 +519,7 @@ fn proof_postpones_auto_demote() {
 
 #[test]
 fn promote_postpones_auto_demote() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		set_rank(10, 5);
 		assert_ok!(CoreFellowship::import(signed(10)));
 
@@ -523,7 +532,7 @@ fn promote_postpones_auto_demote() {
 
 #[test]
 fn get_salary_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		for i in 1..=9u64 {
 			set_rank(10 + i, i as u16);
 			assert_ok!(CoreFellowship::import(signed(10 + i)));
@@ -534,7 +543,7 @@ fn get_salary_works() {
 
 #[test]
 fn active_changing_get_salary_works() {
-	new_test_ext().execute_with(|| {
+	test(|| {
 		for i in 1..=9u64 {
 			set_rank(10 + i, i as u16);
 			assert_ok!(CoreFellowship::import(signed(10 + i)));
@@ -543,5 +552,54 @@ fn active_changing_get_salary_works() {
 			assert_ok!(CoreFellowship::set_active(signed(10 + i), true));
 			assert_eq!(CoreFellowship::get_salary(i as u16, &(10 + i)), i * 10);
 		}
+	});
+}
+
+// These tests corrupt storage on purpose, so they bypass the `test` wrapper (whose own
+// `do_try_state` would trip) and assert the check rejects the inconsistent state.
+
+#[test]
+fn try_state_catches_orphan_evidence() {
+	new_test_ext().execute_with(|| {
+		// Evidence without a member record is inconsistent; importing the member fixes it.
+		let evidence: Evidence<Test, ()> = bounded_vec![0u8; 8];
+		MemberEvidence::<Test>::insert(42, (Wish::Retention, evidence));
+		assert!(CoreFellowship::do_try_state().is_err());
+
+		set_rank(42, 1);
+		assert_ok!(CoreFellowship::import(signed(42)));
+		assert_ok!(CoreFellowship::do_try_state());
+	});
+}
+
+#[test]
+fn try_state_catches_unequal_params() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(CoreFellowship::do_try_state());
+
+		// Parallel rank arrays of differing length.
+		Params::<Test>::mutate(|p| {
+			p.passive_salary = bounded_vec![1, 2, 3];
+		});
+		assert!(CoreFellowship::do_try_state().is_err());
+	});
+}
+
+#[test]
+fn try_state_catches_unpriceable_member() {
+	new_test_ext().execute_with(|| {
+		// Shrink the (still equal-length) arrays, then track a member they cannot price.
+		let params = ParamsType {
+			active_salary: bounded_vec![10, 20, 30, 40, 50],
+			passive_salary: bounded_vec![1, 2, 3, 4, 5],
+			demotion_period: bounded_vec![2, 4, 6, 8, 10],
+			min_promotion_period: bounded_vec![3, 6, 9, 12, 15],
+			offboard_timeout: 1,
+		};
+		assert_ok!(CoreFellowship::set_params(signed(1), Box::new(params)));
+
+		set_rank(7, 7);
+		assert_ok!(CoreFellowship::import(signed(7)));
+		assert!(CoreFellowship::do_try_state().is_err());
 	});
 }


### PR DESCRIPTION
Adds a `try_state` hook to `pallet-core-fellowship` asserting its storage invariants (consistent `Params` rank arrays, every ranked member priceable, every `MemberEvidence` key a tracked `Member`), closing part of #239, which never tracked this pallet since it was added after the tracker was written.