### PR TITLE
Remove deprecated ProposerFactory::with_proof_recording

### DIFF
--- a/prdoc/pr_12653.prdoc
+++ b/prdoc/pr_12653.prdoc
@@ -1,0 +1,12 @@
+title: Remove deprecated ProposerFactory::with_proof_recording
+doc:
+- audience: Node Dev
+  description: |-
+    ## Summary
+    - Remove `ProposerFactory::with_proof_recording`, which only forwarded to `new`.
+    - No in-tree callers remain.
+
+    Part of #11561
+crates:
+- name: sc-basic-authorship
+  bump: major

--- a/substrate/client/basic-authorship/src/basic_authorship.rs
+++ b/substrate/client/basic-authorship/src/basic_authorship.rs
@@ -115,18 +115,6 @@ impl<A, C> ProposerFactory<A, C> {
 		}
 	}
 
-	/// Deprecated, use [`Self::new`] instead.
-	#[deprecated(note = "Proof recording is now handled differently. Use `new` instead.")]
-	pub fn with_proof_recording(
-		spawn_handle: impl SpawnNamed + 'static,
-		client: Arc<C>,
-		transaction_pool: Arc<A>,
-		prometheus: Option<&PrometheusRegistry>,
-		telemetry: Option<TelemetryHandle>,
-	) -> Self {
-		Self::new(spawn_handle, client, transaction_pool, prometheus, telemetry)
-	}
-
 	/// Set the default block size limit in bytes.
 	///
 	/// The default value for the block size limit is:


### PR DESCRIPTION
## Summary
- Remove `ProposerFactory::with_proof_recording`, which only forwarded to `new`.
- No in-tree callers remain.

Part of #11561
