### PR TITLE
Remove deprecated pallet_staking::ExposureOf.

### DIFF
--- a/prdoc/pr_12654.prdoc
+++ b/prdoc/pr_12654.prdoc
@@ -2,11 +2,7 @@ title: Remove deprecated pallet_staking::ExposureOf.
 doc:
 - audience: Runtime Dev
   description: |-
-    ## Summary
-    - Remove deprecated `pallet_staking::ExposureOf` (use `DefaultExposureOf` / `UnitIdentificationOf`).
-    - No remaining in-repo callers.
-
-    Part of #11561
+    Remove deprecated `pallet_staking::ExposureOf` (use `DefaultExposureOf` / `UnitIdentificationOf`).
 crates:
 - name: pallet-staking
   bump: major

--- a/prdoc/pr_12654.prdoc
+++ b/prdoc/pr_12654.prdoc
@@ -1,0 +1,12 @@
+title: Remove deprecated pallet_staking::ExposureOf.
+doc:
+- audience: Runtime Dev
+  description: |-
+    ## Summary
+    - Remove deprecated `pallet_staking::ExposureOf` (use `DefaultExposureOf` / `UnitIdentificationOf`).
+    - No remaining in-repo callers.
+
+    Part of #11561
+crates:
+- name: pallet-staking
+  bump: major

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -1036,20 +1036,15 @@ impl Default for Forcing {
 	}
 }
 
-/// Identify a validator with their default exposure.
+/// Identify a current validator with a default [`Exposure`].
 ///
-/// This type should not be used in a fresh runtime, instead use [`UnitIdentificationOf`].
+/// Returns `Some(Exposure::default())` when the account is in the active validator set, and `None`
+/// otherwise. This keeps `FullIdentification = Exposure<..>` for runtimes that still need to decode
+/// historical session identification data of that shape, without constructing a full exposure for
+/// new identification requests.
 ///
-/// In the past, a type called `ExposureOf` used to return the full exposure of a validator to
-/// identify their exposure. That type has been removed; use [`DefaultExposureOf`] or
-/// [`UnitIdentificationOf`] instead.
-///
-/// In the new model, we don't need to identify a validator with their full exposure anymore, and
-/// therefore [`UnitIdentificationOf`] is perfectly fine. Yet, for runtimes that used to work with
-/// `ExposureOf`, we need to be able to decode old identification data, possibly stored in the
-/// historical session pallet in older blocks. Therefore, this type is a good compromise, allowing
-/// old exposure identifications to be decoded, and returning a few zero bytes
-/// (`Exposure::default`) for any new identification request.
+/// Prefer [`UnitIdentificationOf`] for fresh runtimes that do not need exposure-shaped
+/// identification.
 ///
 /// A typical usage of this type is:
 ///

--- a/substrate/frame/staking/src/lib.rs
+++ b/substrate/frame/staking/src/lib.rs
@@ -1036,35 +1036,17 @@ impl Default for Forcing {
 	}
 }
 
-/// A typed conversion from stash account ID to the active exposure of nominators
-/// on that account.
-///
-/// Active exposure is the exposure of the validator set currently validating, i.e. in
-/// `active_era`. It can differ from the latest planned exposure in `current_era`.
-#[deprecated(note = "Use `DefaultExposureOf` instead")]
-pub struct ExposureOf<T>(core::marker::PhantomData<T>);
-
-#[allow(deprecated)]
-impl<T: Config> Convert<T::AccountId, Option<Exposure<T::AccountId, BalanceOf<T>>>>
-	for ExposureOf<T>
-{
-	fn convert(validator: T::AccountId) -> Option<Exposure<T::AccountId, BalanceOf<T>>> {
-		ActiveEra::<T>::get()
-			.map(|active_era| <Pallet<T>>::eras_stakers(active_era.index, &validator))
-	}
-}
-
 /// Identify a validator with their default exposure.
 ///
 /// This type should not be used in a fresh runtime, instead use [`UnitIdentificationOf`].
 ///
-/// In the past, a type called [`ExposureOf`] used to return the full exposure of a validator to
-/// identify their exposure. This type is kept, marked as deprecated, for backwards compatibility of
-/// external SDK users, but is no longer used in this repo.
+/// In the past, a type called `ExposureOf` used to return the full exposure of a validator to
+/// identify their exposure. That type has been removed; use [`DefaultExposureOf`] or
+/// [`UnitIdentificationOf`] instead.
 ///
 /// In the new model, we don't need to identify a validator with their full exposure anymore, and
 /// therefore [`UnitIdentificationOf`] is perfectly fine. Yet, for runtimes that used to work with
-/// [`ExposureOf`], we need to be able to decode old identification data, possibly stored in the
+/// `ExposureOf`, we need to be able to decode old identification data, possibly stored in the
 /// historical session pallet in older blocks. Therefore, this type is a good compromise, allowing
 /// old exposure identifications to be decoded, and returning a few zero bytes
 /// (`Exposure::default`) for any new identification request.


### PR DESCRIPTION
## Summary
- Remove deprecated `pallet_staking::ExposureOf` (use `DefaultExposureOf` / `UnitIdentificationOf`).
- No remaining in-repo callers.

Part of #11561
