### PR TITLE
[pallet-revive] Test Versioning Invariants and Conventions

### DIFF
--- a/prdoc/pr_12522.prdoc
+++ b/prdoc/pr_12522.prdoc
@@ -1,0 +1,49 @@
+title: '[pallet-revive] Test Versioning Invariants and Conventions'
+doc:
+- audience: Runtime Dev
+  description: |-
+    # Description
+
+    This PR just adds a single test which checks that the invariants and conventions that we have for versioning are upheld in code.
+
+    The test is `test_versioned_runtime_api_invariants` in the dev-node's runtime crate. The reason for it being in that crate rather than other crates is because it's the only place where we have access to the metadata and to the runtime which we depend on heavily for this test.
+
+    The primary methodology of this test is asserting that the data that we observe in the frame metadata for pallet-revive matches the expectations we have. This is made more comprehensive due to the fact that the entire types registry is in the metadata so we can do checks such as "check that this function has a single argument which is an enum of this name and that has these variants", so the fact that we have a schema for these types allows us to perform type-system assertions outside of the type-system.
+
+    The test asserts the following:
+
+    1. For each versioned runtime API function:
+        1. That its name ends with the `_versioned` postfix.
+        2. That if it has an unversioned counterpart (e.g., `eth_block` and `eth_block_versioned`) that the unversioned runtime API has been deprecated in order to push people to use the versioned runtime API functions.
+        3. That is has exactly one input argument.
+        4. That the input argument is of the type `${function-name}VersionedInputPayload` and that the output is of the type `${function-name}VersionedOutputPayload`.
+        5. That the input and output types are enums.
+        6. That the input and output type enums have an equal number of variants which is non-zero.
+        7. For each variant on the input and output enums:
+            1. That the variants have a scale index of `N - 1` where N is the version. In this way, v1 would have a scale index of 0, v2 would have a scale index of 1, and so on.
+            2. That the variant name is `V` followed by the version number where the version number is contiguous, without gaps, and starts from 1.
+            3. That it has a single un-named field.
+            4. That if the field is an input field then it's of the type `${function-name}InputPayloadV{N}` and if it's an output field then it's of the type `${function-name}OutputPayloadV{N}`.
+        8. That it has a declaration in the `ReviveRuntimeApiVersionDeclarations` type.
+        9. That the declared version matches the highest observed versions in the enum variants.
+        10. That the `ReviveRuntimeApiVersionDeclarations` does not contain more declarations than it should.
+
+    This test protects from a number of things which we could get wrong as we evolve. Below are just some examples:
+
+    1. Accidentally adding a V5 input without a corresponding V5 output (or vice versa).
+    2. Accidentally not declaring that we support V5 of a given runtime API function through the `ReviveRuntimeApiVersionDeclarations` when it's indeed supported.
+    3. Accidentally changing the scale encoding of the versioned payloads to use indices which aren't the convention with versioning.
+    4. Accidentally versioning a runtime API function without deprecating the old unversioned runtime API function.
+    5. Accidentally not following the conventions we have for versioning of the runtime API functions.
+    6. Accidentally reusing a v2 input in a v3 variant.
+
+    There are more things that this test protects from, but the above is just a short list of the stuff.
+crates:
+- name: pallet-revive
+  bump: major
+- name: pallet-revive-types
+  bump: major
+- name: pallet-revive-eth-rpc
+  bump: major
+- name: revive-dev-runtime
+  bump: major

--- a/substrate/frame/revive/dev-node/runtime/tests/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/tests/lib.rs
@@ -27,8 +27,11 @@ use polkadot_sdk::{
 	pallet_revive::{
 		pallet_revive_types::runtime_api::ReviveRuntimeApiVersionDeclarations,
 		runtime_decl_for_revive_api::ReviveApi,
-	}, polkadot_sdk_frame::runtime::apis::runtime_decl_for_core::runtime_decl_for_metadata::runtime_decl_for_metadata::runtime_decl_for_metadata::__private::metadata::v16::ItemDeprecationInfo, sp_io::TestExternalities, sp_metadata_ir::frame_metadata::{
-		RuntimeMetadata, RuntimeMetadataPrefixed, v16::{RuntimeApiMetadata, RuntimeMetadataV16},
+	},
+	sp_io::TestExternalities,
+	sp_metadata_ir::frame_metadata::{
+		v16::{ItemDeprecationInfo, RuntimeApiMetadata, RuntimeMetadataV16},
+		RuntimeMetadata, RuntimeMetadataPrefixed,
 	},
 };
 use scale_info::{form::PortableForm, Field, TypeDef};

--- a/substrate/frame/revive/dev-node/runtime/tests/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/tests/lib.rs
@@ -138,11 +138,11 @@ fn test_versioned_runtime_api_invariants() {
 		let input_type = metadata
 			.types
 			.resolve(input.ty.id)
-			.expect("qed; impossible on well-formed metadata");
+			.expect("impossible on well-formed metadata; qed");
 		let output_type = metadata
 			.types
 			.resolve(output.id)
-			.expect("qed; impossible on well-formed metadata");
+			.expect("impossible on well-formed metadata; qed");
 		let output_type = if let TypeDef::Variant(ref variants) = output_type.type_def {
 			if output_type.path.ident().is_some_and(|ident| ident == "Result") {
 				if let [variant1, _] = variants.variants.as_slice() {
@@ -151,7 +151,7 @@ fn test_versioned_runtime_api_invariants() {
 							metadata
 								.types
 								.resolve(field.ty.id)
-								.expect("qed; impossible on well-formed metadata")
+								.expect("impossible on well-formed metadata; qed")
 						} else {
 							output_type
 						}
@@ -168,8 +168,8 @@ fn test_versioned_runtime_api_invariants() {
 			output_type
 		};
 
-		let input_type_name = input_type.path.ident().expect("qed; an input type has an ident");
-		let output_type_name = output_type.path.ident().expect("qed; an output type has an ident");
+		let input_type_name = input_type.path.ident().expect("an input type has an ident; qed");
+		let output_type_name = output_type.path.ident().expect("an output type has an ident; qed");
 
 		assert_eq!(
 			input_type_name,
@@ -277,16 +277,16 @@ fn test_versioned_runtime_api_invariants() {
 			let input_field_type = metadata
 				.types
 				.resolve(input_field.ty.id)
-				.expect("qed; impossible on well-formed metadata");
+				.expect("impossible on well-formed metadata; qed");
 			let output_field_type = metadata
 				.types
 				.resolve(output_field.ty.id)
-				.expect("qed; impossible on well-formed metadata");
+				.expect("impossible on well-formed metadata; qed");
 
 			let input_field_type_name =
-				input_field_type.path.ident().expect("qed; an input type has an ident");
+				input_field_type.path.ident().expect("an input type has an ident; qed");
 			let output_field_type_name =
-				output_field_type.path.ident().expect("qed; an output type has an ident");
+				output_field_type.path.ident().expect("an output type has an ident; qed");
 
 			assert_eq!(
 				input_field_type_name,

--- a/substrate/frame/revive/dev-node/runtime/tests/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/tests/lib.rs
@@ -1,0 +1,388 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for various invariants for the versioned runtime API. They need to be here since this is
+//! the only place where we have the metadata we need to run these tests and a runtime that we can
+//! call.
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use codec::Decode;
+use polkadot_sdk::{
+	pallet_revive::{
+		pallet_revive_types::runtime_api::ReviveRuntimeApiVersionDeclarations,
+		runtime_decl_for_revive_api::ReviveApi,
+	}, polkadot_sdk_frame::runtime::apis::runtime_decl_for_core::runtime_decl_for_metadata::runtime_decl_for_metadata::runtime_decl_for_metadata::__private::metadata::v16::ItemDeprecationInfo, sp_io::TestExternalities, sp_metadata_ir::frame_metadata::{
+		RuntimeMetadata, RuntimeMetadataPrefixed, v16::{RuntimeApiMetadata, RuntimeMetadataV16},
+	},
+};
+use scale_info::{form::PortableForm, Field, TypeDef};
+
+const UNVERSIONED_RUNTIME_APIS: [&str; 28] = [
+	"eth_block",
+	"eth_block_hash",
+	"eth_receipt_data",
+	"block_gas_limit",
+	"max_extrinsic_weight_in_gas",
+	"balance",
+	"gas_price",
+	"nonce",
+	"call",
+	"instantiate",
+	"eth_transact",
+	"eth_transact_with_config",
+	"eth_estimate_gas",
+	"eth_pre_dispatch_weight",
+	"upload_code",
+	"get_storage",
+	"get_storage_var_key",
+	"trace_block",
+	"trace_tx",
+	"trace_call",
+	"trace_call_with_config",
+	"block_author",
+	"address",
+	"account_id",
+	"runtime_pallets_address",
+	"code",
+	"new_balance_with_dust",
+	"version_declarations",
+];
+
+/// Tests all of the invariants which we want to uphold for the versioned runtime API.
+///
+/// 1. That all functions have a "_versioned" suffix.
+/// 2. That if an unversioned counterpart exists that it's been deprecated.
+/// 3. That all functions have exactly 1 input argument.
+/// 4. That the input argument has the name `${function-name-cleaned:camel}VersionedInputPayload`
+///    and all output types have the name `${function-name-cleaned:camel}VersionedOutputPayload`.
+/// 5. That the input and output types are enums.
+/// 6. That the input and output enums have an equal number of variants which is not zero.
+/// 7. That the input and output variants have a scale index of N - 1 where N is the version.
+/// 8. That the input and output variants are `V` followed by a non-zero number and that they're
+///    contiguous.
+/// 9. That the input and output variants have a single un-named field.
+/// 10. That the input and output variant field is of the type
+///     `${function-name-cleaned:camel}(Input|Output)PayloadV${i}`
+/// 11. That the function has a versioned declared in the `ReviveRuntimeApiVersionDeclarations`.
+/// 12. That the declared version matches the highest version available on the versioned payload
+///     enums.
+/// 13. That the `ReviveRuntimeApiVersionDeclarations` does not contain any runtime API function
+///     which is not versioned.
+#[test]
+fn test_versioned_runtime_api_invariants() {
+	let mut version_declarations = version_declarations().into_iter().collect::<BTreeMap<_, _>>();
+	let (metadata, runtime_api_metadata) = metadata();
+	let versioned_runtime_api_functions = runtime_api_metadata
+		.methods
+		.iter()
+		.filter(|function| !UNVERSIONED_RUNTIME_APIS.contains(&function.name.as_str()));
+
+	for function in versioned_runtime_api_functions {
+		// Assertion 1
+		let Some(function_name_no_suffix) = function.name.strip_suffix("_versioned") else {
+			panic!(
+				"All versioned runtime API function names must have a \"_versioned\" suffix, but \
+                {} does not have it",
+				function.name
+			)
+		};
+		let function_name_no_cleaned =
+			function_name_no_suffix.strip_prefix("eth_").unwrap_or(function_name_no_suffix);
+
+		// Assertion 2
+		if let Some(unversioned_function) = runtime_api_metadata
+			.methods
+			.iter()
+			.find(|function| function.name == function_name_no_suffix)
+		{
+			assert!(
+                matches!(unversioned_function.deprecation_info, ItemDeprecationInfo::Deprecated { .. } | ItemDeprecationInfo::DeprecatedWithoutNote),
+                "All versioned runtime API functions must deprecate their unversioned counterparts \
+                but {}, the unversioned variant of {} is not deprecated",
+                unversioned_function.name,
+                function.name
+            )
+		}
+
+		// Assertion 3
+		let [input] = function.inputs.as_slice() else {
+			panic!(
+				"All versioned runtime API functions must have exactly one input argument, but {} \
+                has {} arguments.",
+				function.name,
+				function.inputs.len()
+			)
+		};
+
+		// Assertion 4
+		let output = function.output;
+		let input_type = metadata
+			.types
+			.resolve(input.ty.id)
+			.expect("qed; impossible on well-formed metadata");
+		let output_type = metadata
+			.types
+			.resolve(output.id)
+			.expect("qed; impossible on well-formed metadata");
+		let output_type = if let TypeDef::Variant(ref variants) = output_type.type_def {
+			if output_type.path.ident().is_some_and(|ident| ident == "Result") {
+				if let [variant1, _] = variants.variants.as_slice() {
+					if let [field] = variant1.fields.as_slice() {
+						if field.name.is_none() {
+							metadata
+								.types
+								.resolve(field.ty.id)
+								.expect("qed; impossible on well-formed metadata")
+						} else {
+							output_type
+						}
+					} else {
+						output_type
+					}
+				} else {
+					output_type
+				}
+			} else {
+				output_type
+			}
+		} else {
+			output_type
+		};
+
+		let input_type_name = input_type.path.ident().expect("qed; an input type has an ident");
+		let output_type_name = output_type.path.ident().expect("qed; an output type has an ident");
+
+		assert_eq!(
+			input_type_name,
+			format!("{}VersionedInputPayload", snake_to_camel(function_name_no_cleaned)),
+			"All versioned runtime API functions must have an input payload with the name \
+            ${{function-name-no-suffix:camel}}VersionedInputPayload but {} has an input payload \
+            with the name {}",
+			function.name,
+			input_type_name
+		);
+		assert_eq!(
+			output_type_name,
+			format!("{}VersionedOutputPayload", snake_to_camel(function_name_no_cleaned)),
+			"All versioned runtime API functions must have an output payload with the name \
+            ${{function-name-no-suffix:camel}}VersionedOutputPayload but {} has an output payload \
+            with the name {}",
+			function.name,
+			output_type_name
+		);
+
+		// Assertion 5
+		let TypeDef::Variant(ref input_variants) = input_type.type_def else {
+			panic!(
+				"All versioned runtime API functions must have an argument which is an enum. But \
+                the arguments of {} is of the type definition {:?}",
+				function.name, input_type.type_def
+			)
+		};
+		let TypeDef::Variant(ref output_variants) = output_type.type_def else {
+			panic!(
+				"All versioned runtime API functions must have an output which is an enum. But \
+                the output of {} is of the type definition {:?}",
+				function.name, output_type.type_def
+			)
+		};
+
+		// Assertion 6
+		assert_eq!(
+			input_variants.variants.len(),
+			output_variants.variants.len(),
+			"All versioned runtime API functions must have IO enums which have an equal number of \
+            variants. But {} has {} input variants and {} output variants",
+			function.name,
+			input_variants.variants.len(),
+			output_variants.variants.len(),
+		);
+		assert_ne!(
+			input_variants.variants.len(),
+			0,
+			"All versioned runtime API functions must have IO enums with at least 1 variant. But \
+            {} has zero variants",
+			function.name,
+		);
+
+		for (i, (input_variant, output_variant)) in
+			input_variants.variants.iter().zip(output_variants.variants.iter()).enumerate()
+		{
+			let version = i + 1;
+
+			// Assertion 7
+			assert_eq!(
+				input_variant.index as usize, i,
+				"Expected variant {} in {} to have a scale index of {} but it has an index of {}",
+				input_variant.name, input_type_name, i, input_variant.index
+			);
+			assert_eq!(
+				output_variant.index as usize, i,
+				"Expected variant {} in {} to have a scale index of {} but it has an index of {}",
+				output_variant.name, output_type_name, i, output_variant.index
+			);
+
+			// Assertion 8
+			assert_eq!(
+				input_variant.name,
+				format!("V{version}"),
+				"Expected variant {} in {} to be {} called",
+				input_variant.name,
+				input_type_name,
+				format!("V{version}")
+			);
+			assert_eq!(
+				output_variant.name,
+				format!("V{version}"),
+				"Expected variant {} in {} to be {} called",
+				output_variant.name,
+				output_type_name,
+				format!("V{version}")
+			);
+
+			// Assertion 9
+			let [input_field @ Field { name: None, .. }] = input_variant.fields.as_slice() else {
+				panic!(
+					"Expected variant {} in {} to have a single un-named field",
+					input_variant.name, input_type_name
+				)
+			};
+			let [output_field @ Field { name: None, .. }] = output_variant.fields.as_slice() else {
+				panic!(
+					"Expected variant {} in {} to have a single un-named field",
+					output_variant.name, output_type_name
+				)
+			};
+
+			// Assertion 10
+			let input_field_type = metadata
+				.types
+				.resolve(input_field.ty.id)
+				.expect("qed; impossible on well-formed metadata");
+			let output_field_type = metadata
+				.types
+				.resolve(output_field.ty.id)
+				.expect("qed; impossible on well-formed metadata");
+
+			let input_field_type_name =
+				input_field_type.path.ident().expect("qed; an input type has an ident");
+			let output_field_type_name =
+				output_field_type.path.ident().expect("qed; an output type has an ident");
+
+			assert_eq!(
+				input_field_type_name,
+				format!("{}InputPayloadV{}", snake_to_camel(function_name_no_cleaned), version),
+				"Expected variant {} of {} to have the type {} but it has the type {}",
+				input_variant.name,
+				input_type_name,
+				format!("{}InputPayloadV{}", snake_to_camel(function_name_no_cleaned), version),
+				input_field_type_name
+			);
+			assert_eq!(
+				output_field_type_name,
+				format!("{}OutputPayloadV{}", snake_to_camel(function_name_no_cleaned), version),
+				"Expected variant {} of {} to have the type {} but it has the type {}",
+				output_variant.name,
+				output_type_name,
+				format!("{}OutputPayloadV{}", snake_to_camel(function_name_no_cleaned), version),
+				output_field_type_name
+			);
+		}
+
+		// Assertion 11
+		let Some(declared_version) = version_declarations.remove(&function.name) else {
+			panic!(
+                "All versioned runtime API functions must have a highest version declared for them \
+                on the ReviveRuntimeApiVersionDeclarations but {} has no such declaration",
+                function.name
+            )
+		};
+
+		// Assertion 12
+		assert_eq!(
+			declared_version as usize,
+			input_variants.variants.len(),
+			"The declared version for {} is {} but its enum variants have up to V{}",
+			function.name,
+			declared_version,
+			input_variants.variants.len()
+		);
+	}
+
+	// Assertion 13
+	assert!(
+		version_declarations.is_empty(),
+		"The ReviveRuntimeApiVersionDeclarations contains version declarations for unversioned \
+        runtime API function: {:?}",
+		version_declarations.into_keys().collect::<BTreeSet<_>>()
+	)
+}
+
+fn metadata() -> (RuntimeMetadataV16, RuntimeApiMetadata<PortableForm>) {
+	let metadata = TestExternalities::default().execute_with(|| {
+		let opaque_metadata = revive_dev_runtime::Runtime::metadata_at_version(16)
+			.expect("the runtime serves v16 metadata");
+		let RuntimeMetadata::V16(metadata) =
+			RuntimeMetadataPrefixed::decode(&mut &opaque_metadata[..])
+				.expect("the runtime metadata decodes")
+				.1
+		else {
+			panic!("the runtime must serve v16 metadata")
+		};
+		metadata
+	});
+
+	let runtime_api_metadata = metadata
+		.apis
+		.iter()
+		.find(|api| api.name == "ReviveApi")
+		.expect("the runtime exposes the ReviveApi")
+		.clone();
+
+	(metadata, runtime_api_metadata)
+}
+
+fn version_declarations() -> ReviveRuntimeApiVersionDeclarations {
+	TestExternalities::default().execute_with(|| {
+		<revive_dev_runtime::Runtime as ReviveApi<_, _, _, _, _, _>>::version_declarations()
+	})
+}
+
+fn snake_to_camel(string: &str) -> String {
+	unsafe fn internal(string: &str, acc: &mut String) {
+		match string.as_bytes() {
+			[b'_', c, remaining @ ..] => {
+				let char = *c as char;
+				let uppercase_char = char.to_ascii_uppercase();
+				acc.push(uppercase_char);
+				internal(str::from_utf8_unchecked(remaining), acc);
+			},
+			[c, remaining @ ..] => {
+				let char =
+					if acc.is_empty() { (*c as char).to_ascii_uppercase() } else { *c as char };
+				acc.push(char);
+				internal(str::from_utf8_unchecked(remaining), acc);
+			},
+			[] => {},
+		}
+	}
+	let mut acc = String::new();
+	unsafe { internal(string, &mut acc) };
+	acc
+}

--- a/substrate/frame/revive/dev-node/runtime/tests/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/tests/lib.rs
@@ -34,7 +34,7 @@ use polkadot_sdk::{
 		RuntimeMetadata, RuntimeMetadataPrefixed,
 	},
 };
-use scale_info::{form::PortableForm, Field, TypeDef};
+use scale_info::{form::PortableForm, Field, Type, TypeDef};
 
 const UNVERSIONED_RUNTIME_APIS: [&str; 28] = [
 	"eth_block",
@@ -143,30 +143,8 @@ fn test_versioned_runtime_api_invariants() {
 			.types
 			.resolve(output.id)
 			.expect("impossible on well-formed metadata; qed");
-		let output_type = if let TypeDef::Variant(ref variants) = output_type.type_def {
-			if output_type.path.ident().is_some_and(|ident| ident == "Result") {
-				if let [variant1, _] = variants.variants.as_slice() {
-					if let [field] = variant1.fields.as_slice() {
-						if field.name.is_none() {
-							metadata
-								.types
-								.resolve(field.ty.id)
-								.expect("impossible on well-formed metadata; qed")
-						} else {
-							output_type
-						}
-					} else {
-						output_type
-					}
-				} else {
-					output_type
-				}
-			} else {
-				output_type
-			}
-		} else {
-			output_type
-		};
+		let output_type =
+			extract_ok_type_from_result(output_type, &metadata).unwrap_or(output_type);
 
 		let input_type_name = input_type.path.ident().expect("an input type has an ident; qed");
 		let output_type_name = output_type.path.ident().expect("an output type has an ident; qed");
@@ -388,4 +366,33 @@ fn snake_to_camel(string: &str) -> String {
 	let mut acc = String::new();
 	unsafe { internal(string, &mut acc) };
 	acc
+}
+
+fn extract_ok_type_from_result<'a>(
+	ty: &Type<PortableForm>,
+	metadata: &'a RuntimeMetadataV16,
+) -> Option<&'a Type<PortableForm>> {
+	let Some("Result") = ty.path.ident().as_deref() else { return None };
+
+	let TypeDef::Variant(ref variants) = ty.type_def else {
+		return None;
+	};
+
+	let [variant1, variant2] = variants.variants.as_slice() else {
+		return None;
+	};
+
+	if variant1.name != "Ok" || variant1.index != 0 || variant2.name != "Err" || variant2.index != 1
+	{
+		return None;
+	};
+
+	let [field @ Field { name: None, .. }] = variant1.fields.as_slice() else { return None };
+
+	Some(
+		metadata
+			.types
+			.resolve(field.ty.id)
+			.expect("impossible on well-formed metadata; qed"),
+	)
 }

--- a/substrate/frame/revive/dev-node/runtime/tests/lib.rs
+++ b/substrate/frame/revive/dev-node/runtime/tests/lib.rs
@@ -346,26 +346,35 @@ fn version_declarations() -> ReviveRuntimeApiVersionDeclarations {
 }
 
 fn snake_to_camel(string: &str) -> String {
-	unsafe fn internal(string: &str, acc: &mut String) {
-		match string.as_bytes() {
-			[b'_', c, remaining @ ..] => {
-				let char = *c as char;
-				let uppercase_char = char.to_ascii_uppercase();
-				acc.push(uppercase_char);
-				internal(str::from_utf8_unchecked(remaining), acc);
-			},
-			[c, remaining @ ..] => {
-				let char =
-					if acc.is_empty() { (*c as char).to_ascii_uppercase() } else { *c as char };
+	fn internal(
+		mut chars: core::iter::Peekable<impl Iterator<Item = char>>,
+		mut acc: String,
+	) -> String {
+		let char1 = chars.next();
+		let char2 = chars.peek().copied();
+
+		match (char1, char2) {
+			(Some('_'), Some(char2)) => {
+				let _ = chars.next().expect("peek succeeded, next must succeed; qed");
+				let char = char2.to_ascii_uppercase();
 				acc.push(char);
-				internal(str::from_utf8_unchecked(remaining), acc);
+				internal(chars, acc)
 			},
-			[] => {},
+			(Some(char1), Some(_) | None) => {
+				let char1 = if acc.is_empty() { char1.to_ascii_uppercase() } else { char1 };
+				acc.push(char1);
+				internal(chars, acc)
+			},
+			(None, None) => acc,
+			(None, Some(_)) => {
+				unreachable!(
+					"First pull from the iterator can't fail while subsequent one succeeds"
+				)
+			},
 		}
 	}
-	let mut acc = String::new();
-	unsafe { internal(string, &mut acc) };
-	acc
+
+	internal(string.chars().peekable(), String::new())
 }
 
 fn extract_ok_type_from_result<'a>(

--- a/substrate/frame/revive/rpc/src/subxt_client.rs
+++ b/substrate/frame/revive/rpc/src/subxt_client.rs
@@ -190,20 +190,20 @@ pub use subxt::config::PolkadotConfig as SrcChainConfig;
 		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::NonceVersionedOutputPayload<Nonce>>"
 	),
 	substitute_type(
-		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::EthPreDispatchWeightInputPayloadV1",
-		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::EthPreDispatchWeightInputPayloadV1>"
+		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::PreDispatchWeightInputPayloadV1",
+		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::PreDispatchWeightInputPayloadV1>"
 	),
 	substitute_type(
-		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::EthPreDispatchWeightVersionedInputPayload",
-		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::EthPreDispatchWeightVersionedInputPayload>"
+		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::PreDispatchWeightVersionedInputPayload",
+		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::PreDispatchWeightVersionedInputPayload>"
 	),
 	substitute_type(
-		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::EthPreDispatchWeightOutputPayloadV1",
-		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::EthPreDispatchWeightOutputPayloadV1>"
+		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::PreDispatchWeightOutputPayloadV1",
+		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::PreDispatchWeightOutputPayloadV1>"
 	),
 	substitute_type(
-		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::EthPreDispatchWeightVersionedOutputPayload",
-		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::EthPreDispatchWeightVersionedOutputPayload>"
+		path = "pallet_revive_types::runtime_api::payloads::eth_pre_dispatch_weight::PreDispatchWeightVersionedOutputPayload",
+		with = "::subxt::utils::Static<::pallet_revive_types::runtime_api::PreDispatchWeightVersionedOutputPayload>"
 	),
 	substitute_type(
 		path = "pallet_revive_types::runtime_api::types::upload::CodeUploadReturnValueV1<Balance>",

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -3101,6 +3101,9 @@ sp_api::decl_runtime_apis! {
 		/* Versioned Runtime APIs */
 
 		#[api_version(2)]
+		fn version_declarations() -> ReviveRuntimeApiVersionDeclarations;
+
+		#[api_version(2)]
 		fn eth_block_hash_versioned(input: BlockHashVersionedInputPayload) -> BlockHashVersionedOutputPayload;
 
 		#[api_version(2)]
@@ -3583,6 +3586,33 @@ macro_rules! impl_runtime_apis_plus_revive_traits {
 				}
 
 				/* Versioned Runtime APIs */
+
+				fn version_declarations()
+					-> $crate::pallet_revive_types::runtime_api::ReviveRuntimeApiVersionDeclarations
+				{
+					use $crate::pallet_revive_types::runtime_api::*;
+
+					ReviveRuntimeApiVersionDeclarations::new()
+						.insert("eth_block_hash_versioned", 1)
+						.insert("eth_receipt_data_versioned", 1)
+						.insert("block_gas_limit_versioned", 1)
+						.insert("max_extrinsic_weight_in_gas_versioned", 1)
+						.insert("balance_versioned", 1)
+						.insert("gas_price_versioned", 1)
+						.insert("nonce_versioned", 1)
+						.insert("eth_pre_dispatch_weight_versioned", 1)
+						.insert("upload_code_versioned", 1)
+						.insert("get_storage_versioned", 1)
+						.insert("runtime_pallets_address_versioned", 1)
+						.insert("code_versioned", 1)
+						.insert("account_id_versioned", 1)
+						.insert("new_balance_with_dust_versioned", 1)
+						.insert("block_author_versioned", 1)
+						.insert("address_versioned", 1)
+						.insert("trace_block_versioned", 2)
+						.insert("trace_tx_versioned", 2)
+				}
+
 				fn eth_block_hash_versioned(
 					input: $crate::pallet_revive_types::runtime_api::BlockHashVersionedInputPayload
 				) -> $crate::pallet_revive_types::runtime_api::BlockHashVersionedOutputPayload {

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -3130,8 +3130,8 @@ sp_api::decl_runtime_apis! {
 
 		#[api_version(2)]
 		fn eth_pre_dispatch_weight_versioned(
-			input: EthPreDispatchWeightVersionedInputPayload
-		) -> Result<EthPreDispatchWeightVersionedOutputPayload, EthTransactError>;
+			input: PreDispatchWeightVersionedInputPayload
+		) -> Result<PreDispatchWeightVersionedOutputPayload, EthTransactError>;
 
 		#[api_version(2)]
 		fn upload_code_versioned(
@@ -3353,11 +3353,11 @@ macro_rules! impl_runtime_apis_plus_revive_traits {
 				) -> Result<$crate::Weight, $crate::EthTransactError> {
 					use $crate::pallet_revive_types::runtime_api::*;
 
-					let input = EthPreDispatchWeightVersionedInputPayload::from(
-						EthPreDispatchWeightInputPayloadV1 { tx }
+					let input = PreDispatchWeightVersionedInputPayload::from(
+						PreDispatchWeightInputPayloadV1 { tx }
 					);
 					let output = Self::eth_pre_dispatch_weight_versioned(input)?;
-					Ok(EthPreDispatchWeightOutputPayloadV1::try_from(output)
+					Ok(PreDispatchWeightOutputPayloadV1::try_from(output)
 						.expect("v1 input must produce v1 output; qed")
 						.weight)
 				}
@@ -3777,9 +3777,9 @@ macro_rules! impl_runtime_apis_plus_revive_traits {
 				}
 
 				fn eth_pre_dispatch_weight_versioned(
-					input: $crate::pallet_revive_types::runtime_api::EthPreDispatchWeightVersionedInputPayload
+					input: $crate::pallet_revive_types::runtime_api::PreDispatchWeightVersionedInputPayload
 				) -> Result<
-					$crate::pallet_revive_types::runtime_api::EthPreDispatchWeightVersionedOutputPayload,
+					$crate::pallet_revive_types::runtime_api::PreDispatchWeightVersionedOutputPayload,
 					$crate::EthTransactError
 				> {
 					use $crate::pallet_revive_types::runtime_api::*;
@@ -3788,15 +3788,15 @@ macro_rules! impl_runtime_apis_plus_revive_traits {
 
 					let (input, output_wrapper): (
 						_,
-						Box<dyn Fn(EthPreDispatchWeightOutputPayload) -> EthPreDispatchWeightVersionedOutputPayload>,
+						Box<dyn Fn(PreDispatchWeightOutputPayload) -> PreDispatchWeightVersionedOutputPayload>,
 					) = match input {
-						EthPreDispatchWeightVersionedInputPayload::V1(payload) => (
-							EthPreDispatchWeightInputPayload::from(payload),
-							Box::new(|output| EthPreDispatchWeightVersionedOutputPayload::V1(output.into())),
+						PreDispatchWeightVersionedInputPayload::V1(payload) => (
+							PreDispatchWeightInputPayload::from(payload),
+							Box::new(|output| PreDispatchWeightVersionedOutputPayload::V1(output.into())),
 						),
 					};
 
-					let output = EthPreDispatchWeightOutputPayload {
+					let output = PreDispatchWeightOutputPayload {
 						weight: $crate::Pallet::<Self>::eth_pre_dispatch_weight(input.tx)?
 					};
 					Ok(output_wrapper(output))

--- a/substrate/frame/revive/src/runtime_api/eth_pre_dispatch_weight.rs
+++ b/substrate/frame/revive/src/runtime_api/eth_pre_dispatch_weight.rs
@@ -20,30 +20,30 @@ use pallet_revive_types::runtime_api::*;
 
 use crate::Weight;
 
-pub struct EthPreDispatchWeightInputPayload {
+pub struct PreDispatchWeightInputPayload {
 	pub tx: Vec<u8>,
 }
 
-impl From<EthPreDispatchWeightVersionedInputPayload> for EthPreDispatchWeightInputPayload {
-	fn from(value: EthPreDispatchWeightVersionedInputPayload) -> Self {
+impl From<PreDispatchWeightVersionedInputPayload> for PreDispatchWeightInputPayload {
+	fn from(value: PreDispatchWeightVersionedInputPayload) -> Self {
 		match value {
-			EthPreDispatchWeightVersionedInputPayload::V1(payload) => payload.into(),
+			PreDispatchWeightVersionedInputPayload::V1(payload) => payload.into(),
 		}
 	}
 }
 
-impl From<EthPreDispatchWeightInputPayloadV1> for EthPreDispatchWeightInputPayload {
-	fn from(value: EthPreDispatchWeightInputPayloadV1) -> Self {
+impl From<PreDispatchWeightInputPayloadV1> for PreDispatchWeightInputPayload {
+	fn from(value: PreDispatchWeightInputPayloadV1) -> Self {
 		Self { tx: value.tx }
 	}
 }
 
-pub struct EthPreDispatchWeightOutputPayload {
+pub struct PreDispatchWeightOutputPayload {
 	pub weight: Weight,
 }
 
-impl From<EthPreDispatchWeightOutputPayload> for EthPreDispatchWeightOutputPayloadV1 {
-	fn from(value: EthPreDispatchWeightOutputPayload) -> Self {
+impl From<PreDispatchWeightOutputPayload> for PreDispatchWeightOutputPayloadV1 {
+	fn from(value: PreDispatchWeightOutputPayload) -> Self {
 		Self { weight: value.weight }
 	}
 }

--- a/substrate/frame/revive/types/src/runtime_api/declaration.rs
+++ b/substrate/frame/revive/types/src/runtime_api/declaration.rs
@@ -1,0 +1,55 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloc::{
+	collections::BTreeMap,
+	string::{String, ToString},
+};
+use codec::{Decode, Encode};
+use core::iter::IntoIterator;
+use scale_info::TypeInfo;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, TypeInfo, Default)]
+pub struct ReviveRuntimeApiVersionDeclarations(BTreeMap<String, u8>);
+
+impl ReviveRuntimeApiVersionDeclarations {
+	pub fn new() -> Self {
+		Default::default()
+	}
+
+	pub fn insert(mut self, runtime_api_function: impl ToString, value: u8) -> Self {
+		self.0.insert(runtime_api_function.to_string(), value);
+		self
+	}
+
+	pub fn get(&self, runtime_api_function: impl AsRef<str>) -> Option<u8> {
+		self.0.get(runtime_api_function.as_ref()).copied()
+	}
+
+	pub fn iter(&self) -> impl Iterator<Item = (&str, &u8)> {
+		self.0.iter().map(|(key, value)| (key.as_str(), value))
+	}
+}
+
+impl IntoIterator for ReviveRuntimeApiVersionDeclarations {
+	type Item = <BTreeMap<String, u8> as IntoIterator>::Item;
+	type IntoIter = <BTreeMap<String, u8> as IntoIterator>::IntoIter;
+
+	fn into_iter(self) -> Self::IntoIter {
+		IntoIterator::into_iter(self.0)
+	}
+}

--- a/substrate/frame/revive/types/src/runtime_api/mod.rs
+++ b/substrate/frame/revive/types/src/runtime_api/mod.rs
@@ -15,8 +15,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod declaration;
 mod payloads;
 mod types;
 
+pub use declaration::*;
 pub use payloads::*;
 pub use types::*;

--- a/substrate/frame/revive/types/src/runtime_api/payloads/eth_pre_dispatch_weight.rs
+++ b/substrate/frame/revive/types/src/runtime_api/payloads/eth_pre_dispatch_weight.rs
@@ -22,21 +22,21 @@ use scale_info::TypeInfo;
 use sp_weights::Weight;
 
 #[derive(TypeInfo, Debug, Clone, Encode, Decode, PartialEq)]
-pub struct EthPreDispatchWeightInputPayloadV1 {
+pub struct PreDispatchWeightInputPayloadV1 {
 	pub tx: Vec<u8>,
 }
 
 #[derive(TypeInfo, Debug, Clone, Encode, Decode, PartialEq, From, TryInto)]
-pub enum EthPreDispatchWeightVersionedInputPayload {
-	V1(EthPreDispatchWeightInputPayloadV1),
+pub enum PreDispatchWeightVersionedInputPayload {
+	V1(PreDispatchWeightInputPayloadV1),
 }
 
 #[derive(TypeInfo, Debug, Clone, Encode, Decode, PartialEq)]
-pub struct EthPreDispatchWeightOutputPayloadV1 {
+pub struct PreDispatchWeightOutputPayloadV1 {
 	pub weight: Weight,
 }
 
 #[derive(TypeInfo, Debug, Clone, Encode, Decode, PartialEq, From, TryInto)]
-pub enum EthPreDispatchWeightVersionedOutputPayload {
-	V1(EthPreDispatchWeightOutputPayloadV1),
+pub enum PreDispatchWeightVersionedOutputPayload {
+	V1(PreDispatchWeightOutputPayloadV1),
 }


### PR DESCRIPTION
# Description

This PR just adds a single test which checks that the invariants and conventions that we have for versioning are upheld in code.

The test is `test_versioned_runtime_api_invariants` in the dev-node's runtime crate. The reason for it being in that crate rather than other crates is because it's the only place where we have access to the metadata and to the runtime which we depend on heavily for this test.

The primary methodology of this test is asserting that the data that we observe in the frame metadata for pallet-revive matches the expectations we have. This is made more comprehensive due to the fact that the entire types registry is in the metadata so we can do checks such as "check that this function has a single argument which is an enum of this name and that has these variants", so the fact that we have a schema for these types allows us to perform type-system assertions outside of the type-system.

The test asserts the following:

1. For each versioned runtime API function:
    1. That its name ends with the `_versioned` postfix.
    2. That if it has an unversioned counterpart (e.g., `eth_block` and `eth_block_versioned`) that the unversioned runtime API has been deprecated in order to push people to use the versioned runtime API functions.
    3. That is has exactly one input argument.
    4. That the input argument is of the type `${function-name}VersionedInputPayload` and that the output is of the type `${function-name}VersionedOutputPayload`.
    5. That the input and output types are enums.
    6. That the input and output type enums have an equal number of variants which is non-zero.
    7. For each variant on the input and output enums:
        1. That the variants have a scale index of `N - 1` where N is the version. In this way, v1 would have a scale index of 0, v2 would have a scale index of 1, and so on.
        2. That the variant name is `V` followed by the version number where the version number is contiguous, without gaps, and starts from 1.
        3. That it has a single un-named field.
        4. That if the field is an input field then it's of the type `${function-name}InputPayloadV{N}` and if it's an output field then it's of the type `${function-name}OutputPayloadV{N}`.
    8. That it has a declaration in the `ReviveRuntimeApiVersionDeclarations` type.
    9. That the declared version matches the highest observed versions in the enum variants.
    10. That the `ReviveRuntimeApiVersionDeclarations` does not contain more declarations than it should.

This test protects from a number of things which we could get wrong as we evolve. Below are just some examples:

1. Accidentally adding a V5 input without a corresponding V5 output (or vice versa).
2. Accidentally not declaring that we support V5 of a given runtime API function through the `ReviveRuntimeApiVersionDeclarations` when it's indeed supported.
3. Accidentally changing the scale encoding of the versioned payloads to use indices which aren't the convention with versioning.
4. Accidentally versioning a runtime API function without deprecating the old unversioned runtime API function.
5. Accidentally not following the conventions we have for versioning of the runtime API functions.
6. Accidentally reusing a v2 input in a v3 variant.

There are more things that this test protects from, but the above is just a short list of the stuff.