### PR TITLE
fix(pallet-contracts): assign checked_sub result in charge_ref_time

### DIFF
--- a/substrate/frame/contracts/src/gas.rs
+++ b/substrate/frame/contracts/src/gas.rs
@@ -71,7 +71,7 @@ impl<T: Config> EngineMeter<T> {
 			.checked_div(T::Schedule::get().ref_time_by_fuel())
 			.ok_or(Error::<T>::InvalidSchedule)?;
 
-		self.fuel.checked_sub(amount).ok_or_else(|| Error::<T>::OutOfGas)?;
+		self.fuel = self.fuel.checked_sub(amount).ok_or_else(|| Error::<T>::OutOfGas)?;
 		Ok(Syncable(self.fuel))
 	}
 }


### PR DESCRIPTION
## Summary

EngineMeter::charge_ref_time() called self.fuel.checked_sub(amount) but discarded the result. Since checked_sub() is a pure function in Rust (returns Option<u64> without mutating self), self.fuel was never decremented after each host function call.

## Root Cause

```rust
// Before (gas.rs:74) — BUG: result discarded
self.fuel.checked_sub(amount).ok_or_else(|| Error::<T>::OutOfGas)?;
Ok(Syncable(self.fuel))  // returns STALE fuel

// After — FIX: result assigned
self.fuel = self.fuel.checked_sub(amount).ok_or_else(|| Error::<T>::OutOfGas)?;
Ok(Syncable(self.fuel))  // returns CORRECT decremented fuel
```

## Impact

The engine fuel counter drifts after each host function call. While gas_left remains the authoritative gas enforcement limit, the stale engine.fuel value is returned via Syncable and used to set executor fuel, which could affect fuel-based estimation or accounting.

## Fix

Assign the result of checked_sub back to self.fuel on line 74.

## Note

pallet-revive does not have this issue as it uses a different gas model.