### PR TITLE
Off-Chain Block Verification Design (+ Speculative Messaging v0.4)

### DIFF
--- a/docs/offchain-block-verification-design.md
+++ b/docs/offchain-block-verification-design.md
@@ -554,7 +554,9 @@ code/upgrade timeline.
    construction: blocks whose relay parent is at or past an armed upgrade
    signal are excluded from speculation until a new-code included anchor
    exists (see Code Management).
-3. Messaging-specific: check the target's header digest (provides-set hash),
+3. Messaging-specific: check the target's header digest (provides-set hash;
+   format protocol-standardized—node-side pure check, no wasm involved, see
+   the messaging design),
    batch root ∈ set, recompute root from payloads.
 4. Accept at the returned `Confidence`; advance the verified frontier.
 

--- a/docs/offchain-block-verification-design.md
+++ b/docs/offchain-block-verification-design.md
@@ -1,0 +1,574 @@
+# Off-Chain Parachain Block Verification
+
+## Design Document
+
+| Field | Value |
+|-------|-------|
+| **Authors** | eskimor |
+| **Status** | Draft |
+| **Version** | 0.1 |
+| **Related Designs** | [Speculative Messaging](speculative-messaging-design.md), [Low-Latency Parachains v2](low-latency-v2-design.md) |
+
+### Version History
+
+| Version | Area | Changes |
+|---------|------|---------|
+| 0.1 | | Initial version. |
+
+---
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Motivation](#motivation)
+3. [Goals](#goals)
+4. [Non-Goals](#non-goals)
+5. [Solution Overview](#solution-overview)
+6. [Trust Anchors](#trust-anchors)
+7. [The Verification Runtime API](#the-verification-runtime-api)
+8. [Executing Foreign Wasm Against Proven State](#executing-foreign-wasm-against-proven-state)
+9. [Code Management and Runtime Upgrades](#code-management-and-runtime-upgrades)
+10. [Network Protocols](#network-protocols)
+11. [End-to-End Flows](#end-to-end-flows)
+12. [Overhead](#overhead)
+13. [Security Analysis](#security-analysis)
+
+---
+
+## Introduction
+
+A node that does not follow parachain A sometimes needs to verify facts about
+A's *unincluded* blocks: that a header chain is real, that its blocks were
+authored by A's current collators, and that A's collators have committed to it
+becoming canonical. This document specifies a generic mechanism—working for
+any parachain, under any consensus—by which a foreign node performs these
+checks using only:
+
+- its own view of the relay chain (which every collator follows anyway), and
+- data served by the source chain's collators, all of it verifiable.
+
+The primary consumer is [Speculative
+Messaging](speculative-messaging-design.md): receiving messages *before* the
+sending block's provides commitment appears on chain requires exactly these
+checks. [Low-Latency v2](low-latency-v2-design.md) acknowledgement
+verification by foreign parties is the second consumer.
+
+---
+
+## Motivation
+
+For speculative (pre-inclusion) message consumption, a receiver must verify:
+
+1. **The message was sent by a block**: the block commits to its provides
+   roots and the batch's root is among them.
+2. **The block is legit**: authored by a collator currently valid for that
+   slot, on a lineage connecting to the chain's included state (an eligible
+   collator could otherwise craft an *unconnected* block—a fork that can never
+   become canonical).
+3. **The block will become canonical**: acknowledgement signatures
+   (Low-Latency v2) from the source chain's collators.
+
+Checks (2) and (3) share a problem: they require knowing the *current
+collator set* of a foreign chain—and consensus rules, session logic and slot
+math are chain-specific. Hardcoding per-consensus verifiers in every node does
+not scale and breaks on every consensus innovation.
+
+---
+
+## Goals
+
+1. **Generic**: works for any parachain regardless of consensus (Aura, Babe,
+   custom), session handling, or collator-selection mechanism.
+2. **Trust-anchored in the relay chain**: nothing about the source chain is
+   trusted except what the relay chain already vouches for.
+3. **Cheap hot path**: per-block verification cost comparable to light-client
+   header verification—parent link plus a few signature checks, no block
+   execution.
+4. **Graceful degradation**: any failure (unsupported source, stale state,
+   resource exhaustion) degrades that source to inclusion-based messaging,
+   never to accepting unverified data.
+
+## Non-Goals
+
+- **Verifying state transitions of unincluded blocks.** Content validity is
+  enforced at inclusion (PVF execution); off-chain we verify authorship,
+  lineage and commitment—deception at the content level is priced by the
+  trust-domain/slashing model.
+- **Replacing inclusion-based verification.** This is an additional, faster
+  tier; the inclusion tier remains the floor.
+
+---
+
+## Solution Overview
+
+**Standardize the interface, delegate the logic to the source chain's own
+wasm.** The only party that authoritatively knows a chain's consensus rules is
+that chain's runtime. The receiver obtains exactly that code trustlessly: for
+cumulus chains the validation code *is* the runtime wasm, registered on the
+relay chain and identified by `CurrentCodeHash`. The receiver's node executes
+this wasm—stateless-client style, against storage proofs anchored at an
+*included* head's state root—calling standardized verification entry points.
+
+The three checks then stack (for speculative messaging):
+
+| Tier | Provides root source | Verification |
+|---|---|---|
+| Speculative | Header digest | full stack: code + lineage + authorship + acks |
+| Optimistic (backed) | `CandidateBacked` event (`HeadData` incl. digest) or `candidates_pending_availability` runtime API | backing group validity; availability may still time out |
+| Inclusion-based | `CandidateIncluded` / `paras::Heads` | relay chain |
+
+One code path serves all tiers, differing only in how much of the stack runs.
+
+---
+
+## Trust Anchors
+
+Everything reduces to data the receiver's node obtains from its own relay
+chain view:
+
+- **Included heads**: `paras::Heads` (latest full head data = encoded header
+  for cumulus chains) and `CandidateIncluded` events. Note
+  `CandidateDescriptor::para_head` is the hash of the head data, which for
+  cumulus chains *equals the parachain block hash*—so "became canonical" has
+  a crisp relay-observable meaning.
+- **Code identity and blob**: `CurrentCodeHash` / `FutureCodeHash` (paras
+  pallet). The blob itself is *relay chain state* (`CodeByHash`)—and since
+  collators typically run relay chain full nodes, it is usually already in
+  the local database, no fetch at all. Otherwise: any relay full node
+  (`ParachainHost::validation_code_by_hash`); fetching from source collators
+  is possible (verified by hash, so trust-neutral) but likely not needed at all.
+- **Upgrade timeline**: `FutureCodeUpgrades` (`expected_at`), go-ahead signal
+  timing—see [Code Management](#code-management-and-runtime-upgrades).
+
+Two kinds of anchors, deliberately distinct:
+
+- **Linkage anchors**: any *previously verified* header. The receiver keeps a
+  per-source **verified frontier**; new header chains only need to connect to
+  it (incremental verification).
+- **Proof anchors**: state roots of *included* heads ONLY. An unincluded
+  header's state root is author-claimed and unvalidated until inclusion;
+  anchoring storage proofs at it would let the author fabricate the very
+  state (e.g. authority sets) being consulted.
+
+  This rule is **coupled to tip-only acknowledgement checking** (see
+  [Ancestry transitivity](#ancestry-transitivity)); relaxing it is not just
+  risky but breaks the slashing argument entirely. Concrete attack under
+  unincluded anchoring: a single malicious collator authors invalid block H1
+  whose fabricated state swaps in attacker-controlled *ack* keys while
+  keeping the real *author* keys in place. Nobody acks H1—irrelevant, only
+  the tip is checked. H2 on top (authored with a retained real key) is acked
+  by the fake keys and verified against H1's fabricated state: everything
+  checks out at `Max` confidence. No real collator ever signed an ack, and
+  authoring invalid blocks that die at backing is not slashable—**total
+  attacker exposure: zero**. With included-only anchors, the state judging
+  the acks is relay-validated and every deception step costs real, staked
+  signatures.
+
+  *Considered alternative*: allow unincluded state roots as anchors, but
+  require acknowledgement verification for the **entire unincluded segment**,
+  each block's acks judged against its *parent's* state. This restores
+  linear pricing inductively (any fabricated state transition first needs
+  real-set acks on an invalid block—slashable), at the cost of k ack checks
+  instead of one. Rejected for now: unincluded segments are short in
+  practice and queued keys already cover the one session boundary; revisit
+  only if >1-session unincluded segments ever matter.
+
+The proof-anchor restriction costs nothing in practice: `pallet-session`
+exposes the *queued* keys for the next session, so authority sets are known
+one session ahead from included state. Any unincluded segment spanning at most
+one session boundary verifies entirely from included-state proofs. Beyond that
+(long-idle on-demand chains with time-driven sessions) the source degrades to
+inclusion-based until its next block is included—a startup latency penalty,
+then full speed again. Chains with block-driven sessions (`PeriodicSessions`
+by block number) cannot rotate while idle at all, so their set proofs never
+stale.
+
+---
+
+## The Verification Runtime API
+
+Declared via `decl_runtime_apis!` in a primitives crate, implemented by any
+participating parachain runtime via `impl_runtime_apis!` (precedent for
+node-facing parachain runtime APIs: `AuraUnincludedSegmentApi`,
+`CollectCollationInfo`). Everything chain-specific is opaque; only the
+signatures and the `Confidence` order are protocol:
+
+```rust
+/// Implemented by the parachain runtime; executed by FOREIGN nodes against a
+/// proof-backed state view anchored at an included head of this chain.
+trait OffchainVerify {
+    /// Verify that `headers` is a valid chain from `anchor` (exclusive) to
+    /// its last element: parent hashes link, and every header is authored by
+    /// a collator valid at its slot per THIS chain's own consensus and
+    /// session rules (read through the proof-backed state).
+    ///
+    /// `anchor` is supplied by the caller from its own trust base (an
+    /// included head or its verified frontier)—never peer-supplied.
+    /// Headers are opaque bytes: the chain knows its own header format.
+    fn verify_header_chain(
+        anchor: Hash,
+        headers: Vec<Vec<u8>>,
+    ) -> Result<VerifiedTarget, VerifyError>;
+
+    /// Verify an acknowledgement blob for `target` (which must already be
+    /// verified via `verify_header_chain`). Blob format is chain-internal;
+    /// only this signature and `Confidence` are protocol.
+    fn verify_acks(
+        target: Hash,
+        blob: Vec<u8>,
+    ) -> Result<Confidence, VerifyError>;
+}
+```
+
+### Confidence
+
+Acknowledgement confidence measures **consecutive-slot-author coverage**: the
+parties able to fork at the target's parent are precisely the authors of the
+slots following it, so their signatures are the meaningful commitments.
+
+```rust
+/// Totally ordered, so requests can state a minimum and responses compare.
+enum Confidence {
+    /// Authors of the previous, current and next slot signed.
+    Min,
+    /// Slot-author chain of length k starting at the parent's slot.
+    SlotChain(u32),
+    /// The entire current collator set signed.
+    Max,
+}
+```
+
+(Level names to be finalized; the total order is the requirement.)
+
+### Ancestry transitivity
+
+Acknowledgement commitments are **transitive over ancestry**: an ack on X
+commits to X becoming canonical, which requires X's entire ancestry to become
+canonical—so a tip ack economically stakes on the whole verified chain.
+Low-Latency v2's ack rules reinforce this from the honest side (rule 4: a
+collator only acks a block whose whole ancestry is acknowledged or accepted
+by the relay chain).
+
+Enforcement is entirely Low-Latency v2's: slot-gated relay submission means
+abandoning an acked block requires a *subsequent slot author* to build
+around it—if that author acked, the ack plus their conflicting block form a
+slashable offense pair; if they didn't ack, they were never part of the
+confidence count. The remaining residual—all acked authors staying passive—
+is deliberately unslashed (it would punish honest outages) and is exactly
+why confidence below `Max` is not a guarantee. No additional slashing
+machinery is needed in this design.
+
+Consequences:
+
+- `verify_acks` is called for the **tip** only; no per-ancestor blobs are
+  needed. Consuming data from an ancestor of a C-confidence tip rides on the
+  tip's confidence—every tip-acker staked on that ancestor.
+- Tip-measured confidence is also the *relevant* measure: fork risk lives at
+  the tip (future slot authors choosing what to extend); descended ancestors
+  can only be forked by forking everything above them.
+- **Coupling**: tip-only checking is sound only because acks are judged
+  against relay-validated (included) state—see the proof-anchor rule in
+  [Trust Anchors](#trust-anchors), including the attack that materializes if
+  either half of that pair is relaxed without strengthening the other.
+
+### API discovery
+
+`RuntimeVersion.apis` is readable from the wasm blob's custom section without
+execution (`sc_executor::read_embedded_version`). A source whose runtime does
+not expose `OffchainVerify` (or only an unsupported version) is degraded to
+inclusion-based messaging. Standard runtime API versioning covers evolution.
+
+---
+
+## Executing Foreign Wasm Against Proven State
+
+The machinery is the existing remote-call-with-proof pattern from
+`sp-state-machine`:
+
+- **Source collator** (serving a request): `prove_execution`—runs the call on
+  its full state with a recording backend, returns `(result, StorageProof)`
+  containing every touched key. The prover does not choose what to prove;
+  execution does.
+- **Receiver**: `execution_proof_check`—rebuilds a `MemoryDB` trie backend
+  from `(anchor_state_root, proof)` and *re-executes the call itself* with
+  its own `WasmExecutor` and the hash-verified code. The peer's claimed
+  result is never trusted; only the receiver's own execution counts.
+
+The wasm reads whatever *it* needs through the backend (session keys, queued
+keys, slot configuration)—no well-known storage keys, no per-chain
+conventions. A missing key fails the execution cleanly, signalling the
+receiver to re-request a wider proof (or that the anchor is too stale).
+
+### Resource bounds
+
+The receiver voluntarily executes *foreign* wasm. Hash verification proves
+identity, not benignity: the code can loop or over-allocate. Verification
+calls therefore run under PVF-style resource bounds (execution timeout +
+memory cap). A source whose wasm exhausts them is degraded to inclusion-based
+messaging. Without this, a malicious trust-domain member gets a free DoS on
+every receiver.
+
+### Caching
+
+- **Compiled wasm instance**: per code hash; invalidated only by upgrades.
+- **Proof-backed backend**: per (source, session); the same storage proof
+  serves all verifications of a session. Invalidated by a missing-key error
+  (the natural signal of session rotation).
+- **Verified frontier**: per source; advances with each verified chain,
+  trimmed to the included head's ancestry on inclusion.
+
+---
+
+## Code Management and Runtime Upgrades
+
+Verification semantics for a header are defined by the code active *at that
+block*. Exact upgrade semantics (verified against `paras/mod.rs`):
+
+1. **Scheduling**: an upgrade is announced on the relay chain
+   (`FutureCodeHash`, `FutureCodeUpgrades[para] = expected_at`) sessions in
+   advance. The receiver can prefetch the new blob the moment it is
+   scheduled—at any time there are **at most two candidate codes** per
+   source.
+2. **Arming**: at relay block `expected_at`, a *timer* in the relay
+   initializer sets `UpgradeGoAheadSignal = GoAhead`
+   (`process_scheduled_upgrade_changes`). No inclusion is involved. The
+   signal alone changes nothing about which code is needed.
+3. **Trigger**: the first para block whose relay parent shows the signal—call
+   it B_apply—executes under the **old** code, applies the pending code as
+   its last act, and carries `DigestItem::RuntimeEnvironmentUpdated` in its
+   header. Its *children* run the new code. No para block ⇒ no transition:
+   an idle chain never needs new code, and its first block back is still
+   old-code (it merely applies).
+4. **Relay bookkeeping**: `CurrentCodeHash` swaps at *inclusion* of the first
+   candidate with relay parent ≥ `expected_at` (`note_new_head` →
+   `set_current_code`). This gates relay-side candidate validation, not
+   off-chain verification. Since candidates are included sequentially per
+   para, old-code blocks are never included after new-code ones—the verified
+   frontier never crosses a code boundary backwards.
+
+### Receiver rule: degrade across the upgrade, don't straddle
+
+Speculative verification **pauses** for the upgrade window and resumes on the
+other side. Deterministic, keyed entirely to the receiver's own relay view:
+
+- **Before `expected_at`**: nothing changes—no block can apply the upgrade
+  before the signal arms, so speculation continues untouched.
+- **Degrade per block once the signal arms**: a block is affected only if
+  its *relay parent* is at or past `expected_at`. Every cumulus block
+  carries its relay parent in a header digest, deposited unconditionally by
+  parachain-system (`CumulusDigestItem::RelayParent`, or the RPSR digest
+  with storage root + number; `find_relay_block_identifier` decodes both).
+  Blocks whose digest-claimed relay parent predates the signal remain
+  old-code and stay speculatively verifiable; from the first block at or
+  past it, the source drops to inclusion-based. The digest is
+  author-claimed for unincluded blocks, but lying is fail-safe in both
+  directions: claiming "older" while secretly applying the upgrade makes
+  descendants fail old-wasm verification (fail-closed degrade); claiming
+  "newer" only censors the author's own chain's latency. Missing/unresolvable
+  digest → conservative degrade at `expected_at`.
+- **Resume** at the first included head whose candidate descriptor's
+  `validation_code_hash` equals the new code hash. That head's state was
+  produced *and relay-validated* under the new code, migrations included—the
+  first coherent proof anchor for the new wasm.
+
+Two subtleties this rule deliberately sidesteps:
+
+- **The marker is not reliable off-chain.** `RuntimeEnvironmentUpdated` is
+  produced by execution, which the receiver does not perform for unincluded
+  blocks—a malicious author can serve a marker-less header (an invalid block
+  that dies at backing, but indistinguishable off-chain). Keying degradation
+  to the relay timer instead of the marker removes any reliance on it.
+- **B_apply's included head is NOT a valid proof anchor**, even though it is
+  included: upgrades force a candidate boundary (enforced by the PVF—
+  `validate_block` panics on more than one block per PoV when applying an
+  upgrade), so B_apply's candidate is validated under the *old* code, and its
+  state is pre-migration (`on_runtime_upgrade` runs in its child, under new
+  code). Anchoring the new wasm there would read old-layout state. Hence the
+  resume condition checks the *descriptor's code hash*, not merely "some
+  inclusion happened".
+
+Cost: an inclusion-latency window (seconds to ~a minute) around
+operator-planned events that occur on the order of months. `FutureCodeHash`
+prefetch remains a mild optimization for resume speed.
+
+**Rejected alternative—straddled verification** (verify the old-code prefix
+with the old wasm, the new-code suffix with the new wasm, split at the
+marker): besides relying on the unreliable marker, it rests on an uncheckable
+assumption. The new wasm's verify entry points would read *old-runtime,
+pre-migration* state through the proof backend—the only bridge between the
+two is the chain's migration logic, which runs inside a block the receiver
+cannot execute. Best case a layout change fails as a missing key; worst case
+same keys with changed semantics decode successfully and the verifier
+silently misreads—"verifier judging against unvalidated state" in a subtler
+coat. An upgrade may also rework session/authority logic entirely. Only
+new-wasm × new-code-produced-included-state is a coherent pairing; the
+degrade/resume rule uses exactly and only that.
+
+An upgrade that drops or breaks the `OffchainVerify` API degrades that source
+to inclusion-based messaging until fixed—deployment-checklist item for
+participating chains.
+
+---
+
+## Network Protocols
+
+All request/response with the source chain's collators. Every response is
+verifiable; lying peers can only waste bounded work.
+
+```rust
+/// Fetch the validation code blob (hash known from the relay chain).
+/// Usually unnecessary: the blob is relay state, locally available to any
+/// collator running a relay full node. This request could be introduced for relay
+/// light-client setups; either way, verify blake2_256(code) == hash.
+struct CodeRequest { code_hash: ValidationCodeHash }
+struct CodeResponse { code: Vec<u8> }
+
+/// Header ranges: from the receiver's verified frontier towards a target.
+/// Plain ranges—upgrades never split them: speculative verification pauses
+/// across upgrade windows (see Code Management), so a range is always
+/// single-code.
+struct HeaderRangeRequest { from: Hash, to: Hash, max_bytes: u32 }
+struct HeaderRangeResponse { headers: Vec<Vec<u8>> }
+
+/// Acknowledgement blob at a desired confidence.
+struct AckRequest { block: Hash, min_confidence: Confidence }
+struct AckResponse { blob: Vec<u8> }    // judged only by verify_acks
+
+/// Storage proof for a verification call against an included anchor.
+///
+/// Normally not needed as a separate request: header/ack responses come
+/// with the proof attached—the serving collator runs `prove_execution` of
+/// the corresponding verify call on its own data and includes the recorded
+/// proof. This standalone request exists for re-requests (e.g. the cached
+/// proof went stale after a session rotation): the receiver simply states
+/// the exact call it wants proven, arguments inline.
+struct VerificationProofRequest {
+    /// Included head to anchor the proof at.
+    anchor: Hash,
+    /// The entry point and its full arguments, as the receiver will execute
+    /// them. The prover runs exactly this call with a proof recorder.
+    call: VerifyCall,
+}
+struct VerificationProofResponse { proof: StorageProof }
+
+enum VerifyCall {
+    VerifyHeaderChain { anchor: Hash, headers: Vec<Vec<u8>> },
+    VerifyAcks { target: Hash, blob: Vec<u8> },
+}
+```
+
+Message batches and position-addressed range requests are specified in
+[Speculative Messaging /
+Networking](speculative-messaging-design.md#networking); the ack blob request
+composes with them (one round trip can carry batch + headers + acks + proof).
+
+---
+
+## End-to-End Flows
+
+### Setup per source (once, and per code change)
+
+1. Read `CurrentCodeHash` (+ scheduled `FutureCodeHash`) from the relay.
+2. Obtain the blob: local relay state (`CodeByHash`) in the common
+   collator-with-relay-full-node setup; otherwise any relay full node, or
+   source collators for relay-light-client setups. Verify hash regardless.
+3. `read_embedded_version` → require `OffchainVerify` at a supported version.
+4. Compile and cache.
+
+### Continuous (per relay block)
+
+Track the source's included heads (anchors) and its
+code/upgrade timeline.
+
+### Hot path (per source block / batch)
+
+1. Gap = verified frontier tip → target. One round trip: headers + ack blob
+   (at desired confidence) + storage proof (+ message batch, for messaging).
+2. `execution_proof_check` against the included anchor's state root:
+   `verify_header_chain`, then `verify_acks`. Split at the
+   The segment is single-code by construction: blocks whose relay parent is
+   at or past an armed upgrade signal are excluded from speculation until a
+   new-code included anchor exists (see Code Management).
+3. Messaging-specific: check the target's header digest (provides-set hash),
+   batch root ∈ set, recompute root from payloads.
+4. Accept at the returned `Confidence`; advance the verified frontier.
+
+### Degradation ladder
+
+Unsupported API / stale anchor beyond one session / resource exhaustion /
+verification failure → the source drops to inclusion-based messaging. Never
+"accept less-verified data".
+
+---
+
+## Overhead
+
+| When | What | Cost |
+|---|---|---|
+| Per upgrade (rare) | blob (usually local relay state) + compile | ~seconds compile, cached; network only for relay-light-client setups |
+| Per session per source | storage proof round trip + trie verification | few KB, µs–ms |
+| Per block (hot path) | 1 parent-hash + 1 authorship sig + k ack sigs + root recomputation | comparable to light-client header verification; no block execution |
+| Failure retries | wider-proof re-request | bounded |
+| Per upgrade | speculative pause until first new-code inclusion | seconds to ~a minute, monthly-order events |
+
+---
+
+## Security Analysis
+
+### Threat: Phantom (unconnected) block
+
+**Attack**: An eligible collator signs a slot-valid block on a fabricated
+lineage; colluding collators ack it.
+
+**Mitigation**: the receiver lineage walk—header chains must connect to the
+verified frontier, rooted at included heads—refuses phantoms instantly; no
+protocol-following receiver accepts one. Abandoning a *connected* acked
+block instead requires a subsequent slot author to build around it, which is
+either a slashable offense pair (they acked) or outside the confidence count
+(they didn't)—covered by Low-Latency v2's existing offenses (see [Ancestry
+transitivity](#ancestry-transitivity)). The floor: on-chain safety is
+unaffected regardless—a receiver block built on phantom provides can never
+match anything committed and dies at inclusion.
+
+### Threat: Fabricated authority sets
+
+**Attack**: A peer serves storage proofs claiming a different collator set.
+
+**Mitigation**: Proofs verify against an *included* head's state root, which
+the receiver takes from its own relay view. Unincluded state roots are never
+proof anchors (they are author-claimed): combined with tip-only ack checking,
+anchoring at them would admit a zero-slashing-exposure deception—see the
+proof-anchor rule and its considered alternative in
+[Trust Anchors](#trust-anchors). A wrong proof simply fails trie
+verification.
+
+### Threat: Malicious verification wasm
+
+**Attack**: A chain's runtime loops or over-allocates in the verify entry
+points, DoSing receivers.
+
+**Mitigation**: PVF-style resource bounds on all foreign-wasm execution;
+exhaustion degrades the source to inclusion-based. Identity of the code is
+relay-verified (hash), so peers cannot substitute wasm.
+
+### Threat: Wrong-code verification around upgrades
+
+**Attack**: A peer misrepresents where the code boundary lies (e.g. serves a
+marker-less header for the applying block), hoping the receiver verifies
+new-code blocks with the old wasm or against pre-migration state.
+
+**Mitigation**: The receiver never verifies across the boundary at all:
+speculation pauses when the upgrade signal arms (a fact of the receiver's own
+relay view—peers have no say) and resumes only at an included head whose
+candidate descriptor carries the new code hash. There is no window in which a
+peer-influenced boundary decision exists (see [Code
+Management](#code-management-and-runtime-upgrades)).
+
+### Threat: Stale sets after long idleness
+
+**Attack**: Speculative acceptance based on an outdated collator set.
+
+**Mitigation**: Set knowledge is valid for at most one session past the
+included anchor (queued keys); beyond that, verification fails closed and the
+source degrades to inclusion-based until its next inclusion. Block-driven
+session chains cannot rotate while idle and are unaffected.

--- a/docs/offchain-block-verification-design.md
+++ b/docs/offchain-block-verification-design.md
@@ -137,8 +137,9 @@ chain view:
   the local database, no fetch at all. Otherwise: any relay full node
   (`ParachainHost::validation_code_by_hash`); fetching from source collators
   is possible (verified by hash, so trust-neutral) but likely not needed at all.
-- **Upgrade timeline**: `FutureCodeUpgrades` (`expected_at`), go-ahead signal
-  timing—see [Code Management](#code-management-and-runtime-upgrades).
+- **Upgrade signal**: `UpgradeGoAheadSignal` per source, plus
+  `FutureCodeHash` for prefetching—see
+  [Code Management](#code-management-and-runtime-upgrades).
 
 Two kinds of anchors, deliberately distinct:
 
@@ -149,6 +150,13 @@ Two kinds of anchors, deliberately distinct:
   header's state root is author-claimed and unvalidated until inclusion;
   anchoring storage proofs at it would let the author fabricate the very
   state (e.g. authority sets) being consulted.
+
+  "Included" means on the receiver's current relay view—**finality is not
+  required**, relay-chain *validation* is the point. A relay reorg reverting
+  the inclusion is consistent either way: a low-latency source's block is
+  acked and gets resubmitted unaltered (same state, same anchor), and for
+  other sources the receiver's dependent work is rolled back together with
+  the anchor.
 
   This rule is **coupled to tip-only acknowledgement checking** (see
   [Ancestry transitivity](#ancestry-transitivity)); relaxing it is not just
@@ -217,6 +225,14 @@ trait OffchainVerify {
         target: Hash,
         blob: Vec<u8>,
     ) -> Result<Confidence, VerifyError>;
+}
+
+/// Identity of the verified tip.
+struct VerifiedTarget {
+    /// Hash of the tip header, computed by the chain's own hasher.
+    hash: Hash,
+    /// Its block number—frontier bookkeeping and range addressing.
+    number: u64,
 }
 ```
 
@@ -361,83 +377,63 @@ every receiver.
 
 ## Code Management and Runtime Upgrades
 
-Verification semantics for a header are defined by the code active *at that
-block*. Exact upgrade semantics (verified against `paras/mod.rs`):
+Which code a block runs is determined by one thing—the **upgrade go-ahead
+signal** (`UpgradeGoAheadSignal`, relay chain state). Every scheduling path
+(pre-checked upgrades, forced upgrades) ends in this signal, and it is the
+one thing the parachain itself reacts to (semantics verified against
+`paras/mod.rs`, `validate_block` and `parachain-system`):
 
-1. **Scheduling**: an upgrade is announced on the relay chain
-   (`FutureCodeHash`, `FutureCodeUpgrades[para] = expected_at`) sessions in
-   advance. The receiver can prefetch the new blob the moment it is
-   scheduled—at any time there are **at most two candidate codes** per
-   source.
-2. **Arming**: at relay block `expected_at`, a *timer* in the relay
-   initializer sets `UpgradeGoAheadSignal = GoAhead`
-   (`process_scheduled_upgrade_changes`). No inclusion is involved. The
-   signal alone changes nothing about which code is needed.
-3. **Trigger**: the first para block whose relay parent shows the signal—call
-   it B_apply—executes under the **old** code, applies the pending code as
-   its last act, and carries `DigestItem::RuntimeEnvironmentUpdated` in its
-   header. Its *children* run the new code. No para block ⇒ no transition:
-   an idle chain never needs new code, and its first block back is still
-   old-code (it merely applies).
-4. **Relay bookkeeping**: `CurrentCodeHash` swaps at *inclusion* of the first
-   candidate with relay parent ≥ `expected_at` (`note_new_head` →
-   `set_current_code`). This gates relay-side candidate validation, not
-   off-chain verification. Since candidates are included sequentially per
-   para, old-code blocks are never included after new-code ones—the verified
-   frontier never crosses a code boundary backwards.
+- The signal is set for a para by the relay chain when a scheduled upgrade's
+  activation time is reached, and sits in relay state until consumed.
+- The first para block whose relay parent shows `GoAhead`—call it
+  B_apply—still executes under the **old** code and applies the new code as
+  its last act. Every block after B_apply runs the **new** code. An idle
+  chain never transitions: no block, no application. (An `Abort` signal
+  instead drops the pending code—nothing happens at all.)
+- At B_apply's inclusion the relay swaps its code bookkeeping and clears the
+  signal.
 
-### Receiver rule: degrade across the upgrade, don't straddle
+### Receiver rule
 
-Speculative verification **pauses** for the upgrade window and resumes on the
-other side. Deterministic, keyed entirely to the receiver's own relay view:
+- A block whose relay parent (read from the standard
+  `CumulusDigestItem::RelayParent` header digest) shows **no** `GoAhead`
+  signal for the source, while the pause mode is not active: old code,
+  verify as normal.
+- Walking the chain in order, the first block whose relay parent shows
+  `GoAhead` is B_apply. It still executes the old code—verify it normally.
+  **Pause after it**: everything following is served inclusion-based.
+- **Resume** at the first included head whose candidate descriptor carries
+  the new code hash—the first state that was both produced and
+  relay-validated under the new code (migrations included), i.e. the first
+  coherent anchor for the new wasm.
 
-- **Before `expected_at`**: nothing changes—no block can apply the upgrade
-  before the signal arms, so speculation continues untouched.
-- **Degrade per block once the signal arms**: a block is affected only if
-  its *relay parent* is at or past `expected_at`. Every cumulus block
-  carries its relay parent in a header digest, deposited unconditionally by
-  parachain-system (`CumulusDigestItem::RelayParent`, or the RPSR digest
-  with storage root + number; `find_relay_block_identifier` decodes both).
-  Blocks whose digest-claimed relay parent predates the signal remain
-  old-code and stay speculatively verifiable; from the first block at or
-  past it, the source drops to inclusion-based. The digest is
-  author-claimed for unincluded blocks, but lying is fail-safe in both
-  directions: claiming "older" while secretly applying the upgrade makes
-  descendants fail old-wasm verification (fail-closed degrade); claiming
-  "newer" only censors the author's own chain's latency. Missing/unresolvable
-  digest → conservative degrade at `expected_at`.
-- **Resume** at the first included head whose candidate descriptor's
-  `validation_code_hash` equals the new code hash. That head's state was
-  produced *and relay-validated* under the new code, migrations included—the
-  first coherent proof anchor for the new wasm.
+An aborted upgrade never sets `GoAhead`, so it never pauses anything—no
+special case needed.
 
-Two subtleties this rule deliberately sidesteps:
+Cost: an inclusion-latency pause (seconds to ~a minute) around
+operator-planned, months-apart events. The new blob is prefetchable from the
+moment the upgrade is scheduled on the relay chain (`FutureCodeHash`), so
+resume is immediate.
 
-- **The marker is not reliable off-chain.** `RuntimeEnvironmentUpdated` is
-  produced by execution, which the receiver does not perform for unincluded
-  blocks—a malicious author can serve a marker-less header (an invalid block
-  that dies at backing, but indistinguishable off-chain). Keying degradation
-  to the relay timer instead of the marker removes any reliance on it.
-- **B_apply's included head is NOT a valid proof anchor**, even though it is
-  included: upgrades force a candidate boundary (enforced by the PVF—
-  `validate_block` panics on more than one block per PoV when applying an
-  upgrade), so B_apply's candidate is validated under the *old* code, and its
-  state is pre-migration (`on_runtime_upgrade` runs in its child, under new
-  code). Anchoring the new wasm there would read old-layout state. Hence the
-  resume condition checks the *descriptor's code hash*, not merely "some
-  inclusion happened".
+### Why this shape
 
-Cost: an inclusion-latency window (seconds to ~a minute) around
-operator-planned events that occur on the order of months. `FutureCodeHash`
-prefetch remains a mild optimization for resume speed.
-
-**Rejected alternative—straddled verification** (verify the old-code prefix
-with the old wasm, the new-code suffix with the new wasm): the new wasm would
-read *pre-migration* state through the proof backend—reading state with a
-non-matching runtime is unsound (migrations haven't run; layouts and
-semantics may differ arbitrarily). Only new-wasm ×
-new-code-produced-included-state is a coherent pairing; the degrade/resume
-rule uses exactly and only that.
+- **Why pause instead of verifying across the boundary**: the verifying wasm
+  and the state it reads must match. New wasm × pre-migration state (or old
+  wasm × migrated state) is unsound—migrations haven't run / have run, and
+  layouts or semantics may differ arbitrarily. The rule only ever pairs old
+  wasm with old-code state and new wasm with new-code included state.
+- **Why the author-claimed relay-parent digest is safe to use**: the digest
+  is produced by execution from the same relay parent the PVF validates
+  against—a block lying about it is invalid, can never be backed or
+  included, and thus never becomes canonical. That is the standard case the
+  acknowledgement economics already price; no upgrade-specific reasoning
+  needed. A block whose relay parent cannot be resolved (no digest, or a
+  hash unknown to the receiver's relay view) cannot be classified by this
+  rule at all—classify it conservatively, as if its relay parent showed the
+  signal: pause. Implementations may also skip the per-block check entirely
+  and enter pause mode as soon as their own relay view shows `GoAhead` for
+  the source—a slightly longer pause for less complexity; both behaviors
+  conform.
 
 An upgrade that drops or breaks the `OffchainVerify` API degrades that source
 to inclusion-based messaging until fixed—deployment-checklist item for
@@ -542,8 +538,7 @@ composes with them (one round trip can carry batch + headers + acks + proof).
 
 ### Continuous (per relay block)
 
-Track the source's included heads (anchors) and its
-code/upgrade timeline.
+Track the source's included heads (anchors) and its code/upgrade timeline.
 
 ### Hot path (per source block / batch)
 
@@ -551,13 +546,13 @@ code/upgrade timeline.
    (at desired confidence) + storage proof (+ message batch, for messaging).
 2. `execution_proof_check` against the included anchor's state root:
    `verify_header_chain`, then `verify_acks`. The segment is single-code by
-   construction: blocks whose relay parent is at or past an armed upgrade
-   signal are excluded from speculation until a new-code included anchor
-   exists (see Code Management).
-3. Messaging-specific: check the target's header digest (provides-set hash;
-   format protocol-standardized—node-side pure check, no wasm involved, see
-   the messaging design),
-   batch root ∈ set, recompute root from payloads.
+   construction: after the first block whose relay parent shows the upgrade
+   go-ahead signal (B_apply, itself still old-code), speculation pauses
+   until a new-code included anchor exists (see Code Management).
+3. Messaging-specific: recompute the batch root from the payloads, check it
+   is in the provides set, and check the set's hash against the target's
+   header digest (format protocol-standardized—a node-side pure check, no
+   wasm involved; see the messaging design).
 4. Accept at the returned `Confidence`; advance the verified frontier.
 
 ### Degradation ladder
@@ -572,11 +567,10 @@ verification failure → the source drops to inclusion-based messaging. Never
 
 | When | What | Cost |
 |---|---|---|
-| Per upgrade (rare) | blob (usually local relay state) + compile | ~seconds compile, cached; network only for relay-light-client setups |
+| Per upgrade (rare, operator-planned) | new blob (usually local relay state) + compile; speculative pause until first new-code inclusion | ~seconds compile, cached; pause of seconds to ~a minute |
 | Per relay block per source | storage proof (piggybacked on header/ack responses) + trie verification | few KB, µs–ms |
 | Per block (hot path) | 1 parent-hash + 1 authorship sig + k ack sigs + root recomputation | comparable to light-client header verification; no block execution |
 | Failure retries | wider-proof re-request | bounded |
-| Per upgrade | speculative pause until first new-code inclusion | seconds to ~a minute, monthly-order events |
 
 ---
 
@@ -624,12 +618,15 @@ relay-verified (hash), so peers cannot substitute wasm.
 marker-less header for the applying block), hoping the receiver verifies
 new-code blocks with the old wasm or against pre-migration state.
 
-**Mitigation**: The receiver never verifies across the boundary at all:
-speculation pauses when the upgrade signal arms (a fact of the receiver's own
-relay view—peers have no say) and resumes only at an included head whose
-candidate descriptor carries the new code hash. There is no window in which a
-peer-influenced boundary decision exists (see [Code
-Management](#code-management-and-runtime-upgrades)).
+**Mitigation**: The receiver never verifies across the boundary: whether the
+go-ahead signal is set at a given relay block is a fact of the receiver's own
+relay view, and the only peer-influenced input—the author-claimed
+relay-parent digest deciding which relay block to consult—makes a lying
+block *invalid* (the PVF derives the digest from the validated relay
+parent), i.e. never canonical, priced by the standard acknowledgement
+economics (see [Code Management](#code-management-and-runtime-upgrades)).
+Resumption is gated on an included head whose candidate descriptor carries
+the new code hash, a relay-validated fact.
 
 ### Threat: Stale sets after long idleness
 

--- a/docs/offchain-block-verification-design.md
+++ b/docs/offchain-block-verification-design.md
@@ -227,18 +227,37 @@ parties able to fork at the target's parent are precisely the authors of the
 slots following it, so their signatures are the meaningful commitments.
 
 ```rust
-/// Totally ordered, so requests can state a minimum and responses compare.
+/// Totally ordered (SlotChain(0) < SlotChain(1) < ... < Max), so requests
+/// can state a minimum and responses compare. One logical level, one
+/// representation—no overlapping constructors.
+///
+/// Anything below `MIN` is NOT a confidence level: `verify_acks` errors
+/// (e.g. `InsufficientAcks`). Below it, the *next* slot author—the party
+/// who single-handedly decides whether the block gets extended—has not
+/// committed, so there is no meaningful confidence to report.
 enum Confidence {
-    /// Authors of the previous, current and next slot signed.
-    Min,
-    /// Slot-author chain of length k starting at the parent's slot.
+    /// The mandatory base—authors of the previous, current and next slot—
+    /// plus this many further consecutive slot authors.
     SlotChain(u32),
     /// The entire current collator set signed.
     Max,
 }
+
+impl Confidence {
+    /// Base level: previous, current and next slot authors signed.
+    const MIN: Self = Self::SlotChain(0);
+}
 ```
 
-(Level names to be finalized; the total order is the requirement.)
+(Names to be finalized; the total order is the requirement.)
+
+Small-set/wraparound note: k consecutive *slots* may map to fewer *distinct*
+signers (one collator's ack covers all its slots in the window)—the economic
+meaning is unchanged, since deceptive passivity must be sustained for k slots
+regardless of who owns them. Implementations compare *coverage* and return
+`Max` whenever the entire current set has signed; for sets of ≤ 3 collators
+the base (`MIN`) window already spans the whole rotation, so every valid blob is
+`Max`.
 
 ### Ancestry transitivity
 
@@ -270,6 +289,21 @@ Consequences:
   against relay-validated (included) state—see the proof-anchor rule in
   [Trust Anchors](#trust-anchors), including the attack that materializes if
   either half of that pair is relaxed without strengthening the other.
+
+### Implementation note: session boundaries
+
+The *data* for next-session authorship is in place today: `pallet_session`
+stores `QueuedKeys` (the full next-session key sets, Aura keys included) one
+session ahead, so a proof against an old-session included anchor can answer
+authorship for the following session. The *logic* is not: existing APIs
+(`AuraApi::authorities`, aura-ext) only ever expose the current set.
+"Authorities for the session containing block X, switching to queued keys
+when X lies past the boundary—including a boundary crossing mid-header-chain"
+is new logic each chain implements inside `OffchainVerify`. A **reference
+implementation for the default cumulus stack** (Aura +
+`pallet-session`/`PeriodicSessions` + collator-selection) should ship with
+the primitives, so chains on the standard stack get session-boundary
+handling correct by construction rather than each hand-rolling it.
 
 ### API discovery
 
@@ -311,9 +345,15 @@ every receiver.
 ### Caching
 
 - **Compiled wasm instance**: per code hash; invalidated only by upgrades.
-- **Proof-backed backend**: per (source, session); the same storage proof
-  serves all verifications of a session. Invalidated by a missing-key error
-  (the natural signal of session rotation).
+- **Proof-backed backend**: per (source, latest included anchor)—the anchor
+  advances at most once per relay chain block, so one small proof (a few KB:
+  authority set, session data, slot config) serves all verifications within
+  that window. This is the amortization that matters: chains producing
+  blocks at millisecond cadence (Basti blocks) verify many blocks against
+  one cached backend. No session bookkeeping: the anchor is always fresh
+  enough that the current (plus queued) session data is simply what its
+  state contains; a missing-key error remains the generic
+  re-request-fresher/wider-proof signal.
 - **Verified frontier**: per source; advances with each verified chain,
   trimmed to the included head's ancestry on inclusion.
 
@@ -392,17 +432,12 @@ operator-planned events that occur on the order of months. `FutureCodeHash`
 prefetch remains a mild optimization for resume speed.
 
 **Rejected alternative—straddled verification** (verify the old-code prefix
-with the old wasm, the new-code suffix with the new wasm, split at the
-marker): besides relying on the unreliable marker, it rests on an uncheckable
-assumption. The new wasm's verify entry points would read *old-runtime,
-pre-migration* state through the proof backend—the only bridge between the
-two is the chain's migration logic, which runs inside a block the receiver
-cannot execute. Best case a layout change fails as a missing key; worst case
-same keys with changed semantics decode successfully and the verifier
-silently misreads—"verifier judging against unvalidated state" in a subtler
-coat. An upgrade may also rework session/authority logic entirely. Only
-new-wasm × new-code-produced-included-state is a coherent pairing; the
-degrade/resume rule uses exactly and only that.
+with the old wasm, the new-code suffix with the new wasm): the new wasm would
+read *pre-migration* state through the proof backend—reading state with a
+non-matching runtime is unsound (migrations haven't run; layouts and
+semantics may differ arbitrarily). Only new-wasm ×
+new-code-produced-included-state is a coherent pairing; the degrade/resume
+rule uses exactly and only that.
 
 An upgrade that drops or breaks the `OffchainVerify` API degrades that source
 to inclusion-based messaging until fixed—deployment-checklist item for
@@ -427,12 +462,42 @@ struct CodeResponse { code: Vec<u8> }
 /// Plain ranges—upgrades never split them: speculative verification pauses
 /// across upgrade windows (see Code Management), so a range is always
 /// single-code.
-struct HeaderRangeRequest { from: Hash, to: Hash, max_bytes: u32 }
-struct HeaderRangeResponse { headers: Vec<Vec<u8>> }
+struct HeaderRangeRequest {
+    from: Hash,
+    to: Hash,
+    max_bytes: u32,
+    /// Included head (from the REQUESTER's own relay view—the requester
+    /// decides the anchor, never the server) to generate the storage proof
+    /// against. `None`: requester has a valid session proof cached, no
+    /// proof wanted.
+    proof_anchor: Option<Hash>,
+}
+struct HeaderRangeResponse {
+    headers: Vec<Vec<u8>>,
+    /// Storage proof backing `verify_header_chain` over these headers
+    /// against the requested `proof_anchor`; `None` iff none was requested.
+    proof: Option<StorageProof>,
+}
 
 /// Acknowledgement blob at a desired confidence.
-struct AckRequest { block: Hash, min_confidence: Confidence }
-struct AckResponse { blob: Vec<u8> }    // judged only by verify_acks
+struct AckRequest {
+    block: Hash,
+    min_confidence: Confidence,
+    /// Included head to prove against; `None` = cached session proof, no
+    /// proof wanted. Requester-chosen, as in `HeaderRangeRequest`.
+    proof_anchor: Option<Hash>,
+}
+struct AckResponse {
+    /// Chain-opaque ack data—the *argument* to `verify_acks`, judged only
+    /// by it.
+    blob: Vec<u8>,
+    /// Storage proof backing the *execution* of `verify_acks(block, blob)`
+    /// against the requested `proof_anchor`: the server ran
+    /// `prove_execution` of exactly that call. Distinct from the blob: the
+    /// proof feeds the proof-backed backend, not the wasm's arguments.
+    /// `None` iff none was requested.
+    proof: Option<StorageProof>,
+}
 
 /// Storage proof for a verification call against an included anchor.
 ///
@@ -440,7 +505,7 @@ struct AckResponse { blob: Vec<u8> }    // judged only by verify_acks
 /// with the proof attached—the serving collator runs `prove_execution` of
 /// the corresponding verify call on its own data and includes the recorded
 /// proof. This standalone request exists for re-requests (e.g. the cached
-/// proof went stale after a session rotation): the receiver simply states
+/// proof went stale, e.g. its anchor was superseded): the receiver states
 /// the exact call it wants proven, arguments inline.
 struct VerificationProofRequest {
     /// Included head to anchor the proof at.
@@ -485,10 +550,10 @@ code/upgrade timeline.
 1. Gap = verified frontier tip → target. One round trip: headers + ack blob
    (at desired confidence) + storage proof (+ message batch, for messaging).
 2. `execution_proof_check` against the included anchor's state root:
-   `verify_header_chain`, then `verify_acks`. Split at the
-   The segment is single-code by construction: blocks whose relay parent is
-   at or past an armed upgrade signal are excluded from speculation until a
-   new-code included anchor exists (see Code Management).
+   `verify_header_chain`, then `verify_acks`. The segment is single-code by
+   construction: blocks whose relay parent is at or past an armed upgrade
+   signal are excluded from speculation until a new-code included anchor
+   exists (see Code Management).
 3. Messaging-specific: check the target's header digest (provides-set hash),
    batch root ∈ set, recompute root from payloads.
 4. Accept at the returned `Confidence`; advance the verified frontier.
@@ -506,7 +571,7 @@ verification failure → the source drops to inclusion-based messaging. Never
 | When | What | Cost |
 |---|---|---|
 | Per upgrade (rare) | blob (usually local relay state) + compile | ~seconds compile, cached; network only for relay-light-client setups |
-| Per session per source | storage proof round trip + trie verification | few KB, µs–ms |
+| Per relay block per source | storage proof (piggybacked on header/ack responses) + trie verification | few KB, µs–ms |
 | Per block (hot path) | 1 parent-hash + 1 authorship sig + k ack sigs + root recomputation | comparable to light-client header verification; no block execution |
 | Failure retries | wider-proof re-request | bounded |
 | Per upgrade | speculative pause until first new-code inclusion | seconds to ~a minute, monthly-order events |

--- a/docs/speculative-messaging-design.md
+++ b/docs/speculative-messaging-design.md
@@ -6,13 +6,17 @@
 |-------|-------|
 | **Authors** | eskimor |
 | **Status** | Draft |
-| **Version** | 0.3 |
-| **Related Designs** | [Low-Latency Parachains v2](low-latency-v2-design.md) |
+| **Version** | 0.4 |
+| **Related Designs** | [Low-Latency Parachains v2](low-latency-v2-design.md), [Off-Chain Block Verification](offchain-block-verification-design.md) |
 
 ### Version History
 
 | Version | Area | Changes |
 |---------|------|---------|
+| 0.4 | | **Off-chain verification.** |
+| | Header digest | The hash of the `ProvidesRoots` set is additionally committed into a header digest (engine id TBD), deposited from the same computation that emits the UMP signal—batches become verifiable against a header alone, no candidate required. |
+| | Consumption tiers | Three tiers formalized: speculative (header digest + off-chain verification stack), optimistic (backed candidates via `CandidateBacked` event / `candidates_pending_availability` API), inclusion-based. Optimistic-tier failure (availability timeout) maps onto the existing enactment-dependency/resubmission machinery. |
+| | Separate design | Verification of unincluded sender blocks (header lineage, authorship, ack confidence—generic over parachains, shared with Low-Latency v2) factored out into [Off-Chain Block Verification](offchain-block-verification-design.md). |
 | 0.3 | | **Flat per-destination commitments.** |
 | | Commitments | Hierarchical top-level Merkle root replaced by a flat canonical set of `(ParaId, per-destination MMR root)` entries (`CommitmentSet`), transported as UMP signals—per the analysis on [PR #10449](https://github.com/paritytech/polkadot-sdk/pull/10449) and the implementation direction ([#12346](https://github.com/paritytech/polkadot-sdk/issues/12346), [#12347](https://github.com/paritytech/polkadot-sdk/issues/12347), [#12350](https://github.com/paritytech/polkadot-sdk/issues/12350)). Top-level inclusion proofs gone; extension proofs only needed when the *specific pair's* MMR grew. |
 | | Requires semantics | Explicit: consumed messages are a *prefix* of the required root. Two lifting mechanisms, cleanly separated: in-block catch-up proofs (new) for partial backlog consumption in normal operation, blocks self-contained per the [PR #11413](https://github.com/paritytech/polkadot-sdk/pull/11413) block/candidate split; POV-carried late block proofs (now a single MMR extension proof) for the resubmission flow only. |
@@ -1357,6 +1361,34 @@ Beyond request/response, the protocol needs:
    signatures (Low-Latency v2).
 3. **MMR state sharing**: allow peers to request proofs/peaks where node-local
    data doesn't suffice.
+
+### Off-Chain Verification
+
+Consuming messages *before* the sending block's provides commitment is on
+chain (the speculative and optimistic tiers) requires verifying the sending
+block itself: header lineage from included state, authorship by a currently
+valid collator, and acknowledgement confidence. This is a generic subsystem
+(shared with Low-Latency v2 ack verification) and specified separately:
+[Off-Chain Parachain Block
+Verification](offchain-block-verification-design.md).
+
+Interface points with this document:
+
+- The sender commits the hash of its `ProvidesRoots` set into a **header
+  digest** (engine id TBD), deposited via `frame_system::deposit_log` at
+  block end from the same computation that emits the UMP signal. This lets a
+  batch be verified against a header alone—no candidate required.
+- Tiers, all served by that digest:
+
+| Tier | Provides root source | Trust |
+|---|---|---|
+| Speculative | Header digest + off-chain verification stack | Trust domain (acks + slashing) |
+| Optimistic (backed) | `CandidateBacked` event (`HeadData` incl. digest) or `candidates_pending_availability` API | Backing validity; availability may time out |
+| Inclusion-based | `CandidateIncluded` / `paras::Heads` | Relay chain |
+
+The optimistic tier's failure mode (provider availability timeout) is exactly
+the enactment-dependency / resubmission machinery already specified—a
+latency-vs-certainty knob, not a new mechanism.
 
 ---
 

--- a/docs/speculative-messaging-design.md
+++ b/docs/speculative-messaging-design.md
@@ -14,7 +14,7 @@
 | Version | Area | Changes |
 |---------|------|---------|
 | 0.4 | | **Off-chain verification.** |
-| | Header digest | The hash of the `ProvidesRoots` set is additionally committed into a header digest (engine id TBD), deposited from the same computation that emits the UMP signal—batches become verifiable against a header alone, no candidate required. |
+| | Header digest | The hash of the `ProvidesRoots` set is additionally committed into a header digest, deposited from the same computation that emits the UMP signal—batches become verifiable against a header alone, no candidate required. Digest format is protocol-standard (foreign nodes check it directly, no wasm): `Consensus(SPMS_ENGINE_ID, blake2_256(set.encode()))`, well-defined via `CommitmentSet`'s canonical encoding. |
 | | Consumption tiers | Three tiers formalized: speculative (header digest + off-chain verification stack), optimistic (backed candidates via `CandidateBacked` event / `candidates_pending_availability` API), inclusion-based. Optimistic-tier failure (availability timeout) maps onto the existing enactment-dependency/resubmission machinery. |
 | | Separate design | Verification of unincluded sender blocks (header lineage, authorship, ack confidence—generic over parachains, shared with Low-Latency v2) factored out into [Off-Chain Block Verification](offchain-block-verification-design.md). |
 | 0.3 | | **Flat per-destination commitments.** |
@@ -1375,9 +1375,35 @@ Verification](offchain-block-verification-design.md).
 Interface points with this document:
 
 - The sender commits the hash of its `ProvidesRoots` set into a **header
-  digest** (engine id TBD), deposited via `frame_system::deposit_log` at
-  block end from the same computation that emits the UMP signal. This lets a
-  batch be verified against a header alone—no candidate required.
+  digest**, deposited via `frame_system::deposit_log` at block end from the
+  same computation that emits the UMP signal. This lets a batch be verified
+  against a header alone—no candidate required.
+
+  Unlike headers and ack blobs (chain-opaque, judged by the chain's own wasm
+  via [Off-Chain Block
+  Verification](offchain-block-verification-design.md)), this check is
+  performed by the *foreign node directly*—a pure function of header and
+  set, no state involved. The digest format is therefore **protocol
+  standard**, not chain-internal:
+
+  - `DigestItem::Consensus(SPMS_ENGINE_ID, blake2_256(provides_set.encode()))`,
+    at most one per header (engine id value TBD);
+  - well-defined because `CommitmentSet`'s encoding is canonical—one logical
+    set, exactly one hash;
+  - receiver check: recompute batch root → `(receiver, root)` ∈ supplied
+    set → `blake2_256(set.encode())` == digest payload.
+
+  A chain deviating from the format self-excludes: receivers cannot verify
+  its digests and it simply gets no speculative delivery.
+
+  Freedom removed by this standardization: participating chains must use the
+  standard Substrate header layout (this is the one place a foreign node
+  parses a header itself—everywhere else headers stay chain-opaque), and
+  multiple messaging pallet instances must aggregate into one set per
+  header. Both constraints gate only the speculative/optimistic tiers;
+  inclusion-based messaging rides on UMP signals and is header-format
+  agnostic. Hash and encoding were already protocol-fixed at the messaging
+  layer, so no chain-internal choice is overridden.
 - Tiers, all served by that digest:
 
 | Tier | Provides root source | Trust |


### PR DESCRIPTION
Adds `docs/offchain-block-verification-design.md` (v0.1) and bumps the
speculative messaging design to v0.4.

## Motivation

Speculative messaging wants message consumption *before* the sending block's
provides commitment is on chain. That requires a foreign node — one that does
not follow the sending chain — to verify three things about an unincluded
block: it commits to the claimed messages, it was authored by a currently
valid collator on a lineage rooted in included state, and its collators have
committed to it becoming canonical (acknowledgements, Low-Latency v2). The
first two checks and ack verification all reduce to the same problem: knowing
a foreign chain's collator set and consensus rules, which are chain-specific.

## Approach

**Standardize the interface, delegate the logic to the source chain's own
wasm.** The validation code (= runtime wasm for cumulus chains) is fetched by
relay-known hash — usually already in the local relay-node database — and
executed by the receiver, light-client style, against storage proofs anchored
at *included* heads. New `OffchainVerify` runtime API:

- `verify_header_chain(anchor, headers)` — lineage + per-header authorship,
  per the chain's own consensus/session rules, target included
- `verify_acks(target, blob)` — opaque ack blob → `Confidence`, measured in
  consecutive-slot-author coverage (`Min` / `SlotChain(extra)` / `Max`;
  below `Min` is an error)

Machinery is entirely existing: `prove_execution` / `execution_proof_check`
(sender collators generate proofs, receivers re-execute — results are never
trusted), `read_embedded_version` for API discovery, `pallet-session` queued
keys for the one-session lookahead.

## Key design decisions

- **Proof anchors are included state roots only**, coupled to tip-only ack
  checking. Relaxing either reopens a zero-cost deception (fabricated
  authority sets in author-claimed state); the full-segment-ack alternative
  is documented and rejected.
- **Acknowledgement transitivity**: acks are checked for the tip only; a tip
  ack economically stakes on the whole verified chain. No new slashing
  machinery: slot-gated relay submission means abandoning an acked block
  requires a subsequent slot author who either acked (existing LLv2 offense
  pair) or wasn't in the confidence count; all-passive abandonment is the
  deliberately unslashed residual priced by sub-Max confidence.
- **Runtime upgrades degrade instead of straddling**: speculation pauses when
  the upgrade signal arms (relay-observable; verified against
  `paras`/`validate_block` semantics, incl. the one-block-per-PoV rule) and
  resumes at the first included head validated under the new code. Reading
  state with a non-matching runtime is unsound; the straddled alternative is
  documented and rejected.
- **No session bookkeeping for proofs**: anchors follow the latest included
  head (advancing at most once per relay block); one few-KB proof per window,
  amortized over millisecond-cadence blocks.

## Speculative messaging v0.4

- Sender commits the hash of its `ProvidesRoots` set into a header digest
  (same computation that emits the UMP signal) — batches verify against a
  header alone.
- Three consumption tiers formalized: speculative (full verification stack),
  optimistic (backed candidates via `CandidateBacked` / pending-availability
  API), inclusion-based. Optimistic failure maps onto the existing
  enactment-dependency machinery.

## Follow-ups

- Reference `OffchainVerify` implementation for the default cumulus stack
  (Aura + pallet-session + collator-selection), so session-boundary handling
  exists once instead of per chain.
- Digest engine id and `Confidence` level naming.
- PVF-style resource bounds for foreign-wasm execution on the node side.
