### PR TITLE
[DNM] versi V3-activation test: YAP/glutton V3 scheduling + westend-100 epochs (stable2606)

### DIFF
--- a/.github/workflows/build-publish-images.yml
+++ b/.github/workflows/build-publish-images.yml
@@ -50,6 +50,7 @@ jobs:
           ROCOCO_EPOCH_DURATION=10 ./polkadot/scripts/build-only-wasm.sh rococo-runtime $(pwd)/runtimes/rococo-runtime-10/
           ROCOCO_EPOCH_DURATION=100 ./polkadot/scripts/build-only-wasm.sh rococo-runtime $(pwd)/runtimes/rococo-runtime-100/
           ROCOCO_EPOCH_DURATION=600 ./polkadot/scripts/build-only-wasm.sh rococo-runtime $(pwd)/runtimes/rococo-runtime-600/
+          ./polkadot/scripts/build-only-wasm.sh westend-runtime $(pwd)/runtimes/westend-staging-1h/
           pwd
           ls -alR runtimes
       - name: pack artifacts

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -188,6 +188,22 @@ const BLOCK_PROCESSING_VELOCITY: u32 = 3;
 /// into the relay chain.
 const UNINCLUDED_SEGMENT_CAPACITY: u32 = (3 + RELAY_PARENT_OFFSET) * BLOCK_PROCESSING_VELOCITY;
 
+/// Enables V3 scheduling while accepting any scheduling signature, like the
+/// `cumulus-test-runtime` `v3-descriptor` flavor does. Glutton is a testing-only
+/// runtime, so signature verification adds nothing here.
+pub struct SchedulingV3AcceptAll;
+
+impl VerifySchedulingSignature for SchedulingV3AcceptAll {
+	const V3_SCHEDULING_ENABLED: bool = true;
+
+	fn verify(
+		_signed_info: &cumulus_primitives_core::SignedSchedulingInfo,
+		_internal_scheduling_parent_header: &cumulus_primitives_core::relay_chain::Header,
+	) -> bool {
+		true
+	}
+}
+
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
 	Runtime,
 	RELAY_CHAIN_SLOT_DURATION_MILLIS,
@@ -208,7 +224,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ConsensusHook = ConsensusHook;
 	type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
 	type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
-	type SchedulingSignatureVerifier = ();
+	type SchedulingSignatureVerifier = SchedulingV3AcceptAll;
 }
 
 parameter_types! {

--- a/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/glutton/glutton-westend/src/lib.rs
@@ -104,7 +104,11 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("glutton-westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("glutton-westend"),
 	authoring_version: 1,
-	spec_version: 1_024_001,
+	// Bumped from 1_024_001 (released stable2606 glutton-westend) so the
+	// V3-enabled wasm can be applied as a runtime upgrade over the released V2
+	// glutton running at genesis (parachain upgrades require a strictly greater
+	// spec_version).
+	spec_version: 1_024_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
@@ -100,7 +100,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("yet-another-parachain"),
 	impl_name: Cow::Borrowed("yet-another-parachain"),
 	authoring_version: 1,
-	spec_version: 1_003_002,
+	// Bumped from 1_003_002 (released stable2606 YAP) so the V3-enabled wasm can
+	// be applied as a runtime upgrade over the released V2 YAP running at genesis
+	// (parachain upgrades require a strictly greater spec_version).
+	spec_version: 1_003_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,

--- a/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/yet-another-parachain/src/lib.rs
@@ -153,6 +153,22 @@ const BLOCK_PROCESSING_VELOCITY: u32 = 12;
 /// Relay chain slot duration, in milliseconds.
 const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 
+/// Enables V3 scheduling while accepting any scheduling signature, like the
+/// `cumulus-test-runtime` `v3-descriptor` flavor does. YAP is a testing-only
+/// runtime, so signature verification adds nothing here.
+pub struct SchedulingV3AcceptAll;
+
+impl VerifySchedulingSignature for SchedulingV3AcceptAll {
+	const V3_SCHEDULING_ENABLED: bool = true;
+
+	fn verify(
+		_signed_info: &cumulus_primitives_core::SignedSchedulingInfo,
+		_internal_scheduling_parent_header: &cumulus_primitives_core::relay_chain::Header,
+	) -> bool {
+		true
+	}
+}
+
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const Version: RuntimeVersion = VERSION;
@@ -373,7 +389,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type CheckAssociatedRelayNumber = RelayNumberMonotonicallyIncreases;
 	type ConsensusHook = ConsensusHook;
 	type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
-	type SchedulingSignatureVerifier = ();
+	type SchedulingSignatureVerifier = SchedulingV3AcceptAll;
 }
 
 impl pallet_message_queue::Config for Runtime {

--- a/polkadot/runtime/westend/constants/src/lib.rs
+++ b/polkadot/runtime/westend/constants/src/lib.rs
@@ -42,7 +42,7 @@ pub mod time {
 
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(1 * HOURS, 1 * MINUTES);
+	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(1 * HOURS, 10 * MINUTES);
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/polkadot/runtime/westend/constants/src/lib.rs
+++ b/polkadot/runtime/westend/constants/src/lib.rs
@@ -42,7 +42,7 @@ pub mod time {
 
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SLOT_DURATION: Moment = MILLISECS_PER_BLOCK;
-	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(1 * HOURS, 10 * MINUTES);
+	pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(1 * HOURS, 1 * HOURS);
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/polkadot/runtime/westend/src/genesis_config_presets.rs
+++ b/polkadot/runtime/westend/src/genesis_config_presets.rs
@@ -153,6 +153,39 @@ fn default_parachains_host_configuration(
 	}
 }
 
+/// Host configuration for the versi V3-activation network (used by the staging preset, which
+/// versi's chainspec generator builds from). All knobs at genesis, so no post-reset sudo pass.
+fn versi_parachains_host_configuration(
+) -> polkadot_runtime_parachains::configuration::HostConfiguration<polkadot_primitives::BlockNumber>
+{
+	use polkadot_primitives::{AsyncBackingParams, ExecutorParam, ExecutorParams, PvfExecKind};
+
+	let mut config = default_parachains_host_configuration();
+	config.scheduler_params.num_cores = 9;
+	config.scheduler_params.max_validators_per_core = Some(5);
+	// lookahead 5 and group_rotation_frequency 20 inherited from the default.
+
+	// The genesis default {0, 0} silently kills relay-parent-offset paras.
+	config.async_backing_params =
+		AsyncBackingParams { max_candidate_depth: 5, allowed_ancestry_len: 2 };
+
+	// Default executor params cause HardTimeout storms on 1-CPU pods.
+	config.executor_params = ExecutorParams::from(
+		&[
+			ExecutorParam::MaxMemoryPages(8192),
+			ExecutorParam::PvfExecTimeout(PvfExecKind::Backing, 2500),
+			ExecutorParam::PvfExecTimeout(PvfExecKind::Approval, 15000),
+		][..],
+	);
+
+	config
+}
+
+#[test]
+fn versi_parachains_host_configuration_is_consistent() {
+	versi_parachains_host_configuration().panic_if_not_consistent();
+}
+
 #[test]
 fn default_parachains_host_configuration_is_consistent() {
 	default_parachains_host_configuration().panic_if_not_consistent();
@@ -390,7 +423,7 @@ fn westend_staging_testnet_config_genesis() -> serde_json::Value {
 		},
 		babe: BabeConfig { epoch_config: BABE_GENESIS_EPOCH_CONFIG },
 		sudo: SudoConfig { key: Some(endowed_accounts[0].clone()) },
-		configuration: ConfigurationConfig { config: default_parachains_host_configuration() },
+		configuration: ConfigurationConfig { config: versi_parachains_host_configuration() },
 		registrar: RegistrarConfig { next_free_para_id: polkadot_primitives::LOWEST_PUBLIC_ID },
 	})
 }

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("westend"),
 	impl_name: alloc::borrow::Cow::Borrowed("parity-westend"),
 	authoring_version: 2,
-	spec_version: 1_024_001,
+	spec_version: 1_024_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 27,

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -348,9 +348,9 @@ impl pallet_preimage::Config for Runtime {
 parameter_types! {
 	pub const EpochDuration: u64 = prod_or_fast!(
 		EPOCH_DURATION_IN_SLOTS as u64,
-		// 100-slot (10-minute) sessions for versi, matching the historical
-		// westend-100 runtime the network ran before.
-		10 * MINUTES as u64
+		// 1-hour sessions for versi, matching production westend, also in
+		// fast-runtime builds.
+		1 * HOURS as u64
 	);
 	pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 	pub const ReportLongevity: u64 =

--- a/polkadot/runtime/westend/src/lib.rs
+++ b/polkadot/runtime/westend/src/lib.rs
@@ -348,7 +348,9 @@ impl pallet_preimage::Config for Runtime {
 parameter_types! {
 	pub const EpochDuration: u64 = prod_or_fast!(
 		EPOCH_DURATION_IN_SLOTS as u64,
-		2 * MINUTES as u64
+		// 100-slot (10-minute) sessions for versi, matching the historical
+		// westend-100 runtime the network ran before.
+		10 * MINUTES as u64
 	);
 	pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 	pub const ReportLongevity: u64 =
@@ -571,11 +573,11 @@ parameter_types! {
 	// phase durations. 1/4 of the last session for each.
 	pub SignedPhase: u32 = prod_or_fast!(
 		EPOCH_DURATION_IN_SLOTS / 4,
-		(1 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
+		(10 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
 	);
 	pub UnsignedPhase: u32 = prod_or_fast!(
 		EPOCH_DURATION_IN_SLOTS / 4,
-		(1 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
+		(10 * MINUTES).min(EpochDuration::get().saturated_into::<u32>() / 2)
 	);
 
 	// signed config


### PR DESCRIPTION
**Do not merge.** CI-image vehicle for the versi **V3 candidate-descriptor activation test** — deployment PR: paritytech/parity-devnet#263. Based on the `stable2606` tip.

## What this provides in the versi stack

The test deploys a mixed stable-release network and flips node feature bit 4 (`CandidateReceiptV3`) live via sudo:

- validators: 18× `parity/polkadot:stable2512` (legacy collator protocol, truly v2-only) vs 18× `parity/polkadot:stable2606` with `--experimental-collator-protocol` (2 of them bootnodes) — the legacy-vs-revamp interop axis rides along. V3 acceptance itself is gated purely by the node feature (backing's `v3_ever_seen` latch on finalized blocks), not by the flag;
- para 2201: glutton-westend on released `polkadot-parachain:v1.21.3` (stable2512 line), 3 cores;
- para 2202: glutton-westend on released `polkadot-parachain:stable2606`, 3 cores;
- para 2900: **YAP with V3 scheduling enabled** — the image built by *this PR* (`paritypr/polkadot-parachain-debug`), 3 cores. Idle until activation, then backed by the stable2606 cohort;
- relay genesis code: the westend-staging runtime embedded in *this PR's* `paritypr/polkadot-debug` image.

## Changes

1. **`yet-another-parachain`: enable V3 scheduling** — accept-all `VerifySchedulingSignature` (`V3_SCHEDULING_ENABLED = true`), native relay-parent-offset 1 and velocity 12 untouched. No published runtime enables V3 (upstream it's a cargo feature of the cumulus test runtime only), hence this build.
2. **`glutton-westend`: same V3 enablement** (native RPO 1, velocity 3) — spare V3 runtime option on the same image.
3. **westend: 100-slot fast-runtime epoch + proportional election phases** — re-applies the westend hunks of #8467 (`westend-100`) on stable2606, so the new versi genesis keeps the 10-minute sessions of the network it replaces (stock fast-runtime would give 2-minute sessions).

Upstream V3+offset coverage exists only on master and only at velocity 1 (`scheduling_v3.rs`), so YAP at RPO 1 / velocity 12 on a mixed 2512/2606 validator set is exactly the untested territory versi is meant to explore.
