### PR TITLE
[pallet-revive] Fix revive precompile code

### DIFF
--- a/prdoc/pr_12803.prdoc
+++ b/prdoc/pr_12803.prdoc
@@ -1,0 +1,28 @@
+title: '[pallet-revive] Fix revive precompile code'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Two related fixes to how `pallet-revive` reports the code of a pre-compile address.
+
+    **Fix `EXTCODECOPY` for pre-compiles.** Pre-compile code is virtual: `Precompiles::code`
+    returns a `&'static [u8]` and nothing is written to `PristineCode`. `code_hash` and
+    `code_size` accounted for that, but `copy_code_slice` looked the hash up in `PristineCode`
+    and always missed, returning zeroes. The prestate tracer had the same gap and omitted
+    pre-compile code from `debug_traceTransaction`. Mocked code supplied through
+    `ExecConfig::mock_handler` was affected too.
+
+    **Allow pre-compiles to declare their own `CODE`.** `Precompile` gains a defaulted
+    associated constant `CODE`, defaulting to `EVM_REVERT` (now `pub`). Previously every
+    non-primitive pre-compile reported the same 5-byte blob, so block explorers, which key
+    contract metadata on exact runtime bytecode, attributed an ABI verified against one
+    pre-compile address to all of them. Supply one blob per interface, not per address, so
+    that a single verification covers every address the pre-compile matches.
+
+    Both changes are source-compatible; no existing `Precompile` implementation needs
+    updating. A contract calling `EXTCODECOPY` on a pre-compile address now receives its code
+    instead of zeroes, and runtimes overriding `CODE` also change `EXTCODESIZE`,
+    `EXTCODEHASH` and `eth_getCode` for the affected addresses. No state migration is
+    required, as pre-compile code is never persisted.
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/src/evm/tracing/prestate_tracing.rs
+++ b/substrate/frame/revive/src/evm/tracing/prestate_tracing.rs
@@ -182,6 +182,10 @@ where
 {
 	/// Get the code of the contract.
 	fn bytecode(address: &H160) -> Option<Bytes> {
+		use crate::precompiles::{All, Precompiles};
+		if let Some(code) = <All<T>>::code(address.as_fixed_bytes()) {
+			return Some(code.to_vec().into());
+		}
 		let code_hash = AccountInfo::<T>::load_contract(address)?.code_hash;
 		let code: Vec<u8> = PristineCode::<T>::get(&code_hash)?.into();
 		return Some(code.into());

--- a/substrate/frame/revive/src/evm/tracing/prestate_tracing.rs
+++ b/substrate/frame/revive/src/evm/tracing/prestate_tracing.rs
@@ -183,7 +183,7 @@ where
 	/// Get the code of the contract.
 	fn bytecode(address: &H160) -> Option<Bytes> {
 		use crate::precompiles::{All, Precompiles};
-		if let Some(code) = <All<T>>::code(address.as_fixed_bytes()) {
+		if let Some(code) = <All<T>>::code(address.as_fixed_bytes()).filter(|c| !c.is_empty()) {
 			return Some(code.to_vec().into());
 		}
 		let code_hash = AccountInfo::<T>::load_contract(address)?.code_hash;
@@ -348,6 +348,34 @@ where
 		let include_code = !self.config.disable_code;
 		get_entry!(self, *addr).or_insert_with_key(|addr| {
 			Self::prestate_info(addr, value, include_code.then(|| Self::bytecode(addr)).flatten())
+		});
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{
+		precompiles::{EVM_REVERT, Precompile},
+		tests::{ExtBuilder, Test, precompiles::NoInfo},
+	};
+
+	#[test]
+	fn bytecode_reports_precompile_code() {
+		ExtBuilder::default().build().execute_with(|| {
+			let addr = H160(<NoInfo<Test> as Precompile>::MATCHER.base_address());
+			assert_eq!(PrestateTracer::<Test>::bytecode(&addr), Some(Bytes(EVM_REVERT.to_vec())));
+		});
+	}
+
+	#[test]
+	fn bytecode_reports_no_code_for_primitive_precompiles() {
+		ExtBuilder::default().build().execute_with(|| {
+			// Primitive precompiles declare `CODE = &[]`, which must not be reported as code.
+			for i in 0x01..=0x0A {
+				let addr = H160::from_low_u64_be(i);
+				assert_eq!(PrestateTracer::<Test>::bytecode(&addr), None);
+			}
 		});
 	}
 }

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -2536,20 +2536,26 @@ where
 			return;
 		}
 
-		let copy = |buf: &mut [u8], code: &[u8]| {
-			let len = len.min(code.len().saturating_sub(code_offset));
-			if len > 0 {
-				buf[..len].copy_from_slice(&code[code_offset..code_offset + len]);
-			}
+		let mut copy = move |mut code: &[u8]| {
+			let len = if let Some(code) = code.split_off(code_offset..) {
+				// Get the minimum length of the two slices to avoid out of bounds panics.
+				let len = len.min(code.len());
+				if len > 0 {
+					buf[..len].copy_from_slice(&code[..len]);
+				}
+				len
+			} else {
+				0
+			};
 			buf[len..].fill(0);
 		};
 
 		if let Some(code) = self.virtual_code(address) {
-			return copy(buf, code);
+			return copy(code);
 		}
 
 		let code_hash = self.code_hash(address);
-		copy(buf, &crate::PristineCode::<T>::get(&code_hash).unwrap_or_default());
+		copy(&crate::PristineCode::<T>::get(&code_hash).unwrap_or_default());
 	}
 
 	fn terminate_caller(&mut self, beneficiary: &H160) -> Result<(), DispatchError> {

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1875,6 +1875,16 @@ where
 		top_frame_mut!(self)
 	}
 
+	/// Code that exists only virtually and is never written to `PristineCode`.
+	fn virtual_code(&self, address: &H160) -> Option<&[u8]> {
+		<AllPrecompiles<T>>::code(address.as_fixed_bytes()).or_else(|| {
+			self.exec_config
+				.mock_handler
+				.as_ref()
+				.and_then(|handler| handler.mocked_code(*address))
+		})
+	}
+
 	/// Iterator over all frames.
 	///
 	/// The iterator starts with the top frame and ends with the root frame.
@@ -2364,12 +2374,7 @@ where
 	}
 
 	fn code_hash(&self, address: &H160) -> H256 {
-		if let Some(code) = <AllPrecompiles<T>>::code(address.as_fixed_bytes()).or_else(|| {
-			self.exec_config
-				.mock_handler
-				.as_ref()
-				.and_then(|handler| handler.mocked_code(*address))
-		}) {
+		if let Some(code) = self.virtual_code(address) {
 			return sp_io::hashing::keccak_256(code).into();
 		}
 
@@ -2384,12 +2389,7 @@ where
 	}
 
 	fn code_size(&self, address: &H160) -> u64 {
-		if let Some(code) = <AllPrecompiles<T>>::code(address.as_fixed_bytes()).or_else(|| {
-			self.exec_config
-				.mock_handler
-				.as_ref()
-				.and_then(|handler| handler.mocked_code(*address))
-		}) {
+		if let Some(code) = self.virtual_code(address) {
 			return code.len() as u64;
 		}
 
@@ -2536,15 +2536,20 @@ where
 			return;
 		}
 
-		let code_hash = self.code_hash(address);
-		let code = crate::PristineCode::<T>::get(&code_hash).unwrap_or_default();
+		let copy = |buf: &mut [u8], code: &[u8]| {
+			let len = len.min(code.len().saturating_sub(code_offset));
+			if len > 0 {
+				buf[..len].copy_from_slice(&code[code_offset..code_offset + len]);
+			}
+			buf[len..].fill(0);
+		};
 
-		let len = len.min(code.len().saturating_sub(code_offset));
-		if len > 0 {
-			buf[..len].copy_from_slice(&code[code_offset..code_offset + len]);
+		if let Some(code) = self.virtual_code(address) {
+			return copy(buf, code);
 		}
 
-		buf[len..].fill(0);
+		let code_hash = self.code_hash(address);
+		copy(buf, &crate::PristineCode::<T>::get(&code_hash).unwrap_or_default());
 	}
 
 	fn terminate_caller(&mut self, beneficiary: &H160) -> Result<(), DispatchError> {

--- a/substrate/frame/revive/src/precompiles.rs
+++ b/substrate/frame/revive/src/precompiles.rs
@@ -57,7 +57,11 @@ pub(crate) use builtin::{
 const UNIMPLEMENTED: &str = "A precompile must either implement `call` or `call_with_info`";
 
 /// A minimal EVM bytecode to be returned when a pre-compile is queried for its code.
-pub(crate) const EVM_REVERT: [u8; 5] = sp_core::hex2array!("60006000fd");
+///
+/// This is the default value of [`Precompile::CODE`]. It decodes as `PUSH1 0x00, PUSH1 0x00,
+/// REVERT`, so a pre-compile called through the EVM interpreter rather than through the
+/// pre-compile dispatch would revert rather than do something unexpected.
+pub const EVM_REVERT: [u8; 5] = sp_core::hex2array!("60006000fd");
 
 /// The composition of all available pre-compiles.
 ///
@@ -213,6 +217,19 @@ pub trait Precompile {
 	/// unlocks.
 	const HAS_CONTRACT_INFO: bool;
 
+	/// The bytecode reported for every address this pre-compile matches.
+	///
+	/// This code is never executed. It is only what `EXTCODESIZE`, `EXTCODEHASH`, `EXTCODECOPY`
+	/// and `eth_getCode` observe. The default reverts, which is enough to stop the address being
+	/// mistaken for an externally owned account.
+	///
+	/// Overriding it is worthwhile because block explorers key contract metadata on the exact
+	/// bytecode: two pre-compiles sharing this constant are indistinguishable to them, so an ABI
+	/// verified against one address is attributed to all of them. Supply a distinct blob per
+	/// interface — not per address — so that a single verification covers every address the
+	/// pre-compile matches.
+	const CODE: &[u8] = &EVM_REVERT;
+
 	/// Entry point for your pre-compile when `HAS_CONTRACT_INFO = false`.
 	#[allow(unused_variables)]
 	fn call(
@@ -354,6 +371,7 @@ impl<P: Precompile> BuiltinPrecompile for P {
 	type Interface = <Self as Precompile>::Interface;
 	const MATCHER: BuiltinAddressMatcher = P::MATCHER.into_builtin();
 	const HAS_CONTRACT_INFO: bool = P::HAS_CONTRACT_INFO;
+	const CODE: &[u8] = <P as Precompile>::CODE;
 
 	fn call(
 		address: &[u8; 20],

--- a/substrate/frame/revive/src/precompiles/tests.rs
+++ b/substrate/frame/revive/src/precompiles/tests.rs
@@ -297,3 +297,64 @@ fn code_accessors_agree_for_precompiles() {
 		assert_eq!(buf, [0, 0]);
 	});
 }
+
+/// A pre-compile may override [`Precompile::CODE`], and distinct interfaces get distinct code.
+#[test]
+fn custom_code_is_reported() {
+	use alloy_core::sol;
+
+	sol! {
+		interface IPlain {
+			function plain() external;
+		}
+		interface ICustom {
+			function custom() external;
+		}
+	}
+
+	struct Plain;
+	struct Custom;
+
+	impl Precompile for Plain {
+		type T = Test;
+		type Interface = IPlain::IPlainCalls;
+		const MATCHER: AddressMatcher = AddressMatcher::Fixed(NonZero::new(0xC0DE).unwrap());
+		const HAS_CONTRACT_INFO: bool = false;
+
+		fn call(
+			_address: &[u8; 20],
+			_input: &Self::Interface,
+			_env: &mut impl Ext<T = Self::T>,
+		) -> Result<Vec<u8>, Error> {
+			Ok(Vec::new())
+		}
+	}
+
+	impl Precompile for Custom {
+		type T = Test;
+		type Interface = ICustom::ICustomCalls;
+		const MATCHER: AddressMatcher = AddressMatcher::Fixed(NonZero::new(0xC0DF).unwrap());
+		const HAS_CONTRACT_INFO: bool = false;
+		const CODE: &[u8] = &[0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+
+		fn call(
+			_address: &[u8; 20],
+			_input: &Self::Interface,
+			_env: &mut impl Ext<T = Self::T>,
+		) -> Result<Vec<u8>, Error> {
+			Ok(Vec::new())
+		}
+	}
+
+	type Col = (Plain, Custom);
+
+	let plain = <Plain as Precompile>::MATCHER.base_address();
+	let custom = <Custom as Precompile>::MATCHER.base_address();
+
+	assert_eq!(<Col as Precompiles<Test>>::code(&plain).unwrap(), EVM_REVERT);
+	assert_eq!(<Col as Precompiles<Test>>::code(&custom).unwrap(), <Custom as Precompile>::CODE);
+	assert_ne!(
+		<Col as Precompiles<Test>>::code(&plain).unwrap(),
+		<Col as Precompiles<Test>>::code(&custom).unwrap()
+	);
+}

--- a/substrate/frame/revive/src/precompiles/tests.rs
+++ b/substrate/frame/revive/src/precompiles/tests.rs
@@ -270,3 +270,30 @@ fn benchmarking_precompile_has_code() {
 	let code = <Builtin<Test>>::code(&hex!("000000000000000000000000000000000000FFFF")).unwrap();
 	assert_eq!(code, EVM_REVERT);
 }
+
+/// `EXTCODESIZE`, `EXTCODEHASH` and `EXTCODECOPY` must agree on a pre-compile's virtual code.
+#[test]
+fn code_accessors_agree_for_precompiles() {
+	use crate::tests::precompiles::NoInfo;
+
+	ExtBuilder::default().build().execute_with(|| {
+		let mut call_setup = CallSetup::<Test>::default();
+		let (mut ext, _) = call_setup.ext();
+		let address = sp_core::H160(<NoInfo<Test> as Precompile>::MATCHER.base_address());
+
+		assert_eq!(ext.code_size(&address), EVM_REVERT.len() as u64);
+		assert_eq!(ext.code_hash(&address), sp_io::hashing::keccak_256(&EVM_REVERT).into());
+
+		let mut buf = [0u8; 8];
+		ext.copy_code_slice(&mut buf, &address, 0);
+		assert_eq!(buf, [0x60, 0x00, 0x60, 0x00, 0xfd, 0, 0, 0]);
+
+		let mut buf = [0u8; 3];
+		ext.copy_code_slice(&mut buf, &address, 2);
+		assert_eq!(buf, [0x60, 0x00, 0xfd]);
+
+		let mut buf = [0xAAu8; 2];
+		ext.copy_code_slice(&mut buf, &address, 9);
+		assert_eq!(buf, [0, 0]);
+	});
+}

--- a/substrate/frame/revive/src/tests.rs
+++ b/substrate/frame/revive/src/tests.rs
@@ -19,7 +19,7 @@ mod block_hash;
 mod deposit_payment;
 mod eth_estimate_gas;
 mod pallet_dummy;
-mod precompiles;
+pub(crate) mod precompiles;
 mod pvm;
 mod sol;
 mod stipends;


### PR DESCRIPTION
# Description

Two related changes to how `pallet-revive` reports the code of a pre-compile address.

**1. Fix `EXTCODECOPY` (and prestate tracing) for pre-compiles.** Pre-compile code is virtual —
`Precompiles::code` returns a `&'static [u8]` and nothing is ever written to `PristineCode`.
`Ext::code_hash` and `Ext::code_size` already accounted for that, but `Ext::copy_code_slice` did not:
it computed `self.code_hash(address)` (which *does* consult pre-compiles) and then looked that hash
up in `PristineCode`, which is a guaranteed miss. The result was that `EXTCODESIZE` reported 5 bytes
and `EXTCODEHASH` reported `keccak(0x60006000fd)`, while `EXTCODECOPY` on the same address returned
zeroes. `PrestateTracer::bytecode` had the same gap and omitted pre-compile code from
`debug_traceTransaction` output. The same bug affected mocked code supplied through
`ExecConfig::mock_handler`.

**2. Allow pre-compiles to declare their own `CODE`.** `Precompile` gains a defaulted associated
constant `CODE`, defaulting to the existing `EVM_REVERT`. Today every non-primitive pre-compile
reports the identical 5-byte blob, which means block explorers cannot tell them apart: they key
contract metadata on exact runtime bytecode, so an ABI verified against any one pre-compile address
is attributed to all of them. Being able to supply a distinct blob per interface fixes that, and lets
a runtime ship a real compiled interface stub so that source verification works.

This is half of the work to resolve issue https://github.com/paritytech/contract-issues/issues/280.

## Integration

Both changes are source-compatible; no existing `Precompile` implementation needs to be updated.

- **New defaulted associated const on `Precompile`.** Existing implementations keep the current
  behaviour without any change:

  ```diff
   impl<T: Config> Precompile for MyPrecompile<T> {
       type T = T;
       type Interface = IMyInterface::IMyInterfaceCalls;
       const MATCHER: AddressMatcher = AddressMatcher::Prefix(NonZero::new(0x0900).unwrap());
       const HAS_CONTRACT_INFO: bool = false;
  +    // Optional. Defaults to `EVM_REVERT`.
  +    const CODE: &[u8] = include_bytes!("my_interface_stub.bin");
   }
  ```

- **`EVM_REVERT` is now `pub`** (previously `pub(crate)`), since it is the default value of a public
  associated constant and downstream implementors may want to reference it. Purely additive.

- **Consensus-visible behaviour change.** A contract calling `EXTCODECOPY` against a pre-compile
  address previously received zeroes and now receives the pre-compile's code. Runtimes that
  additionally override `CODE` will change `EXTCODESIZE`/`EXTCODEHASH`/`eth_getCode` for the affected
  addresses too. **No state migration is required** — pre-compile code is never persisted.

- **Tracing output change.** `debug_traceTransaction` with the prestate tracer now includes the code
  of pre-compile accounts touched by the transaction, where it previously omitted them.

- **Guidance for `CODE`:** supply one blob **per interface, not per address**. All addresses matched
  by one pre-compile should report the same bytecode, so that a single explorer verification covers
  every one of them, including addresses that come into existence later. Giving each address a unique
  blob would force every asset to be verified individually.

## Review Notes

### Commit 1 — `Fix EXTCODECOPY for Precompiles.`

- Adds `Stack::virtual_code`, which folds together the `AllPrecompiles::code` lookup and the
  `mock_handler` fallback that `code_hash` and `code_size` were each open-coding. Both now call it, so
  the three accessors share one definition of "code that exists only virtually".
- `copy_code_slice` is restructured so the offset/length/zero-fill logic lives in a single closure
  applied to either the virtual code or the `PristineCode` entry. The virtual lookup is tried first,
  matching the precedence used everywhere else in the pallet.
- `mod precompiles` in `src/tests.rs` becomes `pub(crate)` so `src/precompiles/tests.rs` can reuse
  the existing `NoInfo` test pre-compile rather than declaring a near-duplicate.
- `PrestateTracer::bytecode` gains the same pre-compile-first lookup.

### Commit 2 — `Allow Precompiles to have custom CODE.`

- `const CODE: &[u8] = &EVM_REVERT;` on the public `Precompile` trait, forwarded in the blanket
  `impl<P: Precompile> BuiltinPrecompile for P`. The rest of the chain already existed:
  `BuiltinPrecompile::CODE` → `PrimitivePrecompile::CODE` → `Precompiles::code`, so no change was
  needed in the tuple implementations.
- `EVM_REVERT`'s doc comment now explains what the bytes decode to and why that default is safe.

<details>
<summary>Why the doc comment recommends per-interface granularity</summary>

The guidance is based on measurements against a Blockscout instance pointed at a dev node running a
fake ERC-20 pre-compile:

- Token detection is driven by `Transfer`-topic **logs** plus `eth_call`, not by bytecode. Changing
  `CODE` does not affect whether an address is recognised as a token.
- Blockscout's "verified twin" lookup matches on **exact runtime bytecode**. Verifying one contract
  propagated its ABI to every other address with identical bytecode — both retroactively and to
  addresses first seen afterwards.
- With a `Prefix` matcher and four distinct asset addresses all reporting one compiled interface
  stub, verifying a single address gave all four the ABI, decoded transaction inputs and decoded
  logs, including an asset whose first transaction occurred after the verification.
- Conversely, while every non-primitive pre-compile reports the same `0x60006000fd`, anyone can
  deploy and verify an ordinary contract whose runtime bytecode is those five bytes and have its ABI
  attributed to every pre-compile on the chain.

A pre-compile address has no creation transaction, so verification falls back to a deployed-bytecode
match and is recorded as *partial*; ABI, sources and the Read/Write tabs are all still served.

</details>

### Tests

- `code_accessors_agree_for_precompiles` — pins `EXTCODESIZE`, `EXTCODEHASH` and `EXTCODECOPY` to
  agree for a pre-compile address, covering a full read, an offset read, and a read past the end.
  Fails on `master`.
- `custom_code_is_reported` — two pre-compiles in one collection, one taking the default and one
  overriding `CODE`; asserts each address reports its own blob and that the two differ.

`SKIP_WASM_BUILD=1 cargo test -p pallet-revive --lib` → 655 passed, 0 failed, 1 ignored.
