### PR TITLE
`pallet-broker`: reject duplicate auto-renewal for a core

### DIFF
--- a/prdoc/pr_12689.prdoc
+++ b/prdoc/pr_12689.prdoc
@@ -9,4 +9,4 @@ doc:
     A second enable for an already-enrolled core now returns the new `AutoRenewalAlreadyEnabled` error.
 crates:
 - name: pallet-broker
-  bump: minor
+  bump: major

--- a/prdoc/pr_12689.prdoc
+++ b/prdoc/pr_12689.prdoc
@@ -7,8 +7,6 @@ doc:
     Duplicate entries cause `rotate_sale`/`renew_cores` to renew and charge the payer once per duplicate, consume the `MaxAutoRenewals` bound with spurious records, and leave orphans after `disable_auto_renew` (which removes a single position).
 
     A second enable for an already-enrolled core now returns the new `AutoRenewalAlreadyEnabled` error.
-
-    Closes #12602.
 crates:
 - name: pallet-broker
   bump: minor

--- a/prdoc/pr_12689.prdoc
+++ b/prdoc/pr_12689.prdoc
@@ -1,0 +1,14 @@
+title: '`pallet-broker`: reject duplicate auto-renewal for a core'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `do_enable_auto_renew` computed the insertion index with `binary_search_by(..).unwrap_or_else(|e| e)`, which collapses the "already present" (`Ok`) and "not present" (`Err`) cases into the same position and then calls `try_insert`. Enabling auto-renewal twice for the same core inserted a duplicate `AutoRenewalRecord`, breaking the sorted-unique invariant documented on the `AutoRenewals` storage. The `workload_end_hint` branch only reads `PotentialRenewals` (it does not consume the record), so the preconditions pass on every call and the path is user-reachable.
+
+    Duplicate entries cause `rotate_sale`/`renew_cores` to renew and charge the payer once per duplicate, consume the `MaxAutoRenewals` bound with spurious records, and leave orphans after `disable_auto_renew` (which removes a single position).
+
+    A second enable for an already-enrolled core now returns the new `AutoRenewalAlreadyEnabled` error.
+
+    Closes #12602.
+crates:
+- name: pallet-broker
+  bump: minor

--- a/substrate/frame/broker/src/dispatchable_impls.rs
+++ b/substrate/frame/broker/src/dispatchable_impls.rs
@@ -583,21 +583,24 @@ impl<T: Config> Pallet<T> {
 			return Err(Error::<T>::NotAllowed.into());
 		}
 
-		// We are sorting auto renewals by `CoreIndex`.
-		AutoRenewals::<T>::try_mutate(|renewals| {
-			let pos = renewals
-				.binary_search_by(|r: &AutoRenewalRecord| r.core.cmp(&core))
-				.unwrap_or_else(|e| e);
-			renewals.try_insert(
-				pos,
-				AutoRenewalRecord {
-					core,
-					task,
-					next_renewal: workload_end_hint.unwrap_or(sale.region_end),
-				},
-			)
-		})
-		.map_err(|_| Error::<T>::TooManyAutoRenewals)?;
+		// Auto renewals are kept sorted by and unique per `CoreIndex`.
+		AutoRenewals::<T>::try_mutate(|renewals| -> DispatchResult {
+			let pos = match renewals.binary_search_by(|r: &AutoRenewalRecord| r.core.cmp(&core)) {
+				Ok(_) => return Err(Error::<T>::AutoRenewalAlreadyEnabled.into()),
+				Err(pos) => pos,
+			};
+			renewals
+				.try_insert(
+					pos,
+					AutoRenewalRecord {
+						core,
+						task,
+						next_renewal: workload_end_hint.unwrap_or(sale.region_end),
+					},
+				)
+				.map_err(|_| Error::<T>::TooManyAutoRenewals)?;
+			Ok(())
+		})?;
 
 		Self::deposit_event(Event::AutoRenewalEnabled { core, task });
 		Ok(())

--- a/substrate/frame/broker/src/lib.rs
+++ b/substrate/frame/broker/src/lib.rs
@@ -595,6 +595,8 @@ pub mod pallet {
 		SovereignAccountNotFound,
 		/// Attempted to disable auto-renewal for a core that didn't have it enabled.
 		AutoRenewalNotEnabled,
+		/// Attempted to enable auto-renewal for a core that already has it enabled.
+		AutoRenewalAlreadyEnabled,
 		/// Attempted to force remove an assignment that doesn't exist.
 		AssignmentNotFound,
 		/// Needed to prevent spam attacks.The amount of credits the user attempted to purchase is

--- a/substrate/frame/broker/src/tests.rs
+++ b/substrate/frame/broker/src/tests.rs
@@ -2198,6 +2198,30 @@ fn enable_auto_renew_works() {
 }
 
 #[test]
+fn enable_auto_renew_twice_is_rejected() {
+	TestExt::new().endow(1, 1000).limit_cores_offered(Some(10)).execute_with(|| {
+		assert_ok!(Broker::do_start_sales(100, 5));
+		advance_to(2);
+		let region_id = Broker::do_purchase(1, u64::max_value()).unwrap();
+		assert_ok!(Broker::do_assign(region_id, Some(1), 1001, Final));
+
+		// First enable succeeds via the `workload_end_hint` branch.
+		assert_ok!(Broker::do_enable_auto_renew(1001, region_id.core, 1001, Some(7)));
+		assert_eq!(
+			AutoRenewals::<Test>::get().to_vec(),
+			vec![AutoRenewalRecord { core: region_id.core, task: 1001, next_renewal: 7 }]
+		);
+
+		// Enabling again for the same core is rejected instead of inserting a duplicate.
+		assert_noop!(
+			Broker::do_enable_auto_renew(1001, region_id.core, 1001, Some(7)),
+			Error::<Test>::AutoRenewalAlreadyEnabled
+		);
+		assert_eq!(AutoRenewals::<Test>::get().len(), 1);
+	});
+}
+
+#[test]
 fn enable_auto_renewal_works_for_legacy_leases() {
 	TestExt::new().endow(1, 1000).execute_with(|| {
 		// With this test, we ensure that we don't renew unnecessarily if the task has Coretime


### PR DESCRIPTION
`do_enable_auto_renew` computed the insertion index with `binary_search_by(..).unwrap_or_else(|e| e)`, which collapses the "already present" (`Ok`) and "not present" (`Err`) cases into the same position and then calls `try_insert`. Enabling auto-renewal twice for the same core inserted a duplicate `AutoRenewalRecord`, breaking the sorted-unique invariant documented on the `AutoRenewals` storage. The `workload_end_hint` branch only reads `PotentialRenewals` (it does not consume the record), so the preconditions pass on every call and the path is user-reachable.

Duplicate entries cause `rotate_sale`/`renew_cores` to renew and charge the payer once per duplicate, consume the `MaxAutoRenewals` bound with spurious records, and leave orphans after `disable_auto_renew` (which removes a single position).

A second enable for an already-enrolled core now returns the new `AutoRenewalAlreadyEnabled` error. 

Closes #12602.