### PR TITLE
try state check for indices pallet

### DIFF
--- a/prdoc/pr_12633.prdoc
+++ b/prdoc/pr_12633.prdoc
@@ -1,0 +1,10 @@
+title: try state check for indices pallet
+doc:
+- audience: Todo
+  description: |-
+    This PR introduces try state hook into the Indices Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-indices
+  bump: major

--- a/substrate/frame/indices/src/lib.rs
+++ b/substrate/frame/indices/src/lib.rs
@@ -293,6 +293,14 @@ pub mod pallet {
 		}
 	}
 
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
+	}
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -361,6 +369,57 @@ impl<T: Config> Pallet<T> {
 			MultiAddress::Index(i) => Self::lookup_index(i),
 			_ => None,
 		}
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config> Pallet<T> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_permanent_indices()?;
+		Self::try_state_deposits()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * A permanent index holds no deposit, as the deposit is consumed when the index is frozen.
+	fn try_state_permanent_indices() -> Result<(), sp_runtime::TryRuntimeError> {
+		for (_, (_, deposit, permanent)) in Accounts::<T>::iter() {
+			if permanent {
+				frame_support::ensure!(
+					deposit.is_zero(),
+					"a permanent index must not hold a deposit"
+				);
+			}
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * The deposits held for the indices of an account are reserved on that account. Other
+	///   pallets may reserve from the same account, hence the reserved balance is only required to
+	///   cover the deposits, not to match them.
+	fn try_state_deposits() -> Result<(), sp_runtime::TryRuntimeError> {
+		let mut deposits = alloc::collections::BTreeMap::<T::AccountId, BalanceOf<T>>::new();
+
+		for (_, (who, deposit, _)) in Accounts::<T>::iter() {
+			deposits.entry(who).or_default().saturating_accrue(deposit);
+		}
+
+		for (who, deposit) in deposits {
+			frame_support::ensure!(
+				T::Currency::reserved_balance(&who) >= deposit,
+				"the deposits held for the indices of an account must be reserved on it"
+			);
+		}
+
+		Ok(())
 	}
 }
 

--- a/substrate/frame/indices/src/mock.rs
+++ b/substrate/frame/indices/src/mock.rs
@@ -72,3 +72,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }
+
+// Runs the given test and ensures that all the invariants of the pallet hold afterwards.
+pub fn build_and_execute(test: impl FnOnce() -> ()) {
+	new_test_ext().execute_with(|| {
+		test();
+		Indices::do_try_state().expect("All invariants must hold after a test");
+	})
+}

--- a/substrate/frame/indices/src/tests.rs
+++ b/substrate/frame/indices/src/tests.rs
@@ -26,7 +26,7 @@ use sp_runtime::MultiAddress::Id;
 
 #[test]
 fn claiming_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(
 			Indices::claim(Some(0).into(), 0),
 			BalancesError::<Test, _>::InsufficientBalance
@@ -39,7 +39,7 @@ fn claiming_should_work() {
 
 #[test]
 fn freeing_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_ok!(Indices::claim(Some(2).into(), 1));
 		assert_noop!(Indices::free(Some(0).into(), 0), Error::<Test>::NotOwner);
@@ -53,7 +53,7 @@ fn freeing_should_work() {
 
 #[test]
 fn freezing_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_noop!(Indices::freeze(Some(1).into(), 1), Error::<Test>::NotAssigned);
 		assert_noop!(Indices::freeze(Some(2).into(), 0), Error::<Test>::NotOwner);
@@ -67,7 +67,7 @@ fn freezing_should_work() {
 
 #[test]
 fn indexing_lookup_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_ok!(Indices::claim(Some(2).into(), 1));
 		assert_eq!(Indices::lookup_index(0), Some(1));
@@ -78,7 +78,7 @@ fn indexing_lookup_should_work() {
 
 #[test]
 fn reclaim_index_on_accounts_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_ok!(Indices::free(Some(1).into(), 0));
 		assert_ok!(Indices::claim(Some(2).into(), 0));
@@ -89,7 +89,7 @@ fn reclaim_index_on_accounts_should_work() {
 
 #[test]
 fn transfer_index_on_accounts_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_noop!(Indices::transfer(Some(1).into(), Id(2), 1), Error::<Test>::NotAssigned);
 		assert_noop!(Indices::transfer(Some(2).into(), Id(3), 0), Error::<Test>::NotOwner);
@@ -102,7 +102,7 @@ fn transfer_index_on_accounts_should_work() {
 
 #[test]
 fn force_transfer_index_on_preowned_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_ok!(Indices::force_transfer(RuntimeOrigin::root(), Id(3), 0, false));
 		assert_eq!(Balances::reserved_balance(1), 0);
@@ -113,7 +113,7 @@ fn force_transfer_index_on_preowned_should_work() {
 
 #[test]
 fn force_transfer_index_on_free_should_work() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::force_transfer(RuntimeOrigin::root(), Id(3), 0, false));
 		assert_eq!(Balances::reserved_balance(3), 0);
 		assert_eq!(Indices::lookup_index(0), Some(3));
@@ -122,14 +122,14 @@ fn force_transfer_index_on_free_should_work() {
 
 #[test]
 fn poke_deposit_should_fail_for_unassigned_index() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_noop!(Indices::poke_deposit(Some(1).into(), 0), Error::<Test>::NotAssigned);
 	});
 }
 
 #[test]
 fn poke_deposit_should_fail_for_wrong_owner() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_noop!(Indices::poke_deposit(Some(2).into(), 0), Error::<Test>::NotOwner);
 	});
@@ -137,7 +137,7 @@ fn poke_deposit_should_fail_for_wrong_owner() {
 
 #[test]
 fn poke_deposit_should_fail_for_permanent_index() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_ok!(Indices::freeze(Some(1).into(), 0));
 		assert_noop!(Indices::poke_deposit(Some(1).into(), 0), Error::<Test>::Permanent);
@@ -146,7 +146,7 @@ fn poke_deposit_should_fail_for_permanent_index() {
 
 #[test]
 fn poke_deposit_should_fail_for_insufficient_balance() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 
 		// Set deposit higher than available balance
@@ -161,7 +161,7 @@ fn poke_deposit_should_fail_for_insufficient_balance() {
 
 #[test]
 fn poke_deposit_should_work_when_deposit_increases() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_eq!(Balances::reserved_balance(1), 1);
 
@@ -187,7 +187,7 @@ fn poke_deposit_should_work_when_deposit_increases() {
 
 #[test]
 fn poke_deposit_should_work_when_deposit_decreases() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// Set initial deposit to 3
 		IndexDeposit::set(3);
 		assert_ok!(Indices::claim(Some(1).into(), 0));
@@ -214,7 +214,7 @@ fn poke_deposit_should_work_when_deposit_decreases() {
 
 #[test]
 fn poke_deposit_should_charge_fee_when_deposit_unchanged() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
 		assert_eq!(Balances::reserved_balance(1), 1);
 


### PR DESCRIPTION
This PR introduces try state hook into the Indices Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239