### PR TITLE
[Release|CI/CD] Fix checkout of existing post-crates-release branch

### DIFF
--- a/.github/workflows/release-80_publish-crates.yml
+++ b/.github/workflows/release-80_publish-crates.yml
@@ -165,8 +165,8 @@ jobs:
             echo "Resuming from '$RESUME_FROM' - checking out existing branch $CRATES_RELEASE_BRANCH"
             git fetch origin "$CRATES_RELEASE_BRANCH"
             git checkout "$CRATES_RELEASE_BRANCH"
-          elif git rev-parse --verify -q "$CRATES_RELEASE_BRANCH" &>/dev/null; then
-            echo "Branch $CRATES_RELEASE_BRANCH already exists, switching to it"
+          elif git rev-parse --verify -q "origin/$CRATES_RELEASE_BRANCH" &>/dev/null; then
+            echo "Branch $CRATES_RELEASE_BRANCH already exists on remote, switching to it"
             git checkout "$CRATES_RELEASE_BRANCH"
           else
             echo "Creating branch: $CRATES_RELEASE_BRANCH"


### PR DESCRIPTION
This PR fixes an issue with the checkout of existing `post-crate-release-stablYYMM` branch in case when it was created and pushed to origin, but Publish crates pipeline has not ran yet