### PR TITLE
[RWF] `fork-tree`: Ensure `finalize_root_at` cannot set `best_finalized_number` to a stale value

### DIFF
--- a/prdoc/pr_12617.prdoc
+++ b/prdoc/pr_12617.prdoc
@@ -1,0 +1,17 @@
+title: '[RWF] `fork-tree`: Ensure `finalize_root_at` cannot set `best_finalized_number`
+  to a stale value'
+doc:
+- audience: Node Dev
+  description: |-
+    Closes #12600
+
+    ## Problem
+
+    `ForkTree::finalize_root_at` unconditionally overwrote `best_finalized_number` with the finalized node's own stored number. There was no check that `node.number` actually exceeds the current `best_finalized_number`. This could result in `best_finalized_number` being set to a smaller, stale number.
+
+    ## Solution
+    Make `finalize_root_at` only update `best_finalized_number` when the finalized node's number is strictly greater than
+    the current value. Added a regression test that asserts this invariant.
+crates:
+- name: fork-tree
+  bump: patch

--- a/substrate/utils/fork-tree/src/lib.rs
+++ b/substrate/utils/fork-tree/src/lib.rs
@@ -447,9 +447,9 @@ where
 	fn finalize_root_at(&mut self, position: usize) -> V {
 		let node = self.roots.swap_remove(position);
 		self.roots = node.children;
-		// if self.best_finalized_number.as_ref().is_none_or(|best| node.number > *best) {
+		if self.best_finalized_number.as_ref().is_none_or(|best| node.number > *best) {
 			self.best_finalized_number = Some(node.number);
-		// }
+		}
 		node.data
 	}
 

--- a/substrate/utils/fork-tree/src/lib.rs
+++ b/substrate/utils/fork-tree/src/lib.rs
@@ -447,7 +447,9 @@ where
 	fn finalize_root_at(&mut self, position: usize) -> V {
 		let node = self.roots.swap_remove(position);
 		self.roots = node.children;
-		self.best_finalized_number = Some(node.number);
+		if self.best_finalized_number.as_ref().is_none_or(|best| node.number > *best) {
+			self.best_finalized_number = Some(node.number);
+		}
 		node.data
 	}
 
@@ -842,7 +844,7 @@ impl<H, N, V> Iterator for RemovedIterator<H, N, V> {
 mod test {
 	use crate::FilterAction;
 
-	use super::{Error, FinalizationResult, ForkTree};
+	use super::{Error, FinalizationResult, ForkTree, Node};
 
 	#[derive(Debug, PartialEq)]
 	struct TestError;
@@ -987,6 +989,25 @@ mod test {
 			// all the other forks have been pruned
 			assert!(tree.roots.len() == 1);
 		}
+	}
+
+	#[test]
+	fn finalize_root_does_not_lower_best_finalized_number() {
+		let (mut tree, ..) = test_fork_tree();
+
+		// finalizing "A" then "B" advances `best_finalized_number` to 20.
+		tree.finalize_root(&"A");
+		tree.finalize_root(&"B");
+		assert_eq!(tree.best_finalized_number, Some(20));
+
+
+		// Push a stale root with a lower number than the current `best_finalized_number`.
+		tree.roots.push(Node { hash: "STALE", number: 5, data: 0, children: Vec::new() });
+
+		tree.finalize_root(&"STALE");
+
+		// Assert that `best_finalized_number` is not updated.
+		assert_eq!(tree.best_finalized_number, Some(20));
 	}
 
 	#[test]

--- a/substrate/utils/fork-tree/src/lib.rs
+++ b/substrate/utils/fork-tree/src/lib.rs
@@ -447,9 +447,9 @@ where
 	fn finalize_root_at(&mut self, position: usize) -> V {
 		let node = self.roots.swap_remove(position);
 		self.roots = node.children;
-		if self.best_finalized_number.as_ref().is_none_or(|best| node.number > *best) {
+		// if self.best_finalized_number.as_ref().is_none_or(|best| node.number > *best) {
 			self.best_finalized_number = Some(node.number);
-		}
+		// }
 		node.data
 	}
 

--- a/substrate/utils/fork-tree/src/lib.rs
+++ b/substrate/utils/fork-tree/src/lib.rs
@@ -1000,9 +1000,9 @@ mod test {
 		tree.finalize_root(&"B");
 		assert_eq!(tree.best_finalized_number, Some(20));
 
-
 		// Push a stale root with a lower number than the current `best_finalized_number`.
-		tree.roots.push(Node { hash: "STALE", number: 5, data: 0, children: Vec::new() });
+		tree.roots
+			.push(Node { hash: "STALE", number: 5, data: 0, children: Vec::new() });
 
 		tree.finalize_root(&"STALE");
 


### PR DESCRIPTION
Closes #12600

## Problem

`ForkTree::finalize_root_at` unconditionally overwrote `best_finalized_number` with the finalized node's own stored number. There was no check that `node.number` actually exceeds the current `best_finalized_number`. This could result in `best_finalized_number` being set to a smaller, stale number.

## Solution
Make `finalize_root_at` only update `best_finalized_number` when the finalized node's number is strictly greater than
the current value. Added a regression test that asserts this invariant.


