### PR TITLE
Remove deprecated Utility::derivative_account_id method.

### DIFF
--- a/prdoc/pr_12670.prdoc
+++ b/prdoc/pr_12670.prdoc
@@ -1,0 +1,24 @@
+title: Remove deprecated Utility::derivative_account_id method.
+doc:
+- audience: Runtime Dev
+  description: |-
+    Part of #11561
+
+    Remove the deprecated `pallet_utility::Pallet::derivative_account_id` method.
+
+    It was deprecated with a removal date of August 2025 in favor of the freestanding `pallet_utility::derivative_account_id` function. In-repo callers already use the freestanding helper.
+
+    ## Integration
+
+    Replace:
+
+    ```rust
+    pallet_utility::Pallet::<T>::derivative_account_id(who, index)
+    ```
+    with:
+    ```rust
+    pallet_utility::derivative_account_id(who, index)
+    ```
+crates:
+- name: pallet-utility
+  bump: major

--- a/prdoc/pr_12670.prdoc
+++ b/prdoc/pr_12670.prdoc
@@ -2,11 +2,7 @@ title: Remove deprecated Utility::derivative_account_id method.
 doc:
 - audience: Runtime Dev
   description: |-
-    Part of #11561
-
     Remove the deprecated `pallet_utility::Pallet::derivative_account_id` method.
-
-    It was deprecated with a removal date of August 2025 in favor of the freestanding `pallet_utility::derivative_account_id` function. In-repo callers already use the freestanding helper.
 
     ## Integration
 

--- a/substrate/frame/utility/src/lib.rs
+++ b/substrate/frame/utility/src/lib.rs
@@ -620,15 +620,6 @@ impl TypeId for IndexedUtilityPalletId {
 	const TYPE_ID: [u8; 4] = *b"suba";
 }
 
-impl<T: Config> Pallet<T> {
-	#[deprecated(
-		note = "`Pallet::derivative_account_id` will be removed after August 2025. Please instead use the freestanding module function `derivative_account_id`."
-	)]
-	pub fn derivative_account_id(who: T::AccountId, index: u16) -> T::AccountId {
-		derivative_account_id(who, index)
-	}
-}
-
 /// Derive a derivative account ID from the owner account and the sub-account index.
 ///
 /// The derived account with `index` of `who` is defined as:


### PR DESCRIPTION
Part of #11561

Remove the deprecated `pallet_utility::Pallet::derivative_account_id` method.

It was deprecated with a removal date of August 2025 in favor of the freestanding `pallet_utility::derivative_account_id` function. In-repo callers already use the freestanding helper.

## Integration

Replace:

```rust
pallet_utility::Pallet::<T>::derivative_account_id(who, index)
```
with:
```rust
pallet_utility::derivative_account_id(who, index)
```