### PR TITLE
try state check for lottery pallet

### DIFF
--- a/prdoc/pr_12634.prdoc
+++ b/prdoc/pr_12634.prdoc
@@ -1,0 +1,10 @@
+title: try state check for lottery pallet
+doc:
+- audience: Todo
+  description: |-
+    This PR introduces try state hook into the Lottery Pallet. It also defines the invariants that holds for the pallet.
+
+    Part of: https://github.com/paritytech/polkadot-sdk/issues/239
+crates:
+- name: pallet-lottery
+  bump: major

--- a/substrate/frame/lottery/src/lib.rs
+++ b/substrate/frame/lottery/src/lib.rs
@@ -281,6 +281,11 @@ pub mod pallet {
 				T::DbWeight::get().reads(1)
 			})
 		}
+
+		#[cfg(feature = "try-runtime")]
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Self::do_try_state()
+		}
 	}
 
 	#[pallet::call]
@@ -519,5 +524,71 @@ impl<T: Config> Pallet<T> {
 		let random_number = <u32>::decode(&mut random_seed.as_ref())
 			.expect("secure hashes should always be bigger than u32; qed");
 		random_number
+	}
+}
+
+#[cfg(any(feature = "try-runtime", test))]
+impl<T: Config> Pallet<T> {
+	/// Ensure the correctness of the state of this pallet.
+	///
+	/// This should be valid before or after each state transition of this pallet.
+	pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+		Self::try_state_tickets()?;
+		Self::try_state_lottery()?;
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * Every ticket of the current lottery, i.e. every index below `TicketsCount`, has an owner.
+	///   `Tickets` may hold residual entries of previous lotteries, which is why only the tickets
+	///   below `TicketsCount` are valid mappings.
+	/// * The owner of a ticket of the current lottery participates in the current lottery.
+	fn try_state_tickets() -> Result<(), sp_runtime::TryRuntimeError> {
+		let lottery_index = LotteryIndex::<T>::get();
+
+		for ticket in 0..TicketsCount::<T>::get() {
+			let owner = Tickets::<T>::get(ticket).ok_or("every sold ticket must have an owner")?;
+			ensure!(
+				Participants::<T>::get(&owner).0 == lottery_index,
+				"the owner of a sold ticket must participate in the current lottery"
+			);
+		}
+
+		Ok(())
+	}
+
+	/// # Invariants
+	///
+	/// * A lottery is only ever started with an index greater than zero, as the index of the first
+	///   lottery is one.
+	/// * The pot holds the price of every ticket sold in the current lottery, on top of the
+	///   existential deposit that keeps the pot account alive. It may hold more, since anyone can
+	///   fund the pot.
+	/// * No ticket is sold while no lottery is configured, since the tickets of a lottery are
+	///   cleared once it has paid out.
+	fn try_state_lottery() -> Result<(), sp_runtime::TryRuntimeError> {
+		let tickets_count = TicketsCount::<T>::get();
+
+		let Some(config) = Lottery::<T>::get() else {
+			ensure!(
+				tickets_count.is_zero(),
+				"no ticket must be sold while no lottery is configured"
+			);
+
+			return Ok(());
+		};
+
+		ensure!(!LotteryIndex::<T>::get().is_zero(), "an ongoing lottery must have an index");
+
+		let sold = config.price.saturating_mul(tickets_count.into());
+		let minimum_pot = T::Currency::minimum_balance().saturating_add(sold);
+		ensure!(
+			T::Currency::free_balance(&Self::account_id()) >= minimum_pot,
+			"the pot must hold the price of every ticket sold in the current lottery"
+		);
+
+		Ok(())
 	}
 }

--- a/substrate/frame/lottery/src/mock.rs
+++ b/substrate/frame/lottery/src/mock.rs
@@ -81,3 +81,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	.unwrap();
 	t.into()
 }
+
+// Runs the given test and ensures that all the invariants of the pallet hold afterwards.
+pub fn build_and_execute(test: impl FnOnce() -> ()) {
+	new_test_ext().execute_with(|| {
+		test();
+		Lottery::do_try_state().expect("All invariants must hold after a test");
+	})
+}

--- a/substrate/frame/lottery/src/tests.rs
+++ b/substrate/frame/lottery/src/tests.rs
@@ -26,7 +26,7 @@ use sp_runtime::{traits::BadOrigin, TokenError};
 
 #[test]
 fn initial_state() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert_eq!(Balances::free_balance(Lottery::account_id()), 0);
 		assert!(crate::Lottery::<Test>::get().is_none());
 		assert_eq!(Participants::<Test>::get(&1), (0, Default::default()));
@@ -37,7 +37,7 @@ fn initial_state() {
 
 #[test]
 fn basic_end_to_end_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let price = 10;
 		let length = 20;
 		let delay = 5;
@@ -95,7 +95,7 @@ fn basic_end_to_end_works() {
 /// Only the manager can stop the Lottery from repeating via `stop_repeat`.
 #[test]
 fn stop_repeat_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let price = 10;
 		let length = 20;
 		let delay = 5;
@@ -125,7 +125,7 @@ fn stop_repeat_works() {
 
 #[test]
 fn set_calls_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert!(!CallIndices::<Test>::exists());
 
 		let calls = vec![
@@ -155,7 +155,7 @@ fn set_calls_works() {
 
 #[test]
 fn call_to_indices_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls = vec![
 			RuntimeCall::Balances(BalancesCall::force_transfer { source: 0, dest: 0, value: 0 }),
 			RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 }),
@@ -176,7 +176,7 @@ fn call_to_indices_works() {
 
 #[test]
 fn start_lottery_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let price = 10;
 		let length = 20;
 		let delay = 5;
@@ -202,7 +202,7 @@ fn start_lottery_works() {
 fn buy_ticket_works_as_simple_passthrough() {
 	// This test checks that even if the user could not buy a ticket, that `buy_ticket` acts
 	// as a simple passthrough to the real call.
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// No lottery set up
 		let call = Box::new(RuntimeCall::Balances(BalancesCall::transfer_allow_death {
 			dest: 2,
@@ -260,7 +260,7 @@ fn buy_ticket_works_as_simple_passthrough() {
 
 #[test]
 fn buy_ticket_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		// Set calls for the lottery.
 		let calls = vec![
 			RuntimeCall::System(SystemCall::remark { remark: vec![] }),
@@ -315,7 +315,7 @@ fn buy_ticket_works() {
 /// Errors of `do_buy_ticket` are ignored by `buy_ticket`, therefore this white-box test.
 #[test]
 fn do_buy_ticket_already_participating() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls =
 			vec![RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 })];
 		assert_ok!(Lottery::set_calls(RuntimeOrigin::root(), calls.clone()));
@@ -331,7 +331,7 @@ fn do_buy_ticket_already_participating() {
 /// `buy_ticket` is a storage noop when called with the same ticket again.
 #[test]
 fn buy_ticket_already_participating() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls =
 			vec![RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 })];
 		assert_ok!(Lottery::set_calls(RuntimeOrigin::root(), calls.clone()));
@@ -352,7 +352,7 @@ fn buy_ticket_already_participating() {
 /// `buy_ticket` is a storage noop when called with insufficient balance.
 #[test]
 fn buy_ticket_insufficient_balance() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls =
 			vec![RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 })];
 		assert_ok!(Lottery::set_calls(RuntimeOrigin::root(), calls.clone()));
@@ -368,7 +368,7 @@ fn buy_ticket_insufficient_balance() {
 
 #[test]
 fn do_buy_ticket_insufficient_balance() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls =
 			vec![RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 })];
 		assert_ok!(Lottery::set_calls(RuntimeOrigin::root(), calls.clone()));
@@ -383,7 +383,7 @@ fn do_buy_ticket_insufficient_balance() {
 
 #[test]
 fn do_buy_ticket_keep_alive() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls =
 			vec![RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 })];
 		assert_ok!(Lottery::set_calls(RuntimeOrigin::root(), calls.clone()));
@@ -398,7 +398,7 @@ fn do_buy_ticket_keep_alive() {
 /// The lottery handles the case that no one participated.
 #[test]
 fn no_participants_works() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let length = 20;
 		let delay = 5;
 
@@ -414,7 +414,7 @@ fn no_participants_works() {
 
 #[test]
 fn start_lottery_will_create_account() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let price = 10;
 		let length = 20;
 		let delay = 5;
@@ -427,7 +427,7 @@ fn start_lottery_will_create_account() {
 
 #[test]
 fn choose_ticket_trivial_cases() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		assert!(Lottery::choose_ticket(0).is_none());
 		assert_eq!(Lottery::choose_ticket(1).unwrap(), 0);
 	});
@@ -435,7 +435,7 @@ fn choose_ticket_trivial_cases() {
 
 #[test]
 fn choose_account_one_participant() {
-	new_test_ext().execute_with(|| {
+	build_and_execute(|| {
 		let calls =
 			vec![RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: 0, value: 0 })];
 		assert_ok!(Lottery::set_calls(RuntimeOrigin::root(), calls.clone()));


### PR DESCRIPTION
This PR introduces try state hook into the Lottery Pallet. It also defines the invariants that holds for the pallet.

Part of: https://github.com/paritytech/polkadot-sdk/issues/239