### PR TITLE
Beefy: Make the equivocation time slot more generic

### DIFF
--- a/polkadot/runtime/parachains/src/disputes/slashing.rs
+++ b/polkadot/runtime/parachains/src/disputes/slashing.rs
@@ -129,7 +129,7 @@ where
 {
 	const ID: Kind = *b"disputes:slashin";
 
-	type TimeSlot = DisputesTimeSlot;
+	type Slot = DisputesTimeSlot;
 
 	fn offenders(&self) -> Vec<Offender> {
 		self.offenders.clone()
@@ -143,7 +143,7 @@ where
 		self.validator_set_count
 	}
 
-	fn time_slot(&self) -> Self::TimeSlot {
+	fn slot(&self) -> Self::Slot {
 		self.time_slot.clone()
 	}
 

--- a/prdoc/pr_12542.prdoc
+++ b/prdoc/pr_12542.prdoc
@@ -8,20 +8,20 @@ doc:
     - Adds the equivocation type to the offence slot for Beefy
 crates:
 - name: polkadot-runtime-parachains
-  bump: patch
+  bump: minor
 - name: pallet-babe
-  bump: patch
+  bump: minor
 - name: pallet-beefy
-  bump: patch
+  bump: major
 - name: pallet-grandpa
-  bump: patch
+  bump: minor
 - name: pallet-im-online
-  bump: patch
+  bump: minor
 - name: pallet-offences
-  bump: patch
+  bump: major
 - name: pallet-root-offences
-  bump: patch
+  bump: minor
 - name: pallet-staking
   bump: patch
 - name: sp-staking
-  bump: patch
+  bump: major

--- a/prdoc/pr_12542.prdoc
+++ b/prdoc/pr_12542.prdoc
@@ -1,0 +1,27 @@
+title: 'Beefy: Make the equivocation time slot more generic'
+doc:
+- audience: Runtime Dev
+  description: |-
+    This PR:
+
+    - Adjusts the offence time slot into a more generic slot
+    - Adds the equivocation type to the offence slot for Beefy
+crates:
+- name: polkadot-runtime-parachains
+  bump: patch
+- name: pallet-babe
+  bump: patch
+- name: pallet-beefy
+  bump: patch
+- name: pallet-grandpa
+  bump: patch
+- name: pallet-im-online
+  bump: patch
+- name: pallet-offences
+  bump: patch
+- name: pallet-root-offences
+  bump: patch
+- name: pallet-staking
+  bump: patch
+- name: sp-staking
+  bump: patch

--- a/substrate/frame/babe/src/equivocation.rs
+++ b/substrate/frame/babe/src/equivocation.rs
@@ -70,7 +70,7 @@ pub struct EquivocationOffence<Offender> {
 
 impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 	const ID: Kind = *b"babe:equivocatio";
-	type TimeSlot = Slot;
+	type Slot = Slot;
 
 	fn offenders(&self) -> Vec<Offender> {
 		vec![self.offender.clone()]
@@ -84,7 +84,7 @@ impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 		self.validator_set_count
 	}
 
-	fn time_slot(&self) -> Self::TimeSlot {
+	fn slot(&self) -> Self::Slot {
 		self.slot
 	}
 

--- a/substrate/frame/beefy/src/equivocation.rs
+++ b/substrate/frame/beefy/src/equivocation.rs
@@ -58,14 +58,16 @@ use sp_staking::{
 
 use super::{Call, Config, Error, Pallet, LOG_TARGET};
 
-/// A round number and set id which point on the time of an offence.
+/// A set of fields which point to the time and type of an offence.
 #[derive(Copy, Clone, PartialOrd, Ord, Eq, PartialEq, Encode, Decode)]
-pub struct TimeSlot<N: Copy + Clone + PartialOrd + Ord + Eq + PartialEq + Encode + Decode> {
+pub struct Slot<N: Copy + Clone + PartialOrd + Ord + Eq + PartialEq + Encode + Decode> {
 	// The order of these matters for `derive(Ord)`.
 	/// BEEFY Set ID.
 	pub set_id: ValidatorSetId,
 	/// Round number.
 	pub round: N,
+	/// Equivocation type
+	pub equivocation_type: u8,
 }
 
 /// BEEFY equivocation offence report.
@@ -74,7 +76,7 @@ where
 	N: Copy + Clone + PartialOrd + Ord + Eq + PartialEq + Encode + Decode,
 {
 	/// Time slot at which this incident happened.
-	pub time_slot: TimeSlot<N>,
+	pub slot: Slot<N>,
 	/// The session index in which the incident happened.
 	pub session_index: SessionIndex,
 	/// The size of the validator set at the time of the offence.
@@ -90,7 +92,7 @@ where
 	N: Copy + Clone + PartialOrd + Ord + Eq + PartialEq + Encode + Decode,
 {
 	const ID: Kind = *b"beefy:equivocati";
-	type TimeSlot = TimeSlot<N>;
+	type Slot = Slot<N>;
 
 	fn offenders(&self) -> Vec<Offender> {
 		vec![self.offender.clone()]
@@ -104,8 +106,8 @@ where
 		self.validator_set_count
 	}
 
-	fn time_slot(&self) -> Self::TimeSlot {
-		self.time_slot
+	fn slot(&self) -> Self::Slot {
+		self.slot
 	}
 
 	fn slash_fraction(&self, offenders_count: u32) -> Perbill {
@@ -152,6 +154,14 @@ pub enum EquivocationEvidenceFor<T: Config> {
 }
 
 impl<T: Config> EquivocationEvidenceFor<T> {
+	fn equivocation_type(&self) -> u8 {
+		match self {
+			EquivocationEvidenceFor::DoubleVotingProof(..) => 1,
+			EquivocationEvidenceFor::ForkVotingProof(..) => 2,
+			EquivocationEvidenceFor::FutureBlockVotingProof(..) => 3,
+		}
+	}
+
 	/// Returns the authority id of the equivocator.
 	fn offender_id(&self) -> &T::BeefyId {
 		match self {
@@ -322,8 +332,12 @@ where
 		let offender = evidence.checked_offender::<P>().ok_or(InvalidTransaction::BadProof)?;
 
 		// Check if the offence has already been reported, and if so then we can discard the report.
-		let time_slot = TimeSlot { set_id: evidence.set_id(), round: *evidence.round_number() };
-		if R::is_known_offence(&[offender], &time_slot) {
+		let slot = Slot {
+			set_id: evidence.set_id(),
+			round: *evidence.round_number(),
+			equivocation_type: evidence.equivocation_type(),
+		};
+		if R::is_known_offence(&[offender], &slot) {
 			Err(InvalidTransaction::Stale.into())
 		} else {
 			Ok(())
@@ -339,7 +353,6 @@ where
 
 		// We check the equivocation within the context of its set id (and associated session).
 		let set_id = evidence.set_id();
-		let round = *evidence.round_number();
 		let set_id_session_index = crate::SetIdSession::<T>::get(set_id)
 			.ok_or(Error::<T>::InvalidEquivocationProofSessionMember)?;
 
@@ -356,10 +369,13 @@ where
 		let offender =
 			evidence.checked_offender::<P>().ok_or(Error::<T>::InvalidKeyOwnershipProof)?;
 
+		let round = *evidence.round_number();
+		let equivocation_type = evidence.equivocation_type();
+
 		evidence.check_equivocation_proof()?;
 
 		let offence = EquivocationOffence {
-			time_slot: TimeSlot { set_id, round },
+			slot: Slot { set_id, round, equivocation_type },
 			session_index,
 			validator_set_count: validator_count,
 			offender,

--- a/substrate/frame/beefy/src/lib.rs
+++ b/substrate/frame/beefy/src/lib.rs
@@ -55,7 +55,7 @@ use sp_session::{GetSessionNumber, GetValidatorCount};
 use sp_staking::{offence::OffenceReportSystem, SessionIndex};
 
 use crate::equivocation::EquivocationEvidenceFor;
-pub use crate::equivocation::{EquivocationOffence, EquivocationReportSystem, TimeSlot};
+pub use crate::equivocation::{EquivocationOffence, EquivocationReportSystem, Slot};
 pub use pallet::*;
 
 const LOG_TARGET: &str = "runtime::beefy";

--- a/substrate/frame/grandpa/src/equivocation.rs
+++ b/substrate/frame/grandpa/src/equivocation.rs
@@ -80,7 +80,7 @@ pub struct EquivocationOffence<Offender> {
 
 impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 	const ID: Kind = *b"grandpa:equivoca";
-	type TimeSlot = TimeSlot;
+	type Slot = TimeSlot;
 
 	fn offenders(&self) -> Vec<Offender> {
 		vec![self.offender.clone()]
@@ -94,7 +94,7 @@ impl<Offender: Clone> Offence<Offender> for EquivocationOffence<Offender> {
 		self.validator_set_count
 	}
 
-	fn time_slot(&self) -> Self::TimeSlot {
+	fn slot(&self) -> Self::Slot {
 		self.time_slot
 	}
 

--- a/substrate/frame/im-online/src/lib.rs
+++ b/substrate/frame/im-online/src/lib.rs
@@ -841,7 +841,7 @@ pub struct UnresponsivenessOffence<Offender> {
 
 impl<Offender: Clone> Offence<Offender> for UnresponsivenessOffence<Offender> {
 	const ID: Kind = *b"im-online:offlin";
-	type TimeSlot = SessionIndex;
+	type Slot = SessionIndex;
 
 	fn offenders(&self) -> Vec<Offender> {
 		self.offenders.clone()
@@ -855,7 +855,7 @@ impl<Offender: Clone> Offence<Offender> for UnresponsivenessOffence<Offender> {
 		self.validator_set_count
 	}
 
-	fn time_slot(&self) -> Self::TimeSlot {
+	fn slot(&self) -> Self::Slot {
 		self.session_index
 	}
 

--- a/substrate/frame/offences/src/lib.rs
+++ b/substrate/frame/offences/src/lib.rs
@@ -40,8 +40,8 @@ use sp_staking::{
 
 pub use pallet::*;
 
-/// A binary blob which represents a SCALE codec-encoded `O::TimeSlot`.
-type OpaqueTimeSlot = Vec<u8>;
+/// A binary blob which represents a SCALE codec-encoded `O::Slot`.
+type OpaqueSlot = Vec<u8>;
 
 /// A type alias for a report identifier.
 type ReportIdOf<T> = <T as frame_system::Config>::Hash;
@@ -88,7 +88,7 @@ pub mod pallet {
 		Twox64Concat,
 		Kind,
 		Twox64Concat,
-		OpaqueTimeSlot,
+		OpaqueSlot,
 		Vec<ReportIdOf<T>>,
 		ValueQuery,
 	>;
@@ -100,7 +100,7 @@ pub mod pallet {
 		/// There is an offence reported of the given `kind` happened at the `session_index` and
 		/// (kind-specific) time slot. This event is not deposited for duplicate slashes.
 		/// \[kind, timeslot\].
-		Offence { kind: Kind, timeslot: OpaqueTimeSlot },
+		Offence { kind: Kind, slot: OpaqueSlot },
 	}
 }
 
@@ -111,12 +111,12 @@ where
 {
 	fn report_offence(reporters: Vec<T::AccountId>, offence: O) -> Result<(), OffenceError> {
 		let offenders = offence.offenders();
-		let time_slot = offence.time_slot();
+		let slot = offence.slot();
 
 		// Go through all offenders in the offence report and find all offenders that were spotted
 		// in unique reports.
 		let TriageOutcome { concurrent_offenders } =
-			match Self::triage_offence_report::<O>(reporters, &time_slot, offenders) {
+			match Self::triage_offence_report::<O>(reporters, &slot, offenders) {
 				Some(triage) => triage,
 				// The report contained only duplicates, so there is no need to slash again.
 				None => return Err(OffenceError::DuplicateReport),
@@ -136,14 +136,14 @@ where
 		);
 
 		// Deposit the event.
-		Self::deposit_event(Event::Offence { kind: O::ID, timeslot: time_slot.encode() });
+		Self::deposit_event(Event::Offence { kind: O::ID, slot: slot.encode() });
 
 		Ok(())
 	}
 
-	fn is_known_offence(offenders: &[T::IdentificationTuple], time_slot: &O::TimeSlot) -> bool {
+	fn is_known_offence(offenders: &[T::IdentificationTuple], slot: &O::Slot) -> bool {
 		let any_unknown = offenders.iter().any(|offender| {
-			let report_id = Self::report_id::<O>(time_slot, offender);
+			let report_id = Self::report_id::<O>(slot, offender);
 			!<Reports<T>>::contains_key(&report_id)
 		});
 
@@ -163,24 +163,24 @@ impl<T: Config> Pallet<T> {
 	///
 	/// The report id depends on the offence kind, time slot and the id of offender.
 	fn report_id<O: Offence<T::IdentificationTuple>>(
-		time_slot: &O::TimeSlot,
+		slot: &O::Slot,
 		offender: &T::IdentificationTuple,
 	) -> ReportIdOf<T> {
-		(O::ID, time_slot.encode(), offender).using_encoded(T::Hashing::hash)
+		(O::ID, slot.encode(), offender).using_encoded(T::Hashing::hash)
 	}
 
 	/// Triages the offence report and returns the set of offenders that was involved in unique
 	/// reports along with the list of the concurrent offences.
 	fn triage_offence_report<O: Offence<T::IdentificationTuple>>(
 		reporters: Vec<T::AccountId>,
-		time_slot: &O::TimeSlot,
+		slot: &O::Slot,
 		offenders: Vec<T::IdentificationTuple>,
 	) -> Option<TriageOutcome<T>> {
-		let mut storage = ReportIndexStorage::<T, O>::load(time_slot);
+		let mut storage = ReportIndexStorage::<T, O>::load(slot);
 
 		let mut any_new = false;
 		for offender in offenders {
-			let report_id = Self::report_id::<O>(time_slot, &offender);
+			let report_id = Self::report_id::<O>(slot, &offender);
 
 			if !<Reports<T>>::contains_key(&report_id) {
 				any_new = true;
@@ -222,19 +222,19 @@ struct TriageOutcome<T: Config> {
 /// accessed directly meanwhile.
 #[must_use = "The changes are not saved without called `save`"]
 struct ReportIndexStorage<T: Config, O: Offence<T::IdentificationTuple>> {
-	opaque_time_slot: OpaqueTimeSlot,
+	slot: OpaqueSlot,
 	concurrent_reports: Vec<ReportIdOf<T>>,
 	_phantom: PhantomData<O>,
 }
 
 impl<T: Config, O: Offence<T::IdentificationTuple>> ReportIndexStorage<T, O> {
-	/// Preload indexes from the storage for the specific `time_slot` and the kind of the offence.
-	fn load(time_slot: &O::TimeSlot) -> Self {
-		let opaque_time_slot = time_slot.encode();
+	/// Preload indexes from the storage for the specific `slot` and the kind of the offence.
+	fn load(slot: &O::Slot) -> Self {
+		let slot = slot.encode();
 
-		let concurrent_reports = <ConcurrentReportsIndex<T>>::get(&O::ID, &opaque_time_slot);
+		let concurrent_reports = <ConcurrentReportsIndex<T>>::get(&O::ID, &slot);
 
-		Self { opaque_time_slot, concurrent_reports, _phantom: Default::default() }
+		Self { slot, concurrent_reports, _phantom: Default::default() }
 	}
 
 	/// Insert a new report to the index.
@@ -245,10 +245,6 @@ impl<T: Config, O: Offence<T::IdentificationTuple>> ReportIndexStorage<T, O> {
 
 	/// Dump the indexes to the storage.
 	fn save(self) {
-		<ConcurrentReportsIndex<T>>::insert(
-			&O::ID,
-			&self.opaque_time_slot,
-			&self.concurrent_reports,
-		);
+		<ConcurrentReportsIndex<T>>::insert(&O::ID, &self.slot, &self.concurrent_reports);
 	}
 }

--- a/substrate/frame/offences/src/lib.rs
+++ b/substrate/frame/offences/src/lib.rs
@@ -99,7 +99,7 @@ pub mod pallet {
 	pub enum Event {
 		/// There is an offence reported of the given `kind` happened at the `session_index` and
 		/// (kind-specific) time slot. This event is not deposited for duplicate slashes.
-		/// \[kind, timeslot\].
+		/// \[kind, slot\].
 		Offence { kind: Kind, slot: OpaqueSlot },
 	}
 }

--- a/substrate/frame/offences/src/mock.rs
+++ b/substrate/frame/offences/src/mock.rs
@@ -109,12 +109,12 @@ pub fn offence_reports(kind: Kind, time_slot: u128) -> Vec<OffenceDetails<u64, u
 pub struct Offence {
 	pub validator_set_count: u32,
 	pub offenders: Vec<u64>,
-	pub time_slot: u128,
+	pub slot: u128,
 }
 
 impl offence::Offence<u64> for Offence {
 	const ID: offence::Kind = KIND;
-	type TimeSlot = u128;
+	type Slot = u128;
 
 	fn offenders(&self) -> Vec<u64> {
 		self.offenders.clone()
@@ -124,8 +124,8 @@ impl offence::Offence<u64> for Offence {
 		self.validator_set_count
 	}
 
-	fn time_slot(&self) -> u128 {
-		self.time_slot
+	fn slot(&self) -> u128 {
+		self.slot
 	}
 
 	fn session_index(&self) -> SessionIndex {

--- a/substrate/frame/offences/src/tests.rs
+++ b/substrate/frame/offences/src/tests.rs
@@ -53,10 +53,10 @@ fn should_get_reports_with_storagemap_getter_and_function_getter() {
 fn should_report_an_authority_and_trigger_on_offence() {
 	new_test_ext().execute_with(|| {
 		// given
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let offence = Offence { validator_set_count: 5, time_slot, offenders: vec![5] };
+		let offence = Offence { validator_set_count: 5, slot, offenders: vec![5] };
 
 		// when
 		Offences::report_offence(vec![], offence).unwrap();
@@ -72,10 +72,10 @@ fn should_report_an_authority_and_trigger_on_offence() {
 fn should_not_report_the_same_authority_twice_in_the_same_slot() {
 	new_test_ext().execute_with(|| {
 		// given
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let offence = Offence { validator_set_count: 5, time_slot, offenders: vec![5] };
+		let offence = Offence { validator_set_count: 5, slot, offenders: vec![5] };
 		Offences::report_offence(vec![], offence.clone()).unwrap();
 		with_on_offence_fractions(|f| {
 			assert_eq!(f.clone(), vec![Perbill::from_percent(25)]);
@@ -94,13 +94,13 @@ fn should_not_report_the_same_authority_twice_in_the_same_slot() {
 }
 
 #[test]
-fn should_report_in_different_time_slot() {
+fn should_report_in_different_slot() {
 	new_test_ext().execute_with(|| {
 		// given
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let mut offence = Offence { validator_set_count: 5, time_slot, offenders: vec![5] };
+		let mut offence = Offence { validator_set_count: 5, slot, offenders: vec![5] };
 		Offences::report_offence(vec![], offence.clone()).unwrap();
 		with_on_offence_fractions(|f| {
 			assert_eq!(f.clone(), vec![Perbill::from_percent(25)]);
@@ -109,7 +109,7 @@ fn should_report_in_different_time_slot() {
 
 		// when
 		// report for the second time
-		offence.time_slot += 1;
+		offence.slot += 1;
 		Offences::report_offence(vec![], offence).unwrap();
 
 		// then
@@ -123,10 +123,10 @@ fn should_report_in_different_time_slot() {
 fn should_deposit_event() {
 	new_test_ext().execute_with(|| {
 		// given
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let offence = Offence { validator_set_count: 5, time_slot, offenders: vec![5] };
+		let offence = Offence { validator_set_count: 5, slot, offenders: vec![5] };
 
 		// when
 		Offences::report_offence(vec![], offence).unwrap();
@@ -138,7 +138,7 @@ fn should_deposit_event() {
 				phase: Phase::Initialization,
 				event: RuntimeEvent::Offences(crate::Event::Offence {
 					kind: KIND,
-					timeslot: time_slot.encode()
+					slot: slot.encode()
 				}),
 				topics: vec![],
 			}]
@@ -150,10 +150,10 @@ fn should_deposit_event() {
 fn doesnt_deposit_event_for_dups() {
 	new_test_ext().execute_with(|| {
 		// given
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let offence = Offence { validator_set_count: 5, time_slot, offenders: vec![5] };
+		let offence = Offence { validator_set_count: 5, slot, offenders: vec![5] };
 		Offences::report_offence(vec![], offence.clone()).unwrap();
 		with_on_offence_fractions(|f| {
 			assert_eq!(f.clone(), vec![Perbill::from_percent(25)]);
@@ -172,7 +172,7 @@ fn doesnt_deposit_event_for_dups() {
 				phase: Phase::Initialization,
 				event: RuntimeEvent::Offences(crate::Event::Offence {
 					kind: KIND,
-					timeslot: time_slot.encode()
+					slot: slot.encode()
 				}),
 				topics: vec![],
 			}]
@@ -183,19 +183,18 @@ fn doesnt_deposit_event_for_dups() {
 #[test]
 fn reports_if_an_offence_is_dup() {
 	new_test_ext().execute_with(|| {
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let offence =
-			|time_slot, offenders| Offence { validator_set_count: 5, time_slot, offenders };
+		let offence = |slot, offenders| Offence { validator_set_count: 5, slot, offenders };
 
-		let mut test_offence = offence(time_slot, vec![0]);
+		let mut test_offence = offence(slot, vec![0]);
 
 		// the report for authority 0 at time slot 42 should not be a known
 		// offence
 		assert!(!<Offences as ReportOffence<_, _, Offence>>::is_known_offence(
 			&test_offence.offenders,
-			&test_offence.time_slot
+			&test_offence.slot
 		));
 
 		// we report an offence for authority 0 at time slot 42
@@ -204,7 +203,7 @@ fn reports_if_an_offence_is_dup() {
 		// the same report should be a known offence now
 		assert!(<Offences as ReportOffence<_, _, Offence>>::is_known_offence(
 			&test_offence.offenders,
-			&test_offence.time_slot
+			&test_offence.slot
 		));
 
 		// and reporting it again should yield a duplicate report error
@@ -219,7 +218,7 @@ fn reports_if_an_offence_is_dup() {
 		// it should not be a known offence anymore
 		assert!(!<Offences as ReportOffence<_, _, Offence>>::is_known_offence(
 			&test_offence.offenders,
-			&test_offence.time_slot
+			&test_offence.slot
 		));
 
 		// and reporting it again should work without any error
@@ -227,10 +226,10 @@ fn reports_if_an_offence_is_dup() {
 
 		// creating a new offence for the same authorities on the next slot
 		// should be considered a new offence and therefore not known
-		let test_offence_next_slot = offence(time_slot + 1, vec![0, 1]);
+		let test_offence_next_slot = offence(slot + 1, vec![0, 1]);
 		assert!(!<Offences as ReportOffence<_, _, Offence>>::is_known_offence(
 			&test_offence_next_slot.offenders,
-			&test_offence_next_slot.time_slot
+			&test_offence_next_slot.slot
 		));
 	});
 }
@@ -241,11 +240,11 @@ fn should_properly_count_offences() {
 	// should have `count` equal 2 and the count of the 2nd one should be equal to 1.
 	new_test_ext().execute_with(|| {
 		// given
-		let time_slot = 42;
-		assert_eq!(offence_reports(KIND, time_slot), vec![]);
+		let slot = 42;
+		assert_eq!(offence_reports(KIND, slot), vec![]);
 
-		let offence1 = Offence { validator_set_count: 5, time_slot, offenders: vec![5] };
-		let offence2 = Offence { validator_set_count: 5, time_slot, offenders: vec![4] };
+		let offence1 = Offence { validator_set_count: 5, slot, offenders: vec![5] };
+		let offence2 = Offence { validator_set_count: 5, slot, offenders: vec![4] };
 		Offences::report_offence(vec![], offence1).unwrap();
 		with_on_offence_fractions(|f| {
 			assert_eq!(f.clone(), vec![Perbill::from_percent(25)]);
@@ -259,7 +258,7 @@ fn should_properly_count_offences() {
 		// then
 		// the 1st authority should have count 2 and the 2nd one should be reported only once.
 		assert_eq!(
-			offence_reports(KIND, time_slot),
+			offence_reports(KIND, slot),
 			vec![
 				OffenceDetails { offender: 5, reporters: vec![] },
 				OffenceDetails { offender: 4, reporters: vec![] },

--- a/substrate/frame/root-offences/src/lib.rs
+++ b/substrate/frame/root-offences/src/lib.rs
@@ -58,7 +58,7 @@ pub mod pallet {
 
 	impl<Offender: Clone> Offence<Offender> for TestSpamOffence<Offender> {
 		const ID: Kind = *b"spamspamspamspam";
-		type TimeSlot = u128;
+		type Slot = u128;
 
 		fn offenders(&self) -> Vec<Offender> {
 			vec![self.offender.clone()]
@@ -68,7 +68,7 @@ pub mod pallet {
 			self.session_index
 		}
 
-		fn time_slot(&self) -> Self::TimeSlot {
+		fn slot(&self) -> Self::Slot {
 			self.time_slot
 		}
 

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -1132,7 +1132,7 @@ where
 		}
 	}
 
-	fn is_known_offence(offenders: &[Offender], time_slot: &O::TimeSlot) -> bool {
+	fn is_known_offence(offenders: &[Offender], time_slot: &O::Slot) -> bool {
 		R::is_known_offence(offenders, time_slot)
 	}
 }

--- a/substrate/primitives/staking/src/offence.rs
+++ b/substrate/primitives/staking/src/offence.rs
@@ -43,14 +43,16 @@ pub type OffenceCount = u32;
 ///
 /// Examples of offences include: a BABE equivocation or a GRANDPA unjustified vote.
 pub trait Offence<Offender> {
-	/// Identifier which is unique for this kind of an offence.
+	/// Identifier which is unique for this kind of offence.
 	const ID: Kind;
 
-	/// A type that represents a point in time on an abstract timescale.
+	/// A type used for grouping offences that happened at the "same time".
 	///
-	/// See `Offence::time_slot` for details. The only requirement is that such timescale could be
-	/// represented by a single `u128` value.
-	type TimeSlot: Clone + codec::Codec + Ord;
+	/// Usually this will be a time slot, representing a point in time on an abstract timescale.
+	/// But it can also be a more complex grouping strategy.
+	///
+	/// See `Offence::slot` for details.
+	type Slot: Clone + codec::Codec + Ord;
 
 	/// The list of all offenders involved in this incident.
 	///
@@ -66,18 +68,16 @@ pub trait Offence<Offender> {
 	/// Return a validator set count at the time when the offence took place.
 	fn validator_set_count(&self) -> u32;
 
-	/// A point in time when this offence happened.
+	/// A slot within which this offence happened.
 	///
 	/// This is used for looking up offences that happened at the "same time".
 	///
-	/// The timescale is abstract and doesn't have to be the same across different implementations
-	/// of this trait. The value doesn't represent absolute timescale though since it is interpreted
-	/// along with the `session_index`. Two offences are considered to happen at the same time iff
-	/// both `session_index` and `time_slot` are equal.
+	/// The slot is abstract and doesn't have to be the same across different implementations
+	/// of this trait.
 	///
-	/// As an example, for GRANDPA timescale could be a round number and for BABE it could be a slot
-	/// number. Note that for GRANDPA the round number is reset each epoch.
-	fn time_slot(&self) -> Self::TimeSlot;
+	/// As an example, for GRANDPA the slot could be a round number and for BABE it could be
+	/// a slot number. Note that for GRANDPA the round number is reset each epoch.
+	fn slot(&self) -> Self::Slot;
 
 	/// A slash fraction of the total exposure that should be slashed for this
 	/// particular offence for the `offenders_count` that happened at a singular `TimeSlot`.
@@ -117,7 +117,7 @@ pub trait ReportOffence<Reporter, Offender, O: Offence<Offender>> {
 	/// Returns true iff all of the given offenders have been previously reported
 	/// at the given time slot. This function is useful to prevent the sending of
 	/// duplicate offence reports.
-	fn is_known_offence(offenders: &[Offender], time_slot: &O::TimeSlot) -> bool;
+	fn is_known_offence(offenders: &[Offender], time_slot: &O::Slot) -> bool;
 }
 
 impl<Reporter, Offender, O: Offence<Offender>> ReportOffence<Reporter, Offender, O> for () {
@@ -125,7 +125,7 @@ impl<Reporter, Offender, O: Offence<Offender>> ReportOffence<Reporter, Offender,
 		Ok(())
 	}
 
-	fn is_known_offence(_offenders: &[Offender], _time_slot: &O::TimeSlot) -> bool {
+	fn is_known_offence(_offenders: &[Offender], _time_slot: &O::Slot) -> bool {
 		true
 	}
 }

--- a/substrate/primitives/staking/src/offence.rs
+++ b/substrate/primitives/staking/src/offence.rs
@@ -73,7 +73,8 @@ pub trait Offence<Offender> {
 	/// This is used for looking up offences that happened at the "same time".
 	///
 	/// The slot is abstract and doesn't have to be the same across different implementations
-	/// of this trait.
+	/// of this trait. Two offences are considered to happen at the same time iff  both
+	/// `session_index` and `slot` are equal.
 	///
 	/// As an example, for GRANDPA the slot could be a round number and for BABE it could be
 	/// a slot number. Note that for GRANDPA the round number is reset each epoch.
@@ -115,7 +116,7 @@ pub trait ReportOffence<Reporter, Offender, O: Offence<Offender>> {
 	fn report_offence(reporters: Vec<Reporter>, offence: O) -> Result<(), OffenceError>;
 
 	/// Returns true iff all of the given offenders have been previously reported
-	/// at the given time slot. This function is useful to prevent the sending of
+	/// at the given slot. This function is useful to prevent the sending of
 	/// duplicate offence reports.
 	fn is_known_offence(offenders: &[Offender], time_slot: &O::Slot) -> bool;
 }


### PR DESCRIPTION
This PR:

- Adjusts the offence time slot into a more generic slot
- Adds the equivocation type to the offence slot for Beefy