### PR TITLE
statement-store v2 DHT: replicate to all k closest peers

### DIFF
--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -76,7 +76,9 @@ pub(super) async fn expect_statement(
 	loop {
 		let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
 		if remaining.is_zero() {
-			return Err(anyhow!("Timeout after {timeout_secs}s waiting for the expected statement"));
+			return Err(anyhow!(
+				"Timeout after {timeout_secs}s waiting for the expected statement"
+			));
 		}
 		let item = tokio::time::timeout(remaining, subscription.next())
 			.await

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -65,6 +65,33 @@ pub(super) async fn expect_one_statement(
 	}
 }
 
+/// Reads `subscription` until `expected` arrives, tolerating other statements delivered first — a
+/// subscription serves every statement matching its topic, not only the one under test.
+pub(super) async fn expect_statement(
+	subscription: &mut RpcSubscription<StatementEvent>,
+	expected: &Bytes,
+	timeout_secs: u64,
+) -> Result<(), anyhow::Error> {
+	let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_secs);
+	loop {
+		let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+		if remaining.is_zero() {
+			return Err(anyhow!("Timeout after {timeout_secs}s waiting for the expected statement"));
+		}
+		let item = tokio::time::timeout(remaining, subscription.next())
+			.await
+			.map_err(|_| {
+				anyhow!("Timeout after {timeout_secs}s waiting for the expected statement")
+			})?
+			.ok_or_else(|| anyhow!("Subscription stream ended unexpectedly"))?
+			.map_err(|e| anyhow!("Subscription error: {}", e))?;
+		let StatementEvent::NewStatements { statements, .. } = item;
+		if statements.iter().any(|s| s == expected) {
+			return Ok(());
+		}
+	}
+}
+
 pub(super) async fn assert_no_more_statements(
 	subscription: &mut RpcSubscription<StatementEvent>,
 	timeout_secs: u64,

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/common.rs
@@ -65,9 +65,9 @@ pub(super) async fn expect_one_statement(
 	}
 }
 
-/// Reads `subscription` until `expected` arrives, tolerating other statements delivered first — a
+/// Reads `subscription` until `expected` is delivered, tolerating other statements first — a
 /// subscription serves every statement matching its topic, not only the one under test.
-pub(super) async fn expect_statement(
+pub(super) async fn expect_statement_delivered(
 	subscription: &mut RpcSubscription<StatementEvent>,
 	expected: &Bytes,
 	timeout_secs: u64,

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -8,8 +8,8 @@
 //! by default); the replication factor `K` and gossip target are set via CLI flags.
 
 use super::common::{
-	expect_one_statement, spawn_network_with_injected_allowances_v2, stores_locally,
-	submit_statement, subscribe_topic,
+	expect_statement, spawn_network_with_injected_allowances_v2, stores_locally, submit_statement,
+	subscribe_topic,
 };
 use codec::Encode;
 use sc_statement_store::test_utils::{create_test_statement, get_keypair};
@@ -157,7 +157,7 @@ async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 
 	// node_1's own subscription delivers the matching `topic_a` statement, independent of who
 	// stores it.
-	assert_eq!(expect_one_statement(&mut sub_a, 20).await?, expected_a);
+	expect_statement(&mut sub_a, &expected_a, 20).await?;
 
 	// node_1 decides retention synchronously on submit, so we probe right away. We check the two
 	// specific statements, not a total count: the topic-selection probes above leave other
@@ -339,7 +339,7 @@ async fn explicit_affinity_works() -> Result<(), anyhow::Error> {
 
 	// Subscribing grants the non-replica explicit affinity; it should now receive the statement.
 	let mut subscription = subscribe_topic(non_replica_rpc, topic).await?;
-	assert_eq!(expect_one_statement(&mut subscription, 20).await?, expected);
+	expect_statement(&mut subscription, &expected, 20).await?;
 
 	Ok(())
 }

--- a/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
+++ b/cumulus/zombienet/zombienet-sdk/tests/zombie_ci/statement_store/integration_v2_dht.rs
@@ -8,8 +8,8 @@
 //! by default); the replication factor `K` and gossip target are set via CLI flags.
 
 use super::common::{
-	expect_statement, spawn_network_with_injected_allowances_v2, stores_locally, submit_statement,
-	subscribe_topic,
+	expect_statement_delivered, spawn_network_with_injected_allowances_v2, stores_locally,
+	submit_statement, subscribe_topic,
 };
 use codec::Encode;
 use sc_statement_store::test_utils::{create_test_statement, get_keypair};
@@ -157,7 +157,7 @@ async fn local_submission_retention_works() -> Result<(), anyhow::Error> {
 
 	// node_1's own subscription delivers the matching `topic_a` statement, independent of who
 	// stores it.
-	expect_statement(&mut sub_a, &expected_a, 20).await?;
+	expect_statement_delivered(&mut sub_a, &expected_a, 20).await?;
 
 	// node_1 decides retention synchronously on submit, so we probe right away. We check the two
 	// specific statements, not a total count: the topic-selection probes above leave other
@@ -339,7 +339,7 @@ async fn explicit_affinity_works() -> Result<(), anyhow::Error> {
 
 	// Subscribing grants the non-replica explicit affinity; it should now receive the statement.
 	let mut subscription = subscribe_topic(non_replica_rpc, topic).await?;
-	expect_statement(&mut subscription, &expected, 20).await?;
+	expect_statement_delivered(&mut subscription, &expected, 20).await?;
 
 	Ok(())
 }

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -178,15 +178,22 @@ impl PeersTopology {
 		}
 	}
 
-	/// Connected peers closer to `topic` than the local node, capped at `gossip_target`.
+	/// Connected peers to forward a statement for `topic` to, capped at `gossip_target`.
 	///
-	/// Use these for forwarding decisions: each hop moves the statement towards the peers
-	/// responsible for storing it.
+	/// A replica (in the topic's k-closest set) forwards to its closest connected peers; a
+	/// non-replica, only to those closer to the topic than itself.
 	pub fn routing_targets(&self, topic: Topic) -> Vec<PeerId> {
 		let local_distance = xor_distance(*topic, self.local_key);
+		let is_replica = local_is_replica(
+			&self.discovered_index,
+			self.local_key,
+			self.local_peer,
+			self.config.replication_factor.get(),
+			topic,
+		);
 		self.connected
 			.closest(*topic)
-			.take_while(|(_, key)| xor_distance(*topic, *key) < local_distance)
+			.take_while(|(_, key)| is_replica || xor_distance(*topic, *key) < local_distance)
 			.take(self.config.gossip_target.get())
 			.map(|(peer, _)| peer)
 			.collect()
@@ -294,6 +301,26 @@ fn xor_distance(a: Key, b: Key) -> Key {
 	distance
 }
 
+/// Whether `local_peer`, at `local_key`, is among the `k` closest entries of `index` to `topic` —
+/// i.e. a DHT storage replica for it.
+fn local_is_replica(
+	index: &PeersIndex,
+	local_key: Key,
+	local_peer: PeerId,
+	k: usize,
+	topic: Topic,
+) -> bool {
+	let local_distance = xor_distance(*topic, local_key);
+	let closer_count = index
+		.closest(*topic)
+		.take_while(|(peer, key)| {
+			(xor_distance(*topic, *key), *peer) < (local_distance, local_peer)
+		})
+		.take(k)
+		.count();
+	closer_count < k
+}
+
 /// Standalone DHT-affinity oracle: the minimal snapshot needed to answer "is the local node a
 /// storage replica for a topic", shared with the store so it decides retention without the full
 /// [`PeersTopology`].
@@ -324,20 +351,13 @@ impl DhtAffinity {
 
 	/// Whether the local node is one of the closest DHT storage replicas for `topic`.
 	fn is_topic_affine(&self, topic: Topic) -> bool {
-		let local_distance = xor_distance(*topic, self.local_key);
-		let replication_factor = self.replication_factor.get();
-		// The descent yields candidates in `(distance, peer)` order, so the candidates ranked
-		// before the local node form a prefix; the local node is a replica when that prefix is
-		// shorter than the replication factor.
-		let closer_count = self
-			.index
-			.closest(*topic)
-			.take_while(|(peer, key)| {
-				(xor_distance(*topic, *key), *peer) < (local_distance, self.local_peer)
-			})
-			.take(replication_factor)
-			.count();
-		closer_count < replication_factor
+		local_is_replica(
+			&self.index,
+			self.local_key,
+			self.local_peer,
+			self.replication_factor.get(),
+			topic,
+		)
 	}
 }
 
@@ -489,6 +509,39 @@ mod tests {
 
 		let expected = {
 			let mut peers = closer;
+			peers.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
+			peers.truncate(2);
+			peers
+		};
+
+		assert_eq!(topology.routing_targets(topic), expected);
+	}
+
+	#[test]
+	fn replica_forwards_to_closest_connected_even_when_none_are_closer_than_self() {
+		let mut topology = topology(1); // replication_factor = 2, gossip_target = 2
+		let topic = topic(7);
+		let self_distance = distance_to(topic, &peer(1));
+
+		// Connected peers all farther from the topic than the local node, so the node is itself in
+		// the k-closest set (a replica) and has nobody "closer than self" to route toward.
+		let farther: Vec<PeerId> = (2..=80)
+			.map(peer)
+			.filter(|candidate| distance_to(topic, candidate) > self_distance)
+			.take(3)
+			.collect();
+		assert_eq!(farther.len(), 3, "test peer fixture must include peers farther than self");
+
+		for peer in &farther {
+			dht_peer(&mut topology, *peer);
+			topology.on_substream_opened(*peer);
+		}
+
+		// A replica still forwards to its closest connected co-replicas (capped at gossip_target),
+		// even though none is closer to the topic than itself — where the earlier closer-than-self
+		// rule forwarded nowhere and left the statement on a single node.
+		let expected = {
+			let mut peers = farther;
 			peers.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
 			peers.truncate(2);
 			peers

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -178,22 +178,21 @@ impl PeersTopology {
 		}
 	}
 
-	/// Connected peers to forward a statement for `topic` to, capped at `gossip_target`.
-	///
-	/// A replica (in the topic's k-closest set) forwards to its closest connected peers; a
-	/// non-replica, only to those closer to the topic than itself.
+	/// Connected peers to forward a statement for `topic` to, capped at `gossip_target`: those
+	/// closer to the topic than the local node (routing the statement onward) and those that are
+	/// themselves DHT replicas for it (co-replicas that must store it).
 	pub fn routing_targets(&self, topic: Topic) -> Vec<PeerId> {
+		// TODO: benchmark this per-statement path on large connected sets (see
+		// benches/peers_topology.rs).
+		let local = (self.local_key, self.local_peer);
 		let local_distance = xor_distance(*topic, self.local_key);
-		let is_replica = is_local_replica(
-			&self.discovered_index,
-			self.local_key,
-			self.local_peer,
-			self.config.replication_factor.get(),
-			topic,
-		);
+		let k = self.config.replication_factor.get();
 		self.connected
 			.closest(*topic)
-			.take_while(|(_, key)| is_replica || xor_distance(*topic, *key) < local_distance)
+			.take_while(|(peer, key)| {
+				xor_distance(*topic, *key) < local_distance ||
+					is_peer_topic_affine(&self.discovered_index, local, (*key, *peer), k, topic)
+			})
 			.take(self.config.gossip_target.get())
 			.map(|(peer, _)| peer)
 			.collect()
@@ -301,24 +300,29 @@ fn xor_distance(a: Key, b: Key) -> Key {
 	distance
 }
 
-/// Whether `local_peer`, at `local_key`, is among the `k` closest entries of `index` to `topic` —
-/// i.e. a DHT storage replica for it.
-fn is_local_replica(
+/// Whether `candidate` is among the `k` closest to `topic`, ranked against the peers in `index`
+/// plus the local node — i.e. topic-affine, a DHT storage replica for the topic.
+fn is_peer_topic_affine(
 	index: &PeersIndex,
-	local_key: Key,
-	local_peer: PeerId,
+	local: (Key, PeerId),
+	candidate: (Key, PeerId),
 	k: usize,
 	topic: Topic,
 ) -> bool {
-	let local_distance = xor_distance(*topic, local_key);
-	let closer_count = index
+	let candidate_distance = (xor_distance(*topic, candidate.0), candidate.1);
+	let local_node_is_closer = (xor_distance(*topic, local.0), local.1) < candidate_distance;
+	let mut closer = index
 		.closest(*topic)
-		.take_while(|(peer, key)| {
-			(xor_distance(*topic, *key), *peer) < (local_distance, local_peer)
-		})
+		.take_while(|(peer, key)| (xor_distance(*topic, *key), *peer) < candidate_distance)
 		.take(k)
 		.count();
-	closer_count < k
+	// The local node is not in `index`, so count its slot here when it outranks the candidate.
+	// For the oracle's self query (`candidate == local`) this never fires: a node never outranks
+	// itself.
+	if local_node_is_closer {
+		closer += 1;
+	}
+	closer < k
 }
 
 /// Standalone DHT-affinity oracle: the minimal snapshot needed to answer "is the local node a
@@ -351,13 +355,8 @@ impl DhtAffinity {
 
 	/// Whether the local node is one of the closest DHT storage replicas for `topic`.
 	fn is_topic_affine(&self, topic: Topic) -> bool {
-		is_local_replica(
-			&self.index,
-			self.local_key,
-			self.local_peer,
-			self.replication_factor.get(),
-			topic,
-		)
+		let local = (self.local_key, self.local_peer);
+		is_peer_topic_affine(&self.index, local, local, self.replication_factor.get(), topic)
 	}
 }
 
@@ -518,36 +517,30 @@ mod tests {
 	}
 
 	#[test]
-	fn replica_forwards_to_closest_connected_even_when_none_are_closer_than_self() {
+	fn replica_forwards_to_a_farther_co_replica_but_not_to_non_replicas() {
 		let mut topology = topology(1); // replication_factor = 2, gossip_target = 2
 		let topic = topic(7);
 		let self_distance = distance_to(topic, &peer(1));
 
-		// Connected peers all farther from the topic than the local node, so the node is itself in
-		// the k-closest set (a replica) and has nobody "closer than self" to route toward.
-		let farther: Vec<PeerId> = (2..=80)
+		// Connected peers all farther from the topic than the local node, so the local node is the
+		// closest and, with k=2, only the single nearest of them is its co-replica.
+		let mut farther: Vec<PeerId> = (2..=80)
 			.map(peer)
 			.filter(|candidate| distance_to(topic, candidate) > self_distance)
 			.take(3)
 			.collect();
 		assert_eq!(farther.len(), 3, "test peer fixture must include peers farther than self");
+		farther.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
 
 		for peer in &farther {
 			dht_peer(&mut topology, *peer);
 			topology.on_substream_opened(*peer);
 		}
 
-		// A replica still forwards to its closest connected co-replicas (capped at gossip_target),
-		// even though none is closer to the topic than itself — where the earlier closer-than-self
-		// rule forwarded nowhere and left the statement on a single node.
-		let expected = {
-			let mut peers = farther;
-			peers.sort_by(|a, b| cmp_distance_then_peer(topic, a, b));
-			peers.truncate(2);
-			peers
-		};
-
-		assert_eq!(topology.routing_targets(topic), expected);
+		// The co-replica (nearest farther peer) is forwarded to even though it is farther than
+		// self; the farther non-replicas are not, so a replica does not spray every connected
+		// peer.
+		assert_eq!(topology.routing_targets(topic), vec![farther[0]]);
 	}
 
 	#[test]

--- a/substrate/client/network/statement/src/v2dht/peers_topology.rs
+++ b/substrate/client/network/statement/src/v2dht/peers_topology.rs
@@ -184,7 +184,7 @@ impl PeersTopology {
 	/// non-replica, only to those closer to the topic than itself.
 	pub fn routing_targets(&self, topic: Topic) -> Vec<PeerId> {
 		let local_distance = xor_distance(*topic, self.local_key);
-		let is_replica = local_is_replica(
+		let is_replica = is_local_replica(
 			&self.discovered_index,
 			self.local_key,
 			self.local_peer,
@@ -303,7 +303,7 @@ fn xor_distance(a: Key, b: Key) -> Key {
 
 /// Whether `local_peer`, at `local_key`, is among the `k` closest entries of `index` to `topic` —
 /// i.e. a DHT storage replica for it.
-fn local_is_replica(
+fn is_local_replica(
 	index: &PeersIndex,
 	local_key: Key,
 	local_peer: PeerId,
@@ -351,7 +351,7 @@ impl DhtAffinity {
 
 	/// Whether the local node is one of the closest DHT storage replicas for `topic`.
 	fn is_topic_affine(&self, topic: Topic) -> bool {
-		local_is_replica(
+		is_local_replica(
 			&self.index,
 			self.local_key,
 			self.local_peer,


### PR DESCRIPTION
## What

`routing_targets` forwarded a statement only to connected peers strictly closer
to the topic than itself. That converges the statement to the single closest
node but never fans it out to the rest of the k-closest set, so with `K > 1` a
statement submitted on (or routed only as far as) the closest replica is stored
by one node instead of `K` — `dht_affinity_works`