### PR TITLE
fix(revive): replace usize::MAX sentinel with valid empty range in resize_memory

### DIFF
--- a/substrate/frame/revive/src/vm/evm/instructions/contract.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/contract.rs
@@ -239,7 +239,8 @@ fn run_call<'a, E: Ext>(
 			let return_data = &return_value.data;
 			let did_revert = return_value.did_revert();
 
-			// Note: This can't panic because we resized memory with `get_memory_in_and_out_ranges`
+			// Note: This can't panic because memory was resized (or `target_len` is 0 for
+			// zero-length output ranges, making the call a no-op).
 			interpreter.memory.set(mem_start, &return_data[..target_len]);
 			interpreter.stack.push(U256::from(!did_revert as u8))
 		},

--- a/substrate/frame/revive/src/vm/evm/instructions/contract/call_helpers.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/contract/call_helpers.rs
@@ -38,7 +38,7 @@ pub fn get_memory_in_and_out_ranges<'a, E: Ext>(
 }
 
 /// Resize memory and return range of memory.
-/// If `len` is 0 dont touch memory and return `usize::MAX` as offset and 0 as length.
+/// If `len` is 0, memory is not touched and an empty range starting at 0 is returned.
 pub fn resize_memory<'a, E: Ext>(
 	interpreter: &mut Interpreter<'a, E>,
 	offset: U256,
@@ -50,8 +50,7 @@ pub fn resize_memory<'a, E: Ext>(
 		interpreter.memory.resize(offset, len)?;
 		ControlFlow::Continue(offset..offset + len)
 	} else {
-		// unrealistic value so we are sure it is not used
-		ControlFlow::Continue(usize::MAX..usize::MAX)
+		ControlFlow::Continue(0..0)
 	}
 }
 


### PR DESCRIPTION
## Description

`resize_memory` returns `usize::MAX..usize::MAX` as a sentinel range when `len == 0`, with the comment that this value "is sure not used". However, the returned range **is** used — `mem_start` (which equals `usize::MAX`) is passed directly to `interpreter.memory.set()` in `run_call`.

Currently, this is safe only because `mem_length == 0` → `target_len == 0`, and `memory.set()` is a no-op for empty slices. But this is a latent crash (or worse, UB): the safety comment claims "memory was resized with `get_memory_in_and_out_ranges`", which is **false** — when `len == 0`, no memory resize occurs.

## Changes

1. **`call_helpers.rs`**: Return `0..0` instead of `usize::MAX..usize::MAX` for zero-length memory ranges. This is a valid empty range — address 0 is always valid, and the range length is 0, so no memory is written. Updated the doc comment to be accurate.

2. **`contract.rs`**: Fixed the incorrect safety comment to reflect that the operation is safe either because memory was resized OR because `target_len` is 0 (zero-length output range).

## Testing

`cargo check -p pallet-revive` passes. No behavioral change for zero-length output ranges (still a no-op at runtime).