### PR TITLE
Fix for `rust-lld` regression

### DIFF
--- a/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
+++ b/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
@@ -145,6 +145,7 @@ fn generate_extern_host_function(
 		#[doc = #doc_string]
 		pub fn #function ( #( #unpacked_args ),* ) #unpacked_return_value {
 			#[cfg_attr(target_arch = "riscv64", #crate_::polkavm::polkavm_import(abi = #crate_::polkavm::polkavm_abi))]
+			#[link(wasm_import_module = "env")]
 			extern "C" {
 				pub fn #ext_function (
 					#( #arg_names: <#arg_types as #crate_::RIType>::FFIType ),*

--- a/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
+++ b/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
@@ -145,7 +145,7 @@ fn generate_extern_host_function(
 		#[doc = #doc_string]
 		pub fn #function ( #( #unpacked_args ),* ) #unpacked_return_value {
 			#[cfg_attr(target_arch = "riscv64", #crate_::polkavm::polkavm_import(abi = #crate_::polkavm::polkavm_abi))]
-			#[link(wasm_import_module = "env")]
+			#[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
 			extern "C" {
 				pub fn #ext_function (
 					#( #arg_names: <#arg_types as #crate_::RIType>::FFIType ),*


### PR DESCRIPTION
This adapts code to a `rust-lld` regression observed since 1.96.0, requiring the explicit specification of a Wasm module name from which external functions are imported.