### PR TITLE
statement-store v2 DHT: use a connection-independent coverage target

### DIFF
--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -214,12 +214,6 @@ impl V2DhtOrchestrator {
 	}
 
 	/// Recompute the peers needed to cover the node's topics and hand them to peer steering.
-	// TODO: `peers_for_topics` returns gaps only — it omits topics already served by a connected
-	// peer and never lists connected peers. Peer steering reconciles toward this set and
-	// disconnects connected peers absent from it, so a peer that starts covering its topic drops
-	// out of the next result and gets disconnected, then reconnected — it flaps. A stable,
-	// connection-independent coverage target (e.g. the closest known peers per topic) must replace
-	// this before steering is enabled.
 	pub(crate) fn on_pending_affinities(&mut self) {
 		let topics = self.explicit_affinity.topics();
 		let desired = self.peers_topology.peers_for_topics(&topics);
@@ -446,5 +440,37 @@ mod tests {
 		// Every coverage peer is queued for a connection, since none are connected yet.
 		let connect = orchestrator.peer_steering.peers_to_connect();
 		assert!(desired.iter().all(|peer| connect.contains(peer)));
+	}
+
+	#[test]
+	fn connected_coverage_peer_is_never_disconnected() {
+		let mut orchestrator = V2DhtOrchestrator::new(
+			&[topic(1)],
+			peer(1),
+			topology_config(20, 3),
+			"/statement/test".into(),
+			None,
+		);
+
+		for seed in 2..=10 {
+			orchestrator.on_peers_discovered([peer(seed)]);
+			orchestrator.on_peer_identified(peer(seed), true);
+		}
+
+		// The first tick selects the coverage peers and queues them for connection.
+		orchestrator.on_pending_affinities();
+		let desired = orchestrator.peers_topology.peers_for_topics(&[topic(1)]);
+		assert!(!desired.is_empty());
+
+		// The coverage peers connect, then the next tick recomputes the target.
+		for peer in &desired {
+			orchestrator.on_substream_opened(*peer);
+		}
+		orchestrator.on_pending_affinities();
+
+		// The connected coverage peers stay desired, so peer steering keeps them: nothing left to
+		// connect, nothing to disconnect.
+		assert!(orchestrator.peer_steering.peers_to_connect().is_empty());
+		assert!(orchestrator.peer_steering.peers_to_disconnect().is_empty());
 	}
 }

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -193,8 +193,8 @@ impl PeersTopology {
 	/// Local-only explicit-affinity connection candidates for `topics`.
 	///
 	/// This uses only the locally learned topology, avoiding network lookups that would reveal
-	/// explicit-affinity topics, and tries to minimize new connections by choosing peers that
-	/// cover currently uncovered topics.
+	/// explicit-affinity topics, and selects a minimal set of peers covering every topic,
+	/// independent of connection state.
 	pub fn peers_for_topics(&self, topics: &[Topic]) -> Vec<PeerId> {
 		if topics.is_empty() {
 			return Vec::new();
@@ -207,13 +207,7 @@ impl PeersTopology {
 			.map(|topic| self.closest_known_keyed(*topic, pool_size))
 			.collect::<Vec<_>>();
 
-		let mut uncovered = closest_pools
-			.iter()
-			.enumerate()
-			.filter_map(|(topic_idx, pool)| {
-				(!pool.iter().any(|(peer, _)| self.is_connected(peer))).then_some(topic_idx)
-			})
-			.collect::<HashSet<_>>();
+		let mut uncovered = (0..topics.len()).collect::<HashSet<_>>();
 
 		let mut selected = Vec::new();
 		let limit = topics.len();
@@ -455,7 +449,7 @@ mod tests {
 	}
 
 	#[test]
-	fn peers_for_topics_does_not_select_for_topics_covered_by_connected_peers() {
+	fn peers_for_topics_keeps_connected_coverage_peer() {
 		let mut topology = topology(1);
 		let topic = topic(9);
 
@@ -464,9 +458,11 @@ mod tests {
 		}
 
 		let connected = topology.closest_known(topic, 1)[0];
+		let before = topology.peers_for_topics(&[topic]);
 		topology.on_substream_opened(connected);
 
-		assert!(topology.peers_for_topics(&[topic]).is_empty());
+		assert_eq!(topology.peers_for_topics(&[topic]), before);
+		assert!(topology.peers_for_topics(&[topic]).contains(&connected));
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/12469