### PR TITLE
Fix Candidate Block Session Boundary

### DIFF
--- a/polkadot/node/core/candidate-validation/src/lib.rs
+++ b/polkadot/node/core/candidate-validation/src/lib.rs
@@ -1008,8 +1008,8 @@ async fn update_active_leaves_validation_backend<Sender>(
 
 /// Get list of still valid scheduling parents for the given leaf.
 ///
-/// TODO: This function does not take into account session boundaries, which leads to wasted effort:
-/// https://github.com/paritytech/polkadot-sdk/issues/11301
+/// Stops at the first ancestor that belongs to a different session than `leaf`.
+/// https://github.com/paritytech/polkadot-sdk/issues/11301.
 async fn get_block_ancestors<Sender>(sender: &mut Sender, leaf: Hash) -> Vec<Hash>
 where
 	Sender: SubsystemSender<ChainApiMessage> + SubsystemSender<RuntimeApiMessage>,
@@ -1035,13 +1035,26 @@ where
 			response_channel: tx,
 		})
 		.await;
-	match rx.await {
+	let ancestors = match rx.await {
 		Ok(Ok(x)) => x,
 		res => {
 			gum::warn!(target: LOG_TARGET, ?res, "cannot request ancestors");
-			vec![]
+			return vec![];
 		},
+	};
+
+	let mut same_session_ancestors = Vec::with_capacity(ancestors.len());
+	for ancestor in ancestors {
+		let Some(ancestor_session_index) = get_session_index(sender, ancestor).await else {
+			break;
+		};
+		if ancestor_session_index != session_index {
+			break;
+		}
+		same_session_ancestors.push(ancestor);
 	}
+
+	same_session_ancestors
 }
 
 struct RuntimeRequestFailed;

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -1791,6 +1791,16 @@ async fn assert_new_active_leaf_messages(
 		}
 	);
 
+	// One SessionIndexForChild per ancestor, checking each stays within `expected_session_index`.
+	for _ in 0..(lookahead_value - 1) {
+		assert_matches!(
+			recv_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(expected_session_index));
+			}
+		);
+	}
+
 	// Second SessionIndexForChild — from handle_active_leaves_update's own
 	// get_session_index call (separate from the one in update_active_leaves_validation_backend).
 	assert_matches!(

--- a/polkadot/node/core/candidate-validation/src/tests.rs
+++ b/polkadot/node/core/candidate-validation/src/tests.rs
@@ -1929,6 +1929,67 @@ fn maybe_prepare_validation_checkes_authority_once_per_session() {
 }
 
 #[test]
+fn get_block_ancestors_stops_at_session_boundary() {
+	let pool = TaskExecutor::new();
+	let (mut ctx, mut ctx_handle) = make_subsystem_context::<AllMessages, _>(pool);
+
+	let leaf = Hash::repeat_byte(0xAA);
+	let leaf_session = 5;
+	let lookahead = 5u32; // -> 4 ancestors requested
+	let ancestor_hashes: Vec<Hash> = (0..4).map(|i| Hash::from_low_u64_be(i)).collect();
+
+	let check_fut = get_block_ancestors(ctx.sender(), leaf);
+
+	let test_fut = async {
+		// Session index for the leaf itself.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(leaf_session));
+			}
+		);
+		// Scheduling lookahead for that session.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SchedulingLookahead(index, tx))) => {
+				assert_eq!(index, leaf_session);
+				let _ = tx.send(Ok(lookahead));
+			}
+		);
+		// ChainApi ancestors, `lookahead - 1` of them.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::ChainApi(ChainApiMessage::Ancestors { k, response_channel, .. }) => {
+				assert_eq!(k, (lookahead - 1) as usize);
+				let _ = response_channel.send(Ok(ancestor_hashes.clone()));
+			}
+		);
+
+		// Ancestors 0 and 1: same session as the leaf -> kept.
+		for _ in 0..2 {
+			assert_matches!(
+				ctx_handle.recv().await,
+				AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+					let _ = tx.send(Ok(leaf_session));
+				}
+			);
+		}
+
+		// Ancestor 2: belongs to the previous session -> the walk must stop here.
+		assert_matches!(
+			ctx_handle.recv().await,
+			AllMessages::RuntimeApi(RuntimeApiMessage::Request(_, RuntimeApiRequest::SessionIndexForChild(tx))) => {
+				let _ = tx.send(Ok(leaf_session - 1));
+			}
+		);
+	};
+
+	let (ancestors, _) = executor::block_on(future::join(check_fut, test_fut));
+
+	assert_eq!(ancestors, ancestor_hashes[0..2]);
+}
+
+#[test]
 fn maybe_prepare_validation_resets_state_on_a_new_session() {
 	let pool = TaskExecutor::new();
 	let (mut ctx, mut ctx_handle) = make_subsystem_context::<AllMessages, _>(pool);

--- a/prdoc/pr_12749.prdoc
+++ b/prdoc/pr_12749.prdoc
@@ -1,0 +1,14 @@
+title: Fix Candidate Block Session Boundary
+doc:
+- audience: Node Dev
+  description: |-
+    Advances #11301
+
+    ## Problem
+    `get_block_ancestors` returns all blocks irrespective of whether the block belongs to the same session or not. This may lead to wasted efforts since blocks that do not belong to the same session will not be accepted.
+
+    ## Solution
+    Filters the ancestor list inside `get_block_ancestors` so that only same-session ancestors are returned, which are pruned inside the PVF execute queue - `Queue::prune_old_jobs`.
+crates:
+- name: polkadot-node-core-candidate-validation
+  bump: patch


### PR DESCRIPTION
Advances #11301 

## Problem
`get_block_ancestors` returns all blocks irrespective of whether the block belongs to the same session or not. This may lead to wasted efforts since blocks that do not belong to the same session will not be accepted.

## Solution
Filters the ancestor list inside `get_block_ancestors` so that only same-session ancestors are returned, which are pruned inside the PVF execute queue - `Queue::prune_old_jobs`.