### PR TITLE
statement-store: replay subscriptions from persisted admission cursor

### DIFF
--- a/prdoc/pr_12697.prdoc
+++ b/prdoc/pr_12697.prdoc
@@ -1,0 +1,15 @@
+title: 'statement-store: replay subscriptions from persisted admission cursor'
+
+doc:
+- audience: Node Dev
+  description: |-
+    The statement store now persists a monotonic admission sequence for active statements in
+    parity-db (a new `ADMISSION_SEQ` column, created automatically on startup) and restores it
+    on restart. Subscription filters attached at runtime are replayed from a cursor up to a
+    registration watermark instead of materializing a full snapshot of statement hashes, with
+    replay batches bounded by raw statement bytes. Replay-before-live ordering and re-admission
+    semantics are preserved.
+
+crates:
+- name: sc-statement-store
+  bump: minor

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -2833,6 +2833,10 @@ mod tests {
 		.unwrap();
 		assert_eq!(store.submit_index.read().next_seq, 1);
 
+		let replay = store.replay_batch(&OptimizedTopicFilter::Any, 0, 1).unwrap();
+		assert_eq!(replay.statements, vec![first.encode()]);
+		assert!(replay.done);
+
 		let third = signed_statement(12);
 		assert_eq!(store.submit(third.clone(), StatementSource::Network), SubmitResult::New);
 		assert_eq!(
@@ -2874,6 +2878,24 @@ mod tests {
 			store.replay_batch(&filter, 0, watermark).unwrap().statements,
 			vec![statement.encode()]
 		);
+	}
+
+	#[test]
+	fn admission_cursor_resumes_from_the_middle_of_the_range() {
+		let (store, _temp) = test_store();
+		let first = signed_statement(1);
+		let second = signed_statement(2);
+		let third = signed_statement(3);
+		for statement in [&first, &second, &third] {
+			assert_eq!(
+				store.submit(statement.clone(), StatementSource::Network),
+				SubmitResult::New
+			);
+		}
+		let batch = store.replay_batch(&OptimizedTopicFilter::Any, 1, 3).unwrap();
+		assert_eq!(batch.statements, vec![second.encode(), third.encode()]);
+		assert_eq!(batch.cursor, 3);
+		assert!(batch.done);
 	}
 
 	#[test]

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -455,7 +455,7 @@ struct SubmitEntry {
 	account: AccountId,
 	expiry: Expiry,
 	data_len: usize,
-	admission_seq: Option<u64>,
+	admission_seq: u64,
 }
 
 /// Index for submit operations (constraint checking, entries, accounts).
@@ -562,8 +562,10 @@ impl ReplaySnapshotProvider for Weak<Store> {
 	}
 }
 
-/// What [`SubmitIndex::insert`] evicted to make room for a new statement.
+/// What [`SubmitIndex::insert`] claimed and evicted to make room for a new statement.
 struct InsertOutcome {
+	/// Admission sequence claimed by the new statement.
+	seq: u64,
 	/// All hashes removed from the index and their admission sequences. Their bodies and on-disk
 	/// indexes must be deleted.
 	evicted: Vec<(Hash, u64)>,
@@ -618,9 +620,9 @@ impl SubmitIndex {
 		SubmitIndex { config, ..Default::default() }
 	}
 
-	/// Records a sequence number after its statement and admission entries commit atomically.
+	/// Records a sequence number in the snapshot window, once its statement and admission entries
+	/// have committed atomically. The number itself is claimed earlier, by [`Self::insert`].
 	fn note_seq(&mut self, hash: Hash, seq: u64) {
-		self.next_seq = seq.saturating_add(1);
 		if !self.active_scan_floors.is_empty() {
 			self.recent_seqs.insert(hash, seq);
 		}
@@ -661,7 +663,7 @@ impl SubmitIndex {
 		hash: Hash,
 		account: AccountId,
 		statement: &Statement,
-		admission_seq: Option<u64>,
+		admission_seq: u64,
 	) {
 		let expiry = Expiry(statement.expiry());
 		self.entries.insert(
@@ -679,7 +681,7 @@ impl SubmitIndex {
 			.insert(PriorityKey { hash, expiry }, (statement.channel(), statement.data_len()));
 	}
 
-	fn make_expired(&mut self, hash: &Hash, current_time: u64) -> Option<Eviction> {
+	fn make_expired(&mut self, hash: &Hash, current_time: u64) -> Option<(u64, Eviction)> {
 		if let Some(entry) = self.entries.remove(hash) {
 			self.total_size -= entry.data_len;
 			let eviction = if current_time < entry.expiry.get_expiration_timestamp_secs() {
@@ -707,7 +709,7 @@ impl SubmitIndex {
 				}
 			}
 			log::trace!(target: LOG_TARGET, "Expired statement {:?}", HexDisplay::from(hash));
-			Some(eviction)
+			Some((entry.admission_seq, eviction))
 		} else {
 			None
 		}
@@ -831,16 +833,21 @@ impl SubmitIndex {
 		let mut removed = Vec::with_capacity(evicted.len());
 		let mut banned = Vec::new();
 		for h in &evicted {
-			let admission_seq = self.entries.get(h).and_then(|entry| entry.admission_seq);
-			if let Some(Eviction::Banned(purge_at)) = self.make_expired(h, current_time) {
+			let Some((admission_seq, eviction)) = self.make_expired(h, current_time) else {
+				continue;
+			};
+			if let Eviction::Banned(purge_at) = eviction {
 				banned.push((*h, purge_at));
 			}
-			if let Some(admission_seq) = admission_seq {
-				removed.push((*h, admission_seq));
-			}
+			removed.push((*h, admission_seq));
 		}
-		self.insert_new(hash, *account, statement, Some(self.next_seq));
-		Ok(InsertOutcome { evicted: removed, banned })
+		// Claim the sequence number and advance the counter together. The entry below carries
+		// `seq`, so reissuing it to another hash would let this entry's eviction delete the other
+		// statement's admission entry.
+		let seq = self.next_seq;
+		self.next_seq = seq.saturating_add(1);
+		self.insert_new(hash, *account, statement, seq);
+		Ok(InsertOutcome { seq, evicted: removed, banned })
 	}
 }
 
@@ -1022,6 +1029,26 @@ impl Store {
 			let mut query_index = self.query_index.write();
 			let mut migration = MigrationBatch::new(&self.db);
 			let mut migration_error = None;
+			// Every entry is created with its sequence number, so the persisted ones have to be
+			// read before the statements themselves. A migrating database has none of them yet.
+			let mut admission_seqs = HashMap::new();
+			if !migrate_index {
+				let mut iter =
+					self.db.iter(col::ADMISSION_SEQ).map_err(|e| Error::Db(e.to_string()))?;
+				iter.seek_to_first().map_err(|e| Error::Db(e.to_string()))?;
+				while let Some((key, value)) = iter.next().map_err(|e| Error::Db(e.to_string()))? {
+					let seq = u64::from_be_bytes(
+						key.try_into()
+							.map_err(|_| Error::Db("Invalid admission sequence key".into()))?,
+					);
+					let hash: Hash = value
+						.as_slice()
+						.try_into()
+						.map_err(|_| Error::Db("Invalid admission sequence hash".into()))?;
+					admission_seqs.insert(hash, seq);
+					submit_index.next_seq = submit_index.next_seq.max(seq.saturating_add(1));
+				}
+			}
 			self.db
 				.iter_column_while(col::STATEMENTS, |item| {
 					let statement = item.value;
@@ -1033,28 +1060,29 @@ impl Store {
 							HexDisplay::from(&hash)
 						);
 						if let Some(account_id) = statement.account_id() {
-							let admission_seq = if migrate_index {
+							let persisted_seq = admission_seqs.remove(&hash);
+							let seq = persisted_seq.unwrap_or_else(|| {
 								let seq = submit_index.next_seq;
-								submit_index.next_seq = submit_index.next_seq.saturating_add(1);
-								Some(seq)
-							} else {
-								None
-							};
-							submit_index.insert_new(hash, account_id, &statement, admission_seq);
+								submit_index.next_seq = seq.saturating_add(1);
+								seq
+							});
+							submit_index.insert_new(hash, account_id, &statement, seq);
 							query_index.note_initial(&statement);
-							if let Some(seq) = admission_seq {
-								let operations = statement_index_ops(&hash, &statement, true)
-									.into_iter()
-									.map(DbOperation::from)
-									.chain(std::iter::once(DbOperation {
-										column: col::ADMISSION_SEQ,
-										key: seq.to_be_bytes().to_vec(),
-										value: Some(hash.to_vec()),
-									}));
-								if let Err(error) = migration.extend(operations) {
-									migration_error = Some(error);
-									return false;
-								}
+							let index_ops = if migrate_index {
+								statement_index_ops(&hash, &statement, true)
+							} else {
+								Vec::new()
+							};
+							let admission_op = persisted_seq.is_none().then(|| DbOperation {
+								column: col::ADMISSION_SEQ,
+								key: seq.to_be_bytes().to_vec(),
+								value: Some(hash.to_vec()),
+							});
+							let operations =
+								index_ops.into_iter().map(DbOperation::from).chain(admission_op);
+							if let Err(error) = migration.extend(operations) {
+								migration_error = Some(error);
+								return false;
 							}
 						} else {
 							log::debug!(
@@ -1069,26 +1097,6 @@ impl Store {
 				.map_err(|e| Error::Db(e.to_string()))?;
 			if let Some(error) = migration_error.take() {
 				return Err(error);
-			}
-			if !migrate_index {
-				let mut iter =
-					self.db.iter(col::ADMISSION_SEQ).map_err(|e| Error::Db(e.to_string()))?;
-				iter.seek_to_first().map_err(|e| Error::Db(e.to_string()))?;
-				while let Some((key, value)) = iter.next().map_err(|e| Error::Db(e.to_string()))? {
-					let seq = u64::from_be_bytes(
-						key.try_into()
-							.map_err(|_| Error::Db("Invalid admission sequence key".into()))?,
-					);
-					let hash: Hash = value
-						.as_slice()
-						.try_into()
-						.map_err(|_| Error::Db("Invalid admission sequence hash".into()))?;
-					let Some(entry) = submit_index.entries.get_mut(&hash) else {
-						continue;
-					};
-					entry.admission_seq = Some(seq);
-					submit_index.next_seq = submit_index.next_seq.max(seq.saturating_add(1));
-				}
 			}
 			let mut evicted_count = 0usize;
 			self.db
@@ -1138,6 +1146,12 @@ impl Store {
 			log::info!(
 				target: LOG_TARGET,
 				"Migrated statement store read index to the on-disk format ({} entries)",
+				migrated_entries
+			);
+		} else if migrated_entries > 0 {
+			log::warn!(
+				target: LOG_TARGET,
+				"Restored {} missing statement admission entries",
 				migrated_entries
 			);
 		}
@@ -2055,7 +2069,7 @@ impl StatementStore for Store {
 					},
 				};
 
-			let seq = submit_index.next_seq;
+			let seq = outcome.seq;
 			let mut commit = Vec::new();
 			commit.push((col::STATEMENTS, hash.to_vec(), Some(statement.encode())));
 			commit.push((col::ADMISSION_SEQ, seq.to_be_bytes().to_vec(), Some(hash.to_vec())));
@@ -2128,23 +2142,17 @@ impl StatementStore for Store {
 			// Read the body under the submit-index lock: a concurrent first-time submit could
 			// otherwise commit the statement between the read and `make_expired`, and its
 			// read-index entries would never be cleared.
-			let admission_seq =
-				submit_index.entries.get(hash).and_then(|entry| entry.admission_seq);
 			let statement =
 				match self.db.get(col::STATEMENTS, hash).map_err(|e| Error::Db(e.to_string()))? {
 					Some(encoded) => Statement::decode(&mut encoded.as_slice()).ok(),
 					None => None,
 				};
 			match submit_index.make_expired(hash, current_time) {
-				Some(eviction) => {
-					let mut commit = vec![(col::STATEMENTS, hash.to_vec(), None)];
-					if let Some(admission_seq) = admission_seq {
-						commit.push((
-							col::ADMISSION_SEQ,
-							admission_seq.to_be_bytes().to_vec(),
-							None,
-						));
-					}
+				Some((admission_seq, eviction)) => {
+					let mut commit = vec![
+						(col::STATEMENTS, hash.to_vec(), None),
+						(col::ADMISSION_SEQ, admission_seq.to_be_bytes().to_vec(), None),
+					];
 					if let Some(statement) = &statement {
 						commit.extend(statement_index_ops(hash, statement, false));
 					}
@@ -2195,8 +2203,6 @@ impl StatementStore for Store {
 			let mut commit = Vec::new();
 			let mut removed_statements = Vec::new();
 			for hash in &hashes {
-				let admission_seq =
-					submit_index.entries.get(hash).and_then(|entry| entry.admission_seq);
 				let statement = match self.db.get(col::STATEMENTS, hash) {
 					Ok(Some(encoded)) => Statement::decode(&mut encoded.as_slice()).ok(),
 					Ok(None) => None,
@@ -2210,15 +2216,11 @@ impl StatementStore for Store {
 						None
 					},
 				};
-				if let Some(eviction) = submit_index.make_expired(hash, current_time) {
+				if let Some((admission_seq, eviction)) =
+					submit_index.make_expired(hash, current_time)
+				{
 					commit.push((col::STATEMENTS, hash.to_vec(), None));
-					if let Some(admission_seq) = admission_seq {
-						commit.push((
-							col::ADMISSION_SEQ,
-							admission_seq.to_be_bytes().to_vec(),
-							None,
-						));
-					}
+					commit.push((col::ADMISSION_SEQ, admission_seq.to_be_bytes().to_vec(), None));
 					if let Eviction::Banned(purge_at) = eviction {
 						commit.push((
 							col::EXPIRED,
@@ -2327,11 +2329,12 @@ impl StatementStoreSubscriptionApi for Store {
 
 impl Store {
 	fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
-		// Holding the submit lock across `enqueue` keeps the registration ordered before any
-		// post-watermark live notification. `enqueue` must not block.
-		let submit_index = self.submit_index.write();
-		let watermark = submit_index.next_seq;
-		Ok(enqueue(watermark).then_some(watermark))
+		let registered = {
+			let submit_index = self.submit_index.write();
+			let watermark = submit_index.next_seq;
+			enqueue(watermark).then_some(watermark)
+		}; // Release submit index lock
+		Ok(registered)
 	}
 
 	fn replay_batch(
@@ -2365,20 +2368,25 @@ impl Store {
 				cursor = next_cursor;
 				continue;
 			};
-			let is_current = self
-				.submit_index
-				.read()
-				.entries
-				.get(&hash)
-				.and_then(|entry| entry.admission_seq) ==
-				Some(seq);
+			let is_current =
+				self.submit_index.read().entries.get(&hash).map(|entry| entry.admission_seq) ==
+					Some(seq);
 			if !is_current {
 				cursor = next_cursor;
 				continue;
 			}
-			let Ok(statement) = Statement::decode(&mut encoded.as_slice()) else {
-				cursor = next_cursor;
-				continue;
+			let statement = match Statement::decode(&mut encoded.as_slice()) {
+				Ok(statement) => statement,
+				Err(e) => {
+					log::warn!(
+						target: LOG_TARGET,
+						"Could not decode statement {:?} while replaying it: {:?}",
+						HexDisplay::from(&hash),
+						e
+					);
+					cursor = next_cursor;
+					continue;
+				},
 			};
 			if !filter.matches(&statement) {
 				cursor = next_cursor;
@@ -2830,6 +2838,41 @@ mod tests {
 		assert_eq!(
 			store.db.get(col::ADMISSION_SEQ, &1u64.to_be_bytes()).unwrap(),
 			Some(third.hash().to_vec())
+		);
+	}
+
+	#[test]
+	fn statement_without_admission_entry_is_replayable_after_restart() {
+		let (store, temp) = test_store();
+		let statement = signed_statement_with_topics(20, &[topic(1)], None);
+		assert_eq!(store.submit(statement.clone(), StatementSource::Network), SubmitResult::New);
+		// Drop the admission entry, leaving the body behind.
+		store
+			.db
+			.commit([(col::ADMISSION_SEQ, 0u64.to_be_bytes().to_vec(), None)])
+			.unwrap();
+		let filter = OptimizedTopicFilter::MatchAny([topic(1)].into_iter().collect());
+		assert!(store.replay_batch(&filter, 0, 1).unwrap().statements.is_empty());
+		let keystore = store.keystore.clone();
+		drop(store);
+
+		let mut path: std::path::PathBuf = temp.path().into();
+		path.push("db");
+		let store = Store::new::<Block, TestClient, TestBackend>(
+			&path,
+			Default::default(),
+			std::sync::Arc::new(TestClient),
+			keystore,
+			None,
+			Box::new(sp_core::testing::TaskExecutor::new()),
+		)
+		.unwrap();
+
+		let watermark = store.submit_index.read().next_seq;
+		assert_eq!(watermark, 1);
+		assert_eq!(
+			store.replay_batch(&filter, 0, watermark).unwrap().statements,
+			vec![statement.encode()]
 		);
 	}
 
@@ -3975,7 +4018,7 @@ mod tests {
 		{
 			let mut index = store.submit_index.write();
 			for (seq, statement) in [&s1, &s2, &s3, &s4, &s5].into_iter().enumerate() {
-				index.insert_new(statement.hash(), account(4), statement, Some(seq as u64));
+				index.insert_new(statement.hash(), account(4), statement, seq as u64);
 			}
 		}
 
@@ -4015,8 +4058,8 @@ mod tests {
 		// Directly insert statements for account with no allowance
 		{
 			let mut index = store.submit_index.write();
-			index.insert_new(h1, account(0), &s1, Some(0));
-			index.insert_new(h2, account(0), &s2, Some(1));
+			index.insert_new(h1, account(0), &s1, 0);
+			index.insert_new(h2, account(0), &s2, 1);
 		}
 
 		assert_eq!(store.submit_index.read().entries.len(), 2);
@@ -4050,8 +4093,8 @@ mod tests {
 		// Directly insert both statements (total 1200 bytes > 1000 limit)
 		{
 			let mut index = store.submit_index.write();
-			index.insert_new(s1.hash(), account(2), &s1, Some(0));
-			index.insert_new(s2.hash(), account(2), &s2, Some(1));
+			index.insert_new(s1.hash(), account(2), &s1, 0);
+			index.insert_new(s2.hash(), account(2), &s2, 1);
 		}
 
 		assert_eq!(store.submit_index.read().total_size, 1200);
@@ -4553,8 +4596,7 @@ mod tests {
 			const NUM_STATEMENTS: u8 = 50;
 			const NUM_PRE_FILTER: u8 = 20;
 
-			// Statements stored before the filter is attached; the replay snapshot must cover
-			// exactly these.
+			// Statements stored before the filter is attached; the replay must cover exactly these.
 			for i in 0..NUM_PRE_FILTER {
 				let stmt = signed_statement(i);
 				assert_eq!(store.submit(stmt, StatementSource::Local), SubmitResult::New);
@@ -4562,8 +4604,8 @@ mod tests {
 
 			let filter_id = handle.add_filter(OptimizedTopicFilter::Any).unwrap();
 
-			// The snapshot is collected atomically with the filter registration, so statements
-			// submitted after `add_filter` returns must arrive as live events only.
+			// The watermark is captured atomically with the filter registration, so statements
+			// submitted after `add_filter` returns sit above it and arrive as live events only.
 			for i in NUM_PRE_FILTER..NUM_STATEMENTS {
 				let stmt = signed_statement(i);
 				assert_eq!(store.submit(stmt, StatementSource::Local), SubmitResult::New);

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -90,7 +90,19 @@ const CURRENT_VERSION: u32 = 2;
 
 const MIGRATION_COMMIT_CHUNK: usize = 100_000;
 
-type DbOperation = (u8, Vec<u8>, Option<Vec<u8>>);
+/// A single raw database operation: writes `value` under `key` in `column`, or deletes the key
+/// when `value` is `None`.
+struct DbOperation {
+	column: u8,
+	key: Vec<u8>,
+	value: Option<Vec<u8>>,
+}
+
+impl From<(u8, Vec<u8>, Option<Vec<u8>>)> for DbOperation {
+	fn from((column, key, value): (u8, Vec<u8>, Option<Vec<u8>>)) -> Self {
+		Self { column, key, value }
+	}
+}
 
 struct MigrationBatch<'a> {
 	db: &'a parity_db::Db,
@@ -126,7 +138,13 @@ impl<'a> MigrationBatch<'a> {
 		}
 		let operations = std::mem::take(&mut self.operations);
 		let count = operations.len();
-		self.db.commit(operations).map_err(|error| Error::Db(error.to_string()))?;
+		self.db
+			.commit(
+				operations
+					.into_iter()
+					.map(|operation| (operation.column, operation.key, operation.value)),
+			)
+			.map_err(|error| Error::Db(error.to_string()))?;
 		self.committed += count;
 		Ok(())
 	}
@@ -1025,12 +1043,14 @@ impl Store {
 							submit_index.insert_new(hash, account_id, &statement, admission_seq);
 							query_index.note_initial(&statement);
 							if let Some(seq) = admission_seq {
-								let mut operations = statement_index_ops(&hash, &statement, true);
-								operations.push((
-									col::ADMISSION_SEQ,
-									seq.to_be_bytes().to_vec(),
-									Some(hash.to_vec()),
-								));
+								let operations = statement_index_ops(&hash, &statement, true)
+									.into_iter()
+									.map(DbOperation::from)
+									.chain(std::iter::once(DbOperation {
+										column: col::ADMISSION_SEQ,
+										key: seq.to_be_bytes().to_vec(),
+										value: Some(hash.to_vec()),
+									}));
 								if let Err(error) = migration.extend(operations) {
 									migration_error = Some(error);
 									return false;
@@ -1066,13 +1086,8 @@ impl Store {
 					let Some(entry) = submit_index.entries.get_mut(&hash) else {
 						continue;
 					};
-					if entry.admission_seq.replace(seq).is_some() {
-						return Err(Error::Db("Duplicate admission sequence for statement".into()));
-					}
+					entry.admission_seq = Some(seq);
 					submit_index.next_seq = submit_index.next_seq.max(seq.saturating_add(1));
-				}
-				if submit_index.entries.values().any(|entry| entry.admission_seq.is_none()) {
-					return Err(Error::Db("Statement is missing an admission sequence".into()));
 				}
 			}
 			let mut evicted_count = 0usize;
@@ -1091,11 +1106,11 @@ impl Store {
 						if migrate_index {
 							let purge_at =
 								timestamp.saturating_add(submit_index.config.purge_after_sec);
-							let operation = (
-								col::INDEX_EVICTED,
-								evicted_index_key(purge_at, &hash),
-								Some(INDEX_EMPTY_VALUE.to_vec()),
-							);
+							let operation = DbOperation {
+								column: col::INDEX_EVICTED,
+								key: evicted_index_key(purge_at, &hash),
+								value: Some(INDEX_EMPTY_VALUE.to_vec()),
+							};
 							if let Err(error) = migration.push(operation) {
 								migration_error = Some(error);
 								return false;
@@ -2312,8 +2327,8 @@ impl StatementStoreSubscriptionApi for Store {
 
 impl Store {
 	fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
-		// Enqueue registration while holding the same lock that assigns submit sequence numbers.
-		// Every post-watermark live notification is therefore ordered after that registration.
+		// Holding the submit lock across `enqueue` keeps the registration ordered before any
+		// post-watermark live notification. `enqueue` must not block.
 		let submit_index = self.submit_index.write();
 		let watermark = submit_index.next_seq;
 		Ok(enqueue(watermark).then_some(watermark))

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -934,10 +934,10 @@ impl Store {
 			let column = migrate_config.columns.len() as u8;
 			new_column_options.btree_index = matches!(
 				column,
-				col::INDEX_BY_TOPIC
-					| col::INDEX_BY_DEC_KEY
-					| col::INDEX_EVICTED
-					| col::ADMISSION_SEQ
+				col::INDEX_BY_TOPIC |
+					col::INDEX_BY_DEC_KEY |
+					col::INDEX_EVICTED |
+					col::ADMISSION_SEQ
 			);
 			parity_db::Db::add_column(&mut migrate_config, new_column_options)
 				.map_err(|e| Error::Db(e.to_string()))?;
@@ -2029,7 +2029,8 @@ impl StatementStore for Store {
 			let mut submit_index = self.submit_index.write();
 
 			let outcome =
-				match submit_index.insert(hash, &statement, &account_id, &validation, current_time) {
+				match submit_index.insert(hash, &statement, &account_id, &validation, current_time)
+				{
 					Ok(outcome) => outcome,
 					Err(reason) => {
 						self.metrics.report(|metrics| {
@@ -2112,7 +2113,8 @@ impl StatementStore for Store {
 			// Read the body under the submit-index lock: a concurrent first-time submit could
 			// otherwise commit the statement between the read and `make_expired`, and its
 			// read-index entries would never be cleared.
-			let admission_seq = submit_index.entries.get(hash).and_then(|entry| entry.admission_seq);
+			let admission_seq =
+				submit_index.entries.get(hash).and_then(|entry| entry.admission_seq);
 			let statement =
 				match self.db.get(col::STATEMENTS, hash).map_err(|e| Error::Db(e.to_string()))? {
 					Some(encoded) => Statement::decode(&mut encoded.as_slice()).ok(),
@@ -2262,9 +2264,10 @@ impl StatementStoreSubscriptionApi for Store {
 		topic_filter: OptimizedTopicFilter,
 	) -> Result<(Vec<Vec<u8>>, async_channel::Sender<StatementEvent>, SubscriptionStatementsStream)>
 	{
-		// Avoid overlap between the subscribe-time snapshot and live delivery using a sequence-number
-		// watermark. Under the submit-index write lock, atomically with respect to sequence assignment,
-		// capture the current boundary `W` and enqueue the subscription registration tagged with `W`.
+		// Avoid overlap between the subscribe-time snapshot and live delivery using a
+		// sequence-number watermark. Under the submit-index write lock, atomically with respect
+		// to sequence assignment, capture the current boundary `W` and enqueue the subscription
+		// registration tagged with `W`.
 		let (subscription_sender, subscription_stream, watermark) = {
 			let mut submit_index = self.submit_index.write();
 			let watermark = submit_index.begin_scan();
@@ -2352,8 +2355,8 @@ impl Store {
 				.read()
 				.entries
 				.get(&hash)
-				.and_then(|entry| entry.admission_seq)
-				== Some(seq);
+				.and_then(|entry| entry.admission_seq) ==
+				Some(seq);
 			if !is_current {
 				cursor = next_cursor;
 				continue;

--- a/substrate/client/statement-store/src/lib.rs
+++ b/substrate/client/statement-store/src/lib.rs
@@ -78,15 +78,64 @@ use std::{
 	sync::{Arc, Weak},
 	time::{Duration, Instant},
 };
-use subscription::ReplaySnapshotProvider;
 pub use subscription::{
 	AddFilterError, MultiFilterEventStream, MultiFilterSubscriptionApi,
 	MultiFilterSubscriptionEvent, StatementStoreSubscriptionApi, SubscriptionHandle,
 	MAX_FILTERS_PER_SUBSCRIPTION,
 };
+use subscription::{ReplayBatch, ReplaySnapshotProvider, REPLAY_CHUNK_RAW_BYTES};
 
 const KEY_VERSION: &[u8] = b"version".as_slice();
 const CURRENT_VERSION: u32 = 2;
+
+const MIGRATION_COMMIT_CHUNK: usize = 100_000;
+
+type DbOperation = (u8, Vec<u8>, Option<Vec<u8>>);
+
+struct MigrationBatch<'a> {
+	db: &'a parity_db::Db,
+	operations: Vec<DbOperation>,
+	committed: usize,
+}
+
+impl<'a> MigrationBatch<'a> {
+	fn new(db: &'a parity_db::Db) -> Self {
+		Self { db, operations: Vec::new(), committed: 0 }
+	}
+
+	fn push(&mut self, operation: DbOperation) -> Result<()> {
+		self.operations.push(operation);
+		self.flush_if_full()
+	}
+
+	fn extend(&mut self, operations: impl IntoIterator<Item = DbOperation>) -> Result<()> {
+		self.operations.extend(operations);
+		self.flush_if_full()
+	}
+
+	fn flush_if_full(&mut self) -> Result<()> {
+		if self.operations.len() >= MIGRATION_COMMIT_CHUNK {
+			self.flush()?;
+		}
+		Ok(())
+	}
+
+	fn flush(&mut self) -> Result<()> {
+		if self.operations.is_empty() {
+			return Ok(());
+		}
+		let operations = std::mem::take(&mut self.operations);
+		let count = operations.len();
+		self.db.commit(operations).map_err(|error| Error::Db(error.to_string()))?;
+		self.committed += count;
+		Ok(())
+	}
+
+	fn finish(mut self) -> Result<usize> {
+		self.flush()?;
+		Ok(self.committed)
+	}
+}
 
 const LOG_TARGET: &str = "statement-store";
 
@@ -134,8 +183,9 @@ mod col {
 	pub const INDEX_BY_TOPIC: u8 = 3;
 	pub const INDEX_BY_DEC_KEY: u8 = 4;
 	pub const INDEX_EVICTED: u8 = 5;
+	pub const ADMISSION_SEQ: u8 = 6;
 
-	pub const COUNT: u8 = 6;
+	pub const COUNT: u8 = 7;
 }
 
 const INDEX_EMPTY_VALUE: &[u8] = &[];
@@ -383,12 +433,18 @@ impl QueryIndex {
 	}
 }
 
+struct SubmitEntry {
+	account: AccountId,
+	expiry: Expiry,
+	data_len: usize,
+	admission_seq: Option<u64>,
+}
+
 /// Index for submit operations (constraint checking, entries, accounts).
 #[derive(Default)]
 struct SubmitIndex {
-	/// Statement hash → (account, expiry/priority, data size); the authoritative set of stored
-	/// statements.
-	entries: HashMap<Hash, (AccountId, Expiry, usize)>,
+	/// Statement hash → submit metadata; the authoritative set of stored statements.
+	entries: HashMap<Hash, SubmitEntry>,
 	/// Per-account tracking (priority-ordered hashes, channels, size) for quota enforcement.
 	accounts: HashMap<AccountId, StatementsForAccount>,
 	/// Accounts still pending an expiry/limit check by `enforce_limits`.
@@ -468,30 +524,31 @@ enum Eviction {
 }
 
 impl ReplaySnapshotProvider for Weak<Store> {
-	fn with_snapshot_hashes(
-		&self,
-		filter: &OptimizedTopicFilter,
-		enqueue: &mut dyn FnMut(Vec<Hash>),
-	) -> Result<()> {
+	fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
 		let Some(store) = self.upgrade() else {
 			return Err(Error::InvalidConfig("statement store is closed".into()));
 		};
-		store.with_snapshot_hashes(filter, enqueue)
+		store.register_replay(enqueue)
 	}
 
-	fn statement_by_hash(&self, hash: &Hash) -> Result<Option<Vec<u8>>> {
+	fn replay_batch(
+		&self,
+		filter: &OptimizedTopicFilter,
+		cursor: u64,
+		watermark: u64,
+	) -> Result<ReplayBatch> {
 		let Some(store) = self.upgrade() else {
 			return Err(Error::InvalidConfig("statement store is closed".into()));
 		};
-		store.statement_by_hash(hash)
+		store.replay_batch(filter, cursor, watermark)
 	}
 }
 
 /// What [`SubmitIndex::insert`] evicted to make room for a new statement.
 struct InsertOutcome {
-	/// All hashes removed from the index. Their bodies must be deleted and their read-index
-	/// entries cleared.
-	evicted: HashSet<Hash>,
+	/// All hashes removed from the index and their admission sequences. Their bodies and on-disk
+	/// indexes must be deleted.
+	evicted: Vec<(Hash, u64)>,
 	/// The subset of `evicted` that is banned from re-acceptance, with its purge deadline. These
 	/// must be recorded in the on-disk evicted journal.
 	banned: Vec<(Hash, u64)>,
@@ -543,15 +600,12 @@ impl SubmitIndex {
 		SubmitIndex { config, ..Default::default() }
 	}
 
-	/// Assigns and returns the next store sequence number for `hash`, recording it in `recent_seqs`
-	/// while a snapshot scan is active.
-	fn note_seq(&mut self, hash: Hash) -> u64 {
-		let seq = self.next_seq;
-		self.next_seq += 1;
+	/// Records a sequence number after its statement and admission entries commit atomically.
+	fn note_seq(&mut self, hash: Hash, seq: u64) {
+		self.next_seq = seq.saturating_add(1);
 		if !self.active_scan_floors.is_empty() {
 			self.recent_seqs.insert(hash, seq);
 		}
-		seq
 	}
 
 	/// Registers a subscription snapshot scan and returns its watermark.
@@ -584,9 +638,18 @@ impl SubmitIndex {
 		}
 	}
 
-	fn insert_new(&mut self, hash: Hash, account: AccountId, statement: &Statement) {
+	fn insert_new(
+		&mut self,
+		hash: Hash,
+		account: AccountId,
+		statement: &Statement,
+		admission_seq: Option<u64>,
+	) {
 		let expiry = Expiry(statement.expiry());
-		self.entries.insert(hash, (account, expiry, statement.data_len()));
+		self.entries.insert(
+			hash,
+			SubmitEntry { account, expiry, data_len: statement.data_len(), admission_seq },
+		);
 		self.total_size += statement.data_len();
 		let account_info = self.accounts.entry(account).or_default();
 		account_info.data_size += statement.data_len();
@@ -599,10 +662,11 @@ impl SubmitIndex {
 	}
 
 	fn make_expired(&mut self, hash: &Hash, current_time: u64) -> Option<Eviction> {
-		if let Some((account, expiry, len)) = self.entries.remove(hash) {
-			self.total_size -= len;
-			let eviction = if current_time < expiry.get_expiration_timestamp_secs() {
-				let purge_at = expiry
+		if let Some(entry) = self.entries.remove(hash) {
+			self.total_size -= entry.data_len;
+			let eviction = if current_time < entry.expiry.get_expiration_timestamp_secs() {
+				let purge_at = entry
+					.expiry
 					.get_expiration_timestamp_secs()
 					.min(current_time.saturating_add(self.config.purge_after_sec));
 				self.evicted_count += 1;
@@ -611,9 +675,9 @@ impl SubmitIndex {
 				Eviction::Removed
 			};
 			if let std::collections::hash_map::Entry::Occupied(mut account_rec) =
-				self.accounts.entry(account)
+				self.accounts.entry(entry.account)
 			{
-				let key = PriorityKey { hash: *hash, expiry };
+				let key = PriorityKey { hash: *hash, expiry: entry.expiry };
 				if let Some((channel, len)) = account_rec.get_mut().by_priority.remove(&key) {
 					account_rec.get_mut().data_size -= len;
 					if let Some(channel) = channel {
@@ -746,14 +810,19 @@ impl SubmitIndex {
 			return Err(RejectionReason::StoreFull);
 		}
 
+		let mut removed = Vec::with_capacity(evicted.len());
 		let mut banned = Vec::new();
 		for h in &evicted {
+			let admission_seq = self.entries.get(h).and_then(|entry| entry.admission_seq);
 			if let Some(Eviction::Banned(purge_at)) = self.make_expired(h, current_time) {
 				banned.push((*h, purge_at));
 			}
+			if let Some(admission_seq) = admission_seq {
+				removed.push((*h, admission_seq));
+			}
 		}
-		self.insert_new(hash, *account, statement);
-		Ok(InsertOutcome { evicted, banned })
+		self.insert_new(hash, *account, statement, Some(self.next_seq));
+		Ok(InsertOutcome { evicted: removed, banned })
 	}
 }
 
@@ -862,7 +931,14 @@ impl Store {
 		while migrate_config.columns.len() < col::COUNT as usize {
 			// `add_column` takes the options by value, so build a fresh one each iteration.
 			let mut new_column_options = parity_db::ColumnOptions::default();
-			new_column_options.btree_index = true;
+			let column = migrate_config.columns.len() as u8;
+			new_column_options.btree_index = matches!(
+				column,
+				col::INDEX_BY_TOPIC
+					| col::INDEX_BY_DEC_KEY
+					| col::INDEX_EVICTED
+					| col::ADMISSION_SEQ
+			);
 			parity_db::Db::add_column(&mut migrate_config, new_column_options)
 				.map_err(|e| Error::Db(e.to_string()))?;
 		}
@@ -877,7 +953,9 @@ impl Store {
 		statement_col.ref_counted = false;
 		statement_col.preimage = true;
 		statement_col.uniform = true;
-		for c in [col::INDEX_BY_TOPIC, col::INDEX_BY_DEC_KEY, col::INDEX_EVICTED] {
+		for c in
+			[col::INDEX_BY_TOPIC, col::INDEX_BY_DEC_KEY, col::INDEX_EVICTED, col::ADMISSION_SEQ]
+		{
 			db_config.columns[c as usize].btree_index = true;
 		}
 		parity_db::Db::open_or_create(&db_config).map_err(|e| Error::Db(e.to_string()))
@@ -921,10 +999,11 @@ impl Store {
 	fn populate(&self, migrate_index: bool) -> Result<()> {
 		// Holding both locks here is fine: this runs at startup before any statements are
 		// processed, so there is no contention.
-		let migration_ops = {
+		let migrated_entries = {
 			let mut submit_index = self.submit_index.write();
 			let mut query_index = self.query_index.write();
-			let mut migration_ops: Vec<(u8, Vec<u8>, Option<Vec<u8>>)> = Vec::new();
+			let mut migration = MigrationBatch::new(&self.db);
+			let mut migration_error = None;
 			self.db
 				.iter_column_while(col::STATEMENTS, |item| {
 					let statement = item.value;
@@ -936,10 +1015,26 @@ impl Store {
 							HexDisplay::from(&hash)
 						);
 						if let Some(account_id) = statement.account_id() {
-							submit_index.insert_new(hash, account_id, &statement);
+							let admission_seq = if migrate_index {
+								let seq = submit_index.next_seq;
+								submit_index.next_seq = submit_index.next_seq.saturating_add(1);
+								Some(seq)
+							} else {
+								None
+							};
+							submit_index.insert_new(hash, account_id, &statement, admission_seq);
 							query_index.note_initial(&statement);
-							if migrate_index {
-								migration_ops.extend(statement_index_ops(&hash, &statement, true));
+							if let Some(seq) = admission_seq {
+								let mut operations = statement_index_ops(&hash, &statement, true);
+								operations.push((
+									col::ADMISSION_SEQ,
+									seq.to_be_bytes().to_vec(),
+									Some(hash.to_vec()),
+								));
+								if let Err(error) = migration.extend(operations) {
+									migration_error = Some(error);
+									return false;
+								}
 							}
 						} else {
 							log::debug!(
@@ -952,6 +1047,34 @@ impl Store {
 					true
 				})
 				.map_err(|e| Error::Db(e.to_string()))?;
+			if let Some(error) = migration_error.take() {
+				return Err(error);
+			}
+			if !migrate_index {
+				let mut iter =
+					self.db.iter(col::ADMISSION_SEQ).map_err(|e| Error::Db(e.to_string()))?;
+				iter.seek_to_first().map_err(|e| Error::Db(e.to_string()))?;
+				while let Some((key, value)) = iter.next().map_err(|e| Error::Db(e.to_string()))? {
+					let seq = u64::from_be_bytes(
+						key.try_into()
+							.map_err(|_| Error::Db("Invalid admission sequence key".into()))?,
+					);
+					let hash: Hash = value
+						.as_slice()
+						.try_into()
+						.map_err(|_| Error::Db("Invalid admission sequence hash".into()))?;
+					let Some(entry) = submit_index.entries.get_mut(&hash) else {
+						continue;
+					};
+					if entry.admission_seq.replace(seq).is_some() {
+						return Err(Error::Db("Duplicate admission sequence for statement".into()));
+					}
+					submit_index.next_seq = submit_index.next_seq.max(seq.saturating_add(1));
+				}
+				if submit_index.entries.values().any(|entry| entry.admission_seq.is_none()) {
+					return Err(Error::Db("Statement is missing an admission sequence".into()));
+				}
+			}
 			let mut evicted_count = 0usize;
 			self.db
 				.iter_column_while(col::EXPIRED, |item| {
@@ -968,27 +1091,28 @@ impl Store {
 						if migrate_index {
 							let purge_at =
 								timestamp.saturating_add(submit_index.config.purge_after_sec);
-							migration_ops.push((
+							let operation = (
 								col::INDEX_EVICTED,
 								evicted_index_key(purge_at, &hash),
 								Some(INDEX_EMPTY_VALUE.to_vec()),
-							));
+							);
+							if let Err(error) = migration.push(operation) {
+								migration_error = Some(error);
+								return false;
+							}
 						}
 					}
 					true
 				})
 				.map_err(|e| Error::Db(e.to_string()))?;
+			if let Some(error) = migration_error {
+				return Err(error);
+			}
 			submit_index.evicted_count = evicted_count;
-			migration_ops
+			migration.finish()?
 		};
 
 		if migrate_index {
-			// Commit the rebuilt index in bounded chunks, then mark the database as migrated.
-			const MIGRATION_CHUNK: usize = 100_000;
-			let total = migration_ops.len();
-			for chunk in migration_ops.chunks(MIGRATION_CHUNK) {
-				self.db.commit(chunk.iter().cloned()).map_err(|e| Error::Db(e.to_string()))?;
-			}
 			self.db
 				.commit([(
 					col::META,
@@ -999,7 +1123,7 @@ impl Store {
 			log::info!(
 				target: LOG_TARGET,
 				"Migrated statement store read index to the on-disk format ({} entries)",
-				total
+				migrated_entries
 			);
 		}
 
@@ -1905,8 +2029,7 @@ impl StatementStore for Store {
 			let mut submit_index = self.submit_index.write();
 
 			let outcome =
-				match submit_index.insert(hash, &statement, &account_id, &validation, current_time)
-				{
+				match submit_index.insert(hash, &statement, &account_id, &validation, current_time) {
 					Ok(outcome) => outcome,
 					Err(reason) => {
 						self.metrics.report(|metrics| {
@@ -1916,13 +2039,16 @@ impl StatementStore for Store {
 					},
 				};
 
+			let seq = submit_index.next_seq;
 			let mut commit = Vec::new();
 			commit.push((col::STATEMENTS, hash.to_vec(), Some(statement.encode())));
+			commit.push((col::ADMISSION_SEQ, seq.to_be_bytes().to_vec(), Some(hash.to_vec())));
 			commit.extend(statement_index_ops(&hash, &statement, true));
 
 			let mut evicted_statements = Vec::new();
-			for h in &outcome.evicted {
+			for (h, admission_seq) in &outcome.evicted {
 				commit.push((col::STATEMENTS, h.to_vec(), None));
+				commit.push((col::ADMISSION_SEQ, admission_seq.to_be_bytes().to_vec(), None));
 				match self.db.get(col::STATEMENTS, h) {
 					Ok(Some(encoded)) => {
 						if let Ok(evicted_statement) = Statement::decode(&mut encoded.as_slice()) {
@@ -1960,7 +2086,7 @@ impl StatementStore for Store {
 				});
 				return SubmitResult::InternalError(Error::Db(e.to_string()));
 			}
-			let seq = submit_index.note_seq(hash);
+			submit_index.note_seq(hash, seq);
 			(evicted_statements, seq)
 		}; // Release submit index lock
 		{
@@ -1986,6 +2112,7 @@ impl StatementStore for Store {
 			// Read the body under the submit-index lock: a concurrent first-time submit could
 			// otherwise commit the statement between the read and `make_expired`, and its
 			// read-index entries would never be cleared.
+			let admission_seq = submit_index.entries.get(hash).and_then(|entry| entry.admission_seq);
 			let statement =
 				match self.db.get(col::STATEMENTS, hash).map_err(|e| Error::Db(e.to_string()))? {
 					Some(encoded) => Statement::decode(&mut encoded.as_slice()).ok(),
@@ -1994,6 +2121,13 @@ impl StatementStore for Store {
 			match submit_index.make_expired(hash, current_time) {
 				Some(eviction) => {
 					let mut commit = vec![(col::STATEMENTS, hash.to_vec(), None)];
+					if let Some(admission_seq) = admission_seq {
+						commit.push((
+							col::ADMISSION_SEQ,
+							admission_seq.to_be_bytes().to_vec(),
+							None,
+						));
+					}
 					if let Some(statement) = &statement {
 						commit.extend(statement_index_ops(hash, statement, false));
 					}
@@ -2044,7 +2178,8 @@ impl StatementStore for Store {
 			let mut commit = Vec::new();
 			let mut removed_statements = Vec::new();
 			for hash in &hashes {
-				// Read the body before deleting it, to clear its query-index entries.
+				let admission_seq =
+					submit_index.entries.get(hash).and_then(|entry| entry.admission_seq);
 				let statement = match self.db.get(col::STATEMENTS, hash) {
 					Ok(Some(encoded)) => Statement::decode(&mut encoded.as_slice()).ok(),
 					Ok(None) => None,
@@ -2060,6 +2195,13 @@ impl StatementStore for Store {
 				};
 				if let Some(eviction) = submit_index.make_expired(hash, current_time) {
 					commit.push((col::STATEMENTS, hash.to_vec(), None));
+					if let Some(admission_seq) = admission_seq {
+						commit.push((
+							col::ADMISSION_SEQ,
+							admission_seq.to_be_bytes().to_vec(),
+							None,
+						));
+					}
 					if let Eviction::Banned(purge_at) = eviction {
 						commit.push((
 							col::EXPIRED,
@@ -2120,9 +2262,9 @@ impl StatementStoreSubscriptionApi for Store {
 		topic_filter: OptimizedTopicFilter,
 	) -> Result<(Vec<Vec<u8>>, async_channel::Sender<StatementEvent>, SubscriptionStatementsStream)>
 	{
-		// Exactly-once delivery via a sequence-number watermark. Under the submit-index write lock
-		// we atomically (a) capture the current sequence boundary `W` and (b) register the
-		// subscription with `W` as its watermark.
+		// Avoid overlap between the subscribe-time snapshot and live delivery using a sequence-number
+		// watermark. Under the submit-index write lock, atomically with respect to sequence assignment,
+		// capture the current boundary `W` and enqueue the subscription registration tagged with `W`.
 		let (subscription_sender, subscription_stream, watermark) = {
 			let mut submit_index = self.submit_index.write();
 			let watermark = submit_index.begin_scan();
@@ -2166,34 +2308,81 @@ impl StatementStoreSubscriptionApi for Store {
 }
 
 impl Store {
-	fn with_snapshot_hashes(
-		&self,
-		filter: &OptimizedTopicFilter,
-		enqueue: &mut dyn FnMut(Vec<Hash>),
-	) -> Result<()> {
-		// Hold the submit-index read lock across both the on-disk index scan and the `AddFilter`
-		// enqueue. `submit` assigns the statement's sequence number and commits its body under the
-		// write lock and only notifies matchers afterwards, so with the read lock held here every
-		// statement is either already committed (and therefore visible to the scan below) or its
-		// `NewStatement` notification is enqueued after the `AddFilter` message and matched live.
-		// Statements that end up in both are deduplicated by hash on the matcher side. The lock
-		// order (`submit_index` → `query_index`, taken briefly inside `iterate_with`) matches
-		// `populate`.
-		let _guard = self.submit_index.read();
-		let mut snapshot_hashes = Vec::new();
-		let mut seen = HashSet::new();
-		self.iterate_with(None, filter, |hash| {
-			if seen.insert(*hash) {
-				snapshot_hashes.push(*hash);
-			}
-			Ok(())
-		})?;
-		enqueue(snapshot_hashes);
-		Ok(())
+	fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
+		// Enqueue registration while holding the same lock that assigns submit sequence numbers.
+		// Every post-watermark live notification is therefore ordered after that registration.
+		let submit_index = self.submit_index.write();
+		let watermark = submit_index.next_seq;
+		Ok(enqueue(watermark).then_some(watermark))
 	}
 
-	fn statement_by_hash(&self, hash: &Hash) -> Result<Option<Vec<u8>>> {
-		self.db.get(col::STATEMENTS, hash).map_err(|e| Error::Db(e.to_string()))
+	fn replay_batch(
+		&self,
+		filter: &OptimizedTopicFilter,
+		mut cursor: u64,
+		watermark: u64,
+	) -> Result<ReplayBatch> {
+		let mut statements = Vec::new();
+		let mut chunk_bytes = 0usize;
+		let mut batch_limit_reached = false;
+		let mut iter = self.db.iter(col::ADMISSION_SEQ).map_err(|e| Error::Db(e.to_string()))?;
+		iter.seek(&cursor.to_be_bytes()).map_err(|e| Error::Db(e.to_string()))?;
+
+		while let Some((key, value)) = iter.next().map_err(|e| Error::Db(e.to_string()))? {
+			let seq = u64::from_be_bytes(
+				key.try_into().map_err(|_| Error::Db("Invalid admission sequence key".into()))?,
+			);
+			if seq >= watermark {
+				cursor = watermark;
+				break;
+			}
+			let hash: Hash = value
+				.as_slice()
+				.try_into()
+				.map_err(|_| Error::Db("Invalid admission sequence hash".into()))?;
+			let next_cursor = seq.saturating_add(1);
+			let Some(encoded) =
+				self.db.get(col::STATEMENTS, &hash).map_err(|e| Error::Db(e.to_string()))?
+			else {
+				cursor = next_cursor;
+				continue;
+			};
+			let is_current = self
+				.submit_index
+				.read()
+				.entries
+				.get(&hash)
+				.and_then(|entry| entry.admission_seq)
+				== Some(seq);
+			if !is_current {
+				cursor = next_cursor;
+				continue;
+			}
+			let Ok(statement) = Statement::decode(&mut encoded.as_slice()) else {
+				cursor = next_cursor;
+				continue;
+			};
+			if !filter.matches(&statement) {
+				cursor = next_cursor;
+				continue;
+			}
+			if !statements.is_empty() && chunk_bytes + encoded.len() > REPLAY_CHUNK_RAW_BYTES {
+				batch_limit_reached = true;
+				break;
+			}
+			chunk_bytes += encoded.len();
+			statements.push(encoded);
+			cursor = next_cursor;
+			if chunk_bytes >= REPLAY_CHUNK_RAW_BYTES {
+				batch_limit_reached = true;
+				break;
+			}
+		}
+
+		if !batch_limit_reached && cursor < watermark {
+			cursor = watermark;
+		}
+		Ok(ReplayBatch { statements, cursor, done: cursor >= watermark })
 	}
 }
 
@@ -2244,8 +2433,8 @@ mod tests {
 	use sc_keystore::Keystore;
 	use sp_core::{Decode, Encode, Pair};
 	use sp_statement_store::{
-		AccountId, Channel, DecryptionKey, InvalidReason, Proof, RejectionReason, Statement,
-		StatementSource, StatementStore, SubmitResult, Topic,
+		AccountId, Channel, DecryptionKey, InvalidReason, OptimizedTopicFilter, Proof,
+		RejectionReason, Statement, StatementSource, StatementStore, SubmitResult, Topic,
 	};
 
 	type Extrinsic = sp_runtime::OpaqueExtrinsic;
@@ -2582,6 +2771,70 @@ mod tests {
 	}
 
 	#[test]
+	fn removed_admission_tail_is_reused_after_restart() {
+		let (store, temp) = test_store();
+		let first = signed_statement(10);
+		let second = signed_statement(11);
+		assert_eq!(store.submit(first.clone(), StatementSource::Network), SubmitResult::New);
+		assert_eq!(store.submit(second.clone(), StatementSource::Network), SubmitResult::New);
+		assert_eq!(
+			store.db.get(col::ADMISSION_SEQ, &0u64.to_be_bytes()).unwrap(),
+			Some(first.hash().to_vec())
+		);
+		assert_eq!(
+			store.db.get(col::ADMISSION_SEQ, &1u64.to_be_bytes()).unwrap(),
+			Some(second.hash().to_vec())
+		);
+		store.remove(&second.hash()).unwrap();
+		assert_eq!(
+			store.db.get(col::ADMISSION_SEQ, &0u64.to_be_bytes()).unwrap(),
+			Some(first.hash().to_vec())
+		);
+		assert_eq!(store.db.get(col::ADMISSION_SEQ, &1u64.to_be_bytes()).unwrap(), None);
+		let keystore = store.keystore.clone();
+		drop(store);
+
+		let mut path: std::path::PathBuf = temp.path().into();
+		path.push("db");
+		let store = Store::new::<Block, TestClient, TestBackend>(
+			&path,
+			Default::default(),
+			std::sync::Arc::new(TestClient),
+			keystore,
+			None,
+			Box::new(sp_core::testing::TaskExecutor::new()),
+		)
+		.unwrap();
+		assert_eq!(store.submit_index.read().next_seq, 1);
+
+		let third = signed_statement(12);
+		assert_eq!(store.submit(third.clone(), StatementSource::Network), SubmitResult::New);
+		assert_eq!(
+			store.db.get(col::ADMISSION_SEQ, &1u64.to_be_bytes()).unwrap(),
+			Some(third.hash().to_vec())
+		);
+	}
+
+	#[test]
+	fn admission_cursor_replays_only_current_matching_admissions() {
+		let (store, _temp) = test_store();
+		let matching = signed_statement_with_topics(20, &[topic(1)], None);
+		let non_matching = signed_statement_with_topics(21, &[topic(2)], None);
+		let removed = signed_statement_with_topics(22, &[topic(1)], None);
+		assert_eq!(store.submit(matching.clone(), StatementSource::Network), SubmitResult::New);
+		assert_eq!(store.submit(non_matching, StatementSource::Network), SubmitResult::New);
+		assert_eq!(store.submit(removed.clone(), StatementSource::Network), SubmitResult::New);
+		store.remove(&removed.hash()).unwrap();
+
+		let replay = store
+			.replay_batch(&OptimizedTopicFilter::MatchAny([topic(1)].into_iter().collect()), 0, 3)
+			.unwrap();
+		assert_eq!(replay.statements, vec![matching.encode()]);
+		assert_eq!(replay.cursor, 3);
+		assert!(replay.done);
+	}
+
+	#[test]
 	fn migrates_v1_database_to_on_disk_index() {
 		sp_tracing::init_for_tests();
 		let temp = tempfile::Builder::new().tempdir().expect("Error creating test dir");
@@ -2633,7 +2886,7 @@ mod tests {
 		};
 
 		// Re-open through the store: it must add the index columns, rebuild them from the bodies,
-		// rebuild the evicted journal from EXPIRED, and bump the version to 2.
+		// rebuild the evicted journal and admission sequence, and bump the database version.
 		let store = open(&path);
 
 		// Bodies survived.
@@ -2647,6 +2900,14 @@ mod tests {
 		assert!(store.index_has_topic(&topic(2), &h_addressed));
 		assert!(store.index_has_dec_key(&Some(dec_key(9)), &h_addressed));
 		assert!(store.index_has_dec_key(&None, &h_broadcast));
+		let mut admitted = std::collections::HashSet::new();
+		let mut iter = store.db.iter(col::ADMISSION_SEQ).unwrap();
+		iter.seek_to_first().unwrap();
+		while let Some((_key, value)) = iter.next().unwrap() {
+			admitted.insert(value.as_slice().try_into().expect("admission hash is 32 bytes"));
+		}
+		assert_eq!(admitted, std::collections::HashSet::from([h_addressed, h_broadcast]));
+		assert_eq!(store.submit_index.read().next_seq, 2);
 
 		// And it answers queries: only the broadcast matches topic 1 with no key, only the
 		// addressed statement matches topic 1 for key 9.
@@ -3694,9 +3955,9 @@ mod tests {
 
 		// Directly insert into index, bypassing `submit`'s allowance check
 		{
-			let mut submit_index = store.submit_index.write();
-			for s in [&s1, &s2, &s3, &s4, &s5] {
-				submit_index.insert_new(s.hash(), account(4), s);
+			let mut index = store.submit_index.write();
+			for (seq, statement) in [&s1, &s2, &s3, &s4, &s5].into_iter().enumerate() {
+				index.insert_new(statement.hash(), account(4), statement, Some(seq as u64));
 			}
 		}
 
@@ -3735,9 +3996,9 @@ mod tests {
 
 		// Directly insert statements for account with no allowance
 		{
-			let mut submit_index = store.submit_index.write();
-			submit_index.insert_new(h1, account(0), &s1);
-			submit_index.insert_new(h2, account(0), &s2);
+			let mut index = store.submit_index.write();
+			index.insert_new(h1, account(0), &s1, Some(0));
+			index.insert_new(h2, account(0), &s2, Some(1));
 		}
 
 		assert_eq!(store.submit_index.read().entries.len(), 2);
@@ -3770,9 +4031,9 @@ mod tests {
 
 		// Directly insert both statements (total 1200 bytes > 1000 limit)
 		{
-			let mut submit_index = store.submit_index.write();
-			submit_index.insert_new(h1, account(2), &s1);
-			submit_index.insert_new(h2, account(2), &s2);
+			let mut index = store.submit_index.write();
+			index.insert_new(s1.hash(), account(2), &s1, Some(0));
+			index.insert_new(s2.hash(), account(2), &s2, Some(1));
 		}
 
 		assert_eq!(store.submit_index.read().total_size, 1200);
@@ -4235,6 +4496,35 @@ mod tests {
 				events.push(event);
 			}
 			events
+		}
+
+		#[test]
+		fn replay_watermark_excludes_later_admissions() {
+			let (store, _dir) = test_store();
+			let before = signed_statement(1);
+			let after = signed_statement(2);
+			assert_eq!(store.submit(before.clone(), StatementSource::Local), SubmitResult::New);
+
+			let mut watermark = None;
+			assert!(store
+				.register_replay(&mut |captured| {
+					watermark = Some(captured);
+					true
+				})
+				.unwrap()
+				.is_some());
+			assert_eq!(store.submit(after.clone(), StatementSource::Local), SubmitResult::New);
+
+			let replay =
+				store.replay_batch(&OptimizedTopicFilter::Any, 0, watermark.unwrap()).unwrap();
+			let hashes: HashSet<_> = replay
+				.statements
+				.iter()
+				.map(|encoded| Statement::decode(&mut encoded.as_slice()).unwrap().hash())
+				.collect();
+			assert!(replay.done);
+			assert!(hashes.contains(&before.hash()));
+			assert!(!hashes.contains(&after.hash()));
 		}
 
 		#[tokio::test]

--- a/substrate/client/statement-store/src/subscription.rs
+++ b/substrate/client/statement-store/src/subscription.rs
@@ -1392,8 +1392,6 @@ mod tests {
 			},
 		}
 
-		// The same hash can be admitted again after removal and purge. Its new sequence represents
-		// a distinct admission and must produce another live event.
 		subscriptions.notify_matching_filters(2, &statement);
 		assert!(matches!(
 			rx.try_recv(),

--- a/substrate/client/statement-store/src/subscription.rs
+++ b/substrate/client/statement-store/src/subscription.rs
@@ -1159,6 +1159,7 @@ mod tests {
 	struct TestReplaySnapshotProvider {
 		statements: HashMap<sp_statement_store::Hash, Vec<u8>>,
 		snapshot_hashes: Vec<sp_statement_store::Hash>,
+		batch_len: u64,
 	}
 
 	impl TestReplaySnapshotProvider {
@@ -1169,6 +1170,7 @@ mod tests {
 					.map(|statement| (statement.hash(), statement.encode()))
 					.collect(),
 				snapshot_hashes: snapshot.iter().map(Statement::hash).collect(),
+				batch_len: snapshot.len() as u64,
 			}
 		}
 	}
@@ -1185,7 +1187,7 @@ mod tests {
 			cursor: u64,
 			watermark: u64,
 		) -> Result<ReplayBatch> {
-			let end = watermark.min(self.snapshot_hashes.len() as u64);
+			let end = watermark.min(self.snapshot_hashes.len() as u64).min(cursor + self.batch_len);
 			let statements = self.snapshot_hashes[cursor as usize..end as usize]
 				.iter()
 				.filter_map(|hash| self.statements.get(hash).cloned())
@@ -1410,6 +1412,51 @@ mod tests {
 			Ok(MultiFilterSubscriptionEvent::NewStatement(event))
 				if event.hash == statement.hash() && event.matched_filter_ids == vec![filter_id]
 		));
+	}
+
+	#[test]
+	fn multi_filter_replay_resumes_from_the_returned_cursor() {
+		let mut subscriptions = SubscriptionsInfo::new();
+		let sub_id = SeqID::from(11);
+		let filter_id = FilterId::new(1);
+		let topic = Topic::from([9u8; 32]);
+		let filter = OptimizedTopicFilter::MatchAny(vec![topic].into_iter().collect());
+		let (tx, rx) = async_channel::bounded::<MultiFilterSubscriptionEvent>(10);
+		let replayed: Vec<Statement> = (0..3u8)
+			.map(|seed| {
+				let mut statement = signed_statement(seed);
+				statement.set_topic(0, topic);
+				statement
+			})
+			.collect();
+		let mut provider = TestReplaySnapshotProvider::with_snapshot(&replayed, &replayed);
+		provider.batch_len = 1;
+
+		subscriptions.subscribe_empty(sub_id, Arc::new(provider), tx);
+		subscriptions.add_filter(
+			sub_id,
+			filter_id,
+			filter,
+			replayed.iter().map(Statement::hash).collect(),
+		);
+
+		let mut delivered = Vec::new();
+		let mut replay_done = 0;
+		while let Ok(event) = rx.try_recv() {
+			match event {
+				MultiFilterSubscriptionEvent::ReplayStatements { filter_id: id, statements } => {
+					assert_eq!(id, filter_id);
+					delivered.extend(statements);
+				},
+				MultiFilterSubscriptionEvent::ReplayDone { filter_id: id } => {
+					assert_eq!(id, filter_id);
+					replay_done += 1;
+				},
+				other => panic!("expected replay events, got {other:?}"),
+			}
+		}
+		assert_eq!(delivered, replayed.iter().map(Statement::encode).collect::<Vec<_>>());
+		assert_eq!(replay_done, 1);
 	}
 
 	#[test]

--- a/substrate/client/statement-store/src/subscription.rs
+++ b/substrate/client/statement-store/src/subscription.rs
@@ -1392,8 +1392,8 @@ mod tests {
 			},
 		}
 
-		// The same hash can be admitted again after removal and purge. Its new sequence represents a
-		// distinct admission and must produce another live event.
+		// The same hash can be admitted again after removal and purge. Its new sequence represents
+		// a distinct admission and must produce another live event.
 		subscriptions.notify_matching_filters(2, &statement);
 		assert!(matches!(
 			rx.try_recv(),

--- a/substrate/client/statement-store/src/subscription.rs
+++ b/substrate/client/statement-store/src/subscription.rs
@@ -94,6 +94,9 @@ pub(crate) trait ReplaySnapshotProvider: Send + Sync {
 	/// Capture the committed admission watermark and enqueue filter registration atomically with
 	/// respect to submit.
 	/// Returns the registered watermark, or `None` when registration could not be enqueued.
+	///
+	/// `enqueue` is called at most once, with the submit lock held: it must not block or call
+	/// back into the store.
 	fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>>;
 
 	/// Read the next replay batch from the persisted admission sequence.

--- a/substrate/client/statement-store/src/subscription.rs
+++ b/substrate/client/statement-store/src/subscription.rs
@@ -44,11 +44,7 @@ const STOP_RESERVE_CHANNEL_SLOTS: usize = 1;
 pub const MAX_FILTERS_PER_SUBSCRIPTION: usize = 128;
 // Keep replay batches bounded by raw statement bytes. The JSON response is roughly twice this size
 // because statements are hex-encoded.
-const REPLAY_CHUNK_RAW_BYTES: usize = 4 * 1024 * 1024;
-// Keep live-event dedupe bounded. 64k entries is about 1.3s at the default 50k statements/sec
-// per-peer rate limit.
-const EMITTED_VIA_NEW_HARD_CAP: usize = 64 * 1024;
-
+pub(crate) const REPLAY_CHUNK_RAW_BYTES: usize = 4 * 1024 * 1024;
 use futures::{Stream, StreamExt};
 use itertools::Itertools;
 use parking_lot::Mutex;
@@ -93,21 +89,26 @@ pub trait MultiFilterSubscriptionApi: Send + Sync {
 	fn create_subscription(&self) -> (SubscriptionHandle, MultiFilterEventStream);
 }
 
-/// Provides replay snapshots while holding the store index read lock during snapshot collection.
+/// Provides cursor-based replay for dynamically attached filters.
 pub(crate) trait ReplaySnapshotProvider: Send + Sync {
-	/// Collect the replay snapshot hashes for `filter` while holding the store index read lock,
-	/// then invoke `enqueue` with those hashes while the lock is still held.
-	///
-	/// Keeping snapshot collection and the `AddFilter` enqueue under the same read lock makes the
-	/// pair atomic with respect to `submit`, which inserts a statement and notifies subscribers
-	/// under the index write lock.
-	fn with_snapshot_hashes(
+	/// Capture the committed admission watermark and enqueue filter registration atomically with
+	/// respect to submit.
+	/// Returns the registered watermark, or `None` when registration could not be enqueued.
+	fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>>;
+
+	/// Read the next replay batch from the persisted admission sequence.
+	fn replay_batch(
 		&self,
 		filter: &OptimizedTopicFilter,
-		enqueue: &mut dyn FnMut(Vec<sp_statement_store::Hash>),
-	) -> Result<()>;
+		cursor: u64,
+		watermark: u64,
+	) -> Result<ReplayBatch>;
+}
 
-	fn statement_by_hash(&self, hash: &sp_statement_store::Hash) -> Result<Option<Vec<u8>>>;
+pub(crate) struct ReplayBatch {
+	pub(crate) statements: Vec<Vec<u8>>,
+	pub(crate) cursor: u64,
+	pub(crate) done: bool,
 }
 
 /// A handle that attaches, removes, and inspects filters for one multi-filter subscription
@@ -144,28 +145,34 @@ impl SubscriptionHandle {
 		let filter_id = FilterId::new(inner.next_filter_id);
 		let sub_id = self.sub_id;
 
-		let mut send_result = None;
-		let collect_result = self.snapshot_provider.with_snapshot_hashes(&filter, &mut |hashes| {
-			send_result = Some(
+		let (result_tx, result_rx) = async_channel::bounded(1);
+		let mut result_tx = Some(result_tx);
+		let Some(_watermark) = self
+			.snapshot_provider
+			.register_replay(&mut |watermark| {
+				let result_tx =
+					result_tx.take().expect("register_replay invokes enqueue at most once; qed");
 				self.matchers
 					.try_send_by_seq_id(
 						sub_id,
-						MatcherMessage::AddFilter {
+						MatcherMessage::RegisterFilter {
 							sub_id,
 							filter_id,
 							filter: filter.clone(),
-							snapshot_hashes: hashes,
+							watermark,
+							result_tx,
 						},
 					)
-					.map_err(|_| AddFilterError::Stopped),
-			);
-		});
-
-		// A snapshot collection error means the closure never ran and nothing was enqueued; the
-		// filter was not attached. Surface it without tearing down the whole subscription.
-		collect_result.map_err(|_| AddFilterError::Stopped)?;
-		send_result.expect("with_snapshot_hashes invokes enqueue on successful collection; qed")?;
-
+					.is_ok()
+			})
+			.map_err(|_| AddFilterError::Stopped)?
+		else {
+			return Err(AddFilterError::Stopped);
+		};
+		match result_rx.recv_blocking() {
+			Ok(result) => result?,
+			Err(_) => return Err(AddFilterError::Stopped),
+		}
 		inner.next_filter_id = inner.next_filter_id.wrapping_add(1);
 		inner.active_filter_ids.insert(filter_id);
 		Ok(filter_id)
@@ -187,46 +194,34 @@ impl SubscriptionHandle {
 
 struct PendingReplay {
 	filter_id: FilterId,
-	snapshot_hashes: VecDeque<sp_statement_store::Hash>,
+	filter: OptimizedTopicFilter,
+	cursor: u64,
+	watermark: u64,
 }
 
 pub(crate) struct MultiFilterSubscriptionState {
 	pending_replays: VecDeque<PendingReplay>,
-	replayed_filter_ids_by_hash: HashMap<sp_statement_store::Hash, HashSet<FilterId>>,
-	new_emitted_hashes: HashSet<sp_statement_store::Hash>,
 	stopped: bool,
 	stop_emitted: bool,
 }
 
 impl MultiFilterSubscriptionState {
 	pub(crate) fn new() -> Self {
-		Self {
-			pending_replays: VecDeque::new(),
-			replayed_filter_ids_by_hash: HashMap::new(),
-			new_emitted_hashes: HashSet::new(),
-			stopped: false,
-			stop_emitted: false,
-		}
+		Self { pending_replays: VecDeque::new(), stopped: false, stop_emitted: false }
 	}
 
 	fn record_filter_added(
 		&mut self,
 		filter_id: FilterId,
-		snapshot_hashes: Vec<sp_statement_store::Hash>,
+		filter: OptimizedTopicFilter,
+		watermark: u64,
 	) {
-		for hash in &snapshot_hashes {
-			self.replayed_filter_ids_by_hash.entry(*hash).or_default().insert(filter_id);
-		}
 		self.pending_replays
-			.push_back(PendingReplay { filter_id, snapshot_hashes: snapshot_hashes.into() });
+			.push_back(PendingReplay { filter_id, filter, cursor: 0, watermark });
 	}
 
 	fn record_filter_removed(&mut self, filter_id: FilterId) {
 		self.pending_replays.retain(|replay| replay.filter_id != filter_id);
-		self.replayed_filter_ids_by_hash.retain(|_hash, set| {
-			set.remove(&filter_id);
-			!set.is_empty()
-		});
 	}
 
 	fn next_event(
@@ -252,43 +247,27 @@ impl MultiFilterSubscriptionState {
 	) -> Option<MultiFilterSubscriptionEvent> {
 		let replay = self.pending_replays.front_mut()?;
 		let filter_id = replay.filter_id;
-		if replay.snapshot_hashes.is_empty() {
+		if replay.cursor >= replay.watermark {
 			self.pending_replays.pop_front();
 			return Some(MultiFilterSubscriptionEvent::ReplayDone { filter_id });
 		}
-
-		let mut statements = Vec::new();
-		let mut chunk_bytes = 0usize;
-		while let Some(hash) = replay.snapshot_hashes.front() {
-			let Ok(Some(statement)) = snapshot_provider.statement_by_hash(hash) else {
-				let hash = *hash;
-				replay.snapshot_hashes.pop_front();
-				if let Some(filter_ids) = self.replayed_filter_ids_by_hash.get_mut(&hash) {
-					filter_ids.remove(&filter_id);
-					if filter_ids.is_empty() {
-						self.replayed_filter_ids_by_hash.remove(&hash);
-					}
-				}
-				continue;
+		let batch =
+			match snapshot_provider.replay_batch(&replay.filter, replay.cursor, replay.watermark) {
+				Ok(batch) => batch,
+				Err(_) => {
+					self.stopped = true;
+					return None;
+				},
 			};
-			if !statements.is_empty() && chunk_bytes + statement.len() > REPLAY_CHUNK_RAW_BYTES {
-				break;
-			}
-			replay.snapshot_hashes.pop_front();
-			chunk_bytes += statement.len();
-			statements.push(statement);
-			if chunk_bytes >= REPLAY_CHUNK_RAW_BYTES {
-				break;
-			}
-		}
-		// All remaining snapshot hashes may have disappeared from the store before
-		// lazy replay loads them. Finish the replay instead of emitting an empty batch
-		// or keeping the filter blocked.
-		if statements.is_empty() {
+		replay.cursor = batch.cursor;
+		if batch.done && batch.statements.is_empty() {
 			self.pending_replays.pop_front();
 			return Some(MultiFilterSubscriptionEvent::ReplayDone { filter_id });
 		}
-		Some(MultiFilterSubscriptionEvent::ReplayStatements { filter_id, statements })
+		Some(MultiFilterSubscriptionEvent::ReplayStatements {
+			filter_id,
+			statements: batch.statements,
+		})
 	}
 
 	fn new_statement_event(
@@ -297,31 +276,12 @@ impl MultiFilterSubscriptionState {
 		encoded: Vec<u8>,
 		filter_ids: &HashSet<FilterId>,
 	) -> Option<MultiFilterSubscriptionEvent> {
-		if self.new_emitted_hashes.contains(&hash) {
-			return None;
-		}
-
-		let replayed_filter_ids = self.replayed_filter_ids_by_hash.get(&hash);
-		let matched_filter_ids: Vec<FilterId> = filter_ids
-			.iter()
-			.filter(|f| replayed_filter_ids.map_or(true, |set| !set.contains(f)))
-			.copied()
-			.collect();
+		let matched_filter_ids: Vec<FilterId> = filter_ids.iter().copied().collect();
 
 		if matched_filter_ids.is_empty() {
 			return None;
 		}
 
-		if self.new_emitted_hashes.len() >= EMITTED_VIA_NEW_HARD_CAP {
-			log::warn!(
-				target: LOG_TARGET,
-				"new_emitted_hashes cap reached on statement subscription; sending stop",
-			);
-			self.stopped = true;
-			return None;
-		}
-
-		self.new_emitted_hashes.insert(hash);
 		Some(MultiFilterSubscriptionEvent::NewStatement(LiveStatementEvent {
 			hash,
 			encoded,
@@ -388,13 +348,14 @@ enum MatcherMessage {
 		snapshot_provider: Arc<dyn ReplaySnapshotProvider>,
 		tx: async_channel::Sender<MultiFilterSubscriptionEvent>,
 	},
-	/// Add a filter to an existing multi-filter subscription, with the replay snapshot collected
-	/// on the caller under the store index read lock.
-	AddFilter {
+	/// Register a filter at a store watermark. The matcher drains its cursor replay before
+	/// processing later live-statement messages from this channel.
+	RegisterFilter {
 		sub_id: SeqID,
 		filter_id: FilterId,
 		filter: OptimizedTopicFilter,
-		snapshot_hashes: Vec<sp_statement_store::Hash>,
+		watermark: u64,
+		result_tx: async_channel::Sender<std::result::Result<(), AddFilterError>>,
 	},
 	/// Remove a filter from an existing multi-filter subscription
 	RemoveFilter { sub_id: SeqID, filter_id: FilterId },
@@ -449,18 +410,20 @@ impl SubscriptionsHandle {
 							}) => {
 								subscriptions.subscribe_empty(seq_id, snapshot_provider, tx);
 							},
-							Ok(MatcherMessage::AddFilter {
+							Ok(MatcherMessage::RegisterFilter {
 								sub_id,
 								filter_id,
 								filter,
-								snapshot_hashes,
+								watermark,
+								result_tx,
 							}) => {
-								subscriptions.add_filter(
-									sub_id,
-									filter_id,
-									filter,
-									snapshot_hashes,
-								);
+								let result = subscriptions
+									.register_filter(sub_id, filter_id, filter, watermark);
+								let registered = result.is_ok();
+								let _ = result_tx.try_send(result);
+								if registered {
+									subscriptions.drain_ready_events(sub_id);
+								}
 							},
 							Ok(MatcherMessage::RemoveFilter { sub_id, filter_id }) => {
 								subscriptions.remove_filter(sub_id, filter_id);
@@ -582,9 +545,6 @@ enum ReadyEventDelivery {
 
 enum PostLiveSendAction {
 	None,
-	/// The subscription stopped itself (dedupe cap); drain so the `Stop` reaches the subscriber.
-	Drain,
-	/// The channel is closed; tear the subscription down.
 	Unsubscribe,
 }
 
@@ -665,12 +625,50 @@ impl SubscriptionsInfo {
 		);
 	}
 
+	#[cfg(test)]
 	fn add_filter(
 		&mut self,
 		sub_id: SeqID,
 		filter_id: FilterId,
 		filter: OptimizedTopicFilter,
 		snapshot_hashes: Vec<sp_statement_store::Hash>,
+	) {
+		self.add_filter_with_cursor(sub_id, filter_id, filter, snapshot_hashes.len() as u64);
+		self.drain_ready_events(sub_id);
+	}
+
+	fn register_filter(
+		&mut self,
+		sub_id: SeqID,
+		filter_id: FilterId,
+		filter: OptimizedTopicFilter,
+		watermark: u64,
+	) -> std::result::Result<(), AddFilterError> {
+		let Some(SubscriptionRecord::MultiFilter { filters, .. }) = self.by_sub_id.get(&sub_id)
+		else {
+			return Err(AddFilterError::Stopped);
+		};
+		if filters.contains_key(&filter_id) {
+			return Err(AddFilterError::Stopped);
+		}
+		let output_closed = matches!(
+			self.by_sub_id.get(&sub_id),
+			Some(SubscriptionRecord::MultiFilter { tx, .. }) if tx.is_closed()
+		);
+		if output_closed {
+			self.unsubscribe(sub_id);
+			return Err(AddFilterError::Stopped);
+		}
+		self.add_filter_with_cursor(sub_id, filter_id, filter, watermark);
+		Ok(())
+	}
+
+	fn add_filter_with_cursor(
+		&mut self,
+		sub_id: SeqID,
+		filter_id: FilterId,
+		filter: OptimizedTopicFilter,
+		watermark: u64,
 	) {
 		let filter_key = SubscriptionFilterKey::Dynamic(filter_id);
 		{
@@ -684,19 +682,14 @@ impl SubscriptionsInfo {
 				return;
 			};
 			entry.insert(filter.clone());
-			state.record_filter_added(filter_id, snapshot_hashes);
+			state.record_filter_added(filter_id, filter.clone(), watermark);
 		}
-		// Dynamic filters carry no watermark (0 suppresses nothing): replay/live overlap is
-		// deduplicated by hash in `MultiFilterSubscriptionState` instead, with the snapshot
-		// collected atomically with the `AddFilter` enqueue (see `ReplaySnapshotProvider`).
 		self.index_filter(IndexedSubscription {
 			topic_filter: filter,
 			seq_id: sub_id,
 			filter_key,
-			watermark: 0,
+			watermark,
 		});
-
-		self.drain_ready_events(sub_id);
 	}
 
 	fn remove_filter(&mut self, sub_id: SeqID, filter_id: FilterId) {
@@ -788,7 +781,6 @@ impl SubscriptionsInfo {
 				return;
 			};
 
-			let was_stopped = state.stopped;
 			match state.new_statement_event(hash, encoded, &matched_filter_ids) {
 				Some(event) => match Self::send_ready_event(state, tx, event) {
 					ReadyEventDelivery::Closed => PostLiveSendAction::Unsubscribe,
@@ -796,15 +788,11 @@ impl SubscriptionsInfo {
 						PostLiveSendAction::None
 					},
 				},
-				// The dedupe cap was hit and stopped the subscription; let the drain
-				// emit the resulting `Stop`.
-				None if !was_stopped && state.stopped => PostLiveSendAction::Drain,
 				None => PostLiveSendAction::None,
 			}
 		};
 
 		match action {
-			PostLiveSendAction::Drain => self.drain_ready_events(sub_id),
 			PostLiveSendAction::Unsubscribe => self.unsubscribe(sub_id),
 			PostLiveSendAction::None => {},
 		}
@@ -1123,6 +1111,11 @@ mod tests {
 	use super::*;
 	use sp_core::Decode;
 	use sp_statement_store::Topic;
+	use std::{
+		sync::{mpsc, Mutex as StdMutex},
+		thread,
+		time::{Duration, Instant},
+	};
 
 	fn unwrap_statement(item: StatementEvent) -> Bytes {
 		match item {
@@ -1168,57 +1161,198 @@ mod tests {
 	}
 
 	impl ReplaySnapshotProvider for TestReplaySnapshotProvider {
-		fn with_snapshot_hashes(
+		fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
+			let watermark = self.snapshot_hashes.len() as u64;
+			Ok(enqueue(watermark).then_some(watermark))
+		}
+
+		fn replay_batch(
 			&self,
 			_filter: &OptimizedTopicFilter,
-			enqueue: &mut dyn FnMut(Vec<sp_statement_store::Hash>),
-		) -> Result<()> {
-			enqueue(self.snapshot_hashes.clone());
-			Ok(())
+			cursor: u64,
+			watermark: u64,
+		) -> Result<ReplayBatch> {
+			let end = watermark.min(self.snapshot_hashes.len() as u64);
+			let statements = self.snapshot_hashes[cursor as usize..end as usize]
+				.iter()
+				.filter_map(|hash| self.statements.get(hash).cloned())
+				.collect();
+			Ok(ReplayBatch { statements, cursor: end, done: end >= watermark })
+		}
+	}
+
+	struct BlockingReplaySnapshotProvider {
+		statements: HashMap<sp_statement_store::Hash, Vec<u8>>,
+		snapshot_hashes: Vec<sp_statement_store::Hash>,
+		scan_started: mpsc::SyncSender<()>,
+		continue_scan: StdMutex<mpsc::Receiver<()>>,
+	}
+
+	impl ReplaySnapshotProvider for BlockingReplaySnapshotProvider {
+		fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
+			let watermark = self.snapshot_hashes.len() as u64;
+			Ok(enqueue(watermark).then_some(watermark))
 		}
 
-		fn statement_by_hash(&self, hash: &sp_statement_store::Hash) -> Result<Option<Vec<u8>>> {
-			Ok(self.statements.get(hash).cloned())
+		fn replay_batch(
+			&self,
+			_filter: &OptimizedTopicFilter,
+			cursor: u64,
+			watermark: u64,
+		) -> Result<ReplayBatch> {
+			self.scan_started.send(()).expect("test receiver remains open");
+			self.continue_scan
+				.lock()
+				.expect("test mutex is not poisoned")
+				.recv()
+				.expect("test sender remains open");
+			let end = watermark.min(self.snapshot_hashes.len() as u64);
+			let statements = self.snapshot_hashes[cursor as usize..end as usize]
+				.iter()
+				.filter_map(|hash| self.statements.get(hash).cloned())
+				.collect();
+			Ok(ReplayBatch { statements, cursor: end, done: end >= watermark })
+		}
+	}
+
+	struct ReplayLoadBlockingProvider {
+		body: Vec<u8>,
+		load_started: mpsc::SyncSender<()>,
+		continue_load: StdMutex<mpsc::Receiver<()>>,
+	}
+
+	impl ReplaySnapshotProvider for ReplayLoadBlockingProvider {
+		fn register_replay(&self, enqueue: &mut dyn FnMut(u64) -> bool) -> Result<Option<u64>> {
+			Ok(enqueue(1).then_some(1))
+		}
+
+		fn replay_batch(
+			&self,
+			_filter: &OptimizedTopicFilter,
+			cursor: u64,
+			watermark: u64,
+		) -> Result<ReplayBatch> {
+			assert_eq!(cursor, 0);
+			assert_eq!(watermark, 1);
+			self.load_started.send(()).expect("test receiver remains open");
+			self.continue_load
+				.lock()
+				.expect("test mutex is not poisoned")
+				.recv()
+				.expect("test sender remains open");
+			Ok(ReplayBatch { statements: vec![self.body.clone()], cursor: 1, done: true })
+		}
+	}
+
+	fn recv_multi_filter_event(
+		stream: &MultiFilterEventStream,
+		timeout: Duration,
+	) -> Option<MultiFilterSubscriptionEvent> {
+		let deadline = Instant::now() + timeout;
+		loop {
+			match stream.rx.try_recv() {
+				Ok(event) => return Some(event),
+				Err(async_channel::TryRecvError::Closed) => return None,
+				Err(async_channel::TryRecvError::Empty) if Instant::now() < deadline => {
+					thread::sleep(Duration::from_millis(1));
+				},
+				Err(async_channel::TryRecvError::Empty) => return None,
+			}
 		}
 	}
 
 	#[test]
-	fn multi_filter_does_not_redeliver_live_statement_already_sent_in_replay() {
-		let mut subscriptions = SubscriptionsInfo::new();
-		let sub_id = SeqID::from(11);
-		let filter_id = FilterId::new(1);
-		let topic = Topic::from([9u8; 32]);
-		let filter = OptimizedTopicFilter::MatchAny(vec![topic].into_iter().collect());
-		let (tx, rx) = async_channel::bounded::<MultiFilterSubscriptionEvent>(10);
-		let mut statement = signed_statement(42);
-		statement.set_topic(0, topic);
-		// The statement is part of the filter's replay snapshot, so attaching the filter
-		// delivers it as a replay statement.
-		let provider = Arc::new(TestReplaySnapshotProvider::with_snapshot(
-			std::slice::from_ref(&statement),
-			std::slice::from_ref(&statement),
-		));
+	fn multi_filter_replays_before_live_submissions_committed_during_snapshot() {
+		let subscriptions =
+			SubscriptionsHandle::new(Box::new(sp_core::testing::TaskExecutor::new()), 1);
+		let filter_id = FilterId::new(0);
+		let replayed = signed_statement(41);
+		let delayed = signed_statement(40);
+		let delayed_hash = delayed.hash();
+		let live = signed_statement(42);
+		let (scan_started_tx, scan_started_rx) = mpsc::sync_channel(1);
+		let (continue_scan_tx, continue_scan_rx) = mpsc::sync_channel(1);
+		let provider = Arc::new(BlockingReplaySnapshotProvider {
+			statements: [(replayed.hash(), replayed.encode())].into_iter().collect(),
+			snapshot_hashes: vec![replayed.hash()],
+			scan_started: scan_started_tx,
+			continue_scan: StdMutex::new(continue_scan_rx),
+		});
+		let (sub_id, stream) = subscriptions.subscribe_empty(provider.clone());
+		let handle = SubscriptionHandle {
+			sub_id,
+			inner: Arc::new(Mutex::new(SubscriptionHandleInner::new())),
+			matchers: subscriptions.matchers(),
+			snapshot_provider: provider,
+		};
 
-		subscriptions.subscribe_empty(sub_id, provider, tx);
-		subscriptions.add_filter(sub_id, filter_id, filter, vec![statement.hash()]);
+		let add_filter = thread::spawn(move || handle.add_filter(OptimizedTopicFilter::Any));
+		scan_started_rx.recv().expect("snapshot scan starts");
+
+		// Both post-watermark live events wait behind replay.
+		subscriptions.notify(0, replayed.clone());
+		subscriptions.notify(1, delayed);
+		subscriptions.notify(2, live.clone());
+		continue_scan_tx.send(()).expect("snapshot scan is still waiting");
+		assert_eq!(add_filter.join().expect("add-filter thread does not panic"), Ok(filter_id));
 
 		assert!(matches!(
-			rx.try_recv(),
-			Ok(MultiFilterSubscriptionEvent::ReplayStatements { statements, .. })
-				if statements == vec![statement.encode()]
+			recv_multi_filter_event(&stream, Duration::from_secs(1)),
+			Some(MultiFilterSubscriptionEvent::ReplayStatements { statements, .. })
+				if statements == vec![replayed.encode()]
 		));
 		assert!(matches!(
-			rx.try_recv(),
-			Ok(MultiFilterSubscriptionEvent::ReplayDone { filter_id: done }) if done == filter_id
+			recv_multi_filter_event(&stream, Duration::from_secs(1)),
+			Some(MultiFilterSubscriptionEvent::ReplayDone { filter_id: done }) if done == filter_id
 		));
-
-		// The same statement arriving live must not be delivered a second time.
-		subscriptions.notify_matching_filters(0, &statement);
-		assert!(rx.try_recv().is_err());
+		assert!(matches!(
+			recv_multi_filter_event(&stream, Duration::from_secs(1)),
+			Some(MultiFilterSubscriptionEvent::NewStatement(event))
+				if event.hash == delayed_hash && event.matched_filter_ids == vec![filter_id]
+		));
+		assert!(matches!(
+			recv_multi_filter_event(&stream, Duration::from_secs(1)),
+			Some(MultiFilterSubscriptionEvent::NewStatement(event))
+				if event.hash == live.hash() && event.matched_filter_ids == vec![filter_id]
+		));
+		assert!(recv_multi_filter_event(&stream, Duration::from_millis(10)).is_none());
 	}
 
 	#[test]
-	fn multi_filter_delivers_live_statement_that_was_evicted_before_replay_load() {
+	fn add_filter_returns_before_matcher_drains_replay() {
+		let subscriptions =
+			SubscriptionsHandle::new(Box::new(sp_core::testing::TaskExecutor::new()), 1);
+		let statement = signed_statement(43);
+		let (load_started_tx, load_started_rx) = mpsc::sync_channel(1);
+		let (continue_load_tx, continue_load_rx) = mpsc::sync_channel(1);
+		let provider = Arc::new(ReplayLoadBlockingProvider {
+			body: statement.encode(),
+			load_started: load_started_tx,
+			continue_load: StdMutex::new(continue_load_rx),
+		});
+		let (sub_id, _stream) = subscriptions.subscribe_empty(provider.clone());
+		let handle = SubscriptionHandle {
+			sub_id,
+			inner: Arc::new(Mutex::new(SubscriptionHandleInner::new())),
+			matchers: subscriptions.matchers(),
+			snapshot_provider: provider,
+		};
+		let (result_tx, result_rx) = mpsc::sync_channel(1);
+		let add_filter = thread::spawn(move || {
+			result_tx
+				.send(handle.add_filter(OptimizedTopicFilter::Any))
+				.expect("test receiver remains open");
+		});
+
+		load_started_rx.recv().expect("matcher starts loading replay");
+		let result = result_rx.recv_timeout(Duration::from_secs(1));
+		continue_load_tx.send(()).expect("replay load is still waiting");
+		add_filter.join().expect("add-filter thread does not panic");
+		assert_eq!(result, Ok(Ok(FilterId::new(0))));
+	}
+
+	#[test]
+	fn multi_filter_delivers_re_admitted_hash_skipped_during_replay() {
 		let mut subscriptions = SubscriptionsInfo::new();
 		let sub_id = SeqID::from(12);
 		let filter_id = FilterId::new(1);
@@ -1244,9 +1378,9 @@ mod tests {
 			Ok(MultiFilterSubscriptionEvent::ReplayDone { filter_id: done }) if done == filter_id
 		));
 
-		// The statement is re-submitted later. It was never delivered through the replay, so
-		// it must reach the subscriber as a live event.
-		subscriptions.notify_matching_filters(0, &statement);
+		// The statement is re-admitted at a new sequence. It was never delivered through replay,
+		// so it must reach the subscriber as a live event.
+		subscriptions.notify_matching_filters(1, &statement);
 
 		match rx.try_recv() {
 			Ok(MultiFilterSubscriptionEvent::NewStatement(event)) => {
@@ -1257,6 +1391,15 @@ mod tests {
 				panic!("statement skipped during replay must be delivered live, got {other:?}")
 			},
 		}
+
+		// The same hash can be admitted again after removal and purge. Its new sequence represents a
+		// distinct admission and must produce another live event.
+		subscriptions.notify_matching_filters(2, &statement);
+		assert!(matches!(
+			rx.try_recv(),
+			Ok(MultiFilterSubscriptionEvent::NewStatement(event))
+				if event.hash == statement.hash() && event.matched_filter_ids == vec![filter_id]
+		));
 	}
 
 	#[test]

--- a/substrate/client/statement-store/src/subscription.rs
+++ b/substrate/client/statement-store/src/subscription.rs
@@ -67,7 +67,8 @@ use std::{
 pub enum AddFilterError {
 	/// The subscription already has the maximum number of active filters
 	LimitReached,
-	/// The matcher stopped before the filter request could be queued
+	/// The filter could not be registered: the store or the matcher is gone, or the subscription
+	/// is no longer active
 	Stopped,
 }
 
@@ -257,7 +258,14 @@ impl MultiFilterSubscriptionState {
 		let batch =
 			match snapshot_provider.replay_batch(&replay.filter, replay.cursor, replay.watermark) {
 				Ok(batch) => batch,
-				Err(_) => {
+				Err(e) => {
+					log::error!(
+						target: LOG_TARGET,
+						"Stopping subscription: replaying filter {:?} from {} failed: {:?}",
+						filter_id,
+						replay.cursor,
+						e
+					);
 					self.stopped = true;
 					return None;
 				},
@@ -310,7 +318,7 @@ pub enum MultiFilterSubscriptionEvent {
 	},
 	/// Live statement event matched one or more active filters
 	NewStatement(LiveStatementEvent),
-	/// Subscription stopped because local resource limits were reached
+	/// Subscription stopped: the subscriber fell behind its buffer, or replaying a filter failed
 	Stop,
 }
 
@@ -584,7 +592,8 @@ struct IndexedSubscription {
 	seq_id: SeqID,
 	// The filter key within the subscription.
 	filter_key: SubscriptionFilterKey,
-	// Store sequence-number boundary captured when this subscription was created.
+	// Store sequence-number boundary captured when this entry was registered: at subscription
+	// creation for a fixed filter, at `add_filter` for a dynamic one.
 	watermark: u64,
 }
 
@@ -826,9 +835,10 @@ impl SubscriptionsInfo {
 	}
 
 	// Deliver the statement at store sequence number `seq` to every matching subscription.
-	// Fixed-filter subscriptions whose watermark is above `seq` are skipped: their subscribe-time
-	// snapshot already covers the statement (see
-	// `StatementStoreSubscriptionApi::subscribe_statement`).
+	// Subscriptions and filters registered above `seq` are skipped: the statement predates them, so
+	// it is covered by the subscribe-time snapshot
+	// (`StatementStoreSubscriptionApi::subscribe_statement`) for a fixed filter, or by the
+	// admission-cursor replay (`ReplaySnapshotProvider::replay_batch`) for a dynamic one.
 	fn notify_matching_filters(&mut self, seq: u64, statement: &Statement) {
 		let mut matches = HashMap::new();
 		self.collect_match_all_subscribers(seq, statement, &mut matches);
@@ -876,8 +886,8 @@ impl SubscriptionsInfo {
 	}
 
 	// Record a subscription filter as matched, unless the statement's sequence number is below the
-	// subscription's watermark (exactly-once delivery: such statements are covered by the
-	// subscribe-time snapshot instead).
+	// watermark captured when it was registered (exactly-once delivery: such statements are covered
+	// by the subscribe-time snapshot or the admission-cursor replay instead).
 	fn record_match(
 		matches: &mut HashMap<SeqID, MatchedSubscription>,
 		subscription: &IndexedSubscription,
@@ -1364,9 +1374,8 @@ mod tests {
 		let (tx, rx) = async_channel::bounded::<MultiFilterSubscriptionEvent>(10);
 		let mut statement = signed_statement(42);
 		statement.set_topic(0, topic);
-		// The statement's hash is part of the replay snapshot, but its body is gone from the
-		// store by the time the lazy replay tries to load it (evicted between snapshot
-		// collection and replay).
+		// The statement has an admission entry inside the replay range, but its body is no longer
+		// retrievable, so the replay skips that sequence number.
 		let provider = Arc::new(TestReplaySnapshotProvider::with_snapshot(
 			std::slice::from_ref(&statement),
 			&[],


### PR DESCRIPTION
## Summary

Impl #12153

- persist an active-statement admission sequence in parity-db and restore it on startup
- replay dynamically attached subscription filters from a cursor up to a registration watermark instead of materializing a full hash snapshot
- bound replay batches by raw statement bytes while preserving replay-before-live ordering and re-admission semantics