### PR TITLE
[FRAME] Small Balance Fixes

### DIFF
--- a/substrate/frame/balances/src/impl_fungible.rs
+++ b/substrate/frame/balances/src/impl_fungible.rs
@@ -325,7 +325,11 @@ impl<T: Config<I>, I: 'static> fungible::UnbalancedHold<T::AccountId> for Pallet
 				Ok(())
 			})?;
 
-		Holds::<T, I>::insert(who, holds);
+		if holds.is_empty() {
+			Holds::<T, I>::remove(who)
+		} else {
+			Holds::<T, I>::insert(who, holds)
+		}
 
 		if let Some(dust) = maybe_dust {
 			<Self as fungible::Unbalanced<_>>::handle_raw_dust(dust);

--- a/substrate/frame/balances/src/impl_fungible.rs
+++ b/substrate/frame/balances/src/impl_fungible.rs
@@ -324,11 +324,13 @@ impl<T: Config<I>, I: 'static> fungible::UnbalancedHold<T::AccountId> for Pallet
 				*a = new_account;
 				Ok(())
 			})?;
-		debug_assert!(
-			maybe_dust.is_none(),
-			"Does not alter main balance; dust only happens when it is altered; qed"
-		);
+
 		Holds::<T, I>::insert(who, holds);
+
+		if let Some(dust) = maybe_dust {
+			<Self as fungible::Unbalanced<_>>::handle_raw_dust(dust);
+		}
+
 		Ok(result)
 	}
 }

--- a/substrate/frame/balances/src/impl_fungible.rs
+++ b/substrate/frame/balances/src/impl_fungible.rs
@@ -178,7 +178,7 @@ impl<T: Config<I>, I: 'static> fungible::Unbalanced<T::AccountId> for Pallet<T, 
 
 	fn deactivate(amount: Self::Balance) {
 		InactiveIssuance::<T, I>::mutate(|b| {
-			// InactiveIssuance cannot be greater than TotalIssuance.
+			// Cap newly deactivated issuance at the current TotalIssuance.
 			*b = b.saturating_add(amount).min(TotalIssuance::<T, I>::get());
 		});
 	}

--- a/substrate/frame/balances/src/impl_fungible.rs
+++ b/substrate/frame/balances/src/impl_fungible.rs
@@ -178,8 +178,11 @@ impl<T: Config<I>, I: 'static> fungible::Unbalanced<T::AccountId> for Pallet<T, 
 
 	fn deactivate(amount: Self::Balance) {
 		InactiveIssuance::<T, I>::mutate(|b| {
-			// Cap newly deactivated issuance at the current TotalIssuance.
-			*b = b.saturating_add(amount).min(TotalIssuance::<T, I>::get());
+			let active = TotalIssuance::<T, I>::get().saturating_sub(*b);
+			// Only cap the delta and don't re-cap the existing inactive issuance.
+			let increase = amount.min(active);
+
+			*b = b.saturating_add(increase);
 		});
 	}
 

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -1125,10 +1125,10 @@ pub mod pallet {
 				// Evaluates `maybe_dust`, which is `Some` containing the dust to be dropped, iff
 				// some dust should be dropped.
 				//
-				// We should never be dropping if reserved is non-zero. Reserved being non-zero
-				// should imply that we have a consumer ref, so this is economically safe.
+				// We should never be dropping if there are either reserves or freezes since that
+				// implies a consumer ref.
 				let ed = Self::ed();
-				let maybe_dust = if account.free < ed && account.reserved.is_zero() {
+				let maybe_dust = if account.free < ed && !does_consume {
 					if account.free.is_zero() {
 						None
 					} else {

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -1230,15 +1230,17 @@ pub mod pallet {
 				}
 				after_frozen = b.frozen;
 			})?;
-			if maybe_dust.is_some() {
-				Self::deposit_event(Event::Unexpected(UnexpectedKind::BalanceUpdated));
-				defensive!("caused unexpected dusting/balance update.");
-			}
+
 			if freezes.is_empty() {
 				Freezes::<T, I>::remove(who);
 			} else {
 				Freezes::<T, I>::insert(who, freezes);
 			}
+
+			if let Some(dust) = maybe_dust {
+				<Self as fungible::Unbalanced<_>>::handle_raw_dust(dust);
+			}
+
 			if prev_frozen > after_frozen {
 				let amount = prev_frozen.saturating_sub(after_frozen);
 				Self::deposit_event(Event::Thawed { who: who.clone(), amount });

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -1171,8 +1171,8 @@ pub mod pallet {
 			let freezes = Freezes::<T, I>::get(who);
 			let mut prev_frozen = Zero::zero();
 			let mut after_frozen = Zero::zero();
-			// We do not alter ED, so the account will not get dusted. Yet, consumer limit might be
-			// full, therefore we pass `true` into `mutate_account` to make sure this cannot fail
+			// The consumer limit might be full, therefore we pass `true` into `mutate_account` to
+			// make sure this cannot fail.
 			let res = Self::mutate_account(who, true, |b| {
 				prev_frozen = b.frozen;
 				b.frozen = Zero::zero();
@@ -1184,23 +1184,22 @@ pub mod pallet {
 				}
 				after_frozen = b.frozen;
 			});
-			match res {
-				Ok((_, None)) => {
-					// expected -- all good.
-				},
-				Ok((_, Some(_dust))) => {
-					Self::deposit_event(Event::Unexpected(UnexpectedKind::BalanceUpdated));
-					defensive!("caused unexpected dusting/balance update.");
-				},
-				_ => {
+			let maybe_dust = match res {
+				Ok((_, maybe_dust)) => maybe_dust,
+				Err(_) => {
 					Self::deposit_event(Event::Unexpected(UnexpectedKind::FailedToMutateAccount));
 					defensive!("errored in mutate_account");
+					None
 				},
-			}
+			};
 
 			match locks.is_empty() {
 				true => Locks::<T, I>::remove(who),
 				false => Locks::<T, I>::insert(who, bounded_locks),
+			}
+
+			if let Some(dust) = maybe_dust {
+				<Self as fungible::Unbalanced<_>>::handle_raw_dust(dust);
 			}
 
 			if prev_frozen > after_frozen {

--- a/substrate/frame/balances/src/lib.rs
+++ b/substrate/frame/balances/src/lib.rs
@@ -471,6 +471,10 @@ pub mod pallet {
 	pub type TotalIssuance<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Balance, ValueQuery>;
 
 	/// The total units of outstanding deactivated balance in the system.
+	///
+	/// This is not guaranteed to be less than or equal to [`TotalIssuance`]. Total issuance may be
+	/// reduced independently of this value, including while a reversible imbalance is outstanding.
+	/// Active issuance is therefore derived using saturating subtraction.
 	#[pallet::storage]
 	#[pallet::whitelist_storage]
 	pub type InactiveIssuance<T: Config<I>, I: 'static = ()> =

--- a/substrate/frame/balances/src/tests/currency_tests.rs
+++ b/substrate/frame/balances/src/tests/currency_tests.rs
@@ -762,6 +762,22 @@ fn burn_must_work() {
 }
 
 #[test]
+fn inactive_issuance_survives_reverted_currency_burn() {
+	ExtBuilder::default().monied(true).build_and_execute_with(|| {
+		let init_total_issuance = pallet_balances::TotalIssuance::<Test>::get();
+		Balances::deactivate(init_total_issuance - 5);
+
+		let imbalance = <Balances as Currency<_>>::burn(10);
+		assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), init_total_issuance - 10);
+		assert_eq!(crate::InactiveIssuance::<Test>::get(), init_total_issuance - 5);
+
+		drop(imbalance);
+		assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), init_total_issuance);
+		assert_eq!(crate::InactiveIssuance::<Test>::get(), init_total_issuance - 5);
+	});
+}
+
+#[test]
 #[should_panic = "the balance of any account should always be at least the existential deposit."]
 fn cannot_set_genesis_value_below_ed() {
 	EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = 11);

--- a/substrate/frame/balances/src/tests/fungible_tests.rs
+++ b/substrate/frame/balances/src/tests/fungible_tests.rs
@@ -234,6 +234,31 @@ fn unbalanced_trait_increase_balance_works() {
 }
 
 #[test]
+fn increase_balance_rejects_total_balance_overflow() {
+	ExtBuilder::default().build_and_execute_with(|| {
+		// The free-balance addition is checked, but free and reserved are then combined with
+		// saturating arithmetic. That masks the aggregate overflow and accepts an account whose
+		// mathematical total cannot be represented by `Balance`.
+		let account = 1;
+
+		Balances::set_balance(&account, u64::MAX - 1);
+		assert_ok!(Balances::hold(&TestId::Foo, &account, 1));
+		assert_eq!(get_test_account_data(account).free, u64::MAX - 2);
+		assert_eq!(get_test_account_data(account).reserved, 1);
+
+		// Exact cannot credit the requested amount because it would make the aggregate overflow.
+		assert_noop!(Balances::increase_balance(&account, 2, Exact), ArithmeticError::Overflow);
+
+		// BestEffort must credit only the remaining aggregate headroom, not hide the overflow by
+		// saturating `total_balance` after writing both components.
+		assert_eq!(Balances::increase_balance(&account, 2, BestEffort), Ok(1));
+		assert_eq!(get_test_account_data(account).free, u64::MAX - 1);
+		assert_eq!(get_test_account_data(account).reserved, 1);
+		assert_eq!(Balances::total_balance(&account), u64::MAX);
+	});
+}
+
+#[test]
 fn unbalanced_trait_increase_balance_at_most_works() {
 	ExtBuilder::default().build_and_execute_with(|| {
 		assert_eq!(Balances::increase_balance(&1337, 0, BestEffort), Ok(0));

--- a/substrate/frame/balances/src/tests/fungible_tests.rs
+++ b/substrate/frame/balances/src/tests/fungible_tests.rs
@@ -119,6 +119,24 @@ fn unbalanced_trait_set_total_issuance_works() {
 }
 
 #[test]
+fn inactive_issuance_survives_reverted_rescind() {
+	ExtBuilder::default().build_and_execute_with(|| {
+		assert_ok!(Balances::mint_into(&1, 100));
+		Balances::deactivate(80);
+		assert_eq!(Balances::active_issuance(), 20);
+
+		let debt = <Balances as fungible::Balanced<_>>::rescind(30);
+		assert_eq!(Balances::total_issuance(), 70);
+		assert_eq!(crate::InactiveIssuance::<Test>::get(), 80);
+
+		drop(debt);
+		assert_eq!(Balances::total_issuance(), 100);
+		assert_eq!(crate::InactiveIssuance::<Test>::get(), 80);
+		assert_eq!(Balances::active_issuance(), 20);
+	});
+}
+
+#[test]
 fn unbalanced_trait_decrease_balance_simple_works() {
 	ExtBuilder::default().build_and_execute_with(|| {
 		// An Account that starts at 100

--- a/substrate/frame/balances/src/tests/fungible_tests.rs
+++ b/substrate/frame/balances/src/tests/fungible_tests.rs
@@ -137,6 +137,22 @@ fn inactive_issuance_survives_reverted_rescind() {
 }
 
 #[test]
+fn deactivate_zero_does_not_reduce_inactive_issuance() {
+	ExtBuilder::default().build_and_execute_with(|| {
+		assert_ok!(Balances::mint_into(&1, 100));
+		Balances::deactivate(80);
+
+		let debt = <Balances as fungible::Balanced<_>>::rescind(30);
+		assert_eq!(Balances::total_issuance(), 70);
+		assert_eq!(crate::InactiveIssuance::<Test>::get(), 80);
+
+		assert_storage_noop!(Balances::deactivate(0));
+
+		drop(debt);
+	});
+}
+
+#[test]
 fn unbalanced_trait_decrease_balance_simple_works() {
 	ExtBuilder::default().build_and_execute_with(|| {
 		// An Account that starts at 100

--- a/substrate/frame/balances/src/tests/general_tests.rs
+++ b/substrate/frame/balances/src/tests/general_tests.rs
@@ -30,6 +30,7 @@ use frame_support::{
 	traits::{
 		fungible::{self, InspectFreeze, Mutate, MutateFreeze, MutateHold},
 		tokens::{Fortitude, Precision, Preservation},
+		LockableCurrency, WithdrawReasons,
 	},
 };
 use sp_runtime::DispatchError;
@@ -215,6 +216,28 @@ fn regression_thaw_dusting_sub_ed_account_leaks_issuance() {
 
 		// Thawing the last freeze dusts the 5 free units; the dust must be burned.
 		assert_ok!(Balances::thaw(&TestId::Foo, &alice));
+		ensure_ti_valid();
+	});
+}
+
+/// Removing the last lock from an account dusted below the ED must not leak the
+/// dust from `TotalIssuance` (`update_locks` must handle `maybe_dust`).
+#[test]
+fn regression_remove_lock_dusting_sub_ed_account_leaks_issuance() {
+	ExtBuilder::default().existential_deposit(10).build_and_execute_with(|| {
+		UseSystem::set(true);
+		let (alice, bob) = (0, 1);
+
+		Balances::set_balance(&alice, 100);
+		TotalIssuance::<Test>::put(100);
+		let _ = System::inc_providers(&alice);
+		Balances::set_lock(*b"locktest", &alice, 5, WithdrawReasons::all());
+
+		// Leaves free = 7: below ED, but kept alive by the lock.
+		assert_ok!(Balances::transfer_allow_death(Some(alice).into(), bob, 93));
+
+		// Removing the last lock dusts the 7 free units; the dust must be burned.
+		Balances::remove_lock(*b"locktest", &alice);
 		ensure_ti_valid();
 	});
 }

--- a/substrate/frame/balances/src/tests/general_tests.rs
+++ b/substrate/frame/balances/src/tests/general_tests.rs
@@ -20,15 +20,16 @@
 use crate::{
 	system::AccountInfo,
 	tests::{
-		ensure_ti_valid, get_test_account, Balances, ExtBuilder, System, Test, TestId, UseSystem,
+		ensure_ti_valid, get_test_account, get_test_account_data, Balances, ExtBuilder, System,
+		Test, TestId, UseSystem,
 	},
 	AccountData, ExtraFlags, TotalIssuance,
 };
 use frame_support::{
 	assert_noop, assert_ok, hypothetically,
 	traits::{
-		fungible::{Mutate, MutateHold},
-		tokens::Precision,
+		fungible::{self, InspectFreeze, Mutate, MutateFreeze, MutateHold},
+		tokens::{Fortitude, Precision, Preservation},
 	},
 };
 use sp_runtime::DispatchError;
@@ -109,6 +110,57 @@ fn regression_historic_acc_does_not_evaporate_reserve() {
 			assert_eq!(System::consumers(&alice), 1);
 			ensure_ti_valid();
 		});
+	});
+}
+
+/// Dusting a frozen account (via a `Force` slash) must not desync `Freezes` from
+/// the account's `frozen` field.
+#[test]
+fn regression_force_withdraw_dusting_frozen_account_desyncs_freezes() {
+	ExtBuilder::default().existential_deposit(10).build_and_execute_with(|| {
+		UseSystem::set(true);
+		let alice = 0;
+
+		Balances::set_balance(&alice, 100);
+		let _ = System::inc_providers(&alice); // survives being dusted below ED
+		assert_ok!(Balances::set_freeze(&TestId::Foo, &alice, 30));
+
+		// `Force` ignores the freeze: free drops to 5 (< ED), dusting the account.
+		let credit = <Balances as fungible::Balanced<_>>::withdraw(
+			&alice,
+			95,
+			Precision::Exact,
+			Preservation::Expendable,
+			Fortitude::Force,
+		)
+		.unwrap();
+		drop(credit);
+
+		assert!(
+			Balances::balance_frozen(&TestId::Foo, &alice) <= get_test_account_data(alice).frozen
+		);
+	});
+}
+
+/// Same freeze desync as above, but reachable by an unprivileged
+/// `transfer_allow_death`: a freeze smaller than the ED lets a plain transfer
+/// push free below the ED (but above the freeze) and dust the account.
+#[test]
+fn regression_transfer_allow_death_dusting_frozen_account_desyncs_freezes() {
+	ExtBuilder::default().existential_deposit(10).build_and_execute_with(|| {
+		UseSystem::set(true);
+		let (alice, bob) = (0, 1);
+
+		Balances::set_balance(&alice, 100);
+		let _ = System::inc_providers(&alice); // survives being dusted below ED
+		assert_ok!(Balances::set_freeze(&TestId::Foo, &alice, 5));
+
+		// Leaves free = 7: below ED (10) but at/above the freeze (5), so allowed.
+		assert_ok!(Balances::transfer_allow_death(Some(alice).into(), bob, 93));
+
+		assert!(
+			Balances::balance_frozen(&TestId::Foo, &alice) <= get_test_account_data(alice).frozen
+		);
 	});
 }
 

--- a/substrate/frame/balances/src/tests/general_tests.rs
+++ b/substrate/frame/balances/src/tests/general_tests.rs
@@ -188,6 +188,37 @@ fn regression_transfer_allow_death_dusting_frozen_account_desyncs_freezes() {
 	});
 }
 
+/// Thawing the last freeze of an account dusted below the ED must not leak the
+/// dust from `TotalIssuance` (`update_freezes` discards `maybe_dust`).
+#[test]
+fn regression_thaw_dusting_sub_ed_account_leaks_issuance() {
+	ExtBuilder::default().existential_deposit(10).build_and_execute_with(|| {
+		UseSystem::set(true);
+		let alice = 0;
+
+		Balances::set_balance(&alice, 100);
+		TotalIssuance::<Test>::put(100);
+		// This provider makes the withdraw below work
+		let _ = System::inc_providers(&alice);
+		assert_ok!(Balances::set_freeze(&TestId::Foo, &alice, 30));
+
+		// `Force` slash ignores the freeze: free -> 5 (< ED), kept alive by the freeze.
+		let credit = <Balances as fungible::Balanced<_>>::withdraw(
+			&alice,
+			95,
+			Precision::Exact,
+			Preservation::Expendable,
+			Fortitude::Force,
+		)
+		.unwrap();
+		drop(credit);
+
+		// Thawing the last freeze dusts the 5 free units; the dust must be burned.
+		assert_ok!(Balances::thaw(&TestId::Foo, &alice));
+		ensure_ti_valid();
+	});
+}
+
 #[cfg(feature = "try-runtime")]
 #[test]
 fn try_state_works() {

--- a/substrate/frame/balances/src/tests/general_tests.rs
+++ b/substrate/frame/balances/src/tests/general_tests.rs
@@ -113,6 +113,30 @@ fn regression_historic_acc_does_not_evaporate_reserve() {
 	});
 }
 
+/// Releasing the last hold from an account dusted below the ED must not leak the
+/// dust from `TotalIssuance` (`set_balance_on_hold` discards `maybe_dust`).
+#[test]
+fn regression_release_hold_below_ed_leaks_issuance() {
+	ExtBuilder::default().existential_deposit(10).build_and_execute_with(|| {
+		UseSystem::set(true);
+
+		let (alice, bob) = (0, 1);
+		Balances::set_balance(&alice, 100);
+		TotalIssuance::<Test>::put(100);
+
+		let _ = System::inc_providers(&alice);
+		assert_ok!(Balances::hold(&TestId::Foo, &alice, 50));
+
+		// free -> 5 (< ED), kept alive by the reserve.
+		assert_ok!(Balances::transfer_allow_death(Some(alice).into(), bob, 45));
+
+		// Releasing the last hold dusts the 5 free units; the dust must be burned.
+		assert_ok!(Balances::release(&TestId::Foo, &alice, 50, Precision::Exact));
+
+		ensure_ti_valid();
+	});
+}
+
 /// Dusting a frozen account (via a `Force` slash) must not desync `Freezes` from
 /// the account's `frozen` field.
 #[test]

--- a/substrate/frame/balances/src/tests/mod.rs
+++ b/substrate/frame/balances/src/tests/mod.rs
@@ -164,6 +164,10 @@ impl ExtBuilder {
 		self.reentrant_dust_action = Some(ReentrantDustAction::Hold(account));
 		self
 	}
+	pub fn reentrant_dust_freeze(mut self, account: u64) -> Self {
+		self.reentrant_dust_action = Some(ReentrantDustAction::Freeze(account));
+		self
+	}
 	#[cfg(feature = "try-runtime")]
 	pub fn auto_try_state(self, auto_try_state: bool) -> Self {
 		AutoTryState::set(auto_try_state);
@@ -224,6 +228,7 @@ impl ExtBuilder {
 #[derive(Clone, Copy)]
 enum ReentrantDustAction {
 	Hold(u64),
+	Freeze(u64),
 }
 
 parameter_types! {
@@ -241,6 +246,10 @@ impl OnUnbalanced<CreditOf<Test, ()>> for DustTrap {
 					.expect("reentrant mint should succeed");
 				<Balances as fungible::MutateHold<_>>::hold(&TestId::Bar, &account, 7)
 					.expect("reentrant hold should succeed");
+			},
+			Some(ReentrantDustAction::Freeze(account)) => {
+				<Balances as fungible::MutateFreeze<_>>::set_freeze(&TestId::Bar, &account, 7)
+					.expect("reentrant freeze should succeed");
 			},
 			None => {},
 		}

--- a/substrate/frame/balances/src/tests/mod.rs
+++ b/substrate/frame/balances/src/tests/mod.rs
@@ -137,10 +137,11 @@ pub struct ExtBuilder {
 	existential_deposit: u64,
 	monied: bool,
 	dust_trap: Option<u64>,
+	reentrant_dust_action: Option<ReentrantDustAction>,
 }
 impl Default for ExtBuilder {
 	fn default() -> Self {
-		Self { existential_deposit: 1, monied: false, dust_trap: None }
+		Self { existential_deposit: 1, monied: false, dust_trap: None, reentrant_dust_action: None }
 	}
 }
 impl ExtBuilder {
@@ -159,6 +160,10 @@ impl ExtBuilder {
 		self.dust_trap = Some(account);
 		self
 	}
+	pub fn reentrant_dust_hold(mut self, account: u64) -> Self {
+		self.reentrant_dust_action = Some(ReentrantDustAction::Hold(account));
+		self
+	}
 	#[cfg(feature = "try-runtime")]
 	pub fn auto_try_state(self, auto_try_state: bool) -> Self {
 		AutoTryState::set(auto_try_state);
@@ -166,6 +171,7 @@ impl ExtBuilder {
 	}
 	pub fn set_associated_consts(&self) {
 		DUST_TRAP_TARGET.with(|v| v.replace(self.dust_trap));
+		REENTRANT_DUST_ACTION_VALUE.with(|v| v.replace(self.reentrant_dust_action));
 		EXISTENTIAL_DEPOSIT.with(|v| v.replace(self.existential_deposit));
 	}
 	pub fn build(self) -> sp_io::TestExternalities {
@@ -215,14 +221,30 @@ impl ExtBuilder {
 	}
 }
 
+#[derive(Clone, Copy)]
+enum ReentrantDustAction {
+	Hold(u64),
+}
+
 parameter_types! {
 	static DustTrapTarget: Option<u64> = None;
+	static ReentrantDustActionValue: Option<ReentrantDustAction> = None;
 }
 
 pub struct DustTrap;
 
 impl OnUnbalanced<CreditOf<Test, ()>> for DustTrap {
 	fn on_nonzero_unbalanced(amount: CreditOf<Test, ()>) {
+		match ReentrantDustActionValue::get() {
+			Some(ReentrantDustAction::Hold(account)) => {
+				<Balances as fungible::Mutate<_>>::mint_into(&account, 20)
+					.expect("reentrant mint should succeed");
+				<Balances as fungible::MutateHold<_>>::hold(&TestId::Bar, &account, 7)
+					.expect("reentrant hold should succeed");
+			},
+			None => {},
+		}
+
 		match DustTrapTarget::get() {
 			None => drop(amount),
 			Some(a) => {

--- a/substrate/frame/balances/src/tests/mod.rs
+++ b/substrate/frame/balances/src/tests/mod.rs
@@ -29,8 +29,9 @@ use frame_support::{
 	dispatch::{DispatchInfo, GetDispatchInfo},
 	parameter_types,
 	traits::{
-		fungible, ConstU32, ConstU8, Imbalance as ImbalanceT, OnUnbalanced, StorageMapShim,
-		StoredMap, VariantCount, VariantCountOf, WhitelistedStorageKeys,
+		fungible, ConstU32, ConstU8, Imbalance as ImbalanceT, LockIdentifier, LockableCurrency,
+		OnUnbalanced, StorageMapShim, StoredMap, VariantCount, VariantCountOf,
+		WhitelistedStorageKeys, WithdrawReasons,
 	},
 	weights::{IdentityFee, Weight},
 };
@@ -168,6 +169,10 @@ impl ExtBuilder {
 		self.reentrant_dust_action = Some(ReentrantDustAction::Freeze(account));
 		self
 	}
+	pub fn reentrant_dust_lock(mut self, account: u64) -> Self {
+		self.reentrant_dust_action = Some(ReentrantDustAction::Lock(account));
+		self
+	}
 	#[cfg(feature = "try-runtime")]
 	pub fn auto_try_state(self, auto_try_state: bool) -> Self {
 		AutoTryState::set(auto_try_state);
@@ -229,7 +234,10 @@ impl ExtBuilder {
 enum ReentrantDustAction {
 	Hold(u64),
 	Freeze(u64),
+	Lock(u64),
 }
+
+const REENTRANT_LOCK_ID: LockIdentifier = *b"RELOCK__";
 
 parameter_types! {
 	static DustTrapTarget: Option<u64> = None;
@@ -250,6 +258,16 @@ impl OnUnbalanced<CreditOf<Test, ()>> for DustTrap {
 			Some(ReentrantDustAction::Freeze(account)) => {
 				<Balances as fungible::MutateFreeze<_>>::set_freeze(&TestId::Bar, &account, 7)
 					.expect("reentrant freeze should succeed");
+			},
+			Some(ReentrantDustAction::Lock(account)) => {
+				<Balances as fungible::Mutate<_>>::mint_into(&account, 20)
+					.expect("reentrant mint should succeed");
+				<Balances as LockableCurrency<_>>::set_lock(
+					REENTRANT_LOCK_ID,
+					&account,
+					7,
+					WithdrawReasons::all(),
+				);
 			},
 			None => {},
 		}

--- a/substrate/frame/balances/src/tests/reentrancy_tests.rs
+++ b/substrate/frame/balances/src/tests/reentrancy_tests.rs
@@ -20,10 +20,31 @@
 use super::*;
 use frame_support::traits::tokens::{
 	Fortitude::Force,
-	Precision::BestEffort,
+	Precision::{BestEffort, Exact},
 	Preservation::{Expendable, Protect},
 };
-use fungible::Balanced;
+use fungible::{Balanced, InspectHold, Mutate, MutateHold};
+
+#[test]
+fn reentrant_dust_handler_hold_is_not_overwritten() {
+	let alice = 1;
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.reentrant_dust_hold(alice)
+		.build_and_execute_with(|| {
+			Balances::set_balance(&alice, 100);
+			TotalIssuance::<Test>::put(100);
+			let _ = System::inc_providers(&alice);
+			assert_ok!(Balances::hold(&TestId::Foo, &alice, 50));
+			assert_ok!(Balances::transfer_allow_death(RuntimeOrigin::signed(alice), 2, 45));
+
+			assert_ok!(Balances::release(&TestId::Foo, &alice, 50, Exact));
+
+			assert_eq!(Balances::balance_on_hold(&TestId::Bar, &alice), 7);
+			assert_eq!(Balances::total_balance_on_hold(&alice), 7);
+			ensure_ti_valid();
+		});
+}
 
 #[test]
 fn transfer_dust_removal_tst1_should_work() {

--- a/substrate/frame/balances/src/tests/reentrancy_tests.rs
+++ b/substrate/frame/balances/src/tests/reentrancy_tests.rs
@@ -18,12 +18,17 @@
 //! Tests regarding the reentrancy functionality.
 
 use super::*;
-use frame_support::traits::tokens::{
-	Fortitude::Force,
-	Precision::{BestEffort, Exact},
-	Preservation::{Expendable, Protect},
+use frame_support::traits::{
+	tokens::{
+		Fortitude::Force,
+		Precision::{BestEffort, Exact},
+		Preservation::{Expendable, Protect},
+	},
+	InspectLockableCurrency, LockableCurrency, WithdrawReasons,
 };
 use fungible::{Balanced, InspectFreeze, InspectHold, Mutate, MutateFreeze, MutateHold};
+
+const OUTER_LOCK_ID: LockIdentifier = *b"OUTER___";
 
 #[test]
 fn reentrant_dust_handler_hold_is_not_overwritten() {
@@ -65,6 +70,30 @@ fn reentrant_dust_handler_freeze_is_not_overwritten() {
 			assert_ok!(Balances::thaw(&TestId::Foo, &alice));
 
 			assert_eq!(Balances::balance_frozen(&TestId::Bar, &alice), 7);
+			assert_eq!(get_test_account_data(alice).frozen, 7);
+			ensure_ti_valid();
+		});
+}
+
+#[test]
+fn reentrant_dust_handler_lock_is_not_overwritten() {
+	let alice = 1;
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.reentrant_dust_lock(alice)
+		.build_and_execute_with(|| {
+			Balances::set_balance(&alice, 100);
+			TotalIssuance::<Test>::put(100);
+			let _ = System::inc_providers(&alice);
+			Balances::set_lock(OUTER_LOCK_ID, &alice, 5, WithdrawReasons::all());
+			assert_ok!(Balances::transfer_allow_death(RuntimeOrigin::signed(alice), 2, 93));
+
+			Balances::remove_lock(OUTER_LOCK_ID, &alice);
+
+			assert_eq!(
+				<Balances as InspectLockableCurrency<_>>::balance_locked(REENTRANT_LOCK_ID, &alice),
+				7
+			);
 			assert_eq!(get_test_account_data(alice).frozen, 7);
 			ensure_ti_valid();
 		});

--- a/substrate/frame/balances/src/tests/reentrancy_tests.rs
+++ b/substrate/frame/balances/src/tests/reentrancy_tests.rs
@@ -23,7 +23,7 @@ use frame_support::traits::tokens::{
 	Precision::{BestEffort, Exact},
 	Preservation::{Expendable, Protect},
 };
-use fungible::{Balanced, InspectHold, Mutate, MutateHold};
+use fungible::{Balanced, InspectFreeze, InspectHold, Mutate, MutateFreeze, MutateHold};
 
 #[test]
 fn reentrant_dust_handler_hold_is_not_overwritten() {
@@ -42,6 +42,30 @@ fn reentrant_dust_handler_hold_is_not_overwritten() {
 
 			assert_eq!(Balances::balance_on_hold(&TestId::Bar, &alice), 7);
 			assert_eq!(Balances::total_balance_on_hold(&alice), 7);
+			ensure_ti_valid();
+		});
+}
+
+#[test]
+fn reentrant_dust_handler_freeze_is_not_overwritten() {
+	let alice = 1;
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.reentrant_dust_freeze(alice)
+		.build_and_execute_with(|| {
+			Balances::set_balance(&alice, 100);
+			TotalIssuance::<Test>::put(100);
+			let _ = System::inc_providers(&alice);
+			assert_ok!(Balances::set_freeze(&TestId::Foo, &alice, 30));
+
+			let credit =
+				<Balances as fungible::Balanced<_>>::withdraw(&alice, 95, Exact, Expendable, Force)
+					.unwrap();
+			drop(credit);
+			assert_ok!(Balances::thaw(&TestId::Foo, &alice));
+
+			assert_eq!(Balances::balance_frozen(&TestId::Bar, &alice), 7);
+			assert_eq!(get_test_account_data(alice).frozen, 7);
 			ensure_ti_valid();
 		});
 }

--- a/substrate/frame/support/src/traits/tokens/fungible/regular.rs
+++ b/substrate/frame/support/src/traits/tokens/fungible/regular.rs
@@ -38,7 +38,10 @@ use crate::{
 };
 use core::marker::PhantomData;
 use sp_arithmetic::traits::{CheckedAdd, CheckedSub, One};
-use sp_runtime::{traits::Saturating, ArithmeticError, DispatchError, TokenError};
+use sp_runtime::{
+	traits::{Bounded, Saturating},
+	ArithmeticError, DispatchError, TokenError,
+};
 
 use super::{Credit, Debt, HandleImbalanceDrop, Imbalance};
 
@@ -208,11 +211,15 @@ pub trait Unbalanced<AccountId>: Inspect<AccountId> {
 		precision: Precision,
 	) -> Result<Self::Balance, DispatchError> {
 		let old_balance = Self::balance(who);
+		let reserved = Self::total_balance(who).saturating_sub(old_balance);
 		let new_balance = if let BestEffort = precision {
-			old_balance.saturating_add(amount)
+			let max_balance = Self::Balance::max_value().saturating_sub(reserved);
+			old_balance.saturating_add(amount).min(max_balance)
 		} else {
 			old_balance.checked_add(&amount).ok_or(ArithmeticError::Overflow)?
 		};
+		new_balance.checked_add(&reserved).ok_or(ArithmeticError::Overflow)?;
+
 		if new_balance < Self::minimum_balance() {
 			// Attempt to increase from 0 to below minimum -> stays at zero.
 			if let BestEffort = precision {


### PR DESCRIPTION
Changes:
- Keep frozen accounts alive below ED
- Handle dust when releasing holds
- Remove empty hold entries
- Handle dust when thawing freezes and test reentrant dust handlers
- Handle dust when removing locks and test reentrant dust handlers
- Document inactive issuance during burns
- Prevent aggregate balance overflow
- Preserve inactive issuance when deactivating