### PR TITLE
[pallet-revive] Charge EVM memory-expansion gas

### DIFF
--- a/prdoc/pr_12646.prdoc
+++ b/prdoc/pr_12646.prdoc
@@ -1,0 +1,20 @@
+title: '[pallet-revive] Charge EVM memory-expansion gas'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Fixes https://github.com/paritytech/polkadot-sdk/issues/12640
+
+    The EVM interpreter grew memory without charging Ethereum's quadratic
+    memory-expansion cost (`3 * words + words^2 / 512`): every memory-touching
+    opcode only paid its fixed cost, so memory could be expanded almost for free
+    and gas accounting diverged from Ethereum (breaking `eth_estimateGas` parity).
+
+    Memory growth is now routed through a single `Interpreter::resize_memory`
+    helper that charges the expansion cost for the delta between the current and
+    new word count before resizing, matching `revm`. This covers `MLOAD`,
+    `MSTORE`, `MSTORE8`, `MCOPY`, `CODECOPY`, `CALLDATACOPY`, `RETURNDATACOPY`,
+    `EXTCODECOPY`, `KECCAK256`, `RETURN`/`REVERT`, and the CALL/CREATE memory
+    ranges.
+crates:
+- name: pallet-revive
+  bump: patch

--- a/substrate/frame/revive/src/exec/mock_ext.rs
+++ b/substrate/frame/revive/src/exec/mock_ext.rs
@@ -43,8 +43,14 @@ pub struct MockExt<T: Config> {
 
 impl<T: Config> MockExt<T> {
 	pub fn new() -> Self {
+		Self::with_weight_limit(Weight::MAX)
+	}
+
+	/// Like [`Self::new`] but caps the frame's weight budget, so charges beyond `weight_limit`
+	/// halt with `OutOfGas`.
+	pub fn with_weight_limit(weight_limit: Weight) -> Self {
 		let transaction_meter = TransactionMeter::new(TransactionLimits::WeightAndDeposit {
-			weight_limit: Weight::MAX,
+			weight_limit,
 			deposit_limit: BalanceOf::<T>::max_value(),
 		})
 		.unwrap();

--- a/substrate/frame/revive/src/vm/evm/instructions/contract.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/contract.rs
@@ -63,7 +63,7 @@ pub fn create<const IS_CREATE2: bool, E: Ext>(
 		}
 
 		let code_offset = as_usize_or_halt::<E::T>(code_offset)?;
-		interpreter.memory.resize(code_offset, len)?;
+		interpreter.resize_memory(code_offset, len)?;
 		code = interpreter.memory.slice_len(code_offset, len).to_vec();
 	}
 

--- a/substrate/frame/revive/src/vm/evm/instructions/contract/call_helpers.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/contract/call_helpers.rs
@@ -47,7 +47,7 @@ pub fn resize_memory<'a, E: Ext>(
 	let len = as_usize_or_halt::<E::T>(len)?;
 	if len != 0 {
 		let offset = as_usize_or_halt::<E::T>(offset)?;
-		interpreter.memory.resize(offset, len)?;
+		interpreter.resize_memory(offset, len)?;
 		ControlFlow::Continue(offset..offset + len)
 	} else {
 		// unrealistic value so we are sure it is not used

--- a/substrate/frame/revive/src/vm/evm/instructions/control.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/control.rs
@@ -101,7 +101,7 @@ fn return_inner<E: Ext>(
 	let mut output = Default::default();
 	if len != 0 {
 		let offset = as_usize_or_halt::<E::T>(offset)?;
-		interpreter.memory.resize(offset, len)?;
+		interpreter.resize_memory(offset, len)?;
 		output = interpreter.memory.slice_len(offset, len).to_vec()
 	}
 

--- a/substrate/frame/revive/src/vm/evm/instructions/host.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/host.rs
@@ -86,7 +86,7 @@ pub fn extcodecopy<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt
 	let memory_offset = as_usize_or_halt::<E::T>(memory_offset)?;
 	let code_offset = as_usize_or_halt::<E::T>(code_offset)?;
 
-	interpreter.memory.resize(memory_offset, len)?;
+	interpreter.resize_memory(memory_offset, len)?;
 
 	let mut buf = interpreter.memory.slice_mut(memory_offset, len);
 	// Note: This can't panic because we resized memory to fit.
@@ -265,7 +265,7 @@ pub fn log<'ext, const N: usize, E: Ext>(
 		Vec::new()
 	} else {
 		let offset = as_usize_or_halt::<E::T>(offset)?;
-		interpreter.memory.resize(offset, len)?;
+		interpreter.resize_memory(offset, len)?;
 		interpreter.memory.slice(offset..offset + len).to_vec()
 	};
 	if interpreter.stack.len() < N {

--- a/substrate/frame/revive/src/vm/evm/instructions/memory.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/memory.rs
@@ -30,11 +30,11 @@ use revm::interpreter::gas::{BASE, VERYLOW, copy_cost_verylow};
 /// Loads a 32-byte word from memory.
 pub fn mload<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> {
 	interpreter.ext.charge_or_halt(EVMGas(VERYLOW))?;
-	let ([], top) = interpreter.stack.popn_top()?;
-	let offset = as_usize_or_halt::<E::T>(*top)?;
-	interpreter.memory.resize(offset, 32)?;
-	*top = U256::from_big_endian(interpreter.memory.slice_len(offset, 32));
-	ControlFlow::Continue(())
+	let [offset] = interpreter.stack.popn()?;
+	let offset = as_usize_or_halt::<E::T>(offset)?;
+	interpreter.resize_memory(offset, 32)?;
+	let value = U256::from_big_endian(interpreter.memory.slice_len(offset, 32));
+	interpreter.stack.push(value)
 }
 
 /// Implements the MSTORE instruction.
@@ -44,7 +44,7 @@ pub fn mstore<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> {
 	interpreter.ext.charge_or_halt(EVMGas(VERYLOW))?;
 	let [offset, value] = interpreter.stack.popn()?;
 	let offset = as_usize_or_halt::<E::T>(offset)?;
-	interpreter.memory.resize(offset, 32)?;
+	interpreter.resize_memory(offset, 32)?;
 	interpreter.memory.set(offset, &value.to_big_endian());
 	ControlFlow::Continue(())
 }
@@ -56,7 +56,7 @@ pub fn mstore8<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> {
 	interpreter.ext.charge_or_halt(EVMGas(VERYLOW))?;
 	let [offset, value] = interpreter.stack.popn()?;
 	let offset = as_usize_or_halt::<E::T>(offset)?;
-	interpreter.memory.resize(offset, 1)?;
+	interpreter.resize_memory(offset, 1)?;
 	interpreter.memory.set(offset, &[value.byte(0)]);
 	ControlFlow::Continue(())
 }
@@ -89,8 +89,55 @@ pub fn mcopy<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> {
 	let dst = as_usize_or_halt::<E::T>(dst)?;
 	let src = as_usize_or_halt::<E::T>(src)?;
 	// Resize memory
-	interpreter.memory.resize(max(dst, src), len)?;
+	interpreter.resize_memory(max(dst, src), len)?;
 	// Copy memory in place
 	interpreter.memory.copy(dst, src, len);
 	ControlFlow::Continue(())
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		exec::{PrecompileExt, mock_ext::MockExt},
+		precompiles::Token,
+		tests::Test,
+		vm::evm::{EVMGas, Interpreter},
+	};
+	use frame_support::weights::Weight;
+	use revm::interpreter::{gas::memory_gas, num_words};
+
+	/// Weight of `gas` EVM gas units under the `Test` runtime.
+	fn evm_gas_weight(gas: u64) -> Weight {
+		<EVMGas as Token<Test>>::weight(&EVMGas(gas))
+	}
+
+	// Growing memory must charge the quadratic `memory_gas` cost, not be free.
+	#[test]
+	fn memory_expansion_gas_is_charged() {
+		let mut ext = MockExt::<Test>::new();
+		let mut interpreter = Interpreter::new(Default::default(), vec![], &mut ext);
+
+		// 64 KiB == 2048 words == 14_336 gas, matching Ethereum.
+		let len = 64 * 1024;
+		let words = num_words(len);
+		assert_eq!(memory_gas(words), 14_336);
+
+		let before = interpreter.ext.frame_meter().weight_consumed();
+		assert!(interpreter.resize_memory(0, len).is_continue());
+		let charged = interpreter.ext.frame_meter().weight_consumed().saturating_sub(before);
+
+		assert_eq!(charged, evm_gas_weight(memory_gas(words)));
+		assert!(charged.ref_time() > 0);
+
+		// Re-touching allocated memory is free.
+		let before = interpreter.ext.frame_meter().weight_consumed();
+		assert!(interpreter.resize_memory(0, len).is_continue());
+		assert_eq!(interpreter.ext.frame_meter().weight_consumed(), before);
+
+		// Super-linear: doubling the size costs more than the first half.
+		let before = interpreter.ext.frame_meter().weight_consumed();
+		assert!(interpreter.resize_memory(0, 2 * len).is_continue());
+		let second_half = interpreter.ext.frame_meter().weight_consumed().saturating_sub(before);
+		assert!(second_half.ref_time() > charged.ref_time());
+	}
 }

--- a/substrate/frame/revive/src/vm/evm/instructions/memory.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/memory.rs
@@ -97,18 +97,32 @@ pub fn mcopy<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> {
 
 #[cfg(test)]
 mod tests {
+	use super::mstore;
 	use crate::{
+		Error,
 		exec::{PrecompileExt, mock_ext::MockExt},
 		precompiles::Token,
 		tests::Test,
-		vm::evm::{EVMGas, Interpreter},
+		vm::evm::{
+			EVMGas, Interpreter,
+			instructions::{contract::get_memory_in_and_out_ranges, system::calldatacopy},
+			interpreter::Halt,
+		},
 	};
+	use core::ops::ControlFlow;
 	use frame_support::weights::Weight;
 	use revm::interpreter::{gas::memory_gas, num_words};
+
+	/// Writing 32 bytes here grows memory to exactly 64 KiB (2048 words, 14_336 gas).
+	const EXPAND_OFFSET: usize = 0xFFE0;
 
 	/// Weight of `gas` EVM gas units under the `Test` runtime.
 	fn evm_gas_weight(gas: u64) -> Weight {
 		<EVMGas as Token<Test>>::weight(&EVMGas(gas))
+	}
+
+	fn weight_consumed(interpreter: &Interpreter<MockExt<Test>>) -> Weight {
+		interpreter.ext.frame_meter().weight_consumed()
 	}
 
 	// Growing memory must charge the quadratic `memory_gas` cost, not be free.
@@ -122,22 +136,115 @@ mod tests {
 		let words = num_words(len);
 		assert_eq!(memory_gas(words), 14_336);
 
-		let before = interpreter.ext.frame_meter().weight_consumed();
+		let before = weight_consumed(&interpreter);
 		assert!(interpreter.resize_memory(0, len).is_continue());
-		let charged = interpreter.ext.frame_meter().weight_consumed().saturating_sub(before);
+		let charged = weight_consumed(&interpreter).saturating_sub(before);
 
 		assert_eq!(charged, evm_gas_weight(memory_gas(words)));
 		assert!(charged.ref_time() > 0);
 
 		// Re-touching allocated memory is free.
-		let before = interpreter.ext.frame_meter().weight_consumed();
+		let before = weight_consumed(&interpreter);
 		assert!(interpreter.resize_memory(0, len).is_continue());
-		assert_eq!(interpreter.ext.frame_meter().weight_consumed(), before);
+		assert_eq!(weight_consumed(&interpreter), before);
 
 		// Super-linear: doubling the size costs more than the first half.
-		let before = interpreter.ext.frame_meter().weight_consumed();
+		let before = weight_consumed(&interpreter);
 		assert!(interpreter.resize_memory(0, 2 * len).is_continue());
-		let second_half = interpreter.ext.frame_meter().weight_consumed().saturating_sub(before);
+		let second_half = weight_consumed(&interpreter).saturating_sub(before);
 		assert!(second_half.ref_time() > charged.ref_time());
+	}
+
+	// MSTORE resizes directly; re-touching isolates the expansion from the fixed opcode cost.
+	#[test]
+	fn mstore_charges_memory_expansion_gas() {
+		let mut ext = MockExt::<Test>::new();
+		let mut interpreter = Interpreter::new(Default::default(), vec![], &mut ext);
+		let words = num_words(EXPAND_OFFSET + 32);
+
+		let push = |interpreter: &mut Interpreter<MockExt<Test>>| {
+			assert!(interpreter.stack.push(0u64).is_continue());
+			assert!(interpreter.stack.push(EXPAND_OFFSET as u64).is_continue());
+		};
+
+		push(&mut interpreter);
+		let before = weight_consumed(&interpreter);
+		assert!(mstore(&mut interpreter).is_continue());
+		let fresh = weight_consumed(&interpreter).saturating_sub(before);
+
+		push(&mut interpreter);
+		let before = weight_consumed(&interpreter);
+		assert!(mstore(&mut interpreter).is_continue());
+		let retouch = weight_consumed(&interpreter).saturating_sub(before);
+
+		assert_eq!(fresh.saturating_sub(retouch), evm_gas_weight(memory_gas(words)));
+	}
+
+	// CALLDATACOPY reaches `resize_memory` through the `system::memory_resize` helper.
+	#[test]
+	fn calldatacopy_charges_memory_expansion_gas() {
+		let mut ext = MockExt::<Test>::new();
+		let mut interpreter = Interpreter::new(Default::default(), vec![0u8; 32], &mut ext);
+		let len = 32usize;
+		let words = num_words(EXPAND_OFFSET + len);
+
+		let push = |interpreter: &mut Interpreter<MockExt<Test>>| {
+			assert!(interpreter.stack.push(len as u64).is_continue());
+			assert!(interpreter.stack.push(0u64).is_continue());
+			assert!(interpreter.stack.push(EXPAND_OFFSET as u64).is_continue());
+		};
+
+		push(&mut interpreter);
+		let before = weight_consumed(&interpreter);
+		assert!(calldatacopy(&mut interpreter).is_continue());
+		let fresh = weight_consumed(&interpreter).saturating_sub(before);
+
+		push(&mut interpreter);
+		let before = weight_consumed(&interpreter);
+		assert!(calldatacopy(&mut interpreter).is_continue());
+		let retouch = weight_consumed(&interpreter).saturating_sub(before);
+
+		assert_eq!(fresh.saturating_sub(retouch), evm_gas_weight(memory_gas(words)));
+	}
+
+	// CALL resizes both its input and return ranges; the charge covers up to the highest word.
+	#[test]
+	fn call_ranges_charge_memory_expansion_gas() {
+		let mut ext = MockExt::<Test>::new();
+		let mut interpreter = Interpreter::new(Default::default(), vec![], &mut ext);
+
+		// Input range ends at 32 KiB, return range ends at 64 KiB.
+		let (in_offset, in_len) = (0usize, 32 * 1024usize);
+		let (out_offset, out_len) = (EXPAND_OFFSET, 32usize);
+		let highest = core::cmp::max(in_offset + in_len, out_offset + out_len);
+		let words = num_words(highest);
+
+		assert!(interpreter.stack.push(out_len as u64).is_continue());
+		assert!(interpreter.stack.push(out_offset as u64).is_continue());
+		assert!(interpreter.stack.push(in_len as u64).is_continue());
+		assert!(interpreter.stack.push(in_offset as u64).is_continue());
+
+		let before = weight_consumed(&interpreter);
+		assert!(get_memory_in_and_out_ranges(&mut interpreter).is_continue());
+		let charged = weight_consumed(&interpreter).saturating_sub(before);
+
+		assert_eq!(charged, evm_gas_weight(memory_gas(words)));
+	}
+
+	// A budget covering only the base cost runs out on the expansion that used to be free.
+	#[test]
+	fn memory_bomb_runs_out_of_gas() {
+		let budget = Weight::from_parts(evm_gas_weight(100).ref_time(), u64::MAX);
+		let mut ext = MockExt::<Test>::with_weight_limit(budget);
+		let mut interpreter = Interpreter::new(Default::default(), vec![], &mut ext);
+
+		// 64 KiB expansion costs 14_336 gas, far beyond the 100-gas budget.
+		assert!(interpreter.stack.push(0u64).is_continue());
+		assert!(interpreter.stack.push(EXPAND_OFFSET as u64).is_continue());
+
+		let result = mstore(&mut interpreter);
+		assert!(
+			matches!(result, ControlFlow::Break(Halt::Err(e)) if e == Error::<Test>::OutOfGas.into())
+		);
 	}
 }

--- a/substrate/frame/revive/src/vm/evm/instructions/system.rs
+++ b/substrate/frame/revive/src/vm/evm/instructions/system.rs
@@ -37,8 +37,8 @@ pub const KECCAK_EMPTY: [u8; 32] =
 ///
 /// Computes Keccak-256 hash of memory data.
 pub fn keccak256<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> {
-	let ([offset], top) = interpreter.stack.popn_top()?;
-	let len = as_usize_or_halt::<E::T>(*top)?;
+	let [offset, len] = interpreter.stack.popn()?;
+	let len = as_usize_or_halt::<E::T>(len)?;
 	interpreter
 		.ext
 		.frame_meter_mut()
@@ -48,11 +48,10 @@ pub fn keccak256<E: Ext>(interpreter: &mut Interpreter<E>) -> ControlFlow<Halt> 
 		H256::from(KECCAK_EMPTY)
 	} else {
 		let from = as_usize_or_halt::<E::T>(offset)?;
-		interpreter.memory.resize(from, len)?;
+		interpreter.resize_memory(from, len)?;
 		H256::from(keccak_256(interpreter.memory.slice_len(from, len)))
 	};
-	*top = U256::from_big_endian(hash.as_ref());
-	ControlFlow::Continue(())
+	interpreter.stack.push(U256::from_big_endian(hash.as_ref()))
 }
 
 /// Implements the ADDRESS instruction.
@@ -217,6 +216,6 @@ pub fn memory_resize<'a, E: Ext>(
 
 	interpreter.ext.charge_or_halt(RuntimeCosts::CopyToContract(len as u32))?;
 	let memory_offset = as_usize_or_halt::<E::T>(memory_offset)?;
-	interpreter.memory.resize(memory_offset, len)?;
+	interpreter.resize_memory(memory_offset, len)?;
 	ControlFlow::Continue(Some(memory_offset))
 }

--- a/substrate/frame/revive/src/vm/evm/interpreter.rs
+++ b/substrate/frame/revive/src/vm/evm/interpreter.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::ExtBytecode;
+use super::{EVMGas, ExtBytecode};
 use crate::{
 	Config, DispatchError, Error, Weight,
 	primitives::ExecReturnValue,
@@ -26,7 +26,9 @@ use crate::{
 	},
 };
 use alloc::vec::Vec;
+use core::ops::ControlFlow;
 use pallet_revive_uapi::ReturnFlags;
+use revm::interpreter::{gas::memory_gas, num_words};
 
 /// EVM execution halt - either successful termination or error
 #[derive(Debug, PartialEq)]
@@ -73,6 +75,20 @@ impl<'a, E: Ext> Interpreter<'a, E> {
 	/// Create a new interpreter instance
 	pub fn new(bytecode: ExtBytecode, input: Vec<u8>, ext: &'a mut E) -> Self {
 		Self { ext, bytecode, input, stack: Stack::new(), memory: Memory::new() }
+	}
+
+	/// Charge the quadratic EVM memory-expansion gas and grow memory to fit
+	/// `[offset, offset + len)`. All memory growth must go through here so expansion is never free.
+	pub fn resize_memory(&mut self, offset: usize, len: usize) -> ControlFlow<Halt> {
+		if len != 0 {
+			let current_words = num_words(self.memory.size());
+			let new_words = num_words(offset.saturating_add(len));
+			if new_words > current_words {
+				let cost = memory_gas(new_words).saturating_sub(memory_gas(current_words));
+				self.ext.charge_or_halt(EVMGas(cost))?;
+			}
+		}
+		self.memory.resize(offset, len)
 	}
 }
 


### PR DESCRIPTION
Fixes #12640 by routing all EVM memory growth through a new `Interpreter::resize_memory` helper that charges Ethereum's quadratic expansion cost (`3*words` + `words²/512`), which the interpreter previously skipped entirely.