### PR TITLE
Expose more types from the Scheduler pallet

### DIFF
--- a/polkadot/runtime/parachains/src/scheduler.rs
+++ b/polkadot/runtime/parachains/src/scheduler.rs
@@ -49,7 +49,10 @@ use sp_runtime::traits::{One, Saturating};
 
 const LOG_TARGET: &str = "runtime::parachains::scheduler";
 
-pub use assigner_coretime::{CoreAssignment, PartsOf57600};
+pub use assigner_coretime::{
+	AssignmentState, CoreAssignment, CoreDescriptor, PartsOf57600, QueueDescriptor, Schedule,
+	WorkState,
+};
 pub use pallet::*;
 pub use polkadot_core_primitives::v2::BlockNumber;
 
@@ -125,7 +128,7 @@ pub mod pallet {
 	///
 	/// Managed by the `assigner_coretime` submodule.
 	#[pallet::storage]
-	pub(super) type CoreSchedules<T: Config> = StorageMap<
+	pub type CoreSchedules<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
 		(BlockNumberFor<T>, CoreIndex),
@@ -139,7 +142,7 @@ pub mod pallet {
 	///
 	/// Managed by the `assigner_coretime` submodule.
 	#[pallet::storage]
-	pub(super) type CoreDescriptors<T: Config> = StorageValue<
+	pub type CoreDescriptors<T: Config> = StorageValue<
 		_,
 		BTreeMap<CoreIndex, assigner_coretime::CoreDescriptor<BlockNumberFor<T>>>,
 		ValueQuery,

--- a/polkadot/runtime/parachains/src/scheduler/assigner_coretime/mod.rs
+++ b/polkadot/runtime/parachains/src/scheduler/assigner_coretime/mod.rs
@@ -109,7 +109,7 @@ impl PartsOf57600 {
 /// for a particular core.
 #[derive(Encode, Decode, TypeInfo)]
 #[cfg_attr(test, derive(PartialEq, Debug))]
-pub(super) struct Schedule<N> {
+pub struct Schedule<N> {
 	/// Original assignments.
 	assignments: Vec<(CoreAssignment, PartsOf57600)>,
 	/// When do our assignments become invalid, if at all?
@@ -128,7 +128,7 @@ pub(super) struct Schedule<N> {
 impl<N> Schedule<N> {
 	/// Creates a new Schedule (for tests).
 	#[cfg(test)]
-	pub(super) fn new(
+	pub fn new(
 		assignments: Vec<(CoreAssignment, PartsOf57600)>,
 		end_hint: Option<N>,
 		next_schedule: Option<N>,
@@ -138,13 +138,13 @@ impl<N> Schedule<N> {
 
 	/// Accessor for assignments (needed by tests).
 	#[cfg(test)]
-	pub(super) fn assignments(&self) -> &[(CoreAssignment, PartsOf57600)] {
+	pub fn assignments(&self) -> &[(CoreAssignment, PartsOf57600)] {
 		&self.assignments
 	}
 
 	/// Accessor for end_hint (needed by tests).
 	#[cfg(test)]
-	pub(super) fn end_hint(&self) -> Option<N>
+	pub fn end_hint(&self) -> Option<N>
 	where
 		N: Copy,
 	{
@@ -166,7 +166,7 @@ impl<N> Schedule<N> {
 /// of the currently active work as well.
 #[derive(Encode, Decode, TypeInfo, Default)]
 #[cfg_attr(test, derive(PartialEq, Debug, Clone))]
-pub(super) struct CoreDescriptor<N> {
+pub struct CoreDescriptor<N> {
 	/// Meta data about the queued schedules for this core.
 	queue: Option<QueueDescriptor<N>>,
 	/// Currently performed work.
@@ -191,12 +191,12 @@ impl<N: PartialOrd> CoreDescriptor<N> {
 	}
 
 	/// Accessor for queue (needed by migrations, tests, and try-runtime).
-	pub(super) fn queue(&self) -> Option<&QueueDescriptor<N>> {
+	pub fn queue(&self) -> Option<&QueueDescriptor<N>> {
 		self.queue.as_ref()
 	}
 
 	/// Accessor for current_work (needed by migrations, tests, and try-runtime).
-	pub(super) fn current_work(&self) -> Option<&WorkState<N>> {
+	pub fn current_work(&self) -> Option<&WorkState<N>> {
 		self.current_work.as_ref()
 	}
 }


### PR DESCRIPTION
It is currently impossible to read the state of the Scheduler pallet from the outside, which makes it challenging eg. in tests where it is sometimes necessary to assert that the state has changed in a desired way. The purpose of this PR is to make data structures of the pallet publicly accessible, so that the state can be externally inspected.

Once this is published, it will be possible to simplify the tests in https://github.com/polkadot-fellows/runtimes/pull/1231
