### PR TITLE
`pallet-scheduler`: fix `cancel_named` leaking retry and `preimage` state

### DIFF
--- a/prdoc/pr_12688.prdoc
+++ b/prdoc/pr_12688.prdoc
@@ -1,0 +1,15 @@
+title: '`pallet-scheduler`: fix `cancel_named` leaking retry and `preimage` state'
+doc:
+- audience: Todo
+  description: |-
+    `do_cancel_named` removed the task and its `Lookup` entry regardless of origin,
+    but cleared the `Retries` entry and dropped the preimage only inside the
+    `origin.is_some()` block. The `schedule::v2::Named` and `schedule::v3::Named`
+    trait impls cancel with `origin = None`, so that path left an orphaned
+    `RetryConfig` in `Retries` and leaked a preimage reference. Cleanup now runs
+    whenever the task is removed, matching the anonymous `do_cancel`.
+
+    Closes #12603.
+crates:
+- name: pallet-scheduler
+  bump: major

--- a/prdoc/pr_12688.prdoc
+++ b/prdoc/pr_12688.prdoc
@@ -1,15 +1,10 @@
 title: '`pallet-scheduler`: fix `cancel_named` leaking retry and `preimage` state'
 doc:
-- audience: Todo
+- audience: Runtime Dev
   description: |-
-    `do_cancel_named` removed the task and its `Lookup` entry regardless of origin,
-    but cleared the `Retries` entry and dropped the preimage only inside the
-    `origin.is_some()` block. The `schedule::v2::Named` and `schedule::v3::Named`
-    trait impls cancel with `origin = None`, so that path left an orphaned
-    `RetryConfig` in `Retries` and leaked a preimage reference. Cleanup now runs
-    whenever the task is removed, matching the anonymous `do_cancel`.
+    `do_cancel_named` removed the task and its `Lookup` entry regardless of origin, but cleared the `Retries` entry and dropped the preimage only inside the `origin.is_some()` block. The `schedule::v2::Named` and `schedule::v3::Named` trait impls cancel with `origin = None`, so that path left an orphaned `RetryConfig` in `Retries` and leaked a preimage reference. Cleanup now runs whenever the task is removed, matching the anonymous `do_cancel`.
 
     Closes #12603.
 crates:
 - name: pallet-scheduler
-  bump: major
+  bump: patch

--- a/prdoc/pr_12688.prdoc
+++ b/prdoc/pr_12688.prdoc
@@ -4,7 +4,6 @@ doc:
   description: |-
     `do_cancel_named` removed the task and its `Lookup` entry regardless of origin, but cleared the `Retries` entry and dropped the preimage only inside the `origin.is_some()` block. The `schedule::v2::Named` and `schedule::v3::Named` trait impls cancel with `origin = None`, so that path left an orphaned `RetryConfig` in `Retries` and leaked a preimage reference. Cleanup now runs whenever the task is removed, matching the anonymous `do_cancel`.
 
-    Closes #12603.
 crates:
 - name: pallet-scheduler
   bump: patch

--- a/substrate/frame/scheduler/src/lib.rs
+++ b/substrate/frame/scheduler/src/lib.rs
@@ -1165,12 +1165,13 @@ impl<T: Config> Pallet<T> {
 				let i = index as usize;
 				Agenda::<T>::try_mutate(when, |agenda| -> DispatchResult {
 					if let Some(s) = agenda.get_mut(i) {
-						if let (Some(ref o), Some(ref s)) = (origin, s.borrow()) {
-							Self::ensure_privilege(o, &s.origin)?;
-							Retries::<T>::remove((when, index));
-							T::Preimages::drop(&s.call);
+						if let (Some(ref o), Some(ref task)) = (origin, s.borrow()) {
+							Self::ensure_privilege(o, &task.origin)?;
 						}
-						*s = None;
+						if let Some(task) = s.take() {
+							Retries::<T>::remove((when, index));
+							T::Preimages::drop(&task.call);
+						}
 					}
 					Ok(())
 				})?;

--- a/substrate/frame/scheduler/src/tests.rs
+++ b/substrate/frame/scheduler/src/tests.rs
@@ -2029,6 +2029,36 @@ fn cancel_removes_retry_entry() {
 }
 
 #[test]
+fn cancel_named_with_no_origin_removes_retry_entry() {
+	new_test_ext().execute_with(|| {
+		// Schedule a named task and give it a retry config.
+		assert_ok!(Scheduler::do_schedule_named(
+			[1u8; 32],
+			DispatchTime::At(4),
+			None,
+			127,
+			root(),
+			Preimage::bound(RuntimeCall::Logger(logger::Call::timed_log {
+				i: 42,
+				weight: Weight::from_parts(10, 0)
+			}))
+			.unwrap()
+		));
+		assert_ok!(Scheduler::set_retry_named(root().into(), [1u8; 32], 10, 1));
+		assert!(Retries::<Test>::contains_key((4, 0)));
+
+		// Cancel through the origin-less path used by the `schedule::Named` trait impls.
+		assert_ok!(Scheduler::do_cancel_named(None, [1u8; 32]));
+
+		// Task, lookup and retry config are all removed.
+		assert!(Lookup::<Test>::get([1u8; 32]).is_none());
+		assert!(Agenda::<Test>::get(4).get(0).map_or(true, Option::is_none));
+		assert!(!Retries::<Test>::contains_key((4, 0)));
+		assert_eq!(Retries::<Test>::iter().count(), 0);
+	});
+}
+
+#[test]
 fn cancel_retries_works() {
 	new_test_ext().execute_with(|| {
 		// task fails until block 99 is reached


### PR DESCRIPTION
`do_cancel_named` removed the task and its `Lookup` entry regardless of origin, but cleared the `Retries` entry and dropped the preimage only inside the `origin.is_some()` block. The `schedule::v2::Named` and `schedule::v3::Named` trait impls cancel with `origin = None`, so that path left an orphaned `RetryConfig` in `Retries` and leaked a preimage reference. Cleanup now runs whenever the task is removed, matching the anonymous `do_cancel`.

Closes #12603.