### PR TITLE
[RWF] sc-rpc-api: fix UnsafeRpcCalled module error code

### DIFF
--- a/prdoc/pr_12613.prdoc
+++ b/prdoc/pr_12613.prdoc
@@ -1,0 +1,11 @@
+title: '[RWF] sc-rpc-api: fix UnsafeRpcCalled module error code'
+doc:
+- audience: Node Dev
+  description: "Closes #12463\n\n## Problem\n\nThe `state` RPC module's `Error \u2192\
+    \ ErrorObjectOwned` conversion in `substrate/client/rpc-api/src/state/error.rs`\
+    \ had no explicit match arm for `Error::UnsafeRpcCalled`.\n\n## Fix\n\nAdded the\
+    \ missing explicit match arm `Error::UnsafeRpcCalled(e) => e.into(),` in the `state`\
+    \ module's `From<Error> for ErrorObjectOwned` impl, before the catch-all arm."
+crates:
+- name: sc-rpc-api
+  bump: patch

--- a/substrate/client/rpc-api/src/state/error.rs
+++ b/substrate/client/rpc-api/src/state/error.rs
@@ -64,6 +64,7 @@ impl From<Error> for ErrorObjectOwned {
 			Error::InvalidCount { .. } => {
 				ErrorObject::owned(BASE_ERROR + 2, e.to_string(), None::<()>)
 			},
+			Error::UnsafeRpcCalled(e) => e.into(),
 			e => ErrorObject::owned(BASE_ERROR + 3, e.to_string(), None::<()>),
 		}
 	}


### PR DESCRIPTION
Closes #12463

## Problem

The `state` RPC module's `Error → ErrorObjectOwned` conversion in `substrate/client/rpc-api/src/state/error.rs` had no explicit match arm for `Error::UnsafeRpcCalled`.

## Fix

Added the missing explicit match arm `Error::UnsafeRpcCalled(e) => e.into(),` in the `state` module's `From<Error> for ErrorObjectOwned` impl, before the catch-all arm.
