### PR TITLE
[RWF] `polkadot-gossip-support`: Fix Orphaned Authority Mappings

### DIFF
--- a/polkadot/node/network/gossip-support/src/lib.rs
+++ b/polkadot/node/network/gossip-support/src/lib.rs
@@ -671,6 +671,14 @@ where
 	fn handle_connect_disconnect(&mut self, ev: NetworkBridgeEvent<GossipSupportNetworkMessage>) {
 		match ev {
 			NetworkBridgeEvent::PeerConnected(peer_id, _, _, o_authority) => {
+				// Remove the previous authority ids first so they don't linger orphaned in
+				// `connected_authorities`.
+				if let Some(prev_authority_ids) = self.connected_peers.remove(&peer_id) {
+					prev_authority_ids.iter().for_each(|a| {
+						self.connected_authorities.remove(a);
+					});
+				}
+
 				if let Some(authority_ids) = o_authority {
 					authority_ids.iter().for_each(|a| {
 						self.connected_authorities.insert(a.clone(), peer_id);

--- a/polkadot/node/network/gossip-support/src/tests.rs
+++ b/polkadot/node/network/gossip-support/src/tests.rs
@@ -1238,6 +1238,46 @@ fn test_log_output() {
 	);
 }
 
+// A duplicate `PeerConnected` notification for an already-connected peer must not
+// orphan the peer's previous authority ids in `connected_authorities`.
+#[test]
+fn handle_connect_disconnect_cleans_up_stale_authorities_on_duplicate_connect() {
+	let mock_authority_discovery =
+		MockAuthorityDiscovery::new(PAST_PRESENT_FUTURE_AUTHORITIES.clone());
+	let mut state = make_subsystem_with_authority_discovery(mock_authority_discovery);
+
+	let peer_id = PeerId::random();
+	let alice: AuthorityDiscoveryId = Sr25519Keyring::Alice.public().into();
+	let bob: AuthorityDiscoveryId = Sr25519Keyring::Bob.public().into();
+
+	// First connection notification: peer is authenticated as `alice`.
+	state.handle_connect_disconnect(NetworkBridgeEvent::PeerConnected(
+		peer_id,
+		ObservedRole::Authority,
+		ValidationVersion::V3.into(),
+		Some(HashSet::from([alice.clone()])),
+	));
+
+	assert_eq!(state.connected_peers.get(&peer_id), Some(&HashSet::from([alice.clone()])));
+	assert_eq!(state.connected_authorities.get(&alice), Some(&peer_id));
+
+	// Duplicate connection notification for the same peer, now authenticated as `bob`.
+	state.handle_connect_disconnect(NetworkBridgeEvent::PeerConnected(
+		peer_id,
+		ObservedRole::Authority,
+		ValidationVersion::V3.into(),
+		Some(HashSet::from([bob.clone()])),
+	));
+
+	// The peer's authority set was replaced.
+	assert_eq!(state.connected_peers.get(&peer_id), Some(&HashSet::from([bob.clone()])));
+	// `connected_authorities` should reflect the new mapping.
+	assert_eq!(state.connected_authorities.get(&bob), Some(&peer_id));
+	// And the stale entry for `alice` is not left orphaned.
+	assert_eq!(state.connected_authorities.get(&alice), None);
+	assert_eq!(state.connected_authorities.len(), 1);
+}
+
 #[test]
 fn issues_a_connection_request_when_last_request_was_mostly_unresolved() {
 	let hash = Hash::repeat_byte(0xAA);

--- a/prdoc/pr_12698.prdoc
+++ b/prdoc/pr_12698.prdoc
@@ -1,0 +1,20 @@
+title: '[RWF] `polkadot-gossip-support`: Fix Orphaned Authority Mappings'
+doc:
+- audience: Node Dev
+  description: |-
+    Closes #12604
+
+    ## Description
+
+    In `handle_connect_disconnect`, when a duplicate `PeerConnected` event arrived for an already-connected peer, the handler overwrote `connected_peers[peer_id]` with the new authority set but never removed the previous authorities from `connected_authorities`.
+
+    ## Fix
+
+    `handle_connect_disconnect` now removes the peer's previous authority mappings from `connected_authorities` before applying a new `PeerConnected` mapping, matching the pattern already used in `update_authority_ids`.
+
+    ## Testing
+
+    Added a regression test that sends two `PeerConnected` events for the same `PeerId` with different authority sets and asserts `connected_authorities`/`connected_peers` remain consistent afterwards.
+crates:
+- name: polkadot-gossip-support
+  bump: patch


### PR DESCRIPTION
Closes #12604

## Description

In `handle_connect_disconnect`, when a duplicate `PeerConnected` event arrived for an already-connected peer, the handler overwrote `connected_peers[peer_id]` with the new authority set but never removed the previous authorities from `connected_authorities`.

## Fix

`handle_connect_disconnect` now removes the peer's previous authority mappings from `connected_authorities` before applying a new `PeerConnected` mapping, matching the pattern already used in `update_authority_ids`.

## Testing

Added a regression test that sends two `PeerConnected` events for the same `PeerId` with different authority sets and asserts `connected_authorities`/`connected_peers` remain consistent afterwards.
