### PR TITLE
try state check for i'm online pallet

### DIFF
--- a/prdoc/pr_12632.prdoc
+++ b/prdoc/pr_12632.prdoc
@@ -1,0 +1,10 @@
+title: try state check for i'm online pallet
+doc:
+- audience: Todo
+  description: |-
+    This PR introduces try state hook into the I'm Online Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-im-online
+  bump: major

--- a/substrate/frame/im-online/src/lib.rs
+++ b/substrate/frame/im-online/src/lib.rs
@@ -448,6 +448,11 @@ pub mod pallet {
 				)
 			}
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
 	}
 
 	/// Invalid transaction custom error. Returned when validators_len field in heartbeat is
@@ -741,6 +746,81 @@ impl<T: Config> Pallet<T> {
 		let bounded_keys = WeakBoundedVec::<_, T::MaxKeys>::try_from(keys)
 			.expect("More than the maximum number of keys provided");
 		Keys::<T>::put(bounded_keys);
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config> Pallet<T> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_keys()?;
+		Self::try_state_received_heartbeats()?;
+		Self::try_state_authored_blocks()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * The number of authorities that may issue a heartbeat must not exceed `MaxKeys`. `Keys` is
+	///   only weakly bounded, so a session with more authorities is truncated instead of being
+	///   rejected.
+	fn try_state_keys() -> Result<(), sp_runtime::TryRuntimeError> {
+		ensure!(
+			Keys::<T>::decode_len().unwrap_or_default() as u32 <= T::MaxKeys::get(),
+			"`Keys` must not hold more authorities than `MaxKeys`"
+		);
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * A heartbeat is only ever received for the current session, since the heartbeats of a
+	///   session are removed in `on_before_session_ending`.
+	/// * A heartbeat is issued by an authority of the current session, i.e. its index is a valid
+	///   index into `Keys`.
+	fn try_state_received_heartbeats() -> Result<(), sp_runtime::TryRuntimeError> {
+		let current_session = T::ValidatorSet::session_index();
+		let keys_len = Keys::<T>::decode_len().unwrap_or_default() as u32;
+
+		for (session, authority_index, _) in ReceivedHeartbeats::<T>::iter() {
+			ensure!(
+				session == current_session,
+				"`ReceivedHeartbeats` must not hold a heartbeat of a past session"
+			);
+			ensure!(
+				authority_index < keys_len,
+				"`ReceivedHeartbeats` must not hold a heartbeat of an unknown authority"
+			);
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * A block is only ever authored in the current session, since the authored blocks of a
+	///   session are removed in `on_before_session_ending`.
+	/// * An authority that has an entry in `AuthoredBlocks` has authored at least one block, as the
+	///   entry is only created when a block is authored.
+	fn try_state_authored_blocks() -> Result<(), sp_runtime::TryRuntimeError> {
+		let current_session = T::ValidatorSet::session_index();
+
+		for (session, _, authored_blocks) in AuthoredBlocks::<T>::iter() {
+			ensure!(
+				session == current_session,
+				"`AuthoredBlocks` must not hold the authored blocks of a past session"
+			);
+			ensure!(
+				authored_blocks > 0,
+				"`AuthoredBlocks` must not hold an authority that has not authored a block"
+			);
+		}
+
+		Ok(())
 	}
 }
 

--- a/substrate/frame/im-online/src/mock.rs
+++ b/substrate/frame/im-online/src/mock.rs
@@ -113,6 +113,13 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	result
 }
 
+pub fn build_and_execute(test: impl FnOnce() -> ()) {
+	new_test_ext().execute_with(|| {
+		test();
+		ImOnline::do_try_state().expect("All invariants must hold after a test");
+	})
+}
+
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<u64>;

--- a/substrate/frame/im-online/src/tests.rs
+++ b/substrate/frame/im-online/src/tests.rs
@@ -57,7 +57,7 @@ fn test_unresponsiveness_slash_fraction() {
 
 #[test]
 fn should_report_offline_validators() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// given
 		let block = 1;
 		System::set_block_number(block);
@@ -145,7 +145,7 @@ fn heartbeat(
 
 #[test]
 fn should_mark_online_validator_when_heartbeat_is_received() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		advance_session();
 		// given
 		Validators::mutate(|l| *l = Some(vec![1, 2, 3, 4, 5, 6]));
@@ -180,7 +180,7 @@ fn should_mark_online_validator_when_heartbeat_is_received() {
 
 #[test]
 fn late_heartbeat_and_invalid_keys_len_should_fail() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		advance_session();
 		// given
 		Validators::mutate(|l| *l = Some(vec![1, 2, 3, 4, 5, 6]));
@@ -257,7 +257,7 @@ fn should_generate_heartbeats() {
 
 #[test]
 fn should_cleanup_received_heartbeats_on_session_end() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		advance_session();
 
 		Validators::mutate(|l| *l = Some(vec![1, 2, 3]));
@@ -288,7 +288,7 @@ fn should_cleanup_received_heartbeats_on_session_end() {
 fn should_mark_online_validator_when_block_is_authored() {
 	use pallet_authorship::EventHandler;
 
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		advance_session();
 		// given
 		Validators::mutate(|l| *l = Some(vec![1, 2, 3, 4, 5, 6]));
@@ -362,6 +362,8 @@ fn should_not_send_a_report_if_already_online() {
 			heartbeat,
 			Heartbeat { block_number: 4, session_index: 2, authority_index: 0, validators_len: 3 }
 		);
+
+		ImOnline::do_try_state().expect("All invariants must hold after a test");
 	});
 }
 


### PR DESCRIPTION
This PR introduces try state hook into the I'm Online Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239