### PR TITLE
AHW: populate foreign asset reserves in genesis; use ambient tokio runtime in relay RPC client

### DIFF
--- a/bridges/relays/client-substrate/src/client/rpc.rs
+++ b/bridges/relays/client-substrate/src/client/rpc.rs
@@ -195,7 +195,9 @@ impl<C: Chain> RpcClient<C> {
 	async fn build_client(
 		params: &ConnectionParams,
 	) -> Result<(tokio::runtime::Handle, Arc<WsClient>)> {
-		let tokio = tokio::runtime::Handle::current();
+		let tokio = tokio::runtime::Handle::try_current().map_err(|e| {
+			Error::Custom(format!("Failed to obtain current tokio runtime handle: {e}"))
+		})?;
 		let uri = params.uri.clone();
 		tracing::info!(target: "bridge", node=%C::NAME, %uri, "Connecting");
 

--- a/bridges/relays/client-substrate/src/client/rpc.rs
+++ b/bridges/relays/client-substrate/src/client/rpc.rs
@@ -88,8 +88,7 @@ pub struct RpcClient<C: Chain> {
 
 /// Client data, shared by all `RpcClient` clones.
 struct ClientData {
-	/// Tokio runtime handle.
-	tokio: Arc<tokio::runtime::Runtime>,
+	tokio: tokio::runtime::Handle,
 	/// Substrate RPC client.
 	client: Arc<WsClient>,
 }
@@ -195,8 +194,8 @@ impl<C: Chain> RpcClient<C> {
 	/// Build client to use in connection.
 	async fn build_client(
 		params: &ConnectionParams,
-	) -> Result<(Arc<tokio::runtime::Runtime>, Arc<WsClient>)> {
-		let tokio = tokio::runtime::Runtime::new()?;
+	) -> Result<(tokio::runtime::Handle, Arc<WsClient>)> {
+		let tokio = tokio::runtime::Handle::current();
 		let uri = params.uri.clone();
 		tracing::info!(target: "bridge", node=%C::NAME, %uri, "Connecting");
 
@@ -209,7 +208,7 @@ impl<C: Chain> RpcClient<C> {
 			})
 			.await??;
 
-		Ok((Arc::new(tokio), Arc::new(client)))
+		Ok((tokio, Arc::new(client)))
 	}
 
 	/// Execute jsonrpsee future in tokio context.

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
@@ -34,6 +34,8 @@ use testnet_parachains_constants::westend::{
 use xcm::latest::prelude::*;
 use xcm_builder::GlobalConsensusConvertsFor;
 use xcm_executor::traits::ConvertLocation;
+use crate::migrations::AssetHubWestendForeignAssetsReservesProvider;
+use assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesProvider;
 
 const ASSET_HUB_WESTEND_ED: Balance = ExistentialDeposit::get();
 
@@ -89,6 +91,15 @@ fn asset_hub_westend_genesis(
 			..Default::default()
 		},
 		foreign_assets: ForeignAssetsConfig {
+			reserves: foreign_assets
+				.iter()
+				.map(|asset| {
+					let location = asset.0.clone();
+					let reserves =
+						AssetHubWestendForeignAssetsReservesProvider::reserves_for(&location);
+					(location.try_into().unwrap(), reserves)
+				})
+				.collect(),
 			assets: foreign_assets
 				.into_iter()
 				.map(|asset| (asset.0.try_into().unwrap(), asset.1, false, asset.2))

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/genesis_config_presets.rs
@@ -34,8 +34,6 @@ use testnet_parachains_constants::westend::{
 use xcm::latest::prelude::*;
 use xcm_builder::GlobalConsensusConvertsFor;
 use xcm_executor::traits::ConvertLocation;
-use crate::migrations::AssetHubWestendForeignAssetsReservesProvider;
-use assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesProvider;
 
 const ASSET_HUB_WESTEND_ED: Balance = ExistentialDeposit::get();
 
@@ -91,15 +89,6 @@ fn asset_hub_westend_genesis(
 			..Default::default()
 		},
 		foreign_assets: ForeignAssetsConfig {
-			reserves: foreign_assets
-				.iter()
-				.map(|asset| {
-					let location = asset.0.clone();
-					let reserves =
-						AssetHubWestendForeignAssetsReservesProvider::reserves_for(&location);
-					(location.try_into().unwrap(), reserves)
-				})
-				.collect(),
 			assets: foreign_assets
 				.into_iter()
 				.map(|asset| (asset.0.try_into().unwrap(), asset.1, false, asset.2))


### PR DESCRIPTION
After bridges tests migrated to zombinet-sdk, to update polkadot-sdk update in substrate-relay below changes are required. 
Addresses Issue: https://github.com/paritytech/parity-bridges-common/issues/3167

#### Substrate relay RPC client changes:

stops each RpcClient from spawning its own nested tokio::runtime::Runtime and instead reuses the ambient runtime via tokio::runtime::Handle::current(). This makes the relay client usable inside a caller-provided runtime (e.g. zombienet-sdk) and avoids the "Cannot drop a runtime in a context where blocking is not allowed" panic that occurred when a client was dropped on a runtime thread.

#### Integration

- `RpcClient` (and its build_client) now require an existing tokio runtime to be present on the current thread. Callers that previously relied on the client creating its own runtime must now construct it within a tokio runtime context (#[tokio::main], Runtime::block_on, or an active Handle). The internal ClientData::tokio field type changed from Arc<tokio::runtime::Runtime> to tokio::runtime::Handle.

#### Review Notes

`rpc.rs`
- ClientData::tokio changes from Arc<tokio::runtime::Runtime> to tokio::runtime::Handle.
- build_client now grabs Handle::current() instead of constructing Runtime::new(), and returns the handle directly (no Arc wrapping).
