### PR TITLE
[RWF] `sc-consensus-epochs`: fix ForkTree/epoch-map desync on duplicate import

### DIFF
--- a/prdoc/pr_12511.prdoc
+++ b/prdoc/pr_12511.prdoc
@@ -1,0 +1,19 @@
+title: '[RWF] `sc-consensus-epochs`: fix ForkTree/epoch-map desync on duplicate import'
+doc:
+- audience: Node Dev
+  description: "Fixes #12461.\n\n### Problem\n\n`EpochChanges::import` kept two stores\
+    \ in lockstep \u2014 a `ForkTree` of `PersistedEpochHeader` values and a `BTreeMap`\
+    \ of full `PersistedEpoch` data. When `ForkTree::import` returned `Err(Duplicate)`,\
+    \ the tree left its existing node untouched (original header intact). However,\
+    \ the previous match arm collapsed `Ok(_)` and `Err(Duplicate)` together and unconditionally\
+    \ called `self.epochs.insert(...)`, overwriting the original epoch entry with\
+    \ whatever data was passed in the second import call.\n\nThe result: `ForkTree`\
+    \ held a node header from epoch A while `self.epochs` held epoch B. Any lookup\
+    \ that crosses both stores (e.g. `epoch_data_for_child_of`) would then return\
+    \ inconsistent data.\n\n### Fix\n\nSeparate the two match arms. On `Err(Duplicate)`,\
+    \ skip `epochs.insert` and return `Ok(())` \u2014 making a duplicate import a\
+    \ true no-op for both stores.\n\nA unit test `duplicate_import_does_not_desync_epoch_map`\
+    \ pins this behaviour."
+crates:
+- name: sc-consensus-epochs
+  bump: patch

--- a/substrate/client/consensus/epochs/src/lib.rs
+++ b/substrate/client/consensus/epochs/src/lib.rs
@@ -1181,11 +1181,13 @@ mod tests {
 			.import(&is_descendent_of, *b"A", 1, Default::default(), IncrementedEpoch(epoch_b))
 			.unwrap();
 
-		// epochs map must still hold epoch_a; overwriting it would desync from ForkTree.
-		assert_eq!(
-			epoch_changes.epochs.get(&(*b"A", 1u64)),
-			Some(&epoch_a),
-			"duplicate import must not overwrite existing epoch entry"
-		);
+		// epochs map must still hold epoch_a (start_slot=100); overwriting it would desync from
+		// ForkTree. PersistedEpoch doesn't derive PartialEq, so check the inner field directly.
+		let stored = epoch_changes.epochs.get(&(*b"A", 1u64)).expect("entry must exist");
+		let PersistedEpoch::Regular(inner) = stored else {
+			panic!("expected PersistedEpoch::Regular");
+		};
+		assert_eq!(inner.start_slot, 100, "duplicate import must not overwrite existing epoch entry");
+		assert_eq!(inner.duration, 100);
 	}
 }

--- a/substrate/client/consensus/epochs/src/lib.rs
+++ b/substrate/client/consensus/epochs/src/lib.rs
@@ -1187,7 +1187,10 @@ mod tests {
 		let PersistedEpoch::Regular(inner) = stored else {
 			panic!("expected PersistedEpoch::Regular");
 		};
-		assert_eq!(inner.start_slot, 100, "duplicate import must not overwrite existing epoch entry");
+		assert_eq!(
+			inner.start_slot, 100,
+			"duplicate import must not overwrite existing epoch entry"
+		);
 		assert_eq!(inner.duration, 100);
 	}
 }

--- a/substrate/client/consensus/epochs/src/lib.rs
+++ b/substrate/client/consensus/epochs/src/lib.rs
@@ -645,10 +645,13 @@ where
 		let res = self.inner.import(hash, number, header, &is_descendent_of);
 
 		match res {
-			Ok(_) | Err(fork_tree::Error::Duplicate) => {
+			Ok(_) => {
 				self.epochs.insert((hash, number), epoch);
 				Ok(())
 			},
+			// ForkTree keeps the original node unchanged on a duplicate; skip the map
+			// update too so the two stores stay in sync.
+			Err(fork_tree::Error::Duplicate) => Ok(()),
 			Err(e) => Err(e),
 		}
 	}
@@ -1151,5 +1154,38 @@ mod tests {
 		let mut list: Vec<_> = epoch_changes.inner.iter().map(|e| e.0).collect();
 		list.sort();
 		assert_eq!(list, vec![b"A", b"G", b"L"]);
+	}
+
+	#[test]
+	fn duplicate_import_does_not_desync_epoch_map() {
+		let is_descendent_of = |_: &Hash, _: &Hash| -> Result<bool, TestError> { Ok(true) };
+
+		let mut epoch_changes = EpochChanges::<_, _, Epoch>::new();
+
+		let epoch_a = PersistedEpoch::Regular(Epoch { start_slot: 100, duration: 100 });
+		let epoch_b = PersistedEpoch::Regular(Epoch { start_slot: 200, duration: 100 });
+
+		// First import — ForkTree node and epochs map both record epoch_a.
+		epoch_changes
+			.import(
+				&is_descendent_of,
+				*b"A",
+				1,
+				Default::default(),
+				IncrementedEpoch(epoch_a.clone()),
+			)
+			.unwrap();
+
+		// Duplicate import with different epoch data — must be a no-op for both stores.
+		epoch_changes
+			.import(&is_descendent_of, *b"A", 1, Default::default(), IncrementedEpoch(epoch_b))
+			.unwrap();
+
+		// epochs map must still hold epoch_a; overwriting it would desync from ForkTree.
+		assert_eq!(
+			epoch_changes.epochs.get(&(*b"A", 1u64)),
+			Some(&epoch_a),
+			"duplicate import must not overwrite existing epoch entry"
+		);
 	}
 }


### PR DESCRIPTION
Fixes #12461.

### Problem

`EpochChanges::import` kept two stores in lockstep — a `ForkTree` of `PersistedEpochHeader` values and a `BTreeMap` of full `PersistedEpoch` data. When `ForkTree::import` returned `Err(Duplicate)`, the tree left its existing node untouched (original header intact). However, the previous match arm collapsed `Ok(_)` and `Err(Duplicate)` together and unconditionally called `self.epochs.insert(...)`, overwriting the original epoch entry with whatever data was passed in the second import call.

The result: `ForkTree` held a node header from epoch A while `self.epochs` held epoch B. Any lookup that crosses both stores (e.g. `epoch_data_for_child_of`) would then return inconsistent data.

### Fix

Separate the two match arms. On `Err(Duplicate)`, skip `epochs.insert` and return `Ok(())` — making a duplicate import a true no-op for both stores.

A unit test `duplicate_import_does_not_desync_epoch_map` pins this behaviour.
