### PR TITLE
[RWF] `sc-mixnet`: fix empty `fork_id` producing malformed protocol name

### DIFF
--- a/prdoc/pr_12512.prdoc
+++ b/prdoc/pr_12512.prdoc
@@ -1,0 +1,18 @@
+title: '[RWF] `sc-mixnet`: fix empty `fork_id` producing malformed protocol name'
+doc:
+- audience: Node Dev
+  description: |-
+    Closes #12462.
+
+    ### Problem
+
+    `protocol_name` branched on `Option<&str>` without guarding against the empty string. A chain-spec that sets `fork_id` to `""` (which is represented as `Some("")`) hit the `Some` branch and inserts the empty string directly into the format string, producing a double slash.
+
+    The malformed name caused the notification service to fail on startup, which terminated the event stream and panicked the mixnet run loop.
+
+    ### Fix
+
+    Apply `.filter(|id| !id.is_empty())` to `fork_id` before matching, so `Some("")` is treated identically to `None`. Three unit tests in a new `#[cfg(test)]` block cover the non-empty, absent, and empty-string cases.
+crates:
+- name: sc-mixnet
+  bump: patch

--- a/substrate/client/mixnet/src/protocol.rs
+++ b/substrate/client/mixnet/src/protocol.rs
@@ -28,12 +28,12 @@ use sp_runtime::traits::Block as BlockT;
 
 /// Returns the protocol name to use for the mixnet controlled by the given chain.
 pub fn protocol_name(genesis_hash: &[u8], fork_id: Option<&str>) -> ProtocolName {
-	let name = if let Some(fork_id) = fork_id {
-		format!("/{}/{}/mixnet/1", array_bytes::bytes2hex("", genesis_hash), fork_id)
-	} else {
-		format!("/{}/mixnet/1", array_bytes::bytes2hex("", genesis_hash))
-	};
-	name.into()
+	let genesis_hash = array_bytes::bytes2hex("", genesis_hash);
+	match fork_id.filter(|id| !id.is_empty()) {
+		Some(fork_id) => format!("/{genesis_hash}/{fork_id}/mixnet/1"),
+		None => format!("/{genesis_hash}/mixnet/1"),
+	}
+	.into()
 }
 
 /// Returns the peers set configuration for the mixnet protocol.
@@ -70,4 +70,37 @@ pub fn peers_set_config<Block: BlockT, Network: NetworkBackend<Block, <Block as 
 		metrics,
 		peerstore_handle,
 	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn protocol_name_with_fork_id() {
+		let hash = [0xde, 0xad];
+		assert_eq!(
+			String::from(protocol_name(&hash, Some("foo"))),
+			"/dead/foo/mixnet/1",
+		);
+	}
+
+	#[test]
+	fn protocol_name_without_fork_id() {
+		let hash = [0xde, 0xad];
+		assert_eq!(
+			String::from(protocol_name(&hash, None)),
+			"/dead/mixnet/1",
+		);
+	}
+
+	#[test]
+	fn protocol_name_empty_fork_id_treated_as_none() {
+		let hash = [0xde, 0xad];
+		// Some("") must produce the same name as None — no double slash.
+		assert_eq!(
+			protocol_name(&hash, Some("")),
+			protocol_name(&hash, None),
+		);
+	}
 }

--- a/substrate/client/mixnet/src/protocol.rs
+++ b/substrate/client/mixnet/src/protocol.rs
@@ -79,28 +79,19 @@ mod tests {
 	#[test]
 	fn protocol_name_with_fork_id() {
 		let hash = [0xde, 0xad];
-		assert_eq!(
-			String::from(protocol_name(&hash, Some("foo"))),
-			"/dead/foo/mixnet/1",
-		);
+		assert_eq!(String::from(protocol_name(&hash, Some("foo"))), "/dead/foo/mixnet/1",);
 	}
 
 	#[test]
 	fn protocol_name_without_fork_id() {
 		let hash = [0xde, 0xad];
-		assert_eq!(
-			String::from(protocol_name(&hash, None)),
-			"/dead/mixnet/1",
-		);
+		assert_eq!(String::from(protocol_name(&hash, None)), "/dead/mixnet/1",);
 	}
 
 	#[test]
 	fn protocol_name_empty_fork_id_treated_as_none() {
 		let hash = [0xde, 0xad];
 		// Some("") must produce the same name as None — no double slash.
-		assert_eq!(
-			protocol_name(&hash, Some("")),
-			protocol_name(&hash, None),
-		);
+		assert_eq!(protocol_name(&hash, Some("")), protocol_name(&hash, None),);
 	}
 }

--- a/substrate/client/mixnet/src/protocol.rs
+++ b/substrate/client/mixnet/src/protocol.rs
@@ -79,13 +79,13 @@ mod tests {
 	#[test]
 	fn protocol_name_with_fork_id() {
 		let hash = [0xde, 0xad];
-		assert_eq!(String::from(protocol_name(&hash, Some("foo"))), "/dead/foo/mixnet/1",);
+		assert_eq!(protocol_name(&hash, Some("foo")).as_ref(), "/dead/foo/mixnet/1");
 	}
 
 	#[test]
 	fn protocol_name_without_fork_id() {
 		let hash = [0xde, 0xad];
-		assert_eq!(String::from(protocol_name(&hash, None)), "/dead/mixnet/1",);
+		assert_eq!(protocol_name(&hash, None).as_ref(), "/dead/mixnet/1");
 	}
 
 	#[test]


### PR DESCRIPTION
Closes #12462.

### Problem

`protocol_name` branched on `Option<&str>` without guarding against the empty string. A chain-spec that sets `fork_id` to `""` (which is represented as `Some("")`) hit the `Some` branch and inserts the empty string directly into the format string, producing a double slash.

The malformed name caused the notification service to fail on startup, which terminated the event stream and panicked the mixnet run loop.

### Fix

Apply `.filter(|id| !id.is_empty())` to `fork_id` before matching, so `Some("")` is treated identically to `None`. Three unit tests in a new `#[cfg(test)]` block cover the non-empty, absent, and empty-string cases.


