### PR TITLE
pallet-alliance: reject duplicate members in init_members

### DIFF
--- a/prdoc/pr_12723.prdoc
+++ b/prdoc/pr_12723.prdoc
@@ -1,0 +1,11 @@
+title: 'pallet-alliance: reject duplicate members in init_members'
+doc:
+- audience: Runtime Dev
+  description: |-
+    `init_members` now rejects rosters that list the same account more than once within
+    the fellows or allies list, returning `Error::AlreadyMember`. Previously duplicate
+    entries were sorted and stored as-is, inflating membership counts and letting
+    `remove_member` delete only one copy.
+crates:
+- name: pallet-alliance
+  bump: patch

--- a/substrate/frame/alliance/src/lib.rs
+++ b/substrate/frame/alliance/src/lib.rs
@@ -568,8 +568,10 @@ pub mod pallet {
 			}
 
 			fellows.sort();
+			ensure!(fellows.windows(2).all(|w| w[0] != w[1]), Error::<T, I>::AlreadyMember);
 			Members::<T, I>::insert(&MemberRole::Fellow, fellows.clone());
 			allies.sort();
+			ensure!(allies.windows(2).all(|w| w[0] != w[1]), Error::<T, I>::AlreadyMember);
 			Members::<T, I>::insert(&MemberRole::Ally, allies.clone());
 
 			let mut voteable_members = fellows.clone();

--- a/substrate/frame/alliance/src/tests.rs
+++ b/substrate/frame/alliance/src/tests.rs
@@ -104,6 +104,25 @@ fn init_members_works() {
 }
 
 #[test]
+fn init_members_rejects_duplicates() {
+	build_and_execute(|| {
+		assert_ok!(Alliance::disband(RuntimeOrigin::root(), DisbandWitness::new(3, 0)));
+
+		// Duplicate within fellows.
+		assert_noop!(
+			Alliance::init_members(RuntimeOrigin::root(), vec![8, 8], vec![]),
+			Error::<Test, ()>::AlreadyMember,
+		);
+
+		// Duplicate within allies.
+		assert_noop!(
+			Alliance::init_members(RuntimeOrigin::root(), vec![8], vec![2, 2]),
+			Error::<Test, ()>::AlreadyMember,
+		);
+	})
+}
+
+#[test]
 fn disband_works() {
 	build_and_execute(|| {
 		let id_deposit = test_identity_info_deposit();


### PR DESCRIPTION
Fixes #12723

# Description

`init_members` sorted the fellows and allies lists but did not reject duplicates within each list, letting the root initialization path store the same account more than once. This bypassed the uniqueness rule `add_member` enforces, inflated membership counts, and left `remove_member` able to remove only one copy.

The fix rejects duplicate accounts within each roster and returns `Error::AlreadyMember`, matching how `add_member` handles the same conceptual mistake.

## Integration

No runtime storage or dispatch API changes. Callers of `init_members` (Root only) that previously passed duplicate accounts within a roster will now receive `Error::AlreadyMember` instead of silently succeeding. Runtimes that call `init_members` with unique accounts are unaffected.

## Review Notes

- Scope kept narrow to match the linked issue: within-list duplicates only. Cross-list duplicates (same account in both fellows and allies) are not addressed.
- Implementation: after each `sort()`, check adjacent pairs with `windows(2).all(|w| w[0] != w[1])`. Since the vec is sorted, any duplicate must be adjacent.
- Regression test `init_members_rejects_duplicates` in `substrate/frame/alliance/src/tests.rs` covers both fellows-duplicate and allies-duplicate paths.
- prdoc file named `pr_12723.prdoc` (issue number) as a placeholder — happy to rename to match the PR number.

# Checklist

* [x] My PR includes a detailed description as outlined in the "Description" and its two subsections above.
* [ ] My PR follows the [labeling requirements](https://github.com/paritytech/polkadot-sdk/blob/master/docs/contributor/CONTRIBUTING.md#Process) of this project (at minimum one label for `T` required)
    * Will add `T1-FRAME` via `/cmd label` after creation.
* [ ] I have made corresponding changes to the documentation (if applicable)
* [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
