### PR TITLE
sp-io: report runtime panic messages to the host by default

### DIFF
--- a/prdoc/pr_12684.prdoc
+++ b/prdoc/pr_12684.prdoc
@@ -1,0 +1,17 @@
+title: 'sp-io: report runtime panic messages to the host by default'
+doc:
+- audience: Runtime Dev
+  description: |-
+    The runtime panic handler in `sp-io` now marshals panic (and OOM) messages
+    to the host via the `PanicHandler::abort_on_panic` host function by
+    default, so callers receive `Runtime panicked: <message>` instead of an
+    opaque `wasm trap: wasm 'unreachable' instruction executed` error. This
+    was previously opt-in behind the `improved_panic_error_reporting` feature,
+    which is now a deprecated no-op. Runtimes targeting a host client without
+    the `PanicHandler` host functions can restore the previous behavior with
+    the new `legacy_panic_error_reporting` feature. The polkadot PVF executor
+    instantiates with `allow_missing_func_imports`, so parachain validation is
+    unaffected: a panic during validation traps exactly as before.
+crates:
+- name: sp-io
+  bump: minor

--- a/substrate/primitives/io/Cargo.toml
+++ b/substrate/primitives/io/Cargo.toml
@@ -83,24 +83,24 @@ disable_panic_handler = []
 disable_oom = []
 disable_allocator = []
 
-# This feature flag controls the runtime's behavior when encountering
-# a panic or when it runs out of memory, improving the diagnostics.
+# DEPRECATED: Marshalling the panic message to the host through the
+# `PanicHandler::abort_on_panic` runtime interface is the default behavior
+# now; this feature flag is a no-op kept for backwards compatibility.
+# See `legacy_panic_error_reporting` to opt out of it.
+improved_panic_error_reporting = []
+
+# Restores the legacy behavior when encountering a panic or running out of
+# memory: the error message is only printed to the logs and execution aborts
+# via the `unreachable` instruction, with the caller receiving a generic
+# "wasm `unreachable` instruction executed" error message instead of the
+# panic message.
 #
-# When enabled the runtime will marshal the relevant error message
-# to the host through the `PanicHandler::abort_on_panic` runtime interface.
-# This gives the caller direct programmatic access to the error message.
-#
-# When disabled the error message will only be printed out in the
-# logs, with the caller receiving a generic "wasm `unreachable` instruction executed"
-# error message.
+# Only needed when targeting a host client that does not provide the
+# `PanicHandler::abort_on_panic` host function.
 #
 # This has no effect if both `disable_panic_handler` and `disable_oom`
 # are enabled.
-#
-# WARNING: Enabling this feature flag requires the `PanicHandler::abort_on_panic`
-#          host function to be supported by the host. Do *not* enable it for your
-#          runtime without first upgrading your host client!
-improved_panic_error_reporting = []
+legacy_panic_error_reporting = []
 
 # This feature adds BLS crypto primitives.
 # It should not be used in production since the implementation and interface may still

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -1957,14 +1957,14 @@ pub fn unreachable() -> ! {
 #[panic_handler]
 pub fn panic(info: &core::panic::PanicInfo) -> ! {
 	let message = alloc::format!("{}", info);
-	#[cfg(feature = "improved_panic_error_reporting")]
-	{
-		panic_handler::abort_on_panic(&message);
-	}
-	#[cfg(not(feature = "improved_panic_error_reporting"))]
+	#[cfg(feature = "legacy_panic_error_reporting")]
 	{
 		logging::log(RuntimeInterfaceLogLevel::Error, "runtime", message.as_bytes());
 		unreachable();
+	}
+	#[cfg(not(feature = "legacy_panic_error_reporting"))]
+	{
+		panic_handler::abort_on_panic(&message);
 	}
 }
 
@@ -1972,11 +1972,7 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
 #[cfg(all(not(feature = "disable_oom"), enable_alloc_error_handler))]
 #[alloc_error_handler]
 pub fn oom(_: core::alloc::Layout) -> ! {
-	#[cfg(feature = "improved_panic_error_reporting")]
-	{
-		panic_handler::abort_on_panic("Runtime memory exhausted.");
-	}
-	#[cfg(not(feature = "improved_panic_error_reporting"))]
+	#[cfg(feature = "legacy_panic_error_reporting")]
 	{
 		logging::log(
 			RuntimeInterfaceLogLevel::Error,
@@ -1984,6 +1980,10 @@ pub fn oom(_: core::alloc::Layout) -> ! {
 			b"Runtime memory exhausted. Aborting",
 		);
 		unreachable();
+	}
+	#[cfg(not(feature = "legacy_panic_error_reporting"))]
+	{
+		panic_handler::abort_on_panic("Runtime memory exhausted.");
 	}
 }
 


### PR DESCRIPTION
# Description

Makes `improved_panic_error_reporting` the default behavior of `sp-io`'s runtime panic handler: panics (and OOM aborts) now marshal their message to the host via the `PanicHandler::abort_on_panic` host function instead of logging and executing `unreachable`. Callers get `Runtime panicked: <message>` (`sc_executor_common::Error::AbortedDueToPanic`) instead of the opaque:

```
Execution failed: Execution aborted due to trap: wasm trap: wasm `unreachable` instruction executed
```

The old behavior remains available behind a new opt-out feature, `legacy_panic_error_reporting`, for runtimes that must target a host without the `PanicHandler` host functions. `improved_panic_error_reporting` is kept as a deprecated no-op so existing `Cargo.toml`s don't break.

## Motivation

The `abort_on_panic` mechanism has existed for years, yet outside `sc-executor`'s own test runtime it appears to have virtually no production adoption — chains ship with the opaque-trap default and users pay for it at debugging time. Concrete example from galacticcouncil/hydration-node#1491: a SCALE decode failure of a runtime-API parameter (`Bad input data provided to dry_run_call: Codec error…`) surfaced over public RPC as a bare wasm trap, was misdiagnosed as a runtime execution bug, and took a chopsticks fork to root-cause — the actual panic message only ever reached the node's local logs. With this change the message reaches the RPC caller directly.

## Compatibility

- **`sc-executor`** has captured the panic message (`HostState::panic_message` → `AbortedDueToPanic`) since 2022.
- **smoldot** implements `ext_panic_handler_abort_on_panic_version_1`.
- **Polkadot PVF validation**: the PVF executor's host function list does not include `PanicHandler`, but it instantiates with `allow_missing_func_imports: true`, so PVFs built with the new default still prepare and execute; a panic during validation traps just as it does today (outcome-identical: candidate invalid).
- Hosts predating the host function (or custom embedders without it) can build the runtime with `legacy_panic_error_reporting`.

## Review notes

- `substrate/client/executor/runtime-test` already enables `improved_panic_error_reporting`, so executor tests exercise the new-default path today; trap-asserting tests (`call_not_existing_function`, `unreachable_intrinsic`, host-allocator failure) cover genuine traps and are unaffected.
- The deprecated no-op feature can be removed in a follow-up major release.