### PR TITLE
statement network: accept non-reserved peers into the statement set

### DIFF
--- a/substrate/client/network/statement/src/lib.rs
+++ b/substrate/client/network/statement/src/lib.rs
@@ -399,7 +399,7 @@ impl StatementHandlerPrototype {
 				in_peers: 50,
 				out_peers: 50,
 				reserved_nodes: Vec::new(),
-				non_reserved_mode: NonReservedPeerMode::Deny,
+				non_reserved_mode: NonReservedPeerMode::Accept,
 			},
 			metrics,
 			peer_store_handle,


### PR DESCRIPTION
## Change

Switch the statement set to `NonReservedPeerMode::Accept` so non-reserved peers fill the 50/50 in/out slots and substreams open without reserved-set management.