### PR TITLE
[pallet-revive] Block contract deployment to Precompile addresses and to allow Precompiles to use more of the address space.

### DIFF
--- a/prdoc/pr_12804.prdoc
+++ b/prdoc/pr_12804.prdoc
@@ -1,0 +1,27 @@
+title: '[pallet-revive] Improve precompile address matching'
+doc:
+- audience: Runtime Dev
+  description: |-
+    Two related changes to `pallet-revive`'s pre-compile address handling.
+
+    **Block contract deployment at pre-compile addresses.** Nothing prevented a `CREATE`/`CREATE2`
+    from landing on an address served by a pre-compile. The resulting contract was permanently
+    shadowed: the storage deposit was taken and the code stored, but call dispatch, `code_hash`,
+    `code_size` and `Pallet::code` all consult pre-compiles first, so it could never be called,
+    terminated or refunded. `Stack::new_frame` now rejects such a deployment with the existing
+    `Error::DuplicateContract`, before any state is written.
+
+    **Add `AddressMatcher::VarPrefix { id, data_bytes }`.** `Prefix` hard-codes a 4-byte data
+    window, which is too narrow for pre-compiles that encode a wider identifier in the address,
+    such as a 16-byte asset id. `VarPrefix` makes the window width a parameter, capped at 16 bytes
+    and checked at compile time. `Prefix(x)` is exactly `VarPrefix { id: x, data_bytes: 4 }`, so
+    existing matchers are unaffected. Declare only as many data bytes as the encoded value
+    occupies: a narrower id inside a wider window would leave working duplicate addresses for the
+    same entity.
+
+    `AddressMatcher` is public and not `#[non_exhaustive]`, so downstream `match` expressions over
+    it become non-exhaustive. An instantiation that previously succeeded at a pre-compile address
+    now fails with `DuplicateContract`; no state migration is required.
+crates:
+- name: pallet-revive
+  bump: minor

--- a/substrate/frame/revive/src/exec.rs
+++ b/substrate/frame/revive/src/exec.rs
@@ -1156,6 +1156,13 @@ where
 						},
 					)
 				};
+
+				// A contract here would be permanently shadowed: pre-compiles take precedence on
+				// every lookup, so it could never be called, terminated or refunded.
+				if is_precompile::<T, E>(&address) {
+					return Err(Error::<T>::DuplicateContract.into());
+				}
+
 				let contract = ContractInfo::new(
 					&address,
 					<System<T>>::account_nonce(&sender),

--- a/substrate/frame/revive/src/lib.rs
+++ b/substrate/frame/revive/src/lib.rs
@@ -545,7 +545,8 @@ pub mod pallet {
 		InputForwarded = 0x0E,
 		/// The amount of topics passed to `seal_deposit_events` exceeds the limit.
 		TooManyTopics = 0x0F,
-		/// A contract with the same AccountId already exists.
+		/// A contract with the same AccountId already exists, or the address is occupied by a
+		/// pre-compile.
 		DuplicateContract = 0x12,
 		/// A contract self destructed in its constructor.
 		///

--- a/substrate/frame/revive/src/precompiles.rs
+++ b/substrate/frame/revive/src/precompiles.rs
@@ -92,10 +92,28 @@ pub enum AddressMatcher {
 	/// xxxxxxxx000000000000000000000000pppp0000
 	/// ```
 	///
-	/// Where `p` is the `u16` defined here as big endian. Hence a maximum of 2 byte can be encoded
-	/// into the address. Allowing more bytes could lead to the situation where legitimate
+	/// Where `p` is the `u16` defined here as big endian. Hence a maximum of 4 bytes can be
+	/// encoded into the address. Allowing more bytes could lead to the situation where legitimate
 	/// accounts could exist at this address. Either by accident or on purpose.
+	///
+	/// Use [`Self::VarPrefix`] when a different number of data bytes is required.
 	Prefix(NonZero<u16>),
+	/// Same as [`Self::Prefix`] but with a caller defined number of data bytes.
+	///
+	/// This means the precompile will be invoked for all `x`, shown here for `data_bytes = 8`:
+	/// ```ignore
+	/// xxxxxxxxxxxxxxxx0000000000000000pppp0000
+	/// ```
+	///
+	/// Every byte between the data bytes and the matcher suffix must still be zero. `data_bytes`
+	/// must not exceed 16 because the remaining bytes are reserved for the matcher itself. This
+	/// is enforced at compile time.
+	///
+	/// Widening the window trades collision resistance for id space: a keccak derived address
+	/// (EOA, `CREATE`, `CREATE2`) falls into the range with a probability of
+	/// `2^-(8 * (20 - data_bytes))`. Only declare as many data bytes as the encoded value
+	/// actually occupies, so that no two addresses in the range decode to the same value.
+	VarPrefix { id: NonZero<u16>, data_bytes: u8 },
 }
 
 /// Same as `AddressMatcher` but for builtin pre-compiles.
@@ -105,7 +123,7 @@ pub enum AddressMatcher {
 /// external pre-compiles.
 pub(crate) enum BuiltinAddressMatcher {
 	Fixed(NonZero<u32>),
-	Prefix(NonZero<u32>),
+	Prefix { id: NonZero<u32>, data_bytes: u8 },
 }
 
 /// A pre-compile can error in the same way that a real contract can.
@@ -418,7 +436,9 @@ impl<T: Config> Precompiles<T> for Tuple {
 			#(
 				let is_fixed = Tuple::MATCHER.is_fixed();
 				let has_info = Tuple::HAS_CONTRACT_INFO;
+				let is_valid = Tuple::MATCHER.is_valid();
 				assert!(is_fixed || !has_info, "Only fixed precompiles can have a contract info.");
+				assert!(is_valid, "A VarPrefix precompile must not declare more than 16 data bytes.");
 			)*
 		);
 	};
@@ -522,7 +542,10 @@ impl AddressMatcher {
 
 		match self {
 			Self::Fixed(i) => BuiltinAddressMatcher::Fixed(left_shift(*i)),
-			Self::Prefix(i) => BuiltinAddressMatcher::Prefix(left_shift(*i)),
+			Self::Prefix(i) => BuiltinAddressMatcher::Prefix { id: left_shift(*i), data_bytes: 4 },
+			Self::VarPrefix { id, data_bytes } => {
+				BuiltinAddressMatcher::Prefix { id: left_shift(*id), data_bytes: *data_bytes }
+			},
 		}
 	}
 }
@@ -539,26 +562,28 @@ impl BuiltinAddressMatcher {
 		address
 	}
 
+	/// The number of leading bytes that carry data and are therefore not matched.
+	const fn data_bytes(&self) -> usize {
+		match self {
+			Self::Fixed(_) => 0,
+			Self::Prefix { data_bytes, .. } => *data_bytes as usize,
+		}
+	}
+
 	pub const fn highest_address(&self) -> [u8; 20] {
 		let mut address = self.base_address();
-		match self {
-			Self::Fixed(_) => (),
-			Self::Prefix(_) => {
-				address[0] = 0xFF;
-				address[1] = 0xFF;
-				address[2] = 0xFF;
-				address[3] = 0xFF;
-			},
+		let data_bytes = self.data_bytes();
+		let mut i = 0;
+		while i < data_bytes {
+			address[i] = 0xFF;
+			i = i + 1;
 		}
 		address
 	}
 
 	pub const fn matches(&self, address: &[u8; 20]) -> bool {
 		let base_address = self.base_address();
-		let mut i = match self {
-			Self::Fixed(_) => 0,
-			Self::Prefix(_) => 4,
-		};
+		let mut i = self.data_bytes();
 		while i < base_address.len() {
 			if address[i] != base_address[i] {
 				return false;
@@ -570,9 +595,14 @@ impl BuiltinAddressMatcher {
 
 	const fn suffix(&self) -> u32 {
 		match self {
-			Self::Fixed(i) => i.get(),
-			Self::Prefix(i) => i.get(),
+			Self::Fixed(i) | Self::Prefix { id: i, .. } => i.get(),
 		}
+	}
+
+	/// Data bytes must not reach into `address[16..20]` or the suffix would stop being compared,
+	/// which is what makes the pairwise `has_duplicates` check sufficient.
+	const fn is_valid(&self) -> bool {
+		self.data_bytes() <= 16
 	}
 
 	const fn has_duplicates(nums: &[Self]) -> bool {

--- a/substrate/frame/revive/src/precompiles/tests.rs
+++ b/substrate/frame/revive/src/precompiles/tests.rs
@@ -134,7 +134,7 @@ fn matching_works() {
 	impl PrimitivePrecompile for Matcher2 {
 		type T = Test;
 		const MATCHER: BuiltinAddressMatcher =
-			BuiltinAddressMatcher::Prefix(NonZero::new(0x88).unwrap());
+			BuiltinAddressMatcher::Prefix { id: NonZero::new(0x88).unwrap(), data_bytes: 4 };
 		const HAS_CONTRACT_INFO: bool = false;
 
 		fn call(
@@ -196,6 +196,72 @@ fn matching_works() {
 }
 
 #[test]
+fn var_prefix_matching_works() {
+	struct Wide;
+	struct Narrow;
+
+	// Consumes the whole window: only the matcher suffix is compared.
+	impl PrimitivePrecompile for Wide {
+		type T = Test;
+		const MATCHER: BuiltinAddressMatcher =
+			BuiltinAddressMatcher::Prefix { id: NonZero::new(0x88).unwrap(), data_bytes: 16 };
+		const HAS_CONTRACT_INFO: bool = false;
+
+		fn call(
+			address: &[u8; 20],
+			_input: Vec<u8>,
+			_env: &mut impl Ext<T = Self::T>,
+		) -> Result<Vec<u8>, Error> {
+			Ok(address.to_vec())
+		}
+	}
+
+	// Leaves `address[8..16]` pinned to zero.
+	impl PrimitivePrecompile for Narrow {
+		type T = Test;
+		const MATCHER: BuiltinAddressMatcher =
+			BuiltinAddressMatcher::Prefix { id: NonZero::new(0x77).unwrap(), data_bytes: 8 };
+		const HAS_CONTRACT_INFO: bool = false;
+
+		fn call(
+			address: &[u8; 20],
+			_input: Vec<u8>,
+			_env: &mut impl Ext<T = Self::T>,
+		) -> Result<Vec<u8>, Error> {
+			Ok(address.to_vec())
+		}
+	}
+
+	type Col = (Wide, Narrow);
+
+	assert_eq!(
+		<Wide as PrimitivePrecompile>::MATCHER.base_address(),
+		hex!("0000000000000000000000000000000000000088")
+	);
+	assert_eq!(
+		<Wide as PrimitivePrecompile>::MATCHER.highest_address(),
+		hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000088")
+	);
+	assert_eq!(
+		<Narrow as PrimitivePrecompile>::MATCHER.highest_address(),
+		hex!("FFFFFFFFFFFFFFFF000000000000000000000077")
+	);
+
+	// The whole 16 byte window is free.
+	assert!(Col::get::<Env>(&hex!("aabbccddeeff0011223344556677889900000088")).is_some());
+	assert!(Col::get::<Env>(&hex!("ffffffffffffffffffffffffffffffff00000088")).is_some());
+	assert!(Col::get::<Env>(&hex!("0000000000000000000000000000000000000088")).is_some());
+
+	// A different suffix is still a different pre-compile.
+	assert!(Col::get::<Env>(&hex!("aabbccddeeff0011223344556677889900000089")).is_none());
+
+	// Only the declared data bytes are free; the rest stays pinned to zero.
+	assert!(Col::get::<Env>(&hex!("aabbccddeeff0011000000000000000000000077")).is_some());
+	assert!(Col::get::<Env>(&hex!("aabbccddeeff0011000000000000000100000077")).is_none());
+	assert!(Col::get::<Env>(&hex!("aabbccddeeff0011ff0000000000000000000077")).is_none());
+}
+
+#[test]
 fn builtin_matching_works() {
 	let _ = <All<Test>>::CHECK_COLLISION;
 
@@ -247,12 +313,22 @@ fn builtin_matching_works() {
 fn public_matching_works() {
 	let matcher_fixed = AddressMatcher::Fixed(NonZero::new(0x42).unwrap());
 	let matcher_prefix = AddressMatcher::Prefix(NonZero::new(0x8).unwrap());
+	let matcher_var = AddressMatcher::VarPrefix { id: NonZero::new(0x8).unwrap(), data_bytes: 16 };
 
 	assert_eq!(matcher_fixed.base_address(), hex!("0000000000000000000000000000000000420000"));
 	assert_eq!(matcher_fixed.base_address(), matcher_fixed.highest_address());
 
 	assert_eq!(matcher_prefix.base_address(), hex!("0000000000000000000000000000000000080000"));
 	assert_eq!(matcher_prefix.highest_address(), hex!("FFFFFFFF00000000000000000000000000080000"));
+
+	assert_eq!(matcher_var.base_address(), matcher_prefix.base_address());
+	assert_eq!(matcher_var.highest_address(), hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00080000"));
+
+	// `Prefix` is exactly `VarPrefix` with four data bytes.
+	let matcher_var_4 = AddressMatcher::VarPrefix { id: NonZero::new(0x8).unwrap(), data_bytes: 4 };
+	assert_eq!(matcher_var_4.highest_address(), matcher_prefix.highest_address());
+	assert!(matcher_var_4.matches(&hex!("aabbccdd00000000000000000000000000080000")));
+	assert!(!matcher_var_4.matches(&hex!("aabbccddee000000000000000000000000080000")));
 }
 
 #[test]


### PR DESCRIPTION
# Description

Two related changes to `pallet-revive`'s pre-compile address handling.

**1. Block contract deployment at pre-compile addresses.** Nothing prevented a `CREATE`/`CREATE2`
from landing on an address served by a pre-compile. The resulting contract was permanently shadowed —
the storage deposit was taken and the code stored, but `FrameArgs::Call`, `Ext::code_hash`,
`Ext::code_size` and `Pallet::code` all consult pre-compiles first, so it could never be called,
`terminate`d or refunded. `Stack::new_frame` now rejects such a deployment with the existing
`Error::DuplicateContract`.

**2. Add `AddressMatcher::VarPrefix { id, data_bytes }`.** `Prefix` hard-codes a 4-byte data window,
which is not enough for pre-compiles that need to encode a wider identifier in the address — a
16-byte asset id, for example. Padding such an id into a 4-byte window is not possible, and the
alternative of leaving 12 forced-zero bytes in the middle of the address produces the long zero runs
that some wallets flag as address poisoning. `VarPrefix` makes the window width a parameter.
`Prefix(x)` is now exactly `VarPrefix { id: x, data_bytes: 4 }`.

This is half of the work to resolve issue https://github.com/paritytech/contract-issues/issues/280.

## Integration

- **`AddressMatcher` gains a variant.** The enum is public and non-`#[non_exhaustive]`, so any
  downstream `match` over it becomes non-exhaustive. Existing `Fixed` and `Prefix` users are otherwise
  unaffected — `Prefix` keeps its exact current semantics.

  ```diff
   impl<T: Config> Precompile for MyAssetPrecompile<T> {
       type T = T;
       type Interface = IERC20::IERC20Calls;
  -    const MATCHER: AddressMatcher = AddressMatcher::Prefix(NonZero::new(0x0900).unwrap());
  +    const MATCHER: AddressMatcher =
  +        AddressMatcher::VarPrefix { id: NonZero::new(0x0900).unwrap(), data_bytes: 16 };
       const HAS_CONTRACT_INFO: bool = false;
   }
  ```

  Declare only as many data bytes as the encoded value actually occupies. A 4-byte id inside a
  16-byte window would leave `2^96` working duplicates of every asset — addresses that genuinely
  *are* the token, so `symbol()`, `balanceOf()` and real transfers all succeed against them. That
  breaks address-as-identity, which is what wallet token lists and explorer verification are keyed
  on. This is why the width is a parameter rather than a hard-coded 16.

- **`data_bytes > 16` is a compile-time error**, asserted through `CHECK_COLLISION` alongside the
  existing "only fixed pre-compiles may have contract info" check.

- **Consensus-visible behaviour change.** An instantiation that previously succeeded at a pre-compile
  address now fails with `DuplicateContract`. In practice this was already unreachable with the
  matchers in the tree (`Fixed` is `2^-160`, `Prefix` is `2^-128`); it becomes reachable at `2^-32`
  once a runtime adopts `data_bytes = 16`. **No state migration** — the guard runs before
  `ContractInfo::new`, so nothing was ever written on the failing path.

- **`Error::DuplicateContract`'s doc comment was widened** to mention pre-compiles. No new variant was
  added: the condition is "something already occupies this address", which is the failure callers
  already handle.

## Review Notes

### Commit 1 — `Block deploying of contracts at Precompile addresses.`

- The check sits in the `FrameArgs::Instantiate` branch of `Stack::new_frame`, immediately after the
  `create1`/`create2` derivation and **before** `ContractInfo::new`, so nothing is written on the
  failure path. That branch is the only place a deploy address is derived, so it covers both the
  `run_instantiate` extrinsic path (via `Stack::new`) and nested EVM `CREATE`/`CREATE2` (via
  `Ext::instantiate` → `push_frame`).
- It must **not** go in `ContractInfo::new`, despite that being where the sibling `DuplicateContract`
  check lives: pre-compiles with `HAS_CONTRACT_INFO = true` legitimately call `ContractInfo::new` at
  their own address from the `FrameArgs::Call` branch. `precompiles_with_info_creates_contract`
  catches that mistake.
- `is_precompile::<T, E>` already exists in the same module and the enclosing
  `impl<'a, T, E> Stack<'a, T, E>` already carries the `E: Executable<T>` bound, so no signature
  changes were needed.
- **Cost.** `Precompiles::get` is a walk over `const fn` matchers building a small `Instance`
  (address, bool, function pointer) — no storage reads, no hashing. The identical call already runs
  for every signed origin via `ensure_non_contract_if_signed` (EIP-3607), so there is no new weight
  concern on a path that executes once per instantiation.

<details>
<summary>Why there is no regression test for the guard</summary>

With the matchers currently in the tree, no `create1`/`create2` output can land in a pre-compile
range — the test runtime's pre-compiles are `Fixed`, so a hit is `2^-160`, and `Prefix` is `2^-128`.
There is no test-only hook to override a derived deploy address, so the guard cannot be reached from
a test today. Once a runtime adopts `data_bytes = 16` the range becomes `2^-32` and the test is
straightforward: grind a `CREATE2` salt offline (~`2^32` keccaks, minutes) and hard-code it. Until
then the guard is covered by inspection plus the existing suite, in particular
`precompiles_with_info_creates_contract`, which pins the behaviour the guard must not break.

</details>

### Commit 2 — `Add AddressMatcher::VarPrefix …`

- `BuiltinAddressMatcher::Prefix(NonZero<u32>)` becomes
  `Prefix { id: NonZero<u32>, data_bytes: u8 }`. This type is crate-private, so `VarPrefix` exists
  only on the public enum and lowers into `Prefix { .. }`; there is no second builtin variant to keep
  in sync.
- A single `const fn data_bytes()` now drives both `matches` and `highest_address`, replacing the two
  places that hard-coded `4`. `suffix()` and `is_fixed()` are unchanged, so the existing
  `!Fixed ⇒ !HAS_CONTRACT_INFO` assert covers `VarPrefix` automatically.
- `is_valid()` enforces `data_bytes <= 16`. The bound is load-bearing rather than cosmetic: if data
  bytes reached into `address[16..20]` the suffix would stop being compared, and distinct suffixes
  would no longer imply disjoint address sets — which is the property that makes the pairwise
  `has_duplicates` check sufficient.
- Note on the `impl_trait_for_tuples` block: `Tuple::MATCHER.is_valid()` is bound to a local before
  the `assert!`, because `Tuple` cannot appear inside a nested macro invocation.
- The `Prefix` doc comment was stale — it claimed "a maximum of 2 byte can be encoded" for what has
  always been a 4-byte window.

<details>
<summary>Threat model for a widened window</summary>

The constrained-byte count governs the rate at which an *honest* `CREATE`/`CREATE2`/EOA lands in the
range, not the difficulty of impersonation. Look-alike phishing against a truncated address display
costs `2^32` regardless of the matcher and is universal to every EVM address.

For impersonation to matter the id itself must be attacker-steerable. Where ids are runtime-derived
hashes this does not hold — Polymesh asset ids are
`blake2_128((b"modlpy/pallet_asset", genesis_hash, caller_acc, nonce).encode())`, so an attacker can
sample the space but not aim at a target. The combined attack — grind a `CREATE2` salt into the
range *and* mint an asset whose id equals the resulting top 16 bytes — has expected matches
`A · C / 2^128` for `A` assets created and `C` addresses ground, and the payoff is nil anyway: the
attacker's contract would be shadowed by the pre-compile for their own asset, reachable at its
canonical address already.

EIP-3607 (`ensure_non_contract_if_signed`) covers the grinded-EOA case: such an account cannot be a
transaction origin and calls to it route to the pre-compile, so the attacker has only bricked their
own key.

Precedent: Moonbeam's XC-20 addresses are a fixed `0xFFFFFFFF` tag plus a full 16-byte `u128` asset
id (xcDOT `0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080`), i.e. the same shape as
`VarPrefix { data_bytes: 16 }` at the same `2^-32` exposure, live with mainstream wallet support for
years.

</details>

### Tests

- `var_prefix_matching_works` — a `data_bytes = 16` and a `data_bytes = 8` pre-compile in one
  collection. Covers the whole declared window being free, bytes between the window and the suffix
  staying pinned to zero, and a different suffix still being a different pre-compile.
- `public_matching_works` extended to check the left-shifted public wrapper and to assert
  `Prefix(x) ≡ VarPrefix { id: x, data_bytes: 4 }`.
- `matching_works` updated for the `BuiltinAddressMatcher::Prefix` struct variant.

`SKIP_WASM_BUILD=1 cargo test -p pallet-revive --lib` → 654 passed, 0 failed, 1 ignored.
