### PR TITLE
Serve light-client extrinsics-trie inclusion proof requests (RFC-0174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21923,12 +21923,15 @@ dependencies = [
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build 0.13.2",
+ "sc-block-builder",
  "sc-client-api 28.0.0",
  "sc-network 0.34.0",
  "sc-network-types 0.10.0",
  "sp-blockchain 28.0.0",
+ "sp-consensus 0.32.0",
  "sp-core 28.0.0",
  "sp-runtime 31.0.1",
+ "substrate-test-runtime-client",
  "thiserror 1.0.65",
 ]
 
@@ -22008,13 +22011,16 @@ dependencies = [
 name = "sc-network-test"
 version = "0.8.0"
 dependencies = [
+ "array-bytes 6.2.2",
  "async-channel 1.9.0",
  "async-trait",
  "futures",
  "futures-timer",
  "libp2p",
  "log",
+ "parity-scale-codec",
  "parking_lot 0.12.3",
+ "prost 0.12.6",
  "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api 28.0.0",

--- a/prdoc/pr_12644.prdoc
+++ b/prdoc/pr_12644.prdoc
@@ -1,0 +1,24 @@
+title: Serve light-client extrinsics-trie inclusion proof requests (RFC-0174)
+
+doc:
+- audience: Node Dev
+  description: |-
+    Implements the full-node side of RFC-0174: a new light-client network request,
+    `RemoteReadExtrinsicsRequest`, that returns every leaf of a block's extrinsics trie —
+    each extrinsic verbatim if its encoded length is below the trie's inline-value threshold
+    (33 bytes under trie `state_version` 1), or its hash otherwise. A light client can feed
+    the returned leaves into the same ordered-trie-root construction the runtime uses and
+    compare the result against the `extrinsics_root` in the block header, giving it a
+    trustless proof of inclusion (or non-inclusion) of a transaction, together with its
+    index, without downloading the block body.
+
+    The light-client request-response protocol name is bumped from `/light/2` to `/light/3`
+    to make support for the new request discoverable via multistream-select; `/light/2` is
+    kept as a fallback name, and all pre-existing request types continue to work unchanged
+    on both names.
+
+crates:
+- name: sc-network-light
+  bump: minor
+- name: sc-network
+  bump: none

--- a/substrate/client/network/README.md
+++ b/substrate/client/network/README.md
@@ -106,10 +106,12 @@ more details.
 requests for information about blocks. Each request is the encoding of a `BlockRequest` and
 each response is the encoding of a `BlockResponse`, as defined in the `api.v1.proto` file in
 this source tree.
-- **`/<protocol-id>/light/2`** is a request-response protocol (see below) that lets one perform
-light-client-related requests for information about the state. Each request is the encoding of
-a `light::Request` and each response is the encoding of a `light::Response`, as defined in the
-`light.v1.proto` file in this source tree.
+- **`/<protocol-id>/light/3`** is a request-response protocol (see below) that lets one perform
+light-client-related requests for information about the state and about the extrinsics included
+in a block. Each request is the encoding of a `light::Request` and each response is the encoding
+of a `light::Response`, as defined in the `light.v1.proto` file in this source tree.
+`/<protocol-id>/light/2` is also accepted as a fallback for peers that don't know about the
+`RemoteReadExtrinsicsRequest` request type introduced in `/light/3`.
 - **`/<protocol-id>/transactions/1`** is a notifications protocol (see below) where
 transactions are pushed to other nodes. The handshake is empty on both sides. The message
 format is a SCALE-encoded list of transactions, where each transaction is an opaque list of

--- a/substrate/client/network/light/Cargo.toml
+++ b/substrate/client/network/light/Cargo.toml
@@ -32,3 +32,8 @@ thiserror = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }
+
+[dev-dependencies]
+sc-block-builder = { workspace = true, default-features = true }
+sp-consensus = { workspace = true, default-features = true }
+substrate-test-runtime-client = { workspace = true }

--- a/substrate/client/network/light/src/lib.rs
+++ b/substrate/client/network/light/src/lib.rs
@@ -19,4 +19,4 @@
 //! Light client data structures of the networking layer.
 
 pub mod light_client_requests;
-mod schema;
+pub mod schema;

--- a/substrate/client/network/light/src/light_client_requests.rs
+++ b/substrate/client/network/light/src/light_client_requests.rs
@@ -28,13 +28,25 @@ use std::time::Duration;
 /// For incoming light client requests.
 pub mod handler;
 
-/// Generate the light client protocol name from the genesis hash and fork id.
-fn generate_protocol_name<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option<&str>) -> String {
+/// The version of the light client protocol under which all request types, including
+/// `RemoteReadExtrinsicsRequest`, are served.
+const PROTOCOL_VERSION: u32 = 3;
+
+/// The previous version of the light client protocol, kept as a fallback for peers that only
+/// know about the request types that predate `RemoteReadExtrinsicsRequest`.
+const LEGACY_PROTOCOL_VERSION: u32 = 2;
+
+/// Generate the light client protocol name from the genesis hash, fork id, and protocol version.
+fn generate_protocol_name<Hash: AsRef<[u8]>>(
+	genesis_hash: Hash,
+	fork_id: Option<&str>,
+	version: u32,
+) -> String {
 	let genesis_hash = genesis_hash.as_ref();
 	if let Some(fork_id) = fork_id {
-		format!("/{}/{}/light/2", array_bytes::bytes2hex("", genesis_hash), fork_id)
+		format!("/{}/{}/light/{}", array_bytes::bytes2hex("", genesis_hash), fork_id, version)
 	} else {
-		format!("/{}/light/2", array_bytes::bytes2hex("", genesis_hash))
+		format!("/{}/light/{}", array_bytes::bytes2hex("", genesis_hash), version)
 	}
 }
 
@@ -56,8 +68,11 @@ pub fn generate_protocol_config<
 	inbound_queue: async_channel::Sender<IncomingRequest>,
 ) -> N::RequestResponseProtocolConfig {
 	N::request_response_config(
-		generate_protocol_name(genesis_hash, fork_id).into(),
-		std::iter::once(generate_legacy_protocol_name(protocol_id).into()).collect(),
+		generate_protocol_name(&genesis_hash, fork_id, PROTOCOL_VERSION).into(),
+		vec![
+			generate_protocol_name(&genesis_hash, fork_id, LEGACY_PROTOCOL_VERSION).into(),
+			generate_legacy_protocol_name(protocol_id).into(),
+		],
 		1 * 1024 * 1024,
 		MAX_RESPONSE_SIZE,
 		Duration::from_secs(15),

--- a/substrate/client/network/light/src/light_client_requests/handler.rs
+++ b/substrate/client/network/light/src/light_client_requests/handler.rs
@@ -31,14 +31,17 @@ use sc_client_api::{BlockBackend, ProofProvider};
 use sc_network::{
 	config::ProtocolId,
 	request_responses::{IncomingRequest, OutgoingResponse},
-	NetworkBackend, ReputationChange,
+	NetworkBackend, ReputationChange, MAX_RESPONSE_SIZE,
 };
 use sc_network_types::PeerId;
 use sp_core::{
 	hexdisplay::HexDisplay,
-	storage::{ChildInfo, ChildType, PrefixedStorageKey},
+	storage::{ChildInfo, ChildType, PrefixedStorageKey, TRIE_VALUE_NODE_THRESHOLD},
 };
-use sp_runtime::traits::Block;
+use sp_runtime::{
+	traits::{Block, Hash, HashingFor, Header},
+	StateVersion,
+};
 use std::{marker::PhantomData, sync::Arc};
 
 const LOG_TARGET: &str = "light-client-request-handler";
@@ -157,6 +160,9 @@ where
 			},
 			Some(schema::v1::light::request::Request::RemoteReadChildRequest(r)) => {
 				self.on_remote_read_child_request(&peer, r)?
+			},
+			Some(schema::v1::light::request::Request::RemoteReadExtrinsicsRequest(r)) => {
+				self.on_remote_read_extrinsics_request(&peer, r)?
 			},
 			None => {
 				return Err(HandleRequestError::BadRequest("Remote request without request data."))
@@ -286,6 +292,104 @@ where
 			response: Some(schema::v1::light::response::Response::RemoteReadResponse(response)),
 		})
 	}
+
+	fn on_remote_read_extrinsics_request(
+		&mut self,
+		peer: &PeerId,
+		request: &schema::v1::light::RemoteReadExtrinsicsRequest,
+	) -> Result<schema::v1::light::Response, HandleRequestError> {
+		trace!("Remote read extrinsics request from {} at {:?}.", peer, request.block);
+
+		let block = Decode::decode(&mut request.block.as_ref())?;
+
+		let extrinsics = match self.client.block(block) {
+			Ok(Some(signed_block)) => {
+				let (header, extrinsics) = signed_block.block.deconstruct();
+				let encoded_extrinsics = extrinsics.iter().map(Encode::encode).collect();
+				let leaves = extrinsics_leaves::<HashingFor<B>>(
+					header.extrinsics_root(),
+					encoded_extrinsics,
+				);
+
+				if leaves.is_none() {
+					debug!(
+						"Extrinsics of block {:?} requested by {} don't reproduce the header's \
+						 extrinsics root under any trie version.",
+						request.block, peer,
+					);
+				}
+
+				leaves.map(|leaves| schema::v1::light::ExtrinsicsLeaves { leaves })
+			},
+			Ok(None) => None,
+			Err(error) => {
+				trace!(
+					"remote read extrinsics request from {} at {:?} failed with: {}",
+					peer,
+					request.block,
+					error,
+				);
+				None
+			},
+		};
+
+		let mut response = schema::v1::light::Response {
+			response: Some(schema::v1::light::response::Response::RemoteReadExtrinsicsResponse(
+				schema::v1::light::RemoteReadExtrinsicsResponse { extrinsics },
+			)),
+		};
+
+		// All-or-nothing: a payload that would exceed the maximum response size is replaced by
+		// an absent one, exactly like an unknown or pruned block, leaving the requester to fall
+		// back to downloading the block body.
+		if response.encoded_len() as u64 > MAX_RESPONSE_SIZE {
+			response.response =
+				Some(schema::v1::light::response::Response::RemoteReadExtrinsicsResponse(
+					schema::v1::light::RemoteReadExtrinsicsResponse { extrinsics: None },
+				));
+		}
+
+		Ok(response)
+	}
+}
+
+/// Compute the leaves of a block's extrinsics trie, as served in response to a
+/// [`schema::v1::light::RemoteReadExtrinsicsRequest`].
+///
+/// Under trie `state_version` 1, values of `TRIE_VALUE_NODE_THRESHOLD` bytes or more are
+/// represented in their trie node by their hash, so such extrinsics are served as their hash
+/// only; every other extrinsic is served verbatim.
+///
+/// Which trie `state_version` a block used for its `extrinsics_root` is not committed anywhere,
+/// so it is recovered by recomputing the ordered trie root from the body under each version and
+/// comparing it against the root from the header. This needs nothing beyond the header and the
+/// body, so it keeps working when the block's state has been pruned. Returns `None` if no
+/// version reproduces `extrinsics_root`.
+fn extrinsics_leaves<H: Hash>(
+	extrinsics_root: &H::Output,
+	encoded_extrinsics: Vec<Vec<u8>>,
+) -> Option<Vec<schema::v1::light::ExtrinsicLeaf>> {
+	let state_version = [StateVersion::V1, StateVersion::V0].into_iter().find(|version| {
+		H::ordered_trie_root(encoded_extrinsics.clone(), *version) == *extrinsics_root
+	})?;
+
+	Some(
+		encoded_extrinsics
+			.into_iter()
+			.map(|extrinsic| {
+				let value = if state_version == StateVersion::V1 &&
+					extrinsic.len() >= TRIE_VALUE_NODE_THRESHOLD as usize
+				{
+					schema::v1::light::extrinsic_leaf::Value::Hash(
+						<H as Hash>::hash(&extrinsic).as_ref().to_vec(),
+					)
+				} else {
+					schema::v1::light::extrinsic_leaf::Value::Raw(extrinsic)
+				};
+				schema::v1::light::ExtrinsicLeaf { value: Some(value) }
+			})
+			.collect(),
+	)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -313,5 +417,157 @@ fn fmt_keys(first: Option<&Vec<u8>>, last: Option<&Vec<u8>>) -> String {
 		}
 	} else {
 		String::from("n/a")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use futures::executor::block_on;
+	use sc_block_builder::BlockBuilderBuilder;
+	use schema::v1::light::extrinsic_leaf::Value;
+	use sp_consensus::BlockOrigin;
+	use sp_runtime::traits::BlakeTwo256;
+	use substrate_test_runtime_client::{
+		runtime::{currency::DOLLARS, Block, Transfer},
+		BlockBuilderExt, ClientBlockImportExt, DefaultTestClientBuilderExt, Sr25519Keyring,
+		TestClientBuilder, TestClientBuilderExt,
+	};
+
+	fn ordered_trie_root(extrinsics: &[Vec<u8>], version: StateVersion) -> sp_core::H256 {
+		BlakeTwo256::ordered_trie_root(extrinsics.to_vec(), version)
+	}
+
+	fn leaf_values(leaves: Vec<schema::v1::light::ExtrinsicLeaf>) -> Vec<Value> {
+		leaves.into_iter().map(|leaf| leaf.value.unwrap()).collect()
+	}
+
+	#[test]
+	fn empty_body_yields_empty_leaves() {
+		let root = ordered_trie_root(&[], StateVersion::V1);
+		assert_eq!(extrinsics_leaves::<BlakeTwo256>(&root, Vec::new()), Some(Vec::new()));
+	}
+
+	#[test]
+	fn small_extrinsics_are_served_verbatim() {
+		let extrinsics = vec![vec![1u8; 10], vec![2u8; 32]];
+		let root = ordered_trie_root(&extrinsics, StateVersion::V1);
+
+		let leaves = extrinsics_leaves::<BlakeTwo256>(&root, extrinsics.clone()).unwrap();
+		assert_eq!(
+			leaf_values(leaves),
+			vec![Value::Raw(extrinsics[0].clone()), Value::Raw(extrinsics[1].clone())],
+		);
+	}
+
+	#[test]
+	fn large_extrinsics_are_served_as_hashes() {
+		let extrinsics = vec![vec![1u8; 10], vec![2u8; 33], vec![3u8; 1024]];
+		let root = ordered_trie_root(&extrinsics, StateVersion::V1);
+
+		let leaves = extrinsics_leaves::<BlakeTwo256>(&root, extrinsics.clone()).unwrap();
+		assert_eq!(
+			leaf_values(leaves),
+			vec![
+				Value::Raw(extrinsics[0].clone()),
+				Value::Hash(BlakeTwo256::hash(&extrinsics[1]).as_ref().to_vec()),
+				Value::Hash(BlakeTwo256::hash(&extrinsics[2]).as_ref().to_vec()),
+			],
+		);
+	}
+
+	#[test]
+	fn state_version_0_extrinsics_are_served_verbatim() {
+		let extrinsics = vec![vec![1u8; 33], vec![2u8; 1024]];
+		let root = ordered_trie_root(&extrinsics, StateVersion::V0);
+
+		let leaves = extrinsics_leaves::<BlakeTwo256>(&root, extrinsics.clone()).unwrap();
+		assert_eq!(
+			leaf_values(leaves),
+			vec![Value::Raw(extrinsics[0].clone()), Value::Raw(extrinsics[1].clone())],
+		);
+	}
+
+	#[test]
+	fn mismatching_extrinsics_root_yields_none() {
+		let extrinsics = vec![vec![1u8; 10]];
+		let root = ordered_trie_root(&[vec![2u8; 10]], StateVersion::V1);
+
+		assert_eq!(extrinsics_leaves::<BlakeTwo256>(&root, extrinsics), None);
+	}
+
+	fn handler(
+		client: Arc<substrate_test_runtime_client::TestClient>,
+	) -> LightClientRequestHandler<Block, substrate_test_runtime_client::TestClient> {
+		let (_tx, request_receiver) = async_channel::bounded(1);
+		LightClientRequestHandler { request_receiver, client, _block: PhantomData }
+	}
+
+	fn remote_read_extrinsics(
+		handler: &mut LightClientRequestHandler<Block, substrate_test_runtime_client::TestClient>,
+		block: sp_core::H256,
+	) -> schema::v1::light::RemoteReadExtrinsicsResponse {
+		let request = schema::v1::light::Request {
+			request: Some(schema::v1::light::request::Request::RemoteReadExtrinsicsRequest(
+				schema::v1::light::RemoteReadExtrinsicsRequest { block: block.encode() },
+			)),
+		};
+
+		let response = handler
+			.handle_request(PeerId::random(), request.encode_to_vec())
+			.expect("request is valid; qed");
+		let response = schema::v1::light::Response::decode(&response[..]).unwrap();
+		match response.response {
+			Some(schema::v1::light::response::Response::RemoteReadExtrinsicsResponse(r)) => r,
+			response => panic!("unexpected response: {response:?}"),
+		}
+	}
+
+	#[test]
+	fn serves_extrinsics_leaves_of_imported_blocks() {
+		let client = TestClientBuilder::new().build();
+
+		let mut builder = BlockBuilderBuilder::new(&client)
+			.on_parent_block(client.chain_info().genesis_hash)
+			.with_parent_block_number(0)
+			.build()
+			.unwrap();
+		builder
+			.push_transfer(Transfer {
+				from: Sr25519Keyring::Alice.into(),
+				to: Sr25519Keyring::Ferdie.into(),
+				amount: 42 * DOLLARS,
+				nonce: 0,
+			})
+			.unwrap();
+		builder
+			.push_transfer(Transfer {
+				from: Sr25519Keyring::Bob.into(),
+				to: Sr25519Keyring::Ferdie.into(),
+				amount: 24 * DOLLARS,
+				nonce: 0,
+			})
+			.unwrap();
+		let block = builder.build().unwrap().block;
+		let block_hash = block.header.hash();
+		let extrinsics = block.extrinsics.clone();
+		block_on(client.import(BlockOrigin::Own, block)).unwrap();
+
+		let mut handler = handler(Arc::new(client));
+		let response = remote_read_extrinsics(&mut handler, block_hash);
+
+		// The test runtime computes its extrinsics root with trie `state_version` 0, so every
+		// extrinsic is served verbatim, regardless of its size.
+		assert_eq!(
+			leaf_values(response.extrinsics.unwrap().leaves),
+			extrinsics.iter().map(|xt| Value::Raw(xt.encode())).collect::<Vec<_>>(),
+		);
+	}
+
+	#[test]
+	fn unknown_block_yields_absent_extrinsics() {
+		let mut handler = handler(Arc::new(TestClientBuilder::new().build()));
+		let response = remote_read_extrinsics(&mut handler, sp_core::H256::repeat_byte(0xab));
+		assert_eq!(response.extrinsics, None);
 	}
 }

--- a/substrate/client/network/light/src/schema.rs
+++ b/substrate/client/network/light/src/schema.rs
@@ -18,8 +18,8 @@
 
 //! Include sources generated from protobuf definitions.
 
-pub(crate) mod v1 {
-	pub(crate) mod light {
+pub mod v1 {
+	pub mod light {
 		include!(concat!(env!("OUT_DIR"), "/api.v1.light.rs"));
 	}
 }

--- a/substrate/client/network/light/src/schema/light.v1.proto
+++ b/substrate/client/network/light/src/schema/light.v1.proto
@@ -11,6 +11,8 @@ message Request {
 		RemoteReadRequest remote_read_request = 2;
 		RemoteReadChildRequest remote_read_child_request = 4;
 		// Note: ids 3 and 5 were used in the past. It would be preferable to not re-use them.
+		// Note: id 6 is used by the (currently unimplemented) RFC-0009's RemoteReadRequestV2.
+		RemoteReadExtrinsicsRequest remote_read_extrinsics_request = 7;
 	}
 }
 
@@ -20,6 +22,7 @@ message Response {
 		RemoteCallResponse remote_call_response = 1;
 		RemoteReadResponse remote_read_response = 2;
 		// Note: ids 3 and 4 were used in the past. It would be preferable to not re-use them.
+		RemoteReadExtrinsicsResponse remote_read_extrinsics_response = 5;
 	}
 }
 
@@ -53,6 +56,36 @@ message RemoteReadResponse {
 	// Read proof. If missing, indicates that the remote couldn't answer, for example because
 	// the block is pruned.
 	optional bytes proof = 2;
+}
+
+// Remote read request for a block's extrinsics-trie leaves.
+message RemoteReadExtrinsicsRequest {
+	// Hash of the block whose extrinsics-trie leaves are requested.
+	required bytes block = 1;
+}
+
+// Remote read response carrying every leaf of a block's extrinsics trie,
+// in order, letting the requester reconstruct the trie root itself.
+message RemoteReadExtrinsicsResponse {
+	// Absent if the block is unknown, pruned, or the payload would exceed
+	// the maximum response size.
+	optional ExtrinsicsLeaves extrinsics = 1;
+}
+
+message ExtrinsicsLeaves {
+	// One entry per extrinsic in the block, in the order they appear in
+	// the body. May be empty, for a block with no extrinsics.
+	repeated ExtrinsicLeaf leaves = 1;
+}
+
+message ExtrinsicLeaf {
+	oneof value {
+		// The full SCALE-encoded extrinsic, sent whenever its encoded
+		// length is below the extrinsics trie's inline-value threshold.
+		bytes raw = 1;
+		// The hash of the SCALE-encoded extrinsic, sent otherwise.
+		bytes hash = 2;
+	}
 }
 
 // Remote storage read child request.

--- a/substrate/client/network/src/lib.rs
+++ b/substrate/client/network/src/lib.rs
@@ -127,10 +127,12 @@
 //! requests for information about blocks. Each request is the encoding of a `BlockRequest` and
 //! each response is the encoding of a `BlockResponse`, as defined in the `api.v1.proto` file in
 //! this source tree.
-//! - **`/<protocol-id>/light/2`** is a request-response protocol (see below) that lets one perform
-//! light-client-related requests for information about the state. Each request is the encoding of
-//! a `light::Request` and each response is the encoding of a `light::Response`, as defined in the
-//! `light.v1.proto` file in this source tree.
+//! - **`/<protocol-id>/light/3`** is a request-response protocol (see below) that lets one perform
+//! light-client-related requests for information about the state and about the extrinsics
+//! included in a block. Each request is the encoding of a `light::Request` and each response is
+//! the encoding of a `light::Response`, as defined in the `light.v1.proto` file in this source
+//! tree. `/<protocol-id>/light/2` is also accepted as a fallback for peers that don't know about
+//! the `RemoteReadExtrinsicsRequest` request type introduced in `/light/3`.
 //! - **`/<protocol-id>/transactions/1`** is a notifications protocol (see below) where
 //! transactions are pushed to other nodes. The handshake is empty on both sides. The message
 //! format is a SCALE-encoded list of transactions, where each transaction is an opaque list of

--- a/substrate/client/network/test/Cargo.toml
+++ b/substrate/client/network/test/Cargo.toml
@@ -16,13 +16,16 @@ workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+array-bytes = { workspace = true, default-features = true }
 async-channel = { workspace = true }
 async-trait = { workspace = true }
+codec = { features = ["derive"], workspace = true, default-features = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 libp2p = { workspace = true }
 log = { workspace = true, default-features = true }
 parking_lot = { workspace = true, default-features = true }
+prost = { workspace = true }
 rand = { workspace = true, default-features = true }
 sc-block-builder = { workspace = true, default-features = true }
 sc-client-api = { workspace = true, default-features = true }

--- a/substrate/client/network/test/src/service.rs
+++ b/substrate/client/network/test/src/service.rs
@@ -18,17 +18,22 @@
 
 use futures::prelude::*;
 
+use codec::Encode;
+use prost::Message;
+use sc_block_builder::BlockBuilderBuilder;
 use sc_consensus::{ImportQueue, Link};
 use sc_network::{
 	config::{self, FullNetworkConfiguration, MultiaddrWithPeerId, ProtocolId, TransportConfig},
 	event::Event,
 	peer_store::{PeerStore, PeerStoreProvider},
 	service::traits::{NotificationEvent, ValidationResult},
-	Multiaddr, NetworkEventStream, NetworkPeers, NetworkService, NetworkStateInfo, NetworkWorker,
-	NotificationMetrics, NotificationService, PeerId,
+	IfDisconnected, Multiaddr, NetworkEventStream, NetworkPeers, NetworkRequest, NetworkService,
+	NetworkStateInfo, NetworkWorker, NotificationMetrics, NotificationService, PeerId,
 };
 use sc_network_common::role::Roles;
-use sc_network_light::light_client_requests::handler::LightClientRequestHandler;
+use sc_network_light::{
+	light_client_requests::handler::LightClientRequestHandler, schema::v1::light as light_schema,
+};
 use sc_network_sync::{
 	block_request_handler::BlockRequestHandler,
 	engine::SyncingEngine,
@@ -37,10 +42,15 @@ use sc_network_sync::{
 	strategy::polkadot::{PolkadotSyncingStrategy, PolkadotSyncingStrategyConfig},
 };
 use sp_blockchain::HeaderBackend;
-use sp_runtime::traits::{Block as BlockT, Zero};
+use sp_consensus::BlockOrigin;
+use sp_runtime::{
+	traits::{BlakeTwo256, Block as BlockT, Hash as HashT, Header as HeaderT, Zero},
+	StateVersion,
+};
 use substrate_test_runtime_client::{
-	runtime::{Block as TestBlock, Hash as TestHash},
-	TestClientBuilder, TestClientBuilderExt as _,
+	runtime::{currency::DOLLARS, Block as TestBlock, Hash as TestHash, Transfer},
+	BlockBuilderExt, ClientBlockImportExt, Sr25519Keyring, TestClientBuilder,
+	TestClientBuilderExt as _,
 };
 
 use std::{sync::Arc, time::Duration};
@@ -102,6 +112,11 @@ impl TestNetworkBuilder {
 		self
 	}
 
+	pub fn with_client(mut self, client: Arc<substrate_test_runtime_client::TestClient>) -> Self {
+		self.client = Some(client);
+		self
+	}
+
 	pub fn with_notification_protocol(mut self, config: config::NonDefaultSetConfig) -> Self {
 		self.notification_protocols.push(config);
 		self
@@ -118,10 +133,9 @@ impl TestNetworkBuilder {
 	}
 
 	pub fn build(mut self) -> (TestNetwork, Option<Box<dyn NotificationService>>) {
-		let client = self.client.as_mut().map_or(
-			Arc::new(TestClientBuilder::with_default_backend().build_with_longest_chain().0),
-			|v| v.clone(),
-		);
+		let client = self.client.take().unwrap_or_else(|| {
+			Arc::new(TestClientBuilder::with_default_backend().build_with_longest_chain().0)
+		});
 
 		let network_config = self.config.unwrap_or(config::NetworkConfiguration {
 			listen_addresses: self.listen_addresses,
@@ -849,4 +863,115 @@ async fn ensure_public_addresses_consistent_with_transport_not_memory() {
 		.build()
 		.0
 		.start_network();
+}
+
+/// The full-node side of [RFC-0174]: a peer can request every leaf of a block's extrinsics trie
+/// over the `/light/3` request-response protocol, recompute the trie root from them, and verify
+/// it against the `extrinsics_root` of the block's header, confirming inclusion (and index) of a
+/// tracked extrinsic without ever downloading the block body.
+///
+/// [RFC-0174]: https://github.com/polkadot-fellows/RFCs/pull/174
+#[tokio::test]
+async fn remote_read_extrinsics_request_works() {
+	let client = Arc::new(TestClientBuilder::with_default_backend().build_with_longest_chain().0);
+
+	let mut builder = BlockBuilderBuilder::new(&*client)
+		.on_parent_block(client.chain_info().genesis_hash)
+		.with_parent_block_number(0)
+		.build()
+		.unwrap();
+	builder
+		.push_transfer(Transfer {
+			from: Sr25519Keyring::Alice.into(),
+			to: Sr25519Keyring::Ferdie.into(),
+			amount: 42 * DOLLARS,
+			nonce: 0,
+		})
+		.unwrap();
+	let block = builder.build().unwrap().block;
+	let header = block.header.clone();
+	let tracked_extrinsic = block.extrinsics[0].encode();
+	client.import(BlockOrigin::Own, block).await.unwrap();
+
+	// Node 1 has the block; node 2 requests the leaves of its extrinsics trie from node 1.
+	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
+	let (network1, _) = TestNetworkBuilder::new()
+		.with_client(client.clone())
+		.with_listen_addresses(vec![listen_addr.clone()])
+		.build();
+	let (node1, _) = network1.start_network();
+
+	let (network2, _) = TestNetworkBuilder::new()
+		.with_set_config(config::SetConfig {
+			reserved_nodes: vec![MultiaddrWithPeerId {
+				multiaddr: listen_addr,
+				peer_id: node1.local_peer_id(),
+			}],
+			..Default::default()
+		})
+		.build();
+	let (node2, _) = network2.start_network();
+
+	// The name the light client request handler is registered under in `TestNetworkBuilder`:
+	// no fork id is passed to `LightClientRequestHandler::new`.
+	let protocol_name = format!(
+		"/{}/light/3",
+		array_bytes::bytes2hex("", client.chain_info().genesis_hash.as_ref()),
+	);
+	let request = light_schema::Request {
+		request: Some(light_schema::request::Request::RemoteReadExtrinsicsRequest(
+			light_schema::RemoteReadExtrinsicsRequest { block: header.hash().encode() },
+		)),
+	};
+
+	// Node 2 discovers node 1's address asynchronously, through the reserved-peer set, so
+	// retry until the request can be dialed.
+	let response = tokio::time::timeout(Duration::from_secs(30), async {
+		loop {
+			match node2
+				.request(
+					node1.local_peer_id(),
+					protocol_name.clone().into(),
+					request.encode_to_vec(),
+					None,
+					IfDisconnected::TryConnect,
+				)
+				.await
+			{
+				Ok((response, _)) => break response,
+				Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+			}
+		}
+	})
+	.await
+	.expect("node 2 connects to node 1 and the request succeeds; qed");
+
+	let response = light_schema::Response::decode(&response[..]).unwrap();
+	let leaves = match response.response {
+		Some(light_schema::response::Response::RemoteReadExtrinsicsResponse(response)) => {
+			response.extrinsics.expect("block is known to node 1; qed").leaves
+		},
+		response => panic!("unexpected response: {response:?}"),
+	};
+
+	// Verify the response the way a light client would: recompute the ordered trie root from the
+	// leaves and compare it against the `extrinsics_root` of the independently verified header.
+	// The test runtime computes its extrinsics root with trie `state_version` 0, so every leaf
+	// carries a full extrinsic.
+	let extrinsics = leaves
+		.into_iter()
+		.map(|leaf| match leaf.value.expect("leaf value is always set; qed") {
+			light_schema::extrinsic_leaf::Value::Raw(extrinsic) => extrinsic,
+			light_schema::extrinsic_leaf::Value::Hash(hash) => {
+				panic!("state_version 0 trie inlines all values, but got a hash: {hash:?}")
+			},
+		})
+		.collect::<Vec<_>>();
+	assert_eq!(
+		BlakeTwo256::ordered_trie_root(extrinsics.clone(), StateVersion::V0),
+		*header.extrinsics_root(),
+	);
+
+	// The verified list proves inclusion of the tracked extrinsic, and its index.
+	assert_eq!(extrinsics.iter().position(|extrinsic| *extrinsic == tracked_extrinsic), Some(0),);
 }


### PR DESCRIPTION
# Description

Implements the full-node (responding) side of [RFC-0174: Light client extrinsics-trie inclusion proof request](https://github.com/polkadot-fellows/RFCs/pull/174).

A new light-client network request, `RemoteReadExtrinsicsRequest`, lets a light client ask a full node for every leaf of a block's extrinsics trie: each extrinsic verbatim if its SCALE-encoded length is below the trie's inline-value threshold (`sp_core::storage::TRIE_VALUE_NODE_THRESHOLD`, 33 bytes), or just its 32-byte hash otherwise, mirroring, one-to-one, what a trie `state_version` 1 leaf itself contains. The light client feeds the leaves into the same `ordered_trie_root` construction the runtime uses and compares the result against the `extrinsics_root` already present in the (independently verified) block header. A match proves the entire ordered `(index, extrinsic hash)` list in one step, giving trustless inclusion *and* non-inclusion proofs, plus the extrinsic's index, without downloading the block body.

The light-client request-response protocol name is bumped from `/light/2` to `/light/3` so peers can discover support for the new request upfront via multistream-select. The genesis-based `/light/2` name and the legacy `ProtocolId`-based name are kept as fallbacks; all pre-existing request types keep working unchanged under every name.

## Integration

Purely additive; no action needed by downstream projects.

- `sc-network-light` (minor): new `RemoteReadExtrinsicsRequest` / `RemoteReadExtrinsicsResponse` messages in `light.v1.proto`, served by `LightClientRequestHandler`; the `schema` module is now `pub` so requester implementations can construct the wire messages (same as `sc-network-sync`, which re-exports its schema). `generate_protocol_config`'s signature is unchanged.
- `sc-network`: doc-only update of the protocol listing (`/light/2` -> `/light/3` + fallback note).
- Chains that haven't adopted `system_version = 2` (RFC-0042) remain fully compatible: the request still works and verifies, it just serves every extrinsic verbatim, so it doesn't get the bandwidth benefit.

## Review Notes

- **Wire format**: field numbers follow the RFC exactly, `remote_read_extrinsics_request = 7` on `Request` (ids 3/5 deprecated, 6 reserved for RFC-0009's `RemoteReadRequestV2`), `remote_read_extrinsics_response = 5` on `Response` (ids 3/4 deprecated).
- **State-version detection**: which trie `state_version` a block used for its `extrinsics_root` is not committed anywhere, so the handler recovers it by recomputing the ordered trie root from the body under V1, then V0, and comparing with the header (`extrinsics_leaves` in `handler.rs`). This was chosen over querying `CallApiAt::runtime_version_at(parent)` deliberately: it needs nothing beyond header + body, so it keeps working when the parent's *state* has been pruned (bodies are retained far longer than state on default-pruned full nodes), it adds no new trait bounds or `sp-api` dependency to `sc-network-light`, and it guarantees the node never serves leaves that wouldn't verify. The V1-then-V0 order is sound because the two roots only differ when some value is ≥ 33 bytes, in which case leaves differ too; when they coincide, either choice yields identical (all-verbatim) leaves.
- **All-or-nothing size cap**: per the RFC, a response that would exceed `MAX_RESPONSE_SIZE` (16 MiB) is replaced by an absent `extrinsics`, indistinguishable from an unknown/pruned block, so the requester falls back to a body download. The check measures the encoded outer `Response`, i.e. exactly what goes on the wire.
- **Unknown, pruned, or root-mismatching blocks** absent `extrinsics` (never an error), per the RFC.
- **Tests** (the RFC's minimum matrix): unit tests for empty body, small-only, mixed small/large under V1, V0 blocks, and root mismatch; handler-level tests against a real client (imported block with transfers, unknown block); and an end-to-end test in `sc-network-test` where a peer fetches the leaves over the real libp2p `/light/3` substream, recomputes the root, verifies it against the header, and confirms inclusion + index of a tracked extrinsic without ever requesting the block body.