### PR TITLE
cargo: Bump litep2p to 0.14.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -692,7 +692,7 @@ checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest 0.13.2",
  "serde_json",
  "tower 0.5.3",
@@ -10816,9 +10816,9 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64660564d1f74164ee1d9d7b35482bf107da006d3590c1bea00dd31333b259f"
+checksum = "67508e7500fe69a99a038d2fba84fb30f23cac9d98bfeb7f5a1389ddd137b579"
 dependencies = [
  "async-trait",
  "bs58",
@@ -12003,7 +12003,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.98",
@@ -19198,7 +19198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -19244,7 +19244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.98",
@@ -19257,7 +19257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.98",
@@ -21872,7 +21872,7 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
- "litep2p 0.14.2",
+ "litep2p 0.14.3",
  "log",
  "mockall",
  "multihash-codetable",
@@ -22159,7 +22159,7 @@ dependencies = [
  "ed25519-dalek",
  "libp2p-identity",
  "libp2p-kad",
- "litep2p 0.14.2",
+ "litep2p 0.14.3",
  "log",
  "multiaddr 0.18.2",
  "multihash 0.19.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -925,7 +925,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.14.2", features = ["rsa", "websocket"] }
+litep2p = { version = "0.14.3", features = ["rsa", "websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }

--- a/prdoc/pr_12432.prdoc
+++ b/prdoc/pr_12432.prdoc
@@ -1,0 +1,12 @@
+title: 'cargo: Bump litep2p to 0.14.3'
+doc:
+- audience: Node Dev
+  description: |-
+    This patch release is dedicated entirely to strengthening the WebRTC transport layer, specifically focusing on connection resilience and build stability.
+
+    ### Fixed
+
+    - fix(webrtc): decode errors during opening phase are not recoverable  ([#622](https://github.com/paritytech/litep2p/pull/622))
+    - fix(webrtc): build vendored OpenSSL for str0m  ([#620](https://github.com/paritytech/litep2p/pull/620))
+    - fix(webrtc): time out inbound and outbound opening data channels  ([#617](https://github.com/paritytech/litep2p/pull/617))
+crates: []


### PR DESCRIPTION
This patch release is dedicated entirely to strengthening the WebRTC transport layer, specifically focusing on connection resilience and build stability.

### Fixed

- fix(webrtc): decode errors during opening phase are not recoverable  ([#622](https://github.com/paritytech/litep2p/pull/622))
- fix(webrtc): build vendored OpenSSL for str0m  ([#620](https://github.com/paritytech/litep2p/pull/620))
- fix(webrtc): time out inbound and outbound opening data channels  ([#617](https://github.com/paritytech/litep2p/pull/617))

