### PR TITLE
Remove deprecated FixedPoint::try_sqrt.

### DIFF
--- a/prdoc/pr_12671.prdoc
+++ b/prdoc/pr_12671.prdoc
@@ -1,0 +1,16 @@
+title: Remove deprecated FixedPoint::try_sqrt.
+doc:
+- audience: Runtime Dev
+  description: |-
+    Part of #11561
+
+    Remove the deprecated `try_sqrt` method from the fixed-point arithmetic types in `sp-arithmetic`.
+
+    It was deprecated with a removal date of October 2025 in favor of `checked_sqrt`. There are no remaining in-repo callers.
+
+    ## Integration
+
+    Replace `value.try_sqrt()` with `value.checked_sqrt()`.
+crates:
+- name: sp-arithmetic
+  bump: major

--- a/prdoc/pr_12671.prdoc
+++ b/prdoc/pr_12671.prdoc
@@ -2,11 +2,7 @@ title: Remove deprecated FixedPoint::try_sqrt.
 doc:
 - audience: Runtime Dev
   description: |-
-    Part of #11561
-
     Remove the deprecated `try_sqrt` method from the fixed-point arithmetic types in `sp-arithmetic`.
-
-    It was deprecated with a removal date of October 2025 in favor of `checked_sqrt`. There are no remaining in-repo callers.
 
     ## Integration
 

--- a/substrate/primitives/arithmetic/src/fixed_point.rs
+++ b/substrate/primitives/arithmetic/src/fixed_point.rs
@@ -579,13 +579,6 @@ macro_rules! implement_fixed {
 				}
 			}
 
-			#[deprecated(
-				note = "`try_sqrt` will be removed after October 2025. Use `checked_sqrt` instead."
-			)]
-			pub const fn try_sqrt(self) -> Option<Self> {
-				self.checked_sqrt()
-			}
-
 			/// Compute the square root. If it overflows or is negative, then `None` is returned.
 			pub const fn checked_sqrt(self) -> Option<Self> {
 				if self.0 == 0 {


### PR DESCRIPTION
Part of #11561

Remove the deprecated `try_sqrt` method from the fixed-point arithmetic types in `sp-arithmetic`.

It was deprecated with a removal date of October 2025 in favor of `checked_sqrt`. There are no remaining in-repo callers.

## Integration

Replace `value.try_sqrt()` with `value.checked_sqrt()`.