### PR TITLE
statement-store: DHT PoC add v2 eligible-peers topology metric

### DIFF
--- a/substrate/client/network/statement/src/v2dht/metrics.rs
+++ b/substrate/client/network/statement/src/v2dht/metrics.rs
@@ -27,6 +27,9 @@ pub(crate) struct V2DhtMetrics {
 	known_peers: Gauge<U64>,
 	/// Statement-store peers with an open statement notification substream.
 	connected_peers: Gauge<U64>,
+	/// Known peers with confirmed statement-protocol support: the DHT storage, affinity and
+	/// forwarding candidates.
+	eligible_peers: Gauge<U64>,
 }
 
 impl V2DhtMetrics {
@@ -46,11 +49,24 @@ impl V2DhtMetrics {
 				)?,
 				r,
 			)?,
+			eligible_peers: register(
+				Gauge::new(
+					"substrate_sync_statement_v2dht_eligible_peers",
+					"Known statement-store peers with confirmed protocol support, the DHT storage, affinity and forwarding candidates",
+				)?,
+				r,
+			)?,
 		})
 	}
 
-	pub(crate) fn set_topology_size(&self, known_peers: usize, connected_peers: usize) {
+	pub(crate) fn set_topology_size(
+		&self,
+		known_peers: usize,
+		connected_peers: usize,
+		eligible_peers: usize,
+	) {
 		self.known_peers.set(known_peers as u64);
 		self.connected_peers.set(connected_peers as u64);
+		self.eligible_peers.set(eligible_peers as u64);
 	}
 }

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -70,6 +70,7 @@ impl V2DhtOrchestrator {
 			metrics.set_topology_size(
 				self.peers_topology.known_peers_count(),
 				self.peers_topology.connected_peers().count(),
+				self.peers_topology.dht_eligible_peers_count(),
 			);
 		}
 	}

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -144,6 +144,12 @@ impl PeersTopology {
 		self.discovered.len()
 	}
 
+	/// Number of known statement-protocol peers, the DHT storage, affinity and forwarding
+	/// candidates.
+	pub fn dht_eligible_peers_count(&self) -> usize {
+		self.discovered_index.peers().count()
+	}
+
 	/// Closest known statement-protocol peers for `topic`.
 	///
 	/// "Closest" is computed over the locally learned statement-protocol peers, not by querying


### PR DESCRIPTION
Impl: #12291

Add the `substrate_sync_statement_v2dht_eligible_peers` gauge: known statement-protocol peers — the candidates for DHT storage, affinity and forwarding. `PeersTopology::dht_eligible_peers_count` exposes the `discovered_index` size, and `V2DhtOrchestrator` reports it alongside the existing `known_peers` and `connected_peers` gauges.