### PR TITLE
statement-store v2 DHT PoC: apply affinity retention to local submissions

### DIFF
--- a/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
@@ -87,7 +87,7 @@ pub(crate) fn build_statement_store<
 		})
 	};
 	let retention =
-		sc_network_statement::RetentionHandle::new(network.local_peer_id(), replication_factor.get());
+		sc_network_statement::RetentionHandle::new(network.local_peer_id(), replication_factor);
 	if sc_network_statement::v2dht_enabled() {
 		statement_store.set_retention_resolver(retention.resolver());
 	}

--- a/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/statement_store.rs
@@ -86,6 +86,11 @@ pub(crate) fn build_statement_store<
 			spawn_handle.spawn("network-statement-validator", Some("networking"), fut);
 		})
 	};
+	let retention =
+		sc_network_statement::RetentionHandle::new(network.local_peer_id(), replication_factor.get());
+	if sc_network_statement::v2dht_enabled() {
+		statement_store.set_retention_resolver(retention.resolver());
+	}
 	let statement_handler = statement_handler_proto.build(
 		network,
 		sync_service,
@@ -97,6 +102,7 @@ pub(crate) fn build_statement_store<
 		&affinity_topics,
 		replication_factor,
 		gossip_target,
+		retention,
 	)?;
 	task_manager.spawn_handle().spawn(
 		"network-statement-handler",

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -802,7 +802,7 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 	};
 	let retention = sc_network_statement::RetentionHandle::new(
 		network.local_peer_id(),
-		statement_replication_factor.get(),
+		statement_replication_factor,
 	);
 	if sc_network_statement::v2dht_enabled() {
 		statement_store.set_retention_resolver(retention.resolver());

--- a/substrate/bin/node/cli/src/service.rs
+++ b/substrate/bin/node/cli/src/service.rs
@@ -800,6 +800,13 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 			spawn_handle.spawn("network-statement-validator", Some("networking"), fut);
 		})
 	};
+	let retention = sc_network_statement::RetentionHandle::new(
+		network.local_peer_id(),
+		statement_replication_factor.get(),
+	);
+	if sc_network_statement::v2dht_enabled() {
+		statement_store.set_retention_resolver(retention.resolver());
+	}
 	let statement_handler = statement_handler_proto.build(
 		network.clone(),
 		sync_service.clone(),
@@ -811,6 +818,7 @@ pub fn new_full_base<N: NetworkBackend<Block, <Block as BlockT>::Hash>>(
 		&statement_affinity_topics,
 		statement_replication_factor,
 		statement_gossip_target,
+		retention,
 	)?;
 	task_manager.spawn_handle().spawn(
 		"network-statement-handler",

--- a/substrate/client/network/statement/benches/statement_network.rs
+++ b/substrate/client/network/statement/benches/statement_network.rs
@@ -34,7 +34,7 @@ use sc_network_sync::{SyncEvent, SyncEventStream};
 use sc_network_types::PeerId;
 use sc_statement_store::Store;
 use sp_core::Pair;
-use sp_statement_store::{RetentionReasonMask, Statement, StatementSource, StatementStore};
+use sp_statement_store::{Statement, StatementSource, StatementStore};
 use std::{
 	collections::HashMap,
 	num::{NonZeroU32, NonZeroUsize},
@@ -235,7 +235,6 @@ fn build_handler(
 
 	let (queue_sender, queue_receiver) = async_channel::bounded::<(
 		Statement,
-		RetentionReasonMask,
 		futures::channel::oneshot::Sender<sp_statement_store::SubmitResult>,
 	)>(MAX_PENDING_STATEMENTS);
 
@@ -260,7 +259,7 @@ fn build_handler(
 			loop {
 				let task = receiver.recv().await;
 				match task {
-					Ok((statement, _, completion)) => {
+					Ok((statement, completion)) => {
 						let result = store.submit(statement, StatementSource::Network);
 						let _ = completion.send(result);
 					},

--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -65,8 +65,7 @@ use sc_network_sync::{SyncEvent, SyncEventStream};
 use sc_network_types::PeerId;
 use sp_runtime::traits::Block as BlockT;
 use sp_statement_store::{
-	FilterDecision, Hash, RetentionReasonMask, Statement, StatementSource, StatementStore,
-	SubmitResult, Topic,
+	FilterDecision, Hash, Statement, StatementSource, StatementStore, SubmitResult, Topic,
 };
 use std::{
 	collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
@@ -77,6 +76,7 @@ use std::{
 	time::Instant,
 };
 use tokio::time::timeout;
+pub use v2dht::RetentionHandle;
 use v2dht::{V2DhtMetrics, V2DhtOrchestrator};
 pub mod config;
 #[cfg(test)]
@@ -168,8 +168,9 @@ const SYNC_RECOVERY_READD_DELAY: std::time::Duration = std::time::Duration::from
 
 /// Feature-flag to switch between the legacy flood path and the new DHT-targeted path.
 ///
-/// Off by default; enable the v2 DHT path by setting `STATEMENT_STORE_V2_DHT_ENABLED=1`.
-fn v2dht_enabled() -> bool {
+/// Off by default; enable the v2 DHT path by setting `STATEMENT_STORE_V2_DHT_ENABLED=1`. The node
+/// also reads this to gate v2-only wiring, such as the store's affinity-based retention resolver.
+pub fn v2dht_enabled() -> bool {
 	std::env::var_os("STATEMENT_STORE_V2_DHT_ENABLED").map_or(false, |value| value == "1")
 }
 
@@ -393,6 +394,7 @@ impl StatementHandlerPrototype {
 		configured_topics: &[Topic],
 		replication_factor: std::num::NonZeroUsize,
 		gossip_target: std::num::NonZeroUsize,
+		retention: RetentionHandle,
 	) -> error::Result<StatementHandler<N, S>> {
 		let sync_event_stream = sync.event_stream("statement-handler-sync");
 		let (queue_sender, queue_receiver) = async_channel::bounded(MAX_PENDING_STATEMENTS);
@@ -432,19 +434,12 @@ impl StatementHandlerPrototype {
 			executor(
 				async move {
 					loop {
-						let task: Option<(
-							Statement,
-							RetentionReasonMask,
-							oneshot::Sender<SubmitResult>,
-						)> = queue_receiver.next().await;
+						let task: Option<(Statement, oneshot::Sender<SubmitResult>)> =
+							queue_receiver.next().await;
 						match task {
 							None => return,
-							Some((statement, mask, completion)) => {
-								let result = store.submit_with_retention_mask(
-									statement,
-									StatementSource::Network,
-									mask,
-								);
+							Some((statement, completion)) => {
+								let result = store.submit(statement, StatementSource::Network);
 								if completion.send(result).is_err() {
 									log::debug!(
 										target: LOG_TARGET,
@@ -472,13 +467,14 @@ impl StatementHandlerPrototype {
 		} else {
 			futures::stream::pending::<Event>().boxed()
 		};
-		let v2dht = V2DhtOrchestrator::new(
+		let mut v2dht = V2DhtOrchestrator::new(
 			configured_topics,
 			network.local_peer_id(),
 			PeersTopologyConfig { replication_factor, gossip_target },
 			self.protocol_name.clone(),
 			v2dht_metrics,
 		);
+		v2dht.set_retention_handle(retention);
 		let handler = StatementHandler {
 			protocol_name: self.protocol_name,
 			notification_service: self.notification_service,
@@ -542,8 +538,7 @@ pub struct StatementHandler<
 	// All connected peers
 	peers: HashMap<PeerId, Peer>,
 	statement_store: Arc<dyn StatementStore>,
-	queue_sender:
-		async_channel::Sender<(Statement, RetentionReasonMask, oneshot::Sender<SubmitResult>)>,
+	queue_sender: async_channel::Sender<(Statement, oneshot::Sender<SubmitResult>)>,
 	/// Maximum statements per second per peer.
 	statements_per_second: NonZeroU32,
 	/// Prometheus metrics.
@@ -754,11 +749,7 @@ where
 		sync_event_stream: stream::Fuse<Pin<Box<dyn Stream<Item = SyncEvent> + Send>>>,
 		peers: HashMap<PeerId, Peer>,
 		statement_store: Arc<dyn StatementStore>,
-		queue_sender: async_channel::Sender<(
-			Statement,
-			RetentionReasonMask,
-			oneshot::Sender<SubmitResult>,
-		)>,
+		queue_sender: async_channel::Sender<(Statement, oneshot::Sender<SubmitResult>)>,
 		statements_per_second: NonZeroU32,
 	) -> Self {
 		let local_peer = network.local_peer_id();
@@ -1402,13 +1393,8 @@ where
 
 				match self.pending_statements_peers.entry(hash) {
 					Entry::Vacant(entry) => {
-						let mask = if v2dht_enabled() {
-							self.v2dht.retention_reasons_for(&s)
-						} else {
-							RetentionReasonMask::persistent()
-						};
 						let (completion_sender, completion_receiver) = oneshot::channel();
-						match self.queue_sender.try_send((s, mask, completion_sender)) {
+						match self.queue_sender.try_send((s, completion_sender)) {
 							Ok(()) => {
 								self.pending_statements.push(
 									async move {
@@ -2182,23 +2168,10 @@ mod tests {
 		fn submit(
 			&self,
 			statement: sp_statement_store::Statement,
-			source: sp_statement_store::StatementSource,
-		) -> sp_statement_store::SubmitResult {
-			self.submit_with_retention_mask(statement, source, RetentionReasonMask::persistent())
-		}
-
-		fn submit_with_retention_mask(
-			&self,
-			statement: sp_statement_store::Statement,
 			_source: sp_statement_store::StatementSource,
-			mask: RetentionReasonMask,
 		) -> sp_statement_store::SubmitResult {
 			let hash = statement.hash();
-			// A persistent statement is kept; a transient one is held only for the next
-			// propagation. Both are forwarded once via `recent_statements`.
-			if mask.is_persistent() {
-				self.statements.lock().unwrap().insert(hash, statement.clone());
-			}
+			self.statements.lock().unwrap().insert(hash, statement.clone());
 			self.recent_statements.lock().unwrap().insert(hash, statement);
 			SubmitResult::New
 		}
@@ -2219,7 +2192,7 @@ mod tests {
 		TestStatementStore,
 		TestNetwork,
 		TestNotificationService,
-		async_channel::Receiver<(Statement, RetentionReasonMask, oneshot::Sender<SubmitResult>)>,
+		async_channel::Receiver<(Statement, oneshot::Sender<SubmitResult>)>,
 		Vec<PeerId>,
 	) {
 		let statement_store = TestStatementStore::new();
@@ -2355,7 +2328,7 @@ mod tests {
 		handler.on_statements(peer_id, vec![statement1.clone()]);
 		{
 			// Manually process statements submission
-			let (s, _, _) = queue_receiver.try_recv().unwrap();
+			let (s, _) = queue_receiver.try_recv().unwrap();
 			let _ = statement_store.statements.lock().unwrap().insert(s.hash(), s);
 			handler.network.report_peer(peer_id, rep::ANY_STATEMENT_REFUND);
 		}
@@ -3367,7 +3340,7 @@ mod tests {
 			})
 			.await;
 
-		let (received, _, _) = queue_receiver.try_recv().unwrap();
+		let (received, _) = queue_receiver.try_recv().unwrap();
 		assert_eq!(received.hash(), hash, "V1 peer's raw statement should be decoded correctly");
 	}
 
@@ -3404,7 +3377,7 @@ mod tests {
 			})
 			.await;
 
-		let (received, _, _) = queue_receiver.try_recv().unwrap();
+		let (received, _) = queue_receiver.try_recv().unwrap();
 		assert_eq!(received.hash(), hash, "V2 peer's StatementMessage should be decoded correctly");
 	}
 

--- a/substrate/client/network/statement/src/test_helpers.rs
+++ b/substrate/client/network/statement/src/test_helpers.rs
@@ -28,6 +28,11 @@ pub(crate) fn topic(n: u8) -> Topic {
 	Topic([n; 32])
 }
 
+/// A `NonZeroUsize`, for terse test fixtures.
+pub(crate) fn nz(n: usize) -> NonZeroUsize {
+	NonZeroUsize::new(n).expect("non-zero")
+}
+
 /// A deterministic peer whose identity multihash is seeded by `seed`.
 pub(crate) fn peer(seed: u8) -> PeerId {
 	let mut bytes = [seed; 34];

--- a/substrate/client/network/statement/src/v2dht/explicit_affinity.rs
+++ b/substrate/client/network/statement/src/v2dht/explicit_affinity.rs
@@ -232,7 +232,7 @@ impl ExplicitAffinity {
 	}
 }
 
-// TODO: Rewrite this oracles as a general interface for not PoC
+// TODO: Replace these ad-hoc oracles with an interface before this leaves PoC.
 /// Standalone explicit-affinity oracle: the local topic set, shared with the store so it decides
 /// retention without the full [`ExplicitAffinity`].
 #[derive(Clone, Default)]
@@ -423,6 +423,10 @@ mod tests {
 
 		assert!(affinity.is_affine(&statement_on(topic(1))));
 		assert!(!affinity.is_affine(&statement_on(topic(2))));
+
+		let mut topicless = Statement::new();
+		topicless.set_plain_data(b"broadcast".to_vec());
+		assert!(!affinity.is_affine(&topicless), "a topicless statement is never affine");
 	}
 
 	#[test]

--- a/substrate/client/network/statement/src/v2dht/explicit_affinity.rs
+++ b/substrate/client/network/statement/src/v2dht/explicit_affinity.rs
@@ -49,9 +49,9 @@
 //!    The store owns the subscription set, so the poll cannot drift and the RPC layer stays
 //!    untouched. Needs step 3. Closes "track affinity from active subscriptions" ([#12339]).
 //! 6. [x] **Local queries.** Over the fed topic set, implement `local_filter()` (advertised
-//!    [`AffinityFilter`] built from the topics) and `local_has_explicit_affinity(stmt)` (does any
-//!    of the statement's topics sit in the set). Configured and subscribed topics start being
-//!    advertised here. Tests: filter contents and membership ([#12340]).
+//!    [`AffinityFilter`] built from the topics) and a membership query — does any of a statement's
+//!    topics sit in the set. Configured and subscribed topics start being advertised here. Tests:
+//!    filter contents and membership ([#12340]).
 //! 7. [x] **Peer filters.** `update_peer_filter`/`on_peer_disconnected` maintain a `HashMap<PeerId,
 //!    AffinityFilter>`; `peer_has_explicit_affinity(peer, stmt)` reads it for the forward decision.
 //!    Independent of the local side. The overlapping `Peer::topic_affinity` in `lib.rs` stays until
@@ -59,11 +59,16 @@
 //!    disconnect ([#12342]).
 //!
 //! After step 7 the module is complete. The store and forward decisions live in the orchestrator
-//! (#11937), not here. For storage it stores a statement permanently when affinity holds —
-//! `local_has_explicit_affinity` from this module OR the DHT-closeness half from peers-topology
-//! (#11933) — and otherwise keeps it only until the next propagation, the retention the store
-//! enforces (#11936). It feeds `peer_has_explicit_affinity` into the forward decision and retires
+//! (#11937), not here. For storage it stores a statement permanently when affinity holds — explicit
+//! topic affinity from this module OR the DHT-closeness half from peers-topology (#11933) — and
+//! otherwise keeps it only until the next propagation, the retention the store enforces (#11936).
+//! It feeds `peer_has_explicit_affinity` into the forward decision and retires
 //! `Peer::topic_affinity`.
+//!
+//! Retention runs on the store's thread, not the handler's, so the orchestrator can't be queried
+//! live. Instead it publishes detached oracles — [`TopicAffinity`] here and `DhtAffinity` from
+//! peers-topology — into the store's retention handle, each answering `is_affine(stmt)`. The
+//! store's resolver ORs the two into the statement's retention mask.
 //!
 //! [#12276]: https://github.com/paritytech/polkadot-sdk/pull/12276
 //! [#12278]: https://github.com/paritytech/polkadot-sdk/pull/12278
@@ -161,12 +166,12 @@ impl ExplicitAffinity {
 		}
 	}
 
-	/// Replaces topics with exact source.
+	/// Replaces topics with exact source. Returns whether the source's topic set changed.
 	pub(crate) fn replace_source_topics(
 		&mut self,
 		source: AffinitySource,
 		desired: &HashSet<Topic>,
-	) {
+	) -> bool {
 		let current: HashSet<Topic> = self
 			.local
 			.iter()
@@ -178,11 +183,17 @@ impl ExplicitAffinity {
 		let to_add: Vec<Topic> = desired.difference(&current).copied().collect();
 		self.remove_topics(source, &to_remove);
 		self.add_topics(source, &to_add);
+		!to_remove.is_empty() || !to_add.is_empty()
 	}
 
 	/// The topics this node currently has affinity for
 	pub(crate) fn topics(&self) -> Vec<Topic> {
 		self.local.keys().copied().collect()
+	}
+
+	/// A standalone explicit-affinity oracle, answering topic membership off the handler thread.
+	pub(crate) fn topic_affinity(&self) -> TopicAffinity {
+		TopicAffinity { topics: self.local.keys().copied().collect() }
 	}
 
 	// === Advertise ===
@@ -215,16 +226,25 @@ impl ExplicitAffinity {
 
 	// === Queries ===
 
-	/// Whether any of the statement's topics sits in the local topic set.
-	///
-	/// Reads the exact set, not [`Self::local_filter`] to skip bloom false positives.
-	pub(crate) fn local_has_explicit_affinity(&self, stmt: &Statement) -> bool {
-		stmt.topics().iter().any(|topic| self.local.contains_key(topic))
-	}
-
 	/// Whether the peer's advertised filter accepts the statement.
 	pub(crate) fn peer_has_explicit_affinity(&self, peer: PeerId, stmt: &Statement) -> bool {
 		self.peers.get(&peer).is_some_and(|filter| filter.matches_statement(stmt))
+	}
+}
+
+// TODO: Rewrite this oracles as a general interface for not PoC
+/// Standalone explicit-affinity oracle: the local topic set, shared with the store so it decides
+/// retention without the full [`ExplicitAffinity`].
+#[derive(Clone, Default)]
+pub(crate) struct TopicAffinity {
+	topics: HashSet<Topic>,
+}
+
+impl TopicAffinity {
+	/// Whether any of the statement's topics sits in the local topic set. Reads the exact set, not
+	/// the advertised bloom filter, so there are no false positives.
+	pub(crate) fn is_affine(&self, stmt: &Statement) -> bool {
+		stmt.topics().iter().any(|topic| self.topics.contains(topic))
 	}
 }
 
@@ -398,20 +418,11 @@ mod tests {
 	}
 
 	#[test]
-	fn local_has_explicit_affinity_tracks_membership() {
-		let affinity = ExplicitAffinity::new(&[topic(1)]);
+	fn topic_affinity_tracks_membership() {
+		let affinity = ExplicitAffinity::new(&[topic(1)]).topic_affinity();
 
-		assert!(affinity.local_has_explicit_affinity(&statement_on(topic(1))));
-		assert!(!affinity.local_has_explicit_affinity(&statement_on(topic(2))));
-	}
-
-	#[test]
-	fn local_has_explicit_affinity_false_for_topicless_statement() {
-		let affinity = ExplicitAffinity::new(&[topic(1)]);
-
-		let mut broadcast = Statement::new();
-		broadcast.set_plain_data(b"broadcast".to_vec());
-		assert!(!affinity.local_has_explicit_affinity(&broadcast));
+		assert!(affinity.is_affine(&statement_on(topic(1))));
+		assert!(!affinity.is_affine(&statement_on(topic(2))));
 	}
 
 	#[test]

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -27,13 +27,70 @@ pub mod peers_topology;
 pub(crate) use metrics::V2DhtMetrics;
 
 use crate::{affinity::AffinityFilter, LOG_TARGET};
-use explicit_affinity::{AffinitySource, ExplicitAffinity};
+use explicit_affinity::{AffinitySource, ExplicitAffinity, TopicAffinity};
 use peer_steering::PeerSteering;
-use peers_topology::{PeersTopology, PeersTopologyConfig};
+use peers_topology::{DhtAffinity, PeersTopology, PeersTopologyConfig};
 use sc_network::{types::ProtocolName, NetworkPeers};
 use sc_network_types::PeerId;
 use sp_statement_store::{Hash, RetentionReasonMask, Statement, SubmitResult, Topic};
-use std::collections::{HashMap, HashSet};
+use std::{
+	collections::{HashMap, HashSet},
+	sync::{Arc, RwLock},
+};
+
+/// Shared affinity view to derive a statement's retention mask.
+#[derive(Clone)]
+pub struct RetentionHandle {
+	dht_affinity: Arc<RwLock<DhtAffinity>>,
+	/// Topics the node has explicit affinity for.
+	topic_affinity: Arc<RwLock<TopicAffinity>>,
+}
+
+impl RetentionHandle {
+	/// A handle seeded with an empty topology, so its resolver persists everything until the
+	/// orchestrator publishes the learned affinity.
+	pub fn new(local_peer: PeerId, replication_factor: usize) -> Self {
+		Self {
+			dht_affinity: Arc::new(RwLock::new(DhtAffinity::empty(local_peer, replication_factor))),
+			topic_affinity: Arc::new(RwLock::new(TopicAffinity::default())),
+		}
+	}
+
+	/// The resolver the store calls to derive a statement's retention mask.
+	pub fn resolver(&self) -> Box<dyn Fn(&Statement) -> RetentionReasonMask + Send + Sync> {
+		let dht_affinity = self.dht_affinity.clone();
+		let topic_affinity = self.topic_affinity.clone();
+		Box::new(move |stmt| {
+			// A poisoned lock can't happen (the writers never panic); persist defensively if it
+			// does, since dropping a statement is worse than keeping one.
+			let (Ok(dht), Ok(topics)) = (dht_affinity.read(), topic_affinity.read()) else {
+				return RetentionReasonMask::persistent();
+			};
+			let mut mask = RetentionReasonMask::TRANSIENT;
+			if dht.is_affine(stmt) {
+				mask.insert(RetentionReasonMask::DHT_AFFINITY);
+			}
+			if topics.is_affine(stmt) {
+				mask.insert(RetentionReasonMask::EXPLICIT_AFFINITY);
+			}
+			mask
+		})
+	}
+
+	/// Replace the DHT-affinity oracle
+	fn set_dht_affinity(&self, dht_affinity: DhtAffinity) {
+		if let Ok(mut cell) = self.dht_affinity.write() {
+			*cell = dht_affinity;
+		}
+	}
+
+	/// Replace the explicit topic-affinity oracle
+	fn set_topic_affinity(&self, topic_affinity: TopicAffinity) {
+		if let Ok(mut cell) = self.topic_affinity.write() {
+			*cell = topic_affinity;
+		}
+	}
+}
 
 /// Coordinates the v2 DHT-affinity statement gossip path.
 #[allow(dead_code)]
@@ -44,6 +101,8 @@ pub(crate) struct V2DhtOrchestrator {
 	explicit_affinity: ExplicitAffinity,
 	/// Keeps the connected peer set aligned with the peers needed to cover subscriptions.
 	peer_steering: PeerSteering,
+	/// Shared affinity view the store reads to decide statement retention.
+	retention: Option<RetentionHandle>,
 	/// Prometheus metrics.
 	metrics: Option<V2DhtMetrics>,
 }
@@ -61,7 +120,27 @@ impl V2DhtOrchestrator {
 			peers_topology: PeersTopology::new(local_peer, peers_topology_config),
 			explicit_affinity: ExplicitAffinity::new(configured_topics),
 			peer_steering: PeerSteering::new(protocol),
+			retention: None,
 			metrics,
+		}
+	}
+
+	/// Install the handle the store reads to decide statement retention.
+	pub(crate) fn set_retention_handle(&mut self, handle: RetentionHandle) {
+		self.retention = Some(handle);
+	}
+
+	/// Refresh the store's DHT-affinity oracle
+	fn publish_dht_affinity(&self) {
+		if let Some(handle) = &self.retention {
+			handle.set_dht_affinity(self.peers_topology.dht_affinity());
+		}
+	}
+
+	/// Refresh the store's explicit topic-affinity oracle
+	fn publish_topic_affinity(&self) {
+		if let Some(handle) = &self.retention {
+			handle.set_topic_affinity(self.explicit_affinity.topic_affinity());
 		}
 	}
 
@@ -82,6 +161,8 @@ impl V2DhtOrchestrator {
 
 	pub(crate) fn on_peer_identified(&mut self, peer: PeerId, supports_statement_protocol: bool) {
 		self.peers_topology.on_peer_identified(peer, supports_statement_protocol);
+		// Changes the DHT peer index, hence affinity.
+		self.publish_dht_affinity();
 		self.report_topology_size();
 	}
 
@@ -89,8 +170,12 @@ impl V2DhtOrchestrator {
 
 	/// Refresh the topics the node has affinity for through its active RPC subscriptions.
 	pub(crate) fn set_rpc_subscription_topics(&mut self, topics: &HashSet<Topic>) {
-		self.explicit_affinity
-			.replace_source_topics(AffinitySource::RpcSubscription, topics);
+		if self
+			.explicit_affinity
+			.replace_source_topics(AffinitySource::RpcSubscription, topics)
+		{
+			self.publish_topic_affinity();
+		}
 	}
 
 	/// The topics this node currently has affinity for.
@@ -132,6 +217,8 @@ impl V2DhtOrchestrator {
 	pub(crate) fn on_substream_opened(&mut self, peer: PeerId) {
 		self.peers_topology.on_substream_opened(peer);
 		self.peer_steering.on_substream_opened(peer);
+		// Adds the peer to the DHT index, hence affinity.
+		self.publish_dht_affinity();
 		self.report_topology_size();
 		log::trace!(target: LOG_TARGET, "v2dht: on_substream_opened {peer}");
 	}
@@ -152,21 +239,6 @@ impl V2DhtOrchestrator {
 	/// Whether the peer's advertised filter accepts the statement.
 	pub(crate) fn peer_has_explicit_affinity(&self, peer: PeerId, stmt: &Statement) -> bool {
 		self.explicit_affinity.peer_has_explicit_affinity(peer, stmt)
-	}
-
-	// === Receive decision ===
-
-	/// The reasons this node should store the statement.
-	pub(crate) fn retention_reasons_for(&self, stmt: &Statement) -> RetentionReasonMask {
-		let mut mask = RetentionReasonMask::TRANSIENT;
-		// TODO: can we pass the statement instead of topics to the `is_dht_affine`?
-		if stmt.topics().iter().any(|topic| self.peers_topology.is_dht_affine(*topic)) {
-			mask.insert(RetentionReasonMask::DHT_AFFINITY);
-		}
-		if self.explicit_affinity.local_has_explicit_affinity(stmt) {
-			mask.insert(RetentionReasonMask::EXPLICIT_AFFINITY);
-		}
-		mask
 	}
 
 	// === Post-submit hook ===
@@ -322,64 +394,92 @@ mod tests {
 		assert_eq!(batch, vec![0, 1]);
 	}
 
-	#[test]
-	fn retention_reasons_for_marks_explicit_affinity() {
-		let orchestrator = V2DhtOrchestrator::new(
-			&[topic(1)],
-			PeerId::random(),
-			topology_config(20, 1),
-			"/statement/test".into(),
-			None,
-		);
+	/// A DHT-affinity oracle from many peers with one replica per topic, leaving the local node
+	/// non-affine for most topics, paired with one such non-affine topic.
+	fn dht_without_local_affinity() -> (DhtAffinity, Topic) {
+		let mut topology = PeersTopology::new(peer(1), topology_config(1, 1));
+		let peers: Vec<_> = (2u8..=200).map(peer).collect();
+		topology.on_peers_discovered(peers.clone());
+		for peer in &peers {
+			topology.on_peer_identified(*peer, /* supports_statement_protocol */ true);
+		}
+		let dht = topology.dht_affinity();
+		let topic = (0u8..=255)
+			.map(topic)
+			.find(|topic| !dht.is_affine(&statement_on(*topic)))
+			.expect("199 peers leave some topic without local DHT affinity");
+		(dht, topic)
+	}
 
-		let mask = orchestrator.retention_reasons_for(&statement_on(topic(1)));
+	#[test]
+	fn resolver_persists_with_an_empty_seeded_topology() {
+		// Knowing no peers, the local node is the sole replica for every topic, so it persists.
+		assert!(
+			RetentionHandle::new(peer(1), 1).resolver()(&statement_on(topic(1))).is_persistent()
+		);
+	}
+
+	#[test]
+	fn resolver_marks_explicit_affinity() {
+		let (dht, topic) = dht_without_local_affinity();
+		let handle = RetentionHandle::new(peer(1), 1);
+		handle.set_dht_affinity(dht);
+		handle.set_topic_affinity(ExplicitAffinity::new(&[topic]).topic_affinity());
+
+		let mask = handle.resolver()(&statement_on(topic));
 
 		assert!(mask.contains(RetentionReasonMask::EXPLICIT_AFFINITY));
+		assert!(!mask.contains(RetentionReasonMask::DHT_AFFINITY));
 		assert!(mask.is_persistent());
 	}
 
 	#[test]
-	fn retention_reasons_for_marks_dht_affinity_when_local_is_a_replica() {
+	fn resolver_marks_dht_affinity_when_local_is_a_replica() {
 		// An empty topology makes the local node a replica for every topic.
-		let orchestrator = V2DhtOrchestrator::new(
-			&[],
-			PeerId::random(),
-			topology_config(20, 1),
-			"/statement/test".into(),
-			None,
-		);
+		let handle = RetentionHandle::new(peer(1), 1);
+		handle.set_dht_affinity(PeersTopology::new(peer(1), topology_config(20, 1)).dht_affinity());
 
-		let mask = orchestrator.retention_reasons_for(&statement_on(topic(9)));
+		let mask = handle.resolver()(&statement_on(topic(9)));
 
 		assert!(mask.contains(RetentionReasonMask::DHT_AFFINITY));
 		assert!(!mask.contains(RetentionReasonMask::EXPLICIT_AFFINITY));
 	}
 
 	#[test]
-	fn retention_reasons_for_is_transient_without_any_affinity() {
-		// One replica per topic, so a single closer peer displaces the local node.
+	fn resolver_is_transient_without_any_affinity() {
+		let (dht, topic) = dht_without_local_affinity();
+		let handle = RetentionHandle::new(peer(1), 1);
+		handle.set_dht_affinity(dht);
+
+		assert_eq!(handle.resolver()(&statement_on(topic)), RetentionReasonMask::TRANSIENT);
+	}
+
+	#[test]
+	fn publish_dht_affinity_reflects_the_orchestrator_topology() {
 		let mut orchestrator = V2DhtOrchestrator::new(
 			&[],
-			PeerId::random(),
+			peer(1),
 			topology_config(1, 1),
 			"/statement/test".into(),
 			None,
 		);
-		let peers = (0..32).map(|_| PeerId::random()).collect::<Vec<_>>();
+		let handle = RetentionHandle::new(peer(1), 1);
+		orchestrator.set_retention_handle(handle.clone());
+
+		// Identify enough peers that the local node loses DHT affinity for some topic; each
+		// `on_peer_identified` refreshes the published oracle.
+		let peers: Vec<_> = (2u8..=200).map(peer).collect();
 		orchestrator.on_peers_discovered(peers.clone());
 		for peer in &peers {
-			orchestrator.on_peer_identified(*peer, true);
+			orchestrator.on_peer_identified(*peer, /* supports_statement_protocol */ true);
 		}
 
-		// A topic the local node is not the closest replica for, so DHT affinity does not hold.
-		let topic = (0u8..=255)
+		let dht = orchestrator.peers_topology.dht_affinity();
+		let non_affine = (0u8..=255)
 			.map(topic)
-			.find(|topic| !orchestrator.peers_topology.is_dht_affine(*topic))
-			.expect("32 peers leave some topic without local DHT affinity");
-
-		let mask = orchestrator.retention_reasons_for(&statement_on(topic));
-
-		assert!(!mask.is_persistent());
+			.find(|topic| !dht.is_affine(&statement_on(*topic)))
+			.expect("199 peers leave some topic without local DHT affinity");
+		assert_eq!(handle.resolver()(&statement_on(non_affine)), RetentionReasonMask::TRANSIENT);
 	}
 
 	#[test]

--- a/substrate/client/network/statement/src/v2dht/mod.rs
+++ b/substrate/client/network/statement/src/v2dht/mod.rs
@@ -35,6 +35,7 @@ use sc_network_types::PeerId;
 use sp_statement_store::{Hash, RetentionReasonMask, Statement, SubmitResult, Topic};
 use std::{
 	collections::{HashMap, HashSet},
+	num::NonZeroUsize,
 	sync::{Arc, RwLock},
 };
 
@@ -47,9 +48,9 @@ pub struct RetentionHandle {
 }
 
 impl RetentionHandle {
-	/// A handle seeded with an empty topology, so its resolver persists everything until the
-	/// orchestrator publishes the learned affinity.
-	pub fn new(local_peer: PeerId, replication_factor: usize) -> Self {
+	/// A handle seeded with an empty topology, so its resolver persists every statement carrying a
+	/// topic until the orchestrator publishes the learned affinity.
+	pub fn new(local_peer: PeerId, replication_factor: NonZeroUsize) -> Self {
 		Self {
 			dht_affinity: Arc::new(RwLock::new(DhtAffinity::empty(local_peer, replication_factor))),
 			topic_affinity: Arc::new(RwLock::new(TopicAffinity::default())),
@@ -61,9 +62,11 @@ impl RetentionHandle {
 		let dht_affinity = self.dht_affinity.clone();
 		let topic_affinity = self.topic_affinity.clone();
 		Box::new(move |stmt| {
-			// A poisoned lock can't happen (the writers never panic); persist defensively if it
-			// does, since dropping a statement is worse than keeping one.
 			let (Ok(dht), Ok(topics)) = (dht_affinity.read(), topic_affinity.read()) else {
+				log::error!(
+					target: LOG_TARGET,
+					"v2dht: retention affinity lock poisoned; persisting statement defensively",
+				);
 				return RetentionReasonMask::persistent();
 			};
 			let mut mask = RetentionReasonMask::TRANSIENT;
@@ -128,6 +131,10 @@ impl V2DhtOrchestrator {
 	/// Install the handle the store reads to decide statement retention.
 	pub(crate) fn set_retention_handle(&mut self, handle: RetentionHandle) {
 		self.retention = Some(handle);
+		// Seed both oracles from the current state so configured topics and the learned topology
+		// drive retention before the first peer or subscription event publishes them.
+		self.publish_dht_affinity();
+		self.publish_topic_affinity();
 	}
 
 	/// Refresh the store's DHT-affinity oracle
@@ -307,7 +314,7 @@ impl V2DhtOrchestrator {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::test_helpers::{filter_over, peer, statement_on, topic, topology_config};
+	use crate::test_helpers::{filter_over, nz, peer, statement_on, topic, topology_config};
 
 	fn orchestrator() -> V2DhtOrchestrator {
 		V2DhtOrchestrator::new(
@@ -414,15 +421,14 @@ mod tests {
 	#[test]
 	fn resolver_persists_with_an_empty_seeded_topology() {
 		// Knowing no peers, the local node is the sole replica for every topic, so it persists.
-		assert!(
-			RetentionHandle::new(peer(1), 1).resolver()(&statement_on(topic(1))).is_persistent()
-		);
+		assert!(RetentionHandle::new(peer(1), nz(1)).resolver()(&statement_on(topic(1)))
+			.is_persistent());
 	}
 
 	#[test]
 	fn resolver_marks_explicit_affinity() {
 		let (dht, topic) = dht_without_local_affinity();
-		let handle = RetentionHandle::new(peer(1), 1);
+		let handle = RetentionHandle::new(peer(1), nz(1));
 		handle.set_dht_affinity(dht);
 		handle.set_topic_affinity(ExplicitAffinity::new(&[topic]).topic_affinity());
 
@@ -436,7 +442,7 @@ mod tests {
 	#[test]
 	fn resolver_marks_dht_affinity_when_local_is_a_replica() {
 		// An empty topology makes the local node a replica for every topic.
-		let handle = RetentionHandle::new(peer(1), 1);
+		let handle = RetentionHandle::new(peer(1), nz(1));
 		handle.set_dht_affinity(PeersTopology::new(peer(1), topology_config(20, 1)).dht_affinity());
 
 		let mask = handle.resolver()(&statement_on(topic(9)));
@@ -448,7 +454,7 @@ mod tests {
 	#[test]
 	fn resolver_is_transient_without_any_affinity() {
 		let (dht, topic) = dht_without_local_affinity();
-		let handle = RetentionHandle::new(peer(1), 1);
+		let handle = RetentionHandle::new(peer(1), nz(1));
 		handle.set_dht_affinity(dht);
 
 		assert_eq!(handle.resolver()(&statement_on(topic)), RetentionReasonMask::TRANSIENT);
@@ -463,7 +469,7 @@ mod tests {
 			"/statement/test".into(),
 			None,
 		);
-		let handle = RetentionHandle::new(peer(1), 1);
+		let handle = RetentionHandle::new(peer(1), nz(1));
 		orchestrator.set_retention_handle(handle.clone());
 
 		// Identify enough peers that the local node loses DHT affinity for some topic; each
@@ -480,6 +486,60 @@ mod tests {
 			.find(|topic| !dht.is_affine(&statement_on(*topic)))
 			.expect("199 peers leave some topic without local DHT affinity");
 		assert_eq!(handle.resolver()(&statement_on(non_affine)), RetentionReasonMask::TRANSIENT);
+	}
+
+	#[test]
+	fn set_retention_handle_publishes_configured_topics() {
+		// Configured topics must drive retention from the moment the handle is installed, before
+		// any peer or subscription event.
+		let mut orchestrator = V2DhtOrchestrator::new(
+			&[topic(1)],
+			peer(1),
+			topology_config(1, 1),
+			"/statement/test".into(),
+			None,
+		);
+		let handle = RetentionHandle::new(peer(1), nz(1));
+		orchestrator.set_retention_handle(handle.clone());
+
+		assert!(handle.resolver()(&statement_on(topic(1)))
+			.contains(RetentionReasonMask::EXPLICIT_AFFINITY));
+	}
+
+	#[test]
+	fn set_rpc_subscription_topics_publishes_topic_affinity() {
+		let mut orchestrator = V2DhtOrchestrator::new(
+			&[],
+			peer(1),
+			topology_config(1, 1),
+			"/statement/test".into(),
+			None,
+		);
+		let handle = RetentionHandle::new(peer(1), nz(1));
+		orchestrator.set_retention_handle(handle.clone());
+		assert!(!handle.resolver()(&statement_on(topic(1)))
+			.contains(RetentionReasonMask::EXPLICIT_AFFINITY));
+
+		// A subscription change reaches the store's oracle.
+		orchestrator.set_rpc_subscription_topics(&HashSet::from([topic(1)]));
+
+		assert!(handle.resolver()(&statement_on(topic(1)))
+			.contains(RetentionReasonMask::EXPLICIT_AFFINITY));
+	}
+
+	#[test]
+	fn resolver_marks_both_affinities() {
+		// An empty topology makes the local node a DHT replica for every topic; configure the same
+		// topic so both retention reasons hold at once.
+		let handle = RetentionHandle::new(peer(1), nz(1));
+		handle.set_dht_affinity(PeersTopology::new(peer(1), topology_config(20, 1)).dht_affinity());
+		handle.set_topic_affinity(ExplicitAffinity::new(&[topic(9)]).topic_affinity());
+
+		let mask = handle.resolver()(&statement_on(topic(9)));
+
+		assert!(mask.contains(RetentionReasonMask::DHT_AFFINITY));
+		assert!(mask.contains(RetentionReasonMask::EXPLICIT_AFFINITY));
+		assert!(mask.is_persistent());
 	}
 
 	#[test]

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -172,7 +172,7 @@ impl PeersTopology {
 			index: self.discovered_index.clone(),
 			local_peer: self.local_peer,
 			local_key: self.local_key,
-			replication_factor: self.config.replication_factor.get(),
+			replication_factor: self.config.replication_factor,
 		}
 	}
 
@@ -300,12 +300,12 @@ pub struct DhtAffinity {
 	index: PeersIndex,
 	local_peer: PeerId,
 	local_key: Key,
-	replication_factor: usize,
+	replication_factor: NonZeroUsize,
 }
 
 impl DhtAffinity {
 	/// An oracle that knows no peers yet, so the local node is the sole replica for every topic.
-	pub fn empty(local_peer: PeerId, replication_factor: usize) -> Self {
+	pub fn empty(local_peer: PeerId, replication_factor: NonZeroUsize) -> Self {
 		Self {
 			index: PeersIndex::default(),
 			local_peer,
@@ -320,15 +320,16 @@ impl DhtAffinity {
 		stmt.topics().iter().any(|topic| {
 			let topic = *topic;
 			let local_distance = xor_distance(*topic, self.local_key);
+			let replication_factor = self.replication_factor.get();
 			let closer_count = self
 				.index
 				.closest(*topic)
 				.take_while(|(peer, key)| {
 					(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
 				})
-				.take(self.replication_factor)
+				.take(replication_factor)
 				.count();
-			closer_count < self.replication_factor
+			closer_count < replication_factor
 		})
 	}
 }

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -321,6 +321,9 @@ impl DhtAffinity {
 			let topic = *topic;
 			let local_distance = xor_distance(*topic, self.local_key);
 			let replication_factor = self.replication_factor.get();
+			// The descent yields candidates in `(distance, peer)` order, so the candidates ranked
+			// before the local node form a prefix; the local node is a replica when that prefix is
+			// shorter than the replication factor.
 			let closer_count = self
 				.index
 				.closest(*topic)

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -167,6 +167,8 @@ impl PeersTopology {
 	///
 	/// Clones only the data the decision needs — the statement-protocol peer index and the local
 	/// identity — not the full topology.
+	///
+	/// TODO: deep-copies the index on every peer-churn event that republishes the oracle.
 	pub fn dht_affinity(&self) -> DhtAffinity {
 		DhtAffinity {
 			index: self.discovered_index.clone(),
@@ -317,23 +319,25 @@ impl DhtAffinity {
 	/// Whether the local node is one of the closest DHT storage replicas for any of the statement's
 	/// topics, over the locally learned statement-store peers.
 	pub fn is_affine(&self, stmt: &Statement) -> bool {
-		stmt.topics().iter().any(|topic| {
-			let topic = *topic;
-			let local_distance = xor_distance(*topic, self.local_key);
-			let replication_factor = self.replication_factor.get();
-			// The descent yields candidates in `(distance, peer)` order, so the candidates ranked
-			// before the local node form a prefix; the local node is a replica when that prefix is
-			// shorter than the replication factor.
-			let closer_count = self
-				.index
-				.closest(*topic)
-				.take_while(|(peer, key)| {
-					(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
-				})
-				.take(replication_factor)
-				.count();
-			closer_count < replication_factor
-		})
+		stmt.topics().iter().any(|topic| self.is_topic_affine(*topic))
+	}
+
+	/// Whether the local node is one of the closest DHT storage replicas for `topic`.
+	fn is_topic_affine(&self, topic: Topic) -> bool {
+		let local_distance = xor_distance(*topic, self.local_key);
+		let replication_factor = self.replication_factor.get();
+		// The descent yields candidates in `(distance, peer)` order, so the candidates ranked
+		// before the local node form a prefix; the local node is a replica when that prefix is
+		// shorter than the replication factor.
+		let closer_count = self
+			.index
+			.closest(*topic)
+			.take_while(|(peer, key)| {
+				(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
+			})
+			.take(replication_factor)
+			.count();
+		closer_count < replication_factor
 	}
 }
 

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -18,6 +18,7 @@
 
 use super::peers_index::{Key, PeersIndex};
 use sc_network_types::PeerId;
+use sp_statement_store::Statement;
 pub use sp_statement_store::Topic;
 use std::{
 	cmp::Reverse,
@@ -29,7 +30,7 @@ use std::{
 pub struct PeersTopologyConfig {
 	/// Number of statement-protocol peers responsible for storing a topic.
 	///
-	/// `is_dht_affine` uses this to decide whether the local node belongs to the
+	/// The DHT-affinity decision uses this to decide whether the local node belongs to the
 	/// K-closest peers for a topic according to the locally learned topology.
 	pub replication_factor: NonZeroUsize,
 	/// Maximum number of connected nodes that we gossip to.
@@ -161,25 +162,18 @@ impl PeersTopology {
 			.collect()
 	}
 
-	/// Returns whether the local node is one of the closest DHT storage replicas for `topic`.
+	/// A standalone DHT-affinity oracle, answering "is the local node a storage replica for a
+	/// topic" off the handler thread.
 	///
-	/// This answers whether this node should store statements for `topic` according to DHT
-	/// affinity over the locally learned statement-store peers.
-	pub fn is_dht_affine(&self, topic: Topic) -> bool {
-		let local_distance = xor_distance(*topic, self.local_key);
-		let replication_factor = self.config.replication_factor.get();
-		// The descent yields candidates in `(distance, peer)` order, so the candidates ranked
-		// before the local node form a prefix; the local node is a replica when that prefix is
-		// shorter than the replication factor.
-		let closer_count = self
-			.discovered_index
-			.closest(*topic)
-			.take_while(|(peer, key)| {
-				(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
-			})
-			.take(replication_factor)
-			.count();
-		closer_count < replication_factor
+	/// Clones only the data the decision needs — the statement-protocol peer index and the local
+	/// identity — not the full topology.
+	pub fn dht_affinity(&self) -> DhtAffinity {
+		DhtAffinity {
+			index: self.discovered_index.clone(),
+			local_peer: self.local_peer,
+			local_key: self.local_key,
+			replication_factor: self.config.replication_factor.get(),
+		}
 	}
 
 	/// Connected peers closer to `topic` than the local node, capped at `gossip_target`.
@@ -298,10 +292,51 @@ fn xor_distance(a: Key, b: Key) -> Key {
 	distance
 }
 
+/// Standalone DHT-affinity oracle: the minimal snapshot needed to answer "is the local node a
+/// storage replica for a topic", shared with the store so it decides retention without the full
+/// [`PeersTopology`].
+#[derive(Clone)]
+pub struct DhtAffinity {
+	index: PeersIndex,
+	local_peer: PeerId,
+	local_key: Key,
+	replication_factor: usize,
+}
+
+impl DhtAffinity {
+	/// An oracle that knows no peers yet, so the local node is the sole replica for every topic.
+	pub fn empty(local_peer: PeerId, replication_factor: usize) -> Self {
+		Self {
+			index: PeersIndex::default(),
+			local_peer,
+			local_key: peer_key(&local_peer),
+			replication_factor,
+		}
+	}
+
+	/// Whether the local node is one of the closest DHT storage replicas for any of the statement's
+	/// topics, over the locally learned statement-store peers.
+	pub fn is_affine(&self, stmt: &Statement) -> bool {
+		stmt.topics().iter().any(|topic| {
+			let topic = *topic;
+			let local_distance = xor_distance(*topic, self.local_key);
+			let closer_count = self
+				.index
+				.closest(*topic)
+				.take_while(|(peer, key)| {
+					(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
+				})
+				.take(self.replication_factor)
+				.count();
+			closer_count < self.replication_factor
+		})
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::test_helpers::{peer, topic, topology_config};
+	use crate::test_helpers::{peer, statement_on, topic, topology_config};
 	use std::cmp::Ordering;
 
 	fn distance_to(topic: Topic, peer: &PeerId) -> [u8; 32] {
@@ -399,7 +434,7 @@ mod tests {
 		responsible.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
 		let expected = responsible.into_iter().take(2).any(|p| p == peer(10));
 
-		assert_eq!(topology.is_dht_affine(topic), expected);
+		assert_eq!(topology.dht_affinity().is_affine(&statement_on(topic)), expected);
 	}
 
 	#[test]
@@ -529,6 +564,7 @@ mod tests {
 			topology.on_peer_identified(peer, supports);
 			records.push((peer, supports, connected));
 		}
+		let dht = topology.dht_affinity();
 
 		for topic_seed in 0..32 {
 			let topic = topic(topic_seed);
@@ -548,7 +584,7 @@ mod tests {
 			with_local.push(local);
 			with_local.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
 			let expected_affine = with_local.iter().take(5).any(|peer| *peer == local);
-			assert_eq!(topology.is_dht_affine(topic), expected_affine);
+			assert_eq!(dht.is_affine(&statement_on(topic)), expected_affine);
 
 			let local_distance = distance_to(topic, &local);
 			let mut connected = records

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -368,6 +368,9 @@ pub struct Store {
 	query_index: RwLock<QueryIndex>,
 	read_allowance_fn:
 		Box<dyn Fn(&AccountId, AllowanceBlock) -> Result<Option<StatementAllowance>> + Send + Sync>,
+	/// Derives the retention mask for each submitted statement.
+	/// By default every submission is persisted unconditionally.
+	retention_fn: std::sync::OnceLock<Box<dyn Fn(&Statement) -> RetentionReasonMask + Send + Sync>>,
 	subscription_manager: SubscriptionsHandle,
 	keystore: Arc<LocalKeystore>,
 	// Used for testing
@@ -813,6 +816,7 @@ impl Store {
 			submit_index: RwLock::new(SubmitIndex::new(config)),
 			query_index: RwLock::new(QueryIndex::default()),
 			read_allowance_fn,
+			retention_fn: std::sync::OnceLock::new(),
 			keystore,
 			time_override: None,
 			metrics: PrometheusMetrics::new(prometheus),
@@ -823,6 +827,16 @@ impl Store {
 		};
 		store.populate()?;
 		Ok(store)
+	}
+
+	/// Install the resolver that derives the retention mask for each submitted statement.
+	///
+	/// Without it, the store persists every submission.
+	pub fn set_retention_resolver(
+		&self,
+		resolver: Box<dyn Fn(&Statement) -> RetentionReasonMask + Send + Sync>,
+	) {
+		let _ = self.retention_fn.set(resolver);
 	}
 
 	/// Create memory index from the data.
@@ -1388,18 +1402,13 @@ impl StatementStore for Store {
 		})
 	}
 
-	/// Submit a persistent statement to the store.
+	/// Submit a statement to the store.
 	fn submit(&self, statement: Statement, source: StatementSource) -> SubmitResult {
-		self.submit_with_retention_mask(statement, source, RetentionReasonMask::persistent())
-	}
+		let mask = self
+			.retention_fn
+			.get()
+			.map_or_else(RetentionReasonMask::persistent, |resolver| resolver(&statement));
 
-	/// Submit a statement to the store. Validates the statement and returns validation result.
-	fn submit_with_retention_mask(
-		&self,
-		statement: Statement,
-		source: StatementSource,
-		mask: RetentionReasonMask,
-	) -> SubmitResult {
 		let _histogram_submit_start_timer = self.metrics.start_submit_timer();
 		let hash = statement.hash();
 		// Get unix timestamp
@@ -2088,17 +2097,11 @@ mod tests {
 	#[test]
 	fn transient_statement_is_served_once_then_dropped() {
 		let (store, _temp) = test_store();
+		store.set_retention_resolver(Box::new(|_| RetentionReasonMask::TRANSIENT));
 		let statement = signed_statement(0);
 		let hash = statement.hash();
 
-		assert_eq!(
-			store.submit_with_retention_mask(
-				statement.clone(),
-				StatementSource::Network,
-				RetentionReasonMask::TRANSIENT,
-			),
-			SubmitResult::New,
-		);
+		assert_eq!(store.submit(statement.clone(), StatementSource::Network), SubmitResult::New,);
 
 		// Invisible to the query API: the store behaves as if it holds no transient statement.
 		assert!(!store.has_statement(&hash));
@@ -2119,24 +2122,21 @@ mod tests {
 	#[test]
 	fn resubmitting_transient_statement_reports_known() {
 		let (store, _temp) = test_store();
+		store.set_retention_resolver(Box::new(|_| RetentionReasonMask::TRANSIENT));
 		let statement = signed_statement(0);
 
-		assert_eq!(
-			store.submit_with_retention_mask(
-				statement.clone(),
-				StatementSource::Network,
-				RetentionReasonMask::TRANSIENT,
-			),
-			SubmitResult::New,
-		);
-		assert_eq!(
-			store.submit_with_retention_mask(
-				statement,
-				StatementSource::Network,
-				RetentionReasonMask::TRANSIENT,
-			),
-			SubmitResult::Known,
-		);
+		assert_eq!(store.submit(statement.clone(), StatementSource::Network), SubmitResult::New,);
+		assert_eq!(store.submit(statement, StatementSource::Network), SubmitResult::Known);
+	}
+
+	#[test]
+	fn submit_persists_without_a_resolver() {
+		let (store, _temp) = test_store();
+		let statement = signed_statement(0);
+		let hash = statement.hash();
+
+		assert_eq!(store.submit(statement, StatementSource::Local), SubmitResult::New);
+		assert!(store.has_statement(&hash));
 	}
 
 	#[test]

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -831,12 +831,18 @@ impl Store {
 
 	/// Install the resolver that derives the retention mask for each submitted statement.
 	///
-	/// Without it, the store persists every submission.
+	/// Without it, the store persists every submission. Installation is first-wins: the resolver is
+	/// wired once at node startup, so a second install means a wiring bug and is rejected loudly.
 	pub fn set_retention_resolver(
 		&self,
 		resolver: Box<dyn Fn(&Statement) -> RetentionReasonMask + Send + Sync>,
 	) {
-		let _ = self.retention_fn.set(resolver);
+		if self.retention_fn.set(resolver).is_err() {
+			log::error!(
+				target: LOG_TARGET,
+				"retention resolver already installed; ignoring the second install (wiring bug)",
+			);
+		}
 	}
 
 	/// Create memory index from the data.
@@ -2137,6 +2143,19 @@ mod tests {
 
 		assert_eq!(store.submit(statement, StatementSource::Local), SubmitResult::New);
 		assert!(store.has_statement(&hash));
+	}
+
+	#[test]
+	fn set_retention_resolver_is_first_wins() {
+		let (store, _temp) = test_store();
+		store.set_retention_resolver(Box::new(|_| RetentionReasonMask::TRANSIENT));
+		// The second install is rejected; the first resolver stays in force.
+		store.set_retention_resolver(Box::new(|_| RetentionReasonMask::persistent()));
+		let statement = signed_statement(0);
+		let hash = statement.hash();
+
+		assert_eq!(store.submit(statement, StatementSource::Network), SubmitResult::New);
+		assert!(!store.has_statement(&hash), "the first, transient resolver still applies");
 	}
 
 	#[test]

--- a/substrate/primitives/statement-store/src/store_api.rs
+++ b/substrate/primitives/statement-store/src/store_api.rs
@@ -341,19 +341,6 @@ pub trait StatementStore: Send + Sync {
 	/// Submit a statement.
 	fn submit(&self, statement: Statement, source: StatementSource) -> SubmitResult;
 
-	/// Submit a statement with the reasons it is worth storing.
-	///
-	/// The default ignores the mask and defers to [`Self::submit`], so stores that do
-	/// not distinguish transient statements keep their behavior. See [`RetentionReasonMask`].
-	fn submit_with_retention_mask(
-		&self,
-		statement: Statement,
-		source: StatementSource,
-		_mask: RetentionReasonMask,
-	) -> SubmitResult {
-		self.submit(statement, source)
-	}
-
 	/// Remove a statement from the store.
 	fn remove(&self, hash: &Hash) -> Result<()>;
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/12455
Local RPC submissions bypassed the v2 DHT-affinity retention rule and were always persisted. The store now derives each submission's retention mask from affinity oracles the orchestrator publishes, so a node keeps only the statements it has affinity for.