### PR TITLE
spec-msg/node: on-chain-driven relay-DHT source discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,6 +5158,7 @@ version = "0.1.0"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
+ "cumulus-client-bootnodes",
  "cumulus-primitives-core",
  "cumulus-primitives-spec-messaging",
  "cumulus-relay-chain-interface",

--- a/cumulus/client/bootnodes/src/discovery.rs
+++ b/cumulus/client/bootnodes/src/discovery.rs
@@ -37,7 +37,7 @@ use codec::{CompactRef, Decode, Encode};
 use cumulus_primitives_core::{relay_chain::Hash as RelayHash, ParaId};
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
 use futures::{
-	channel::oneshot,
+	channel::{mpsc::UnboundedSender, oneshot},
 	future::{BoxFuture, Fuse, FusedFuture},
 	pin_mut,
 	stream::FuturesUnordered,
@@ -78,6 +78,14 @@ pub struct BootnodeDiscoveryParams {
 	pub relay_chain_network: Arc<dyn NetworkService>,
 	/// `/paranode` protocol name.
 	pub paranode_protocol_name: ProtocolName,
+	/// Optional sink for each resolved `(peer_id, addresses)` as `/paranode`
+	/// responses land. `None` keeps the own-parachain bootstrap behaviour
+	/// (addresses only injected into `parachain_network`); `Some` additionally
+	/// streams them to the caller — the seam a *cross-parachain* discoverer
+	/// (e.g. Speculative Messaging peer discovery, which runs this against a
+	/// source parachain's `para_id`/genesis) uses to learn that parachain's
+	/// node set.
+	pub discovered_tx: Option<UnboundedSender<(PeerId, Vec<Multiaddr>)>>,
 }
 
 /// Parachain bootnode discovery service.
@@ -101,6 +109,7 @@ pub struct BootnodeDiscovery {
 	find_node_queries: HashSet<PeerId>,
 	pending_start_discovery: Pin<Box<Fuse<Sleep>>>,
 	succeeded: bool,
+	discovered_tx: Option<UnboundedSender<(PeerId, Vec<Multiaddr>)>>,
 }
 
 impl BootnodeDiscovery {
@@ -114,6 +123,7 @@ impl BootnodeDiscovery {
 			relay_chain_interface,
 			relay_chain_network,
 			paranode_protocol_name,
+			discovered_tx,
 		}: BootnodeDiscoveryParams,
 	) -> Self {
 		Self {
@@ -132,6 +142,7 @@ impl BootnodeDiscovery {
 			// Trigger the discovery immediately on startup.
 			pending_start_discovery: Box::pin(sleep(Duration::ZERO).fuse()),
 			succeeded: false,
+			discovered_tx,
 		}
 	}
 
@@ -367,6 +378,12 @@ impl BootnodeDiscovery {
 			target: LOG_TARGET,
 			"Discovered parachain bootnode {paranode_peer_id:?} with addresses {paranode_addresses:?}",
 		);
+
+		// Stream the resolved node to a cross-parachain caller, if any, before
+		// the addresses are consumed by the own-network injection below.
+		if let Some(tx) = &self.discovered_tx {
+			let _ = tx.unbounded_send((paranode_peer_id, paranode_addresses.clone()));
+		}
 
 		paranode_addresses.into_iter().for_each(|addr| {
 			self.parachain_network.add_known_address(paranode_peer_id, addr);

--- a/cumulus/client/bootnodes/src/lib.rs
+++ b/cumulus/client/bootnodes/src/lib.rs
@@ -28,5 +28,6 @@ mod schema {
 	include!(concat!(env!("OUT_DIR"), "/response.rs"));
 }
 
-pub use config::bootnode_request_response_config;
+pub use config::{bootnode_request_response_config, paranode_protocol_name};
+pub use discovery::{BootnodeDiscovery, BootnodeDiscoveryParams};
 pub use task::{start_bootnode_tasks, StartBootnodeTasksParams};

--- a/cumulus/client/bootnodes/src/task.rs
+++ b/cumulus/client/bootnodes/src/task.rs
@@ -132,6 +132,9 @@ async fn bootnode_discovery(
 		relay_chain_interface,
 		relay_chain_network,
 		paranode_protocol_name,
+		// Own-parachain bootstrap: addresses are injected into the parachain
+		// network, not streamed to a caller.
+		discovered_tx: None,
 	});
 
 	match bootnode_discovery.run().await {

--- a/cumulus/client/spec-msg/Cargo.toml
+++ b/cumulus/client/spec-msg/Cargo.toml
@@ -33,6 +33,7 @@ sp-runtime = { workspace = true, default-features = true }
 polkadot-core-primitives = { workspace = true, default-features = true }
 
 # Cumulus
+cumulus-client-bootnodes = { workspace = true, default-features = true }
 cumulus-primitives-core = { workspace = true, default-features = true }
 cumulus-primitives-spec-messaging = { workspace = true, default-features = true }
 cumulus-relay-chain-interface = { workspace = true, default-features = true }

--- a/cumulus/client/spec-msg/src/discovery.rs
+++ b/cumulus/client/spec-msg/src/discovery.rs
@@ -1,0 +1,326 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus. If not, see <https://www.gnu.org/licenses/>.
+
+//! Dynamic discovery of a source parachain's exchange-serving peers, replacing
+//! the static [`crate::PeerRegistry`] wiring (the MVP `--spec-msg-source-peer`
+//! flag) with relay-chain-DHT discovery.
+//!
+//! The receiver fetches a source's streams from *that source's* collators, so
+//! it must learn their `PeerId`s per source parachain. The mechanism is
+//! RFC-0008 parachain bootnode discovery — the relay chain DHT holds each
+//! parachain's advertised bootnodes under a `para_id + epoch` provider key, and
+//! the `/{genesis}/paranode` request-response protocol returns their addresses
+//! (see `cumulus-client-bootnodes`). Doing it for an *arbitrary* source
+//! parachain (not the node's own) is what this module wires up.
+//!
+//! This half is the discovery *loop*: it derives the consumed sources exactly
+//! like [`crate::run_relay_provides_monitor`] (`consumed_streams()` keys plus
+//! `out_channels()` peers), resolves each source's peers on an interval, and
+//! keeps the shared [`crate::PeerRegistry`] populated for the fetch pipeline.
+//!
+//! The actual DHT resolution sits behind [`SourceDiscovery`] — the same
+//! trait-seam pattern as [`crate::ExchangeNetwork`] / [`crate::SourcePeers`].
+//! The production impl reuses `cumulus-client-bootnodes`' discovery mechanism
+//! (`get_providers` on the source's epoch key + the `/paranode` request), and,
+//! as a side effect, registers the discovered multiaddrs with the network
+//! service (`add_known_address`) so the exchange transport's `TryConnect` can
+//! dial them; it then returns the `PeerId`s to pool here. That impl needs the
+//! relay-chain interface + network handles and a genesis-hash source per
+//! parachain, so it is wired at the node layer — a small addition to
+//! `cumulus-client-bootnodes` to *return* the resolved addresses (rather than
+//! only inject them into the own-parachain network) is the one upstream change
+//! it needs.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use futures::{channel::mpsc, pin_mut, FutureExt, StreamExt};
+use futures_timer::Delay;
+use sc_network::{service::traits::NetworkService, PeerId};
+use sp_api::{ApiExt, ProvideRuntimeApi};
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::Block as BlockT;
+
+use cumulus_client_bootnodes::{
+	paranode_protocol_name, BootnodeDiscovery, BootnodeDiscoveryParams,
+};
+use cumulus_primitives_core::{ParaId, SpecMsgApi};
+use cumulus_relay_chain_interface::RelayChainInterface;
+
+use crate::{exchange::PeerRegistry, LOG_TARGET};
+
+/// How often the discovery loop re-resolves each source's peers. Discovery is a
+/// safety net over steady-state connectivity (the fetch loop reuses live peers
+/// and evicts bad ones), so this is deliberately unhurried.
+pub const DISCOVERY_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Resolves the exchange-serving peers of a source parachain over the relay
+/// chain DHT, given that source's genesis hash. The production impl reuses
+/// `cumulus-client-bootnodes` (RFC-0008 `/paranode` discovery) and registers
+/// the discovered addresses with the network as a side effect, so the returned
+/// `PeerId`s are dialable by the exchange transport.
+#[async_trait]
+pub trait SourceDiscovery: Send + Sync {
+	/// The currently-discovered peers serving `source` (whose parachain genesis
+	/// is `genesis_hash`, fork `fork_id`), best-effort. An empty result is not
+	/// an error — discovery retries on the next refresh.
+	async fn discover(
+		&self,
+		source: ParaId,
+		genesis_hash: Vec<u8>,
+		fork_id: Option<String>,
+	) -> Vec<PeerId>;
+}
+
+/// Runs the discovery loop until the task is dropped. Each tick reads the
+/// configured sources' reachability (`SpecMsgApi::source_discovery_info()`, set
+/// on-chain by governance) merged with `overrides` (the CLI
+/// `--spec-msg-source-genesis` values, which win), resolves each source's peers
+/// over the relay-chain DHT, and repopulates `registry`. Spawn next to
+/// [`crate::run_relay_provides_monitor`] / [`crate::run_spec_msg_fetcher`],
+/// sharing the same [`PeerRegistry`] the fetch pipeline reads.
+pub async fn run_spec_msg_discovery<Block, Client>(
+	parachain: Arc<Client>,
+	discovery: Arc<dyn SourceDiscovery>,
+	registry: Arc<PeerRegistry>,
+	overrides: HashMap<ParaId, (Vec<u8>, Option<String>)>,
+	interval: Duration,
+) where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+	Client::Api: SpecMsgApi<Block>,
+{
+	loop {
+		if let Err(error) = refresh(&*parachain, &*discovery, &registry, &overrides).await {
+			tracing::warn!(target: LOG_TARGET, ?error, "Spec-msg peer discovery refresh failed");
+		}
+		Delay::new(interval).await;
+	}
+}
+
+/// The configured sources and their `(genesis_hash, fork_id)`, from the runtime
+/// API merged with the CLI `overrides` (overrides win). Version-gated: no
+/// `SpecMsgApi` means no configured sources.
+fn source_genesis_map<Block, Client>(
+	parachain: &Client,
+	overrides: &HashMap<ParaId, (Vec<u8>, Option<String>)>,
+) -> Result<HashMap<ParaId, (Vec<u8>, Option<String>)>, sp_api::ApiError>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+	Client::Api: SpecMsgApi<Block>,
+{
+	let best = parachain.info().best_hash;
+	let mut map: HashMap<ParaId, (Vec<u8>, Option<String>)> =
+		if parachain.runtime_api().has_api::<dyn SpecMsgApi<Block>>(best)? {
+			parachain
+				.runtime_api()
+				.source_discovery_info(best)?
+				.into_iter()
+				.map(|(source, (genesis, fork))| {
+					(source, (genesis.to_vec(), fork.and_then(|f| String::from_utf8(f).ok())))
+				})
+				.collect()
+		} else {
+			HashMap::new()
+		};
+	// CLI overrides win — an operator can pin or patch a source's reachability.
+	map.extend(overrides.iter().map(|(source, info)| (*source, info.clone())));
+	Ok(map)
+}
+
+/// One refresh pass: resolve and repopulate every configured source. `set_peers`
+/// replaces the whole set per source — a fresh discovery each round; the fetch
+/// loop re-evicts any still-bad peer within its own round via `report_bad`.
+async fn refresh<Block, Client>(
+	parachain: &Client,
+	discovery: &dyn SourceDiscovery,
+	registry: &PeerRegistry,
+	overrides: &HashMap<ParaId, (Vec<u8>, Option<String>)>,
+) -> Result<(), sp_api::ApiError>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+	Client::Api: SpecMsgApi<Block>,
+{
+	for (source, (genesis_hash, fork_id)) in source_genesis_map(parachain, overrides)? {
+		let peers = discovery.discover(source, genesis_hash, fork_id).await;
+		tracing::debug!(
+			target: LOG_TARGET,
+			source = %u32::from(source),
+			count = peers.len(),
+			"Discovered spec-msg source peers",
+		);
+		registry.set_peers(source, peers);
+	}
+	Ok(())
+}
+
+/// Timeout for a single source's `/paranode` discovery round. Discovery
+/// succeeds-once then stops; if a source has no reachable providers this bounds
+/// how long we wait before returning what (if anything) resolved.
+pub const DISCOVERY_ROUND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The production [`SourceDiscovery`]: resolves a source parachain's
+/// exchange-serving peers via RFC-0008 relay-chain-DHT bootnode discovery,
+/// reusing `cumulus-client-bootnodes` against the *source's* `para_id`/genesis
+/// (the `discovered_tx` seam streams the resolved peers back). Resolved
+/// addresses are also injected into the own parachain network by
+/// `BootnodeDiscovery`, so the exchange transport's `TryConnect` can dial them.
+pub struct BootnodeSourceDiscovery {
+	/// Own parachain network — where the resolved addresses are made dialable
+	/// and where `/spec-msg/exchange` requests are sent.
+	parachain_network: Arc<dyn NetworkService>,
+	/// Relay chain interface (drives the DHT provider query + epoch key).
+	relay_chain_interface: Arc<dyn RelayChainInterface>,
+	/// Relay chain network — the DHT the source's bootnodes are advertised on.
+	relay_chain_network: Arc<dyn NetworkService>,
+	/// Per-source discovery round timeout.
+	timeout: Duration,
+}
+
+impl BootnodeSourceDiscovery {
+	/// New resolver over the given relay/parachain network handles. The source
+	/// genesis hashes are supplied per `discover` call (from
+	/// `SpecMsgApi::source_discovery_info()` + CLI overrides), so no per-source
+	/// config is held here.
+	pub fn new(
+		parachain_network: Arc<dyn NetworkService>,
+		relay_chain_interface: Arc<dyn RelayChainInterface>,
+		relay_chain_network: Arc<dyn NetworkService>,
+	) -> Self {
+		Self {
+			parachain_network,
+			relay_chain_interface,
+			relay_chain_network,
+			timeout: DISCOVERY_ROUND_TIMEOUT,
+		}
+	}
+}
+
+#[async_trait]
+impl SourceDiscovery for BootnodeSourceDiscovery {
+	async fn discover(
+		&self,
+		source: ParaId,
+		genesis_hash: Vec<u8>,
+		fork_id: Option<String>,
+	) -> Vec<PeerId> {
+		let (tx, mut rx) = mpsc::unbounded();
+		let discovery = BootnodeDiscovery::new(BootnodeDiscoveryParams {
+			para_id: source,
+			parachain_network: self.parachain_network.clone(),
+			parachain_genesis_hash: genesis_hash.clone(),
+			parachain_fork_id: fork_id.clone(),
+			relay_chain_interface: self.relay_chain_interface.clone(),
+			relay_chain_network: self.relay_chain_network.clone(),
+			paranode_protocol_name: paranode_protocol_name(&genesis_hash, fork_id.as_deref()),
+			discovered_tx: Some(tx),
+		});
+
+		// Drive one discovery round, collecting resolved peers until it
+		// completes (succeed-once) or the round times out.
+		let mut peers = Vec::new();
+		let run = discovery.run().fuse();
+		let timeout = Delay::new(self.timeout).fuse();
+		pin_mut!(run, timeout);
+		loop {
+			futures::select! {
+				resolved = rx.next() => match resolved {
+					Some((peer_id, _addrs)) if !peers.contains(&peer_id) => peers.push(peer_id),
+					Some(_) => {},
+					None => break,
+				},
+				result = run => {
+					if let Err(error) = result {
+						tracing::debug!(
+							target: LOG_TARGET,
+							?error,
+							source = %u32::from(source),
+							"Bootnode discovery round ended with error",
+						);
+					}
+					break;
+				},
+				_ = timeout => {
+					tracing::debug!(
+						target: LOG_TARGET,
+						source = %u32::from(source),
+						"Bootnode discovery round timed out",
+					);
+					break;
+				},
+			}
+		}
+		// Drain any peers resolved-but-buffered before the round ended.
+		while let Ok(Some((peer_id, _))) = rx.try_next() {
+			if !peers.contains(&peer_id) {
+				peers.push(peer_id);
+			}
+		}
+		peers
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::exchange::SourcePeers;
+	use futures::executor::block_on;
+
+	/// A `SourceDiscovery` returning a fixed per-source peer set.
+	struct StaticDiscovery(HashMap<ParaId, Vec<PeerId>>);
+
+	#[async_trait]
+	impl SourceDiscovery for StaticDiscovery {
+		async fn discover(&self, source: ParaId, _: Vec<u8>, _: Option<String>) -> Vec<PeerId> {
+			self.0.get(&source).cloned().unwrap_or_default()
+		}
+	}
+
+	/// The resolve→register leg for `sources` (the runtime-derived source set is
+	/// exercised via the node; this drives what `refresh` does per source).
+	fn resolve_into(discovery: &dyn SourceDiscovery, registry: &PeerRegistry, sources: &[ParaId]) {
+		for source in sources {
+			let peers = block_on(discovery.discover(*source, vec![0u8; 32], None));
+			registry.set_peers(*source, peers);
+		}
+	}
+
+	#[test]
+	fn refresh_populates_the_registry_per_source() {
+		let a = ParaId::from(2000);
+		let b = ParaId::from(2001);
+		let (pa, pb) = (PeerId::random(), PeerId::random());
+		let discovery = StaticDiscovery(HashMap::from([(a, vec![pa]), (b, vec![pb])]));
+		let registry = PeerRegistry::default();
+
+		resolve_into(&discovery, &registry, &[a, b]);
+
+		assert_eq!(registry.peers(a), vec![pa]);
+		assert_eq!(registry.peers(b), vec![pb]);
+		assert!(registry.peers(ParaId::from(2002)).is_empty());
+	}
+
+	#[test]
+	fn a_source_with_no_peers_yields_an_empty_entry() {
+		let registry = PeerRegistry::default();
+		let discovery = StaticDiscovery(HashMap::new());
+		resolve_into(&discovery, &registry, &[ParaId::from(2000)]);
+		assert!(registry.peers(ParaId::from(2000)).is_empty());
+	}
+}

--- a/cumulus/client/spec-msg/src/discovery.rs
+++ b/cumulus/client/spec-msg/src/discovery.rs
@@ -45,11 +45,16 @@
 //! only inject them into the own-parachain network) is the one upstream change
 //! it needs.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+	collections::HashMap,
+	sync::Arc,
+	time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use futures::{channel::mpsc, pin_mut, FutureExt, StreamExt};
 use futures_timer::Delay;
+use sc_client_api::BlockchainEvents;
 use sc_network::{service::traits::NetworkService, PeerId};
 use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
@@ -58,10 +63,13 @@ use sp_runtime::traits::Block as BlockT;
 use cumulus_client_bootnodes::{
 	paranode_protocol_name, BootnodeDiscovery, BootnodeDiscoveryParams,
 };
-use cumulus_primitives_core::{ParaId, SpecMsgApi};
+use cumulus_primitives_core::{relay_chain::BlockId, ParaId, SpecMsgApi};
 use cumulus_relay_chain_interface::RelayChainInterface;
 
-use crate::{exchange::PeerRegistry, LOG_TARGET};
+use crate::{
+	exchange::{PeerRegistry, SourcePeers},
+	LOG_TARGET,
+};
 
 /// How often the discovery loop re-resolves each source's peers. Discovery is a
 /// safety net over steady-state connectivity (the fetch loop reuses live peers
@@ -86,38 +94,63 @@ pub trait SourceDiscovery: Send + Sync {
 	) -> Vec<PeerId>;
 }
 
-/// Runs the discovery loop until the task is dropped. Each tick reads the
-/// configured sources' reachability (`SpecMsgApi::source_discovery_info()`, set
-/// on-chain by governance) merged with `overrides` (the CLI
-/// `--spec-msg-source-genesis` values, which win), resolves each source's peers
-/// over the relay-chain DHT, and repopulates `registry`. Spawn next to
+/// Runs the discovery loop until the task is dropped. Keeps the shared
+/// `registry` (the set the fetch pipeline reads) populated with each configured
+/// source's peers, resolved over the relay-chain DHT. The source set comes from
+/// `SpecMsgApi::source_discovery_info()` (set on-chain by governance via
+/// `set_source_genesis`).
+///
+/// Event-driven: on every new best block it reads the (cheap) source set and
+/// DHT-resolves only the sources whose reachability changed or that still have
+/// no peers — so a `set_source_genesis` extrinsic takes effect within ~one block
+/// — and once `fallback` has elapsed it re-resolves the whole set as a
+/// steady-state safety net (peers that dropped, etc.). Spawn next to
 /// [`crate::run_relay_provides_monitor`] / [`crate::run_spec_msg_fetcher`],
-/// sharing the same [`PeerRegistry`] the fetch pipeline reads.
+/// sharing their [`PeerRegistry`].
 pub async fn run_spec_msg_discovery<Block, Client>(
 	parachain: Arc<Client>,
 	discovery: Arc<dyn SourceDiscovery>,
 	registry: Arc<PeerRegistry>,
-	overrides: HashMap<ParaId, (Vec<u8>, Option<String>)>,
-	interval: Duration,
+	fallback: Duration,
 ) where
 	Block: BlockT,
-	Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+	Client: BlockchainEvents<Block> + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	Client::Api: SpecMsgApi<Block>,
 {
-	loop {
-		if let Err(error) = refresh(&*parachain, &*discovery, &registry, &overrides).await {
-			tracing::warn!(target: LOG_TARGET, ?error, "Spec-msg peer discovery refresh failed");
+	let mut known: HashMap<ParaId, (Vec<u8>, Option<String>)> = HashMap::new();
+
+	// Resolve whatever is already configured before the first block arrives.
+	if let Err(error) = refresh(&*parachain, &*discovery, &registry, &mut known, true).await {
+		tracing::warn!(target: LOG_TARGET, ?error, "Initial spec-msg peer discovery failed");
+	}
+	let mut last_full = Instant::now();
+
+	let mut imports = parachain.import_notification_stream();
+	while let Some(notification) = imports.next().await {
+		if !notification.is_new_best {
+			continue;
 		}
-		Delay::new(interval).await;
+		// Full re-resolve once `fallback` has elapsed (steady-state health);
+		// otherwise only changed / peerless sources are re-resolved.
+		let force = last_full.elapsed() >= fallback;
+		match refresh(&*parachain, &*discovery, &registry, &mut known, force).await {
+			Ok(()) => {
+				if force {
+					last_full = Instant::now();
+				}
+			},
+			Err(error) => {
+				tracing::warn!(target: LOG_TARGET, ?error, "Spec-msg peer discovery failed")
+			},
+		}
 	}
 }
 
-/// The configured sources and their `(genesis_hash, fork_id)`, from the runtime
-/// API merged with the CLI `overrides` (overrides win). Version-gated: no
-/// `SpecMsgApi` means no configured sources.
+/// The configured sources and their `(genesis_hash, fork_id)`, read from
+/// `SpecMsgApi::source_discovery_info()`. Version-gated: no `SpecMsgApi` (or a
+/// runtime without the method) means no configured sources.
 fn source_genesis_map<Block, Client>(
 	parachain: &Client,
-	overrides: &HashMap<ParaId, (Vec<u8>, Option<String>)>,
 ) -> Result<HashMap<ParaId, (Vec<u8>, Option<String>)>, sp_api::ApiError>
 where
 	Block: BlockT,
@@ -125,48 +158,58 @@ where
 	Client::Api: SpecMsgApi<Block>,
 {
 	let best = parachain.info().best_hash;
-	let mut map: HashMap<ParaId, (Vec<u8>, Option<String>)> =
-		if parachain.runtime_api().has_api::<dyn SpecMsgApi<Block>>(best)? {
-			parachain
-				.runtime_api()
-				.source_discovery_info(best)?
-				.into_iter()
-				.map(|(source, (genesis, fork))| {
-					(source, (genesis.to_vec(), fork.and_then(|f| String::from_utf8(f).ok())))
-				})
-				.collect()
-		} else {
-			HashMap::new()
-		};
-	// CLI overrides win — an operator can pin or patch a source's reachability.
-	map.extend(overrides.iter().map(|(source, info)| (*source, info.clone())));
-	Ok(map)
+	if !parachain.runtime_api().has_api::<dyn SpecMsgApi<Block>>(best)? {
+		return Ok(HashMap::new());
+	}
+	Ok(parachain
+		.runtime_api()
+		.source_discovery_info(best)?
+		.into_iter()
+		.map(|(source, (genesis, fork))| {
+			(source, (genesis.to_vec(), fork.and_then(|f| String::from_utf8(f).ok())))
+		})
+		.collect())
 }
 
-/// One refresh pass: resolve and repopulate every configured source. `set_peers`
-/// replaces the whole set per source — a fresh discovery each round; the fetch
-/// loop re-evicts any still-bad peer within its own round via `report_bad`.
+/// One refresh pass. `force` re-resolves every configured source; otherwise only
+/// those whose `(genesis, fork)` changed since `known` or that currently hold no
+/// peers — the cheap per-block path. Sources dropped from the on-chain set have
+/// their registry entry cleared. `set_peers` replaces the whole set per source;
+/// the fetch loop re-evicts any still-bad peer within its own round.
 async fn refresh<Block, Client>(
 	parachain: &Client,
 	discovery: &dyn SourceDiscovery,
 	registry: &PeerRegistry,
-	overrides: &HashMap<ParaId, (Vec<u8>, Option<String>)>,
+	known: &mut HashMap<ParaId, (Vec<u8>, Option<String>)>,
+	force: bool,
 ) -> Result<(), sp_api::ApiError>
 where
 	Block: BlockT,
 	Client: ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	Client::Api: SpecMsgApi<Block>,
 {
-	for (source, (genesis_hash, fork_id)) in source_genesis_map(parachain, overrides)? {
-		let peers = discovery.discover(source, genesis_hash, fork_id).await;
-		tracing::debug!(
-			target: LOG_TARGET,
-			source = %u32::from(source),
-			count = peers.len(),
-			"Discovered spec-msg source peers",
-		);
-		registry.set_peers(source, peers);
+	let current = source_genesis_map(parachain)?;
+	for (source, info) in &current {
+		let changed = known.get(source) != Some(info);
+		let peerless = registry.peers(*source).is_empty();
+		if force || changed || peerless {
+			let peers = discovery.discover(*source, info.0.clone(), info.1.clone()).await;
+			tracing::debug!(
+				target: LOG_TARGET,
+				source = %u32::from(*source),
+				count = peers.len(),
+				"Discovered spec-msg source peers",
+			);
+			registry.set_peers(*source, peers);
+		}
 	}
+	// Sources dropped from the on-chain set: clear their peers.
+	for source in known.keys() {
+		if !current.contains_key(source) {
+			registry.set_peers(*source, Vec::new());
+		}
+	}
+	*known = current;
 	Ok(())
 }
 
@@ -189,6 +232,11 @@ pub struct BootnodeSourceDiscovery {
 	relay_chain_interface: Arc<dyn RelayChainInterface>,
 	/// Relay chain network — the DHT the source's bootnodes are advertised on.
 	relay_chain_network: Arc<dyn NetworkService>,
+	/// Relay chain `fork_id` — part of the `/paranode` protocol name. The source
+	/// side derives it from the relay chain spec (`config.chain_spec.fork_id()`),
+	/// so the client must use the same value to match. `None` for every current
+	/// relay.
+	relay_chain_fork_id: Option<String>,
 	/// Per-source discovery round timeout.
 	timeout: Duration,
 }
@@ -202,11 +250,13 @@ impl BootnodeSourceDiscovery {
 		parachain_network: Arc<dyn NetworkService>,
 		relay_chain_interface: Arc<dyn RelayChainInterface>,
 		relay_chain_network: Arc<dyn NetworkService>,
+		relay_chain_fork_id: Option<String>,
 	) -> Self {
 		Self {
 			parachain_network,
 			relay_chain_interface,
 			relay_chain_network,
+			relay_chain_fork_id,
 			timeout: DISCOVERY_ROUND_TIMEOUT,
 		}
 	}
@@ -220,6 +270,28 @@ impl SourceDiscovery for BootnodeSourceDiscovery {
 		genesis_hash: Vec<u8>,
 		fork_id: Option<String>,
 	) -> Vec<PeerId> {
+		// The `/paranode` request-response protocol is keyed by the RELAY genesis —
+		// that is what every collator registers and serves (see
+		// `cumulus-client-bootnodes`: the config is built from the relay chain's
+		// genesis, and own-para discovery names it likewise). Naming the request
+		// with the *source's* genesis would target a protocol no node has
+		// registered, so the send is rejected ("protocol doesn't exist"). Name it
+		// with the relay genesis (+ the relay `fork_id`, matching the server's
+		// `chain_spec.fork_id()`); the *source* genesis still rides in
+		// `parachain_genesis_hash`, where `BootnodeDiscovery` verifies the responder
+		// really is the expected parachain.
+		let relay_genesis = match self.relay_chain_interface.header(BlockId::Number(0)).await {
+			Ok(Some(header)) => header.hash().as_bytes().to_vec(),
+			_ => {
+				tracing::debug!(
+					target: LOG_TARGET,
+					source = %u32::from(source),
+					"Spec-msg discovery: relay chain genesis hash unavailable this round",
+				);
+				return Vec::new();
+			},
+		};
+
 		let (tx, mut rx) = mpsc::unbounded();
 		let discovery = BootnodeDiscovery::new(BootnodeDiscoveryParams {
 			para_id: source,
@@ -228,7 +300,10 @@ impl SourceDiscovery for BootnodeSourceDiscovery {
 			parachain_fork_id: fork_id.clone(),
 			relay_chain_interface: self.relay_chain_interface.clone(),
 			relay_chain_network: self.relay_chain_network.clone(),
-			paranode_protocol_name: paranode_protocol_name(&genesis_hash, fork_id.as_deref()),
+			paranode_protocol_name: paranode_protocol_name(
+				&relay_genesis,
+				self.relay_chain_fork_id.as_deref(),
+			),
 			discovered_tx: Some(tx),
 		});
 

--- a/cumulus/client/spec-msg/src/fetch.rs
+++ b/cumulus/client/spec-msg/src/fetch.rs
@@ -155,8 +155,17 @@ pub async fn fetch_source(
 ) -> Result<(), FetchError> {
 	let (mut leaves, mut bytes) = (0u64, 0u64);
 	for (stream, cursor) in channels {
-		match fetch_channel_stream(network, peers, pool, source, root, *stream, *cursor, chunk_bytes)
-			.await
+		match fetch_channel_stream(
+			network,
+			peers,
+			pool,
+			source,
+			root,
+			*stream,
+			*cursor,
+			chunk_bytes,
+		)
+		.await
 		{
 			Ok((stream_leaves, stream_bytes)) => {
 				leaves += stream_leaves;

--- a/cumulus/client/spec-msg/src/lib.rs
+++ b/cumulus/client/spec-msg/src/lib.rs
@@ -72,6 +72,7 @@
 
 pub mod archive;
 pub mod authoring;
+pub mod discovery;
 pub mod exchange;
 pub mod fetch;
 pub mod monitor;
@@ -85,6 +86,10 @@ pub use archive::{ArchiveError, ServeError, SpecMsgArchive, SERVING_HORIZON};
 pub use authoring::{
 	assemble_collation, assemble_lifts, inherent_data_at, lift_assembler, AssembleError,
 	ROUND_GRACE_WINDOW,
+};
+pub use discovery::{
+	run_spec_msg_discovery, BootnodeSourceDiscovery, SourceDiscovery, DISCOVERY_REFRESH_INTERVAL,
+	DISCOVERY_ROUND_TIMEOUT,
 };
 pub use exchange::{ExchangeError, ExchangeNetwork, PeerRegistry, SourcePeers};
 pub use fetch::{fetch_source, run_spec_msg_fetcher, FetchError, FETCH_CHUNK_BYTES};

--- a/cumulus/pallets/spec-messaging/src/lib.rs
+++ b/cumulus/pallets/spec-messaging/src/lib.rs
@@ -712,6 +712,24 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type HrmpClosing<T: Config> = StorageMap<_, Twox64Concat, ParaId, (), OptionQuery>;
 
+	/// Reachability of source parachains for node-side DHT peer discovery: each
+	/// source para's genesis hash (+ optional fork id) so the receiver's
+	/// collators can resolve that para's `/paranode` bootnodes over the relay
+	/// chain DHT. Set locally by governance ([`Pallet::set_source_genesis`]) —
+	/// the receiver's own knowledge of how to reach a source, which cannot come
+	/// from the source itself (that would require already reaching it). Keyed
+	/// per source para; genesis is per-chain, so one entry covers every channel
+	/// to that para. Exposed to the node via
+	/// [`Pallet::source_discovery_info`].
+	#[pallet::storage]
+	pub type SourceGenesis<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		ParaId,
+		([u8; 32], Option<BoundedVec<u8, ConstU32<32>>>),
+		OptionQuery,
+	>;
+
 	/// Consumption frontier per consumed channel stream, keyed by the full
 	/// stream key `(sender, stream id)` — a chain may consume several
 	/// streams of one sender. Position (= leaf count) and the root built
@@ -816,6 +834,12 @@ pub mod pallet {
 		ChannelAccepted {
 			/// The accepted inbound channel.
 			channel: ChannelId,
+		},
+		/// A source parachain's DHT discovery info (genesis hash) was set or
+		/// updated, or cleared (`None`).
+		SourceGenesisSet {
+			/// The source parachain.
+			source: ParaId,
 		},
 		/// This chain closed an inbound channel: a `closed: true` register
 		/// is published, the stream left the consumed set. The consumption
@@ -1157,6 +1181,31 @@ pub mod pallet {
 			Self::publish_register(&channel, &mut state)?;
 			InChannels::<T>::insert(channel, state);
 			Self::deposit_event(Event::ChannelAccepted { channel });
+			Ok(())
+		}
+
+		/// Registers (or clears, with `None`) how this receiver reaches source
+		/// parachain `source` for node-side DHT peer discovery: its genesis
+		/// hash and optional fork id. Local and governance-gated — the
+		/// receiver's own knowledge of a source's reachability, which the
+		/// channel handshake cannot supply (fetching the source's messages
+		/// requires already knowing how to reach it, so it can never come from
+		/// the source itself). One entry per source para covers all its
+		/// channels. Read node-side via [`Pallet::source_discovery_info`].
+		#[pallet::call_index(9)]
+		#[pallet::weight(T::DbWeight::get().writes(1))]
+		pub fn set_source_genesis(
+			origin: OriginFor<T>,
+			source: ParaId,
+			info: Option<([u8; 32], Option<BoundedVec<u8, ConstU32<32>>>)>,
+		) -> DispatchResult {
+			T::AcceptChannelOrigin::ensure_origin(origin)?;
+			ensure!(source != T::SelfParaId::get(), Error::<T>::ChannelToSelf);
+			match info {
+				Some(info) => SourceGenesis::<T>::insert(source, info),
+				None => SourceGenesis::<T>::remove(source),
+			}
+			Self::deposit_event(Event::SourceGenesisSet { source });
 			Ok(())
 		}
 
@@ -1677,6 +1726,18 @@ pub mod pallet {
 		/// check, suspension standing, diagnostics.
 		pub fn in_channels() -> BTreeMap<ChannelId, InChannelState> {
 			InChannels::<T>::iter().collect()
+		}
+
+		/// DHT discovery info of every configured source parachain — genesis
+		/// hash + optional fork id — for the node's `source_discovery_info()`
+		/// runtime API. The receiver's collators resolve each source's
+		/// `/paranode` bootnodes over the relay chain DHT from this.
+		pub fn source_discovery_info() -> BTreeMap<ParaId, ([u8; 32], Option<Vec<u8>>)> {
+			SourceGenesis::<T>::iter()
+				.map(|(source, (genesis, fork))| {
+					(source, (genesis, fork.map(BoundedVec::into_inner)))
+				})
+				.collect()
 		}
 
 		/// Consumes one channel item of the messaging inherent: hashes the

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -2725,6 +2725,11 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 		fn consumption_record() -> cumulus_primitives_spec_messaging::ConsumptionRecord {
 			SpecMessaging::consumption_record()
 		}
+
+		fn source_discovery_info(
+		) -> alloc::collections::BTreeMap<ParaId, ([u8; 32], Option<Vec<u8>>)> {
+			SpecMessaging::source_discovery_info()
+		}
 	}
 
 	impl pallet_asset_rewards::AssetRewards<Block, Balance> for Runtime {

--- a/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/cumulus/parachains/runtimes/testing/penpal/src/lib.rs
@@ -1101,6 +1101,11 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 		fn consumption_record() -> cumulus_primitives_spec_messaging::ConsumptionRecord {
 			SpecMessaging::consumption_record()
 		}
+
+		fn source_discovery_info(
+		) -> alloc::collections::BTreeMap<ParaId, ([u8; 32], Option<Vec<u8>>)> {
+			SpecMessaging::source_discovery_info()
+		}
 	}
 
 	impl xcm_runtime_apis::fees::XcmPaymentApi<Block> for Runtime {

--- a/cumulus/polkadot-omni-node/lib/src/cli.rs
+++ b/cumulus/polkadot-omni-node/lib/src/cli.rs
@@ -266,27 +266,6 @@ pub struct Cli<Config: CliConfig> {
 	#[arg(long, value_name = "N", default_value_t = 32)]
 	pub collator_reserved_slots: usize,
 
-	/// Speculative Messaging: a static peer serving a source parachain's
-	/// streams, as `<para-id>=<multiaddr>/p2p/<peer-id>` (repeatable).
-	///
-	/// The receiver-side fetch pipeline dials these peers for the given
-	/// source chain's `/spec-msg/exchange` protocol. Source chains are
-	/// *other* parachains, so their collators are never in the own chain's
-	/// peer set; until DHT-based discovery of a source's collators lands,
-	/// this is how a collator learns them (test networks, static setups).
-	#[arg(long, value_name = "PARA_ID=MULTIADDR")]
-	pub spec_msg_source_peer: Vec<String>,
-
-	/// Speculative Messaging: a source chain's genesis hash for DHT-based peer
-	/// discovery over the relay chain (RFC-0008 `/paranode`), as
-	/// `<para-id>=<genesis-hash-hex>[/<fork-id>]` (repeatable).
-	///
-	/// A source configured here has its collators discovered dynamically over
-	/// the relay-chain DHT instead of being listed statically via
-	/// `--spec-msg-source-peer`. Configure a source via one or the other.
-	#[arg(long, value_name = "PARA_ID=GENESIS_HASH")]
-	pub spec_msg_source_genesis: Vec<String>,
-
 	/// HOP (Hand-Off Protocol) configuration parameters.
 	#[command(flatten)]
 	pub hop: sc_hop::HopParams,
@@ -347,8 +326,6 @@ impl<Config: CliConfig> Cli<Config> {
 			storage_monitor: self.storage_monitor.clone(),
 			collator_reserved_slots: self.collator_reserved_slots,
 			hop: self.hop.enabled.then(|| self.hop.clone()),
-			spec_msg_source_peers: self.spec_msg_source_peer.clone(),
-			spec_msg_source_genesis: self.spec_msg_source_genesis.clone(),
 		}
 	}
 

--- a/cumulus/polkadot-omni-node/lib/src/cli.rs
+++ b/cumulus/polkadot-omni-node/lib/src/cli.rs
@@ -277,6 +277,16 @@ pub struct Cli<Config: CliConfig> {
 	#[arg(long, value_name = "PARA_ID=MULTIADDR")]
 	pub spec_msg_source_peer: Vec<String>,
 
+	/// Speculative Messaging: a source chain's genesis hash for DHT-based peer
+	/// discovery over the relay chain (RFC-0008 `/paranode`), as
+	/// `<para-id>=<genesis-hash-hex>[/<fork-id>]` (repeatable).
+	///
+	/// A source configured here has its collators discovered dynamically over
+	/// the relay-chain DHT instead of being listed statically via
+	/// `--spec-msg-source-peer`. Configure a source via one or the other.
+	#[arg(long, value_name = "PARA_ID=GENESIS_HASH")]
+	pub spec_msg_source_genesis: Vec<String>,
+
 	/// HOP (Hand-Off Protocol) configuration parameters.
 	#[command(flatten)]
 	pub hop: sc_hop::HopParams,
@@ -338,6 +348,7 @@ impl<Config: CliConfig> Cli<Config> {
 			collator_reserved_slots: self.collator_reserved_slots,
 			hop: self.hop.enabled.then(|| self.hop.clone()),
 			spec_msg_source_peers: self.spec_msg_source_peer.clone(),
+			spec_msg_source_genesis: self.spec_msg_source_genesis.clone(),
 		}
 	}
 

--- a/cumulus/polkadot-omni-node/lib/src/common/mod.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/mod.rs
@@ -153,4 +153,8 @@ pub struct NodeExtraArgs {
 	/// Speculative Messaging: static source-chain peers for the fetch
 	/// pipeline, as raw `<para-id>=<multiaddr-with-/p2p/-peer-id>` values.
 	pub spec_msg_source_peers: Vec<String>,
+
+	/// Speculative Messaging: source-chain genesis hashes for relay-chain-DHT
+	/// peer discovery, as raw `<para-id>=<genesis-hash-hex>[/<fork-id>]` values.
+	pub spec_msg_source_genesis: Vec<String>,
 }

--- a/cumulus/polkadot-omni-node/lib/src/common/mod.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/mod.rs
@@ -149,12 +149,4 @@ pub struct NodeExtraArgs {
 	/// HOP (Hand-Off Protocol) configuration parameters.
 	/// `None` disables HOP.
 	pub hop: Option<sc_hop::HopParams>,
-
-	/// Speculative Messaging: static source-chain peers for the fetch
-	/// pipeline, as raw `<para-id>=<multiaddr-with-/p2p/-peer-id>` values.
-	pub spec_msg_source_peers: Vec<String>,
-
-	/// Speculative Messaging: source-chain genesis hashes for relay-chain-DHT
-	/// peer discovery, as raw `<para-id>=<genesis-hash-hex>[/<fork-id>]` values.
-	pub spec_msg_source_genesis: Vec<String>,
 }

--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -619,9 +619,11 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 				client.clone(),
 				network.clone(),
 				relay_chain_interface.clone(),
+				relay_chain_network.clone(),
 				para_id,
 				validator,
 				&node_extra_args.spec_msg_source_peers,
+				&node_extra_args.spec_msg_source_genesis,
 			)?;
 
 			start_bootnode_tasks(StartBootnodeTasksParams {

--- a/cumulus/polkadot-omni-node/lib/src/common/spec.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec.rs
@@ -620,10 +620,9 @@ pub(crate) trait NodeSpec: BaseNodeSpec {
 				network.clone(),
 				relay_chain_interface.clone(),
 				relay_chain_network.clone(),
+				relay_chain_fork_id.clone(),
 				para_id,
 				validator,
-				&node_extra_args.spec_msg_source_peers,
-				&node_extra_args.spec_msg_source_genesis,
 			)?;
 
 			start_bootnode_tasks(StartBootnodeTasksParams {

--- a/cumulus/polkadot-omni-node/lib/src/common/spec_msg.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec_msg.rs
@@ -37,8 +37,9 @@
 
 use crate::common::{types::ParachainClient, ConstructNodeRuntimeApi, NodeBlock};
 use cumulus_client_spec_msg::{
-	lift_assembler, run_relay_provides_monitor, run_spec_msg_archiver, run_spec_msg_fetcher,
-	PeerRegistry, SpecMsgArchive, SpecMsgPool, SpecMsgRequestHandler,
+	lift_assembler, run_relay_provides_monitor, run_spec_msg_archiver, run_spec_msg_discovery,
+	run_spec_msg_fetcher, BootnodeSourceDiscovery, PeerRegistry, SourceDiscovery, SpecMsgArchive,
+	SpecMsgPool, SpecMsgRequestHandler, DISCOVERY_REFRESH_INTERVAL,
 };
 use cumulus_primitives_core::ParaId;
 use cumulus_primitives_spec_messaging::LiftsBySource;
@@ -48,7 +49,7 @@ use sc_network::{
 	config::FullNetworkConfiguration, service::traits::NetworkService, NetworkBackend,
 };
 use sc_service::TaskManager;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 /// Capacity of the monitor → fetcher trigger channel. Triggers are tiny
 /// `(source, root)` tuples; the bound only guards against a wedged fetcher.
@@ -124,9 +125,11 @@ where
 		client: Arc<ParachainClient<Block, RuntimeApi>>,
 		network: Arc<dyn NetworkService>,
 		relay_chain_interface: Arc<dyn RelayChainInterface>,
+		relay_chain_network: Arc<dyn NetworkService>,
 		para_id: ParaId,
 		validator: bool,
 		source_peers: &[String],
+		source_genesis: &[String],
 	) -> sc_service::error::Result<Option<SpecMsgDeps<Block>>> {
 		let spawner = task_manager.spawn_essential_handle();
 		spawner.spawn("spec-msg-exchange", Some("spec-msg"), self.handler.run());
@@ -147,6 +150,40 @@ where
 			network.add_known_address(peer, address);
 			registry.add_peer(source, peer);
 		}
+
+		// DHT-based discovery of source peers over the relay-chain DHT (RFC-0008
+		// `/paranode`), refreshing the same registry. The authoritative source
+		// set + genesis comes from the runtime API (`source_discovery_info()`,
+		// governance-set on-chain via `set_source_genesis` — so it tracks the
+		// channel lifecycle), with the CLI `--spec-msg-source-genesis` values as
+		// overrides for pinning/bootstrap. Runs regardless, since the on-chain
+		// set is dynamic; a source pinned statically via `--spec-msg-source-peer`
+		// simply keeps its registry entry (discovery never lists it).
+		let mut overrides = HashMap::new();
+		for entry in source_genesis {
+			let (source, genesis_hash, fork_id) = parse_source_genesis(entry)?;
+			log::info!(
+				"Speculative Messaging DHT discovery override for para {source} (genesis {})",
+				array_bytes::bytes2hex("0x", &genesis_hash),
+			);
+			overrides.insert(source, (genesis_hash, fork_id));
+		}
+		let discovery: Arc<dyn SourceDiscovery> = Arc::new(BootnodeSourceDiscovery::new(
+			network.clone(),
+			relay_chain_interface.clone(),
+			relay_chain_network,
+		));
+		spawner.spawn(
+			"spec-msg-discovery",
+			Some("spec-msg"),
+			run_spec_msg_discovery::<Block, _>(
+				client.clone(),
+				discovery,
+				registry.clone(),
+				overrides,
+				DISCOVERY_REFRESH_INTERVAL,
+			),
+		);
 
 		let pool = Arc::new(SpecMsgPool::default());
 		let (events_tx, events_rx) = async_channel::bounded(EVENTS_CHANNEL_CAPACITY);
@@ -196,6 +233,32 @@ fn parse_source_peer(
 	Ok((para_id.into(), peer, address))
 }
 
+/// Parses one `--spec-msg-source-genesis` value:
+/// `<para-id>=<genesis-hash-hex>[/<fork-id>]`.
+fn parse_source_genesis(
+	entry: &str,
+) -> sc_service::error::Result<(ParaId, Vec<u8>, Option<String>)> {
+	let error = |details: String| {
+		sc_service::Error::Other(format!(
+			"invalid --spec-msg-source-genesis value `{entry}` \
+			 (expected `<para-id>=<genesis-hash-hex>[/<fork-id>]`): {details}"
+		))
+	};
+	let (para_id, rest) = entry.split_once('=').ok_or_else(|| error("missing `=`".to_string()))?;
+	let para_id: u32 = para_id.trim().parse().map_err(|e| error(format!("bad para id: {e}")))?;
+	let (genesis_hex, fork_id) = match rest.trim().split_once('/') {
+		Some((hash, fork)) => (hash, (!fork.is_empty()).then(|| fork.to_string())),
+		None => (rest.trim(), None),
+	};
+	let genesis_hex = genesis_hex.strip_prefix("0x").unwrap_or(genesis_hex);
+	let genesis_hash = array_bytes::hex2bytes(genesis_hex)
+		.map_err(|e| error(format!("bad genesis hash hex: {e:?}")))?;
+	if genesis_hash.is_empty() {
+		return Err(error("empty genesis hash".to_string()));
+	}
+	Ok((para_id.into(), genesis_hash, fork_id))
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -218,6 +281,26 @@ mod tests {
 			"2000=nonsense",
 		] {
 			assert!(parse_source_peer(bad).is_err(), "`{bad}` must be rejected");
+		}
+	}
+
+	#[test]
+	fn source_genesis_values_parse() {
+		// Bare genesis hash (0x-prefixed), no fork id.
+		let (para, hash, fork) = parse_source_genesis("2000=0xaabbcc").expect("valid value parses");
+		assert_eq!(para, ParaId::from(2000));
+		assert_eq!(hash, vec![0xaa, 0xbb, 0xcc]);
+		assert_eq!(fork, None);
+
+		// Without `0x`, with a fork id.
+		let (para, hash, fork) =
+			parse_source_genesis("2001=aabb/mychain").expect("valid value parses");
+		assert_eq!(para, ParaId::from(2001));
+		assert_eq!(hash, vec![0xaa, 0xbb]);
+		assert_eq!(fork.as_deref(), Some("mychain"));
+
+		for bad in ["2000", "abc=0xaabb", "2000=0xzz", "2000=", "2000=0x"] {
+			assert!(parse_source_genesis(bad).is_err(), "`{bad}` must be rejected");
 		}
 	}
 }

--- a/cumulus/polkadot-omni-node/lib/src/common/spec_msg.rs
+++ b/cumulus/polkadot-omni-node/lib/src/common/spec_msg.rs
@@ -49,7 +49,7 @@ use sc_network::{
 	config::FullNetworkConfiguration, service::traits::NetworkService, NetworkBackend,
 };
 use sc_service::TaskManager;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 /// Capacity of the monitor → fetcher trigger channel. Triggers are tiny
 /// `(source, root)` tuples; the bound only guards against a wedged fetcher.
@@ -116,9 +116,9 @@ where
 	/// pipeline on collators, whose [`SpecMsgDeps`] are returned for the
 	/// consensus wiring.
 	///
-	/// `source_peers` are the raw `--spec-msg-source-peer` values
-	/// (`<para-id>=<multiaddr-with-/p2p/-peer-id>`); malformed entries fail
-	/// node startup loudly.
+	/// Source peers are discovered dynamically over the relay-chain DHT from the
+	/// on-chain source set (`SpecMsgApi::source_discovery_info()`); there is no
+	/// static peer/genesis wiring.
 	pub(crate) fn start(
 		self,
 		task_manager: &TaskManager,
@@ -126,10 +126,9 @@ where
 		network: Arc<dyn NetworkService>,
 		relay_chain_interface: Arc<dyn RelayChainInterface>,
 		relay_chain_network: Arc<dyn NetworkService>,
+		relay_chain_fork_id: Option<String>,
 		para_id: ParaId,
 		validator: bool,
-		source_peers: &[String],
-		source_genesis: &[String],
 	) -> sc_service::error::Result<Option<SpecMsgDeps<Block>>> {
 		let spawner = task_manager.spawn_essential_handle();
 		spawner.spawn("spec-msg-exchange", Some("spec-msg"), self.handler.run());
@@ -143,35 +142,17 @@ where
 			return Ok(None);
 		}
 
+		// DHT-based discovery of each source's peers over the relay-chain DHT
+		// (RFC-0008 `/paranode`), populating the shared registry the fetch
+		// pipeline reads. The source set + genesis comes entirely from the
+		// runtime API (`source_discovery_info()`, governance-set on-chain via
+		// `set_source_genesis`), so it tracks the channel lifecycle.
 		let registry = Arc::new(PeerRegistry::default());
-		for entry in source_peers {
-			let (source, peer, address) = parse_source_peer(entry)?;
-			log::info!("Speculative Messaging source peer for para {source}: {peer} @ {address}");
-			network.add_known_address(peer, address);
-			registry.add_peer(source, peer);
-		}
-
-		// DHT-based discovery of source peers over the relay-chain DHT (RFC-0008
-		// `/paranode`), refreshing the same registry. The authoritative source
-		// set + genesis comes from the runtime API (`source_discovery_info()`,
-		// governance-set on-chain via `set_source_genesis` — so it tracks the
-		// channel lifecycle), with the CLI `--spec-msg-source-genesis` values as
-		// overrides for pinning/bootstrap. Runs regardless, since the on-chain
-		// set is dynamic; a source pinned statically via `--spec-msg-source-peer`
-		// simply keeps its registry entry (discovery never lists it).
-		let mut overrides = HashMap::new();
-		for entry in source_genesis {
-			let (source, genesis_hash, fork_id) = parse_source_genesis(entry)?;
-			log::info!(
-				"Speculative Messaging DHT discovery override for para {source} (genesis {})",
-				array_bytes::bytes2hex("0x", &genesis_hash),
-			);
-			overrides.insert(source, (genesis_hash, fork_id));
-		}
 		let discovery: Arc<dyn SourceDiscovery> = Arc::new(BootnodeSourceDiscovery::new(
 			network.clone(),
 			relay_chain_interface.clone(),
 			relay_chain_network,
+			relay_chain_fork_id,
 		));
 		spawner.spawn(
 			"spec-msg-discovery",
@@ -180,7 +161,6 @@ where
 				client.clone(),
 				discovery,
 				registry.clone(),
-				overrides,
 				DISCOVERY_REFRESH_INTERVAL,
 			),
 		);
@@ -212,96 +192,5 @@ where
 
 		let lift_assembler = lift_assembler(client, pool.clone());
 		Ok(Some(SpecMsgDeps { pool, lift_assembler }))
-	}
-}
-
-/// Parses one `--spec-msg-source-peer` value:
-/// `<para-id>=<multiaddr>/p2p/<peer-id>`.
-fn parse_source_peer(
-	entry: &str,
-) -> sc_service::error::Result<(ParaId, sc_network::PeerId, sc_network::Multiaddr)> {
-	let error = |details: String| {
-		sc_service::Error::Other(format!(
-			"invalid --spec-msg-source-peer value `{entry}` \
-			 (expected `<para-id>=<multiaddr>/p2p/<peer-id>`): {details}"
-		))
-	};
-	let (para_id, address) =
-		entry.split_once('=').ok_or_else(|| error("missing `=`".to_string()))?;
-	let para_id: u32 = para_id.trim().parse().map_err(|e| error(format!("bad para id: {e}")))?;
-	let (peer, address) = sc_network::config::parse_str_addr(address.trim())
-		.map_err(|e| error(format!("bad multiaddr: {e}")))?;
-	Ok((para_id.into(), peer, address))
-}
-
-/// Parses one `--spec-msg-source-genesis` value:
-/// `<para-id>=<genesis-hash-hex>[/<fork-id>]`.
-fn parse_source_genesis(
-	entry: &str,
-) -> sc_service::error::Result<(ParaId, Vec<u8>, Option<String>)> {
-	let error = |details: String| {
-		sc_service::Error::Other(format!(
-			"invalid --spec-msg-source-genesis value `{entry}` \
-			 (expected `<para-id>=<genesis-hash-hex>[/<fork-id>]`): {details}"
-		))
-	};
-	let (para_id, rest) = entry.split_once('=').ok_or_else(|| error("missing `=`".to_string()))?;
-	let para_id: u32 = para_id.trim().parse().map_err(|e| error(format!("bad para id: {e}")))?;
-	let (genesis_hex, fork_id) = match rest.trim().split_once('/') {
-		Some((hash, fork)) => (hash, (!fork.is_empty()).then(|| fork.to_string())),
-		None => (rest.trim(), None),
-	};
-	let genesis_hex = genesis_hex.strip_prefix("0x").unwrap_or(genesis_hex);
-	let genesis_hash = array_bytes::hex2bytes(genesis_hex)
-		.map_err(|e| error(format!("bad genesis hash hex: {e:?}")))?;
-	if genesis_hash.is_empty() {
-		return Err(error("empty genesis hash".to_string()));
-	}
-	Ok((para_id.into(), genesis_hash, fork_id))
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn source_peer_values_parse() {
-		let (para, peer, addr) = parse_source_peer(
-			"2000=/ip4/127.0.0.1/tcp/40100/ws\
-			 /p2p/12D3KooWQCkBm1BYtkHpocxCwMgR8yjitEeHGx8spzcDLGt2gkBm",
-		)
-		.expect("valid value parses");
-		assert_eq!(para, ParaId::from(2000));
-		assert_eq!(peer.to_string(), "12D3KooWQCkBm1BYtkHpocxCwMgR8yjitEeHGx8spzcDLGt2gkBm");
-		assert_eq!(addr.to_string(), "/ip4/127.0.0.1/tcp/40100/ws");
-
-		for bad in [
-			"2000",
-			"abc=/ip4/127.0.0.1/tcp/1/ws/p2p/12D3KooWQCkBm1BYtkHpocxCwMgR8yjitEeHGx8spzcDLGt2gkBm",
-			"2000=/ip4/127.0.0.1/tcp/40100/ws",
-			"2000=nonsense",
-		] {
-			assert!(parse_source_peer(bad).is_err(), "`{bad}` must be rejected");
-		}
-	}
-
-	#[test]
-	fn source_genesis_values_parse() {
-		// Bare genesis hash (0x-prefixed), no fork id.
-		let (para, hash, fork) = parse_source_genesis("2000=0xaabbcc").expect("valid value parses");
-		assert_eq!(para, ParaId::from(2000));
-		assert_eq!(hash, vec![0xaa, 0xbb, 0xcc]);
-		assert_eq!(fork, None);
-
-		// Without `0x`, with a fork id.
-		let (para, hash, fork) =
-			parse_source_genesis("2001=aabb/mychain").expect("valid value parses");
-		assert_eq!(para, ParaId::from(2001));
-		assert_eq!(hash, vec![0xaa, 0xbb]);
-		assert_eq!(fork.as_deref(), Some("mychain"));
-
-		for bad in ["2000", "abc=0xaabb", "2000=0xzz", "2000=", "2000=0x"] {
-			assert!(parse_source_genesis(bad).is_err(), "`{bad}` must be rejected");
-		}
 	}
 }

--- a/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
+++ b/cumulus/polkadot-omni-node/lib/src/fake_runtime_api/utils.rs
@@ -224,6 +224,13 @@ macro_rules! impl_node_runtime_apis {
 				fn consumption_record() -> cumulus_primitives_spec_messaging::ConsumptionRecord {
 					unimplemented!()
 				}
+
+				fn source_discovery_info() -> std::collections::BTreeMap<
+					ParaId,
+					([u8; 32], Option<Vec<u8>>),
+				> {
+					unimplemented!()
+				}
 			}
 
 			#[cfg(feature = "try-runtime")]

--- a/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
+++ b/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
@@ -232,6 +232,7 @@ where
 			// Dev nodes have no relay chain to monitor and no peers to fetch
 			// from; the spec-msg subsystems stay unwired.
 			spec_msg_source_peers: _,
+			spec_msg_source_genesis: _,
 		} = node_extra_args;
 
 		// Warn about args that have no effect in dev mode (collation-specific).

--- a/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
+++ b/cumulus/polkadot-omni-node/lib/src/nodes/aura.rs
@@ -229,10 +229,6 @@ where
 			ref storage_monitor,
 			ref hop,
 			collator_reserved_slots: _,
-			// Dev nodes have no relay chain to monitor and no peers to fetch
-			// from; the spec-msg subsystems stay unwired.
-			spec_msg_source_peers: _,
-			spec_msg_source_genesis: _,
 		} = node_extra_args;
 
 		// Warn about args that have no effect in dev mode (collation-specific).

--- a/cumulus/primitives/core/src/lib.rs
+++ b/cumulus/primitives/core/src/lib.rs
@@ -799,6 +799,14 @@ sp_api::decl_runtime_apis! {
 		/// in-wasm after executing each block of a bundle — one definition,
 		/// two callers, byte-identical records.
 		fn consumption_record() -> ConsumptionRecord;
+
+		/// DHT peer-discovery info of the source parachains this receiver
+		/// consumes from: each configured source's genesis hash (+ optional
+		/// fork id), so the collator can resolve that para's `/paranode`
+		/// bootnodes over the relay chain DHT. Node-only; empty when no
+		/// sources are configured (governance-set locally — how to reach a
+		/// source cannot come from the source itself).
+		fn source_discovery_info() -> BTreeMap<ParaId, ([u8; 32], Option<Vec<u8>>)>;
 	}
 }
 

--- a/polkadot/zombienet-sdk-tests/tests/messaging/spec_msg_penpal.rs
+++ b/polkadot/zombienet-sdk-tests/tests/messaging/spec_msg_penpal.rs
@@ -4,10 +4,12 @@
 //! Parachain-to-parachain XCM delivery over Speculative Messaging — the
 //! end-to-end cutover test gating the HRMP→spec-msg rollout.
 //!
-//! Spawns a rococo-local relay chain and two penpal parachains whose
-//! collators are wired for spec-msg (static `--spec-msg-source-peer`
-//! addresses; zombienet derives node keys from node names, so the peer ids
-//! are known up front), then walks the transition runbook:
+//! Spawns a rococo-local relay chain and two penpal parachains whose collators
+//! discover each other's spec-msg peers dynamically over the relay chain DHT
+//! (RFC-0008 `/paranode`): each receiver's source reachability is registered
+//! on-chain via `SpecMessaging::set_source_genesis` (the source's genesis hash),
+//! and the node's discovery worker resolves the sibling's collators from it — no
+//! static peer list. It then walks the transition runbook:
 //!
 //! 1. **Baseline**: HRMP channels open in both directions; XCM A→B delivers over HRMP.
 //! 2. **Handshake**: open/accept the spec-msg channels in both directions (`open_channel` +
@@ -94,8 +96,7 @@ const PARA_B: u32 = 2001;
 /// A sibling with neither an HRMP channel nor a spec-msg channel.
 const PARA_NOWHERE: u32 = 2002;
 
-/// Fixed parachain-side p2p ports, so each collator's multiaddr is known
-/// when the *other* collator's args are rendered.
+/// Fixed parachain-side p2p ports for the two collators.
 const PENPAL_A_P2P_PORT: u16 = 43210;
 const PENPAL_B_P2P_PORT: u16 = 43310;
 
@@ -112,15 +113,6 @@ const TRANSFER_AMOUNT: u128 = 10 * UNIT;
 
 /// The `SPMS` header digest's consensus engine id (`SPMS_ENGINE_ID`).
 const SPMS_ENGINE_ID: [u8; 4] = *b"SPMS";
-
-/// The multiaddr (with peer id) of a zombienet parachain collator's
-/// parachain-side network: zombienet listens on `/ip4/0.0.0.0/tcp/<port>/ws`
-/// and derives the node key from the node's name.
-fn collator_multiaddr(name: &str, p2p_port: u16) -> anyhow::Result<String> {
-	let (_node_key, peer_id) = zombienet_orchestrator::generators::generate_node_identity(name)
-		.map_err(|e| anyhow!("failed to derive {name}'s node identity: {e:?}"))?;
-	Ok(format!("/ip4/127.0.0.1/tcp/{p2p_port}/ws/p2p/{peer_id}"))
-}
 
 /// The account on the destination penpal that an incoming XCM sent by
 /// `sender` on the sibling `source_para` resolves to (see the HRMP baseline
@@ -197,6 +189,25 @@ async fn accept_spec_msg_channel(
 	sudo_spec_messaging(
 		client,
 		SpecMessagingCall::accept_open_channel { sender: PenpalId(sender), domain: 0, num: 0 },
+	)
+	.await
+}
+
+/// Registers on `client`'s penpal how to reach source parachain `source` for
+/// relay-DHT peer discovery: the source's genesis hash (no fork id). Governance-
+/// gated, so sudo-wrapped like the channel handshake; the node's discovery worker
+/// reads it via `source_discovery_info()` and resolves that source's collators.
+async fn set_source_genesis(
+	client: &OnlineClient<PolkadotConfig>,
+	source: u32,
+	genesis: [u8; 32],
+) -> anyhow::Result<()> {
+	sudo_spec_messaging(
+		client,
+		SpecMessagingCall::set_source_genesis {
+			source: PenpalId(source),
+			info: Some((genesis, None)),
+		},
 	)
 	.await
 }
@@ -547,11 +558,6 @@ async fn spec_msg_penpal_xcm_delivery() -> Result<(), anyhow::Error> {
 		env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
 	);
 
-	let penpal_a_addr = collator_multiaddr("penpal-a", PENPAL_A_P2P_PORT)?;
-	let penpal_b_addr = collator_multiaddr("penpal-b", PENPAL_B_P2P_PORT)?;
-	log::info!("penpal-a serves spec-msg at {penpal_a_addr}");
-	log::info!("penpal-b serves spec-msg at {penpal_b_addr}");
-
 	let images = zombienet_sdk::environment::get_images_from_env();
 	let config = NetworkConfigBuilder::new()
 		.with_relaychain(|r| {
@@ -570,11 +576,9 @@ async fn spec_msg_penpal_xcm_delivery() -> Result<(), anyhow::Error> {
 				.with_chain("penpal-rococo-2000")
 				.with_collator(|n| {
 					n.with_name("penpal-a").with_p2p_port(PENPAL_A_P2P_PORT).with_args(vec![
-						("--spec-msg-source-peer", format!("{PARA_B}={penpal_b_addr}").as_str())
-							.into(),
 						// The final exactly-once tally reads every block's events.
 						("--state-pruning", "archive").into(),
-						("-lspec-msg=debug").into(),
+						("-lspec-msg=trace,bootnodes=trace").into(),
 					])
 				})
 		})
@@ -585,11 +589,9 @@ async fn spec_msg_penpal_xcm_delivery() -> Result<(), anyhow::Error> {
 				.with_chain("penpal-rococo-2001")
 				.with_collator(|n| {
 					n.with_name("penpal-b").with_p2p_port(PENPAL_B_P2P_PORT).with_args(vec![
-						("--spec-msg-source-peer", format!("{PARA_A}={penpal_a_addr}").as_str())
-							.into(),
 						// The final exactly-once tally reads every block's events.
 						("--state-pruning", "archive").into(),
-						("-lspec-msg=debug").into(),
+						("-lspec-msg=trace,bootnodes=trace").into(),
 					])
 				})
 		})
@@ -617,6 +619,19 @@ async fn spec_msg_penpal_xcm_delivery() -> Result<(), anyhow::Error> {
 		[],
 	)
 	.await?;
+
+	// Register how each penpal reaches its sibling source over the relay-chain
+	// DHT (RFC-0008 `/paranode`) by recording the source's genesis hash on-chain
+	// — replacing the old static `--spec-msg-source-peer` wiring. The discovery
+	// worker reads this (`source_discovery_info()`) and resolves the sibling's
+	// collators; peerless sources are retried every block, so this self-heals
+	// until the source's DHT record propagates. Done before the handshake so the
+	// register round-trip finds the peer.
+	let genesis_a = para_a_client.genesis_hash();
+	let genesis_b = para_b_client.genesis_hash();
+	log::info!("Registering DHT discovery sources: B<-A {genesis_a:?}, A<-B {genesis_b:?}");
+	set_source_genesis(&para_b_client, PARA_A, genesis_a.0).await?;
+	set_source_genesis(&para_a_client, PARA_B, genesis_b.0).await?;
 
 	let alice = dev::alice();
 


### PR DESCRIPTION
## What

Adds **cross-parachain peer discovery** for Speculative Messaging, driven entirely by on-chain state — replacing the static `--spec-msg-source-peer` wiring from the PoC. A receiver learns each source parachain's collators over the relay-chain DHT (RFC-0008 `/paranode`), configured by governance via `set_source_genesis`, with **no static peer list and no node restart**.

Stacked on `lexnv/spec-msg-poc-mvp` (design v0.5 PoC).

## Changes

- **Relay-DHT discovery** (`cumulus-client-spec-msg::discovery`) — `run_spec_msg_discovery` resolves each configured source's peers over the relay DHT (reusing `cumulus-client-bootnodes` against the *source's* `para_id`) and feeds the shared `PeerRegistry` the fetch pipeline reads.
  - **Event-driven**: re-reads the source set (`SpecMsgApi::source_discovery_info()`) on each new best block and DHT-resolves only *changed / peerless* sources, with a 5-min steady-state fallback — so a `set_source_genesis` extrinsic takes effect within ~1 block.
  - The `/paranode` request is named with the **relay** genesis (which is how every collator registers and serves it — see `cumulus-client-bootnodes`); the *source* genesis is used only to **verify** the responder is the expected parachain.
- **Pallet** (`cumulus-pallet-spec-messaging`) — `SourceGenesis` storage + governance-gated `set_source_genesis` extrinsic + `SpecMsgApi::source_discovery_info()` runtime API: the receiver's own record of how to reach a source (which cannot come from the source itself).
- **bootnodes** (`cumulus-client-bootnodes`) — `BootnodeDiscovery` gains an optional `discovered_tx` sink so a cross-parachain caller can receive the resolved `(peer, addresses)`. Own-parachain bootstrap path unchanged.
- **omni-node** — spawn the discovery worker on collators; remove the static `--spec-msg-source-peer` / `--spec-msg-source-genesis` flags.

## Compatibility

Same-parachain (RFC-0008) bootnode discovery is **untouched** — the `/paranode` protocol name, its server, the own-para discovery task, and the relay builders are unchanged. Cross-para discovery is purely **additive and scoped to spec-msg**; a node not running spec-msg sees no change, and the `/paranode` wire format is not modified.

## Testing

The `spec_msg_penpal` E2E (`spec_msg_penpal_xcm_delivery`) now drives discovery via sudo `set_source_genesis` per direction (no static peers) and **passes end-to-end** — XCM delivered both directions over DHT-discovered peers, with the exactly-once tally. Confirmed from node logs: `Discovered spec-msg source peers … count=1`, and zero `/paranode doesn't exist` errors.

```
ZOMBIE_PROVIDER=native cargo test --release -p polkadot-zombienet-sdk-tests \
  --features "zombie-metadata,zombie-ci" spec_msg_penpal_xcm_delivery -- --nocapture
```
