### PR TITLE
[Release|CI/CD] Add eth-rpc docker image to release flow

### DIFF
--- a/.github/workflows/release-31_promote-rc-to-final.yml
+++ b/.github/workflows/release-31_promote-rc-to-final.yml
@@ -13,6 +13,7 @@ on:
           - polkadot-omni-node
           - frame-omni-bencher
           - chain-spec-builder
+          - eth-rpc
           - all
       release_tag:
         description: Tag matching the actual release candidate with the format polkadot-stableYYMM(-X)-rcX
@@ -146,6 +147,23 @@ jobs:
         target: [ x86_64-unknown-linux-gnu, aarch64-apple-darwin ]
     with:
       package: chain-spec-builder
+      release_tag: ${{ needs.validate-inputs.outputs.release_tag }}
+      final_tag: ${{ needs.validate-inputs.outputs.final_tag }}
+      target: ${{ matrix.target }}
+    secrets:
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_RELEASE_ACCESS_KEY_ID: ${{ secrets.AWS_RELEASE_ACCESS_KEY_ID }}
+      AWS_RELEASE_SECRET_ACCESS_KEY: ${{ secrets.AWS_RELEASE_SECRET_ACCESS_KEY }}
+
+  promote-eth-rpc-rc-to-final:
+    if: ${{ inputs.binary == 'eth-rpc' || inputs.binary == 'all' }}
+    needs: [ validate-inputs ]
+    uses: ./.github/workflows/release-reusable-promote-to-final.yml
+    strategy:
+      matrix:
+        target: [ x86_64-unknown-linux-gnu, aarch64-apple-darwin ]
+    with:
+      package: eth-rpc
       release_tag: ${{ needs.validate-inputs.outputs.release_tag }}
       final_tag: ${{ needs.validate-inputs.outputs.final_tag }}
       target: ${{ matrix.target }}

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -25,6 +25,7 @@ on:
           - polkadot-omni-node
           - polkadot-parachain
           - chain-spec-builder
+          - eth-rpc
 
       registry:
         description: Container registry
@@ -139,11 +140,11 @@ jobs:
 
     steps:
       - name: Checkout sources
-        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.image_type == 'rc' }}
+        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.binary == 'eth-rpc' || inputs.image_type == 'rc' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Fetch rc artifacts or release artifacts from s3 based on version
-        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.image_type == 'rc' }}
+        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.binary == 'eth-rpc' || inputs.image_type == 'rc' }}
         env:
           VERSION: ${{ needs.validate-inputs.outputs.stable_tag }}
         run: |
@@ -159,7 +160,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.image_type == 'rc' }}
+        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.binary == 'eth-rpc' || inputs.image_type == 'rc' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts-${{ env.BINARY }}
@@ -175,14 +176,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download artifacts
-        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.image_type == 'rc' }}
+        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.binary == 'eth-rpc' || inputs.image_type == 'rc' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts-${{ env.BINARY }}
           path: release-artifacts
 
       - name: Check sha256 ${{ env.BINARY }}
-        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.image_type == 'rc' }}
+        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.binary == 'eth-rpc' || inputs.image_type == 'rc' }}
         working-directory: release-artifacts
         run: |
           . ../.github/scripts/common/lib.sh
@@ -191,7 +192,7 @@ jobs:
           check_sha256 $BINARY && echo "OK" || echo "ERR"
 
       - name: Check GPG ${{ env.BINARY }}
-        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.image_type == 'rc' }}
+        if: ${{ inputs.binary == 'polkadot-omni-node' || inputs.binary == 'polkadot-parachain' || inputs.binary == 'chain-spec-builder' || inputs.binary == 'eth-rpc' || inputs.image_type == 'rc' }}
         working-directory: release-artifacts
         run: |
           . ../.github/scripts/common/lib.sh
@@ -288,6 +289,22 @@ jobs:
           echo "Building container for $BINARY"
           ./docker/scripts/build-injected.sh
 
+      - name: Build Injected Container image for eth-rpc
+        if: ${{ env.BINARY == 'eth-rpc' }}
+        shell: bash
+        env:
+          ARTIFACTS_FOLDER: release-artifacts
+          IMAGE_NAME: ${{ env.BINARY }}
+          OWNER: ${{ env.DOCKER_OWNER }}
+          DOCKERFILE: docker/dockerfiles/eth-rpc/eth-rpc_injected.Dockerfile
+          TAGS: ${{ join(steps.fetch_rc_refs.outputs.*, ',') || join(steps.fetch_release_refs.outputs.*, ',') }}
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+          SKIP_IMAGE_VALIDATION: "true"
+        run: |
+          ls -al
+          echo "Building container for $BINARY"
+          ./docker/scripts/build-injected.sh
+
       - name: Login to Dockerhub to publish polkadot
         if: ${{ env.BINARY == 'polkadot' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -295,8 +312,8 @@ jobs:
           username: ${{ secrets.POLKADOT_DOCKERHUB_USERNAME }}
           password: ${{ secrets.POLKADOT_DOCKERHUB_TOKEN }}
 
-      - name: Login to Dockerhub to publish polkadot-omni-node/polkadot-parachain/chain-spec-builder
-        if: ${{ env.BINARY == 'polkadot-omni-node' || env.BINARY == 'polkadot-parachain' || env.BINARY == 'chain-spec-builder' }}
+      - name: Login to Dockerhub to publish polkadot-omni-node/polkadot-parachain/chain-spec-builder/eth-rpc
+        if: ${{ env.BINARY == 'polkadot-omni-node' || env.BINARY == 'polkadot-parachain' || env.BINARY == 'chain-spec-builder' || env.BINARY == 'eth-rpc' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.CUMULUS_DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -101,16 +101,16 @@ env:
   IMAGE_TYPE: ${{ inputs.image_type }}
 
 jobs:
-  check-synchronization:
-    uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
-    with:
-      concurrency_suffix: publish-docker-${{ inputs.binary }}
-    secrets:
-      fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
+  # check-synchronization:
+  #   uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
+  #   with:
+  #     concurrency_suffix: publish-docker-${{ inputs.binary }}
+  #   secrets:
+  #     fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
 
   validate-inputs:
-    needs: [check-synchronization]
-    if: needs.check-synchronization.outputs.checks_passed == 'true'
+    # needs: [check-synchronization]
+    # if: needs.check-synchronization.outputs.checks_passed == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.validate_inputs.outputs.VERSION }}

--- a/.github/workflows/release-50_publish-docker.yml
+++ b/.github/workflows/release-50_publish-docker.yml
@@ -101,16 +101,16 @@ env:
   IMAGE_TYPE: ${{ inputs.image_type }}
 
 jobs:
-  # check-synchronization:
-  #   uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
-  #   with:
-  #     concurrency_suffix: publish-docker-${{ inputs.binary }}
-  #   secrets:
-  #     fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
+  check-synchronization:
+    uses: paritytech-release/sync-workflows/.github/workflows/check-synchronization.yml@main
+    with:
+      concurrency_suffix: publish-docker-${{ inputs.binary }}
+    secrets:
+      fork_writer_app_key: ${{ secrets.UPSTREAM_CONTENT_SYNC_APP_KEY }}
 
   validate-inputs:
-    # needs: [check-synchronization]
-    # if: needs.check-synchronization.outputs.checks_passed == 'true'
+    needs: [check-synchronization]
+    if: needs.check-synchronization.outputs.checks_passed == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.validate_inputs.outputs.VERSION }}

--- a/.github/workflows/release-70_combined-publish-release.yml
+++ b/.github/workflows/release-70_combined-publish-release.yml
@@ -25,6 +25,7 @@ on:
           - polkadot-omni-node
           - frame-omni-bencher
           - chain-spec-builder
+          - eth-rpc
 
       registry:
         description: Container registry for Docker images
@@ -160,6 +161,24 @@ jobs:
     with:
       image_type: release
       binary: chain-spec-builder
+      registry: ${{ inputs.registry }}
+      owner: ${{ inputs.owner }}
+      version: ${{ inputs.version }}
+      stable_tag: ${{ needs.promote-rc-to-final.outputs.final_tag }}
+
+    secrets: inherit
+    permissions:
+      contents: write
+
+  publish-docker-eth-rpc:
+    name: Publish Docker image - eth-rpc
+    # needs: [publish-deb-package, publish-rpm-package]
+    needs: [promote-rc-to-final]
+    if: ${{ inputs.binary == 'eth-rpc' || inputs.binary == 'all' }}
+    uses: ./.github/workflows/release-50_publish-docker.yml
+    with:
+      image_type: release
+      binary: eth-rpc
       registry: ${{ inputs.registry }}
       owner: ${{ inputs.owner }}
       version: ${{ inputs.version }}

--- a/docker/dockerfiles/eth-rpc/eth-rpc_injected.Dockerfile
+++ b/docker/dockerfiles/eth-rpc/eth-rpc_injected.Dockerfile
@@ -1,0 +1,47 @@
+FROM docker.io/parity/base-bin:latest
+
+# This file builds the official eth-rpc release image by injecting the
+# pre-built, signed `eth-rpc` release artifact into the base image.
+# The runtime layout is kept in sync with the source-built image at
+# substrate/frame/revive/rpc/dockerfiles/eth-rpc/Dockerfile.
+
+# metadata
+ARG VCS_REF
+ARG BUILD_DATE
+ARG IMAGE_NAME
+# That can be a single one or a comma separated list
+ARG BINARY=eth-rpc
+
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="${IMAGE_NAME}" \
+	io.parity.image.description="Ethereum JSON-RPC proxy for pallet-revive. This is the official Parity image with an injected binary." \
+	io.parity.image.source="https://github.com/paritytech/polkadot-sdk/blob/${VCS_REF}/docker/dockerfiles/eth-rpc/eth-rpc_injected.Dockerfile" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}" \
+	io.parity.image.documentation="https://github.com/paritytech/polkadot-sdk/"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+USER root
+
+# add the pre-built eth-rpc binary to the docker image
+COPY bin/* /usr/local/bin/
+
+RUN chmod -R a+rx "/usr/local/bin" && \
+	useradd -m -u 1001 -U -s /bin/sh -d /polkadot polkadot && \
+	rm -rf /usr/bin /usr/sbin && \
+	# check if executable works in this container
+	/usr/local/bin/eth-rpc --version
+
+USER polkadot
+
+# 8545 is the default port for the RPC server
+# 9616 is the default port for the prometheus metrics
+EXPOSE 8545 9616
+
+ENTRYPOINT ["/usr/local/bin/eth-rpc"]
+
+# We call the help by default
+CMD ["--help"]


### PR DESCRIPTION
This PR adds publishing and versioning of the eth-rpc aligned with the main sdk release.

Closes: https://github.com/paritytech/devops/issues/4431 & https://github.com/paritytech/release-engineering/issues/283