### PR TITLE
statement-store: DHT PoC Add v2 topology-size metrics

### DIFF
--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -418,8 +418,11 @@ impl StatementHandlerPrototype {
 
 		let metrics =
 			if let Some(r) = metrics_registry { Some(Metrics::register(r)?) } else { None };
-		let v2dht_metrics =
-			if let Some(r) = metrics_registry { Some(V2DhtMetrics::register(r)?) } else { None };
+		let v2dht_metrics = if let (true, Some(r)) = (v2dht_enabled(), metrics_registry) {
+			Some(V2DhtMetrics::register(r)?)
+		} else {
+			None
+		};
 
 		for _ in 0..num_submission_workers {
 			let store = statement_store.clone();

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -77,7 +77,7 @@ use std::{
 	time::Instant,
 };
 use tokio::time::timeout;
-use v2dht::V2DhtOrchestrator;
+use v2dht::{V2DhtMetrics, V2DhtOrchestrator};
 pub mod config;
 #[cfg(test)]
 mod test_helpers;
@@ -418,6 +418,8 @@ impl StatementHandlerPrototype {
 
 		let metrics =
 			if let Some(r) = metrics_registry { Some(Metrics::register(r)?) } else { None };
+		let v2dht_metrics =
+			if let Some(r) = metrics_registry { Some(V2DhtMetrics::register(r)?) } else { None };
 
 		for _ in 0..num_submission_workers {
 			let store = statement_store.clone();
@@ -470,6 +472,7 @@ impl StatementHandlerPrototype {
 			network.local_peer_id(),
 			PeersTopologyConfig::default(),
 			self.protocol_name.clone(),
+			v2dht_metrics,
 		);
 		let handler = StatementHandler {
 			protocol_name: self.protocol_name,
@@ -759,6 +762,7 @@ where
 			local_peer,
 			PeersTopologyConfig::default(),
 			protocol_name.clone(),
+			None,
 		);
 		Self {
 			protocol_name,
@@ -2266,6 +2270,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 		(handler, statement_store, network, notification_service, queue_receiver, peer_ids)
@@ -2599,6 +2604,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 		(handler, statement_store, network, notification_service)
@@ -2651,6 +2657,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 		(handler, statement_store, network, notification_service)
@@ -4077,6 +4084,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 
@@ -4441,6 +4449,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 
@@ -4515,6 +4524,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 
@@ -4601,6 +4611,7 @@ mod tests {
 				network.local_peer_id(),
 				PeersTopologyConfig::default(),
 				"/statement/test".into(),
+				None,
 			),
 		};
 
@@ -4711,6 +4722,7 @@ mod tests {
 						local_peer,
 						PeersTopologyConfig::default(),
 						"/statement/test".into(),
+						None,
 					),
 				}
 			};

--- a/substrate/client/network/statement/src/v2dht/metrics.rs
+++ b/substrate/client/network/statement/src/v2dht/metrics.rs
@@ -1,0 +1,56 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Prometheus metrics for the v2 DHT gossip path.
+
+use prometheus_endpoint::{register, Gauge, PrometheusError, Registry, U64};
+
+#[derive(Clone)]
+pub(crate) struct V2DhtMetrics {
+	/// Statement-store peers known to the topology, including peers without confirmed protocol
+	/// support.
+	known_peers: Gauge<U64>,
+	/// Statement-store peers with an open statement notification substream.
+	connected_peers: Gauge<U64>,
+}
+
+impl V2DhtMetrics {
+	pub(crate) fn register(r: &Registry) -> Result<Self, PrometheusError> {
+		Ok(Self {
+			known_peers: register(
+				Gauge::new(
+					"substrate_sync_statement_v2dht_known_peers",
+					"Statement-store peers known to the v2 DHT topology, including peers without confirmed protocol support",
+				)?,
+				r,
+			)?,
+			connected_peers: register(
+				Gauge::new(
+					"substrate_sync_statement_v2dht_connected_peers",
+					"Statement-store peers with an open statement notification substream",
+				)?,
+				r,
+			)?,
+		})
+	}
+
+	pub(crate) fn set_topology_size(&self, known_peers: usize, connected_peers: usize) {
+		self.known_peers.set(known_peers as u64);
+		self.connected_peers.set(connected_peers as u64);
+	}
+}

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -19,9 +19,12 @@
 //! DHT-targeted gossip path for the statement protocol.
 
 mod explicit_affinity;
+mod metrics;
 mod peer_steering;
 mod peers_index;
 pub mod peers_topology;
+
+pub(crate) use metrics::V2DhtMetrics;
 
 use crate::{affinity::AffinityFilter, LOG_TARGET};
 use explicit_affinity::{AffinitySource, ExplicitAffinity};
@@ -41,6 +44,8 @@ pub(crate) struct V2DhtOrchestrator {
 	explicit_affinity: ExplicitAffinity,
 	/// Keeps the connected peer set aligned with the peers needed to cover subscriptions.
 	peer_steering: PeerSteering,
+	/// Prometheus metrics.
+	metrics: Option<V2DhtMetrics>,
 }
 
 #[allow(dead_code)]
@@ -50,20 +55,33 @@ impl V2DhtOrchestrator {
 		local_peer: PeerId,
 		peers_topology_config: PeersTopologyConfig,
 		protocol: ProtocolName,
+		metrics: Option<V2DhtMetrics>,
 	) -> Self {
 		Self {
 			peers_topology: PeersTopology::new(local_peer, peers_topology_config),
 			explicit_affinity: ExplicitAffinity::new(configured_topics),
 			peer_steering: PeerSteering::new(protocol),
+			metrics,
+		}
+	}
+
+	fn report_topology_size(&self) {
+		if let Some(metrics) = &self.metrics {
+			metrics.set_topology_size(
+				self.peers_topology.known_peers_count(),
+				self.peers_topology.connected_peers().count(),
+			);
 		}
 	}
 
 	pub(crate) fn on_peers_discovered(&mut self, peers: impl IntoIterator<Item = PeerId>) {
 		self.peers_topology.on_peers_discovered(peers);
+		self.report_topology_size();
 	}
 
 	pub(crate) fn on_peer_identified(&mut self, peer: PeerId, supports_statement_protocol: bool) {
 		self.peers_topology.on_peer_identified(peer, supports_statement_protocol);
+		self.report_topology_size();
 	}
 
 	// === RPC-subscription source ===
@@ -113,12 +131,14 @@ impl V2DhtOrchestrator {
 	pub(crate) fn on_substream_opened(&mut self, peer: PeerId) {
 		self.peers_topology.on_substream_opened(peer);
 		self.peer_steering.on_substream_opened(peer);
+		self.report_topology_size();
 		log::trace!(target: LOG_TARGET, "v2dht: on_substream_opened {peer}");
 	}
 
 	pub(crate) fn on_substream_closed(&mut self, peer: PeerId) {
 		self.peers_topology.on_substream_closed(peer);
 		self.peer_steering.on_substream_closed(peer);
+		self.report_topology_size();
 		log::trace!(target: LOG_TARGET, "v2dht: on_substream_closed {peer}");
 	}
 
@@ -228,13 +248,14 @@ mod tests {
 			PeerId::random(),
 			PeersTopologyConfig::default(),
 			"/statement/test".into(),
+			None,
 		)
 	}
 
 	/// Like [`orchestrator`] but with a deterministic local identity, so the XOR routing
 	/// distances the propagation tests assert on stay reproducible across runs.
 	fn orchestrator_with(local_seed: u8, config: PeersTopologyConfig) -> V2DhtOrchestrator {
-		V2DhtOrchestrator::new(&[], peer(local_seed), config, "/statement/test".into())
+		V2DhtOrchestrator::new(&[], peer(local_seed), config, "/statement/test".into(), None)
 	}
 
 	fn statement(seed: u8, topics: &[Topic]) -> (Hash, Statement) {
@@ -313,6 +334,7 @@ mod tests {
 			PeerId::random(),
 			topology_config(20, 1),
 			"/statement/test".into(),
+			None,
 		);
 
 		let mask = orchestrator.retention_reasons_for(&statement_on(topic(1)));
@@ -329,6 +351,7 @@ mod tests {
 			PeerId::random(),
 			topology_config(20, 1),
 			"/statement/test".into(),
+			None,
 		);
 
 		let mask = orchestrator.retention_reasons_for(&statement_on(topic(9)));
@@ -345,6 +368,7 @@ mod tests {
 			PeerId::random(),
 			topology_config(1, 1),
 			"/statement/test".into(),
+			None,
 		);
 		let peers = (0..32).map(|_| PeerId::random()).collect::<Vec<_>>();
 		orchestrator.on_peers_discovered(peers.clone());
@@ -405,6 +429,7 @@ mod tests {
 			PeerId::random(),
 			PeersTopologyConfig::default(),
 			"/statement/test".into(),
+			None,
 		);
 
 		let peers: Vec<PeerId> = (0..5).map(|_| PeerId::random()).collect();


### PR DESCRIPTION
## What

Adds the first Prometheus metrics for the v2 DHT gossip path: two gauges that
report the size of the locally learned peer topology.

| Metric | Type | Meaning |
|--------|------|---------|
| `substrate_sync_statement_v2dht_known_peers` | Gauge | Statement-store peers known to the topology, including peers without confirmed protocol support |
| `substrate_sync_statement_v2dht_connected_peers` | Gauge | Statement-store peers with an open statement notification substream |

## How

- **`v2dht/metrics.rs`** (new) – `V2DhtMetrics` holds the two `Gauge<U64>` and
  registers them against the node's shared `Registry`, following the existing
  `Metrics` pattern in `lib.rs` (plain `Gauge::new(name, help)`, `register(..)`,
  `substrate_sync_statement_*` prefix).
- **`v2dht/mod.rs`** – `V2DhtOrchestrator` owns `Option<V2DhtMetrics>` and a
  private `report_topology_size()` that samples the gauges from `PeersTopology`
  after each event that changes the count: `on_peers_discovered`,
  `on_peer_identified`, `on_substream_opened`, `on_substream_closed`.
- **`lib.rs`** – registers `V2DhtMetrics` when a metrics registry is present and
  passes it into the orchestrator; the test constructor passes `None`.