### PR TITLE
[RWF] `sc-consensus-slots`: fix `SlotProportion::new` allowing NaN to escape clamp

### DIFF
--- a/prdoc/pr_12509.prdoc
+++ b/prdoc/pr_12509.prdoc
@@ -1,0 +1,14 @@
+title: '[RWF] `sc-consensus-slots`: fix `SlotProportion::new` allowing NaN to escape
+  clamp'
+doc:
+- audience: Runtime Dev
+  description: "Closes #12459.\n\n### Problem\n\n`SlotProportion::new` called `f32::clamp(0.0,\
+    \ 1.0)` to enforce the `[0, 1]` invariant on `get()`. Per the Rust spec, `f32::clamp`\
+    \ is a no-op for NaN: it returns NaN unchanged. A caller passing `f32::NAN` would\
+    \ silently get a `SlotProportion` whose `get()` returned NaN, violating the documented\
+    \ guarantee, and feeding an unexpected value into `Duration::mul_f32` inside `proposing_remaining_duration`.\n\
+    \n### Fix\n\nAdd an explicit NaN guard in `new`: map `NaN \u2192 0.0` before clamping.\
+    \ A unit test `slot_proportion_clamps_nan_to_zero` pins the corrected behaviour."
+crates:
+- name: sc-consensus-slots
+  bump: patch

--- a/substrate/client/consensus/slots/src/lib.rs
+++ b/substrate/client/consensus/slots/src/lib.rs
@@ -538,9 +538,10 @@ impl SlotProportion {
 	/// Create a new proportion.
 	///
 	/// The given value `inner` should be in the range `[0,1]`. If the value is not in the required
-	/// range, it is clamped into the range.
+	/// range, it is clamped into the range. NaN is mapped to `0.0`.
 	pub fn new(inner: f32) -> Self {
-		Self(inner.clamp(0.0, 1.0))
+		// f32::clamp propagates NaN unchanged; treat it as 0.0 to uphold the [0,1] invariant.
+		Self(if inner.is_nan() { 0.0 } else { inner.clamp(0.0, 1.0) })
 	}
 
 	/// Returns the inner that is guaranteed to be in the range `[0,1]`.
@@ -893,6 +894,13 @@ mod test {
 			),
 			SLOT_DURATION.mul_f32(0.9),
 		);
+	}
+
+	#[test]
+	fn slot_proportion_clamps_nan_to_zero() {
+		let p = SlotProportion::new(f32::NAN);
+		assert!(!p.get().is_nan(), "NaN must not escape SlotProportion::new");
+		assert_eq!(p.get(), 0.0);
 	}
 
 	#[derive(PartialEq, Debug)]


### PR DESCRIPTION
Closes #12459.

### Problem

`SlotProportion::new` called `f32::clamp(0.0, 1.0)` to enforce the `[0, 1]` invariant on `get()`. Per the Rust spec, `f32::clamp` is a no-op for NaN: it returns NaN unchanged. A caller passing `f32::NAN` would silently get a `SlotProportion` whose `get()` returned NaN, violating the documented guarantee, and feeding an unexpected value into `Duration::mul_f32` inside `proposing_remaining_duration`.

### Fix

Add an explicit NaN guard in `new`: map `NaN → 0.0` before clamping. A unit test `slot_proportion_clamps_nan_to_zero` pins the corrected behaviour.
