### PR TITLE
statement-store: v2 DHT e2e test for local-submission retention

### DIFF
--- a/.github/zombienet-tests/zombienet_cumulus_tests.yml
+++ b/.github/zombienet-tests/zombienet_cumulus_tests.yml
@@ -156,8 +156,3 @@
   test-filter: "zombie_ci::statement_store::integration::statement_store_lite_person_submit_and_propagate"
   runner-type: "default"
   cumulus-image: "test-parachain"
-
-- job-name: "zombienet-cumulus-0035-local_submission_retention_works"
-  test-filter: "zombie_ci::statement_store::integration_v2_dht::local_submission_retention_works"
-  runner-type: "default"
-  cumulus-image: "test-parachain"

--- a/.github/zombienet-tests/zombienet_cumulus_tests.yml
+++ b/.github/zombienet-tests/zombienet_cumulus_tests.yml
@@ -156,3 +156,8 @@
   test-filter: "zombie_ci::statement_store::integration::statement_store_lite_person_submit_and_propagate"
   runner-type: "default"
   cumulus-image: "test-parachain"
+
+- job-name: "zombienet-cumulus-0035-local_submission_retention_works"
+  test-filter: "zombie_ci::statement_store::integration_v2_dht::local_submission_retention_works"
+  runner-type: "default"
+  cumulus-image: "test-parachain"

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -414,6 +414,8 @@ pub(super) async fn stores_locally(
 	topic: Topic,
 	expected: &Bytes,
 ) -> Result<bool, anyhow::Error> {
+	// TODO: replace this subscription-replay probe with a direct "is this stored locally?" store
+	// query once the store exposes one.
 	let mut subscription = subscribe_topic(rpc, topic).await?;
 	loop {
 		let item = match tokio::time::timeout(Duration::from_secs(10), subscription.next()).await {

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -236,6 +236,7 @@ async fn launch_network(
 	collators: &[&str],
 	chain_spec_path: &Path,
 	collator_args: Vec<zombienet_sdk::Arg>,
+	collator_env: &[(&str, &str)],
 ) -> Result<Network<LocalFileSystem>, anyhow::Error> {
 	let images = zombienet_sdk::environment::get_images_from_env();
 	let base_dir = base_dir()?;
@@ -256,11 +257,11 @@ async fn launch_network(
 				.with_default_command("polkadot-parachain")
 				.with_default_image(images.cumulus.as_str())
 				.with_default_args(collator_args)
-				.with_collator(|n| n.with_name(collators[0]));
+				.with_collator(|n| n.with_name(collators[0]).with_env(collator_env.to_vec()));
 
-			collators[1..]
-				.iter()
-				.fold(p, |acc, &name| acc.with_collator(|n| n.with_name(name)))
+			collators[1..].iter().fold(p, |acc, &name| {
+				acc.with_collator(|n| n.with_name(name).with_env(collator_env.to_vec()))
+			})
 		})
 		.with_global_settings(|global_settings| {
 			global_settings
@@ -298,7 +299,7 @@ pub(super) async fn spawn_network_with_injected_allowances(
 	let base_dir = base_dir()?;
 	let chain_spec_path = create_chain_spec_with_allowances(participant_count, &base_dir)?;
 	let args = collator_args(participant_count, COLLATOR_TRACE_LOG_FILTER);
-	launch_network(collators, &chain_spec_path, args).await
+	launch_network(collators, &chain_spec_path, args, &[]).await
 }
 
 /// Spawns a network using `people-westend-local-spec.json`, waits for block production
@@ -316,7 +317,7 @@ async fn spawn_network_inner(
 	let participant_count_u32 = u32::try_from(participant_count)
 		.expect("participant_count must fit in u32 for collator args");
 	let args = collator_args(participant_count_u32, log_filter);
-	let network = launch_network(collators, &chain_spec_path, args).await?;
+	let network = launch_network(collators, &chain_spec_path, args, &[]).await?;
 
 	info!("Waiting for parachain to produce blocks...");
 	let node = network.get_node(collators[0])?;
@@ -360,4 +361,73 @@ pub(super) async fn wait_for_first_block(
 		.await?;
 	}
 	Ok(())
+}
+
+/// Builds collator CLI args that pin the v2 DHT replication factor `K` and gossip target, on top of
+/// [`collator_args`]. The v2 path itself is switched on by the `STATEMENT_STORE_V2_DHT_ENABLED`
+/// environment variable, not a CLI flag (see [`spawn_network_with_injected_allowances_v2`]).
+pub(super) fn collator_args_v2(
+	participant_count: u32,
+	log_filter: &str,
+	replication_factor: u32,
+	gossip_target: u32,
+) -> Vec<zombienet_sdk::Arg> {
+	let mut args = collator_args(participant_count, log_filter);
+	let replication = format!("--statement-replication-factor={replication_factor}");
+	args.push(replication.as_str().into());
+	let gossip = format!("--statement-gossip-target={gossip_target}");
+	args.push(gossip.as_str().into());
+	args
+}
+
+/// Spawns a network on the v2 DHT path with injected allowances, pinning `K` and the gossip target.
+///
+/// The v2 DHT path is gated by `v2dht_enabled()`, which reads `STATEMENT_STORE_V2_DHT_ENABLED`, so we
+/// set that on every collator rather than passing a CLI flag.
+pub(super) async fn spawn_network_with_injected_allowances_v2(
+	collators: &[&str],
+	participant_count: u32,
+	replication_factor: u32,
+	gossip_target: u32,
+) -> Result<Network<LocalFileSystem>, anyhow::Error> {
+	assert!(!collators.is_empty());
+	let base_dir = base_dir()?;
+	let chain_spec_path = create_chain_spec_with_allowances(participant_count, &base_dir)?;
+	let args = collator_args_v2(
+		participant_count,
+		COLLATOR_TRACE_LOG_FILTER,
+		replication_factor,
+		gossip_target,
+	);
+	launch_network(collators, &chain_spec_path, args, &[("STATEMENT_STORE_V2_DHT_ENABLED", "1")])
+		.await
+}
+
+/// Probes whether the node behind `rpc` persistently stores `expected` for `topic`.
+///
+/// A fresh subscription first replays every matching statement already in the store, ending the
+/// replay with `remaining == Some(0)` (or a single empty batch when the store holds none). We scan
+/// that replay for `expected`. Subscribing grants explicit affinity for *future* statements only, so
+/// the probe cannot turn an already-dropped statement into a stored one.
+pub(super) async fn stores_locally(
+	rpc: &RpcClient,
+	topic: Topic,
+	expected: &Bytes,
+) -> Result<bool, anyhow::Error> {
+	let mut subscription = subscribe_topic(rpc, topic).await?;
+	loop {
+		let item = match tokio::time::timeout(Duration::from_secs(10), subscription.next()).await {
+			Ok(Some(Ok(item))) => item,
+			// Timeout or stream end before `expected` appeared: the node does not store it.
+			_ => return Ok(false),
+		};
+		let StatementEvent::NewStatements { statements, remaining } = item;
+		if statements.iter().any(|s| s == expected) {
+			return Ok(true);
+		}
+		// The replay is done once a batch is empty or reports nothing more to come.
+		if statements.is_empty() || remaining == Some(0) {
+			return Ok(false);
+		}
+	}
 }

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -382,8 +382,8 @@ pub(super) fn collator_args_v2(
 
 /// Spawns a network on the v2 DHT path with injected allowances, pinning `K` and the gossip target.
 ///
-/// The v2 DHT path is gated by `v2dht_enabled()`, which reads `STATEMENT_STORE_V2_DHT_ENABLED`, so we
-/// set that on every collator rather than passing a CLI flag.
+/// The v2 DHT path is gated by `v2dht_enabled()`, which reads `STATEMENT_STORE_V2_DHT_ENABLED`, so
+/// we set that on every collator rather than passing a CLI flag.
 pub(super) async fn spawn_network_with_injected_allowances_v2(
 	collators: &[&str],
 	participant_count: u32,
@@ -407,8 +407,8 @@ pub(super) async fn spawn_network_with_injected_allowances_v2(
 ///
 /// A fresh subscription first replays every matching statement already in the store, ending the
 /// replay with `remaining == Some(0)` (or a single empty batch when the store holds none). We scan
-/// that replay for `expected`. Subscribing grants explicit affinity for *future* statements only, so
-/// the probe cannot turn an already-dropped statement into a stored one.
+/// that replay for `expected`. Subscribing grants explicit affinity for *future* statements only,
+/// so the probe cannot turn an already-dropped statement into a stored one.
 pub(super) async fn stores_locally(
 	rpc: &RpcClient,
 	topic: Topic,

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -1,0 +1,149 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for the v2 DHT-affinity statement routing.
+//!
+//! v2 routes a statement to the `K` nodes with affinity to its topic instead of flooding every
+//! peer. It is enabled per node by the `STATEMENT_STORE_V2_DHT_ENABLED` environment variable (off by
+//! default); the replication factor `K` and gossip target are set via CLI flags.
+
+use super::common::{
+	expect_one_statement, spawn_network_with_injected_allowances_v2, stores_locally,
+	submit_statement, subscribe_topic,
+};
+use codec::Encode;
+use sc_statement_store::test_utils::{create_test_statement, get_keypair};
+use sp_core::{sr25519, Bytes};
+use sp_statement_store::{SubmitResult, Topic};
+use std::time::Duration;
+
+const TEST_GOSSIP_TARGET: u32 = 3;
+// Statement peers with an open notification substream, exported per node by the v2 DHT path.
+const CONNECTED_PEERS_METRIC: &str = "substrate_sync_statement_v2dht_connected_peers";
+
+/// Scans `[i; 32]` topics and returns the first `count` to which the node behind `non_affine` is not
+/// a DHT replica. With `K=1` over two nodes the other node is then the replica.
+///
+/// A non-affine node keeps none of its own submissions (it holds them transiently, which the query
+/// API never surfaces), so we submit a throwaway statement on each candidate and pick the topics the
+/// node does not report storing.
+async fn select_topics_non_affine_to(
+	non_affine: &zombienet_sdk::subxt::backend::rpc::RpcClient,
+	keypair: &sr25519::Pair,
+	count: usize,
+) -> Result<Vec<Topic>, anyhow::Error> {
+	const CANDIDATES: u8 = 24;
+
+	let mut found = Vec::with_capacity(count);
+	for i in 0..CANDIDATES {
+		let topic: Topic = [i; 32].into();
+		let probe =
+			create_test_statement(keypair, &[topic], None, vec![i, 0xfe], u32::MAX, 5000 + i as u32);
+		let expected: Bytes = probe.encode().into();
+		assert_eq!(submit_statement(non_affine, &probe).await?, SubmitResult::New);
+
+		// The node decides retention synchronously on submit: a topic it is a replica for is kept
+		// (persistent, visible to the query API), one it is not is held transiently (never surfaced).
+		// So a topic the node does not report storing is one it is not a DHT replica for.
+		if !stores_locally(non_affine, topic, &expected).await? {
+			found.push(topic);
+			if found.len() == count {
+				return Ok(found);
+			}
+		}
+	}
+
+	Err(anyhow::anyhow!(
+		"found only {} of {count} topics the node is not a DHT replica for",
+		found.len()
+	))
+}
+
+/// Polls [`stores_locally`] until the node reports storing `expected`, once a second up to
+/// `attempts` times. Use for statements that arrive by forwarding: forwarding is asynchronous, so a
+/// single probe could miss a not-yet-delivered statement.
+async fn wait_until_stored(
+	rpc: &zombienet_sdk::subxt::backend::rpc::RpcClient,
+	topic: Topic,
+	expected: &Bytes,
+	attempts: u32,
+) -> Result<(), anyhow::Error> {
+	for _ in 0..attempts {
+		if stores_locally(rpc, topic, expected).await? {
+			return Ok(());
+		}
+		tokio::time::sleep(Duration::from_secs(1)).await;
+	}
+	Err(anyhow::anyhow!("statement not stored after {attempts} probes"))
+}
+
+/// A node applies the affinity rule to its own RPC submissions, and the responsible node stores them
+/// regardless of where they originate.
+///
+/// Two nodes, `K=1`. We pick `topic_a` and `topic_b` to which node_1 is not a DHT replica, so node_2
+/// is. node_1 subscribes to `topic_a` only, then submits one statement on each topic. node_1 keeps
+/// `topic_a` (its subscription grants explicit affinity) but drops `topic_b` (no affinity). node_2,
+/// the DHT replica for both, stores both — reached by forwarding from node_1.
+///
+/// We first wait for node_1 to open its statement substream to node_2: affinity is computed over the
+/// peers a node has learned, so until then node_1 knows no peer, judges itself the closest to every
+/// topic, and every affinity decision would be wrong.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
+	let _ = env_logger::try_init_from_env(
+		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+	);
+
+	let network =
+		spawn_network_with_injected_allowances_v2(&["charlie", "dave"], 4, 1, TEST_GOSSIP_TARGET)
+			.await?;
+
+	let node_1 = network.get_node("charlie")?;
+	let node_2 = network.get_node("dave")?;
+	let rpc_1 = node_1.rpc().await?;
+	let rpc_2 = node_2.rpc().await?;
+	let keypair = get_keypair(0);
+
+	// Wait until node_1 has an open statement substream to node_2
+	node_1
+		.wait_metric_with_timeout(CONNECTED_PEERS_METRIC, |peers| peers >= 1.0, 120)
+		.await?;
+
+	// Pick two topics node_1 is not a DHT replica for; with K=1 over two nodes, node_2 is the replica
+	// for both.
+	let topics = select_topics_non_affine_to(&rpc_1, &keypair, 2).await?;
+	let topic_a = topics[0];
+	let topic_b = topics[1];
+
+	// Subscribing grants node_1 explicit affinity for `topic_a` only; `topic_b` stays affinity-free.
+	let mut sub_a = subscribe_topic(&rpc_1, topic_a).await?;
+
+	let statement_a =
+		create_test_statement(&keypair, &[topic_a], None, vec![0xaa, 1, 2, 3], u32::MAX, 1001);
+	let statement_b =
+		create_test_statement(&keypair, &[topic_b], None, vec![0xbb, 1, 2, 3], u32::MAX, 1002);
+	let expected_a: Bytes = statement_a.encode().into();
+	let expected_b: Bytes = statement_b.encode().into();
+
+	// Both statements originate on node_1, the non-replica for either topic.
+	assert_eq!(submit_statement(&rpc_1, &statement_a).await?, SubmitResult::New);
+	assert_eq!(submit_statement(&rpc_1, &statement_b).await?, SubmitResult::New);
+
+	// node_1's own subscription delivers the matching `topic_a` statement, independent of who stores
+	// it.
+	assert_eq!(expect_one_statement(&mut sub_a, 20).await?, expected_a);
+
+	// node_1 decides retention synchronously on submit, so we probe right away. We check the two
+	// specific statements, not a total count: the topic-selection probes above leave other statements
+	// in node_1's store.
+	assert!(stores_locally(&rpc_1, topic_a, &expected_a).await?); // kept by explicit affinity
+	assert!(!stores_locally(&rpc_1, topic_b, &expected_b).await?); // dropped, no affinity
+
+	// node_2 is the K=1 DHT replica for both topics, so both statements reach it by forwarding from
+	// node_1 — including `topic_b`, which node_1 itself dropped. Forwarding is asynchronous, so we poll
+	// until they arrive instead of sleeping a fixed time.
+	wait_until_stored(&rpc_2, topic_a, &expected_a, 30).await?; // stored by DHT affinity
+	wait_until_stored(&rpc_2, topic_b, &expected_b, 30).await?; // stored by DHT affinity
+
+	Ok(())
+}

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -122,6 +122,16 @@ async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 	let topic_a = topics[0];
 	let topic_b = topics[1];
 
+	// Control: with no affinity for `topic_a` yet, node_1 drops its own submission.
+	let probe_a =
+		create_test_statement(&keypair, &[topic_a], None, vec![0xa0, 9, 9, 9], u32::MAX, 1000);
+	let probe_a_encoded: Bytes = probe_a.encode().into();
+	assert_eq!(submit_statement(&rpc_1, &probe_a).await?, SubmitResult::New);
+	assert!(
+		!stores_locally(&rpc_1, topic_a, &probe_a_encoded).await?,
+		"node_1 accepted but must not store its own topic_a submission while non-affine",
+	);
+
 	// Subscribing grants node_1 explicit affinity for `topic_a` only; `topic_b` stays
 	// affinity-free.
 	let mut sub_a = subscribe_topic(&rpc_1, topic_a).await?;

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -4,8 +4,8 @@
 //! End-to-end tests for the v2 DHT-affinity statement routing.
 //!
 //! v2 routes a statement to the `K` nodes with affinity to its topic instead of flooding every
-//! peer. It is enabled per node by the `STATEMENT_STORE_V2_DHT_ENABLED` environment variable (off by
-//! default); the replication factor `K` and gossip target are set via CLI flags.
+//! peer. It is enabled per node by the `STATEMENT_STORE_V2_DHT_ENABLED` environment variable (off
+//! by default); the replication factor `K` and gossip target are set via CLI flags.
 
 use super::common::{
 	expect_one_statement, spawn_network_with_injected_allowances_v2, stores_locally,
@@ -21,12 +21,12 @@ const TEST_GOSSIP_TARGET: u32 = 3;
 // Statement peers with an open notification substream, exported per node by the v2 DHT path.
 const CONNECTED_PEERS_METRIC: &str = "substrate_sync_statement_v2dht_connected_peers";
 
-/// Scans `[i; 32]` topics and returns the first `count` to which the node behind `non_affine` is not
-/// a DHT replica. With `K=1` over two nodes the other node is then the replica.
+/// Scans `[i; 32]` topics and returns the first `count` to which the node behind `non_affine` is
+/// not a DHT replica. With `K=1` over two nodes the other node is then the replica.
 ///
 /// A non-affine node keeps none of its own submissions (it holds them transiently, which the query
-/// API never surfaces), so we submit a throwaway statement on each candidate and pick the topics the
-/// node does not report storing.
+/// API never surfaces), so we submit a throwaway statement on each candidate and pick the topics
+/// the node does not report storing.
 async fn select_topics_non_affine_to(
 	non_affine: &zombienet_sdk::subxt::backend::rpc::RpcClient,
 	keypair: &sr25519::Pair,
@@ -37,14 +37,21 @@ async fn select_topics_non_affine_to(
 	let mut found = Vec::with_capacity(count);
 	for i in 0..CANDIDATES {
 		let topic: Topic = [i; 32].into();
-		let probe =
-			create_test_statement(keypair, &[topic], None, vec![i, 0xfe], u32::MAX, 5000 + i as u32);
+		let probe = create_test_statement(
+			keypair,
+			&[topic],
+			None,
+			vec![i, 0xfe],
+			u32::MAX,
+			5000 + i as u32,
+		);
 		let expected: Bytes = probe.encode().into();
 		assert_eq!(submit_statement(non_affine, &probe).await?, SubmitResult::New);
 
 		// The node decides retention synchronously on submit: a topic it is a replica for is kept
-		// (persistent, visible to the query API), one it is not is held transiently (never surfaced).
-		// So a topic the node does not report storing is one it is not a DHT replica for.
+		// (persistent, visible to the query API), one it is not is held transiently (never
+		// surfaced). So a topic the node does not report storing is one it is not a DHT replica
+		// for.
 		if !stores_locally(non_affine, topic, &expected).await? {
 			found.push(topic);
 			if found.len() == count {
@@ -77,17 +84,17 @@ async fn wait_until_stored(
 	Err(anyhow::anyhow!("statement not stored after {attempts} probes"))
 }
 
-/// A node applies the affinity rule to its own RPC submissions, and the responsible node stores them
-/// regardless of where they originate.
+/// A node applies the affinity rule to its own RPC submissions, and the responsible node stores
+/// them regardless of where they originate.
 ///
-/// Two nodes, `K=1`. We pick `topic_a` and `topic_b` to which node_1 is not a DHT replica, so node_2
-/// is. node_1 subscribes to `topic_a` only, then submits one statement on each topic. node_1 keeps
-/// `topic_a` (its subscription grants explicit affinity) but drops `topic_b` (no affinity). node_2,
-/// the DHT replica for both, stores both — reached by forwarding from node_1.
+/// Two nodes, `K=1`. We pick `topic_a` and `topic_b` to which node_1 is not a DHT replica, so
+/// node_2 is. node_1 subscribes to `topic_a` only, then submits one statement on each topic. node_1
+/// keeps `topic_a` (its subscription grants explicit affinity) but drops `topic_b` (no affinity).
+/// node_2, the DHT replica for both, stores both — reached by forwarding from node_1.
 ///
-/// We first wait for node_1 to open its statement substream to node_2: affinity is computed over the
-/// peers a node has learned, so until then node_1 knows no peer, judges itself the closest to every
-/// topic, and every affinity decision would be wrong.
+/// We first wait for node_1 to open its statement substream to node_2: affinity is computed over
+/// the peers a node has learned, so until then node_1 knows no peer, judges itself the closest to
+/// every topic, and every affinity decision would be wrong.
 #[tokio::test(flavor = "multi_thread")]
 async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 	let _ = env_logger::try_init_from_env(
@@ -109,13 +116,14 @@ async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 		.wait_metric_with_timeout(CONNECTED_PEERS_METRIC, |peers| peers >= 1.0, 120)
 		.await?;
 
-	// Pick two topics node_1 is not a DHT replica for; with K=1 over two nodes, node_2 is the replica
-	// for both.
+	// Pick two topics node_1 is not a DHT replica for; with K=1 over two nodes, node_2 is the
+	// replica for both.
 	let topics = select_topics_non_affine_to(&rpc_1, &keypair, 2).await?;
 	let topic_a = topics[0];
 	let topic_b = topics[1];
 
-	// Subscribing grants node_1 explicit affinity for `topic_a` only; `topic_b` stays affinity-free.
+	// Subscribing grants node_1 explicit affinity for `topic_a` only; `topic_b` stays
+	// affinity-free.
 	let mut sub_a = subscribe_topic(&rpc_1, topic_a).await?;
 
 	let statement_a =
@@ -129,19 +137,19 @@ async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 	assert_eq!(submit_statement(&rpc_1, &statement_a).await?, SubmitResult::New);
 	assert_eq!(submit_statement(&rpc_1, &statement_b).await?, SubmitResult::New);
 
-	// node_1's own subscription delivers the matching `topic_a` statement, independent of who stores
-	// it.
+	// node_1's own subscription delivers the matching `topic_a` statement, independent of who
+	// stores it.
 	assert_eq!(expect_one_statement(&mut sub_a, 20).await?, expected_a);
 
 	// node_1 decides retention synchronously on submit, so we probe right away. We check the two
-	// specific statements, not a total count: the topic-selection probes above leave other statements
-	// in node_1's store.
+	// specific statements, not a total count: the topic-selection probes above leave other
+	// statements in node_1's store.
 	assert!(stores_locally(&rpc_1, topic_a, &expected_a).await?); // kept by explicit affinity
 	assert!(!stores_locally(&rpc_1, topic_b, &expected_b).await?); // dropped, no affinity
 
 	// node_2 is the K=1 DHT replica for both topics, so both statements reach it by forwarding from
-	// node_1 — including `topic_b`, which node_1 itself dropped. Forwarding is asynchronous, so we poll
-	// until they arrive instead of sleeping a fixed time.
+	// node_1 — including `topic_b`, which node_1 itself dropped. Forwarding is asynchronous, so we
+	// poll until they arrive instead of sleeping a fixed time.
 	wait_until_stored(&rpc_2, topic_a, &expected_a, 30).await?; // stored by DHT affinity
 	wait_until_stored(&rpc_2, topic_b, &expected_b, 30).await?; // stored by DHT affinity
 

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -113,7 +113,7 @@ async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 
 	// Wait until node_1 has an open statement substream to node_2
 	node_1
-		.wait_metric_with_timeout(CONNECTED_PEERS_METRIC, |peers| peers >= 1.0, 120)
+		.wait_metric_with_timeout(CONNECTED_PEERS_METRIC, |peers| peers >= 1.0, 120u64)
 		.await?;
 
 	// Pick two topics node_1 is not a DHT replica for; with K=1 over two nodes, node_2 is the

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/mod.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/mod.rs
@@ -4,3 +4,4 @@
 mod bench;
 mod common;
 mod integration;
+mod integration_v2_dht;


### PR DESCRIPTION
## What

Adds an end-to-end zombienet test, `submission_retention_works`, proving that a node applies the affinity retention rule to its **own RPC submissions** on the v2 DHT path:

- `node_1` (not a DHT replica for the chosen topics) subscribes to `topic_a` only, then submits one statement on `topic_a` and one on `topic_b`.
- `node_1` **keeps** `topic_a` (subscription → explicit affinity) and **drops** `topic_b` (no affinity).
- `node_2` (the `K=1` DHT replica) **stores both**, reached by forwarding from `node_1`.
- `node_1`'s own subscription receives the `topic_a` statement.

## Details

- New test file `cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs`.
- Restores the v2 test helpers in `common.rs`: `collator_args_v2`, `spawn_network_with_injected_allowances_v2`, and `stores_locally` (probes the subscription replay; transient statements are invisible to the query API).
- `launch_network` gains a per-collator env argument; the v2 spawn enables the path via `STATEMENT_STORE_V2_DHT_ENABLED=1` — there is no CLI flag, `v2dht_enabled()` reads the env var.
- Topology readiness is awaited via the `substrate_sync_statement_v2dht_connected_peers` metric; forwarding latency is handled by polling, with no fixed sleeps.

