### PR TITLE
statement-store: first v2 DHT e2e test 

### DIFF
--- a/cumulus/polkadot-omni-node/lib/src/cli.rs
+++ b/cumulus/polkadot-omni-node/lib/src/cli.rs
@@ -272,6 +272,24 @@ pub struct Cli<Config: CliConfig> {
 	#[arg(long = "statement-affinity-topic", value_name = "TOPIC")]
 	pub statement_affinity_topics: Vec<sc_statement_store::Topic>,
 
+	/// Enable the v2 DHT-affinity statement routing path instead of the legacy flood path.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long = "enable-statement-store-v2-dht", default_value_t = false)]
+	pub statement_enable_v2_dht: bool,
+
+	/// Number of K-closest peers (replication factor) used for DHT-affinity statement routing.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "K", default_value_t = sc_statement_store::DEFAULT_REPLICATION_FACTOR)]
+	pub statement_replication_factor: std::num::NonZeroUsize,
+
+	/// Number of peers to gossip a statement to in addition to DHT-affinity routing targets.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "N", default_value_t = sc_statement_store::DEFAULT_GOSSIP_TARGET)]
+	pub statement_gossip_target: std::num::NonZeroUsize,
+
 	/// HOP (Hand-Off Protocol) configuration parameters.
 	#[command(flatten)]
 	pub hop: sc_hop::HopParams,
@@ -328,6 +346,9 @@ impl<Config: CliConfig> Cli<Config> {
 					network_workers: self.statement_network_workers,
 					rate_limit: self.statement_rate_limit,
 					affinity_topics: self.statement_affinity_topics.clone(),
+					v2dht_enabled: self.statement_enable_v2_dht,
+					replication_factor: self.statement_replication_factor,
+					gossip_target: self.statement_gossip_target,
 				},
 			),
 			storage_monitor: self.storage_monitor.clone(),

--- a/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
@@ -68,6 +68,9 @@ pub(crate) fn build_statement_store<
 	let network_workers = config.network_workers;
 	let rate_limit = config.rate_limit;
 	let affinity_topics = config.affinity_topics.clone();
+	let v2dht_enabled = config.v2dht_enabled;
+	let replication_factor = config.replication_factor;
+	let gossip_target = config.gossip_target;
 
 	let statement_store = sc_statement_store::Store::new_shared(
 		&parachain_config.data_path,
@@ -93,6 +96,9 @@ pub(crate) fn build_statement_store<
 		network_workers,
 		rate_limit,
 		&affinity_topics,
+		v2dht_enabled,
+		replication_factor,
+		gossip_target,
 	)?;
 	task_manager.spawn_handle().spawn(
 		"network-statement-handler",

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -216,6 +216,71 @@ pub(super) fn collator_args(participant_count: u32, log_filter: &str) -> Vec<zom
 	args.iter().map(|s| s.as_str().into()).collect()
 }
 
+/// Collator args for the v2 DHT-affinity tests: [`collator_args`] plus the v2 flags.
+pub(super) fn collator_args_v2(
+	participant_count: u32,
+	log_filter: &str,
+	k: u32,
+	gossip_target: u32,
+) -> Vec<zombienet_sdk::Arg> {
+	let mut args: Vec<zombienet_sdk::Arg> = collator_args(participant_count, log_filter);
+	args.push("--enable-statement-store-v2-dht".into());
+	args.push(format!("--statement-replication-factor={k}").as_str().into());
+	args.push(format!("--statement-gossip-target={gossip_target}").as_str().into());
+	args
+}
+
+/// Returns whether a node's local store holds `statement` for `topic`.
+pub(super) async fn stores_locally(
+	rpc: &RpcClient,
+	topic: Topic,
+	statement: &Bytes,
+) -> Result<bool, anyhow::Error> {
+	const PROBE_TIMEOUT_SECS: u64 = 30;
+
+	let mut subscription = subscribe_topic(rpc, topic).await?;
+
+	loop {
+		let item = match tokio::time::timeout(
+			Duration::from_secs(PROBE_TIMEOUT_SECS),
+			subscription.next(),
+		)
+		.await
+		{
+			// Timeout or end of stream: replay is over without a match.
+			Err(_) | Ok(None) => return Ok(false),
+			Ok(Some(item)) => item.map_err(|e| anyhow!("Subscription error: {}", e))?,
+		};
+
+		match item {
+			StatementEvent::NewStatements { statements: batch, remaining } => {
+				if batch.iter().any(|s| s == statement) {
+					return Ok(true);
+				}
+				if remaining == Some(0) {
+					return Ok(false);
+				}
+			},
+		}
+	}
+}
+
+/// Counts how many of `rpcs` hold `statement` for `topic` locally. With replication factor
+/// `K`, exactly `K` nodes should store it.
+pub(super) async fn count_storers(
+	rpcs: &[&RpcClient],
+	topic: Topic,
+	statement: &Bytes,
+) -> Result<usize, anyhow::Error> {
+	let mut count: usize = 0;
+	for rpc in rpcs {
+		if stores_locally(rpc, topic, statement).await? {
+			count = count.saturating_add(1);
+		}
+	}
+	Ok(count)
+}
+
 pub(super) fn base_dir() -> Result<PathBuf, anyhow::Error> {
 	let path = std::env::var("ZOMBIENET_SDK_BASE_DIR")
 		.ok()
@@ -298,6 +363,25 @@ pub(super) async fn spawn_network_with_injected_allowances(
 	let base_dir = base_dir()?;
 	let chain_spec_path = create_chain_spec_with_allowances(participant_count, &base_dir)?;
 	let args = collator_args(participant_count, COLLATOR_TRACE_LOG_FILTER);
+	launch_network(collators, &chain_spec_path, args).await
+}
+
+/// Spawns a zombienet network for the v2 DHT-affinity tests.
+///
+/// Identical to [`spawn_network_with_injected_allowances`] except that it uses
+/// [`collator_args_v2`] to pin an explicit replication factor `k` and
+/// `gossip_target` on EVERY collator (see `launch_network`'s
+/// `.with_default_args`)
+pub(super) async fn spawn_network_with_injected_allowances_v2(
+	collators: &[&str],
+	participant_count: u32,
+	k: u32,
+	gossip_target: u32,
+) -> Result<Network<LocalFileSystem>, anyhow::Error> {
+	assert!(!collators.is_empty());
+	let base_dir = base_dir()?;
+	let chain_spec_path = create_chain_spec_with_allowances(participant_count, &base_dir)?;
+	let args = collator_args_v2(participant_count, COLLATOR_TRACE_LOG_FILTER, k, gossip_target);
 	launch_network(collators, &chain_spec_path, args).await
 }
 

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -1,0 +1,78 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for the v2 DHT-affinity statement routing.
+//!
+//! v2 routes a statement to the `K` nodes with affinity to its topic instead of
+//! flooding every peer. It is enabled per node via `--enable-statement-store-v2-dht`
+//! (off by default).
+//!
+
+use super::common::{
+	count_storers, expect_one_statement, spawn_network_with_injected_allowances_v2,
+	submit_statement, subscribe_topic,
+};
+use codec::Encode;
+use sc_statement_store::test_utils::{create_test_statement, get_keypair};
+use sp_core::Bytes;
+use sp_statement_store::{SubmitResult, Topic};
+
+const TEST_GOSSIP_TARGET: u32 = 3;
+
+/// With `K=1`, a submitted statement reaches a subscriber and lands on exactly one
+/// node, and a second statement still arrives after the subscriber re-subscribes.
+#[tokio::test(flavor = "multi_thread")]
+async fn v2_dht_k1_subscribe_submit_resubscribe() -> Result<(), anyhow::Error> {
+	let _ = env_logger::try_init_from_env(
+		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+	);
+
+	let network =
+		spawn_network_with_injected_allowances_v2(&["charlie", "dave"], 8, 1, TEST_GOSSIP_TARGET)
+			.await?;
+
+	let node_a = network.get_node("charlie")?;
+	let node_b = network.get_node("dave")?;
+
+	let rpc_a = node_a.rpc().await?;
+	let rpc_b = node_b.rpc().await?;
+
+	let topic: Topic = [0u8; 32].into();
+	let keypair = get_keypair(0);
+
+	// Subscribe on A, submit on B, expect A to receive it.
+	let statement = create_test_statement(&keypair, &[topic], None, vec![1, 2, 3], u32::MAX, 0);
+	let expected: Bytes = statement.encode().into();
+
+	let mut sub_a = subscribe_topic(&rpc_a, topic).await?;
+	let result = submit_statement(&rpc_b, &statement).await?;
+	assert_eq!(result, SubmitResult::New);
+
+	let received = expect_one_statement(&mut sub_a, 20).await?;
+	assert_eq!(received, expected);
+
+	// K=1, so the statement lives on a single node rather than on everyone.
+	let storers = count_storers(&[&rpc_a, &rpc_b], topic, &expected).await?;
+	assert_eq!(storers, 1);
+
+	// Re-subscribe and submit a second statement on the same topic.
+	let statement2 = create_test_statement(&keypair, &[topic], None, vec![4, 5, 6], u32::MAX, 1);
+	let expected2: Bytes = statement2.encode().into();
+
+	drop(sub_a);
+	let mut sub_a2 = subscribe_topic(&rpc_a, topic).await?;
+	let result2 = submit_statement(&rpc_b, &statement2).await?;
+	assert_eq!(result2, SubmitResult::New);
+
+	let mut saw_s2 = false;
+	let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
+	while tokio::time::Instant::now() < deadline {
+		if expect_one_statement(&mut sub_a2, 20).await? == expected2 {
+			saw_s2 = true;
+			break;
+		}
+	}
+	assert!(saw_s2);
+
+	Ok(())
+}

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -6,7 +6,6 @@
 //! v2 routes a statement to the `K` nodes with affinity to its topic instead of
 //! flooding every peer. It is enabled per node via `--enable-statement-store-v2-dht`
 //! (off by default).
-//!
 
 use super::common::{
 	count_storers, expect_one_statement, spawn_network_with_injected_allowances_v2,

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/mod.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/mod.rs
@@ -4,3 +4,4 @@
 mod bench;
 mod common;
 mod integration;
+mod integration_v2_dht;

--- a/substrate/bin/node/cli/src/cli.rs
+++ b/substrate/bin/node/cli/src/cli.rs
@@ -89,6 +89,24 @@ pub struct Cli {
 	#[arg(long = "statement-affinity-topic", value_name = "TOPIC")]
 	pub statement_affinity_topics: Vec<sc_statement_store::Topic>,
 
+	/// Enable the v2 DHT-affinity statement routing path.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long = "enable-statement-store-v2-dht", default_value_t = false)]
+	pub statement_enable_v2_dht: bool,
+
+	/// DHT replication factor (K): number of closest peers a statement is routed to.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "K", default_value_t = sc_statement_store::DEFAULT_REPLICATION_FACTOR)]
+	pub statement_replication_factor: std::num::NonZeroUsize,
+
+	/// Number of peers to gossip a statement to within the affinity set.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "N", default_value_t = sc_statement_store::DEFAULT_GOSSIP_TARGET)]
+	pub statement_gossip_target: std::num::NonZeroUsize,
+
 	#[allow(missing_docs)]
 	#[clap(flatten)]
 	pub storage_monitor: sc_storage_monitor::StorageMonitorParams,

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -451,6 +451,9 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	let statement_network_workers = statement_store_config.network_workers;
 	let statement_rate_limit = statement_store_config.rate_limit;
 	let statement_affinity_topics = statement_store_config.affinity_topics.clone();
+	let statement_v2dht_enabled = statement_store_config.v2dht_enabled;
+	let statement_replication_factor = statement_store_config.replication_factor;
+	let statement_gossip_target = statement_store_config.gossip_target;
 
 	let sc_service::PartialComponents {
 		client,
@@ -807,6 +810,9 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 		statement_network_workers,
 		statement_rate_limit,
 		&statement_affinity_topics,
+		statement_v2dht_enabled,
+		statement_replication_factor,
+		statement_gossip_target,
 	)?;
 	task_manager.spawn_handle().spawn(
 		"network-statement-handler",
@@ -859,6 +865,9 @@ pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceE
 		network_workers: cli.statement_network_workers,
 		rate_limit: cli.statement_rate_limit,
 		affinity_topics: cli.statement_affinity_topics.clone(),
+		v2dht_enabled: cli.statement_enable_v2_dht,
+		replication_factor: cli.statement_replication_factor,
+		gossip_target: cli.statement_gossip_target,
 	};
 
 	let task_manager = match config.network.network_backend {

--- a/substrate/client/network/statement/src/config.rs
+++ b/substrate/client/network/statement/src/config.rs
@@ -18,7 +18,7 @@
 
 //! Configuration of the statement protocol
 
-use std::time;
+use std::{num::NonZeroUsize, time};
 
 /// Interval at which we propagate statements;
 pub(crate) const PROPAGATE_TIMEOUT: time::Duration = time::Duration::from_millis(1000);
@@ -37,3 +37,11 @@ pub const DEFAULT_STATEMENTS_PER_SECOND: u32 = 50_000;
 
 /// Burst capacity coefficient for the rate limiter.
 pub const STATEMENTS_BURST_COEFFICIENT: u32 = 5;
+
+/// Default replication factor (K) for v2 DHT-affinity routing: number of statement-protocol peers
+/// responsible for storing a given topic.
+pub const DEFAULT_REPLICATION_FACTOR: NonZeroUsize = NonZeroUsize::new(20).expect("20 is non-zero");
+
+/// Default gossip target for v2 DHT-affinity routing: maximum number of connected peers we forward
+/// a statement to for a given topic.
+pub const DEFAULT_GOSSIP_TARGET: NonZeroUsize = NonZeroUsize::new(3).expect("3 is non-zero");

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -786,6 +786,7 @@ where
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
 			v2dht,
+			v2dht_enabled: false,
 		}
 	}
 
@@ -2261,6 +2262,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -2594,6 +2596,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -2646,6 +2649,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4072,6 +4076,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4436,6 +4441,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4510,6 +4516,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4596,6 +4603,7 @@ mod tests {
 			dropped_statements_during_sync: true,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4706,6 +4714,7 @@ mod tests {
 					dropped_statements_during_sync: dropped,
 					sync_recovery_peer: None,
 					sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+					v2dht_enabled: false,
 					v2dht: V2DhtOrchestrator::new(
 						&[],
 						local_peer,

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -166,13 +166,6 @@ const PENDING_AFFINITIES_INTERVAL: std::time::Duration = std::time::Duration::fr
 /// Delay before re-adding a peer to the reserved set after a forced disconnect for sync recovery.
 const SYNC_RECOVERY_READD_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// Feature-flag to switch between the legacy flood path and the new DHT-targeted path.
-///
-/// Hard-coded for now.
-const fn v2dht_enabled() -> bool {
-	false
-}
-
 struct Metrics {
 	propagated_statements: Counter<U64>,
 	known_statements_received: Counter<U64>,
@@ -391,6 +384,9 @@ impl StatementHandlerPrototype {
 		mut num_submission_workers: usize,
 		statements_per_second: u32,
 		configured_topics: &[Topic],
+		v2dht_enabled: bool,
+		replication_factor: std::num::NonZeroUsize,
+		gossip_target: std::num::NonZeroUsize,
 	) -> error::Result<StatementHandler<N, S>> {
 		let sync_event_stream = sync.event_stream("statement-handler-sync");
 		let (queue_sender, queue_receiver) = async_channel::bounded(MAX_PENDING_STATEMENTS);
@@ -452,7 +448,7 @@ impl StatementHandlerPrototype {
 			);
 		}
 
-		let network_event_stream = if v2dht_enabled() {
+		let network_event_stream = if v2dht_enabled {
 			network
 				.event_stream("statement-handler-network")
 				.filter(|event| {
@@ -468,7 +464,7 @@ impl StatementHandlerPrototype {
 		let v2dht = V2DhtOrchestrator::new(
 			configured_topics,
 			network.local_peer_id(),
-			PeersTopologyConfig::default(),
+			PeersTopologyConfig { replication_factor, gossip_target },
 		);
 		let handler = StatementHandler {
 			protocol_name: self.protocol_name,
@@ -498,6 +494,7 @@ impl StatementHandlerPrototype {
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
 			v2dht,
+			v2dht_enabled,
 		};
 
 		Ok(handler)
@@ -556,8 +553,11 @@ pub struct StatementHandler<
 	sync_recovery_peer: Option<PeerId>,
 	/// Fires when the `sync_recovery_peer` re-add delay has elapsed
 	sync_recovery_readd_timeout: Pin<Box<dyn FusedFuture<Output = ()> + Send>>,
-	/// Only invoked when [`v2dht_enabled`] returns `true`.
+	/// Orchestrates the v2 DHT-affinity path. Only driven when `v2dht_enabled` is `true`.
 	v2dht: V2DhtOrchestrator,
+	/// Selects the v2 DHT-affinity path. Off by default; opt in via
+	/// `--enable-statement-store-v2-dht`.
+	v2dht_enabled: bool,
 }
 
 /// Per-peer rate limiter using a token bucket algorithm.
@@ -837,7 +837,7 @@ where
 					}
 				}
 				_ = &mut self.initial_sync_timeout => {
-					if v2dht_enabled() {
+					if self.v2dht_enabled {
 						self.v2dht.on_initial_sync().await;
 					}
 					self.process_initial_sync_burst().await;
@@ -845,7 +845,7 @@ where
 						Box::pin(tokio::time::sleep(INITIAL_SYNC_BURST_INTERVAL).fuse());
 				},
 				_ = &mut self.pending_affinities_timeout => {
-					if v2dht_enabled() {
+					if self.v2dht_enabled {
 						// Advertise this node's filter changes before serving peers their backlog.
 						let topics = self.statement_store.subscription_topics();
 						self.v2dht.set_rpc_subscription_topics(&topics);
@@ -875,7 +875,7 @@ where
 			}
 
 			if !self.sync.is_major_syncing() {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_major_sync_end();
 				} else {
 					self.drain_deferred_peers();
@@ -887,8 +887,8 @@ where
 
 	/// Handle a network topology event.
 	///
-	/// The network event stream is `pending()` unless `v2dht_enabled()`, so this runs only on the
-	/// v2 DHT path.
+	/// The network event stream is `pending()` unless `v2dht_enabled` is set, so this runs only on
+	/// the v2 DHT path.
 	fn handle_network_event(&mut self, event: Event) {
 		match event {
 			Event::PeerRoutingTableUpdate(peers) => self.v2dht.on_peers_discovered(peers),
@@ -1086,7 +1086,7 @@ where
 	fn handle_sync_event(&mut self, event: SyncEvent) {
 		match event {
 			SyncEvent::PeerConnected(remote) => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_peer_connected(remote);
 				}
 				if self.sync.is_major_syncing() {
@@ -1108,7 +1108,7 @@ where
 				}
 			},
 			SyncEvent::PeerDisconnected(remote) => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_peer_disconnected(remote);
 				}
 				if self.deferred_peers.remove(&remote) {
@@ -1128,7 +1128,7 @@ where
 	async fn handle_notification_event(&mut self, event: NotificationEvent) {
 		match event {
 			NotificationEvent::ValidateInboundSubstream { peer, handshake, result_tx, .. } => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_validate_inbound_substream(peer)
 				}
 				// Only accept peers whose role can be determined
@@ -1191,7 +1191,7 @@ where
 					}
 				});
 
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					if !is_light {
 						// TODO: Do we need to pass light nodes to the Orchestrator?
 						self.v2dht.on_substream_opened(peer);
@@ -1206,7 +1206,7 @@ where
 				}
 			},
 			NotificationEvent::NotificationStreamClosed { peer } => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_substream_closed(peer);
 				}
 				let removed_peer = self.peers.remove(&peer);
@@ -1272,7 +1272,7 @@ where
 									self.on_statements(peer, statements);
 								},
 								StatementMessage::ExplicitTopicAffinity(filter) => {
-									if v2dht_enabled() {
+									if self.v2dht_enabled {
 										self.v2dht.on_peer_filter_update(peer, filter);
 									} else if let Some(peer_data) = self.peers.get_mut(&peer) {
 										if peer_data.rate_limiter.is_flooding(1) {
@@ -1375,7 +1375,7 @@ where
 
 				match self.pending_statements_peers.entry(hash) {
 					Entry::Vacant(entry) => {
-						let mask = if v2dht_enabled() {
+						let mask = if self.v2dht_enabled {
 							self.v2dht.retention_reasons_for(&s)
 						} else {
 							RetentionReasonMask::persistent()
@@ -1420,7 +1420,7 @@ where
 	}
 
 	fn on_handle_statement_import(&mut self, who: PeerId, import: &SubmitResult) {
-		if v2dht_enabled() {
+		if self.v2dht_enabled {
 			self.v2dht.on_statement_imported(who, import);
 		}
 		match import {
@@ -1564,7 +1564,7 @@ where
 			return;
 		}
 
-		if v2dht_enabled() {
+		if self.v2dht_enabled {
 			for (who, indices) in self.v2dht.propagation_plan(&statements) {
 				self.send_targeted_statements_to_peer(&who, &statements, &indices).await;
 			}

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -42,8 +42,8 @@ pub struct PeersTopologyConfig {
 impl Default for PeersTopologyConfig {
 	fn default() -> Self {
 		Self {
-			replication_factor: NonZeroUsize::new(20).expect("20 is non-zero"),
-			gossip_target: NonZeroUsize::new(3).expect("3 is non-zero"),
+			replication_factor: crate::config::DEFAULT_REPLICATION_FACTOR,
+			gossip_target: crate::config::DEFAULT_GOSSIP_TARGET,
 		}
 	}
 }

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -193,6 +193,12 @@ pub const DEFAULT_NETWORK_WORKERS: usize = 1;
 /// Default maximum statements per second per peer before rate limiting kicks in.
 pub use sc_network_statement::config::DEFAULT_STATEMENTS_PER_SECOND as DEFAULT_RATE_LIMIT;
 
+/// Default replication factor (K) for v2 DHT-affinity statement routing.
+pub use sc_network_statement::config::DEFAULT_REPLICATION_FACTOR;
+
+/// Default gossip target for v2 DHT-affinity statement routing.
+pub use sc_network_statement::config::DEFAULT_GOSSIP_TARGET;
+
 /// Statement store and network handler configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -210,6 +216,15 @@ pub struct Config {
 	pub rate_limit: u32,
 	/// Topics this node advertises affinity for, so peers route matching statements to it.
 	pub affinity_topics: Vec<sp_statement_store::Topic>,
+	/// Selects the v2 DHT-affinity routing path over the legacy flood path. Off by default; the
+	/// v2 path is enabled per node via `--enable-statement-store-v2-dht`.
+	pub v2dht_enabled: bool,
+	/// Replication factor (K) for v2 DHT-affinity routing: number of statement-protocol peers
+	/// responsible for storing a given topic.
+	pub replication_factor: std::num::NonZeroUsize,
+	/// Gossip target for v2 DHT-affinity routing: maximum number of connected peers we forward a
+	/// statement to for a given topic.
+	pub gossip_target: std::num::NonZeroUsize,
 }
 
 impl Config {
@@ -239,6 +254,9 @@ impl Default for Config {
 			network_workers: DEFAULT_NETWORK_WORKERS,
 			rate_limit: DEFAULT_RATE_LIMIT,
 			affinity_topics: Vec::new(),
+			v2dht_enabled: false,
+			replication_factor: DEFAULT_REPLICATION_FACTOR,
+			gossip_target: DEFAULT_GOSSIP_TARGET,
 		}
 	}
 }


### PR DESCRIPTION
Implementation (#12428)

## What

Lands the first end-to-end test for the v2 DHT-affinity statement routing path,
plus the minimal wiring required to exercise it from zombienet.

## Changes
- **Make the v2 path opt-in.** `v2dht_enabled()` was a hard-coded `const fn`.
  It is now a per-node runtime flag (`StatementHandler::v2dht_enabled`), threaded   
  from a new CLI option `--enable-statement-store-v2-dht` (default **off**).
- **Expose topology parameters as CLI flags**:
  - `--statement-replication-factor <K>`
  - `--statement-gossip-target <N>`
- **New zombienet test `v2_dht_k1_subscribe_submit_resubscribe`** 
  on a 2-node network with `K=1` it asserts
  1. the subscriber receives the submitted statement (delivery),
  2. exactly one node stores it locally (`count_storers == 1`, selectivity),
  3. after dropping and recreating the subscription, a second statement is
     delivered again (resubscribe stability).
- **Test helpers** in `common.rs`: `collator_args_v2`, `stores_locally`,
  `count_storers`.
