### PR TITLE
[RWF] `polkadot-node-subsystem-types`: Fix ActiveLeavesUpdate PartialEq asymmetry

### DIFF
--- a/polkadot/node/subsystem-types/src/lib.rs
+++ b/polkadot/node/subsystem-types/src/lib.rs
@@ -23,7 +23,7 @@
 #![warn(missing_docs)]
 
 use smallvec::SmallVec;
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
 pub use polkadot_primitives::{Block, BlockNumber, Hash};
 
@@ -93,8 +93,8 @@ impl PartialEq for ActiveLeavesUpdate {
 	/// Instead, it means equality when `activated` and `deactivated` are considered as sets.
 	fn eq(&self, other: &Self) -> bool {
 		self.activated.as_ref().map(|a| a.hash) == other.activated.as_ref().map(|a| a.hash) &&
-			self.deactivated.len() == other.deactivated.len() &&
-			self.deactivated.iter().all(|a| other.deactivated.contains(a))
+			self.deactivated.iter().collect::<HashSet<_>>() ==
+				other.deactivated.iter().collect::<HashSet<_>>()
 	}
 }
 
@@ -116,4 +116,37 @@ pub enum OverseerSignal {
 	BlockFinalized(Hash, BlockNumber),
 	/// Conclude the work of the `Overseer` and all `Subsystem`s.
 	Conclude,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn leaves_update(deactivated: &[Hash]) -> ActiveLeavesUpdate {
+		ActiveLeavesUpdate { activated: None, deactivated: deactivated.into() }
+	}
+
+	#[test]
+	fn eq_is_symmetric_with_duplicate_deactivated_hashes() {
+		let h1 = Hash::repeat_byte(0x01);
+		let h2 = Hash::repeat_byte(0x02);
+
+		let dup = leaves_update(&[h1, h1]);
+		let distinct = leaves_update(&[h1, h2]);
+
+		assert_eq!(dup == distinct, distinct == dup, "PartialEq symmetry violated");
+		assert_ne!(dup, distinct);
+	}
+
+	#[test]
+	fn eq_treats_deactivated_as_a_set() {
+		let h1 = Hash::repeat_byte(0x01);
+		let h2 = Hash::repeat_byte(0x02);
+
+		let a = leaves_update(&[h1, h2, h1]);
+		let b = leaves_update(&[h2, h1]);
+
+		assert_eq!(a, b);
+		assert_eq!(b, a);
+	}
 }

--- a/prdoc/pr_12703.prdoc
+++ b/prdoc/pr_12703.prdoc
@@ -1,0 +1,20 @@
+title: '[RWF] `polkadot-node-subsystem-types`: Fix ActiveLeavesUpdate PartialEq asymmetry'
+doc:
+- audience: Node Dev
+  description: "Closes #12605\n\n## Description\n\n`ActiveLeavesUpdate`'s hand-written\
+    \ `PartialEq` implementation was meant to compare `deactivated` as a set, but\
+    \ the actual check \u2014 `self.deactivated.len() == other.deactivated.len() &&\
+    \ self.deactivated.iter().all(|a| other.deactivated.contains(a))` \u2014 is a\
+    \ one-directional subset check. It only behaves correctly when neither side contains\
+    \ duplicate hashes.\n\nWith duplicates, e.g. `dup = [h1, h1]` vs `distinct = [h1,\
+    \ h2]`, both have equal length and every element of `dup` is found in `distinct`,\
+    \ so `dup == distinct` is `true`. But `h2` is not found in `dup`, so `distinct\
+    \ == dup` is `false` \u2014 violating Rust's `PartialEq` symmetry invariant.\n\
+    \n## Fix\n\nReplaced the check with a proper symmetric set comparison, collecting\
+    \ both `deactivated` slices into `HashSet<&Hash>` and comparing the sets directly.\n\
+    \n## Testing\n\nAdded regression tests reproducing the issue's counterexample\
+    \ (asserting `a == b` iff `b == a`) and verifying duplicates/ordering in `deactivated`\
+    \ are correctly ignored, per the type's existing \"considered as sets\" doc comment."
+crates:
+- name: polkadot-node-subsystem-types
+  bump: patch


### PR DESCRIPTION
Closes #12605

## Description

`ActiveLeavesUpdate`'s hand-written `PartialEq` implementation was meant to compare `deactivated` as a set, but the actual check — `self.deactivated.len() == other.deactivated.len() && self.deactivated.iter().all(|a| other.deactivated.contains(a))` — is a one-directional subset check. It only behaves correctly when neither side contains duplicate hashes.

With duplicates, e.g. `dup = [h1, h1]` vs `distinct = [h1, h2]`, both have equal length and every element of `dup` is found in `distinct`, so `dup == distinct` is `true`. But `h2` is not found in `dup`, so `distinct == dup` is `false` — violating Rust's `PartialEq` symmetry invariant.

## Fix

Replaced the check with a proper symmetric set comparison, collecting both `deactivated` slices into `HashSet<&Hash>` and comparing the sets directly.

## Testing

Added regression tests reproducing the issue's counterexample (asserting `a == b` iff `b == a`) and verifying duplicates/ordering in `deactivated` are correctly ignored, per the type's existing "considered as sets" doc comment.
