### PR TITLE
Remove deprecated TREASURER_INDEX constants

### DIFF
--- a/polkadot/runtime/westend/constants/src/lib.rs
+++ b/polkadot/runtime/westend/constants/src/lib.rs
@@ -181,9 +181,6 @@ pub mod xcm {
 		const ROOT_INDEX: u32 = 0;
 		// The bodies corresponding to the Polkadot OpenGov Origins.
 		pub const FELLOWSHIP_ADMIN_INDEX: u32 = 1;
-		#[deprecated = "Will be removed after August 2024; Use `xcm::latest::BodyId::Treasury` \
-			instead"]
-		pub const TREASURER_INDEX: u32 = 2;
 	}
 }
 

--- a/prdoc/pr_12664.prdoc
+++ b/prdoc/pr_12664.prdoc
@@ -2,11 +2,7 @@ title: Remove deprecated TREASURER_INDEX constants
 doc:
 - audience: Runtime Dev
   description: |-
-    Part of #11561
-
     Removes the deprecated `xcm::body::TREASURER_INDEX` constants from the Westend and RC runtime constants modules.
-
-    These constants were deprecated in favor of `xcm::latest::BodyId::Treasury` with a removal date of August 2024, and there are no remaining in-repo uses.
 
     ## Integration
 

--- a/prdoc/pr_12664.prdoc
+++ b/prdoc/pr_12664.prdoc
@@ -1,0 +1,18 @@
+title: Remove deprecated TREASURER_INDEX constants
+doc:
+- audience: Runtime Dev
+  description: |-
+    Part of #11561
+
+    Removes the deprecated `xcm::body::TREASURER_INDEX` constants from the Westend and RC runtime constants modules.
+
+    These constants were deprecated in favor of `xcm::latest::BodyId::Treasury` with a removal date of August 2024, and there are no remaining in-repo uses.
+
+    ## Integration
+
+    Downstream users should use `xcm::latest::BodyId::Treasury` instead of the old numeric `TREASURER_INDEX` constant.
+crates:
+- name: westend-runtime-constants
+  bump: major
+- name: pallet-staking-async-rc-runtime-constants
+  bump: major

--- a/substrate/frame/staking-async/runtimes/rc/constants/src/lib.rs
+++ b/substrate/frame/staking-async/runtimes/rc/constants/src/lib.rs
@@ -141,9 +141,6 @@ pub mod xcm {
 		const ROOT_INDEX: u32 = 0;
 		// The bodies corresponding to the Polkadot OpenGov Origins.
 		pub const FELLOWSHIP_ADMIN_INDEX: u32 = 1;
-		#[deprecated = "Will be removed after August 2024; Use `xcm::latest::BodyId::Treasury` \
-			instead"]
-		pub const TREASURER_INDEX: u32 = 2;
 	}
 }
 


### PR DESCRIPTION
Part of #11561

Removes the deprecated `xcm::body::TREASURER_INDEX` constants from the Westend and RC runtime constants modules.

These constants were deprecated in favor of `xcm::latest::BodyId::Treasury` with a removal date of August 2024, and there are no remaining in-repo uses.

## Integration

Downstream users should use `xcm::latest::BodyId::Treasury` instead of the old numeric `TREASURER_INDEX` constant.