### PR TITLE
Simplify WebRTC DTLS key/cert derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21486,6 +21486,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
+ "hmac 0.12.1",
  "ip_network",
  "libp2p",
  "linked_hash_set",

--- a/prdoc/pr_12693.prdoc
+++ b/prdoc/pr_12693.prdoc
@@ -11,14 +11,10 @@ doc:
 
     While this PR change the approach entirely and instead uses the node secret key as a seed for a deterministically generated WebRTC certificate.
 
-    A new optional `--webrtc-seed <u64>` flag rotates that certificate: the seed is appended to the key-derivation domain-separation tag, so the certhash changes while the node key and peer id stay the same. Without the flag the derivation is unchanged.
-
     ## Review Notes
 
     `derive_certificate` derives a P-256 signing key from the 32-byte node key seed via RFC 9380 `hash_to_field` then builds a minimal self-signed X.509 certificate and loads it into litep2p's `DtlsCertificate`.
 
 crates:
-- name: sc-cli
-  bump: major
 - name: sc-network
   bump: major

--- a/substrate/client/cli/src/params/network_params.rs
+++ b/substrate/client/cli/src/params/network_params.rs
@@ -81,17 +81,6 @@ pub struct NetworkParams {
 	#[arg(long)]
 	pub experimental_webrtc: bool,
 
-	/// Seed for the WebRTC DTLS certificate derivation.
-	///
-	/// The certificate, and therefore the advertised `/certhash`,
-	/// is derived from the node key.
-	/// Incrementing this seed rotates the certificate,
-	/// omitting it derives from the node key alone.
-	///
-	/// Only works on litep2p network backend.
-	#[arg(long, value_name = "SEED", requires = "experimental_webrtc")]
-	pub webrtc_seed: Option<u64>,
-
 	/// Specify p2p protocol TCP port.
 	#[arg(long, value_name = "PORT", conflicts_with_all = &[ "listen_addr" ])]
 	pub port: Option<u16>,
@@ -295,7 +284,6 @@ impl NetworkParams {
 			default_peers_set_num_full: self.in_peers + self.out_peers,
 			listen_addresses,
 			experimental_webrtc: self.experimental_webrtc,
-			webrtc_seed: self.webrtc_seed,
 			public_addresses,
 			node_key,
 			node_name: node_name.to_string(),
@@ -369,16 +357,5 @@ mod tests {
 		let params = Cli::try_parse_from(["", "--sync", "wArP"]).expect("Parses network params");
 
 		assert_eq!(SyncMode::Warp, params.network_params.sync);
-	}
-
-	#[test]
-	fn webrtc_seed_requires_experimental_webrtc() {
-		let params = Cli::try_parse_from(["", "--experimental-webrtc", "--webrtc-seed", "7"])
-			.expect("Parses network params");
-		assert_eq!(Some(7), params.network_params.webrtc_seed);
-
-		// The seed only feeds the WebRTC certificate derivation,
-		// so it is an error rather than a silent no-op without the transport enabled.
-		assert!(Cli::try_parse_from(["", "--webrtc-seed", "7"]).is_err());
 	}
 }

--- a/substrate/client/network/Cargo.toml
+++ b/substrate/client/network/Cargo.toml
@@ -36,6 +36,7 @@ either = { workspace = true, default-features = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
+hmac = { workspace = true }
 ip_network = { workspace = true }
 libp2p = { features = ["dns", "identify", "kad", "macros", "mdns", "noise", "ping", "request-response", "tcp", "tokio", "websocket", "yamux"], workspace = true }
 linked_hash_set = { workspace = true }

--- a/substrate/client/network/src/config.rs
+++ b/substrate/client/network/src/config.rs
@@ -621,13 +621,6 @@ pub struct NetworkConfiguration {
 	/// Allow WebRtc addresses, this is an experimental feature.
 	pub experimental_webrtc: bool,
 
-	/// Optional seed appended to the WebRTC DTLS certificate derivation domain,
-	/// rotating the certificate and therefore the node's `/certhash`
-	/// without changing the node key.
-	///
-	/// `None` derives the certificate from the node key alone.
-	pub webrtc_seed: Option<u64>,
-
 	/// Multiaddresses to advertise. Detected automatically if empty.
 	pub public_addresses: Vec<Multiaddr>,
 
@@ -717,7 +710,6 @@ impl NetworkConfiguration {
 			net_config_path,
 			listen_addresses: Vec::new(),
 			experimental_webrtc: false,
-			webrtc_seed: None,
 			public_addresses: Vec::new(),
 			boot_nodes: Vec::new(),
 			node_key,

--- a/substrate/client/network/src/error.rs
+++ b/substrate/client/network/src/error.rs
@@ -80,9 +80,6 @@ pub enum Error {
 	/// Litep2p error.
 	#[error("Litep2p error: `{0}`")]
 	Litep2p(litep2p::Error),
-	/// WebRTC certificate generation error.
-	#[error(transparent)]
-	WebRtcCertificate(#[from] crate::webrtc::CertificateError),
 }
 
 // Make `Debug` use the `Display` implementation.

--- a/substrate/client/network/src/lib.rs
+++ b/substrate/client/network/src/lib.rs
@@ -295,7 +295,6 @@ pub use service::{
 	PublicKey,
 };
 pub use types::ProtocolName;
-pub use webrtc::CertificateError;
 
 /// Log target for `sc-network`.
 const LOG_TARGET: &str = "sub-libp2p";

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -267,13 +267,9 @@ impl Litep2pNetworkBackend {
 	}
 
 	/// Configure transport protocols for `Litep2pNetworkBackend`.
-	///
-	/// `node_secret_key` is the node's ed25519 secret-key bytes, the same key that backs the
-	/// node's peer id. It is used to derive a deterministic WebRTC DTLS certificate so the
-	/// node's `/certhash` stays associated with its identity and stable across restarts.
 	fn configure_transport<B: BlockT + 'static, H: ExHashT>(
 		config: &FullNetworkConfiguration<B, H, Self>,
-		node_secret_key: &[u8; 32],
+		keypair: Keypair,
 	) -> Result<ConfigBuilder, Error> {
 		let _ = match config.network_config.transport {
 			TransportConfig::MemoryOnly => panic!("memory transport not supported"),
@@ -352,7 +348,7 @@ impl Litep2pNetworkBackend {
 			// Always provide a deterministic DTLS certificate derived from the node's secret key,
 			// so the WebRTC certhash is associated with the node identity and stable across
 			// restarts.
-			let certificate = webrtc::derive_certificate(node_secret_key)?;
+			let certificate = webrtc::derive_certificate(keypair.secret())?;
 			config_builder = config_builder.with_webrtc(WebRtcTransportConfig {
 				listen_addresses: webrtc_addresses.into_iter().map(Into::into).collect(),
 				certificate: Some(certificate),
@@ -364,6 +360,8 @@ impl Litep2pNetworkBackend {
 				"WebRTC enabled but no listen address specified"
 			);
 		}
+
+		config_builder = config_builder.with_keypair(keypair);
 
 		Ok(config_builder)
 	}
@@ -429,10 +427,8 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkBackend<B, H> for Litep2pNetworkBac
 		params.network_config.sanity_check_addresses()?;
 		params.network_config.sanity_check_bootnodes()?;
 
-		let node_secret_key = zeroize::Zeroizing::new(keypair.secret().to_bytes());
 		let mut config_builder =
-			Self::configure_transport(&params.network_config, &node_secret_key)?
-				.with_keypair(keypair.clone());
+			Self::configure_transport(&params.network_config, keypair.clone())?;
 		let known_addresses = params.network_config.known_addresses();
 		let peer_store_handle = params.network_config.peer_store_handle();
 		let executor = Arc::new(Litep2pExecutor { executor: params.executor });

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -271,7 +271,6 @@ impl Litep2pNetworkBackend {
 	/// `node_secret_key` is the node's ed25519 secret-key bytes, the same key that backs the
 	/// node's peer id. It is used to derive a deterministic WebRTC DTLS certificate so the
 	/// node's `/certhash` stays associated with its identity and stable across restarts.
-	/// `--webrtc-seed` rotates that certificate without changing the node key.
 	fn configure_transport<B: BlockT + 'static, H: ExHashT>(
 		config: &FullNetworkConfiguration<B, H, Self>,
 		node_secret_key: &[u8; 32],
@@ -353,8 +352,7 @@ impl Litep2pNetworkBackend {
 			// Always provide a deterministic DTLS certificate derived from the node's secret key,
 			// so the WebRTC certhash is associated with the node identity and stable across
 			// restarts.
-			let certificate =
-				webrtc::derive_certificate(node_secret_key, config.network_config.webrtc_seed)?;
+			let certificate = webrtc::derive_certificate(node_secret_key)?;
 			config_builder = config_builder.with_webrtc(WebRtcTransportConfig {
 				listen_addresses: webrtc_addresses.into_iter().map(Into::into).collect(),
 				certificate: Some(certificate),

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -348,7 +348,8 @@ impl Litep2pNetworkBackend {
 			// Always provide a deterministic DTLS certificate derived from the node's secret key,
 			// so the WebRTC certhash is associated with the node identity and stable across
 			// restarts.
-			let certificate = webrtc::derive_certificate(keypair.secret())?;
+			let certificate =
+				webrtc::derive_certificate(keypair.secret()).map_err(Error::Litep2p)?;
 			config_builder = config_builder.with_webrtc(WebRtcTransportConfig {
 				listen_addresses: webrtc_addresses.into_iter().map(Into::into).collect(),
 				certificate: Some(certificate),

--- a/substrate/client/network/src/webrtc.rs
+++ b/substrate/client/network/src/webrtc.rs
@@ -22,92 +22,43 @@
 //! advertised WebRTC multiaddresses. Reusing a certificate across restarts keeps the
 //! certhash stable, similarly to how reusing the node secret key keeps the peer id stable.
 
+use hmac::{Hmac, Mac};
 use p256::{
-	ecdsa::{DerSignature, SigningKey},
-	elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest},
+	ecdsa::{DerSignature, SigningKey, VerifyingKey},
 	pkcs8::EncodePrivateKey,
-	NistP256, NonZeroScalar, SecretKey,
 };
 use sha2::{Digest, Sha256};
 use x509_cert::{
 	builder::{Builder, CertificateBuilder, Profile},
-	der::{
-		self,
-		asn1::{GeneralizedTime, ObjectIdentifier, UtcTime},
-		oid::AssociatedOid,
-		DateTime, Encode as _, EncodeValue, FixedTag, Length, Tag, Writer,
-	},
-	ext::{pkix::constraints::BasicConstraints, AsExtension, Extension},
+	der::{asn1::UtcTime, oid::db::rfc5280::ANY_EXTENDED_KEY_USAGE, DateTime, Encode as _},
+	ext::pkix::ExtendedKeyUsage,
 	name::Name,
 	serial_number::SerialNumber,
 	spki::SubjectPublicKeyInfoOwned,
 	time::{Time, Validity},
 };
 
-use litep2p::transport::webrtc::DtlsCertificate;
+use litep2p::{crypto::ed25519::SecretKey as Ed25519SecretKey, transport::webrtc::DtlsCertificate};
 use std::str::FromStr;
 
-/// RFC 9380 hash-to-field domain-separation tag (DST)
-/// for key derivation in [`derive_certificate`].
-///
-/// Changing this changes the derived key, and therefore the certificate and its certhash.
+/// Domain-separation tag used when deriving P-256 key from ed25519 key via HMAC-SHA256.
 const CERTIFICATE_KEY_DST: &[u8] = b"substrate-webrtc-dtls-p256-v1";
 
-/// Domain-separation context for deriving the certificate's serial number from the seed
-/// in [`derive_certificate`].
-///
-/// Distinct from [`CERTIFICATE_KEY_DST`] so the derived key and the derived serial number
-/// have no accidental structural relationship. Changing this changes the derived serial
-/// number, and therefore the certificate and its certhash.
+/// Domain-separation tag used to derive cert serial from public key.
 const CERTIFICATE_SERIAL_DST: &[u8] = b"substrate-webrtc-dtls-certificate-serial-v1";
 
-/// The certificate needs at least one extension to stay at v3,
-/// and `BasicConstraints` is the minimal end-entity choice.
-struct BasicExtension(BasicConstraints);
-
-impl AssociatedOid for BasicExtension {
-	const OID: ObjectIdentifier = BasicConstraints::OID;
-}
-
-impl FixedTag for BasicExtension {
-	const TAG: Tag = Tag::Sequence;
-}
-
-impl EncodeValue for BasicExtension {
-	fn value_len(&self) -> der::Result<Length> {
-		self.0.value_len()
-	}
-
-	fn encode_value(&self, writer: &mut impl Writer) -> der::Result<()> {
-		self.0.encode_value(writer)
-	}
-}
-
-impl AsExtension for BasicExtension {
-	fn critical(&self, _subject: &Name, _extensions: &[Extension]) -> bool {
-		false
-	}
-}
-
-/// Errors that can occur while deterministically deriving a WebRTC DTLS certificate
-/// from a node's secret key seed.
+/// Error when deriving DTLS cert/key from the node ed25519 network key.
 #[derive(Debug, thiserror::Error)]
 pub enum CertificateError {
-	/// Failed to derive the P-256 signing key from the seed via RFC 9380 hash-to-field.
-	#[error("failed to derive a P-256 scalar from the seed: {0}")]
-	ScalarDerivation(#[from] p256::elliptic_curve::Error),
-	/// The RFC 9380 derivation produced a zero scalar.
-	#[error("derived a zero P-256 scalar from the seed")]
-	ZeroScalar,
 	/// Failed to encode the certificate public key.
 	#[error("failed to encode certificate public key: {0}")]
 	PublicKeyEncoding(#[from] x509_cert::spki::Error),
 	/// Failed to build the certificate.
 	#[error("failed to build certificate: {0}")]
-	CertificateBuild(#[source] x509_cert::builder::Error),
+	CertificateBuild(#[from] x509_cert::builder::Error),
 	/// Failed to DER-encode the certificate.
 	#[error("failed to encode certificate: {0}")]
-	CertificateEncoding(#[source] x509_cert::der::Error),
+	CertificateEncoding(#[from] x509_cert::der::Error),
 	/// Failed to PKCS#8-encode the certificate private key.
 	#[error("failed to encode certificate private key: {0}")]
 	PrivateKeyEncoding(#[from] p256::pkcs8::Error),
@@ -116,19 +67,16 @@ pub enum CertificateError {
 	CertificateLoad(#[from] litep2p::Error),
 }
 
-/// Deterministically generate a WebRTC DTLS certificate from a 32-byte seed, typically the
-/// node's Ed25519 secret key bytes.
-///
-/// The DTLS key is derived from the seed via RFC 9380 `hash_to_field`, and the certificate's
-/// serial number via a domain-separated SHA-256 hash of the seed, neither derivation reveals
-/// the node key.
-pub fn derive_certificate(seed: &[u8; 32]) -> Result<DtlsCertificate, CertificateError> {
-	let (signing_key, private_key) = derive_keys(seed)?;
-	let public_key = SubjectPublicKeyInfoOwned::from_key(*signing_key.verifying_key())?;
-	let serial = derive_serial(seed)?;
+/// Deterministically generate a WebRTC DTLS certificate from a node's secret key.
+pub fn derive_certificate(
+	node_secret_key: Ed25519SecretKey,
+) -> Result<DtlsCertificate, CertificateError> {
+	let signing_key = derive_keys(node_secret_key);
+	let spki = SubjectPublicKeyInfoOwned::from_key(*signing_key.verifying_key())?;
+	let serial = derive_serial(signing_key.verifying_key());
 	let validity = generate_validity();
 	let name = Name::from_str("CN=polkadot-sdk-webrtc")
-		.expect("polkadot-sdk-webrtc is a valid RDN string; qed");
+		.expect("`CN=polkadot-sdk-webrtc` is a valid RDN; qed");
 
 	// `Profile::Manual` opts out of the builder's default extension set,
 	//  and a `None` issuer makes the certificate self-issued.
@@ -138,53 +86,47 @@ pub fn derive_certificate(seed: &[u8; 32]) -> Result<DtlsCertificate, Certificat
 		serial,
 		validity,
 		name,
-		public_key,
+		spki,
 		&signing_key,
-	)
-	.map_err(CertificateError::CertificateBuild)?;
+	)?;
 
-	// The builder downgrades the certificate to v1 whenever the extension list is empty.
-	// One end-entity constraint keeps us on v3.
-	builder
-		.add_extension(&BasicExtension(BasicConstraints { ca: false, path_len_constraint: None }))
-		.map_err(CertificateError::CertificateBuild)?;
+	// Every other WebRTC stack emits v3, but [`CertificateBuilders`] downgrades the certificates
+	// without extensions to v1. Include one non-critical extension to force v3.
+	builder.add_extension(&ExtendedKeyUsage(vec![ANY_EXTENDED_KEY_USAGE]))?;
 
-	let certificate = builder
-		.build::<DerSignature>()
-		.map_err(CertificateError::CertificateBuild)?
-		.to_der()
-		.map_err(CertificateError::CertificateEncoding)?;
+	let certificate = builder.build::<DerSignature>()?.to_der()?;
 
-	DtlsCertificate::load(certificate, private_key).map_err(CertificateError::CertificateLoad)
+	// `DtlsCertificate` below expects PKCS#8 private key.
+	let pk_pkcs8_der = signing_key.to_pkcs8_der()?.as_bytes().to_vec();
+
+	Ok(DtlsCertificate::load(certificate, pk_pkcs8_der)?)
 }
 
-/// Returns the derivated signing and private keys.
-fn derive_keys(seed: &[u8]) -> Result<(SigningKey, Vec<u8>), CertificateError> {
-	// Derive the P-256 signing key via RFC 9380 hash-to-field.
-	// This stretches the seed into pseudorandom bytes via `expand_message_xmd`,
-	// with field reduction for producing an EC private key.
-	let scalar =
-		NistP256::hash_to_scalar::<ExpandMsgXmd<Sha256>>(&[&seed], &[CERTIFICATE_KEY_DST])?;
-	let secret_scalar =
-		NonZeroScalar::new(scalar).into_option().ok_or(CertificateError::ZeroScalar)?;
-	let secret = SecretKey::from(secret_scalar);
-	let signing_key = SigningKey::from(&secret);
-
-	// PKCS#8, loadable by both OpenSSL and rust-native DTLS backends.
-	let private_key = secret.to_pkcs8_der()?.as_bytes().to_vec();
-
-	Ok((signing_key, private_key))
+/// Derive P-256 key from ed25519 key.
+fn derive_keys(node_secret_key: Ed25519SecretKey) -> SigningKey {
+	// P-256 private key is generated via rejection-sampling of a node-secret-key-keyed HMAC-SHA256
+	// of `DST || counter` message.
+	(0u8..)
+		.find_map(|counter| {
+			let okm = Hmac::<Sha256>::new_from_slice(node_secret_key.as_ref())
+				.expect("HMAC accepts keys of any length; qed")
+				.chain_update(CERTIFICATE_KEY_DST)
+				.chain_update([counter])
+				.finalize()
+				.into_bytes();
+			SigningKey::from_slice(&okm).ok()
+		})
+		.expect("each iteration success rate is 1 - 2^(-32), and we have 256 of them; qed")
 }
 
-/// Serial number derived from the seed.
-fn derive_serial(seed: &[u8]) -> Result<SerialNumber, CertificateError> {
-	// WebRTC peers pin the certificate by certhash
-	// and never inspect the serial, so this isn't a security requirement, it just keeps
-	// `(Issuer, Serial)` meaningful for X.509 tooling that assumes that pair identifies a
-	// certificate, since every node otherwise shares the same hardcoded issuer name.
-	let serial_digest =
-		Sha256::new().chain_update(CERTIFICATE_SERIAL_DST).chain_update(seed).finalize();
-	Ok(SerialNumber::new(&serial_digest[..16]).expect("below the 20-byte serial number limit; qed"))
+/// Derive serial number from public key. Not required for the operation, only used to not
+/// hardcode identical/zero serials for all certificates.
+fn derive_serial(pubkey: &VerifyingKey) -> SerialNumber {
+	let serial_digest = Sha256::new()
+		.chain_update(CERTIFICATE_SERIAL_DST)
+		.chain_update(pubkey.to_sec1_bytes())
+		.finalize();
+	SerialNumber::new(&serial_digest[..16]).expect("below the 20-byte serial number limit; qed")
 }
 
 /// Fixed validity dates, required for determinism. WebRTC peers pin the certificate by
@@ -192,11 +134,9 @@ fn derive_serial(seed: &[u8]) -> Result<SerialNumber, CertificateError> {
 fn generate_validity() -> Validity {
 	let not_before = DateTime::new(2000, 1, 1, 0, 0, 0)
 		.and_then(UtcTime::from_date_time)
-		.expect("2000-01-01 00:00:00 is a valid date within the UTCTime range; qed");
-	let not_after = DateTime::new(9999, 12, 31, 23, 59, 59)
-		.map(GeneralizedTime::from_date_time)
-		.expect("9999-12-31 23:59:59 is a valid date, the maximum DER DateTime supports; qed");
-	Validity { not_before: Time::UtcTime(not_before), not_after: Time::GeneralTime(not_after) }
+		.expect("2000-01-01 00:00:00 is a valid date within the `DateTime`/`UtcTime` range; qed")
+		.into();
+	Validity { not_before, not_after: Time::INFINITY }
 }
 
 #[cfg(test)]
@@ -207,6 +147,12 @@ mod tests {
 		multihash::Code,
 	};
 
+	/// Node secret key with every byte set to `byte`.
+	fn node_key(byte: u8) -> Ed25519SecretKey {
+		Ed25519SecretKey::try_from_bytes([byte; 32])
+			.expect("any 32 bytes are a valid ed25519 secret key; qed")
+	}
+
 	/// Compute the `/certhash/<hash>` multiaddress component of a certificate.
 	fn certhash(certificate: &DtlsCertificate) -> String {
 		let hash = Code::Sha2_256.digest(certificate.as_parts().0);
@@ -215,9 +161,9 @@ mod tests {
 
 	#[test]
 	fn deterministic_certificate_generation() {
-		let seed = [7u8; 32];
-		let first = derive_certificate(&seed).unwrap();
-		let second = derive_certificate(&seed).unwrap();
+		let key = node_key(7);
+		let first = derive_certificate(key.clone()).unwrap();
+		let second = derive_certificate(key).unwrap();
 
 		assert_eq!(first.as_parts(), second.as_parts());
 		assert_eq!(certhash(&first), certhash(&second));
@@ -227,8 +173,7 @@ mod tests {
 	fn derive_certificate_uses_version3() {
 		use x509_cert::{der::Decode, Certificate, Version};
 
-		let seed = [1u8; 32];
-		let certificate = derive_certificate(&seed).unwrap();
+		let certificate = derive_certificate(node_key(1)).unwrap();
 		let (certificate_der, _) = certificate.as_parts();
 
 		let parsed = Certificate::from_der(certificate_der).unwrap();
@@ -240,9 +185,9 @@ mod tests {
 	}
 
 	#[test]
-	fn different_seeds_produce_different_certificates() {
-		let first = derive_certificate(&[1u8; 32]).unwrap();
-		let second = derive_certificate(&[2u8; 32]).unwrap();
+	fn different_node_keys_produce_different_certificates() {
+		let first = derive_certificate(node_key(1)).unwrap();
+		let second = derive_certificate(node_key(2)).unwrap();
 
 		assert_ne!(first.as_parts().0, second.as_parts().0);
 		assert_ne!(first.as_parts().1, second.as_parts().1);
@@ -251,21 +196,21 @@ mod tests {
 
 	#[test]
 	fn stable_certhash() {
-		// Pins the seed -> certificate derivation. If this test ever fails, the derivation
+		// Pins the node key -> certificate derivation. If this test ever fails, the derivation
 		// changed and the certhash published by every node relying on it breaks.
-		let certificate = derive_certificate(&[42u8; 32]).unwrap();
+		let certificate = derive_certificate(node_key(42)).unwrap();
 		assert_eq!(
 			certhash(&certificate),
-			"/certhash/uEiBU1jyJxUmj0eUBMpzL8lhUYvBy5UdXdhEAH_GbC7Kxcg"
+			"/certhash/uEiDMlF3mQR1NNRWTKgfPitsu9g9STfkSI5cW2UPRZBvYSA"
 		);
 	}
 
 	#[test]
 	fn generated_certificate_is_valid() {
-		use p256::ecdsa::{signature::Verifier, VerifyingKey};
+		use p256::ecdsa::signature::Verifier;
 		use x509_cert::{der::Decode, Certificate};
 
-		let certificate = derive_certificate(&[8u8; 32]).unwrap();
+		let certificate = derive_certificate(node_key(8)).unwrap();
 		let (certificate_der, _) = certificate.as_parts();
 
 		let parsed = Certificate::from_der(certificate_der).unwrap();

--- a/substrate/client/network/src/webrtc.rs
+++ b/substrate/client/network/src/webrtc.rs
@@ -122,15 +122,8 @@ pub enum CertificateError {
 /// The DTLS key is derived from the seed via RFC 9380 `hash_to_field`, and the certificate's
 /// serial number via a domain-separated SHA-256 hash of the seed, neither derivation reveals
 /// the node key.
-///
-/// `webrtc_seed` rotates the derived key, and therefore the certificate and its certhash,
-/// while leaving the node key and peer id untouched.
-/// Every value, including `Some(0)`, derives a distinct certificate from `None`.
-pub fn derive_certificate(
-	seed: &[u8; 32],
-	webrtc_seed: Option<u64>,
-) -> Result<DtlsCertificate, CertificateError> {
-	let (signing_key, private_key) = derive_keys(seed, webrtc_seed)?;
+pub fn derive_certificate(seed: &[u8; 32]) -> Result<DtlsCertificate, CertificateError> {
+	let (signing_key, private_key) = derive_keys(seed)?;
 	let public_key = SubjectPublicKeyInfoOwned::from_key(*signing_key.verifying_key())?;
 	let serial = derive_serial(seed)?;
 	let validity = generate_validity();
@@ -166,22 +159,12 @@ pub fn derive_certificate(
 }
 
 /// Returns the derivated signing and private keys.
-fn derive_keys(
-	seed: &[u8],
-	webrtc_seed: Option<u64>,
-) -> Result<(SigningKey, Vec<u8>), CertificateError> {
-	// The DST parts are concatenated, so an absent seed leaves the tag unchanged.
-	// A present one always contributes 8 bytes, keeping `Some(0)` distinct from `None`.
-	let webrtc_seed = webrtc_seed.map(u64::to_be_bytes);
-	let dst_suffix: &[u8] = webrtc_seed.as_ref().map_or(&[], |bytes| bytes);
-
+fn derive_keys(seed: &[u8]) -> Result<(SigningKey, Vec<u8>), CertificateError> {
 	// Derive the P-256 signing key via RFC 9380 hash-to-field.
 	// This stretches the seed into pseudorandom bytes via `expand_message_xmd`,
 	// with field reduction for producing an EC private key.
-	let scalar = NistP256::hash_to_scalar::<ExpandMsgXmd<Sha256>>(
-		&[&seed],
-		&[CERTIFICATE_KEY_DST, dst_suffix],
-	)?;
+	let scalar =
+		NistP256::hash_to_scalar::<ExpandMsgXmd<Sha256>>(&[&seed], &[CERTIFICATE_KEY_DST])?;
 	let secret_scalar =
 		NonZeroScalar::new(scalar).into_option().ok_or(CertificateError::ZeroScalar)?;
 	let secret = SecretKey::from(secret_scalar);
@@ -233,8 +216,8 @@ mod tests {
 	#[test]
 	fn deterministic_certificate_generation() {
 		let seed = [7u8; 32];
-		let first = derive_certificate(&seed, None).unwrap();
-		let second = derive_certificate(&seed, None).unwrap();
+		let first = derive_certificate(&seed).unwrap();
+		let second = derive_certificate(&seed).unwrap();
 
 		assert_eq!(first.as_parts(), second.as_parts());
 		assert_eq!(certhash(&first), certhash(&second));
@@ -245,7 +228,7 @@ mod tests {
 		use x509_cert::{der::Decode, Certificate, Version};
 
 		let seed = [1u8; 32];
-		let certificate = derive_certificate(&seed, None).unwrap();
+		let certificate = derive_certificate(&seed).unwrap();
 		let (certificate_der, _) = certificate.as_parts();
 
 		let parsed = Certificate::from_der(certificate_der).unwrap();
@@ -258,8 +241,8 @@ mod tests {
 
 	#[test]
 	fn different_seeds_produce_different_certificates() {
-		let first = derive_certificate(&[1u8; 32], None).unwrap();
-		let second = derive_certificate(&[2u8; 32], None).unwrap();
+		let first = derive_certificate(&[1u8; 32]).unwrap();
+		let second = derive_certificate(&[2u8; 32]).unwrap();
 
 		assert_ne!(first.as_parts().0, second.as_parts().0);
 		assert_ne!(first.as_parts().1, second.as_parts().1);
@@ -270,74 +253,10 @@ mod tests {
 	fn stable_certhash() {
 		// Pins the seed -> certificate derivation. If this test ever fails, the derivation
 		// changed and the certhash published by every node relying on it breaks.
-		let certificate = derive_certificate(&[42u8; 32], None).unwrap();
+		let certificate = derive_certificate(&[42u8; 32]).unwrap();
 		assert_eq!(
 			certhash(&certificate),
 			"/certhash/uEiBU1jyJxUmj0eUBMpzL8lhUYvBy5UdXdhEAH_GbC7Kxcg"
-		);
-	}
-
-	#[test]
-	fn webrtc_seed_rotates_certificate() {
-		use x509_cert::{der::Decode, Certificate};
-
-		let seed = [3u8; 32];
-		let unseeded = derive_certificate(&seed, None).unwrap();
-		let first = derive_certificate(&seed, Some(1)).unwrap();
-		let second = derive_certificate(&seed, Some(2)).unwrap();
-
-		// Every seed yields a distinct certificate, key and certhash, for the same node key.
-		let certificates = [&unseeded, &first, &second];
-		for (index, left) in certificates.iter().enumerate() {
-			for right in certificates.iter().skip(index + 1) {
-				assert_ne!(left.as_parts().0, right.as_parts().0);
-				assert_ne!(left.as_parts().1, right.as_parts().1);
-				assert_ne!(certhash(left), certhash(right));
-			}
-		}
-
-		// The serial number is derived from the node key alone, so rotation leaves it alone.
-		let serial = |certificate: &DtlsCertificate| {
-			Certificate::from_der(certificate.as_parts().0)
-				.unwrap()
-				.tbs_certificate
-				.serial_number
-				.clone()
-		};
-		assert_eq!(serial(&unseeded), serial(&first));
-		assert_eq!(serial(&unseeded), serial(&second));
-	}
-
-	#[test]
-	fn webrtc_seed_derivation_is_deterministic() {
-		let seed = [9u8; 32];
-		let first = derive_certificate(&seed, Some(1)).unwrap();
-		let second = derive_certificate(&seed, Some(1)).unwrap();
-
-		assert_eq!(first.as_parts(), second.as_parts());
-		assert_eq!(certhash(&first), certhash(&second));
-	}
-
-	#[test]
-	fn boundary_webrtc_seeds_are_distinct() {
-		// A present seed always contributes its 8 bytes to the DST, so seed `0` is a rotation
-		// rather than an alias of "no seed".
-		let seed = [11u8; 32];
-		let unseeded = derive_certificate(&seed, None).unwrap();
-		let zero = derive_certificate(&seed, Some(0)).unwrap();
-		let max = derive_certificate(&seed, Some(u64::MAX)).unwrap();
-
-		assert_ne!(certhash(&unseeded), certhash(&zero));
-		assert_ne!(certhash(&unseeded), certhash(&max));
-		assert_ne!(certhash(&zero), certhash(&max));
-	}
-
-	#[test]
-	fn stable_certhash_with_webrtc_seed() {
-		let certificate = derive_certificate(&[42u8; 32], Some(1)).unwrap();
-		assert_eq!(
-			certhash(&certificate),
-			"/certhash/uEiCSnl2zX3egog3X8nATV2RcJXCXHMjF5GTVUtrKFbcGjQ"
 		);
 	}
 
@@ -346,7 +265,7 @@ mod tests {
 		use p256::ecdsa::{signature::Verifier, VerifyingKey};
 		use x509_cert::{der::Decode, Certificate};
 
-		let certificate = derive_certificate(&[8u8; 32], None).unwrap();
+		let certificate = derive_certificate(&[8u8; 32]).unwrap();
 		let (certificate_der, _) = certificate.as_parts();
 
 		let parsed = Certificate::from_der(certificate_der).unwrap();

--- a/substrate/client/network/src/webrtc.rs
+++ b/substrate/client/network/src/webrtc.rs
@@ -55,7 +55,6 @@ pub fn derive_certificate(
 	node_secret_key: Ed25519SecretKey,
 ) -> Result<DtlsCertificate, litep2p::Error> {
 	// NOTE: none of the expects in this function are input-dependent.
-
 	let signing_key = derive_keys(node_secret_key);
 	let spki = SubjectPublicKeyInfoOwned::from_key(*signing_key.verifying_key())
 		.expect("a P-256 verifying key is SPKI-encodable; qed");
@@ -85,20 +84,18 @@ pub fn derive_certificate(
 
 	// Signing fails only if the RFC 6979 nonce or either signature scalar is zero, each with
 	// probability 2^-256.
-	let certificate = builder
+	let certificate_der = builder
 		.build::<DerSignature>()
 		.expect("the certificate is well-formed and the signing key valid; qed")
 		.to_der()
 		.expect("a built certificate is DER-encodable; qed");
-
-	// `DtlsCertificate` below expects PKCS#8 private key.
 	let pk_pkcs8_der = signing_key
 		.to_pkcs8_der()
 		.expect("a P-256 signing key is PKCS#8-encodable; qed")
 		.as_bytes()
 		.to_vec();
 
-	DtlsCertificate::load(certificate, pk_pkcs8_der)
+	DtlsCertificate::load(certificate_der, pk_pkcs8_der)
 }
 
 /// Derive P-256 key from ed25519 key.
@@ -115,7 +112,7 @@ fn derive_keys(node_secret_key: Ed25519SecretKey) -> SigningKey {
 				.into_bytes();
 			SigningKey::from_slice(&okm).ok()
 		})
-		.expect("each iteration success rate is 1 - 2^(-32), and we have 256 of them; qed")
+		.expect("each iteration succeeds with probability 1 - 2^-32, and we have 256 of them; qed")
 }
 
 /// Derive serial number from public key. Not required for the operation, only used to not

--- a/substrate/client/network/src/webrtc.rs
+++ b/substrate/client/network/src/webrtc.rs
@@ -47,32 +47,18 @@ const CERTIFICATE_KEY_DST: &[u8] = b"substrate-webrtc-dtls-p256-v1";
 /// Domain-separation tag used to derive cert serial from public key.
 const CERTIFICATE_SERIAL_DST: &[u8] = b"substrate-webrtc-dtls-certificate-serial-v1";
 
-/// Error when deriving DTLS cert/key from the node ed25519 network key.
-#[derive(Debug, thiserror::Error)]
-pub enum CertificateError {
-	/// Failed to encode the certificate public key.
-	#[error("failed to encode certificate public key: {0}")]
-	PublicKeyEncoding(#[from] x509_cert::spki::Error),
-	/// Failed to build the certificate.
-	#[error("failed to build certificate: {0}")]
-	CertificateBuild(#[from] x509_cert::builder::Error),
-	/// Failed to DER-encode the certificate.
-	#[error("failed to encode certificate: {0}")]
-	CertificateEncoding(#[from] x509_cert::der::Error),
-	/// Failed to PKCS#8-encode the certificate private key.
-	#[error("failed to encode certificate private key: {0}")]
-	PrivateKeyEncoding(#[from] p256::pkcs8::Error),
-	/// Failed to load the generated certificate/key pair into a WebRTC DTLS certificate.
-	#[error("failed to load WebRTC certificate: {0}")]
-	CertificateLoad(#[from] litep2p::Error),
-}
-
 /// Deterministically generate a WebRTC DTLS certificate from a node's secret key.
+///
+/// Returns `Err` if litep2p's [`DtlsCertificate::load`] doesn't accept DER inputs (logically
+/// impossible as of litep2p v0.14.3).
 pub fn derive_certificate(
 	node_secret_key: Ed25519SecretKey,
-) -> Result<DtlsCertificate, CertificateError> {
+) -> Result<DtlsCertificate, litep2p::Error> {
+	// NOTE: none of the expects in this function are input-dependent.
+
 	let signing_key = derive_keys(node_secret_key);
-	let spki = SubjectPublicKeyInfoOwned::from_key(*signing_key.verifying_key())?;
+	let spki = SubjectPublicKeyInfoOwned::from_key(*signing_key.verifying_key())
+		.expect("a P-256 verifying key is SPKI-encodable; qed");
 	let serial = derive_serial(signing_key.verifying_key());
 	let validity = generate_validity();
 	let name = Name::from_str("CN=polkadot-sdk-webrtc")
@@ -88,18 +74,31 @@ pub fn derive_certificate(
 		name,
 		spki,
 		&signing_key,
-	)?;
+	)
+	.expect("the signature algorithm is fixed and both validity bounds are in range; qed");
 
-	// Every other WebRTC stack emits v3, but [`CertificateBuilders`] downgrades the certificates
-	// without extensions to v1. Include one non-critical extension to force v3.
-	builder.add_extension(&ExtendedKeyUsage(vec![ANY_EXTENDED_KEY_USAGE]))?;
+	// Every other WebRTC stack emits v3, but [`CertificateBuilder`] downgrades the certificates
+	// without extensions to v1. Include one non-critical extension to also emit v3.
+	builder
+		.add_extension(&ExtendedKeyUsage(vec![ANY_EXTENDED_KEY_USAGE]))
+		.expect("a single OID is DER-encodable; qed");
 
-	let certificate = builder.build::<DerSignature>()?.to_der()?;
+	// Signing fails only if the RFC 6979 nonce or either signature scalar is zero, each with
+	// probability 2^-256.
+	let certificate = builder
+		.build::<DerSignature>()
+		.expect("the certificate is well-formed and the signing key valid; qed")
+		.to_der()
+		.expect("a built certificate is DER-encodable; qed");
 
 	// `DtlsCertificate` below expects PKCS#8 private key.
-	let pk_pkcs8_der = signing_key.to_pkcs8_der()?.as_bytes().to_vec();
+	let pk_pkcs8_der = signing_key
+		.to_pkcs8_der()
+		.expect("a P-256 signing key is PKCS#8-encodable; qed")
+		.as_bytes()
+		.to_vec();
 
-	Ok(DtlsCertificate::load(certificate, pk_pkcs8_der)?)
+	DtlsCertificate::load(certificate, pk_pkcs8_der)
 }
 
 /// Derive P-256 key from ed25519 key.


### PR DESCRIPTION
Use HMAC-SHA256 with rejection sampling to derive P-256 key.