### PR TITLE
try state check for oracle pallet

### DIFF
--- a/prdoc/pr_12631.prdoc
+++ b/prdoc/pr_12631.prdoc
@@ -1,0 +1,10 @@
+title: try state check for oracle pallet
+doc:
+- audience: Todo
+  description: |-
+    This PR introduces try state hook into the Oracle Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-oracle
+  bump: major

--- a/substrate/frame/honzon/oracle/src/lib.rs
+++ b/substrate/frame/honzon/oracle/src/lib.rs
@@ -91,6 +91,8 @@ use sp_runtime::{
 	traits::{AccountIdConversion, Member},
 	Debug, DispatchResult,
 };
+#[cfg(any(feature = "try-runtime", test))]
+use sp_std::collections::btree_set::BTreeSet;
 use sp_std::{prelude::*, vec};
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -308,6 +310,11 @@ pub mod pallet {
 			// cleanup for next block
 			<HasDispatched<T, I>>::kill();
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
 	}
 
 	#[pallet::view_functions]
@@ -426,6 +433,76 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			T::OnNewData::on_new_data(&who, key, value);
 		}
 		Self::deposit_event(Event::NewFeedData { sender: who, values });
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config<I>, I: 'static> Pallet<T, I> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_raw_values_feeders()?;
+		Self::try_state_has_dispatched()?;
+		Self::try_state_timestamps()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every account holding data in `RawValues` must be allowed to feed data, i.e. it is either
+	///   an oracle member or the pallet account (used when values are fed by root). The data of a
+	///   member is cleared in `change_members_sorted` when it leaves the oracle.
+	fn try_state_raw_values_feeders() -> Result<(), sp_runtime::TryRuntimeError> {
+		let members = T::Members::sorted_members().into_iter().collect::<BTreeSet<_>>();
+		let pallet_account = Self::get_pallet_account();
+
+		for (who, _, _) in RawValues::<T, I>::iter() {
+			ensure!(
+				who == pallet_account || members.contains(&who),
+				"`RawValues` must only hold data of oracle members or of the pallet account"
+			);
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * The number of accounts that have fed data in the current block must not exceed
+	///   `MaxHasDispatchedSize`.
+	fn try_state_has_dispatched() -> Result<(), sp_runtime::TryRuntimeError> {
+		ensure!(
+			HasDispatched::<T, I>::get().len() as u32 <= T::MaxHasDispatchedSize::get(),
+			"`HasDispatched` must not hold more accounts than `MaxHasDispatchedSize`"
+		);
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * No value can be timestamped in the future, both in `RawValues` and in `Values`, since
+	///   values are timestamped with the time of the block they were fed in.
+	fn try_state_timestamps() -> Result<(), sp_runtime::TryRuntimeError> {
+		let now = T::Time::now();
+
+		for (_, _, timestamped) in RawValues::<T, I>::iter() {
+			ensure!(
+				timestamped.timestamp <= now,
+				"`RawValues` must not hold a value timestamped in the future"
+			);
+		}
+
+		for (_, timestamped) in Values::<T, I>::iter() {
+			ensure!(
+				timestamped.timestamp <= now,
+				"`Values` must not hold a value timestamped in the future"
+			);
+		}
+
+		Ok(())
 	}
 }
 

--- a/substrate/frame/honzon/oracle/src/mock.rs
+++ b/substrate/frame/honzon/oracle/src/mock.rs
@@ -117,3 +117,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 	t
 }
+
+// Runs the given test and ensures that all the invariants of the pallet hold afterwards.
+pub fn build_and_execute(test: impl FnOnce() -> ()) {
+	new_test_ext().execute_with(|| {
+		test();
+		ModuleOracle::do_try_state().expect("All invariants must hold after a test");
+	})
+}

--- a/substrate/frame/honzon/oracle/src/tests.rs
+++ b/substrate/frame/honzon/oracle/src/tests.rs
@@ -21,7 +21,7 @@ use mock::*;
 
 #[test]
 fn should_feed_values_from_member() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		System::set_block_number(1);
 		let account_id: AccountId = 1;
 
@@ -66,7 +66,7 @@ fn should_feed_values_from_member() {
 
 #[test]
 fn should_feed_values_from_root() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let root_feeder: AccountId = OraclePalletId::get().into_account_truncating();
 
 		assert_ok!(ModuleOracle::feed_values(
@@ -101,7 +101,7 @@ fn should_feed_values_from_root() {
 
 #[test]
 fn should_not_feed_values_from_root_directly() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let root_feeder: AccountId = OraclePalletId::get().into_account_truncating();
 
 		assert_noop!(
@@ -116,7 +116,7 @@ fn should_not_feed_values_from_root_directly() {
 
 #[test]
 fn should_read_raw_values() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let key: u32 = 50;
 
 		let raw_values = ModuleOracle::read_raw_values(&key);
@@ -144,7 +144,7 @@ fn should_read_raw_values() {
 
 #[test]
 fn should_combined_data() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let key: u32 = 50;
 
 		assert_ok!(ModuleOracle::feed_values(
@@ -172,14 +172,14 @@ fn should_combined_data() {
 
 #[test]
 fn should_return_none_for_non_exist_key() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_eq!(ModuleOracle::get(&50), None);
 	});
 }
 
 #[test]
 fn multiple_calls_should_fail() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(ModuleOracle::feed_values(
 			RuntimeOrigin::signed(1),
 			vec![(50, 1300)].try_into().unwrap()
@@ -208,7 +208,7 @@ fn multiple_calls_should_fail() {
 
 #[test]
 fn get_all_values_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let eur: u32 = 1;
 		let jpy: u32 = 2;
 
@@ -274,7 +274,7 @@ fn get_all_values_should_work() {
 
 #[test]
 fn change_member_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		set_members(vec![2, 3, 4]);
 		<ModuleOracle as ChangeMembers<AccountId>>::change_members_sorted(&[4], &[1], &[2, 3, 4]);
 		assert_noop!(
@@ -297,7 +297,7 @@ fn change_member_should_work() {
 
 #[test]
 fn should_clear_data_for_removed_members() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(ModuleOracle::feed_values(
 			RuntimeOrigin::signed(1),
 			vec![(50, 1000)].try_into().unwrap()
@@ -314,8 +314,41 @@ fn should_clear_data_for_removed_members() {
 }
 
 #[test]
-fn values_are_updated_on_feed() {
+fn try_state_detects_raw_values_of_non_feeders() {
 	new_test_ext().execute_with(|| {
+		assert_ok!(ModuleOracle::feed_values(
+			RuntimeOrigin::signed(1),
+			vec![(50, 1000)].try_into().unwrap()
+		));
+		assert_ok!(ModuleOracle::do_try_state());
+
+		// Member 1 leaves the oracle, but its data is not cleared.
+		set_members(vec![2, 3]);
+		assert!(ModuleOracle::do_try_state().is_err());
+
+		// Clearing the data of the removed member restores the invariant.
+		ModuleOracle::change_members_sorted(&[], &[1], &[2, 3]);
+		assert_ok!(ModuleOracle::do_try_state());
+	});
+}
+
+#[test]
+fn try_state_detects_values_timestamped_in_the_future() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(ModuleOracle::feed_values(
+			RuntimeOrigin::signed(1),
+			vec![(50, 1000)].try_into().unwrap()
+		));
+		assert_ok!(ModuleOracle::do_try_state());
+
+		Timestamp::set_timestamp(12344);
+		assert!(ModuleOracle::do_try_state().is_err());
+	});
+}
+
+#[test]
+fn values_are_updated_on_feed() {
+	build_and_execute(|| {
 		assert_ok!(ModuleOracle::feed_values(
 			RuntimeOrigin::signed(1),
 			vec![(50, 900)].try_into().unwrap()


### PR DESCRIPTION
This PR introduces try state hook into the Oracle Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239