### PR TITLE
[RFC-145] Add a non-clobbering buffer write strategy

### DIFF
--- a/substrate/frame/benchmarking/src/utils.rs
+++ b/substrate/frame/benchmarking/src/utils.rs
@@ -357,8 +357,10 @@ pub trait Benchmarking {
 	fn get_whitelist(&self, out: PassFatPointerAndWrite<&mut [u8]>) -> u32 {
 		let whitelist = self.get_whitelist();
 		let encoded = codec::Encode::encode(&whitelist);
-		let copy_len = encoded.len().min(out.len());
-		out[..copy_len].copy_from_slice(&encoded[..copy_len]);
+		// Copy as much of the encoded whitelist as fits, recording exactly how many bytes were
+		// written so only those are flushed back. The caller retries with a larger buffer if the
+		// returned length exceeds it.
+		out.write_truncated(&encoded);
 		encoded.len() as u32
 	}
 
@@ -421,8 +423,10 @@ pub trait Benchmarking {
 	fn get_read_and_written_keys(&self, out: PassFatPointerAndWrite<&mut [u8]>) -> u32 {
 		let keys = self.get_read_and_written_keys();
 		let encoded = codec::Encode::encode(&keys);
-		let copy_len = encoded.len().min(out.len());
-		out[..copy_len].copy_from_slice(&encoded[..copy_len]);
+		// Copy as much of the encoded keys as fits, recording exactly how many bytes were written
+		// so only those are flushed back. The caller retries with a larger buffer if the returned
+		// length exceeds it.
+		out.write_truncated(&encoded);
 		encoded.len() as u32
 	}
 

--- a/substrate/primitives/crypto/ec-utils/src/bls12_377.rs
+++ b/substrate/primitives/crypto/ec-utils/src/bls12_377.rs
@@ -143,7 +143,7 @@ pub trait HostCalls {
 		b: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::multi_miller_loop::<ark_bls12_377::Bls12_377>(a, b, out)
+		utils::multi_miller_loop::<ark_bls12_377::Bls12_377>(a, b, out.as_fully_written_slice())
 	}
 
 	/// Pairing final exponentiation for *BLS12-377*.
@@ -167,7 +167,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_bls12_377::g1::Config>(bases, scalars, out)
+		utils::msm_sw::<ark_bls12_377::g1::Config>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Multi scalar multiplication on *G2* for *BLS12-377*.
@@ -181,7 +181,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_bls12_377::g2::Config>(bases, scalars, out)
+		utils::msm_sw::<ark_bls12_377::g2::Config>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Affine multiplication on *G1* for *BLS12-377*.
@@ -195,7 +195,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_bls12_377::g1::Config>(base, scalar, out)
+		utils::mul_sw::<ark_bls12_377::g1::Config>(base, scalar, out.as_fully_written_slice())
 	}
 
 	/// Affine multiplication on *G2* for *BLS12-377*.
@@ -209,7 +209,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_bls12_377::g2::Config>(base, scalar, out)
+		utils::mul_sw::<ark_bls12_377::g2::Config>(base, scalar, out.as_fully_written_slice())
 	}
 }
 

--- a/substrate/primitives/crypto/ec-utils/src/bls12_381.rs
+++ b/substrate/primitives/crypto/ec-utils/src/bls12_381.rs
@@ -143,7 +143,7 @@ pub trait HostCalls {
 		b: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::multi_miller_loop::<ark_bls12_381::Bls12_381>(a, b, out)
+		utils::multi_miller_loop::<ark_bls12_381::Bls12_381>(a, b, out.as_fully_written_slice())
 	}
 
 	/// Pairing final exponentiation for *BLS12-381*.
@@ -167,7 +167,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_bls12_381::g1::Config>(bases, scalars, out)
+		utils::msm_sw::<ark_bls12_381::g1::Config>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Multi scalar multiplication on *G2* for *BLS12-381*.
@@ -181,7 +181,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_bls12_381::g2::Config>(bases, scalars, out)
+		utils::msm_sw::<ark_bls12_381::g2::Config>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Affine multiplication on *G1* for *BLS12-381*.
@@ -195,7 +195,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_bls12_381::g1::Config>(base, scalar, out)
+		utils::mul_sw::<ark_bls12_381::g1::Config>(base, scalar, out.as_fully_written_slice())
 	}
 
 	/// Affine multiplication on *G2* for *BLS12-381*.
@@ -209,7 +209,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_bls12_381::g2::Config>(base, scalar, out)
+		utils::mul_sw::<ark_bls12_381::g2::Config>(base, scalar, out.as_fully_written_slice())
 	}
 }
 

--- a/substrate/primitives/crypto/ec-utils/src/bw6_761.rs
+++ b/substrate/primitives/crypto/ec-utils/src/bw6_761.rs
@@ -143,7 +143,7 @@ pub trait HostCalls {
 		b: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::multi_miller_loop::<ark_bw6_761::BW6_761>(a, b, out)
+		utils::multi_miller_loop::<ark_bw6_761::BW6_761>(a, b, out.as_fully_written_slice())
 	}
 
 	/// Pairing final exponentiation for *BW6-761*.
@@ -167,7 +167,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_bw6_761::g1::Config>(bases, scalars, out)
+		utils::msm_sw::<ark_bw6_761::g1::Config>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Multi scalar multiplication on *G2* for *BW6-761*.
@@ -181,7 +181,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_bw6_761::g2::Config>(bases, scalars, out)
+		utils::msm_sw::<ark_bw6_761::g2::Config>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Affine multiplication on *G1* for *BW6-761*.
@@ -195,7 +195,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_bw6_761::g1::Config>(base, scalar, out)
+		utils::mul_sw::<ark_bw6_761::g1::Config>(base, scalar, out.as_fully_written_slice())
 	}
 
 	/// Affine multiplication on *G2* for *BW6-761*.
@@ -209,7 +209,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_bw6_761::g2::Config>(base, scalar, out)
+		utils::mul_sw::<ark_bw6_761::g2::Config>(base, scalar, out.as_fully_written_slice())
 	}
 }
 

--- a/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_377.rs
+++ b/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_377.rs
@@ -82,7 +82,11 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_te::<ark_ed_on_bls12_377::EdwardsConfig>(bases, scalars, out)
+		utils::msm_te::<ark_ed_on_bls12_377::EdwardsConfig>(
+			bases,
+			scalars,
+			out.as_fully_written_slice(),
+		)
 	}
 
 	/// Twisted Edwards affine multiplication for *Ed-on-BLS12-377*.
@@ -96,7 +100,11 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_te::<ark_ed_on_bls12_377::EdwardsConfig>(base, scalar, out)
+		utils::mul_te::<ark_ed_on_bls12_377::EdwardsConfig>(
+			base,
+			scalar,
+			out.as_fully_written_slice(),
+		)
 	}
 }
 

--- a/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_381_bandersnatch.rs
+++ b/substrate/primitives/crypto/ec-utils/src/ed_on_bls12_381_bandersnatch.rs
@@ -132,7 +132,11 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_te::<ark_ed_on_bls12_381_bandersnatch::EdwardsConfig>(bases, scalars, out)
+		utils::msm_te::<ark_ed_on_bls12_381_bandersnatch::EdwardsConfig>(
+			bases,
+			scalars,
+			out.as_fully_written_slice(),
+		)
 	}
 
 	/// Twisted Edwards affine multiplication for *Ed-on-BLS12-381-Bandersnatch*.
@@ -146,7 +150,11 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_te::<ark_ed_on_bls12_381_bandersnatch::EdwardsConfig>(base, scalar, out)
+		utils::mul_te::<ark_ed_on_bls12_381_bandersnatch::EdwardsConfig>(
+			base,
+			scalar,
+			out.as_fully_written_slice(),
+		)
 	}
 }
 

--- a/substrate/primitives/crypto/ec-utils/src/pallas.rs
+++ b/substrate/primitives/crypto/ec-utils/src/pallas.rs
@@ -78,7 +78,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_pallas::PallasConfig>(bases, scalars, out)
+		utils::msm_sw::<ark_pallas::PallasConfig>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Short Weierstrass affine multiplication for *Pallas*.
@@ -92,7 +92,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_pallas::PallasConfig>(base, scalar, out)
+		utils::mul_sw::<ark_pallas::PallasConfig>(base, scalar, out.as_fully_written_slice())
 	}
 }
 

--- a/substrate/primitives/crypto/ec-utils/src/utils.rs
+++ b/substrate/primitives/crypto/ec-utils/src/utils.rs
@@ -102,6 +102,7 @@ pub struct HostcallResult;
 impl RIType for HostcallResult {
 	type FFIType = u32;
 	type Inner = Result<(), Error>;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]

--- a/substrate/primitives/crypto/ec-utils/src/vesta.rs
+++ b/substrate/primitives/crypto/ec-utils/src/vesta.rs
@@ -78,7 +78,7 @@ pub trait HostCalls {
 		scalars: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::msm_sw::<ark_vesta::VestaConfig>(bases, scalars, out)
+		utils::msm_sw::<ark_vesta::VestaConfig>(bases, scalars, out.as_fully_written_slice())
 	}
 
 	/// Short Weierstrass affine multiplication for *Vesta*.
@@ -92,7 +92,7 @@ pub trait HostCalls {
 		scalar: PassFatPointerAndRead<&[u8]>,
 		out: PassFatPointerAndWrite<&mut [u8]>,
 	) -> HostcallResult {
-		utils::mul_sw::<ark_vesta::VestaConfig>(base, scalar, out)
+		utils::mul_sw::<ark_vesta::VestaConfig>(base, scalar, out.as_fully_written_slice())
 	}
 }
 

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -662,9 +662,10 @@ pub trait Storage {
 		self.storage(key).map(|value| {
 			let value_offset = value_offset as usize;
 			let data = &value[value_offset.min(value.len())..];
-			let out_len = core::cmp::min(data.len(), value_out.len());
+			// Copy the value into the output buffer only when the whole value fits or partial
+			// reads are explicitly allowed; otherwise leave the buffer untouched.
 			if value_out.len() >= data.len() || allow_partial != 0 {
-				value_out[..out_len].copy_from_slice(&data[..out_len]);
+				value_out.write_truncated(data);
 			}
 			data.len() as u32
 		})
@@ -823,9 +824,8 @@ pub trait Storage {
 		let cursor_out_len = removal_results.maybe_cursor.as_ref().map(|c| c.len()).unwrap_or(0);
 		if let Some(cursor_out) = removal_results.maybe_cursor {
 			self.store_last_cursor(&cursor_out[..]);
-			if maybe_cursor_out.len() >= cursor_out_len {
-				maybe_cursor_out[..cursor_out_len].copy_from_slice(&cursor_out[..]);
-			}
+			// Write the cursor back only if it fits; otherwise leave the buffer untouched.
+			maybe_cursor_out.write(&cursor_out);
 		}
 		counters_out.backend = removal_results.backend;
 		counters_out.unique = removal_results.unique;
@@ -916,7 +916,7 @@ pub trait Storage {
 			out_len >= encoded_len,
 			"Output buffer ({out_len} bytes) provided to store the storage root hash is not large enough ({encoded_len} bytes needed)"
 		);
-		out[..encoded_len].copy_from_slice(&encoded[..]);
+		out.write(&encoded);
 	}
 
 	/// A convenience wrapper providing a developer-friendly interface for the `root` host
@@ -960,9 +960,8 @@ pub trait Storage {
 		let next_key = self.next_storage_key(key_in);
 		let next_key_len = next_key.as_ref().map(|k| k.len()).unwrap_or(0);
 		if let Some(next_key) = next_key {
-			if key_out.len() >= next_key_len {
-				key_out[..next_key_len].copy_from_slice(&next_key[..]);
-			}
+			// Write the key back only if it fits; otherwise leave the buffer untouched.
+			key_out.write(&next_key);
 		}
 		next_key_len as u32
 	}
@@ -1101,9 +1100,10 @@ pub trait DefaultChildStorage {
 			.map(|value| {
 				let value_offset = value_offset as usize;
 				let data = &value[value_offset.min(value.len())..];
-				let out_len = core::cmp::min(data.len(), value_out.len());
+				// Copy the value into the output buffer only when the whole value fits or partial
+				// reads are explicitly allowed; otherwise leave the buffer untouched.
 				if value_out.len() >= data.len() || allow_partial != 0 {
-					value_out[..out_len].copy_from_slice(&data[..out_len]);
+					value_out.write_truncated(data);
 				}
 				data.len() as u32
 			})
@@ -1245,9 +1245,8 @@ pub trait DefaultChildStorage {
 		let cursor_out_len = removal_results.maybe_cursor.as_ref().map(|c| c.len()).unwrap_or(0);
 		if let Some(cursor_out) = removal_results.maybe_cursor {
 			self.store_last_cursor(&cursor_out[..]);
-			if maybe_cursor_out.len() >= cursor_out_len {
-				maybe_cursor_out[..cursor_out_len].copy_from_slice(&cursor_out[..]);
-			}
+			// Write the cursor back only if it fits; otherwise leave the buffer untouched.
+			maybe_cursor_out.write(&cursor_out);
 		}
 		counters_out.backend = removal_results.backend;
 		counters_out.unique = removal_results.unique;
@@ -1374,9 +1373,8 @@ pub trait DefaultChildStorage {
 		let cursor_out_len = removal_results.maybe_cursor.as_ref().map(|c| c.len()).unwrap_or(0);
 		if let Some(cursor_out) = removal_results.maybe_cursor {
 			self.store_last_cursor(&cursor_out[..]);
-			if maybe_cursor_out.len() >= cursor_out_len {
-				maybe_cursor_out[..cursor_out_len].copy_from_slice(&cursor_out[..]);
-			}
+			// Write the cursor back only if it fits; otherwise leave the buffer untouched.
+			maybe_cursor_out.write(&cursor_out);
 		}
 		counters_out.backend = removal_results.backend;
 		counters_out.unique = removal_results.unique;
@@ -1474,7 +1472,7 @@ pub trait DefaultChildStorage {
 			out_len >= encoded_len,
 			"Output buffer ({out_len} bytes) provided to store the child storage root hash is not large enough ({encoded_len} bytes needed)"
 		);
-		out[..encoded.len()].copy_from_slice(&encoded[..]);
+		out.write(&encoded);
 	}
 
 	/// A convenience wrapper providing a developer-friendly interface for the `root` host
@@ -1517,9 +1515,8 @@ pub trait DefaultChildStorage {
 		let next_key = self.next_child_storage_key(&child_info, key_in);
 		let next_key_len = next_key.as_ref().map(|k| k.len()).unwrap_or(0);
 		if let Some(next_key) = next_key {
-			if key_out.len() >= next_key_len {
-				key_out[..next_key_len].copy_from_slice(&next_key[..]);
-			}
+			// Write the key back only if it fits; otherwise leave the buffer untouched.
+			key_out.write(&next_key);
 		}
 		next_key_len as u32
 	}
@@ -1910,9 +1907,8 @@ pub trait Misc {
 			.read_runtime_version(wasm, &mut ext)
 		{
 			Ok(v) => {
-				if out.len() >= v.len() {
-					out[..v.len()].copy_from_slice(v.as_slice());
-				}
+				// Write the version back only if it fits; otherwise leave the buffer untouched.
+				out.write(&v);
 				Some(v.len() as u32)
 			},
 			Err(err) => {
@@ -1952,8 +1948,10 @@ pub trait Misc {
 		let cursor = self.take_last_cursor()?;
 
 		if out.len() >= cursor.len() {
-			out[..cursor.len()].copy_from_slice(&cursor[..]);
+			out.write(&cursor);
 		} else {
+			// The buffer is too small; leave it untouched and cache the cursor so the caller can
+			// retry with a large enough buffer.
 			self.store_last_cursor(&cursor[..]);
 		}
 
@@ -3530,9 +3528,8 @@ pub trait Offchain {
 			.map(|v| {
 				let value_offset = offset as usize;
 				let data = &v[value_offset.min(v.len())..];
-				if data.len() <= value_out.len() {
-					value_out[..data.len()].copy_from_slice(data);
-				}
+				// Write the value back only if it fits; otherwise leave the buffer untouched.
+				value_out.write(data);
 				data.len() as u32
 			})
 	}
@@ -3690,9 +3687,11 @@ pub trait Offchain {
 			.extension::<OffchainWorkerExt>()
 			.expect("http_response_wait can be called only in the offchain worker context")
 			.http_response_wait(ids, deadline);
-		statuses.into_iter().zip(out).for_each(|(status, out)| {
-			*out = status.into();
+		statuses.into_iter().zip(out.iter_mut()).for_each(|(status, slot)| {
+			*slot = status.into();
 		});
+		// Every slot is filled with the status of the corresponding request id.
+		out.set_fully_written();
 	}
 
 	/// A convenience wrapper providing a developer-friendly interface for the `http_response_wait`
@@ -3742,9 +3741,9 @@ pub trait Offchain {
 			.expect("http_response_header_name can be called only in the offchain worker context")
 			.http_response_headers(request_id);
 		let res = &headers.get(header_index as usize)?.0;
-		if res.len() <= out.len() {
-			out[..res.len()].copy_from_slice(res);
-		}
+		// Store the name only if it fits; otherwise (and on the out-of-bounds path above) the
+		// buffer is left untouched.
+		out.write(res);
 		Some(res.len() as u32)
 	}
 
@@ -3766,9 +3765,9 @@ pub trait Offchain {
 			.expect("http_response_header_value can be called only in the offchain worker context")
 			.http_response_headers(request_id);
 		let res = &headers.get(header_index as usize)?.1;
-		if res.len() <= out.len() {
-			out[..res.len()].copy_from_slice(res);
-		}
+		// Store the value only if it fits; otherwise (and on the out-of-bounds path above) the
+		// buffer is left untouched.
+		out.write(res);
 		Some(res.len() as u32)
 	}
 
@@ -3838,10 +3837,15 @@ pub trait Offchain {
 		buffer_out: PassFatPointerAndWrite<&mut [u8]>,
 		deadline: PassFatPointerAndDecode<Option<Timestamp>>,
 	) -> ConvertAndReturnAs<Result<u32, HttpError>, RIIntResult<u32, RIHttpError>, i64> {
-		self.extension::<OffchainWorkerExt>()
+		let result = self
+			.extension::<OffchainWorkerExt>()
 			.expect("http_response_read_body can be called only in the offchain worker context")
-			.http_response_read_body(request_id, buffer_out, deadline)
-			.map(|r| r as u32)
+			.http_response_read_body(request_id, &mut buffer_out, deadline);
+		// Only the bytes actually read into the buffer are flushed back into the runtime.
+		if let Ok(bytes_read) = &result {
+			buffer_out.set_written_len(*bytes_read);
+		}
+		result.map(|r| r as u32)
 	}
 
 	/// Set the authorized nodes and authorized_only flag.
@@ -4090,7 +4094,7 @@ pub trait Input {
 			.take_input_data()
 			.expect("input data is not empty on code entry and is only taken once; qed");
 		assert!(buffer.len() >= data.len());
-		buffer.copy_from_slice(&data[..]);
+		buffer.write(&data);
 	}
 }
 

--- a/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/bare_function_interface.rs
+++ b/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/bare_function_interface.rs
@@ -32,7 +32,8 @@
 use crate::utils::{
 	create_exchangeable_host_function_ident, create_function_ident_with_version,
 	generate_crate_access, get_function_argument_names, get_function_arguments,
-	get_runtime_interface, host_inner_return_ty, pat_ty_to_host_inner, RuntimeInterfaceFunction,
+	get_runtime_interface, host_inner_return_ty, pat_ty_to_host_arg, pat_ty_to_host_inner,
+	RuntimeInterfaceFunction,
 };
 
 use syn::{
@@ -201,13 +202,22 @@ fn function_std_latest_impl(
 	let latest_function_name =
 		create_function_ident_with_version(&method.sig.ident, latest_version);
 
+	// This public entry point takes the arguments as their `RIType::Inner` type; the versioned
+	// implementation it dispatches to takes them as the `RIType::HostArg` type. Convert here via
+	// `Into` (relying on `Inner: Into<HostArg>`). This is a no-op for almost every strategy and
+	// only does real work for strategies like `PassFatPointerAndWrite` that hand the host function
+	// a dedicated handle.
+	let converted_args = arg_names
+		.iter()
+		.map(|name| quote_spanned! { name.span() => ::core::convert::Into::into(#name) });
+
 	Ok(quote_spanned! { method.span() =>
 		#[cfg(not(substrate_runtime))]
 		#( #attrs )*
 		#maybe_allow_non_snake
 		pub fn #function_name( #( #args, )* ) #return_value {
 			#latest_function_name(
-				#( #arg_names, )*
+				#( #converted_args, )*
 			)
 		}
 	})
@@ -225,8 +235,11 @@ fn function_std_impl(
 	let function_name_str = function_name.to_string();
 
 	let crate_ = generate_crate_access();
+	// The versioned implementation receives its arguments as the `RIType::HostArg` type, matching
+	// what the trait implementation expects and what the wasm host-function wrapper produces via
+	// `take_from_owned`.
 	let args = get_function_arguments(&method.sig)
-		.map(pat_ty_to_host_inner)
+		.map(pat_ty_to_host_arg)
 		.map(FnArg::Typed)
 		.chain(
 			// Add the function context as last parameter when this is a wasm only interface.
@@ -275,6 +288,9 @@ fn generate_call_to_trait(
 	let method_name = create_function_ident_with_version(&method.sig.ident, version);
 	let expect_msg =
 		format!("`{}` called outside of an Externalities-provided environment.", method_name);
+	// The versioned bare function already receives its arguments as the `RIType::HostArg` type
+	// (see `function_std_impl`), which is exactly what the trait implementation expects, so the
+	// arguments can be forwarded as-is.
 	let arg_names = get_function_argument_names(&method.sig);
 
 	if takes_self_argument(&method.sig) {

--- a/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/trait_decl_impl.rs
+++ b/substrate/primitives/runtime-interface/proc-macro/src/runtime_interface/trait_decl_impl.rs
@@ -75,7 +75,7 @@ impl ToEssentialTraitDef {
 	fn process(&mut self, method: &TraitItemFn, version: u32) {
 		let mut folded = self.fold_trait_item_fn(method.clone());
 		folded.sig.ident = create_function_ident_with_version(&folded.sig.ident, version);
-		crate::utils::unpack_inner_types_in_signature(&mut folded.sig);
+		crate::utils::unpack_host_arg_types_in_signature(&mut folded.sig);
 		self.methods.push(folded);
 	}
 
@@ -157,7 +157,12 @@ fn impl_trait_for_externalities(trait_def: &ItemTrait, is_wasm_only: bool) -> Re
 		let mut cloned = (*method).clone();
 		cloned.attrs.retain(|a| !a.path().is_ident("version"));
 		cloned.sig.ident = create_function_ident_with_version(&cloned.sig.ident, version);
-		crate::utils::unpack_inner_types_in_signature(&mut cloned.sig);
+		crate::utils::unpack_host_arg_types_in_signature(&mut cloned.sig);
+		// The host implementation may need mutable argument bindings (e.g. a `WriteBuffer` handle
+		// that the host function writes into). Make all argument bindings `mut` and silence the
+		// resulting warnings for the arguments that are not actually mutated.
+		crate::utils::make_arg_bindings_mut(&mut cloned.sig);
+		cloned.attrs.push(syn::parse_quote!(#[allow(unused_mut)]));
 		cloned
 	});
 

--- a/substrate/primitives/runtime-interface/proc-macro/src/utils.rs
+++ b/substrate/primitives/runtime-interface/proc-macro/src/utils.rs
@@ -378,6 +378,38 @@ pub fn pat_ty_to_host_inner(mut pat: syn::PatType) -> syn::PatType {
 	pat
 }
 
+/// The type actually handed to the host function implementation for an argument of the given
+/// strategy type, i.e. `<#ty as RIType>::HostArg`. This equals [`host_inner_arg_ty`] for almost
+/// every strategy; it only differs for strategies (like `PassFatPointerAndWrite`) whose host
+/// implementation receives a dedicated handle.
+pub fn host_arg_ty(ty: &syn::Type) -> syn::Type {
+	let crate_ = generate_crate_access();
+	syn::parse2::<syn::Type>(quote! { <#ty as #crate_::RIType>::HostArg })
+		.expect("parsing doesn't fail")
+}
+
+pub fn pat_ty_to_host_arg(mut pat: syn::PatType) -> syn::PatType {
+	pat.ty = Box::new(host_arg_ty(&pat.ty));
+	pat
+}
+
+/// Make every named argument binding in the signature `mut`.
+///
+/// Used only for the host trait implementation, whose arguments may need to be mutable — for
+/// example a [`pass_by::PassFatPointerAndWrite`](crate) argument is handed to the host function as
+/// a `WriteBuffer` handle that it writes into. The receiver (`self`) is left untouched. This is
+/// paired with `#[allow(unused_mut)]` on the method, since the vast majority of arguments are not
+/// mutated.
+pub fn make_arg_bindings_mut(sig: &mut syn::Signature) {
+	for arg in sig.inputs.iter_mut() {
+		if let syn::FnArg::Typed(pat_ty) = arg {
+			if let syn::Pat::Ident(pat_ident) = &mut *pat_ty.pat {
+				pat_ident.mutability = Some(Default::default());
+			}
+		}
+	}
+}
+
 pub fn host_inner_return_ty(ty: &syn::ReturnType) -> syn::ReturnType {
 	let crate_ = generate_crate_access();
 	match ty {
@@ -395,6 +427,22 @@ pub fn unpack_inner_types_in_signature(sig: &mut syn::Signature) {
 		match arg {
 			syn::FnArg::Typed(ref mut pat_ty) => {
 				*pat_ty = crate::utils::pat_ty_to_host_inner(pat_ty.clone());
+			},
+			syn::FnArg::Receiver(..) => {},
+		}
+	}
+}
+
+/// Like [`unpack_inner_types_in_signature`], but maps the argument types to the host-function
+/// argument type (`<Ty as RIType>::HostArg`) rather than the plain inner type. The return type is
+/// still mapped to the inner type, since return values do not go through
+/// [`crate::host::FromFFIValue`]. Used for the host-side trait declaration and implementation.
+pub fn unpack_host_arg_types_in_signature(sig: &mut syn::Signature) {
+	sig.output = crate::utils::host_inner_return_ty(&sig.output);
+	for arg in sig.inputs.iter_mut() {
+		match arg {
+			syn::FnArg::Typed(ref mut pat_ty) => {
+				*pat_ty = crate::utils::pat_ty_to_host_arg(pat_ty.clone());
 			},
 			syn::FnArg::Receiver(..) => {},
 		}

--- a/substrate/primitives/runtime-interface/src/host.rs
+++ b/substrate/primitives/runtime-interface/src/host.rs
@@ -44,8 +44,8 @@ pub trait FromFFIValue<'a>: RIType {
 	fn from_ffi_value(context: &mut dyn FunctionContext, arg: Self::FFIType)
 		-> Result<Self::Owned>;
 
-	/// Creates `Self::Inner` from an owned value.
-	fn take_from_owned(owned: &'a mut Self::Owned) -> Self::Inner;
+	/// Creates the host function argument ([`RIType::HostArg`]) from an owned value.
+	fn take_from_owned(owned: &'a mut Self::Owned) -> Self::HostArg;
 
 	/// Write back a modified `value` back into the runtime's memory.
 	///

--- a/substrate/primitives/runtime-interface/src/impls.rs
+++ b/substrate/primitives/runtime-interface/src/impls.rs
@@ -50,6 +50,7 @@ macro_rules! impl_traits_for_primitives {
 			impl RIType for $rty {
 				type FFIType = $fty;
 				type Inner = Self;
+				type HostArg = Self::Inner;
 			}
 
 			#[cfg(substrate_runtime)]
@@ -109,6 +110,7 @@ impl_traits_for_primitives! {
 impl RIType for bool {
 	type FFIType = u32;
 	type Inner = Self;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(substrate_runtime)]
@@ -151,6 +153,7 @@ impl IntoFFIValue for bool {
 impl<T: sp_wasm_interface::PointerType> RIType for Pointer<T> {
 	type FFIType = u32;
 	type Inner = Self;
+	type HostArg = Self::Inner;
 }
 
 /// The type is passed as `u32`.
@@ -158,6 +161,7 @@ impl<T: sp_wasm_interface::PointerType> RIType for Pointer<T> {
 impl<T> RIType for Pointer<T> {
 	type FFIType = u32;
 	type Inner = Self;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(substrate_runtime)]

--- a/substrate/primitives/runtime-interface/src/lib.rs
+++ b/substrate/primitives/runtime-interface/src/lib.rs
@@ -384,6 +384,17 @@ pub trait RIType: Sized {
 
 	/// The inner type without any serialization strategy wrapper.
 	type Inner;
+
+	/// The type that is actually handed to the host function implementation.
+	///
+	/// For almost every strategy this is simply [`Self::Inner`], and impls set
+	/// `type HostArg = Self::Inner;`. Strategies that need the host function to communicate
+	/// something back to the marshalling layer — for example [`pass_by::PassFatPointerAndWrite`],
+	/// where the host reports how many bytes it wrote into the output buffer — use a dedicated
+	/// handle type here instead. On the native execution path the handle is built directly from an
+	/// [`Self::Inner`] value via `Inner: Into<HostArg>`; on the wasm boundary it is built by
+	/// [`host::FromFFIValue::take_from_owned`](crate::host::FromFFIValue::take_from_owned).
+	type HostArg;
 }
 
 /// A raw pointer that can be used in a runtime interface function signature.

--- a/substrate/primitives/runtime-interface/src/pass_by.rs
+++ b/substrate/primitives/runtime-interface/src/pass_by.rs
@@ -40,6 +40,9 @@ use alloc::{format, string::String, vec};
 use alloc::vec::Vec;
 use core::{any::type_name, marker::PhantomData};
 
+#[cfg(not(substrate_runtime))]
+use core::ops::{Deref, DerefMut};
+
 /// Pass a value into the host by a thin pointer.
 ///
 /// This casts the value into a `&[u8]` using `AsRef<[u8]>` and passes a pointer to that byte blob
@@ -55,6 +58,7 @@ pub struct PassPointerAndReadCopy<T, const N: usize>(PhantomData<(T, [u8; N])>);
 impl<T, const N: usize> RIType for PassPointerAndReadCopy<T, N> {
 	type FFIType = u32;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -109,6 +113,7 @@ pub struct PassPointerAndRead<T, const N: usize>(PhantomData<(T, [u8; N])>);
 impl<'a, T, const N: usize> RIType for PassPointerAndRead<&'a T, N> {
 	type FFIType = u32;
 	type Inner = &'a T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -158,6 +163,7 @@ pub struct PassFatPointerAndRead<T>(PhantomData<T>);
 impl<T> RIType for PassFatPointerAndRead<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -237,6 +243,7 @@ pub struct PassOptionalFatPointerAndRead<T>(PhantomData<T>);
 impl<T> RIType for PassOptionalFatPointerAndRead<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -291,6 +298,7 @@ pub struct PassFatPointerAndReadOption<T>(PhantomData<T>);
 impl<T> RIType for PassFatPointerAndReadOption<T> {
 	type FFIType = u64;
 	type Inner = Option<T>;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -345,6 +353,7 @@ pub struct PassFatPointerAndReadWrite<T>(PhantomData<T>);
 impl<T> RIType for PassFatPointerAndReadWrite<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -387,33 +396,181 @@ impl<'a, T> IntoFFIValue for PassFatPointerAndReadWrite<&'a mut [T]> {
 /// Pass a buffer into the host by a fat pointer. The host will write data into it.
 ///
 /// This casts the value into a `&mut [u8]` and passes a pointer to that byte blob and its length
-/// to the host. Then the host allocates a temporary buffer of the same size and passes it
-/// as a mutable reference to the host function. After the host function finishes the data is
-/// written back into the guest memory.
+/// to the host. The host function receives the buffer wrapped in a [`WriteBuffer`], writes its
+/// output into it and declares how many leading bytes it actually wrote (through the
+/// [`WriteBuffer::write`], [`WriteBuffer::write_truncated`], [`WriteBuffer::set_written_len`] or
+/// [`WriteBuffer::set_fully_written`] helpers).
+///
+/// Only that declared prefix is copied back into the guest memory; everything the host function
+/// did not write is left untouched. In particular, if the host function declares nothing (the
+/// default), the guest buffer is not modified at all. This is what makes it possible to honor the
+/// "the buffer is not written into, and its contents are unchanged" contract for undersized output
+/// buffers, and it avoids writing back bytes the host never touched. Unlike
+/// [`PassFatPointerAndReadWrite`], the guest buffer is never read on the way in.
 ///
 /// Raw FFI type: `u64` (a fat pointer; upper 32 bits is the size, lower 32 bits is the pointer)
 pub struct PassFatPointerAndWrite<T>(PhantomData<T>);
 
+// On the runtime (guest) side the inner type is the caller's mutable slice; there is no
+// length-reporting handle, so `HostArg` just mirrors `Inner`.
+#[cfg(substrate_runtime)]
 impl<T> RIType for PassFatPointerAndWrite<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = T;
+}
+
+// On the host side the host function receives a [`WriteBuffer`] so it can declare how many bytes it
+// actually wrote into the output buffer.
+#[cfg(not(substrate_runtime))]
+impl<'a, T> RIType for PassFatPointerAndWrite<&'a mut [T]> {
+	type FFIType = u64;
+	type Inner = &'a mut [T];
+	type HostArg = WriteBuffer<'a, T>;
+}
+
+/// A host-side handle to a runtime-provided output buffer, used by the [`PassFatPointerAndWrite`]
+/// marshalling strategy.
+///
+/// The host function writes its output into the buffer — either through the [`DerefMut`] slice view
+/// or through the [`write`](Self::write) / [`write_truncated`](Self::write_truncated) helpers — and
+/// declares how many leading elements make up the output. Only that prefix is flushed back into the
+/// runtime's memory when the host function returns; everything past it is left unchanged. When
+/// nothing is declared (the default), the runtime buffer is left completely untouched.
+#[cfg(not(substrate_runtime))]
+pub struct WriteBuffer<'a, T> {
+	buffer: &'a mut [T],
+	/// Number of leading *bytes* of `buffer` to flush back into the runtime's memory. `None` on
+	/// the native execution path, where the host function writes straight into the caller's
+	/// buffer and there is no separate write-back step.
+	to_write: Option<&'a mut usize>,
+}
+
+#[cfg(not(substrate_runtime))]
+impl<'a, T> WriteBuffer<'a, T> {
+	/// Length of the whole buffer, in bytes.
+	#[inline]
+	fn byte_capacity(&self) -> usize {
+		self.buffer.len().saturating_mul(core::mem::size_of::<T>())
+	}
+
+	#[inline]
+	fn record(&mut self, bytes: usize) {
+		let capped = bytes.min(self.byte_capacity());
+		if let Some(to_write) = self.to_write.as_mut() {
+			**to_write = capped;
+		}
+	}
+
+	/// Declare that the first `len` elements of the buffer are the output and must be flushed back
+	/// into the runtime's memory. `len` is clamped to the buffer's capacity. Elements past `len`
+	/// are left unchanged in the runtime.
+	#[inline]
+	pub fn set_written_len(&mut self, len: usize) {
+		self.record(len.saturating_mul(core::mem::size_of::<T>()));
+	}
+
+	/// Declare that the entire buffer was written and must be flushed back.
+	#[inline]
+	pub fn set_fully_written(&mut self) {
+		let cap = self.byte_capacity();
+		self.record(cap);
+	}
+
+	/// Mark the whole buffer as written and return a mutable slice view of it.
+	///
+	/// Convenience for host functions that hand the output buffer off to a helper which fills it
+	/// (or a fixed-size prefix whose padding the runtime reads back in full) and does not itself
+	/// report how many bytes it wrote.
+	#[inline]
+	pub fn as_fully_written_slice(&mut self) -> &mut [T] {
+		self.set_fully_written();
+		&mut *self.buffer
+	}
+
+	/// All-or-nothing write: if `src` fits into the buffer, copy it to the front and flush exactly
+	/// `src.len()` elements back into the runtime; otherwise leave the buffer untouched and flush
+	/// nothing.
+	#[inline]
+	pub fn write(&mut self, src: &[T])
+	where
+		T: Copy,
+	{
+		if src.len() <= self.buffer.len() {
+			self.buffer[..src.len()].copy_from_slice(src);
+			self.record(src.len().saturating_mul(core::mem::size_of::<T>()));
+		}
+	}
+
+	/// Copy as many leading elements of `src` as fit into the buffer and flush exactly that many
+	/// back into the runtime. Returns the number of elements copied.
+	#[inline]
+	pub fn write_truncated(&mut self, src: &[T]) -> usize
+	where
+		T: Copy,
+	{
+		let n = src.len().min(self.buffer.len());
+		self.buffer[..n].copy_from_slice(&src[..n]);
+		self.record(n.saturating_mul(core::mem::size_of::<T>()));
+		n
+	}
+}
+
+#[cfg(not(substrate_runtime))]
+impl<'a, T> Deref for WriteBuffer<'a, T> {
+	type Target = [T];
+
+	#[inline]
+	fn deref(&self) -> &[T] {
+		self.buffer
+	}
+}
+
+#[cfg(not(substrate_runtime))]
+impl<'a, T> DerefMut for WriteBuffer<'a, T> {
+	#[inline]
+	fn deref_mut(&mut self) -> &mut [T] {
+		self.buffer
+	}
+}
+
+/// Construction used on the native execution path: the host function writes straight into the
+/// caller's buffer, so there is no write-back and no length to record.
+#[cfg(not(substrate_runtime))]
+impl<'a, T> From<&'a mut [T]> for WriteBuffer<'a, T> {
+	#[inline]
+	fn from(buffer: &'a mut [T]) -> Self {
+		WriteBuffer { buffer, to_write: None }
+	}
+}
+
+/// Owned host-side state backing a [`WriteBuffer`] on the wasm → host boundary: the scratch buffer
+/// plus the number of leading bytes the host function declared as written.
+#[cfg(not(substrate_runtime))]
+#[doc(hidden)]
+pub struct WriteBufferOwned {
+	buffer: Vec<u8>,
+	to_write: usize,
 }
 
 #[cfg(not(substrate_runtime))]
 impl<'a, T: FromByteSlice> FromFFIValue<'a> for PassFatPointerAndWrite<&'a mut [T]> {
-	type Owned = Vec<u8>;
+	type Owned = WriteBufferOwned;
 
 	fn from_ffi_value(
 		_context: &mut dyn FunctionContext,
 		arg: Self::FFIType,
 	) -> Result<Self::Owned> {
 		let (_, len) = unpack_ptr_and_len(arg);
-		Ok(vec![0u8; len as usize])
+		// Nothing is flushed back into the runtime unless the host function declares a written
+		// region, so the guest buffer is left untouched by default.
+		Ok(WriteBufferOwned { buffer: vec![0u8; len as usize], to_write: 0 })
 	}
 
-	fn take_from_owned(owned: &'a mut Self::Owned) -> Self::Inner {
-		FromByteSlice::from_mut_byte_slice(owned)
-			.expect("byte slice has wrong alignment or size for target type")
+	fn take_from_owned(owned: &'a mut Self::Owned) -> Self::HostArg {
+		let buffer = FromByteSlice::from_mut_byte_slice(&mut owned.buffer)
+			.expect("byte slice has wrong alignment or size for target type");
+		WriteBuffer { buffer, to_write: Some(&mut owned.to_write) }
 	}
 
 	fn write_back_into_runtime(
@@ -421,9 +578,10 @@ impl<'a, T: FromByteSlice> FromFFIValue<'a> for PassFatPointerAndWrite<&'a mut [
 		context: &mut dyn FunctionContext,
 		arg: Self::FFIType,
 	) -> Result<()> {
-		let (ptr, len) = unpack_ptr_and_len(arg);
-		assert_eq!(len as usize, value.len());
-		context.write_memory(Pointer::new(ptr), &value)
+		let (ptr, _len) = unpack_ptr_and_len(arg);
+		// Only flush back the prefix the host function declared as written; the rest of the guest
+		// buffer is left untouched.
+		context.write_memory(Pointer::new(ptr), &value.buffer[..value.to_write])
 	}
 }
 
@@ -450,6 +608,7 @@ pub struct PassPointerAndWrite<T, const N: usize>(PhantomData<(T, [u8; N])>);
 impl<T, const N: usize> RIType for PassPointerAndWrite<T, N> {
 	type FFIType = u32;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -507,6 +666,7 @@ pub struct PassFatPointerAndDecode<T>(PhantomData<T>);
 impl<T> RIType for PassFatPointerAndDecode<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -553,6 +713,7 @@ pub struct PassFatPointerAndDecodeSlice<T>(PhantomData<T>);
 impl<T> RIType for PassFatPointerAndDecodeSlice<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -610,6 +771,7 @@ where
 {
 	type FFIType = <U as RIType>::FFIType;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -665,6 +827,7 @@ where
 {
 	type FFIType = <V as RIType>::FFIType;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -724,6 +887,7 @@ where
 {
 	type FFIType = <U as RIType>::FFIType;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -778,6 +942,7 @@ where
 {
 	type FFIType = <V as RIType>::FFIType;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -844,6 +1009,7 @@ pub struct AllocateAndReturnPointer<T, const N: usize>(PhantomData<(T, [u8; N])>
 impl<T, const N: usize> RIType for AllocateAndReturnPointer<T, N> {
 	type FFIType = u32;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -903,6 +1069,7 @@ pub struct AllocateAndReturnFatPointer<T>(PhantomData<T>);
 impl<T> RIType for AllocateAndReturnFatPointer<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]
@@ -958,6 +1125,7 @@ pub struct AllocateAndReturnByCodec<T>(PhantomData<T>);
 impl<T> RIType for AllocateAndReturnByCodec<T> {
 	type FFIType = u64;
 	type Inner = T;
+	type HostArg = Self::Inner;
 }
 
 #[cfg(not(substrate_runtime))]

--- a/substrate/primitives/runtime-interface/test-wasm/src/lib.rs
+++ b/substrate/primitives/runtime-interface/test-wasm/src/lib.rs
@@ -157,8 +157,9 @@ pub trait TestApi {
 		data: PassFatPointerAndRead<&[u8]>,
 		out: sp_runtime_interface::pass_by::PassFatPointerAndWrite<&mut [u8]>,
 	) -> u32 {
-		let copy_len = data.len().min(out.len());
-		out[..copy_len].copy_from_slice(&data[..copy_len]);
+		// Copy as much of the input as fits into the output buffer, recording exactly how many
+		// bytes were written so only those are flushed back into the runtime.
+		out.write_truncated(data);
 		data.len() as u32
 	}
 
@@ -230,6 +231,28 @@ wasm_export_functions! {
 		let res = test_api::return_input(input.clone());
 
 		assert_eq!(input, res);
+	}
+
+	// Regression test for the `PassFatPointerAndWrite` contract: the host must only write back the
+	// bytes it actually wrote and leave the rest of the runtime-provided buffer untouched.
+	fn test_write_buffer_preserves_unwritten_bytes() {
+		// The host writes a 3-byte prefix; the sentinel-filled tail must survive unchanged (it must
+		// NOT be zeroed by the marshalling layer).
+		let data = vec![1u8, 2, 3];
+		let mut buf = [0xAAu8; 8];
+		let len = test_api::return_input__raw(&data, &mut buf[..]);
+		assert_eq!(len, 3);
+		assert_eq!(&buf[..3], &[1, 2, 3]);
+		assert_eq!(&buf[3..], &[0xAA; 5]);
+
+		// When the buffer is too small for the input, `write_truncated` still only writes (and
+		// flushes) as many bytes as fit; there is no out-of-bounds write and the whole buffer is a
+		// prefix of the input.
+		let data = vec![9u8; 16];
+		let mut small = [0xAAu8; 4];
+		let len = test_api::return_input__raw(&data, &mut small[..]);
+		assert_eq!(len, 16);
+		assert_eq!(&small, &[9u8; 4]);
 	}
 
 	fn test_set_storage() {

--- a/substrate/primitives/runtime-interface/test/src/lib.rs
+++ b/substrate/primitives/runtime-interface/test/src/lib.rs
@@ -155,6 +155,14 @@ fn test_v2_marshalling_strategies() {
 	call_wasm_method::<HostFunctions>(wasm_binary_unwrap(), "test_v2_marshalling_strategies");
 }
 
+#[test]
+fn test_write_buffer_preserves_unwritten_bytes() {
+	call_wasm_method::<HostFunctions>(
+		wasm_binary_unwrap(),
+		"test_write_buffer_preserves_unwritten_bytes",
+	);
+}
+
 fn run_test_in_another_process(
 	test_name: &str,
 	test_body: impl FnOnce(),

--- a/substrate/primitives/virtualization/src/host_functions.rs
+++ b/substrate/primitives/virtualization/src/host_functions.rs
@@ -531,7 +531,7 @@ pub trait Virtualization {
 		use sp_externalities::ExternalitiesExt as _;
 		self.extension::<crate::VirtManagerExt>()
 			.expect("VirtManagerExt not registered in externalities")
-			.read_memory(instance_id, offset, dest)
+			.read_memory(instance_id, offset, dest.as_fully_written_slice())
 	}
 
 	/// See [`crate::Execution::write_memory`].


### PR DESCRIPTION
This PR addresses the problem of buffer clobbering in RFC-145 implementation, currently requiring the host to read buffer before writing it, introducing an unneeded overhead.

This is proposed as a possible refactoring after the main implementation PR of RFC-145 is settled.

Claude's comments are left in place as they are to make reviewers' life easier.