### PR TITLE
Remove deprecated `relay_dispatch_queue_size` well-known keys

### DIFF
--- a/cumulus/client/parachain-inherent/src/lib.rs
+++ b/cumulus/client/parachain-inherent/src/lib.rs
@@ -112,11 +112,6 @@ async fn get_static_relay_storage_keys(
 		relay_well_known_keys::CURRENT_SLOT.to_vec(),
 		relay_well_known_keys::ACTIVE_CONFIG.to_vec(),
 		relay_well_known_keys::dmq_mqc_head(para_id),
-		// TODO paritytech/polkadot#6283: Remove all usages of `relay_dispatch_queue_size`
-		// We need to keep this here until all parachains have migrated to
-		// `relay_dispatch_queue_remaining_capacity`.
-		#[allow(deprecated)]
-		relay_well_known_keys::relay_dispatch_queue_size(para_id),
 		relay_well_known_keys::relay_dispatch_queue_remaining_capacity(para_id).key,
 		relay_well_known_keys::hrmp_ingress_channel_index(para_id),
 		relay_well_known_keys::hrmp_egress_channel_index(para_id),

--- a/cumulus/pallets/parachain-system/src/relay_state_snapshot.rs
+++ b/cumulus/pallets/parachain-system/src/relay_state_snapshot.rs
@@ -193,43 +193,26 @@ impl RelayChainStateProof {
 		)
 		.map_err(Error::DmqMqcHead)?;
 
-		let relay_dispatch_queue_remaining_capacity = read_optional_entry::<
+		// The `relay_dispatch_queue_remaining_capacity` entry is only written by the relay chain
+		// once a parachain has enqueued its first upward message. For a parachain that has never
+		// sent an upward message the entry is absent, in which case the queue is empty and the
+		// full capacity configured by the host is still available.
+		//
+		// A `Decode` or `Proof` error is potentially the result of meddling by a malicious
+		// collator, so we reject the block in those cases by propagating the error.
+		let relay_dispatch_queue_remaining_capacity = read_entry::<
 			RelayDispatchQueueRemainingCapacity,
 			_,
 		>(
 			&self.trie_backend,
 			&relay_chain::well_known_keys::relay_dispatch_queue_remaining_capacity(self.para_id)
 				.key,
-		);
-
-		// TODO paritytech/polkadot#6283: Remove all usages of `relay_dispatch_queue_size`
-		//
-		// When the relay chain and all parachains support
-		// `relay_dispatch_queue_remaining_capacity`, this code here needs to be removed and above
-		// needs to be changed to `read_entry` that returns an error if
-		// `relay_dispatch_queue_remaining_capacity` can not be found/decoded.
-		//
-		// For now we just fallback to the old dispatch queue size on `ReadEntryErr::Absent`.
-		// `ReadEntryErr::Decode` and `ReadEntryErr::Proof` are potentially subject to meddling
-		// by malicious collators, so we reject the block in those cases.
-		let relay_dispatch_queue_remaining_capacity = match relay_dispatch_queue_remaining_capacity
-		{
-			Ok(Some(r)) => r,
-			Ok(None) => {
-				let res = read_entry::<(u32, u32), _>(
-					&self.trie_backend,
-					#[allow(deprecated)]
-					&relay_chain::well_known_keys::relay_dispatch_queue_size(self.para_id),
-					Some((0, 0)),
-				)
-				.map_err(Error::RelayDispatchQueueRemainingCapacity)?;
-
-				let remaining_count = host_config.max_upward_queue_count.saturating_sub(res.0);
-				let remaining_size = host_config.max_upward_queue_size.saturating_sub(res.1);
-				RelayDispatchQueueRemainingCapacity { remaining_count, remaining_size }
-			},
-			Err(e) => return Err(Error::RelayDispatchQueueRemainingCapacity(e)),
-		};
+			Some(RelayDispatchQueueRemainingCapacity {
+				remaining_count: host_config.max_upward_queue_count,
+				remaining_size: host_config.max_upward_queue_size,
+			}),
+		)
+		.map_err(Error::RelayDispatchQueueRemainingCapacity)?;
 
 		let ingress_channel_index: Vec<ParaId> = read_entry(
 			&self.trie_backend,

--- a/polkadot/primitives/src/v9/mod.rs
+++ b/polkadot/primitives/src/v9/mod.rs
@@ -283,34 +283,6 @@ pub mod well_known_keys {
 		})
 	}
 
-	/// The upward message dispatch queue for the given para id.
-	///
-	/// The storage entry stores a tuple of two values:
-	///
-	/// - `count: u32`, the number of messages currently in the queue for given para,
-	/// - `total_size: u32`, the total size of all messages in the queue.
-	#[deprecated = "Use `relay_dispatch_queue_remaining_capacity` instead"]
-	pub fn relay_dispatch_queue_size(para_id: Id) -> Vec<u8> {
-		let prefix = hex!["f5207f03cfdce586301014700e2c2593fad157e461d71fd4c1f936839a5f1f3e"];
-
-		para_id.using_encoded(|para_id: &[u8]| {
-			prefix
-				.as_ref()
-				.iter()
-				.chain(twox_64(para_id).iter())
-				.chain(para_id.iter())
-				.cloned()
-				.collect()
-		})
-	}
-
-	/// Type safe version of `relay_dispatch_queue_size`.
-	#[deprecated = "Use `relay_dispatch_queue_remaining_capacity` instead"]
-	pub fn relay_dispatch_queue_size_typed(para: Id) -> WellKnownKey<(u32, u32)> {
-		#[allow(deprecated)]
-		relay_dispatch_queue_size(para).into()
-	}
-
 	/// The upward message dispatch queue remaining capacity for the given para id.
 	///
 	/// The storage entry stores a tuple of two values:

--- a/polkadot/runtime/parachains/src/inclusion/mod.rs
+++ b/polkadot/runtime/parachains/src/inclusion/mod.rs
@@ -1194,10 +1194,7 @@ impl<T: Config> OnQueueChanged<AggregateMessageOrigin> for Pallet<T> {
 			AggregateMessageOrigin::Ump(UmpQueueId::Para(p)) => p,
 		};
 		let QueueFootprint { storage: Footprint { count, size }, .. } = fp;
-		let (count, size) = (count.saturated_into(), size.saturated_into());
-		// TODO paritytech/polkadot#6283: Remove all usages of `relay_dispatch_queue_size`
-		#[allow(deprecated)]
-		well_known_keys::relay_dispatch_queue_size_typed(para).set((count, size));
+		let (count, size): (u32, u32) = (count.saturated_into(), size.saturated_into());
 
 		let config = configuration::ActiveConfig::<T>::get();
 		let remaining_count = config.max_upward_queue_count.saturating_sub(count);

--- a/polkadot/runtime/parachains/src/ump_tests.rs
+++ b/polkadot/runtime/parachains/src/ump_tests.rs
@@ -35,7 +35,7 @@ use polkadot_primitives::{
 	well_known_keys, ClaimQueueOffset, CoreSelector, Id as ParaId, UMPSignal, UpwardMessage,
 	UMP_SEPARATOR,
 };
-use sp_crypto_hashing::{blake2_256, twox_64};
+use sp_crypto_hashing::blake2_256;
 use sp_runtime::traits::Bounded;
 
 pub(super) struct GenesisConfigBuilder {
@@ -416,29 +416,10 @@ fn relay_dispatch_queue_size_is_updated() {
 	});
 }
 
-/// Assert that the old and the new way of accessing `relay_dispatch_queue_size` is the same.
 #[test]
-fn relay_dispatch_queue_size_key_is_correct() {
-	#![allow(deprecated)]
-	// Storage alias to the old way of accessing the queue size.
-	#[frame_support::storage_alias]
-	type RelayDispatchQueueSize = StorageMap<Ump, Twox64Concat, ParaId, (u32, u32), ValueQuery>;
-
-	for i in 0..1024 {
-		// A "random" para id.
-		let para: ParaId = u32::from_ne_bytes(twox_64(&i.encode())[..4].try_into().unwrap()).into();
-
-		let well_known = polkadot_primitives::well_known_keys::relay_dispatch_queue_size(para);
-		let aliased = RelayDispatchQueueSize::hashed_key_for(para);
-
-		assert_eq!(well_known, aliased, "Old and new key must match");
-	}
-}
-
-#[test]
-fn verify_relay_dispatch_queue_size_is_externally_accessible() {
-	// Make sure that the relay dispatch queue size storage entry is accessible via well known
-	// keys and is decodable into a (u32, u32).
+fn verify_relay_dispatch_queue_remaining_capacity_is_externally_accessible() {
+	// Make sure that the relay dispatch queue remaining capacity storage entry is accessible via
+	// well known keys and is decodable into a (u32, u32).
 	new_test_ext(GenesisConfigBuilder::default().build()).execute_with(|| {
 		let cfg = configuration::ActiveConfig::<Test>::get();
 
@@ -464,23 +445,13 @@ fn verify_relay_dispatch_queue_size_is_externally_accessible() {
 }
 
 fn assert_queue_size(para: ParaId, count: u32, size: u32) {
-	#[allow(deprecated)]
-	let raw_queue_size = sp_io::storage::get(&well_known_keys::relay_dispatch_queue_size(para))
-		.expect(
-			"enqueuing a message should create the dispatch queue\
-				and it should be accessible via the well known keys",
-		);
-	let (c, s) = <(u32, u32)>::decode(&mut &raw_queue_size[..])
-		.expect("the dispatch queue size should be decodable into (u32, u32)");
-	assert_eq!((c, s), (count, size));
-
-	// Test the deprecated but at least type-safe `relay_dispatch_queue_size_typed`:
-	#[allow(deprecated)]
-	let (c, s) = well_known_keys::relay_dispatch_queue_size_typed(para).get().expect(
-		"enqueuing a message should create the dispatch queue\
-				and it should be accessible via the well known keys",
+	let fp = MessageQueue::footprint(AggregateMessageOrigin::Ump(UmpQueueId::Para(para)));
+	assert_eq!(
+		(fp.storage.count as u32, fp.storage.size as u32),
+		(count, size),
+		"Wrong queue footprint for Q{}",
+		para,
 	);
-	assert_eq!((c, s), (count, size));
 }
 
 fn assert_queue_remaining(para: ParaId, count: u32, size: u32) {

--- a/prdoc/pr_12445.prdoc
+++ b/prdoc/pr_12445.prdoc
@@ -1,0 +1,31 @@
+title: Remove deprecated `relay_dispatch_queue_size` well-known keys
+
+doc:
+  - audience: Runtime Dev
+    description: |
+      Removes the long-deprecated `relay_dispatch_queue_size` and
+      `relay_dispatch_queue_size_typed` helpers from `polkadot_primitives::well_known_keys`.
+      Use `relay_dispatch_queue_remaining_capacity` instead, which exposes the remaining
+      capacity of a parachain's upward message queue rather than its raw size.
+
+      As part of this, the relay chain no longer writes the deprecated
+      `relay_dispatch_queue_size` storage entry from `pallet-inclusion`'s
+      `on_queue_changed` hook; only `relay_dispatch_queue_remaining_capacity` is written.
+  - audience: Node Dev
+    description: |
+      The parachain inherent no longer includes the deprecated `relay_dispatch_queue_size`
+      key in the relay chain storage proof. When reading the messaging state snapshot,
+      `cumulus-pallet-parachain-system` now reads `relay_dispatch_queue_remaining_capacity`
+      directly, falling back to the full configured queue capacity when the entry is absent
+      (i.e. a parachain that has never sent an upward message). `Decode`/`Proof` errors are
+      still rejected. This removes the previous fallback to the deprecated queue-size key.
+
+crates:
+  - name: polkadot-primitives
+    bump: major
+  - name: polkadot-runtime-parachains
+    bump: minor
+  - name: cumulus-pallet-parachain-system
+    bump: minor
+  - name: cumulus-client-parachain-inherent
+    bump: patch


### PR DESCRIPTION
closes #12330 

Removes the deprecated `relay_dispatch_queue_size`/`relay_dispatch_queue_size_typed` well-known keys and migrates all relay-chain writers and parachain readers to `relay_dispatch_queue_remaining_capacity`, falling back to the full configured queue capacity when the entry is absent.
