### PR TITLE
statement-store: opt-in CLI flags for v2 DHT-affinity routing

### DIFF
--- a/cumulus/polkadot-omni-node/lib/src/cli.rs
+++ b/cumulus/polkadot-omni-node/lib/src/cli.rs
@@ -272,12 +272,6 @@ pub struct Cli<Config: CliConfig> {
 	#[arg(long = "statement-affinity-topic", value_name = "TOPIC")]
 	pub statement_affinity_topics: Vec<sc_statement_store::Topic>,
 
-	/// Enable the v2 DHT-affinity statement routing path instead of the legacy flood path.
-	///
-	/// Only relevant when `--enable-statement-store` is used.
-	#[arg(long = "enable-statement-store-v2-dht", default_value_t = false)]
-	pub statement_enable_v2_dht: bool,
-
 	/// Number of K-closest peers (replication factor) used for DHT-affinity statement routing.
 	///
 	/// Only relevant when `--enable-statement-store` is used.
@@ -346,7 +340,6 @@ impl<Config: CliConfig> Cli<Config> {
 					network_workers: self.statement_network_workers,
 					rate_limit: self.statement_rate_limit,
 					affinity_topics: self.statement_affinity_topics.clone(),
-					v2dht_enabled: self.statement_enable_v2_dht,
 					replication_factor: self.statement_replication_factor,
 					gossip_target: self.statement_gossip_target,
 				},

--- a/cumulus/polkadot-omni-node/lib/src/cli.rs
+++ b/cumulus/polkadot-omni-node/lib/src/cli.rs
@@ -272,6 +272,24 @@ pub struct Cli<Config: CliConfig> {
 	#[arg(long = "statement-affinity-topic", value_name = "TOPIC")]
 	pub statement_affinity_topics: Vec<sc_statement_store::Topic>,
 
+	/// Enable the v2 DHT-affinity statement routing path instead of the legacy flood path.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long = "enable-statement-store-v2-dht", default_value_t = false)]
+	pub statement_enable_v2_dht: bool,
+
+	/// Number of K-closest peers (replication factor) used for DHT-affinity statement routing.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "K", default_value_t = sc_statement_store::DEFAULT_REPLICATION_FACTOR)]
+	pub statement_replication_factor: std::num::NonZeroUsize,
+
+	/// Number of peers to gossip a statement to in addition to DHT-affinity routing targets.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "N", default_value_t = sc_statement_store::DEFAULT_GOSSIP_TARGET)]
+	pub statement_gossip_target: std::num::NonZeroUsize,
+
 	/// HOP (Hand-Off Protocol) configuration parameters.
 	#[command(flatten)]
 	pub hop: sc_hop::HopParams,
@@ -328,6 +346,9 @@ impl<Config: CliConfig> Cli<Config> {
 					network_workers: self.statement_network_workers,
 					rate_limit: self.statement_rate_limit,
 					affinity_topics: self.statement_affinity_topics.clone(),
+					v2dht_enabled: self.statement_enable_v2_dht,
+					replication_factor: self.statement_replication_factor,
+					gossip_target: self.statement_gossip_target,
 				},
 			),
 			storage_monitor: self.storage_monitor.clone(),

--- a/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
@@ -68,6 +68,9 @@ pub(crate) fn build_statement_store<
 	let network_workers = config.network_workers;
 	let rate_limit = config.rate_limit;
 	let affinity_topics = config.affinity_topics.clone();
+	let v2dht_enabled = config.v2dht_enabled;
+	let replication_factor = config.replication_factor;
+	let gossip_target = config.gossip_target;
 
 	let statement_store = sc_statement_store::Store::new_shared(
 		&parachain_config.data_path,
@@ -93,6 +96,9 @@ pub(crate) fn build_statement_store<
 		network_workers,
 		rate_limit,
 		&affinity_topics,
+		v2dht_enabled,
+		replication_factor,
+		gossip_target,
 	)?;
 	task_manager.spawn_handle().spawn(
 		"network-statement-handler",

--- a/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
@@ -68,7 +68,6 @@ pub(crate) fn build_statement_store<
 	let network_workers = config.network_workers;
 	let rate_limit = config.rate_limit;
 	let affinity_topics = config.affinity_topics.clone();
-	let v2dht_enabled = config.v2dht_enabled;
 	let replication_factor = config.replication_factor;
 	let gossip_target = config.gossip_target;
 
@@ -96,7 +95,6 @@ pub(crate) fn build_statement_store<
 		network_workers,
 		rate_limit,
 		&affinity_topics,
-		v2dht_enabled,
 		replication_factor,
 		gossip_target,
 	)?;

--- a/substrate/bin/node/cli/src/cli.rs
+++ b/substrate/bin/node/cli/src/cli.rs
@@ -89,6 +89,24 @@ pub struct Cli {
 	#[arg(long = "statement-affinity-topic", value_name = "TOPIC")]
 	pub statement_affinity_topics: Vec<sc_statement_store::Topic>,
 
+	/// Enable the v2 DHT-affinity statement routing path.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long = "enable-statement-store-v2-dht", default_value_t = false)]
+	pub statement_enable_v2_dht: bool,
+
+	/// DHT replication factor (K): number of closest peers a statement is routed to.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "K", default_value_t = sc_statement_store::DEFAULT_REPLICATION_FACTOR)]
+	pub statement_replication_factor: std::num::NonZeroUsize,
+
+	/// Number of peers to gossip a statement to within the affinity set.
+	///
+	/// Only relevant when `--enable-statement-store` is used.
+	#[arg(long, value_name = "N", default_value_t = sc_statement_store::DEFAULT_GOSSIP_TARGET)]
+	pub statement_gossip_target: std::num::NonZeroUsize,
+
 	#[allow(missing_docs)]
 	#[clap(flatten)]
 	pub storage_monitor: sc_storage_monitor::StorageMonitorParams,

--- a/substrate/bin/node/cli/src/cli.rs
+++ b/substrate/bin/node/cli/src/cli.rs
@@ -89,12 +89,6 @@ pub struct Cli {
 	#[arg(long = "statement-affinity-topic", value_name = "TOPIC")]
 	pub statement_affinity_topics: Vec<sc_statement_store::Topic>,
 
-	/// Enable the v2 DHT-affinity statement routing path.
-	///
-	/// Only relevant when `--enable-statement-store` is used.
-	#[arg(long = "enable-statement-store-v2-dht", default_value_t = false)]
-	pub statement_enable_v2_dht: bool,
-
 	/// DHT replication factor (K): number of closest peers a statement is routed to.
 	///
 	/// Only relevant when `--enable-statement-store` is used.

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -451,7 +451,6 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	let statement_network_workers = statement_store_config.network_workers;
 	let statement_rate_limit = statement_store_config.rate_limit;
 	let statement_affinity_topics = statement_store_config.affinity_topics.clone();
-	let statement_v2dht_enabled = statement_store_config.v2dht_enabled;
 	let statement_replication_factor = statement_store_config.replication_factor;
 	let statement_gossip_target = statement_store_config.gossip_target;
 
@@ -810,7 +809,6 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 		statement_network_workers,
 		statement_rate_limit,
 		&statement_affinity_topics,
-		statement_v2dht_enabled,
 		statement_replication_factor,
 		statement_gossip_target,
 	)?;
@@ -865,7 +863,6 @@ pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceE
 		network_workers: cli.statement_network_workers,
 		rate_limit: cli.statement_rate_limit,
 		affinity_topics: cli.statement_affinity_topics.clone(),
-		v2dht_enabled: cli.statement_enable_v2_dht,
 		replication_factor: cli.statement_replication_factor,
 		gossip_target: cli.statement_gossip_target,
 	};

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -451,6 +451,9 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	let statement_network_workers = statement_store_config.network_workers;
 	let statement_rate_limit = statement_store_config.rate_limit;
 	let statement_affinity_topics = statement_store_config.affinity_topics.clone();
+	let statement_v2dht_enabled = statement_store_config.v2dht_enabled;
+	let statement_replication_factor = statement_store_config.replication_factor;
+	let statement_gossip_target = statement_store_config.gossip_target;
 
 	let sc_service::PartialComponents {
 		client,
@@ -807,6 +810,9 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 		statement_network_workers,
 		statement_rate_limit,
 		&statement_affinity_topics,
+		statement_v2dht_enabled,
+		statement_replication_factor,
+		statement_gossip_target,
 	)?;
 	task_manager.spawn_handle().spawn(
 		"network-statement-handler",
@@ -859,6 +865,9 @@ pub fn new_full(config: Configuration, cli: Cli) -> Result<TaskManager, ServiceE
 		network_workers: cli.statement_network_workers,
 		rate_limit: cli.statement_rate_limit,
 		affinity_topics: cli.statement_affinity_topics.clone(),
+		v2dht_enabled: cli.statement_enable_v2_dht,
+		replication_factor: cli.statement_replication_factor,
+		gossip_target: cli.statement_gossip_target,
 	};
 
 	let task_manager = match config.network.network_backend {

--- a/substrate/client/network/statement/src/config.rs
+++ b/substrate/client/network/statement/src/config.rs
@@ -18,7 +18,7 @@
 
 //! Configuration of the statement protocol
 
-use std::time;
+use std::{num::NonZeroUsize, time};
 
 /// Interval at which we propagate statements;
 pub(crate) const PROPAGATE_TIMEOUT: time::Duration = time::Duration::from_millis(1000);
@@ -37,3 +37,11 @@ pub const DEFAULT_STATEMENTS_PER_SECOND: u32 = 50_000;
 
 /// Burst capacity coefficient for the rate limiter.
 pub const STATEMENTS_BURST_COEFFICIENT: u32 = 5;
+
+/// Default replication factor (K) for v2 DHT-affinity routing: number of statement-protocol peers
+/// responsible for storing a given topic.
+pub const DEFAULT_REPLICATION_FACTOR: NonZeroUsize = NonZeroUsize::new(20).expect("20 is non-zero");
+
+/// Default gossip target for v2 DHT-affinity routing: maximum number of connected peers we forward
+/// a statement to for a given topic.
+pub const DEFAULT_GOSSIP_TARGET: NonZeroUsize = NonZeroUsize::new(3).expect("3 is non-zero");

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -2266,7 +2266,8 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -2598,7 +2599,8 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -2649,7 +2651,8 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -4074,7 +4077,8 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -4437,7 +4441,8 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(pending().fuse()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -4510,7 +4515,8 @@ mod tests {
 			deferred_peers: deferred,
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(pending().fuse()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -4595,7 +4601,8 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: true,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
 				topology_config(20, 3),
@@ -4704,7 +4711,8 @@ mod tests {
 					deferred_peers: HashSet::new(),
 					dropped_statements_during_sync: dropped,
 					sync_recovery_peer: None,
-					sync_recovery_readd_timeout: Box::pin(pending().fuse()),					v2dht: V2DhtOrchestrator::new(
+					sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+					v2dht: V2DhtOrchestrator::new(
 						&[],
 						local_peer,
 						topology_config(20, 3),

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -166,13 +166,6 @@ const PENDING_AFFINITIES_INTERVAL: std::time::Duration = std::time::Duration::fr
 /// Delay before re-adding a peer to the reserved set after a forced disconnect for sync recovery.
 const SYNC_RECOVERY_READD_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// Feature-flag to switch between the legacy flood path and the new DHT-targeted path.
-///
-/// Hard-coded for now.
-const fn v2dht_enabled() -> bool {
-	false
-}
-
 struct Metrics {
 	propagated_statements: Counter<U64>,
 	known_statements_received: Counter<U64>,
@@ -391,6 +384,9 @@ impl StatementHandlerPrototype {
 		mut num_submission_workers: usize,
 		statements_per_second: u32,
 		configured_topics: &[Topic],
+		v2dht_enabled: bool,
+		replication_factor: std::num::NonZeroUsize,
+		gossip_target: std::num::NonZeroUsize,
 	) -> error::Result<StatementHandler<N, S>> {
 		let sync_event_stream = sync.event_stream("statement-handler-sync");
 		let (queue_sender, queue_receiver) = async_channel::bounded(MAX_PENDING_STATEMENTS);
@@ -452,7 +448,7 @@ impl StatementHandlerPrototype {
 			);
 		}
 
-		let network_event_stream = if v2dht_enabled() {
+		let network_event_stream = if v2dht_enabled {
 			network
 				.event_stream("statement-handler-network")
 				.filter(|event| {
@@ -468,7 +464,7 @@ impl StatementHandlerPrototype {
 		let v2dht = V2DhtOrchestrator::new(
 			configured_topics,
 			network.local_peer_id(),
-			PeersTopologyConfig::default(),
+			PeersTopologyConfig { replication_factor, gossip_target },
 			self.protocol_name.clone(),
 		);
 		let handler = StatementHandler {
@@ -499,6 +495,7 @@ impl StatementHandlerPrototype {
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
 			v2dht,
+			v2dht_enabled,
 		};
 
 		Ok(handler)
@@ -557,8 +554,11 @@ pub struct StatementHandler<
 	sync_recovery_peer: Option<PeerId>,
 	/// Fires when the `sync_recovery_peer` re-add delay has elapsed
 	sync_recovery_readd_timeout: Pin<Box<dyn FusedFuture<Output = ()> + Send>>,
-	/// Only invoked when [`v2dht_enabled`] returns `true`.
+	/// Orchestrates the v2 DHT-affinity path. Only driven when `v2dht_enabled` is `true`.
 	v2dht: V2DhtOrchestrator,
+	/// Selects the v2 DHT-affinity path. Off by default; opt in via
+	/// `--enable-statement-store-v2-dht`.
+	v2dht_enabled: bool,
 }
 
 /// Per-peer rate limiter using a token bucket algorithm.
@@ -786,6 +786,7 @@ where
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
 			v2dht,
+			v2dht_enabled: false,
 		}
 	}
 
@@ -843,7 +844,7 @@ where
 					}
 				}
 				_ = &mut self.initial_sync_timeout => {
-					if v2dht_enabled() {
+					if self.v2dht_enabled {
 						self.v2dht.on_initial_sync().await;
 					}
 					self.process_initial_sync_burst().await;
@@ -851,7 +852,7 @@ where
 						Box::pin(tokio::time::sleep(INITIAL_SYNC_BURST_INTERVAL).fuse());
 				},
 				_ = &mut self.pending_affinities_timeout => {
-					if v2dht_enabled() {
+					if self.v2dht_enabled {
 						// Advertise this node's filter changes before serving peers their backlog.
 						let topics = self.statement_store.subscription_topics();
 						self.v2dht.set_rpc_subscription_topics(&topics);
@@ -882,7 +883,7 @@ where
 			}
 
 			if !self.sync.is_major_syncing() {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_major_sync_end();
 				} else {
 					self.drain_deferred_peers();
@@ -894,8 +895,8 @@ where
 
 	/// Handle a network topology event.
 	///
-	/// The network event stream is `pending()` unless `v2dht_enabled()`, so this runs only on the
-	/// v2 DHT path.
+	/// The network event stream is `pending()` unless `v2dht_enabled` is set, so this runs only on
+	/// the v2 DHT path.
 	fn handle_network_event(&mut self, event: Event) {
 		match event {
 			Event::PeerRoutingTableUpdate(peers) => self.v2dht.on_peers_discovered(peers),
@@ -1093,7 +1094,7 @@ where
 	fn handle_sync_event(&mut self, event: SyncEvent) {
 		match event {
 			SyncEvent::PeerConnected(remote) => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_peer_connected(remote);
 				}
 				if self.sync.is_major_syncing() {
@@ -1115,7 +1116,7 @@ where
 				}
 			},
 			SyncEvent::PeerDisconnected(remote) => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_peer_disconnected(remote);
 				}
 				if self.deferred_peers.remove(&remote) {
@@ -1135,7 +1136,7 @@ where
 	async fn handle_notification_event(&mut self, event: NotificationEvent) {
 		match event {
 			NotificationEvent::ValidateInboundSubstream { peer, handshake, result_tx, .. } => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_validate_inbound_substream(peer)
 				}
 				// Only accept peers whose role can be determined
@@ -1198,7 +1199,7 @@ where
 					}
 				});
 
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					if !is_light {
 						// TODO: Do we need to pass light nodes to the Orchestrator?
 						self.v2dht.on_substream_opened(peer);
@@ -1213,7 +1214,7 @@ where
 				}
 			},
 			NotificationEvent::NotificationStreamClosed { peer } => {
-				if v2dht_enabled() {
+				if self.v2dht_enabled {
 					self.v2dht.on_substream_closed(peer);
 				}
 				let removed_peer = self.peers.remove(&peer);
@@ -1279,7 +1280,7 @@ where
 									self.on_statements(peer, statements);
 								},
 								StatementMessage::ExplicitTopicAffinity(filter) => {
-									if v2dht_enabled() {
+									if self.v2dht_enabled {
 										self.v2dht.on_peer_filter_update(peer, filter);
 									} else if let Some(peer_data) = self.peers.get_mut(&peer) {
 										if peer_data.rate_limiter.is_flooding(1) {
@@ -1382,7 +1383,7 @@ where
 
 				match self.pending_statements_peers.entry(hash) {
 					Entry::Vacant(entry) => {
-						let mask = if v2dht_enabled() {
+						let mask = if self.v2dht_enabled {
 							self.v2dht.retention_reasons_for(&s)
 						} else {
 							RetentionReasonMask::persistent()
@@ -1427,7 +1428,7 @@ where
 	}
 
 	fn on_handle_statement_import(&mut self, who: PeerId, import: &SubmitResult) {
-		if v2dht_enabled() {
+		if self.v2dht_enabled {
 			self.v2dht.on_statement_imported(who, import);
 		}
 		match import {
@@ -1571,7 +1572,7 @@ where
 			return;
 		}
 
-		if v2dht_enabled() {
+		if self.v2dht_enabled {
 			for (who, indices) in self.v2dht.propagation_plan(&statements) {
 				self.send_targeted_statements_to_peer(&who, &statements, &indices).await;
 			}
@@ -2261,6 +2262,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -2594,6 +2596,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -2646,6 +2649,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4072,6 +4076,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4436,6 +4441,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4510,6 +4516,7 @@ mod tests {
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4596,6 +4603,7 @@ mod tests {
 			dropped_statements_during_sync: true,
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
+			v2dht_enabled: false,
 			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
@@ -4706,6 +4714,7 @@ mod tests {
 					dropped_statements_during_sync: dropped,
 					sync_recovery_peer: None,
 					sync_recovery_readd_timeout: Box::pin(pending().fuse()),
+					v2dht_enabled: false,
 					v2dht: V2DhtOrchestrator::new(
 						&[],
 						local_peer,

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -166,6 +166,13 @@ const PENDING_AFFINITIES_INTERVAL: std::time::Duration = std::time::Duration::fr
 /// Delay before re-adding a peer to the reserved set after a forced disconnect for sync recovery.
 const SYNC_RECOVERY_READD_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Feature-flag to switch between the legacy flood path and the new DHT-targeted path.
+///
+/// Off by default; enable the v2 DHT path by setting `STATEMENT_STORE_V2_DHT_ENABLED=1`.
+fn v2dht_enabled() -> bool {
+	std::env::var_os("STATEMENT_STORE_V2_DHT_ENABLED").map_or(false, |value| value == "1")
+}
+
 struct Metrics {
 	propagated_statements: Counter<U64>,
 	known_statements_received: Counter<U64>,
@@ -384,7 +391,6 @@ impl StatementHandlerPrototype {
 		mut num_submission_workers: usize,
 		statements_per_second: u32,
 		configured_topics: &[Topic],
-		v2dht_enabled: bool,
 		replication_factor: std::num::NonZeroUsize,
 		gossip_target: std::num::NonZeroUsize,
 	) -> error::Result<StatementHandler<N, S>> {
@@ -448,7 +454,7 @@ impl StatementHandlerPrototype {
 			);
 		}
 
-		let network_event_stream = if v2dht_enabled {
+		let network_event_stream = if v2dht_enabled() {
 			network
 				.event_stream("statement-handler-network")
 				.filter(|event| {
@@ -495,7 +501,6 @@ impl StatementHandlerPrototype {
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
 			v2dht,
-			v2dht_enabled,
 		};
 
 		Ok(handler)
@@ -554,11 +559,8 @@ pub struct StatementHandler<
 	sync_recovery_peer: Option<PeerId>,
 	/// Fires when the `sync_recovery_peer` re-add delay has elapsed
 	sync_recovery_readd_timeout: Pin<Box<dyn FusedFuture<Output = ()> + Send>>,
-	/// Orchestrates the v2 DHT-affinity path. Only driven when `v2dht_enabled` is `true`.
+	/// Only invoked when [`v2dht_enabled`] returns `true`.
 	v2dht: V2DhtOrchestrator,
-	/// Selects the v2 DHT-affinity path. Off by default; opt in via
-	/// `--enable-statement-store-v2-dht`.
-	v2dht_enabled: bool,
 }
 
 /// Per-peer rate limiter using a token bucket algorithm.
@@ -757,7 +759,10 @@ where
 		let v2dht = V2DhtOrchestrator::new(
 			&[],
 			local_peer,
-			PeersTopologyConfig::default(),
+			PeersTopologyConfig {
+				replication_factor: crate::config::DEFAULT_REPLICATION_FACTOR,
+				gossip_target: crate::config::DEFAULT_GOSSIP_TARGET,
+			},
 			protocol_name.clone(),
 		);
 		Self {
@@ -786,7 +791,6 @@ where
 			sync_recovery_peer: None,
 			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
 			v2dht,
-			v2dht_enabled: false,
 		}
 	}
 
@@ -844,7 +848,7 @@ where
 					}
 				}
 				_ = &mut self.initial_sync_timeout => {
-					if self.v2dht_enabled {
+					if v2dht_enabled() {
 						self.v2dht.on_initial_sync().await;
 					}
 					self.process_initial_sync_burst().await;
@@ -852,7 +856,7 @@ where
 						Box::pin(tokio::time::sleep(INITIAL_SYNC_BURST_INTERVAL).fuse());
 				},
 				_ = &mut self.pending_affinities_timeout => {
-					if self.v2dht_enabled {
+					if v2dht_enabled() {
 						// Advertise this node's filter changes before serving peers their backlog.
 						let topics = self.statement_store.subscription_topics();
 						self.v2dht.set_rpc_subscription_topics(&topics);
@@ -883,7 +887,7 @@ where
 			}
 
 			if !self.sync.is_major_syncing() {
-				if self.v2dht_enabled {
+				if v2dht_enabled() {
 					self.v2dht.on_major_sync_end();
 				} else {
 					self.drain_deferred_peers();
@@ -895,8 +899,8 @@ where
 
 	/// Handle a network topology event.
 	///
-	/// The network event stream is `pending()` unless `v2dht_enabled` is set, so this runs only on
-	/// the v2 DHT path.
+	/// The network event stream is `pending()` unless `v2dht_enabled()`, so this runs only on the
+	/// v2 DHT path.
 	fn handle_network_event(&mut self, event: Event) {
 		match event {
 			Event::PeerRoutingTableUpdate(peers) => self.v2dht.on_peers_discovered(peers),
@@ -1094,7 +1098,7 @@ where
 	fn handle_sync_event(&mut self, event: SyncEvent) {
 		match event {
 			SyncEvent::PeerConnected(remote) => {
-				if self.v2dht_enabled {
+				if v2dht_enabled() {
 					self.v2dht.on_peer_connected(remote);
 				}
 				if self.sync.is_major_syncing() {
@@ -1116,7 +1120,7 @@ where
 				}
 			},
 			SyncEvent::PeerDisconnected(remote) => {
-				if self.v2dht_enabled {
+				if v2dht_enabled() {
 					self.v2dht.on_peer_disconnected(remote);
 				}
 				if self.deferred_peers.remove(&remote) {
@@ -1136,7 +1140,7 @@ where
 	async fn handle_notification_event(&mut self, event: NotificationEvent) {
 		match event {
 			NotificationEvent::ValidateInboundSubstream { peer, handshake, result_tx, .. } => {
-				if self.v2dht_enabled {
+				if v2dht_enabled() {
 					self.v2dht.on_validate_inbound_substream(peer)
 				}
 				// Only accept peers whose role can be determined
@@ -1199,7 +1203,7 @@ where
 					}
 				});
 
-				if self.v2dht_enabled {
+				if v2dht_enabled() {
 					if !is_light {
 						// TODO: Do we need to pass light nodes to the Orchestrator?
 						self.v2dht.on_substream_opened(peer);
@@ -1214,7 +1218,7 @@ where
 				}
 			},
 			NotificationEvent::NotificationStreamClosed { peer } => {
-				if self.v2dht_enabled {
+				if v2dht_enabled() {
 					self.v2dht.on_substream_closed(peer);
 				}
 				let removed_peer = self.peers.remove(&peer);
@@ -1280,7 +1284,7 @@ where
 									self.on_statements(peer, statements);
 								},
 								StatementMessage::ExplicitTopicAffinity(filter) => {
-									if self.v2dht_enabled {
+									if v2dht_enabled() {
 										self.v2dht.on_peer_filter_update(peer, filter);
 									} else if let Some(peer_data) = self.peers.get_mut(&peer) {
 										if peer_data.rate_limiter.is_flooding(1) {
@@ -1383,7 +1387,7 @@ where
 
 				match self.pending_statements_peers.entry(hash) {
 					Entry::Vacant(entry) => {
-						let mask = if self.v2dht_enabled {
+						let mask = if v2dht_enabled() {
 							self.v2dht.retention_reasons_for(&s)
 						} else {
 							RetentionReasonMask::persistent()
@@ -1428,7 +1432,7 @@ where
 	}
 
 	fn on_handle_statement_import(&mut self, who: PeerId, import: &SubmitResult) {
-		if self.v2dht_enabled {
+		if v2dht_enabled() {
 			self.v2dht.on_statement_imported(who, import);
 		}
 		match import {
@@ -1572,7 +1576,7 @@ where
 			return;
 		}
 
-		if self.v2dht_enabled {
+		if v2dht_enabled() {
 			for (who, indices) in self.v2dht.propagation_plan(&statements) {
 				self.send_targeted_statements_to_peer(&who, &statements, &indices).await;
 			}
@@ -1753,6 +1757,7 @@ where
 mod tests {
 
 	use super::*;
+	use crate::test_helpers::topology_config;
 	use std::sync::{
 		atomic::{AtomicBool, Ordering},
 		Mutex,
@@ -2261,12 +2266,10 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -2595,12 +2598,10 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -2648,12 +2649,10 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -4075,12 +4074,10 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -4440,12 +4437,10 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(pending().fuse()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -4515,12 +4510,10 @@ mod tests {
 			deferred_peers: deferred,
 			dropped_statements_during_sync: false,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(pending().fuse()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(pending().fuse()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -4602,12 +4595,10 @@ mod tests {
 			deferred_peers: HashSet::new(),
 			dropped_statements_during_sync: true,
 			sync_recovery_peer: None,
-			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),
-			v2dht_enabled: false,
-			v2dht: V2DhtOrchestrator::new(
+			sync_recovery_readd_timeout: Box::pin(futures::future::pending()),			v2dht: V2DhtOrchestrator::new(
 				&[],
 				network.local_peer_id(),
-				PeersTopologyConfig::default(),
+				topology_config(20, 3),
 				"/statement/test".into(),
 			),
 		};
@@ -4713,12 +4704,10 @@ mod tests {
 					deferred_peers: HashSet::new(),
 					dropped_statements_during_sync: dropped,
 					sync_recovery_peer: None,
-					sync_recovery_readd_timeout: Box::pin(pending().fuse()),
-					v2dht_enabled: false,
-					v2dht: V2DhtOrchestrator::new(
+					sync_recovery_readd_timeout: Box::pin(pending().fuse()),					v2dht: V2DhtOrchestrator::new(
 						&[],
 						local_peer,
-						PeersTopologyConfig::default(),
+						topology_config(20, 3),
 						"/statement/test".into(),
 					),
 				}

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -226,7 +226,7 @@ mod tests {
 		V2DhtOrchestrator::new(
 			&[],
 			PeerId::random(),
-			PeersTopologyConfig::default(),
+			topology_config(20, 3),
 			"/statement/test".into(),
 		)
 	}
@@ -403,7 +403,7 @@ mod tests {
 		let mut orchestrator = V2DhtOrchestrator::new(
 			&[topic(1)],
 			PeerId::random(),
-			PeersTopologyConfig::default(),
+			topology_config(20, 3),
 			"/statement/test".into(),
 		);
 

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -42,8 +42,8 @@ pub struct PeersTopologyConfig {
 impl Default for PeersTopologyConfig {
 	fn default() -> Self {
 		Self {
-			replication_factor: NonZeroUsize::new(20).expect("20 is non-zero"),
-			gossip_target: NonZeroUsize::new(3).expect("3 is non-zero"),
+			replication_factor: crate::config::DEFAULT_REPLICATION_FACTOR,
+			gossip_target: crate::config::DEFAULT_GOSSIP_TARGET,
 		}
 	}
 }

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -39,15 +39,6 @@ pub struct PeersTopologyConfig {
 	pub gossip_target: NonZeroUsize,
 }
 
-impl Default for PeersTopologyConfig {
-	fn default() -> Self {
-		Self {
-			replication_factor: crate::config::DEFAULT_REPLICATION_FACTOR,
-			gossip_target: crate::config::DEFAULT_GOSSIP_TARGET,
-		}
-	}
-}
-
 #[derive(Debug, Clone)]
 struct PeerInfo {
 	supports_protocol: bool,

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -216,9 +216,6 @@ pub struct Config {
 	pub rate_limit: u32,
 	/// Topics this node advertises affinity for, so peers route matching statements to it.
 	pub affinity_topics: Vec<sp_statement_store::Topic>,
-	/// Selects the v2 DHT-affinity routing path over the legacy flood path. Off by default; the
-	/// v2 path is enabled per node via `--enable-statement-store-v2-dht`.
-	pub v2dht_enabled: bool,
 	/// Replication factor (K) for v2 DHT-affinity routing: number of statement-protocol peers
 	/// responsible for storing a given topic.
 	pub replication_factor: std::num::NonZeroUsize,
@@ -254,7 +251,6 @@ impl Default for Config {
 			network_workers: DEFAULT_NETWORK_WORKERS,
 			rate_limit: DEFAULT_RATE_LIMIT,
 			affinity_topics: Vec::new(),
-			v2dht_enabled: false,
 			replication_factor: DEFAULT_REPLICATION_FACTOR,
 			gossip_target: DEFAULT_GOSSIP_TARGET,
 		}

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -193,6 +193,12 @@ pub const DEFAULT_NETWORK_WORKERS: usize = 1;
 /// Default maximum statements per second per peer before rate limiting kicks in.
 pub use sc_network_statement::config::DEFAULT_STATEMENTS_PER_SECOND as DEFAULT_RATE_LIMIT;
 
+/// Default replication factor (K) for v2 DHT-affinity statement routing.
+pub use sc_network_statement::config::DEFAULT_REPLICATION_FACTOR;
+
+/// Default gossip target for v2 DHT-affinity statement routing.
+pub use sc_network_statement::config::DEFAULT_GOSSIP_TARGET;
+
 /// Statement store and network handler configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -210,6 +216,15 @@ pub struct Config {
 	pub rate_limit: u32,
 	/// Topics this node advertises affinity for, so peers route matching statements to it.
 	pub affinity_topics: Vec<sp_statement_store::Topic>,
+	/// Selects the v2 DHT-affinity routing path over the legacy flood path. Off by default; the
+	/// v2 path is enabled per node via `--enable-statement-store-v2-dht`.
+	pub v2dht_enabled: bool,
+	/// Replication factor (K) for v2 DHT-affinity routing: number of statement-protocol peers
+	/// responsible for storing a given topic.
+	pub replication_factor: std::num::NonZeroUsize,
+	/// Gossip target for v2 DHT-affinity routing: maximum number of connected peers we forward a
+	/// statement to for a given topic.
+	pub gossip_target: std::num::NonZeroUsize,
 }
 
 impl Config {
@@ -239,6 +254,9 @@ impl Default for Config {
 			network_workers: DEFAULT_NETWORK_WORKERS,
 			rate_limit: DEFAULT_RATE_LIMIT,
 			affinity_topics: Vec::new(),
+			v2dht_enabled: false,
+			replication_factor: DEFAULT_REPLICATION_FACTOR,
+			gossip_target: DEFAULT_GOSSIP_TARGET,
 		}
 	}
 }


### PR DESCRIPTION
Description

## Summary

Turns the v2 DHT-affinity statement routing path into a runtime opt-in
instead of a hard-coded compile-time constant.

Previously `v2dht_enabled()` was a `const fn` returning `false`, so the
flag through configuration and exposes it (plus its two tuning
parameters) on the CLI.